### PR TITLE
fix: redirect OIDC callbacks from apex to tenant subdomain

### DIFF
--- a/src/API/Nocturne.API/Controllers/OidcController.cs
+++ b/src/API/Nocturne.API/Controllers/OidcController.cs
@@ -104,7 +104,8 @@ public class OidcController : ControllerBase
 
         try
         {
-            var authRequest = await _authService.GenerateAuthorizationUrlAsync(provider, returnUrl);
+            var tenantSlug = (HttpContext.Items["TenantContext"] as TenantContext)?.Slug;
+            var authRequest = await _authService.GenerateAuthorizationUrlAsync(provider, returnUrl, tenantSlug: tenantSlug);
 
             // Store state in a secure cookie for verification on callback
             SetStateCookie(authRequest.State, authRequest.ExpiresAt);

--- a/src/API/Nocturne.API/Controllers/OidcController.cs
+++ b/src/API/Nocturne.API/Controllers/OidcController.cs
@@ -8,6 +8,7 @@ using Nocturne.API.Extensions;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts;
 using Nocturne.Core.Models.Authorization;
+using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Configuration;
 using Nocturne.Infrastructure.Data.Entities;
 using SameSiteMode = Nocturne.Core.Models.Configuration.SameSiteMode;
@@ -243,8 +244,9 @@ public class OidcController : ControllerBase
 
         try
         {
+            var tenantSlug = (HttpContext.Items["TenantContext"] as TenantContext)?.Slug;
             var req = await _authService.GenerateLinkAuthorizationUrlAsync(
-                provider, auth.SubjectId.Value, returnUrl);
+                provider, auth.SubjectId.Value, returnUrl, tenantSlug);
             SetLinkStateCookie(req.State, req.ExpiresAt);
 
             _logger.LogInformation(

--- a/src/API/Nocturne.API/Middleware/OidcCallbackRedirectMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/OidcCallbackRedirectMiddleware.cs
@@ -1,0 +1,122 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using Nocturne.API.Multitenancy;
+
+namespace Nocturne.API.Middleware;
+
+/// <summary>
+/// Redirects OIDC callbacks that land on the apex domain to the originating
+/// tenant subdomain. Runs before <see cref="TenantResolutionMiddleware"/> so
+/// cookies set on the tenant subdomain are available when the callback is
+/// actually processed.
+/// </summary>
+public partial class OidcCallbackRedirectMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<OidcCallbackRedirectMiddleware> _logger;
+    private readonly MultitenancyConfiguration _config;
+
+    private static readonly string[] CallbackPaths =
+    [
+        "/api/v4/oidc/callback",
+        "/api/v4/oidc/link/callback",
+    ];
+
+    public OidcCallbackRedirectMiddleware(
+        RequestDelegate next,
+        ILogger<OidcCallbackRedirectMiddleware> logger,
+        IOptions<MultitenancyConfiguration> config)
+    {
+        _next = next;
+        _logger = logger;
+        _config = config.Value;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (string.IsNullOrEmpty(_config.BaseDomain) || !IsOidcCallbackPath(context.Request.Path))
+        {
+            await _next(context);
+            return;
+        }
+
+        var host = context.Request.Headers["X-Forwarded-Host"].FirstOrDefault()?.Split(':')[0]
+                   ?? context.Request.Host.Host;
+        var baseDomainHost = _config.BaseDomain.Split(':')[0];
+
+        // If there's already a subdomain, pass through — the callback is on the right host.
+        if (host.EndsWith($".{baseDomainHost}", StringComparison.OrdinalIgnoreCase))
+        {
+            await _next(context);
+            return;
+        }
+
+        // Apex domain — try to extract TenantSlug from the state query parameter.
+        var stateParam = context.Request.Query["state"].FirstOrDefault();
+        if (string.IsNullOrEmpty(stateParam))
+        {
+            await _next(context);
+            return;
+        }
+
+        var tenantSlug = ExtractTenantSlug(stateParam);
+        if (string.IsNullOrEmpty(tenantSlug))
+        {
+            await _next(context);
+            return;
+        }
+
+        if (!SlugPattern().IsMatch(tenantSlug))
+        {
+            await _next(context);
+            return;
+        }
+
+        var scheme = context.Request.Headers["X-Forwarded-Proto"].FirstOrDefault()
+                     ?? context.Request.Scheme;
+        var redirectUrl = $"{scheme}://{tenantSlug}.{baseDomainHost}{context.Request.Path}{context.Request.QueryString}";
+
+        _logger.LogInformation(
+            "Redirecting OIDC callback from apex to tenant subdomain {TenantSlug}",
+            tenantSlug);
+
+        context.Response.Redirect(redirectUrl);
+    }
+
+    private static bool IsOidcCallbackPath(PathString path)
+    {
+        var value = path.Value ?? "";
+        return CallbackPaths.Any(p => value.Equals(p, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string? ExtractTenantSlug(string encoded)
+    {
+        try
+        {
+            // Restore base64 padding
+            var padded = (encoded.Length % 4) switch
+            {
+                2 => encoded + "==",
+                3 => encoded + "=",
+                _ => encoded,
+            };
+
+            var bytes = Convert.FromBase64String(padded.Replace("-", "+").Replace("_", "/"));
+            var json = Encoding.UTF8.GetString(bytes);
+
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.TryGetProperty("TenantSlug", out var prop))
+                return prop.GetString();
+
+            return null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    [System.Text.RegularExpressions.GeneratedRegex(@"^[a-z0-9][a-z0-9\-]{0,61}[a-z0-9]$")]
+    private static partial System.Text.RegularExpressions.Regex SlugPattern();
+}

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -259,6 +259,9 @@ app.UseMiddleware<JsonExtensionMiddleware>();
 // Block most API traffic when recovery mode is active (orphaned subjects detected)
 app.UseMiddleware<RecoveryModeMiddleware>();
 
+// Redirect OIDC callbacks from apex to the originating tenant subdomain
+app.UseMiddleware<OidcCallbackRedirectMiddleware>();
+
 // Resolve tenant from subdomain (must run before authentication)
 app.UseMiddleware<TenantResolutionMiddleware>();
 

--- a/src/API/Nocturne.API/Services/Auth/OidcAuthService.cs
+++ b/src/API/Nocturne.API/Services/Auth/OidcAuthService.cs
@@ -52,7 +52,8 @@ public class OidcAuthService : IOidcAuthService
     public async Task<OidcAuthorizationRequest> GenerateAuthorizationUrlAsync(
         Guid? providerId,
         string? returnUrl = null,
-        string? state = null
+        string? state = null,
+        string? tenantSlug = null
     )
     {
         OidcProvider provider;
@@ -92,6 +93,7 @@ public class OidcAuthService : IOidcAuthService
             CreatedAt = DateTimeOffset.UtcNow,
             ExpiresAt = DateTimeOffset.UtcNow.Add(_options.State.Lifetime),
             Intent = "login",
+            TenantSlug = tenantSlug,
         };
 
         return await BuildAuthorizationUrlAsync(provider, stateData, returnUrl, state);

--- a/src/API/Nocturne.API/Services/Auth/OidcAuthService.cs
+++ b/src/API/Nocturne.API/Services/Auth/OidcAuthService.cs
@@ -782,6 +782,7 @@ public class OidcAuthService : IOidcAuthService
         public DateTimeOffset ExpiresAt { get; set; }
         public string Intent { get; set; } = "login";
         public Guid? SubjectId { get; set; }
+        public string? TenantSlug { get; set; }
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Services/Auth/OidcAuthService.cs
+++ b/src/API/Nocturne.API/Services/Auth/OidcAuthService.cs
@@ -480,7 +480,7 @@ public class OidcAuthService : IOidcAuthService
 
     /// <inheritdoc />
     public async Task<OidcAuthorizationRequest> GenerateLinkAuthorizationUrlAsync(
-        Guid providerId, Guid subjectId, string? returnUrl = null)
+        Guid providerId, Guid subjectId, string? returnUrl = null, string? tenantSlug = null)
     {
         var provider =
             await _providerService.GetProviderByIdAsync(providerId)
@@ -500,6 +500,7 @@ public class OidcAuthService : IOidcAuthService
             ExpiresAt = DateTimeOffset.UtcNow.Add(_options.State.Lifetime),
             Intent = "link",
             SubjectId = subjectId,
+            TenantSlug = tenantSlug,
         };
 
         return await BuildAuthorizationUrlAsync(provider, stateData, returnUrl, callbackPath: LinkCallbackPath);

--- a/src/Core/Nocturne.Core.Contracts/IOidcAuthService.cs
+++ b/src/Core/Nocturne.Core.Contracts/IOidcAuthService.cs
@@ -18,7 +18,8 @@ public interface IOidcAuthService
     Task<OidcAuthorizationRequest> GenerateAuthorizationUrlAsync(
         Guid? providerId,
         string? returnUrl = null,
-        string? state = null
+        string? state = null,
+        string? tenantSlug = null
     );
 
     /// <summary>

--- a/src/Core/Nocturne.Core.Contracts/IOidcAuthService.cs
+++ b/src/Core/Nocturne.Core.Contracts/IOidcAuthService.cs
@@ -74,7 +74,7 @@ public interface IOidcAuthService
     Task<Guid?> ValidateSessionAsync(string refreshToken);
 
     Task<OidcAuthorizationRequest> GenerateLinkAuthorizationUrlAsync(
-        Guid providerId, Guid subjectId, string? returnUrl = null);
+        Guid providerId, Guid subjectId, string? returnUrl = null, string? tenantSlug = null);
 
     Task<OidcLinkResult> HandleLinkCallbackAsync(
         string code, string state, string expectedState,

--- a/tests/Unit/Nocturne.API.Tests/Middleware/OidcCallbackRedirectMiddlewareTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/OidcCallbackRedirectMiddlewareTests.cs
@@ -1,0 +1,184 @@
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Nocturne.API.Middleware;
+using Nocturne.API.Multitenancy;
+using Xunit;
+
+namespace Nocturne.API.Tests.Middleware;
+
+public class OidcCallbackRedirectMiddlewareTests
+{
+    private readonly MultitenancyConfiguration _config = new() { BaseDomain = "nocturne.run" };
+
+    private OidcCallbackRedirectMiddleware CreateMiddleware(RequestDelegate? next = null)
+    {
+        next ??= _ => Task.CompletedTask;
+        return new OidcCallbackRedirectMiddleware(
+            next,
+            NullLogger<OidcCallbackRedirectMiddleware>.Instance,
+            Options.Create(_config));
+    }
+
+    private static string EncodeState(object data)
+    {
+        var json = JsonSerializer.Serialize(data);
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(json))
+            .Replace("+", "-").Replace("/", "_").TrimEnd('=');
+    }
+
+    [Fact]
+    public async Task Redirects_apex_oidc_callback_to_tenant_subdomain()
+    {
+        var middleware = CreateMiddleware();
+        var state = EncodeState(new { TenantSlug = "ryceg" });
+        var context = new DefaultHttpContext();
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("nocturne.run");
+        context.Request.Path = "/api/v4/oidc/link/callback";
+        context.Request.QueryString = new QueryString($"?code=abc&state={state}");
+        context.Request.Headers["X-Forwarded-Proto"] = "https";
+
+        await middleware.InvokeAsync(context);
+
+        context.Response.StatusCode.Should().Be(302);
+        context.Response.Headers.Location.ToString()
+            .Should().StartWith("https://ryceg.nocturne.run/api/v4/oidc/link/callback?")
+            .And.Contain("code=abc")
+            .And.Contain($"state={state}");
+    }
+
+    [Fact]
+    public async Task Redirects_apex_login_callback_to_tenant_subdomain()
+    {
+        var middleware = CreateMiddleware();
+        var state = EncodeState(new { TenantSlug = "alice" });
+        var context = new DefaultHttpContext();
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("nocturne.run");
+        context.Request.Path = "/api/v4/oidc/callback";
+        context.Request.QueryString = new QueryString($"?code=xyz&state={state}");
+        context.Request.Headers["X-Forwarded-Proto"] = "https";
+
+        await middleware.InvokeAsync(context);
+
+        context.Response.StatusCode.Should().Be(302);
+        context.Response.Headers.Location.ToString()
+            .Should().StartWith("https://alice.nocturne.run/api/v4/oidc/callback?");
+    }
+
+    [Fact]
+    public async Task Passes_through_when_subdomain_present()
+    {
+        var called = false;
+        var middleware = CreateMiddleware(_ => { called = true; return Task.CompletedTask; });
+        var state = EncodeState(new { TenantSlug = "ryceg" });
+        var context = new DefaultHttpContext();
+        context.Request.Host = new HostString("ryceg.nocturne.run");
+        context.Request.Path = "/api/v4/oidc/link/callback";
+        context.Request.QueryString = new QueryString($"?code=abc&state={state}");
+
+        await middleware.InvokeAsync(context);
+
+        called.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Passes_through_for_non_oidc_paths()
+    {
+        var called = false;
+        var middleware = CreateMiddleware(_ => { called = true; return Task.CompletedTask; });
+        var context = new DefaultHttpContext();
+        context.Request.Host = new HostString("nocturne.run");
+        context.Request.Path = "/api/v4/entries";
+
+        await middleware.InvokeAsync(context);
+
+        called.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Passes_through_when_state_has_no_tenant_slug()
+    {
+        var called = false;
+        var middleware = CreateMiddleware(_ => { called = true; return Task.CompletedTask; });
+        var state = EncodeState(new { Intent = "login" });
+        var context = new DefaultHttpContext();
+        context.Request.Host = new HostString("nocturne.run");
+        context.Request.Path = "/api/v4/oidc/callback";
+        context.Request.QueryString = new QueryString($"?code=abc&state={state}");
+
+        await middleware.InvokeAsync(context);
+
+        called.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Passes_through_when_multitenancy_not_configured()
+    {
+        var called = false;
+        var config = new MultitenancyConfiguration { BaseDomain = null };
+        var middleware = new OidcCallbackRedirectMiddleware(
+            _ => { called = true; return Task.CompletedTask; },
+            NullLogger<OidcCallbackRedirectMiddleware>.Instance,
+            Options.Create(config));
+        var context = new DefaultHttpContext();
+        context.Request.Host = new HostString("nocturne.run");
+        context.Request.Path = "/api/v4/oidc/callback";
+
+        await middleware.InvokeAsync(context);
+
+        called.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Passes_through_when_state_parameter_missing()
+    {
+        var called = false;
+        var middleware = CreateMiddleware(_ => { called = true; return Task.CompletedTask; });
+        var context = new DefaultHttpContext();
+        context.Request.Host = new HostString("nocturne.run");
+        context.Request.Path = "/api/v4/oidc/callback";
+        context.Request.QueryString = new QueryString("?code=abc");
+
+        await middleware.InvokeAsync(context);
+
+        called.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Uses_x_forwarded_host_for_subdomain_detection()
+    {
+        var called = false;
+        var middleware = CreateMiddleware(_ => { called = true; return Task.CompletedTask; });
+        var state = EncodeState(new { TenantSlug = "ryceg" });
+        var context = new DefaultHttpContext();
+        context.Request.Host = new HostString("nocturne-api");
+        context.Request.Headers["X-Forwarded-Host"] = "ryceg.nocturne.run";
+        context.Request.Path = "/api/v4/oidc/link/callback";
+        context.Request.QueryString = new QueryString($"?code=abc&state={state}");
+
+        await middleware.InvokeAsync(context);
+
+        called.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Passes_through_when_tenant_slug_contains_invalid_characters()
+    {
+        var called = false;
+        var middleware = CreateMiddleware(_ => { called = true; return Task.CompletedTask; });
+        var state = EncodeState(new { TenantSlug = "evil.attacker.com" });
+        var context = new DefaultHttpContext();
+        context.Request.Host = new HostString("nocturne.run");
+        context.Request.Path = "/api/v4/oidc/callback";
+        context.Request.QueryString = new QueryString($"?code=abc&state={state}");
+
+        await middleware.InvokeAsync(context);
+
+        called.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `TenantSlug` to the OIDC state parameter, populated from the resolved tenant context when login or link flows start on a subdomain
- Adds `OidcCallbackRedirectMiddleware` that runs before `TenantResolutionMiddleware` — when an OIDC callback arrives on the apex domain, it decodes the state, extracts the tenant slug, and 302 redirects to `https://{slug}.{baseDomain}/api/v4/oidc/...` with all query params preserved
- Includes slug regex validation to prevent open redirect attacks via crafted state parameters

## Problem

Google OAuth requires pre-registered redirect URIs, so all OIDC callbacks use the apex domain (`nocturne.run`). But session cookies and link state cookies are set on the tenant subdomain (`ryceg.nocturne.run`), and `TenantResolutionMiddleware` resolves the default tenant on apex — which has no credentials, so `TenantSetupMiddleware` returns 503.

## Solution

Instead of changing cookie domains (which would leak sessions across tenants), the middleware bounces the callback to the correct subdomain before any cookie or tenant resolution happens. One extra redirect hop, zero cross-tenant cookie leakage.

## Test plan

- [ ] 9 new unit tests for the middleware (redirect cases, pass-through cases, slug validation, X-Forwarded-Host)
- [ ] All 51 existing OIDC tests pass with no changes needed
- [ ] Manual test: initiate Google OAuth link from a tenant subdomain, verify callback redirects correctly