### PR TITLE
feat: overhaul API migration with batch decomposition and full collection support

### DIFF
--- a/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
+++ b/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
@@ -852,71 +852,89 @@ internal class MigrationJob
     )
     {
         _currentOperation = "Migrating food";
-        var collectionName = "food";
+        const string collectionName = "food";
+        var knownTotal = _collectionProgress.TryGetValue(collectionName, out var existing)
+            ? existing.TotalDocuments : 0;
 
         var totalMigrated = 0L;
         var totalFailed = 0L;
+        var totalSkipped = 0;
+        const int pageSize = 10000;
 
         try
         {
-            var response = await httpClient.GetAsync("/api/v1/food.json?count=10000", ct);
-            if (!response.IsSuccessStatusCode)
-            {
-                _logger.LogError("Failed to fetch food: {StatusCode}", response.StatusCode);
-                return;
-            }
-
-            var content = await response.Content.ReadAsStringAsync(ct);
-            var foods = System.Text.Json.JsonSerializer.Deserialize<Food[]>(content) ?? [];
-
-            UpdateCollectionProgress(collectionName, foods.Length, 0, 0, false);
-            UpdateOverallProgress();
-
-            foreach (var food in foods)
+            while (true)
             {
                 ct.ThrowIfCancellationRequested();
 
-                try
-                {
-                    var exists = await dbContext.Foods.AnyAsync(
-                        f => f.Name == (food.Name ?? "") && f.Type == (food.Type ?? "food"),
-                        ct
-                    );
+                var url = $"/api/v1/food.json?count={pageSize}&skip={totalSkipped}";
 
-                    if (!exists)
-                    {
-                        dbContext.Foods.Add(
-                            new Infrastructure.Data.Entities.FoodEntity
-                            {
-                                Id = Guid.CreateVersion7(),
-                                Type = food.Type ?? "food",
-                                Category = food.Category ?? "",
-                                Subcategory = food.Subcategory ?? "",
-                                Name = food.Name ?? "",
-                                Portion = food.Portion,
-                                Carbs = food.Carbs,
-                                Fat = food.Fat,
-                                Protein = food.Protein,
-                                Energy = food.Energy,
-                                Gi = (Infrastructure.Data.Entities.GlycemicIndex)(food.Gi > 0 ? food.Gi : 2),
-                                Unit = food.Unit ?? "g",
-                                Foods = food.Foods != null ? System.Text.Json.JsonSerializer.Serialize(food.Foods) : null,
-                                HideAfterUse = food.HideAfterUse,
-                                Hidden = food.Hidden,
-                                Position = food.Position,
-                            }
-                        );
-                    }
-                    totalMigrated++;
-                }
-                catch
+                var response = await httpClient.GetAsync(url, ct);
+                if (!response.IsSuccessStatusCode)
                 {
-                    totalFailed++;
+                    _logger.LogError("Failed to fetch food: {StatusCode}", response.StatusCode);
+                    break;
                 }
+
+                var content = await response.Content.ReadAsStringAsync(ct);
+                var foods = System.Text.Json.JsonSerializer.Deserialize<Food[]>(content) ?? [];
+
+                if (foods.Length == 0) break;
+
+                foreach (var food in foods)
+                {
+                    try
+                    {
+                        var exists = await dbContext.Foods.AnyAsync(
+                            f => f.Name == (food.Name ?? "") && f.Type == (food.Type ?? "food"),
+                            ct
+                        );
+
+                        if (!exists)
+                        {
+                            dbContext.Foods.Add(
+                                new Infrastructure.Data.Entities.FoodEntity
+                                {
+                                    Id = Guid.CreateVersion7(),
+                                    Type = food.Type ?? "food",
+                                    Category = food.Category ?? "",
+                                    Subcategory = food.Subcategory ?? "",
+                                    Name = food.Name ?? "",
+                                    Portion = food.Portion,
+                                    Carbs = food.Carbs,
+                                    Fat = food.Fat,
+                                    Protein = food.Protein,
+                                    Energy = food.Energy,
+                                    Gi = (Infrastructure.Data.Entities.GlycemicIndex)(food.Gi > 0 ? food.Gi : 2),
+                                    Unit = food.Unit ?? "g",
+                                    Foods = food.Foods != null ? System.Text.Json.JsonSerializer.Serialize(food.Foods) : null,
+                                    HideAfterUse = food.HideAfterUse,
+                                    Hidden = food.Hidden,
+                                    Position = food.Position,
+                                }
+                            );
+                        }
+                        totalMigrated++;
+                    }
+                    catch
+                    {
+                        totalFailed++;
+                    }
+                }
+
+                await dbContext.SaveChangesAsync(ct);
+                totalSkipped += foods.Length;
+
+                UpdateCollectionProgress(collectionName,
+                    Math.Max(knownTotal, totalSkipped),
+                    totalMigrated, totalFailed, false);
+                UpdateOverallProgress();
+
+                if (foods.Length < pageSize) break;
             }
 
-            await dbContext.SaveChangesAsync(ct);
-            UpdateCollectionProgress(collectionName, foods.Length, totalMigrated, totalFailed, true);
+            UpdateCollectionProgress(collectionName, Math.Max(knownTotal, totalMigrated + totalFailed),
+                totalMigrated, totalFailed, true);
             UpdateOverallProgress();
         }
         catch (Exception ex)

--- a/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
+++ b/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
@@ -1149,7 +1149,8 @@ internal class MigrationJob
         CancellationToken ct
     )
     {
-        // Legacy treatments table has been dropped; BSON treatment import is a no-op.
+        // MongoDB BSON treatment decomposition is not yet implemented (MongoDB mode is out of scope).
+        // The API migration path handles treatments via ITreatmentDecomposer.DecomposeBatchAsync.
         return Task.CompletedTask;
     }
 

--- a/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
+++ b/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
@@ -6,6 +6,7 @@ using MongoDB.Bson;
 using MongoDB.Driver;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Models;
+using Nocturne.Core.Contracts.V4;
 using Nocturne.Infrastructure.Data;
 
 namespace Nocturne.API.Services.Migration;
@@ -458,10 +459,12 @@ internal class MigrationJob
         // Build the list of collections to migrate
         var allCollections = new (string name, Func<HttpClient, NocturneDbContext, CancellationToken, Task> migrate)[]
         {
+            ("entries", MigrateEntriesViaApiAsync),
             ("treatments", MigrateTreatmentsViaApiAsync),
             ("devicestatus", MigrateDeviceStatusViaApiAsync),
             ("profile", MigrateProfilesViaApiAsync),
             ("food", MigrateFoodViaApiAsync),
+            ("activity", MigrateActivityViaApiAsync),
         };
 
         var collectionsToMigrate = allCollections
@@ -559,16 +562,151 @@ internal class MigrationJob
         };
     }
 
-    private Task MigrateTreatmentsViaApiAsync(
+    private async Task MigrateEntriesViaApiAsync(
         HttpClient httpClient,
         NocturneDbContext dbContext,
         CancellationToken ct
     )
     {
-        // Legacy treatments table has been dropped; treatment migration is a no-op.
-        // Treatments are now stored exclusively in V4 granular tables.
-        _logger.LogInformation("Skipping legacy treatments migration (table dropped)");
-        return Task.CompletedTask;
+        _currentOperation = "Migrating entries";
+        const string collectionName = "entries";
+        var knownTotal = _collectionProgress.TryGetValue(collectionName, out var existing)
+            ? existing.TotalDocuments : 0;
+
+        var totalMigrated = 0L;
+        var totalFailed = 0L;
+        DateTime? currentTo = null;
+        const int pageSize = 10000;
+
+        using var scope = _serviceProvider.CreateScope();
+        var decomposer = scope.ServiceProvider.GetRequiredService<IEntryDecomposer>();
+
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var url = $"/api/v1/entries.json?count={pageSize}";
+            if (currentTo.HasValue)
+            {
+                var toMs = new DateTimeOffset(currentTo.Value, TimeSpan.Zero).ToUnixTimeMilliseconds();
+                url += $"&find[date][$lte]={toMs}";
+            }
+
+            var response = await httpClient.GetAsync(url, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogError("Failed to fetch entries: {StatusCode}", response.StatusCode);
+                break;
+            }
+
+            var content = await response.Content.ReadAsStringAsync(ct);
+            var entries = System.Text.Json.JsonSerializer.Deserialize<Entry[]>(content) ?? [];
+
+            if (entries.Length == 0) break;
+
+            try
+            {
+                await decomposer.DecomposeBatchAsync(entries, ct);
+                totalMigrated += entries.Length;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to decompose entries page");
+                totalFailed += entries.Length;
+            }
+
+            UpdateCollectionProgress(collectionName,
+                Math.Max(knownTotal, totalMigrated + totalFailed),
+                totalMigrated, totalFailed, false);
+            UpdateOverallProgress();
+
+            if (entries.Length < pageSize) break;
+
+            var oldestMs = entries.Min(e => e.Mills);
+            if (oldestMs <= 0) break;
+
+            var oldestDate = DateTimeOffset.FromUnixTimeMilliseconds(oldestMs).UtcDateTime;
+            if (currentTo.HasValue && oldestDate >= currentTo.Value) break;
+            currentTo = oldestDate.AddMilliseconds(-1);
+        }
+
+        UpdateCollectionProgress(collectionName, Math.Max(knownTotal, totalMigrated + totalFailed),
+            totalMigrated, totalFailed, true);
+        UpdateOverallProgress();
+        _logger.LogInformation("Migrated {Count} entries via API", totalMigrated);
+    }
+
+    private async Task MigrateTreatmentsViaApiAsync(
+        HttpClient httpClient,
+        NocturneDbContext dbContext,
+        CancellationToken ct
+    )
+    {
+        _currentOperation = "Migrating treatments";
+        const string collectionName = "treatments";
+        var knownTotal = _collectionProgress.TryGetValue(collectionName, out var existing)
+            ? existing.TotalDocuments : 0;
+
+        var totalMigrated = 0L;
+        var totalFailed = 0L;
+        DateTime? currentTo = null;
+        const int pageSize = 10000;
+
+        using var scope = _serviceProvider.CreateScope();
+        var decomposer = scope.ServiceProvider.GetRequiredService<ITreatmentDecomposer>();
+
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var url = $"/api/v1/treatments.json?count={pageSize}";
+            if (currentTo.HasValue)
+                url += $"&find[created_at][$lte]={currentTo.Value.ToUniversalTime():o}";
+
+            var response = await httpClient.GetAsync(url, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogError("Failed to fetch treatments: {StatusCode}", response.StatusCode);
+                break;
+            }
+
+            var content = await response.Content.ReadAsStringAsync(ct);
+            var treatments = System.Text.Json.JsonSerializer.Deserialize<Treatment[]>(content) ?? [];
+
+            if (treatments.Length == 0) break;
+
+            try
+            {
+                await decomposer.DecomposeBatchAsync(treatments, ct);
+                totalMigrated += treatments.Length;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to decompose treatments page");
+                totalFailed += treatments.Length;
+            }
+
+            UpdateCollectionProgress(collectionName,
+                Math.Max(knownTotal, totalMigrated + totalFailed),
+                totalMigrated, totalFailed, false);
+            UpdateOverallProgress();
+
+            if (treatments.Length < pageSize) break;
+
+            var oldestDate = treatments
+                .Select(t => DateTimeOffset.TryParse(t.CreatedAt, out var dto) ? dto.UtcDateTime : (DateTime?)null)
+                .Where(dt => dt.HasValue)
+                .Min();
+
+            if (!oldestDate.HasValue) break;
+            if (currentTo.HasValue && oldestDate.Value >= currentTo.Value) break;
+            currentTo = oldestDate.Value.AddMilliseconds(-1);
+        }
+
+        UpdateCollectionProgress(collectionName, Math.Max(knownTotal, totalMigrated + totalFailed),
+            totalMigrated, totalFailed, true);
+        UpdateOverallProgress();
+        _logger.LogInformation("Migrated {Count} treatments via API", totalMigrated);
     }
 
     private async Task MigrateDeviceStatusViaApiAsync(
@@ -578,56 +716,69 @@ internal class MigrationJob
     )
     {
         _currentOperation = "Migrating device statuses";
-        var collectionName = "devicestatus";
-        var knownTotal = _collectionProgress.TryGetValue(collectionName, out var existing) ? existing.TotalDocuments : 0;
+        const string collectionName = "devicestatus";
+        var knownTotal = _collectionProgress.TryGetValue(collectionName, out var existing)
+            ? existing.TotalDocuments : 0;
 
         var totalMigrated = 0L;
         var totalFailed = 0L;
+        DateTime? currentTo = null;
+        const int pageSize = 10000;
 
-        try
+        using var scope = _serviceProvider.CreateScope();
+        var decomposer = scope.ServiceProvider.GetRequiredService<IDeviceStatusDecomposer>();
+
+        while (true)
         {
-            var response = await httpClient.GetAsync("/api/v1/devicestatus.json?count=10000", ct);
+            ct.ThrowIfCancellationRequested();
+
+            var url = $"/api/v1/devicestatus.json?count={pageSize}";
+            if (currentTo.HasValue)
+                url += $"&find[created_at][$lte]={currentTo.Value.ToUniversalTime():o}";
+
+            var response = await httpClient.GetAsync(url, ct);
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogError("Failed to fetch device statuses: {StatusCode}", response.StatusCode);
-                return;
+                break;
             }
 
             var content = await response.Content.ReadAsStringAsync(ct);
             var statuses = System.Text.Json.JsonSerializer.Deserialize<DeviceStatus[]>(content) ?? [];
 
-            if (knownTotal == 0) knownTotal = statuses.Length;
-            UpdateCollectionProgress(collectionName, knownTotal, 0, 0, false);
-            UpdateOverallProgress();
+            if (statuses.Length == 0) break;
 
-            using var scope = _serviceProvider.CreateScope();
-            var decomposer = scope.ServiceProvider.GetRequiredService<Core.Contracts.V4.IDeviceStatusDecomposer>();
-
-            foreach (var status in statuses)
+            try
             {
-                ct.ThrowIfCancellationRequested();
-
-                try
-                {
-                    await decomposer.DecomposeAsync(status, ct);
-                    totalMigrated++;
-                    UpdateCollectionProgress(collectionName, knownTotal, totalMigrated, totalFailed, false);
-                    UpdateOverallProgress();
-                }
-                catch
-                {
-                    totalFailed++;
-                }
+                await decomposer.DecomposeBatchAsync(statuses, ct);
+                totalMigrated += statuses.Length;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to decompose device status page");
+                totalFailed += statuses.Length;
             }
 
-            UpdateCollectionProgress(collectionName, knownTotal, totalMigrated, totalFailed, true);
+            UpdateCollectionProgress(collectionName,
+                Math.Max(knownTotal, totalMigrated + totalFailed),
+                totalMigrated, totalFailed, false);
             UpdateOverallProgress();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error migrating device statuses via API");
+
+            if (statuses.Length < pageSize) break;
+
+            var oldestDate = statuses
+                .Select(d => DateTimeOffset.TryParse(d.CreatedAt, out var dto) ? dto.UtcDateTime : (DateTime?)null)
+                .Where(dt => dt.HasValue)
+                .Min();
+
+            if (!oldestDate.HasValue) break;
+            if (currentTo.HasValue && oldestDate.Value >= currentTo.Value) break;
+            currentTo = oldestDate.Value.AddMilliseconds(-1);
         }
 
+        UpdateCollectionProgress(collectionName, Math.Max(knownTotal, totalMigrated + totalFailed),
+            totalMigrated, totalFailed, true);
+        UpdateOverallProgress();
         _logger.LogInformation("Migrated {Count} device statuses via API", totalMigrated);
     }
 
@@ -708,7 +859,7 @@ internal class MigrationJob
 
         try
         {
-            var response = await httpClient.GetAsync("/api/v1/food.json", ct);
+            var response = await httpClient.GetAsync("/api/v1/food.json?count=10000", ct);
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogError("Failed to fetch food: {StatusCode}", response.StatusCode);
@@ -774,6 +925,79 @@ internal class MigrationJob
         }
 
         _logger.LogInformation("Migrated {Count} food items via API", totalMigrated);
+    }
+
+    private async Task MigrateActivityViaApiAsync(
+        HttpClient httpClient,
+        NocturneDbContext dbContext,
+        CancellationToken ct
+    )
+    {
+        _currentOperation = "Migrating activities";
+        const string collectionName = "activity";
+        var knownTotal = _collectionProgress.TryGetValue(collectionName, out var existing)
+            ? existing.TotalDocuments : 0;
+
+        var totalMigrated = 0L;
+        var totalFailed = 0L;
+        DateTime? currentTo = null;
+        const int pageSize = 10000;
+
+        using var scope = _serviceProvider.CreateScope();
+        var decomposer = scope.ServiceProvider.GetRequiredService<IActivityDecomposer>();
+
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var url = $"/api/v1/activity.json?count={pageSize}";
+            if (currentTo.HasValue)
+                url += $"&find[created_at][$lte]={currentTo.Value.ToUniversalTime():o}";
+
+            var response = await httpClient.GetAsync(url, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogError("Failed to fetch activities: {StatusCode}", response.StatusCode);
+                break;
+            }
+
+            var content = await response.Content.ReadAsStringAsync(ct);
+            var activities = System.Text.Json.JsonSerializer.Deserialize<Activity[]>(content) ?? [];
+
+            if (activities.Length == 0) break;
+
+            try
+            {
+                await decomposer.DecomposeBatchAsync(activities, ct);
+                totalMigrated += activities.Length;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to decompose activity page");
+                totalFailed += activities.Length;
+            }
+
+            UpdateCollectionProgress(collectionName,
+                Math.Max(knownTotal, totalMigrated + totalFailed),
+                totalMigrated, totalFailed, false);
+            UpdateOverallProgress();
+
+            if (activities.Length < pageSize) break;
+
+            var oldestDate = activities
+                .Select(a => DateTimeOffset.TryParse(a.CreatedAt, out var dto) ? dto.UtcDateTime : (DateTime?)null)
+                .Where(dt => dt.HasValue)
+                .Min();
+
+            if (!oldestDate.HasValue) break;
+            if (currentTo.HasValue && oldestDate.Value >= currentTo.Value) break;
+            currentTo = oldestDate.Value.AddMilliseconds(-1);
+        }
+
+        UpdateCollectionProgress(collectionName, Math.Max(knownTotal, totalMigrated + totalFailed),
+            totalMigrated, totalFailed, true);
+        UpdateOverallProgress();
+        _logger.LogInformation("Migrated {Count} activities via API", totalMigrated);
     }
 
     private async Task ExecuteMongoMigrationAsync(CancellationToken ct)

--- a/src/API/Nocturne.API/Services/V4/ActivityDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/ActivityDecomposer.cs
@@ -143,18 +143,66 @@ public class ActivityDecomposer : IActivityDecomposer, IDecomposer<Activity>
 
         if (heartRateList.Count > 0)
         {
-            var entities = heartRateList.Select(HeartRateMapper.ToEntity).ToList();
-            await _dbContext.HeartRates.AddRangeAsync(entities, ct);
-            await _dbContext.SaveChangesAsync(ct);
-            result.CreatedRecords.AddRange(entities.Select(HeartRateMapper.ToDomainModel));
+            // Filter out records that already exist by OriginalId to avoid duplicates on re-migration
+            var hrOriginalIds = heartRateList
+                .Where(hr => hr.Id != null)
+                .Select(hr => hr.Id!)
+                .ToHashSet();
+
+            var existingHrIds = hrOriginalIds.Count > 0
+                ? (await _dbContext.HeartRates
+                    .Where(h => h.OriginalId != null && hrOriginalIds.Contains(h.OriginalId))
+                    .Select(h => h.OriginalId!)
+                    .ToListAsync(ct))
+                    .ToHashSet()
+                : new HashSet<string>();
+
+            var newHeartRates = heartRateList
+                .Where(hr => hr.Id == null || !existingHrIds.Contains(hr.Id))
+                .ToList();
+
+            if (newHeartRates.Count > 0)
+            {
+                var entities = newHeartRates.Select(HeartRateMapper.ToEntity).ToList();
+                await _dbContext.HeartRates.AddRangeAsync(entities, ct);
+                await _dbContext.SaveChangesAsync(ct);
+                result.CreatedRecords.AddRange(entities.Select(HeartRateMapper.ToDomainModel));
+            }
+
+            if (existingHrIds.Count > 0)
+                _logger.LogDebug("Skipped {Count} duplicate heart rate records by OriginalId", existingHrIds.Count);
         }
 
         if (stepCountList.Count > 0)
         {
-            var entities = stepCountList.Select(StepCountMapper.ToEntity).ToList();
-            await _dbContext.StepCounts.AddRangeAsync(entities, ct);
-            await _dbContext.SaveChangesAsync(ct);
-            result.CreatedRecords.AddRange(entities.Select(StepCountMapper.ToDomainModel));
+            // Filter out records that already exist by OriginalId to avoid duplicates on re-migration
+            var scOriginalIds = stepCountList
+                .Where(sc => sc.Id != null)
+                .Select(sc => sc.Id!)
+                .ToHashSet();
+
+            var existingScIds = scOriginalIds.Count > 0
+                ? (await _dbContext.StepCounts
+                    .Where(s => s.OriginalId != null && scOriginalIds.Contains(s.OriginalId))
+                    .Select(s => s.OriginalId!)
+                    .ToListAsync(ct))
+                    .ToHashSet()
+                : new HashSet<string>();
+
+            var newStepCounts = stepCountList
+                .Where(sc => sc.Id == null || !existingScIds.Contains(sc.Id))
+                .ToList();
+
+            if (newStepCounts.Count > 0)
+            {
+                var entities = newStepCounts.Select(StepCountMapper.ToEntity).ToList();
+                await _dbContext.StepCounts.AddRangeAsync(entities, ct);
+                await _dbContext.SaveChangesAsync(ct);
+                result.CreatedRecords.AddRange(entities.Select(StepCountMapper.ToDomainModel));
+            }
+
+            if (existingScIds.Count > 0)
+                _logger.LogDebug("Skipped {Count} duplicate step count records by OriginalId", existingScIds.Count);
         }
 
         if (regularActivities.Count > 0)

--- a/src/API/Nocturne.API/Services/V4/ActivityDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/ActivityDecomposer.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Nocturne.Core.Contracts.Repositories;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
@@ -19,13 +20,19 @@ namespace Nocturne.API.Services.V4;
 public class ActivityDecomposer : IActivityDecomposer, IDecomposer<Activity>
 {
     private readonly NocturneDbContext _dbContext;
+    private readonly IStateSpanRepository _stateSpanRepository;
     private readonly ILogger<ActivityDecomposer> _logger;
 
     /// <param name="dbContext">EF Core context used for direct entity read/write operations.</param>
+    /// <param name="stateSpanRepository">Repository for bulk-creating regular activities as StateSpans.</param>
     /// <param name="logger">Logger instance for this decomposer.</param>
-    public ActivityDecomposer(NocturneDbContext dbContext, ILogger<ActivityDecomposer> logger)
+    public ActivityDecomposer(
+        NocturneDbContext dbContext,
+        IStateSpanRepository stateSpanRepository,
+        ILogger<ActivityDecomposer> logger)
     {
         _dbContext = dbContext;
+        _stateSpanRepository = stateSpanRepository;
         _logger = logger;
     }
 
@@ -97,6 +104,69 @@ public class ActivityDecomposer : IActivityDecomposer, IDecomposer<Activity>
                 activity.Id
             );
         }
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public async Task<DecompositionResult> DecomposeBatchAsync(
+        IReadOnlyList<Activity> activities, CancellationToken ct = default)
+    {
+        if (activities.Count == 0)
+            return new DecompositionResult();
+
+        var batch = new DecompositionBatchEntity
+        {
+            TenantId = _dbContext.TenantId,
+            Source = "activity_decomposer_batch",
+            SourceRecordId = null,
+            CreatedAt = DateTime.UtcNow,
+        };
+        _dbContext.DecompositionBatches.Add(batch);
+        await _dbContext.SaveChangesAsync(ct);
+
+        var result = new DecompositionResult { CorrelationId = batch.Id };
+
+        var heartRateList = new List<HeartRate>();
+        var stepCountList = new List<StepCount>();
+        var regularActivities = new List<Activity>();
+
+        foreach (var activity in activities)
+        {
+            if (IsHeartRate(activity))
+                heartRateList.Add(MapToHeartRate(activity));
+            else if (IsStepCount(activity))
+                stepCountList.Add(MapToStepCount(activity));
+            else
+                regularActivities.Add(activity);
+        }
+
+        if (heartRateList.Count > 0)
+        {
+            var entities = heartRateList.Select(HeartRateMapper.ToEntity).ToList();
+            await _dbContext.HeartRates.AddRangeAsync(entities, ct);
+            await _dbContext.SaveChangesAsync(ct);
+            result.CreatedRecords.AddRange(entities.Select(HeartRateMapper.ToDomainModel));
+        }
+
+        if (stepCountList.Count > 0)
+        {
+            var entities = stepCountList.Select(StepCountMapper.ToEntity).ToList();
+            await _dbContext.StepCounts.AddRangeAsync(entities, ct);
+            await _dbContext.SaveChangesAsync(ct);
+            result.CreatedRecords.AddRange(entities.Select(StepCountMapper.ToDomainModel));
+        }
+
+        if (regularActivities.Count > 0)
+        {
+            var stateSpans = regularActivities.Select(ActivityStateSpanMapper.ToStateSpan).ToList();
+            var created = await _stateSpanRepository.CreateActivitiesAsStateSpansAsync(stateSpans, ct);
+            result.CreatedRecords.AddRange(created.Select(s => ActivityStateSpanMapper.ToActivity(s)!));
+        }
+
+        _logger.LogDebug(
+            "Batch-decomposed {Count} activities ({HeartRate} HR, {StepCount} steps, {Regular} regular)",
+            activities.Count, heartRateList.Count, stepCountList.Count, regularActivities.Count);
 
         return result;
     }

--- a/src/API/Nocturne.API/Services/V4/DeviceStatusDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/DeviceStatusDecomposer.cs
@@ -525,7 +525,9 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
             result.CreatedRecords.AddRange(created);
         }
 
-        // Upsert override state spans individually (overrides are rare)
+        // Upsert override state spans individually — IStateSpanService only exposes
+        // single-item UpsertStateSpanAsync; BulkUpsertAsync lives on IStateSpanRepository
+        // (returns count, not the upserted entities) and overrides are rare in practice.
         foreach (var span in overrideSpans)
         {
             var upserted = await _stateSpanService.UpsertStateSpanAsync(span, ct);

--- a/src/API/Nocturne.API/Services/V4/DeviceStatusDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/DeviceStatusDecomposer.cs
@@ -126,48 +126,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
     private async Task DecomposeApsFromOpenApsAsync(
         DeviceStatus ds, string? legacyId, V4Models.DecompositionResult result, Guid? pumpDeviceId, CancellationToken ct)
     {
-        var command = ds.OpenAps!.Enacted ?? ds.OpenAps.Suggested;
-        var predBGs = command?.PredBGs;
-        var apsSystem = DetectOpenApsVariant(ds);
-
-        var model = new V4Models.ApsSnapshot
-        {
-            Timestamp = ResolveTimestamp(ds),
-            UtcOffset = ds.UtcOffset,
-            Device = ds.Device,
-            LegacyId = legacyId,
-            AidAlgorithm = apsSystem,
-            Iob = ds.OpenAps.Iob?.Iob,
-            BasalIob = ds.OpenAps.Iob?.BasalIob,
-            BolusIob = ds.OpenAps.Iob?.BolusIob,
-            Cob = ds.OpenAps.Cob ?? command?.COB,
-            CurrentBg = command?.Bg,
-            EventualBg = command?.EventualBG,
-            TargetBg = command?.TargetBG,
-            RecommendedBolus = command?.InsulinReq,
-            SensitivityRatio = command?.SensitivityRatio,
-            Enacted = ds.OpenAps.Enacted != null
-                && (ds.OpenAps.Enacted.Received == true || ds.OpenAps.Enacted.Recieved == true),
-            EnactedRate = ds.OpenAps.Enacted?.Rate,
-            EnactedDuration = ds.OpenAps.Enacted?.Duration,
-            EnactedBolusVolume = ds.OpenAps.Enacted?.Smb is > 0
-                ? ds.OpenAps.Enacted.Smb
-                : ds.OpenAps.Enacted?.Units,
-            SuggestedJson = SerializeOrNull(ds.OpenAps.Suggested),
-            EnactedJson = SerializeOrNull(ds.OpenAps.Enacted),
-            // Trio uses oref multi-curve predictions exclusively; PredictedDefaultJson
-            // is reserved for Loop's single combined curve. OpenAPS/AAPS duplicate IOB
-            // into the default slot for backwards compatibility.
-            PredictedDefaultJson = apsSystem == V4Models.AidAlgorithm.Trio
-                ? null
-                : SerializeOrNull(predBGs?.IOB),
-            PredictedIobJson = SerializeOrNull(predBGs?.IOB),
-            PredictedZtJson = SerializeOrNull(predBGs?.ZT),
-            PredictedCobJson = SerializeOrNull(predBGs?.COB),
-            PredictedUamJson = SerializeOrNull(predBGs?.UAM),
-            PredictedStartTimestamp = ParseTimestampToDateTime(command?.Timestamp),
-            AidVersion = ds.OpenAps?.Version,
-        };
+        var model = MapToApsSnapshotFromOpenAps(ds, legacyId, result.CorrelationId);
 
         model.DeviceId = pumpDeviceId;
         model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(pumpDeviceId, ds.Mills, ct);
@@ -178,32 +137,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
     private async Task DecomposeApsFromLoopAsync(
         DeviceStatus ds, string? legacyId, V4Models.DecompositionResult result, Guid? pumpDeviceId, CancellationToken ct)
     {
-        var model = new V4Models.ApsSnapshot
-        {
-            Timestamp = ResolveTimestamp(ds),
-            UtcOffset = ds.UtcOffset,
-            Device = ds.Device,
-            LegacyId = legacyId,
-            AidAlgorithm = V4Models.AidAlgorithm.Loop,
-            Iob = ds.Loop!.Iob?.Iob,
-            BasalIob = ds.Loop.Iob?.BasalIob,
-            BolusIob = null,
-            Cob = ds.Loop.Cob?.Cob,
-            CurrentBg = ds.Loop.Predicted?.Values?.FirstOrDefault(),
-            EventualBg = ds.Loop.Predicted?.Values?.LastOrDefault(),
-            RecommendedBolus = ds.Loop.RecommendedBolus,
-            Enacted = ds.Loop.Enacted?.Received == true,
-            EnactedRate = ds.Loop.Enacted?.Rate,
-            EnactedDuration = ds.Loop.Enacted?.Duration,
-            EnactedBolusVolume = ds.Loop.Enacted?.BolusVolume,
-            SuggestedJson = SerializeOrNull(ds.Loop.Recommended),
-            EnactedJson = SerializeOrNull(ds.Loop.Enacted),
-            PredictedDefaultJson = SerializeOrNull(ds.Loop.Predicted?.Values),
-            PredictedStartTimestamp = ParseTimestampToDateTime(ds.Loop.Predicted?.StartDate),
-            LoopJson = SerializeOrNull(ds.Loop),
-            // Loop's version is captured from the device string (e.g. "Loop/3.0"), not from the Loop data object
-            AidVersion = null,
-        };
+        var model = MapToApsSnapshotFromLoop(ds, legacyId, result.CorrelationId);
 
         model.DeviceId = pumpDeviceId;
         model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(pumpDeviceId, ds.Mills, ct);
@@ -240,28 +174,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
     private async Task<Guid?> DecomposePumpAsync(
         DeviceStatus ds, string? legacyId, V4Models.DecompositionResult result, CancellationToken ct)
     {
-        var model = new V4Models.PumpSnapshot
-        {
-            Timestamp = ResolveTimestamp(ds),
-            UtcOffset = ds.UtcOffset,
-            Device = ds.Device,
-            LegacyId = legacyId,
-            Manufacturer = ds.Pump!.Manufacturer,
-            Model = ds.Pump.Model,
-            Reservoir = ds.Pump.Reservoir,
-            ReservoirDisplay = ds.Pump.ReservoirDisplayOverride,
-            BatteryPercent = ds.Pump.Battery?.Percent,
-            BatteryVoltage = ds.Pump.Battery?.Voltage,
-            Bolusing = ds.Pump.Status?.Bolusing,
-            Suspended = ds.Pump.Status?.Suspended,
-            PumpStatus = ds.Pump.Status?.Status,
-            Clock = ds.Pump.Clock,
-            Iob = ds.Pump.Iob?.Iob,
-            BolusIob = ds.Pump.Iob?.BolusIob,
-            AdditionalProperties = ds.Pump.Extended is { Count: > 0 }
-                ? ds.Pump.Extended.ToDictionary(kvp => kvp.Key, kvp => (object?)kvp.Value)
-                : null,
-        };
+        var model = MapToPumpSnapshot(ds, legacyId, result.CorrelationId);
 
         model.DeviceId = await _deviceService.ResolveAsync(
             V4Models.DeviceCategory.InsulinPump,
@@ -381,19 +294,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
     private async Task DecomposeUploaderAsync(
         DeviceStatus ds, string? legacyId, V4Models.DecompositionResult result, CancellationToken ct)
     {
-        var model = new V4Models.UploaderSnapshot
-        {
-            Timestamp = ResolveTimestamp(ds),
-            UtcOffset = ds.UtcOffset,
-            Device = ds.Device,
-            LegacyId = legacyId,
-            Name = ds.Uploader?.Name,
-            Battery = ds.Uploader?.Battery ?? ds.UploaderBattery,
-            BatteryVoltage = ds.Uploader?.BatteryVoltage,
-            IsCharging = ds.IsCharging,
-            Temperature = ds.Uploader?.Temperature,
-            Type = ds.Uploader?.Type,
-        };
+        var model = MapToUploaderSnapshot(ds, legacyId, result.CorrelationId);
 
         model.DeviceId = await _deviceService.ResolveAsync(
             V4Models.DeviceCategory.Uploader,
@@ -493,6 +394,331 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
         result.CreatedRecords.Add(created);
         _logger.LogDebug("Created DeviceStatusExtras with {Count} keys for correlation {CorrelationId}",
             extras.Count, result.CorrelationId);
+    }
+
+    #endregion
+
+    #region Batch Decomposition
+
+    /// <inheritdoc />
+    public async Task<V4Models.DecompositionResult> DecomposeBatchAsync(
+        IReadOnlyList<DeviceStatus> statuses, CancellationToken ct = default)
+    {
+        if (statuses.Count == 0)
+            return new V4Models.DecompositionResult();
+
+        var batch = new DecompositionBatchEntity
+        {
+            TenantId = _dbContext.TenantId,
+            Source = "device_status_decomposer_batch",
+            SourceRecordId = null,
+            CreatedAt = DateTime.UtcNow,
+        };
+        _dbContext.DecompositionBatches.Add(batch);
+        await _dbContext.SaveChangesAsync(ct);
+
+        var result = new V4Models.DecompositionResult
+        {
+            CorrelationId = batch.Id
+        };
+
+        var apsList = new List<V4Models.ApsSnapshot>();
+        var pumpList = new List<V4Models.PumpSnapshot>();
+        var uploaderList = new List<V4Models.UploaderSnapshot>();
+        var extrasList = new List<V4Models.DeviceStatusExtras>();
+        var overrideSpans = new List<StateSpan>();
+
+        foreach (var ds in statuses)
+        {
+            // AAPS sends "date" instead of "mills" — normalize before decomposition
+            if (ds.Mills == 0 && ds.Date is > 0)
+                ds.Mills = ds.Date.Value;
+
+            var legacyId = ds.Id;
+
+            Guid? pumpDeviceId = null;
+
+            if (ds.Pump != null)
+            {
+                var pumpModel = MapToPumpSnapshot(ds, legacyId, batch.Id);
+
+                pumpModel.DeviceId = await _deviceService.ResolveAsync(
+                    V4Models.DeviceCategory.InsulinPump,
+                    ds.Pump.Manufacturer,
+                    ds.Pump.Model,
+                    ds.Mills, ct);
+                pumpModel.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(pumpModel.DeviceId, ds.Mills, ct);
+
+                pumpDeviceId = pumpModel.DeviceId;
+                pumpList.Add(pumpModel);
+            }
+
+            if (ds.OpenAps != null)
+            {
+                var apsModel = MapToApsSnapshotFromOpenAps(ds, legacyId, batch.Id);
+                apsModel.DeviceId = pumpDeviceId;
+                apsModel.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(pumpDeviceId, ds.Mills, ct);
+                apsList.Add(apsModel);
+            }
+            else if (ds.Loop != null)
+            {
+                var apsModel = MapToApsSnapshotFromLoop(ds, legacyId, batch.Id);
+                apsModel.DeviceId = pumpDeviceId;
+                apsModel.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(pumpDeviceId, ds.Mills, ct);
+                apsList.Add(apsModel);
+            }
+
+            if (ds.Uploader != null || ds.UploaderBattery.HasValue)
+            {
+                var uploaderModel = MapToUploaderSnapshot(ds, legacyId, batch.Id);
+                uploaderModel.DeviceId = await _deviceService.ResolveAsync(
+                    V4Models.DeviceCategory.Uploader,
+                    ds.Uploader?.Name,
+                    ds.Uploader?.Type ?? "unknown",
+                    ds.Mills, ct);
+                uploaderList.Add(uploaderModel);
+            }
+
+            if (ds.Override is { Active: true })
+            {
+                var timestamp = ResolveTimestamp(ds);
+                var stateSpan = new StateSpan
+                {
+                    Category = StateSpanCategory.Override,
+                    State = OverrideState.Custom.ToString(),
+                    StartTimestamp = timestamp,
+                    EndTimestamp = ds.Override.Duration is > 0
+                        ? timestamp.AddMinutes(ds.Override.Duration.Value)
+                        : null,
+                    Source = ds.Device,
+                    OriginalId = legacyId,
+                    Metadata = BuildOverrideMetadata(ds.Override),
+                };
+                overrideSpans.Add(stateSpan);
+            }
+
+            CollectExtras(ds, batch.Id, extrasList);
+        }
+
+        // Bulk-insert all snapshot types
+        if (apsList.Count > 0)
+        {
+            var created = await _apsRepo.BulkCreateAsync(apsList, ct);
+            result.CreatedRecords.AddRange(created);
+        }
+
+        if (pumpList.Count > 0)
+        {
+            var created = await _pumpRepo.BulkCreateAsync(pumpList, ct);
+            result.CreatedRecords.AddRange(created);
+        }
+
+        if (uploaderList.Count > 0)
+        {
+            var created = await _uploaderRepo.BulkCreateAsync(uploaderList, ct);
+            result.CreatedRecords.AddRange(created);
+        }
+
+        if (extrasList.Count > 0)
+        {
+            var created = await _extrasRepo.BulkCreateAsync(extrasList, ct);
+            result.CreatedRecords.AddRange(created);
+        }
+
+        // Upsert override state spans individually (overrides are rare)
+        foreach (var span in overrideSpans)
+        {
+            var upserted = await _stateSpanService.UpsertStateSpanAsync(span, ct);
+            result.CreatedRecords.Add(upserted);
+        }
+
+        // Post-insert pump suspension pass: sequential, order-dependent
+        if (pumpList.Count > 0)
+        {
+            var persistedPumps = result.CreatedRecords.OfType<V4Models.PumpSnapshot>()
+                .OrderBy(p => p.Timestamp)
+                .ToList();
+
+            for (var i = 0; i < persistedPumps.Count; i++)
+            {
+                var pumpSnapshot = persistedPumps[i];
+                // Find the original DeviceStatus that produced this pump snapshot
+                var ds = statuses.FirstOrDefault(s => s.Id == pumpSnapshot.LegacyId);
+                if (ds != null)
+                {
+                    await DecomposePumpSuspensionAsync(ds, pumpSnapshot, result, ct);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Collects extras from a DeviceStatus into the provided list without persisting.
+    /// </summary>
+    private static void CollectExtras(
+        DeviceStatus ds, Guid correlationId, List<V4Models.DeviceStatusExtras> extrasList)
+    {
+        var extras = new Dictionary<string, object?>();
+
+        if (ds.XDripJs != null)
+            extras["xdripjs"] = ds.XDripJs;
+        if (ds.RadioAdapter != null)
+            extras["radioAdapter"] = ds.RadioAdapter;
+        if (ds.Connect != null)
+            extras["connect"] = ds.Connect;
+        if (ds.Cgm != null)
+            extras["cgm"] = ds.Cgm;
+        if (ds.Meter != null)
+            extras["meter"] = ds.Meter;
+        if (ds.InsulinPen != null)
+            extras["insulinPen"] = ds.InsulinPen;
+        if (ds.MmTune != null)
+            extras["mmtune"] = ds.MmTune;
+
+        if (ds.ExtensionData != null)
+        {
+            foreach (var kvp in ds.ExtensionData)
+                extras[kvp.Key] = kvp.Value;
+        }
+
+        if (extras.Count == 0)
+            return;
+
+        extrasList.Add(new V4Models.DeviceStatusExtras
+        {
+            CorrelationId = correlationId,
+            Timestamp = ResolveTimestamp(ds),
+            Extras = extras,
+        });
+    }
+
+    #endregion
+
+    #region Mapping Helpers
+
+    private static V4Models.ApsSnapshot MapToApsSnapshotFromOpenAps(
+        DeviceStatus ds, string? legacyId, Guid? correlationId)
+    {
+        var command = ds.OpenAps!.Enacted ?? ds.OpenAps.Suggested;
+        var predBGs = command?.PredBGs;
+        var apsSystem = DetectOpenApsVariant(ds);
+
+        return new V4Models.ApsSnapshot
+        {
+            Timestamp = ResolveTimestamp(ds),
+            UtcOffset = ds.UtcOffset,
+            Device = ds.Device,
+            LegacyId = legacyId,
+            CorrelationId = correlationId,
+            AidAlgorithm = apsSystem,
+            Iob = ds.OpenAps.Iob?.Iob,
+            BasalIob = ds.OpenAps.Iob?.BasalIob,
+            BolusIob = ds.OpenAps.Iob?.BolusIob,
+            Cob = ds.OpenAps.Cob ?? command?.COB,
+            CurrentBg = command?.Bg,
+            EventualBg = command?.EventualBG,
+            TargetBg = command?.TargetBG,
+            RecommendedBolus = command?.InsulinReq,
+            SensitivityRatio = command?.SensitivityRatio,
+            Enacted = ds.OpenAps.Enacted != null
+                && (ds.OpenAps.Enacted.Received == true || ds.OpenAps.Enacted.Recieved == true),
+            EnactedRate = ds.OpenAps.Enacted?.Rate,
+            EnactedDuration = ds.OpenAps.Enacted?.Duration,
+            EnactedBolusVolume = ds.OpenAps.Enacted?.Smb is > 0
+                ? ds.OpenAps.Enacted.Smb
+                : ds.OpenAps.Enacted?.Units,
+            SuggestedJson = SerializeOrNull(ds.OpenAps.Suggested),
+            EnactedJson = SerializeOrNull(ds.OpenAps.Enacted),
+            PredictedDefaultJson = apsSystem == V4Models.AidAlgorithm.Trio
+                ? null
+                : SerializeOrNull(predBGs?.IOB),
+            PredictedIobJson = SerializeOrNull(predBGs?.IOB),
+            PredictedZtJson = SerializeOrNull(predBGs?.ZT),
+            PredictedCobJson = SerializeOrNull(predBGs?.COB),
+            PredictedUamJson = SerializeOrNull(predBGs?.UAM),
+            PredictedStartTimestamp = ParseTimestampToDateTime(command?.Timestamp),
+            AidVersion = ds.OpenAps?.Version,
+        };
+    }
+
+    private static V4Models.ApsSnapshot MapToApsSnapshotFromLoop(
+        DeviceStatus ds, string? legacyId, Guid? correlationId)
+    {
+        return new V4Models.ApsSnapshot
+        {
+            Timestamp = ResolveTimestamp(ds),
+            UtcOffset = ds.UtcOffset,
+            Device = ds.Device,
+            LegacyId = legacyId,
+            CorrelationId = correlationId,
+            AidAlgorithm = V4Models.AidAlgorithm.Loop,
+            Iob = ds.Loop!.Iob?.Iob,
+            BasalIob = ds.Loop.Iob?.BasalIob,
+            BolusIob = null,
+            Cob = ds.Loop.Cob?.Cob,
+            CurrentBg = ds.Loop.Predicted?.Values?.FirstOrDefault(),
+            EventualBg = ds.Loop.Predicted?.Values?.LastOrDefault(),
+            RecommendedBolus = ds.Loop.RecommendedBolus,
+            Enacted = ds.Loop.Enacted?.Received == true,
+            EnactedRate = ds.Loop.Enacted?.Rate,
+            EnactedDuration = ds.Loop.Enacted?.Duration,
+            EnactedBolusVolume = ds.Loop.Enacted?.BolusVolume,
+            SuggestedJson = SerializeOrNull(ds.Loop.Recommended),
+            EnactedJson = SerializeOrNull(ds.Loop.Enacted),
+            PredictedDefaultJson = SerializeOrNull(ds.Loop.Predicted?.Values),
+            PredictedStartTimestamp = ParseTimestampToDateTime(ds.Loop.Predicted?.StartDate),
+            LoopJson = SerializeOrNull(ds.Loop),
+            AidVersion = null,
+        };
+    }
+
+    private static V4Models.PumpSnapshot MapToPumpSnapshot(
+        DeviceStatus ds, string? legacyId, Guid? correlationId)
+    {
+        return new V4Models.PumpSnapshot
+        {
+            Timestamp = ResolveTimestamp(ds),
+            UtcOffset = ds.UtcOffset,
+            Device = ds.Device,
+            LegacyId = legacyId,
+            CorrelationId = correlationId,
+            Manufacturer = ds.Pump!.Manufacturer,
+            Model = ds.Pump.Model,
+            Reservoir = ds.Pump.Reservoir,
+            ReservoirDisplay = ds.Pump.ReservoirDisplayOverride,
+            BatteryPercent = ds.Pump.Battery?.Percent,
+            BatteryVoltage = ds.Pump.Battery?.Voltage,
+            Bolusing = ds.Pump.Status?.Bolusing,
+            Suspended = ds.Pump.Status?.Suspended,
+            PumpStatus = ds.Pump.Status?.Status,
+            Clock = ds.Pump.Clock,
+            Iob = ds.Pump.Iob?.Iob,
+            BolusIob = ds.Pump.Iob?.BolusIob,
+            AdditionalProperties = ds.Pump.Extended is { Count: > 0 }
+                ? ds.Pump.Extended.ToDictionary(kvp => kvp.Key, kvp => (object?)kvp.Value)
+                : null,
+        };
+    }
+
+    private static V4Models.UploaderSnapshot MapToUploaderSnapshot(
+        DeviceStatus ds, string? legacyId, Guid? correlationId)
+    {
+        return new V4Models.UploaderSnapshot
+        {
+            Timestamp = ResolveTimestamp(ds),
+            UtcOffset = ds.UtcOffset,
+            Device = ds.Device,
+            LegacyId = legacyId,
+            CorrelationId = correlationId,
+            Name = ds.Uploader?.Name,
+            Battery = ds.Uploader?.Battery ?? ds.UploaderBattery,
+            BatteryVoltage = ds.Uploader?.BatteryVoltage,
+            IsCharging = ds.IsCharging,
+            Temperature = ds.Uploader?.Temperature,
+            Type = ds.Uploader?.Type,
+        };
     }
 
     #endregion

--- a/src/API/Nocturne.API/Services/V4/EntryDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/EntryDecomposer.cs
@@ -175,6 +175,88 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
     }
 
     /// <inheritdoc />
+    public async Task<DecompositionResult> DecomposeBatchAsync(
+        IReadOnlyList<Entry> entries, CancellationToken ct = default)
+    {
+        if (entries.Count == 0)
+            return new DecompositionResult();
+
+        var batch = new DecompositionBatchEntity
+        {
+            TenantId = _dbContext.TenantId,
+            Source = "entry_decomposer_batch",
+            SourceRecordId = null,
+            CreatedAt = DateTime.UtcNow,
+        };
+        _dbContext.DecompositionBatches.Add(batch);
+        await _dbContext.SaveChangesAsync(ct);
+
+        var result = new DecompositionResult { CorrelationId = batch.Id };
+
+        var sgvList = new List<SensorGlucose>();
+        var mbgList = new List<MeterGlucose>();
+        var calList = new List<Calibration>();
+
+        foreach (var entry in entries)
+        {
+            switch (entry.Type?.ToLowerInvariant())
+            {
+                case "sgv":
+                {
+                    var model = MapToSensorGlucose(entry, batch.Id);
+
+                    string? gpHint = null;
+                    double? smoothedHint = null;
+                    double? unsmoothedHint = null;
+
+                    if (entry.AdditionalProperties is { } props)
+                    {
+                        if (TryGetString(props, "glucoseProcessing", out var gpStr))
+                            gpHint = gpStr;
+                        if (TryGetDouble(props, "smoothedMgdl", out var sm))
+                            smoothedHint = sm;
+                        if (TryGetDouble(props, "unsmoothedMgdl", out var um))
+                            unsmoothedHint = um;
+                    }
+
+                    await _glucoseResolver.ResolveAsync(model, gpHint, smoothedHint, unsmoothedHint, ct);
+                    sgvList.Add(model);
+                    break;
+                }
+                case "mbg":
+                    mbgList.Add(MapToMeterGlucose(entry, batch.Id));
+                    break;
+                case "cal":
+                    calList.Add(MapToCalibration(entry, batch.Id));
+                    break;
+                default:
+                    _logger.LogDebug("Skipping entry with unknown type: {Type}", entry.Type);
+                    break;
+            }
+        }
+
+        if (sgvList.Count > 0)
+        {
+            var created = await _sensorGlucoseRepository.BulkCreateAsync(sgvList, ct);
+            result.CreatedRecords.AddRange(created);
+        }
+
+        if (mbgList.Count > 0)
+        {
+            var created = await _meterGlucoseRepository.BulkCreateAsync(mbgList, ct);
+            result.CreatedRecords.AddRange(created);
+        }
+
+        if (calList.Count > 0)
+        {
+            var created = await _calibrationRepository.BulkCreateAsync(calList, ct);
+            result.CreatedRecords.AddRange(created);
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
     public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
         var deleted = 0;

--- a/src/API/Nocturne.API/Services/V4/ProfileDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/ProfileDecomposer.cs
@@ -93,6 +93,89 @@ public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
         return result;
     }
 
+    /// <inheritdoc />
+    public async Task<V4Models.DecompositionResult> DecomposeBatchAsync(
+        IReadOnlyList<Profile> profiles, CancellationToken ct = default)
+    {
+        if (profiles.Count == 0)
+            return new V4Models.DecompositionResult();
+
+        var batch = new DecompositionBatchEntity
+        {
+            TenantId = _dbContext.TenantId,
+            Source = "profile_decomposer_batch",
+            SourceRecordId = null,
+            CreatedAt = DateTime.UtcNow,
+        };
+        _dbContext.DecompositionBatches.Add(batch);
+        await _dbContext.SaveChangesAsync(ct);
+
+        var result = new V4Models.DecompositionResult { CorrelationId = batch.Id };
+
+        var therapySettingsList = new List<V4Models.TherapySettings>();
+        var basalScheduleList = new List<V4Models.BasalSchedule>();
+        var carbRatioScheduleList = new List<V4Models.CarbRatioSchedule>();
+        var sensitivityScheduleList = new List<V4Models.SensitivitySchedule>();
+        var targetRangeScheduleList = new List<V4Models.TargetRangeSchedule>();
+
+        foreach (var profile in profiles)
+        {
+            if (profile.Store.Count == 0)
+            {
+                _logger.LogWarning("Profile {Id} has no store entries, skipping", profile.Id);
+                continue;
+            }
+
+            foreach (var (storeName, profileData) in profile.Store)
+            {
+                var legacyId = $"{profile.Id}:{storeName}";
+                var isDefault = string.Equals(storeName, profile.DefaultProfile, StringComparison.OrdinalIgnoreCase);
+
+                therapySettingsList.Add(MapToTherapySettings(profile, profileData, storeName, legacyId, isDefault, batch.Id));
+                basalScheduleList.Add(MapToBasalSchedule(profile, profileData, storeName, legacyId, batch.Id));
+                carbRatioScheduleList.Add(MapToCarbRatioSchedule(profile, profileData, storeName, legacyId, batch.Id));
+                sensitivityScheduleList.Add(MapToSensitivitySchedule(profile, profileData, storeName, legacyId, batch.Id));
+                targetRangeScheduleList.Add(MapToTargetRangeSchedule(profile, profileData, storeName, legacyId, batch.Id));
+            }
+        }
+
+        if (therapySettingsList.Count > 0)
+        {
+            var created = await _therapySettingsRepo.BulkCreateAsync(therapySettingsList, ct);
+            result.CreatedRecords.AddRange(created);
+        }
+
+        if (basalScheduleList.Count > 0)
+        {
+            var created = await _basalScheduleRepo.BulkCreateAsync(basalScheduleList, ct);
+            result.CreatedRecords.AddRange(created);
+        }
+
+        if (carbRatioScheduleList.Count > 0)
+        {
+            var created = await _carbRatioScheduleRepo.BulkCreateAsync(carbRatioScheduleList, ct);
+            result.CreatedRecords.AddRange(created);
+        }
+
+        if (sensitivityScheduleList.Count > 0)
+        {
+            var created = await _sensitivityScheduleRepo.BulkCreateAsync(sensitivityScheduleList, ct);
+            result.CreatedRecords.AddRange(created);
+        }
+
+        if (targetRangeScheduleList.Count > 0)
+        {
+            var created = await _targetRangeScheduleRepo.BulkCreateAsync(targetRangeScheduleList, ct);
+            result.CreatedRecords.AddRange(created);
+        }
+
+        _logger.LogDebug(
+            "Batch-decomposed {ProfileCount} profiles into {RecordCount} V4 records",
+            profiles.Count, result.CreatedRecords.Count);
+
+        return result;
+    }
+
     #region Decomposition Methods
 
     private async Task DecomposeTherapySettingsAsync(

--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -937,6 +937,285 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
     #endregion
 
     /// <inheritdoc />
+    public async Task<V4Models.DecompositionResult> DecomposeBatchAsync(
+        IReadOnlyList<Treatment> treatments, CancellationToken ct = default)
+    {
+        if (treatments.Count == 0)
+            return new V4Models.DecompositionResult();
+
+        var batch = new DecompositionBatchEntity
+        {
+            TenantId = _dbContext.TenantId,
+            Source = "treatment_decomposer_batch",
+            SourceRecordId = null,
+            CreatedAt = DateTime.UtcNow,
+        };
+        _dbContext.DecompositionBatches.Add(batch);
+        await _dbContext.SaveChangesAsync(ct);
+
+        var result = new V4Models.DecompositionResult { CorrelationId = batch.Id };
+
+        // Typed collection lists for bulk insert
+        var bolusList = new List<V4Models.Bolus>();
+        var carbList = new List<V4Models.CarbIntake>();
+        var bgCheckList = new List<V4Models.BGCheck>();
+        var noteList = new List<V4Models.Note>();
+        var bolusCalcList = new List<V4Models.BolusCalculation>();
+        var deviceEventList = new List<V4Models.DeviceEvent>();
+        var tempBasalList = new List<V4Models.TempBasal>();
+
+        // State span treatments are upserted individually (idempotent semantics)
+        var stateSpanTreatments = new List<(Treatment Treatment, bool IsProfileSwitch, bool IsOverride, bool IsTemporaryTarget)>();
+
+        // Track treatments that produce both bolus AND bolusCalculation for post-insert linking
+        var bolusCalcLinkTreatmentIds = new HashSet<string>();
+
+        foreach (var treatment in treatments)
+        {
+            var eventType = treatment.EventType?.Trim();
+            var hasInsulin = treatment.Insulin is > 0;
+            var hasCarbs = treatment.Carbs is > 0;
+
+            // Classification flags (same logic as DecomposeAsync)
+            var produceBolus = false;
+            var produceCarbIntake = false;
+            var produceBGCheck = false;
+            var produceNote = false;
+            var produceBolusCalc = false;
+            var produceDeviceEvent = false;
+            var delegateToStateSpan = false;
+            var isProfileSwitch = false;
+            var isOverride = false;
+            var isTemporaryTarget = false;
+            var isAnnouncement = false;
+            DeviceEventType parsedDeviceEventType = default;
+
+            if (IsTempBasal(eventType))
+            {
+                delegateToStateSpan = true;
+            }
+            else if (string.Equals(eventType, "Profile Switch", StringComparison.OrdinalIgnoreCase))
+            {
+                isProfileSwitch = true;
+                delegateToStateSpan = true;
+            }
+            else if (string.Equals(eventType, "Temporary Override", StringComparison.OrdinalIgnoreCase))
+            {
+                isOverride = true;
+                delegateToStateSpan = true;
+            }
+            else if (string.Equals(eventType, "Temporary Target", StringComparison.OrdinalIgnoreCase)
+                  || string.Equals(eventType, "Temporary Target Cancel", StringComparison.OrdinalIgnoreCase))
+            {
+                isTemporaryTarget = true;
+                delegateToStateSpan = true;
+            }
+            else if (eventType != null && TreatmentTypes.DeviceEventTypeMap.TryGetValue(eventType, out parsedDeviceEventType))
+            {
+                produceDeviceEvent = true;
+            }
+            else if (string.Equals(eventType, "Meal Bolus", StringComparison.OrdinalIgnoreCase)
+                  || string.Equals(eventType, "Snack Bolus", StringComparison.OrdinalIgnoreCase))
+            {
+                produceBolus = true;
+                produceCarbIntake = true;
+            }
+            else if (string.Equals(eventType, "Correction Bolus", StringComparison.OrdinalIgnoreCase))
+            {
+                produceBolus = true;
+            }
+            else if (string.Equals(eventType, "Carb Correction", StringComparison.OrdinalIgnoreCase))
+            {
+                produceCarbIntake = true;
+            }
+            else if (string.Equals(eventType, "BG Check", StringComparison.OrdinalIgnoreCase))
+            {
+                produceBGCheck = true;
+            }
+            else if (string.Equals(eventType, "Announcement", StringComparison.OrdinalIgnoreCase))
+            {
+                produceNote = true;
+                isAnnouncement = true;
+            }
+            else if (string.Equals(eventType, "Note", StringComparison.OrdinalIgnoreCase))
+            {
+                produceNote = true;
+            }
+            else if (string.Equals(eventType, "Bolus Wizard", StringComparison.OrdinalIgnoreCase))
+            {
+                produceBolusCalc = true;
+                if (hasInsulin)
+                    produceBolus = true;
+            }
+
+            // Override rule: both insulin and carbs → always produce both
+            if (hasInsulin && hasCarbs)
+            {
+                produceBolus = true;
+                produceCarbIntake = true;
+            }
+
+            // Note for any treatment with non-empty Notes (unless already producing a Note)
+            if (!produceNote && !string.IsNullOrWhiteSpace(treatment.Notes))
+                produceNote = true;
+
+            // Collect state span treatments for individual upsert
+            if (delegateToStateSpan)
+            {
+                // TempBasal treatments can also be bulk-inserted
+                if (!isProfileSwitch && !isOverride && !isTemporaryTarget)
+                {
+                    var tempBasal = MapToTempBasal(treatment, batch.Id);
+                    tempBasal.DeviceId = await _deviceService.ResolveAsync(
+                        V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
+                    tempBasal.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(tempBasal.DeviceId, treatment.Mills, ct);
+                    tempBasalList.Add(tempBasal);
+                }
+                else
+                {
+                    stateSpanTreatments.Add((treatment, isProfileSwitch, isOverride, isTemporaryTarget));
+                }
+            }
+
+            if (produceBolus)
+            {
+                var isAlgorithmBolus = (treatment.IsBasalInsulin == true && treatment.Insulin > 0)
+                    || (string.Equals(treatment.EventType, "Correction Bolus", StringComparison.OrdinalIgnoreCase) && IsAapsUpload(treatment));
+
+                var model = MapToBolus(treatment, batch.Id);
+
+                if (isAlgorithmBolus)
+                {
+                    model.Kind = V4Models.BolusKind.Algorithm;
+                    model.Automatic = true;
+                }
+
+                model.DeviceId = await _deviceService.ResolveAsync(
+                    V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
+                model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
+                bolusList.Add(model);
+            }
+
+            if (produceCarbIntake)
+                carbList.Add(MapToCarbIntake(treatment, batch.Id));
+
+            if (produceBGCheck)
+                bgCheckList.Add(MapToBGCheck(treatment, batch.Id));
+
+            if (produceNote)
+                noteList.Add(MapToNote(treatment, batch.Id, isAnnouncement));
+
+            if (produceBolusCalc)
+                bolusCalcList.Add(MapToBolusCalculation(treatment, batch.Id));
+
+            if (produceDeviceEvent)
+            {
+                var model = MapToDeviceEvent(treatment, batch.Id, parsedDeviceEventType);
+                model.DeviceId = await _deviceService.ResolveAsync(
+                    V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
+                model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
+                deviceEventList.Add(model);
+            }
+
+            // Track for post-insert linking
+            if (produceBolus && produceBolusCalc && treatment.Id != null)
+                bolusCalcLinkTreatmentIds.Add(treatment.Id);
+
+            // Log unrecognized treatments
+            if (!produceBolus && !produceCarbIntake && !produceBGCheck
+                && !produceNote && !produceBolusCalc && !produceDeviceEvent && !delegateToStateSpan)
+            {
+                _logger.LogWarning(
+                    "Unknown event type '{EventType}' for treatment {Id} with no insulin/carbs, skipping decomposition",
+                    treatment.EventType, treatment.Id);
+            }
+        }
+
+        // Bulk-insert all typed lists
+        if (bolusList.Count > 0)
+        {
+            var created = await _bolusRepository.BulkCreateAsync(bolusList, ct);
+            result.CreatedRecords.AddRange(created);
+        }
+
+        if (carbList.Count > 0)
+        {
+            var created = await _carbIntakeRepository.BulkCreateAsync(carbList, ct);
+            result.CreatedRecords.AddRange(created);
+        }
+
+        if (bgCheckList.Count > 0)
+        {
+            var created = await _bgCheckRepository.BulkCreateAsync(bgCheckList, ct);
+            result.CreatedRecords.AddRange(created);
+        }
+
+        if (noteList.Count > 0)
+        {
+            var created = await _noteRepository.BulkCreateAsync(noteList, ct);
+            result.CreatedRecords.AddRange(created);
+        }
+
+        if (bolusCalcList.Count > 0)
+        {
+            var created = await _bolusCalculationRepository.BulkCreateAsync(bolusCalcList, ct);
+            result.CreatedRecords.AddRange(created);
+        }
+
+        if (deviceEventList.Count > 0)
+        {
+            var created = await _deviceEventRepository.BulkCreateAsync(deviceEventList, ct);
+            result.CreatedRecords.AddRange(created);
+        }
+
+        if (tempBasalList.Count > 0)
+        {
+            var created = await _tempBasalRepository.BulkCreateAsync(tempBasalList, ct);
+            result.CreatedRecords.AddRange(created);
+        }
+
+        // Upsert state spans individually (ProfileSwitch, Override, TemporaryTarget)
+        foreach (var (treatment, isPs, isOv, isTt) in stateSpanTreatments)
+        {
+            // Use a temporary result to collect records from helper methods
+            var spanResult = new V4Models.DecompositionResult { CorrelationId = batch.Id };
+
+            if (isPs)
+                await DecomposeProfileSwitchAsync(treatment, spanResult, ct);
+            else if (isOv)
+                await DecomposeOverrideAsync(treatment, spanResult, ct);
+            else if (isTt)
+                await DecomposeTemporaryTargetAsync(treatment, spanResult, ct);
+
+            result.CreatedRecords.AddRange(spanResult.CreatedRecords);
+            result.UpdatedRecords.AddRange(spanResult.UpdatedRecords);
+        }
+
+        // Post-insert linking: Bolus → BolusCalculation by matching LegacyId
+        if (bolusCalcLinkTreatmentIds.Count > 0)
+        {
+            var persistedBoluses = result.CreatedRecords.OfType<V4Models.Bolus>()
+                .Where(b => b.LegacyId != null && bolusCalcLinkTreatmentIds.Contains(b.LegacyId))
+                .ToList();
+            var persistedCalcs = result.CreatedRecords.OfType<V4Models.BolusCalculation>()
+                .Where(c => c.LegacyId != null && bolusCalcLinkTreatmentIds.Contains(c.LegacyId))
+                .ToDictionary(c => c.LegacyId!);
+
+            foreach (var bolus in persistedBoluses)
+            {
+                if (persistedCalcs.TryGetValue(bolus.LegacyId!, out var calc)
+                    && bolus.BolusCalculationId != calc.Id)
+                {
+                    bolus.BolusCalculationId = calc.Id;
+                    await _bolusRepository.UpdateAsync(bolus.Id, bolus, ct);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
     public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
         var deleted = 0;

--- a/src/Core/Nocturne.Core.Contracts/V4/IActivityDecomposer.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/IActivityDecomposer.cs
@@ -23,6 +23,19 @@ public interface IActivityDecomposer
     Task<DecompositionResult> DecomposeAsync(Activity activity, CancellationToken ct = default);
 
     /// <summary>
+    /// Decomposes a batch of legacy Activities into dedicated v4 models, using bulk insert.
+    /// Heart rate records are bulk-inserted into the heart_rates table, step counts into step_counts,
+    /// and regular activities are bulk-created as StateSpans.
+    /// </summary>
+    /// <param name="activities">The legacy Activities to decompose</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>
+    /// A <see cref="DecompositionResult"/> containing all created V4 records across all activities.
+    /// </returns>
+    Task<DecompositionResult> DecomposeBatchAsync(
+        IReadOnlyList<Activity> activities, CancellationToken ct = default);
+
+    /// <summary>
     /// Deletes all dedicated records that were decomposed from a legacy Activity with the given ID.
     /// </summary>
     /// <returns>Total number of records deleted across heart_rates and step_counts tables</returns>

--- a/src/Core/Nocturne.Core.Contracts/V4/IDeviceStatusDecomposer.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/IDeviceStatusDecomposer.cs
@@ -17,6 +17,16 @@ public interface IDeviceStatusDecomposer
     Task<DecompositionResult> DecomposeAsync(DeviceStatus deviceStatus, CancellationToken ct = default);
 
     /// <summary>
+    /// Decomposes a batch of DeviceStatus records into typed v4 snapshot tables using bulk-insert
+    /// operations to eliminate N+1 DB round-trips. Pump suspension state spans are processed as a
+    /// post-insert sequential pass since transition detection depends on prior committed snapshots.
+    /// </summary>
+    /// <param name="statuses">DeviceStatus records to decompose.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<DecompositionResult> DecomposeBatchAsync(
+        IReadOnlyList<DeviceStatus> statuses, CancellationToken ct = default);
+
+    /// <summary>
     /// Deletes all v4 snapshot records that were decomposed from a legacy DeviceStatus with the given ID.
     /// </summary>
     /// <param name="legacyId">The legacy DeviceStatus ID</param>

--- a/src/Core/Nocturne.Core.Contracts/V4/IEntryDecomposer.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/IEntryDecomposer.cs
@@ -41,4 +41,18 @@ public interface IEntryDecomposer
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Total number of records deleted across all V4 tables.</returns>
     Task<long> BulkDeleteAsync(string? find, CancellationToken ct = default);
+
+    /// <summary>
+    /// Decomposes a batch of legacy entries into v4 records using bulk-insert,
+    /// eliminating per-entry round-trips. All entries share a single
+    /// <see cref="DecompositionResult.CorrelationId"/>.
+    /// </summary>
+    /// <param name="entries">The legacy entries to decompose.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// A <see cref="DecompositionResult"/> whose <see cref="DecompositionResult.CreatedRecords"/>
+    /// contains all bulk-inserted v4 records. Entries with unrecognised types are skipped.
+    /// </returns>
+    Task<DecompositionResult> DecomposeBatchAsync(
+        IReadOnlyList<Entry> entries, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/IProfileDecomposer.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/IProfileDecomposer.cs
@@ -26,6 +26,18 @@ public interface IProfileDecomposer
     Task<DecompositionResult> DecomposeAsync(Profile profile, CancellationToken ct = default);
 
     /// <summary>
+    /// Decomposes a batch of legacy Profiles into V4 records, using bulk insert for each schedule type.
+    /// Flattens all Store entries across all profiles into per-type lists and bulk-creates them.
+    /// </summary>
+    /// <param name="profiles">The legacy Profiles to decompose</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>
+    /// A <see cref="DecompositionResult"/> containing all created V4 records across all profiles.
+    /// </returns>
+    Task<DecompositionResult> DecomposeBatchAsync(
+        IReadOnlyList<Profile> profiles, CancellationToken ct = default);
+
+    /// <summary>
     /// Deletes all V4 records that were decomposed from a legacy Profile with the given ID.
     /// Uses prefix matching since one legacy Profile fans out to multiple composite LegacyIds.
     /// </summary>

--- a/src/Core/Nocturne.Core.Contracts/V4/ITreatmentDecomposer.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/ITreatmentDecomposer.cs
@@ -28,6 +28,18 @@ public interface ITreatmentDecomposer
     Task<DecompositionResult> DecomposeAsync(Treatment treatment, CancellationToken ct = default);
 
     /// <summary>
+    /// Decomposes a batch of legacy Treatments into v4 records using bulk-insert operations,
+    /// eliminating per-record DB round-trips. State span treatments (TempBasal, ProfileSwitch,
+    /// Override, TemporaryTarget) are upserted individually since they require idempotent semantics.
+    /// Bolus-to-BolusCalculation linking is performed in a post-insert pass.
+    /// </summary>
+    /// <param name="treatments">The batch of legacy Treatments to decompose.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A single <see cref="DecompositionResult"/> containing all created v4 records.</returns>
+    Task<DecompositionResult> DecomposeBatchAsync(
+        IReadOnlyList<Treatment> treatments, CancellationToken ct = default);
+
+    /// <summary>
     /// Deletes all v4 records that were decomposed from a legacy Treatment with the given ID.
     /// </summary>
     /// <param name="legacyId">The legacy Treatment ID</param>

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IApsSnapshotRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IApsSnapshotRepository.cs
@@ -105,4 +105,14 @@ public interface IApsSnapshotRepository : IV4Repository<ApsSnapshot>
     /// <param name="asOf">When non-null, restricts to snapshots with <c>Timestamp &lt;= asOf</c>.</param>
     /// <param name="ct">Cancellation token.</param>
     Task<decimal?> GetLatestSensitivityRatioAsync(DateTime? asOf, CancellationToken ct = default);
+
+    /// <summary>
+    /// Bulk-insert <see cref="ApsSnapshot"/> records with batch-level and DB-level deduplication by LegacyId.
+    /// </summary>
+    /// <param name="records">Records to insert.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The records that were actually inserted (duplicates excluded).</returns>
+    Task<IEnumerable<ApsSnapshot>> BulkCreateAsync(
+        IEnumerable<ApsSnapshot> records,
+        CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ICalibrationRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ICalibrationRepository.cs
@@ -102,4 +102,14 @@ public interface ICalibrationRepository : IV4Repository<Calibration>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted.</returns>
     Task<int> DeleteByTimeRangeAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
+
+    /// <summary>
+    /// Bulk-insert <see cref="Calibration"/> records with batch-level and DB-level deduplication by LegacyId.
+    /// </summary>
+    /// <param name="records">Records to insert.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The records that were actually inserted (duplicates excluded).</returns>
+    Task<IEnumerable<Calibration>> BulkCreateAsync(
+        IEnumerable<Calibration> records,
+        CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IDeviceStatusExtrasRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IDeviceStatusExtrasRepository.cs
@@ -26,4 +26,14 @@ public interface IDeviceStatusExtrasRepository
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted.</returns>
     Task<int> DeleteByCorrelationIdAsync(Guid correlationId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Bulk-insert <see cref="DeviceStatusExtras"/> records with batch-level and DB-level deduplication by CorrelationId.
+    /// </summary>
+    /// <param name="records">Records to insert.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The records that were actually inserted (duplicates excluded).</returns>
+    Task<IEnumerable<DeviceStatusExtras>> BulkCreateAsync(
+        IEnumerable<DeviceStatusExtras> records,
+        CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IMeterGlucoseRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IMeterGlucoseRepository.cs
@@ -102,4 +102,14 @@ public interface IMeterGlucoseRepository : IV4Repository<MeterGlucose>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted.</returns>
     Task<int> DeleteByTimeRangeAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
+
+    /// <summary>
+    /// Bulk-insert <see cref="MeterGlucose"/> records with batch-level and DB-level deduplication by LegacyId.
+    /// </summary>
+    /// <param name="records">Records to insert.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The records that were actually inserted (duplicates excluded).</returns>
+    Task<IEnumerable<MeterGlucose>> BulkCreateAsync(
+        IEnumerable<MeterGlucose> records,
+        CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IPumpSnapshotRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IPumpSnapshotRepository.cs
@@ -96,4 +96,14 @@ public interface IPumpSnapshotRepository : IV4Repository<PumpSnapshot>
     /// <param name="to">Inclusive end, or <c>null</c> for no upper bound.</param>
     /// <param name="ct">Cancellation token.</param>
     new Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
+
+    /// <summary>
+    /// Bulk-insert <see cref="PumpSnapshot"/> records with batch-level and DB-level deduplication by LegacyId.
+    /// </summary>
+    /// <param name="records">Records to insert.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The records that were actually inserted (duplicates excluded).</returns>
+    Task<IEnumerable<PumpSnapshot>> BulkCreateAsync(
+        IEnumerable<PumpSnapshot> records,
+        CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IUploaderSnapshotRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IUploaderSnapshotRepository.cs
@@ -85,4 +85,14 @@ public interface IUploaderSnapshotRepository : IV4Repository<UploaderSnapshot>
     /// when <c>null</c>, returns the absolute latest snapshot per the lowest-battery rule.</param>
     /// <param name="ct">Cancellation token.</param>
     Task<UploaderSnapshot?> GetLatestAsync(DateTime? asOf, CancellationToken ct = default);
+
+    /// <summary>
+    /// Bulk-insert <see cref="UploaderSnapshot"/> records with batch-level and DB-level deduplication by LegacyId.
+    /// </summary>
+    /// <param name="records">Records to insert.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The records that were actually inserted (duplicates excluded).</returns>
+    Task<IEnumerable<UploaderSnapshot>> BulkCreateAsync(
+        IEnumerable<UploaderSnapshot> records,
+        CancellationToken ct = default);
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
@@ -223,4 +223,53 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
             .FirstOrDefaultAsync(ct);
         return value is double v && double.IsFinite(v) ? (decimal)v : null;
     }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<ApsSnapshot>> BulkCreateAsync(
+        IEnumerable<ApsSnapshot> records,
+        CancellationToken ct = default)
+    {
+        var entities = records.Select(ApsSnapshotMapper.ToEntity).ToList();
+        if (entities.Count == 0)
+            return [];
+
+        // Batch-level dedup: keep first occurrence per LegacyId
+        entities = entities
+            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
+            .Select(g => g.First())
+            .ToList();
+
+        // DB-level dedup: filter out records whose LegacyId already exists
+        var legacyIds = entities
+            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
+            .Select(e => e.LegacyId!)
+            .ToHashSet();
+
+        if (legacyIds.Count > 0)
+        {
+            var existingIds = await _context
+                .ApsSnapshots.AsNoTracking()
+                .Where(e => legacyIds.Contains(e.LegacyId!))
+                .Select(e => e.LegacyId)
+                .ToListAsync(ct);
+
+            var existingSet = existingIds.ToHashSet();
+            entities = entities
+                .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                .ToList();
+        }
+
+        if (entities.Count == 0)
+            return [];
+
+        const int batchSize = 500;
+        foreach (var batch in entities.Chunk(batchSize))
+        {
+            _context.ApsSnapshots.AddRange(batch);
+            await _context.SaveChangesAsync(ct);
+            _context.ChangeTracker.Clear();
+        }
+
+        return entities.Select(ApsSnapshotMapper.ToDomainModel);
+    }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CalibrationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CalibrationRepository.cs
@@ -221,4 +221,53 @@ public class CalibrationRepository : ICalibrationRepository
 
         return await query.ExecuteDeleteAsync(ct);
     }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<Calibration>> BulkCreateAsync(
+        IEnumerable<Calibration> records,
+        CancellationToken ct = default)
+    {
+        var entities = records.Select(CalibrationMapper.ToEntity).ToList();
+        if (entities.Count == 0)
+            return [];
+
+        // Batch-level dedup: keep first occurrence per LegacyId
+        entities = entities
+            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
+            .Select(g => g.First())
+            .ToList();
+
+        // DB-level dedup: filter out records whose LegacyId already exists
+        var legacyIds = entities
+            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
+            .Select(e => e.LegacyId!)
+            .ToHashSet();
+
+        if (legacyIds.Count > 0)
+        {
+            var existingIds = await _context
+                .Calibrations.AsNoTracking()
+                .Where(e => legacyIds.Contains(e.LegacyId!))
+                .Select(e => e.LegacyId)
+                .ToListAsync(ct);
+
+            var existingSet = existingIds.ToHashSet();
+            entities = entities
+                .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                .ToList();
+        }
+
+        if (entities.Count == 0)
+            return [];
+
+        const int batchSize = 500;
+        foreach (var batch in entities.Chunk(batchSize))
+        {
+            _context.Calibrations.AddRange(batch);
+            await _context.SaveChangesAsync(ct);
+            _context.ChangeTracker.Clear();
+        }
+
+        return entities.Select(CalibrationMapper.ToDomainModel);
+    }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceStatusExtrasRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceStatusExtrasRepository.cs
@@ -70,4 +70,52 @@ public class DeviceStatusExtrasRepository : IDeviceStatusExtrasRepository
             .Where(e => e.CorrelationId == correlationId)
             .ExecuteDeleteAsync(ct);
     }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<DeviceStatusExtras>> BulkCreateAsync(
+        IEnumerable<DeviceStatusExtras> records,
+        CancellationToken ct = default)
+    {
+        var entities = records.Select(DeviceStatusExtrasMapper.ToEntity).ToList();
+        if (entities.Count == 0)
+            return [];
+
+        // Batch-level dedup: keep first occurrence per CorrelationId
+        entities = entities
+            .GroupBy(e => e.CorrelationId)
+            .Select(g => g.First())
+            .ToList();
+
+        // DB-level dedup: filter out records whose CorrelationId already exists
+        var correlationIds = entities
+            .Select(e => e.CorrelationId)
+            .ToHashSet();
+
+        if (correlationIds.Count > 0)
+        {
+            var existingIds = await _context
+                .DeviceStatusExtras.AsNoTracking()
+                .Where(e => correlationIds.Contains(e.CorrelationId))
+                .Select(e => e.CorrelationId)
+                .ToListAsync(ct);
+
+            var existingSet = existingIds.ToHashSet();
+            entities = entities
+                .Where(e => !existingSet.Contains(e.CorrelationId))
+                .ToList();
+        }
+
+        if (entities.Count == 0)
+            return [];
+
+        const int batchSize = 500;
+        foreach (var batch in entities.Chunk(batchSize))
+        {
+            _context.DeviceStatusExtras.AddRange(batch);
+            await _context.SaveChangesAsync(ct);
+            _context.ChangeTracker.Clear();
+        }
+
+        return entities.Select(DeviceStatusExtrasMapper.ToDomainModel);
+    }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/MeterGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/MeterGlucoseRepository.cs
@@ -221,4 +221,53 @@ public class MeterGlucoseRepository : IMeterGlucoseRepository
 
         return await query.ExecuteDeleteAsync(ct);
     }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<MeterGlucose>> BulkCreateAsync(
+        IEnumerable<MeterGlucose> records,
+        CancellationToken ct = default)
+    {
+        var entities = records.Select(MeterGlucoseMapper.ToEntity).ToList();
+        if (entities.Count == 0)
+            return [];
+
+        // Batch-level dedup: keep first occurrence per LegacyId
+        entities = entities
+            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
+            .Select(g => g.First())
+            .ToList();
+
+        // DB-level dedup: filter out records whose LegacyId already exists
+        var legacyIds = entities
+            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
+            .Select(e => e.LegacyId!)
+            .ToHashSet();
+
+        if (legacyIds.Count > 0)
+        {
+            var existingIds = await _context
+                .MeterGlucose.AsNoTracking()
+                .Where(e => legacyIds.Contains(e.LegacyId!))
+                .Select(e => e.LegacyId)
+                .ToListAsync(ct);
+
+            var existingSet = existingIds.ToHashSet();
+            entities = entities
+                .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                .ToList();
+        }
+
+        if (entities.Count == 0)
+            return [];
+
+        const int batchSize = 500;
+        foreach (var batch in entities.Chunk(batchSize))
+        {
+            _context.MeterGlucose.AddRange(batch);
+            await _context.SaveChangesAsync(ct);
+            _context.ChangeTracker.Clear();
+        }
+
+        return entities.Select(MeterGlucoseMapper.ToDomainModel);
+    }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
@@ -187,4 +187,53 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
             .Where(e => e.LegacyId == legacyId)
             .ExecuteDeleteAsync(ct);
     }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<PumpSnapshot>> BulkCreateAsync(
+        IEnumerable<PumpSnapshot> records,
+        CancellationToken ct = default)
+    {
+        var entities = records.Select(PumpSnapshotMapper.ToEntity).ToList();
+        if (entities.Count == 0)
+            return [];
+
+        // Batch-level dedup: keep first occurrence per LegacyId
+        entities = entities
+            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
+            .Select(g => g.First())
+            .ToList();
+
+        // DB-level dedup: filter out records whose LegacyId already exists
+        var legacyIds = entities
+            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
+            .Select(e => e.LegacyId!)
+            .ToHashSet();
+
+        if (legacyIds.Count > 0)
+        {
+            var existingIds = await _context
+                .PumpSnapshots.AsNoTracking()
+                .Where(e => legacyIds.Contains(e.LegacyId!))
+                .Select(e => e.LegacyId)
+                .ToListAsync(ct);
+
+            var existingSet = existingIds.ToHashSet();
+            entities = entities
+                .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                .ToList();
+        }
+
+        if (entities.Count == 0)
+            return [];
+
+        const int batchSize = 500;
+        foreach (var batch in entities.Chunk(batchSize))
+        {
+            _context.PumpSnapshots.AddRange(batch);
+            await _context.SaveChangesAsync(ct);
+            _context.ChangeTracker.Clear();
+        }
+
+        return entities.Select(PumpSnapshotMapper.ToDomainModel);
+    }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
@@ -178,4 +178,53 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
             .FirstOrDefaultAsync(ct);
         return entity is null ? null : UploaderSnapshotMapper.ToDomainModel(entity);
     }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<UploaderSnapshot>> BulkCreateAsync(
+        IEnumerable<UploaderSnapshot> records,
+        CancellationToken ct = default)
+    {
+        var entities = records.Select(UploaderSnapshotMapper.ToEntity).ToList();
+        if (entities.Count == 0)
+            return [];
+
+        // Batch-level dedup: keep first occurrence per LegacyId
+        entities = entities
+            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
+            .Select(g => g.First())
+            .ToList();
+
+        // DB-level dedup: filter out records whose LegacyId already exists
+        var legacyIds = entities
+            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
+            .Select(e => e.LegacyId!)
+            .ToHashSet();
+
+        if (legacyIds.Count > 0)
+        {
+            var existingIds = await _context
+                .UploaderSnapshots.AsNoTracking()
+                .Where(e => legacyIds.Contains(e.LegacyId!))
+                .Select(e => e.LegacyId)
+                .ToListAsync(ct);
+
+            var existingSet = existingIds.ToHashSet();
+            entities = entities
+                .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                .ToList();
+        }
+
+        if (entities.Count == 0)
+            return [];
+
+        const int batchSize = 500;
+        foreach (var batch in entities.Chunk(batchSize))
+        {
+            _context.UploaderSnapshots.AddRange(batch);
+            await _context.SaveChangesAsync(ct);
+            _context.ChangeTracker.Clear();
+        }
+
+        return entities.Select(UploaderSnapshotMapper.ToDomainModel);
+    }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/ActivityDecomposerBatchTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/ActivityDecomposerBatchTests.cs
@@ -1,0 +1,204 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.API.Services.V4;
+using Nocturne.Core.Contracts.Repositories;
+using Nocturne.Core.Models.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Nocturne.Infrastructure.Data;
+
+namespace Nocturne.API.Tests.Services.V4;
+
+public class ActivityDecomposerBatchTests : IDisposable
+{
+    private readonly NocturneDbContext _context;
+    private readonly Mock<IStateSpanRepository> _stateSpanRepoMock;
+    private readonly ActivityDecomposer _decomposer;
+
+    public ActivityDecomposerBatchTests()
+    {
+        _context = TestDbContextFactory.CreateInMemoryContext();
+        _context.TenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+        _stateSpanRepoMock = new Mock<IStateSpanRepository>();
+        _stateSpanRepoMock
+            .Setup(x => x.CreateActivitiesAsStateSpansAsync(
+                It.IsAny<IEnumerable<StateSpan>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<StateSpan> spans, CancellationToken _) => spans);
+
+        _decomposer = new ActivityDecomposer(
+            _context,
+            _stateSpanRepoMock.Object,
+            NullLogger<ActivityDecomposer>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_RoutesHeartRateToRepo()
+    {
+        // Arrange
+        var activities = new List<Activity>
+        {
+            CreateHeartRateActivity("hr1", 72),
+            CreateHeartRateActivity("hr2", 85),
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync(activities);
+
+        // Assert - heart rates stored via DbContext
+        _context.HeartRates.Should().HaveCount(2);
+        result.CreatedRecords.Should().HaveCount(2);
+        result.CorrelationId.Should().NotBeNull();
+
+        _stateSpanRepoMock.Verify(
+            x => x.CreateActivitiesAsStateSpansAsync(
+                It.IsAny<IEnumerable<StateSpan>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_RoutesStepCountToRepo()
+    {
+        // Arrange
+        var activities = new List<Activity>
+        {
+            CreateStepCountActivity("sc1", 1500),
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync(activities);
+
+        // Assert - step counts stored via DbContext
+        _context.StepCounts.Should().HaveCount(1);
+        result.CreatedRecords.Should().HaveCount(1);
+
+        _stateSpanRepoMock.Verify(
+            x => x.CreateActivitiesAsStateSpansAsync(
+                It.IsAny<IEnumerable<StateSpan>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_RoutesRegularActivityToStateSpans()
+    {
+        // Arrange
+        var activities = new List<Activity>
+        {
+            CreateRegularActivity("ex1", "exercise"),
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync(activities);
+
+        // Assert
+        _stateSpanRepoMock.Verify(
+            x => x.CreateActivitiesAsStateSpansAsync(
+                It.Is<IEnumerable<StateSpan>>(spans => spans.Count() == 1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _context.HeartRates.Should().BeEmpty();
+        _context.StepCounts.Should().BeEmpty();
+        result.CreatedRecords.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_EmptyBatch_NoRepositoryCalls()
+    {
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync([]);
+
+        // Assert
+        _context.HeartRates.Should().BeEmpty();
+        _context.StepCounts.Should().BeEmpty();
+        _stateSpanRepoMock.Verify(
+            x => x.CreateActivitiesAsStateSpansAsync(
+                It.IsAny<IEnumerable<StateSpan>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        result.CreatedRecords.Should().BeEmpty();
+        result.CorrelationId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_MixedTypes()
+    {
+        // Arrange - one of each type
+        var activities = new List<Activity>
+        {
+            CreateHeartRateActivity("hr1", 72),
+            CreateStepCountActivity("sc1", 3000),
+            CreateRegularActivity("ex1", "exercise"),
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync(activities);
+
+        // Assert - correct routing
+        _context.HeartRates.Should().HaveCount(1);
+        _context.StepCounts.Should().HaveCount(1);
+
+        _stateSpanRepoMock.Verify(
+            x => x.CreateActivitiesAsStateSpansAsync(
+                It.Is<IEnumerable<StateSpan>>(spans => spans.Count() == 1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        result.CreatedRecords.Should().HaveCount(3);
+        result.CorrelationId.Should().NotBeNull();
+
+        // Verify decomposition batch was persisted
+        var batch = _context.DecompositionBatches.SingleOrDefault(b => b.Id == result.CorrelationId);
+        batch.Should().NotBeNull();
+        batch!.Source.Should().Be("activity_decomposer_batch");
+    }
+
+    #region Helpers
+
+    private static Activity CreateHeartRateActivity(string id, int bpm)
+    {
+        return new Activity
+        {
+            Id = id,
+            Mills = 1700000000000,
+            EnteredBy = "test",
+            AdditionalProperties = new Dictionary<string, object>
+            {
+                ["bpm"] = bpm,
+                ["accuracy"] = 1,
+            },
+        };
+    }
+
+    private static Activity CreateStepCountActivity(string id, int metric)
+    {
+        return new Activity
+        {
+            Id = id,
+            Mills = 1700000000000,
+            EnteredBy = "test",
+            AdditionalProperties = new Dictionary<string, object>
+            {
+                ["metric"] = metric,
+                ["source"] = 1,
+            },
+        };
+    }
+
+    private static Activity CreateRegularActivity(string id, string type)
+    {
+        return new Activity
+        {
+            Id = id,
+            Mills = 1700000000000,
+            Type = type,
+            EnteredBy = "test",
+        };
+    }
+
+    #endregion
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerBatchTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerBatchTests.cs
@@ -1,0 +1,321 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.V4;
+using Nocturne.Core.Contracts.Devices;
+using Nocturne.Core.Contracts.Glucose;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+using V4Models = Nocturne.Core.Models.V4;
+
+namespace Nocturne.API.Tests.Services.V4;
+
+public class DeviceStatusDecomposerBatchTests : IDisposable
+{
+    private readonly NocturneDbContext _context;
+    private readonly Mock<IApsSnapshotRepository> _apsRepoMock;
+    private readonly Mock<IPumpSnapshotRepository> _pumpRepoMock;
+    private readonly Mock<IUploaderSnapshotRepository> _uploaderRepoMock;
+    private readonly Mock<IDeviceStatusExtrasRepository> _extrasRepoMock;
+    private readonly Mock<IStateSpanService> _stateSpanServiceMock;
+    private readonly Mock<IDeviceService> _deviceServiceMock;
+    private readonly DeviceStatusDecomposer _decomposer;
+
+    public DeviceStatusDecomposerBatchTests()
+    {
+        _context = TestDbContextFactory.CreateInMemoryContext();
+        _context.TenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+        _apsRepoMock = new Mock<IApsSnapshotRepository>();
+        _pumpRepoMock = new Mock<IPumpSnapshotRepository>();
+        _uploaderRepoMock = new Mock<IUploaderSnapshotRepository>();
+        _extrasRepoMock = new Mock<IDeviceStatusExtrasRepository>();
+        _stateSpanServiceMock = new Mock<IStateSpanService>();
+        _deviceServiceMock = new Mock<IDeviceService>();
+
+        // BulkCreateAsync returns the input records
+        _apsRepoMock
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.ApsSnapshot>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<V4Models.ApsSnapshot> records, CancellationToken _) => records);
+        _pumpRepoMock
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.PumpSnapshot>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<V4Models.PumpSnapshot> records, CancellationToken _) => records);
+        _uploaderRepoMock
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.UploaderSnapshot>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<V4Models.UploaderSnapshot> records, CancellationToken _) => records);
+        _extrasRepoMock
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.DeviceStatusExtras>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<V4Models.DeviceStatusExtras> records, CancellationToken _) => records);
+
+        _decomposer = new DeviceStatusDecomposer(
+            _context,
+            _apsRepoMock.Object,
+            _pumpRepoMock.Object,
+            _uploaderRepoMock.Object,
+            _extrasRepoMock.Object,
+            _stateSpanServiceMock.Object,
+            _deviceServiceMock.Object,
+            NullLogger<DeviceStatusDecomposer>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_DecomposesAllSnapshotTypes()
+    {
+        // Arrange - one OpenAPS, one pump-only, one uploader-only
+        var statuses = new List<DeviceStatus>
+        {
+            new()
+            {
+                Id = "ds-openaps",
+                Mills = 1700000000000,
+                Device = "openaps://Samsung",
+                OpenAps = new OpenApsStatus
+                {
+                    Iob = new OpenApsIobData { Iob = 2.0 },
+                    Suggested = new OpenApsSuggested
+                    {
+                        Bg = 120.0, EventualBG = 100.0, Timestamp = "2023-11-14T12:00:00Z"
+                    }
+                }
+            },
+            new()
+            {
+                Id = "ds-pump",
+                Mills = 1700000001000,
+                Device = "openaps://Samsung",
+                Pump = new PumpStatus
+                {
+                    Manufacturer = "Insulet",
+                    Reservoir = 100.0,
+                    Battery = new PumpBattery { Percent = 85 }
+                }
+            },
+            new()
+            {
+                Id = "ds-uploader",
+                Mills = 1700000002000,
+                Device = "xDrip+",
+                Uploader = new UploaderStatus { Name = "Pixel 8", Battery = 55 }
+            }
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync(statuses);
+
+        // Assert
+        _apsRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<V4Models.ApsSnapshot>>(list => list.Count() == 1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _pumpRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<V4Models.PumpSnapshot>>(list => list.Count() == 1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _uploaderRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<V4Models.UploaderSnapshot>>(list => list.Count() == 1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        result.CreatedRecords.Should().HaveCount(3);
+        result.CorrelationId.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_EmptyBatch_NoRepositoryCalls()
+    {
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync([]);
+
+        // Assert
+        _apsRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.ApsSnapshot>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _pumpRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.PumpSnapshot>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _uploaderRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.UploaderSnapshot>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _extrasRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.DeviceStatusExtras>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        result.CreatedRecords.Should().BeEmpty();
+        result.CorrelationId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_CreatesDecompositionBatch()
+    {
+        // Arrange
+        var statuses = new List<DeviceStatus>
+        {
+            new()
+            {
+                Id = "ds-batch-1",
+                Mills = 1700000000000,
+                Device = "openaps://Samsung",
+                Pump = new PumpStatus { Reservoir = 100.0 }
+            }
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync(statuses);
+
+        // Assert
+        var batch = _context.DecompositionBatches.SingleOrDefault(b => b.Id == result.CorrelationId);
+        batch.Should().NotBeNull();
+        batch!.Source.Should().Be("device_status_decomposer_batch");
+        batch.SourceRecordId.Should().BeNull();
+        batch.TenantId.Should().Be(_context.TenantId);
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_HandlesMultipleSnapshotTypes()
+    {
+        // Arrange - single status with pump + APS + uploader
+        var statuses = new List<DeviceStatus>
+        {
+            new()
+            {
+                Id = "ds-full",
+                Mills = 1700000000000,
+                Device = "openaps://Samsung",
+                OpenAps = new OpenApsStatus
+                {
+                    Iob = new OpenApsIobData { Iob = 2.0 },
+                    Suggested = new OpenApsSuggested
+                    {
+                        Bg = 110.0, EventualBG = 100.0, Timestamp = "2023-11-14T12:00:00Z"
+                    }
+                },
+                Pump = new PumpStatus
+                {
+                    Manufacturer = "Medtronic",
+                    Reservoir = 100.0,
+                    Battery = new PumpBattery { Percent = 90 }
+                },
+                Uploader = new UploaderStatus { Name = "Pixel 8", Battery = 55 }
+            }
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync(statuses);
+
+        // Assert - all three snapshot types extracted from one device status
+        _apsRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<V4Models.ApsSnapshot>>(list => list.Count() == 1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _pumpRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<V4Models.PumpSnapshot>>(list => list.Count() == 1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _uploaderRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<V4Models.UploaderSnapshot>>(list => list.Count() == 1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        result.CreatedRecords.Should().HaveCount(3);
+        result.CreatedRecords.OfType<V4Models.ApsSnapshot>().Should().HaveCount(1);
+        result.CreatedRecords.OfType<V4Models.PumpSnapshot>().Should().HaveCount(1);
+        result.CreatedRecords.OfType<V4Models.UploaderSnapshot>().Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_CollectsExtras()
+    {
+        // Arrange - status with xDripJS data
+        var statuses = new List<DeviceStatus>
+        {
+            new()
+            {
+                Id = "ds-xdripjs",
+                Mills = 1700000000000,
+                Device = "xDrip+",
+                XDripJs = new XDripJsStatus { State = 6, StateString = "OK", VoltageA = 217, VoltageB = 212 },
+                Uploader = new UploaderStatus { Battery = 80 }
+            }
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync(statuses);
+
+        // Assert
+        _extrasRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<V4Models.DeviceStatusExtras>>(list =>
+                    list.Count() == 1
+                    && list.First().Extras!.ContainsKey("xdripjs")),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_CollectsOverrideStateSpans()
+    {
+        // Arrange - status with active override
+        var expectedStateSpan = new StateSpan
+        {
+            Id = "ss-override-batch",
+            Category = StateSpanCategory.Override,
+            StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(1700000000000).UtcDateTime,
+        };
+
+        _stateSpanServiceMock
+            .Setup(s => s.UpsertStateSpanAsync(It.IsAny<StateSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedStateSpan);
+
+        var statuses = new List<DeviceStatus>
+        {
+            new()
+            {
+                Id = "ds-override",
+                Mills = 1700000000000,
+                Device = "Loop/3.0",
+                Override = new OverrideStatus
+                {
+                    Active = true,
+                    Name = "Exercise",
+                    Duration = 60.0,
+                    Multiplier = 1.5,
+                }
+            }
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync(statuses);
+
+        // Assert
+        _stateSpanServiceMock.Verify(
+            s => s.UpsertStateSpanAsync(
+                It.Is<StateSpan>(ss =>
+                    ss.Category == StateSpanCategory.Override
+                    && ss.State == "Custom"
+                    && ss.OriginalId == "ds-override"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        result.CreatedRecords.Should().Contain(x => x is StateSpan);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/EntryDecomposerBatchTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/EntryDecomposerBatchTests.cs
@@ -1,0 +1,172 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.V4;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Nocturne.Infrastructure.Data;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.V4;
+
+public class EntryDecomposerBatchTests : IDisposable
+{
+    private readonly NocturneDbContext _context;
+    private readonly Mock<ISensorGlucoseRepository> _sgRepoMock;
+    private readonly Mock<IMeterGlucoseRepository> _mgRepoMock;
+    private readonly Mock<ICalibrationRepository> _calRepoMock;
+    private readonly EntryDecomposer _decomposer;
+
+    public EntryDecomposerBatchTests()
+    {
+        _context = TestDbContextFactory.CreateInMemoryContext();
+        _context.TenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+        _sgRepoMock = new Mock<ISensorGlucoseRepository>();
+        _mgRepoMock = new Mock<IMeterGlucoseRepository>();
+        _calRepoMock = new Mock<ICalibrationRepository>();
+
+        // BulkCreateAsync returns the input records
+        _sgRepoMock
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<SensorGlucose> records, CancellationToken _) => records);
+        _mgRepoMock
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<MeterGlucose>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<MeterGlucose> records, CancellationToken _) => records);
+        _calRepoMock
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<Calibration>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<Calibration> records, CancellationToken _) => records);
+
+        var mockConfigProvider = new Mock<IGlucoseProcessingConfigProvider>();
+        mockConfigProvider.Setup(x => x.GetSourceDefaultsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<GlucoseProcessingSourceDefault>());
+        mockConfigProvider.Setup(x => x.GetPreferredProcessingAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GlucoseProcessing?)null);
+        var glucoseResolver = new GlucoseProcessingResolver(mockConfigProvider.Object);
+
+        _decomposer = new EntryDecomposer(
+            _context,
+            _sgRepoMock.Object,
+            _mgRepoMock.Object,
+            _calRepoMock.Object,
+            glucoseResolver,
+            NullLogger<EntryDecomposer>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_PartitionsByType_CallsBulkCreate()
+    {
+        // Arrange — 2 sgv + 1 mbg + 1 cal
+        var entries = new List<Entry>
+        {
+            new() { Id = "sgv1", Type = "sgv", Mills = 1700000000000, Sgv = 120.0 },
+            new() { Id = "sgv2", Type = "sgv", Mills = 1700000001000, Sgv = 130.0 },
+            new() { Id = "mbg1", Type = "mbg", Mills = 1700000002000, Mbg = 140.0 },
+            new() { Id = "cal1", Type = "cal", Mills = 1700000003000, Slope = 850.0 },
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync(entries);
+
+        // Assert — correct partition sizes
+        _sgRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<SensorGlucose>>(list => list.Count() == 2),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _mgRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<MeterGlucose>>(list => list.Count() == 1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _calRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<Calibration>>(list => list.Count() == 1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        result.CreatedRecords.Should().HaveCount(4);
+        result.CorrelationId.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_EmptyBatch_NoRepositoryCalls()
+    {
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync([]);
+
+        // Assert
+        _sgRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mgRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<MeterGlucose>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _calRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<Calibration>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        result.CreatedRecords.Should().BeEmpty();
+        result.CorrelationId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_CreatesDecompositionBatch()
+    {
+        // Arrange
+        var entries = new List<Entry>
+        {
+            new() { Id = "sgv1", Type = "sgv", Mills = 1700000000000, Sgv = 100.0 },
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync(entries);
+
+        // Assert — a DecompositionBatchEntity was persisted
+        var batch = _context.DecompositionBatches.SingleOrDefault(b => b.Id == result.CorrelationId);
+        batch.Should().NotBeNull();
+        batch!.Source.Should().Be("entry_decomposer_batch");
+        batch.SourceRecordId.Should().BeNull();
+        batch.TenantId.Should().Be(_context.TenantId);
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_SkipsUnknownEntryTypes()
+    {
+        // Arrange — includes an unknown type "rawbg"
+        var entries = new List<Entry>
+        {
+            new() { Id = "sgv1", Type = "sgv", Mills = 1700000000000, Sgv = 100.0 },
+            new() { Id = "rawbg1", Type = "rawbg", Mills = 1700000001000 },
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync(entries);
+
+        // Assert — only 1 sgv, rawbg skipped
+        _sgRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<SensorGlucose>>(list => list.Count() == 1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mgRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<MeterGlucose>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _calRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<Calibration>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        result.CreatedRecords.Should().HaveCount(1);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/ProfileDecomposerBatchTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/ProfileDecomposerBatchTests.cs
@@ -1,0 +1,267 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.API.Services.V4;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Nocturne.Infrastructure.Data;
+
+namespace Nocturne.API.Tests.Services.V4;
+
+public class ProfileDecomposerBatchTests : IDisposable
+{
+    private readonly NocturneDbContext _context;
+    private readonly Mock<ITherapySettingsRepository> _therapySettingsRepoMock;
+    private readonly Mock<IBasalScheduleRepository> _basalScheduleRepoMock;
+    private readonly Mock<ICarbRatioScheduleRepository> _carbRatioScheduleRepoMock;
+    private readonly Mock<ISensitivityScheduleRepository> _sensitivityScheduleRepoMock;
+    private readonly Mock<ITargetRangeScheduleRepository> _targetRangeScheduleRepoMock;
+    private readonly ProfileDecomposer _decomposer;
+
+    public ProfileDecomposerBatchTests()
+    {
+        _context = TestDbContextFactory.CreateInMemoryContext();
+        _context.TenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+        _therapySettingsRepoMock = new Mock<ITherapySettingsRepository>();
+        _basalScheduleRepoMock = new Mock<IBasalScheduleRepository>();
+        _carbRatioScheduleRepoMock = new Mock<ICarbRatioScheduleRepository>();
+        _sensitivityScheduleRepoMock = new Mock<ISensitivityScheduleRepository>();
+        _targetRangeScheduleRepoMock = new Mock<ITargetRangeScheduleRepository>();
+
+        SetupBulkCreateReturnsInput(_therapySettingsRepoMock);
+        SetupBulkCreateReturnsInput(_basalScheduleRepoMock);
+        SetupBulkCreateReturnsInput(_carbRatioScheduleRepoMock);
+        SetupBulkCreateReturnsInput(_sensitivityScheduleRepoMock);
+        SetupBulkCreateReturnsInput(_targetRangeScheduleRepoMock);
+
+        _decomposer = new ProfileDecomposer(
+            _context,
+            _therapySettingsRepoMock.Object,
+            _basalScheduleRepoMock.Object,
+            _carbRatioScheduleRepoMock.Object,
+            _sensitivityScheduleRepoMock.Object,
+            _targetRangeScheduleRepoMock.Object,
+            NullLogger<ProfileDecomposer>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_FlattenAndBulkInsertSchedules()
+    {
+        // Arrange - 2 profiles with 1 store each
+        var profiles = new List<Profile>
+        {
+            CreateProfile("profile1", new Dictionary<string, ProfileData>
+            {
+                ["Default"] = CreateProfileData()
+            }),
+            CreateProfile("profile2", new Dictionary<string, ProfileData>
+            {
+                ["Night"] = CreateProfileData()
+            }),
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync(profiles);
+
+        // Assert - 2 profiles x 5 record types = 10 total records
+        _therapySettingsRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<TherapySettings>>(list => list.Count() == 2),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _basalScheduleRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<BasalSchedule>>(list => list.Count() == 2),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _carbRatioScheduleRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<CarbRatioSchedule>>(list => list.Count() == 2),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _sensitivityScheduleRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<SensitivitySchedule>>(list => list.Count() == 2),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _targetRangeScheduleRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<TargetRangeSchedule>>(list => list.Count() == 2),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        result.CreatedRecords.Should().HaveCount(10);
+        result.CorrelationId.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_EmptyBatch_NoRepositoryCalls()
+    {
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync([]);
+
+        // Assert
+        _therapySettingsRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<TherapySettings>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _basalScheduleRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<BasalSchedule>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _carbRatioScheduleRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<CarbRatioSchedule>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _sensitivityScheduleRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<SensitivitySchedule>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _targetRangeScheduleRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<TargetRangeSchedule>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        result.CreatedRecords.Should().BeEmpty();
+        result.CorrelationId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_BulkInsertsTherapySettings()
+    {
+        // Arrange
+        var profiles = new List<Profile>
+        {
+            CreateProfile("profile1", new Dictionary<string, ProfileData>
+            {
+                ["Default"] = CreateProfileData(dia: 4.0, timezone: "US/Eastern")
+            }),
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync(profiles);
+
+        // Assert - verify therapy settings were created with correct values
+        _therapySettingsRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<TherapySettings>>(list =>
+                    list.Any(ts =>
+                        ts.LegacyId == "profile1:Default" &&
+                        ts.Dia == 4.0 &&
+                        ts.Timezone == "US/Eastern" &&
+                        ts.IsDefault == true)),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // A DecompositionBatchEntity was persisted
+        var batch = _context.DecompositionBatches.SingleOrDefault(b => b.Id == result.CorrelationId);
+        batch.Should().NotBeNull();
+        batch!.Source.Should().Be("profile_decomposer_batch");
+        batch.TenantId.Should().Be(_context.TenantId);
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_MultipleStoresPerProfile()
+    {
+        // Arrange - 1 profile with 2 named stores
+        var profiles = new List<Profile>
+        {
+            CreateProfile("profile1", new Dictionary<string, ProfileData>
+            {
+                ["Default"] = CreateProfileData(),
+                ["Exercise"] = CreateProfileData(dia: 5.0),
+            }, defaultProfile: "Default"),
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync(profiles);
+
+        // Assert - 2 stores x 5 record types = 10 total records
+        _therapySettingsRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<TherapySettings>>(list =>
+                    list.Count() == 2 &&
+                    list.Any(ts => ts.LegacyId == "profile1:Default" && ts.IsDefault == true) &&
+                    list.Any(ts => ts.LegacyId == "profile1:Exercise" && ts.IsDefault == false)),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _basalScheduleRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<BasalSchedule>>(list => list.Count() == 2),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        result.CreatedRecords.Should().HaveCount(10);
+    }
+
+    #region Helpers
+
+    private static Profile CreateProfile(
+        string id,
+        Dictionary<string, ProfileData> store,
+        string defaultProfile = "Default")
+    {
+        return new Profile
+        {
+            Id = id,
+            Mills = 1700000000000,
+            DefaultProfile = defaultProfile,
+            EnteredBy = "test",
+            Store = store,
+        };
+    }
+
+    private static ProfileData CreateProfileData(
+        double dia = 3.0,
+        string? timezone = "UTC")
+    {
+        return new ProfileData
+        {
+            Dia = dia,
+            Timezone = timezone,
+            Basal = [new TimeValue { Time = "00:00", Value = 1.0 }],
+            CarbRatio = [new TimeValue { Time = "00:00", Value = 10.0 }],
+            Sens = [new TimeValue { Time = "00:00", Value = 50.0 }],
+            TargetLow = [new TimeValue { Time = "00:00", Value = 80.0 }],
+            TargetHigh = [new TimeValue { Time = "00:00", Value = 120.0 }],
+        };
+    }
+
+    private static void SetupBulkCreateReturnsInput(Mock<ITherapySettingsRepository> mock)
+    {
+        mock.Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<TherapySettings>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<TherapySettings> records, CancellationToken _) => records);
+    }
+
+    private static void SetupBulkCreateReturnsInput(Mock<IBasalScheduleRepository> mock)
+    {
+        mock.Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<BasalSchedule>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<BasalSchedule> records, CancellationToken _) => records);
+    }
+
+    private static void SetupBulkCreateReturnsInput(Mock<ICarbRatioScheduleRepository> mock)
+    {
+        mock.Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<CarbRatioSchedule>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<CarbRatioSchedule> records, CancellationToken _) => records);
+    }
+
+    private static void SetupBulkCreateReturnsInput(Mock<ISensitivityScheduleRepository> mock)
+    {
+        mock.Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<SensitivitySchedule>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<SensitivitySchedule> records, CancellationToken _) => records);
+    }
+
+    private static void SetupBulkCreateReturnsInput(Mock<ITargetRangeScheduleRepository> mock)
+    {
+        mock.Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<TargetRangeSchedule>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<TargetRangeSchedule> records, CancellationToken _) => records);
+    }
+
+    #endregion
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerBatchTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerBatchTests.cs
@@ -1,0 +1,355 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.V4;
+using Nocturne.Core.Contracts.Devices;
+using Nocturne.Core.Contracts.Treatments;
+using Nocturne.Core.Contracts.Glucose;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+using V4Models = Nocturne.Core.Models.V4;
+
+namespace Nocturne.API.Tests.Services.V4;
+
+public class TreatmentDecomposerBatchTests : IDisposable
+{
+    private readonly NocturneDbContext _context;
+    private readonly Mock<IBolusRepository> _bolusRepoMock;
+    private readonly Mock<ICarbIntakeRepository> _carbRepoMock;
+    private readonly Mock<IBGCheckRepository> _bgCheckRepoMock;
+    private readonly Mock<INoteRepository> _noteRepoMock;
+    private readonly Mock<IBolusCalculationRepository> _bolusCalcRepoMock;
+    private readonly Mock<IDeviceEventRepository> _deviceEventRepoMock;
+    private readonly Mock<ITempBasalRepository> _tempBasalRepoMock;
+    private readonly Mock<IStateSpanService> _stateSpanServiceMock;
+    private readonly Mock<ITreatmentFoodService> _treatmentFoodServiceMock;
+    private readonly Mock<IDeviceService> _deviceServiceMock;
+    private readonly Mock<IProfileDecomposer> _profileDecomposerMock;
+    private readonly TreatmentDecomposer _decomposer;
+
+    public TreatmentDecomposerBatchTests()
+    {
+        _context = TestDbContextFactory.CreateInMemoryContext();
+        _context.TenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+        _bolusRepoMock = new Mock<IBolusRepository>();
+        _carbRepoMock = new Mock<ICarbIntakeRepository>();
+        _bgCheckRepoMock = new Mock<IBGCheckRepository>();
+        _noteRepoMock = new Mock<INoteRepository>();
+        _bolusCalcRepoMock = new Mock<IBolusCalculationRepository>();
+        _deviceEventRepoMock = new Mock<IDeviceEventRepository>();
+        _tempBasalRepoMock = new Mock<ITempBasalRepository>();
+        _stateSpanServiceMock = new Mock<IStateSpanService>();
+        _treatmentFoodServiceMock = new Mock<ITreatmentFoodService>();
+        _deviceServiceMock = new Mock<IDeviceService>();
+        _profileDecomposerMock = new Mock<IProfileDecomposer>();
+
+        // BulkCreateAsync returns the input records
+        _bolusRepoMock
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.Bolus>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<V4Models.Bolus> records, CancellationToken _) => records);
+        _carbRepoMock
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.CarbIntake>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<V4Models.CarbIntake> records, CancellationToken _) => records);
+        _bgCheckRepoMock
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.BGCheck>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<V4Models.BGCheck> records, CancellationToken _) => records);
+        _noteRepoMock
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.Note>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<V4Models.Note> records, CancellationToken _) => records);
+        _bolusCalcRepoMock
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.BolusCalculation>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<V4Models.BolusCalculation> records, CancellationToken _) => records);
+        _deviceEventRepoMock
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.DeviceEvent>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<V4Models.DeviceEvent> records, CancellationToken _) => records);
+        _tempBasalRepoMock
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.TempBasal>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<V4Models.TempBasal> records, CancellationToken _) => records);
+
+        // StateSpanService returns a new StateSpan
+        _stateSpanServiceMock
+            .Setup(x => x.UpsertStateSpanAsync(It.IsAny<StateSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StateSpan span, CancellationToken _) => span);
+
+        // UpdateAsync returns the input bolus (for linking pass)
+        _bolusRepoMock
+            .Setup(x => x.UpdateAsync(It.IsAny<Guid>(), It.IsAny<V4Models.Bolus>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid _, V4Models.Bolus b, CancellationToken _) => b);
+
+        // DeviceService returns null by default
+        _deviceServiceMock
+            .Setup(s => s.ResolveAsync(It.IsAny<V4Models.DeviceCategory>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid?)null);
+
+        _decomposer = new TreatmentDecomposer(
+            _context,
+            _bolusRepoMock.Object,
+            _tempBasalRepoMock.Object,
+            _carbRepoMock.Object,
+            _bgCheckRepoMock.Object,
+            _noteRepoMock.Object,
+            _deviceEventRepoMock.Object,
+            _bolusCalcRepoMock.Object,
+            _stateSpanServiceMock.Object,
+            _treatmentFoodServiceMock.Object,
+            _deviceServiceMock.Object,
+            _profileDecomposerMock.Object,
+            NullLogger<TreatmentDecomposer>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_ClassifiesAndBulkInserts()
+    {
+        // Arrange — batch with a bolus, carb correction, note, and bg check
+        var treatments = new List<Treatment>
+        {
+            new() { Id = "bolus-1", EventType = "Correction Bolus", Mills = 1700000000000, Insulin = 2.5 },
+            new() { Id = "carb-1", EventType = "Carb Correction", Mills = 1700000001000, Carbs = 15 },
+            new() { Id = "note-1", EventType = "Note", Mills = 1700000002000, Notes = "Felt low" },
+            new() { Id = "bg-1", EventType = "BG Check", Mills = 1700000003000, Glucose = 95, GlucoseType = "Finger" },
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync(treatments);
+
+        // Assert — correct partition sizes
+        _bolusRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<V4Models.Bolus>>(list => list.Count() == 1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _carbRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<V4Models.CarbIntake>>(list => list.Count() == 1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _noteRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<V4Models.Note>>(list => list.Count() == 1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _bgCheckRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<V4Models.BGCheck>>(list => list.Count() == 1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // No bolus calc, device event, or temp basal calls
+        _bolusCalcRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.BolusCalculation>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _deviceEventRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.DeviceEvent>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _tempBasalRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.TempBasal>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        result.CreatedRecords.Should().HaveCount(4);
+        result.CorrelationId.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_EmptyBatch_NoRepositoryCalls()
+    {
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync([]);
+
+        // Assert
+        _bolusRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.Bolus>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _carbRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.CarbIntake>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _bgCheckRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.BGCheck>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _noteRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.Note>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _bolusCalcRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.BolusCalculation>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _deviceEventRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.DeviceEvent>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _tempBasalRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.TempBasal>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        result.CreatedRecords.Should().BeEmpty();
+        result.CorrelationId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_StateSpanTreatments_UsesTempBasalBulkAndIndividualUpsert()
+    {
+        // Arrange — temp basal (bulk-insertable) + temporary target (individual upsert)
+        var treatments = new List<Treatment>
+        {
+            new() { Id = "tb-1", EventType = "Temp Basal", Mills = 1700000000000, Duration = 30, Absolute = 1.5 },
+            new() { Id = "tt-1", EventType = "Temporary Target", Mills = 1700000001000, Duration = 60, TargetTop = 120, TargetBottom = 100 },
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync(treatments);
+
+        // Assert — temp basal uses bulk insert
+        _tempBasalRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<V4Models.TempBasal>>(list => list.Count() == 1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Temporary target uses individual state span upsert
+        _stateSpanServiceMock.Verify(
+            x => x.UpsertStateSpanAsync(
+                It.Is<StateSpan>(s => s.Category == StateSpanCategory.TemporaryTarget),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        result.CreatedRecords.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_LinksBolusToCalculation()
+    {
+        // Arrange — Bolus Wizard treatment that produces both bolus and calculation
+        var treatments = new List<Treatment>
+        {
+            new()
+            {
+                Id = "bw-1",
+                EventType = "Bolus Wizard",
+                Mills = 1700000000000,
+                Insulin = 3.0,
+                Carbs = 30,
+                BloodGlucoseInput = 150,
+                CR = 10,
+            },
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync(treatments);
+
+        // Assert — both bolus and calculation created
+        _bolusRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<V4Models.Bolus>>(list => list.Count() == 1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _bolusCalcRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<V4Models.BolusCalculation>>(list => list.Count() == 1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Carb intake also produced (insulin + carbs override rule)
+        _carbRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<V4Models.CarbIntake>>(list => list.Count() == 1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Linking pass: UpdateAsync called to set BolusCalculationId on the bolus
+        _bolusRepoMock.Verify(
+            x => x.UpdateAsync(It.IsAny<Guid>(), It.IsAny<V4Models.Bolus>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Verify the bolus in CreatedRecords has a linked BolusCalculationId
+        var bolus = result.CreatedRecords.OfType<V4Models.Bolus>().Single();
+        var calc = result.CreatedRecords.OfType<V4Models.BolusCalculation>().Single();
+        bolus.BolusCalculationId.Should().Be(calc.Id);
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_CreatesDecompositionBatch()
+    {
+        // Arrange
+        var treatments = new List<Treatment>
+        {
+            new() { Id = "bolus-1", EventType = "Correction Bolus", Mills = 1700000000000, Insulin = 1.0 },
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync(treatments);
+
+        // Assert — a DecompositionBatchEntity was persisted
+        var batch = _context.DecompositionBatches.SingleOrDefault(b => b.Id == result.CorrelationId);
+        batch.Should().NotBeNull();
+        batch!.Source.Should().Be("treatment_decomposer_batch");
+        batch.SourceRecordId.Should().BeNull();
+        batch.TenantId.Should().Be(_context.TenantId);
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_MealBolus_ProducesBothBolusAndCarbIntake()
+    {
+        // Arrange — Meal Bolus should produce both bolus + carb
+        var treatments = new List<Treatment>
+        {
+            new() { Id = "meal-1", EventType = "Meal Bolus", Mills = 1700000000000, Insulin = 5.0, Carbs = 45 },
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync(treatments);
+
+        // Assert
+        _bolusRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<V4Models.Bolus>>(list => list.Count() == 1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _carbRepoMock.Verify(
+            x => x.BulkCreateAsync(
+                It.Is<IEnumerable<V4Models.CarbIntake>>(list => list.Count() == 1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        result.CreatedRecords.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task DecomposeBatchAsync_ProfileSwitch_DelegatesToStateSpanService()
+    {
+        // Arrange
+        var treatments = new List<Treatment>
+        {
+            new() { Id = "ps-1", EventType = "Profile Switch", Mills = 1700000000000, Profile = "Default", Duration = 0 },
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync(treatments);
+
+        // Assert — profile switch uses individual upsert, not bulk insert
+        _stateSpanServiceMock.Verify(
+            x => x.UpsertStateSpanAsync(
+                It.Is<StateSpan>(s => s.Category == StateSpanCategory.Profile),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _tempBasalRepoMock.Verify(
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.TempBasal>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        result.CreatedRecords.Should().HaveCount(1);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/ApsSnapshotRepositoryBulkCreateTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/ApsSnapshotRepositoryBulkCreateTests.cs
@@ -1,0 +1,107 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class ApsSnapshotRepositoryBulkCreateTests : IDisposable
+{
+    private static readonly Guid TenantA = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    private readonly NocturneDbContext _context;
+    private readonly ApsSnapshotRepository _repository;
+
+    public ApsSnapshotRepositoryBulkCreateTests()
+    {
+        var dbName = $"aps_snapshot_bulk_tests_{Guid.NewGuid()}";
+        _context = TestDbContextFactory.CreateInMemoryContext(dbName);
+        _context.TenantId = TenantA;
+        _repository = new ApsSnapshotRepository(_context, NullLogger<ApsSnapshotRepository>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static ApsSnapshot CreateSnapshot(string? legacyId = null, DateTime? timestamp = null)
+    {
+        return new ApsSnapshot
+        {
+            Timestamp = timestamp ?? new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc),
+            UtcOffset = 0,
+            LegacyId = legacyId,
+            AidAlgorithm = AidAlgorithm.Loop,
+            Enacted = false,
+        };
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_InsertsNewRecords()
+    {
+        var snapshots = new[]
+        {
+            CreateSnapshot("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)),
+            CreateSnapshot("legacy-2", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
+            CreateSnapshot("legacy-3", new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc)),
+        };
+
+        var result = (await _repository.BulkCreateAsync(snapshots)).ToList();
+
+        result.Should().HaveCount(3);
+        var dbCount = _context.ApsSnapshots.Count();
+        dbCount.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_DeduplicatesByLegacyId_SkipsExisting()
+    {
+        // Pre-insert a record with legacy-1
+        await _repository.CreateAsync(CreateSnapshot("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)));
+
+        var snapshots = new[]
+        {
+            CreateSnapshot("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)),
+            CreateSnapshot("legacy-new", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
+        };
+
+        var result = (await _repository.BulkCreateAsync(snapshots)).ToList();
+
+        result.Should().HaveCount(1);
+        result[0].LegacyId.Should().Be("legacy-new");
+        var dbCount = _context.ApsSnapshots.Count();
+        dbCount.Should().Be(2); // 1 pre-existing + 1 new
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_DeduplicatesWithinBatch()
+    {
+        var snapshots = new[]
+        {
+            CreateSnapshot("legacy-dup", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)),
+            CreateSnapshot("legacy-dup", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
+        };
+
+        var result = (await _repository.BulkCreateAsync(snapshots)).ToList();
+
+        result.Should().HaveCount(1);
+        var dbCount = _context.ApsSnapshots.Count();
+        dbCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_EmptyInput_ReturnsEmpty()
+    {
+        var result = (await _repository.BulkCreateAsync([])).ToList();
+
+        result.Should().BeEmpty();
+        var dbCount = _context.ApsSnapshots.Count();
+        dbCount.Should().Be(0);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/CalibrationRepositoryBulkCreateTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/CalibrationRepositoryBulkCreateTests.cs
@@ -1,0 +1,105 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class CalibrationRepositoryBulkCreateTests : IDisposable
+{
+    private static readonly Guid TenantA = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    private readonly NocturneDbContext _context;
+    private readonly CalibrationRepository _repository;
+
+    public CalibrationRepositoryBulkCreateTests()
+    {
+        var dbName = $"calibration_bulk_tests_{Guid.NewGuid()}";
+        _context = TestDbContextFactory.CreateInMemoryContext(dbName);
+        _context.TenantId = TenantA;
+        _repository = new CalibrationRepository(_context, NullLogger<CalibrationRepository>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static Calibration CreateRecord(string? legacyId = null, DateTime? timestamp = null)
+    {
+        return new Calibration
+        {
+            Timestamp = timestamp ?? new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc),
+            UtcOffset = 0,
+            LegacyId = legacyId,
+        };
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_InsertsNewRecords()
+    {
+        var records = new[]
+        {
+            CreateRecord("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)),
+            CreateRecord("legacy-2", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
+            CreateRecord("legacy-3", new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc)),
+        };
+
+        var result = (await _repository.BulkCreateAsync(records)).ToList();
+
+        result.Should().HaveCount(3);
+        var dbCount = _context.Calibrations.Count();
+        dbCount.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_DeduplicatesByLegacyId_SkipsExisting()
+    {
+        // Pre-insert a record with legacy-1
+        await _repository.CreateAsync(CreateRecord("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)));
+
+        var records = new[]
+        {
+            CreateRecord("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)),
+            CreateRecord("legacy-new", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
+        };
+
+        var result = (await _repository.BulkCreateAsync(records)).ToList();
+
+        result.Should().HaveCount(1);
+        result[0].LegacyId.Should().Be("legacy-new");
+        var dbCount = _context.Calibrations.Count();
+        dbCount.Should().Be(2); // 1 pre-existing + 1 new
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_DeduplicatesWithinBatch()
+    {
+        var records = new[]
+        {
+            CreateRecord("legacy-dup", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)),
+            CreateRecord("legacy-dup", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
+        };
+
+        var result = (await _repository.BulkCreateAsync(records)).ToList();
+
+        result.Should().HaveCount(1);
+        var dbCount = _context.Calibrations.Count();
+        dbCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_EmptyInput_ReturnsEmpty()
+    {
+        var result = (await _repository.BulkCreateAsync([])).ToList();
+
+        result.Should().BeEmpty();
+        var dbCount = _context.Calibrations.Count();
+        dbCount.Should().Be(0);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/DeviceStatusExtrasRepositoryBulkCreateTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/DeviceStatusExtrasRepositoryBulkCreateTests.cs
@@ -1,0 +1,108 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class DeviceStatusExtrasRepositoryBulkCreateTests : IDisposable
+{
+    private static readonly Guid TenantA = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    private readonly NocturneDbContext _context;
+    private readonly DeviceStatusExtrasRepository _repository;
+
+    public DeviceStatusExtrasRepositoryBulkCreateTests()
+    {
+        var dbName = $"device_status_extras_bulk_tests_{Guid.NewGuid()}";
+        _context = TestDbContextFactory.CreateInMemoryContext(dbName);
+        _context.TenantId = TenantA;
+        _repository = new DeviceStatusExtrasRepository(_context, NullLogger<DeviceStatusExtrasRepository>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static DeviceStatusExtras CreateRecord(Guid? correlationId = null, DateTime? timestamp = null)
+    {
+        return new DeviceStatusExtras
+        {
+            Timestamp = timestamp ?? new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc),
+            CorrelationId = correlationId ?? Guid.NewGuid(),
+        };
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_InsertsNewRecords()
+    {
+        var records = new[]
+        {
+            CreateRecord(Guid.NewGuid(), new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)),
+            CreateRecord(Guid.NewGuid(), new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
+            CreateRecord(Guid.NewGuid(), new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc)),
+        };
+
+        var result = (await _repository.BulkCreateAsync(records)).ToList();
+
+        result.Should().HaveCount(3);
+        var dbCount = _context.DeviceStatusExtras.Count();
+        dbCount.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_DeduplicatesByCorrelationId_SkipsExisting()
+    {
+        var existingCorrelationId = Guid.NewGuid();
+        var newCorrelationId = Guid.NewGuid();
+
+        // Pre-insert a record
+        await _repository.CreateAsync(CreateRecord(existingCorrelationId, new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)));
+
+        var records = new[]
+        {
+            CreateRecord(existingCorrelationId, new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)),
+            CreateRecord(newCorrelationId, new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
+        };
+
+        var result = (await _repository.BulkCreateAsync(records)).ToList();
+
+        result.Should().HaveCount(1);
+        result[0].CorrelationId.Should().Be(newCorrelationId);
+        var dbCount = _context.DeviceStatusExtras.Count();
+        dbCount.Should().Be(2); // 1 pre-existing + 1 new
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_DeduplicatesWithinBatch()
+    {
+        var sharedCorrelationId = Guid.NewGuid();
+        var records = new[]
+        {
+            CreateRecord(sharedCorrelationId, new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)),
+            CreateRecord(sharedCorrelationId, new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
+        };
+
+        var result = (await _repository.BulkCreateAsync(records)).ToList();
+
+        result.Should().HaveCount(1);
+        var dbCount = _context.DeviceStatusExtras.Count();
+        dbCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_EmptyInput_ReturnsEmpty()
+    {
+        var result = (await _repository.BulkCreateAsync([])).ToList();
+
+        result.Should().BeEmpty();
+        var dbCount = _context.DeviceStatusExtras.Count();
+        dbCount.Should().Be(0);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/MeterGlucoseRepositoryBulkCreateTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/MeterGlucoseRepositoryBulkCreateTests.cs
@@ -1,0 +1,106 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class MeterGlucoseRepositoryBulkCreateTests : IDisposable
+{
+    private static readonly Guid TenantA = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    private readonly NocturneDbContext _context;
+    private readonly MeterGlucoseRepository _repository;
+
+    public MeterGlucoseRepositoryBulkCreateTests()
+    {
+        var dbName = $"meter_glucose_bulk_tests_{Guid.NewGuid()}";
+        _context = TestDbContextFactory.CreateInMemoryContext(dbName);
+        _context.TenantId = TenantA;
+        _repository = new MeterGlucoseRepository(_context, NullLogger<MeterGlucoseRepository>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static MeterGlucose CreateRecord(string? legacyId = null, DateTime? timestamp = null)
+    {
+        return new MeterGlucose
+        {
+            Timestamp = timestamp ?? new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc),
+            UtcOffset = 0,
+            LegacyId = legacyId,
+            Mgdl = 120,
+        };
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_InsertsNewRecords()
+    {
+        var records = new[]
+        {
+            CreateRecord("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)),
+            CreateRecord("legacy-2", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
+            CreateRecord("legacy-3", new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc)),
+        };
+
+        var result = (await _repository.BulkCreateAsync(records)).ToList();
+
+        result.Should().HaveCount(3);
+        var dbCount = _context.MeterGlucose.Count();
+        dbCount.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_DeduplicatesByLegacyId_SkipsExisting()
+    {
+        // Pre-insert a record with legacy-1
+        await _repository.CreateAsync(CreateRecord("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)));
+
+        var records = new[]
+        {
+            CreateRecord("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)),
+            CreateRecord("legacy-new", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
+        };
+
+        var result = (await _repository.BulkCreateAsync(records)).ToList();
+
+        result.Should().HaveCount(1);
+        result[0].LegacyId.Should().Be("legacy-new");
+        var dbCount = _context.MeterGlucose.Count();
+        dbCount.Should().Be(2); // 1 pre-existing + 1 new
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_DeduplicatesWithinBatch()
+    {
+        var records = new[]
+        {
+            CreateRecord("legacy-dup", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)),
+            CreateRecord("legacy-dup", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
+        };
+
+        var result = (await _repository.BulkCreateAsync(records)).ToList();
+
+        result.Should().HaveCount(1);
+        var dbCount = _context.MeterGlucose.Count();
+        dbCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_EmptyInput_ReturnsEmpty()
+    {
+        var result = (await _repository.BulkCreateAsync([])).ToList();
+
+        result.Should().BeEmpty();
+        var dbCount = _context.MeterGlucose.Count();
+        dbCount.Should().Be(0);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/PumpSnapshotRepositoryBulkCreateTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/PumpSnapshotRepositoryBulkCreateTests.cs
@@ -1,0 +1,105 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class PumpSnapshotRepositoryBulkCreateTests : IDisposable
+{
+    private static readonly Guid TenantA = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    private readonly NocturneDbContext _context;
+    private readonly PumpSnapshotRepository _repository;
+
+    public PumpSnapshotRepositoryBulkCreateTests()
+    {
+        var dbName = $"pump_snapshot_bulk_tests_{Guid.NewGuid()}";
+        _context = TestDbContextFactory.CreateInMemoryContext(dbName);
+        _context.TenantId = TenantA;
+        _repository = new PumpSnapshotRepository(_context, NullLogger<PumpSnapshotRepository>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static PumpSnapshot CreateSnapshot(string? legacyId = null, DateTime? timestamp = null)
+    {
+        return new PumpSnapshot
+        {
+            Timestamp = timestamp ?? new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc),
+            UtcOffset = 0,
+            LegacyId = legacyId,
+        };
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_InsertsNewRecords()
+    {
+        var snapshots = new[]
+        {
+            CreateSnapshot("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)),
+            CreateSnapshot("legacy-2", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
+            CreateSnapshot("legacy-3", new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc)),
+        };
+
+        var result = (await _repository.BulkCreateAsync(snapshots)).ToList();
+
+        result.Should().HaveCount(3);
+        var dbCount = _context.PumpSnapshots.Count();
+        dbCount.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_DeduplicatesByLegacyId_SkipsExisting()
+    {
+        // Pre-insert a record with legacy-1
+        await _repository.CreateAsync(CreateSnapshot("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)));
+
+        var snapshots = new[]
+        {
+            CreateSnapshot("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)),
+            CreateSnapshot("legacy-new", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
+        };
+
+        var result = (await _repository.BulkCreateAsync(snapshots)).ToList();
+
+        result.Should().HaveCount(1);
+        result[0].LegacyId.Should().Be("legacy-new");
+        var dbCount = _context.PumpSnapshots.Count();
+        dbCount.Should().Be(2); // 1 pre-existing + 1 new
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_DeduplicatesWithinBatch()
+    {
+        var snapshots = new[]
+        {
+            CreateSnapshot("legacy-dup", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)),
+            CreateSnapshot("legacy-dup", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
+        };
+
+        var result = (await _repository.BulkCreateAsync(snapshots)).ToList();
+
+        result.Should().HaveCount(1);
+        var dbCount = _context.PumpSnapshots.Count();
+        dbCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_EmptyInput_ReturnsEmpty()
+    {
+        var result = (await _repository.BulkCreateAsync([])).ToList();
+
+        result.Should().BeEmpty();
+        var dbCount = _context.PumpSnapshots.Count();
+        dbCount.Should().Be(0);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/UploaderSnapshotRepositoryBulkCreateTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/UploaderSnapshotRepositoryBulkCreateTests.cs
@@ -1,0 +1,105 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class UploaderSnapshotRepositoryBulkCreateTests : IDisposable
+{
+    private static readonly Guid TenantA = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    private readonly NocturneDbContext _context;
+    private readonly UploaderSnapshotRepository _repository;
+
+    public UploaderSnapshotRepositoryBulkCreateTests()
+    {
+        var dbName = $"uploader_snapshot_bulk_tests_{Guid.NewGuid()}";
+        _context = TestDbContextFactory.CreateInMemoryContext(dbName);
+        _context.TenantId = TenantA;
+        _repository = new UploaderSnapshotRepository(_context, NullLogger<UploaderSnapshotRepository>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static UploaderSnapshot CreateSnapshot(string? legacyId = null, DateTime? timestamp = null)
+    {
+        return new UploaderSnapshot
+        {
+            Timestamp = timestamp ?? new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc),
+            UtcOffset = 0,
+            LegacyId = legacyId,
+        };
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_InsertsNewRecords()
+    {
+        var snapshots = new[]
+        {
+            CreateSnapshot("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)),
+            CreateSnapshot("legacy-2", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
+            CreateSnapshot("legacy-3", new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc)),
+        };
+
+        var result = (await _repository.BulkCreateAsync(snapshots)).ToList();
+
+        result.Should().HaveCount(3);
+        var dbCount = _context.UploaderSnapshots.Count();
+        dbCount.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_DeduplicatesByLegacyId_SkipsExisting()
+    {
+        // Pre-insert a record with legacy-1
+        await _repository.CreateAsync(CreateSnapshot("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)));
+
+        var snapshots = new[]
+        {
+            CreateSnapshot("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)),
+            CreateSnapshot("legacy-new", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
+        };
+
+        var result = (await _repository.BulkCreateAsync(snapshots)).ToList();
+
+        result.Should().HaveCount(1);
+        result[0].LegacyId.Should().Be("legacy-new");
+        var dbCount = _context.UploaderSnapshots.Count();
+        dbCount.Should().Be(2); // 1 pre-existing + 1 new
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_DeduplicatesWithinBatch()
+    {
+        var snapshots = new[]
+        {
+            CreateSnapshot("legacy-dup", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)),
+            CreateSnapshot("legacy-dup", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
+        };
+
+        var result = (await _repository.BulkCreateAsync(snapshots)).ToList();
+
+        result.Should().HaveCount(1);
+        var dbCount = _context.UploaderSnapshots.Count();
+        dbCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_EmptyInput_ReturnsEmpty()
+    {
+        var result = (await _repository.BulkCreateAsync([])).ToList();
+
+        result.Should().BeEmpty();
+        var dbCount = _context.UploaderSnapshots.Count();
+        dbCount.Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Summary

- **Fix completeness**: API migration now imports ALL 6 Nightscout collections (entries, treatments, devicestatus, profiles, food, activity). Previously entries, treatments, and activity were entirely missing; devicestatus was capped at 10K; food got ~10-20 records.
- **Fix performance**: Added `DecomposeBatchAsync` to all 5 decomposers (Entry, DeviceStatus, Treatment, Profile, Activity) that use `BulkCreateAsync` on repositories — eliminates N+1 DB round-trips. ~300K DB calls per 100K entries → ~200.
- **Backward pagination**: All collections paginate through the entire Nightscout dataset at 10K records per page with no artificial limits.
- **6 new `BulkCreateAsync` repositories**: ApsSnapshot, PumpSnapshot, UploaderSnapshot, MeterGlucose, Calibration, DeviceStatusExtras — all follow the established SensorGlucoseRepository pattern (LegacyId dedup, 500-record chunks, ChangeTracker.Clear).
- **Idempotent**: Re-running a migration safely skips already-imported records via LegacyId deduplication.
- **61 new tests** across 11 test files.

## Key design decisions

- Pump suspension state spans processed as a post-insert sequential pass (order-dependent `GetLatestBeforeAsync`)
- Mapping helpers extracted into shared `MapTo*` methods — both `DecomposeAsync` and `DecomposeBatchAsync` call the same mappers (DRY)
- Existing single-document `DecomposeAsync` unchanged — no impact to API controllers or connector service
- MongoDB mode untouched (out of scope)

## Test plan

- [ ] Build succeeds with 0 errors
- [ ] 300 Infrastructure.Data unit tests pass
- [ ] 3000+ API unit tests pass (excluding known integration/parity tests)
- [ ] Manual: run migration against a real Nightscout instance and verify all collections imported
- [ ] Manual: re-run same migration, verify idempotent (no duplicates)