### PR TITLE
feat(glooko-connector): Adding Glooko v2 BGM readings

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConstants.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConstants.cs
@@ -54,6 +54,7 @@ public static class GlookoConstants
     public const string ScheduledBasalsPath = "/api/v2/pumps/scheduled_basals";
     public const string NormalBolusesPath = "/api/v2/pumps/normal_boluses";
     public const string CgmReadingsPath = "/api/v2/cgm/readings";
+    public const string MeterReadingsPath = "/api/v2/readings";
     public const string SuspendBasalsPath = "/api/v2/pumps/suspend_basals";
     public const string TemporaryBasalsPath = "/api/v2/pumps/temporary_basals";
     public const string V3UsersPath = "/api/v3/session/users";

--- a/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoSensorGlucoseMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoSensorGlucoseMapper.cs
@@ -77,32 +77,69 @@ public class GlookoSensorGlucoseMapper
         return results;
     }
 
+    /// <summary>
+    /// Maps V2 meter readings to BGCheck records (finger stick / manual blood glucose).
+    /// Values are always mg/dL × 100 from Glooko, regardless of account meter units.
+    /// </summary>
+    public IEnumerable<BGCheck> TransformBatchDataToBGChecks(GlookoBatchData batchData)
+    {
+        var results = new List<BGCheck>();
+        if (batchData?.MeterReadings == null) return results;
+
+        foreach (var reading in batchData.MeterReadings)
+        {
+            var bgCheck = ParseBGCheck(reading);
+            if (bgCheck != null) results.Add(bgCheck);
+        }
+
+        return results;
+    }
+
+    // ── Parsing helpers ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// Parses and timezone-corrects a Glooko V2 timestamp string.
+    /// Returns null if the timestamp is missing or unparseable.
+    /// </summary>
+    private DateTime? ParseV2Timestamp(string? timestamp)
+    {
+        if (string.IsNullOrWhiteSpace(timestamp))
+            return null;
+
+        if (!DateTime.TryParse(timestamp, out var parsedDate))
+        {
+            _logger.LogWarning("Failed to parse Glooko timestamp: '{Timestamp}'", timestamp);
+            return null;
+        }
+
+        var date = parsedDate.ToUniversalTime();
+        if (_config.TimezoneOffset != 0)
+            date = date.AddHours(-_config.TimezoneOffset);
+
+        return date;
+    }
+
     private SensorGlucose? ParseSensorGlucose(GlookoCgmReading reading)
     {
         try
         {
-            if (string.IsNullOrWhiteSpace(reading.Timestamp) || reading.Value <= 0)
-                return null;
+            if (reading.Value <= 0) return null;
 
-            if (!DateTime.TryParse(reading.Timestamp, out var parsedDate))
-            {
-                _logger.LogWarning("Failed to parse Glooko timestamp: '{Timestamp}'", reading.Timestamp);
-                return null;
-            }
+            var date = ParseV2Timestamp(reading.Timestamp);
+            if (date == null) return null;
 
-            var date = parsedDate.ToUniversalTime();
-            if (_config.TimezoneOffset != 0)
-                date = date.AddHours(-_config.TimezoneOffset);
+            // Glooko V2 CGM values are mg/dL × 100 (integer encoding for 2-decimal precision)
+            var mgdl = reading.Value / 100.0;
 
             var now = DateTime.UtcNow;
             return new SensorGlucose
             {
                 Id = Guid.CreateVersion7(),
-                Timestamp = date,
-                LegacyId = $"glooko_{date.Ticks}",
+                Timestamp = date.Value,
+                LegacyId = $"glooko_{date.Value.Ticks}",
                 Device = _connectorSource,
                 DataSource = _connectorSource,
-                Mgdl = reading.Value,
+                Mgdl = mgdl,
                 Direction = ParseTrendToDirection(reading.Trend),
                 CreatedAt = now,
                 ModifiedAt = now
@@ -111,6 +148,44 @@ public class GlookoSensorGlucoseMapper
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error parsing Glooko CGM reading");
+            return null;
+        }
+    }
+
+    private BGCheck? ParseBGCheck(GlookoMeterReading reading)
+    {
+        try
+        {
+            if (reading.Value <= 0 || reading.SoftDeleted == true) return null;
+
+            var date = ParseV2Timestamp(reading.Timestamp);
+            if (date == null) return null;
+
+            // Glooko meter values are mg/dL × 100 (integer encoding for 2-decimal precision)
+            var mgdl = reading.Value / 100.0;
+
+            var legacyId = !string.IsNullOrEmpty(reading.Guid)
+                ? $"glooko_meter_{reading.Guid}"
+                : $"glooko_meter_{date.Value.Ticks}";
+
+            var now = DateTime.UtcNow;
+            return new BGCheck
+            {
+                Id = Guid.CreateVersion7(),
+                Timestamp = date.Value,
+                LegacyId = legacyId,
+                Device = _connectorSource,
+                DataSource = _connectorSource,
+                Glucose = mgdl,
+                Units = GlucoseUnit.MgDl,
+                GlucoseType = GlucoseType.Finger,
+                CreatedAt = now,
+                ModifiedAt = now
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error parsing Glooko meter reading");
             return null;
         }
     }

--- a/src/Connectors/Nocturne.Connectors.Glooko/Models/GlookoBatchData.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Models/GlookoBatchData.cs
@@ -13,6 +13,8 @@ public class GlookoBatchData
 
     [JsonPropertyName("readings")] public GlookoCgmReading[]? Readings { get; set; }
 
+    [JsonPropertyName("meterReadings")] public GlookoMeterReading[]? MeterReadings { get; set; }
+
     [JsonPropertyName("suspendBasals")] public GlookoSuspendBasal[]? SuspendBasals { get; set; }
 
     [JsonPropertyName("temporaryBasals")] public GlookoTempBasal[]? TempBasals { get; set; }
@@ -131,4 +133,25 @@ public class GlookoTempBasal
     [JsonPropertyName("percent")] public int? Percent { get; set; }
 
     [JsonPropertyName("tempBasalType")] public string? TempBasalType { get; set; }
+}
+
+public class GlookoMeterReading
+{
+    [JsonPropertyName("timestamp")] public string Timestamp { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Glucose value in mg/dL × 100 (integer encoding for 2-decimal precision).
+    /// Must be divided by 100 to get actual mg/dL.
+    /// </summary>
+    [JsonPropertyName("value")] public double Value { get; set; }
+
+    [JsonPropertyName("meterUnits")] public string? MeterUnits { get; set; }
+
+    [JsonPropertyName("meterMealTag")] public int? MeterMealTag { get; set; }
+
+    [JsonPropertyName("guid")] public string? Guid { get; set; }
+
+    [JsonPropertyName("softDeleted")] public bool? SoftDeleted { get; set; }
+
+    [JsonPropertyName("meterGuid")] public string? MeterGuid { get; set; }
 }

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -338,6 +338,17 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                             ConnectorSource, v3Glucose.Count);
                     }
                 }
+
+                // V2 meter readings → BGCheck records
+                var bgChecks = _sensorGlucoseMapper.TransformBatchDataToBGChecks(batchData).ToList();
+                if (bgChecks.Count > 0)
+                {
+                    if (await PublishBGCheckDataAsync(bgChecks, config, cancellationToken))
+                    {
+                        _logger.LogInformation("[{ConnectorSource}] Published {Count} BG checks from meter readings",
+                            ConnectorSource, bgChecks.Count);
+                    }
+                }
             }
 
             // 2. Process Treatments (boluses, carb intake)
@@ -611,6 +622,11 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                     if (json.TryGetProperty("readings", out var el))
                         batchData.Readings = JsonSerializer.Deserialize<GlookoCgmReading[]>(el.GetRawText()) ?? [];
                 }),
+                (GlookoConstants.MeterReadingsPath, json =>
+                {
+                    if (json.TryGetProperty("readings", out var el))
+                        batchData.MeterReadings = JsonSerializer.Deserialize<GlookoMeterReading[]>(el.GetRawText()) ?? [];
+                }),
                 (GlookoConstants.SuspendBasalsPath, json =>
                 {
                     if (json.TryGetProperty("suspendBasals", out var el))
@@ -647,11 +663,12 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
 
             _logger.LogInformation(
                 "[{ConnectorSource}] Fetched Glooko batch data summary: "
-                + "Readings={ReadingsCount}, Foods={FoodsCount}, "
+                + "Readings={ReadingsCount}, MeterReadings={MeterReadingsCount}, Foods={FoodsCount}, "
                 + "NormalBoluses={BolusCount}, TempBasals={TempBasalCount}, "
                 + "ScheduledBasals={ScheduledBasalCount}, Suspends={SuspendCount}",
                 ConnectorSource,
                 batchData.Readings?.Length ?? 0,
+                batchData.MeterReadings?.Length ?? 0,
                 batchData.Foods?.Length ?? 0,
                 batchData.NormalBoluses?.Length ?? 0,
                 batchData.TempBasals?.Length ?? 0,


### PR DESCRIPTION
Adding Glooko BGM readings from the Glooko v2 API. BGM readings do not show up on the frontend, but I can confirm they're stored in the database.