### PR TITLE
feat(v4): stamp DeviceId and PatientDeviceId FKs on device-sourced records

### DIFF
--- a/src/API/Nocturne.API/Services/Devices/DeviceService.cs
+++ b/src/API/Nocturne.API/Services/Devices/DeviceService.cs
@@ -15,15 +15,18 @@ namespace Nocturne.API.Services.Devices;
 public class DeviceService : IDeviceService
 {
     private readonly IDeviceRepository _repository;
+    private readonly IPatientDeviceRepository _patientDeviceRepository;
     private readonly ITenantAccessor _tenantAccessor;
     private readonly ConcurrentDictionary<(string, string, string, string), Guid> _cache = new();
+    private readonly ConcurrentDictionary<(string, Guid), IReadOnlyList<PatientDevice>> _patientDeviceCache = new();
 
     private string TenantCacheId => _tenantAccessor.Context?.TenantId.ToString()
         ?? throw new InvalidOperationException("Tenant context is not resolved");
 
-    public DeviceService(IDeviceRepository repository, ITenantAccessor tenantAccessor)
+    public DeviceService(IDeviceRepository repository, IPatientDeviceRepository patientDeviceRepository, ITenantAccessor tenantAccessor)
     {
         _repository = repository;
+        _patientDeviceRepository = patientDeviceRepository;
         _tenantAccessor = tenantAccessor;
     }
 
@@ -62,5 +65,26 @@ public class DeviceService : IDeviceService
         var created = await _repository.CreateAsync(device, ct);
         _cache[key] = created.Id;
         return created.Id;
+    }
+
+    public async Task<Guid?> ResolvePatientDeviceAsync(Guid? deviceId, long mills, CancellationToken ct = default)
+    {
+        if (deviceId is null)
+            return null;
+
+        var tenantId = TenantCacheId;
+        var key = (tenantId, deviceId.Value);
+
+        if (!_patientDeviceCache.TryGetValue(key, out var patientDevices))
+        {
+            patientDevices = await _patientDeviceRepository.GetByDeviceIdAsync(deviceId.Value, ct);
+            _patientDeviceCache[key] = patientDevices;
+        }
+
+        var date = DateOnly.FromDateTime(DateTimeOffset.FromUnixTimeMilliseconds(mills).UtcDateTime);
+
+        return patientDevices.FirstOrDefault(pd =>
+            (pd.StartDate is null || pd.StartDate <= date) &&
+            (pd.EndDate is null || pd.EndDate >= date))?.Id;
     }
 }

--- a/src/API/Nocturne.API/Services/V4/DeviceStatusDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/DeviceStatusDecomposer.cs
@@ -90,18 +90,20 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
 
         var legacyId = ds.Id;
 
-        if (ds.OpenAps != null)
-        {
-            await DecomposeApsFromOpenApsAsync(ds, legacyId, result, ct);
-        }
-        else if (ds.Loop != null)
-        {
-            await DecomposeApsFromLoopAsync(ds, legacyId, result, ct);
-        }
+        Guid? pumpDeviceId = null;
 
         if (ds.Pump != null)
         {
-            await DecomposePumpAsync(ds, legacyId, result, ct);
+            pumpDeviceId = await DecomposePumpAsync(ds, legacyId, result, ct);
+        }
+
+        if (ds.OpenAps != null)
+        {
+            await DecomposeApsFromOpenApsAsync(ds, legacyId, result, pumpDeviceId, ct);
+        }
+        else if (ds.Loop != null)
+        {
+            await DecomposeApsFromLoopAsync(ds, legacyId, result, pumpDeviceId, ct);
         }
 
         if (ds.Uploader != null || ds.UploaderBattery.HasValue)
@@ -122,7 +124,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
     #region APS Decomposition
 
     private async Task DecomposeApsFromOpenApsAsync(
-        DeviceStatus ds, string? legacyId, V4Models.DecompositionResult result, CancellationToken ct)
+        DeviceStatus ds, string? legacyId, V4Models.DecompositionResult result, Guid? pumpDeviceId, CancellationToken ct)
     {
         var command = ds.OpenAps!.Enacted ?? ds.OpenAps.Suggested;
         var predBGs = command?.PredBGs;
@@ -167,11 +169,14 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
             AidVersion = ds.OpenAps?.Version,
         };
 
+        model.DeviceId = pumpDeviceId;
+        model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(pumpDeviceId, ds.Mills, ct);
+
         await UpsertApsSnapshotAsync(legacyId, model, result, ct);
     }
 
     private async Task DecomposeApsFromLoopAsync(
-        DeviceStatus ds, string? legacyId, V4Models.DecompositionResult result, CancellationToken ct)
+        DeviceStatus ds, string? legacyId, V4Models.DecompositionResult result, Guid? pumpDeviceId, CancellationToken ct)
     {
         var model = new V4Models.ApsSnapshot
         {
@@ -199,6 +204,9 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
             // Loop's version is captured from the device string (e.g. "Loop/3.0"), not from the Loop data object
             AidVersion = null,
         };
+
+        model.DeviceId = pumpDeviceId;
+        model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(pumpDeviceId, ds.Mills, ct);
 
         await UpsertApsSnapshotAsync(legacyId, model, result, ct);
     }
@@ -229,7 +237,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
 
     #region Pump Decomposition
 
-    private async Task DecomposePumpAsync(
+    private async Task<Guid?> DecomposePumpAsync(
         DeviceStatus ds, string? legacyId, V4Models.DecompositionResult result, CancellationToken ct)
     {
         var model = new V4Models.PumpSnapshot
@@ -260,6 +268,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
             ds.Pump?.Manufacturer,
             ds.Pump?.Model,
             ds.Mills, ct);
+        model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, ds.Mills, ct);
 
         var existing = legacyId != null
             ? await _pumpRepo.GetByLegacyIdAsync(legacyId, ct)
@@ -281,6 +290,8 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
         }
 
         await DecomposePumpSuspensionAsync(ds, persisted, result, ct);
+
+        return model.DeviceId;
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -312,6 +312,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         var model = MapToBolus(treatment, result.CorrelationId);
         model.DeviceId = await _deviceService.ResolveAsync(
             V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
+        model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
 
         if (existing != null)
         {
@@ -339,6 +340,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         model.Automatic = true;
         model.DeviceId = await _deviceService.ResolveAsync(
             V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
+        model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
 
         if (existing != null)
         {
@@ -447,6 +449,9 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             : null;
 
         var model = MapToDeviceEvent(treatment, result.CorrelationId, deviceEventType);
+        model.DeviceId = await _deviceService.ResolveAsync(
+            V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
+        model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
 
         if (existing != null)
         {
@@ -495,6 +500,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         var model = MapToTempBasal(treatment, result.CorrelationId);
         model.DeviceId = await _deviceService.ResolveAsync(
             V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
+        model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
 
         if (existing != null)
         {

--- a/src/Core/Nocturne.Core.Contracts/Devices/IDeviceService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Devices/IDeviceService.cs
@@ -19,4 +19,14 @@ public interface IDeviceService
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The canonical device <see cref="Guid"/>, or <c>null</c> if resolution failed.</returns>
     Task<Guid?> ResolveAsync(DeviceCategory category, string? type, string? serial, long mills, CancellationToken ct = default);
+
+    /// <summary>
+    /// Resolve a <see cref="PatientDevice"/> by matching the given <paramref name="deviceId"/>
+    /// to patient device records whose date range contains the timestamp.
+    /// </summary>
+    /// <param name="deviceId">The resolved device ID, or <c>null</c> to short-circuit.</param>
+    /// <param name="mills">Timestamp in Unix milliseconds.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The matching patient device <see cref="Guid"/>, or <c>null</c> if no match.</returns>
+    Task<Guid?> ResolvePatientDeviceAsync(Guid? deviceId, long mills, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IPatientDeviceRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IPatientDeviceRepository.cs
@@ -19,6 +19,9 @@ public interface IPatientDeviceRepository
     /// <summary>Returns devices that were active during the specified date range.</summary>
     Task<IEnumerable<PatientDevice>> GetByDateRangeAsync(DateTime from, DateTime to, CancellationToken ct = default);
 
+    /// <summary>Returns all patient devices linked to the specified device.</summary>
+    Task<IReadOnlyList<PatientDevice>> GetByDeviceIdAsync(Guid deviceId, CancellationToken ct = default);
+
     /// <summary>Returns a device by its ID, or null if not found.</summary>
     Task<PatientDevice?> GetByIdAsync(Guid id, CancellationToken ct = default);
 

--- a/src/Core/Nocturne.Core.Models/V4/ApsSnapshot.cs
+++ b/src/Core/Nocturne.Core.Models/V4/ApsSnapshot.cs
@@ -47,6 +47,11 @@ public class ApsSnapshot : IV4Record
     /// </summary>
     public Guid? DeviceId { get; set; }
 
+    /// <summary>
+    /// Foreign key to the <see cref="PatientDevice"/> table.
+    /// </summary>
+    public Guid? PatientDeviceId { get; set; }
+
     /// <inheritdoc />
     public string? App { get; set; }
 

--- a/src/Core/Nocturne.Core.Models/V4/ApsSnapshot.cs
+++ b/src/Core/Nocturne.Core.Models/V4/ApsSnapshot.cs
@@ -42,6 +42,11 @@ public class ApsSnapshot : IV4Record
     /// <inheritdoc />
     public string? Device { get; set; }
 
+    /// <summary>
+    /// Foreign key to the <see cref="Device"/> table.
+    /// </summary>
+    public Guid? DeviceId { get; set; }
+
     /// <inheritdoc />
     public string? App { get; set; }
 

--- a/src/Core/Nocturne.Core.Models/V4/Bolus.cs
+++ b/src/Core/Nocturne.Core.Models/V4/Bolus.cs
@@ -143,6 +143,11 @@ public class Bolus : IV4Record
     public Guid? DeviceId { get; set; }
 
     /// <summary>
+    /// Foreign key to the <see cref="PatientDevice"/> table.
+    /// </summary>
+    public Guid? PatientDeviceId { get; set; }
+
+    /// <summary>
     /// Per-record pump counter (AAPS internal identifier)
     /// </summary>
     public string? PumpRecordId { get; set; }

--- a/src/Core/Nocturne.Core.Models/V4/DeviceEvent.cs
+++ b/src/Core/Nocturne.Core.Models/V4/DeviceEvent.cs
@@ -42,6 +42,11 @@ public class DeviceEvent : IV4Record
     public string? Device { get; set; }
 
     /// <summary>
+    /// Foreign key to the <see cref="Device"/> table.
+    /// </summary>
+    public Guid? DeviceId { get; set; }
+
+    /// <summary>
     /// Application that uploaded this record
     /// </summary>
     public string? App { get; set; }

--- a/src/Core/Nocturne.Core.Models/V4/DeviceEvent.cs
+++ b/src/Core/Nocturne.Core.Models/V4/DeviceEvent.cs
@@ -47,6 +47,11 @@ public class DeviceEvent : IV4Record
     public Guid? DeviceId { get; set; }
 
     /// <summary>
+    /// Foreign key to the <see cref="PatientDevice"/> table.
+    /// </summary>
+    public Guid? PatientDeviceId { get; set; }
+
+    /// <summary>
     /// Application that uploaded this record
     /// </summary>
     public string? App { get; set; }

--- a/src/Core/Nocturne.Core.Models/V4/PumpSnapshot.cs
+++ b/src/Core/Nocturne.Core.Models/V4/PumpSnapshot.cs
@@ -104,6 +104,11 @@ public class PumpSnapshot : IV4Record
     /// </summary>
     public Guid? DeviceId { get; set; }
 
+    /// <summary>
+    /// Foreign key to the <see cref="PatientDevice"/> table.
+    /// </summary>
+    public Guid? PatientDeviceId { get; set; }
+
     /// <summary>Pump-reported total IOB (when no APS algorithm is running).</summary>
     public double? Iob { get; set; }
 

--- a/src/Core/Nocturne.Core.Models/V4/TempBasal.cs
+++ b/src/Core/Nocturne.Core.Models/V4/TempBasal.cs
@@ -113,6 +113,11 @@ public class TempBasal
     public Guid? DeviceId { get; set; }
 
     /// <summary>
+    /// Foreign key to the <see cref="PatientDevice"/> table.
+    /// </summary>
+    public Guid? PatientDeviceId { get; set; }
+
+    /// <summary>
     /// Pump-specific record identifier for deduplication.
     /// </summary>
     public string? PumpRecordId { get; set; }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/ApsSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/ApsSnapshotEntity.cs
@@ -215,6 +215,18 @@ public class ApsSnapshotEntity : ITenantScoped
     public string? AidVersion { get; set; }
 
     /// <summary>
+    /// Foreign key to the Device table.
+    /// </summary>
+    [Column("device_id")]
+    public Guid? DeviceId { get; set; }
+
+    /// <summary>
+    /// Foreign key to the PatientDevice table.
+    /// </summary>
+    [Column("patient_device_id")]
+    public Guid? PatientDeviceId { get; set; }
+
+    /// <summary>
     /// Catch-all JSONB column for fields not mapped to dedicated columns
     /// </summary>
     [Column("additional_properties", TypeName = "jsonb")]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusEntity.cs
@@ -161,6 +161,12 @@ public class BolusEntity : ITenantScoped, IAuditable
     public Guid? DeviceId { get; set; }
 
     /// <summary>
+    /// Foreign key to the PatientDevice table.
+    /// </summary>
+    [Column("patient_device_id")]
+    public Guid? PatientDeviceId { get; set; }
+
+    /// <summary>
     /// Pump-specific record identifier for deduplication.
     /// </summary>
     [Column("pump_record_id")]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceEventEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceEventEntity.cs
@@ -106,6 +106,18 @@ public class DeviceEventEntity : ITenantScoped, IAuditable
     public string? SyncIdentifier { get; set; }
 
     /// <summary>
+    /// Foreign key to the Device table.
+    /// </summary>
+    [Column("device_id")]
+    public Guid? DeviceId { get; set; }
+
+    /// <summary>
+    /// Foreign key to the PatientDevice table.
+    /// </summary>
+    [Column("patient_device_id")]
+    public Guid? PatientDeviceId { get; set; }
+
+    /// <summary>
     /// Catch-all JSONB column for fields not mapped to dedicated columns
     /// </summary>
     [Column("additional_properties", TypeName = "jsonb")]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PumpSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PumpSnapshotEntity.cs
@@ -140,6 +140,12 @@ public class PumpSnapshotEntity : ITenantScoped
     public Guid? DeviceId { get; set; }
 
     /// <summary>
+    /// Foreign key to the PatientDevice table.
+    /// </summary>
+    [Column("patient_device_id")]
+    public Guid? PatientDeviceId { get; set; }
+
+    /// <summary>
     /// Pump-reported total IOB (when no APS algorithm is running)
     /// </summary>
     [Column("iob")]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TempBasalEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TempBasalEntity.cs
@@ -116,6 +116,12 @@ public class TempBasalEntity : ITenantScoped, IAuditable
     public Guid? DeviceId { get; set; }
 
     /// <summary>
+    /// Foreign key to the PatientDevice table.
+    /// </summary>
+    [Column("patient_device_id")]
+    public Guid? PatientDeviceId { get; set; }
+
+    /// <summary>
     /// Pump-specific record identifier for deduplication
     /// </summary>
     [Column("pump_record_id")]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/ApsSnapshotMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/ApsSnapshotMapper.cs
@@ -22,6 +22,8 @@ public static class ApsSnapshotMapper
             Timestamp = model.Timestamp,
             UtcOffset = model.UtcOffset,
             Device = model.Device,
+            DeviceId = model.DeviceId,
+            PatientDeviceId = model.PatientDeviceId,
             CorrelationId = model.CorrelationId,
             LegacyId = model.LegacyId,
             SysCreatedAt = DateTime.UtcNow,
@@ -69,6 +71,8 @@ public static class ApsSnapshotMapper
             Timestamp = entity.Timestamp,
             UtcOffset = entity.UtcOffset,
             Device = entity.Device,
+            DeviceId = entity.DeviceId,
+            PatientDeviceId = entity.PatientDeviceId,
             CorrelationId = entity.CorrelationId,
             LegacyId = entity.LegacyId,
             CreatedAt = entity.SysCreatedAt,
@@ -113,6 +117,8 @@ public static class ApsSnapshotMapper
         entity.Timestamp = model.Timestamp;
         entity.UtcOffset = model.UtcOffset;
         entity.Device = model.Device;
+        entity.DeviceId = model.DeviceId;
+        entity.PatientDeviceId = model.PatientDeviceId;
         entity.CorrelationId = model.CorrelationId;
         entity.LegacyId = model.LegacyId;
         entity.SysUpdatedAt = DateTime.UtcNow;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BolusMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BolusMapper.cs
@@ -42,6 +42,7 @@ public static class BolusMapper
                 : null,
             Unabsorbed = model.Unabsorbed,
             DeviceId = model.DeviceId,
+            PatientDeviceId = model.PatientDeviceId,
             PumpRecordId = model.PumpRecordId,
             BolusCalculationId = model.BolusCalculationId,
             ApsSnapshotId = model.ApsSnapshotId,
@@ -84,6 +85,7 @@ public static class BolusMapper
                 : null,
             Unabsorbed = entity.Unabsorbed,
             DeviceId = entity.DeviceId,
+            PatientDeviceId = entity.PatientDeviceId,
             PumpRecordId = entity.PumpRecordId,
             BolusCalculationId = entity.BolusCalculationId,
             ApsSnapshotId = entity.ApsSnapshotId,
@@ -122,6 +124,7 @@ public static class BolusMapper
             : null;
         entity.Unabsorbed = model.Unabsorbed;
         entity.DeviceId = model.DeviceId;
+        entity.PatientDeviceId = model.PatientDeviceId;
         entity.PumpRecordId = model.PumpRecordId;
         entity.BolusCalculationId = model.BolusCalculationId;
         entity.ApsSnapshotId = model.ApsSnapshotId;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/DeviceEventMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/DeviceEventMapper.cs
@@ -23,6 +23,8 @@ public static class DeviceEventMapper
             Timestamp = model.Timestamp,
             UtcOffset = model.UtcOffset,
             Device = model.Device,
+            DeviceId = model.DeviceId,
+            PatientDeviceId = model.PatientDeviceId,
             App = model.App,
             DataSource = model.DataSource,
             CorrelationId = model.CorrelationId,
@@ -51,6 +53,8 @@ public static class DeviceEventMapper
             Timestamp = entity.Timestamp,
             UtcOffset = entity.UtcOffset,
             Device = entity.Device,
+            DeviceId = entity.DeviceId,
+            PatientDeviceId = entity.PatientDeviceId,
             App = entity.App,
             DataSource = entity.DataSource,
             CorrelationId = entity.CorrelationId,
@@ -78,6 +82,8 @@ public static class DeviceEventMapper
         entity.Timestamp = model.Timestamp;
         entity.UtcOffset = model.UtcOffset;
         entity.Device = model.Device;
+        entity.DeviceId = model.DeviceId;
+        entity.PatientDeviceId = model.PatientDeviceId;
         entity.App = model.App;
         entity.DataSource = model.DataSource;
         entity.CorrelationId = model.CorrelationId;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/PumpSnapshotMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/PumpSnapshotMapper.cs
@@ -37,6 +37,7 @@ public static class PumpSnapshotMapper
             PumpStatus = model.PumpStatus,
             Clock = model.Clock,
             DeviceId = model.DeviceId,
+            PatientDeviceId = model.PatientDeviceId,
             Iob = model.Iob,
             BolusIob = model.BolusIob,
             AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
@@ -73,6 +74,7 @@ public static class PumpSnapshotMapper
             PumpStatus = entity.PumpStatus,
             Clock = entity.Clock,
             DeviceId = entity.DeviceId,
+            PatientDeviceId = entity.PatientDeviceId,
             Iob = entity.Iob,
             BolusIob = entity.BolusIob,
             AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
@@ -105,6 +107,7 @@ public static class PumpSnapshotMapper
         entity.PumpStatus = model.PumpStatus;
         entity.Clock = model.Clock;
         entity.DeviceId = model.DeviceId;
+        entity.PatientDeviceId = model.PatientDeviceId;
         entity.Iob = model.Iob;
         entity.BolusIob = model.BolusIob;
         entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/TempBasalMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/TempBasalMapper.cs
@@ -33,6 +33,7 @@ public static class TempBasalMapper
             ScheduledRate = model.ScheduledRate,
             Origin = model.Origin.ToString(),
             DeviceId = model.DeviceId,
+            PatientDeviceId = model.PatientDeviceId,
             PumpRecordId = model.PumpRecordId,
             ApsSnapshotId = model.ApsSnapshotId,
             AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
@@ -67,6 +68,7 @@ public static class TempBasalMapper
                 ? origin
                 : TempBasalOrigin.Inferred,
             DeviceId = entity.DeviceId,
+            PatientDeviceId = entity.PatientDeviceId,
             PumpRecordId = entity.PumpRecordId,
             ApsSnapshotId = entity.ApsSnapshotId,
             AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
@@ -95,6 +97,7 @@ public static class TempBasalMapper
         entity.ScheduledRate = model.ScheduledRate;
         entity.Origin = model.Origin.ToString();
         entity.DeviceId = model.DeviceId;
+        entity.PatientDeviceId = model.PatientDeviceId;
         entity.PumpRecordId = model.PumpRecordId;
         entity.ApsSnapshotId = model.ApsSnapshotId;
         entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260504070333_AddDeviceAndPatientDeviceForeignKeys.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260504070333_AddDeviceAndPatientDeviceForeignKeys.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260504070333_AddDeviceAndPatientDeviceForeignKeys")]
+    partial class AddDeviceAndPatientDeviceForeignKeys
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260504070333_AddDeviceAndPatientDeviceForeignKeys.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260504070333_AddDeviceAndPatientDeviceForeignKeys.cs
@@ -1,0 +1,236 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDeviceAndPatientDeviceForeignKeys : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "patient_device_id",
+                table: "temp_basals",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "patient_device_id",
+                table: "pump_snapshots",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "device_id",
+                table: "device_events",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "patient_device_id",
+                table: "device_events",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "patient_device_id",
+                table: "boluses",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "device_id",
+                table: "aps_snapshots",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "patient_device_id",
+                table: "aps_snapshots",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_temp_basals_patient_device_id",
+                table: "temp_basals",
+                column: "patient_device_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_pump_snapshots_patient_device_id",
+                table: "pump_snapshots",
+                column: "patient_device_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_device_events_device_id",
+                table: "device_events",
+                column: "device_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_device_events_patient_device_id",
+                table: "device_events",
+                column: "patient_device_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_boluses_patient_device_id",
+                table: "boluses",
+                column: "patient_device_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_aps_snapshots_device_id",
+                table: "aps_snapshots",
+                column: "device_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_aps_snapshots_patient_device_id",
+                table: "aps_snapshots",
+                column: "patient_device_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_aps_snapshots_devices_device_id",
+                table: "aps_snapshots",
+                column: "device_id",
+                principalTable: "devices",
+                principalColumn: "id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_aps_snapshots_patient_devices_patient_device_id",
+                table: "aps_snapshots",
+                column: "patient_device_id",
+                principalTable: "patient_devices",
+                principalColumn: "id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_boluses_patient_devices_patient_device_id",
+                table: "boluses",
+                column: "patient_device_id",
+                principalTable: "patient_devices",
+                principalColumn: "id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_device_events_devices_device_id",
+                table: "device_events",
+                column: "device_id",
+                principalTable: "devices",
+                principalColumn: "id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_device_events_patient_devices_patient_device_id",
+                table: "device_events",
+                column: "patient_device_id",
+                principalTable: "patient_devices",
+                principalColumn: "id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_pump_snapshots_patient_devices_patient_device_id",
+                table: "pump_snapshots",
+                column: "patient_device_id",
+                principalTable: "patient_devices",
+                principalColumn: "id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_temp_basals_patient_devices_patient_device_id",
+                table: "temp_basals",
+                column: "patient_device_id",
+                principalTable: "patient_devices",
+                principalColumn: "id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_aps_snapshots_devices_device_id",
+                table: "aps_snapshots");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_aps_snapshots_patient_devices_patient_device_id",
+                table: "aps_snapshots");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_boluses_patient_devices_patient_device_id",
+                table: "boluses");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_device_events_devices_device_id",
+                table: "device_events");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_device_events_patient_devices_patient_device_id",
+                table: "device_events");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_pump_snapshots_patient_devices_patient_device_id",
+                table: "pump_snapshots");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_temp_basals_patient_devices_patient_device_id",
+                table: "temp_basals");
+
+            migrationBuilder.DropIndex(
+                name: "IX_temp_basals_patient_device_id",
+                table: "temp_basals");
+
+            migrationBuilder.DropIndex(
+                name: "IX_pump_snapshots_patient_device_id",
+                table: "pump_snapshots");
+
+            migrationBuilder.DropIndex(
+                name: "IX_device_events_device_id",
+                table: "device_events");
+
+            migrationBuilder.DropIndex(
+                name: "IX_device_events_patient_device_id",
+                table: "device_events");
+
+            migrationBuilder.DropIndex(
+                name: "IX_boluses_patient_device_id",
+                table: "boluses");
+
+            migrationBuilder.DropIndex(
+                name: "IX_aps_snapshots_device_id",
+                table: "aps_snapshots");
+
+            migrationBuilder.DropIndex(
+                name: "IX_aps_snapshots_patient_device_id",
+                table: "aps_snapshots");
+
+            migrationBuilder.DropColumn(
+                name: "patient_device_id",
+                table: "temp_basals");
+
+            migrationBuilder.DropColumn(
+                name: "patient_device_id",
+                table: "pump_snapshots");
+
+            migrationBuilder.DropColumn(
+                name: "device_id",
+                table: "device_events");
+
+            migrationBuilder.DropColumn(
+                name: "patient_device_id",
+                table: "device_events");
+
+            migrationBuilder.DropColumn(
+                name: "patient_device_id",
+                table: "boluses");
+
+            migrationBuilder.DropColumn(
+                name: "device_id",
+                table: "aps_snapshots");
+
+            migrationBuilder.DropColumn(
+                name: "patient_device_id",
+                table: "aps_snapshots");
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -1994,6 +1994,56 @@ public class NocturneDbContext : DbContext
             .OnDelete(DeleteBehavior.SetNull);
 
         modelBuilder
+            .Entity<ApsSnapshotEntity>()
+            .HasOne<DeviceEntity>()
+            .WithMany()
+            .HasForeignKey(e => e.DeviceId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        modelBuilder
+            .Entity<DeviceEventEntity>()
+            .HasOne<DeviceEntity>()
+            .WithMany()
+            .HasForeignKey(e => e.DeviceId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        // PatientDevice foreign keys
+        modelBuilder
+            .Entity<ApsSnapshotEntity>()
+            .HasOne<PatientDeviceEntity>()
+            .WithMany()
+            .HasForeignKey(e => e.PatientDeviceId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        modelBuilder
+            .Entity<DeviceEventEntity>()
+            .HasOne<PatientDeviceEntity>()
+            .WithMany()
+            .HasForeignKey(e => e.PatientDeviceId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        modelBuilder
+            .Entity<TempBasalEntity>()
+            .HasOne<PatientDeviceEntity>()
+            .WithMany()
+            .HasForeignKey(e => e.PatientDeviceId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        modelBuilder
+            .Entity<PumpSnapshotEntity>()
+            .HasOne<PatientDeviceEntity>()
+            .WithMany()
+            .HasForeignKey(e => e.PatientDeviceId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        modelBuilder
+            .Entity<BolusEntity>()
+            .HasOne<PatientDeviceEntity>()
+            .WithMany()
+            .HasForeignKey(e => e.PatientDeviceId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        modelBuilder
             .Entity<UploaderSnapshotEntity>()
             .HasOne<DeviceEntity>()
             .WithMany()

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PatientDeviceRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PatientDeviceRepository.cs
@@ -85,6 +85,18 @@ public class PatientDeviceRepository : IPatientDeviceRepository
         return entities.Select(PatientDeviceMapper.ToDomainModel);
     }
 
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<PatientDevice>> GetByDeviceIdAsync(Guid deviceId, CancellationToken ct = default)
+    {
+        var entities = await _context.PatientDevices
+            .AsNoTracking()
+            .Where(e => e.DeviceId == deviceId)
+            .OrderByDescending(e => e.StartDate)
+            .ToListAsync(ct);
+
+        return entities.Select(PatientDeviceMapper.ToDomainModel).ToList();
+    }
+
     /// <summary>
     /// Gets a patient device record by its unique identifier.
     /// </summary>

--- a/tests/Unit/Nocturne.API.Tests/Services/Devices/DeviceServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Devices/DeviceServiceTests.cs
@@ -14,12 +14,14 @@ namespace Nocturne.API.Tests.Services.Devices;
 public class DeviceServiceTests
 {
     private readonly Mock<IDeviceRepository> _mockRepository;
+    private readonly Mock<IPatientDeviceRepository> _mockPatientDeviceRepository;
     private readonly DeviceService _service;
 
     public DeviceServiceTests()
     {
         _mockRepository = new Mock<IDeviceRepository>();
-        _service = new DeviceService(_mockRepository.Object, MockTenantAccessor.Create().Object);
+        _mockPatientDeviceRepository = new Mock<IPatientDeviceRepository>();
+        _service = new DeviceService(_mockRepository.Object, _mockPatientDeviceRepository.Object, MockTenantAccessor.Create().Object);
     }
 
     [Fact]
@@ -247,6 +249,135 @@ public class DeviceServiceTests
         result2.Should().Be(existingId);
         _mockRepository.Verify(
             r => r.FindByCategoryTypeAndSerialAsync(category, type, serial, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ResolvePatientDeviceAsync_WithMatchingDeviceAndTimestamp_ReturnsPatientDeviceId()
+    {
+        var deviceId = Guid.CreateVersion7();
+        var patientDeviceId = Guid.CreateVersion7();
+        var mills = DateTimeOffset.Parse("2026-03-15T12:00:00Z").ToUnixTimeMilliseconds();
+
+        _mockPatientDeviceRepository
+            .Setup(r => r.GetByDeviceIdAsync(deviceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PatientDevice>
+            {
+                new()
+                {
+                    Id = patientDeviceId,
+                    DeviceId = deviceId,
+                    StartDate = new DateOnly(2026, 1, 1),
+                    EndDate = new DateOnly(2026, 6, 1),
+                }
+            });
+
+        var result = await _service.ResolvePatientDeviceAsync(deviceId, mills);
+        result.Should().Be(patientDeviceId);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ResolvePatientDeviceAsync_WithNullDeviceId_ReturnsNull()
+    {
+        var result = await _service.ResolvePatientDeviceAsync(null, 1700000000000L);
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ResolvePatientDeviceAsync_WithNoMatchingPatientDevice_ReturnsNull()
+    {
+        var deviceId = Guid.CreateVersion7();
+        var mills = DateTimeOffset.Parse("2026-03-15T12:00:00Z").ToUnixTimeMilliseconds();
+
+        _mockPatientDeviceRepository
+            .Setup(r => r.GetByDeviceIdAsync(deviceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PatientDevice>());
+
+        var result = await _service.ResolvePatientDeviceAsync(deviceId, mills);
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ResolvePatientDeviceAsync_WithTimestampOutsideDateRange_ReturnsNull()
+    {
+        var deviceId = Guid.CreateVersion7();
+        var patientDeviceId = Guid.CreateVersion7();
+        var mills = DateTimeOffset.Parse("2025-06-15T12:00:00Z").ToUnixTimeMilliseconds();
+
+        _mockPatientDeviceRepository
+            .Setup(r => r.GetByDeviceIdAsync(deviceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PatientDevice>
+            {
+                new()
+                {
+                    Id = patientDeviceId,
+                    DeviceId = deviceId,
+                    StartDate = new DateOnly(2026, 1, 1),
+                    EndDate = new DateOnly(2026, 6, 1),
+                }
+            });
+
+        var result = await _service.ResolvePatientDeviceAsync(deviceId, mills);
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ResolvePatientDeviceAsync_WithNullEndDate_MatchesCurrentDevice()
+    {
+        var deviceId = Guid.CreateVersion7();
+        var patientDeviceId = Guid.CreateVersion7();
+        var mills = DateTimeOffset.Parse("2030-01-01T12:00:00Z").ToUnixTimeMilliseconds();
+
+        _mockPatientDeviceRepository
+            .Setup(r => r.GetByDeviceIdAsync(deviceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PatientDevice>
+            {
+                new()
+                {
+                    Id = patientDeviceId,
+                    DeviceId = deviceId,
+                    StartDate = new DateOnly(2026, 1, 1),
+                    EndDate = null,
+                }
+            });
+
+        var result = await _service.ResolvePatientDeviceAsync(deviceId, mills);
+        result.Should().Be(patientDeviceId);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ResolvePatientDeviceAsync_SameDeviceTwice_UsesCacheSecondTime()
+    {
+        var deviceId = Guid.CreateVersion7();
+        var patientDeviceId = Guid.CreateVersion7();
+        var mills = DateTimeOffset.Parse("2026-03-15T12:00:00Z").ToUnixTimeMilliseconds();
+
+        _mockPatientDeviceRepository
+            .Setup(r => r.GetByDeviceIdAsync(deviceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PatientDevice>
+            {
+                new()
+                {
+                    Id = patientDeviceId,
+                    DeviceId = deviceId,
+                    StartDate = new DateOnly(2026, 1, 1),
+                    EndDate = null,
+                }
+            });
+
+        var result1 = await _service.ResolvePatientDeviceAsync(deviceId, mills);
+        var result2 = await _service.ResolvePatientDeviceAsync(deviceId, mills);
+
+        result1.Should().Be(patientDeviceId);
+        result2.Should().Be(patientDeviceId);
+        _mockPatientDeviceRepository.Verify(
+            r => r.GetByDeviceIdAsync(deviceId, It.IsAny<CancellationToken>()),
             Times.Once);
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerTests.cs
@@ -1994,6 +1994,120 @@ public class DeviceStatusDecomposerTests : IDisposable
         extrasEntities[0].ExtrasJson.Should().Contain("anotherField");
     }
 
+    [Fact]
+    public async Task DecomposeAsync_ApsSnapshotGetsPumpDeviceId()
+    {
+        // Arrange
+        var expectedDeviceId = Guid.CreateVersion7();
+        _deviceServiceMock
+            .Setup(s => s.ResolveAsync(
+                V4Models.DeviceCategory.InsulinPump,
+                "Insulet",
+                "Omnipod 5",
+                1700000000000,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedDeviceId);
+
+        var ds = new DeviceStatus
+        {
+            Id = "aps-pump-device-id",
+            Mills = 1700000000000,
+            Device = "openaps://Samsung",
+            OpenAps = new OpenApsStatus
+            {
+                Iob = new OpenApsIobData { Iob = 2.0 },
+                Suggested = new OpenApsSuggested
+                {
+                    Bg = 110.0, EventualBG = 100.0, Timestamp = "2023-11-14T12:00:00Z"
+                }
+            },
+            Pump = new PumpStatus
+            {
+                Manufacturer = "Insulet",
+                Model = "Omnipod 5",
+                Reservoir = 100.0
+            }
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeAsync(ds);
+
+        // Assert
+        var aps = result.CreatedRecords.OfType<V4Models.ApsSnapshot>().Single();
+        aps.DeviceId.Should().Be(expectedDeviceId);
+    }
+
+    [Fact]
+    public async Task DecomposeAsync_ApsSnapshotWithNoPump_HasNullDeviceId()
+    {
+        // Arrange — no Pump section means no DeviceId to propagate
+        var ds = new DeviceStatus
+        {
+            Id = "aps-no-pump-device-id",
+            Mills = 1700000000000,
+            Device = "openaps://Samsung",
+            OpenAps = new OpenApsStatus
+            {
+                Iob = new OpenApsIobData { Iob = 1.5 },
+                Suggested = new OpenApsSuggested
+                {
+                    Bg = 120.0, EventualBG = 100.0, Timestamp = "2023-11-14T12:00:00Z"
+                }
+            }
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeAsync(ds);
+
+        // Assert
+        var aps = result.CreatedRecords.OfType<V4Models.ApsSnapshot>().Single();
+        aps.DeviceId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DecomposeAsync_PumpSnapshotGetsPatientDeviceId()
+    {
+        // Arrange
+        var expectedDeviceId = Guid.CreateVersion7();
+        var expectedPatientDeviceId = Guid.CreateVersion7();
+
+        _deviceServiceMock
+            .Setup(s => s.ResolveAsync(
+                V4Models.DeviceCategory.InsulinPump,
+                "Insulet",
+                "Omnipod 5",
+                1700000000000,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedDeviceId);
+
+        _deviceServiceMock
+            .Setup(s => s.ResolvePatientDeviceAsync(
+                expectedDeviceId,
+                1700000000000,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedPatientDeviceId);
+
+        var ds = new DeviceStatus
+        {
+            Id = "pump-patient-device-id",
+            Mills = 1700000000000,
+            Device = "openaps://Samsung",
+            Pump = new PumpStatus
+            {
+                Manufacturer = "Insulet",
+                Model = "Omnipod 5",
+                Reservoir = 150.0
+            }
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeAsync(ds);
+
+        // Assert
+        var pump = result.CreatedRecords.OfType<V4Models.PumpSnapshot>().Single();
+        pump.PatientDeviceId.Should().Be(expectedPatientDeviceId);
+    }
+
     #endregion
 
     #region AAPS SMB Volume Fallback

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
@@ -2079,6 +2079,78 @@ public class TreatmentDecomposerTests : IDisposable
         bolus.Automatic.Should().BeFalse();
     }
 
+    [Fact]
+    public async Task DecomposeAsync_DeviceEvent_GetsDeviceIdFromPumpInfo()
+    {
+        // Arrange
+        var expectedDeviceId = Guid.CreateVersion7();
+        _deviceServiceMock
+            .Setup(s => s.ResolveAsync(
+                V4Models.DeviceCategory.InsulinPump,
+                "Insulet",
+                "Omnipod 5",
+                1700000000000,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedDeviceId);
+
+        var treatment = new Treatment
+        {
+            Id = "device-event-fk-1",
+            EventType = "Site Change",
+            Mills = 1700000000000,
+            PumpType = "Insulet",
+            PumpSerial = "Omnipod 5"
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeAsync(treatment);
+
+        // Assert
+        var deviceEvent = result.CreatedRecords.OfType<V4Models.DeviceEvent>().Single();
+        deviceEvent.DeviceId.Should().Be(expectedDeviceId);
+    }
+
+    [Fact]
+    public async Task DecomposeAsync_Bolus_GetsPatientDeviceId()
+    {
+        // Arrange
+        var expectedDeviceId = Guid.CreateVersion7();
+        var expectedPatientDeviceId = Guid.CreateVersion7();
+
+        _deviceServiceMock
+            .Setup(s => s.ResolveAsync(
+                V4Models.DeviceCategory.InsulinPump,
+                "Insulet",
+                "Omnipod 5",
+                1700000000000,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedDeviceId);
+
+        _deviceServiceMock
+            .Setup(s => s.ResolvePatientDeviceAsync(
+                expectedDeviceId,
+                1700000000000,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedPatientDeviceId);
+
+        var treatment = new Treatment
+        {
+            Id = "bolus-patient-device-1",
+            EventType = "Correction Bolus",
+            Mills = 1700000000000,
+            Insulin = 3.0,
+            PumpType = "Insulet",
+            PumpSerial = "Omnipod 5"
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeAsync(treatment);
+
+        // Assert
+        var bolus = result.CreatedRecords.OfType<V4Models.Bolus>().Single();
+        bolus.PatientDeviceId.Should().Be(expectedPatientDeviceId);
+    }
+
     #endregion
 
     #region Profile Switch with Inline ProfileJson


### PR DESCRIPTION
## Summary

Adds `DeviceId` and `PatientDeviceId` foreign-key attribution to V4 device-sourced records (ApsSnapshot, DeviceEvent, Bolus, PumpSnapshot, TempBasal). Previously these models carried only the freeform `Device` string; this branch wires them to canonical `Device` and `PatientDevice` entities.

- New FK columns + indices via migration `AddDeviceAndPatientDeviceForeignKeys` (nullable, additive)
- `DeviceService.ResolvePatientDeviceAsync` resolves a `(DeviceId, mills)` pair to the active `PatientDevice` for that tenant
- `PatientDeviceRepository.GetByDeviceIdAsync` lookup
- `TreatmentDecomposer` and `DeviceStatusDecomposer` stamp both FKs as records are ingested
- TDD-style: each behavior has a failing-test commit followed by impl

## Notes / open questions

- **Migration timestamp** is `20251108` — older than main's most recent migrations (`20260503...`). On existing databases this will be applied after newer migrations because it's pending. The migration is purely additive (nullable columns + indices), so out-of-order apply should be safe, but worth a sanity check.
- **No backfill** for existing rows — old records remain with `DeviceId = null` until re-decomposed. Acceptable if downstream consumers treat absence as "unknown".
- Rebased onto current main; one conflict resolved in `DeviceStatusDecomposer.DecomposePumpAsync` (main added a pump-suspension state-span side-effect; this branch changed the method to return `Guid?`. Both retained.)

## Test plan

- [ ] CI build + unit tests pass
- [ ] `dotnet ef migrations script` produces a clean diff against current main
- [ ] Spot-check that re-decomposing an existing legacy `DeviceStatus` upserts the FK columns on the existing rows