### PR TITLE
Fix find query parameter support for devicestatus.json endpoint

### DIFF
--- a/src/API/Nocturne.API/Services/DeviceStatusService.cs
+++ b/src/API/Nocturne.API/Services/DeviceStatusService.cs
@@ -72,16 +72,18 @@ public class DeviceStatusService : IDeviceStatusService
             return deviceStatus ?? new List<DeviceStatus>();
         }
 
-        // For non-default parameters, go directly to database
+        // For non-default parameters, go directly to database with advanced filtering
         _logger.LogDebug(
             "Bypassing cache for device status with custom parameters (find: {Find}, count: {Count}, skip: {Skip})",
             find,
             count,
             skip
         );
-        return await _postgreSqlService.GetDeviceStatusAsync(
+        return await _postgreSqlService.GetDeviceStatusWithAdvancedFilterAsync(
             count ?? 10,
             skip ?? 0,
+            findQuery: find,
+            reverseResults: false,
             cancellationToken
         );
     }


### PR DESCRIPTION
## Summary
- Adds `find` query parameter support to `/api/v1/devicestatus.json` endpoint
- Fixes the issue where MongoDB-style filtering was being ignored

Fixes #28

## Changes

**DeviceStatusController.cs:**
- Added `[FromQuery] string? find` parameter to `GetDeviceStatus()` and `GetDeviceStatusJson()`
- Added query string parsing for `find[field]=value` and URL-encoded `find%5Bfield%5D=value` syntax
- Follows the same pattern used in `EntriesController`

**DeviceStatusService.cs:**
- Changed non-cached path to use `GetDeviceStatusWithAdvancedFilterAsync()` instead of `GetDeviceStatusAsync()`
- The advanced filter method already existed in the data layer, just wasn't being called

## Test plan
- [x] Verified with test data (3 device status entries with different devices)
- [x] `find[device]=loop://iPhone` correctly returns 2 entries
- [x] `find[device]=openaps://pi` correctly returns 1 entry
- [x] `find[device]=nonexistent` correctly returns 0 entries
- [x] No `find` parameter returns all entries (backward compatible)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)