### PR TITLE
fix(glooko): prevent OOM during historical syncs via 14-day chunked iteration

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Core/Utilities/DateChunker.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Utilities/DateChunker.cs
@@ -1,0 +1,21 @@
+namespace Nocturne.Connectors.Core.Utilities;
+
+public static class DateChunker
+{
+    public static IEnumerable<(DateTime From, DateTime To)> Chunk(
+        DateTime from, DateTime to, TimeSpan chunkSize)
+    {
+        var current = from;
+        while (current < to)
+        {
+            var chunkEnd = current + chunkSize;
+            if (chunkEnd > to) chunkEnd = to;
+            yield return (current, chunkEnd);
+            current = chunkEnd;
+        }
+
+        // Edge case: from == to
+        if (from == to)
+            yield return (from, to);
+    }
+}

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -17,19 +17,6 @@ using Nocturne.Core.Models.V4;
 namespace Nocturne.Connectors.Glooko.Services;
 
 /// <summary>
-///     Lightweight context for food-to-carb attribution within a sync chunk.
-/// </summary>
-internal sealed class GlookoFoodContext
-{
-    /// <summary>
-    ///     Resolves a food entry's ExternalEntryId to the LegacyId of the CarbIntake it belongs to.
-    ///     V2: direct mapping (glooko_food_{externalEntryId}).
-    ///     V3: food guid → meal guid → glooko_v3meal_{mealGuid}.
-    /// </summary>
-    public Func<string, string?>? FoodEntryToCarbLegacyId { get; set; }
-}
-
-/// <summary>
 ///     Connector service for Glooko data source.
 ///     Based on the original nightscout-connect Glooko implementation.
 /// </summary>
@@ -382,14 +369,17 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         await PublishFoodEntriesAndAttributeAsync(
             foodEntryImports, carbs, foodResolver, config, cancellationToken);
 
-        // 4. State spans + temp basals
-        var stateSpans = _stateSpanMapper.TransformV2ToStateSpans(batchData);
-        await PublishRecordTypeAsync(result, SyncDataType.StateSpans, activeTypes,
-            stateSpans, PublishStateSpanDataAsync, config, cancellationToken);
+        // 4. State spans + temp basals (old code only counted temp basals in ItemsSynced)
+        if (activeTypes.Contains(SyncDataType.StateSpans))
+        {
+            var stateSpans = _stateSpanMapper.TransformV2ToStateSpans(batchData);
+            if (stateSpans.Count > 0)
+                await PublishStateSpanDataAsync(stateSpans, config, cancellationToken);
 
-        var tempBasals = _tempBasalMapper.TransformV2ToTempBasals(batchData);
-        await PublishRecordTypeAsync(result, SyncDataType.StateSpans, activeTypes,
-            tempBasals, PublishTempBasalDataAsync, config, cancellationToken);
+            var tempBasals = _tempBasalMapper.TransformV2ToTempBasals(batchData);
+            if (tempBasals.Count > 0 && await PublishTempBasalDataAsync(tempBasals, config, cancellationToken))
+                result.ItemsSynced[SyncDataType.StateSpans] = tempBasals.Count;
+        }
 
         return true;
     }
@@ -489,23 +479,34 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         await PublishFoodEntriesAndAttributeAsync(
             foodEntryImports, allCarbs, foodResolver, config, cancellationToken);
 
-        // 4. State spans + temp basals
-        var stateSpans = _stateSpanMapper.TransformV3ToStateSpans(v3Data);
-        await PublishRecordTypeAsync(result, SyncDataType.StateSpans, activeTypes,
-            stateSpans, PublishStateSpanDataAsync, config, cancellationToken);
+        // 4. State spans + temp basals (old code only counted temp basals in ItemsSynced)
+        if (activeTypes.Contains(SyncDataType.StateSpans))
+        {
+            var stateSpans = _stateSpanMapper.TransformV3ToStateSpans(v3Data);
+            if (stateSpans.Count > 0)
+                await PublishStateSpanDataAsync(stateSpans, config, cancellationToken);
 
-        var tempBasals = _tempBasalMapper.TransformV3ToTempBasals(v3Data);
-        await PublishRecordTypeAsync(result, SyncDataType.StateSpans, activeTypes,
-            tempBasals, PublishTempBasalDataAsync, config, cancellationToken);
+            var tempBasals = _tempBasalMapper.TransformV3ToTempBasals(v3Data);
+            if (tempBasals.Count > 0 && await PublishTempBasalDataAsync(tempBasals, config, cancellationToken))
+                result.ItemsSynced[SyncDataType.StateSpans] = tempBasals.Count;
+        }
 
-        // 5. Device events + system events
-        var deviceEvents = _v4TreatmentMapper.MapV3DeviceEvents(v3Data);
-        await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, activeTypes,
-            deviceEvents, PublishDeviceEventDataAsync, config, cancellationToken);
+        // 5. Device events + system events (summed into single ItemsSynced entry)
+        if (activeTypes.Contains(SyncDataType.DeviceEvents))
+        {
+            var deviceEventCount = 0;
 
-        var systemEvents = _systemEventMapper.TransformV3ToSystemEvents(v3Data);
-        await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, activeTypes,
-            systemEvents, PublishSystemEventDataAsync, config, cancellationToken);
+            var deviceEvents = _v4TreatmentMapper.MapV3DeviceEvents(v3Data);
+            if (deviceEvents.Count > 0 && await PublishDeviceEventDataAsync(deviceEvents, config, cancellationToken))
+                deviceEventCount += deviceEvents.Count;
+
+            var systemEvents = _systemEventMapper.TransformV3ToSystemEvents(v3Data);
+            if (systemEvents.Count > 0 && await PublishSystemEventDataAsync(systemEvents, config, cancellationToken))
+                deviceEventCount += systemEvents.Count;
+
+            if (deviceEventCount > 0)
+                result.ItemsSynced[SyncDataType.DeviceEvents] = deviceEventCount;
+        }
 
         return true;
     }

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -289,16 +289,17 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
 
             var from = request.From.HasValue
                 ? _timeMapper.ToGlookoTime(request.From.Value)
-                : (DateTime?)null;
+                : _timeMapper.ToGlookoTime(DateTime.UtcNow.AddDays(-1));
+            var to = _timeMapper.ToGlookoTime(DateTime.UtcNow);
 
             await ReportMessageAsync(progressReporter, SyncMessageType.FetchingData,
-                new() { ["from"] = (from ?? DateTime.UtcNow.AddMonths(-6)).ToString("MMM dd"), ["to"] = DateTime.UtcNow.ToString("MMM dd") },
+                new() { ["from"] = from.ToString("MMM dd"), ["to"] = to.ToString("MMM dd") },
                 cancellationToken);
 
             // Fetch + map: V2 or V3 path fills the same data structure
             var syncData = _config.UseV3Api
-                ? await FetchAndMapViaV3Async(from)
-                : await FetchAndMapViaV2Async(from);
+                ? await FetchAndMapViaV3Async(from, to)
+                : await FetchAndMapViaV2Async(from, to);
 
             if (syncData == null)
             {
@@ -361,9 +362,9 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     /// <summary>
     ///     Fetches from all V2 endpoints and maps to the common <see cref="GlookoSyncData"/> structure.
     /// </summary>
-    private async Task<GlookoSyncData?> FetchAndMapViaV2Async(DateTime? from)
+    private async Task<GlookoSyncData?> FetchAndMapViaV2Async(DateTime fromDate, DateTime toDate)
     {
-        var batchData = await FetchBatchDataAsync(from);
+        var batchData = await FetchBatchDataAsync(fromDate, toDate);
         if (batchData == null) return null;
 
         var (boluses, carbs, batches) = _v4TreatmentMapper.MapBatchData(batchData);
@@ -392,17 +393,17 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     /// <summary>
     ///     Fetches from V3 graph/data and histories endpoints, maps to the common <see cref="GlookoSyncData"/> structure.
     /// </summary>
-    private async Task<GlookoSyncData?> FetchAndMapViaV3Async(DateTime? from)
+    private async Task<GlookoSyncData?> FetchAndMapViaV3Async(DateTime fromDate, DateTime toDate)
     {
         _logger.LogInformation("[{ConnectorSource}] Fetching data from v3 API...", ConnectorSource);
 
-        var v3Data = await FetchV3GraphDataAsync(from);
+        var v3Data = await FetchV3GraphDataAsync(fromDate, toDate);
         if (v3Data == null) return null;
 
         GlookoV3HistoriesResponse? v3Histories = null;
         try
         {
-            v3Histories = await FetchV3HistoriesAsync(from);
+            v3Histories = await FetchV3HistoriesAsync(fromDate, toDate);
         }
         catch (Exception histEx)
         {
@@ -431,7 +432,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         {
             try
             {
-                v2Foods = await FetchV2FoodsAsync(from);
+                v2Foods = await FetchV2FoodsAsync(fromDate, toDate);
             }
             catch (Exception v2Ex)
             {
@@ -664,15 +665,12 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     /// <summary>
     ///     Fetches comprehensive batch data from all v2 Glooko endpoints.
     /// </summary>
-    public async Task<GlookoBatchData?> FetchBatchDataAsync(DateTime? since = null)
+    public async Task<GlookoBatchData?> FetchBatchDataAsync(DateTime fromDate, DateTime toDate)
     {
         try
         {
             var patientCode = EnsureAuthenticatedAndGetCode();
             if (patientCode == null) return null;
-
-            var fromDate = since ?? _timeMapper.ToGlookoTime(DateTime.UtcNow.AddDays(-1));
-            var toDate = _timeMapper.ToGlookoTime(DateTime.UtcNow);
 
             _logger.LogInformation("Fetching comprehensive Glooko data from {From:yyyy-MM-dd} to {To:yyyy-MM-dd}", fromDate, toDate);
 
@@ -770,15 +768,12 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     ///     Fetches only the V2 foods endpoint. Used by the V3 sync path to get
     ///     rich food metadata (externalId, brand) that V3 histories doesn't provide.
     /// </summary>
-    public async Task<GlookoFood[]?> FetchV2FoodsAsync(DateTime? since = null)
+    public async Task<GlookoFood[]?> FetchV2FoodsAsync(DateTime fromDate, DateTime toDate)
     {
         try
         {
             var patientCode = EnsureAuthenticatedAndGetCode();
             if (patientCode == null) return null;
-
-            var fromDate = since ?? _timeMapper.ToGlookoTime(DateTime.UtcNow.AddDays(-1));
-            var toDate = _timeMapper.ToGlookoTime(DateTime.UtcNow);
 
             var url = ConstructV2Url(GlookoConstants.FoodsPath, fromDate, toDate);
             var result = await FetchFromGlookoEndpointWithRetry(url);
@@ -835,7 +830,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     /// <summary>
     ///     Fetches data from v3 graph/data API — single call for all data types.
     /// </summary>
-    public async Task<GlookoV3GraphResponse?> FetchV3GraphDataAsync(DateTime? since = null)
+    public async Task<GlookoV3GraphResponse?> FetchV3GraphDataAsync(DateTime fromDate, DateTime toDate)
     {
         try
         {
@@ -843,9 +838,6 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             if (patientCode == null) return null;
 
             if (string.IsNullOrEmpty(_meterUnits)) await FetchV3UserProfileAsync();
-
-            var fromDate = since ?? _timeMapper.ToGlookoTime(DateTime.UtcNow.AddDays(-1));
-            var toDate = _timeMapper.ToGlookoTime(DateTime.UtcNow);
 
             var url = ConstructV3GraphUrl(fromDate, toDate);
             _logger.LogInformation("[{ConnectorSource}] Fetching v3 graph data from {StartDate:yyyy-MM-dd} to {EndDate:yyyy-MM-dd}",
@@ -932,15 +924,12 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     ///     Fetches rich history data from the v3 users/summary/histories API.
     ///     Contains meals with per-food nutritional data, medications, exercises, etc.
     /// </summary>
-    public async Task<GlookoV3HistoriesResponse?> FetchV3HistoriesAsync(DateTime? since = null)
+    public async Task<GlookoV3HistoriesResponse?> FetchV3HistoriesAsync(DateTime fromDate, DateTime toDate)
     {
         try
         {
             var patientCode = EnsureAuthenticatedAndGetCode();
             if (patientCode == null) return null;
-
-            var fromDate = since ?? _timeMapper.ToGlookoTime(DateTime.UtcNow.AddDays(-1));
-            var toDate = _timeMapper.ToGlookoTime(DateTime.UtcNow);
 
             var url = $"{GlookoConstants.V3HistoriesPath}?patient={patientCode}"
                     + $"&startDate={fromDate:yyyy-MM-ddTHH:mm:ss.fffZ}"

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Options;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
 using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.Core.Utilities;
 using Nocturne.Connectors.Glooko.Configurations;
 using Nocturne.Connectors.Glooko.Mappers;
 using Nocturne.Connectors.Glooko.Models;
@@ -262,23 +263,46 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
 
             var from = request.From.HasValue
                 ? _timeMapper.ToGlookoTime(request.From.Value)
-                : (DateTime?)null;
+                : _timeMapper.ToGlookoTime(DateTime.UtcNow.AddMonths(-6));
+            var to = _timeMapper.ToGlookoTime(DateTime.UtcNow);
 
-            await ReportMessageAsync(progressReporter, SyncMessageType.FetchingData,
-                new() { ["from"] = (from ?? DateTime.UtcNow.AddMonths(-6)).ToString("MMM dd"), ["to"] = DateTime.UtcNow.ToString("MMM dd") },
-                cancellationToken);
+            var chunks = DateChunker.Chunk(from, to, TimeSpan.FromDays(14)).ToList();
 
-            // Fetch + map + publish: V2 or V3 path handles everything per-type
-            var success = _config.UseV3Api
-                ? await FetchAndMapViaV3Async(from, activeTypes, result, config, cancellationToken)
-                : await FetchAndMapViaV2Async(from, activeTypes, result, config, cancellationToken);
+            _logger.LogInformation(
+                "[{ConnectorSource}] Syncing {From:yyyy-MM-dd} to {To:yyyy-MM-dd} in {ChunkCount} chunk(s)",
+                ConnectorSource, from, to, chunks.Count);
 
-            if (!success)
+            for (var i = 0; i < chunks.Count; i++)
             {
-                result.Success = false;
-                result.Message = "Failed to fetch data";
-                result.Errors.Add("No data returned from Glooko");
-                return result;
+                var (chunkFrom, chunkTo) = chunks[i];
+
+                await ReportMessageAsync(progressReporter, SyncMessageType.FetchingData,
+                    new()
+                    {
+                        ["from"] = chunkFrom.ToString("MMM dd"),
+                        ["to"] = chunkTo.ToString("MMM dd"),
+                        ["chunk"] = $"{i + 1}/{chunks.Count}",
+                    },
+                    cancellationToken);
+
+                var chunkSuccess = _config.UseV3Api
+                    ? await FetchAndMapViaV3Async(chunkFrom, chunkTo, activeTypes, result, config, cancellationToken)
+                    : await FetchAndMapViaV2Async(chunkFrom, chunkTo, activeTypes, result, config, cancellationToken);
+
+                if (!chunkSuccess)
+                {
+                    _logger.LogWarning(
+                        "[{ConnectorSource}] Chunk {Chunk}/{Total} ({From:yyyy-MM-dd} to {To:yyyy-MM-dd}) failed, stopping sync",
+                        ConnectorSource, i + 1, chunks.Count, chunkFrom, chunkTo);
+                    result.Success = false;
+                    result.Message = "Sync failed during data fetch";
+                    result.Errors.Add($"Chunk {i + 1}/{chunks.Count} failed ({chunkFrom:yyyy-MM-dd} to {chunkTo:yyyy-MM-dd})");
+                    break;
+                }
+
+                _logger.LogInformation(
+                    "[{ConnectorSource}] Completed chunk {Chunk}/{Total} ({From:yyyy-MM-dd} to {To:yyyy-MM-dd})",
+                    ConnectorSource, i + 1, chunks.Count, chunkFrom, chunkTo);
             }
 
             // Profiles (V3 device settings — used in both modes, no V2 equivalent)
@@ -332,19 +356,21 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     ///     Fetches from all V2 endpoints, maps each record type, and publishes inline.
     /// </summary>
     private async Task<bool> FetchAndMapViaV2Async(
-        DateTime? from,
+        DateTime fromDate,
+        DateTime toDate,
         HashSet<SyncDataType> activeTypes,
         SyncResult result,
         GlookoConnectorConfiguration config,
         CancellationToken cancellationToken)
     {
-        var batchData = await FetchBatchDataAsync(from);
+        var batchData = await FetchBatchDataAsync(fromDate, toDate);
         if (batchData == null) return false;
 
         // 1. Glucose
         var sensorGlucose = _sensorGlucoseMapper.TransformBatchDataToSensorGlucose(batchData).ToList();
         await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
             sensorGlucose, PublishSensorGlucoseDataAsync, config, cancellationToken);
+        UpdateLastEntryTime(result, SyncDataType.Glucose, sensorGlucose);
 
         var bgChecks = _sensorGlucoseMapper.TransformBatchDataToBGChecks(batchData).ToList();
         await PublishRecordTypeAsync(result, SyncDataType.ManualBG, activeTypes,
@@ -390,7 +416,8 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     ///     Fetches from V3 graph/data and histories endpoints, maps each record type, and publishes inline.
     /// </summary>
     private async Task<bool> FetchAndMapViaV3Async(
-        DateTime? from,
+        DateTime fromDate,
+        DateTime toDate,
         HashSet<SyncDataType> activeTypes,
         SyncResult result,
         GlookoConnectorConfiguration config,
@@ -398,11 +425,11 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     {
         _logger.LogInformation("[{ConnectorSource}] Fetching data from v3 API...", ConnectorSource);
 
-        var v3Data = await FetchV3GraphDataAsync(from);
+        var v3Data = await FetchV3GraphDataAsync(fromDate, toDate);
         if (v3Data == null) return false;
 
         GlookoV3HistoriesResponse? v3Histories = null;
-        try { v3Histories = await FetchV3HistoriesAsync(from); }
+        try { v3Histories = await FetchV3HistoriesAsync(fromDate, toDate); }
         catch (Exception histEx)
         {
             _logger.LogWarning(histEx, "[{ConnectorSource}] V3 histories fetch failed, meal data will be unavailable", ConnectorSource);
@@ -414,6 +441,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             var sensorGlucose = _sensorGlucoseMapper.TransformV3ToSensorGlucose(v3Data, _meterUnits).ToList();
             await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
                 sensorGlucose, PublishSensorGlucoseDataAsync, config, cancellationToken);
+            UpdateLastEntryTime(result, SyncDataType.Glucose, sensorGlucose);
         }
 
         var bgChecks = _sensorGlucoseMapper.TransformV3ToBGChecks(v3Data, _meterUnits).ToList();
@@ -446,7 +474,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         GlookoFood[]? v2Foods = null;
         if (historyMealCarbs.Count > 0)
         {
-            try { v2Foods = await FetchV2FoodsAsync(from); }
+            try { v2Foods = await FetchV2FoodsAsync(fromDate, toDate); }
             catch (Exception v2Ex)
             {
                 _logger.LogWarning(v2Ex, "[{ConnectorSource}] V2 foods fetch failed, food entries will lack externalId/brand metadata", ConnectorSource);
@@ -574,20 +602,29 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             ConnectorSource, attributedCount, pendingEntries.Count);
     }
 
+    /// <summary>
+    ///     Updates <see cref="SyncResult.LastEntryTimes"/> with the most recent glucose timestamp,
+    ///     keeping the max across multiple chunks.
+    /// </summary>
+    private static void UpdateLastEntryTime(SyncResult result, SyncDataType dataType, List<SensorGlucose> records)
+    {
+        if (records.Count == 0) return;
+        var maxTime = DateTimeOffset.FromUnixTimeMilliseconds(records.Max(s => s.Mills)).UtcDateTime;
+        if (!result.LastEntryTimes.TryGetValue(dataType, out var existing) || maxTime > existing)
+            result.LastEntryTimes[dataType] = maxTime;
+    }
+
     // ── V2 batch data fetching ──────────────────────────────────────────
 
     /// <summary>
     ///     Fetches comprehensive batch data from all v2 Glooko endpoints.
     /// </summary>
-    public async Task<GlookoBatchData?> FetchBatchDataAsync(DateTime? since = null)
+    public async Task<GlookoBatchData?> FetchBatchDataAsync(DateTime fromDate, DateTime toDate)
     {
         try
         {
             var patientCode = EnsureAuthenticatedAndGetCode();
             if (patientCode == null) return null;
-
-            var fromDate = since ?? _timeMapper.ToGlookoTime(DateTime.UtcNow.AddDays(-1));
-            var toDate = _timeMapper.ToGlookoTime(DateTime.UtcNow);
 
             _logger.LogInformation("Fetching comprehensive Glooko data from {From:yyyy-MM-dd} to {To:yyyy-MM-dd}", fromDate, toDate);
 
@@ -685,15 +722,12 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     ///     Fetches only the V2 foods endpoint. Used by the V3 sync path to get
     ///     rich food metadata (externalId, brand) that V3 histories doesn't provide.
     /// </summary>
-    public async Task<GlookoFood[]?> FetchV2FoodsAsync(DateTime? since = null)
+    public async Task<GlookoFood[]?> FetchV2FoodsAsync(DateTime fromDate, DateTime toDate)
     {
         try
         {
             var patientCode = EnsureAuthenticatedAndGetCode();
             if (patientCode == null) return null;
-
-            var fromDate = since ?? _timeMapper.ToGlookoTime(DateTime.UtcNow.AddDays(-1));
-            var toDate = _timeMapper.ToGlookoTime(DateTime.UtcNow);
 
             var url = ConstructV2Url(GlookoConstants.FoodsPath, fromDate, toDate);
             var result = await FetchFromGlookoEndpointWithRetry(url);
@@ -750,7 +784,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     /// <summary>
     ///     Fetches data from v3 graph/data API — single call for all data types.
     /// </summary>
-    public async Task<GlookoV3GraphResponse?> FetchV3GraphDataAsync(DateTime? since = null)
+    public async Task<GlookoV3GraphResponse?> FetchV3GraphDataAsync(DateTime fromDate, DateTime toDate)
     {
         try
         {
@@ -758,9 +792,6 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             if (patientCode == null) return null;
 
             if (string.IsNullOrEmpty(_meterUnits)) await FetchV3UserProfileAsync();
-
-            var fromDate = since ?? _timeMapper.ToGlookoTime(DateTime.UtcNow.AddDays(-1));
-            var toDate = _timeMapper.ToGlookoTime(DateTime.UtcNow);
 
             var url = ConstructV3GraphUrl(fromDate, toDate);
             _logger.LogInformation("[{ConnectorSource}] Fetching v3 graph data from {StartDate:yyyy-MM-dd} to {EndDate:yyyy-MM-dd}",
@@ -847,15 +878,12 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     ///     Fetches rich history data from the v3 users/summary/histories API.
     ///     Contains meals with per-food nutritional data, medications, exercises, etc.
     /// </summary>
-    public async Task<GlookoV3HistoriesResponse?> FetchV3HistoriesAsync(DateTime? since = null)
+    public async Task<GlookoV3HistoriesResponse?> FetchV3HistoriesAsync(DateTime fromDate, DateTime toDate)
     {
         try
         {
             var patientCode = EnsureAuthenticatedAndGetCode();
             if (patientCode == null) return null;
-
-            var fromDate = since ?? _timeMapper.ToGlookoTime(DateTime.UtcNow.AddDays(-1));
-            var toDate = _timeMapper.ToGlookoTime(DateTime.UtcNow);
 
             var url = $"{GlookoConstants.V3HistoriesPath}?patient={patientCode}"
                     + $"&startDate={fromDate:yyyy-MM-ddTHH:mm:ss.fffZ}"

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -17,24 +17,10 @@ using Nocturne.Core.Models.V4;
 namespace Nocturne.Connectors.Glooko.Services;
 
 /// <summary>
-///     All mapped data produced by a V2 or V3 fetch-and-transform pass.
-///     Populated by <see cref="GlookoConnectorService.FetchAndMapViaV2Async"/> or
-///     <see cref="GlookoConnectorService.FetchAndMapViaV3Async"/>, then consumed
-///     by the shared <see cref="GlookoConnectorService.PublishAllAsync"/> pipeline.
+///     Lightweight context for food-to-carb attribution within a sync chunk.
 /// </summary>
-internal sealed class GlookoSyncData
+internal sealed class GlookoFoodContext
 {
-    public List<SensorGlucose> SensorGlucose { get; init; } = [];
-    public List<BGCheck> BgChecks { get; init; } = [];
-    public List<Bolus> Boluses { get; init; } = [];
-    public List<CarbIntake> CarbIntakes { get; init; } = [];
-    public List<DecompositionBatch> Batches { get; init; } = [];
-    public List<StateSpan> StateSpans { get; init; } = [];
-    public List<TempBasal> TempBasals { get; init; } = [];
-    public List<DeviceEvent> DeviceEvents { get; init; } = [];
-    public List<SystemEvent> SystemEvents { get; init; } = [];
-    public List<ConnectorFoodEntryImport> FoodEntryImports { get; init; } = [];
-
     /// <summary>
     ///     Resolves a food entry's ExternalEntryId to the LegacyId of the CarbIntake it belongs to.
     ///     V2: direct mapping (glooko_food_{externalEntryId}).
@@ -289,28 +275,24 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
 
             var from = request.From.HasValue
                 ? _timeMapper.ToGlookoTime(request.From.Value)
-                : _timeMapper.ToGlookoTime(DateTime.UtcNow.AddDays(-1));
-            var to = _timeMapper.ToGlookoTime(DateTime.UtcNow);
+                : (DateTime?)null;
 
             await ReportMessageAsync(progressReporter, SyncMessageType.FetchingData,
-                new() { ["from"] = from.ToString("MMM dd"), ["to"] = to.ToString("MMM dd") },
+                new() { ["from"] = (from ?? DateTime.UtcNow.AddMonths(-6)).ToString("MMM dd"), ["to"] = DateTime.UtcNow.ToString("MMM dd") },
                 cancellationToken);
 
-            // Fetch + map: V2 or V3 path fills the same data structure
-            var syncData = _config.UseV3Api
-                ? await FetchAndMapViaV3Async(from, to)
-                : await FetchAndMapViaV2Async(from, to);
+            // Fetch + map + publish: V2 or V3 path handles everything per-type
+            var success = _config.UseV3Api
+                ? await FetchAndMapViaV3Async(from, activeTypes, result, config, cancellationToken)
+                : await FetchAndMapViaV2Async(from, activeTypes, result, config, cancellationToken);
 
-            if (syncData == null)
+            if (!success)
             {
                 result.Success = false;
                 result.Message = "Failed to fetch data";
                 result.Errors.Add("No data returned from Glooko");
                 return result;
             }
-
-            // Single publish pipeline for all data types
-            await PublishAllAsync(syncData, activeTypes, result, config, progressReporter, cancellationToken);
 
             // Profiles (V3 device settings — used in both modes, no V2 equivalent)
             await ReportMessageAsync(progressReporter, SyncMessageType.ProcessingDataType,
@@ -360,80 +342,121 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     // ── V2 fetch + map ──────────────────────────────────────────────────
 
     /// <summary>
-    ///     Fetches from all V2 endpoints and maps to the common <see cref="GlookoSyncData"/> structure.
+    ///     Fetches from all V2 endpoints, maps each record type, and publishes inline.
     /// </summary>
-    private async Task<GlookoSyncData?> FetchAndMapViaV2Async(DateTime fromDate, DateTime toDate)
+    private async Task<bool> FetchAndMapViaV2Async(
+        DateTime? from,
+        HashSet<SyncDataType> activeTypes,
+        SyncResult result,
+        GlookoConnectorConfiguration config,
+        CancellationToken cancellationToken)
     {
-        var batchData = await FetchBatchDataAsync(fromDate, toDate);
-        if (batchData == null) return null;
+        var batchData = await FetchBatchDataAsync(from);
+        if (batchData == null) return false;
 
+        // 1. Glucose
+        var sensorGlucose = _sensorGlucoseMapper.TransformBatchDataToSensorGlucose(batchData).ToList();
+        await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
+            sensorGlucose, PublishSensorGlucoseDataAsync, config, cancellationToken);
+
+        var bgChecks = _sensorGlucoseMapper.TransformBatchDataToBGChecks(batchData).ToList();
+        await PublishRecordTypeAsync(result, SyncDataType.ManualBG, activeTypes,
+            bgChecks, PublishBGCheckDataAsync, config, cancellationToken);
+
+        // 2. Treatments (FK order: batches → boluses → carbs+foods)
         var (boluses, carbs, batches) = _v4TreatmentMapper.MapBatchData(batchData);
 
-        var data = new GlookoSyncData
-        {
-            SensorGlucose = _sensorGlucoseMapper.TransformBatchDataToSensorGlucose(batchData).ToList(),
-            BgChecks = _sensorGlucoseMapper.TransformBatchDataToBGChecks(batchData).ToList(),
-            Boluses = boluses,
-            CarbIntakes = carbs,
-            Batches = batches,
-            StateSpans = _stateSpanMapper.TransformV2ToStateSpans(batchData),
-            TempBasals = _tempBasalMapper.TransformV2ToTempBasals(batchData),
-            FoodEntryImports = batchData.Foods is { Length: > 0 }
-                ? _v4TreatmentMapper.MapFoodsToConnectorEntries(batchData)
-                : [],
-            // V2: direct guid correlation — food.Guid → CarbIntake.LegacyId "glooko_food_{guid}"
-            FoodEntryToCarbLegacyId = externalEntryId => $"glooko_food_{externalEntryId}",
-        };
+        if (batches.Count > 0)
+            await PublishDecompositionBatchesAsync(batches, config, cancellationToken);
 
-        return data;
+        await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
+            boluses, PublishBolusDataAsync, config, cancellationToken);
+
+        await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, activeTypes,
+            carbs, PublishCarbIntakeDataAsync, config, cancellationToken);
+
+        // 3. Foods + attribution (coupled with carbs)
+        var foodEntryImports = batchData.Foods is { Length: > 0 }
+            ? _v4TreatmentMapper.MapFoodsToConnectorEntries(batchData) : [];
+        Func<string, string?> foodResolver = externalEntryId => $"glooko_food_{externalEntryId}";
+        await PublishFoodEntriesAndAttributeAsync(
+            foodEntryImports, carbs, foodResolver, config, cancellationToken);
+
+        // 4. State spans + temp basals
+        var stateSpans = _stateSpanMapper.TransformV2ToStateSpans(batchData);
+        await PublishRecordTypeAsync(result, SyncDataType.StateSpans, activeTypes,
+            stateSpans, PublishStateSpanDataAsync, config, cancellationToken);
+
+        var tempBasals = _tempBasalMapper.TransformV2ToTempBasals(batchData);
+        await PublishRecordTypeAsync(result, SyncDataType.StateSpans, activeTypes,
+            tempBasals, PublishTempBasalDataAsync, config, cancellationToken);
+
+        return true;
     }
 
     // ── V3 fetch + map ──────────────────────────────────────────────────
 
     /// <summary>
-    ///     Fetches from V3 graph/data and histories endpoints, maps to the common <see cref="GlookoSyncData"/> structure.
+    ///     Fetches from V3 graph/data and histories endpoints, maps each record type, and publishes inline.
     /// </summary>
-    private async Task<GlookoSyncData?> FetchAndMapViaV3Async(DateTime fromDate, DateTime toDate)
+    private async Task<bool> FetchAndMapViaV3Async(
+        DateTime? from,
+        HashSet<SyncDataType> activeTypes,
+        SyncResult result,
+        GlookoConnectorConfiguration config,
+        CancellationToken cancellationToken)
     {
         _logger.LogInformation("[{ConnectorSource}] Fetching data from v3 API...", ConnectorSource);
 
-        var v3Data = await FetchV3GraphDataAsync(fromDate, toDate);
-        if (v3Data == null) return null;
+        var v3Data = await FetchV3GraphDataAsync(from);
+        if (v3Data == null) return false;
 
         GlookoV3HistoriesResponse? v3Histories = null;
-        try
-        {
-            v3Histories = await FetchV3HistoriesAsync(fromDate, toDate);
-        }
+        try { v3Histories = await FetchV3HistoriesAsync(from); }
         catch (Exception histEx)
         {
             _logger.LogWarning(histEx, "[{ConnectorSource}] V3 histories fetch failed, meal data will be unavailable", ConnectorSource);
         }
 
+        // 1. Glucose
+        if (_config.V3IncludeCgmBackfill)
+        {
+            var sensorGlucose = _sensorGlucoseMapper.TransformV3ToSensorGlucose(v3Data, _meterUnits).ToList();
+            await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
+                sensorGlucose, PublishSensorGlucoseDataAsync, config, cancellationToken);
+        }
+
+        var bgChecks = _sensorGlucoseMapper.TransformV3ToBGChecks(v3Data, _meterUnits).ToList();
+        await PublishRecordTypeAsync(result, SyncDataType.ManualBG, activeTypes,
+            bgChecks, PublishBGCheckDataAsync, config, cancellationToken);
+
+        // 2. Treatments (FK order: batches → boluses → carbs+foods)
         var (v3Boluses, v3BolusCarbIntakes, v3Batches) = _v4TreatmentMapper.MapV3Boluses(v3Data);
 
-        // Carbs: from bolus wizard + from V3 history meals (preferred) or carbAll series (fallback).
-        // History meals are preferred because their legacy IDs ("glooko_v3meal_{mealGuid}")
-        // are needed for food attribution. carbAll would create duplicate carb entries
-        // with different legacy IDs, breaking the food → carb correlation.
+        // Carbs: bolus wizard + history meals (preferred) or carbAll (fallback)
         var allCarbs = new List<CarbIntake>(v3BolusCarbIntakes);
         var historyMealCarbs = v3Histories?.Histories != null
-            ? _v4TreatmentMapper.MapV3HistoryMealsToCarbIntakes(v3Histories)
-            : [];
+            ? _v4TreatmentMapper.MapV3HistoryMealsToCarbIntakes(v3Histories) : [];
 
         if (historyMealCarbs.Count > 0)
             allCarbs.AddRange(historyMealCarbs);
         else
             allCarbs.AddRange(_v4TreatmentMapper.MapV3CarbAll(v3Data));
 
-        // Food entries: merge V3 history meals (structure + meal type) with V2 foods (externalId, brand)
+        if (v3Batches.Count > 0)
+            await PublishDecompositionBatchesAsync(v3Batches, config, cancellationToken);
+
+        await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
+            v3Boluses, PublishBolusDataAsync, config, cancellationToken);
+
+        await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, activeTypes,
+            allCarbs, PublishCarbIntakeDataAsync, config, cancellationToken);
+
+        // 3. Foods + attribution (coupled with carbs)
         GlookoFood[]? v2Foods = null;
         if (historyMealCarbs.Count > 0)
         {
-            try
-            {
-                v2Foods = await FetchV2FoodsAsync(fromDate, toDate);
-            }
+            try { v2Foods = await FetchV2FoodsAsync(from); }
             catch (Exception v2Ex)
             {
                 _logger.LogWarning(v2Ex, "[{ConnectorSource}] V2 foods fetch failed, food entries will lack externalId/brand metadata", ConnectorSource);
@@ -441,10 +464,9 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         }
 
         var foodEntryImports = historyMealCarbs.Count > 0 && v3Histories?.Histories != null
-            ? _v4TreatmentMapper.MapV3HistoryMealsToConnectorEntries(v3Histories, v2Foods)
-            : [];
+            ? _v4TreatmentMapper.MapV3HistoryMealsToConnectorEntries(v3Histories, v2Foods) : [];
 
-        // Build food guid → meal guid lookup for attribution (only when using history meals)
+        // Build food resolver
         Func<string, string?>? foodResolver = null;
         if (historyMealCarbs.Count > 0 && v3Histories?.Histories != null)
         {
@@ -461,203 +483,94 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
 
             foodResolver = externalEntryId =>
                 foodGuidToMealGuid.TryGetValue(externalEntryId, out var mealGuid)
-                    ? $"glooko_v3meal_{mealGuid}"
-                    : null;
+                    ? $"glooko_v3meal_{mealGuid}" : null;
         }
 
-        var data = new GlookoSyncData
-        {
-            SensorGlucose = _config.V3IncludeCgmBackfill
-                ? _sensorGlucoseMapper.TransformV3ToSensorGlucose(v3Data, _meterUnits).ToList()
-                : [],
-            BgChecks = _sensorGlucoseMapper.TransformV3ToBGChecks(v3Data, _meterUnits).ToList(),
-            Boluses = v3Boluses,
-            CarbIntakes = allCarbs,
-            Batches = v3Batches,
-            StateSpans = _stateSpanMapper.TransformV3ToStateSpans(v3Data),
-            TempBasals = _tempBasalMapper.TransformV3ToTempBasals(v3Data),
-            DeviceEvents = _v4TreatmentMapper.MapV3DeviceEvents(v3Data),
-            SystemEvents = _systemEventMapper.TransformV3ToSystemEvents(v3Data),
-            FoodEntryImports = foodEntryImports,
-            FoodEntryToCarbLegacyId = foodResolver,
-        };
-
-        return data;
-    }
-
-    // ── Shared publish pipeline ──────────────────────────────────────────
-
-    /// <summary>
-    ///     Publishes all data types from a <see cref="GlookoSyncData"/> bag.
-    ///     Shared between V2 and V3 — the only difference is how the bag was filled.
-    /// </summary>
-    private async Task PublishAllAsync(
-        GlookoSyncData data,
-        HashSet<SyncDataType> activeTypes,
-        SyncResult result,
-        GlookoConnectorConfiguration config,
-        ISyncProgressReporter? progressReporter,
-        CancellationToken cancellationToken)
-    {
-        // 1. Glucose
-        await ReportMessageAsync(progressReporter, SyncMessageType.ProcessingDataType,
-            new() { ["dataType"] = SyncDataType.Glucose.ToString() }, cancellationToken);
-
-        if (activeTypes.Contains(SyncDataType.Glucose))
-        {
-            if (data.SensorGlucose.Count > 0)
-            {
-                if (await PublishSensorGlucoseDataAsync(data.SensorGlucose, config, cancellationToken))
-                {
-                    result.ItemsSynced[SyncDataType.Glucose] = data.SensorGlucose.Count;
-                    result.LastEntryTimes[SyncDataType.Glucose] = DateTimeOffset
-                        .FromUnixTimeMilliseconds(data.SensorGlucose.Max(s => s.Mills)).UtcDateTime;
-
-                    await ReportMessageAsync(progressReporter, SyncMessageType.PublishingDataType,
-                        new() { ["dataType"] = SyncDataType.Glucose.ToString(), ["count"] = data.SensorGlucose.Count.ToString() },
-                        cancellationToken);
-
-                    _logger.LogInformation("[{ConnectorSource}] Published {Count} sensor glucose records",
-                        ConnectorSource, data.SensorGlucose.Count);
-                }
-            }
-
-            if (data.BgChecks.Count > 0)
-            {
-                if (await PublishBGCheckDataAsync(data.BgChecks, config, cancellationToken))
-                    _logger.LogInformation("[{ConnectorSource}] Published {Count} BG checks",
-                        ConnectorSource, data.BgChecks.Count);
-            }
-        }
-
-        // 2. Treatments (batches → boluses → carb intakes)
-        if (data.Batches.Count > 0)
-            await PublishDecompositionBatchesAsync(data.Batches, config, cancellationToken);
-
-        await ReportMessageAsync(progressReporter, SyncMessageType.ProcessingDataType,
-            new() { ["dataType"] = SyncDataType.Boluses.ToString() }, cancellationToken);
-
-        if (activeTypes.Contains(SyncDataType.Boluses) && data.Boluses.Count > 0)
-        {
-            if (await PublishBolusDataAsync(data.Boluses, config, cancellationToken))
-            {
-                result.ItemsSynced[SyncDataType.Boluses] = data.Boluses.Count;
-                _logger.LogInformation("[{ConnectorSource}] Published {Count} boluses", ConnectorSource, data.Boluses.Count);
-                await ReportMessageAsync(progressReporter, SyncMessageType.PublishingDataType,
-                    new() { ["dataType"] = SyncDataType.Boluses.ToString(), ["count"] = data.Boluses.Count.ToString() }, cancellationToken);
-            }
-        }
-
-        await ReportMessageAsync(progressReporter, SyncMessageType.ProcessingDataType,
-            new() { ["dataType"] = SyncDataType.CarbIntake.ToString() }, cancellationToken);
-
-        if (activeTypes.Contains(SyncDataType.CarbIntake) && data.CarbIntakes.Count > 0)
-        {
-            if (await PublishCarbIntakeDataAsync(data.CarbIntakes, config, cancellationToken))
-            {
-                result.ItemsSynced[SyncDataType.CarbIntake] = data.CarbIntakes.Count;
-                _logger.LogInformation("[{ConnectorSource}] Published {Count} carb intakes", ConnectorSource, data.CarbIntakes.Count);
-                await ReportMessageAsync(progressReporter, SyncMessageType.PublishingDataType,
-                    new() { ["dataType"] = SyncDataType.CarbIntake.ToString(), ["count"] = data.CarbIntakes.Count.ToString() }, cancellationToken);
-            }
-        }
-
-        // 3. Food catalog + attribution
-        if (data.FoodEntryImports.Count > 0 && _connectorPublisher is { IsAvailable: true })
-        {
-            var importedEntries = await _connectorPublisher.Metadata.PublishConnectorFoodEntriesAsync(
-                data.FoodEntryImports, ConnectorSource, cancellationToken);
-
-            if (importedEntries is { Count: > 0 })
-            {
-                _logger.LogInformation("[{ConnectorSource}] Published {Count} food entries to connector food catalog",
-                    ConnectorSource, importedEntries.Count);
-
-                if (_mealMatchingService != null && data.CarbIntakes.Count > 0 && data.FoodEntryToCarbLegacyId != null)
-                {
-                    var pendingEntries = importedEntries
-                        .Where(e => e.Status == ConnectorFoodEntryStatus.Pending)
-                        .ToList();
-
-                    if (pendingEntries.Count > 0)
-                    {
-                        var carbsByLegacyId = data.CarbIntakes
-                            .Where(ci => ci.LegacyId != null)
-                            .ToDictionary(ci => ci.LegacyId!, StringComparer.OrdinalIgnoreCase);
-
-                        var attributedCount = 0;
-
-                        foreach (var entry in pendingEntries)
-                        {
-                            var legacyKey = data.FoodEntryToCarbLegacyId(entry.ExternalEntryId);
-                            if (legacyKey == null || !carbsByLegacyId.TryGetValue(legacyKey, out var carbIntake))
-                                continue;
-
-                            try
-                            {
-                                await _mealMatchingService.AcceptMatchAsync(
-                                    entry.Id, carbIntake.Id, entry.Carbs, timeOffsetMinutes: 0, cancellationToken);
-                                attributedCount++;
-                            }
-                            catch (Exception ex)
-                            {
-                                _logger.LogWarning(ex,
-                                    "[{ConnectorSource}] Failed to attribute food entry {FoodEntryId} to CarbIntake {CarbIntakeId}",
-                                    ConnectorSource, entry.Id, carbIntake.Id);
-                            }
-                        }
-
-                        _logger.LogInformation("[{ConnectorSource}] Attributed {Count}/{Total} food entries to carb intakes",
-                            ConnectorSource, attributedCount, pendingEntries.Count);
-                    }
-                }
-            }
-        }
+        await PublishFoodEntriesAndAttributeAsync(
+            foodEntryImports, allCarbs, foodResolver, config, cancellationToken);
 
         // 4. State spans + temp basals
-        await ReportMessageAsync(progressReporter, SyncMessageType.ProcessingDataType,
-            new() { ["dataType"] = SyncDataType.StateSpans.ToString() }, cancellationToken);
+        var stateSpans = _stateSpanMapper.TransformV3ToStateSpans(v3Data);
+        await PublishRecordTypeAsync(result, SyncDataType.StateSpans, activeTypes,
+            stateSpans, PublishStateSpanDataAsync, config, cancellationToken);
 
-        if (activeTypes.Contains(SyncDataType.StateSpans))
-        {
-            var tempBasalCount = 0;
-
-            if (data.StateSpans.Count > 0 && await PublishStateSpanDataAsync(data.StateSpans, config, cancellationToken))
-                _logger.LogInformation("[{ConnectorSource}] Published {Count} state spans", ConnectorSource, data.StateSpans.Count);
-
-            if (data.TempBasals.Count > 0 && await PublishTempBasalDataAsync(data.TempBasals, config, cancellationToken))
-            {
-                tempBasalCount = data.TempBasals.Count;
-                _logger.LogInformation("[{ConnectorSource}] Published {Count} temp basals", ConnectorSource, data.TempBasals.Count);
-            }
-
-            if (tempBasalCount > 0)
-                result.ItemsSynced[SyncDataType.StateSpans] = tempBasalCount;
-        }
+        var tempBasals = _tempBasalMapper.TransformV3ToTempBasals(v3Data);
+        await PublishRecordTypeAsync(result, SyncDataType.StateSpans, activeTypes,
+            tempBasals, PublishTempBasalDataAsync, config, cancellationToken);
 
         // 5. Device events + system events
-        await ReportMessageAsync(progressReporter, SyncMessageType.ProcessingDataType,
-            new() { ["dataType"] = SyncDataType.DeviceEvents.ToString() }, cancellationToken);
+        var deviceEvents = _v4TreatmentMapper.MapV3DeviceEvents(v3Data);
+        await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, activeTypes,
+            deviceEvents, PublishDeviceEventDataAsync, config, cancellationToken);
 
-        if (activeTypes.Contains(SyncDataType.DeviceEvents))
+        var systemEvents = _systemEventMapper.TransformV3ToSystemEvents(v3Data);
+        await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, activeTypes,
+            systemEvents, PublishSystemEventDataAsync, config, cancellationToken);
+
+        return true;
+    }
+
+    // ── Food attribution helper ────────────────────────────────────────
+
+    /// <summary>
+    ///     Publishes food catalog entries and attributes them to carb intakes via the meal matching service.
+    /// </summary>
+    private async Task PublishFoodEntriesAndAttributeAsync(
+        List<ConnectorFoodEntryImport> foodEntryImports,
+        List<CarbIntake> carbIntakes,
+        Func<string, string?>? foodEntryToCarbLegacyId,
+        GlookoConnectorConfiguration config,
+        CancellationToken cancellationToken)
+    {
+        if (foodEntryImports.Count == 0 || _connectorPublisher is not { IsAvailable: true })
+            return;
+
+        var importedEntries = await _connectorPublisher.Metadata.PublishConnectorFoodEntriesAsync(
+            foodEntryImports, ConnectorSource, cancellationToken);
+
+        if (importedEntries is not { Count: > 0 })
+            return;
+
+        _logger.LogInformation("[{ConnectorSource}] Published {Count} food entries to connector food catalog",
+            ConnectorSource, importedEntries.Count);
+
+        if (_mealMatchingService == null || carbIntakes.Count == 0 || foodEntryToCarbLegacyId == null)
+            return;
+
+        var pendingEntries = importedEntries
+            .Where(e => e.Status == ConnectorFoodEntryStatus.Pending)
+            .ToList();
+
+        if (pendingEntries.Count == 0) return;
+
+        var carbsByLegacyId = carbIntakes
+            .Where(ci => ci.LegacyId != null)
+            .ToDictionary(ci => ci.LegacyId!, StringComparer.OrdinalIgnoreCase);
+
+        var attributedCount = 0;
+
+        foreach (var entry in pendingEntries)
         {
-            var deviceEventCount = 0;
+            var legacyKey = foodEntryToCarbLegacyId(entry.ExternalEntryId);
+            if (legacyKey == null || !carbsByLegacyId.TryGetValue(legacyKey, out var carbIntake))
+                continue;
 
-            if (data.DeviceEvents.Count > 0 && await PublishDeviceEventDataAsync(data.DeviceEvents, config, cancellationToken))
+            try
             {
-                deviceEventCount += data.DeviceEvents.Count;
-                _logger.LogInformation("[{ConnectorSource}] Published {Count} device events", ConnectorSource, data.DeviceEvents.Count);
+                await _mealMatchingService.AcceptMatchAsync(
+                    entry.Id, carbIntake.Id, entry.Carbs, timeOffsetMinutes: 0, cancellationToken);
+                attributedCount++;
             }
-
-            if (data.SystemEvents.Count > 0 && await PublishSystemEventDataAsync(data.SystemEvents, config, cancellationToken))
+            catch (Exception ex)
             {
-                deviceEventCount += data.SystemEvents.Count;
-                _logger.LogInformation("[{ConnectorSource}] Published {Count} system events", ConnectorSource, data.SystemEvents.Count);
+                _logger.LogWarning(ex,
+                    "[{ConnectorSource}] Failed to attribute food entry {FoodEntryId} to CarbIntake {CarbIntakeId}",
+                    ConnectorSource, entry.Id, carbIntake.Id);
             }
-
-            if (deviceEventCount > 0)
-                result.ItemsSynced[SyncDataType.DeviceEvents] = deviceEventCount;
         }
+
+        _logger.LogInformation("[{ConnectorSource}] Attributed {Count}/{Total} food entries to carb intakes",
+            ConnectorSource, attributedCount, pendingEntries.Count);
     }
 
     // ── V2 batch data fetching ──────────────────────────────────────────
@@ -665,12 +578,15 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     /// <summary>
     ///     Fetches comprehensive batch data from all v2 Glooko endpoints.
     /// </summary>
-    public async Task<GlookoBatchData?> FetchBatchDataAsync(DateTime fromDate, DateTime toDate)
+    public async Task<GlookoBatchData?> FetchBatchDataAsync(DateTime? since = null)
     {
         try
         {
             var patientCode = EnsureAuthenticatedAndGetCode();
             if (patientCode == null) return null;
+
+            var fromDate = since ?? _timeMapper.ToGlookoTime(DateTime.UtcNow.AddDays(-1));
+            var toDate = _timeMapper.ToGlookoTime(DateTime.UtcNow);
 
             _logger.LogInformation("Fetching comprehensive Glooko data from {From:yyyy-MM-dd} to {To:yyyy-MM-dd}", fromDate, toDate);
 
@@ -768,12 +684,15 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     ///     Fetches only the V2 foods endpoint. Used by the V3 sync path to get
     ///     rich food metadata (externalId, brand) that V3 histories doesn't provide.
     /// </summary>
-    public async Task<GlookoFood[]?> FetchV2FoodsAsync(DateTime fromDate, DateTime toDate)
+    public async Task<GlookoFood[]?> FetchV2FoodsAsync(DateTime? since = null)
     {
         try
         {
             var patientCode = EnsureAuthenticatedAndGetCode();
             if (patientCode == null) return null;
+
+            var fromDate = since ?? _timeMapper.ToGlookoTime(DateTime.UtcNow.AddDays(-1));
+            var toDate = _timeMapper.ToGlookoTime(DateTime.UtcNow);
 
             var url = ConstructV2Url(GlookoConstants.FoodsPath, fromDate, toDate);
             var result = await FetchFromGlookoEndpointWithRetry(url);
@@ -830,7 +749,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     /// <summary>
     ///     Fetches data from v3 graph/data API — single call for all data types.
     /// </summary>
-    public async Task<GlookoV3GraphResponse?> FetchV3GraphDataAsync(DateTime fromDate, DateTime toDate)
+    public async Task<GlookoV3GraphResponse?> FetchV3GraphDataAsync(DateTime? since = null)
     {
         try
         {
@@ -838,6 +757,9 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             if (patientCode == null) return null;
 
             if (string.IsNullOrEmpty(_meterUnits)) await FetchV3UserProfileAsync();
+
+            var fromDate = since ?? _timeMapper.ToGlookoTime(DateTime.UtcNow.AddDays(-1));
+            var toDate = _timeMapper.ToGlookoTime(DateTime.UtcNow);
 
             var url = ConstructV3GraphUrl(fromDate, toDate);
             _logger.LogInformation("[{ConnectorSource}] Fetching v3 graph data from {StartDate:yyyy-MM-dd} to {EndDate:yyyy-MM-dd}",
@@ -924,12 +846,15 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     ///     Fetches rich history data from the v3 users/summary/histories API.
     ///     Contains meals with per-food nutritional data, medications, exercises, etc.
     /// </summary>
-    public async Task<GlookoV3HistoriesResponse?> FetchV3HistoriesAsync(DateTime fromDate, DateTime toDate)
+    public async Task<GlookoV3HistoriesResponse?> FetchV3HistoriesAsync(DateTime? since = null)
     {
         try
         {
             var patientCode = EnsureAuthenticatedAndGetCode();
             if (patientCode == null) return null;
+
+            var fromDate = since ?? _timeMapper.ToGlookoTime(DateTime.UtcNow.AddDays(-1));
+            var toDate = _timeMapper.ToGlookoTime(DateTime.UtcNow);
 
             var url = $"{GlookoConstants.V3HistoriesPath}?patient={patientCode}"
                     + $"&startDate={fromDate:yyyy-MM-ddTHH:mm:ss.fffZ}"

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Nocturne.Connectors.Core.Tests.csproj
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Nocturne.Connectors.Core.Tests.csproj
@@ -17,6 +17,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
+        <PackageReference Include="FluentAssertions"/>
         <PackageReference Include="Moq"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Utilities/DateChunkerTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Utilities/DateChunkerTests.cs
@@ -62,6 +62,38 @@ public class DateChunkerTests
     }
 
     [Fact]
+    public void Chunk_ThirtyDayRange_ProducesThreeChunks_MatchingGlookoSyncPattern()
+    {
+        // GlookoConnectorService.PerformSyncInternalAsync chunks with 14-day windows.
+        // A 30-day sync range must produce exactly 3 API call batches: 14 + 14 + 2 days.
+        var from = new DateTime(2025, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+        var to = new DateTime(2025, 3, 31, 0, 0, 0, DateTimeKind.Utc); // 30 days
+
+        var chunks = DateChunker.Chunk(from, to, TimeSpan.FromDays(14)).ToList();
+
+        chunks.Should().HaveCount(3, "a 30-day range with 14-day chunks yields 14 + 14 + 2");
+
+        // Chunk 1: days 1–14
+        chunks[0].From.Should().Be(from);
+        chunks[0].To.Should().Be(from.AddDays(14));
+        (chunks[0].To - chunks[0].From).TotalDays.Should().Be(14);
+
+        // Chunk 2: days 15–28
+        chunks[1].From.Should().Be(from.AddDays(14));
+        chunks[1].To.Should().Be(from.AddDays(28));
+        (chunks[1].To - chunks[1].From).TotalDays.Should().Be(14);
+
+        // Chunk 3: days 29–30 (remainder)
+        chunks[2].From.Should().Be(from.AddDays(28));
+        chunks[2].To.Should().Be(to);
+        (chunks[2].To - chunks[2].From).TotalDays.Should().Be(2);
+
+        // Contiguous — no gaps between chunks
+        for (var i = 1; i < chunks.Count; i++)
+            chunks[i].From.Should().Be(chunks[i - 1].To);
+    }
+
+    [Fact]
     public void Chunk_SixMonthRange_ReturnsExpectedChunkCount()
     {
         var from = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Utilities/DateChunkerTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Utilities/DateChunkerTests.cs
@@ -1,0 +1,80 @@
+using FluentAssertions;
+using Nocturne.Connectors.Core.Utilities;
+using Xunit;
+
+namespace Nocturne.Connectors.Core.Tests.Utilities;
+
+public class DateChunkerTests
+{
+    [Fact]
+    public void Chunk_RangeSmallerThanChunkSize_ReturnsSingleChunk()
+    {
+        var from = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var to = new DateTime(2025, 1, 5, 0, 0, 0, DateTimeKind.Utc);
+
+        var chunks = DateChunker.Chunk(from, to, TimeSpan.FromDays(14)).ToList();
+
+        chunks.Should().HaveCount(1);
+        chunks[0].From.Should().Be(from);
+        chunks[0].To.Should().Be(to);
+    }
+
+    [Fact]
+    public void Chunk_RangeExactlyChunkSize_ReturnsSingleChunk()
+    {
+        var from = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var to = new DateTime(2025, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        var chunks = DateChunker.Chunk(from, to, TimeSpan.FromDays(14)).ToList();
+
+        chunks.Should().HaveCount(1);
+        chunks[0].From.Should().Be(from);
+        chunks[0].To.Should().Be(to);
+    }
+
+    [Fact]
+    public void Chunk_RangeLargerThanChunkSize_ReturnsMultipleChunks()
+    {
+        var from = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var to = new DateTime(2025, 2, 1, 0, 0, 0, DateTimeKind.Utc); // 31 days
+
+        var chunks = DateChunker.Chunk(from, to, TimeSpan.FromDays(14)).ToList();
+
+        chunks.Should().HaveCount(3); // 14 + 14 + 3
+        chunks[0].From.Should().Be(from);
+        chunks[0].To.Should().Be(from.AddDays(14));
+        chunks[1].From.Should().Be(from.AddDays(14));
+        chunks[1].To.Should().Be(from.AddDays(28));
+        chunks[2].From.Should().Be(from.AddDays(28));
+        chunks[2].To.Should().Be(to);
+    }
+
+    [Fact]
+    public void Chunk_FromEqualsTo_ReturnsSingleChunk()
+    {
+        var date = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var chunks = DateChunker.Chunk(date, date, TimeSpan.FromDays(14)).ToList();
+
+        chunks.Should().HaveCount(1);
+        chunks[0].From.Should().Be(date);
+        chunks[0].To.Should().Be(date);
+    }
+
+    [Fact]
+    public void Chunk_SixMonthRange_ReturnsExpectedChunkCount()
+    {
+        var from = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var to = new DateTime(2025, 7, 1, 0, 0, 0, DateTimeKind.Utc); // 181 days
+
+        var chunks = DateChunker.Chunk(from, to, TimeSpan.FromDays(14)).ToList();
+
+        chunks.Should().HaveCount(13); // ceil(181/14) = 13
+        chunks.First().From.Should().Be(from);
+        chunks.Last().To.Should().Be(to);
+
+        // Chunks should be contiguous (no gaps or overlaps)
+        for (var i = 1; i < chunks.Count; i++)
+            chunks[i].From.Should().Be(chunks[i - 1].To);
+    }
+}


### PR DESCRIPTION
## Summary

- Splits the Glooko sync date range into 14-day chunks processed sequentially, capping peak memory to one chunk's worth of data regardless of total range (fixes OOM on first login with years of history)
- Replaces accumulate-then-publish (`GlookoSyncData` + `PublishAllAsync`) with publish-as-you-map via the existing `PublishRecordTypeAsync<T>` helper — only one record type is in memory at a time within each chunk
- Adds `DateChunker` utility to `Nocturne.Connectors.Core` for splitting date ranges into fixed-size windows (reusable for MyLife fix)
- Restores `LastEntryTimes` tracking for glucose (was lost in the refactor)

**Memory profile:**

| Scenario | Before | After |
|----------|--------|-------|
| 6-month first login (V3) | ~150–300 MB peak | ~2–4 MB peak |
| Normal periodic sync (1 day) | ~500 KB | ~500 KB (unchanged) |
| 2-year historical import | OOM risk | ~2–4 MB peak |

## Test plan

- [ ] `dotnet test tests/Unit/Nocturne.Connectors.Glooko.Tests` — 8 mapper tests pass
- [ ] `dotnet test tests/Unit/Nocturne.Connectors.Core.Tests` — 14 tests pass (incl. 6 DateChunker tests)
- [ ] Trigger a Glooko sync with a long historical range and verify memory stays flat in Grafana
- [ ] Verify normal periodic sync (1 day) behaves identically to pre-change