### PR TITLE
fix(dashboard): correct BG delta and flat trend icon

### DIFF
--- a/src/Web/packages/app/src/lib/stores/realtime-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/realtime-store.svelte.ts
@@ -151,7 +151,7 @@ export class RealtimeStore {
 
   /** Delta calculation - prefer entry delta, fallback to computed */
   bgDelta = $derived.by(() => {
-    if (this.currentEntry?.delta !== undefined) {
+    if (this.currentEntry?.delta != null) {
       return this.currentEntry.delta;
     }
     return this.currentBG - this.previousBG;

--- a/src/Web/packages/app/src/lib/utils/index.ts
+++ b/src/Web/packages/app/src/lib/utils/index.ts
@@ -3,9 +3,9 @@ import { getLocalTimeZone, now, fromDate } from "@internationalized/date";
 import {
   ArrowUp,
   ArrowUpRight,
+  ArrowRight,
   ArrowDown,
   ArrowDownRight,
-  Minus,
   HelpCircle,
   AlertTriangle,
 } from "lucide-svelte";
@@ -90,7 +90,7 @@ export function getDirectionInfo(direction?: Direction | string) {
       icon: ArrowUpRight,
       css: "text-yellow-500",
     },
-    [Direction.Flat]: { label: "stable", icon: Minus, css: "text-green-500" },
+    [Direction.Flat]: { label: "stable", icon: ArrowRight, css: "text-green-500" },
     [Direction.FortyFiveDown]: {
       label: "falling slowly",
       icon: ArrowDownRight,


### PR DESCRIPTION
## Summary

- **BG delta always showed 0**: The v4 `/api/v4/glucose/sensor` endpoint returns `delta: null` for entries with no stored delta. The guard `!== undefined` passes for `null` (`null !== undefined` is `true`), so the store was returning `null` as `bgDelta` instead of falling through to compute `currentBG - previousBG`. Fixed by changing the check to `!= null`, which correctly treats both `null` and `undefined` as absent.

- **Flat trend displayed as `—` instead of `→`**: The `Flat` direction was mapped to the Lucide `Minus` icon, which renders as a horizontal line and is visually indistinguishable from a separator. Nightscout convention is a right-pointing arrow for stable glucose. Fixed by replacing `Minus` with `ArrowRight`.

## Test plan

- [ ] Inject two SGV entries with different `mgdl` values — BG Delta card should show the computed difference (not 0)
- [ ] Inject entries with `direction: "Flat"` — sidebar and header should show `→`, not `—`
- [ ] Inject entries with `direction: "FortyFiveDown"` — should still show `↘` (regression check)
- [ ] Verify on production with real CGM data that BG Delta reflects the actual reading-to-reading change

🤖 Generated with [Claude Code](https://claude.com/claude-code)