### PR TITLE
fix(auth): grant platform_admin to X-Instance-Key authentication

### DIFF
--- a/src/API/Nocturne.API/Middleware/Handlers/InstanceKeyHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/InstanceKeyHandler.cs
@@ -56,6 +56,14 @@ public class InstanceKeyHandler : IAuthHandler
             SubjectName = "instance-service",
             Permissions = ["*"],
             Roles = ["admin"],
+            // The instance key is the highest-trust service credential in
+            // the system (shared only with trusted in-cluster services). It
+            // already skips tenant membership checks and grants permission
+            // wildcard, so it must also carry platform_admin so that cross-
+            // tenant admin endpoints (e.g. /api/v4/admin/tenants/provision)
+            // are callable by provisioners. Without this, external admin
+            // calls authenticated via X-Instance-Key get 403 Forbidden.
+            IsPlatformAdmin = true,
         }));
     }
 }


### PR DESCRIPTION
## Summary
- \`InstanceKeyHandler\` builds an \`AuthContext\` with \`Permissions = [\"*\"]\` and \`Roles = [\"admin\"]\` but \`IsPlatformAdmin = false\` (default).
- Admin controllers (e.g. \`/api/v4/admin/tenants/provision\`) are guarded by \`[Authorize(Roles = \"platform_admin\")]\`, so instance-authenticated callers get **403 Forbidden**.
- The instance key is the highest-trust service credential in the system — shared only with in-cluster services, already skips tenant membership checks, and carries permission wildcard. Granting \`platform_admin\` matches that trust level and aligns with the existing ApiSecret handler.

## Context
Surfaced in nocturne-cloud's billing service, which holds the instance key and calls \`POST /api/v4/admin/tenants/provision\` from its \`NocturneAdminClient\`. After PR #95 unblocked the middleware bypass, the request hit the controller but couldn't clear \`[Authorize]\`.

## Test plan
- [ ] \`POST /api/v4/admin/tenants/provision\` with a valid \`X-Instance-Key\` header returns 2xx on a fresh deployment