### PR TITLE
fix(coach): make primary button text adapt to design system foreground

### DIFF
--- a/src/Web/packages/app/src/styles/coach-theme-overrides.css
+++ b/src/Web/packages/app/src/styles/coach-theme-overrides.css
@@ -6,6 +6,7 @@
   --coach-text-muted: var(--muted-foreground);
   --coach-primary: var(--primary);
   --coach-primary-hover: var(--primary);
+  --coach-primary-text: var(--primary-foreground);
   --coach-radius: var(--radius);
   --coach-hotspot-color: var(--primary);
   --coach-shadow: 0 4px 16px oklch(0 0 0 / 0.08);

--- a/src/Web/packages/coach/src/lib/theme.css
+++ b/src/Web/packages/coach/src/lib/theme.css
@@ -6,6 +6,7 @@
   --coach-text-muted: hsl(0 0% 65%);
   --coach-primary: hsl(210 100% 60%);
   --coach-primary-hover: hsl(210 100% 50%);
+  --coach-primary-text: white;
   --coach-radius: 10px;
   --coach-shadow: 0 8px 32px hsl(0 0% 0% / 0.4);
   --coach-hotspot-size: 12px;
@@ -126,7 +127,7 @@
 
 .coach-btn--primary {
   background: var(--coach-primary);
-  color: white;
+  color: var(--coach-primary-text);
 }
 
 .coach-btn--primary:hover {


### PR DESCRIPTION
## Problem

The "Got it" button in coach mark popovers was unreadable in dark mode. The app's `coach-theme-overrides.css` correctly maps `--coach-primary` to shadcn's `--primary`, which is near-white in dark mode. However, the coach package hardcoded `color: white` on `.coach-btn--primary`, producing white text on a near-white background.

## Solution

Add a `--coach-primary-text` token to the coach package (defaulting to `white` for its standalone dark theme) and use it in `.coach-btn--primary` instead of the hardcoded value. Map the token to `--primary-foreground` in the app's override file so the button label always contrasts correctly with whatever `--primary` resolves to.

**Changes:**
- `packages/coach/src/lib/theme.css` — add `--coach-primary-text: white` to `:root`; use `var(--coach-primary-text)` on `.coach-btn--primary`
- `packages/app/src/styles/coach-theme-overrides.css` — map `--coach-primary-text: var(--primary-foreground)`

## Smoke test

Reset coach marks via browser console (`await fetch('/api/v4/coach-marks', { method: 'DELETE' })`), triggered the coach mark popover, and confirmed the "Got it" button shows dark readable text on the light primary background in dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)