### PR TITLE
fix: use https scheme in onboarding instance URL

### DIFF
--- a/scripts/publish-release.cs
+++ b/scripts/publish-release.cs
@@ -62,6 +62,18 @@ try
     {
         composeContent = composeContent.Replace(oldName, newName);
     }
+
+    // Bind the gateway to loopback only so a reverse proxy (e.g. Caddy) can own ports 80/443.
+    composeContent = composeContent.Replace(
+        "      - \"80:5000\"",
+        "      - \"127.0.0.1:8080:5000\"");
+
+    // Inject Multitenancy__BaseDomain into the API container so the WebAuthn RP ID is derived
+    // from the public domain rather than defaulting to localhost:1612.
+    composeContent = composeContent.Replace(
+        "      INSTANCE_KEY: \"${INSTANCE_KEY}\"",
+        "      INSTANCE_KEY: \"${INSTANCE_KEY}\"\n      Multitenancy__BaseDomain: \"${PUBLIC_BASE_DOMAIN}\"");
+
     File.WriteAllText(Path.Combine(outputDir, "docker-compose.yaml"), composeContent);
     Console.WriteLine($"[publish-release] Wrote {Path.Combine(outputDir, "docker-compose.yaml")}");
 
@@ -97,12 +109,13 @@ static void GenerateEnvExample(
     // Known defaults for non-secret values
     var defaults = new Dictionary<string, string>
     {
-        ["NOCTURNE_API_IMAGE"] = "ghcr.io/nightscout/nocturne/api:latest",
-        ["NOCTURNE_WEB_IMAGE"] = "ghcr.io/nightscout/nocturne/web:latest",
+        ["NOCTURNE_API_IMAGE"] = "ghcr.io/nightscout/nocturne/nocturne-api:latest",
+        ["NOCTURNE_WEB_IMAGE"] = "ghcr.io/nightscout/nocturne/nocturne-web:latest",
         ["NOCTURNE_API_PORT"] = "8080",
         ["POSTGRES_USERNAME"] = "nocturne",
         ["POSTGRES_INIT_DIR"] = "./init",
         ["NOCTURNE_POSTGRES_SERVER_BINDMOUNT_0"] = "./init",
+        ["PUBLIC_BASE_DOMAIN"] = "",
     };
 
     // Secret vars -- leave blank
@@ -122,7 +135,6 @@ static void GenerateEnvExample(
         "TELEGRAM_BOT_TOKEN",
         "SLACK_BOT_TOKEN",
         "WHATSAPP_ACCESS_TOKEN",
-        "PUBLIC_BASE_DOMAIN",
     };
 
     using var writer = new StreamWriter(outputPath);
@@ -181,8 +193,8 @@ static void GenerateEnvExample(
     else
     {
         // Fallback if aspire didn't generate .env
-        writer.WriteLine("NOCTURNE_API_IMAGE=ghcr.io/nightscout/nocturne/api:latest");
-        writer.WriteLine("NOCTURNE_WEB_IMAGE=ghcr.io/nightscout/nocturne/web:latest");
+        writer.WriteLine("NOCTURNE_API_IMAGE=ghcr.io/nightscout/nocturne/nocturne-api:latest");
+        writer.WriteLine("NOCTURNE_WEB_IMAGE=ghcr.io/nightscout/nocturne/nocturne-web:latest");
         writer.WriteLine("NOCTURNE_API_PORT=8080");
         writer.WriteLine("POSTGRES_USERNAME=nocturne");
         writer.WriteLine("POSTGRES_INIT_DIR=./init");
@@ -193,7 +205,7 @@ static void GenerateEnvExample(
         writer.WriteLine("POSTGRES_WEB_PASSWORD=");
         writer.WriteLine("INSTANCE_KEY=");
         writer.WriteLine();
-        writer.WriteLine("# PUBLIC_BASE_DOMAIN=");
+        writer.WriteLine("PUBLIC_BASE_DOMAIN=");
     }
 }
 

--- a/src/API/Nocturne.API/Controllers/V4/Platform/ServicesController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/ServicesController.cs
@@ -3,6 +3,7 @@ using OpenApi.Remote.Attributes;
 using Nocturne.API.Models;
 using Nocturne.API.Services.Connectors;
 using Nocturne.Core.Contracts.Connectors;
+using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Services;
 
 namespace Nocturne.API.Controllers.V4.Platform;
@@ -538,11 +539,21 @@ public class ServicesController : ControllerBase
         // Try to get configured base URL first
         var configuredUrl = _configuration["BaseUrl"];
         if (!string.IsNullOrEmpty(configuredUrl))
-        {
             return configuredUrl.TrimEnd('/');
+
+        // In production the API runs as plain HTTP behind a TLS-terminating reverse proxy,
+        // so request.Scheme is always "http" for internal calls from the web container.
+        // Build the correct https:// URL from Multitenancy:BaseDomain + the tenant slug instead.
+        var baseDomain = _configuration["Multitenancy:BaseDomain"];
+        if (!string.IsNullOrEmpty(baseDomain) &&
+            !baseDomain.StartsWith("localhost", StringComparison.OrdinalIgnoreCase))
+        {
+            var slug = (HttpContext.Items["TenantContext"] as TenantContext)?.Slug;
+            if (!string.IsNullOrEmpty(slug))
+                return $"https://{slug}.{baseDomain.Split(':')[0]}";
         }
 
-        // Fall back to request URL
+        // Development fallback: derive from the incoming request
         var request = HttpContext.Request;
         return $"{request.Scheme}://{request.Host}";
     }


### PR DESCRIPTION
In production the API runs as plain HTTP behind a TLS-terminating reverse proxy (Caddy → YARP → API). The SvelteKit web container calls the API internally over HTTP, so `request.Scheme` is always `"http"` — the HTTPS context from the original client request is not preserved through the proxy chain.

`GetBaseUrl()` in `ServicesController` was therefore returning `http://jja.nocturne.jacob-arnould.com`, which is displayed verbatim in the onboarding "Configure & sync" step. Apps like Trio reject non-HTTPS Nightscout URLs, so users had to manually correct the URL before they could connect.

### Fix

When `Multitenancy:BaseDomain` is set to a real (non-localhost) domain, construct the URL as `https://{slug}.{baseDomain}` using the resolved `TenantContext`. The existing `request.Scheme` fallback is preserved for local development where the domain is `localhost:1612`.

The `BaseUrl` configuration escape hatch (checked first) is unchanged.