### PR TITLE
feat: AAPS v4 insulin concentration alignment

### DIFF
--- a/src/API/Nocturne.API/Services/Profiles/Resolvers/ActiveProfileResolver.cs
+++ b/src/API/Nocturne.API/Services/Profiles/Resolvers/ActiveProfileResolver.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -184,6 +185,6 @@ internal sealed class ActiveProfileResolver : IActiveProfileResolver
         long l => l,
         float f => f,
         JsonElement { ValueKind: JsonValueKind.Number } je => je.GetDouble(),
-        _ => double.TryParse(value.ToString(), out var d) ? d : null,
+        _ => double.TryParse(value.ToString(), NumberStyles.Number, CultureInfo.InvariantCulture, out var d) ? d : null,
     };
 }

--- a/src/API/Nocturne.API/Services/Profiles/Resolvers/ActiveProfileResolver.cs
+++ b/src/API/Nocturne.API/Services/Profiles/Resolvers/ActiveProfileResolver.cs
@@ -5,6 +5,7 @@ using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
 
 namespace Nocturne.API.Services.Profiles.Resolvers;
 
@@ -45,6 +46,12 @@ internal sealed class ActiveProfileResolver : IActiveProfileResolver
     {
         var span = await GetActiveProfileSpanAsync(timeMills, ct);
         return ExtractCircadianAdjustment(span);
+    }
+
+    public async Task<TreatmentInsulinContext?> GetActiveInsulinContextAsync(long timeMills, CancellationToken ct = default)
+    {
+        var span = await GetActiveProfileSpanAsync(timeMills, ct);
+        return ExtractInsulinContext(span);
     }
 
     private async Task<StateSpan?> GetActiveProfileSpanAsync(long timeMills, CancellationToken ct)
@@ -109,6 +116,48 @@ internal sealed class ActiveProfileResolver : IActiveProfileResolver
         }
 
         return new CircadianAdjustment(percentage.Value, timeshiftMs);
+    }
+
+    private static TreatmentInsulinContext? ExtractInsulinContext(StateSpan? span)
+    {
+        if (span?.Metadata is null)
+            return null;
+
+        if (!span.Metadata.TryGetValue("insulinDia", out var diaValue))
+            return null;
+
+        var dia = ConvertToDouble(diaValue);
+        if (dia is null or <= 0)
+            return null;
+
+        var peak = span.Metadata.TryGetValue("insulinPeak", out var peakValue)
+            ? (int)(ConvertToDouble(peakValue) ?? 0)
+            : 0;
+
+        if (peak <= 0)
+            return null;
+
+        var name = span.Metadata.TryGetValue("insulinName", out var nameValue)
+            ? ConvertToString(nameValue) ?? ""
+            : "";
+
+        var concentration = span.Metadata.TryGetValue("insulinConcentration", out var concValue)
+            ? (int)(ConvertToDouble(concValue) ?? 100)
+            : 100;
+
+        var curve = span.Metadata.TryGetValue("insulinCurve", out var curveValue)
+            ? ConvertToString(curveValue) ?? "rapid-acting"
+            : "rapid-acting";
+
+        return new TreatmentInsulinContext
+        {
+            PatientInsulinId = Guid.Empty,
+            InsulinName = name,
+            Dia = dia.Value,
+            Peak = peak,
+            Concentration = concentration,
+            Curve = curve,
+        };
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Services/Treatments/IobCalculator.cs
+++ b/src/API/Nocturne.API/Services/Treatments/IobCalculator.cs
@@ -202,7 +202,8 @@ public class IobCalculator(
             return new IobContribution { IobContrib = 0, ActivityContrib = 0 };
         }
 
-        var dia = therapySettings.GetDIAAsync(currentTime, null).GetAwaiter().GetResult();
+        var dia = tempBasal.InsulinContext?.Dia
+            ?? therapySettings.GetDIAAsync(currentTime, null).GetAwaiter().GetResult();
 
         var scheduledBasalRate = tempBasal.ScheduledRate
             ?? basalRate.GetBasalRateAsync(tempBasal.StartMills, null).GetAwaiter().GetResult();

--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -664,6 +664,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             SyncIdentifier = treatment.SyncIdentifier,
             InsulinType = treatment.InsulinType,
             Unabsorbed = treatment.Unabsorbed,
+            InsulinContext = ExtractAapsIcfg(treatment),
             DeviceId = null, // Resolved by caller via IDeviceService
             PumpRecordId = treatment.PumpId?.ToString(),
         };

--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -847,6 +847,51 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         return string.Equals(appString, "AAPS", StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// Extracts AAPS v4 insulin configuration from the <c>icfg</c> JSON field in
+    /// <see cref="Treatment.AdditionalProperties"/> and converts it into a
+    /// <see cref="V4Models.TreatmentInsulinContext"/>.
+    /// </summary>
+    /// <returns>
+    /// A populated <see cref="V4Models.TreatmentInsulinContext"/> when the treatment carries a
+    /// valid <c>icfg</c> object with positive <c>insulinEndTime</c> and <c>insulinPeakTime</c>;
+    /// <c>null</c> otherwise.
+    /// </returns>
+    internal static V4Models.TreatmentInsulinContext? ExtractAapsIcfg(Treatment treatment)
+    {
+        if (treatment.AdditionalProperties is null
+            || !treatment.AdditionalProperties.TryGetValue("icfg", out var icfgRaw))
+            return null;
+
+        try
+        {
+            if (icfgRaw is not JsonElement icfgElement || icfgElement.ValueKind != JsonValueKind.Object)
+                return null;
+
+            var label = icfgElement.TryGetProperty("insulinLabel", out var lp) ? lp.GetString() ?? "" : "";
+            var endTimeMs = icfgElement.TryGetProperty("insulinEndTime", out var ep) ? ep.GetInt64() : 0L;
+            var peakTimeMs = icfgElement.TryGetProperty("insulinPeakTime", out var pp) ? pp.GetInt64() : 0L;
+            var concentrationRatio = icfgElement.TryGetProperty("concentration", out var cp) ? cp.GetDouble() : 1.0;
+
+            if (endTimeMs <= 0 || peakTimeMs <= 0)
+                return null;
+
+            return new V4Models.TreatmentInsulinContext
+            {
+                PatientInsulinId = Guid.Empty,
+                InsulinName = label,
+                Dia = Math.Round(endTimeMs / 3_600_000.0, 1),
+                Peak = (int)(peakTimeMs / 60_000),
+                Concentration = (int)Math.Round(concentrationRatio * 100),
+                Curve = "rapid-acting",
+            };
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     private static bool IsTempBasal(string? eventType)
     {
         if (string.IsNullOrEmpty(eventType))
@@ -876,6 +921,16 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             metadata["enteredBy"] = treatment.EnteredBy;
 
         metadata["utcOffset"] = treatment.UtcOffset ?? 0;
+
+        var icfg = ExtractAapsIcfg(treatment);
+        if (icfg is not null)
+        {
+            metadata["insulinName"] = icfg.InsulinName;
+            metadata["insulinDia"] = icfg.Dia.ToString("F1");
+            metadata["insulinPeak"] = icfg.Peak.ToString();
+            metadata["insulinConcentration"] = icfg.Concentration.ToString();
+            metadata["insulinCurve"] = icfg.Curve;
+        }
 
         return metadata.Count > 0 ? metadata : null;
     }

--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -955,7 +956,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         if (icfg is not null)
         {
             metadata["insulinName"] = icfg.InsulinName;
-            metadata["insulinDia"] = icfg.Dia.ToString("F1");
+            metadata["insulinDia"] = icfg.Dia.ToString("F1", CultureInfo.InvariantCulture);
             metadata["insulinPeak"] = icfg.Peak.ToString();
             metadata["insulinConcentration"] = icfg.Concentration.ToString();
             metadata["insulinCurve"] = icfg.Curve;
@@ -1230,33 +1231,46 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         }
 
         // Resolve insulin context for each temp basal
+        // primaryInsulin is fetched at most once lazily if the third tier is ever needed.
+        V4Models.PatientInsulin? primaryInsulin = null;
+        var primaryInsulinFetched = false;
+
         foreach (var tb in tempBasalList)
         {
-            // Try batch-local profile switch first (avoids cache staleness)
-            var icfg = batchInsulinTimeline
-                .Where(kvp => kvp.Key <= tb.StartMills)
-                .OrderByDescending(kvp => kvp.Key)
-                .Select(kvp => kvp.Value)
-                .FirstOrDefault();
+            // Tier 1: batch-local profile switch timeline (avoids cache staleness).
+            // Walk the sorted keys in reverse to find the most-recent switch at or before StartMills.
+            V4Models.TreatmentInsulinContext? icfg = null;
+            foreach (var key in batchInsulinTimeline.Keys.Reverse())
+            {
+                if (key <= tb.StartMills)
+                {
+                    icfg = batchInsulinTimeline[key];
+                    break;
+                }
+            }
 
-            // Fall back to ActiveProfileResolver (covers previous batches)
+            // Tier 2: ActiveProfileResolver (covers profile switches from previous batches)
             if (icfg is null)
                 icfg = await _activeProfileResolver.GetActiveInsulinContextAsync(tb.StartMills, ct);
 
-            // Fall back to primary insulin
+            // Tier 3: primary configured insulin — fetched once per batch, not per record
             if (icfg is null)
             {
-                var primary = await _insulinRepo.GetPrimaryBolusInsulinAsync(ct);
-                if (primary is not null)
+                if (!primaryInsulinFetched)
+                {
+                    primaryInsulin = await _insulinRepo.GetPrimaryBolusInsulinAsync(ct);
+                    primaryInsulinFetched = true;
+                }
+                if (primaryInsulin is not null)
                 {
                     icfg = new V4Models.TreatmentInsulinContext
                     {
-                        PatientInsulinId = primary.Id,
-                        InsulinName = primary.Name,
-                        Dia = primary.Dia,
-                        Peak = primary.Peak,
-                        Curve = primary.Curve,
-                        Concentration = primary.Concentration,
+                        PatientInsulinId = primaryInsulin.Id,
+                        InsulinName = primaryInsulin.Name,
+                        Dia = primaryInsulin.Dia,
+                        Peak = primaryInsulin.Peak,
+                        Curve = primaryInsulin.Curve,
+                        Concentration = primaryInsulin.Concentration,
                     };
                 }
             }

--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -5,6 +5,7 @@ using Nocturne.Connectors.Core.Constants;
 using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.Glucose;
+using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Models;
 using Nocturne.Core.Contracts.V4.Repositories;
@@ -46,6 +47,8 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
     private readonly ITreatmentFoodService _treatmentFoodService;
     private readonly IDeviceService _deviceService;
     private readonly IProfileDecomposer _profileDecomposer;
+    private readonly IActiveProfileResolver _activeProfileResolver;
+    private readonly IPatientInsulinRepository _insulinRepo;
     private readonly ILogger<TreatmentDecomposer> _logger;
 
     /// <summary>
@@ -70,6 +73,8 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
     /// <param name="treatmentFoodService">Service for preserving legacy <see cref="Treatment.FoodType"/> as a <see cref="TreatmentFood"/> entry.</param>
     /// <param name="deviceService">Service that resolves or creates canonical device references.</param>
     /// <param name="profileDecomposer">Decomposes inline profile JSON from profile switch treatments into V4 schedule records.</param>
+    /// <param name="activeProfileResolver">Resolves insulin context from profile switches active at a given timestamp.</param>
+    /// <param name="insulinRepo">Repository for patient insulin records, used as fallback for insulin context resolution.</param>
     /// <param name="logger">Logger instance for this decomposer.</param>
     public TreatmentDecomposer(
         NocturneDbContext dbContext,
@@ -84,6 +89,8 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         ITreatmentFoodService treatmentFoodService,
         IDeviceService deviceService,
         IProfileDecomposer profileDecomposer,
+        IActiveProfileResolver activeProfileResolver,
+        IPatientInsulinRepository insulinRepo,
         ILogger<TreatmentDecomposer> logger)
     {
         _dbContext = dbContext;
@@ -98,6 +105,8 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         _treatmentFoodService = treatmentFoodService;
         _deviceService = deviceService;
         _profileDecomposer = profileDecomposer;
+        _activeProfileResolver = activeProfileResolver;
+        _insulinRepo = insulinRepo;
         _logger = logger;
     }
 
@@ -501,6 +510,25 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         model.DeviceId = await _deviceService.ResolveAsync(
             V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
         model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
+
+        // Resolve insulin context: active profile switch → primary insulin → null
+        model.InsulinContext = await _activeProfileResolver.GetActiveInsulinContextAsync(treatment.Mills, ct);
+        if (model.InsulinContext is null)
+        {
+            var primaryInsulin = await _insulinRepo.GetPrimaryBolusInsulinAsync(ct);
+            if (primaryInsulin is not null)
+            {
+                model.InsulinContext = new V4Models.TreatmentInsulinContext
+                {
+                    PatientInsulinId = primaryInsulin.Id,
+                    InsulinName = primaryInsulin.Name,
+                    Dia = primaryInsulin.Dia,
+                    Peak = primaryInsulin.Peak,
+                    Curve = primaryInsulin.Curve,
+                    Concentration = primaryInsulin.Concentration,
+                };
+            }
+        }
 
         if (existing != null)
         {
@@ -1187,6 +1215,55 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             }
         }
 
+        // Pre-pass: upsert profile switch StateSpans first (temp basals depend on them for insulin context)
+        var batchInsulinTimeline = new SortedDictionary<long, V4Models.TreatmentInsulinContext>();
+        foreach (var (treatment, isPs, _, _) in stateSpanTreatments.Where(t => t.IsProfileSwitch))
+        {
+            var spanResult = new V4Models.DecompositionResult { CorrelationId = batch.Id };
+            await DecomposeProfileSwitchAsync(treatment, spanResult, ct);
+            result.CreatedRecords.AddRange(spanResult.CreatedRecords);
+            result.UpdatedRecords.AddRange(spanResult.UpdatedRecords);
+
+            var icfg = ExtractAapsIcfg(treatment);
+            if (icfg is not null)
+                batchInsulinTimeline[treatment.Mills] = icfg;
+        }
+
+        // Resolve insulin context for each temp basal
+        foreach (var tb in tempBasalList)
+        {
+            // Try batch-local profile switch first (avoids cache staleness)
+            var icfg = batchInsulinTimeline
+                .Where(kvp => kvp.Key <= tb.StartMills)
+                .OrderByDescending(kvp => kvp.Key)
+                .Select(kvp => kvp.Value)
+                .FirstOrDefault();
+
+            // Fall back to ActiveProfileResolver (covers previous batches)
+            if (icfg is null)
+                icfg = await _activeProfileResolver.GetActiveInsulinContextAsync(tb.StartMills, ct);
+
+            // Fall back to primary insulin
+            if (icfg is null)
+            {
+                var primary = await _insulinRepo.GetPrimaryBolusInsulinAsync(ct);
+                if (primary is not null)
+                {
+                    icfg = new V4Models.TreatmentInsulinContext
+                    {
+                        PatientInsulinId = primary.Id,
+                        InsulinName = primary.Name,
+                        Dia = primary.Dia,
+                        Peak = primary.Peak,
+                        Curve = primary.Curve,
+                        Concentration = primary.Concentration,
+                    };
+                }
+            }
+
+            tb.InsulinContext = icfg;
+        }
+
         // Bulk-insert all typed lists
         if (bolusList.Count > 0)
         {
@@ -1230,15 +1307,13 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             result.CreatedRecords.AddRange(created);
         }
 
-        // Upsert state spans individually (ProfileSwitch, Override, TemporaryTarget)
-        foreach (var (treatment, isPs, isOv, isTt) in stateSpanTreatments)
+        // Upsert remaining state spans (Override, TemporaryTarget — ProfileSwitch already done in pre-pass)
+        foreach (var (treatment, isPs, isOv, isTt) in stateSpanTreatments.Where(t => !t.IsProfileSwitch))
         {
             // Use a temporary result to collect records from helper methods
             var spanResult = new V4Models.DecompositionResult { CorrelationId = batch.Id };
 
-            if (isPs)
-                await DecomposeProfileSwitchAsync(treatment, spanResult, ct);
-            else if (isOv)
+            if (isOv)
                 await DecomposeOverrideAsync(treatment, spanResult, ct);
             else if (isTt)
                 await DecomposeTemporaryTargetAsync(treatment, spanResult, ct);

--- a/src/Core/Nocturne.Core.Contracts/Profiles/Resolvers/IActiveProfileResolver.cs
+++ b/src/Core/Nocturne.Core.Contracts/Profiles/Resolvers/IActiveProfileResolver.cs
@@ -1,3 +1,5 @@
+using Nocturne.Core.Models.V4;
+
 namespace Nocturne.Core.Contracts.Profiles.Resolvers;
 
 /// <summary>
@@ -17,6 +19,12 @@ public interface IActiveProfileResolver
     /// or null if no CCP data is present in the active profile switch.
     /// </summary>
     Task<CircadianAdjustment?> GetCircadianAdjustmentAsync(long timeMills, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the insulin pharmacokinetic configuration from the profile switch active at the given time,
+    /// or null if the active profile switch has no insulin metadata (e.g., non-AAPS source).
+    /// </summary>
+    Task<TreatmentInsulinContext?> GetActiveInsulinContextAsync(long timeMills, CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/Core/Nocturne.Core.Models/V4/InsulinCatalog.cs
+++ b/src/Core/Nocturne.Core.Models/V4/InsulinCatalog.cs
@@ -17,6 +17,15 @@ public static class InsulinCatalog
         new() { Id = "lyumjev",      Name = "Lyumjev (URLi Lispro)",         Category = InsulinCategory.RapidActing, DefaultDia = 3.5, DefaultPeak = 55,  Curve = "ultra-rapid",  Concentration = 100 },
         new() { Id = "lyumjev-u200", Name = "Lyumjev U200 (URLi Lispro)",    Category = InsulinCategory.RapidActing, DefaultDia = 3.5, DefaultPeak = 55,  Curve = "ultra-rapid",  Concentration = 200 },
 
+        // Diluted rapid-acting (pediatric / very low basal)
+        new() { Id = "humalog-u10",   Name = "Humalog U10 (Insulin Lispro)",   Category = InsulinCategory.RapidActing, DefaultDia = 4.0, DefaultPeak = 75, Curve = "rapid-acting", Concentration = 10 },
+        new() { Id = "humalog-u40",   Name = "Humalog U40 (Insulin Lispro)",   Category = InsulinCategory.RapidActing, DefaultDia = 4.0, DefaultPeak = 75, Curve = "rapid-acting", Concentration = 40 },
+        new() { Id = "humalog-u50",   Name = "Humalog U50 (Insulin Lispro)",   Category = InsulinCategory.RapidActing, DefaultDia = 4.0, DefaultPeak = 75, Curve = "rapid-acting", Concentration = 50 },
+        new() { Id = "novorapid-u10", Name = "NovoRapid U10 (Insulin Aspart)", Category = InsulinCategory.RapidActing, DefaultDia = 4.0, DefaultPeak = 75, Curve = "rapid-acting", Concentration = 10 },
+        new() { Id = "novorapid-u40", Name = "NovoRapid U40 (Insulin Aspart)", Category = InsulinCategory.RapidActing, DefaultDia = 4.0, DefaultPeak = 75, Curve = "rapid-acting", Concentration = 40 },
+        new() { Id = "novorapid-u50", Name = "NovoRapid U50 (Insulin Aspart)", Category = InsulinCategory.RapidActing, DefaultDia = 4.0, DefaultPeak = 75, Curve = "rapid-acting", Concentration = 50 },
+        new() { Id = "fiasp-u10",     Name = "Fiasp U10 (Faster Aspart)",      Category = InsulinCategory.RapidActing, DefaultDia = 3.5, DefaultPeak = 55, Curve = "ultra-rapid",  Concentration = 10 },
+
         // Short-acting
         new() { Id = "humulin-r",      Name = "Humulin R (Regular)",      Category = InsulinCategory.ShortActing, DefaultDia = 5.0, DefaultPeak = 90,  Curve = "bilinear", Concentration = 100 },
         new() { Id = "humulin-r-u500", Name = "Humulin R U500 (Regular)", Category = InsulinCategory.ShortActing, DefaultDia = 5.0, DefaultPeak = 90,  Curve = "bilinear", Concentration = 500 },

--- a/src/Core/Nocturne.Core.Models/V4/TempBasal.cs
+++ b/src/Core/Nocturne.Core.Models/V4/TempBasal.cs
@@ -128,6 +128,13 @@ public class TempBasal
     public Guid? ApsSnapshotId { get; set; }
 
     /// <summary>
+    /// Snapshot of the insulin pharmacokinetic settings active when this temp basal was set.
+    /// Used by the IOB calculator for per-insulin basal IOB decay curves.
+    /// When null, falls back to profile-level DIA.
+    /// </summary>
+    public TreatmentInsulinContext? InsulinContext { get; set; }
+
+    /// <summary>
     /// Catch-all for fields not mapped to dedicated columns
     /// </summary>
     public Dictionary<string, object?>? AdditionalProperties { get; set; }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TempBasalEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TempBasalEntity.cs
@@ -135,6 +135,12 @@ public class TempBasalEntity : ITenantScoped, IAuditable
     public Guid? ApsSnapshotId { get; set; }
 
     /// <summary>
+    /// Snapshot of insulin pharmacokinetic settings at the time this temp basal was set (JSONB).
+    /// </summary>
+    [Column("insulin_context", TypeName = "jsonb")]
+    public string? InsulinContextJson { get; set; }
+
+    /// <summary>
     /// Catch-all JSONB column for fields not mapped to dedicated columns
     /// </summary>
     [Column("additional_properties", TypeName = "jsonb")]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/TempBasalMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/TempBasalMapper.cs
@@ -36,6 +36,9 @@ public static class TempBasalMapper
             PatientDeviceId = model.PatientDeviceId,
             PumpRecordId = model.PumpRecordId,
             ApsSnapshotId = model.ApsSnapshotId,
+            InsulinContextJson = model.InsulinContext is not null
+                ? JsonSerializer.Serialize(model.InsulinContext)
+                : null,
             AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
                 ? JsonSerializer.Serialize(model.AdditionalProperties)
                 : null,
@@ -71,6 +74,9 @@ public static class TempBasalMapper
             PatientDeviceId = entity.PatientDeviceId,
             PumpRecordId = entity.PumpRecordId,
             ApsSnapshotId = entity.ApsSnapshotId,
+            InsulinContext = !string.IsNullOrEmpty(entity.InsulinContextJson)
+                ? JsonSerializer.Deserialize<TreatmentInsulinContext>(entity.InsulinContextJson)
+                : null,
             AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
                 ? JsonSerializer.Deserialize<Dictionary<string, object?>>(entity.AdditionalPropertiesJson)
                 : null,
@@ -100,6 +106,9 @@ public static class TempBasalMapper
         entity.PatientDeviceId = model.PatientDeviceId;
         entity.PumpRecordId = model.PumpRecordId;
         entity.ApsSnapshotId = model.ApsSnapshotId;
+        entity.InsulinContextJson = model.InsulinContext is not null
+            ? JsonSerializer.Serialize(model.InsulinContext)
+            : null;
         entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
             ? JsonSerializer.Serialize(model.AdditionalProperties)
             : null;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260510072400_AddTempBasalInsulinContext.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260510072400_AddTempBasalInsulinContext.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260510072400_AddTempBasalInsulinContext")]
+    partial class AddTempBasalInsulinContext
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260510072400_AddTempBasalInsulinContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260510072400_AddTempBasalInsulinContext.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTempBasalInsulinContext : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "insulin_context",
+                table: "temp_basals",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "insulin_context",
+                table: "temp_basals");
+        }
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Profiles/Resolvers/ActiveProfileResolverTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Profiles/Resolvers/ActiveProfileResolverTests.cs
@@ -7,6 +7,7 @@ using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
 
 namespace Nocturne.API.Tests.Services.Profiles.Resolvers;
 
@@ -159,6 +160,97 @@ public class ActiveProfileResolverTests : IDisposable
             SetupSpans(span);
 
             var result = await _sut.GetActiveProfileNameAsync(NoonMills);
+
+            result.Should().BeNull();
+        }
+    }
+
+    private static StateSpan MakeInsulinProfileSpan(
+        long startMills,
+        long? endMills,
+        string? insulinName = null,
+        string? insulinDia = null,
+        string? insulinPeak = null,
+        string? insulinConcentration = null,
+        string? insulinCurve = null,
+        string? profileName = null)
+    {
+        var metadata = new Dictionary<string, object>();
+        if (profileName is not null)
+            metadata["profileName"] = profileName;
+        if (insulinName is not null)
+            metadata["insulinName"] = insulinName;
+        if (insulinDia is not null)
+            metadata["insulinDia"] = insulinDia;
+        if (insulinPeak is not null)
+            metadata["insulinPeak"] = insulinPeak;
+        if (insulinConcentration is not null)
+            metadata["insulinConcentration"] = insulinConcentration;
+        if (insulinCurve is not null)
+            metadata["insulinCurve"] = insulinCurve;
+
+        return new StateSpan
+        {
+            Id = Guid.NewGuid().ToString(),
+            Category = StateSpanCategory.Profile,
+            State = "Active",
+            StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(startMills).UtcDateTime,
+            EndTimestamp = endMills.HasValue
+                ? DateTimeOffset.FromUnixTimeMilliseconds(endMills.Value).UtcDateTime
+                : null,
+            Metadata = metadata.Count > 0 ? metadata : null,
+        };
+    }
+
+    public class GetActiveInsulinContextAsync : ActiveProfileResolverTests
+    {
+        [Fact]
+        public async Task WithInsulinMetadata_ReturnsContext()
+        {
+            var span = MakeInsulinProfileSpan(
+                startMills: NoonMills - 3_600_000,
+                endMills: null,
+                profileName: "AAPS",
+                insulinName: "Fiasp",
+                insulinDia: "3.5",
+                insulinPeak: "55",
+                insulinConcentration: "100",
+                insulinCurve: "ultra-rapid");
+
+            SetupSpans(span);
+
+            var result = await _sut.GetActiveInsulinContextAsync(NoonMills);
+
+            result.Should().NotBeNull();
+            result!.PatientInsulinId.Should().Be(Guid.Empty);
+            result.InsulinName.Should().Be("Fiasp");
+            result.Dia.Should().Be(3.5);
+            result.Peak.Should().Be(55);
+            result.Concentration.Should().Be(100);
+            result.Curve.Should().Be("ultra-rapid");
+        }
+
+        [Fact]
+        public async Task WithoutInsulinMetadata_ReturnsNull()
+        {
+            var span = MakeProfileSpan(
+                startMills: NoonMills - 3_600_000,
+                endMills: null,
+                profileName: "Default");
+
+            SetupSpans(span);
+
+            var result = await _sut.GetActiveInsulinContextAsync(NoonMills);
+
+            result.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task NoActiveSpan_ReturnsNull()
+        {
+            SetupSpans();
+
+            var result = await _sut.GetActiveInsulinContextAsync(NoonMills);
 
             result.Should().BeNull();
         }

--- a/tests/Unit/Nocturne.API.Tests/Services/Treatments/IobCalculatorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Treatments/IobCalculatorTests.cs
@@ -138,6 +138,67 @@ public class IobCalculatorTests
 
     #endregion
 
+    #region CalcTempBasal Tests
+
+    [Fact]
+    public void CalcTempBasal_WithInsulinContext_UsesDiaFromContext()
+    {
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var oneHourAgo = now - 60 * 60 * 1000;
+        var thirtyMinAgo = now - 30 * 60 * 1000;
+
+        var tempBasal = new TempBasal
+        {
+            StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(oneHourAgo).UtcDateTime,
+            EndTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(thirtyMinAgo).UtcDateTime,
+            Rate = 2.0,
+            ScheduledRate = 1.0,
+            Origin = TempBasalOrigin.Algorithm,
+            InsulinContext = new TreatmentInsulinContext
+            {
+                Dia = 5.0,
+                Peak = 55,
+                Curve = "ultra-rapid",
+                Concentration = 100,
+            },
+        };
+
+        var resultWithContext = _calculator.CalcTempBasal(tempBasal, now);
+
+        // Now remove InsulinContext so it falls back to profile DIA=3
+        tempBasal.InsulinContext = null;
+        var resultWithoutContext = _calculator.CalcTempBasal(tempBasal, now);
+
+        // Longer DIA (5h) means slower decay, so MORE IOB remaining
+        Assert.True(
+            resultWithContext.IobContrib > resultWithoutContext.IobContrib,
+            $"DIA=5h IOB ({resultWithContext.IobContrib}) should exceed DIA=3h IOB ({resultWithoutContext.IobContrib})");
+    }
+
+    [Fact]
+    public void CalcTempBasal_WithoutInsulinContext_FallsBackToProfileDia()
+    {
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var oneHourAgo = now - 60 * 60 * 1000;
+        var thirtyMinAgo = now - 30 * 60 * 1000;
+
+        var tempBasal = new TempBasal
+        {
+            StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(oneHourAgo).UtcDateTime,
+            EndTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(thirtyMinAgo).UtcDateTime,
+            Rate = 2.0,
+            ScheduledRate = 1.0,
+            Origin = TempBasalOrigin.Algorithm,
+            InsulinContext = null,
+        };
+
+        var result = _calculator.CalcTempBasal(tempBasal, now);
+
+        Assert.True(result.IobContrib > 0, "TempBasal with rate > scheduled should have non-zero IOB");
+    }
+
+    #endregion
+
     #region FromBoluses Tests
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerBatchTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerBatchTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.API.Services.V4;
 using Nocturne.Core.Contracts.Devices;
+using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Contracts.V4;
@@ -30,6 +31,8 @@ public class TreatmentDecomposerBatchTests : IDisposable
     private readonly Mock<ITreatmentFoodService> _treatmentFoodServiceMock;
     private readonly Mock<IDeviceService> _deviceServiceMock;
     private readonly Mock<IProfileDecomposer> _profileDecomposerMock;
+    private readonly Mock<IActiveProfileResolver> _activeProfileResolverMock;
+    private readonly Mock<IPatientInsulinRepository> _insulinRepoMock;
     private readonly TreatmentDecomposer _decomposer;
 
     public TreatmentDecomposerBatchTests()
@@ -48,6 +51,8 @@ public class TreatmentDecomposerBatchTests : IDisposable
         _treatmentFoodServiceMock = new Mock<ITreatmentFoodService>();
         _deviceServiceMock = new Mock<IDeviceService>();
         _profileDecomposerMock = new Mock<IProfileDecomposer>();
+        _activeProfileResolverMock = new Mock<IActiveProfileResolver>();
+        _insulinRepoMock = new Mock<IPatientInsulinRepository>();
 
         // BulkCreateAsync returns the input records
         _bolusRepoMock
@@ -100,6 +105,8 @@ public class TreatmentDecomposerBatchTests : IDisposable
             _treatmentFoodServiceMock.Object,
             _deviceServiceMock.Object,
             _profileDecomposerMock.Object,
+            _activeProfileResolverMock.Object,
+            _insulinRepoMock.Object,
             NullLogger<TreatmentDecomposer>.Instance);
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerNotesTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerNotesTests.cs
@@ -4,6 +4,7 @@ using Moq;
 using Nocturne.API.Services.V4;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Devices;
+using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Contracts.V4;
@@ -45,6 +46,8 @@ public class TreatmentDecomposerNotesTests : IDisposable
             .ReturnsAsync((Guid?)null);
 
         var profileDecomposerMock = new Mock<IProfileDecomposer>();
+        var activeProfileResolverMock = new Mock<IActiveProfileResolver>();
+        var insulinRepoMock = new Mock<IPatientInsulinRepository>();
 
         _decomposer = new TreatmentDecomposer(
             _context,
@@ -54,6 +57,8 @@ public class TreatmentDecomposerNotesTests : IDisposable
             treatmentFoodServiceMock.Object,
             deviceServiceMock.Object,
             profileDecomposerMock.Object,
+            activeProfileResolverMock.Object,
+            insulinRepoMock.Object,
             NullLogger<TreatmentDecomposer>.Instance);
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
@@ -5,6 +5,7 @@ using Moq;
 using Nocturne.API.Services.V4;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Devices;
+using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Contracts.V4;
@@ -27,6 +28,8 @@ public class TreatmentDecomposerTests : IDisposable
     private readonly Mock<ITempBasalRepository> _tempBasalRepoMock;
     private readonly Mock<IDeviceService> _deviceServiceMock;
     private readonly Mock<IProfileDecomposer> _profileDecomposerMock;
+    private readonly Mock<IActiveProfileResolver> _activeProfileResolverMock;
+    private readonly Mock<IPatientInsulinRepository> _insulinRepoMock;
     private readonly TreatmentDecomposer _decomposer;
 
     public TreatmentDecomposerTests()
@@ -46,6 +49,8 @@ public class TreatmentDecomposerTests : IDisposable
         _tempBasalRepoMock = new Mock<ITempBasalRepository>();
         _deviceServiceMock = new Mock<IDeviceService>();
         _profileDecomposerMock = new Mock<IProfileDecomposer>();
+        _activeProfileResolverMock = new Mock<IActiveProfileResolver>();
+        _insulinRepoMock = new Mock<IPatientInsulinRepository>();
 
         // Default: DeviceService returns null (no device resolved)
         _deviceServiceMock
@@ -60,6 +65,8 @@ public class TreatmentDecomposerTests : IDisposable
             _treatmentFoodServiceMock.Object,
             _deviceServiceMock.Object,
             _profileDecomposerMock.Object,
+            _activeProfileResolverMock.Object,
+            _insulinRepoMock.Object,
             NullLogger<TreatmentDecomposer>.Instance);
     }
 
@@ -2449,6 +2456,164 @@ public class TreatmentDecomposerTests : IDisposable
 
         // Assert
         bolus.InsulinContext.Should().BeNull();
+    }
+
+    #endregion
+
+    #region TempBasal InsulinContext Resolution
+
+    [Fact]
+    public async Task DecomposeTempBasal_Single_ResolvesFromActiveProfileSwitch()
+    {
+        // Arrange
+        var expectedContext = new V4Models.TreatmentInsulinContext
+        {
+            PatientInsulinId = Guid.Empty,
+            InsulinName = "Lyumjev U200",
+            Dia = 8.8,
+            Peak = 45,
+            Curve = "rapid-acting",
+            Concentration = 200,
+        };
+
+        _activeProfileResolverMock
+            .Setup(r => r.GetActiveInsulinContextAsync(1700000000000, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedContext);
+
+        _tempBasalRepoMock
+            .Setup(r => r.GetByLegacyIdAsync("tb-ps-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((V4Models.TempBasal?)null);
+        _tempBasalRepoMock
+            .Setup(r => r.CreateAsync(It.IsAny<V4Models.TempBasal>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((V4Models.TempBasal tb, CancellationToken _) => tb);
+
+        var treatment = new Treatment
+        {
+            Id = "tb-ps-1",
+            EventType = "Temp Basal",
+            Mills = 1700000000000,
+            Rate = 1.2,
+            Duration = 30,
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeAsync(treatment);
+
+        // Assert
+        var tempBasal = result.CreatedRecords.OfType<V4Models.TempBasal>().Single();
+        tempBasal.InsulinContext.Should().NotBeNull();
+        tempBasal.InsulinContext!.InsulinName.Should().Be("Lyumjev U200");
+        tempBasal.InsulinContext.Dia.Should().BeApproximately(8.8, 0.01);
+        tempBasal.InsulinContext.Peak.Should().Be(45);
+        tempBasal.InsulinContext.Concentration.Should().Be(200);
+    }
+
+    [Fact]
+    public async Task DecomposeTempBasal_Single_FallsBackToPrimaryInsulin()
+    {
+        // Arrange — resolver returns null, primary insulin is configured
+        _activeProfileResolverMock
+            .Setup(r => r.GetActiveInsulinContextAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((V4Models.TreatmentInsulinContext?)null);
+
+        var primaryInsulinId = Guid.NewGuid();
+        _insulinRepoMock
+            .Setup(r => r.GetPrimaryBolusInsulinAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new V4Models.PatientInsulin
+            {
+                Id = primaryInsulinId,
+                Name = "Fiasp",
+                Dia = 5.0,
+                Peak = 55,
+                Curve = "ultra-rapid",
+                Concentration = 100,
+            });
+
+        _tempBasalRepoMock
+            .Setup(r => r.GetByLegacyIdAsync("tb-fallback-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((V4Models.TempBasal?)null);
+        _tempBasalRepoMock
+            .Setup(r => r.CreateAsync(It.IsAny<V4Models.TempBasal>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((V4Models.TempBasal tb, CancellationToken _) => tb);
+
+        var treatment = new Treatment
+        {
+            Id = "tb-fallback-1",
+            EventType = "Temp Basal",
+            Mills = 1700000000000,
+            Rate = 0.8,
+            Duration = 60,
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeAsync(treatment);
+
+        // Assert
+        var tempBasal = result.CreatedRecords.OfType<V4Models.TempBasal>().Single();
+        tempBasal.InsulinContext.Should().NotBeNull();
+        tempBasal.InsulinContext!.PatientInsulinId.Should().Be(primaryInsulinId);
+        tempBasal.InsulinContext.InsulinName.Should().Be("Fiasp");
+        tempBasal.InsulinContext.Dia.Should().BeApproximately(5.0, 0.01);
+        tempBasal.InsulinContext.Peak.Should().Be(55);
+        tempBasal.InsulinContext.Curve.Should().Be("ultra-rapid");
+        tempBasal.InsulinContext.Concentration.Should().Be(100);
+    }
+
+    [Fact]
+    public async Task DecomposeBatch_TempBasalAfterProfileSwitch_UsesProfileSwitchIcfg()
+    {
+        // Arrange — a batch with a profile switch at T=0 and a temp basal at T+5min
+        var icfgJson = JsonSerializer.SerializeToElement(new
+        {
+            insulinLabel = "Lyumjev 45m 8.8h U200",
+            insulinEndTime = 31680000L,
+            insulinPeakTime = 2700000L,
+            concentration = 2.0
+        });
+
+        var profileSwitchTreatment = new Treatment
+        {
+            Id = "ps-batch-1",
+            EventType = "Profile Switch",
+            Mills = 1700000000000,
+            Profile = "Day Profile",
+            Duration = 60,
+            EnteredBy = "AAPS",
+            AdditionalProperties = new Dictionary<string, object>
+            {
+                ["icfg"] = icfgJson
+            }
+        };
+
+        var tempBasalTreatment = new Treatment
+        {
+            Id = "tb-batch-1",
+            EventType = "Temp Basal",
+            Mills = 1700000000000 + (5 * 60 * 1000), // T+5min
+            Rate = 1.5,
+            Duration = 30,
+        };
+
+        _stateSpanServiceMock
+            .Setup(s => s.UpsertStateSpanAsync(It.IsAny<StateSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StateSpan ss, CancellationToken _) => ss);
+
+        _tempBasalRepoMock
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.TempBasal>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<V4Models.TempBasal> list, CancellationToken _) => list.ToList());
+
+        // Act
+        var result = await _decomposer.DecomposeBatchAsync(
+            new List<Treatment> { profileSwitchTreatment, tempBasalTreatment });
+
+        // Assert
+        var tempBasal = result.CreatedRecords.OfType<V4Models.TempBasal>().Single();
+        tempBasal.InsulinContext.Should().NotBeNull();
+        tempBasal.InsulinContext!.InsulinName.Should().Be("Lyumjev 45m 8.8h U200");
+        tempBasal.InsulinContext.Dia.Should().BeApproximately(8.8, 0.01);
+        tempBasal.InsulinContext.Peak.Should().Be(45);
+        tempBasal.InsulinContext.Concentration.Should().Be(200);
+        tempBasal.InsulinContext.Curve.Should().Be("rapid-acting");
     }
 
     #endregion

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -2149,6 +2150,150 @@ public class TreatmentDecomposerTests : IDisposable
         // Assert
         var bolus = result.CreatedRecords.OfType<V4Models.Bolus>().Single();
         bolus.PatientDeviceId.Should().Be(expectedPatientDeviceId);
+    }
+
+    #endregion
+
+    #region ExtractAapsIcfg
+
+    [Fact]
+    public void ExtractAapsIcfg_ValidIcfg_ReturnsContext()
+    {
+        // Arrange — Lyumjev U200 with 8.8h DIA, 45min peak
+        var icfgJson = JsonSerializer.SerializeToElement(new
+        {
+            insulinLabel = "Lyumjev 45m 8.8h U200",
+            insulinEndTime = 31680000L,   // 8.8 hours in ms
+            insulinPeakTime = 2700000L,   // 45 minutes in ms
+            concentration = 2.0
+        });
+
+        var treatment = new Treatment
+        {
+            Id = "icfg-valid",
+            Mills = 1700000000000,
+            AdditionalProperties = new Dictionary<string, object>
+            {
+                ["icfg"] = icfgJson
+            }
+        };
+
+        // Act
+        var ctx = TreatmentDecomposer.ExtractAapsIcfg(treatment);
+
+        // Assert
+        ctx.Should().NotBeNull();
+        ctx!.InsulinName.Should().Be("Lyumjev 45m 8.8h U200");
+        ctx.Dia.Should().BeApproximately(8.8, 0.01);
+        ctx.Peak.Should().Be(45);
+        ctx.Concentration.Should().Be(200);
+        ctx.Curve.Should().Be("rapid-acting");
+        ctx.PatientInsulinId.Should().Be(Guid.Empty);
+    }
+
+    [Fact]
+    public void ExtractAapsIcfg_NoAdditionalProperties_ReturnsNull()
+    {
+        var treatment = new Treatment
+        {
+            Id = "icfg-no-props",
+            Mills = 1700000000000,
+            AdditionalProperties = null
+        };
+
+        TreatmentDecomposer.ExtractAapsIcfg(treatment).Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractAapsIcfg_MalformedIcfg_ReturnsNull()
+    {
+        // icfg is a string instead of an object
+        var icfgElement = JsonSerializer.SerializeToElement("not-json");
+
+        var treatment = new Treatment
+        {
+            Id = "icfg-malformed",
+            Mills = 1700000000000,
+            AdditionalProperties = new Dictionary<string, object>
+            {
+                ["icfg"] = icfgElement
+            }
+        };
+
+        TreatmentDecomposer.ExtractAapsIcfg(treatment).Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractAapsIcfg_U40Concentration_ConvertsCorrectly()
+    {
+        var icfgJson = JsonSerializer.SerializeToElement(new
+        {
+            insulinLabel = "Insulin U40",
+            insulinEndTime = 12600000L,   // 3.5 hours
+            insulinPeakTime = 3300000L,   // 55 minutes
+            concentration = 0.4
+        });
+
+        var treatment = new Treatment
+        {
+            Id = "icfg-u40",
+            Mills = 1700000000000,
+            AdditionalProperties = new Dictionary<string, object>
+            {
+                ["icfg"] = icfgJson
+            }
+        };
+
+        var ctx = TreatmentDecomposer.ExtractAapsIcfg(treatment);
+
+        ctx.Should().NotBeNull();
+        ctx!.Concentration.Should().Be(40);
+        ctx.Dia.Should().BeApproximately(3.5, 0.01);
+        ctx.Peak.Should().Be(55);
+    }
+
+    [Fact]
+    public async Task DecomposeProfileSwitch_WithAapsIcfg_StoresInMetadata()
+    {
+        // Arrange — Profile Switch with icfg in AdditionalProperties
+        var icfgJson = JsonSerializer.SerializeToElement(new
+        {
+            insulinLabel = "NovoRapid",
+            insulinEndTime = 12600000L,   // 3.5 hours
+            insulinPeakTime = 3300000L,   // 55 minutes
+            concentration = 1.0
+        });
+
+        var treatment = new Treatment
+        {
+            Id = "profile-switch-icfg",
+            EventType = "Profile Switch",
+            Mills = 1700000000000,
+            Profile = "Default",
+            EnteredBy = "AAPS",
+            AdditionalProperties = new Dictionary<string, object>
+            {
+                ["icfg"] = icfgJson
+            }
+        };
+
+        StateSpan? capturedSpan = null;
+        _stateSpanServiceMock
+            .Setup(s => s.UpsertStateSpanAsync(It.IsAny<StateSpan>(), It.IsAny<CancellationToken>()))
+            .Callback<StateSpan, CancellationToken>((ss, _) => capturedSpan = ss)
+            .ReturnsAsync((StateSpan ss, CancellationToken _) => ss);
+
+        // Act
+        await _decomposer.DecomposeAsync(treatment);
+
+        // Assert
+        capturedSpan.Should().NotBeNull();
+        capturedSpan!.Metadata.Should().NotBeNull();
+        capturedSpan.Metadata!["insulinName"].Should().Be("NovoRapid");
+        capturedSpan.Metadata["insulinDia"].Should().Be("3.5");
+        capturedSpan.Metadata["insulinPeak"].Should().Be("55");
+        capturedSpan.Metadata["insulinConcentration"].Should().Be("100");
+        capturedSpan.Metadata["insulinCurve"].Should().Be("rapid-acting");
     }
 
     #endregion

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
@@ -2560,6 +2560,42 @@ public class TreatmentDecomposerTests : IDisposable
     }
 
     [Fact]
+    public async Task DecomposeTempBasal_Single_AllTiersReturnNull_InsulinContextIsNull()
+    {
+        // Arrange — no active profile switch, no primary insulin configured
+        _activeProfileResolverMock
+            .Setup(r => r.GetActiveInsulinContextAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((V4Models.TreatmentInsulinContext?)null);
+
+        _insulinRepoMock
+            .Setup(r => r.GetPrimaryBolusInsulinAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((V4Models.PatientInsulin?)null);
+
+        _tempBasalRepoMock
+            .Setup(r => r.GetByLegacyIdAsync("tb-notiers-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((V4Models.TempBasal?)null);
+        _tempBasalRepoMock
+            .Setup(r => r.CreateAsync(It.IsAny<V4Models.TempBasal>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((V4Models.TempBasal tb, CancellationToken _) => tb);
+
+        var treatment = new Treatment
+        {
+            Id = "tb-notiers-1",
+            EventType = "Temp Basal",
+            Mills = 1700000000000,
+            Rate = 0.5,
+            Duration = 30,
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeAsync(treatment);
+
+        // Assert — record is created but InsulinContext is null; IOB falls back to profile DIA
+        var tempBasal = result.CreatedRecords.OfType<V4Models.TempBasal>().Single();
+        tempBasal.InsulinContext.Should().BeNull();
+    }
+
+    [Fact]
     public async Task DecomposeBatch_TempBasalAfterProfileSwitch_UsesProfileSwitchIcfg()
     {
         // Arrange — a batch with a profile switch at T=0 and a temp basal at T+5min

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
@@ -2395,4 +2395,61 @@ public class TreatmentDecomposerTests : IDisposable
     }
 
     #endregion
+
+    #region MapToBolus InsulinContext
+
+    [Fact]
+    public void MapToBolus_WithAapsIcfg_ExtractsInsulinContext()
+    {
+        // Arrange
+        var icfgJson = JsonSerializer.SerializeToElement(new
+        {
+            insulinLabel = "Lyumjev 45m 8.8h U200",
+            insulinEndTime = 31680000L,
+            insulinPeakTime = 2700000L,
+            concentration = 2.0
+        });
+
+        var treatment = new Treatment
+        {
+            Id = "bolus-icfg-1",
+            Mills = 1700000000000,
+            Insulin = 2.0,
+            AdditionalProperties = new Dictionary<string, object>
+            {
+                ["icfg"] = icfgJson
+            }
+        };
+
+        // Act
+        var bolus = TreatmentDecomposer.MapToBolus(treatment, null);
+
+        // Assert
+        bolus.InsulinContext.Should().NotBeNull();
+        bolus.InsulinContext!.InsulinName.Should().Be("Lyumjev 45m 8.8h U200");
+        bolus.InsulinContext.Dia.Should().BeApproximately(8.8, 0.01);
+        bolus.InsulinContext.Peak.Should().Be(45);
+        bolus.InsulinContext.Concentration.Should().Be(200);
+        bolus.InsulinContext.Curve.Should().Be("rapid-acting");
+    }
+
+    [Fact]
+    public void MapToBolus_WithoutIcfg_InsulinContextRemainsNull()
+    {
+        // Arrange
+        var treatment = new Treatment
+        {
+            Id = "bolus-no-icfg",
+            Mills = 1700000000000,
+            Insulin = 2.0,
+        };
+
+        // Act
+        var bolus = TreatmentDecomposer.MapToBolus(treatment, null);
+
+        // Assert
+        bolus.InsulinContext.Should().BeNull();
+    }
+
+    #endregion
 }

--- a/tests/Unit/Nocturne.Core.Models.Tests/V4/InsulinCatalogTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/V4/InsulinCatalogTests.cs
@@ -72,4 +72,30 @@ public class InsulinCatalogTests
         custom!.Category.Should().Be(InsulinCategory.RapidActing);
         custom.Concentration.Should().Be(100);
     }
+
+    [Theory]
+    [InlineData("humalog-u10", 10)]
+    [InlineData("humalog-u40", 40)]
+    [InlineData("humalog-u50", 50)]
+    [InlineData("novorapid-u10", 10)]
+    [InlineData("novorapid-u40", 40)]
+    [InlineData("novorapid-u50", 50)]
+    [InlineData("fiasp-u10", 10)]
+    public void GetById_DilutedFormulations_ReturnsExpectedConcentration(string id, int expectedConcentration)
+    {
+        var formulation = InsulinCatalog.GetById(id);
+
+        formulation.Should().NotBeNull();
+        formulation!.Concentration.Should().Be(expectedConcentration);
+    }
+
+    [Fact]
+    public void GetByCategory_RapidActing_IncludesDilutedVariants()
+    {
+        var rapidActing = InsulinCatalog.GetByCategory(InsulinCategory.RapidActing);
+
+        rapidActing.Should().Contain(f => f.Concentration == 10);
+        rapidActing.Should().Contain(f => f.Concentration == 40);
+        rapidActing.Should().Contain(f => f.Concentration == 50);
+    }
 }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/V4/TempBasalMapperTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/V4/TempBasalMapperTests.cs
@@ -355,6 +355,61 @@ public class TempBasalMapperTests
 
     [Fact]
     [Trait("Category", "Unit")]
+    public void RoundTrip_WithInsulinContext_PreservesAllFields()
+    {
+        var insulinId = Guid.NewGuid();
+        var original = new TempBasal
+        {
+            Id = Guid.CreateVersion7(),
+            StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(1700000000000).UtcDateTime,
+            Rate = 0.8,
+            Origin = TempBasalOrigin.Algorithm,
+            InsulinContext = new TreatmentInsulinContext
+            {
+                PatientInsulinId = insulinId,
+                InsulinName = "Humalog",
+                Dia = 4.0,
+                Peak = 75,
+                Curve = "rapid-acting",
+                Concentration = 100,
+            },
+        };
+
+        var entity = TempBasalMapper.ToEntity(original);
+        entity.InsulinContextJson.Should().NotBeNullOrEmpty();
+
+        var roundTripped = TempBasalMapper.ToDomainModel(entity);
+
+        roundTripped.InsulinContext.Should().NotBeNull();
+        roundTripped.InsulinContext!.PatientInsulinId.Should().Be(insulinId);
+        roundTripped.InsulinContext.InsulinName.Should().Be("Humalog");
+        roundTripped.InsulinContext.Dia.Should().Be(4.0);
+        roundTripped.InsulinContext.Peak.Should().Be(75);
+        roundTripped.InsulinContext.Curve.Should().Be("rapid-acting");
+        roundTripped.InsulinContext.Concentration.Should().Be(100);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void RoundTrip_WithNullInsulinContext_StaysNull()
+    {
+        var model = new TempBasal
+        {
+            Id = Guid.CreateVersion7(),
+            StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(1700000000000).UtcDateTime,
+            Rate = 1.0,
+            Origin = TempBasalOrigin.Manual,
+        };
+
+        var entity = TempBasalMapper.ToEntity(model);
+        entity.InsulinContextJson.Should().BeNull();
+
+        var roundTripped = TempBasalMapper.ToDomainModel(entity);
+        roundTripped.InsulinContext.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
     public void RoundTrip_AllOriginValues_PreserveCorrectly()
     {
         foreach (var origin in Enum.GetValues<TempBasalOrigin>())


### PR DESCRIPTION
## Summary

- Adds diluted insulin formulations (U10, U40, U50) to the catalog for Humalog, NovoRapid, and Fiasp
- Extracts AAPS v4 `icfg` JSON from bolus and profile switch treatments into a `TreatmentInsulinContext` snapshot (label, DIA, peak, concentration)
- Stores insulin context on profile switch `StateSpan` metadata so future temp basals can resolve it
- Adds `GetActiveInsulinContextAsync` to `IActiveProfileResolver` for timestamp-aware insulin context lookup
- Adds `InsulinContext` (JSONB) to the `TempBasal` model and database with a three-tier resolution at decomposition time: batch-local profile switch timeline → `IActiveProfileResolver` → primary configured `PatientInsulin`
- Uses per-insulin DIA from `TempBasal.InsulinContext` in `IobCalculator.CalcTempBasal`, falling back to profile DIA when absent

## Test plan

- [ ] All 192 decomposer / resolver / IOB calculator unit tests pass
- [ ] New test covers all-three-tiers-null path (fresh install, no configured insulin)
- [ ] Concentration unit conversion: AAPS ratio × 100 = int (2.0 → 200 for U200)
- [ ] Batch pre-pass processes profile switches before temp basals — no cache staleness within a batch
- [ ] `GetPrimaryBolusInsulinAsync` fetched at most once per batch (N+1 fix)
- [ ] `insulinDia` stored and parsed with `CultureInfo.InvariantCulture` (locale safety)