### PR TITLE
fix(realtime-store): reconnect WebSocket and suppress noisy toast on tab resume

### DIFF
--- a/src/Web/packages/app/src/lib/stores/realtime-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/realtime-store.svelte.ts
@@ -263,6 +263,12 @@ export class RealtimeStore {
           // Snap now immediately so time-since displays don't lag
           this.now = Date.now();
           this.stopBackgroundPolling();
+          // Reconnect if the socket dropped while backgrounded — Socket.io
+          // exhausts its retry budget (~4 min) well before long idle periods.
+          if (!this.websocketClient.isConnected) {
+            console.log('[RealtimeStore] WebSocket disconnected, reconnecting...');
+            this.reconnect();
+          }
           console.log('[RealtimeStore] Page became visible, backfilling missed data...');
           // Always backfill on return — timers are unreliable in hidden tabs
           // so we can't trust lastDataReceived to be meaningful
@@ -401,8 +407,6 @@ export class RealtimeStore {
   /** Setup WebSocket event handlers */
   private setupEventHandlers(): void {
     this.websocketClient.on("connect", () => {
-      toast.success("Connected to real-time data");
-      // Backfill any missed data on reconnection
       this.performBackfillIfNeeded();
     });
 


### PR DESCRIPTION
## Summary

- **WebSocket reconnect on visibility**: When the browser tab becomes visible after a long idle period, the app now checks if the WebSocket is disconnected and calls `reconnect()` before backfilling. Socket.io exhausts its 10-attempt retry budget in ~4.5 minutes of background; without this fix, the WebSocket stays dead indefinitely and ongoing real-time updates stop even after the backfill completes.
- **Remove "Connected to real-time data" toast**: The `connect` event fired ~1 second after the visibility-triggered `reconnect()`, causing a double-toast sequence ("Connected to real-time data" immediately followed by "Synced X missed data points"). Removing the connected toast eliminates the noise — disconnect/error toasts are preserved so failures remain visible.

## Test plan

- [ ] Background a tab for >5 minutes, return — WebSocket should reconnect and data should update without a page refresh
- [ ] On normal page load, confirm no "Connected to real-time data" toast appears
- [ ] On disconnect/reconnect, confirm the backfill "Synced X missed data points" toast still appears
- [ ] Confirm disconnect/error toasts still fire on connection loss

🤖 Generated with [Claude Code](https://claude.com/claude-code)