### PR TITLE
feat(connector): Allowing connectors to override active/stale/inactive status

### DIFF
--- a/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
@@ -77,6 +77,11 @@ public class DataSourceService : IDataSourceService
             .Select(g => new { Device = g.Key!, LastMills = new DateTimeOffset(g.Max(ds => ds.Timestamp), TimeSpan.Zero).ToUnixTimeMilliseconds() })
             .ToListAsync(cancellationToken);
 
+        // Build a lookup of connector stats providers keyed by DataSourceId
+        var connectorProviders = ConnectorMetadataService.GetAll()
+            .Where(c => !string.IsNullOrEmpty(c.DataSourceId))
+            .ToDictionary(c => c.DataSourceId, c => c, StringComparer.OrdinalIgnoreCase);
+
         var dataSources = new List<DataSourceInfo>();
 
         foreach (var device in entryDevices)
@@ -95,15 +100,29 @@ public class DataSourceService : IDataSourceService
                 info.LastSeen = DateTimeOffset.FromUnixTimeMilliseconds(dsDevice.LastMills);
             }
 
-            // Calculate status
-            var minutesSinceLast = (int)(now - info.LastSeen.Value).TotalMinutes;
-            info.MinutesSinceLastData = minutesSinceLast;
-            info.Status = minutesSinceLast switch
+            // If this device belongs to a server connector with a custom stats provider,
+            // let it customize the displayed stats (total entries, last seen, status thresholds).
+            // Connectors without a custom provider use the default glucose-only behavior.
+            var dataSourceId = device.DataSource ?? device.Device;
+            if (dataSourceId != null
+                && connectorProviders.TryGetValue(dataSourceId, out var connectorMeta)
+                && connectorMeta.StatsProvider != null)
             {
-                < 15 => "active",
-                < 60 => "stale",
-                _ => "inactive",
-            };
+                try
+                {
+                    var stats = await GetDataSourceStatsAsync(dataSourceId, cancellationToken);
+                    connectorMeta.StatsProvider.ApplyStats(info, stats, now);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to apply connector stats for {DataSource}", dataSourceId);
+                    ApplyDefaultStatus(info, now);
+                }
+            }
+            else
+            {
+                ApplyDefaultStatus(info, now);
+            }
 
             dataSources.Add(info);
         }
@@ -119,20 +138,50 @@ public class DataSourceService : IDataSourceService
                 info.TotalEntries = 0;
                 info.EntriesLast24Hours = 0;
 
-                var minutesSinceLast = (int)(now - info.LastSeen.Value).TotalMinutes;
-                info.MinutesSinceLastData = minutesSinceLast;
-                info.Status = minutesSinceLast switch
-                {
-                    < 15 => "active",
-                    < 60 => "stale",
-                    _ => "inactive",
-                };
-
+                ApplyDefaultStatus(info, now);
                 dataSources.Add(info);
             }
         }
 
+        // Add server connectors that have a custom stats provider and data but no sensor glucose records
+        // (e.g., connectors that only sync treatments/food without CGM backfill)
+        foreach (var (dsId, connectorMeta) in connectorProviders)
+        {
+            if (connectorMeta.StatsProvider == null) continue;
+            if (dataSources.Any(d => d.DeviceId == dsId || d.SourceType == dsId))
+                continue;
+
+            try
+            {
+                var stats = await GetDataSourceStatsAsync(dsId, cancellationToken);
+                if (stats.TotalItems <= 0) continue;
+
+                var info = CreateDataSourceInfo(dsId, dsId);
+                connectorMeta.StatsProvider.ApplyStats(info, stats, now);
+
+                dataSources.Add(info);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to get stats for connector data source {DataSource}", dsId);
+            }
+        }
+
         return dataSources.OrderByDescending(d => d.LastSeen).ToList();
+    }
+
+    private static void ApplyDefaultStatus(DataSourceInfo info, DateTimeOffset now)
+    {
+        var minutesSinceLast = info.LastSeen.HasValue
+            ? (int)(now - info.LastSeen.Value).TotalMinutes
+            : int.MaxValue;
+        info.MinutesSinceLastData = minutesSinceLast;
+        info.Status = minutesSinceLast switch
+        {
+            < 15 => "active",
+            < 60 => "stale",
+            _ => "inactive",
+        };
     }
 
     /// <inheritdoc />

--- a/src/Connectors/Nocturne.Connectors.Core/Extensions/AspireAttributes.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Extensions/AspireAttributes.cs
@@ -1,4 +1,5 @@
 using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Core.Services;
 
 namespace Nocturne.Connectors.Core.Extensions;
 
@@ -125,4 +126,11 @@ public class ConnectorRegistrationAttribute(
     ///     Supported data types for this connector.
     /// </summary>
     public SyncDataType[] SupportedDataTypes { get; set; } = [SyncDataType.Glucose];
+
+    /// <summary>
+    ///     Optional type of a <see cref="ConnectorStatsProvider"/> subclass that customizes
+    ///     how this connector's data appears in the Active Data Sources UI.
+    ///     Must have a parameterless constructor. When null, the default provider is used.
+    /// </summary>
+    public Type? StatsProviderType { get; set; }
 }

--- a/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorMetadataService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorMetadataService.cs
@@ -123,7 +123,10 @@ public static class ConnectorMetadataService
                             Icon = attr.Icon,
                             Category = attr.Category,
                             Description = attr.Description,
-                            ServiceName = attr.ServiceName
+                            ServiceName = attr.ServiceName,
+                            StatsProvider = attr.StatsProviderType != null
+                                ? Activator.CreateInstance(attr.StatsProviderType) as ConnectorStatsProvider
+                                : null,
                         };
 
                         ConnectorsByDataSourceId[attr.DataSourceId] = info;
@@ -153,6 +156,14 @@ public static class ConnectorMetadataService
         public ConnectorCategory Category { get; init; } = ConnectorCategory.Other;
         public string Description { get; init; } = string.Empty;
         public string ServiceName { get; set; } = string.Empty;
+
+        /// <summary>
+        ///     Optional custom stats provider for this connector.
+        ///     When set, <see cref="ConnectorStatsProvider.ApplyStats"/> is called to customize
+        ///     how this connector's data appears in the Active Data Sources UI.
+        ///     When null, <see cref="ConnectorStatsProvider.Default"/> is used.
+        /// </summary>
+        public ConnectorStatsProvider? StatsProvider { get; set; }
 
         /// <summary>
         ///     Converts this connector info to an AvailableService for UI consumption.

--- a/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorStatsProvider.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorStatsProvider.cs
@@ -1,0 +1,69 @@
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Services;
+
+namespace Nocturne.Connectors.Core.Services;
+
+/// <summary>
+///     Provides customizable stats presentation for a connector's data source entry
+///     in the Active Data Sources UI. Connectors can subclass this to override how
+///     their stats (total entries, last seen, status thresholds) are calculated from
+///     the raw <see cref="DataSourceStats"/>.
+/// </summary>
+/// <remarks>
+///     The default implementation uses all data across all tables with a 6-hour
+///     stale threshold (appropriate for batch/periodic connectors). Real-time uploaders
+///     (xDrip, Loop) don't use this — they use the built-in 15-minute threshold.
+/// </remarks>
+public class ConnectorStatsProvider
+{
+    /// <summary>
+    ///     Singleton default provider used when a connector doesn't specify a custom one.
+    /// </summary>
+    public static ConnectorStatsProvider Default { get; } = new();
+
+    /// <summary>
+    ///     Applies stats from <paramref name="stats"/> to the <paramref name="info"/> data source entry.
+    ///     Override this method in a connector-specific subclass to customize which stats
+    ///     are displayed and how the active/stale/inactive status is determined.
+    /// </summary>
+    /// <param name="info">The data source info to populate. May already have glucose-only stats set.</param>
+    /// <param name="stats">Comprehensive stats across all V4 tables for this data source.</param>
+    /// <param name="now">Current time for calculating minutes-since-last.</param>
+    public virtual void ApplyStats(DataSourceInfo info, DataSourceStats stats, DateTimeOffset now)
+    {
+        // Use total items across all tables (glucose + treatments + state spans)
+        info.TotalEntries = stats.TotalItems;
+        info.EntriesLast24Hours = stats.ItemsLast24Hours;
+
+        // Use the most recent item time across all tables
+        if (stats.LastItemTime.HasValue)
+        {
+            var lastItemOffset = new DateTimeOffset(stats.LastItemTime.Value, TimeSpan.Zero);
+            if (!info.LastSeen.HasValue || lastItemOffset > info.LastSeen.Value)
+                info.LastSeen = lastItemOffset;
+        }
+
+        // Use the earliest item time for FirstSeen
+        var firstTimes = new[] { stats.FirstEntryTime, stats.FirstTreatmentTime, stats.FirstStateSpanTime }
+            .Where(t => t.HasValue)
+            .ToArray();
+        if (firstTimes.Length > 0)
+        {
+            var earliest = new DateTimeOffset(firstTimes.Min()!.Value, TimeSpan.Zero);
+            if (!info.FirstSeen.HasValue || earliest < info.FirstSeen.Value)
+                info.FirstSeen = earliest;
+        }
+
+        // Apply status with batch connector thresholds (6h stale window)
+        var minutesSinceLast = info.LastSeen.HasValue
+            ? (int)(now - info.LastSeen.Value).TotalMinutes
+            : int.MaxValue;
+        info.MinutesSinceLastData = minutesSinceLast;
+        info.Status = minutesSinceLast switch
+        {
+            < 60 => "active",
+            < 360 => "stale",
+            _ => "inactive",
+        };
+    }
+}

--- a/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConnectorConfiguration.cs
@@ -1,5 +1,6 @@
 using Nocturne.Connectors.Core.Extensions;
 using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Glooko.Services;
 using Nocturne.Core.Constants;
 
 namespace Nocturne.Connectors.Glooko.Configurations;
@@ -19,6 +20,7 @@ namespace Nocturne.Connectors.Glooko.Configurations;
     "Glooko",
     SupportsHistoricalSync = true,
     SupportsManualSync = true,
+    StatsProviderType = typeof(GlookoStatsProvider),
     SupportedDataTypes = [
         SyncDataType.Glucose,
         SyncDataType.Boluses,

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoStatsProvider.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoStatsProvider.cs
@@ -1,0 +1,56 @@
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Services;
+
+namespace Nocturne.Connectors.Glooko.Services;
+
+/// <summary>
+///     Custom stats provider for the Glooko connector.
+///     Glooko syncs periodically (every few hours) and produces data across multiple tables
+///     (CGM, BG checks, boluses, carb intakes, food entries, state spans). The default
+///     glucose-only stats would undercount records and show "inactive" between syncs.
+/// </summary>
+public class GlookoStatsProvider : ConnectorStatsProvider
+{
+    /// <summary>
+    ///     Uses comprehensive stats across all V4 tables with a 6-hour stale threshold
+    ///     appropriate for a batch connector that syncs every few hours.
+    /// </summary>
+    public override void ApplyStats(DataSourceInfo info, DataSourceStats stats, DateTimeOffset now)
+    {
+        // Use total items across all tables (glucose + treatments + state spans)
+        info.TotalEntries = stats.TotalItems;
+        info.EntriesLast24Hours = stats.ItemsLast24Hours;
+
+        // Use the most recent item time across all tables
+        if (stats.LastItemTime.HasValue)
+        {
+            var lastItemOffset = new DateTimeOffset(stats.LastItemTime.Value, TimeSpan.Zero);
+            if (!info.LastSeen.HasValue || lastItemOffset > info.LastSeen.Value)
+                info.LastSeen = lastItemOffset;
+        }
+
+        // Use the earliest item time for FirstSeen
+        var firstTimes = new[] { stats.FirstEntryTime, stats.FirstTreatmentTime, stats.FirstStateSpanTime }
+            .Where(t => t.HasValue)
+            .ToArray();
+        if (firstTimes.Length > 0)
+        {
+            var earliest = new DateTimeOffset(firstTimes.Min()!.Value, TimeSpan.Zero);
+            if (!info.FirstSeen.HasValue || earliest < info.FirstSeen.Value)
+                info.FirstSeen = earliest;
+        }
+
+        // Batch connector thresholds: 3h active, 6h stale, then inactive
+        var minutesSinceLast = info.LastSeen.HasValue
+            ? (int)(now - info.LastSeen.Value).TotalMinutes
+            : int.MaxValue;
+        info.MinutesSinceLastData = minutesSinceLast;
+        info.Status = minutesSinceLast switch
+        {
+            < 180 => "active",
+            < 360 => "stale",
+            _ => "inactive",
+        };
+    }
+}

--- a/src/Web/packages/app/src/lib/components/connectors/DataSourceManageDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/DataSourceManageDialog.svelte
@@ -19,10 +19,12 @@
   let {
     open = $bindable(false),
     selectedDataSource,
+    lastSuccessfulSync,
     onDeleteComplete,
   } = $props<{
     open: boolean;
     selectedDataSource: DataSourceInfo | null;
+    lastSuccessfulSync?: Date;
     onDeleteComplete?: () => Promise<void>;
   }>();
 
@@ -148,11 +150,19 @@
             </div>
           </div>
           <div>
-            <span class="text-muted-foreground">Last Seen</span>
+            <span class="text-muted-foreground">Last Record Received</span>
             <p class="mt-1 font-medium">
               {formatLastSeen(selectedDataSource.lastSeen)}
             </p>
           </div>
+          {#if lastSuccessfulSync}
+          <div>
+            <span class="text-muted-foreground">Last Successful Sync</span>
+            <p class="mt-1 font-medium">
+              {formatLastSeen(lastSuccessfulSync)}
+            </p>
+          </div>
+          {/if}
           <div>
             <span class="text-muted-foreground">Records (24h)</span>
             <p class="mt-1 font-medium">

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/+page.svelte
@@ -89,6 +89,7 @@
 
   // Data source management dialog state
   let selectedDataSource = $state<DataSourceInfo | null>(null);
+  let selectedDataSourceLastSync = $state<Date | undefined>(undefined);
   let showManageDataSourceDialog = $state(false);
 
   // Manual sync state
@@ -205,7 +206,17 @@
 
   function openDataSourceDialog(source: DataSourceInfo) {
     selectedDataSource = source;
-    showManageDataSourceDialog = true;
+    // Look up matching connector health data for last successful sync.
+    // Match via availableConnectors which maps dataSourceId → connector id.
+    const matchingAvailable = servicesOverview?.availableConnectors?.find(
+      (c) => c.dataSourceId === source.deviceId || c.dataSourceId === source.sourceType
+        || c.id === source.sourceType || c.id === source.deviceId
+    );
+    const matchingConnector = matchingAvailable
+      ? connectorStatuses.find((cs) => cs.id === matchingAvailable.id)
+      : null;
+    selectedDataSourceLastSync = matchingConnector?.lastSuccessfulSync ?? undefined;
+   showManageDataSourceDialog = true;
   }
 
   function isDemoDataSource(source: DataSourceInfo): boolean {
@@ -672,6 +683,7 @@
 <DataSourceManageDialog
   bind:open={showManageDataSourceDialog}
   {selectedDataSource}
+  lastSuccessfulSync={selectedDataSourceLastSync}
   onDeleteComplete={loadServices}
 />
 


### PR DESCRIPTION
Before:
<img width="520" height="216" alt="Screenshot 2026-05-06 at 9 41 01 AM" src="https://github.com/user-attachments/assets/a99b435f-308a-4cfe-afe4-1834b31e32b3" />

After:
<img width="464" height="190" alt="Screenshot 2026-05-09 at 4 03 46 PM" src="https://github.com/user-attachments/assets/c93e72fb-09db-42f8-b6ae-09063d3c85a5" />
