### PR TITLE
fix(multitenancy): bypass tenant resolution for admin tenants endpoints

### DIFF
--- a/src/API/Nocturne.API/Middleware/RecoveryModeMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/RecoveryModeMiddleware.cs
@@ -58,6 +58,7 @@ public class RecoveryModeMiddleware
             path.StartsWith("/api/auth/totp/", StringComparison.OrdinalIgnoreCase) ||
             path.StartsWith("/api/metadata", StringComparison.OrdinalIgnoreCase) ||
             path.Equals("/api/admin/tenants/validate-slug", StringComparison.OrdinalIgnoreCase) ||
+            path.Equals("/api/v4/admin/tenants/validate-slug", StringComparison.OrdinalIgnoreCase) ||
             path.Equals("/api/v4/me/tenants/validate-slug", StringComparison.OrdinalIgnoreCase))
         {
             await _next(context);

--- a/src/API/Nocturne.API/Middleware/TenantSetupMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/TenantSetupMiddleware.cs
@@ -21,6 +21,7 @@ public class TenantSetupMiddleware
     private static readonly string[] AllowedPrefixes =
     [
         "/api/admin/",
+        "/api/v4/admin/",
         "/api/auth/passkey/",
         "/api/auth/totp/",
         "/api/metadata",
@@ -29,6 +30,7 @@ public class TenantSetupMiddleware
     private static readonly string[] AllowedPaths =
     [
         "/api/admin/tenants/validate-slug",
+        "/api/v4/admin/tenants/validate-slug",
         "/api/v4/me/tenants/validate-slug",
     ];
 

--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -38,9 +38,22 @@ public class TenantResolutionMiddleware
     [
         "/api/v4/me/tenants/validate-slug",
         "/api/admin/tenants/validate-slug",
+        "/api/v4/admin/tenants/validate-slug",
         "/api/metadata",
         "/api/v4/chat-identity/directory/resolve",
         "/api/v4/chat-identity/directory/pending-links",
+    ];
+
+    /// <summary>
+    /// Prefixes that are cross-tenant by design and must never be gated on
+    /// a resolved tenant. Admin tenant management (create, provision, member
+    /// management) operates on arbitrary tenants by ID and cannot rely on
+    /// subdomain resolution.
+    /// </summary>
+    private static readonly string[] TenantlessAllowedPrefixes =
+    [
+        "/api/admin/tenants",
+        "/api/v4/admin/tenants",
     ];
 
     public async Task InvokeAsync(HttpContext context)
@@ -51,8 +64,9 @@ public class TenantResolutionMiddleware
                    ?? context.Request.Host.Host;
         var slug = ExtractSubdomain(host);
         var path = context.Request.Path.Value ?? "";
-        var isTenantlessAllowedPath = TenantlessAllowedPaths.Any(
-            p => path.Equals(p, StringComparison.OrdinalIgnoreCase));
+        var isTenantlessAllowedPath =
+            TenantlessAllowedPaths.Any(p => path.Equals(p, StringComparison.OrdinalIgnoreCase)) ||
+            TenantlessAllowedPrefixes.Any(p => path.StartsWith(p, StringComparison.OrdinalIgnoreCase));
 
         // Tenantless-allowed paths on the apex (no slug) operate across tenants
         // and must not fall through to the IsDefault tenant — otherwise any

--- a/tests/Unit/Nocturne.API.Tests/Middleware/TenantSetupMiddlewareTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/TenantSetupMiddlewareTests.cs
@@ -136,6 +136,8 @@ public class TenantSetupMiddlewareTests : IDisposable
     [InlineData("/api/auth/totp/setup")]
     [InlineData("/api/metadata")]
     [InlineData("/api/admin/tenants/validate-slug")]
+    [InlineData("/api/v4/admin/tenants/validate-slug")]
+    [InlineData("/api/v4/admin/tenants/provision")]
     [InlineData("/api/v4/me/tenants/validate-slug")]
     public async Task AllowListPaths_AreNotBlocked_EvenWithNoCredentials(string path)
     {


### PR DESCRIPTION
## Summary
- `/api/v4/admin/tenants/provision` (and the rest of the admin tenants tree) was 503'ing under `TenantResolutionMiddleware` with \`Tenant not found for slug 'foo'\`. Cross-tenant admin endpoints have no subdomain by design, so they can never satisfy the resolver.
- Add `/api/v4/admin/tenants` as a tenantless-allowed **prefix** in `TenantResolutionMiddleware`.
- Mirror the `/api/v4/admin/` prefix and the new `/api/v4/admin/tenants/validate-slug` path in `TenantSetupMiddleware` and `RecoveryModeMiddleware`.
- Preserve the old `/api/admin/*` paths so any stragglers still work.
- Added `/api/v4/admin/tenants/provision` to the allow-list test in `TenantSetupMiddlewareTests`.

## Context
The bypass lists were only half-migrated when the admin controller moved to `/api/v4/admin/tenants`. `validate-slug` got the update, but `provision` and friends didn't — so SaaS provisioners calling through an internal hostname got blocked before the controller ran.

## Test plan
- [x] `dotnet test tests/Unit/Nocturne.API.Tests --filter FullyQualifiedName~TenantSetupMiddleware` — 15/15 pass
- [ ] Smoke: POST `/api/v4/admin/tenants/provision` with `api-secret` header returns 200 on an apex hostname