### PR TITLE
fix(web): propagate rotated auth cookies from SSR API calls to browser

### DIFF
--- a/src/Web/packages/app/src/hooks.server.ts
+++ b/src/Web/packages/app/src/hooks.server.ts
@@ -54,7 +54,10 @@ const authHandle: Handle = async ({ event, resolve }) => {
   }
 
   try {
-    // Create a temporary API client with auth tokens for session validation
+    // Create a temporary API client with auth tokens for session validation.
+    // `responseCookies` lets the client forward any auth-cookie rotations
+    // performed by the API (via SessionCookieHandler auto-refresh) back to
+    // the browser, so rotated refresh tokens don't silently disappear.
     const refreshToken = event.cookies.get(AUTH_COOKIE_NAMES.refreshToken);
     const hostHeader = event.request.headers.get("host");
     const apiClient = createServerApiClient(apiBaseUrl, fetch, {
@@ -62,6 +65,7 @@ const authHandle: Handle = async ({ event, resolve }) => {
       refreshToken,
       hashedInstanceKey: getHashedInstanceKey(),
       extraHeaders: hostHeader ? { "X-Forwarded-Host": hostHeader } : undefined,
+      responseCookies: event.cookies,
     });
 
     // Validate session with the API using the typed client
@@ -280,12 +284,16 @@ const apiClientHandle: Handle = async ({ event, resolve }) => {
     extraHeaders["X-Forwarded-Host"] = originalHost;
   }
 
-  // Create API client with SvelteKit's fetch, auth headers, and both tokens
+  // Create API client with SvelteKit's fetch, auth headers, and both tokens.
+  // `responseCookies` lets any token rotation performed by the backend's
+  // session middleware (during remote function / load function calls) flow
+  // back to the browser as Set-Cookie on the outgoing SvelteKit response.
   event.locals.apiClient = createServerApiClient(apiBaseUrl, event.fetch, {
     accessToken,
     refreshToken,
     hashedInstanceKey: getHashedInstanceKey(),
     extraHeaders,
+    responseCookies: event.cookies,
   });
 
   return resolve(event);

--- a/src/Web/packages/app/src/lib/server/api-client-factory.ts
+++ b/src/Web/packages/app/src/lib/server/api-client-factory.ts
@@ -3,6 +3,10 @@ import { env } from "$env/dynamic/private";
 import { env as publicEnv } from "$env/dynamic/public";
 import { ApiClient } from "$lib/api/api-client.generated";
 import { AUTH_COOKIE_NAMES } from "$lib/config/auth-cookies";
+import {
+  propagateAuthCookies,
+  type CookieSetter,
+} from "./auth-cookie-propagation";
 
 /**
  * Helper to get the API base URL (server-side internal or public).
@@ -23,6 +27,13 @@ export function getHashedInstanceKey(): string | null {
 
 /**
  * Create an API client with custom fetch that includes auth headers.
+ *
+ * When `responseCookies` is provided, any auth-related Set-Cookie headers
+ * on the response are forwarded onto the outgoing SvelteKit response so
+ * that token rotation performed by the API middleware reaches the browser.
+ * Without this, SSR-initiated calls would silently rotate tokens that
+ * never make it back to the client, causing the next request to fail auth
+ * (since the old refresh token is now revoked).
  */
 export function createServerApiClient(
   baseUrl: string,
@@ -32,6 +43,7 @@ export function createServerApiClient(
     refreshToken?: string;
     hashedInstanceKey?: string | null;
     extraHeaders?: Record<string, string>;
+    responseCookies?: CookieSetter;
   }
 ): ApiClient {
   const httpClient = {
@@ -59,10 +71,19 @@ export function createServerApiClient(
         headers.set("Cookie", cookies.join("; "));
       }
 
-      return fetchFn(url, {
+      const response = await fetchFn(url, {
         ...init,
         headers,
       });
+
+      if (options?.responseCookies) {
+        propagateAuthCookies(
+          response.headers.getSetCookie(),
+          options.responseCookies
+        );
+      }
+
+      return response;
     },
   };
 

--- a/src/Web/packages/app/src/lib/server/auth-cookie-propagation.test.ts
+++ b/src/Web/packages/app/src/lib/server/auth-cookie-propagation.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from "vitest";
+import {
+  propagateAuthCookies,
+  type CookieSetter,
+  type CookieSetOptions,
+} from "./auth-cookie-propagation";
+import { AUTH_COOKIE_NAMES } from "../config/auth-cookies";
+
+interface SetCall {
+  op: "set";
+  name: string;
+  value: string;
+  opts: CookieSetOptions & { path: string };
+}
+
+interface DeleteCall {
+  op: "delete";
+  name: string;
+  opts: { path: string; domain?: string };
+}
+
+type RecordedCall = SetCall | DeleteCall;
+
+function createRecordingCookies(): {
+  cookies: CookieSetter;
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  const cookies: CookieSetter = {
+    set(name, value, opts) {
+      calls.push({ op: "set", name, value, opts });
+    },
+    delete(name, opts) {
+      calls.push({ op: "delete", name, opts });
+    },
+  };
+  return { cookies, calls };
+}
+
+describe("propagateAuthCookies", () => {
+  it("propagates a rotated access token Set-Cookie onto the outgoing response", () => {
+    const { cookies, calls } = createRecordingCookies();
+
+    propagateAuthCookies(
+      [
+        ".Nocturne.AccessToken=new-access-token; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=900",
+      ],
+      cookies
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      op: "set",
+      name: ".Nocturne.AccessToken",
+      value: "new-access-token",
+      opts: {
+        path: "/",
+        httpOnly: true,
+        secure: true,
+        sameSite: "lax",
+        maxAge: 900,
+      },
+    });
+  });
+
+  it("propagates a rotated refresh token so the browser gets the new token after rotation (regression for SSR auto-refresh bug)", () => {
+    const { cookies, calls } = createRecordingCookies();
+
+    propagateAuthCookies(
+      [
+        `${AUTH_COOKIE_NAMES.accessToken}=access; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=900`,
+        `${AUTH_COOKIE_NAMES.refreshToken}=rotated-refresh; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=604800`,
+        `IsAuthenticated=true; Path=/; Secure; SameSite=Lax; Max-Age=604800`,
+      ],
+      cookies
+    );
+
+    const setByName = Object.fromEntries(
+      calls
+        .filter((c): c is SetCall => c.op === "set")
+        .map((c) => [c.name, c])
+    );
+
+    expect(setByName[AUTH_COOKIE_NAMES.accessToken]?.value).toBe("access");
+    expect(setByName[AUTH_COOKIE_NAMES.refreshToken]?.value).toBe(
+      "rotated-refresh"
+    );
+    expect(setByName[AUTH_COOKIE_NAMES.refreshToken]?.opts.httpOnly).toBe(true);
+    expect(setByName[AUTH_COOKIE_NAMES.refreshToken]?.opts.maxAge).toBe(604800);
+
+    expect(setByName.IsAuthenticated?.value).toBe("true");
+    // IsAuthenticated is frontend-visible, so must not be httpOnly
+    expect(setByName.IsAuthenticated?.opts.httpOnly).toBeUndefined();
+  });
+
+  it("ignores Set-Cookie headers for cookies that are not auth-related", () => {
+    const { cookies, calls } = createRecordingCookies();
+
+    propagateAuthCookies(
+      [
+        "nocturne-language=en; Path=/; Max-Age=31536000",
+        "some_analytics_id=abc123; Path=/",
+      ],
+      cookies
+    );
+
+    expect(calls).toHaveLength(0);
+  });
+
+  it("propagates cookie deletion when the server expires an auth cookie", () => {
+    const { cookies, calls } = createRecordingCookies();
+
+    propagateAuthCookies(
+      [
+        `${AUTH_COOKIE_NAMES.accessToken}=; Path=/; Max-Age=0`,
+        `${AUTH_COOKIE_NAMES.refreshToken}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT`,
+      ],
+      cookies
+    );
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toMatchObject({
+      op: "delete",
+      name: AUTH_COOKIE_NAMES.accessToken,
+      opts: { path: "/" },
+    });
+    expect(calls[1]).toMatchObject({
+      op: "delete",
+      name: AUTH_COOKIE_NAMES.refreshToken,
+      opts: { path: "/" },
+    });
+  });
+
+  it("forwards the Domain attribute when the backend sets it", () => {
+    const { cookies, calls } = createRecordingCookies();
+
+    propagateAuthCookies(
+      [
+        `${AUTH_COOKIE_NAMES.accessToken}=t; Path=/; Domain=.example.com; HttpOnly; Secure; SameSite=Lax; Max-Age=900`,
+      ],
+      cookies
+    );
+
+    expect(calls[0]).toMatchObject({
+      op: "set",
+      name: AUTH_COOKIE_NAMES.accessToken,
+      opts: { domain: ".example.com" },
+    });
+  });
+
+  it("handles an empty list safely", () => {
+    const { cookies, calls } = createRecordingCookies();
+    propagateAuthCookies([], cookies);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("defaults Path to / when the Set-Cookie omits it", () => {
+    const { cookies, calls } = createRecordingCookies();
+
+    propagateAuthCookies(
+      [`${AUTH_COOKIE_NAMES.accessToken}=t; HttpOnly; Secure`],
+      cookies
+    );
+
+    expect(calls[0]).toMatchObject({
+      op: "set",
+      opts: { path: "/" },
+    });
+  });
+
+  it("skips malformed Set-Cookie headers without throwing", () => {
+    const { cookies, calls } = createRecordingCookies();
+
+    propagateAuthCookies(
+      [
+        "", // empty
+        "no-equals-sign",
+        `=noname; Path=/`,
+        `${AUTH_COOKIE_NAMES.accessToken}=valid; Path=/; HttpOnly`,
+      ],
+      cookies
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      op: "set",
+      name: AUTH_COOKIE_NAMES.accessToken,
+      value: "valid",
+    });
+  });
+});

--- a/src/Web/packages/app/src/lib/server/auth-cookie-propagation.ts
+++ b/src/Web/packages/app/src/lib/server/auth-cookie-propagation.ts
@@ -1,0 +1,157 @@
+import { AUTH_COOKIE_NAMES } from "../config/auth-cookies";
+
+/**
+ * Minimal subset of SvelteKit's Cookies interface we need for propagation.
+ * Kept narrow so this module can be unit-tested without importing SvelteKit.
+ */
+export interface CookieSetter {
+  set(
+    name: string,
+    value: string,
+    opts: CookieSetOptions & { path: string }
+  ): void;
+  delete(name: string, opts: { path: string; domain?: string }): void;
+}
+
+export interface CookieSetOptions {
+  httpOnly?: boolean;
+  secure?: boolean;
+  sameSite?: "lax" | "strict" | "none" | boolean;
+  maxAge?: number;
+  expires?: Date;
+  domain?: string;
+}
+
+const AUTH_COOKIE_SET: ReadonlySet<string> = new Set([
+  AUTH_COOKIE_NAMES.accessToken,
+  AUTH_COOKIE_NAMES.refreshToken,
+  AUTH_COOKIE_NAMES.isAuthenticated,
+]);
+
+/**
+ * Propagate auth-related Set-Cookie headers from a server-to-server fetch
+ * response onto the outgoing SvelteKit response cookies, so the browser
+ * actually receives rotated tokens after an internal session refresh.
+ *
+ * Without this, SSR-initiated calls (authHandle, remote functions, load
+ * functions) trigger token rotation on the backend but the rotated cookies
+ * never make it back to the browser — causing the next request to fail
+ * authentication and redirect to /auth/login.
+ *
+ * Only auth cookies are propagated; unrelated Set-Cookie headers from the
+ * backend are ignored.
+ */
+export function propagateAuthCookies(
+  setCookieHeaders: readonly string[],
+  cookies: CookieSetter
+): void {
+  for (const header of setCookieHeaders) {
+    const parsed = parseSetCookieHeader(header);
+    if (!parsed) continue;
+    if (!AUTH_COOKIE_SET.has(parsed.name)) continue;
+
+    if (parsed.isDeletion) {
+      cookies.delete(parsed.name, {
+        path: parsed.path ?? "/",
+        ...(parsed.domain !== undefined ? { domain: parsed.domain } : {}),
+      });
+      continue;
+    }
+
+    const opts: CookieSetOptions & { path: string } = {
+      path: parsed.path ?? "/",
+    };
+    if (parsed.httpOnly !== undefined) opts.httpOnly = parsed.httpOnly;
+    if (parsed.secure !== undefined) opts.secure = parsed.secure;
+    if (parsed.sameSite !== undefined) opts.sameSite = parsed.sameSite;
+    if (parsed.maxAge !== undefined) opts.maxAge = parsed.maxAge;
+    if (parsed.expires !== undefined) opts.expires = parsed.expires;
+    if (parsed.domain !== undefined) opts.domain = parsed.domain;
+
+    cookies.set(parsed.name, parsed.value, opts);
+  }
+}
+
+interface ParsedSetCookie {
+  name: string;
+  value: string;
+  path?: string;
+  domain?: string;
+  httpOnly?: boolean;
+  secure?: boolean;
+  sameSite?: "lax" | "strict" | "none";
+  maxAge?: number;
+  expires?: Date;
+  isDeletion: boolean;
+}
+
+function parseSetCookieHeader(header: string): ParsedSetCookie | null {
+  const parts = header.split(";").map((p) => p.trim());
+  const first = parts.shift();
+  if (!first) return null;
+
+  const eqIdx = first.indexOf("=");
+  if (eqIdx < 0) return null;
+
+  const name = first.slice(0, eqIdx).trim();
+  const value = first.slice(eqIdx + 1).trim();
+  if (!name) return null;
+
+  const result: ParsedSetCookie = { name, value, isDeletion: false };
+
+  for (const part of parts) {
+    if (!part) continue;
+    const eq = part.indexOf("=");
+    const rawKey = eq < 0 ? part : part.slice(0, eq);
+    const val = eq < 0 ? "" : part.slice(eq + 1).trim();
+    const key = rawKey.trim().toLowerCase();
+
+    switch (key) {
+      case "path":
+        result.path = val;
+        break;
+      case "domain":
+        result.domain = val;
+        break;
+      case "httponly":
+        result.httpOnly = true;
+        break;
+      case "secure":
+        result.secure = true;
+        break;
+      case "samesite": {
+        const normalized = val.toLowerCase();
+        if (
+          normalized === "lax" ||
+          normalized === "strict" ||
+          normalized === "none"
+        ) {
+          result.sameSite = normalized;
+        }
+        break;
+      }
+      case "max-age": {
+        const n = Number.parseInt(val, 10);
+        if (!Number.isNaN(n)) result.maxAge = n;
+        break;
+      }
+      case "expires": {
+        const exp = new Date(val);
+        if (!Number.isNaN(exp.getTime())) result.expires = exp;
+        break;
+      }
+    }
+  }
+
+  // Treat as deletion if the server has explicitly expired the cookie:
+  // empty value plus either Max-Age<=0 or an Expires in the past.
+  const now = Date.now();
+  const expiredByMaxAge = result.maxAge !== undefined && result.maxAge <= 0;
+  const expiredByExpires =
+    result.expires !== undefined && result.expires.getTime() <= now;
+  if (value === "" && (expiredByMaxAge || expiredByExpires)) {
+    result.isDeletion = true;
+  }
+
+  return result;
+}

--- a/src/Web/packages/app/vitest.config.ts
+++ b/src/Web/packages/app/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    exclude: ["node_modules/**", "e2e/**", ".svelte-kit/**"],
+  },
+});


### PR DESCRIPTION
## Summary

SSR-initiated calls to the backend (authHandle's `getSession`, `load` functions, and remote functions via `event.locals.apiClient`) go through `createServerApiClient`, which previously discarded `Set-Cookie` headers on the internal response. When the API's `SessionCookieHandler` auto-refreshed on an expired access token, it would rotate the refresh token and emit new cookies — but those never reached the browser. The next request arrived with an old (now-revoked) refresh token, got treated as token reuse, and the user was bounced to `/auth/login`.

Most visible symptom: tabs left idle past the 15-minute access-token lifetime appeared to be logged out on every return. Observed on production.

## Fix

Thread `event.cookies` through `createServerApiClient` as `responseCookies`, parse `Set-Cookie` headers on each response, and replay the auth-relevant ones (access token, refresh token, `IsAuthenticated`) onto the outgoing SvelteKit response. Non-auth cookies are ignored.

## Relationship to recent cookie work

The recently-landed `1e7dff37` ("fix cookies request") addresses a related but distinct issue in `oauth.remote.ts`. This PR does not overlap — different files, different call path (SSR API client vs OAuth remote function).

## Test plan

- [x] New unit test at `src/Web/packages/app/src/lib/server/auth-cookie-propagation.test.ts` covering the cookie-parsing and replay logic (8 tests, all passing locally).
- [ ] CI (build + existing tests).
- [ ] Manual: log in, wait 15+ minutes, return to an idle tab, verify session persists without redirect to `/auth/login`.
