### PR TITLE
ci: restore top-level permissions on tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: tests-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Commit 3206613 (skip E2E job) accidentally dropped the
`permissions: contents: read` block added by 2027a8e to satisfy the
CodeQL "Workflow does not contain permissions" finding. Restore it.

https://claude.ai/code/session_01Nb124JvJN5cvU93zyqEBEJ