### PR TITLE
Fix API_SECRET not being passed to nocturne-api in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -57,6 +57,7 @@ services:
       services__mylife-connector__http__0: "http://mylife-connector:${MYLIFE_CONNECTOR_PORT}"
       TCONNECTSYNC_CONNECTOR_HTTP: "http://tconnectsync-connector:8000"
       services__tconnectsync-connector__http__0: "http://tconnectsync-connector:8000"
+      API_SECRET: "${API_SECRET}"
       DemoService__Enabled: "false"
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://compose-dashboard:18889"
       OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"


### PR DESCRIPTION
The nocturne-api service was missing the API_SECRET environment variable,
causing "API secret not configured" errors when clients sent the api-secret
header. The connectors all had ApiSecret configured but the API itself
(which validates it) never received the value.

https://claude.ai/code/session_01BE1816Kk9hpjEevSJip6Ln