### PR TITLE
perf(dedup): collapse O(N*M) hot loop in DeduplicateBatchAsync

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
@@ -421,8 +421,27 @@ public class DeduplicationService : IDeduplicationService
             .ToListAsync(ct))
             .ToHashSet();
 
-        // 5. In-memory matching + intra-batch canonical assignment
-        var batchAssignments = new List<(DeduplicationInput input, Guid canonicalId)>();
+        // 5. Pre-compute structures so the per-record loop is O(log M + window) instead of O(N*(M+N)):
+        //    - sortedMatches: timestamp-sorted, sliced via binary search
+        //    - existingCanonicals: O(1) "is this canonical already in DB?" check for IsPrimary
+        //    - newCanonicalsSeen: O(1) "did this batch already create a primary for this canonical?"
+        //    - newCanonicalReps: one (mills, canonicalId, criteria) per new canonical for intra-batch
+        //      matching — record-vs-canonical instead of record-vs-every-prior-record
+        allPotentialMatches.Sort((a, b) => a.SourceTimestamp.CompareTo(b.SourceTimestamp));
+        var sortedTimestamps = new long[allPotentialMatches.Count];
+        for (int i = 0; i < allPotentialMatches.Count; i++)
+        {
+            sortedTimestamps[i] = allPotentialMatches[i].SourceTimestamp;
+        }
+
+        var existingCanonicals = new HashSet<Guid>(allPotentialMatches.Count);
+        foreach (var m in allPotentialMatches)
+        {
+            existingCanonicals.Add(m.CanonicalId);
+        }
+
+        var newCanonicalsSeen = new HashSet<Guid>();
+        var newCanonicalReps = new List<(long mills, Guid canonicalId, MatchCriteria criteria)>();
         var newLinks = new List<LinkedRecordEntity>();
         var groupsCreated = 0;
         var duplicateGroups = 0;
@@ -435,31 +454,31 @@ public class DeduplicationService : IDeduplicationService
             var windowStart = record.Mills - MatchingWindowMillis;
             var windowEnd = record.Mills + MatchingWindowMillis;
 
-            // Check DB matches
-            var myMatches = allPotentialMatches
-                .Where(m => m.SourceTimestamp >= windowStart && m.SourceTimestamp <= windowEnd)
-                .ToList();
-
             Guid? canonicalId = null;
 
-            // Try to match against existing canonical groups
-            foreach (var group in myMatches.GroupBy(m => m.CanonicalId))
+            // Match against existing canonical groups: scan only the timestamp slice.
+            int lo = LowerBoundTimestamp(sortedTimestamps, windowStart);
+            int hi = UpperBoundTimestamp(sortedTimestamps, windowEnd);
+            for (int i = lo; i < hi; i++)
             {
-                if (group.Any(m => matcher(m.RecordId, record.Criteria)))
+                var m = allPotentialMatches[i];
+                if (matcher(m.RecordId, record.Criteria))
                 {
-                    canonicalId = group.Key;
+                    canonicalId = m.CanonicalId;
                     duplicateGroups++;
                     break;
                 }
             }
 
-            // Try intra-batch matches
+            // Intra-batch match: scan canonicals created earlier in this batch, not records.
+            // Records sharing a canonical share matching criteria by transitivity, so checking
+            // one representative per canonical is sufficient.
             if (canonicalId == null)
             {
-                foreach (var (priorInput, priorCanonical) in batchAssignments)
+                foreach (var (priorMills, priorCanonical, priorCriteria) in newCanonicalReps)
                 {
-                    if (Math.Abs(priorInput.Mills - record.Mills) <= MatchingWindowMillis
-                        && CriteriaMatch(recordType, priorInput.Criteria, record.Criteria))
+                    if (Math.Abs(priorMills - record.Mills) <= MatchingWindowMillis
+                        && CriteriaMatch(recordType, priorCriteria, record.Criteria))
                     {
                         canonicalId = priorCanonical;
                         duplicateGroups++;
@@ -468,13 +487,18 @@ public class DeduplicationService : IDeduplicationService
                 }
             }
 
+            bool isNewCanonical = false;
             if (canonicalId == null)
             {
                 canonicalId = Guid.CreateVersion7();
                 groupsCreated++;
+                isNewCanonical = true;
             }
 
-            batchAssignments.Add((record, canonicalId.Value));
+            // IsPrimary iff this is the first link this batch creates for a not-already-existing canonical.
+            var isPrimary = !existingCanonicals.Contains(canonicalId.Value)
+                            && newCanonicalsSeen.Add(canonicalId.Value);
+
             newLinks.Add(new LinkedRecordEntity
             {
                 CanonicalId = canonicalId.Value,
@@ -482,9 +506,13 @@ public class DeduplicationService : IDeduplicationService
                 RecordId = record.RecordId,
                 SourceTimestamp = record.Mills,
                 DataSource = record.DataSource,
-                IsPrimary = !allPotentialMatches.Any(m => m.CanonicalId == canonicalId.Value)
-                            && !newLinks.Any(l => l.CanonicalId == canonicalId.Value)
+                IsPrimary = isPrimary
             });
+
+            if (isNewCanonical)
+            {
+                newCanonicalReps.Add((record.Mills, canonicalId.Value, record.Criteria));
+            }
         }
 
         // 6. Bulk insert
@@ -620,6 +648,30 @@ public class DeduplicationService : IDeduplicationService
             default:
                 return (_, _) => false;
         }
+    }
+
+    private static int LowerBoundTimestamp(long[] sortedTimestamps, long value)
+    {
+        int lo = 0, hi = sortedTimestamps.Length;
+        while (lo < hi)
+        {
+            int mid = lo + ((hi - lo) >> 1);
+            if (sortedTimestamps[mid] < value) lo = mid + 1;
+            else hi = mid;
+        }
+        return lo;
+    }
+
+    private static int UpperBoundTimestamp(long[] sortedTimestamps, long value)
+    {
+        int lo = 0, hi = sortedTimestamps.Length;
+        while (lo < hi)
+        {
+            int mid = lo + ((hi - lo) >> 1);
+            if (sortedTimestamps[mid] <= value) lo = mid + 1;
+            else hi = mid;
+        }
+        return lo;
     }
 
     private static bool CriteriaMatch(RecordType recordType, MatchCriteria a, MatchCriteria b)

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationServiceTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationServiceTests.cs
@@ -584,6 +584,93 @@ public class DeduplicationServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task DeduplicateBatchAsync_DoesNotPromoteToPrimary_WhenCanonicalAlreadyExists()
+    {
+        await using var context = new NocturneDbContext(_contextOptions);
+        context.TenantId = TestTenantId;
+        var scopeFactory = _serviceProvider.GetRequiredService<IServiceScopeFactory>();
+        var logger = new Mock<ILogger<DeduplicationService>>();
+        var service = new DeduplicationService(context, scopeFactory, logger.Object);
+
+        var baseTime = new DateTime(2025, 6, 15, 10, 0, 0, DateTimeKind.Utc);
+
+        var tbA = CreateTestTempBasalEntity(startTimestamp: baseTime, rate: 1.5, origin: "Scheduled", dataSource: "glooko-connector");
+        context.TempBasals.Add(tbA);
+        await context.SaveChangesAsync();
+        await service.DeduplicateBatchAsync(RecordType.TempBasal, new List<DeduplicationInput> { ToDeduplicationInput(tbA) });
+
+        var tbB = CreateTestTempBasalEntity(startTimestamp: baseTime.AddSeconds(10), rate: 1.5, origin: "Scheduled", dataSource: "mylife-connector");
+        context.TempBasals.Add(tbB);
+        await context.SaveChangesAsync();
+        await service.DeduplicateBatchAsync(RecordType.TempBasal, new List<DeduplicationInput> { ToDeduplicationInput(tbB) });
+
+        var linked = await context.LinkedRecords.OrderBy(lr => lr.SourceTimestamp).ToListAsync();
+        linked.Should().HaveCount(2);
+        linked[0].RecordId.Should().Be(tbA.Id);
+        linked[0].IsPrimary.Should().BeTrue("A is the only member when first inserted");
+        linked[1].RecordId.Should().Be(tbB.Id);
+        linked[1].IsPrimary.Should().BeFalse("primary is sticky — B joining A's existing canonical does not promote B");
+    }
+
+    [Fact]
+    public async Task DeduplicateBatchAsync_HandlesMixedBatch_NewExistingAndIntraBatch()
+    {
+        await using var context = new NocturneDbContext(_contextOptions);
+        context.TenantId = TestTenantId;
+        var scopeFactory = _serviceProvider.GetRequiredService<IServiceScopeFactory>();
+        var logger = new Mock<ILogger<DeduplicationService>>();
+        var service = new DeduplicationService(context, scopeFactory, logger.Object);
+
+        var baseTime = new DateTime(2025, 6, 15, 10, 0, 0, DateTimeKind.Utc);
+
+        // Seed: pre-existing canonical group via prior batch
+        var existing = CreateTestTempBasalEntity(startTimestamp: baseTime, rate: 1.5, origin: "Scheduled", dataSource: "glooko-connector");
+        context.TempBasals.Add(existing);
+        await context.SaveChangesAsync();
+        await service.DeduplicateBatchAsync(RecordType.TempBasal, new List<DeduplicationInput> { ToDeduplicationInput(existing) });
+
+        // New batch:
+        //   tbMatchExisting: matches existing canonical → joins it, IsPrimary=false
+        //   tbNew1 + tbNew2: same time + rate → intra-batch dedup → one canonical, one primary
+        //   tbStandalone: distinct time + rate → new canonical, IsPrimary=true
+        var tbMatchExisting = CreateTestTempBasalEntity(startTimestamp: baseTime.AddSeconds(5), rate: 1.5, origin: "Scheduled", dataSource: "mylife-connector");
+        var tbNew1 = CreateTestTempBasalEntity(startTimestamp: baseTime.AddMinutes(10), rate: 2.0, origin: "Scheduled", dataSource: "glooko-connector");
+        var tbNew2 = CreateTestTempBasalEntity(startTimestamp: baseTime.AddMinutes(10).AddSeconds(2), rate: 2.0, origin: "Scheduled", dataSource: "mylife-connector");
+        var tbStandalone = CreateTestTempBasalEntity(startTimestamp: baseTime.AddMinutes(20), rate: 0.5, origin: "Scheduled", dataSource: "glooko-connector");
+
+        context.TempBasals.AddRange(tbMatchExisting, tbNew1, tbNew2, tbStandalone);
+        await context.SaveChangesAsync();
+
+        var inputs = new List<DeduplicationInput>
+        {
+            ToDeduplicationInput(tbMatchExisting),
+            ToDeduplicationInput(tbNew1),
+            ToDeduplicationInput(tbNew2),
+            ToDeduplicationInput(tbStandalone),
+        };
+
+        var result = await service.DeduplicateBatchAsync(RecordType.TempBasal, inputs);
+
+        result.Processed.Should().Be(4);
+        result.RecordsLinked.Should().Be(4);
+        result.GroupsCreated.Should().Be(2, "tbNew1+tbNew2 share one new canonical; tbStandalone is another new canonical");
+
+        var linked = await context.LinkedRecords.ToListAsync();
+        linked.Should().HaveCount(5, "1 seed + 4 new");
+
+        var canonicalCounts = linked.GroupBy(lr => lr.CanonicalId).ToDictionary(g => g.Key, g => g.ToList());
+        canonicalCounts.Should().HaveCount(3, "existing + intra-batch group + standalone");
+
+        foreach (var (canonicalId, members) in canonicalCounts)
+        {
+            members.Count(m => m.IsPrimary).Should().Be(1, $"canonical {canonicalId} should have exactly one primary");
+        }
+
+        var matchExistingLink = linked.Single(lr => lr.RecordId == tbMatchExisting.Id);
+        matchExistingLink.IsPrimary.Should().BeFalse("joining existing canonical never promotes");
+    }
+
+    [Fact]
     public async Task DeduplicateBatchAsync_ReturnsEmptyResultForEmptyBatch()
     {
         // Arrange


### PR DESCRIPTION
## Summary

Production CPU profile of nocturne-api showed it pinned at ~100% of one core sustained, with the hot path entirely inside `DeduplicateBatchAsync` (`Nocturne.Infrastructure.Data.Services.DeduplicationService`). The batched implementation correctly reduced *query* count (the goal of #167), but the per-record loop did O(N*M) and O(N^2) in-memory scans:

1. **Re-walked `allPotentialMatches` per record** to slice by timestamp window — O(N*M)
2. **Scanned the growing `batchAssignments` list** for intra-batch duplicates — O(N^2)
3. **Two more linear scans** (`allPotentialMatches.Any` + `newLinks.Any`) per record to compute `IsPrimary` — O(N*(M+N))

For an ingest batch of 1k records with 10k in-window potential matches, that's ~10^7 inner-loop iterations.

## Fix

Three precomputations + one tracking change:

| Old (per record) | New (per record) |
|---|---|
| `allPotentialMatches.Where(...).ToList()` | binary search on sorted timestamp slice |
| `myMatches.GroupBy(...).Any(matcher)` | linear scan of slice (early exit on first matcher hit) |
| `foreach (priorInput in batchAssignments)` | `foreach (rep in newCanonicalReps)` — one rep per canonical |
| `allPotentialMatches.Any(m => m.CanonicalId == X)` | `existingCanonicals.Contains(X)` |
| `newLinks.Any(l => l.CanonicalId == X)` | `newCanonicalsSeen.Add(X)` |

Per-batch work: **~N*M + N^2 → ~N*log(M) + N*window + N*C** (where C = canonicals created, typically <<N).

## Behavior preservation

All 13 existing `DeduplicateBatchAsync` / `DeduplicateAllAsync` tests pass unchanged. Added 2 characterization tests that pin down semantics the refactor rearranges:

- `DeduplicateBatchAsync_DoesNotPromoteToPrimary_WhenCanonicalAlreadyExists` — primary is sticky across batches
- `DeduplicateBatchAsync_HandlesMixedBatch_NewExistingAndIntraBatch` — exercises the merged matched-existing + intra-batch-dup + standalone paths and verifies exactly one IsPrimary per canonical

`IsPrimary` semantics are equivalent to the original (a canonical's primary is the first link created in its first batch).

## Test plan

- [x] `dotnet test tests/Unit/Nocturne.Infrastructure.Data.Tests` — 308/308 green
- [x] `DeduplicationServiceTests` — 15/15 green (13 existing + 2 new)
- [ ] Production validation: deploy to nocturne.run VPS and observe CPU drop on nocturne-api (currently 100-115% sustained on one core)