### PR TITLE
feat(devcontainer): match Nocturne project stack (fix #173)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,10 +17,19 @@
 		"ghcr.io/devcontainers/features/git:1": {}
 	},
 	"postCreateCommand": "dotnet tool install -g Aspire.Cli && dotnet restore && (cd src/Web && pnpm install)",
+	"postAttachCommand": {
+		"aspire": "pgrep -f 'aspire run' >/dev/null || nohup bash -lc 'cd /workspaces/nocturne && aspire run' > /tmp/aspire.log 2>&1 & disown; echo 'aspire run started in background; tail -f /tmp/aspire.log'"
+	},
 	"remoteEnv": {
 		"PATH": "${containerEnv:PATH}:/home/vscode/.dotnet/tools"
 	},
 	"forwardPorts": [1612],
+	"portsAttributes": {
+		"1612": {
+			"label": "Aspire gateway",
+			"onAutoForward": "openBrowser"
+		}
+	},
 	"remoteUser": "vscode",
 	"customizations": {
 		"vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,31 +1,35 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
 {
-	"name": "C# (.NET)",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/dotnet:1-9.0-bookworm",
+	"name": "Nocturne (.NET 10 + Aspire + SvelteKit)",
+	"image": "mcr.microsoft.com/devcontainers/dotnet:1-10.0-bookworm",
 	"features": {
 		"ghcr.io/devcontainers/features/dotnet:2": {},
-		"ghcr.io/nikiforovall/devcontainer-features/dotnet-csharpier:1": {}
+		"ghcr.io/nikiforovall/devcontainer-features/dotnet-csharpier:1": {},
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "24",
+			"nodeGypDependencies": true
+		},
+		"ghcr.io/devcontainers-extra/features/pnpm:2": {
+			"version": "9"
+		},
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
+		"ghcr.io/devcontainers/features/git:1": {}
+	},
+	"postCreateCommand": "dotnet tool install -g Aspire.Cli && dotnet restore && (cd src/Web && pnpm install)",
+	"remoteEnv": {
+		"PATH": "${containerEnv:PATH}:/home/vscode/.dotnet/tools"
+	},
+	"forwardPorts": [1612],
+	"remoteUser": "vscode",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-dotnettools.csdevkit",
+				"svelte.svelte-vscode",
+				"bradlc.vscode-tailwindcss",
+				"dbaeumer.vscode-eslint"
+			]
+		}
 	}
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [5000, 5001],
-	// "portsAttributes": {
-	//		"5001": {
-	//			"protocol": "https"
-	//		}
-	// }
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "dotnet restore",
-
-	// Configure tool-specific properties.
-	// "customizations": {},
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
 {
 	"name": "Nocturne (.NET 10 + Aspire + SvelteKit)",
-	"image": "mcr.microsoft.com/devcontainers/dotnet:1-10.0-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/dotnet:2-10.0-noble",
 	"features": {
 		"ghcr.io/devcontainers/features/dotnet:2": {},
 		"ghcr.io/nikiforovall/devcontainer-features/dotnet-csharpier:1": {},


### PR DESCRIPTION
Bump to .NET 10, add Node 24 + pnpm 9, Docker-in-Docker for Testcontainers and Aspire's container resources, and install Aspire.Cli + restore packages on first create. Forward the YARP gateway port and add Svelte/Tailwind/ESLint extensions for the code-server experience.

tested by spinning up a github codespace and could access the aspire UI
<img width="1796" height="778" alt="image" src="https://github.com/user-attachments/assets/cda78155-254b-4b1e-b254-2b80b9e7c771" />
