### PR TITLE
fix: suppress EF Core per-query SQL logging in production

### DIFF
--- a/src/Aspire/Nocturne.Aspire.ServiceDefaults/Extensions.cs
+++ b/src/Aspire/Nocturne.Aspire.ServiceDefaults/Extensions.cs
@@ -20,6 +20,12 @@ public static class Extensions
 {
     public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)
     {
+        // EF Core logs every executed SQL command at Information by default. Under
+        // load (e.g. connector ingest) this floods stdout and the OTEL pipeline
+        // with thousands of entries per second. Suppress at the source so all
+        // downstream providers (Console, OTEL) see the reduced volume.
+        builder.Logging.AddFilter("Microsoft.EntityFrameworkCore.Database.Command", LogLevel.Warning);
+
         builder.ConfigureOpenTelemetry();
 
         builder.AddDefaultHealthChecks();


### PR DESCRIPTION
## Summary

- Adds a log filter for `Microsoft.EntityFrameworkCore.Database.Command` → `Warning` in `ServiceDefaults.AddServiceDefaults()`, so all Nocturne services suppress per-query SQL logging by default.

## Problem

EF Core's `Database.Command` logger emits every executed SQL statement at `Information` level. Under connector ingest load (e.g. temp_basals sync), the API container was:

- **115% CPU sustained** (single .NET process)
- **~800 log lines/sec** through stdout + OTEL
- **107 GB cumulative net I/O** on the otel-collector from serializing full SQL + parameters for every query

Top queries in a 5-minute sample: 12,102 SELECTs from `temp_basals`, 1,300 from `linked_records` — all logged individually.

## Fix

Single `AddFilter` call in ServiceDefaults, applied before OpenTelemetry configuration. Filters at the ILogger source so both Console and OTEL providers see reduced volume.

- Only `Database.Command` is suppressed — migrations, model validation, connection lifecycle still log normally
- Configuration-based overrides (`appsettings.json`, env vars) still win for ad-hoc debugging
- Lives in ServiceDefaults so API + all connector services inherit the behavior

## Test plan

- [x] `dotnet build` — clean, 0 warnings
- [ ] Deploy to staging/prod and verify CPU drop on nocturne-api container
- [ ] Verify migration logs still appear on startup