### PR TITLE
Fix API token create dialog height on small viewports

### DIFF
--- a/src/Web/packages/app/src/lib/components/settings/ApiTokens.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/ApiTokens.svelte
@@ -299,7 +299,7 @@
 
 <!-- Create Token Dialog -->
 <Dialog.Root bind:open={showCreateDialog}>
-  <Dialog.Content class="max-w-lg">
+  <Dialog.Content class="max-w-lg max-h-[90vh] overflow-y-auto">
     {#if createdToken}
       <!-- Token created - show the value -->
       <Dialog.Header>


### PR DESCRIPTION
The TokenScopeSelector contains many permission categories that pushed
the dialog past the viewport on 1080p screens, hiding the Create button
with no way to scroll. Cap the dialog at 90vh and enable internal
scrolling, matching the pattern used by other dialogs in the app.