### PR TITLE
feat: configurable connector status thresholds & universal data source stats

### DIFF
--- a/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Nocturne.Connectors.Core.Models;
@@ -40,6 +41,163 @@ public class DataSourceService : IDataSourceService
         _logger = logger;
     }
 
+    private record TableStats(long Count, int CountLast24H, DateTime Latest, DateTime? Oldest);
+
+    private static void ApplyStatus(DataSourceInfo info, DateTimeOffset now, int activeMinutes, int staleMinutes)
+    {
+        var minutesSinceLast = info.LastSeen.HasValue
+            ? (int)(now - info.LastSeen.Value).TotalMinutes
+            : int.MaxValue;
+        info.MinutesSinceLastData = minutesSinceLast;
+        info.Status = minutesSinceLast switch
+        {
+            _ when minutesSinceLast < activeMinutes => "active",
+            _ when minutesSinceLast < staleMinutes => "stale",
+            _ => "inactive",
+        };
+    }
+
+    private (int activeMinutes, int staleMinutes) ResolveThresholds(
+        string? connectorDataSourceId,
+        Dictionary<string, (int active, int stale)>? configOverrides)
+    {
+        const int defaultActive = 15;
+        const int defaultStale = 60;
+
+        if (connectorDataSourceId == null)
+            return (defaultActive, defaultStale);
+
+        if (configOverrides != null &&
+            configOverrides.TryGetValue(connectorDataSourceId, out var overrides))
+        {
+            var active = overrides.active > 0 ? overrides.active : 0;
+            var stale = overrides.stale > 0 ? overrides.stale : 0;
+
+            if (active > 0 || stale > 0)
+            {
+                var meta = ConnectorMetadataService.GetByDataSourceId(connectorDataSourceId);
+                return (
+                    active > 0 ? active : meta?.DefaultActiveThresholdMinutes ?? defaultActive,
+                    stale > 0 ? stale : meta?.DefaultStaleThresholdMinutes ?? defaultStale);
+            }
+        }
+
+        var connectorMeta = ConnectorMetadataService.GetByDataSourceId(connectorDataSourceId);
+        if (connectorMeta != null)
+            return (connectorMeta.DefaultActiveThresholdMinutes, connectorMeta.DefaultStaleThresholdMinutes);
+
+        return (defaultActive, defaultStale);
+    }
+
+    private async Task<Dictionary<string, (int active, int stale)>> LoadThresholdOverridesAsync(
+        CancellationToken ct)
+    {
+        var configs = await _context.ConnectorConfigurations
+            .AsNoTracking()
+            .Select(c => new { c.ConnectorName, c.ConfigurationJson })
+            .ToListAsync(ct);
+
+        var result = new Dictionary<string, (int active, int stale)>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var config in configs)
+        {
+            var meta = ConnectorMetadataService.GetByConnectorId(config.ConnectorName);
+            if (meta == null || string.IsNullOrEmpty(meta.DataSourceId)) continue;
+
+            try
+            {
+                using var doc = JsonDocument.Parse(config.ConfigurationJson);
+                var root = doc.RootElement;
+
+                var active = root.TryGetProperty("activeThresholdMinutes", out var aProp) && aProp.TryGetInt32(out var a) ? a : 0;
+                var stale = root.TryGetProperty("staleThresholdMinutes", out var sProp) && sProp.TryGetInt32(out var s) ? s : 0;
+
+                result[meta.DataSourceId] = (active, stale);
+            }
+            catch
+            {
+                // Invalid JSON — skip
+            }
+        }
+
+        return result;
+    }
+
+    private async Task<Dictionary<string, TableStats>> GetNonGlucoseStatsAsync(
+        DateTime thirtyDaysAgo, DateTime last24HoursDate, CancellationToken ct)
+    {
+        var result = new Dictionary<string, TableStats>(StringComparer.OrdinalIgnoreCase);
+
+        void Merge(string? key, long count, int count24h, DateTime latest, DateTime? oldest)
+        {
+            if (string.IsNullOrEmpty(key) || count == 0) return;
+            if (result.TryGetValue(key, out var existing))
+            {
+                result[key] = new TableStats(
+                    existing.Count + count,
+                    existing.CountLast24H + count24h,
+                    latest > existing.Latest ? latest : existing.Latest,
+                    oldest.HasValue && (!existing.Oldest.HasValue || oldest.Value < existing.Oldest.Value)
+                        ? oldest : existing.Oldest);
+            }
+            else
+            {
+                result[key] = new TableStats(count, count24h, latest, oldest);
+            }
+        }
+
+        var mgStats = await _context.MeterGlucose
+            .Where(mg => mg.Timestamp >= thirtyDaysAgo)
+            .GroupBy(mg => mg.DataSource ?? mg.Device)
+            .Select(g => new { Key = g.Key, Count = g.LongCount(), Count24H = g.Count(x => x.Timestamp >= last24HoursDate), Latest = g.Max(x => x.Timestamp), Oldest = (DateTime?)g.Min(x => x.Timestamp) })
+            .ToListAsync(ct);
+        foreach (var s in mgStats) Merge(s.Key, s.Count, s.Count24H, s.Latest, s.Oldest);
+
+        var bolusStats = await _context.Boluses
+            .Where(b => b.Timestamp >= thirtyDaysAgo)
+            .GroupBy(b => b.DataSource ?? b.Device)
+            .Select(g => new { Key = g.Key, Count = g.LongCount(), Count24H = g.Count(x => x.Timestamp >= last24HoursDate), Latest = g.Max(x => x.Timestamp), Oldest = (DateTime?)g.Min(x => x.Timestamp) })
+            .ToListAsync(ct);
+        foreach (var s in bolusStats) Merge(s.Key, s.Count, s.Count24H, s.Latest, s.Oldest);
+
+        var carbStats = await _context.CarbIntakes
+            .Where(c => c.Timestamp >= thirtyDaysAgo)
+            .GroupBy(c => c.DataSource ?? c.Device)
+            .Select(g => new { Key = g.Key, Count = g.LongCount(), Count24H = g.Count(x => x.Timestamp >= last24HoursDate), Latest = g.Max(x => x.Timestamp), Oldest = (DateTime?)g.Min(x => x.Timestamp) })
+            .ToListAsync(ct);
+        foreach (var s in carbStats) Merge(s.Key, s.Count, s.Count24H, s.Latest, s.Oldest);
+
+        var bgStats = await _context.BGChecks
+            .Where(b => b.Timestamp >= thirtyDaysAgo)
+            .GroupBy(b => b.DataSource ?? b.Device)
+            .Select(g => new { Key = g.Key, Count = g.LongCount(), Count24H = g.Count(x => x.Timestamp >= last24HoursDate), Latest = g.Max(x => x.Timestamp), Oldest = (DateTime?)g.Min(x => x.Timestamp) })
+            .ToListAsync(ct);
+        foreach (var s in bgStats) Merge(s.Key, s.Count, s.Count24H, s.Latest, s.Oldest);
+
+        var noteStats = await _context.Notes
+            .Where(n => n.Timestamp >= thirtyDaysAgo)
+            .GroupBy(n => n.DataSource ?? n.Device)
+            .Select(g => new { Key = g.Key, Count = g.LongCount(), Count24H = g.Count(x => x.Timestamp >= last24HoursDate), Latest = g.Max(x => x.Timestamp), Oldest = (DateTime?)g.Min(x => x.Timestamp) })
+            .ToListAsync(ct);
+        foreach (var s in noteStats) Merge(s.Key, s.Count, s.Count24H, s.Latest, s.Oldest);
+
+        var deStats = await _context.DeviceEvents
+            .Where(de => de.Timestamp >= thirtyDaysAgo)
+            .GroupBy(de => de.DataSource ?? de.Device)
+            .Select(g => new { Key = g.Key, Count = g.LongCount(), Count24H = g.Count(x => x.Timestamp >= last24HoursDate), Latest = g.Max(x => x.Timestamp), Oldest = (DateTime?)g.Min(x => x.Timestamp) })
+            .ToListAsync(ct);
+        foreach (var s in deStats) Merge(s.Key, s.Count, s.Count24H, s.Latest, s.Oldest);
+
+        var ssStats = await _context.StateSpans
+            .Where(s => s.StartTimestamp >= thirtyDaysAgo)
+            .GroupBy(s => s.Source)
+            .Select(g => new { Key = g.Key, Count = g.LongCount(), Count24H = g.Count(x => x.StartTimestamp >= last24HoursDate), Latest = g.Max(x => x.StartTimestamp), Oldest = (DateTime?)g.Min(x => x.StartTimestamp) })
+            .ToListAsync(ct);
+        foreach (var s in ssStats) Merge(s.Key, s.Count, s.Count24H, s.Latest, s.Oldest);
+
+        return result;
+    }
+
     /// <inheritdoc />
     public async Task<List<DataSourceInfo>> GetActiveDataSourcesAsync(
         CancellationToken cancellationToken = default
@@ -68,16 +226,26 @@ public class DataSourceService : IDataSourceService
             .ToListAsync(cancellationToken);
 
         // Also check APS snapshots for devices that might not have entries
-        var thirtyDaysAgo = now.AddDays(-30).UtcDateTime;
         var deviceStatusDevices = await _context
             .ApsSnapshots.Where(ds =>
-                ds.Timestamp >= thirtyDaysAgo && ds.Device != null && ds.Device != ""
+                ds.Timestamp >= thirtyDaysAgoDate && ds.Device != null && ds.Device != ""
             )
             .GroupBy(ds => ds.Device)
             .Select(g => new { Device = g.Key!, LastMills = new DateTimeOffset(g.Max(ds => ds.Timestamp), TimeSpan.Zero).ToUnixTimeMilliseconds() })
             .ToListAsync(cancellationToken);
 
+        // Batch-aggregate non-glucose tables
+        var nonGlucoseStats = await GetNonGlucoseStatsAsync(thirtyDaysAgoDate, last24HoursDate, cancellationToken);
+
+        // Load user threshold overrides and connector configs for LastSuccessfulSync
+        var thresholdOverrides = await LoadThresholdOverridesAsync(cancellationToken);
+        var connectorConfigs = await _context.ConnectorConfigurations
+            .AsNoTracking()
+            .Select(c => new { c.ConnectorName, c.LastSuccessfulSync })
+            .ToListAsync(cancellationToken);
+
         var dataSources = new List<DataSourceInfo>();
+        var processedNonGlucoseKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var device in entryDevices)
         {
@@ -95,15 +263,55 @@ public class DataSourceService : IDataSourceService
                 info.LastSeen = DateTimeOffset.FromUnixTimeMilliseconds(dsDevice.LastMills);
             }
 
-            // Calculate status
-            var minutesSinceLast = (int)(now - info.LastSeen.Value).TotalMinutes;
-            info.MinutesSinceLastData = minutesSinceLast;
-            info.Status = minutesSinceLast switch
+            // Set ConnectorId if this is a connector data source
+            var connectorKey = device.DataSource ?? device.Device;
+            var connectorMeta = ConnectorMetadataService.GetByDataSourceId(connectorKey);
+            if (connectorMeta != null)
             {
-                < 15 => "active",
-                < 60 => "stale",
-                _ => "inactive",
-            };
+                info.ConnectorId = connectorMeta.ConnectorName.ToLowerInvariant();
+                var connConfig = connectorConfigs.FirstOrDefault(c =>
+                    c.ConnectorName.Equals(connectorMeta.ConnectorName, StringComparison.OrdinalIgnoreCase));
+                if (connConfig?.LastSuccessfulSync != null)
+                    info.LastSuccessfulSync = new DateTimeOffset(connConfig.LastSuccessfulSync.Value, TimeSpan.Zero);
+            }
+
+            // Merge non-glucose stats
+            var mergeKey = device.DataSource ?? device.Device;
+            if (nonGlucoseStats.TryGetValue(mergeKey, out var ngStats))
+            {
+                info.TotalEntries += ngStats.Count;
+                info.EntriesLast24Hours += ngStats.CountLast24H;
+                var ngLastSeen = new DateTimeOffset(ngStats.Latest, TimeSpan.Zero);
+                if (ngLastSeen > info.LastSeen)
+                    info.LastSeen = ngLastSeen;
+                if (ngStats.Oldest.HasValue)
+                {
+                    var ngFirstSeen = new DateTimeOffset(ngStats.Oldest.Value, TimeSpan.Zero);
+                    if (!info.FirstSeen.HasValue || ngFirstSeen < info.FirstSeen)
+                        info.FirstSeen = ngFirstSeen;
+                }
+                processedNonGlucoseKeys.Add(mergeKey);
+            }
+            // Also try matching by Device field
+            if (mergeKey != device.Device && nonGlucoseStats.TryGetValue(device.Device, out var ngDeviceStats))
+            {
+                info.TotalEntries += ngDeviceStats.Count;
+                info.EntriesLast24Hours += ngDeviceStats.CountLast24H;
+                var ngLastSeen = new DateTimeOffset(ngDeviceStats.Latest, TimeSpan.Zero);
+                if (ngLastSeen > info.LastSeen)
+                    info.LastSeen = ngLastSeen;
+                if (ngDeviceStats.Oldest.HasValue)
+                {
+                    var ngFirstSeen = new DateTimeOffset(ngDeviceStats.Oldest.Value, TimeSpan.Zero);
+                    if (!info.FirstSeen.HasValue || ngFirstSeen < info.FirstSeen)
+                        info.FirstSeen = ngFirstSeen;
+                }
+                processedNonGlucoseKeys.Add(device.Device);
+            }
+
+            // Apply status with resolved thresholds
+            var (activeMinutes, staleMinutes) = ResolveThresholds(connectorKey, thresholdOverrides);
+            ApplyStatus(info, now, activeMinutes, staleMinutes);
 
             dataSources.Add(info);
         }
@@ -119,17 +327,49 @@ public class DataSourceService : IDataSourceService
                 info.TotalEntries = 0;
                 info.EntriesLast24Hours = 0;
 
-                var minutesSinceLast = (int)(now - info.LastSeen.Value).TotalMinutes;
-                info.MinutesSinceLastData = minutesSinceLast;
-                info.Status = minutesSinceLast switch
+                // Merge non-glucose stats if available
+                if (nonGlucoseStats.TryGetValue(dsDevice.Device, out var ngStats))
                 {
-                    < 15 => "active",
-                    < 60 => "stale",
-                    _ => "inactive",
-                };
+                    info.TotalEntries = ngStats.Count;
+                    info.EntriesLast24Hours = ngStats.CountLast24H;
+                    var ngLastSeen = new DateTimeOffset(ngStats.Latest, TimeSpan.Zero);
+                    if (ngLastSeen > info.LastSeen)
+                        info.LastSeen = ngLastSeen;
+                    processedNonGlucoseKeys.Add(dsDevice.Device);
+                }
+
+                var (activeMinutes, staleMinutes) = ResolveThresholds(dsDevice.Device, thresholdOverrides);
+                ApplyStatus(info, now, activeMinutes, staleMinutes);
 
                 dataSources.Add(info);
             }
+        }
+
+        // Add data sources found only in non-glucose tables
+        foreach (var (key, stats) in nonGlucoseStats)
+        {
+            if (processedNonGlucoseKeys.Contains(key)) continue;
+
+            var info = CreateDataSourceInfo(key, key);
+            info.LastSeen = new DateTimeOffset(stats.Latest, TimeSpan.Zero);
+            info.FirstSeen = stats.Oldest.HasValue ? new DateTimeOffset(stats.Oldest.Value, TimeSpan.Zero) : info.LastSeen;
+            info.TotalEntries = stats.Count;
+            info.EntriesLast24Hours = stats.CountLast24H;
+
+            var connectorMeta = ConnectorMetadataService.GetByDataSourceId(key);
+            if (connectorMeta != null)
+            {
+                info.ConnectorId = connectorMeta.ConnectorName.ToLowerInvariant();
+                var connConfig = connectorConfigs.FirstOrDefault(c =>
+                    c.ConnectorName.Equals(connectorMeta.ConnectorName, StringComparison.OrdinalIgnoreCase));
+                if (connConfig?.LastSuccessfulSync != null)
+                    info.LastSuccessfulSync = new DateTimeOffset(connConfig.LastSuccessfulSync.Value, TimeSpan.Zero);
+            }
+
+            var (activeMinutes, staleMinutes) = ResolveThresholds(key, thresholdOverrides);
+            ApplyStatus(info, now, activeMinutes, staleMinutes);
+
+            dataSources.Add(info);
         }
 
         return dataSources.OrderByDescending(d => d.LastSeen).ToList();

--- a/src/Connectors/Nocturne.Connectors.Core/Extensions/AspireAttributes.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Extensions/AspireAttributes.cs
@@ -125,4 +125,16 @@ public class ConnectorRegistrationAttribute(
     ///     Supported data types for this connector.
     /// </summary>
     public SyncDataType[] SupportedDataTypes { get; set; } = [SyncDataType.Glucose];
+
+    /// <summary>
+    ///     Default minutes without data before status changes from active to stale.
+    ///     Real-time connectors (CGM) use 15; batch connectors use 180.
+    /// </summary>
+    public int DefaultActiveThresholdMinutes { get; set; } = 15;
+
+    /// <summary>
+    ///     Default minutes without data before status changes from stale to inactive.
+    ///     Real-time connectors use 60; batch connectors use 360.
+    /// </summary>
+    public int DefaultStaleThresholdMinutes { get; set; } = 60;
 }

--- a/src/Connectors/Nocturne.Connectors.Core/Extensions/ConnectorPropertyKey.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Extensions/ConnectorPropertyKey.cs
@@ -30,6 +30,10 @@ public enum ConnectorPropertyKey
     SyncActivity,
     SyncFood,
 
+    // Status thresholds
+    ActiveThresholdMinutes,
+    StaleThresholdMinutes,
+
     // Common credentials
     Username,
     Password,

--- a/src/Connectors/Nocturne.Connectors.Core/Models/BaseConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Models/BaseConnectorConfiguration.cs
@@ -89,6 +89,18 @@ public abstract class BaseConnectorConfiguration : IConnectorConfiguration
     [ConnectorProperty(ConnectorPropertyKey.SyncFood, DefaultValue = "true")]
     public bool SyncFood { get; set; } = true;
 
+    /// <summary>
+    ///     Override for active threshold (minutes). 0 = use connector default.
+    /// </summary>
+    [ConnectorProperty(ConnectorPropertyKey.ActiveThresholdMinutes, MinValue = 1)]
+    public int ActiveThresholdMinutes { get; set; } = 0;
+
+    /// <summary>
+    ///     Override for stale threshold (minutes). 0 = use connector default.
+    /// </summary>
+    [ConnectorProperty(ConnectorPropertyKey.StaleThresholdMinutes, MinValue = 1)]
+    public int StaleThresholdMinutes { get; set; } = 0;
+
     public bool IsDataTypeEnabled(SyncDataType type) => type switch
     {
         SyncDataType.Glucose => SyncGlucose,

--- a/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorMetadataService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorMetadataService.cs
@@ -123,7 +123,9 @@ public static class ConnectorMetadataService
                             Icon = attr.Icon,
                             Category = attr.Category,
                             Description = attr.Description,
-                            ServiceName = attr.ServiceName
+                            ServiceName = attr.ServiceName,
+                            DefaultActiveThresholdMinutes = attr.DefaultActiveThresholdMinutes,
+                            DefaultStaleThresholdMinutes = attr.DefaultStaleThresholdMinutes
                         };
 
                         ConnectorsByDataSourceId[attr.DataSourceId] = info;
@@ -153,6 +155,8 @@ public static class ConnectorMetadataService
         public ConnectorCategory Category { get; init; } = ConnectorCategory.Other;
         public string Description { get; init; } = string.Empty;
         public string ServiceName { get; set; } = string.Empty;
+        public int DefaultActiveThresholdMinutes { get; init; } = 15;
+        public int DefaultStaleThresholdMinutes { get; init; } = 60;
 
         /// <summary>
         ///     Converts this connector info to an AvailableService for UI consumption.

--- a/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConnectorConfiguration.cs
@@ -19,6 +19,8 @@ namespace Nocturne.Connectors.Glooko.Configurations;
     "Glooko",
     SupportsHistoricalSync = true,
     SupportsManualSync = true,
+    DefaultActiveThresholdMinutes = 180,
+    DefaultStaleThresholdMinutes = 360,
     SupportedDataTypes = [
         SyncDataType.Glucose,
         SyncDataType.Boluses,

--- a/src/Connectors/Nocturne.Connectors.MyFitnessPal/Configurations/MyFitnessPalConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.MyFitnessPal/Configurations/MyFitnessPalConnectorConfiguration.cs
@@ -17,6 +17,8 @@ namespace Nocturne.Connectors.MyFitnessPal.Configurations;
     SupportsHistoricalSync = true,
     MaxHistoricalDays = 365,
     SupportsManualSync = true,
+    DefaultActiveThresholdMinutes = 180,
+    DefaultStaleThresholdMinutes = 360,
     SupportedDataTypes = [SyncDataType.Food]
 )]
 public class MyFitnessPalConnectorConfiguration : BaseConnectorConfiguration

--- a/src/Connectors/Nocturne.Connectors.MyLife/Configurations/MyLifeConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Configurations/MyLifeConnectorConfiguration.cs
@@ -16,6 +16,8 @@ namespace Nocturne.Connectors.MyLife.Configurations;
     "MyLife",
     SupportsHistoricalSync = true,
     SupportsManualSync = true,
+    DefaultActiveThresholdMinutes = 180,
+    DefaultStaleThresholdMinutes = 360,
     SupportedDataTypes = [
         SyncDataType.Glucose,
         SyncDataType.ManualBG,

--- a/src/Connectors/Nocturne.Connectors.Tidepool/Configurations/TidepoolConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.Tidepool/Configurations/TidepoolConnectorConfiguration.cs
@@ -17,6 +17,8 @@ namespace Nocturne.Connectors.Tidepool.Configurations;
     SupportsHistoricalSync = true,
     MaxHistoricalDays = 365,
     SupportsManualSync = true,
+    DefaultActiveThresholdMinutes = 180,
+    DefaultStaleThresholdMinutes = 360,
     SupportedDataTypes = [
         SyncDataType.Glucose,
         SyncDataType.Boluses,

--- a/src/Core/Nocturne.Core.Models/Services/DataSourceInfo.cs
+++ b/src/Core/Nocturne.Core.Models/Services/DataSourceInfo.cs
@@ -87,11 +87,24 @@ public class DataSourceInfo
     public string Icon { get; set; } = string.Empty;
 
     /// <summary>
+    /// If this data source is from a server connector, the connector's identifier.
+    /// Null for uploader apps and unknown sources.
+    /// </summary>
+    [JsonPropertyName("connectorId")]
+    public string? ConnectorId { get; set; }
+
+    /// <summary>
+    /// When the connector last successfully completed a sync.
+    /// Null for non-connector data sources.
+    /// </summary>
+    [JsonPropertyName("lastSuccessfulSync")]
+    public DateTimeOffset? LastSuccessfulSync { get; set; }
+
+    /// <summary>
     /// Whether this source is currently considered healthy (received data recently)
     /// </summary>
     [JsonPropertyName("isHealthy")]
-    public bool IsHealthy =>
-        Status == "active" || (MinutesSinceLastData.HasValue && MinutesSinceLastData.Value < 15);
+    public bool IsHealthy => Status == "active";
 }
 
 /// <summary>

--- a/src/Web/packages/app/src/lib/components/connectors/DataSourceManageDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/DataSourceManageDialog.svelte
@@ -148,7 +148,7 @@
             </div>
           </div>
           <div>
-            <span class="text-muted-foreground">Last Seen</span>
+            <span class="text-muted-foreground">Last Record Received</span>
             <p class="mt-1 font-medium">
               {formatLastSeen(selectedDataSource.lastSeen)}
             </p>

--- a/src/Web/packages/app/src/lib/config/connectorPropertyMeta.ts
+++ b/src/Web/packages/app/src/lib/config/connectorPropertyMeta.ts
@@ -44,6 +44,8 @@ export enum ConnectorPropertyKey {
   AccessToken = "AccessToken",
   WebhookEnabled = "WebhookEnabled",
   WebhookSecret = "WebhookSecret",
+  ActiveThresholdMinutes = "ActiveThresholdMinutes",
+  StaleThresholdMinutes = "StaleThresholdMinutes",
   WriteBackEnabled = "WriteBackEnabled",
   WriteBackBatchSize = "WriteBackBatchSize",
   GlucoseProcessing = "GlucoseProcessing",
@@ -273,6 +275,17 @@ export const connectorPropertyMeta: Record<ConnectorPropertyKeyName, PropertyMet
     label: 'Webhook Secret',
     description: 'Secret key for validating webhook requests',
     category: 'Credentials',
+  },
+  // Status thresholds
+  ActiveThresholdMinutes: {
+    label: 'Active threshold (minutes)',
+    description: 'Minutes without new data before status changes from active to stale',
+    category: 'Advanced',
+  },
+  StaleThresholdMinutes: {
+    label: 'Stale threshold (minutes)',
+    description: 'Minutes without new data before status changes from stale to inactive',
+    category: 'Advanced',
   },
   // Write-back
   WriteBackEnabled: {


### PR DESCRIPTION
## Summary
- Add configurable active/stale status thresholds per connector (defaults: 15/60 min for real-time, 180/360 min for batch connectors like Glooko, Tidepool, MyFitnessPal, MyLife)
- Refactor `DataSourceService.GetActiveDataSourcesAsync` to aggregate stats across all V4 tables (meter glucose, boluses, carbs, BG checks, notes, device events, state spans) — not just sensor glucose
- Expose `ConnectorId` and `LastSuccessfulSync` on `DataSourceInfo` for exact frontend connector matching
- Add user-overridable threshold properties to `BaseConnectorConfiguration` (stored in config JSONB)
- Fix hardcoded `IsHealthy` to use threshold-aware status instead of magic `< 15` check

## Test Plan
- [x] Connector core tests pass (8/8)
- [x] DataSource-related API tests pass (22/22)
- [x] API builds successfully
- [x] NSwag client regenerates with new fields (`connectorId`, `lastSuccessfulSync`)
- [x] Frontend type-checks pass (0 errors)
- [ ] Smoke test: verify threshold fields appear in connector config Advanced section
- [ ] Smoke test: verify data sources show enriched multi-table stats