### PR TITLE
fix: initialize realtime store for public site visitors

### DIFF
--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.server.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.server.ts
@@ -2,6 +2,22 @@ import { redirect } from "@sveltejs/kit";
 import type { LayoutServerLoad } from "./$types";
 import { checkOnboarding } from "$lib/server/onboarding-check";
 
+/** Permissions that grant read access to glucose data (mirrors API's CanRead + OAuth scopes). */
+const GLUCOSE_READ_PERMISSIONS = [
+  "*",
+  "api:*",
+  "api:*:read",
+  "readable",
+  "glucose.read",
+  "glucose.readwrite",
+  "health.read",
+  "health.readwrite",
+];
+
+function hasGlucoseReadPermission(permissions: string[]): boolean {
+  return permissions.some((p) => GLUCOSE_READ_PERMISSIONS.includes(p));
+}
+
 export const load: LayoutServerLoad = async ({ locals, cookies, url }) => {
   // Guest sessions bypass onboarding — the data owner's instance is already set up.
   if (!locals.isGuestSession) {
@@ -25,9 +41,18 @@ export const load: LayoutServerLoad = async ({ locals, cookies, url }) => {
     }
   }
 
+  // Enable realtime glucose data for:
+  // - Public sites (requireAuthentication: false) — authDefaultRoles grants readable
+  // - Authenticated users with glucose read permissions
+  // The API enforces authorization on each endpoint as defense in depth.
+  const canViewRealtimeData =
+    !locals.requireAuthentication ||
+    hasGlucoseReadPermission(locals.effectivePermissions ?? []);
+
   return {
     user: locals.user ?? null,
     isGuestSession: locals.isGuestSession ?? false,
     guestExpiresAt: locals.guestExpiresAt ?? null,
+    canViewRealtimeData,
   };
 };

--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
@@ -95,9 +95,10 @@
     }
   }
 
-  // Initialize realtime and title/favicon services
+  // Initialize realtime and title/favicon services for users authorized to
+  // view glucose data (authenticated with read permissions, or public site visitors).
   $effect(() => {
-    if (data.isAuthenticated) {
+    if (data.canViewRealtimeData) {
       realtimeStore.initialize();
       titleFaviconService.initialize();
     }


### PR DESCRIPTION
## Summary

- On sites with `requireAuthentication: false`, unauthenticated visitors had `data.isAuthenticated = false`, so `realtimeStore.initialize()` was never called. The live glucose number showed a loading skeleton forever while the sidebar graph (which uses server-side remote functions) worked fine.
- Added `canViewRealtimeData` flag to the layout server load, computed from either public site status or glucose read permissions, mirroring the API's `CanRead()` check.
- Changed the `$effect` gate from `data.isAuthenticated` to `data.canViewRealtimeData`.

## Test plan

- [ ] Visit a public site (`requireAuthentication: false`) without logging in — live number should load
- [ ] Visit a private site (`requireAuthentication: true`) without logging in — redirect to login (unchanged behaviour)
- [ ] Visit as an authenticated user with glucose read permissions — live number loads (unchanged)
- [ ] Visit as an authenticated user without glucose read permissions — live number does not load (PHI protected)