### PR TITLE
fix: use StateSpan basal data for TDD in multi-period statistics

### DIFF
--- a/src/Core/Nocturne.Core.Contracts/IStatisticsService.cs
+++ b/src/Core/Nocturne.Core.Contracts/IStatisticsService.cs
@@ -111,6 +111,21 @@ public interface IStatisticsService
         DateTime endDate
     );
 
+    /// <summary>
+    /// Calculate comprehensive insulin delivery statistics using StateSpans for basal data
+    /// </summary>
+    InsulinDeliveryStatistics CalculateInsulinDeliveryStatistics(
+        IEnumerable<Treatment> treatments,
+        IEnumerable<StateSpan> basalStateSpans,
+        DateTime startDate,
+        DateTime endDate
+    );
+
+    /// <summary>
+    /// Sum total basal insulin delivered across a collection of BasalDelivery StateSpans
+    /// </summary>
+    double SumBasalFromStateSpans(IEnumerable<StateSpan> basalStateSpans);
+
     // Formatting Utilities
     string FormatInsulinDisplay(double value);
     string FormatCarbDisplay(double value);

--- a/src/Web/packages/app/src/lib/components/reports/BasalBolusRatioChart.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/BasalBolusRatioChart.svelte
@@ -36,8 +36,6 @@
   const chartData = $derived(ratioData?.dailyData ?? []);
   const averageBasalPercent = $derived(ratioData?.averageBasalPercent ?? 0);
   const averageBolusPercent = $derived(ratioData?.averageBolusPercent ?? 0);
-  const averageTdd = $derived(ratioData?.averageTdd ?? 0);
-  const dayCount = $derived(ratioData?.dayCount ?? 0);
 </script>
 
 <div class="w-full">
@@ -51,32 +49,6 @@
       </div>
     </div>
   {:else if chartData.length > 0 && chartData.some((d) => (d.total ?? 0) > 0)}
-    <!-- Summary Cards -->
-    <div class="mb-6 grid grid-cols-2 gap-4 md:grid-cols-4">
-      <div class="rounded-lg border bg-card p-4 text-center">
-        <div class="text-2xl font-bold text-amber-600 dark:text-amber-400">
-          {averageBasalPercent.toFixed(0)}%
-        </div>
-        <div class="text-xs font-medium text-muted-foreground">Avg Basal</div>
-      </div>
-      <div class="rounded-lg border bg-card p-4 text-center">
-        <div class="text-2xl font-bold text-blue-600 dark:text-blue-400">
-          {averageBolusPercent.toFixed(0)}%
-        </div>
-        <div class="text-xs font-medium text-muted-foreground">Avg Bolus</div>
-      </div>
-      <div class="rounded-lg border bg-card p-4 text-center">
-        <div class="text-2xl font-bold">
-          {averageTdd.toFixed(1)}U
-        </div>
-        <div class="text-xs font-medium text-muted-foreground">Avg TDD</div>
-      </div>
-      <div class="rounded-lg border bg-card p-4 text-center">
-        <div class="text-2xl font-bold">{dayCount}</div>
-        <div class="text-xs font-medium text-muted-foreground">Days</div>
-      </div>
-    </div>
-
     <!-- Stacked Bar Chart -->
     <div class="h-[300px] w-full">
       <BarChart


### PR DESCRIPTION
The summary cards on the Insulin Delivery page showed a different TDD
(42.0U) than the Daily Basal/Bolus Breakdown chart (80.8U) because
they used different basal data sources. The summary cards used
profile-schedule-based basal calculation while the chart used actual
pump delivery data from StateSpans.

Now both use StateSpan data when available, with profile-based
calculation as a fallback. This ensures consistent TDD values across
the entire Insulin Delivery page.

https://claude.ai/code/session_019a8MoyJKC2ZBjf22ovFD3M