### PR TITLE
fix(bridge): resolve apex-domain socket.io clients to sole tenant

### DIFF
--- a/src/Web/packages/bridge/src/lib/socketio-server.ts
+++ b/src/Web/packages/bridge/src/lib/socketio-server.ts
@@ -20,10 +20,17 @@ class SocketIOServer {
   private clients: Map<string, ClientInfo> = new Map();
   private config: SocketIOConfig;
   private baseDomain?: string;
+  private tenantSlugs: string[];
 
-  constructor(httpServer: HttpServer, config: SocketIOConfig = {}, baseDomain?: string) {
+  constructor(
+    httpServer: HttpServer,
+    config: SocketIOConfig = {},
+    baseDomain?: string,
+    tenantSlugs: string[] = [],
+  ) {
     this.httpServer = httpServer;
     this.baseDomain = baseDomain;
+    this.tenantSlugs = tenantSlugs;
     this.config = {
       cors: config.cors || {
         origin: '*',
@@ -123,7 +130,10 @@ class SocketIOServer {
 
   /** Extract tenant slug from the Socket.IO handshake headers.
    *  Checks X-Forwarded-Host first (set by YARP's X-Forwarded transform),
-   *  then falls back to Host (preserved by RequestHeaderOriginalHost). */
+   *  then falls back to Host (preserved by RequestHeaderOriginalHost).
+   *  Apex-domain connections fall back to the sole tenant when exactly one
+   *  exists, mirroring the API's TenantResolutionMiddleware behavior so
+   *  self-hosted single-tenant deployments work without a subdomain. */
   private extractTenantSlug(socket: Socket): string | null {
     if (!this.baseDomain) return null;
 
@@ -133,11 +143,18 @@ class SocketIOServer {
     if (!candidate) return null;
 
     const hostname = candidate.split(':')[0];
-    const suffix = `.${this.baseDomain.split(':')[0]}`;
-    if (!hostname.endsWith(suffix)) return null;
+    const baseDomainHost = this.baseDomain.split(':')[0];
 
-    const slug = hostname.slice(0, -suffix.length);
-    return slug || null;
+    if (hostname.endsWith(`.${baseDomainHost}`)) {
+      const slug = hostname.slice(0, -(baseDomainHost.length + 1));
+      return slug || null;
+    }
+
+    if (hostname === baseDomainHost && this.tenantSlugs.length === 1) {
+      return this.tenantSlugs[0];
+    }
+
+    return null;
   }
 
   /** Return the Socket.IO emit target: tenant room if scoped, or all clients. */

--- a/src/Web/packages/bridge/src/setup.ts
+++ b/src/Web/packages/bridge/src/setup.ts
@@ -78,16 +78,9 @@ export async function setupBridge(
       logger.info(`SignalR ConfigHub URL: ${config.signalr.configHubUrl}`);
     }
 
-    const socketIOServer = new SocketIOServer(
-      httpServer,
-      config.socketio,
-      config.baseDomain,
-    );
-
-    await socketIOServer.start();
-    logger.info('Socket.IO server started');
-
-    // Multi-tenant mode: discover tenants, create per-tenant SignalR connections
+    // Discover tenants before starting the socket.io server so apex-domain
+    // connections can auto-resolve to the sole tenant during the handshake.
+    let tenantSlugs: string[] = [];
     if (config.baseDomain) {
       logger.info(`Multi-tenant mode enabled (baseDomain: ${config.baseDomain})`);
 
@@ -98,8 +91,20 @@ export async function setupBridge(
 
       // Extract the API base URL from the hub URL (strip /hubs/data)
       const apiBaseUrl = config.signalr.hubUrl.replace(/\/hubs\/\w+$/, '');
-      const tenantSlugs = await discoverTenants(apiBaseUrl, instanceKeyHash);
+      tenantSlugs = await discoverTenants(apiBaseUrl, instanceKeyHash);
+    }
 
+    const socketIOServer = new SocketIOServer(
+      httpServer,
+      config.socketio,
+      config.baseDomain,
+      tenantSlugs,
+    );
+
+    await socketIOServer.start();
+    logger.info('Socket.IO server started');
+
+    if (config.baseDomain) {
       const clients: SignalRClient[] = [];
 
       for (const slug of tenantSlugs) {


### PR DESCRIPTION
## Summary

Self-hosted single-tenant deployments are broken: real-time updates never reach the browser, even with the tab in the foreground. Hard refreshes show current data (HTTP API works), but no live BG/treatment/devicestatus events arrive over the WebSocket. Users have to refresh manually to see new readings.

## Root cause

The bridge enters multi-tenant mode whenever `PUBLIC_BASE_DOMAIN` is set — which the production docker-compose template requires for every deployment. In multi-tenant mode, every socket.io client must be joined to a `tenant:<slug>` room, with the slug extracted from the connection's host header.

`extractTenantSlug` only matches `<slug>.<baseDomain>` patterns (e.g. `alice.nocturne.example.com`). Self-hosted users access the app at the **apex** of the base domain (e.g. `nocturne.example.com` IS the base domain) — there's no subdomain to extract. The function returns `null`, the client is logged as `connected without resolvable tenant`, and is never joined to any room.

Meanwhile, the bridge happily receives SignalR events from the API and broadcasts them to `io.to('tenant:<slug>')` — a room with zero members. Events vanish silently. The misleading log line `Broadcasting storage create event to N connected clients` reports the **total** socket.io client count, not the room size, so it hides the failure.

Production bridge logs from a self-hosted instance:

```
info: Multi-tenant mode enabled (baseDomain: nocturne.jacob-arnould.com)
info: Discovered 1 active tenant(s): jja
info: SignalR client connected for tenant: jja
info: Client 6t4Yhx0c... connected from ::ffff:172.18.0.6
warn: Client 6t4Yhx0c... connected without resolvable tenant   ← here
info: Broadcasting storage create event to 1 connected clients (tenant: jja)   ← misleading
```

## Fix

Mirror the API's `TenantResolutionMiddleware.GetSoleTenantAsync` behavior. The middleware already auto-resolves apex-domain HTTP requests to the sole active tenant when exactly one exists ([TenantResolutionMiddleware.cs:87-115](https://github.com/nightscout/nocturne/blob/main/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs#L87-L115)). The bridge should do the same.

Two changes:

1. **`setup.ts`**: discover tenants **before** creating the `SocketIOServer` so the slug list is available at connection-handshake time. Pass the discovered slugs into the constructor.

2. **`socketio-server.ts`**: extend `extractTenantSlug` — if the hostname equals the base domain (apex) AND exactly one tenant is known, return that tenant's slug. Otherwise behavior is unchanged.

Behavior across deployment shapes:

| Deployment | Hostname | Tenants in DB | Result |
|---|---|---|---|
| Multi-tenant SaaS (subdomain) | `alice.example.com` | many | resolves `alice` ✓ |
| Multi-tenant SaaS (apex) | `example.com` | many | unresolved (correctly ambiguous) ✓ |
| Self-hosted single-tenant (apex) | `nocturne.example.com` | 1 | resolves to sole tenant ✓ (NEW) |

No env-var changes, no docker-compose template changes, no breaking change for existing multi-tenant deployments.

## Test results

**Local (Aspire):** browser at `localhost:NNNN` (apex) connects through the gateway. Bridge log:
```
info: Client DYIqT_gHUuNuShZZAAAB joined tenant room: jja
```

**Production (self-hosted, apex):** patched image deployed to `https://nocturne.jacob-arnould.com`. Bridge log:
```
info: Client 6tsvjc7-nPJffDPjAAAD joined tenant room: jja
```

Dashboard updates live without manual refresh as new CGM readings arrive.

## Latent issues observed (separate PRs/issues)

These were present before this change and remain — worth filing separately:

1. **SignalR DataHub authentication failure**: bridge calls `Authorize` and receives `{success:false, read:false, write:false}` but continues anyway. Storage events flow regardless, but alarms don't (`SignalR AlarmHub subscription failed`).
2. **Misleading log**: `broadcastStorageEvent` logs `to N connected clients` using the total client count, not the target room size. This hid the room-join bug for a long time.

## Test plan

- [ ] Self-hosted single-tenant deployment at apex domain — `Client X joined tenant room: <slug>` appears in `nocturne-web` logs when a browser connects
- [ ] BG dashboard updates without refresh as new CGM data arrives
- [ ] Multi-tenant SaaS deployment — subdomain resolution still works as before (no regression)
- [ ] Apex connection on a multi-tenant deployment with multiple tenants — correctly stays unjoined (no regression, and not silently mis-joined to wrong tenant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)