### PR TITLE
fix(glooko import): Fixing date for Glooko API startDate to avoid data gaps

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoTimeMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoTimeMapper.cs
@@ -28,6 +28,16 @@ public class GlookoTimeMapper
         return corrected;
     }
 
+    /// <summary>
+    ///     Converts a real UTC timestamp back to Glooko's fake-UTC format
+    ///     (local time with Z suffix) for use in API request parameters.
+    ///     This is the reverse of <see cref="GetCorrectedGlookoTime(DateTime)"/>.
+    /// </summary>
+    public DateTime ToGlookoTime(DateTime utcTime)
+    {
+        return utcTime.AddHours(_config.TimezoneOffset);
+    }
+
     public DateTime GetCorrectedGlookoTime(long unixSeconds)
     {
         var rawUtc = DateTimeOffset.FromUnixTimeSeconds(unixSeconds).UtcDateTime;

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -129,6 +129,8 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         if (response.IsSuccessStatusCode)
         {
             var json = await GlookoHttpHelper.ReadResponseAsync(response);
+            _logger.LogDebug("[{ConnectorSource}] Response {StatusCode} from {Url}: {Json}",
+                ConnectorSource, (int)response.StatusCode, absoluteUrl, json);
             return JsonSerializer.Deserialize<JsonElement>(json);
         }
 
@@ -253,7 +255,12 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes);
             var activeTypes = request.DataTypes.Where(t => enabledTypes.Contains(t)).ToHashSet();
 
-            var from = request.From;
+            // Convert real UTC (from database) back to Glooko's fake-UTC format
+            // for API requests. Glooko timestamps are labeled as UTC but are actually
+            // local time, so we reverse the timezone correction applied during inbound processing.
+            var from = request.From.HasValue
+                ? _timeMapper.ToGlookoTime(request.From.Value)
+                : (DateTime?)null;
 
             await ReportMessageAsync(progressReporter, SyncMessageType.FetchingData,
                 new() { ["from"] = (from ?? DateTime.UtcNow.AddMonths(-6)).ToString("MMM dd"), ["to"] = DateTime.UtcNow.ToString("MMM dd") },
@@ -508,8 +515,8 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             var patientCode = EnsureAuthenticatedAndGetCode();
             if (patientCode == null) return null;
 
-            var fromDate = since ?? DateTime.UtcNow.AddDays(-1);
-            var toDate = DateTime.UtcNow;
+            var fromDate = since ?? _timeMapper.ToGlookoTime(DateTime.UtcNow.AddDays(-1));
+            var toDate = _timeMapper.ToGlookoTime(DateTime.UtcNow);
 
             _logger.LogInformation("Fetching comprehensive Glooko data from {From:yyyy-MM-dd} to {To:yyyy-MM-dd}", fromDate, toDate);
 
@@ -641,8 +648,8 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             // Ensure we have meter units
             if (string.IsNullOrEmpty(_meterUnits)) await FetchV3UserProfileAsync();
 
-            var fromDate = since ?? DateTime.UtcNow.AddDays(-1);
-            var toDate = DateTime.UtcNow;
+            var fromDate = since ?? _timeMapper.ToGlookoTime(DateTime.UtcNow.AddDays(-1));
+            var toDate = _timeMapper.ToGlookoTime(DateTime.UtcNow);
 
             var url = ConstructV3GraphUrl(fromDate, toDate);
             _logger.LogInformation("[{ConnectorSource}] Fetching v3 graph data from {StartDate:yyyy-MM-dd} to {EndDate:yyyy-MM-dd}",


### PR DESCRIPTION
Glooko uses localized timestamps marked as UTC. Incoming data is adjusted with the timezone offset, that's not changed. The sync requests with start and end timestamps were using actual UTC adjusted time, which caused gaps in the imported data, especially CGM data, because it's loaded from a partner site (Dexcom in my case) which has a delay.

So let's say a user on a TZ UTC-4 is importing data from Glooko, and the server has CGM data up to 2pm EST (6pm UTC). The data from Glooko will show 2026-05-01T14:00:00.000Z for the last reading, and not T18:00. If the user has a -4 timezone offset configured, the connector will adjust the timestamp adding 4 hours and record the actual UTC timestamp 2026-05-01T18:00:00.000Z in the DB, which is what we want.

The problem is, when the connector syncs again, it picks the latest recoded timestamp in UTC and sends it in the request to Glooko. So let's say at 7pm EST, the sync request will ask for data from 2026-05-01T18:00:00.000Z (last recorded data) to 2026-05-01T23:00:00.000Z (current UTC). But Glooko will understand this as a request for data from 6pm EST to 11pm (in the future), and will retrieve only data from 6pm to 7pm EST, leaving a gap between 2pm and 6pm.

The solution is to adjust the timestamps for the Glooko API requests using the same timezone offset that was used during data import.

I also sneaked in an additional debug message to capture Glooko's responses to better understand the data available.

Sorry if the description is actually longer than the PR :-P