### PR TITLE
feat(web): xDrip Nocturne uploader integration

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Platform/ServicesController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/ServicesController.cs
@@ -245,20 +245,19 @@ public class ServicesController : ControllerBase
 
         var baseUrl = GetBaseUrl();
 
-        return Ok(
-            new UploaderSetupResponse
-            {
-                App = app,
-                BaseUrl = baseUrl,
-                ApiSecretPlaceholder = "YOUR-API-SECRET",
-                FullApiUrl = $"{baseUrl}/api/v1",
-                EntriesUrl = $"{baseUrl}/api/v1/entries",
-                TreatmentsUrl = $"{baseUrl}/api/v1/treatments",
-                DeviceStatusUrl = $"{baseUrl}/api/v1/devicestatus",
-                // Format for xDrip+ style URL with embedded secret
-                XdripStyleUrl = $"https://YOUR-API-SECRET@{GetHostFromUrl(baseUrl)}/api/v1",
-            }
-        );
+        var response = new UploaderSetupResponse
+        {
+            App = app,
+            BaseUrl = baseUrl,
+        };
+
+        // Apps that support OAuth device authorization get a deep-link URL for QR code scanning
+        if (appId.Equals("xdrip", StringComparison.OrdinalIgnoreCase))
+        {
+            response.ConnectUrl = $"xdrip://connect/nocturne?url={Uri.EscapeDataString(baseUrl)}";
+        }
+
+        return Ok(response);
     }
 
     /// <summary>
@@ -550,18 +549,6 @@ public class ServicesController : ControllerBase
         return $"{request.Scheme}://{request.Host}";
     }
 
-    private static string GetHostFromUrl(string url)
-    {
-        try
-        {
-            var uri = new Uri(url);
-            return uri.Host + (uri.Port != 80 && uri.Port != 443 ? $":{uri.Port}" : "");
-        }
-        catch
-        {
-            return url.Replace("https://", "").Replace("http://", "").TrimEnd('/');
-        }
-    }
 }
 
 /// <summary>
@@ -580,34 +567,11 @@ public class UploaderSetupResponse
     public string BaseUrl { get; set; } = string.Empty;
 
     /// <summary>
-    /// Placeholder for where the API secret goes
+    /// Deep-link URL for apps that support OAuth device authorization via QR code
+    /// (e.g. xdrip://connect/nocturne?url=https://your-instance.com).
+    /// When present, the frontend shows a QR code and inline device-code input.
     /// </summary>
-    public string ApiSecretPlaceholder { get; set; } = "YOUR-API-SECRET";
-
-    /// <summary>
-    /// Full API URL (base + /api/v1)
-    /// </summary>
-    public string FullApiUrl { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Entries endpoint URL
-    /// </summary>
-    public string EntriesUrl { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Treatments endpoint URL
-    /// </summary>
-    public string TreatmentsUrl { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Device status endpoint URL
-    /// </summary>
-    public string DeviceStatusUrl { get; set; } = string.Empty;
-
-    /// <summary>
-    /// xDrip+ style URL with embedded secret placeholder
-    /// </summary>
-    public string XdripStyleUrl { get; set; } = string.Empty;
+    public string? ConnectUrl { get; set; }
 }
 
 /// <summary>

--- a/src/API/Nocturne.API/Services/DataSourceService.cs
+++ b/src/API/Nocturne.API/Services/DataSourceService.cs
@@ -212,387 +212,82 @@ public class DataSourceService : IDataSourceService
             new()
             {
                 Id = "xdrip",
-                Name = "xDrip+",
-                Platform = "android",
-                Category = "cgm",
-                Description =
-                    "Popular Android CGM app supporting many sensors. Can upload data directly to Nocturne.",
+                Platform = UploaderPlatform.Android,
+                Category = UploaderCategory.Cgm,
                 Icon = "xdrip",
                 Url = "https://github.com/NightscoutFoundation/xDrip",
-                SetupInstructions = new List<SetupStep>
-                {
-                    new() { Step = 1, Title = "scan_qr", Description = "scan_qr" },
-                    new() { Step = 2, Title = "approve_connection", Description = "approve_connection" },
-                    new() { Step = 3, Title = "done", Description = "done" },
-                },
             },
             new()
             {
                 Id = "spike",
-                Name = "Spike",
-                Platform = "ios",
-                Category = "cgm",
-                Description = "iOS CGM app supporting Dexcom, Libre, and other sensors.",
+                Platform = UploaderPlatform.iOS,
+                Category = UploaderCategory.Cgm,
                 Icon = "spike",
                 Url = "https://spike-app.com",
-                SetupInstructions = new List<SetupStep>
-                {
-                    new()
-                    {
-                        Step = 1,
-                        Title = "Open Spike Settings",
-                        Description = "Go to Settings in the Spike app.",
-                    },
-                    new()
-                    {
-                        Step = 2,
-                        Title = "Integration",
-                        Description = "Navigate to Integration → Nightscout.",
-                    },
-                    new()
-                    {
-                        Step = 3,
-                        Title = "Configure URL",
-                        Description = "Enter your Nocturne URL.",
-                    },
-                    new()
-                    {
-                        Step = 4,
-                        Title = "API Secret",
-                        Description = "Enter your API secret.",
-                    },
-                    new()
-                    {
-                        Step = 5,
-                        Title = "Enable Upload",
-                        Description = "Toggle on 'Upload readings to Nightscout'.",
-                    },
-                },
             },
             new()
             {
                 Id = "loop",
-                Name = "Loop",
-                Platform = "ios",
-                Category = "aid-system",
-                Description = "DIY automated insulin delivery system for iOS.",
+                Platform = UploaderPlatform.iOS,
+                Category = UploaderCategory.AidSystem,
                 Icon = "loop",
                 Url = "https://loopkit.github.io/loopdocs/",
-                SetupInstructions = new List<SetupStep>
-                {
-                    new()
-                    {
-                        Step = 1,
-                        Title = "Open Loop Settings",
-                        Description = "Go to Loop Settings in the app.",
-                    },
-                    new()
-                    {
-                        Step = 2,
-                        Title = "Services",
-                        Description = "Navigate to Services → Nightscout.",
-                    },
-                    new()
-                    {
-                        Step = 3,
-                        Title = "Configure",
-                        Description = "Enter your Nocturne URL and API secret.",
-                    },
-                    new()
-                    {
-                        Step = 4,
-                        Title = "Enable",
-                        Description = "Toggle on Nightscout upload.",
-                    },
-                },
             },
             new()
             {
                 Id = "aaps",
-                Name = "AAPS (AndroidAPS)",
-                Platform = "android",
-                Category = "aid-system",
-                Description = "DIY automated insulin delivery system for Android.",
+                Platform = UploaderPlatform.Android,
+                Category = UploaderCategory.AidSystem,
                 Icon = "aaps",
                 Url = "https://wiki.aaps.app",
-                SetupInstructions = new List<SetupStep>
-                {
-                    new()
-                    {
-                        Step = 1,
-                        Title = "Open AAPS Config Builder",
-                        Description = "Navigate to Config Builder in AAPS.",
-                    },
-                    new()
-                    {
-                        Step = 2,
-                        Title = "Enable NSClient",
-                        Description = "Enable NSClient or NSClientV3 under Synchronization.",
-                    },
-                    new()
-                    {
-                        Step = 3,
-                        Title = "Configure URL",
-                        Description = "Enter your Nocturne URL in NSClient settings.",
-                    },
-                    new()
-                    {
-                        Step = 4,
-                        Title = "API Secret",
-                        Description = "Enter your API secret (use SHA-1 hash if using v1).",
-                    },
-                    new()
-                    {
-                        Step = 5,
-                        Title = "Select Data",
-                        Description =
-                            "Choose which data to upload (BG, treatments, profiles, etc.).",
-                    },
-                },
             },
             new()
             {
                 Id = "trio",
-                Name = "Trio",
-                Platform = "ios",
-                Category = "aid-system",
-                Description = "Open source automated insulin delivery system for iOS.",
+                Platform = UploaderPlatform.iOS,
+                Category = UploaderCategory.AidSystem,
                 Icon = "trio",
                 Url = "https://diy-trio.org",
-                SetupInstructions = new List<SetupStep>
-                {
-                    new()
-                    {
-                        Step = 1,
-                        Title = "Open Trio Settings",
-                        Description = "Go to Settings in the Trio app.",
-                    },
-                    new()
-                    {
-                        Step = 2,
-                        Title = "Services",
-                        Description = "Navigate to Services → Nightscout.",
-                    },
-                    new()
-                    {
-                        Step = 3,
-                        Title = "Configure",
-                        Description = "Enter your Nocturne URL and API secret.",
-                    },
-                    new()
-                    {
-                        Step = 4,
-                        Title = "Enable Upload",
-                        Description = "Enable the data you want to upload.",
-                    },
-                },
             },
             new()
             {
                 Id = "iaps",
-                Name = "iAPS",
-                Platform = "ios",
-                Category = "aid-system",
-                Description =
-                    "Open source automated insulin delivery system for iOS (fork of OpenAPS).",
+                Platform = UploaderPlatform.iOS,
+                Category = UploaderCategory.AidSystem,
                 Icon = "iaps",
                 Url = "https://iaps.readthedocs.io",
-                SetupInstructions = new List<SetupStep>
-                {
-                    new()
-                    {
-                        Step = 1,
-                        Title = "Open iAPS Settings",
-                        Description = "Go to Settings in the iAPS app.",
-                    },
-                    new()
-                    {
-                        Step = 2,
-                        Title = "Nightscout",
-                        Description = "Navigate to Services → Nightscout.",
-                    },
-                    new()
-                    {
-                        Step = 3,
-                        Title = "Configure URL",
-                        Description = "Enter your Nocturne URL.",
-                    },
-                    new()
-                    {
-                        Step = 4,
-                        Title = "API Secret",
-                        Description = "Enter your API secret.",
-                    },
-                },
             },
             new()
             {
                 Id = "nightscout-uploader",
-                Name = "Nightscout Uploader",
-                Platform = "android",
-                Category = "uploader",
-                Description = "Android app for uploading data from various BG meters and CGMs.",
+                Platform = UploaderPlatform.Android,
+                Category = UploaderCategory.Uploader,
                 Icon = "nightscout",
                 Url = "https://github.com/nightscout/android-uploader",
-                SetupInstructions = new List<SetupStep>
-                {
-                    new()
-                    {
-                        Step = 1,
-                        Title = "Install App",
-                        Description = "Install from Google Play or GitHub releases.",
-                    },
-                    new()
-                    {
-                        Step = 2,
-                        Title = "Configure",
-                        Description = "Enter your Nocturne URL.",
-                    },
-                    new()
-                    {
-                        Step = 3,
-                        Title = "API Secret",
-                        Description = "Enter your API secret.",
-                    },
-                    new()
-                    {
-                        Step = 4,
-                        Title = "Select Source",
-                        Description = "Choose your data source device.",
-                    },
-                },
             },
             new()
             {
                 Id = "xdrip4ios",
-                Name = "xDrip4iOS",
-                Platform = "ios",
-                Category = "cgm",
-                Description =
-                    "iOS CGM app supporting Dexcom, Libre, and other sensors with Nightscout upload.",
+                Platform = UploaderPlatform.iOS,
+                Category = UploaderCategory.Cgm,
                 Icon = "xdrip4ios",
                 Url = "https://github.com/JohanDegraworksve/xdripswift",
-                SetupInstructions = new List<SetupStep>
-                {
-                    new()
-                    {
-                        Step = 1,
-                        Title = "Open xDrip4iOS Settings",
-                        Description = "Tap the Settings tab in the app.",
-                    },
-                    new()
-                    {
-                        Step = 2,
-                        Title = "Nightscout Upload",
-                        Description = "Navigate to Nightscout → Upload.",
-                    },
-                    new()
-                    {
-                        Step = 3,
-                        Title = "Configure URL",
-                        Description = "Enter your Nocturne URL.",
-                    },
-                    new()
-                    {
-                        Step = 4,
-                        Title = "API Secret",
-                        Description = "Enter your API secret.",
-                    },
-                    new()
-                    {
-                        Step = 5,
-                        Title = "Enable Upload",
-                        Description = "Toggle on 'Upload to Nightscout'.",
-                    },
-                },
             },
             new()
             {
                 Id = "juggluco",
-                Name = "Juggluco",
-                Platform = "android",
-                Category = "cgm",
-                Description =
-                    "Android app for FreeStyle Libre sensors with Nightscout upload support.",
+                Platform = UploaderPlatform.Android,
+                Category = UploaderCategory.Cgm,
                 Icon = "juggluco",
                 Url = "https://juggluco.nl",
-                SetupInstructions = new List<SetupStep>
-                {
-                    new()
-                    {
-                        Step = 1,
-                        Title = "Open Juggluco Settings",
-                        Description = "Tap the hamburger menu and select Settings.",
-                    },
-                    new()
-                    {
-                        Step = 2,
-                        Title = "Nightscout Connection",
-                        Description = "Navigate to the Nightscout section.",
-                    },
-                    new()
-                    {
-                        Step = 3,
-                        Title = "Configure URL",
-                        Description = "Enter your Nocturne URL.",
-                    },
-                    new()
-                    {
-                        Step = 4,
-                        Title = "API Secret",
-                        Description = "Enter your API secret.",
-                    },
-                    new()
-                    {
-                        Step = 5,
-                        Title = "Enable Sync",
-                        Description = "Toggle on Nightscout synchronisation.",
-                    },
-                },
             },
             new()
             {
                 Id = "glucotracker",
-                Name = "GlucoTracker",
-                Platform = "android",
-                Category = "cgm",
-                Description =
-                    "Android glucose tracking app with Nightscout upload capability.",
+                Platform = UploaderPlatform.Android,
+                Category = UploaderCategory.Cgm,
                 Icon = "glucotracker",
                 Url = "https://glucotracker.app",
-                SetupInstructions = new List<SetupStep>
-                {
-                    new()
-                    {
-                        Step = 1,
-                        Title = "Open GlucoTracker Settings",
-                        Description = "Go to Settings in the app.",
-                    },
-                    new()
-                    {
-                        Step = 2,
-                        Title = "Cloud Sync",
-                        Description = "Navigate to Cloud Sync → Nightscout.",
-                    },
-                    new()
-                    {
-                        Step = 3,
-                        Title = "Configure URL",
-                        Description = "Enter your Nocturne URL.",
-                    },
-                    new()
-                    {
-                        Step = 4,
-                        Title = "API Secret",
-                        Description = "Enter your API secret.",
-                    },
-                    new()
-                    {
-                        Step = 5,
-                        Title = "Enable Upload",
-                        Description = "Toggle on 'Upload to Nightscout'.",
-                    },
-                },
             },
         };
     }

--- a/src/API/Nocturne.API/Services/DataSourceService.cs
+++ b/src/API/Nocturne.API/Services/DataSourceService.cs
@@ -221,37 +221,9 @@ public class DataSourceService : IDataSourceService
                 Url = "https://github.com/NightscoutFoundation/xDrip",
                 SetupInstructions = new List<SetupStep>
                 {
-                    new()
-                    {
-                        Step = 1,
-                        Title = "Open xDrip+ Settings",
-                        Description = "Tap the hamburger menu (☰) and select Settings.",
-                    },
-                    new()
-                    {
-                        Step = 2,
-                        Title = "Cloud Upload",
-                        Description = "Navigate to Cloud Upload → Nightscout Sync (REST-API).",
-                    },
-                    new()
-                    {
-                        Step = 3,
-                        Title = "Enable Upload",
-                        Description = "Enable 'Nightscout Sync (REST-API)'.",
-                    },
-                    new()
-                    {
-                        Step = 4,
-                        Title = "Set Base URL",
-                        Description =
-                            "Enter your Nocturne URL with API secret: https://YOUR-API-SECRET@your-nocturne-url.com/api/v1",
-                    },
-                    new()
-                    {
-                        Step = 5,
-                        Title = "Test Connection",
-                        Description = "Tap 'Test Connection' to verify the setup.",
-                    },
+                    new() { Step = 1, Title = "scan_qr", Description = "scan_qr" },
+                    new() { Step = 2, Title = "approve_connection", Description = "approve_connection" },
+                    new() { Step = 3, Title = "done", Description = "done" },
                 },
             },
             new()

--- a/src/Core/Nocturne.Core.Models/Services/DataSourceInfo.cs
+++ b/src/Core/Nocturne.Core.Models/Services/DataSourceInfo.cs
@@ -230,24 +230,24 @@ public class SelectOption
 /// <summary>
 /// Platform an uploader app runs on
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter<UploaderPlatform>))]
 public enum UploaderPlatform
 {
-    Android,
-    iOS,
-    Desktop,
-    Web,
+    [JsonStringEnumMemberName("android")] Android,
+    [JsonStringEnumMemberName("ios")] iOS,
+    [JsonStringEnumMemberName("desktop")] Desktop,
+    [JsonStringEnumMemberName("web")] Web,
 }
 
 /// <summary>
 /// Category of uploader app
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter<UploaderCategory>))]
 public enum UploaderCategory
 {
-    Cgm,
-    AidSystem,
-    Uploader,
+    [JsonStringEnumMemberName("cgm")] Cgm,
+    [JsonStringEnumMemberName("aid-system")] AidSystem,
+    [JsonStringEnumMemberName("uploader")] Uploader,
 }
 
 /// <summary>

--- a/src/Core/Nocturne.Core.Models/Services/DataSourceInfo.cs
+++ b/src/Core/Nocturne.Core.Models/Services/DataSourceInfo.cs
@@ -228,39 +228,52 @@ public class SelectOption
 }
 
 /// <summary>
-/// Represents an uploader application that can push data to Nocturne
+/// Platform an uploader app runs on
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum UploaderPlatform
+{
+    Android,
+    iOS,
+    Desktop,
+    Web,
+}
+
+/// <summary>
+/// Category of uploader app
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum UploaderCategory
+{
+    Cgm,
+    AidSystem,
+    Uploader,
+}
+
+/// <summary>
+/// Represents an uploader application that can push data to Nocturne.
+/// Display strings (name, description, setup instructions) live on the frontend,
+/// keyed by <see cref="Id"/>.
 /// </summary>
 public class UploaderApp
 {
     /// <summary>
-    /// Unique identifier
+    /// Unique identifier (e.g. "xdrip", "loop", "aaps")
     /// </summary>
     [JsonPropertyName("id")]
     public string Id { get; set; } = string.Empty;
 
     /// <summary>
-    /// Display name
-    /// </summary>
-    [JsonPropertyName("name")]
-    public string Name { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Platform: android, ios, desktop, web
+    /// Platform the app runs on
     /// </summary>
     [JsonPropertyName("platform")]
-    public string Platform { get; set; } = string.Empty;
+    public UploaderPlatform Platform { get; set; }
 
     /// <summary>
-    /// Short description
-    /// </summary>
-    [JsonPropertyName("description")]
-    public string Description { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Category: cgm, pump, aid-system, uploader
+    /// Category of uploader
     /// </summary>
     [JsonPropertyName("category")]
-    public string Category { get; set; } = string.Empty;
+    public UploaderCategory Category { get; set; }
 
     /// <summary>
     /// Icon identifier
@@ -269,34 +282,10 @@ public class UploaderApp
     public string Icon { get; set; } = string.Empty;
 
     /// <summary>
-    /// Setup instructions
-    /// </summary>
-    [JsonPropertyName("setupInstructions")]
-    public List<SetupStep>? SetupInstructions { get; set; }
-
-    /// <summary>
     /// URL for app download or more info
     /// </summary>
     [JsonPropertyName("url")]
     public string? Url { get; set; }
-}
-
-/// <summary>
-/// A step in setup instructions
-/// </summary>
-public class SetupStep
-{
-    [JsonPropertyName("step")]
-    public int Step { get; set; }
-
-    [JsonPropertyName("title")]
-    public string Title { get; set; } = string.Empty;
-
-    [JsonPropertyName("description")]
-    public string Description { get; set; } = string.Empty;
-
-    [JsonPropertyName("imageUrl")]
-    public string? ImageUrl { get; set; }
 }
 
 /// <summary>

--- a/src/Web/locales/de.po
+++ b/src/Web/locales/de.po
@@ -319,6 +319,8 @@ msgstr ""
 #: src/lib/components/WebSocketStatus.svelte
 #: src/lib/components/dashboard/widgets/ConnectionStatusWidget.svelte
 #: src/routes/(fullscreen)/auth/bot/authorize/done/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/auth/bot/authorize/done/+page.svelte
@@ -1258,6 +1260,7 @@ msgstr ""
 #: src/lib/components/patient/PatientDeviceManager.svelte
 #: src/lib/components/profile/ProfileEditDialog.svelte
 #: src/lib/components/status-pills/TrackerPill.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
@@ -1534,6 +1537,7 @@ msgid "Method"
 msgstr ""
 
 #: src/lib/components/treatments/TreatmentCategoryTabs.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/compatibility/+page.svelte
 #: src/routes/compatibility/+page.svelte
@@ -2823,11 +2827,8 @@ msgstr ""
 msgid "Available"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Coming Soon"
-msgstr ""
+#~ msgid "Coming Soon"
+#~ msgstr ""
 
 #: src/routes/reports/executive-summary/+page.svelte
 msgid "Clinical details"
@@ -3193,8 +3194,8 @@ msgstr ""
 msgid "Customize themes, colors, units, and display preferences"
 msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/lib/components/rbac/PermissionPicker.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/+page.svelte
 #: src/routes/settings/devices/+page.svelte
 #: src/routes/settings/patient/+page.svelte
@@ -3261,7 +3262,6 @@ msgid "Connect data sources like Dexcom, Libre, and more"
 msgstr ""
 
 #: src/lib/components/StepIndicator.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/download/+page.svelte
 #: src/routes/settings/+page.svelte
 #: src/routes/settings/setup/+page.svelte
@@ -6953,6 +6953,8 @@ msgid "Or continue with"
 msgstr ""
 
 #: src/lib/components/auth/LoginForm.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "<0/> Redirecting..."
 msgstr ""
@@ -7815,6 +7817,7 @@ msgstr ""
 msgid "Performance"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
 msgid "← Back"
 msgstr ""
@@ -9438,6 +9441,7 @@ msgstr ""
 msgid "Failed to load admin data"
 msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/settings/admin/+page.svelte
 #: src/routes/settings/admin/+page.svelte
 msgid "Public"
@@ -11014,6 +11018,7 @@ msgstr ""
 msgid "Connect your CGM app or AID system to push data to Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 #: src/routes/settings/services/+page.svelte
@@ -11021,6 +11026,7 @@ msgstr ""
 msgid "CGM Apps"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 #: src/routes/settings/services/+page.svelte
@@ -12697,7 +12703,6 @@ msgstr ""
 
 #: src/lib/components/StepIndicator.svelte
 #: src/lib/components/layout/AppSidebar.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Setup"
 msgstr ""
@@ -12717,6 +12722,7 @@ msgstr ""
 #: src/lib/components/SiteFooter.svelte
 #: src/lib/components/SiteHeader.svelte
 #: src/lib/components/SiteHeader.svelte
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/migrate/+page.svelte
 #: src/routes/settings/setup/migrate/+page.svelte
 msgid "Get Started"
@@ -12824,6 +12830,7 @@ msgstr ""
 #~ msgid "Fresh Install Setup"
 #~ msgstr ""
 
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/setup/+page.svelte
 msgid "Migrate from Nightscout"
 msgstr ""
@@ -13938,6 +13945,7 @@ msgstr ""
 #~ msgid "Positive = ate after bolusing, Negative = ate before bolusing"
 #~ msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/lib/components/meal-matching/MealMatchReviewDialog.svelte
 #: src/routes/meals/+page.svelte
 msgid "Dismiss"
@@ -18187,6 +18195,7 @@ msgid "Checking availability..."
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -18903,7 +18912,6 @@ msgid "mg/dL/U <0/>"
 msgstr ""
 
 #: src/lib/components/layout/AppSidebar.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/patient/+page.svelte
 #: src/routes/settings/patient/+page.svelte
 #: src/routes/settings/setup/+page.svelte
@@ -19058,7 +19066,7 @@ msgstr ""
 msgid "SN: {0}"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/settings/patient/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Insulins"
@@ -19124,7 +19132,6 @@ msgid "Serial Number"
 msgstr ""
 
 #: src/lib/components/patient/PatientDeviceManager.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Optional"
 msgstr ""
@@ -19193,34 +19200,28 @@ msgid ""
 "undone."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Set your diabetes type and clinical information"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Add the devices you currently use"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Add the insulins you currently use"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Connect external data sources"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/profile/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 #: src/routes/settings/setup/profile/+page.svelte
 msgid "Therapy Profile"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Configure your basal rates and therapy settings"
 msgstr ""
@@ -19583,14 +19584,12 @@ msgstr ""
 msgid "Alert when CGM signal is lost for an extended period"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Browser Push Notification"
-msgstr ""
+#~ msgid "Browser Push Notification"
+#~ msgstr ""
 
+#: src/lib/components/alerts/ChannelPicker.svelte
 #: src/lib/components/alerts/RuleEditorSheet.svelte
 #: src/lib/components/alerts/RuleEditorSheet.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
 msgid "Webhook"
 msgstr ""
 
@@ -19654,39 +19653,34 @@ msgstr ""
 msgid "Choose how you want to receive alert notifications."
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Browser Push Notifications"
-msgstr ""
+#~ msgid "Browser Push Notifications"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
 msgid "Receive alerts directly in your browser"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
 msgid "Send alert data to a custom URL"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Webhook URL"
-msgstr ""
+#~ msgid "Webhook URL"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 msgid "Discord"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Send alerts to a Discord channel"
-msgstr ""
+#~ msgid "Send alerts to a Discord channel"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
 msgid "Telegram"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Send alerts to a Telegram chat"
-msgstr ""
+#~ msgid "Send alerts to a Telegram chat"
+#~ msgstr ""
 
 #: src/routes/settings/alerts/setup/+page.svelte
 msgid "Review your alert configuration before saving."
@@ -19715,10 +19709,8 @@ msgid ""
 "the dashboard, but no push notifications will be sent."
 msgstr ""
 
-#. placeholder {0}: webhookUrl
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Webhook: {0}"
-msgstr ""
+#~ msgid "Webhook: {0}"
+#~ msgstr ""
 
 #: src/routes/settings/alerts/setup/+page.svelte
 msgid "Medical Disclaimer"
@@ -20285,16 +20277,15 @@ msgstr ""
 #~ msgid "<0/> {0} Synced Successfully"
 #~ msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Uploaders"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Configure a phone app to push data to Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "General Uploaders"
@@ -20307,16 +20298,19 @@ msgstr ""
 msgid "Failed to load uploader apps"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Android"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Desktop"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Web"
@@ -20376,11 +20370,13 @@ msgstr ""
 
 #. placeholder {0}: selectedApp?.name
 #. placeholder {1}: ds.entriesLast24h ?? 0
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "{0} is sending data. {1} entries in the last 24 hours."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Waiting for data"
@@ -20392,22 +20388,26 @@ msgstr ""
 msgid "Once you've configured {0}, it can take up to five minutes for the first glucose data to arrive. This page will update automatically."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Failed to load setup instructions"
 msgstr ""
 
 #. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Could not load setup details for {0}. Please try again."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "<0/> iOS"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "<0/> Android"
@@ -20896,6 +20896,7 @@ msgstr ""
 msgid "{0} - Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Device Authorized"
 msgstr ""
@@ -20904,14 +20905,17 @@ msgstr ""
 msgid "You can close this window and return to your device."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Authorization Denied"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "The device will not be granted access."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Authorize Application"
@@ -20930,11 +20934,13 @@ msgid ""
 "approve if you trust this application."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "This application is requesting permission to:"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "This app cannot delete your data."
@@ -20947,12 +20953,14 @@ msgid ""
 "data."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 #: src/routes/settings/access-requests/+page.svelte
 msgid "<0/> Deny"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 #: src/routes/settings/access-requests/+page.svelte
@@ -21120,6 +21128,7 @@ msgstr ""
 msgid "<0/> is requesting additional access to your Nocturne data."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 msgid "<0/> wants to access your Nocturne data."
 msgstr ""
@@ -21151,6 +21160,7 @@ msgstr ""
 msgid "Invite Not Found"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "This invite link is invalid or has expired."
 msgstr ""
@@ -21199,6 +21209,7 @@ msgstr ""
 #~ msgid "You'll be able to see:"
 #~ msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "<0/> Accept Invite"
 msgstr ""
@@ -21218,6 +21229,8 @@ msgstr ""
 msgid "Invite not found or has expired."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.server.ts
 #: src/routes/invite/[token]/+page.svelte
 msgid "Failed to accept invite."
@@ -21245,6 +21258,7 @@ msgstr ""
 #: src/lib/components/auth/LoginForm.svelte
 #: src/lib/components/auth/LoginForm.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21269,6 +21283,7 @@ msgstr ""
 #: src/lib/components/auth/LoginForm.svelte
 #: src/lib/components/auth/LoginForm.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21310,12 +21325,10 @@ msgstr ""
 msgid "API Access"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Passkey"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Set up passwordless authentication with a passkey"
 msgstr ""
@@ -21448,6 +21461,7 @@ msgstr ""
 
 #: src/routes/(fullscreen)/auth/help/+page.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/help/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
@@ -21462,6 +21476,7 @@ msgid "Save these recovery codes in a safe place. Each code can only be used onc
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21470,6 +21485,7 @@ msgid "<0/> Codes copied"
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21477,6 +21493,7 @@ msgstr ""
 msgid "<0/> Copy recovery codes"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "Continue to Nocturne"
 msgstr ""
@@ -21488,6 +21505,7 @@ msgid "Copy your recovery codes before continuing."
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21499,6 +21517,7 @@ msgstr ""
 msgid "<0/> Register with passkey"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/settings/account/+page.svelte
 #: src/routes/settings/security/+page.svelte
 msgid "Failed to register passkey."
@@ -21727,16 +21746,15 @@ msgstr ""
 msgid "Passkey Setup - Setup - Nocturne"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "Set Up Your Passkey"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "Create a passkey for secure, passwordless authentication. You will also receive recovery codes in case you lose access to your passkey."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "This is how you will appear to others."
@@ -21769,11 +21787,13 @@ msgid ""
 "be used once."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "You must copy your recovery codes before continuing."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid ""
@@ -21813,6 +21833,7 @@ msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/auth/bot/authorize/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
@@ -22947,6 +22968,7 @@ msgstr ""
 msgid "Full access"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "Loading invite..."
 msgstr ""
@@ -23185,12 +23207,10 @@ msgstr ""
 msgid "{0} synced so far"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Coming from Nightscout?"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Migrate your data and keep both systems in sync during transition"
 msgstr ""
@@ -23465,30 +23485,26 @@ msgstr ""
 msgid "Register a passkey to restore normal access."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/(fullscreen)/setup/permissions/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 #: src/routes/settings/setup/permissions/+page.svelte
 msgid "Sharing & Privacy"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Choose who can see your data"
 msgstr ""
 
 #. placeholder {0}: requiredComplete
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "{0} of 6 required steps complete"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Finishing..."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Finish Setup"
 msgstr ""
@@ -24328,84 +24344,286 @@ msgstr ""
 msgid "Weight (kg)"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Opening xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "No invite token provided. Please check the link you were given."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Redirecting to xDrip+ to start the connection..."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite has expired."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Connect xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite has been revoked."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "xDrip+ didn't open automatically. You can try these options:"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite is no longer valid."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "<0/> Open in xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Join - Nocturne"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Manual setup"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Invalid Invite"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "In xDrip+, go to Settings > Cloud Upload > Nocturne, enter this URL:"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "You're In"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Then tap \"Connect to Nocturne\" to authorize."
+#. placeholder {0}: inviteInfo.tenantName ?? "the site"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Your account has been created and you've joined {0}."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Don't have xDrip+ installed?"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid ""
+"Save these recovery codes in a safe place. If you lose access to\n"
+"your passkey, you can use one of these codes to sign in. Each code\n"
+"can only be used once."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "<0/> Download xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Accept Invite"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Quick Connect"
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> has invited you to join"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Automatically configure xDrip+ with your Nocturne instance."
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "You've been invited to join"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Or scan from another device"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> Joining..."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "QR code to connect xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Join Nocturne"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Scan this QR code with your phone's camera"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid ""
+"<0/> <1/>.\n"
+"Create an account or sign in to accept."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Or open this link on your phone"
+#. placeholder {0}: provider.name
+#. placeholder {0}: provider.name
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "<0/> Continue with {0}"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "<0/> Waiting for data from xDrip+..."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Or create an account with a passkey"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "<0/> Connected! Data is flowing from xDrip+."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "A unique identifier for your account."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> Create account with passkey"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Check now"
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Set Up Your Account"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Choose how you want to authenticate. You can use an external provider for quick setup, or register a passkey for passwordless authentication."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Or set up with a passkey"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "Discord DM"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "Slack DM"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "WhatsApp"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Browser Push"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts as a Discord direct message"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts as a Slack direct message"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts to your Telegram chat"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts to your WhatsApp"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "No notification channels are currently available."
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Service hasn't reported recently — alerts may be delayed"
+msgstr ""
+
+#. placeholder {0}: getPlatformName(ct)
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid ""
+"Account not linked. Use /connect in {0} to\n"
+"enable delivery."
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Patient details"
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Therapy profile"
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Finish setting up"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Choose how you'd like to set up Nocturne."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Import your existing data — entries, treatments, and history."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Start Fresh"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Connect a glucose data source to get started."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to load data sources"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Connect a Data Source - Setup - Nocturne"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Connect a Data Source"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Choose a cloud service or phone app to start sending glucose and treatment data to Nocturne."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Cloud Services"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Phone Apps"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "No data sources available"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "There are no data sources available at this time."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Skip for now"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Back to data sources"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Continue to Dashboard"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Invalid or expired device code."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Invalid or expired device code. Please check and try again."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to approve. The code may have expired."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to deny the request."
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "{0} is now connected. You can return to your device."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Receiving Data"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "It can take a few minutes for the first glucose reading to arrive. This page will update automatically."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "This application is not in the Nocturne known app directory. Only approve if you trust it."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "This app is requesting full access, including the ability to delete data."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Scan to Connect"
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Scan this QR code with your phone's camera to open {0} and start the connection."
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "QR code to connect {0}"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Enter Authorization Code"
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "After scanning, {0} will show an 8-character code. Enter it here to approve the connection."
 msgstr ""

--- a/src/Web/locales/de.po
+++ b/src/Web/locales/de.po
@@ -24327,3 +24327,85 @@ msgstr ""
 #: src/routes/(fullscreen)/setup/patient/+page.svelte
 msgid "Weight (kg)"
 msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Opening xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Redirecting to xDrip+ to start the connection..."
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Connect xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "xDrip+ didn't open automatically. You can try these options:"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "<0/> Open in xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Manual setup"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "In xDrip+, go to Settings > Cloud Upload > Nocturne, enter this URL:"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Then tap \"Connect to Nocturne\" to authorize."
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Don't have xDrip+ installed?"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "<0/> Download xDrip+"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Quick Connect"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Automatically configure xDrip+ with your Nocturne instance."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Or scan from another device"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "QR code to connect xDrip+"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Scan this QR code with your phone's camera"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Or open this link on your phone"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "<0/> Waiting for data from xDrip+..."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "<0/> Connected! Data is flowing from xDrip+."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Check now"
+msgstr ""

--- a/src/Web/locales/en.po
+++ b/src/Web/locales/en.po
@@ -21102,3 +21102,85 @@ msgstr "Failed to update food entry"
 #: src/routes/(fullscreen)/setup/patient/+page.svelte
 msgid "Weight (kg)"
 msgstr "Weight (kg)"
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Opening xDrip+"
+msgstr "Opening xDrip+"
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Redirecting to xDrip+ to start the connection..."
+msgstr "Redirecting to xDrip+ to start the connection..."
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Connect xDrip+"
+msgstr "Connect xDrip+"
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "xDrip+ didn't open automatically. You can try these options:"
+msgstr "xDrip+ didn't open automatically. You can try these options:"
+
+#: src/lib/components/XdripQuickConnect.svelte
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "<0/> Open in xDrip+"
+msgstr "<0/> Open in xDrip+"
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Manual setup"
+msgstr "Manual setup"
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "In xDrip+, go to Settings > Cloud Upload > Nocturne, enter this URL:"
+msgstr "In xDrip+, go to Settings > Cloud Upload > Nocturne, enter this URL:"
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Then tap \"Connect to Nocturne\" to authorize."
+msgstr "Then tap \"Connect to Nocturne\" to authorize."
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Don't have xDrip+ installed?"
+msgstr "Don't have xDrip+ installed?"
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "<0/> Download xDrip+"
+msgstr "<0/> Download xDrip+"
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Quick Connect"
+msgstr "Quick Connect"
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Automatically configure xDrip+ with your Nocturne instance."
+msgstr "Automatically configure xDrip+ with your Nocturne instance."
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Or scan from another device"
+msgstr "Or scan from another device"
+
+#: src/lib/components/XdripQuickConnect.svelte
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "QR code to connect xDrip+"
+msgstr "QR code to connect xDrip+"
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Scan this QR code with your phone's camera"
+msgstr "Scan this QR code with your phone's camera"
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Or open this link on your phone"
+msgstr "Or open this link on your phone"
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "<0/> Waiting for data from xDrip+..."
+msgstr "<0/> Waiting for data from xDrip+..."
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "<0/> Connected! Data is flowing from xDrip+."
+msgstr "<0/> Connected! Data is flowing from xDrip+."
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading."
+msgstr "No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading."
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Check now"
+msgstr "Check now"

--- a/src/Web/locales/en.po
+++ b/src/Web/locales/en.po
@@ -34,6 +34,8 @@ msgstr "Error ID: {0}"
 #: src/lib/components/WebSocketStatus.svelte
 #: src/lib/components/dashboard/widgets/ConnectionStatusWidget.svelte
 #: src/routes/(fullscreen)/auth/bot/authorize/done/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/auth/bot/authorize/done/+page.svelte
@@ -852,6 +854,7 @@ msgstr "Auto-detecting..."
 #: src/lib/components/patient/PatientDeviceManager.svelte
 #: src/lib/components/profile/ProfileEditDialog.svelte
 #: src/lib/components/status-pills/TrackerPill.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
@@ -913,6 +916,7 @@ msgid "Method"
 msgstr "Method"
 
 #: src/lib/components/treatments/TreatmentCategoryTabs.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/compatibility/+page.svelte
 #: src/routes/compatibility/+page.svelte
@@ -1813,6 +1817,7 @@ msgstr ""
 "{0}g carbs\n"
 "· {1}% match"
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/lib/components/meal-matching/MealMatchReviewDialog.svelte
 #: src/routes/meals/+page.svelte
 msgid "Dismiss"
@@ -2231,6 +2236,7 @@ msgid "Available"
 msgstr "Available"
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -2709,6 +2715,8 @@ msgid "Or continue with"
 msgstr "Or continue with"
 
 #: src/lib/components/auth/LoginForm.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "<0/> Redirecting..."
 msgstr "<0/> Redirecting..."
@@ -3937,7 +3945,6 @@ msgid "Settings"
 msgstr "Settings"
 
 #: src/lib/components/layout/AppSidebar.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Setup"
 msgstr "Setup"
@@ -3949,7 +3956,6 @@ msgid "Account"
 msgstr "Account"
 
 #: src/lib/components/layout/AppSidebar.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/patient/+page.svelte
 #: src/routes/settings/patient/+page.svelte
 #: src/routes/settings/setup/+page.svelte
@@ -3981,7 +3987,6 @@ msgstr "Features"
 msgid "Notifications & Trackers"
 msgstr "Notifications & Trackers"
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Connectors"
 msgstr "Connectors"
@@ -8362,6 +8367,7 @@ msgstr "Array Length"
 msgid "Performance"
 msgstr "Performance"
 
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
 msgid "← Back"
 msgstr "← Back"
@@ -10724,6 +10730,7 @@ msgstr ""
 msgid "Failed to load admin data"
 msgstr "Failed to load admin data"
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/settings/admin/+page.svelte
 #: src/routes/settings/admin/+page.svelte
 msgid "Public"
@@ -11371,12 +11378,14 @@ msgstr "<0/> Set Up an Uploader"
 msgid "Connect your CGM app or AID system to push data to Nocturne"
 msgstr "Connect your CGM app or AID system to push data to Nocturne"
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "CGM Apps"
 msgstr "CGM Apps"
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
@@ -12179,8 +12188,8 @@ msgstr "Pronouns"
 msgid "<0/> Save Changes"
 msgstr "<0/> Save Changes"
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/lib/components/rbac/PermissionPicker.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/patient/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Devices"
@@ -12223,7 +12232,7 @@ msgstr "Until {0}"
 msgid "SN: {0}"
 msgstr "SN: {0}"
 
-#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/settings/patient/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Insulins"
@@ -12289,7 +12298,6 @@ msgid "Serial Number"
 msgstr "Serial Number"
 
 #: src/lib/components/patient/PatientDeviceManager.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Optional"
 msgstr "Optional"
@@ -13276,34 +13284,28 @@ msgstr "Therapy - Settings - Nocturne"
 msgid "Redirecting to Profile..."
 msgstr "Redirecting to Profile..."
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Set your diabetes type and clinical information"
 msgstr "Set your diabetes type and clinical information"
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Add the devices you currently use"
 msgstr "Add the devices you currently use"
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Add the insulins you currently use"
 msgstr "Add the insulins you currently use"
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Connect external data sources"
 msgstr "Connect external data sources"
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/profile/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 #: src/routes/settings/setup/profile/+page.svelte
 msgid "Therapy Profile"
 msgstr "Therapy Profile"
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Configure your basal rates and therapy settings"
 msgstr "Configure your basal rates and therapy settings"
@@ -15023,14 +15025,12 @@ msgstr "Sensor Lost"
 msgid "Alert when CGM signal is lost for an extended period"
 msgstr "Alert when CGM signal is lost for an extended period"
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Browser Push Notification"
-msgstr "Browser Push Notification"
+#~ msgid "Browser Push Notification"
+#~ msgstr "Browser Push Notification"
 
+#: src/lib/components/alerts/ChannelPicker.svelte
 #: src/lib/components/alerts/RuleEditorSheet.svelte
 #: src/lib/components/alerts/RuleEditorSheet.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
 msgid "Webhook"
 msgstr "Webhook"
 
@@ -15096,45 +15096,37 @@ msgstr "{0}m hysteresis"
 msgid "Choose how you want to receive alert notifications."
 msgstr "Choose how you want to receive alert notifications."
 
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Browser Push Notifications"
-msgstr "Browser Push Notifications"
+#~ msgid "Browser Push Notifications"
+#~ msgstr "Browser Push Notifications"
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
 msgid "Receive alerts directly in your browser"
 msgstr "Receive alerts directly in your browser"
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
 msgid "Send alert data to a custom URL"
 msgstr "Send alert data to a custom URL"
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Webhook URL"
-msgstr "Webhook URL"
+#~ msgid "Webhook URL"
+#~ msgstr "Webhook URL"
 
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Coming Soon"
-msgstr "Coming Soon"
+#~ msgid "Coming Soon"
+#~ msgstr "Coming Soon"
 
-#: src/routes/settings/alerts/setup/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 msgid "Discord"
 msgstr "Discord"
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Send alerts to a Discord channel"
-msgstr "Send alerts to a Discord channel"
+#~ msgid "Send alerts to a Discord channel"
+#~ msgstr "Send alerts to a Discord channel"
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
 msgid "Telegram"
 msgstr "Telegram"
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Send alerts to a Telegram chat"
-msgstr "Send alerts to a Telegram chat"
+#~ msgid "Send alerts to a Telegram chat"
+#~ msgstr "Send alerts to a Telegram chat"
 
 #: src/routes/settings/alerts/setup/+page.svelte
 msgid "Review your alert configuration before saving."
@@ -15167,10 +15159,8 @@ msgstr ""
 "No delivery channels configured. Alerts will still be visible in\n"
 "the dashboard, but no push notifications will be sent."
 
-#. placeholder {0}: webhookUrl
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Webhook: {0}"
-msgstr "Webhook: {0}"
+#~ msgid "Webhook: {0}"
+#~ msgstr "Webhook: {0}"
 
 #: src/routes/settings/alerts/setup/+page.svelte
 msgid "Medical Disclaimer"
@@ -15507,16 +15497,15 @@ msgstr "Allow critical alerts during quiet hours"
 #~ msgid "<0/> {0} Synced Successfully"
 #~ msgstr "<0/> {0} Synced Successfully"
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Uploaders"
 msgstr "Uploaders"
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Configure a phone app to push data to Nocturne"
 msgstr "Configure a phone app to push data to Nocturne"
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "General Uploaders"
@@ -15529,16 +15518,19 @@ msgstr "General Uploaders"
 msgid "Failed to load uploader apps"
 msgstr "Failed to load uploader apps"
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Android"
 msgstr "Android"
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Desktop"
 msgstr "Desktop"
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Web"
@@ -15598,11 +15590,13 @@ msgstr "<0/> Download {0}"
 
 #. placeholder {0}: selectedApp?.name
 #. placeholder {1}: ds.entriesLast24h ?? 0
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "{0} is sending data. {1} entries in the last 24 hours."
 msgstr "{0} is sending data. {1} entries in the last 24 hours."
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Waiting for data"
@@ -15614,22 +15608,26 @@ msgstr "Waiting for data"
 msgid "Once you've configured {0}, it can take up to five minutes for the first glucose data to arrive. This page will update automatically."
 msgstr "Once you've configured {0}, it can take up to five minutes for the first glucose data to arrive. This page will update automatically."
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Failed to load setup instructions"
 msgstr "Failed to load setup instructions"
 
 #. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Could not load setup details for {0}. Please try again."
 msgstr "Could not load setup details for {0}. Please try again."
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "<0/> iOS"
 msgstr "<0/> iOS"
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "<0/> Android"
@@ -16155,6 +16153,7 @@ msgstr "Accept Invite - Nocturne"
 msgid "Invite Not Found"
 msgstr "Invite Not Found"
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "This invite link is invalid or has expired."
 msgstr "This invite link is invalid or has expired."
@@ -16203,6 +16202,7 @@ msgstr "You're Invited"
 #~ msgid "You'll be able to see:"
 #~ msgstr "You'll be able to see:"
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "<0/> Accept Invite"
 msgstr "<0/> Accept Invite"
@@ -16242,6 +16242,7 @@ msgstr "Link a Device"
 msgid "{0} - Nocturne"
 msgstr "{0} - Nocturne"
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Device Authorized"
 msgstr "Device Authorized"
@@ -16250,14 +16251,17 @@ msgstr "Device Authorized"
 msgid "You can close this window and return to your device."
 msgstr "You can close this window and return to your device."
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Authorization Denied"
 msgstr "Authorization Denied"
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "The device will not be granted access."
 msgstr "The device will not be granted access."
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Authorize Application"
@@ -16280,11 +16284,13 @@ msgstr ""
 "This application is not in the Nocturne known app directory. Only\n"
 "approve if you trust this application."
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "This application is requesting permission to:"
 msgstr "This application is requesting permission to:"
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "This app cannot delete your data."
@@ -16299,12 +16305,14 @@ msgstr ""
 "This app is requesting full access, including the ability to delete\n"
 "data."
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 #: src/routes/settings/access-requests/+page.svelte
 msgid "<0/> Deny"
 msgstr "<0/> Deny"
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 #: src/routes/settings/access-requests/+page.svelte
@@ -16333,6 +16341,7 @@ msgstr "Additional Permissions"
 msgid "<0/> is requesting additional access to your Nocturne data."
 msgstr "<0/> is requesting additional access to your Nocturne data."
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 msgid "<0/> wants to access your Nocturne data."
 msgstr "<0/> wants to access your Nocturne data."
@@ -16502,6 +16511,8 @@ msgstr "No access token available for this user."
 msgid "Invite not found or has expired."
 msgstr "Invite not found or has expired."
 
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.server.ts
 #: src/routes/invite/[token]/+page.svelte
 msgid "Failed to accept invite."
@@ -16529,6 +16540,7 @@ msgstr "Recovery code verification failed"
 #: src/lib/components/auth/LoginForm.svelte
 #: src/lib/components/auth/LoginForm.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -16553,6 +16565,7 @@ msgstr "Use a recovery code"
 #: src/lib/components/auth/LoginForm.svelte
 #: src/lib/components/auth/LoginForm.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -16607,6 +16620,7 @@ msgstr "Account created and passkey registered."
 
 #: src/routes/(fullscreen)/auth/help/+page.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/help/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
@@ -16621,6 +16635,7 @@ msgid "Save these recovery codes in a safe place. Each code can only be used onc
 msgstr "Save these recovery codes in a safe place. Each code can only be used once."
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -16629,6 +16644,7 @@ msgid "<0/> Codes copied"
 msgstr "<0/> Codes copied"
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -16636,6 +16652,7 @@ msgstr "<0/> Codes copied"
 msgid "<0/> Copy recovery codes"
 msgstr "<0/> Copy recovery codes"
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "Continue to Nocturne"
 msgstr "Continue to Nocturne"
@@ -16647,6 +16664,7 @@ msgid "Copy your recovery codes before continuing."
 msgstr "Copy your recovery codes before continuing."
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -16782,6 +16800,7 @@ msgstr ""
 msgid "Revoke"
 msgstr "Revoke"
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/settings/account/+page.svelte
 #: src/routes/settings/security/+page.svelte
 msgid "Failed to register passkey."
@@ -17020,12 +17039,10 @@ msgstr "<0/> Copied"
 msgid "<0/> Copy all codes"
 msgstr "<0/> Copy all codes"
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Passkey"
 msgstr "Passkey"
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Set up passwordless authentication with a passkey"
 msgstr "Set up passwordless authentication with a passkey"
@@ -17046,16 +17063,15 @@ msgstr "Failed to register passkey"
 msgid "Passkey Setup - Setup - Nocturne"
 msgstr "Passkey Setup - Setup - Nocturne"
 
-#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "Set Up Your Passkey"
 msgstr "Set Up Your Passkey"
 
-#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "Create a passkey for secure, passwordless authentication. You will also receive recovery codes in case you lose access to your passkey."
 msgstr "Create a passkey for secure, passwordless authentication. You will also receive recovery codes in case you lose access to your passkey."
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "This is how you will appear to others."
@@ -17091,11 +17107,13 @@ msgstr ""
 "passkey, you can use one of these codes to sign in. Each code can only\n"
 "be used once."
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "You must copy your recovery codes before continuing."
 msgstr "You must copy your recovery codes before continuing."
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid ""
@@ -17137,6 +17155,7 @@ msgstr "Optional. Updates your display name if provided."
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/auth/bot/authorize/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
@@ -18190,6 +18209,7 @@ msgstr "Manage sharing"
 msgid "Full access"
 msgstr "Full access"
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "Loading invite..."
 msgstr "Loading invite..."
@@ -18587,12 +18607,10 @@ msgstr "<0/> Sync Failed"
 msgid "{0} synced so far"
 msgstr "{0} synced so far"
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Coming from Nightscout?"
 msgstr "Coming from Nightscout?"
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Migrate your data and keep both systems in sync during transition"
 msgstr "Migrate your data and keep both systems in sync during transition"
@@ -18811,6 +18829,7 @@ msgstr "Migration - Setup - Nocturne"
 #: src/lib/components/SiteFooter.svelte
 #: src/lib/components/SiteHeader.svelte
 #: src/lib/components/SiteHeader.svelte
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/migrate/+page.svelte
 #: src/routes/settings/setup/migrate/+page.svelte
 msgid "Get Started"
@@ -18894,30 +18913,26 @@ msgstr "Enter your Nightscout URL and API secret to begin migrating your data"
 msgid "Passkey registered successfully. Recovery mode has been deactivated."
 msgstr "Passkey registered successfully. Recovery mode has been deactivated."
 
-#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/(fullscreen)/setup/permissions/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 #: src/routes/settings/setup/permissions/+page.svelte
 msgid "Sharing & Privacy"
 msgstr "Sharing & Privacy"
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Choose who can see your data"
 msgstr "Choose who can see your data"
 
 #. placeholder {0}: requiredComplete
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "{0} of 6 required steps complete"
 msgstr "{0} of 6 required steps complete"
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Finishing..."
 msgstr "Finishing..."
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Finish Setup"
 msgstr "Finish Setup"
@@ -21103,84 +21118,297 @@ msgstr "Failed to update food entry"
 msgid "Weight (kg)"
 msgstr "Weight (kg)"
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Opening xDrip+"
-msgstr "Opening xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "No invite token provided. Please check the link you were given."
+msgstr "No invite token provided. Please check the link you were given."
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Redirecting to xDrip+ to start the connection..."
-msgstr "Redirecting to xDrip+ to start the connection..."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite has expired."
+msgstr "This invite has expired."
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Connect xDrip+"
-msgstr "Connect xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite has been revoked."
+msgstr "This invite has been revoked."
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "xDrip+ didn't open automatically. You can try these options:"
-msgstr "xDrip+ didn't open automatically. You can try these options:"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite is no longer valid."
+msgstr "This invite is no longer valid."
 
-#: src/lib/components/XdripQuickConnect.svelte
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "<0/> Open in xDrip+"
-msgstr "<0/> Open in xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Join - Nocturne"
+msgstr "Join - Nocturne"
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Manual setup"
-msgstr "Manual setup"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Invalid Invite"
+msgstr "Invalid Invite"
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "In xDrip+, go to Settings > Cloud Upload > Nocturne, enter this URL:"
-msgstr "In xDrip+, go to Settings > Cloud Upload > Nocturne, enter this URL:"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "You're In"
+msgstr "You're In"
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Then tap \"Connect to Nocturne\" to authorize."
-msgstr "Then tap \"Connect to Nocturne\" to authorize."
+#. placeholder {0}: inviteInfo.tenantName ?? "the site"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Your account has been created and you've joined {0}."
+msgstr "Your account has been created and you've joined {0}."
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Don't have xDrip+ installed?"
-msgstr "Don't have xDrip+ installed?"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid ""
+"Save these recovery codes in a safe place. If you lose access to\n"
+"your passkey, you can use one of these codes to sign in. Each code\n"
+"can only be used once."
+msgstr ""
+"Save these recovery codes in a safe place. If you lose access to\n"
+"your passkey, you can use one of these codes to sign in. Each code\n"
+"can only be used once."
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "<0/> Download xDrip+"
-msgstr "<0/> Download xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Accept Invite"
+msgstr "Accept Invite"
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Quick Connect"
-msgstr "Quick Connect"
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> has invited you to join"
+msgstr "<0/> has invited you to join"
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Automatically configure xDrip+ with your Nocturne instance."
-msgstr "Automatically configure xDrip+ with your Nocturne instance."
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "You've been invited to join"
+msgstr "You've been invited to join"
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Or scan from another device"
-msgstr "Or scan from another device"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> Joining..."
+msgstr "<0/> Joining..."
 
-#: src/lib/components/XdripQuickConnect.svelte
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "QR code to connect xDrip+"
-msgstr "QR code to connect xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Join Nocturne"
+msgstr "Join Nocturne"
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Scan this QR code with your phone's camera"
-msgstr "Scan this QR code with your phone's camera"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid ""
+"<0/> <1/>.\n"
+"Create an account or sign in to accept."
+msgstr ""
+"<0/> <1/>.\n"
+"Create an account or sign in to accept."
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Or open this link on your phone"
-msgstr "Or open this link on your phone"
+#. placeholder {0}: provider.name
+#. placeholder {0}: provider.name
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "<0/> Continue with {0}"
+msgstr "<0/> Continue with {0}"
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "<0/> Waiting for data from xDrip+..."
-msgstr "<0/> Waiting for data from xDrip+..."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Or create an account with a passkey"
+msgstr "Or create an account with a passkey"
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "<0/> Connected! Data is flowing from xDrip+."
-msgstr "<0/> Connected! Data is flowing from xDrip+."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "A unique identifier for your account."
+msgstr "A unique identifier for your account."
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading."
-msgstr "No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> Create account with passkey"
+msgstr "<0/> Create account with passkey"
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Check now"
-msgstr "Check now"
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Set Up Your Account"
+msgstr "Set Up Your Account"
+
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Choose how you want to authenticate. You can use an external provider for quick setup, or register a passkey for passwordless authentication."
+msgstr "Choose how you want to authenticate. You can use an external provider for quick setup, or register a passkey for passwordless authentication."
+
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Or set up with a passkey"
+msgstr "Or set up with a passkey"
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "Discord DM"
+msgstr "Discord DM"
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "Slack DM"
+msgstr "Slack DM"
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "WhatsApp"
+msgstr "WhatsApp"
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Browser Push"
+msgstr "Browser Push"
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts as a Discord direct message"
+msgstr "Send alerts as a Discord direct message"
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts as a Slack direct message"
+msgstr "Send alerts as a Slack direct message"
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts to your Telegram chat"
+msgstr "Send alerts to your Telegram chat"
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts to your WhatsApp"
+msgstr "Send alerts to your WhatsApp"
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "No notification channels are currently available."
+msgstr "No notification channels are currently available."
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Service hasn't reported recently — alerts may be delayed"
+msgstr "Service hasn't reported recently — alerts may be delayed"
+
+#. placeholder {0}: getPlatformName(ct)
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid ""
+"Account not linked. Use /connect in {0} to\n"
+"enable delivery."
+msgstr ""
+"Account not linked. Use /connect in {0} to\n"
+"enable delivery."
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Patient details"
+msgstr "Patient details"
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Therapy profile"
+msgstr "Therapy profile"
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Finish setting up"
+msgstr "Finish setting up"
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Choose how you'd like to set up Nocturne."
+msgstr "Choose how you'd like to set up Nocturne."
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Migrate from Nightscout"
+msgstr "Migrate from Nightscout"
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Import your existing data — entries, treatments, and history."
+msgstr "Import your existing data — entries, treatments, and history."
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Start Fresh"
+msgstr "Start Fresh"
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Connect a glucose data source to get started."
+msgstr "Connect a glucose data source to get started."
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to load data sources"
+msgstr "Failed to load data sources"
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Connect a Data Source - Setup - Nocturne"
+msgstr "Connect a Data Source - Setup - Nocturne"
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Connect a Data Source"
+msgstr "Connect a Data Source"
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Choose a cloud service or phone app to start sending glucose and treatment data to Nocturne."
+msgstr "Choose a cloud service or phone app to start sending glucose and treatment data to Nocturne."
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Cloud Services"
+msgstr "<0/> Cloud Services"
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Phone Apps"
+msgstr "<0/> Phone Apps"
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "No data sources available"
+msgstr "No data sources available"
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "There are no data sources available at this time."
+msgstr "There are no data sources available at this time."
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Skip for now"
+msgstr "Skip for now"
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Back to data sources"
+msgstr "<0/> Back to data sources"
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Continue to Dashboard"
+msgstr "Continue to Dashboard"
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Invalid or expired device code."
+msgstr "Invalid or expired device code."
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Invalid or expired device code. Please check and try again."
+msgstr "Invalid or expired device code. Please check and try again."
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to approve. The code may have expired."
+msgstr "Failed to approve. The code may have expired."
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to deny the request."
+msgstr "Failed to deny the request."
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "{0} is now connected. You can return to your device."
+msgstr "{0} is now connected. You can return to your device."
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Receiving Data"
+msgstr "Receiving Data"
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "It can take a few minutes for the first glucose reading to arrive. This page will update automatically."
+msgstr "It can take a few minutes for the first glucose reading to arrive. This page will update automatically."
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "This application is not in the Nocturne known app directory. Only approve if you trust it."
+msgstr "This application is not in the Nocturne known app directory. Only approve if you trust it."
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "This app is requesting full access, including the ability to delete data."
+msgstr "This app is requesting full access, including the ability to delete data."
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Scan to Connect"
+msgstr "Scan to Connect"
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Scan this QR code with your phone's camera to open {0} and start the connection."
+msgstr "Scan this QR code with your phone's camera to open {0} and start the connection."
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "QR code to connect {0}"
+msgstr "QR code to connect {0}"
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Enter Authorization Code"
+msgstr "Enter Authorization Code"
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "After scanning, {0} will show an 8-character code. Enter it here to approve the connection."
+msgstr "After scanning, {0} will show an 8-character code. Enter it here to approve the connection."

--- a/src/Web/locales/es.po
+++ b/src/Web/locales/es.po
@@ -24327,3 +24327,85 @@ msgstr ""
 #: src/routes/(fullscreen)/setup/patient/+page.svelte
 msgid "Weight (kg)"
 msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Opening xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Redirecting to xDrip+ to start the connection..."
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Connect xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "xDrip+ didn't open automatically. You can try these options:"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "<0/> Open in xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Manual setup"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "In xDrip+, go to Settings > Cloud Upload > Nocturne, enter this URL:"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Then tap \"Connect to Nocturne\" to authorize."
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Don't have xDrip+ installed?"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "<0/> Download xDrip+"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Quick Connect"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Automatically configure xDrip+ with your Nocturne instance."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Or scan from another device"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "QR code to connect xDrip+"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Scan this QR code with your phone's camera"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Or open this link on your phone"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "<0/> Waiting for data from xDrip+..."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "<0/> Connected! Data is flowing from xDrip+."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Check now"
+msgstr ""

--- a/src/Web/locales/es.po
+++ b/src/Web/locales/es.po
@@ -319,6 +319,8 @@ msgstr ""
 #: src/lib/components/WebSocketStatus.svelte
 #: src/lib/components/dashboard/widgets/ConnectionStatusWidget.svelte
 #: src/routes/(fullscreen)/auth/bot/authorize/done/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/auth/bot/authorize/done/+page.svelte
@@ -1258,6 +1260,7 @@ msgstr ""
 #: src/lib/components/patient/PatientDeviceManager.svelte
 #: src/lib/components/profile/ProfileEditDialog.svelte
 #: src/lib/components/status-pills/TrackerPill.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
@@ -1534,6 +1537,7 @@ msgid "Method"
 msgstr ""
 
 #: src/lib/components/treatments/TreatmentCategoryTabs.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/compatibility/+page.svelte
 #: src/routes/compatibility/+page.svelte
@@ -2823,11 +2827,8 @@ msgstr ""
 msgid "Available"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Coming Soon"
-msgstr ""
+#~ msgid "Coming Soon"
+#~ msgstr ""
 
 #: src/routes/reports/executive-summary/+page.svelte
 msgid "Clinical details"
@@ -3193,8 +3194,8 @@ msgstr ""
 msgid "Customize themes, colors, units, and display preferences"
 msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/lib/components/rbac/PermissionPicker.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/+page.svelte
 #: src/routes/settings/devices/+page.svelte
 #: src/routes/settings/patient/+page.svelte
@@ -3261,7 +3262,6 @@ msgid "Connect data sources like Dexcom, Libre, and more"
 msgstr ""
 
 #: src/lib/components/StepIndicator.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/download/+page.svelte
 #: src/routes/settings/+page.svelte
 #: src/routes/settings/setup/+page.svelte
@@ -6953,6 +6953,8 @@ msgid "Or continue with"
 msgstr ""
 
 #: src/lib/components/auth/LoginForm.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "<0/> Redirecting..."
 msgstr ""
@@ -7815,6 +7817,7 @@ msgstr ""
 msgid "Performance"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
 msgid "← Back"
 msgstr ""
@@ -9438,6 +9441,7 @@ msgstr ""
 msgid "Failed to load admin data"
 msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/settings/admin/+page.svelte
 #: src/routes/settings/admin/+page.svelte
 msgid "Public"
@@ -11014,6 +11018,7 @@ msgstr ""
 msgid "Connect your CGM app or AID system to push data to Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 #: src/routes/settings/services/+page.svelte
@@ -11021,6 +11026,7 @@ msgstr ""
 msgid "CGM Apps"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 #: src/routes/settings/services/+page.svelte
@@ -12697,7 +12703,6 @@ msgstr ""
 
 #: src/lib/components/StepIndicator.svelte
 #: src/lib/components/layout/AppSidebar.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Setup"
 msgstr ""
@@ -12717,6 +12722,7 @@ msgstr ""
 #: src/lib/components/SiteFooter.svelte
 #: src/lib/components/SiteHeader.svelte
 #: src/lib/components/SiteHeader.svelte
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/migrate/+page.svelte
 #: src/routes/settings/setup/migrate/+page.svelte
 msgid "Get Started"
@@ -12824,6 +12830,7 @@ msgstr ""
 #~ msgid "Fresh Install Setup"
 #~ msgstr ""
 
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/setup/+page.svelte
 msgid "Migrate from Nightscout"
 msgstr ""
@@ -13938,6 +13945,7 @@ msgstr ""
 #~ msgid "Positive = ate after bolusing, Negative = ate before bolusing"
 #~ msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/lib/components/meal-matching/MealMatchReviewDialog.svelte
 #: src/routes/meals/+page.svelte
 msgid "Dismiss"
@@ -18187,6 +18195,7 @@ msgid "Checking availability..."
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -18903,7 +18912,6 @@ msgid "mg/dL/U <0/>"
 msgstr ""
 
 #: src/lib/components/layout/AppSidebar.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/patient/+page.svelte
 #: src/routes/settings/patient/+page.svelte
 #: src/routes/settings/setup/+page.svelte
@@ -19058,7 +19066,7 @@ msgstr ""
 msgid "SN: {0}"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/settings/patient/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Insulins"
@@ -19124,7 +19132,6 @@ msgid "Serial Number"
 msgstr ""
 
 #: src/lib/components/patient/PatientDeviceManager.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Optional"
 msgstr ""
@@ -19193,34 +19200,28 @@ msgid ""
 "undone."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Set your diabetes type and clinical information"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Add the devices you currently use"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Add the insulins you currently use"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Connect external data sources"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/profile/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 #: src/routes/settings/setup/profile/+page.svelte
 msgid "Therapy Profile"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Configure your basal rates and therapy settings"
 msgstr ""
@@ -19583,14 +19584,12 @@ msgstr ""
 msgid "Alert when CGM signal is lost for an extended period"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Browser Push Notification"
-msgstr ""
+#~ msgid "Browser Push Notification"
+#~ msgstr ""
 
+#: src/lib/components/alerts/ChannelPicker.svelte
 #: src/lib/components/alerts/RuleEditorSheet.svelte
 #: src/lib/components/alerts/RuleEditorSheet.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
 msgid "Webhook"
 msgstr ""
 
@@ -19654,39 +19653,34 @@ msgstr ""
 msgid "Choose how you want to receive alert notifications."
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Browser Push Notifications"
-msgstr ""
+#~ msgid "Browser Push Notifications"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
 msgid "Receive alerts directly in your browser"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
 msgid "Send alert data to a custom URL"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Webhook URL"
-msgstr ""
+#~ msgid "Webhook URL"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 msgid "Discord"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Send alerts to a Discord channel"
-msgstr ""
+#~ msgid "Send alerts to a Discord channel"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
 msgid "Telegram"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Send alerts to a Telegram chat"
-msgstr ""
+#~ msgid "Send alerts to a Telegram chat"
+#~ msgstr ""
 
 #: src/routes/settings/alerts/setup/+page.svelte
 msgid "Review your alert configuration before saving."
@@ -19715,10 +19709,8 @@ msgid ""
 "the dashboard, but no push notifications will be sent."
 msgstr ""
 
-#. placeholder {0}: webhookUrl
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Webhook: {0}"
-msgstr ""
+#~ msgid "Webhook: {0}"
+#~ msgstr ""
 
 #: src/routes/settings/alerts/setup/+page.svelte
 msgid "Medical Disclaimer"
@@ -20285,16 +20277,15 @@ msgstr ""
 #~ msgid "<0/> {0} Synced Successfully"
 #~ msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Uploaders"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Configure a phone app to push data to Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "General Uploaders"
@@ -20307,16 +20298,19 @@ msgstr ""
 msgid "Failed to load uploader apps"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Android"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Desktop"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Web"
@@ -20376,11 +20370,13 @@ msgstr ""
 
 #. placeholder {0}: selectedApp?.name
 #. placeholder {1}: ds.entriesLast24h ?? 0
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "{0} is sending data. {1} entries in the last 24 hours."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Waiting for data"
@@ -20392,22 +20388,26 @@ msgstr ""
 msgid "Once you've configured {0}, it can take up to five minutes for the first glucose data to arrive. This page will update automatically."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Failed to load setup instructions"
 msgstr ""
 
 #. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Could not load setup details for {0}. Please try again."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "<0/> iOS"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "<0/> Android"
@@ -20896,6 +20896,7 @@ msgstr ""
 msgid "{0} - Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Device Authorized"
 msgstr ""
@@ -20904,14 +20905,17 @@ msgstr ""
 msgid "You can close this window and return to your device."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Authorization Denied"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "The device will not be granted access."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Authorize Application"
@@ -20930,11 +20934,13 @@ msgid ""
 "approve if you trust this application."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "This application is requesting permission to:"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "This app cannot delete your data."
@@ -20947,12 +20953,14 @@ msgid ""
 "data."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 #: src/routes/settings/access-requests/+page.svelte
 msgid "<0/> Deny"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 #: src/routes/settings/access-requests/+page.svelte
@@ -21120,6 +21128,7 @@ msgstr ""
 msgid "<0/> is requesting additional access to your Nocturne data."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 msgid "<0/> wants to access your Nocturne data."
 msgstr ""
@@ -21151,6 +21160,7 @@ msgstr ""
 msgid "Invite Not Found"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "This invite link is invalid or has expired."
 msgstr ""
@@ -21199,6 +21209,7 @@ msgstr ""
 #~ msgid "You'll be able to see:"
 #~ msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "<0/> Accept Invite"
 msgstr ""
@@ -21218,6 +21229,8 @@ msgstr ""
 msgid "Invite not found or has expired."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.server.ts
 #: src/routes/invite/[token]/+page.svelte
 msgid "Failed to accept invite."
@@ -21245,6 +21258,7 @@ msgstr ""
 #: src/lib/components/auth/LoginForm.svelte
 #: src/lib/components/auth/LoginForm.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21269,6 +21283,7 @@ msgstr ""
 #: src/lib/components/auth/LoginForm.svelte
 #: src/lib/components/auth/LoginForm.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21323,6 +21338,7 @@ msgstr ""
 
 #: src/routes/(fullscreen)/auth/help/+page.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/help/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
@@ -21337,6 +21353,7 @@ msgid "Save these recovery codes in a safe place. Each code can only be used onc
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21345,6 +21362,7 @@ msgid "<0/> Codes copied"
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21352,6 +21370,7 @@ msgstr ""
 msgid "<0/> Copy recovery codes"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "Continue to Nocturne"
 msgstr ""
@@ -21363,6 +21382,7 @@ msgid "Copy your recovery codes before continuing."
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21374,6 +21394,7 @@ msgstr ""
 msgid "<0/> Register with passkey"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/settings/account/+page.svelte
 #: src/routes/settings/security/+page.svelte
 msgid "Failed to register passkey."
@@ -21701,12 +21722,10 @@ msgstr ""
 msgid "Revoke"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Passkey"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Set up passwordless authentication with a passkey"
 msgstr ""
@@ -21727,16 +21746,15 @@ msgstr ""
 msgid "Passkey Setup - Setup - Nocturne"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "Set Up Your Passkey"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "Create a passkey for secure, passwordless authentication. You will also receive recovery codes in case you lose access to your passkey."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "This is how you will appear to others."
@@ -21769,11 +21787,13 @@ msgid ""
 "be used once."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "You must copy your recovery codes before continuing."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid ""
@@ -21813,6 +21833,7 @@ msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/auth/bot/authorize/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
@@ -22710,6 +22731,7 @@ msgstr ""
 msgid "Full access"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "Loading invite..."
 msgstr ""
@@ -23185,12 +23207,10 @@ msgstr ""
 msgid "{0} synced so far"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Coming from Nightscout?"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Migrate your data and keep both systems in sync during transition"
 msgstr ""
@@ -23465,30 +23485,26 @@ msgstr ""
 msgid "Register a passkey to restore normal access."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/(fullscreen)/setup/permissions/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 #: src/routes/settings/setup/permissions/+page.svelte
 msgid "Sharing & Privacy"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Choose who can see your data"
 msgstr ""
 
 #. placeholder {0}: requiredComplete
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "{0} of 6 required steps complete"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Finishing..."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Finish Setup"
 msgstr ""
@@ -24328,84 +24344,286 @@ msgstr ""
 msgid "Weight (kg)"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Opening xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "No invite token provided. Please check the link you were given."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Redirecting to xDrip+ to start the connection..."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite has expired."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Connect xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite has been revoked."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "xDrip+ didn't open automatically. You can try these options:"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite is no longer valid."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "<0/> Open in xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Join - Nocturne"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Manual setup"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Invalid Invite"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "In xDrip+, go to Settings > Cloud Upload > Nocturne, enter this URL:"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "You're In"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Then tap \"Connect to Nocturne\" to authorize."
+#. placeholder {0}: inviteInfo.tenantName ?? "the site"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Your account has been created and you've joined {0}."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Don't have xDrip+ installed?"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid ""
+"Save these recovery codes in a safe place. If you lose access to\n"
+"your passkey, you can use one of these codes to sign in. Each code\n"
+"can only be used once."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "<0/> Download xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Accept Invite"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Quick Connect"
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> has invited you to join"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Automatically configure xDrip+ with your Nocturne instance."
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "You've been invited to join"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Or scan from another device"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> Joining..."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "QR code to connect xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Join Nocturne"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Scan this QR code with your phone's camera"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid ""
+"<0/> <1/>.\n"
+"Create an account or sign in to accept."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Or open this link on your phone"
+#. placeholder {0}: provider.name
+#. placeholder {0}: provider.name
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "<0/> Continue with {0}"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "<0/> Waiting for data from xDrip+..."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Or create an account with a passkey"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "<0/> Connected! Data is flowing from xDrip+."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "A unique identifier for your account."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> Create account with passkey"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Check now"
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Set Up Your Account"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Choose how you want to authenticate. You can use an external provider for quick setup, or register a passkey for passwordless authentication."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Or set up with a passkey"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "Discord DM"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "Slack DM"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "WhatsApp"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Browser Push"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts as a Discord direct message"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts as a Slack direct message"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts to your Telegram chat"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts to your WhatsApp"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "No notification channels are currently available."
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Service hasn't reported recently — alerts may be delayed"
+msgstr ""
+
+#. placeholder {0}: getPlatformName(ct)
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid ""
+"Account not linked. Use /connect in {0} to\n"
+"enable delivery."
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Patient details"
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Therapy profile"
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Finish setting up"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Choose how you'd like to set up Nocturne."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Import your existing data — entries, treatments, and history."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Start Fresh"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Connect a glucose data source to get started."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to load data sources"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Connect a Data Source - Setup - Nocturne"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Connect a Data Source"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Choose a cloud service or phone app to start sending glucose and treatment data to Nocturne."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Cloud Services"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Phone Apps"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "No data sources available"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "There are no data sources available at this time."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Skip for now"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Back to data sources"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Continue to Dashboard"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Invalid or expired device code."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Invalid or expired device code. Please check and try again."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to approve. The code may have expired."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to deny the request."
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "{0} is now connected. You can return to your device."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Receiving Data"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "It can take a few minutes for the first glucose reading to arrive. This page will update automatically."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "This application is not in the Nocturne known app directory. Only approve if you trust it."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "This app is requesting full access, including the ability to delete data."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Scan to Connect"
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Scan this QR code with your phone's camera to open {0} and start the connection."
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "QR code to connect {0}"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Enter Authorization Code"
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "After scanning, {0} will show an 8-character code. Enter it here to approve the connection."
 msgstr ""

--- a/src/Web/locales/fr.po
+++ b/src/Web/locales/fr.po
@@ -24307,3 +24307,85 @@ msgstr ""
 #: src/routes/(fullscreen)/setup/patient/+page.svelte
 msgid "Weight (kg)"
 msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Opening xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Redirecting to xDrip+ to start the connection..."
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Connect xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "xDrip+ didn't open automatically. You can try these options:"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "<0/> Open in xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Manual setup"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "In xDrip+, go to Settings > Cloud Upload > Nocturne, enter this URL:"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Then tap \"Connect to Nocturne\" to authorize."
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Don't have xDrip+ installed?"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "<0/> Download xDrip+"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Quick Connect"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Automatically configure xDrip+ with your Nocturne instance."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Or scan from another device"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "QR code to connect xDrip+"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Scan this QR code with your phone's camera"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Or open this link on your phone"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "<0/> Waiting for data from xDrip+..."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "<0/> Connected! Data is flowing from xDrip+."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Check now"
+msgstr ""

--- a/src/Web/locales/fr.po
+++ b/src/Web/locales/fr.po
@@ -319,6 +319,8 @@ msgstr ""
 #: src/lib/components/WebSocketStatus.svelte
 #: src/lib/components/dashboard/widgets/ConnectionStatusWidget.svelte
 #: src/routes/(fullscreen)/auth/bot/authorize/done/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/auth/bot/authorize/done/+page.svelte
@@ -1258,6 +1260,7 @@ msgstr ""
 #: src/lib/components/patient/PatientDeviceManager.svelte
 #: src/lib/components/profile/ProfileEditDialog.svelte
 #: src/lib/components/status-pills/TrackerPill.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
@@ -1534,6 +1537,7 @@ msgid "Method"
 msgstr ""
 
 #: src/lib/components/treatments/TreatmentCategoryTabs.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/compatibility/+page.svelte
 #: src/routes/compatibility/+page.svelte
@@ -2967,8 +2971,8 @@ msgstr ""
 msgid "Customize themes, colors, units, and display preferences"
 msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/lib/components/rbac/PermissionPicker.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/+page.svelte
 #: src/routes/settings/devices/+page.svelte
 #: src/routes/settings/patient/+page.svelte
@@ -3035,7 +3039,6 @@ msgid "Connect data sources like Dexcom, Libre, and more"
 msgstr ""
 
 #: src/lib/components/StepIndicator.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/download/+page.svelte
 #: src/routes/settings/+page.svelte
 #: src/routes/settings/setup/+page.svelte
@@ -6694,6 +6697,8 @@ msgid "Or continue with"
 msgstr ""
 
 #: src/lib/components/auth/LoginForm.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "<0/> Redirecting..."
 msgstr ""
@@ -7555,6 +7560,7 @@ msgstr ""
 msgid "Performance"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
 msgid "← Back"
 msgstr ""
@@ -9158,6 +9164,7 @@ msgstr ""
 msgid "Failed to load admin data"
 msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/settings/admin/+page.svelte
 #: src/routes/settings/admin/+page.svelte
 msgid "Public"
@@ -10730,6 +10737,7 @@ msgstr ""
 msgid "Connect your CGM app or AID system to push data to Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 #: src/routes/settings/services/+page.svelte
@@ -10737,6 +10745,7 @@ msgstr ""
 msgid "CGM Apps"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 #: src/routes/settings/services/+page.svelte
@@ -12480,11 +12489,8 @@ msgstr ""
 msgid "Available"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Coming Soon"
-msgstr ""
+#~ msgid "Coming Soon"
+#~ msgstr ""
 
 #~ msgid "View Report <0/>"
 #~ msgstr ""
@@ -12718,7 +12724,6 @@ msgstr ""
 
 #: src/lib/components/StepIndicator.svelte
 #: src/lib/components/layout/AppSidebar.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Setup"
 msgstr ""
@@ -12738,6 +12743,7 @@ msgstr ""
 #: src/lib/components/SiteFooter.svelte
 #: src/lib/components/SiteHeader.svelte
 #: src/lib/components/SiteHeader.svelte
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/migrate/+page.svelte
 #: src/routes/settings/setup/migrate/+page.svelte
 msgid "Get Started"
@@ -12804,6 +12810,7 @@ msgstr ""
 #~ msgid "Fresh Install Setup"
 #~ msgstr ""
 
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/setup/+page.svelte
 msgid "Migrate from Nightscout"
 msgstr ""
@@ -13918,6 +13925,7 @@ msgstr ""
 #~ msgid "Positive = ate after bolusing, Negative = ate before bolusing"
 #~ msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/lib/components/meal-matching/MealMatchReviewDialog.svelte
 #: src/routes/meals/+page.svelte
 msgid "Dismiss"
@@ -18167,6 +18175,7 @@ msgid "Checking availability..."
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -18883,7 +18892,6 @@ msgid "mg/dL/U <0/>"
 msgstr ""
 
 #: src/lib/components/layout/AppSidebar.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/patient/+page.svelte
 #: src/routes/settings/patient/+page.svelte
 #: src/routes/settings/setup/+page.svelte
@@ -19038,7 +19046,7 @@ msgstr ""
 msgid "SN: {0}"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/settings/patient/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Insulins"
@@ -19104,7 +19112,6 @@ msgid "Serial Number"
 msgstr ""
 
 #: src/lib/components/patient/PatientDeviceManager.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Optional"
 msgstr ""
@@ -19173,34 +19180,28 @@ msgid ""
 "undone."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Set your diabetes type and clinical information"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Add the devices you currently use"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Add the insulins you currently use"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Connect external data sources"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/profile/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 #: src/routes/settings/setup/profile/+page.svelte
 msgid "Therapy Profile"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Configure your basal rates and therapy settings"
 msgstr ""
@@ -19563,14 +19564,12 @@ msgstr ""
 msgid "Alert when CGM signal is lost for an extended period"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Browser Push Notification"
-msgstr ""
+#~ msgid "Browser Push Notification"
+#~ msgstr ""
 
+#: src/lib/components/alerts/ChannelPicker.svelte
 #: src/lib/components/alerts/RuleEditorSheet.svelte
 #: src/lib/components/alerts/RuleEditorSheet.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
 msgid "Webhook"
 msgstr ""
 
@@ -19634,39 +19633,34 @@ msgstr ""
 msgid "Choose how you want to receive alert notifications."
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Browser Push Notifications"
-msgstr ""
+#~ msgid "Browser Push Notifications"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
 msgid "Receive alerts directly in your browser"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
 msgid "Send alert data to a custom URL"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Webhook URL"
-msgstr ""
+#~ msgid "Webhook URL"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 msgid "Discord"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Send alerts to a Discord channel"
-msgstr ""
+#~ msgid "Send alerts to a Discord channel"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
 msgid "Telegram"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Send alerts to a Telegram chat"
-msgstr ""
+#~ msgid "Send alerts to a Telegram chat"
+#~ msgstr ""
 
 #: src/routes/settings/alerts/setup/+page.svelte
 msgid "Review your alert configuration before saving."
@@ -19695,10 +19689,8 @@ msgid ""
 "the dashboard, but no push notifications will be sent."
 msgstr ""
 
-#. placeholder {0}: webhookUrl
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Webhook: {0}"
-msgstr ""
+#~ msgid "Webhook: {0}"
+#~ msgstr ""
 
 #: src/routes/settings/alerts/setup/+page.svelte
 msgid "Medical Disclaimer"
@@ -20265,16 +20257,15 @@ msgstr ""
 #~ msgid "<0/> {0} Synced Successfully"
 #~ msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Uploaders"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Configure a phone app to push data to Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "General Uploaders"
@@ -20287,16 +20278,19 @@ msgstr ""
 msgid "Failed to load uploader apps"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Android"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Desktop"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Web"
@@ -20356,11 +20350,13 @@ msgstr ""
 
 #. placeholder {0}: selectedApp?.name
 #. placeholder {1}: ds.entriesLast24h ?? 0
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "{0} is sending data. {1} entries in the last 24 hours."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Waiting for data"
@@ -20372,22 +20368,26 @@ msgstr ""
 msgid "Once you've configured {0}, it can take up to five minutes for the first glucose data to arrive. This page will update automatically."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Failed to load setup instructions"
 msgstr ""
 
 #. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Could not load setup details for {0}. Please try again."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "<0/> iOS"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "<0/> Android"
@@ -20876,6 +20876,7 @@ msgstr ""
 msgid "{0} - Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Device Authorized"
 msgstr ""
@@ -20884,14 +20885,17 @@ msgstr ""
 msgid "You can close this window and return to your device."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Authorization Denied"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "The device will not be granted access."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Authorize Application"
@@ -20910,11 +20914,13 @@ msgid ""
 "approve if you trust this application."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "This application is requesting permission to:"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "This app cannot delete your data."
@@ -20927,12 +20933,14 @@ msgid ""
 "data."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 #: src/routes/settings/access-requests/+page.svelte
 msgid "<0/> Deny"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 #: src/routes/settings/access-requests/+page.svelte
@@ -21100,6 +21108,7 @@ msgstr ""
 msgid "<0/> is requesting additional access to your Nocturne data."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 msgid "<0/> wants to access your Nocturne data."
 msgstr ""
@@ -21131,6 +21140,7 @@ msgstr ""
 msgid "Invite Not Found"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "This invite link is invalid or has expired."
 msgstr ""
@@ -21179,6 +21189,7 @@ msgstr ""
 #~ msgid "You'll be able to see:"
 #~ msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "<0/> Accept Invite"
 msgstr ""
@@ -21198,6 +21209,8 @@ msgstr ""
 msgid "Invite not found or has expired."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.server.ts
 #: src/routes/invite/[token]/+page.svelte
 msgid "Failed to accept invite."
@@ -21225,6 +21238,7 @@ msgstr ""
 #: src/lib/components/auth/LoginForm.svelte
 #: src/lib/components/auth/LoginForm.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21249,6 +21263,7 @@ msgstr ""
 #: src/lib/components/auth/LoginForm.svelte
 #: src/lib/components/auth/LoginForm.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21402,12 +21417,10 @@ msgstr ""
 msgid "Revoke"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Passkey"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Set up passwordless authentication with a passkey"
 msgstr ""
@@ -21428,6 +21441,7 @@ msgstr ""
 
 #: src/routes/(fullscreen)/auth/help/+page.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/help/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
@@ -21442,6 +21456,7 @@ msgid "Save these recovery codes in a safe place. Each code can only be used onc
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21450,6 +21465,7 @@ msgid "<0/> Codes copied"
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21457,6 +21473,7 @@ msgstr ""
 msgid "<0/> Copy recovery codes"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "Continue to Nocturne"
 msgstr ""
@@ -21468,6 +21485,7 @@ msgid "Copy your recovery codes before continuing."
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21479,6 +21497,7 @@ msgstr ""
 msgid "<0/> Register with passkey"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/settings/account/+page.svelte
 #: src/routes/settings/security/+page.svelte
 msgid "Failed to register passkey."
@@ -21707,16 +21726,15 @@ msgstr ""
 msgid "Passkey Setup - Setup - Nocturne"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "Set Up Your Passkey"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "Create a passkey for secure, passwordless authentication. You will also receive recovery codes in case you lose access to your passkey."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "This is how you will appear to others."
@@ -21749,11 +21767,13 @@ msgid ""
 "be used once."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "You must copy your recovery codes before continuing."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid ""
@@ -21793,6 +21813,7 @@ msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/auth/bot/authorize/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
@@ -22790,6 +22811,7 @@ msgstr ""
 msgid "Full access"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "Loading invite..."
 msgstr ""
@@ -23165,12 +23187,10 @@ msgstr ""
 msgid "{0} synced so far"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Coming from Nightscout?"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Migrate your data and keep both systems in sync during transition"
 msgstr ""
@@ -23445,30 +23465,26 @@ msgstr ""
 msgid "Register a passkey to restore normal access."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/(fullscreen)/setup/permissions/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 #: src/routes/settings/setup/permissions/+page.svelte
 msgid "Sharing & Privacy"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Choose who can see your data"
 msgstr ""
 
 #. placeholder {0}: requiredComplete
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "{0} of 6 required steps complete"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Finishing..."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Finish Setup"
 msgstr ""
@@ -24308,84 +24324,286 @@ msgstr ""
 msgid "Weight (kg)"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Opening xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "No invite token provided. Please check the link you were given."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Redirecting to xDrip+ to start the connection..."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite has expired."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Connect xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite has been revoked."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "xDrip+ didn't open automatically. You can try these options:"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite is no longer valid."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "<0/> Open in xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Join - Nocturne"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Manual setup"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Invalid Invite"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "In xDrip+, go to Settings > Cloud Upload > Nocturne, enter this URL:"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "You're In"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Then tap \"Connect to Nocturne\" to authorize."
+#. placeholder {0}: inviteInfo.tenantName ?? "the site"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Your account has been created and you've joined {0}."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Don't have xDrip+ installed?"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid ""
+"Save these recovery codes in a safe place. If you lose access to\n"
+"your passkey, you can use one of these codes to sign in. Each code\n"
+"can only be used once."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "<0/> Download xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Accept Invite"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Quick Connect"
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> has invited you to join"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Automatically configure xDrip+ with your Nocturne instance."
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "You've been invited to join"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Or scan from another device"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> Joining..."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "QR code to connect xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Join Nocturne"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Scan this QR code with your phone's camera"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid ""
+"<0/> <1/>.\n"
+"Create an account or sign in to accept."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Or open this link on your phone"
+#. placeholder {0}: provider.name
+#. placeholder {0}: provider.name
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "<0/> Continue with {0}"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "<0/> Waiting for data from xDrip+..."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Or create an account with a passkey"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "<0/> Connected! Data is flowing from xDrip+."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "A unique identifier for your account."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> Create account with passkey"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Check now"
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Set Up Your Account"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Choose how you want to authenticate. You can use an external provider for quick setup, or register a passkey for passwordless authentication."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Or set up with a passkey"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "Discord DM"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "Slack DM"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "WhatsApp"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Browser Push"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts as a Discord direct message"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts as a Slack direct message"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts to your Telegram chat"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts to your WhatsApp"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "No notification channels are currently available."
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Service hasn't reported recently — alerts may be delayed"
+msgstr ""
+
+#. placeholder {0}: getPlatformName(ct)
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid ""
+"Account not linked. Use /connect in {0} to\n"
+"enable delivery."
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Patient details"
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Therapy profile"
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Finish setting up"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Choose how you'd like to set up Nocturne."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Import your existing data — entries, treatments, and history."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Start Fresh"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Connect a glucose data source to get started."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to load data sources"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Connect a Data Source - Setup - Nocturne"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Connect a Data Source"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Choose a cloud service or phone app to start sending glucose and treatment data to Nocturne."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Cloud Services"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Phone Apps"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "No data sources available"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "There are no data sources available at this time."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Skip for now"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Back to data sources"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Continue to Dashboard"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Invalid or expired device code."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Invalid or expired device code. Please check and try again."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to approve. The code may have expired."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to deny the request."
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "{0} is now connected. You can return to your device."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Receiving Data"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "It can take a few minutes for the first glucose reading to arrive. This page will update automatically."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "This application is not in the Nocturne known app directory. Only approve if you trust it."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "This app is requesting full access, including the ability to delete data."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Scan to Connect"
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Scan this QR code with your phone's camera to open {0} and start the connection."
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "QR code to connect {0}"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Enter Authorization Code"
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "After scanning, {0} will show an 8-character code. Enter it here to approve the connection."
 msgstr ""

--- a/src/Web/locales/it.po
+++ b/src/Web/locales/it.po
@@ -319,6 +319,8 @@ msgstr ""
 #: src/lib/components/WebSocketStatus.svelte
 #: src/lib/components/dashboard/widgets/ConnectionStatusWidget.svelte
 #: src/routes/(fullscreen)/auth/bot/authorize/done/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/auth/bot/authorize/done/+page.svelte
@@ -1258,6 +1260,7 @@ msgstr ""
 #: src/lib/components/patient/PatientDeviceManager.svelte
 #: src/lib/components/profile/ProfileEditDialog.svelte
 #: src/lib/components/status-pills/TrackerPill.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
@@ -1534,6 +1537,7 @@ msgid "Method"
 msgstr ""
 
 #: src/lib/components/treatments/TreatmentCategoryTabs.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/compatibility/+page.svelte
 #: src/routes/compatibility/+page.svelte
@@ -2823,11 +2827,8 @@ msgstr ""
 msgid "Available"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Coming Soon"
-msgstr ""
+#~ msgid "Coming Soon"
+#~ msgstr ""
 
 #: src/routes/reports/executive-summary/+page.svelte
 msgid "Clinical details"
@@ -3193,8 +3194,8 @@ msgstr ""
 msgid "Customize themes, colors, units, and display preferences"
 msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/lib/components/rbac/PermissionPicker.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/+page.svelte
 #: src/routes/settings/devices/+page.svelte
 #: src/routes/settings/patient/+page.svelte
@@ -3261,7 +3262,6 @@ msgid "Connect data sources like Dexcom, Libre, and more"
 msgstr ""
 
 #: src/lib/components/StepIndicator.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/download/+page.svelte
 #: src/routes/settings/+page.svelte
 #: src/routes/settings/setup/+page.svelte
@@ -6953,6 +6953,8 @@ msgid "Or continue with"
 msgstr ""
 
 #: src/lib/components/auth/LoginForm.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "<0/> Redirecting..."
 msgstr ""
@@ -7815,6 +7817,7 @@ msgstr ""
 msgid "Performance"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
 msgid "← Back"
 msgstr ""
@@ -9438,6 +9441,7 @@ msgstr ""
 msgid "Failed to load admin data"
 msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/settings/admin/+page.svelte
 #: src/routes/settings/admin/+page.svelte
 msgid "Public"
@@ -11014,6 +11018,7 @@ msgstr ""
 msgid "Connect your CGM app or AID system to push data to Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 #: src/routes/settings/services/+page.svelte
@@ -11021,6 +11026,7 @@ msgstr ""
 msgid "CGM Apps"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 #: src/routes/settings/services/+page.svelte
@@ -12697,7 +12703,6 @@ msgstr ""
 
 #: src/lib/components/StepIndicator.svelte
 #: src/lib/components/layout/AppSidebar.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Setup"
 msgstr ""
@@ -12717,6 +12722,7 @@ msgstr ""
 #: src/lib/components/SiteFooter.svelte
 #: src/lib/components/SiteHeader.svelte
 #: src/lib/components/SiteHeader.svelte
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/migrate/+page.svelte
 #: src/routes/settings/setup/migrate/+page.svelte
 msgid "Get Started"
@@ -12824,6 +12830,7 @@ msgstr ""
 #~ msgid "Fresh Install Setup"
 #~ msgstr ""
 
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/setup/+page.svelte
 msgid "Migrate from Nightscout"
 msgstr ""
@@ -13938,6 +13945,7 @@ msgstr ""
 #~ msgid "Positive = ate after bolusing, Negative = ate before bolusing"
 #~ msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/lib/components/meal-matching/MealMatchReviewDialog.svelte
 #: src/routes/meals/+page.svelte
 msgid "Dismiss"
@@ -18187,6 +18195,7 @@ msgid "Checking availability..."
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -18903,7 +18912,6 @@ msgid "mg/dL/U <0/>"
 msgstr ""
 
 #: src/lib/components/layout/AppSidebar.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/patient/+page.svelte
 #: src/routes/settings/patient/+page.svelte
 #: src/routes/settings/setup/+page.svelte
@@ -19058,7 +19066,7 @@ msgstr ""
 msgid "SN: {0}"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/settings/patient/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Insulins"
@@ -19124,7 +19132,6 @@ msgid "Serial Number"
 msgstr ""
 
 #: src/lib/components/patient/PatientDeviceManager.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Optional"
 msgstr ""
@@ -19193,34 +19200,28 @@ msgid ""
 "undone."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Set your diabetes type and clinical information"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Add the devices you currently use"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Add the insulins you currently use"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Connect external data sources"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/profile/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 #: src/routes/settings/setup/profile/+page.svelte
 msgid "Therapy Profile"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Configure your basal rates and therapy settings"
 msgstr ""
@@ -19583,14 +19584,12 @@ msgstr ""
 msgid "Alert when CGM signal is lost for an extended period"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Browser Push Notification"
-msgstr ""
+#~ msgid "Browser Push Notification"
+#~ msgstr ""
 
+#: src/lib/components/alerts/ChannelPicker.svelte
 #: src/lib/components/alerts/RuleEditorSheet.svelte
 #: src/lib/components/alerts/RuleEditorSheet.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
 msgid "Webhook"
 msgstr ""
 
@@ -19654,39 +19653,34 @@ msgstr ""
 msgid "Choose how you want to receive alert notifications."
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Browser Push Notifications"
-msgstr ""
+#~ msgid "Browser Push Notifications"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
 msgid "Receive alerts directly in your browser"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
 msgid "Send alert data to a custom URL"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Webhook URL"
-msgstr ""
+#~ msgid "Webhook URL"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 msgid "Discord"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Send alerts to a Discord channel"
-msgstr ""
+#~ msgid "Send alerts to a Discord channel"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
 msgid "Telegram"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Send alerts to a Telegram chat"
-msgstr ""
+#~ msgid "Send alerts to a Telegram chat"
+#~ msgstr ""
 
 #: src/routes/settings/alerts/setup/+page.svelte
 msgid "Review your alert configuration before saving."
@@ -19715,10 +19709,8 @@ msgid ""
 "the dashboard, but no push notifications will be sent."
 msgstr ""
 
-#. placeholder {0}: webhookUrl
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Webhook: {0}"
-msgstr ""
+#~ msgid "Webhook: {0}"
+#~ msgstr ""
 
 #: src/routes/settings/alerts/setup/+page.svelte
 msgid "Medical Disclaimer"
@@ -20285,16 +20277,15 @@ msgstr ""
 #~ msgid "<0/> {0} Synced Successfully"
 #~ msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Uploaders"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Configure a phone app to push data to Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "General Uploaders"
@@ -20307,16 +20298,19 @@ msgstr ""
 msgid "Failed to load uploader apps"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Android"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Desktop"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Web"
@@ -20376,11 +20370,13 @@ msgstr ""
 
 #. placeholder {0}: selectedApp?.name
 #. placeholder {1}: ds.entriesLast24h ?? 0
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "{0} is sending data. {1} entries in the last 24 hours."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Waiting for data"
@@ -20392,22 +20388,26 @@ msgstr ""
 msgid "Once you've configured {0}, it can take up to five minutes for the first glucose data to arrive. This page will update automatically."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Failed to load setup instructions"
 msgstr ""
 
 #. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Could not load setup details for {0}. Please try again."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "<0/> iOS"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "<0/> Android"
@@ -20896,6 +20896,7 @@ msgstr ""
 msgid "{0} - Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Device Authorized"
 msgstr ""
@@ -20904,14 +20905,17 @@ msgstr ""
 msgid "You can close this window and return to your device."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Authorization Denied"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "The device will not be granted access."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Authorize Application"
@@ -20930,11 +20934,13 @@ msgid ""
 "approve if you trust this application."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "This application is requesting permission to:"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "This app cannot delete your data."
@@ -20947,12 +20953,14 @@ msgid ""
 "data."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 #: src/routes/settings/access-requests/+page.svelte
 msgid "<0/> Deny"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 #: src/routes/settings/access-requests/+page.svelte
@@ -21120,6 +21128,7 @@ msgstr ""
 msgid "<0/> is requesting additional access to your Nocturne data."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 msgid "<0/> wants to access your Nocturne data."
 msgstr ""
@@ -21151,6 +21160,7 @@ msgstr ""
 msgid "Invite Not Found"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "This invite link is invalid or has expired."
 msgstr ""
@@ -21199,6 +21209,7 @@ msgstr ""
 #~ msgid "You'll be able to see:"
 #~ msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "<0/> Accept Invite"
 msgstr ""
@@ -21218,6 +21229,8 @@ msgstr ""
 msgid "Invite not found or has expired."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.server.ts
 #: src/routes/invite/[token]/+page.svelte
 msgid "Failed to accept invite."
@@ -21245,6 +21258,7 @@ msgstr ""
 #: src/lib/components/auth/LoginForm.svelte
 #: src/lib/components/auth/LoginForm.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21269,6 +21283,7 @@ msgstr ""
 #: src/lib/components/auth/LoginForm.svelte
 #: src/lib/components/auth/LoginForm.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21310,12 +21325,10 @@ msgstr ""
 msgid "API Access"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Passkey"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Set up passwordless authentication with a passkey"
 msgstr ""
@@ -21448,6 +21461,7 @@ msgstr ""
 
 #: src/routes/(fullscreen)/auth/help/+page.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/help/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
@@ -21462,6 +21476,7 @@ msgid "Save these recovery codes in a safe place. Each code can only be used onc
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21470,6 +21485,7 @@ msgid "<0/> Codes copied"
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21477,6 +21493,7 @@ msgstr ""
 msgid "<0/> Copy recovery codes"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "Continue to Nocturne"
 msgstr ""
@@ -21488,6 +21505,7 @@ msgid "Copy your recovery codes before continuing."
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21499,6 +21517,7 @@ msgstr ""
 msgid "<0/> Register with passkey"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/settings/account/+page.svelte
 #: src/routes/settings/security/+page.svelte
 msgid "Failed to register passkey."
@@ -21727,16 +21746,15 @@ msgstr ""
 msgid "Passkey Setup - Setup - Nocturne"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "Set Up Your Passkey"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "Create a passkey for secure, passwordless authentication. You will also receive recovery codes in case you lose access to your passkey."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "This is how you will appear to others."
@@ -21769,11 +21787,13 @@ msgid ""
 "be used once."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "You must copy your recovery codes before continuing."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid ""
@@ -21813,6 +21833,7 @@ msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/auth/bot/authorize/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
@@ -22947,6 +22968,7 @@ msgstr ""
 msgid "Full access"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "Loading invite..."
 msgstr ""
@@ -23185,12 +23207,10 @@ msgstr ""
 msgid "{0} synced so far"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Coming from Nightscout?"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Migrate your data and keep both systems in sync during transition"
 msgstr ""
@@ -23465,30 +23485,26 @@ msgstr ""
 msgid "Register a passkey to restore normal access."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/(fullscreen)/setup/permissions/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 #: src/routes/settings/setup/permissions/+page.svelte
 msgid "Sharing & Privacy"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Choose who can see your data"
 msgstr ""
 
 #. placeholder {0}: requiredComplete
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "{0} of 6 required steps complete"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Finishing..."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Finish Setup"
 msgstr ""
@@ -24328,84 +24344,286 @@ msgstr ""
 msgid "Weight (kg)"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Opening xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "No invite token provided. Please check the link you were given."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Redirecting to xDrip+ to start the connection..."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite has expired."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Connect xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite has been revoked."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "xDrip+ didn't open automatically. You can try these options:"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite is no longer valid."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "<0/> Open in xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Join - Nocturne"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Manual setup"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Invalid Invite"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "In xDrip+, go to Settings > Cloud Upload > Nocturne, enter this URL:"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "You're In"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Then tap \"Connect to Nocturne\" to authorize."
+#. placeholder {0}: inviteInfo.tenantName ?? "the site"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Your account has been created and you've joined {0}."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Don't have xDrip+ installed?"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid ""
+"Save these recovery codes in a safe place. If you lose access to\n"
+"your passkey, you can use one of these codes to sign in. Each code\n"
+"can only be used once."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "<0/> Download xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Accept Invite"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Quick Connect"
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> has invited you to join"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Automatically configure xDrip+ with your Nocturne instance."
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "You've been invited to join"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Or scan from another device"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> Joining..."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "QR code to connect xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Join Nocturne"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Scan this QR code with your phone's camera"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid ""
+"<0/> <1/>.\n"
+"Create an account or sign in to accept."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Or open this link on your phone"
+#. placeholder {0}: provider.name
+#. placeholder {0}: provider.name
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "<0/> Continue with {0}"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "<0/> Waiting for data from xDrip+..."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Or create an account with a passkey"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "<0/> Connected! Data is flowing from xDrip+."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "A unique identifier for your account."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> Create account with passkey"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Check now"
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Set Up Your Account"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Choose how you want to authenticate. You can use an external provider for quick setup, or register a passkey for passwordless authentication."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Or set up with a passkey"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "Discord DM"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "Slack DM"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "WhatsApp"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Browser Push"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts as a Discord direct message"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts as a Slack direct message"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts to your Telegram chat"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts to your WhatsApp"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "No notification channels are currently available."
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Service hasn't reported recently — alerts may be delayed"
+msgstr ""
+
+#. placeholder {0}: getPlatformName(ct)
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid ""
+"Account not linked. Use /connect in {0} to\n"
+"enable delivery."
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Patient details"
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Therapy profile"
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Finish setting up"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Choose how you'd like to set up Nocturne."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Import your existing data — entries, treatments, and history."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Start Fresh"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Connect a glucose data source to get started."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to load data sources"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Connect a Data Source - Setup - Nocturne"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Connect a Data Source"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Choose a cloud service or phone app to start sending glucose and treatment data to Nocturne."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Cloud Services"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Phone Apps"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "No data sources available"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "There are no data sources available at this time."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Skip for now"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Back to data sources"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Continue to Dashboard"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Invalid or expired device code."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Invalid or expired device code. Please check and try again."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to approve. The code may have expired."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to deny the request."
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "{0} is now connected. You can return to your device."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Receiving Data"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "It can take a few minutes for the first glucose reading to arrive. This page will update automatically."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "This application is not in the Nocturne known app directory. Only approve if you trust it."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "This app is requesting full access, including the ability to delete data."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Scan to Connect"
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Scan this QR code with your phone's camera to open {0} and start the connection."
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "QR code to connect {0}"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Enter Authorization Code"
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "After scanning, {0} will show an 8-character code. Enter it here to approve the connection."
 msgstr ""

--- a/src/Web/locales/it.po
+++ b/src/Web/locales/it.po
@@ -24327,3 +24327,85 @@ msgstr ""
 #: src/routes/(fullscreen)/setup/patient/+page.svelte
 msgid "Weight (kg)"
 msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Opening xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Redirecting to xDrip+ to start the connection..."
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Connect xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "xDrip+ didn't open automatically. You can try these options:"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "<0/> Open in xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Manual setup"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "In xDrip+, go to Settings > Cloud Upload > Nocturne, enter this URL:"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Then tap \"Connect to Nocturne\" to authorize."
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Don't have xDrip+ installed?"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "<0/> Download xDrip+"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Quick Connect"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Automatically configure xDrip+ with your Nocturne instance."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Or scan from another device"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "QR code to connect xDrip+"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Scan this QR code with your phone's camera"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Or open this link on your phone"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "<0/> Waiting for data from xDrip+..."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "<0/> Connected! Data is flowing from xDrip+."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Check now"
+msgstr ""

--- a/src/Web/locales/ja.po
+++ b/src/Web/locales/ja.po
@@ -24327,3 +24327,85 @@ msgstr ""
 #: src/routes/(fullscreen)/setup/patient/+page.svelte
 msgid "Weight (kg)"
 msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Opening xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Redirecting to xDrip+ to start the connection..."
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Connect xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "xDrip+ didn't open automatically. You can try these options:"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "<0/> Open in xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Manual setup"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "In xDrip+, go to Settings > Cloud Upload > Nocturne, enter this URL:"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Then tap \"Connect to Nocturne\" to authorize."
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Don't have xDrip+ installed?"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "<0/> Download xDrip+"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Quick Connect"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Automatically configure xDrip+ with your Nocturne instance."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Or scan from another device"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "QR code to connect xDrip+"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Scan this QR code with your phone's camera"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Or open this link on your phone"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "<0/> Waiting for data from xDrip+..."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "<0/> Connected! Data is flowing from xDrip+."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Check now"
+msgstr ""

--- a/src/Web/locales/ja.po
+++ b/src/Web/locales/ja.po
@@ -319,6 +319,8 @@ msgstr ""
 #: src/lib/components/WebSocketStatus.svelte
 #: src/lib/components/dashboard/widgets/ConnectionStatusWidget.svelte
 #: src/routes/(fullscreen)/auth/bot/authorize/done/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/auth/bot/authorize/done/+page.svelte
@@ -1258,6 +1260,7 @@ msgstr ""
 #: src/lib/components/patient/PatientDeviceManager.svelte
 #: src/lib/components/profile/ProfileEditDialog.svelte
 #: src/lib/components/status-pills/TrackerPill.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
@@ -1534,6 +1537,7 @@ msgid "Method"
 msgstr ""
 
 #: src/lib/components/treatments/TreatmentCategoryTabs.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/compatibility/+page.svelte
 #: src/routes/compatibility/+page.svelte
@@ -2823,11 +2827,8 @@ msgstr ""
 msgid "Available"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Coming Soon"
-msgstr ""
+#~ msgid "Coming Soon"
+#~ msgstr ""
 
 #: src/routes/reports/executive-summary/+page.svelte
 msgid "Clinical details"
@@ -3193,8 +3194,8 @@ msgstr ""
 msgid "Customize themes, colors, units, and display preferences"
 msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/lib/components/rbac/PermissionPicker.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/+page.svelte
 #: src/routes/settings/devices/+page.svelte
 #: src/routes/settings/patient/+page.svelte
@@ -3261,7 +3262,6 @@ msgid "Connect data sources like Dexcom, Libre, and more"
 msgstr ""
 
 #: src/lib/components/StepIndicator.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/download/+page.svelte
 #: src/routes/settings/+page.svelte
 #: src/routes/settings/setup/+page.svelte
@@ -6953,6 +6953,8 @@ msgid "Or continue with"
 msgstr ""
 
 #: src/lib/components/auth/LoginForm.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "<0/> Redirecting..."
 msgstr ""
@@ -7815,6 +7817,7 @@ msgstr ""
 msgid "Performance"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
 msgid "← Back"
 msgstr ""
@@ -9438,6 +9441,7 @@ msgstr ""
 msgid "Failed to load admin data"
 msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/settings/admin/+page.svelte
 #: src/routes/settings/admin/+page.svelte
 msgid "Public"
@@ -11014,6 +11018,7 @@ msgstr ""
 msgid "Connect your CGM app or AID system to push data to Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 #: src/routes/settings/services/+page.svelte
@@ -11021,6 +11026,7 @@ msgstr ""
 msgid "CGM Apps"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 #: src/routes/settings/services/+page.svelte
@@ -12697,7 +12703,6 @@ msgstr ""
 
 #: src/lib/components/StepIndicator.svelte
 #: src/lib/components/layout/AppSidebar.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Setup"
 msgstr ""
@@ -12717,6 +12722,7 @@ msgstr ""
 #: src/lib/components/SiteFooter.svelte
 #: src/lib/components/SiteHeader.svelte
 #: src/lib/components/SiteHeader.svelte
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/migrate/+page.svelte
 #: src/routes/settings/setup/migrate/+page.svelte
 msgid "Get Started"
@@ -12824,6 +12830,7 @@ msgstr ""
 #~ msgid "Fresh Install Setup"
 #~ msgstr ""
 
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/setup/+page.svelte
 msgid "Migrate from Nightscout"
 msgstr ""
@@ -13938,6 +13945,7 @@ msgstr ""
 #~ msgid "Positive = ate after bolusing, Negative = ate before bolusing"
 #~ msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/lib/components/meal-matching/MealMatchReviewDialog.svelte
 #: src/routes/meals/+page.svelte
 msgid "Dismiss"
@@ -18187,6 +18195,7 @@ msgid "Checking availability..."
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -18903,7 +18912,6 @@ msgid "mg/dL/U <0/>"
 msgstr ""
 
 #: src/lib/components/layout/AppSidebar.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/patient/+page.svelte
 #: src/routes/settings/patient/+page.svelte
 #: src/routes/settings/setup/+page.svelte
@@ -19058,7 +19066,7 @@ msgstr ""
 msgid "SN: {0}"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/settings/patient/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Insulins"
@@ -19124,7 +19132,6 @@ msgid "Serial Number"
 msgstr ""
 
 #: src/lib/components/patient/PatientDeviceManager.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Optional"
 msgstr ""
@@ -19193,34 +19200,28 @@ msgid ""
 "undone."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Set your diabetes type and clinical information"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Add the devices you currently use"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Add the insulins you currently use"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Connect external data sources"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/profile/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 #: src/routes/settings/setup/profile/+page.svelte
 msgid "Therapy Profile"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Configure your basal rates and therapy settings"
 msgstr ""
@@ -19835,14 +19836,12 @@ msgstr ""
 msgid "Alert when CGM signal is lost for an extended period"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Browser Push Notification"
-msgstr ""
+#~ msgid "Browser Push Notification"
+#~ msgstr ""
 
+#: src/lib/components/alerts/ChannelPicker.svelte
 #: src/lib/components/alerts/RuleEditorSheet.svelte
 #: src/lib/components/alerts/RuleEditorSheet.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
 msgid "Webhook"
 msgstr ""
 
@@ -19906,39 +19905,34 @@ msgstr ""
 msgid "Choose how you want to receive alert notifications."
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Browser Push Notifications"
-msgstr ""
+#~ msgid "Browser Push Notifications"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
 msgid "Receive alerts directly in your browser"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
 msgid "Send alert data to a custom URL"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Webhook URL"
-msgstr ""
+#~ msgid "Webhook URL"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 msgid "Discord"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Send alerts to a Discord channel"
-msgstr ""
+#~ msgid "Send alerts to a Discord channel"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
 msgid "Telegram"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Send alerts to a Telegram chat"
-msgstr ""
+#~ msgid "Send alerts to a Telegram chat"
+#~ msgstr ""
 
 #: src/routes/settings/alerts/setup/+page.svelte
 msgid "Review your alert configuration before saving."
@@ -19967,10 +19961,8 @@ msgid ""
 "the dashboard, but no push notifications will be sent."
 msgstr ""
 
-#. placeholder {0}: webhookUrl
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Webhook: {0}"
-msgstr ""
+#~ msgid "Webhook: {0}"
+#~ msgstr ""
 
 #: src/routes/settings/alerts/setup/+page.svelte
 msgid "Medical Disclaimer"
@@ -20285,16 +20277,15 @@ msgstr ""
 #~ msgid "<0/> {0} Synced Successfully"
 #~ msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Uploaders"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Configure a phone app to push data to Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "General Uploaders"
@@ -20307,16 +20298,19 @@ msgstr ""
 msgid "Failed to load uploader apps"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Android"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Desktop"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Web"
@@ -20376,11 +20370,13 @@ msgstr ""
 
 #. placeholder {0}: selectedApp?.name
 #. placeholder {1}: ds.entriesLast24h ?? 0
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "{0} is sending data. {1} entries in the last 24 hours."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Waiting for data"
@@ -20392,22 +20388,26 @@ msgstr ""
 msgid "Once you've configured {0}, it can take up to five minutes for the first glucose data to arrive. This page will update automatically."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Failed to load setup instructions"
 msgstr ""
 
 #. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Could not load setup details for {0}. Please try again."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "<0/> iOS"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "<0/> Android"
@@ -20896,6 +20896,7 @@ msgstr ""
 msgid "{0} - Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Device Authorized"
 msgstr ""
@@ -20904,14 +20905,17 @@ msgstr ""
 msgid "You can close this window and return to your device."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Authorization Denied"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "The device will not be granted access."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Authorize Application"
@@ -20930,11 +20934,13 @@ msgid ""
 "approve if you trust this application."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "This application is requesting permission to:"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "This app cannot delete your data."
@@ -20947,12 +20953,14 @@ msgid ""
 "data."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 #: src/routes/settings/access-requests/+page.svelte
 msgid "<0/> Deny"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 #: src/routes/settings/access-requests/+page.svelte
@@ -21120,6 +21128,7 @@ msgstr ""
 msgid "<0/> is requesting additional access to your Nocturne data."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 msgid "<0/> wants to access your Nocturne data."
 msgstr ""
@@ -21151,6 +21160,7 @@ msgstr ""
 msgid "Invite Not Found"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "This invite link is invalid or has expired."
 msgstr ""
@@ -21199,6 +21209,7 @@ msgstr ""
 #~ msgid "You'll be able to see:"
 #~ msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "<0/> Accept Invite"
 msgstr ""
@@ -21218,6 +21229,8 @@ msgstr ""
 msgid "Invite not found or has expired."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.server.ts
 #: src/routes/invite/[token]/+page.svelte
 msgid "Failed to accept invite."
@@ -21245,6 +21258,7 @@ msgstr ""
 #: src/lib/components/auth/LoginForm.svelte
 #: src/lib/components/auth/LoginForm.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21269,6 +21283,7 @@ msgstr ""
 #: src/lib/components/auth/LoginForm.svelte
 #: src/lib/components/auth/LoginForm.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21435,6 +21450,7 @@ msgstr ""
 
 #: src/routes/(fullscreen)/auth/help/+page.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/help/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
@@ -21449,6 +21465,7 @@ msgid "Save these recovery codes in a safe place. Each code can only be used onc
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21457,6 +21474,7 @@ msgid "<0/> Codes copied"
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21464,6 +21482,7 @@ msgstr ""
 msgid "<0/> Copy recovery codes"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "Continue to Nocturne"
 msgstr ""
@@ -21475,6 +21494,7 @@ msgid "Copy your recovery codes before continuing."
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21486,12 +21506,10 @@ msgstr ""
 msgid "<0/> Register with passkey"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Passkey"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Set up passwordless authentication with a passkey"
 msgstr ""
@@ -21512,16 +21530,15 @@ msgstr ""
 msgid "Passkey Setup - Setup - Nocturne"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "Set Up Your Passkey"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "Create a passkey for secure, passwordless authentication. You will also receive recovery codes in case you lose access to your passkey."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "This is how you will appear to others."
@@ -21554,11 +21571,13 @@ msgid ""
 "be used once."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "You must copy your recovery codes before continuing."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid ""
@@ -21566,6 +21585,7 @@ msgid ""
 "from your account settings."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/settings/account/+page.svelte
 #: src/routes/settings/security/+page.svelte
 msgid "Failed to register passkey."
@@ -21813,6 +21833,7 @@ msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/auth/bot/authorize/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
@@ -23072,6 +23093,7 @@ msgstr ""
 msgid "Full access"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "Loading invite..."
 msgstr ""
@@ -23185,12 +23207,10 @@ msgstr ""
 msgid "{0} synced so far"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Coming from Nightscout?"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Migrate your data and keep both systems in sync during transition"
 msgstr ""
@@ -23465,30 +23485,26 @@ msgstr ""
 msgid "Register a passkey to restore normal access."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/(fullscreen)/setup/permissions/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 #: src/routes/settings/setup/permissions/+page.svelte
 msgid "Sharing & Privacy"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Choose who can see your data"
 msgstr ""
 
 #. placeholder {0}: requiredComplete
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "{0} of 6 required steps complete"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Finishing..."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Finish Setup"
 msgstr ""
@@ -24328,84 +24344,286 @@ msgstr ""
 msgid "Weight (kg)"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Opening xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "No invite token provided. Please check the link you were given."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Redirecting to xDrip+ to start the connection..."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite has expired."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Connect xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite has been revoked."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "xDrip+ didn't open automatically. You can try these options:"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite is no longer valid."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "<0/> Open in xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Join - Nocturne"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Manual setup"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Invalid Invite"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "In xDrip+, go to Settings > Cloud Upload > Nocturne, enter this URL:"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "You're In"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Then tap \"Connect to Nocturne\" to authorize."
+#. placeholder {0}: inviteInfo.tenantName ?? "the site"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Your account has been created and you've joined {0}."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Don't have xDrip+ installed?"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid ""
+"Save these recovery codes in a safe place. If you lose access to\n"
+"your passkey, you can use one of these codes to sign in. Each code\n"
+"can only be used once."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "<0/> Download xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Accept Invite"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Quick Connect"
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> has invited you to join"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Automatically configure xDrip+ with your Nocturne instance."
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "You've been invited to join"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Or scan from another device"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> Joining..."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "QR code to connect xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Join Nocturne"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Scan this QR code with your phone's camera"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid ""
+"<0/> <1/>.\n"
+"Create an account or sign in to accept."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Or open this link on your phone"
+#. placeholder {0}: provider.name
+#. placeholder {0}: provider.name
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "<0/> Continue with {0}"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "<0/> Waiting for data from xDrip+..."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Or create an account with a passkey"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "<0/> Connected! Data is flowing from xDrip+."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "A unique identifier for your account."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> Create account with passkey"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Check now"
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Set Up Your Account"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Choose how you want to authenticate. You can use an external provider for quick setup, or register a passkey for passwordless authentication."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Or set up with a passkey"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "Discord DM"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "Slack DM"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "WhatsApp"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Browser Push"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts as a Discord direct message"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts as a Slack direct message"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts to your Telegram chat"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts to your WhatsApp"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "No notification channels are currently available."
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Service hasn't reported recently — alerts may be delayed"
+msgstr ""
+
+#. placeholder {0}: getPlatformName(ct)
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid ""
+"Account not linked. Use /connect in {0} to\n"
+"enable delivery."
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Patient details"
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Therapy profile"
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Finish setting up"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Choose how you'd like to set up Nocturne."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Import your existing data — entries, treatments, and history."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Start Fresh"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Connect a glucose data source to get started."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to load data sources"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Connect a Data Source - Setup - Nocturne"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Connect a Data Source"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Choose a cloud service or phone app to start sending glucose and treatment data to Nocturne."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Cloud Services"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Phone Apps"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "No data sources available"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "There are no data sources available at this time."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Skip for now"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Back to data sources"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Continue to Dashboard"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Invalid or expired device code."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Invalid or expired device code. Please check and try again."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to approve. The code may have expired."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to deny the request."
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "{0} is now connected. You can return to your device."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Receiving Data"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "It can take a few minutes for the first glucose reading to arrive. This page will update automatically."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "This application is not in the Nocturne known app directory. Only approve if you trust it."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "This app is requesting full access, including the ability to delete data."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Scan to Connect"
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Scan this QR code with your phone's camera to open {0} and start the connection."
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "QR code to connect {0}"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Enter Authorization Code"
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "After scanning, {0} will show an 8-character code. Enter it here to approve the connection."
 msgstr ""

--- a/src/Web/locales/ko.po
+++ b/src/Web/locales/ko.po
@@ -24326,3 +24326,85 @@ msgstr ""
 #: src/routes/(fullscreen)/setup/patient/+page.svelte
 msgid "Weight (kg)"
 msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Opening xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Redirecting to xDrip+ to start the connection..."
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Connect xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "xDrip+ didn't open automatically. You can try these options:"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "<0/> Open in xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Manual setup"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "In xDrip+, go to Settings > Cloud Upload > Nocturne, enter this URL:"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Then tap \"Connect to Nocturne\" to authorize."
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Don't have xDrip+ installed?"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "<0/> Download xDrip+"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Quick Connect"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Automatically configure xDrip+ with your Nocturne instance."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Or scan from another device"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "QR code to connect xDrip+"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Scan this QR code with your phone's camera"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Or open this link on your phone"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "<0/> Waiting for data from xDrip+..."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "<0/> Connected! Data is flowing from xDrip+."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Check now"
+msgstr ""

--- a/src/Web/locales/ko.po
+++ b/src/Web/locales/ko.po
@@ -319,6 +319,8 @@ msgstr ""
 #: src/lib/components/WebSocketStatus.svelte
 #: src/lib/components/dashboard/widgets/ConnectionStatusWidget.svelte
 #: src/routes/(fullscreen)/auth/bot/authorize/done/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/auth/bot/authorize/done/+page.svelte
@@ -1258,6 +1260,7 @@ msgstr ""
 #: src/lib/components/patient/PatientDeviceManager.svelte
 #: src/lib/components/profile/ProfileEditDialog.svelte
 #: src/lib/components/status-pills/TrackerPill.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
@@ -1534,6 +1537,7 @@ msgid "Method"
 msgstr ""
 
 #: src/lib/components/treatments/TreatmentCategoryTabs.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/compatibility/+page.svelte
 #: src/routes/compatibility/+page.svelte
@@ -2823,11 +2827,8 @@ msgstr ""
 msgid "Available"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Coming Soon"
-msgstr ""
+#~ msgid "Coming Soon"
+#~ msgstr ""
 
 #: src/routes/reports/executive-summary/+page.svelte
 msgid "Clinical details"
@@ -3193,8 +3194,8 @@ msgstr ""
 msgid "Customize themes, colors, units, and display preferences"
 msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/lib/components/rbac/PermissionPicker.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/+page.svelte
 #: src/routes/settings/devices/+page.svelte
 #: src/routes/settings/patient/+page.svelte
@@ -3261,7 +3262,6 @@ msgid "Connect data sources like Dexcom, Libre, and more"
 msgstr ""
 
 #: src/lib/components/StepIndicator.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/download/+page.svelte
 #: src/routes/settings/+page.svelte
 #: src/routes/settings/setup/+page.svelte
@@ -6953,6 +6953,8 @@ msgid "Or continue with"
 msgstr ""
 
 #: src/lib/components/auth/LoginForm.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "<0/> Redirecting..."
 msgstr ""
@@ -7815,6 +7817,7 @@ msgstr ""
 msgid "Performance"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
 msgid "← Back"
 msgstr ""
@@ -9438,6 +9441,7 @@ msgstr ""
 msgid "Failed to load admin data"
 msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/settings/admin/+page.svelte
 #: src/routes/settings/admin/+page.svelte
 msgid "Public"
@@ -11014,6 +11018,7 @@ msgstr ""
 msgid "Connect your CGM app or AID system to push data to Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 #: src/routes/settings/services/+page.svelte
@@ -11021,6 +11026,7 @@ msgstr ""
 msgid "CGM Apps"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 #: src/routes/settings/services/+page.svelte
@@ -12697,7 +12703,6 @@ msgstr ""
 
 #: src/lib/components/StepIndicator.svelte
 #: src/lib/components/layout/AppSidebar.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Setup"
 msgstr ""
@@ -12717,6 +12722,7 @@ msgstr ""
 #: src/lib/components/SiteFooter.svelte
 #: src/lib/components/SiteHeader.svelte
 #: src/lib/components/SiteHeader.svelte
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/migrate/+page.svelte
 #: src/routes/settings/setup/migrate/+page.svelte
 msgid "Get Started"
@@ -12824,6 +12830,7 @@ msgstr ""
 #~ msgid "Fresh Install Setup"
 #~ msgstr ""
 
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/setup/+page.svelte
 msgid "Migrate from Nightscout"
 msgstr ""
@@ -13938,6 +13945,7 @@ msgstr ""
 #~ msgid "Positive = ate after bolusing, Negative = ate before bolusing"
 #~ msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/lib/components/meal-matching/MealMatchReviewDialog.svelte
 #: src/routes/meals/+page.svelte
 msgid "Dismiss"
@@ -18187,6 +18195,7 @@ msgid "Checking availability..."
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -18903,7 +18912,6 @@ msgid "mg/dL/U <0/>"
 msgstr ""
 
 #: src/lib/components/layout/AppSidebar.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/patient/+page.svelte
 #: src/routes/settings/patient/+page.svelte
 #: src/routes/settings/setup/+page.svelte
@@ -19058,7 +19066,7 @@ msgstr ""
 msgid "SN: {0}"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/settings/patient/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Insulins"
@@ -19124,7 +19132,6 @@ msgid "Serial Number"
 msgstr ""
 
 #: src/lib/components/patient/PatientDeviceManager.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Optional"
 msgstr ""
@@ -19193,34 +19200,28 @@ msgid ""
 "undone."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Set your diabetes type and clinical information"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Add the devices you currently use"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Add the insulins you currently use"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Connect external data sources"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/profile/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 #: src/routes/settings/setup/profile/+page.svelte
 msgid "Therapy Profile"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Configure your basal rates and therapy settings"
 msgstr ""
@@ -19835,14 +19836,12 @@ msgstr ""
 msgid "Alert when CGM signal is lost for an extended period"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Browser Push Notification"
-msgstr ""
+#~ msgid "Browser Push Notification"
+#~ msgstr ""
 
+#: src/lib/components/alerts/ChannelPicker.svelte
 #: src/lib/components/alerts/RuleEditorSheet.svelte
 #: src/lib/components/alerts/RuleEditorSheet.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
 msgid "Webhook"
 msgstr ""
 
@@ -19906,39 +19905,34 @@ msgstr ""
 msgid "Choose how you want to receive alert notifications."
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Browser Push Notifications"
-msgstr ""
+#~ msgid "Browser Push Notifications"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
 msgid "Receive alerts directly in your browser"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
 msgid "Send alert data to a custom URL"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Webhook URL"
-msgstr ""
+#~ msgid "Webhook URL"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 msgid "Discord"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Send alerts to a Discord channel"
-msgstr ""
+#~ msgid "Send alerts to a Discord channel"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
 msgid "Telegram"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Send alerts to a Telegram chat"
-msgstr ""
+#~ msgid "Send alerts to a Telegram chat"
+#~ msgstr ""
 
 #: src/routes/settings/alerts/setup/+page.svelte
 msgid "Review your alert configuration before saving."
@@ -19967,10 +19961,8 @@ msgid ""
 "the dashboard, but no push notifications will be sent."
 msgstr ""
 
-#. placeholder {0}: webhookUrl
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Webhook: {0}"
-msgstr ""
+#~ msgid "Webhook: {0}"
+#~ msgstr ""
 
 #: src/routes/settings/alerts/setup/+page.svelte
 msgid "Medical Disclaimer"
@@ -20285,16 +20277,15 @@ msgstr ""
 #~ msgid "<0/> {0} Synced Successfully"
 #~ msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Uploaders"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Configure a phone app to push data to Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "General Uploaders"
@@ -20307,16 +20298,19 @@ msgstr ""
 msgid "Failed to load uploader apps"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Android"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Desktop"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Web"
@@ -20376,11 +20370,13 @@ msgstr ""
 
 #. placeholder {0}: selectedApp?.name
 #. placeholder {1}: ds.entriesLast24h ?? 0
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "{0} is sending data. {1} entries in the last 24 hours."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Waiting for data"
@@ -20392,22 +20388,26 @@ msgstr ""
 msgid "Once you've configured {0}, it can take up to five minutes for the first glucose data to arrive. This page will update automatically."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Failed to load setup instructions"
 msgstr ""
 
 #. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Could not load setup details for {0}. Please try again."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "<0/> iOS"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "<0/> Android"
@@ -20896,6 +20896,7 @@ msgstr ""
 msgid "{0} - Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Device Authorized"
 msgstr ""
@@ -20904,14 +20905,17 @@ msgstr ""
 msgid "You can close this window and return to your device."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Authorization Denied"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "The device will not be granted access."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Authorize Application"
@@ -20930,11 +20934,13 @@ msgid ""
 "approve if you trust this application."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "This application is requesting permission to:"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "This app cannot delete your data."
@@ -20947,12 +20953,14 @@ msgid ""
 "data."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 #: src/routes/settings/access-requests/+page.svelte
 msgid "<0/> Deny"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 #: src/routes/settings/access-requests/+page.svelte
@@ -21120,6 +21128,7 @@ msgstr ""
 msgid "<0/> is requesting additional access to your Nocturne data."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 msgid "<0/> wants to access your Nocturne data."
 msgstr ""
@@ -21151,6 +21160,7 @@ msgstr ""
 msgid "Invite Not Found"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "This invite link is invalid or has expired."
 msgstr ""
@@ -21199,6 +21209,7 @@ msgstr ""
 #~ msgid "You'll be able to see:"
 #~ msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "<0/> Accept Invite"
 msgstr ""
@@ -21218,6 +21229,8 @@ msgstr ""
 msgid "Invite not found or has expired."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.server.ts
 #: src/routes/invite/[token]/+page.svelte
 msgid "Failed to accept invite."
@@ -21245,6 +21258,7 @@ msgstr ""
 #: src/lib/components/auth/LoginForm.svelte
 #: src/lib/components/auth/LoginForm.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21269,6 +21283,7 @@ msgstr ""
 #: src/lib/components/auth/LoginForm.svelte
 #: src/lib/components/auth/LoginForm.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21323,6 +21338,7 @@ msgstr ""
 
 #: src/routes/(fullscreen)/auth/help/+page.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/help/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
@@ -21337,6 +21353,7 @@ msgid "Save these recovery codes in a safe place. Each code can only be used onc
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21345,6 +21362,7 @@ msgid "<0/> Codes copied"
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21352,6 +21370,7 @@ msgstr ""
 msgid "<0/> Copy recovery codes"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "Continue to Nocturne"
 msgstr ""
@@ -21363,6 +21382,7 @@ msgid "Copy your recovery codes before continuing."
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21486,12 +21506,10 @@ msgstr ""
 msgid "Revoke"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Passkey"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Set up passwordless authentication with a passkey"
 msgstr ""
@@ -21512,16 +21530,15 @@ msgstr ""
 msgid "Passkey Setup - Setup - Nocturne"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "Set Up Your Passkey"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "Create a passkey for secure, passwordless authentication. You will also receive recovery codes in case you lose access to your passkey."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "This is how you will appear to others."
@@ -21554,11 +21571,13 @@ msgid ""
 "be used once."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "You must copy your recovery codes before continuing."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid ""
@@ -21566,6 +21585,7 @@ msgid ""
 "from your account settings."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/settings/account/+page.svelte
 #: src/routes/settings/security/+page.svelte
 msgid "Failed to register passkey."
@@ -21813,6 +21833,7 @@ msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/auth/bot/authorize/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
@@ -23119,6 +23140,7 @@ msgstr ""
 msgid "Full access"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "Loading invite..."
 msgstr ""
@@ -23185,12 +23207,10 @@ msgstr ""
 msgid "{0} synced so far"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Coming from Nightscout?"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Migrate your data and keep both systems in sync during transition"
 msgstr ""
@@ -23465,30 +23485,26 @@ msgstr ""
 msgid "Register a passkey to restore normal access."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/(fullscreen)/setup/permissions/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 #: src/routes/settings/setup/permissions/+page.svelte
 msgid "Sharing & Privacy"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Choose who can see your data"
 msgstr ""
 
 #. placeholder {0}: requiredComplete
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "{0} of 6 required steps complete"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Finishing..."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Finish Setup"
 msgstr ""
@@ -24327,84 +24343,286 @@ msgstr ""
 msgid "Weight (kg)"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Opening xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "No invite token provided. Please check the link you were given."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Redirecting to xDrip+ to start the connection..."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite has expired."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Connect xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite has been revoked."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "xDrip+ didn't open automatically. You can try these options:"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite is no longer valid."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "<0/> Open in xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Join - Nocturne"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Manual setup"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Invalid Invite"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "In xDrip+, go to Settings > Cloud Upload > Nocturne, enter this URL:"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "You're In"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Then tap \"Connect to Nocturne\" to authorize."
+#. placeholder {0}: inviteInfo.tenantName ?? "the site"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Your account has been created and you've joined {0}."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Don't have xDrip+ installed?"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid ""
+"Save these recovery codes in a safe place. If you lose access to\n"
+"your passkey, you can use one of these codes to sign in. Each code\n"
+"can only be used once."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "<0/> Download xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Accept Invite"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Quick Connect"
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> has invited you to join"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Automatically configure xDrip+ with your Nocturne instance."
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "You've been invited to join"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Or scan from another device"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> Joining..."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "QR code to connect xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Join Nocturne"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Scan this QR code with your phone's camera"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid ""
+"<0/> <1/>.\n"
+"Create an account or sign in to accept."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Or open this link on your phone"
+#. placeholder {0}: provider.name
+#. placeholder {0}: provider.name
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "<0/> Continue with {0}"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "<0/> Waiting for data from xDrip+..."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Or create an account with a passkey"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "<0/> Connected! Data is flowing from xDrip+."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "A unique identifier for your account."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> Create account with passkey"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Check now"
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Set Up Your Account"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Choose how you want to authenticate. You can use an external provider for quick setup, or register a passkey for passwordless authentication."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Or set up with a passkey"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "Discord DM"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "Slack DM"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "WhatsApp"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Browser Push"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts as a Discord direct message"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts as a Slack direct message"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts to your Telegram chat"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts to your WhatsApp"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "No notification channels are currently available."
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Service hasn't reported recently — alerts may be delayed"
+msgstr ""
+
+#. placeholder {0}: getPlatformName(ct)
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid ""
+"Account not linked. Use /connect in {0} to\n"
+"enable delivery."
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Patient details"
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Therapy profile"
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Finish setting up"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Choose how you'd like to set up Nocturne."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Import your existing data — entries, treatments, and history."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Start Fresh"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Connect a glucose data source to get started."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to load data sources"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Connect a Data Source - Setup - Nocturne"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Connect a Data Source"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Choose a cloud service or phone app to start sending glucose and treatment data to Nocturne."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Cloud Services"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Phone Apps"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "No data sources available"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "There are no data sources available at this time."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Skip for now"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Back to data sources"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Continue to Dashboard"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Invalid or expired device code."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Invalid or expired device code. Please check and try again."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to approve. The code may have expired."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to deny the request."
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "{0} is now connected. You can return to your device."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Receiving Data"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "It can take a few minutes for the first glucose reading to arrive. This page will update automatically."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "This application is not in the Nocturne known app directory. Only approve if you trust it."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "This app is requesting full access, including the ability to delete data."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Scan to Connect"
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Scan this QR code with your phone's camera to open {0} and start the connection."
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "QR code to connect {0}"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Enter Authorization Code"
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "After scanning, {0} will show an 8-character code. Enter it here to approve the connection."
 msgstr ""

--- a/src/Web/locales/nl.po
+++ b/src/Web/locales/nl.po
@@ -24327,3 +24327,85 @@ msgstr ""
 #: src/routes/(fullscreen)/setup/patient/+page.svelte
 msgid "Weight (kg)"
 msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Opening xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Redirecting to xDrip+ to start the connection..."
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Connect xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "xDrip+ didn't open automatically. You can try these options:"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "<0/> Open in xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Manual setup"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "In xDrip+, go to Settings > Cloud Upload > Nocturne, enter this URL:"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Then tap \"Connect to Nocturne\" to authorize."
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Don't have xDrip+ installed?"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "<0/> Download xDrip+"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Quick Connect"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Automatically configure xDrip+ with your Nocturne instance."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Or scan from another device"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "QR code to connect xDrip+"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Scan this QR code with your phone's camera"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Or open this link on your phone"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "<0/> Waiting for data from xDrip+..."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "<0/> Connected! Data is flowing from xDrip+."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Check now"
+msgstr ""

--- a/src/Web/locales/nl.po
+++ b/src/Web/locales/nl.po
@@ -319,6 +319,8 @@ msgstr ""
 #: src/lib/components/WebSocketStatus.svelte
 #: src/lib/components/dashboard/widgets/ConnectionStatusWidget.svelte
 #: src/routes/(fullscreen)/auth/bot/authorize/done/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/auth/bot/authorize/done/+page.svelte
@@ -1258,6 +1260,7 @@ msgstr ""
 #: src/lib/components/patient/PatientDeviceManager.svelte
 #: src/lib/components/profile/ProfileEditDialog.svelte
 #: src/lib/components/status-pills/TrackerPill.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
@@ -1534,6 +1537,7 @@ msgid "Method"
 msgstr ""
 
 #: src/lib/components/treatments/TreatmentCategoryTabs.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/compatibility/+page.svelte
 #: src/routes/compatibility/+page.svelte
@@ -2823,11 +2827,8 @@ msgstr ""
 msgid "Available"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Coming Soon"
-msgstr ""
+#~ msgid "Coming Soon"
+#~ msgstr ""
 
 #: src/routes/reports/executive-summary/+page.svelte
 msgid "Clinical details"
@@ -3193,8 +3194,8 @@ msgstr ""
 msgid "Customize themes, colors, units, and display preferences"
 msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/lib/components/rbac/PermissionPicker.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/+page.svelte
 #: src/routes/settings/devices/+page.svelte
 #: src/routes/settings/patient/+page.svelte
@@ -3261,7 +3262,6 @@ msgid "Connect data sources like Dexcom, Libre, and more"
 msgstr ""
 
 #: src/lib/components/StepIndicator.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/download/+page.svelte
 #: src/routes/settings/+page.svelte
 #: src/routes/settings/setup/+page.svelte
@@ -6953,6 +6953,8 @@ msgid "Or continue with"
 msgstr ""
 
 #: src/lib/components/auth/LoginForm.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "<0/> Redirecting..."
 msgstr ""
@@ -7815,6 +7817,7 @@ msgstr ""
 msgid "Performance"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
 msgid "← Back"
 msgstr ""
@@ -9438,6 +9441,7 @@ msgstr ""
 msgid "Failed to load admin data"
 msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/settings/admin/+page.svelte
 #: src/routes/settings/admin/+page.svelte
 msgid "Public"
@@ -11014,6 +11018,7 @@ msgstr ""
 msgid "Connect your CGM app or AID system to push data to Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 #: src/routes/settings/services/+page.svelte
@@ -11021,6 +11026,7 @@ msgstr ""
 msgid "CGM Apps"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 #: src/routes/settings/services/+page.svelte
@@ -12697,7 +12703,6 @@ msgstr ""
 
 #: src/lib/components/StepIndicator.svelte
 #: src/lib/components/layout/AppSidebar.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Setup"
 msgstr ""
@@ -12717,6 +12722,7 @@ msgstr ""
 #: src/lib/components/SiteFooter.svelte
 #: src/lib/components/SiteHeader.svelte
 #: src/lib/components/SiteHeader.svelte
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/migrate/+page.svelte
 #: src/routes/settings/setup/migrate/+page.svelte
 msgid "Get Started"
@@ -12824,6 +12830,7 @@ msgstr ""
 #~ msgid "Fresh Install Setup"
 #~ msgstr ""
 
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/setup/+page.svelte
 msgid "Migrate from Nightscout"
 msgstr ""
@@ -13938,6 +13945,7 @@ msgstr ""
 #~ msgid "Positive = ate after bolusing, Negative = ate before bolusing"
 #~ msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/lib/components/meal-matching/MealMatchReviewDialog.svelte
 #: src/routes/meals/+page.svelte
 msgid "Dismiss"
@@ -18187,6 +18195,7 @@ msgid "Checking availability..."
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -18903,7 +18912,6 @@ msgid "mg/dL/U <0/>"
 msgstr ""
 
 #: src/lib/components/layout/AppSidebar.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/patient/+page.svelte
 #: src/routes/settings/patient/+page.svelte
 #: src/routes/settings/setup/+page.svelte
@@ -19058,7 +19066,7 @@ msgstr ""
 msgid "SN: {0}"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/settings/patient/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Insulins"
@@ -19124,7 +19132,6 @@ msgid "Serial Number"
 msgstr ""
 
 #: src/lib/components/patient/PatientDeviceManager.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Optional"
 msgstr ""
@@ -19193,34 +19200,28 @@ msgid ""
 "undone."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Set your diabetes type and clinical information"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Add the devices you currently use"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Add the insulins you currently use"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Connect external data sources"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/profile/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 #: src/routes/settings/setup/profile/+page.svelte
 msgid "Therapy Profile"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Configure your basal rates and therapy settings"
 msgstr ""
@@ -19583,14 +19584,12 @@ msgstr ""
 msgid "Alert when CGM signal is lost for an extended period"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Browser Push Notification"
-msgstr ""
+#~ msgid "Browser Push Notification"
+#~ msgstr ""
 
+#: src/lib/components/alerts/ChannelPicker.svelte
 #: src/lib/components/alerts/RuleEditorSheet.svelte
 #: src/lib/components/alerts/RuleEditorSheet.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
 msgid "Webhook"
 msgstr ""
 
@@ -19654,39 +19653,34 @@ msgstr ""
 msgid "Choose how you want to receive alert notifications."
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Browser Push Notifications"
-msgstr ""
+#~ msgid "Browser Push Notifications"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
 msgid "Receive alerts directly in your browser"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
 msgid "Send alert data to a custom URL"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Webhook URL"
-msgstr ""
+#~ msgid "Webhook URL"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 msgid "Discord"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Send alerts to a Discord channel"
-msgstr ""
+#~ msgid "Send alerts to a Discord channel"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
 msgid "Telegram"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Send alerts to a Telegram chat"
-msgstr ""
+#~ msgid "Send alerts to a Telegram chat"
+#~ msgstr ""
 
 #: src/routes/settings/alerts/setup/+page.svelte
 msgid "Review your alert configuration before saving."
@@ -19715,10 +19709,8 @@ msgid ""
 "the dashboard, but no push notifications will be sent."
 msgstr ""
 
-#. placeholder {0}: webhookUrl
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Webhook: {0}"
-msgstr ""
+#~ msgid "Webhook: {0}"
+#~ msgstr ""
 
 #: src/routes/settings/alerts/setup/+page.svelte
 msgid "Medical Disclaimer"
@@ -20285,16 +20277,15 @@ msgstr ""
 #~ msgid "<0/> {0} Synced Successfully"
 #~ msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Uploaders"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Configure a phone app to push data to Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "General Uploaders"
@@ -20307,16 +20298,19 @@ msgstr ""
 msgid "Failed to load uploader apps"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Android"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Desktop"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Web"
@@ -20376,11 +20370,13 @@ msgstr ""
 
 #. placeholder {0}: selectedApp?.name
 #. placeholder {1}: ds.entriesLast24h ?? 0
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "{0} is sending data. {1} entries in the last 24 hours."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Waiting for data"
@@ -20392,22 +20388,26 @@ msgstr ""
 msgid "Once you've configured {0}, it can take up to five minutes for the first glucose data to arrive. This page will update automatically."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Failed to load setup instructions"
 msgstr ""
 
 #. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Could not load setup details for {0}. Please try again."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "<0/> iOS"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "<0/> Android"
@@ -20896,6 +20896,7 @@ msgstr ""
 msgid "{0} - Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Device Authorized"
 msgstr ""
@@ -20904,14 +20905,17 @@ msgstr ""
 msgid "You can close this window and return to your device."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Authorization Denied"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "The device will not be granted access."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Authorize Application"
@@ -20930,11 +20934,13 @@ msgid ""
 "approve if you trust this application."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "This application is requesting permission to:"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "This app cannot delete your data."
@@ -20947,12 +20953,14 @@ msgid ""
 "data."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 #: src/routes/settings/access-requests/+page.svelte
 msgid "<0/> Deny"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 #: src/routes/settings/access-requests/+page.svelte
@@ -21120,6 +21128,7 @@ msgstr ""
 msgid "<0/> is requesting additional access to your Nocturne data."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 msgid "<0/> wants to access your Nocturne data."
 msgstr ""
@@ -21151,6 +21160,7 @@ msgstr ""
 msgid "Invite Not Found"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "This invite link is invalid or has expired."
 msgstr ""
@@ -21199,6 +21209,7 @@ msgstr ""
 #~ msgid "You'll be able to see:"
 #~ msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "<0/> Accept Invite"
 msgstr ""
@@ -21218,6 +21229,8 @@ msgstr ""
 msgid "Invite not found or has expired."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.server.ts
 #: src/routes/invite/[token]/+page.svelte
 msgid "Failed to accept invite."
@@ -21245,6 +21258,7 @@ msgstr ""
 #: src/lib/components/auth/LoginForm.svelte
 #: src/lib/components/auth/LoginForm.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21269,6 +21283,7 @@ msgstr ""
 #: src/lib/components/auth/LoginForm.svelte
 #: src/lib/components/auth/LoginForm.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21310,12 +21325,10 @@ msgstr ""
 msgid "API Access"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Passkey"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Set up passwordless authentication with a passkey"
 msgstr ""
@@ -21336,6 +21349,7 @@ msgstr ""
 
 #: src/routes/(fullscreen)/auth/help/+page.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/help/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
@@ -21350,6 +21364,7 @@ msgid "Save these recovery codes in a safe place. Each code can only be used onc
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21358,6 +21373,7 @@ msgid "<0/> Codes copied"
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21365,6 +21381,7 @@ msgstr ""
 msgid "<0/> Copy recovery codes"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "Continue to Nocturne"
 msgstr ""
@@ -21376,6 +21393,7 @@ msgid "Copy your recovery codes before continuing."
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21499,6 +21517,7 @@ msgstr ""
 msgid "Revoke"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/settings/account/+page.svelte
 #: src/routes/settings/security/+page.svelte
 msgid "Failed to register passkey."
@@ -21727,16 +21746,15 @@ msgstr ""
 msgid "Passkey Setup - Setup - Nocturne"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "Set Up Your Passkey"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "Create a passkey for secure, passwordless authentication. You will also receive recovery codes in case you lose access to your passkey."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "This is how you will appear to others."
@@ -21769,11 +21787,13 @@ msgid ""
 "be used once."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "You must copy your recovery codes before continuing."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid ""
@@ -21813,6 +21833,7 @@ msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/auth/bot/authorize/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
@@ -23032,6 +23053,7 @@ msgstr ""
 msgid "Full access"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "Loading invite..."
 msgstr ""
@@ -23185,12 +23207,10 @@ msgstr ""
 msgid "{0} synced so far"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Coming from Nightscout?"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Migrate your data and keep both systems in sync during transition"
 msgstr ""
@@ -23465,30 +23485,26 @@ msgstr ""
 msgid "Register a passkey to restore normal access."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/(fullscreen)/setup/permissions/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 #: src/routes/settings/setup/permissions/+page.svelte
 msgid "Sharing & Privacy"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Choose who can see your data"
 msgstr ""
 
 #. placeholder {0}: requiredComplete
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "{0} of 6 required steps complete"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Finishing..."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Finish Setup"
 msgstr ""
@@ -24328,84 +24344,286 @@ msgstr ""
 msgid "Weight (kg)"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Opening xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "No invite token provided. Please check the link you were given."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Redirecting to xDrip+ to start the connection..."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite has expired."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Connect xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite has been revoked."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "xDrip+ didn't open automatically. You can try these options:"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite is no longer valid."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "<0/> Open in xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Join - Nocturne"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Manual setup"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Invalid Invite"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "In xDrip+, go to Settings > Cloud Upload > Nocturne, enter this URL:"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "You're In"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Then tap \"Connect to Nocturne\" to authorize."
+#. placeholder {0}: inviteInfo.tenantName ?? "the site"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Your account has been created and you've joined {0}."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Don't have xDrip+ installed?"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid ""
+"Save these recovery codes in a safe place. If you lose access to\n"
+"your passkey, you can use one of these codes to sign in. Each code\n"
+"can only be used once."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "<0/> Download xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Accept Invite"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Quick Connect"
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> has invited you to join"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Automatically configure xDrip+ with your Nocturne instance."
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "You've been invited to join"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Or scan from another device"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> Joining..."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "QR code to connect xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Join Nocturne"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Scan this QR code with your phone's camera"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid ""
+"<0/> <1/>.\n"
+"Create an account or sign in to accept."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Or open this link on your phone"
+#. placeholder {0}: provider.name
+#. placeholder {0}: provider.name
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "<0/> Continue with {0}"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "<0/> Waiting for data from xDrip+..."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Or create an account with a passkey"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "<0/> Connected! Data is flowing from xDrip+."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "A unique identifier for your account."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> Create account with passkey"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Check now"
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Set Up Your Account"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Choose how you want to authenticate. You can use an external provider for quick setup, or register a passkey for passwordless authentication."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Or set up with a passkey"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "Discord DM"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "Slack DM"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "WhatsApp"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Browser Push"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts as a Discord direct message"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts as a Slack direct message"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts to your Telegram chat"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts to your WhatsApp"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "No notification channels are currently available."
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Service hasn't reported recently — alerts may be delayed"
+msgstr ""
+
+#. placeholder {0}: getPlatformName(ct)
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid ""
+"Account not linked. Use /connect in {0} to\n"
+"enable delivery."
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Patient details"
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Therapy profile"
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Finish setting up"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Choose how you'd like to set up Nocturne."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Import your existing data — entries, treatments, and history."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Start Fresh"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Connect a glucose data source to get started."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to load data sources"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Connect a Data Source - Setup - Nocturne"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Connect a Data Source"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Choose a cloud service or phone app to start sending glucose and treatment data to Nocturne."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Cloud Services"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Phone Apps"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "No data sources available"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "There are no data sources available at this time."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Skip for now"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Back to data sources"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Continue to Dashboard"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Invalid or expired device code."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Invalid or expired device code. Please check and try again."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to approve. The code may have expired."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to deny the request."
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "{0} is now connected. You can return to your device."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Receiving Data"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "It can take a few minutes for the first glucose reading to arrive. This page will update automatically."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "This application is not in the Nocturne known app directory. Only approve if you trust it."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "This app is requesting full access, including the ability to delete data."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Scan to Connect"
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Scan this QR code with your phone's camera to open {0} and start the connection."
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "QR code to connect {0}"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Enter Authorization Code"
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "After scanning, {0} will show an 8-character code. Enter it here to approve the connection."
 msgstr ""

--- a/src/Web/locales/pt.po
+++ b/src/Web/locales/pt.po
@@ -24327,3 +24327,85 @@ msgstr ""
 #: src/routes/(fullscreen)/setup/patient/+page.svelte
 msgid "Weight (kg)"
 msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Opening xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Redirecting to xDrip+ to start the connection..."
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Connect xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "xDrip+ didn't open automatically. You can try these options:"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "<0/> Open in xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Manual setup"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "In xDrip+, go to Settings > Cloud Upload > Nocturne, enter this URL:"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Then tap \"Connect to Nocturne\" to authorize."
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Don't have xDrip+ installed?"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "<0/> Download xDrip+"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Quick Connect"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Automatically configure xDrip+ with your Nocturne instance."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Or scan from another device"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "QR code to connect xDrip+"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Scan this QR code with your phone's camera"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Or open this link on your phone"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "<0/> Waiting for data from xDrip+..."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "<0/> Connected! Data is flowing from xDrip+."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Check now"
+msgstr ""

--- a/src/Web/locales/pt.po
+++ b/src/Web/locales/pt.po
@@ -319,6 +319,8 @@ msgstr ""
 #: src/lib/components/WebSocketStatus.svelte
 #: src/lib/components/dashboard/widgets/ConnectionStatusWidget.svelte
 #: src/routes/(fullscreen)/auth/bot/authorize/done/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/auth/bot/authorize/done/+page.svelte
@@ -1258,6 +1260,7 @@ msgstr ""
 #: src/lib/components/patient/PatientDeviceManager.svelte
 #: src/lib/components/profile/ProfileEditDialog.svelte
 #: src/lib/components/status-pills/TrackerPill.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
@@ -1534,6 +1537,7 @@ msgid "Method"
 msgstr ""
 
 #: src/lib/components/treatments/TreatmentCategoryTabs.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/compatibility/+page.svelte
 #: src/routes/compatibility/+page.svelte
@@ -2823,11 +2827,8 @@ msgstr ""
 msgid "Available"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Coming Soon"
-msgstr ""
+#~ msgid "Coming Soon"
+#~ msgstr ""
 
 #: src/routes/reports/executive-summary/+page.svelte
 msgid "Clinical details"
@@ -3193,8 +3194,8 @@ msgstr ""
 msgid "Customize themes, colors, units, and display preferences"
 msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/lib/components/rbac/PermissionPicker.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/+page.svelte
 #: src/routes/settings/devices/+page.svelte
 #: src/routes/settings/patient/+page.svelte
@@ -3261,7 +3262,6 @@ msgid "Connect data sources like Dexcom, Libre, and more"
 msgstr ""
 
 #: src/lib/components/StepIndicator.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/download/+page.svelte
 #: src/routes/settings/+page.svelte
 #: src/routes/settings/setup/+page.svelte
@@ -6953,6 +6953,8 @@ msgid "Or continue with"
 msgstr ""
 
 #: src/lib/components/auth/LoginForm.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "<0/> Redirecting..."
 msgstr ""
@@ -7815,6 +7817,7 @@ msgstr ""
 msgid "Performance"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
 msgid "← Back"
 msgstr ""
@@ -9438,6 +9441,7 @@ msgstr ""
 msgid "Failed to load admin data"
 msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/settings/admin/+page.svelte
 #: src/routes/settings/admin/+page.svelte
 msgid "Public"
@@ -11014,6 +11018,7 @@ msgstr ""
 msgid "Connect your CGM app or AID system to push data to Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 #: src/routes/settings/services/+page.svelte
@@ -11021,6 +11026,7 @@ msgstr ""
 msgid "CGM Apps"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 #: src/routes/settings/services/+page.svelte
@@ -12697,7 +12703,6 @@ msgstr ""
 
 #: src/lib/components/StepIndicator.svelte
 #: src/lib/components/layout/AppSidebar.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Setup"
 msgstr ""
@@ -12717,6 +12722,7 @@ msgstr ""
 #: src/lib/components/SiteFooter.svelte
 #: src/lib/components/SiteHeader.svelte
 #: src/lib/components/SiteHeader.svelte
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/migrate/+page.svelte
 #: src/routes/settings/setup/migrate/+page.svelte
 msgid "Get Started"
@@ -12824,6 +12830,7 @@ msgstr ""
 #~ msgid "Fresh Install Setup"
 #~ msgstr ""
 
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/setup/+page.svelte
 msgid "Migrate from Nightscout"
 msgstr ""
@@ -13938,6 +13945,7 @@ msgstr ""
 #~ msgid "Positive = ate after bolusing, Negative = ate before bolusing"
 #~ msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/lib/components/meal-matching/MealMatchReviewDialog.svelte
 #: src/routes/meals/+page.svelte
 msgid "Dismiss"
@@ -18187,6 +18195,7 @@ msgid "Checking availability..."
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -18903,7 +18912,6 @@ msgid "mg/dL/U <0/>"
 msgstr ""
 
 #: src/lib/components/layout/AppSidebar.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/patient/+page.svelte
 #: src/routes/settings/patient/+page.svelte
 #: src/routes/settings/setup/+page.svelte
@@ -19058,7 +19066,7 @@ msgstr ""
 msgid "SN: {0}"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/settings/patient/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Insulins"
@@ -19124,7 +19132,6 @@ msgid "Serial Number"
 msgstr ""
 
 #: src/lib/components/patient/PatientDeviceManager.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Optional"
 msgstr ""
@@ -19193,34 +19200,28 @@ msgid ""
 "undone."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Set your diabetes type and clinical information"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Add the devices you currently use"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Add the insulins you currently use"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Connect external data sources"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/profile/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 #: src/routes/settings/setup/profile/+page.svelte
 msgid "Therapy Profile"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Configure your basal rates and therapy settings"
 msgstr ""
@@ -19583,14 +19584,12 @@ msgstr ""
 msgid "Alert when CGM signal is lost for an extended period"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Browser Push Notification"
-msgstr ""
+#~ msgid "Browser Push Notification"
+#~ msgstr ""
 
+#: src/lib/components/alerts/ChannelPicker.svelte
 #: src/lib/components/alerts/RuleEditorSheet.svelte
 #: src/lib/components/alerts/RuleEditorSheet.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
 msgid "Webhook"
 msgstr ""
 
@@ -19654,39 +19653,34 @@ msgstr ""
 msgid "Choose how you want to receive alert notifications."
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Browser Push Notifications"
-msgstr ""
+#~ msgid "Browser Push Notifications"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
 msgid "Receive alerts directly in your browser"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
 msgid "Send alert data to a custom URL"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Webhook URL"
-msgstr ""
+#~ msgid "Webhook URL"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 msgid "Discord"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Send alerts to a Discord channel"
-msgstr ""
+#~ msgid "Send alerts to a Discord channel"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
 msgid "Telegram"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Send alerts to a Telegram chat"
-msgstr ""
+#~ msgid "Send alerts to a Telegram chat"
+#~ msgstr ""
 
 #: src/routes/settings/alerts/setup/+page.svelte
 msgid "Review your alert configuration before saving."
@@ -19715,10 +19709,8 @@ msgid ""
 "the dashboard, but no push notifications will be sent."
 msgstr ""
 
-#. placeholder {0}: webhookUrl
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Webhook: {0}"
-msgstr ""
+#~ msgid "Webhook: {0}"
+#~ msgstr ""
 
 #: src/routes/settings/alerts/setup/+page.svelte
 msgid "Medical Disclaimer"
@@ -20285,16 +20277,15 @@ msgstr ""
 #~ msgid "<0/> {0} Synced Successfully"
 #~ msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Uploaders"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Configure a phone app to push data to Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "General Uploaders"
@@ -20307,16 +20298,19 @@ msgstr ""
 msgid "Failed to load uploader apps"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Android"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Desktop"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Web"
@@ -20376,11 +20370,13 @@ msgstr ""
 
 #. placeholder {0}: selectedApp?.name
 #. placeholder {1}: ds.entriesLast24h ?? 0
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "{0} is sending data. {1} entries in the last 24 hours."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Waiting for data"
@@ -20392,22 +20388,26 @@ msgstr ""
 msgid "Once you've configured {0}, it can take up to five minutes for the first glucose data to arrive. This page will update automatically."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Failed to load setup instructions"
 msgstr ""
 
 #. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Could not load setup details for {0}. Please try again."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "<0/> iOS"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "<0/> Android"
@@ -20896,6 +20896,7 @@ msgstr ""
 msgid "{0} - Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Device Authorized"
 msgstr ""
@@ -20904,14 +20905,17 @@ msgstr ""
 msgid "You can close this window and return to your device."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Authorization Denied"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "The device will not be granted access."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Authorize Application"
@@ -20930,11 +20934,13 @@ msgid ""
 "approve if you trust this application."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "This application is requesting permission to:"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "This app cannot delete your data."
@@ -20947,12 +20953,14 @@ msgid ""
 "data."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 #: src/routes/settings/access-requests/+page.svelte
 msgid "<0/> Deny"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 #: src/routes/settings/access-requests/+page.svelte
@@ -21120,6 +21128,7 @@ msgstr ""
 msgid "<0/> is requesting additional access to your Nocturne data."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 msgid "<0/> wants to access your Nocturne data."
 msgstr ""
@@ -21151,6 +21160,7 @@ msgstr ""
 msgid "Invite Not Found"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "This invite link is invalid or has expired."
 msgstr ""
@@ -21199,6 +21209,7 @@ msgstr ""
 #~ msgid "You'll be able to see:"
 #~ msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "<0/> Accept Invite"
 msgstr ""
@@ -21218,6 +21229,8 @@ msgstr ""
 msgid "Invite not found or has expired."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.server.ts
 #: src/routes/invite/[token]/+page.svelte
 msgid "Failed to accept invite."
@@ -21245,6 +21258,7 @@ msgstr ""
 #: src/lib/components/auth/LoginForm.svelte
 #: src/lib/components/auth/LoginForm.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21269,6 +21283,7 @@ msgstr ""
 #: src/lib/components/auth/LoginForm.svelte
 #: src/lib/components/auth/LoginForm.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21310,12 +21325,10 @@ msgstr ""
 msgid "API Access"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Passkey"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Set up passwordless authentication with a passkey"
 msgstr ""
@@ -21448,6 +21461,7 @@ msgstr ""
 
 #: src/routes/(fullscreen)/auth/help/+page.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/help/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
@@ -21462,6 +21476,7 @@ msgid "Save these recovery codes in a safe place. Each code can only be used onc
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21470,6 +21485,7 @@ msgid "<0/> Codes copied"
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21477,6 +21493,7 @@ msgstr ""
 msgid "<0/> Copy recovery codes"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "Continue to Nocturne"
 msgstr ""
@@ -21488,6 +21505,7 @@ msgid "Copy your recovery codes before continuing."
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21499,6 +21517,7 @@ msgstr ""
 msgid "<0/> Register with passkey"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/settings/account/+page.svelte
 #: src/routes/settings/security/+page.svelte
 msgid "Failed to register passkey."
@@ -21727,16 +21746,15 @@ msgstr ""
 msgid "Passkey Setup - Setup - Nocturne"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "Set Up Your Passkey"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "Create a passkey for secure, passwordless authentication. You will also receive recovery codes in case you lose access to your passkey."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "This is how you will appear to others."
@@ -21769,11 +21787,13 @@ msgid ""
 "be used once."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "You must copy your recovery codes before continuing."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid ""
@@ -21813,6 +21833,7 @@ msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/auth/bot/authorize/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
@@ -22895,6 +22916,7 @@ msgstr ""
 msgid "Full access"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "Loading invite..."
 msgstr ""
@@ -23185,12 +23207,10 @@ msgstr ""
 msgid "{0} synced so far"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Coming from Nightscout?"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Migrate your data and keep both systems in sync during transition"
 msgstr ""
@@ -23465,30 +23485,26 @@ msgstr ""
 msgid "Register a passkey to restore normal access."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/(fullscreen)/setup/permissions/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 #: src/routes/settings/setup/permissions/+page.svelte
 msgid "Sharing & Privacy"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Choose who can see your data"
 msgstr ""
 
 #. placeholder {0}: requiredComplete
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "{0} of 6 required steps complete"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Finishing..."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Finish Setup"
 msgstr ""
@@ -24328,84 +24344,286 @@ msgstr ""
 msgid "Weight (kg)"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Opening xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "No invite token provided. Please check the link you were given."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Redirecting to xDrip+ to start the connection..."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite has expired."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Connect xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite has been revoked."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "xDrip+ didn't open automatically. You can try these options:"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite is no longer valid."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "<0/> Open in xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Join - Nocturne"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Manual setup"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Invalid Invite"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "In xDrip+, go to Settings > Cloud Upload > Nocturne, enter this URL:"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "You're In"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Then tap \"Connect to Nocturne\" to authorize."
+#. placeholder {0}: inviteInfo.tenantName ?? "the site"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Your account has been created and you've joined {0}."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Don't have xDrip+ installed?"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid ""
+"Save these recovery codes in a safe place. If you lose access to\n"
+"your passkey, you can use one of these codes to sign in. Each code\n"
+"can only be used once."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "<0/> Download xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Accept Invite"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Quick Connect"
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> has invited you to join"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Automatically configure xDrip+ with your Nocturne instance."
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "You've been invited to join"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Or scan from another device"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> Joining..."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "QR code to connect xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Join Nocturne"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Scan this QR code with your phone's camera"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid ""
+"<0/> <1/>.\n"
+"Create an account or sign in to accept."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Or open this link on your phone"
+#. placeholder {0}: provider.name
+#. placeholder {0}: provider.name
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "<0/> Continue with {0}"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "<0/> Waiting for data from xDrip+..."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Or create an account with a passkey"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "<0/> Connected! Data is flowing from xDrip+."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "A unique identifier for your account."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> Create account with passkey"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Check now"
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Set Up Your Account"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Choose how you want to authenticate. You can use an external provider for quick setup, or register a passkey for passwordless authentication."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Or set up with a passkey"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "Discord DM"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "Slack DM"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "WhatsApp"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Browser Push"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts as a Discord direct message"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts as a Slack direct message"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts to your Telegram chat"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts to your WhatsApp"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "No notification channels are currently available."
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Service hasn't reported recently — alerts may be delayed"
+msgstr ""
+
+#. placeholder {0}: getPlatformName(ct)
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid ""
+"Account not linked. Use /connect in {0} to\n"
+"enable delivery."
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Patient details"
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Therapy profile"
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Finish setting up"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Choose how you'd like to set up Nocturne."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Import your existing data — entries, treatments, and history."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Start Fresh"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Connect a glucose data source to get started."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to load data sources"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Connect a Data Source - Setup - Nocturne"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Connect a Data Source"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Choose a cloud service or phone app to start sending glucose and treatment data to Nocturne."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Cloud Services"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Phone Apps"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "No data sources available"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "There are no data sources available at this time."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Skip for now"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Back to data sources"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Continue to Dashboard"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Invalid or expired device code."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Invalid or expired device code. Please check and try again."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to approve. The code may have expired."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to deny the request."
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "{0} is now connected. You can return to your device."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Receiving Data"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "It can take a few minutes for the first glucose reading to arrive. This page will update automatically."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "This application is not in the Nocturne known app directory. Only approve if you trust it."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "This app is requesting full access, including the ability to delete data."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Scan to Connect"
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Scan this QR code with your phone's camera to open {0} and start the connection."
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "QR code to connect {0}"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Enter Authorization Code"
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "After scanning, {0} will show an 8-character code. Enter it here to approve the connection."
 msgstr ""

--- a/src/Web/locales/ru.po
+++ b/src/Web/locales/ru.po
@@ -24327,3 +24327,85 @@ msgstr ""
 #: src/routes/(fullscreen)/setup/patient/+page.svelte
 msgid "Weight (kg)"
 msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Opening xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Redirecting to xDrip+ to start the connection..."
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Connect xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "xDrip+ didn't open automatically. You can try these options:"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "<0/> Open in xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Manual setup"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "In xDrip+, go to Settings > Cloud Upload > Nocturne, enter this URL:"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Then tap \"Connect to Nocturne\" to authorize."
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Don't have xDrip+ installed?"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "<0/> Download xDrip+"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Quick Connect"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Automatically configure xDrip+ with your Nocturne instance."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Or scan from another device"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "QR code to connect xDrip+"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Scan this QR code with your phone's camera"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Or open this link on your phone"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "<0/> Waiting for data from xDrip+..."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "<0/> Connected! Data is flowing from xDrip+."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Check now"
+msgstr ""

--- a/src/Web/locales/ru.po
+++ b/src/Web/locales/ru.po
@@ -319,6 +319,8 @@ msgstr ""
 #: src/lib/components/WebSocketStatus.svelte
 #: src/lib/components/dashboard/widgets/ConnectionStatusWidget.svelte
 #: src/routes/(fullscreen)/auth/bot/authorize/done/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/auth/bot/authorize/done/+page.svelte
@@ -1258,6 +1260,7 @@ msgstr ""
 #: src/lib/components/patient/PatientDeviceManager.svelte
 #: src/lib/components/profile/ProfileEditDialog.svelte
 #: src/lib/components/status-pills/TrackerPill.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
@@ -1534,6 +1537,7 @@ msgid "Method"
 msgstr ""
 
 #: src/lib/components/treatments/TreatmentCategoryTabs.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/compatibility/+page.svelte
 #: src/routes/compatibility/+page.svelte
@@ -2823,11 +2827,8 @@ msgstr ""
 msgid "Available"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Coming Soon"
-msgstr ""
+#~ msgid "Coming Soon"
+#~ msgstr ""
 
 #: src/routes/reports/executive-summary/+page.svelte
 msgid "Clinical details"
@@ -3193,8 +3194,8 @@ msgstr ""
 msgid "Customize themes, colors, units, and display preferences"
 msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/lib/components/rbac/PermissionPicker.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/+page.svelte
 #: src/routes/settings/devices/+page.svelte
 #: src/routes/settings/patient/+page.svelte
@@ -3261,7 +3262,6 @@ msgid "Connect data sources like Dexcom, Libre, and more"
 msgstr ""
 
 #: src/lib/components/StepIndicator.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/download/+page.svelte
 #: src/routes/settings/+page.svelte
 #: src/routes/settings/setup/+page.svelte
@@ -6953,6 +6953,8 @@ msgid "Or continue with"
 msgstr ""
 
 #: src/lib/components/auth/LoginForm.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "<0/> Redirecting..."
 msgstr ""
@@ -7815,6 +7817,7 @@ msgstr ""
 msgid "Performance"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
 msgid "← Back"
 msgstr ""
@@ -9438,6 +9441,7 @@ msgstr ""
 msgid "Failed to load admin data"
 msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/settings/admin/+page.svelte
 #: src/routes/settings/admin/+page.svelte
 msgid "Public"
@@ -11014,6 +11018,7 @@ msgstr ""
 msgid "Connect your CGM app or AID system to push data to Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 #: src/routes/settings/services/+page.svelte
@@ -11021,6 +11026,7 @@ msgstr ""
 msgid "CGM Apps"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 #: src/routes/settings/services/+page.svelte
@@ -12697,7 +12703,6 @@ msgstr ""
 
 #: src/lib/components/StepIndicator.svelte
 #: src/lib/components/layout/AppSidebar.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Setup"
 msgstr ""
@@ -12717,6 +12722,7 @@ msgstr ""
 #: src/lib/components/SiteFooter.svelte
 #: src/lib/components/SiteHeader.svelte
 #: src/lib/components/SiteHeader.svelte
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/migrate/+page.svelte
 #: src/routes/settings/setup/migrate/+page.svelte
 msgid "Get Started"
@@ -12824,6 +12830,7 @@ msgstr ""
 #~ msgid "Fresh Install Setup"
 #~ msgstr ""
 
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/setup/+page.svelte
 msgid "Migrate from Nightscout"
 msgstr ""
@@ -13938,6 +13945,7 @@ msgstr ""
 #~ msgid "Positive = ate after bolusing, Negative = ate before bolusing"
 #~ msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/lib/components/meal-matching/MealMatchReviewDialog.svelte
 #: src/routes/meals/+page.svelte
 msgid "Dismiss"
@@ -18187,6 +18195,7 @@ msgid "Checking availability..."
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -18903,7 +18912,6 @@ msgid "mg/dL/U <0/>"
 msgstr ""
 
 #: src/lib/components/layout/AppSidebar.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/patient/+page.svelte
 #: src/routes/settings/patient/+page.svelte
 #: src/routes/settings/setup/+page.svelte
@@ -19058,7 +19066,7 @@ msgstr ""
 msgid "SN: {0}"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/settings/patient/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Insulins"
@@ -19124,7 +19132,6 @@ msgid "Serial Number"
 msgstr ""
 
 #: src/lib/components/patient/PatientDeviceManager.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Optional"
 msgstr ""
@@ -19193,34 +19200,28 @@ msgid ""
 "undone."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Set your diabetes type and clinical information"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Add the devices you currently use"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Add the insulins you currently use"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Connect external data sources"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/profile/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 #: src/routes/settings/setup/profile/+page.svelte
 msgid "Therapy Profile"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Configure your basal rates and therapy settings"
 msgstr ""
@@ -19583,14 +19584,12 @@ msgstr ""
 msgid "Alert when CGM signal is lost for an extended period"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Browser Push Notification"
-msgstr ""
+#~ msgid "Browser Push Notification"
+#~ msgstr ""
 
+#: src/lib/components/alerts/ChannelPicker.svelte
 #: src/lib/components/alerts/RuleEditorSheet.svelte
 #: src/lib/components/alerts/RuleEditorSheet.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
 msgid "Webhook"
 msgstr ""
 
@@ -19654,39 +19653,34 @@ msgstr ""
 msgid "Choose how you want to receive alert notifications."
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Browser Push Notifications"
-msgstr ""
+#~ msgid "Browser Push Notifications"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
 msgid "Receive alerts directly in your browser"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
 msgid "Send alert data to a custom URL"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Webhook URL"
-msgstr ""
+#~ msgid "Webhook URL"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 msgid "Discord"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Send alerts to a Discord channel"
-msgstr ""
+#~ msgid "Send alerts to a Discord channel"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
 msgid "Telegram"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Send alerts to a Telegram chat"
-msgstr ""
+#~ msgid "Send alerts to a Telegram chat"
+#~ msgstr ""
 
 #: src/routes/settings/alerts/setup/+page.svelte
 msgid "Review your alert configuration before saving."
@@ -19715,10 +19709,8 @@ msgid ""
 "the dashboard, but no push notifications will be sent."
 msgstr ""
 
-#. placeholder {0}: webhookUrl
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Webhook: {0}"
-msgstr ""
+#~ msgid "Webhook: {0}"
+#~ msgstr ""
 
 #: src/routes/settings/alerts/setup/+page.svelte
 msgid "Medical Disclaimer"
@@ -20285,16 +20277,15 @@ msgstr ""
 #~ msgid "<0/> {0} Synced Successfully"
 #~ msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Uploaders"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Configure a phone app to push data to Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "General Uploaders"
@@ -20307,16 +20298,19 @@ msgstr ""
 msgid "Failed to load uploader apps"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Android"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Desktop"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Web"
@@ -20376,11 +20370,13 @@ msgstr ""
 
 #. placeholder {0}: selectedApp?.name
 #. placeholder {1}: ds.entriesLast24h ?? 0
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "{0} is sending data. {1} entries in the last 24 hours."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Waiting for data"
@@ -20392,22 +20388,26 @@ msgstr ""
 msgid "Once you've configured {0}, it can take up to five minutes for the first glucose data to arrive. This page will update automatically."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Failed to load setup instructions"
 msgstr ""
 
 #. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Could not load setup details for {0}. Please try again."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "<0/> iOS"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "<0/> Android"
@@ -20896,6 +20896,7 @@ msgstr ""
 msgid "{0} - Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Device Authorized"
 msgstr ""
@@ -20904,14 +20905,17 @@ msgstr ""
 msgid "You can close this window and return to your device."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Authorization Denied"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "The device will not be granted access."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Authorize Application"
@@ -20930,11 +20934,13 @@ msgid ""
 "approve if you trust this application."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "This application is requesting permission to:"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "This app cannot delete your data."
@@ -20947,12 +20953,14 @@ msgid ""
 "data."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 #: src/routes/settings/access-requests/+page.svelte
 msgid "<0/> Deny"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 #: src/routes/settings/access-requests/+page.svelte
@@ -20981,6 +20989,7 @@ msgstr ""
 msgid "<0/> is requesting additional access to your Nocturne data."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 msgid "<0/> wants to access your Nocturne data."
 msgstr ""
@@ -21151,6 +21160,7 @@ msgstr ""
 msgid "Invite Not Found"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "This invite link is invalid or has expired."
 msgstr ""
@@ -21199,6 +21209,7 @@ msgstr ""
 #~ msgid "You'll be able to see:"
 #~ msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "<0/> Accept Invite"
 msgstr ""
@@ -21218,6 +21229,8 @@ msgstr ""
 msgid "Invite not found or has expired."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.server.ts
 #: src/routes/invite/[token]/+page.svelte
 msgid "Failed to accept invite."
@@ -21245,6 +21258,7 @@ msgstr ""
 #: src/lib/components/auth/LoginForm.svelte
 #: src/lib/components/auth/LoginForm.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21269,6 +21283,7 @@ msgstr ""
 #: src/lib/components/auth/LoginForm.svelte
 #: src/lib/components/auth/LoginForm.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21310,12 +21325,10 @@ msgstr ""
 msgid "API Access"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Passkey"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Set up passwordless authentication with a passkey"
 msgstr ""
@@ -21336,6 +21349,7 @@ msgstr ""
 
 #: src/routes/(fullscreen)/auth/help/+page.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/help/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
@@ -21350,6 +21364,7 @@ msgid "Save these recovery codes in a safe place. Each code can only be used onc
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21358,6 +21373,7 @@ msgid "<0/> Codes copied"
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21365,6 +21381,7 @@ msgstr ""
 msgid "<0/> Copy recovery codes"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "Continue to Nocturne"
 msgstr ""
@@ -21376,6 +21393,7 @@ msgid "Copy your recovery codes before continuing."
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21512,16 +21530,15 @@ msgstr ""
 msgid "Passkey Setup - Setup - Nocturne"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "Set Up Your Passkey"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "Create a passkey for secure, passwordless authentication. You will also receive recovery codes in case you lose access to your passkey."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "This is how you will appear to others."
@@ -21554,11 +21571,13 @@ msgid ""
 "be used once."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "You must copy your recovery codes before continuing."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid ""
@@ -21566,6 +21585,7 @@ msgid ""
 "from your account settings."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/settings/account/+page.svelte
 #: src/routes/settings/security/+page.svelte
 msgid "Failed to register passkey."
@@ -21813,6 +21833,7 @@ msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/auth/bot/authorize/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
@@ -23034,6 +23055,7 @@ msgstr ""
 msgid "Full access"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "Loading invite..."
 msgstr ""
@@ -23185,12 +23207,10 @@ msgstr ""
 msgid "{0} synced so far"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Coming from Nightscout?"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Migrate your data and keep both systems in sync during transition"
 msgstr ""
@@ -23465,30 +23485,26 @@ msgstr ""
 msgid "Register a passkey to restore normal access."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/(fullscreen)/setup/permissions/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 #: src/routes/settings/setup/permissions/+page.svelte
 msgid "Sharing & Privacy"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Choose who can see your data"
 msgstr ""
 
 #. placeholder {0}: requiredComplete
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "{0} of 6 required steps complete"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Finishing..."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Finish Setup"
 msgstr ""
@@ -24328,84 +24344,286 @@ msgstr ""
 msgid "Weight (kg)"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Opening xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "No invite token provided. Please check the link you were given."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Redirecting to xDrip+ to start the connection..."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite has expired."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Connect xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite has been revoked."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "xDrip+ didn't open automatically. You can try these options:"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite is no longer valid."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "<0/> Open in xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Join - Nocturne"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Manual setup"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Invalid Invite"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "In xDrip+, go to Settings > Cloud Upload > Nocturne, enter this URL:"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "You're In"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Then tap \"Connect to Nocturne\" to authorize."
+#. placeholder {0}: inviteInfo.tenantName ?? "the site"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Your account has been created and you've joined {0}."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Don't have xDrip+ installed?"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid ""
+"Save these recovery codes in a safe place. If you lose access to\n"
+"your passkey, you can use one of these codes to sign in. Each code\n"
+"can only be used once."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "<0/> Download xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Accept Invite"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Quick Connect"
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> has invited you to join"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Automatically configure xDrip+ with your Nocturne instance."
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "You've been invited to join"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Or scan from another device"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> Joining..."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "QR code to connect xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Join Nocturne"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Scan this QR code with your phone's camera"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid ""
+"<0/> <1/>.\n"
+"Create an account or sign in to accept."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Or open this link on your phone"
+#. placeholder {0}: provider.name
+#. placeholder {0}: provider.name
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "<0/> Continue with {0}"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "<0/> Waiting for data from xDrip+..."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Or create an account with a passkey"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "<0/> Connected! Data is flowing from xDrip+."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "A unique identifier for your account."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> Create account with passkey"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Check now"
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Set Up Your Account"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Choose how you want to authenticate. You can use an external provider for quick setup, or register a passkey for passwordless authentication."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Or set up with a passkey"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "Discord DM"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "Slack DM"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "WhatsApp"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Browser Push"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts as a Discord direct message"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts as a Slack direct message"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts to your Telegram chat"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts to your WhatsApp"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "No notification channels are currently available."
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Service hasn't reported recently — alerts may be delayed"
+msgstr ""
+
+#. placeholder {0}: getPlatformName(ct)
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid ""
+"Account not linked. Use /connect in {0} to\n"
+"enable delivery."
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Patient details"
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Therapy profile"
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Finish setting up"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Choose how you'd like to set up Nocturne."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Import your existing data — entries, treatments, and history."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Start Fresh"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Connect a glucose data source to get started."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to load data sources"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Connect a Data Source - Setup - Nocturne"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Connect a Data Source"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Choose a cloud service or phone app to start sending glucose and treatment data to Nocturne."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Cloud Services"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Phone Apps"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "No data sources available"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "There are no data sources available at this time."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Skip for now"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Back to data sources"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Continue to Dashboard"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Invalid or expired device code."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Invalid or expired device code. Please check and try again."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to approve. The code may have expired."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to deny the request."
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "{0} is now connected. You can return to your device."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Receiving Data"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "It can take a few minutes for the first glucose reading to arrive. This page will update automatically."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "This application is not in the Nocturne known app directory. Only approve if you trust it."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "This app is requesting full access, including the ability to delete data."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Scan to Connect"
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Scan this QR code with your phone's camera to open {0} and start the connection."
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "QR code to connect {0}"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Enter Authorization Code"
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "After scanning, {0} will show an 8-character code. Enter it here to approve the connection."
 msgstr ""

--- a/src/Web/locales/zh.po
+++ b/src/Web/locales/zh.po
@@ -24327,3 +24327,85 @@ msgstr ""
 #: src/routes/(fullscreen)/setup/patient/+page.svelte
 msgid "Weight (kg)"
 msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Opening xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Redirecting to xDrip+ to start the connection..."
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Connect xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "xDrip+ didn't open automatically. You can try these options:"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "<0/> Open in xDrip+"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Manual setup"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "In xDrip+, go to Settings > Cloud Upload > Nocturne, enter this URL:"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Then tap \"Connect to Nocturne\" to authorize."
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "Don't have xDrip+ installed?"
+msgstr ""
+
+#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
+msgid "<0/> Download xDrip+"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Quick Connect"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Automatically configure xDrip+ with your Nocturne instance."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Or scan from another device"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "QR code to connect xDrip+"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Scan this QR code with your phone's camera"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Or open this link on your phone"
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "<0/> Waiting for data from xDrip+..."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "<0/> Connected! Data is flowing from xDrip+."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading."
+msgstr ""
+
+#: src/lib/components/XdripQuickConnect.svelte
+msgid "Check now"
+msgstr ""

--- a/src/Web/locales/zh.po
+++ b/src/Web/locales/zh.po
@@ -319,6 +319,8 @@ msgstr ""
 #: src/lib/components/WebSocketStatus.svelte
 #: src/lib/components/dashboard/widgets/ConnectionStatusWidget.svelte
 #: src/routes/(fullscreen)/auth/bot/authorize/done/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/auth/bot/authorize/done/+page.svelte
@@ -1258,6 +1260,7 @@ msgstr ""
 #: src/lib/components/patient/PatientDeviceManager.svelte
 #: src/lib/components/profile/ProfileEditDialog.svelte
 #: src/lib/components/status-pills/TrackerPill.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
@@ -1534,6 +1537,7 @@ msgid "Method"
 msgstr ""
 
 #: src/lib/components/treatments/TreatmentCategoryTabs.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/compatibility/+page.svelte
 #: src/routes/compatibility/+page.svelte
@@ -2823,11 +2827,8 @@ msgstr ""
 msgid "Available"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Coming Soon"
-msgstr ""
+#~ msgid "Coming Soon"
+#~ msgstr ""
 
 #: src/routes/reports/executive-summary/+page.svelte
 msgid "Clinical details"
@@ -3193,8 +3194,8 @@ msgstr ""
 msgid "Customize themes, colors, units, and display preferences"
 msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/lib/components/rbac/PermissionPicker.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/+page.svelte
 #: src/routes/settings/devices/+page.svelte
 #: src/routes/settings/patient/+page.svelte
@@ -3261,7 +3262,6 @@ msgid "Connect data sources like Dexcom, Libre, and more"
 msgstr ""
 
 #: src/lib/components/StepIndicator.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/download/+page.svelte
 #: src/routes/settings/+page.svelte
 #: src/routes/settings/setup/+page.svelte
@@ -6953,6 +6953,8 @@ msgid "Or continue with"
 msgstr ""
 
 #: src/lib/components/auth/LoginForm.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "<0/> Redirecting..."
 msgstr ""
@@ -7815,6 +7817,7 @@ msgstr ""
 msgid "Performance"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/compatibility/[id]/+page.svelte
 msgid "← Back"
 msgstr ""
@@ -9438,6 +9441,7 @@ msgstr ""
 msgid "Failed to load admin data"
 msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/settings/admin/+page.svelte
 #: src/routes/settings/admin/+page.svelte
 msgid "Public"
@@ -11014,6 +11018,7 @@ msgstr ""
 msgid "Connect your CGM app or AID system to push data to Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 #: src/routes/settings/services/+page.svelte
@@ -11021,6 +11026,7 @@ msgstr ""
 msgid "CGM Apps"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 #: src/routes/settings/services/+page.svelte
@@ -12697,7 +12703,6 @@ msgstr ""
 
 #: src/lib/components/StepIndicator.svelte
 #: src/lib/components/layout/AppSidebar.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Setup"
 msgstr ""
@@ -12717,6 +12722,7 @@ msgstr ""
 #: src/lib/components/SiteFooter.svelte
 #: src/lib/components/SiteHeader.svelte
 #: src/lib/components/SiteHeader.svelte
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/migrate/+page.svelte
 #: src/routes/settings/setup/migrate/+page.svelte
 msgid "Get Started"
@@ -12824,6 +12830,7 @@ msgstr ""
 #~ msgid "Fresh Install Setup"
 #~ msgstr ""
 
+#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/setup/+page.svelte
 msgid "Migrate from Nightscout"
 msgstr ""
@@ -13938,6 +13945,7 @@ msgstr ""
 #~ msgid "Positive = ate after bolusing, Negative = ate before bolusing"
 #~ msgstr ""
 
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/lib/components/meal-matching/MealMatchReviewDialog.svelte
 #: src/routes/meals/+page.svelte
 msgid "Dismiss"
@@ -18187,6 +18195,7 @@ msgid "Checking availability..."
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -18903,7 +18912,6 @@ msgid "mg/dL/U <0/>"
 msgstr ""
 
 #: src/lib/components/layout/AppSidebar.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/patient/+page.svelte
 #: src/routes/settings/patient/+page.svelte
 #: src/routes/settings/setup/+page.svelte
@@ -19058,7 +19066,7 @@ msgstr ""
 msgid "SN: {0}"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/settings/patient/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Insulins"
@@ -19124,7 +19132,6 @@ msgid "Serial Number"
 msgstr ""
 
 #: src/lib/components/patient/PatientDeviceManager.svelte
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Optional"
 msgstr ""
@@ -19193,34 +19200,28 @@ msgid ""
 "undone."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Set your diabetes type and clinical information"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Add the devices you currently use"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Add the insulins you currently use"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Connect external data sources"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/(fullscreen)/setup/profile/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 #: src/routes/settings/setup/profile/+page.svelte
 msgid "Therapy Profile"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Configure your basal rates and therapy settings"
 msgstr ""
@@ -19583,14 +19584,12 @@ msgstr ""
 msgid "Alert when CGM signal is lost for an extended period"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Browser Push Notification"
-msgstr ""
+#~ msgid "Browser Push Notification"
+#~ msgstr ""
 
+#: src/lib/components/alerts/ChannelPicker.svelte
 #: src/lib/components/alerts/RuleEditorSheet.svelte
 #: src/lib/components/alerts/RuleEditorSheet.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
 msgid "Webhook"
 msgstr ""
 
@@ -19654,39 +19653,34 @@ msgstr ""
 msgid "Choose how you want to receive alert notifications."
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Browser Push Notifications"
-msgstr ""
+#~ msgid "Browser Push Notifications"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
 msgid "Receive alerts directly in your browser"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
 msgid "Send alert data to a custom URL"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Webhook URL"
-msgstr ""
+#~ msgid "Webhook URL"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
 #: src/routes/settings/connectors/+page.svelte
 msgid "Discord"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Send alerts to a Discord channel"
-msgstr ""
+#~ msgid "Send alerts to a Discord channel"
+#~ msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
 msgid "Telegram"
 msgstr ""
 
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Send alerts to a Telegram chat"
-msgstr ""
+#~ msgid "Send alerts to a Telegram chat"
+#~ msgstr ""
 
 #: src/routes/settings/alerts/setup/+page.svelte
 msgid "Review your alert configuration before saving."
@@ -19715,10 +19709,8 @@ msgid ""
 "the dashboard, but no push notifications will be sent."
 msgstr ""
 
-#. placeholder {0}: webhookUrl
-#: src/routes/settings/alerts/setup/+page.svelte
-msgid "Webhook: {0}"
-msgstr ""
+#~ msgid "Webhook: {0}"
+#~ msgstr ""
 
 #: src/routes/settings/alerts/setup/+page.svelte
 msgid "Medical Disclaimer"
@@ -20285,16 +20277,15 @@ msgstr ""
 #~ msgid "<0/> {0} Synced Successfully"
 #~ msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Uploaders"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Configure a phone app to push data to Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "General Uploaders"
@@ -20307,16 +20298,19 @@ msgstr ""
 msgid "Failed to load uploader apps"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Android"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Desktop"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Web"
@@ -20376,11 +20370,13 @@ msgstr ""
 
 #. placeholder {0}: selectedApp?.name
 #. placeholder {1}: ds.entriesLast24h ?? 0
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "{0} is sending data. {1} entries in the last 24 hours."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Waiting for data"
@@ -20392,22 +20388,26 @@ msgstr ""
 msgid "Once you've configured {0}, it can take up to five minutes for the first glucose data to arrive. This page will update automatically."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Failed to load setup instructions"
 msgstr ""
 
 #. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "Could not load setup details for {0}. Please try again."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "<0/> iOS"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/(fullscreen)/setup/uploaders/+page.svelte
 #: src/routes/settings/setup/uploaders/+page.svelte
 msgid "<0/> Android"
@@ -20896,6 +20896,7 @@ msgstr ""
 msgid "{0} - Nocturne"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Device Authorized"
 msgstr ""
@@ -20904,14 +20905,17 @@ msgstr ""
 msgid "You can close this window and return to your device."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Authorization Denied"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "The device will not be granted access."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "Authorize Application"
@@ -20930,11 +20934,13 @@ msgid ""
 "approve if you trust this application."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "This application is requesting permission to:"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 msgid "This app cannot delete your data."
@@ -20947,12 +20953,14 @@ msgid ""
 "data."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 #: src/routes/settings/access-requests/+page.svelte
 msgid "<0/> Deny"
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 #: src/routes/oauth/device/+page.svelte
 #: src/routes/settings/access-requests/+page.svelte
@@ -21120,6 +21128,7 @@ msgstr ""
 msgid "<0/> is requesting additional access to your Nocturne data."
 msgstr ""
 
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/oauth/consent/+page.svelte
 msgid "<0/> wants to access your Nocturne data."
 msgstr ""
@@ -21151,6 +21160,7 @@ msgstr ""
 msgid "Invite Not Found"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "This invite link is invalid or has expired."
 msgstr ""
@@ -21199,6 +21209,7 @@ msgstr ""
 #~ msgid "You'll be able to see:"
 #~ msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "<0/> Accept Invite"
 msgstr ""
@@ -21218,6 +21229,8 @@ msgstr ""
 msgid "Invite not found or has expired."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.server.ts
 #: src/routes/invite/[token]/+page.svelte
 msgid "Failed to accept invite."
@@ -21245,6 +21258,7 @@ msgstr ""
 #: src/lib/components/auth/LoginForm.svelte
 #: src/lib/components/auth/LoginForm.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21269,6 +21283,7 @@ msgstr ""
 #: src/lib/components/auth/LoginForm.svelte
 #: src/lib/components/auth/LoginForm.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21422,12 +21437,10 @@ msgstr ""
 msgid "Revoke"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Passkey"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Set up passwordless authentication with a passkey"
 msgstr ""
@@ -21448,6 +21461,7 @@ msgstr ""
 
 #: src/routes/(fullscreen)/auth/help/+page.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/help/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
@@ -21462,6 +21476,7 @@ msgid "Save these recovery codes in a safe place. Each code can only be used onc
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21470,6 +21485,7 @@ msgid "<0/> Codes copied"
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21477,6 +21493,7 @@ msgstr ""
 msgid "<0/> Copy recovery codes"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "Continue to Nocturne"
 msgstr ""
@@ -21488,6 +21505,7 @@ msgid "Copy your recovery codes before continuing."
 msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
@@ -21512,16 +21530,15 @@ msgstr ""
 msgid "Passkey Setup - Setup - Nocturne"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "Set Up Your Passkey"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "Create a passkey for secure, passwordless authentication. You will also receive recovery codes in case you lose access to your passkey."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "This is how you will appear to others."
@@ -21554,11 +21571,13 @@ msgid ""
 "be used once."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid "You must copy your recovery codes before continuing."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/(fullscreen)/setup/passkey/+page.svelte
 #: src/routes/settings/setup/passkey/+page.svelte
 msgid ""
@@ -21566,6 +21585,7 @@ msgid ""
 "from your account settings."
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/settings/account/+page.svelte
 #: src/routes/settings/security/+page.svelte
 msgid "Failed to register passkey."
@@ -21813,6 +21833,7 @@ msgstr ""
 
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
 #: src/routes/(fullscreen)/auth/recovery/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
 #: src/routes/auth/bot/authorize/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
 #: src/routes/auth/recovery/+page.svelte
@@ -23034,6 +23055,7 @@ msgstr ""
 msgid "Full access"
 msgstr ""
 
+#: src/routes/(fullscreen)/join/+page.svelte
 #: src/routes/invite/[token]/+page.svelte
 msgid "Loading invite..."
 msgstr ""
@@ -23185,12 +23207,10 @@ msgstr ""
 msgid "{0} synced so far"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Coming from Nightscout?"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Migrate your data and keep both systems in sync during transition"
 msgstr ""
@@ -23465,30 +23485,26 @@ msgstr ""
 msgid "Register a passkey to restore normal access."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/lib/components/dashboard/SetupCard.svelte
 #: src/routes/(fullscreen)/setup/permissions/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 #: src/routes/settings/setup/permissions/+page.svelte
 msgid "Sharing & Privacy"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Choose who can see your data"
 msgstr ""
 
 #. placeholder {0}: requiredComplete
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "{0} of 6 required steps complete"
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Finishing..."
 msgstr ""
 
-#: src/routes/(fullscreen)/setup/+page.svelte
 #: src/routes/settings/setup/+page.svelte
 msgid "Finish Setup"
 msgstr ""
@@ -24328,84 +24344,286 @@ msgstr ""
 msgid "Weight (kg)"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Opening xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "No invite token provided. Please check the link you were given."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Redirecting to xDrip+ to start the connection..."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite has expired."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Connect xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite has been revoked."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "xDrip+ didn't open automatically. You can try these options:"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "This invite is no longer valid."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "<0/> Open in xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Join - Nocturne"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Manual setup"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Invalid Invite"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "In xDrip+, go to Settings > Cloud Upload > Nocturne, enter this URL:"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "You're In"
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Then tap \"Connect to Nocturne\" to authorize."
+#. placeholder {0}: inviteInfo.tenantName ?? "the site"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Your account has been created and you've joined {0}."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "Don't have xDrip+ installed?"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid ""
+"Save these recovery codes in a safe place. If you lose access to\n"
+"your passkey, you can use one of these codes to sign in. Each code\n"
+"can only be used once."
 msgstr ""
 
-#: src/routes/(fullscreen)/connect/xdrip/+page.svelte
-msgid "<0/> Download xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Accept Invite"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Quick Connect"
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> has invited you to join"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Automatically configure xDrip+ with your Nocturne instance."
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "You've been invited to join"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Or scan from another device"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> Joining..."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "QR code to connect xDrip+"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Join Nocturne"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Scan this QR code with your phone's camera"
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid ""
+"<0/> <1/>.\n"
+"Create an account or sign in to accept."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Or open this link on your phone"
+#. placeholder {0}: provider.name
+#. placeholder {0}: provider.name
+#: src/routes/(fullscreen)/join/+page.svelte
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "<0/> Continue with {0}"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "<0/> Waiting for data from xDrip+..."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "Or create an account with a passkey"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "<0/> Connected! Data is flowing from xDrip+."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "A unique identifier for your account."
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading."
+#: src/routes/(fullscreen)/join/+page.svelte
+msgid "<0/> Create account with passkey"
 msgstr ""
 
-#: src/lib/components/XdripQuickConnect.svelte
-msgid "Check now"
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Set Up Your Account"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Choose how you want to authenticate. You can use an external provider for quick setup, or register a passkey for passwordless authentication."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/passkey/+page.svelte
+msgid "Or set up with a passkey"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "Discord DM"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "Slack DM"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+#: src/lib/components/alerts/RuleEditorSheet.svelte
+msgid "WhatsApp"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Browser Push"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts as a Discord direct message"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts as a Slack direct message"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts to your Telegram chat"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Send alerts to your WhatsApp"
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "No notification channels are currently available."
+msgstr ""
+
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid "Service hasn't reported recently — alerts may be delayed"
+msgstr ""
+
+#. placeholder {0}: getPlatformName(ct)
+#: src/lib/components/alerts/ChannelPicker.svelte
+msgid ""
+"Account not linked. Use /connect in {0} to\n"
+"enable delivery."
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Patient details"
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Therapy profile"
+msgstr ""
+
+#: src/lib/components/dashboard/SetupCard.svelte
+msgid "Finish setting up"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Choose how you'd like to set up Nocturne."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Import your existing data — entries, treatments, and history."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Start Fresh"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+msgid "Connect a glucose data source to get started."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to load data sources"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Connect a Data Source - Setup - Nocturne"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Connect a Data Source"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Choose a cloud service or phone app to start sending glucose and treatment data to Nocturne."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Cloud Services"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Phone Apps"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "No data sources available"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "There are no data sources available at this time."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Skip for now"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "<0/> Back to data sources"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/+page.svelte
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Continue to Dashboard"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Invalid or expired device code."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Invalid or expired device code. Please check and try again."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to approve. The code may have expired."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Failed to deny the request."
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "{0} is now connected. You can return to your device."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Receiving Data"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "It can take a few minutes for the first glucose reading to arrive. This page will update automatically."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "This application is not in the Nocturne known app directory. Only approve if you trust it."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "This app is requesting full access, including the ability to delete data."
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Scan to Connect"
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Scan this QR code with your phone's camera to open {0} and start the connection."
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "QR code to connect {0}"
+msgstr ""
+
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "Enter Authorization Code"
+msgstr ""
+
+#. placeholder {0}: selectedApp?.name
+#: src/routes/(fullscreen)/setup/connect/+page.svelte
+msgid "After scanning, {0} will show an 8-character code. Enter it here to approve the connection."
 msgstr ""

--- a/src/Web/packages/app/e2e/connect-xdrip.test.ts
+++ b/src/Web/packages/app/e2e/connect-xdrip.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("/connect/xdrip trampoline", () => {
+	test("renders without authentication", async ({ page }) => {
+		const response = await page.goto("/connect/xdrip");
+		expect(response?.status()).toBe(200);
+		await expect(page).toHaveURL(/\/connect\/xdrip$/);
+	});
+
+	test("shows redirecting state then falls back to manual UI", async ({ page }) => {
+		await page.goto("/connect/xdrip");
+		// Initial "redirecting" state visible
+		await expect(page.getByText("Opening xDrip+")).toBeVisible();
+		// After 2 seconds, fallback UI appears
+		await expect(page.getByText("xDrip+ didn't open automatically")).toBeVisible({
+			timeout: 5_000,
+		});
+	});
+
+	test("fallback UI shows the instance URL", async ({ page }) => {
+		await page.goto("/connect/xdrip");
+		// Wait for fallback
+		await expect(page.getByText("xDrip+ didn't open automatically")).toBeVisible({
+			timeout: 5_000,
+		});
+		// The code block should contain the origin URL
+		const codeBlock = page.locator("code").first();
+		await expect(codeBlock).toContainText("http");
+	});
+});

--- a/src/Web/packages/app/src/lib/components/XdripQuickConnect.svelte
+++ b/src/Web/packages/app/src/lib/components/XdripQuickConnect.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onMount, onDestroy } from "svelte";
   import { browser } from "$app/environment";
   import QRCode from "qrcode";
+  import { getActiveDataSources } from "$api/generated/services.generated.remote";
+  import type { DataSourceInfo } from "$lib/api/generated/nocturne-api-client";
   import { Button } from "$lib/components/ui/button";
-  import { Smartphone } from "lucide-svelte";
+  import { Smartphone, CheckCircle, Loader2 } from "lucide-svelte";
   import { buildXdripDeepLink, buildConnectPageUrl } from "$lib/utils/xdrip-links";
 
   /** Origin URL of the Nocturne instance (trailing slash tolerated). */
@@ -11,6 +13,13 @@
 
   let qrDataUrl = $state<string | null>(null);
   let isAndroid = $state(false);
+
+  type ConnectionState = "waiting" | "connected" | "timeout";
+  let connectionState = $state<ConnectionState>("waiting");
+  let pollInterval: ReturnType<typeof setInterval> | null = null;
+  let pollStartTime = 0;
+  const POLL_INTERVAL_MS = 10_000;
+  const POLL_TIMEOUT_MS = 60_000;
 
   const connectPageUrl = $derived(buildConnectPageUrl(instanceUrl));
   const deepLink = $derived(buildXdripDeepLink(instanceUrl));
@@ -28,10 +37,74 @@
     } catch {
       // QR generation failed — users can still copy the connect URL below.
     }
+    startPolling();
   });
+
+  onDestroy(() => {
+    stopPolling();
+  });
+
+  function isXdripDetected(sources: DataSourceInfo[]): boolean {
+    return sources.some((ds) => ds.sourceType?.toLowerCase() === "xdrip");
+  }
+
+  async function checkStatus() {
+    try {
+      const sources = (await getActiveDataSources()) ?? [];
+      if (isXdripDetected(sources)) {
+        connectionState = "connected";
+        stopPolling();
+        return;
+      }
+      if (Date.now() - pollStartTime > POLL_TIMEOUT_MS) {
+        connectionState = "timeout";
+        stopPolling();
+      }
+    } catch {
+      // Network errors — keep polling until the timeout fires
+    }
+  }
+
+  function startPolling() {
+    stopPolling();
+    connectionState = "waiting";
+    pollStartTime = Date.now();
+    checkStatus();
+    pollInterval = setInterval(checkStatus, POLL_INTERVAL_MS);
+  }
+
+  function stopPolling() {
+    if (pollInterval !== null) {
+      clearInterval(pollInterval);
+      pollInterval = null;
+    }
+  }
+
+  function retryCheck() {
+    startPolling();
+  }
 </script>
 
 <div class="space-y-4">
+  {#if connectionState === "waiting"}
+    <div class="bg-muted text-muted-foreground flex items-center gap-2 rounded p-3 text-sm">
+      <Loader2 class="h-4 w-4 animate-spin" />
+      Waiting for data from xDrip+...
+    </div>
+  {:else if connectionState === "connected"}
+    <div class="flex items-center gap-2 rounded bg-green-50 p-3 text-sm text-green-900 dark:bg-green-950 dark:text-green-100">
+      <CheckCircle class="h-4 w-4" />
+      Connected! Data is flowing from xDrip+.
+    </div>
+  {:else if connectionState === "timeout"}
+    <div class="bg-muted space-y-2 rounded p-3 text-sm">
+      <p>No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading.</p>
+      <Button variant="outline" size="sm" onclick={retryCheck}>
+        Check now
+      </Button>
+    </div>
+  {/if}
+
   <div>
     <p class="text-sm font-medium">Quick Connect</p>
     <p class="text-muted-foreground text-sm">

--- a/src/Web/packages/app/src/lib/components/XdripQuickConnect.svelte
+++ b/src/Web/packages/app/src/lib/components/XdripQuickConnect.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import QRCode from "qrcode";
+  import { Button } from "$lib/components/ui/button";
+  import { Smartphone } from "lucide-svelte";
+
+  let { instanceUrl }: { instanceUrl: string } = $props();
+
+  let qrDataUrl = $state<string | null>(null);
+  let isAndroid = $state(false);
+
+  const connectPageUrl = $derived(`${instanceUrl}/connect/xdrip`);
+  const deepLink = $derived(
+    `xdrip://connect/nocturne?url=${encodeURIComponent(instanceUrl)}`,
+  );
+
+  onMount(async () => {
+    if (typeof navigator !== "undefined") {
+      isAndroid = /android/i.test(navigator.userAgent);
+    }
+    qrDataUrl = await QRCode.toDataURL(connectPageUrl, {
+      width: 200,
+      margin: 2,
+      color: { dark: "#000000", light: "#ffffff" },
+    });
+  });
+</script>
+
+<div class="space-y-4">
+  <div>
+    <p class="text-sm font-medium">Quick Connect</p>
+    <p class="text-muted-foreground text-sm">
+      Automatically configure xDrip+ with your Nocturne instance.
+    </p>
+  </div>
+
+  {#if isAndroid}
+    <Button href={deepLink} class="w-full">
+      <Smartphone class="mr-2 h-4 w-4" />
+      Open in xDrip+
+    </Button>
+    {#if qrDataUrl}
+      <details class="text-sm">
+        <summary class="text-muted-foreground cursor-pointer">
+          Or scan from another device
+        </summary>
+        <div class="flex justify-center pt-3">
+          <img src={qrDataUrl} alt="QR code to connect xDrip+" class="rounded" />
+        </div>
+      </details>
+    {/if}
+  {:else if qrDataUrl}
+    <div class="flex justify-center">
+      <img src={qrDataUrl} alt="QR code to connect xDrip+" class="rounded" />
+    </div>
+    <p class="text-muted-foreground text-center text-sm">
+      Scan this QR code with your phone's camera
+    </p>
+    <details class="text-sm">
+      <summary class="text-muted-foreground cursor-pointer">
+        Or open this link on your phone
+      </summary>
+      <code class="bg-muted mt-2 block rounded px-3 py-2 text-xs break-all">
+        {connectPageUrl}
+      </code>
+    </details>
+  {/if}
+</div>

--- a/src/Web/packages/app/src/lib/components/XdripQuickConnect.svelte
+++ b/src/Web/packages/app/src/lib/components/XdripQuickConnect.svelte
@@ -34,8 +34,8 @@
         margin: 2,
         color: { dark: "#000000", light: "#ffffff" },
       });
-    } catch {
-      // QR generation failed — users can still copy the connect URL below.
+    } catch (err) {
+      console.warn("[XdripQuickConnect] QR code generation failed:", err);
     }
     startPolling();
   });
@@ -60,8 +60,8 @@
         connectionState = "timeout";
         stopPolling();
       }
-    } catch {
-      // Network errors — keep polling until the timeout fires
+    } catch (err) {
+      console.warn("[XdripQuickConnect] Data source poll failed:", err);
     }
   }
 
@@ -87,17 +87,32 @@
 
 <div class="space-y-4">
   {#if connectionState === "waiting"}
-    <div class="bg-muted text-muted-foreground flex items-center gap-2 rounded p-3 text-sm">
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      class="bg-muted text-muted-foreground flex items-center gap-2 rounded p-3 text-sm"
+    >
       <Loader2 class="h-4 w-4 animate-spin" />
       Waiting for data from xDrip+...
     </div>
   {:else if connectionState === "connected"}
-    <div class="flex items-center gap-2 rounded bg-green-50 p-3 text-sm text-green-900 dark:bg-green-950 dark:text-green-100">
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      class="flex items-center gap-2 rounded bg-green-50 p-3 text-sm text-green-900 dark:bg-green-950 dark:text-green-100"
+    >
       <CheckCircle class="h-4 w-4" />
       Connected! Data is flowing from xDrip+.
     </div>
   {:else if connectionState === "timeout"}
-    <div class="bg-muted space-y-2 rounded p-3 text-sm">
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      class="bg-muted space-y-2 rounded p-3 text-sm"
+    >
       <p>No data from xDrip+ yet. This is normal if xDrip+ hasn't had a new reading.</p>
       <Button variant="outline" size="sm" onclick={retryCheck}>
         Check now

--- a/src/Web/packages/app/src/lib/components/XdripQuickConnect.svelte
+++ b/src/Web/packages/app/src/lib/components/XdripQuickConnect.svelte
@@ -1,28 +1,33 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import { browser } from "$app/environment";
   import QRCode from "qrcode";
   import { Button } from "$lib/components/ui/button";
   import { Smartphone } from "lucide-svelte";
+  import { buildXdripDeepLink, buildConnectPageUrl } from "$lib/utils/xdrip-links";
 
+  /** Origin URL of the Nocturne instance (trailing slash tolerated). */
   let { instanceUrl }: { instanceUrl: string } = $props();
 
   let qrDataUrl = $state<string | null>(null);
   let isAndroid = $state(false);
 
-  const connectPageUrl = $derived(`${instanceUrl}/connect/xdrip`);
-  const deepLink = $derived(
-    `xdrip://connect/nocturne?url=${encodeURIComponent(instanceUrl)}`,
-  );
+  const connectPageUrl = $derived(buildConnectPageUrl(instanceUrl));
+  const deepLink = $derived(buildXdripDeepLink(instanceUrl));
 
   onMount(async () => {
-    if (typeof navigator !== "undefined") {
+    if (browser) {
       isAndroid = /android/i.test(navigator.userAgent);
     }
-    qrDataUrl = await QRCode.toDataURL(connectPageUrl, {
-      width: 200,
-      margin: 2,
-      color: { dark: "#000000", light: "#ffffff" },
-    });
+    try {
+      qrDataUrl = await QRCode.toDataURL(connectPageUrl, {
+        width: 200,
+        margin: 2,
+        color: { dark: "#000000", light: "#ffffff" },
+      });
+    } catch {
+      // QR generation failed — users can still copy the connect URL below.
+    }
   });
 </script>
 
@@ -45,17 +50,31 @@
           Or scan from another device
         </summary>
         <div class="flex justify-center pt-3">
-          <img src={qrDataUrl} alt="QR code to connect xDrip+" class="rounded" />
+          <img
+            src={qrDataUrl}
+            alt="QR code to connect xDrip+"
+            width="200"
+            height="200"
+            class="rounded"
+          />
         </div>
       </details>
     {/if}
-  {:else if qrDataUrl}
-    <div class="flex justify-center">
-      <img src={qrDataUrl} alt="QR code to connect xDrip+" class="rounded" />
-    </div>
-    <p class="text-muted-foreground text-center text-sm">
-      Scan this QR code with your phone's camera
-    </p>
+  {:else}
+    {#if qrDataUrl}
+      <div class="flex justify-center">
+        <img
+          src={qrDataUrl}
+          alt="QR code to connect xDrip+"
+          width="200"
+          height="200"
+          class="rounded"
+        />
+      </div>
+      <p class="text-muted-foreground text-center text-sm">
+        Scan this QR code with your phone's camera
+      </p>
+    {/if}
     <details class="text-sm">
       <summary class="text-muted-foreground cursor-pointer">
         Or open this link on your phone

--- a/src/Web/packages/app/src/lib/config/public-routes.ts
+++ b/src/Web/packages/app/src/lib/config/public-routes.ts
@@ -8,6 +8,7 @@ export const PUBLIC_ROUTE_PREFIXES = [
   "/setup",
   "/clock",
   "/invite",
+  "/connect",
 ] as const;
 
 /**

--- a/src/Web/packages/app/src/lib/utils/xdrip-links.ts
+++ b/src/Web/packages/app/src/lib/utils/xdrip-links.ts
@@ -1,0 +1,26 @@
+/**
+ * Normalizes an instance URL by removing trailing slashes.
+ * Returns empty string if input is empty (for SSR safety).
+ */
+function normalize(instanceUrl: string): string {
+  return instanceUrl.replace(/\/+$/, "");
+}
+
+/**
+ * Builds the xDrip+ deep link that triggers auto-configuration of the
+ * Nocturne uploader.
+ *
+ * @param instanceUrl — the Nocturne instance origin URL (with or without trailing slash)
+ */
+export function buildXdripDeepLink(instanceUrl: string): string {
+  const normalized = normalize(instanceUrl);
+  return `xdrip://connect/nocturne?url=${encodeURIComponent(normalized)}`;
+}
+
+/**
+ * Builds the public connect page URL that a phone QR scanner can open.
+ * This URL serves a trampoline page that redirects to the xDrip+ deep link.
+ */
+export function buildConnectPageUrl(instanceUrl: string): string {
+  return `${normalize(instanceUrl)}/connect/xdrip`;
+}

--- a/src/Web/packages/app/src/routes/(fullscreen)/connect/xdrip/+page.svelte
+++ b/src/Web/packages/app/src/routes/(fullscreen)/connect/xdrip/+page.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { Button } from "$lib/components/ui/button";
+  import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+  } from "$lib/components/ui/card";
+  import { ExternalLink, Smartphone, Copy, Check } from "lucide-svelte";
+
+  let viewState: "redirecting" | "fallback" = $state("redirecting");
+  let copied = $state(false);
+
+  const instanceUrl = typeof window !== "undefined" ? window.location.origin : "";
+  const deepLink = `xdrip://connect/nocturne?url=${encodeURIComponent(instanceUrl)}`;
+
+  onMount(() => {
+    window.location.href = deepLink;
+    const timeout = setTimeout(() => {
+      viewState = "fallback";
+    }, 2000);
+    return () => clearTimeout(timeout);
+  });
+
+  async function copyUrl() {
+    await navigator.clipboard.writeText(instanceUrl);
+    copied = true;
+    setTimeout(() => (copied = false), 2000);
+  }
+</script>
+
+<div class="flex min-h-screen items-center justify-center p-4">
+  {#if viewState === "redirecting"}
+    <Card class="w-full max-w-md text-center">
+      <CardHeader>
+        <CardTitle>Opening xDrip+</CardTitle>
+        <CardDescription>Redirecting to xDrip+ to start the connection...</CardDescription>
+      </CardHeader>
+    </Card>
+  {:else}
+    <Card class="w-full max-w-md">
+      <CardHeader>
+        <CardTitle>Connect xDrip+</CardTitle>
+        <CardDescription>
+          xDrip+ didn't open automatically. You can try these options:
+        </CardDescription>
+      </CardHeader>
+      <CardContent class="space-y-4">
+        <Button href={deepLink} class="w-full">
+          <Smartphone class="mr-2 h-4 w-4" />
+          Open in xDrip+
+        </Button>
+
+        <div class="space-y-2">
+          <p class="text-sm font-medium">Manual setup</p>
+          <p class="text-muted-foreground text-sm">
+            In xDrip+, go to Settings &gt; Cloud Upload &gt; Nocturne, enter this URL:
+          </p>
+          <div class="flex items-center gap-2">
+            <code class="bg-muted flex-1 rounded px-3 py-2 text-sm break-all">
+              {instanceUrl}
+            </code>
+            <Button variant="ghost" size="icon" onclick={copyUrl}>
+              {#if copied}
+                <Check class="h-4 w-4" />
+              {:else}
+                <Copy class="h-4 w-4" />
+              {/if}
+            </Button>
+          </div>
+          <p class="text-muted-foreground text-sm">
+            Then tap "Connect to Nocturne" to authorize.
+          </p>
+        </div>
+
+        <div class="pt-2">
+          <p class="text-muted-foreground text-sm">Don't have xDrip+ installed?</p>
+          <Button
+            href="https://github.com/NightscoutFoundation/xDrip/releases"
+            target="_blank"
+            variant="link"
+            class="px-0"
+          >
+            <ExternalLink class="mr-1 h-3 w-3" />
+            Download xDrip+
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  {/if}
+</div>

--- a/src/Web/packages/app/src/routes/(fullscreen)/connect/xdrip/+page.svelte
+++ b/src/Web/packages/app/src/routes/(fullscreen)/connect/xdrip/+page.svelte
@@ -12,6 +12,7 @@
 
   let viewState: "redirecting" | "fallback" = $state("redirecting");
   let copied = $state(false);
+  let copyTimeout: ReturnType<typeof setTimeout> | null = null;
 
   const instanceUrl = typeof window !== "undefined" ? window.location.origin : "";
   const deepLink = `xdrip://connect/nocturne?url=${encodeURIComponent(instanceUrl)}`;
@@ -21,13 +22,21 @@
     const timeout = setTimeout(() => {
       viewState = "fallback";
     }, 2000);
-    return () => clearTimeout(timeout);
+    return () => {
+      clearTimeout(timeout);
+      if (copyTimeout) clearTimeout(copyTimeout);
+    };
   });
 
   async function copyUrl() {
-    await navigator.clipboard.writeText(instanceUrl);
-    copied = true;
-    setTimeout(() => (copied = false), 2000);
+    try {
+      await navigator.clipboard.writeText(instanceUrl);
+      copied = true;
+      if (copyTimeout) clearTimeout(copyTimeout);
+      copyTimeout = setTimeout(() => (copied = false), 2000);
+    } catch {
+      // Clipboard API unavailable; user can still long-press the code block.
+    }
   }
 </script>
 

--- a/src/Web/packages/app/src/routes/(fullscreen)/connect/xdrip/+page.svelte
+++ b/src/Web/packages/app/src/routes/(fullscreen)/connect/xdrip/+page.svelte
@@ -9,13 +9,14 @@
     CardTitle,
   } from "$lib/components/ui/card";
   import { ExternalLink, Smartphone, Copy, Check } from "lucide-svelte";
+  import { buildXdripDeepLink } from "$lib/utils/xdrip-links";
 
   let viewState: "redirecting" | "fallback" = $state("redirecting");
   let copied = $state(false);
   let copyTimeout: ReturnType<typeof setTimeout> | null = null;
 
   const instanceUrl = typeof window !== "undefined" ? window.location.origin : "";
-  const deepLink = `xdrip://connect/nocturne?url=${encodeURIComponent(instanceUrl)}`;
+  const deepLink = buildXdripDeepLink(instanceUrl);
 
   onMount(() => {
     window.location.href = deepLink;

--- a/src/Web/packages/app/src/routes/(fullscreen)/setup/connect/+page.svelte
+++ b/src/Web/packages/app/src/routes/(fullscreen)/setup/connect/+page.svelte
@@ -7,6 +7,10 @@
     getActiveDataSources,
     getServicesOverview,
   } from "$api/generated/services.generated.remote";
+  import {
+    UploaderPlatform,
+    UploaderCategory,
+  } from "$lib/api/generated/nocturne-api-client";
   import type {
     UploaderApp,
     UploaderSetupResponse,
@@ -89,18 +93,18 @@
 
   // ── Platform filter ──────────────────────────────────────────────
 
-  type PlatformFilter = "all" | "ios" | "android";
+  type PlatformFilter = "all" | UploaderPlatform;
   let platformFilter = $state<PlatformFilter>("all");
 
   // ── Categories ────────────────────────────────────────────────────
 
   const categoryLabels: Record<string, string> = {
-    cgm: "CGM Apps",
-    "aid-system": "AID Systems",
-    uploader: "General Uploaders",
+    [UploaderCategory.Cgm]: "CGM Apps",
+    [UploaderCategory.AidSystem]: "AID Systems",
+    [UploaderCategory.Uploader]: "General Uploaders",
   };
 
-  const categoryOrder = ["cgm", "aid-system", "uploader"];
+  const categoryOrder = [UploaderCategory.Cgm, UploaderCategory.AidSystem, UploaderCategory.Uploader];
 
   const filteredApps = $derived(
     platformFilter === "all"
@@ -111,7 +115,7 @@
   const groupedApps = $derived.by(() => {
     const groups: Record<string, UploaderApp[]> = {};
     for (const app of filteredApps) {
-      const cat = app.category ?? "uploader";
+      const cat = app.category ?? UploaderCategory.Uploader as string;
       if (!groups[cat]) groups[cat] = [];
       groups[cat].push(app);
     }
@@ -337,28 +341,27 @@
 
   // ── Platform icon helper ──────────────────────────────────────────
 
-  function getPlatformLabel(platform: string | undefined): string {
+  function getPlatformLabel(platform: UploaderPlatform | undefined): string {
     switch (platform) {
-      case "ios":
+      case UploaderPlatform.IOS:
         return "iOS";
-      case "android":
+      case UploaderPlatform.Android:
         return "Android";
-      case "desktop":
+      case UploaderPlatform.Desktop:
         return "Desktop";
-      case "web":
+      case UploaderPlatform.Web:
         return "Web";
       default:
-        return platform ?? "Unknown";
+        return "Unknown";
     }
   }
 
-  function getCategoryIcon(category: string | undefined) {
+  function getCategoryIcon(category: UploaderCategory | undefined) {
     switch (category) {
-      case "cgm":
+      case UploaderCategory.Cgm:
+      case UploaderCategory.AidSystem:
         return Activity;
-      case "aid-system":
-        return Activity;
-      case "uploader":
+      case UploaderCategory.Uploader:
         return Upload;
       default:
         return Upload;
@@ -465,19 +468,19 @@
                   All
                 </Button>
                 <Button
-                  variant={platformFilter === "ios" ? "default" : "outline"}
+                  variant={platformFilter === UploaderPlatform.IOS ? "default" : "outline"}
                   size="sm"
                   class="gap-1.5"
-                  onclick={() => (platformFilter = "ios")}
+                  onclick={() => (platformFilter = UploaderPlatform.IOS)}
                 >
                   <Apple class="h-3.5 w-3.5" />
                   iOS
                 </Button>
                 <Button
-                  variant={platformFilter === "android" ? "default" : "outline"}
+                  variant={platformFilter === UploaderPlatform.Android ? "default" : "outline"}
                   size="sm"
                   class="gap-1.5"
-                  onclick={() => (platformFilter = "android")}
+                  onclick={() => (platformFilter = UploaderPlatform.Android)}
                 >
                   <Smartphone class="h-3.5 w-3.5" />
                   Android

--- a/src/Web/packages/app/src/routes/(fullscreen)/setup/connect/+page.svelte
+++ b/src/Web/packages/app/src/routes/(fullscreen)/setup/connect/+page.svelte
@@ -1,0 +1,853 @@
+<script lang="ts">
+  import { onMount, onDestroy } from "svelte";
+  import { goto } from "$app/navigation";
+  import {
+    getUploaderApps,
+    getUploaderSetup,
+    getActiveDataSources,
+    getServicesOverview,
+  } from "$api/generated/services.generated.remote";
+  import type {
+    UploaderApp,
+    UploaderSetupResponse,
+    DataSourceInfo,
+    AvailableConnector,
+    SyncResult,
+  } from "$lib/api/generated/nocturne-api-client";
+  import { markSetupComplete } from "../setup.remote";
+  import ConnectorSetup from "$lib/components/connectors/ConnectorSetup.svelte";
+  import * as Card from "$lib/components/ui/card";
+  import { Button } from "$lib/components/ui/button";
+  import { Badge } from "$lib/components/ui/badge";
+  import {
+    AlertCircle,
+    CheckCircle,
+    ChevronLeft,
+    ChevronRight,
+    Check,
+    Loader2,
+    Upload,
+    Activity,
+    Smartphone,
+    Clock,
+    Cloud,
+    Plug,
+    Shield,
+    ShieldAlert,
+    AlertTriangle,
+    X,
+  } from "lucide-svelte";
+  import Apple from "lucide-svelte/icons/apple";
+  import { Input } from "$lib/components/ui/input";
+  import { Separator } from "$lib/components/ui/separator";
+  import { getDeviceInfo, approveDevice, denyDevice } from "../../../oauth/oauth.remote";
+  import { getOAuthScopeDescription } from "$lib/constants/oauth-scopes";
+  import QRCode from "qrcode";
+
+  // ── View state ──────────────────────────────────────────────────────
+
+  type ViewState = "selection" | "connector" | "uploader";
+  let viewState = $state<ViewState>("selection");
+
+  // ── Connector state ───────────────────────────────────────────────
+  let selectedConnectorId = $state<string | null>(null);
+
+  // ── Uploader state ────────────────────────────────────────────────
+  let selectedApp = $state<UploaderApp | null>(null);
+  let setupResponse = $state<UploaderSetupResponse | null>(null);
+  let setupLoading = $state(false);
+
+  // ── Data state ────────────────────────────────────────────────────
+
+  let uploaderApps = $state<UploaderApp[]>([]);
+  let connectors = $state<AvailableConnector[]>([]);
+  let dataSources = $state<DataSourceInfo[]>([]);
+  let isLoading = $state(true);
+  let loadError = $state<string | null>(null);
+
+
+  // ── Device authorization (OAuth) state ────────────────────────────
+
+  let qrCodeDataUrl = $state<string | null>(null);
+  let deviceCodeInput = $state("");
+  let deviceLookupLoading = $state(false);
+  let deviceLookupError = $state<string | null>(null);
+  let deviceInfo = $state<{
+    userCode: string;
+    clientId: string;
+    displayName: string | null;
+    isKnown: boolean;
+    scopes: string[];
+  } | null>(null);
+  let deviceApproveLoading = $state(false);
+  let deviceApproved = $state(false);
+  let deviceDenied = $state(false);
+
+  // ── Connection polling ────────────────────────────────────────────
+
+  let pollInterval = $state<ReturnType<typeof setInterval> | null>(null);
+
+  // ── Platform filter ──────────────────────────────────────────────
+
+  type PlatformFilter = "all" | "ios" | "android";
+  let platformFilter = $state<PlatformFilter>("all");
+
+  // ── Categories ────────────────────────────────────────────────────
+
+  const categoryLabels: Record<string, string> = {
+    cgm: "CGM Apps",
+    "aid-system": "AID Systems",
+    uploader: "General Uploaders",
+  };
+
+  const categoryOrder = ["cgm", "aid-system", "uploader"];
+
+  const filteredApps = $derived(
+    platformFilter === "all"
+      ? uploaderApps
+      : uploaderApps.filter((app) => app.platform === platformFilter),
+  );
+
+  const groupedApps = $derived.by(() => {
+    const groups: Record<string, UploaderApp[]> = {};
+    for (const app of filteredApps) {
+      const cat = app.category ?? "uploader";
+      if (!groups[cat]) groups[cat] = [];
+      groups[cat].push(app);
+    }
+    return categoryOrder
+      .filter((cat) => groups[cat]?.length)
+      .map((cat) => ({ category: cat, label: categoryLabels[cat] ?? cat, apps: groups[cat] }));
+  });
+
+  // ── Detect which uploaders have sent data ─────────────────────────
+
+  function isDetected(appId: string | undefined): boolean {
+    if (!appId) return false;
+    return dataSources.some(
+      (ds) => ds.sourceType?.toLowerCase() === appId.toLowerCase(),
+    );
+  }
+
+  function getDataSource(appId: string | undefined): DataSourceInfo | undefined {
+    if (!appId) return undefined;
+    return dataSources.find(
+      (ds) => ds.sourceType?.toLowerCase() === appId.toLowerCase(),
+    );
+  }
+
+  // ── Load data ─────────────────────────────────────────────────────
+
+  onMount(async () => {
+    await loadData();
+  });
+
+  onDestroy(() => {
+    stopPolling();
+  });
+
+  async function loadData() {
+    isLoading = true;
+    loadError = null;
+
+    try {
+      const [apps, sources, overview] = await Promise.all([
+        getUploaderApps(),
+        getActiveDataSources().catch(() => [] as DataSourceInfo[]),
+        getServicesOverview(),
+      ]);
+
+      uploaderApps = apps ?? [];
+      dataSources = sources ?? [];
+
+      // Filter out "nightscout" connector (handled on the triage page)
+      connectors = (overview?.availableConnectors ?? []).filter(
+        (c) => c.id?.toLowerCase() !== "nightscout",
+      );
+    } catch (e) {
+      loadError = e instanceof Error ? e.message : "Failed to load data sources";
+    } finally {
+      isLoading = false;
+    }
+  }
+
+  // ── Select a connector ────────────────────────────────────────────
+
+  function selectConnector(connector: AvailableConnector) {
+    selectedConnectorId = connector.id ?? null;
+    viewState = "connector";
+  }
+
+  async function handleConnectorComplete(_result: SyncResult) {
+    await markSetupComplete();
+    await goto("/", { invalidateAll: true });
+  }
+
+  function handleConnectorCancel() {
+    selectedConnectorId = null;
+    viewState = "selection";
+  }
+
+  // ── Select an uploader app ────────────────────────────────────────
+
+  async function selectApp(app: UploaderApp) {
+    selectedApp = app;
+    setupLoading = true;
+    viewState = "uploader";
+    resetDeviceState();
+
+    try {
+      const result = await getUploaderSetup(app.id!);
+      setupResponse = result;
+
+      // Generate QR code for apps with OAuth deep-link support
+      if (result?.connectUrl) {
+        await generateQrCode(result.connectUrl);
+      }
+    } catch {
+      setupResponse = null;
+    } finally {
+      setupLoading = false;
+    }
+
+    // Start polling for connection if not already detected (legacy uploaders only)
+    if (!isDetected(app.id) && !setupResponse?.connectUrl) {
+      startPolling();
+    }
+  }
+
+  function handleBackToSelection() {
+    stopPolling();
+    selectedApp = null;
+    setupResponse = null;
+    selectedConnectorId = null;
+    resetDeviceState();
+    viewState = "selection";
+  }
+
+  function resetDeviceState() {
+    qrCodeDataUrl = null;
+    deviceCodeInput = "";
+    deviceLookupLoading = false;
+    deviceLookupError = null;
+    deviceInfo = null;
+    deviceApproveLoading = false;
+    deviceApproved = false;
+    deviceDenied = false;
+  }
+
+  async function generateQrCode(url: string) {
+    try {
+      qrCodeDataUrl = await QRCode.toDataURL(url, {
+        width: 200,
+        margin: 2,
+        color: { dark: "#000000", light: "#ffffff" },
+      });
+    } catch {
+      qrCodeDataUrl = null;
+    }
+  }
+
+  async function lookupDeviceCode() {
+    const code = deviceCodeInput.trim();
+    if (!code) return;
+
+    deviceLookupLoading = true;
+    deviceLookupError = null;
+
+    try {
+      const info = await getDeviceInfo({ userCode: code });
+      if (!info) {
+        deviceLookupError = "Invalid or expired device code.";
+        return;
+      }
+      deviceInfo = {
+        userCode: info.userCode ?? code,
+        clientId: info.clientId ?? "",
+        displayName: info.clientDisplayName ?? null,
+        isKnown: info.isKnownClient ?? false,
+        scopes: (info.scopes ?? []).filter(Boolean) as string[],
+      };
+    } catch {
+      deviceLookupError = "Invalid or expired device code. Please check and try again.";
+    } finally {
+      deviceLookupLoading = false;
+    }
+  }
+
+  async function handleApproveDevice() {
+    if (!deviceInfo) return;
+    deviceApproveLoading = true;
+    try {
+      await approveDevice({ userCode: deviceInfo.userCode });
+      deviceApproved = true;
+      startPolling();
+    } catch {
+      deviceLookupError = "Failed to approve. The code may have expired.";
+    } finally {
+      deviceApproveLoading = false;
+    }
+  }
+
+  async function handleDenyDevice() {
+    if (!deviceInfo) return;
+    deviceApproveLoading = true;
+    try {
+      await denyDevice({ userCode: deviceInfo.userCode });
+      deviceDenied = true;
+    } catch {
+      deviceLookupError = "Failed to deny the request.";
+    } finally {
+      deviceApproveLoading = false;
+    }
+  }
+
+  // ── Polling ───────────────────────────────────────────────────────
+
+  function startPolling() {
+    stopPolling();
+    pollInterval = setInterval(async () => {
+      try {
+        const sources = await getActiveDataSources();
+        dataSources = sources ?? [];
+
+        // Stop polling if we detect data from the selected app
+        if (selectedApp && isDetected(selectedApp.id)) {
+          stopPolling();
+        }
+      } catch {
+        // Silently continue polling
+      }
+    }, 15_000);
+  }
+
+  function stopPolling() {
+    if (pollInterval) {
+      clearInterval(pollInterval);
+      pollInterval = null;
+    }
+  }
+
+  // ── Skip ──────────────────────────────────────────────────────────
+
+  async function handleSkip() {
+    await markSetupComplete();
+    await goto("/", { invalidateAll: true });
+  }
+
+  // ── Platform icon helper ──────────────────────────────────────────
+
+  function getPlatformLabel(platform: string | undefined): string {
+    switch (platform) {
+      case "ios":
+        return "iOS";
+      case "android":
+        return "Android";
+      case "desktop":
+        return "Desktop";
+      case "web":
+        return "Web";
+      default:
+        return platform ?? "Unknown";
+    }
+  }
+
+  function getCategoryIcon(category: string | undefined) {
+    switch (category) {
+      case "cgm":
+        return Activity;
+      case "aid-system":
+        return Activity;
+      case "uploader":
+        return Upload;
+      default:
+        return Upload;
+    }
+  }
+</script>
+
+<svelte:head>
+  <title>Connect a Data Source - Setup - Nocturne</title>
+</svelte:head>
+
+<div class="container mx-auto max-w-2xl p-6 space-y-6">
+  {#if viewState === "selection"}
+    <!-- ── Selection View ──────────────────────────────────────── -->
+    <div>
+      <h1 class="text-2xl font-bold tracking-tight">Connect a Data Source</h1>
+      <p class="text-muted-foreground">
+        Choose a cloud service or phone app to start sending glucose and treatment data to Nocturne.
+      </p>
+    </div>
+
+    {#if isLoading}
+      <div class="flex items-center justify-center py-12">
+        <Loader2 class="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    {:else if loadError}
+      <Card.Root class="border-destructive">
+        <Card.Content class="flex items-center gap-3 pt-6">
+          <AlertCircle class="h-5 w-5 text-destructive" />
+          <div>
+            <p class="font-medium">Failed to load data sources</p>
+            <p class="text-sm text-muted-foreground">{loadError}</p>
+          </div>
+        </Card.Content>
+      </Card.Root>
+    {:else}
+      <div class="space-y-8">
+        <!-- Cloud Services (Connectors) -->
+        {#if connectors.length > 0}
+          <div class="space-y-3">
+            <h2 class="text-sm font-medium text-muted-foreground flex items-center gap-2">
+              <Cloud class="h-4 w-4" />
+              Cloud Services
+            </h2>
+            <div class="grid gap-3 sm:grid-cols-2">
+              {#each connectors as connector (connector.id)}
+                {@const configured = connector.isConfigured ?? false}
+                <button
+                  type="button"
+                  class="flex items-center gap-4 p-4 rounded-lg border transition-colors text-left group {configured
+                    ? 'border-green-500/30 bg-green-500/5 hover:bg-green-500/10'
+                    : 'bg-muted/30 hover:border-primary/50 hover:bg-accent/50'}"
+                  onclick={() => selectConnector(connector)}
+                >
+                  <div
+                    class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg {configured
+                      ? 'bg-green-500/10 text-green-600'
+                      : 'bg-primary/10 text-primary'}"
+                  >
+                    {#if configured}
+                      <CheckCircle class="h-5 w-5" />
+                    {:else}
+                      <Plug class="h-5 w-5" />
+                    {/if}
+                  </div>
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-center gap-2 flex-wrap">
+                      <span class="font-medium">{connector.name}</span>
+                      {#if configured}
+                        <Badge variant="secondary" class="text-xs text-green-600">
+                          Connected
+                        </Badge>
+                      {/if}
+                    </div>
+                    {#if connector.description}
+                      <p class="text-sm text-muted-foreground line-clamp-1">
+                        {connector.description}
+                      </p>
+                    {/if}
+                  </div>
+                  <ChevronRight
+                    class="h-4 w-4 text-muted-foreground group-hover:text-foreground transition-colors shrink-0"
+                  />
+                </button>
+              {/each}
+            </div>
+          </div>
+        {/if}
+
+        <!-- Phone Apps (Uploaders) -->
+        {#if uploaderApps.length > 0}
+          <div class="space-y-3">
+            <div class="flex items-center justify-between">
+              <h2 class="text-sm font-medium text-muted-foreground flex items-center gap-2">
+                <Smartphone class="h-4 w-4" />
+                Phone Apps
+              </h2>
+              <div class="flex items-center gap-1">
+                <Button
+                  variant={platformFilter === "all" ? "default" : "outline"}
+                  size="sm"
+                  onclick={() => (platformFilter = "all")}
+                >
+                  All
+                </Button>
+                <Button
+                  variant={platformFilter === "ios" ? "default" : "outline"}
+                  size="sm"
+                  class="gap-1.5"
+                  onclick={() => (platformFilter = "ios")}
+                >
+                  <Apple class="h-3.5 w-3.5" />
+                  iOS
+                </Button>
+                <Button
+                  variant={platformFilter === "android" ? "default" : "outline"}
+                  size="sm"
+                  class="gap-1.5"
+                  onclick={() => (platformFilter = "android")}
+                >
+                  <Smartphone class="h-3.5 w-3.5" />
+                  Android
+                </Button>
+              </div>
+            </div>
+
+            <div class="space-y-6">
+              {#each groupedApps as group (group.category)}
+                <div class="space-y-3">
+                  <h3 class="text-sm font-medium text-muted-foreground">{group.label}</h3>
+                  <div class="grid gap-3 sm:grid-cols-2">
+                    {#each group.apps as app (app.id)}
+                      {@const detected = isDetected(app.id)}
+                      {@const Icon = getCategoryIcon(app.category)}
+                      <button
+                        type="button"
+                        class="flex items-center gap-4 p-4 rounded-lg border transition-colors text-left group {detected
+                          ? 'border-green-500/30 bg-green-500/5 hover:bg-green-500/10'
+                          : 'bg-muted/30 hover:border-primary/50 hover:bg-accent/50'}"
+                        onclick={() => selectApp(app)}
+                      >
+                        <div
+                          class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg {detected
+                            ? 'bg-green-500/10 text-green-600'
+                            : 'bg-primary/10 text-primary'}"
+                        >
+                          {#if detected}
+                            <CheckCircle class="h-5 w-5" />
+                          {:else}
+                            <Icon class="h-5 w-5" />
+                          {/if}
+                        </div>
+                        <div class="flex-1 min-w-0">
+                          <div class="flex items-center gap-2 flex-wrap">
+                            <span class="font-medium">{app.name}</span>
+                            <Badge variant="outline" class="text-xs gap-1">
+                              {getPlatformLabel(app.platform)}
+                            </Badge>
+                            {#if detected}
+                              <Badge variant="secondary" class="text-xs text-green-600">
+                                Connected
+                              </Badge>
+                            {/if}
+                          </div>
+                          {#if app.description}
+                            <p class="text-sm text-muted-foreground line-clamp-1">
+                              {app.description}
+                            </p>
+                          {/if}
+                        </div>
+                        <ChevronRight
+                          class="h-4 w-4 text-muted-foreground group-hover:text-foreground transition-colors shrink-0"
+                        />
+                      </button>
+                    {/each}
+                  </div>
+                </div>
+              {/each}
+            </div>
+          </div>
+        {/if}
+
+        <!-- Empty state when both are empty -->
+        {#if connectors.length === 0 && uploaderApps.length === 0}
+          <Card.Root>
+            <Card.Content class="py-8 text-center">
+              <Plug class="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
+              <p class="font-medium">No data sources available</p>
+              <p class="text-sm text-muted-foreground mt-1">
+                There are no data sources available at this time.
+              </p>
+            </Card.Content>
+          </Card.Root>
+        {/if}
+      </div>
+
+      <!-- Skip link -->
+      <div class="pt-4 text-center">
+        <button
+          type="button"
+          class="text-sm text-muted-foreground hover:text-foreground underline-offset-4 hover:underline transition-colors"
+          onclick={handleSkip}
+        >
+          Skip for now
+        </button>
+      </div>
+    {/if}
+
+  {:else if viewState === "connector"}
+    <!-- ── Connector View ──────────────────────────────────────── -->
+    <div class="space-y-4">
+      <Button
+        variant="ghost"
+        size="sm"
+        class="gap-1 -ml-2"
+        onclick={handleConnectorCancel}
+      >
+        <ChevronLeft class="h-4 w-4" />
+        Back to data sources
+      </Button>
+
+      <ConnectorSetup
+        connectorId={selectedConnectorId ?? undefined}
+        onComplete={handleConnectorComplete}
+        onCancel={handleConnectorCancel}
+        showToggle={false}
+        showDangerZone={false}
+        showCapabilities={false}
+        primaryAction="save-and-sync"
+      />
+    </div>
+
+  {:else if viewState === "uploader"}
+    <!-- ── Uploader View ───────────────────────────────────────── -->
+    <div class="space-y-4">
+      <Button
+        variant="ghost"
+        size="sm"
+        class="gap-1 -ml-2"
+        onclick={handleBackToSelection}
+      >
+        <ChevronLeft class="h-4 w-4" />
+        Back to data sources
+      </Button>
+
+      {#if setupLoading}
+        <div class="flex items-center justify-center py-8">
+          <Loader2 class="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      {:else if setupResponse}
+        <div>
+          <h2 class="text-lg font-semibold">{selectedApp?.name}</h2>
+          {#if selectedApp?.description}
+            <p class="text-sm text-muted-foreground">
+              {selectedApp.description}
+            </p>
+          {/if}
+        </div>
+
+        {#if setupResponse.connectUrl}
+          <!-- ── OAuth Device Flow (QR code + inline authorization) ── -->
+          {#if deviceApproved}
+            <!-- Approved — waiting for data -->
+            <Card.Root class="border-green-500/30">
+              <Card.Content class="space-y-2 pt-6">
+                <div class="flex items-center gap-3">
+                  <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/30">
+                    <Check class="h-5 w-5 text-green-600 dark:text-green-400" />
+                  </div>
+                  <div>
+                    <p class="font-medium text-green-600">Device Authorized</p>
+                    <p class="text-sm text-muted-foreground">
+                      {selectedApp?.name} is now connected. You can return to your device.
+                    </p>
+                  </div>
+                </div>
+              </Card.Content>
+            </Card.Root>
+
+            <!-- Connection status (polling for data) -->
+            {@const detected = isDetected(selectedApp?.id)}
+            {@const ds = getDataSource(selectedApp?.id)}
+            {#if detected && ds}
+              <Card.Root class="border-green-500/30">
+                <Card.Content class="flex items-center gap-3 pt-6">
+                  <CheckCircle class="h-5 w-5 text-green-500" />
+                  <div>
+                    <p class="font-medium text-green-600">Receiving Data</p>
+                    <p class="text-sm text-muted-foreground">
+                      {selectedApp?.name} is sending data. {ds.entriesLast24h ?? 0} entries in the last 24 hours.
+                    </p>
+                  </div>
+                </Card.Content>
+              </Card.Root>
+
+              <div class="flex justify-end">
+                <Button onclick={handleSkip}>Continue to Dashboard</Button>
+              </div>
+            {:else}
+              <Card.Root class="border-muted">
+                <Card.Content class="flex items-center gap-3 pt-6">
+                  <Clock class="h-5 w-5 text-muted-foreground" />
+                  <div>
+                    <p class="font-medium">Waiting for data</p>
+                    <p class="text-sm text-muted-foreground">
+                      It can take a few minutes for the first glucose reading to arrive. This page will update automatically.
+                    </p>
+                  </div>
+                </Card.Content>
+              </Card.Root>
+            {/if}
+
+          {:else if deviceDenied}
+            <!-- Denied -->
+            <Card.Root>
+              <Card.Content class="flex items-center gap-3 pt-6">
+                <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-muted">
+                  <X class="h-5 w-5 text-muted-foreground" />
+                </div>
+                <div>
+                  <p class="font-medium">Authorization Denied</p>
+                  <p class="text-sm text-muted-foreground">The device will not be granted access.</p>
+                </div>
+              </Card.Content>
+            </Card.Root>
+
+          {:else if deviceInfo}
+            <!-- Step 2: Approve / deny the device -->
+            <Card.Root>
+              <Card.Header class="space-y-1 text-center">
+                <div class="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+                  <Shield class="h-6 w-6 text-primary" />
+                </div>
+                <Card.Title class="text-lg">Authorize Application</Card.Title>
+                <Card.Description>
+                  <span class="font-semibold text-foreground">{deviceInfo.displayName ?? deviceInfo.clientId}</span>
+                  wants to access your Nocturne data.
+                </Card.Description>
+              </Card.Header>
+              <Card.Content class="space-y-4">
+                {#if !deviceInfo.isKnown}
+                  <div class="flex items-start gap-3 rounded-md border border-yellow-200 bg-yellow-50 p-3 dark:border-yellow-900/50 dark:bg-yellow-900/20">
+                    <AlertTriangle class="mt-0.5 h-4 w-4 shrink-0 text-yellow-600 dark:text-yellow-400" />
+                    <p class="text-sm text-yellow-800 dark:text-yellow-200">
+                      This application is not in the Nocturne known app directory. Only approve if you trust it.
+                    </p>
+                  </div>
+                {/if}
+
+                <Separator />
+
+                <div>
+                  <p class="mb-3 text-sm font-medium">This application is requesting permission to:</p>
+                  <ul class="space-y-2">
+                    {#each deviceInfo.scopes as scope}
+                      <li class="flex items-start gap-3 text-sm">
+                        <Check class="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                        <span class="text-muted-foreground">{getOAuthScopeDescription(scope)}</span>
+                      </li>
+                    {/each}
+                  </ul>
+                </div>
+
+                {#if deviceInfo.scopes.includes("*")}
+                  <div class="flex items-start gap-3 rounded-md border border-destructive/20 bg-destructive/5 p-3">
+                    <ShieldAlert class="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+                    <p class="text-sm text-destructive">This app is requesting full access, including the ability to delete data.</p>
+                  </div>
+                {:else}
+                  <div class="flex items-start gap-3 rounded-md bg-muted/50 p-3">
+                    <Shield class="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                    <p class="text-sm text-muted-foreground">This app cannot delete your data.</p>
+                  </div>
+                {/if}
+
+                {#if deviceLookupError}
+                  <div class="flex items-start gap-3 rounded-md border border-destructive/20 bg-destructive/5 p-3">
+                    <AlertTriangle class="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+                    <p class="text-sm text-destructive">{deviceLookupError}</p>
+                  </div>
+                {/if}
+
+                <Separator />
+
+                <div class="flex gap-3">
+                  <Button
+                    variant="outline"
+                    class="flex-1"
+                    disabled={deviceApproveLoading}
+                    onclick={handleDenyDevice}
+                  >
+                    {#if deviceApproveLoading}
+                      <Loader2 class="mr-2 h-4 w-4 animate-spin" />
+                    {/if}
+                    Deny
+                  </Button>
+                  <Button
+                    class="flex-1"
+                    disabled={deviceApproveLoading}
+                    onclick={handleApproveDevice}
+                  >
+                    {#if deviceApproveLoading}
+                      <Loader2 class="mr-2 h-4 w-4 animate-spin" />
+                    {/if}
+                    Approve
+                  </Button>
+                </div>
+              </Card.Content>
+            </Card.Root>
+
+          {:else}
+            <!-- Step 1: QR code + code entry -->
+            <Card.Root>
+              <Card.Header class="text-center pb-3">
+                <Card.Title class="text-sm">Scan to Connect</Card.Title>
+                <Card.Description>
+                  Scan this QR code with your phone's camera to open {selectedApp?.name} and start the connection.
+                </Card.Description>
+              </Card.Header>
+              <Card.Content class="flex flex-col items-center gap-4">
+                {#if qrCodeDataUrl}
+                  <div class="rounded-lg border bg-white p-2">
+                    <img src={qrCodeDataUrl} alt="QR code to connect {selectedApp?.name}" class="h-48 w-48" />
+                  </div>
+                {:else}
+                  <div class="flex h-48 w-48 items-center justify-center rounded-lg border bg-muted">
+                    <Loader2 class="h-6 w-6 animate-spin text-muted-foreground" />
+                  </div>
+                {/if}
+              </Card.Content>
+            </Card.Root>
+
+            <Card.Root>
+              <Card.Header class="pb-3">
+                <Card.Title class="text-sm">Enter Authorization Code</Card.Title>
+                <Card.Description>
+                  After scanning, {selectedApp?.name} will show an 8-character code. Enter it here to approve the connection.
+                </Card.Description>
+              </Card.Header>
+              <Card.Content class="space-y-4">
+                {#if deviceLookupError}
+                  <div class="flex items-start gap-3 rounded-md border border-destructive/20 bg-destructive/5 p-3">
+                    <AlertTriangle class="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+                    <p class="text-sm text-destructive">{deviceLookupError}</p>
+                  </div>
+                {/if}
+
+                <form
+                  class="flex gap-2"
+                  onsubmit={(e) => {
+                    e.preventDefault();
+                    lookupDeviceCode();
+                  }}
+                >
+                  <Input
+                    type="text"
+                    placeholder="XXXX-YYYY"
+                    maxlength={9}
+                    autocomplete="off"
+                    class="text-center text-lg tracking-widest uppercase"
+                    bind:value={deviceCodeInput}
+                    disabled={deviceLookupLoading}
+                  />
+                  <Button type="submit" disabled={deviceLookupLoading || !deviceCodeInput.trim()}>
+                    {#if deviceLookupLoading}
+                      <Loader2 class="h-4 w-4 animate-spin" />
+                    {:else}
+                      Continue
+                    {/if}
+                  </Button>
+                </form>
+              </Card.Content>
+            </Card.Root>
+          {/if}
+
+        {/if}
+      {:else}
+        <Card.Root class="border-destructive">
+          <Card.Content class="flex items-center gap-3 pt-6">
+            <AlertCircle class="h-5 w-5 text-destructive" />
+            <div>
+              <p class="font-medium">Failed to load setup instructions</p>
+              <p class="text-sm text-muted-foreground">
+                Could not load setup details for {selectedApp?.name}. Please try again.
+              </p>
+            </div>
+          </Card.Content>
+        </Card.Root>
+      {/if}
+    </div>
+  {/if}
+</div>

--- a/src/Web/packages/app/src/routes/(fullscreen)/setup/uploaders/+page.svelte
+++ b/src/Web/packages/app/src/routes/(fullscreen)/setup/uploaders/+page.svelte
@@ -11,6 +11,7 @@
     DataSourceInfo,
   } from "$lib/api/generated/nocturne-api-client";
   import WizardShell from "$lib/components/setup/WizardShell.svelte";
+  import XdripQuickConnect from "$lib/components/XdripQuickConnect.svelte";
   import {
     Card,
     CardContent,
@@ -389,6 +390,14 @@
             </p>
           {/if}
         </div>
+
+        {#if selectedApp?.id === "xdrip"}
+          <Card>
+            <CardContent class="pt-6">
+              <XdripQuickConnect instanceUrl={window.location.origin} />
+            </CardContent>
+          </Card>
+        {/if}
 
         <!-- API URLs to copy -->
         <Card>

--- a/src/Web/packages/app/src/routes/settings/connectors/+page.svelte
+++ b/src/Web/packages/app/src/routes/settings/connectors/+page.svelte
@@ -110,6 +110,7 @@
   import type { DataSourceStatus } from "$lib/components/settings/DataSourceRow.svelte";
   import ConnectedApps from "$lib/components/settings/ConnectedApps.svelte";
   import ApiTokens from "$lib/components/settings/ApiTokens.svelte";
+  import XdripQuickConnect from "$lib/components/XdripQuickConnect.svelte";
   import Apple from "lucide-svelte/icons/apple";
   import TabletSmartphone from "lucide-svelte/icons/tablet-smartphone";
   import { getApiClient } from "$lib/api";
@@ -1714,6 +1715,12 @@
       </Dialog.Header>
 
       <div class="space-y-6 py-4">
+        {#if selectedUploader?.id === "xdrip" && typeof window !== "undefined"}
+          <div class="border-b pb-4 mb-4">
+            <XdripQuickConnect instanceUrl={window.location.origin} />
+          </div>
+        {/if}
+
         <!-- Connection Info -->
         <div class="space-y-3">
           <h4 class="font-medium">Connection Details</h4>

--- a/src/Web/packages/ui/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
+++ b/src/Web/packages/ui/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
@@ -23,7 +23,7 @@
     bind:ref
     data-slot="alert-dialog-content"
     class={cn(
-      "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+      "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed inset-0 z-50 m-auto grid h-fit w-full max-w-[calc(100%-2rem)] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
       className
     )}
     {...restProps}

--- a/src/Web/packages/ui/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/src/Web/packages/ui/src/lib/components/ui/dialog/dialog-content.svelte
@@ -23,7 +23,7 @@
     bind:ref
     data-slot="dialog-content"
     class={cn(
-      "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+      "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed inset-0 z-50 m-auto grid h-fit w-full max-w-[calc(100%-2rem)] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
       className
     )}
     {...restProps}


### PR DESCRIPTION
## Summary

Adds xDrip quick-connect flow for Nocturne:

- Trampoline page at `/connect/xdrip` with QR code and deep link for easy mobile setup
- `XdripQuickConnect` component wired into both `/setup/uploaders` and connectors settings dialog
- Polls for data arrival after connect
- i18n strings extracted to locale catalogs
- E2E test for the trampoline page
- ARIA live region and error logging for accessibility

## Test plan

- [ ] CI (build + tests)
- [ ] Manual: scan QR from xDrip app, verify data flows through to Nocturne