### PR TITLE
feat(glooko-connector): Added BG and food/meal import from Glooko

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConstants.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConstants.cs
@@ -50,6 +50,7 @@ public static class GlookoConstants
     // -- API paths ------------------------------------------------------------
 
     public const string SignInPath = "/api/v2/users/sign_in";
+    public const string V3SignInPath = "/api/v3/users/sign_in";
     public const string FoodsPath = "/api/v2/foods";
     public const string ScheduledBasalsPath = "/api/v2/pumps/scheduled_basals";
     public const string NormalBolusesPath = "/api/v2/pumps/normal_boluses";
@@ -60,6 +61,7 @@ public static class GlookoConstants
     public const string V3UsersPath = "/api/v3/session/users";
     public const string V3GraphDataPath = "/api/v3/graph/data";
     public const string V3DeviceSettingsPath = "/api/v3/devices_and_settings";
+    public const string V3HistoriesPath = "/api/v3/users/summary/histories";
 
     // -- V3 graph series ------------------------------------------------------
 
@@ -69,9 +71,11 @@ public static class GlookoConstants
     public static readonly string[] V3GraphSeries =
     [
         "automaticBolus", "deliveredBolus", "injectionBolus",
+        "gkInsulinBasal", "gkInsulinBolus",
         "pumpAlarm", "reservoirChange", "setSiteChange",
         "carbAll", "scheduledBasal", "temporaryBasal",
         "suspendBasal", "lgsPlgs", "profileChange",
+        "bgHigh", "bgNormal", "bgLow",
     ];
 
     /// <summary>

--- a/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoSensorGlucoseMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoSensorGlucoseMapper.cs
@@ -78,6 +78,54 @@ public class GlookoSensorGlucoseMapper
     }
 
     /// <summary>
+    /// Maps V3 BG meter series (bgHigh, bgNormal, bgLow) to BGCheck records.
+    /// Values use the same encoding as CGM: Y is in display units, Value is mg/dL × 100.
+    /// </summary>
+    public IEnumerable<BGCheck> TransformV3ToBGChecks(GlookoV3GraphResponse graphData, string? meterUnits)
+    {
+        var results = new List<BGCheck>();
+        if (graphData?.Series == null) return results;
+
+        var series = graphData.Series;
+        var allBg = (series.BgHigh ?? [])
+            .Concat(series.BgNormal ?? [])
+            .Concat(series.BgLow ?? [])
+            .OrderBy(p => p.X);
+
+        foreach (var reading in allBg)
+        {
+            var timestamp = _timeMapper.GetCorrectedGlookoTime(reading.X);
+            var mgdl = reading.Value / 100.0;
+            if (mgdl <= 0) continue;
+
+            var legacyId = !string.IsNullOrEmpty(reading.Id)
+                ? $"glooko_v3_bg_{reading.Id}"
+                : $"glooko_v3_bg_{reading.X}";
+
+            var now = DateTime.UtcNow;
+            results.Add(new BGCheck
+            {
+                Id = Guid.CreateVersion7(),
+                Timestamp = timestamp,
+                LegacyId = legacyId,
+                Device = _connectorSource,
+                DataSource = _connectorSource,
+                Glucose = mgdl,
+                Units = GlucoseUnit.MgDl,
+                GlucoseType = GlucoseType.Finger,
+                CreatedAt = now,
+                ModifiedAt = now
+            });
+        }
+
+        _logger.LogInformation(
+            "[{ConnectorSource}] Transformed {Count} BG checks from v3 data",
+            _connectorSource, results.Count);
+
+        return results;
+    }
+
+    /// <summary>
     /// Maps V2 meter readings to BGCheck records (finger stick / manual blood glucose).
     /// Values are always mg/dL × 100 from Glooko, regardless of account meter units.
     /// </summary>
@@ -123,7 +171,7 @@ public class GlookoSensorGlucoseMapper
     {
         try
         {
-            if (reading.Value <= 0) return null;
+            if (reading.Value <= 0 || reading.SoftDeleted == true) return null;
 
             var date = ParseV2Timestamp(reading.Timestamp);
             if (date == null) return null;
@@ -131,12 +179,16 @@ public class GlookoSensorGlucoseMapper
             // Glooko V2 CGM values are mg/dL × 100 (integer encoding for 2-decimal precision)
             var mgdl = reading.Value / 100.0;
 
+            var legacyId = !string.IsNullOrEmpty(reading.Guid)
+                ? $"glooko_cgm_{reading.Guid}"
+                : $"glooko_{date.Value.Ticks}";
+
             var now = DateTime.UtcNow;
             return new SensorGlucose
             {
                 Id = Guid.CreateVersion7(),
                 Timestamp = date.Value,
-                LegacyId = $"glooko_{date.Value.Ticks}",
+                LegacyId = legacyId,
                 Device = _connectorSource,
                 DataSource = _connectorSource,
                 Mgdl = mgdl,

--- a/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoV4TreatmentMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoV4TreatmentMapper.cs
@@ -291,6 +291,7 @@ public class GlookoV4TreatmentMapper(string connectorSource, GlookoTimeMapper ti
 
     /// <summary>
     /// Maps V3 bolus series (DeliveredBolus, AutomaticBolus, InjectionBolus) to Bolus and CarbIntake records.
+    /// TODO: Add code to deal with manual insulin, informed in gkInsulinBasal, gkInsulinBolus, gkInsulinPremixed, gkInsulinOther
     /// </summary>
     public (List<Bolus> boluses, List<CarbIntake> carbs, List<DecompositionBatch> batches) MapV3Boluses(GlookoV3GraphResponse graphData)
     {
@@ -385,6 +386,55 @@ public class GlookoV4TreatmentMapper(string connectorSource, GlookoTimeMapper ti
     }
 
     /// <summary>
+    /// Maps V3 carbAll series to CarbIntake records.
+    /// These are standalone carb entries from the graph data (meals logged without a bolus wizard,
+    /// or quick carb entries). Complements carbs extracted from bolus.Data.CarbsInput in MapV3Boluses.
+    /// </summary>
+    public List<CarbIntake> MapV3CarbAll(GlookoV3GraphResponse graphData)
+    {
+        var carbs = new List<CarbIntake>();
+
+        if (graphData?.Series?.CarbAll == null)
+            return carbs;
+
+        foreach (var point in graphData.Series.CarbAll)
+        {
+            try
+            {
+                var carbValue = point.ActualCarbs ?? 0;
+                if (carbValue <= 0) continue;
+
+                var rawTimestamp = DateTimeOffset.FromUnixTimeSeconds(point.X).UtcDateTime;
+                var correctedTimestamp = _timeMapper.GetCorrectedGlookoTime(point.X);
+                var now = DateTime.UtcNow;
+
+                carbs.Add(new CarbIntake
+                {
+                    Id = Guid.CreateVersion7(),
+                    Timestamp = correctedTimestamp,
+                    LegacyId = GenerateLegacyId("v3_carball", rawTimestamp, $"carbs:{carbValue}"),
+                    Device = _connectorSource,
+                    DataSource = _connectorSource,
+                    Carbs = carbValue,
+                    CreatedAt = now,
+                    ModifiedAt = now
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "[{ConnectorSource}] Error mapping V3 carbAll record at X={X}",
+                    _connectorSource, point.X);
+            }
+        }
+
+        _logger.LogInformation(
+            "[{ConnectorSource}] Transformed {Count} carb intakes from v3 carbAll series",
+            _connectorSource, carbs.Count);
+
+        return carbs;
+    }
+
+    /// <summary>
     /// Maps V3 consumable change series (ReservoirChange, SetSiteChange) to DeviceEvent records.
     /// PumpAlarms are skipped here — they are handled by GlookoSystemEventMapper.
     /// </summary>
@@ -462,6 +512,237 @@ public class GlookoV4TreatmentMapper(string connectorSource, GlookoTimeMapper ti
             _connectorSource, deviceEvents.Count);
 
         return deviceEvents;
+    }
+
+    // ── V3 Histories: Meals → CarbIntake + ConnectorFoodEntryImport ────
+
+    /// <summary>
+    /// Maps V3 history meals to CarbIntake records.
+    /// Each meal becomes one CarbIntake using the meal-level totals.
+    /// Uses the meal guid for stable LegacyId correlation with food entries.
+    /// </summary>
+    public List<CarbIntake> MapV3HistoryMealsToCarbIntakes(GlookoV3HistoriesResponse historiesData)
+    {
+        var carbs = new List<CarbIntake>();
+        if (historiesData?.Histories == null) return carbs;
+
+        foreach (var meal in ExtractMeals(historiesData))
+        {
+            try
+            {
+                if (meal.SoftDeleted == true) continue;
+
+                var totalCarbs = meal.Carbs ?? 0;
+                if (totalCarbs <= 0) continue;
+
+                var timestamp = ParseHistoryTimestamp(meal.Timestamp);
+                if (timestamp == null) continue;
+
+                var legacyId = !string.IsNullOrEmpty(meal.Guid)
+                    ? $"glooko_v3meal_{meal.Guid}"
+                    : GenerateLegacyId("v3meal", timestamp.Value, $"carbs:{totalCarbs}");
+
+                var now = DateTime.UtcNow;
+                carbs.Add(new CarbIntake
+                {
+                    Id = Guid.CreateVersion7(),
+                    Timestamp = timestamp.Value,
+                    LegacyId = legacyId,
+                    Device = _connectorSource,
+                    DataSource = _connectorSource,
+                    Carbs = totalCarbs,
+                    CreatedAt = now,
+                    ModifiedAt = now
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "[{ConnectorSource}] Error mapping V3 history meal", _connectorSource);
+            }
+        }
+
+        _logger.LogInformation(
+            "[{ConnectorSource}] Transformed {Count} carb intakes from v3 history meals",
+            _connectorSource, carbs.Count);
+
+        return carbs;
+    }
+
+    /// <summary>
+    /// Maps V3 history meals to ConnectorFoodEntryImport records for the food catalog pipeline.
+    /// Each food item within a meal becomes a separate ConnectorFoodEntryImport.
+    /// The ExternalEntryId uses the food guid for deduplication; the meal guid is preserved
+    /// in the MealName field for correlation with the CarbIntake record.
+    /// When V2 foods are provided, they are used to enrich the food entries with
+    /// externalId (Nutritionix ID) and brand data that V3 histories doesn't include.
+    /// </summary>
+    public List<ConnectorFoodEntryImport> MapV3HistoryMealsToConnectorEntries(
+        GlookoV3HistoriesResponse historiesData,
+        GlookoFood[]? v2Foods = null)
+    {
+        var results = new List<ConnectorFoodEntryImport>();
+        if (historiesData?.Histories == null) return results;
+
+        // Build a lookup from V2 food guid → V2 food record for metadata enrichment
+        var v2FoodByGuid = new Dictionary<string, GlookoFood>(StringComparer.OrdinalIgnoreCase);
+        if (v2Foods != null)
+        {
+            foreach (var f in v2Foods)
+            {
+                if (!string.IsNullOrEmpty(f.Guid) && f.SoftDeleted != true)
+                    v2FoodByGuid.TryAdd(f.Guid, f);
+            }
+        }
+
+        foreach (var meal in ExtractMeals(historiesData))
+        {
+            try
+            {
+                if (meal.SoftDeleted == true) continue;
+
+                var timestamp = ParseHistoryTimestamp(meal.Timestamp);
+                if (timestamp == null) continue;
+
+                if (meal.Foods == null || meal.Foods.Length == 0) continue;
+
+                var mealLabel = meal.MealType ?? "Meal";
+
+                foreach (var food in meal.Foods)
+                {
+                    try
+                    {
+                        if (food.SoftDeleted == true) continue;
+
+                        // Try to enrich with V2 food metadata (externalId, brand)
+                        var v2Match = food.Guid != null && v2FoodByGuid.TryGetValue(food.Guid, out var v2)
+                            ? v2
+                            : null;
+
+                        var carbValue = food.Carbs ?? 0;
+
+                        var externalEntryId = food.Guid ?? $"v3meal_{meal.Guid}_{food.Name}";
+
+                        // ExternalFoodId: prefer V2 externalId (Nutritionix ID) for proper deduplication,
+                        // fall back to food name when V2 data is unavailable
+                        var externalFoodId = v2Match?.ExternalId ?? food.ExternalId ?? food.Name ?? string.Empty;
+
+                        var servingQty = food.ServingQuantity ?? 1;
+                        var numServings = food.NumberOfServings ?? 1;
+                        var portions = servingQty * numServings;
+                        if (portions <= 0) portions = 1;
+
+                        results.Add(new ConnectorFoodEntryImport
+                        {
+                            ConnectorSource = _connectorSource,
+                            ExternalEntryId = externalEntryId,
+                            ExternalFoodId = externalFoodId,
+                            ConsumedAt = new DateTimeOffset(timestamp.Value, TimeSpan.Zero),
+                            MealName = mealLabel,
+                            Carbs = (decimal)carbValue,
+                            Protein = (decimal)(food.Protein ?? 0),
+                            Fat = (decimal)(food.Fat ?? 0),
+                            Energy = (decimal)(food.Calories ?? 0),
+                            Servings = (decimal)portions,
+                            ServingDescription = BuildV3ServingDescription(food),
+                            Food = BuildMergedFoodImport(food, v2Match, externalFoodId),
+                        });
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "[{ConnectorSource}] Error mapping V3 history food item '{FoodName}'",
+                            _connectorSource, food.Name);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "[{ConnectorSource}] Error mapping V3 history meal", _connectorSource);
+            }
+        }
+
+        var enrichedCount = results.Count(r => !string.IsNullOrEmpty(r.Food?.BrandName) || r.ExternalFoodId != r.Food?.Name);
+        _logger.LogInformation(
+            "[{ConnectorSource}] Transformed {Count} food entries from v3 history meals ({Enriched} enriched with v2 metadata)",
+            _connectorSource, results.Count, enrichedCount);
+
+        return results;
+    }
+
+    /// <summary>
+    /// Builds a ConnectorFoodImport for the food catalog, merging V3 history food data
+    /// with V2 food metadata (externalId, brand) when available.
+    /// </summary>
+    private static ConnectorFoodImport? BuildMergedFoodImport(
+        GlookoV3HistoryFood food, GlookoFood? v2Match, string externalFoodId)
+    {
+        if (string.IsNullOrEmpty(food.Name))
+            return null;
+
+        return new ConnectorFoodImport
+        {
+            ExternalId = externalFoodId,
+            Name = food.Name,
+            BrandName = v2Match?.Brand ?? food.Brand,
+            Carbs = (decimal)(food.Carbs ?? 0),
+            Protein = (decimal)(food.Protein ?? 0),
+            Fat = (decimal)(food.Fat ?? 0),
+            Energy = (decimal)(food.Calories ?? 0),
+            Portion = (decimal)(food.ServingQuantity ?? 1),
+            Unit = food.ServingUnit,
+        };
+    }
+
+    /// <summary>
+    /// Builds a human-readable serving description from V3 history food data.
+    /// </summary>
+    private static string? BuildV3ServingDescription(GlookoV3HistoryFood food)
+    {
+        var qty = food.ServingQuantity;
+        var unit = food.ServingUnit;
+        var numServings = food.NumberOfServings;
+
+        if (qty == null && string.IsNullOrEmpty(unit)) return null;
+
+        var parts = new List<string>();
+        if (qty.HasValue) parts.Add(qty.Value.ToString("G"));
+        if (!string.IsNullOrEmpty(unit)) parts.Add(unit);
+        if (numServings is > 0 and not 1) parts.Add($"x{numServings.Value:G}");
+
+        return parts.Count > 0 ? string.Join(" ", parts) : null;
+    }
+
+    /// <summary>
+    /// Parses a V3 histories timestamp string and applies timezone correction.
+    /// V3 histories timestamps follow the same pattern as V2: labeled as UTC but actually local time.
+    /// </summary>
+    private DateTime? ParseHistoryTimestamp(string? timestamp)
+    {
+        if (string.IsNullOrWhiteSpace(timestamp)) return null;
+
+        if (!DateTime.TryParse(timestamp, out var parsedDate))
+        {
+            logger.LogWarning("Failed to parse V3 history timestamp: '{Timestamp}'", timestamp);
+            return null;
+        }
+
+        // V3 histories timestamps are in the same fake-UTC format as V2
+        return _timeMapper.GetCorrectedGlookoTime(parsedDate.ToUniversalTime());
+    }
+
+    /// <summary>
+    /// Extracts meal items from the flat V3 histories list.
+    /// The histories array contains typed entries; this filters for type == "meals"
+    /// and returns the meal data from each entry's Item property.
+    /// </summary>
+    public static IEnumerable<GlookoV3HistoryMeal> ExtractMeals(GlookoV3HistoriesResponse historiesData)
+    {
+        if (historiesData?.Histories == null) yield break;
+
+        foreach (var entry in historiesData.Histories)
+        {
+            if (entry.Type == "meals" && entry.Item != null && entry.SoftDeleted != true)
+                yield return entry.Item;
+        }
     }
 
     private static string GenerateLegacyId(string eventType, DateTime timestamp, string? additionalData = null)

--- a/src/Connectors/Nocturne.Connectors.Glooko/Models/GlookoBatchData.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Models/GlookoBatchData.cs
@@ -106,11 +106,19 @@ public class GlookoBolus
 
 public class GlookoCgmReading
 {
-    [JsonPropertyName("timestamp")] public string Timestamp { get; set; } = string.Empty;
+    [JsonPropertyName("display_time")] public string Timestamp { get; set; } = string.Empty;
 
-    [JsonPropertyName("value")] public double Value { get; set; }
+    /// <summary>
+    /// Glucose value in mg/dL × 100 (integer encoding for 2-decimal precision).
+    /// Must be divided by 100 to get actual mg/dL.
+    /// </summary>
+    [JsonPropertyName("bg_value")] public double Value { get; set; }
 
     [JsonPropertyName("trend")] public string? Trend { get; set; }
+
+    [JsonPropertyName("guid")] public string? Guid { get; set; }
+
+    [JsonPropertyName("soft_deleted")] public bool? SoftDeleted { get; set; }
 }
 
 public class GlookoSuspendBasal

--- a/src/Connectors/Nocturne.Connectors.Glooko/Models/GlookoV3HistoriesModels.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Models/GlookoV3HistoriesModels.cs
@@ -1,0 +1,218 @@
+using System.Text.Json.Serialization;
+
+namespace Nocturne.Connectors.Glooko.Models;
+
+/// <summary>
+///     Response from /api/v3/users/summary/histories endpoint.
+///     Contains a flat list of typed history entries (meals, medications, exercises, etc.).
+/// </summary>
+public class GlookoV3HistoriesResponse
+{
+    [JsonPropertyName("histories")] public GlookoV3HistoryEntry[]? Histories { get; set; }
+}
+
+/// <summary>
+///     A single typed history entry. The <see cref="Type"/> field indicates the data type
+///     (e.g., "meals", "medications") and the corresponding item property contains the data.
+/// </summary>
+public class GlookoV3HistoryEntry
+{
+    [JsonPropertyName("type")] public string? Type { get; set; }
+
+    [JsonPropertyName("guid")] public string? Guid { get; set; }
+
+    [JsonPropertyName("softDeleted")] public bool? SoftDeleted { get; set; }
+
+    [JsonPropertyName("updatedAt")] public string? UpdatedAt { get; set; }
+
+    [JsonPropertyName("updatedBy")] public string? UpdatedBy { get; set; }
+
+    /// <summary>
+    ///     The typed payload. Deserialized as a generic element; use helper methods
+    ///     or check <see cref="Type"/> to interpret the contents.
+    /// </summary>
+    [JsonPropertyName("item")]
+    public GlookoV3HistoryMeal? Item { get; set; }
+}
+
+// ── Meals ────────────────────────────────────────────────────────────
+
+/// <summary>
+///     A meal entry containing one or more food items with per-food nutritional data.
+///     Used as the <see cref="GlookoV3HistoryEntry.Item"/> when type == "meals".
+/// </summary>
+public class GlookoV3HistoryMeal
+{
+    [JsonPropertyName("guid")] public string? Guid { get; set; }
+
+    [JsonPropertyName("timestamp")] public string? Timestamp { get; set; }
+
+    [JsonPropertyName("name")] public string? Name { get; set; }
+
+    /// <summary>Meal type: "breakfast", "lunch", "dinner", "snack"</summary>
+    [JsonPropertyName("type")] public string? MealType { get; set; }
+
+    [JsonPropertyName("carbs")] public double? Carbs { get; set; }
+
+    [JsonPropertyName("fat")] public double? Fat { get; set; }
+
+    [JsonPropertyName("protein")] public double? Protein { get; set; }
+
+    [JsonPropertyName("calories")] public double? Calories { get; set; }
+
+    [JsonPropertyName("foods")] public GlookoV3HistoryFood[]? Foods { get; set; }
+
+    [JsonPropertyName("softDeleted")] public bool? SoftDeleted { get; set; }
+
+    [JsonPropertyName("updatedAt")] public string? UpdatedAt { get; set; }
+
+    [JsonPropertyName("updatedBy")] public string? UpdatedBy { get; set; }
+}
+
+/// <summary>
+///     An individual food item within a V3 history meal.
+/// </summary>
+public class GlookoV3HistoryFood
+{
+    [JsonPropertyName("guid")] public string? Guid { get; set; }
+
+    [JsonPropertyName("timestamp")] public string? Timestamp { get; set; }
+
+    [JsonPropertyName("name")] public string? Name { get; set; }
+
+    [JsonPropertyName("brand")] public string? Brand { get; set; }
+
+    [JsonPropertyName("carbs")] public double? Carbs { get; set; }
+
+    [JsonPropertyName("fat")] public double? Fat { get; set; }
+
+    [JsonPropertyName("protein")] public double? Protein { get; set; }
+
+    [JsonPropertyName("calories")] public double? Calories { get; set; }
+
+    [JsonPropertyName("servingQuantity")] public double? ServingQuantity { get; set; }
+
+    [JsonPropertyName("servingUnit")] public string? ServingUnit { get; set; }
+
+    [JsonPropertyName("numberOfServings")] public double? NumberOfServings { get; set; }
+
+    [JsonPropertyName("externalId")] public string? ExternalId { get; set; }
+
+    [JsonPropertyName("source")] public string? Source { get; set; }
+
+    [JsonPropertyName("imageUrl")] public string? ImageUrl { get; set; }
+
+    [JsonPropertyName("softDeleted")] public bool? SoftDeleted { get; set; }
+}
+
+// ── Medications ──────────────────────────────────────────────────────
+
+/// <summary>
+///     A medication entry (insulin or oral medication).
+/// </summary>
+public class GlookoV3HistoryMedication
+{
+    [JsonPropertyName("guid")] public string? Guid { get; set; }
+
+    [JsonPropertyName("timestamp")] public string? Timestamp { get; set; }
+
+    [JsonPropertyName("medicationName")] public string? MedicationName { get; set; }
+
+    [JsonPropertyName("medicationType")] public string? MedicationType { get; set; }
+
+    [JsonPropertyName("units")] public double? Units { get; set; }
+
+    [JsonPropertyName("insulinType")] public string? InsulinType { get; set; }
+
+    [JsonPropertyName("softDeleted")] public bool? SoftDeleted { get; set; }
+}
+
+// ── Exercises ────────────────────────────────────────────────────────
+
+/// <summary>
+///     An exercise/activity entry.
+/// </summary>
+public class GlookoV3HistoryExercise
+{
+    [JsonPropertyName("guid")] public string? Guid { get; set; }
+
+    [JsonPropertyName("timestamp")] public string? Timestamp { get; set; }
+
+    [JsonPropertyName("exerciseName")] public string? ExerciseName { get; set; }
+
+    [JsonPropertyName("duration")] public int? Duration { get; set; }
+
+    [JsonPropertyName("intensity")] public string? Intensity { get; set; }
+
+    [JsonPropertyName("softDeleted")] public bool? SoftDeleted { get; set; }
+}
+
+// ── Weights ──────────────────────────────────────────────────────────
+
+/// <summary>
+///     A weight measurement entry.
+/// </summary>
+public class GlookoV3HistoryWeight
+{
+    [JsonPropertyName("guid")] public string? Guid { get; set; }
+
+    [JsonPropertyName("timestamp")] public string? Timestamp { get; set; }
+
+    [JsonPropertyName("value")] public double? Value { get; set; }
+
+    [JsonPropertyName("unit")] public string? Unit { get; set; }
+
+    [JsonPropertyName("softDeleted")] public bool? SoftDeleted { get; set; }
+}
+
+// ── Readings ─────────────────────────────────────────────────────────
+
+/// <summary>
+///     A BG reading entry from the histories endpoint.
+/// </summary>
+public class GlookoV3HistoryReading
+{
+    [JsonPropertyName("guid")] public string? Guid { get; set; }
+
+    [JsonPropertyName("timestamp")] public string? Timestamp { get; set; }
+
+    [JsonPropertyName("value")] public double? Value { get; set; }
+
+    [JsonPropertyName("mealTag")] public string? MealTag { get; set; }
+
+    [JsonPropertyName("softDeleted")] public bool? SoftDeleted { get; set; }
+}
+
+// ── Notes ────────────────────────────────────────────────────────────
+
+/// <summary>
+///     A user note entry.
+/// </summary>
+public class GlookoV3HistoryNote
+{
+    [JsonPropertyName("guid")] public string? Guid { get; set; }
+
+    [JsonPropertyName("timestamp")] public string? Timestamp { get; set; }
+
+    [JsonPropertyName("body")] public string? Body { get; set; }
+
+    [JsonPropertyName("softDeleted")] public bool? SoftDeleted { get; set; }
+}
+
+// ── Pump Alerts ──────────────────────────────────────────────────────
+
+/// <summary>
+///     A pump alert entry.
+/// </summary>
+public class GlookoV3HistoryPumpAlert
+{
+    [JsonPropertyName("guid")] public string? Guid { get; set; }
+
+    [JsonPropertyName("timestamp")] public string? Timestamp { get; set; }
+
+    [JsonPropertyName("alertType")] public string? AlertType { get; set; }
+
+    [JsonPropertyName("message")] public string? Message { get; set; }
+
+    [JsonPropertyName("softDeleted")] public bool? SoftDeleted { get; set; }
+}

--- a/src/Connectors/Nocturne.Connectors.Glooko/Models/GlookoV3Models.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Models/GlookoV3Models.cs
@@ -125,7 +125,7 @@ public class GlookoV3GlucoseDataPoint : GlookoV3DataPointBase
     public string? MealTag { get; set; }
 
     /// <summary>
-    ///     Internal Glooko value (scaled)
+    ///     Internal Glooko value (mg/dL × 100)
     /// </summary>
     [JsonPropertyName("value")]
     public long Value { get; set; }
@@ -135,6 +135,18 @@ public class GlookoV3GlucoseDataPoint : GlookoV3DataPointBase
     /// </summary>
     [JsonPropertyName("calculated")]
     public bool Calculated { get; set; }
+
+    /// <summary>
+    ///     Glooko internal record ID (MongoDB ObjectId)
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    /// <summary>
+    ///     Reading type (e.g., "meter" for BGM)
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
 }
 
 /// <summary>
@@ -184,9 +196,51 @@ public class GlookoV3BolusData
 /// </summary>
 public class GlookoV3InsulinDataPoint : GlookoV3DataPointBase
 {
-    [JsonPropertyName("y")] public double? Y { get; set; }
+    /// <summary>
+    ///     Insulin units (graph Y-axis value)
+    /// </summary>
+    [JsonPropertyName("y")]
+    public double? Y { get; set; }
 
-    [JsonPropertyName("label")] public string? Label { get; set; }
+    /// <summary>
+    ///     Insulin units (explicit value field, same as Y)
+    /// </summary>
+    [JsonPropertyName("value")]
+    public double? Value { get; set; }
+
+    /// <summary>
+    ///     Insulin name (e.g., "Admelog®", "Tresiba®U100")
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    ///     Label (alternative name field used in some responses)
+    /// </summary>
+    [JsonPropertyName("label")]
+    public string? Label { get; set; }
+
+    /// <summary>
+    ///     Unit of measurement (e.g., "units")
+    /// </summary>
+    [JsonPropertyName("units")]
+    public string? Units { get; set; }
+
+    /// <summary>
+    ///     Whether the insulin was actually delivered (false for pen/injection records)
+    /// </summary>
+    [JsonPropertyName("delivered")]
+    public bool? Delivered { get; set; }
+
+    /// <summary>
+    ///     Gets the insulin dose, preferring Value, then Y.
+    /// </summary>
+    public double ActualUnits => Value ?? Y ?? 0;
+
+    /// <summary>
+    ///     Gets the insulin name, preferring Name, then Label.
+    /// </summary>
+    public string? InsulinName => Name ?? Label;
 }
 
 /// <summary>

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoAuthTokenProvider.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoAuthTokenProvider.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Connectors.Glooko.Configurations;
+using Nocturne.Connectors.Glooko.Models;
 using Nocturne.Connectors.Glooko.Utilities;
 
 namespace Nocturne.Connectors.Glooko.Services;
@@ -41,27 +42,46 @@ public class GlookoAuthTokenProvider : AuthTokenProviderBase<GlookoConnectorConf
     {
         try
         {
-            _logger.LogInformation("Authenticating with Glooko server: {Server}", _config.Server);
+            _logger.LogInformation("Authenticating with Glooko server: {Server} (v3={UseV3})",
+                _config.Server, _config.UseV3Api);
 
             var baseUrl = GlookoConstants.ResolveBaseUrl(_config.Server);
             var webOrigin = GlookoConstants.ResolveWebOrigin(_config.Server);
 
-            var loginData = new
-            {
-                userLogin = new
-                {
-                    email = _config.Email,
-                    password = _config.Password
-                },
-                deviceInformation = GlookoConstants.DeviceInformation
-            };
+            string signInPath;
+            string loginJson;
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"{baseUrl}{GlookoConstants.SignInPath}")
+            if (_config.UseV3Api)
             {
-                Content = new StringContent(
-                    JsonSerializer.Serialize(loginData),
-                    Encoding.UTF8,
-                    "application/json")
+                signInPath = GlookoConstants.V3SignInPath;
+                var loginData = new
+                {
+                    user = new
+                    {
+                        email = _config.Email,
+                        password = _config.Password
+                    }
+                };
+                loginJson = JsonSerializer.Serialize(loginData);
+            }
+            else
+            {
+                signInPath = GlookoConstants.SignInPath;
+                var loginData = new
+                {
+                    userLogin = new
+                    {
+                        email = _config.Email,
+                        password = _config.Password
+                    },
+                    deviceInformation = GlookoConstants.DeviceInformation
+                };
+                loginJson = JsonSerializer.Serialize(loginData);
+            }
+
+            var request = new HttpRequestMessage(HttpMethod.Post, $"{baseUrl}{signInPath}")
+            {
+                Content = new StringContent(loginJson, Encoding.UTF8, "application/json")
             };
 
             GlookoHttpHelper.ApplyStandardHeaders(request, webOrigin);
@@ -86,23 +106,50 @@ public class GlookoAuthTokenProvider : AuthTokenProviderBase<GlookoConnectorConf
                         break;
                     }
 
-            // Parse user data
+            // Parse user data from sign-in response (V2 only — V3 sign-in returns { success, two_fa_required })
             var responseJson = await GlookoHttpHelper.ReadResponseAsync(response, cancellationToken);
-            try
+            if (!_config.UseV3Api)
             {
-                UserData = JsonSerializer.Deserialize<GlookoUserData>(responseJson);
-                if (UserData?.UserLogin?.GlookoCode != null)
-                    _logger.LogInformation(
-                        "User data parsed successfully. Glooko code: {GlookoCode}",
-                        UserData.UserLogin.GlookoCode);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning("Could not parse user data: {Message}", ex.Message);
+                try
+                {
+                    UserData = JsonSerializer.Deserialize<GlookoUserData>(responseJson);
+                    if (UserData?.GlookoCode != null)
+                        _logger.LogInformation(
+                            "User data parsed successfully. Glooko code: {GlookoCode}",
+                            UserData.GlookoCode);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning("Could not parse user data: {Message}", ex.Message);
+                }
             }
 
             if (!string.IsNullOrEmpty(SessionCookie))
             {
+                // V3 sign-in doesn't return user data — fetch it from /api/v3/session/users
+                if (_config.UseV3Api)
+                {
+                    try
+                    {
+                        var userData = await FetchV3UserDataAsync(baseUrl, webOrigin, cancellationToken);
+                        if (userData != null)
+                        {
+                            UserData = new GlookoUserData { User = new GlookoUserLogin { GlookoCode = userData.GlookoCode } };
+                            _logger.LogInformation(
+                                "V3 user profile loaded. Glooko code: {GlookoCode}, MeterUnits: {Units}",
+                                userData.GlookoCode, userData.MeterUnits);
+                        }
+                        else
+                        {
+                            _logger.LogWarning("V3 sign-in succeeded but failed to fetch user profile");
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to fetch V3 user profile after sign-in");
+                    }
+                }
+
                 _logger.LogInformation("Glooko authentication successful");
                 return (SessionCookie, DateTime.UtcNow.Add(GlookoConstants.SessionLifetime));
             }
@@ -116,14 +163,47 @@ public class GlookoAuthTokenProvider : AuthTokenProviderBase<GlookoConnectorConf
             return (null, DateTime.MinValue);
         }
     }
+
+    /// <summary>
+    ///     Fetches the user profile from /api/v3/session/users after V3 sign-in.
+    ///     The V3 sign-in response only contains { success, two_fa_required } —
+    ///     the glookoCode and meter units come from this follow-up call.
+    /// </summary>
+    private async Task<GlookoV3User?> FetchV3UserDataAsync(
+        string baseUrl, string webOrigin, CancellationToken cancellationToken)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}{GlookoConstants.V3UsersPath}");
+        GlookoHttpHelper.ApplyStandardHeaders(request, webOrigin, SessionCookie);
+
+        var response = await _httpClient.SendAsync(request, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogWarning("Failed to fetch V3 user profile: {StatusCode}", response.StatusCode);
+            return null;
+        }
+
+        var json = await GlookoHttpHelper.ReadResponseAsync(response, cancellationToken);
+        var profile = JsonSerializer.Deserialize<GlookoV3UsersResponse>(json);
+
+        return profile?.CurrentUser ?? profile?.CurrentPatient;
+    }
 }
 
 /// <summary>
 ///     Glooko user data returned from authentication.
+///     V2 returns { userLogin: { glookoCode } }, V3 returns { user: { glookoCode } }.
+///     Both shapes are deserialized into this single model.
 /// </summary>
 public class GlookoUserData
 {
     [JsonPropertyName("userLogin")] public GlookoUserLogin? UserLogin { get; set; }
+
+    [JsonPropertyName("user")] public GlookoUserLogin? User { get; set; }
+
+    /// <summary>
+    ///     Gets the Glooko code from whichever response shape was returned.
+    /// </summary>
+    public string? GlookoCode => UserLogin?.GlookoCode ?? User?.GlookoCode;
 }
 
 /// <summary>

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -17,6 +17,33 @@ using Nocturne.Core.Models.V4;
 namespace Nocturne.Connectors.Glooko.Services;
 
 /// <summary>
+///     All mapped data produced by a V2 or V3 fetch-and-transform pass.
+///     Populated by <see cref="GlookoConnectorService.FetchAndMapViaV2Async"/> or
+///     <see cref="GlookoConnectorService.FetchAndMapViaV3Async"/>, then consumed
+///     by the shared <see cref="GlookoConnectorService.PublishAllAsync"/> pipeline.
+/// </summary>
+internal sealed class GlookoSyncData
+{
+    public List<SensorGlucose> SensorGlucose { get; init; } = [];
+    public List<BGCheck> BgChecks { get; init; } = [];
+    public List<Bolus> Boluses { get; init; } = [];
+    public List<CarbIntake> CarbIntakes { get; init; } = [];
+    public List<DecompositionBatch> Batches { get; init; } = [];
+    public List<StateSpan> StateSpans { get; init; } = [];
+    public List<TempBasal> TempBasals { get; init; } = [];
+    public List<DeviceEvent> DeviceEvents { get; init; } = [];
+    public List<SystemEvent> SystemEvents { get; init; } = [];
+    public List<ConnectorFoodEntryImport> FoodEntryImports { get; init; } = [];
+
+    /// <summary>
+    ///     Resolves a food entry's ExternalEntryId to the LegacyId of the CarbIntake it belongs to.
+    ///     V2: direct mapping (glooko_food_{externalEntryId}).
+    ///     V3: food guid → meal guid → glooko_v3meal_{mealGuid}.
+    /// </summary>
+    public Func<string, string?>? FoodEntryToCarbLegacyId { get; set; }
+}
+
+/// <summary>
 ///     Connector service for Glooko data source.
 ///     Based on the original nightscout-connect Glooko implementation.
 /// </summary>
@@ -102,7 +129,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             throw new InvalidOperationException(
                 "Not authenticated with Glooko. Call AuthenticateAsync first.");
 
-        var code = _tokenProvider.UserData?.UserLogin?.GlookoCode;
+        var code = _tokenProvider.UserData?.GlookoCode;
         if (code == null)
             _logger.LogWarning("Missing Glooko user code, cannot fetch data");
 
@@ -198,7 +225,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
 
     private string ConstructV2Url(string endpoint, DateTime startDate, DateTime endDate)
     {
-        var patientCode = _tokenProvider.UserData?.UserLogin?.GlookoCode;
+        var patientCode = _tokenProvider.UserData?.GlookoCode;
         var maxCount = Math.Max(1, (int)Math.Ceiling((endDate - startDate).TotalMinutes / 5));
 
         return $"{endpoint}?patient={patientCode}"
@@ -211,7 +238,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
 
     private string ConstructV3GraphUrl(DateTime startDate, DateTime endDate)
     {
-        var patientCode = _tokenProvider.UserData?.UserLogin?.GlookoCode;
+        var patientCode = _tokenProvider.UserData?.GlookoCode;
 
         var series = _config.V3IncludeCgmBackfill
             ? GlookoConstants.V3GraphSeries.Concat(GlookoConstants.V3CgmBackfillSeries)
@@ -255,15 +282,11 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                     return result;
                 }
 
-            // Compute active types: intersection of requested and enabled types
             if (!request.DataTypes.Any())
                 request.DataTypes = SupportedDataTypes;
             var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes);
             var activeTypes = request.DataTypes.Where(t => enabledTypes.Contains(t)).ToHashSet();
 
-            // Convert real UTC (from database) back to Glooko's fake-UTC format
-            // for API requests. Glooko timestamps are labeled as UTC but are actually
-            // local time, so we reverse the timezone correction applied during inbound processing.
             var from = request.From.HasValue
                 ? _timeMapper.ToGlookoTime(request.From.Value)
                 : (DateTime?)null;
@@ -272,9 +295,12 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                 new() { ["from"] = (from ?? DateTime.UtcNow.AddMonths(-6)).ToString("MMM dd"), ["to"] = DateTime.UtcNow.ToString("MMM dd") },
                 cancellationToken);
 
-            var batchData = await FetchBatchDataAsync(from);
+            // Fetch + map: V2 or V3 path fills the same data structure
+            var syncData = _config.UseV3Api
+                ? await FetchAndMapViaV3Async(from)
+                : await FetchAndMapViaV2Async(from);
 
-            if (batchData == null)
+            if (syncData == null)
             {
                 result.Success = false;
                 result.Message = "Failed to fetch data";
@@ -282,261 +308,10 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                 return result;
             }
 
-            // Fetch V3 data once upfront if needed for any data type
-            GlookoV3GraphResponse? v3Data = null;
-            var needsV3Data = _config.UseV3Api && (
-                activeTypes.Contains(SyncDataType.Boluses) ||
-                activeTypes.Contains(SyncDataType.CarbIntake) ||
-                activeTypes.Contains(SyncDataType.StateSpans) ||
-                activeTypes.Contains(SyncDataType.DeviceEvents) ||
-                (_config.V3IncludeCgmBackfill && activeTypes.Contains(SyncDataType.Glucose))
-            );
+            // Single publish pipeline for all data types
+            await PublishAllAsync(syncData, activeTypes, result, config, progressReporter, cancellationToken);
 
-            if (needsV3Data)
-            {
-                try
-                {
-                    _logger.LogInformation("[{ConnectorSource}] Fetching additional data from v3 API...", ConnectorSource);
-                    v3Data = await FetchV3GraphDataAsync(from);
-                }
-                catch (Exception v3Ex)
-                {
-                    _logger.LogWarning(v3Ex, "[{ConnectorSource}] V3 API fetch failed, continuing with v2 data only", ConnectorSource);
-                }
-            }
-
-            // 1. Process Glucose
-            await ReportMessageAsync(progressReporter, SyncMessageType.ProcessingDataType,
-                new() { ["dataType"] = SyncDataType.Glucose.ToString() }, cancellationToken);
-
-            if (activeTypes.Contains(SyncDataType.Glucose))
-            {
-                var sensorGlucose = _sensorGlucoseMapper.TransformBatchDataToSensorGlucose(batchData).ToList();
-                if (sensorGlucose.Count > 0)
-                {
-                    var success = await PublishSensorGlucoseDataAsync(sensorGlucose, config, cancellationToken);
-                    if (success)
-                    {
-                        result.ItemsSynced[SyncDataType.Glucose] = sensorGlucose.Count;
-                        result.LastEntryTimes[SyncDataType.Glucose] = DateTimeOffset
-                            .FromUnixTimeMilliseconds(sensorGlucose.Max(s => s.Mills)).UtcDateTime;
-
-                        await ReportMessageAsync(progressReporter, SyncMessageType.PublishingDataType,
-                            new() { ["dataType"] = SyncDataType.Glucose.ToString(), ["count"] = sensorGlucose.Count.ToString() },
-                            cancellationToken);
-                    }
-                }
-
-                // V3 CGM backfill
-                if (_config.V3IncludeCgmBackfill && v3Data != null)
-                {
-                    var v3Glucose = _sensorGlucoseMapper.TransformV3ToSensorGlucose(v3Data, _meterUnits).ToList();
-                    if (v3Glucose.Count > 0)
-                    {
-                        await PublishSensorGlucoseDataAsync(v3Glucose, config, cancellationToken);
-                        _logger.LogInformation("[{ConnectorSource}] Published {Count} CGM backfill sensor glucose from v3",
-                            ConnectorSource, v3Glucose.Count);
-                    }
-                }
-
-                // V2 meter readings → BGCheck records
-                var bgChecks = _sensorGlucoseMapper.TransformBatchDataToBGChecks(batchData).ToList();
-                if (bgChecks.Count > 0)
-                {
-                    if (await PublishBGCheckDataAsync(bgChecks, config, cancellationToken))
-                    {
-                        _logger.LogInformation("[{ConnectorSource}] Published {Count} BG checks from meter readings",
-                            ConnectorSource, bgChecks.Count);
-                    }
-                }
-            }
-
-            // 2. Process Treatments (boluses, carb intake)
-            var allBoluses = new List<Bolus>();
-            var allCarbs = new List<CarbIntake>();
-            var allDeviceEvents = new List<DeviceEvent>();
-            var allBatches = new List<DecompositionBatch>();
-
-            if (_config.UseV3Api && v3Data != null)
-            {
-                var (v3Boluses, v3BolusCarbIntakes, v3Batches) = _v4TreatmentMapper.MapV3Boluses(v3Data);
-                allBoluses.AddRange(v3Boluses);
-                allCarbs.AddRange(v3BolusCarbIntakes);
-                allBatches.AddRange(v3Batches);
-
-                // V2 standalone food records have no V3 equivalent — create CarbIntake records
-                allCarbs.AddRange(_v4TreatmentMapper.MapFoodsToCarbIntakes(batchData));
-                allDeviceEvents.AddRange(_v4TreatmentMapper.MapV3DeviceEvents(v3Data));
-            }
-            else
-            {
-                var (v2Boluses, v2Carbs, v2Batches) = _v4TreatmentMapper.MapBatchData(batchData);
-                allBoluses.AddRange(v2Boluses);
-                allCarbs.AddRange(v2Carbs);
-                allBatches.AddRange(v2Batches);
-            }
-
-            // Persist decomposition batches before V4 records (FK constraint)
-            if (allBatches.Count > 0)
-                await PublishDecompositionBatchesAsync(allBatches, config, cancellationToken);
-
-            // Publish boluses
-            await ReportMessageAsync(progressReporter, SyncMessageType.ProcessingDataType,
-                new() { ["dataType"] = SyncDataType.Boluses.ToString() }, cancellationToken);
-
-            if (activeTypes.Contains(SyncDataType.Boluses) && allBoluses.Count > 0)
-            {
-                if (await PublishBolusDataAsync(allBoluses, config, cancellationToken))
-                {
-                    result.ItemsSynced[SyncDataType.Boluses] = allBoluses.Count;
-                    _logger.LogInformation("[{ConnectorSource}] Published {Count} boluses", ConnectorSource, allBoluses.Count);
-                    await ReportMessageAsync(progressReporter, SyncMessageType.PublishingDataType,
-                        new() { ["dataType"] = SyncDataType.Boluses.ToString(), ["count"] = allBoluses.Count.ToString() }, cancellationToken);
-                }
-            }
-
-            // Publish carb intakes
-            await ReportMessageAsync(progressReporter, SyncMessageType.ProcessingDataType,
-                new() { ["dataType"] = SyncDataType.CarbIntake.ToString() }, cancellationToken);
-
-            if (activeTypes.Contains(SyncDataType.CarbIntake) && allCarbs.Count > 0)
-            {
-                if (await PublishCarbIntakeDataAsync(allCarbs, config, cancellationToken))
-                {
-                    result.ItemsSynced[SyncDataType.CarbIntake] = allCarbs.Count;
-                    _logger.LogInformation("[{ConnectorSource}] Published {Count} carb intakes", ConnectorSource, allCarbs.Count);
-                    await ReportMessageAsync(progressReporter, SyncMessageType.PublishingDataType,
-                        new() { ["dataType"] = SyncDataType.CarbIntake.ToString(), ["count"] = allCarbs.Count.ToString() }, cancellationToken);
-                }
-            }
-
-            // Publish V2 food records as connector food entries (creates Food catalog + ConnectorFoodEntry records)
-            if (_config.UseV3Api && batchData.Foods is { Length: > 0 })
-            {
-                var foodEntryImports = _v4TreatmentMapper.MapFoodsToConnectorEntries(batchData);
-                if (foodEntryImports.Count > 0 && _connectorPublisher is { IsAvailable: true })
-                {
-                    var importedEntries = await _connectorPublisher.Metadata.PublishConnectorFoodEntriesAsync(
-                        foodEntryImports, ConnectorSource, cancellationToken);
-
-                    if (importedEntries is { Count: > 0 })
-                    {
-                        _logger.LogInformation(
-                            "[{ConnectorSource}] Published {Count} food entries to connector food catalog",
-                            ConnectorSource, importedEntries.Count);
-
-                        // Attribute food entries to CarbIntakes using the Glooko guid correlation:
-                        // ConnectorFoodEntry.ExternalEntryId == food.Guid
-                        // CarbIntake.LegacyId == "glooko_food_{food.Guid}"
-                        // Only process Pending entries (newly created this sync); already-matched
-                        // entries from previous syncs are skipped to avoid FK errors from
-                        // in-memory CarbIntake IDs that don't match the persisted DB IDs.
-                        if (_mealMatchingService != null && allCarbs.Count > 0)
-                        {
-                            var pendingEntries = importedEntries
-                                .Where(e => e.Status == ConnectorFoodEntryStatus.Pending)
-                                .ToList();
-
-                            if (pendingEntries.Count > 0)
-                            {
-                                var carbsByLegacyId = allCarbs
-                                    .Where(ci => ci.LegacyId != null)
-                                    .ToDictionary(ci => ci.LegacyId!, StringComparer.OrdinalIgnoreCase);
-
-                                foreach (var entry in pendingEntries)
-                                {
-                                    var legacyKey = $"glooko_food_{entry.ExternalEntryId}";
-                                    if (!carbsByLegacyId.TryGetValue(legacyKey, out var carbIntake))
-                                        continue;
-
-                                    try
-                                    {
-                                        await _mealMatchingService.AcceptMatchAsync(
-                                            entry.Id, carbIntake.Id, entry.Carbs, timeOffsetMinutes: 0, cancellationToken);
-                                    }
-                                    catch (Exception ex)
-                                    {
-                                        _logger.LogWarning(ex,
-                                            "[{ConnectorSource}] Failed to attribute food entry {FoodEntryId} to CarbIntake {CarbIntakeId}",
-                                            ConnectorSource, entry.Id, carbIntake.Id);
-                                    }
-                                }
-
-                                _logger.LogInformation(
-                                    "[{ConnectorSource}] Attributed {Count} food entries to carb intakes",
-                                    ConnectorSource, pendingEntries.Count);
-                            }
-                        }
-                    }
-                }
-            }
-
-            // 3. Process DeviceEvents
-            await ReportMessageAsync(progressReporter, SyncMessageType.ProcessingDataType,
-                new() { ["dataType"] = SyncDataType.DeviceEvents.ToString() }, cancellationToken);
-
-            if (activeTypes.Contains(SyncDataType.DeviceEvents))
-            {
-                var deviceEventCount = 0;
-
-                if (allDeviceEvents.Count > 0 && await PublishDeviceEventDataAsync(allDeviceEvents, config, cancellationToken))
-                {
-                    deviceEventCount += allDeviceEvents.Count;
-                    _logger.LogInformation("[{ConnectorSource}] Published {Count} device events", ConnectorSource, allDeviceEvents.Count);
-                }
-
-                if (v3Data != null)
-                {
-                    var systemEvents = _systemEventMapper.TransformV3ToSystemEvents(v3Data);
-                    if (systemEvents.Any() && await PublishSystemEventDataAsync(systemEvents, config, cancellationToken))
-                    {
-                        deviceEventCount += systemEvents.Count;
-                        _logger.LogInformation("[{ConnectorSource}] Published {Count} system events from v3", ConnectorSource, systemEvents.Count);
-                    }
-                }
-
-                if (deviceEventCount > 0)
-                    result.ItemsSynced[SyncDataType.DeviceEvents] = deviceEventCount;
-            }
-
-            // 4. Process StateSpans and TempBasals
-            await ReportMessageAsync(progressReporter, SyncMessageType.ProcessingDataType,
-                new() { ["dataType"] = SyncDataType.StateSpans.ToString() }, cancellationToken);
-
-            if (activeTypes.Contains(SyncDataType.StateSpans))
-            {
-                var tempBasalCount = 0;
-
-                if (v3Data != null)
-                {
-                    var stateSpans = _stateSpanMapper.TransformV3ToStateSpans(v3Data);
-                    if (stateSpans.Any() && await PublishStateSpanDataAsync(stateSpans, config, cancellationToken))
-                        _logger.LogInformation("[{ConnectorSource}] Published {Count} state spans from v3", ConnectorSource, stateSpans.Count);
-
-                    var v3TempBasals = _tempBasalMapper.TransformV3ToTempBasals(v3Data);
-                    if (v3TempBasals.Any() && await PublishTempBasalDataAsync(v3TempBasals, config, cancellationToken))
-                    {
-                        tempBasalCount += v3TempBasals.Count;
-                        _logger.LogInformation("[{ConnectorSource}] Published {Count} temp basals from v3", ConnectorSource, v3TempBasals.Count);
-                    }
-                }
-
-                var v2StateSpans = _stateSpanMapper.TransformV2ToStateSpans(batchData);
-                if (v2StateSpans.Any() && await PublishStateSpanDataAsync(v2StateSpans, config, cancellationToken))
-                    _logger.LogInformation("[{ConnectorSource}] Published {Count} state spans from v2", ConnectorSource, v2StateSpans.Count);
-
-                var v2TempBasals = _tempBasalMapper.TransformV2ToTempBasals(batchData);
-                if (v2TempBasals.Any() && await PublishTempBasalDataAsync(v2TempBasals, config, cancellationToken))
-                {
-                    tempBasalCount += v2TempBasals.Count;
-                    _logger.LogInformation("[{ConnectorSource}] Published {Count} temp basals from v2", ConnectorSource, v2TempBasals.Count);
-                }
-
-                if (tempBasalCount > 0)
-                    result.ItemsSynced[SyncDataType.StateSpans] = tempBasalCount;
-            }
-
-            // 5. Process Profiles
+            // Profiles (V3 device settings — used in both modes, no V2 equivalent)
             await ReportMessageAsync(progressReporter, SyncMessageType.ProcessingDataType,
                 new() { ["dataType"] = SyncDataType.Profiles.ToString() }, cancellationToken);
 
@@ -581,7 +356,310 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         }
     }
 
-    // ── V2 batch data ───────────────────────────────────────────────────
+    // ── V2 fetch + map ──────────────────────────────────────────────────
+
+    /// <summary>
+    ///     Fetches from all V2 endpoints and maps to the common <see cref="GlookoSyncData"/> structure.
+    /// </summary>
+    private async Task<GlookoSyncData?> FetchAndMapViaV2Async(DateTime? from)
+    {
+        var batchData = await FetchBatchDataAsync(from);
+        if (batchData == null) return null;
+
+        var (boluses, carbs, batches) = _v4TreatmentMapper.MapBatchData(batchData);
+
+        var data = new GlookoSyncData
+        {
+            SensorGlucose = _sensorGlucoseMapper.TransformBatchDataToSensorGlucose(batchData).ToList(),
+            BgChecks = _sensorGlucoseMapper.TransformBatchDataToBGChecks(batchData).ToList(),
+            Boluses = boluses,
+            CarbIntakes = carbs,
+            Batches = batches,
+            StateSpans = _stateSpanMapper.TransformV2ToStateSpans(batchData),
+            TempBasals = _tempBasalMapper.TransformV2ToTempBasals(batchData),
+            FoodEntryImports = batchData.Foods is { Length: > 0 }
+                ? _v4TreatmentMapper.MapFoodsToConnectorEntries(batchData)
+                : [],
+            // V2: direct guid correlation — food.Guid → CarbIntake.LegacyId "glooko_food_{guid}"
+            FoodEntryToCarbLegacyId = externalEntryId => $"glooko_food_{externalEntryId}",
+        };
+
+        return data;
+    }
+
+    // ── V3 fetch + map ──────────────────────────────────────────────────
+
+    /// <summary>
+    ///     Fetches from V3 graph/data and histories endpoints, maps to the common <see cref="GlookoSyncData"/> structure.
+    /// </summary>
+    private async Task<GlookoSyncData?> FetchAndMapViaV3Async(DateTime? from)
+    {
+        _logger.LogInformation("[{ConnectorSource}] Fetching data from v3 API...", ConnectorSource);
+
+        var v3Data = await FetchV3GraphDataAsync(from);
+        if (v3Data == null) return null;
+
+        GlookoV3HistoriesResponse? v3Histories = null;
+        try
+        {
+            v3Histories = await FetchV3HistoriesAsync(from);
+        }
+        catch (Exception histEx)
+        {
+            _logger.LogWarning(histEx, "[{ConnectorSource}] V3 histories fetch failed, meal data will be unavailable", ConnectorSource);
+        }
+
+        var (v3Boluses, v3BolusCarbIntakes, v3Batches) = _v4TreatmentMapper.MapV3Boluses(v3Data);
+
+        // Carbs: from bolus wizard + from V3 history meals (preferred) or carbAll series (fallback).
+        // History meals are preferred because their legacy IDs ("glooko_v3meal_{mealGuid}")
+        // are needed for food attribution. carbAll would create duplicate carb entries
+        // with different legacy IDs, breaking the food → carb correlation.
+        var allCarbs = new List<CarbIntake>(v3BolusCarbIntakes);
+        var historyMealCarbs = v3Histories?.Histories != null
+            ? _v4TreatmentMapper.MapV3HistoryMealsToCarbIntakes(v3Histories)
+            : [];
+
+        if (historyMealCarbs.Count > 0)
+            allCarbs.AddRange(historyMealCarbs);
+        else
+            allCarbs.AddRange(_v4TreatmentMapper.MapV3CarbAll(v3Data));
+
+        // Food entries: merge V3 history meals (structure + meal type) with V2 foods (externalId, brand)
+        GlookoFood[]? v2Foods = null;
+        if (historyMealCarbs.Count > 0)
+        {
+            try
+            {
+                v2Foods = await FetchV2FoodsAsync(from);
+            }
+            catch (Exception v2Ex)
+            {
+                _logger.LogWarning(v2Ex, "[{ConnectorSource}] V2 foods fetch failed, food entries will lack externalId/brand metadata", ConnectorSource);
+            }
+        }
+
+        var foodEntryImports = historyMealCarbs.Count > 0 && v3Histories?.Histories != null
+            ? _v4TreatmentMapper.MapV3HistoryMealsToConnectorEntries(v3Histories, v2Foods)
+            : [];
+
+        // Build food guid → meal guid lookup for attribution (only when using history meals)
+        Func<string, string?>? foodResolver = null;
+        if (historyMealCarbs.Count > 0 && v3Histories?.Histories != null)
+        {
+            var foodGuidToMealGuid = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var meal in GlookoV4TreatmentMapper.ExtractMeals(v3Histories))
+            {
+                if (meal.SoftDeleted == true || string.IsNullOrEmpty(meal.Guid) || meal.Foods == null) continue;
+                foreach (var food in meal.Foods)
+                {
+                    if (food.SoftDeleted != true && !string.IsNullOrEmpty(food.Guid))
+                        foodGuidToMealGuid.TryAdd(food.Guid, meal.Guid!);
+                }
+            }
+
+            foodResolver = externalEntryId =>
+                foodGuidToMealGuid.TryGetValue(externalEntryId, out var mealGuid)
+                    ? $"glooko_v3meal_{mealGuid}"
+                    : null;
+        }
+
+        var data = new GlookoSyncData
+        {
+            SensorGlucose = _config.V3IncludeCgmBackfill
+                ? _sensorGlucoseMapper.TransformV3ToSensorGlucose(v3Data, _meterUnits).ToList()
+                : [],
+            BgChecks = _sensorGlucoseMapper.TransformV3ToBGChecks(v3Data, _meterUnits).ToList(),
+            Boluses = v3Boluses,
+            CarbIntakes = allCarbs,
+            Batches = v3Batches,
+            StateSpans = _stateSpanMapper.TransformV3ToStateSpans(v3Data),
+            TempBasals = _tempBasalMapper.TransformV3ToTempBasals(v3Data),
+            DeviceEvents = _v4TreatmentMapper.MapV3DeviceEvents(v3Data),
+            SystemEvents = _systemEventMapper.TransformV3ToSystemEvents(v3Data),
+            FoodEntryImports = foodEntryImports,
+            FoodEntryToCarbLegacyId = foodResolver,
+        };
+
+        return data;
+    }
+
+    // ── Shared publish pipeline ──────────────────────────────────────────
+
+    /// <summary>
+    ///     Publishes all data types from a <see cref="GlookoSyncData"/> bag.
+    ///     Shared between V2 and V3 — the only difference is how the bag was filled.
+    /// </summary>
+    private async Task PublishAllAsync(
+        GlookoSyncData data,
+        HashSet<SyncDataType> activeTypes,
+        SyncResult result,
+        GlookoConnectorConfiguration config,
+        ISyncProgressReporter? progressReporter,
+        CancellationToken cancellationToken)
+    {
+        // 1. Glucose
+        await ReportMessageAsync(progressReporter, SyncMessageType.ProcessingDataType,
+            new() { ["dataType"] = SyncDataType.Glucose.ToString() }, cancellationToken);
+
+        if (activeTypes.Contains(SyncDataType.Glucose))
+        {
+            if (data.SensorGlucose.Count > 0)
+            {
+                if (await PublishSensorGlucoseDataAsync(data.SensorGlucose, config, cancellationToken))
+                {
+                    result.ItemsSynced[SyncDataType.Glucose] = data.SensorGlucose.Count;
+                    result.LastEntryTimes[SyncDataType.Glucose] = DateTimeOffset
+                        .FromUnixTimeMilliseconds(data.SensorGlucose.Max(s => s.Mills)).UtcDateTime;
+
+                    await ReportMessageAsync(progressReporter, SyncMessageType.PublishingDataType,
+                        new() { ["dataType"] = SyncDataType.Glucose.ToString(), ["count"] = data.SensorGlucose.Count.ToString() },
+                        cancellationToken);
+
+                    _logger.LogInformation("[{ConnectorSource}] Published {Count} sensor glucose records",
+                        ConnectorSource, data.SensorGlucose.Count);
+                }
+            }
+
+            if (data.BgChecks.Count > 0)
+            {
+                if (await PublishBGCheckDataAsync(data.BgChecks, config, cancellationToken))
+                    _logger.LogInformation("[{ConnectorSource}] Published {Count} BG checks",
+                        ConnectorSource, data.BgChecks.Count);
+            }
+        }
+
+        // 2. Treatments (batches → boluses → carb intakes)
+        if (data.Batches.Count > 0)
+            await PublishDecompositionBatchesAsync(data.Batches, config, cancellationToken);
+
+        await ReportMessageAsync(progressReporter, SyncMessageType.ProcessingDataType,
+            new() { ["dataType"] = SyncDataType.Boluses.ToString() }, cancellationToken);
+
+        if (activeTypes.Contains(SyncDataType.Boluses) && data.Boluses.Count > 0)
+        {
+            if (await PublishBolusDataAsync(data.Boluses, config, cancellationToken))
+            {
+                result.ItemsSynced[SyncDataType.Boluses] = data.Boluses.Count;
+                _logger.LogInformation("[{ConnectorSource}] Published {Count} boluses", ConnectorSource, data.Boluses.Count);
+                await ReportMessageAsync(progressReporter, SyncMessageType.PublishingDataType,
+                    new() { ["dataType"] = SyncDataType.Boluses.ToString(), ["count"] = data.Boluses.Count.ToString() }, cancellationToken);
+            }
+        }
+
+        await ReportMessageAsync(progressReporter, SyncMessageType.ProcessingDataType,
+            new() { ["dataType"] = SyncDataType.CarbIntake.ToString() }, cancellationToken);
+
+        if (activeTypes.Contains(SyncDataType.CarbIntake) && data.CarbIntakes.Count > 0)
+        {
+            if (await PublishCarbIntakeDataAsync(data.CarbIntakes, config, cancellationToken))
+            {
+                result.ItemsSynced[SyncDataType.CarbIntake] = data.CarbIntakes.Count;
+                _logger.LogInformation("[{ConnectorSource}] Published {Count} carb intakes", ConnectorSource, data.CarbIntakes.Count);
+                await ReportMessageAsync(progressReporter, SyncMessageType.PublishingDataType,
+                    new() { ["dataType"] = SyncDataType.CarbIntake.ToString(), ["count"] = data.CarbIntakes.Count.ToString() }, cancellationToken);
+            }
+        }
+
+        // 3. Food catalog + attribution
+        if (data.FoodEntryImports.Count > 0 && _connectorPublisher is { IsAvailable: true })
+        {
+            var importedEntries = await _connectorPublisher.Metadata.PublishConnectorFoodEntriesAsync(
+                data.FoodEntryImports, ConnectorSource, cancellationToken);
+
+            if (importedEntries is { Count: > 0 })
+            {
+                _logger.LogInformation("[{ConnectorSource}] Published {Count} food entries to connector food catalog",
+                    ConnectorSource, importedEntries.Count);
+
+                if (_mealMatchingService != null && data.CarbIntakes.Count > 0 && data.FoodEntryToCarbLegacyId != null)
+                {
+                    var pendingEntries = importedEntries
+                        .Where(e => e.Status == ConnectorFoodEntryStatus.Pending)
+                        .ToList();
+
+                    if (pendingEntries.Count > 0)
+                    {
+                        var carbsByLegacyId = data.CarbIntakes
+                            .Where(ci => ci.LegacyId != null)
+                            .ToDictionary(ci => ci.LegacyId!, StringComparer.OrdinalIgnoreCase);
+
+                        var attributedCount = 0;
+
+                        foreach (var entry in pendingEntries)
+                        {
+                            var legacyKey = data.FoodEntryToCarbLegacyId(entry.ExternalEntryId);
+                            if (legacyKey == null || !carbsByLegacyId.TryGetValue(legacyKey, out var carbIntake))
+                                continue;
+
+                            try
+                            {
+                                await _mealMatchingService.AcceptMatchAsync(
+                                    entry.Id, carbIntake.Id, entry.Carbs, timeOffsetMinutes: 0, cancellationToken);
+                                attributedCount++;
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogWarning(ex,
+                                    "[{ConnectorSource}] Failed to attribute food entry {FoodEntryId} to CarbIntake {CarbIntakeId}",
+                                    ConnectorSource, entry.Id, carbIntake.Id);
+                            }
+                        }
+
+                        _logger.LogInformation("[{ConnectorSource}] Attributed {Count}/{Total} food entries to carb intakes",
+                            ConnectorSource, attributedCount, pendingEntries.Count);
+                    }
+                }
+            }
+        }
+
+        // 4. State spans + temp basals
+        await ReportMessageAsync(progressReporter, SyncMessageType.ProcessingDataType,
+            new() { ["dataType"] = SyncDataType.StateSpans.ToString() }, cancellationToken);
+
+        if (activeTypes.Contains(SyncDataType.StateSpans))
+        {
+            var tempBasalCount = 0;
+
+            if (data.StateSpans.Count > 0 && await PublishStateSpanDataAsync(data.StateSpans, config, cancellationToken))
+                _logger.LogInformation("[{ConnectorSource}] Published {Count} state spans", ConnectorSource, data.StateSpans.Count);
+
+            if (data.TempBasals.Count > 0 && await PublishTempBasalDataAsync(data.TempBasals, config, cancellationToken))
+            {
+                tempBasalCount = data.TempBasals.Count;
+                _logger.LogInformation("[{ConnectorSource}] Published {Count} temp basals", ConnectorSource, data.TempBasals.Count);
+            }
+
+            if (tempBasalCount > 0)
+                result.ItemsSynced[SyncDataType.StateSpans] = tempBasalCount;
+        }
+
+        // 5. Device events + system events
+        await ReportMessageAsync(progressReporter, SyncMessageType.ProcessingDataType,
+            new() { ["dataType"] = SyncDataType.DeviceEvents.ToString() }, cancellationToken);
+
+        if (activeTypes.Contains(SyncDataType.DeviceEvents))
+        {
+            var deviceEventCount = 0;
+
+            if (data.DeviceEvents.Count > 0 && await PublishDeviceEventDataAsync(data.DeviceEvents, config, cancellationToken))
+            {
+                deviceEventCount += data.DeviceEvents.Count;
+                _logger.LogInformation("[{ConnectorSource}] Published {Count} device events", ConnectorSource, data.DeviceEvents.Count);
+            }
+
+            if (data.SystemEvents.Count > 0 && await PublishSystemEventDataAsync(data.SystemEvents, config, cancellationToken))
+            {
+                deviceEventCount += data.SystemEvents.Count;
+                _logger.LogInformation("[{ConnectorSource}] Published {Count} system events", ConnectorSource, data.SystemEvents.Count);
+            }
+
+            if (deviceEventCount > 0)
+                result.ItemsSynced[SyncDataType.DeviceEvents] = deviceEventCount;
+        }
+    }
+
+    // ── V2 batch data fetching ──────────────────────────────────────────
 
     /// <summary>
     ///     Fetches comprehensive batch data from all v2 Glooko endpoints.
@@ -686,7 +764,42 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         }
     }
 
-    // ── V3 API methods ──────────────────────────────────────────────────
+    // ── V3 data fetching ────────────────────────────────────────────────
+
+    /// <summary>
+    ///     Fetches only the V2 foods endpoint. Used by the V3 sync path to get
+    ///     rich food metadata (externalId, brand) that V3 histories doesn't provide.
+    /// </summary>
+    public async Task<GlookoFood[]?> FetchV2FoodsAsync(DateTime? since = null)
+    {
+        try
+        {
+            var patientCode = EnsureAuthenticatedAndGetCode();
+            if (patientCode == null) return null;
+
+            var fromDate = since ?? _timeMapper.ToGlookoTime(DateTime.UtcNow.AddDays(-1));
+            var toDate = _timeMapper.ToGlookoTime(DateTime.UtcNow);
+
+            var url = ConstructV2Url(GlookoConstants.FoodsPath, fromDate, toDate);
+            var result = await FetchFromGlookoEndpointWithRetry(url);
+            if (!result.HasValue) return null;
+
+            if (result.Value.TryGetProperty("foods", out var el))
+            {
+                var foods = JsonSerializer.Deserialize<GlookoFood[]>(el.GetRawText()) ?? [];
+                _logger.LogInformation("[{ConnectorSource}] Fetched {Count} V2 food records for metadata enrichment",
+                    ConnectorSource, foods.Length);
+                return foods;
+            }
+
+            return [];
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "[{ConnectorSource}] Failed to fetch V2 foods for metadata enrichment", ConnectorSource);
+            return null;
+        }
+    }
 
     private string? _meterUnits;
 
@@ -729,7 +842,6 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             var patientCode = EnsureAuthenticatedAndGetCode();
             if (patientCode == null) return null;
 
-            // Ensure we have meter units
             if (string.IsNullOrEmpty(_meterUnits)) await FetchV3UserProfileAsync();
 
             var fromDate = since ?? _timeMapper.ToGlookoTime(DateTime.UtcNow.AddDays(-1));
@@ -745,20 +857,34 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             var graphData = JsonSerializer.Deserialize<GlookoV3GraphResponse>(result.Value.GetRawText());
 
             if (graphData?.Series != null)
+            {
+                var s = graphData.Series;
                 _logger.LogInformation(
                     "[{ConnectorSource}] Fetched v3 graph data: "
-                    + "AutomaticBolus={AutoBolus}, DeliveredBolus={Bolus}, "
-                    + "PumpAlarm={Alarms}, ReservoirChange={Reservoir}, SetSiteChange={SetSite}, "
-                    + "CgmReadings={Cgm}",
+                    + "Cgm={Cgm}, Bg={Bg}, "
+                    + "DeliveredBolus={DeliveredBolus}, AutomaticBolus={AutoBolus}, InjectionBolus={InjectionBolus}, "
+                    + "GkInsulinBasal={GkBasal}, GkInsulinBolus={GkBolus}, "
+                    + "CarbAll={Carbs}, "
+                    + "ScheduledBasal={SchedBasal}, TemporaryBasal={TempBasal}, SuspendBasal={Suspend}, LgsPlgs={LgsPlgs}, "
+                    + "PumpAlarm={Alarms}, ReservoirChange={Reservoir}, SetSiteChange={SetSite}, ProfileChange={Profile}",
                     ConnectorSource,
-                    graphData.Series.AutomaticBolus?.Length ?? 0,
-                    graphData.Series.DeliveredBolus?.Length ?? 0,
-                    graphData.Series.PumpAlarm?.Length ?? 0,
-                    graphData.Series.ReservoirChange?.Length ?? 0,
-                    graphData.Series.SetSiteChange?.Length ?? 0,
-                    (graphData.Series.CgmHigh?.Length ?? 0)
-                    + (graphData.Series.CgmNormal?.Length ?? 0)
-                    + (graphData.Series.CgmLow?.Length ?? 0));
+                    (s.CgmHigh?.Length ?? 0) + (s.CgmNormal?.Length ?? 0) + (s.CgmLow?.Length ?? 0),
+                    (s.BgHigh?.Length ?? 0) + (s.BgNormal?.Length ?? 0) + (s.BgLow?.Length ?? 0),
+                    s.DeliveredBolus?.Length ?? 0,
+                    s.AutomaticBolus?.Length ?? 0,
+                    s.InjectionBolus?.Length ?? 0,
+                    s.GkInsulinBasal?.Length ?? 0,
+                    s.GkInsulinBolus?.Length ?? 0,
+                    s.CarbAll?.Length ?? 0,
+                    s.ScheduledBasal?.Length ?? 0,
+                    s.TemporaryBasal?.Length ?? 0,
+                    s.SuspendBasal?.Length ?? 0,
+                    s.LgsPlgs?.Length ?? 0,
+                    s.PumpAlarm?.Length ?? 0,
+                    s.ReservoirChange?.Length ?? 0,
+                    s.SetSiteChange?.Length ?? 0,
+                    s.ProfileChange?.Length ?? 0);
+            }
 
             return graphData;
         }
@@ -798,6 +924,51 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error fetching Glooko v3 device settings");
+            return null;
+        }
+    }
+
+    /// <summary>
+    ///     Fetches rich history data from the v3 users/summary/histories API.
+    ///     Contains meals with per-food nutritional data, medications, exercises, etc.
+    /// </summary>
+    public async Task<GlookoV3HistoriesResponse?> FetchV3HistoriesAsync(DateTime? since = null)
+    {
+        try
+        {
+            var patientCode = EnsureAuthenticatedAndGetCode();
+            if (patientCode == null) return null;
+
+            var fromDate = since ?? _timeMapper.ToGlookoTime(DateTime.UtcNow.AddDays(-1));
+            var toDate = _timeMapper.ToGlookoTime(DateTime.UtcNow);
+
+            var url = $"{GlookoConstants.V3HistoriesPath}?patient={patientCode}"
+                    + $"&startDate={fromDate:yyyy-MM-ddTHH:mm:ss.fffZ}"
+                    + $"&endDate={toDate:yyyy-MM-ddTHH:mm:ss.fffZ}";
+
+            _logger.LogInformation("[{ConnectorSource}] Fetching v3 histories from {StartDate:yyyy-MM-dd} to {EndDate:yyyy-MM-dd}",
+                ConnectorSource, fromDate, toDate);
+
+            var result = await FetchFromGlookoEndpointWithRetry(url);
+            if (!result.HasValue) return null;
+
+            var historiesData = JsonSerializer.Deserialize<GlookoV3HistoriesResponse>(result.Value.GetRawText());
+
+            var entryCount = historiesData?.Histories?.Length ?? 0;
+            var meals = GlookoV4TreatmentMapper.ExtractMeals(historiesData!).ToList();
+            var mealCount = meals.Count;
+            var foodCount = meals.Sum(m => m.Foods?.Length ?? 0);
+            var mealsWithCarbs = meals.Count(m => (m.Carbs ?? 0) > 0);
+
+            _logger.LogInformation(
+                "[{ConnectorSource}] Fetched v3 histories: {EntryCount} entries, {MealCount} meals ({MealsWithCarbs} with carbs), {FoodCount} food items",
+                ConnectorSource, entryCount, mealCount, mealsWithCarbs, foodCount);
+
+            return historiesData;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error fetching Glooko v3 histories");
             return null;
         }
     }

--- a/src/Core/Nocturne.Core.Models/V4/InsulinCatalog.cs
+++ b/src/Core/Nocturne.Core.Models/V4/InsulinCatalog.cs
@@ -10,6 +10,7 @@ public static class InsulinCatalog
         // Rapid-acting
         new() { Id = "humalog",      Name = "Humalog (Insulin Lispro)",      Category = InsulinCategory.RapidActing, DefaultDia = 4.0, DefaultPeak = 75,  Curve = "rapid-acting", Concentration = 100 },
         new() { Id = "humalog-u200", Name = "Humalog U200 (Insulin Lispro)", Category = InsulinCategory.RapidActing, DefaultDia = 4.0, DefaultPeak = 75,  Curve = "rapid-acting", Concentration = 200 },
+        new() { Id = "admelog",      Name = "Admelog (Insulin Lispro)",      Category = InsulinCategory.RapidActing, DefaultDia = 4.0, DefaultPeak = 75,  Curve = "rapid-acting", Concentration = 100 },
         new() { Id = "novorapid",    Name = "NovoRapid (Insulin Aspart)",    Category = InsulinCategory.RapidActing, DefaultDia = 4.0, DefaultPeak = 75,  Curve = "rapid-acting", Concentration = 100 },
         new() { Id = "apidra",       Name = "Apidra (Insulin Glulisine)",    Category = InsulinCategory.RapidActing, DefaultDia = 4.0, DefaultPeak = 75,  Curve = "rapid-acting", Concentration = 100 },
         new() { Id = "fiasp",        Name = "Fiasp (Faster Aspart)",         Category = InsulinCategory.RapidActing, DefaultDia = 3.5, DefaultPeak = 55,  Curve = "ultra-rapid",  Concentration = 100 },


### PR DESCRIPTION
- Added meals and food import
- Added fingerprick BG import
- Separated sync flows using Glooko v2 and v3 API. The only exception is that the v2 foods endpoint has an external id which is essential to correlate meals to food entries. The v3 information is currently coming from the histories endpoint which doesn't carry that information, so we're still calling the v2 food endpoint even when the v3 flag is enabled. If I find out there's a v3 food endpoint, I might revisit this in the future.
- Added Admelog to the list of insulin

Manual bolus and basal information is available in Glooko, but Nocturne is not yet ready for it, so I left it as a TODO.