### PR TITLE
fix(charts): prevent each_key_duplicate crashes from duplicate-timestamp keys

### DIFF
--- a/src/Web/packages/app/src/lib/components/actogram/Actogram.svelte
+++ b/src/Web/packages/app/src/lib/components/actogram/Actogram.svelte
@@ -125,7 +125,7 @@
   </div>
 
   <!-- Rows -->
-  {#each visibleDataRows as dataRow, i (dataRow.day.getTime())}
+  {#each visibleDataRows as dataRow, i (`${dataRow.day.getTime()}-${i}`)}
     <div
       class="flex items-center"
       style:height="{rowHeight}px"

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte.ts
@@ -486,6 +486,10 @@ export function createChartDataEngine(
   });
 
   // ---- Glucose data (merged with realtime) ----
+  // Dedupe by timestamp: server data wins on collision, realtime fills gaps.
+  // A keyed {#each} downstream requires a unique key per point, so the same
+  // mills value must never appear twice — even if base or realtimeStore
+  // emit duplicates.
   const glucoseData = $derived.by(() => {
     const base = serverChartData?.glucoseData ?? [];
     if (!serverChartData) return base as GlucosePoint[];
@@ -493,29 +497,31 @@ export function createChartDataEngine(
     const thresholds = serverChartData.thresholds;
     const fromMs = fullDataRange.from.getTime();
     const toMs = fullDataRange.to.getTime();
-    const existingTimes = new Set(base.map((p) => p.time.getTime()));
 
-    const realtimePoints: GlucosePoint[] = realtimeStore.entries
-      .filter(
-        (e) =>
-          e.type === "sgv" &&
-          e.mills != null &&
-          e.sgv != null &&
-          e.mills >= fromMs &&
-          e.mills <= toMs &&
-          !existingTimes.has(e.mills)
-      )
-      .map((e) => ({
-        time: new Date(e.mills!),
-        sgv: e.sgv!,
+    const byMills = new Map<number, GlucosePoint>();
+    for (const p of base) byMills.set(p.time.getTime(), p);
+
+    for (const e of realtimeStore.entries) {
+      if (
+        e.type !== "sgv" ||
+        e.mills == null ||
+        e.sgv == null ||
+        e.mills < fromMs ||
+        e.mills > toMs ||
+        byMills.has(e.mills)
+      ) {
+        continue;
+      }
+      byMills.set(e.mills, {
+        time: new Date(e.mills),
+        sgv: e.sgv,
         direction: e.direction,
         dataSource: e.data_source,
-        color: getGlucoseColor(e.sgv!, thresholds),
-      }));
+        color: getGlucoseColor(e.sgv, thresholds),
+      });
+    }
 
-    if (realtimePoints.length === 0) return base as GlucosePoint[];
-
-    return [...base, ...realtimePoints].sort(
+    return [...byMills.values()].sort(
       (a, b) => a.time.getTime() - b.time.getTime()
     ) as GlucosePoint[];
   });

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/DeviceEventMarkers.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/DeviceEventMarkers.svelte
@@ -20,7 +20,7 @@
 
 {#if visible}
   <ChartClipPath>
-    {#each markers as marker (marker.time.getTime())}
+    {#each markers as marker, i (marker.treatmentId ?? `${marker.time.getTime()}-${i}`)}
       {@const xPos = chartCtx.xScale(marker.time)}
       {@const yPos = chartCtx.yScale(medianY)}
       <DeviceEventMarker

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/tracks/GlucoseTrack.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/tracks/GlucoseTrack.svelte
@@ -161,7 +161,7 @@
   {/if}
 
   {#if effectiveShowPoints}
-    {#each glucoseData as point (point.time)}
+    {#each glucoseData as point (point.time.getTime())}
       <Points
         data={[point]}
         x={(d) => d.time}


### PR DESCRIPTION
## Summary

Fixes a class of `each_key_duplicate` crashes that take down the dashboard error boundary when the source data has multiple items sharing the same timestamp. Three components were affected:

- **Glucose chart merge** — `chart-data-engine.svelte.ts` could produce duplicate-mills points when realtime entries overlapped server data; `GlucoseTrack.svelte` used a Date object as the keyed-each key.
- **Device event markers** — keyed by `marker.time.getTime()` alone. When multiple events share a timestamp (e.g., a connector sync that produces several SiteChange events at the same instant), the reconciler throws.
- **Actogram** — keyed by `dataRow.day.getTime()` alone. Defensive fix; same pattern.

I personally hit this in production with 300+ SiteChange device events all carrying the same timestamp from a single sync batch, which collapsed the entire dashboard into the error overlay. Confirmed via Brave DevTools that the duplicate key was `1778537825137` (a `getTime()` value) and the `Proxy(Array)` being iterated held identical-timestamp markers.

## Root cause

Svelte 5's keyed each enforces unique keys via `SameValueZero`. Several components on the dashboard used `time.getTime()` as the key with no tiebreaker, assuming timestamp uniqueness. That assumption fails when the upstream data has duplicates — which can happen from realtime/server merge overlap, connector backfills, or import scripts.

When the key collides, the error is thrown during reactive flush (not during user-code execution), so the stack trace points only at Svelte runtime chunks and gives no direct hint about which component is failing. Identification required setting a breakpoint inside the error function and inspecting the iterated array's shape.

## Changes

### `chart-data-engine.svelte.ts` (glucose merge)

Replaced the filter+merge approach with a `Map<mills, GlucosePoint>` that dedupes by mills. Server data wins on collision; realtime fills gaps. This is correct under all four input shapes: duplicates in base, duplicates in realtime, overlap between base and realtime, no duplicates at all. Previous code only checked realtime against base, leaving two holes (base-vs-base and realtime-vs-realtime).

### `GlucoseTrack.svelte`

Changed key from `(point.time)` (a Date object — reference-compared) to `(point.time.getTime())` (a primitive number — value-compared). Matches the pattern already used in `DeviceEventMarkers`.

### `DeviceEventMarkers.svelte`

Changed key from `(marker.time.getTime())` to `(marker.treatmentId ?? \`\${marker.time.getTime()}-\${i}\`)`. Prefers the GUID treatmentId when available; falls back to a timestamp+index combination for markers without an ID.

### `Actogram.svelte`

Changed key from `(dataRow.day.getTime())` to `(\`\${dataRow.day.getTime()}-\${i}\`)`. Defensive — same pattern.

## Test plan

- [ ] Dashboard renders without `each_key_duplicate` when realtime overlaps server data
- [ ] Dashboard renders without `each_key_duplicate` when the device-event marker array contains duplicate timestamps
- [ ] Glucose chart still updates in real time
- [ ] Server-side glucose points take priority over realtime when both exist for the same mills
- [ ] Actogram renders without `each_key_duplicate` even if the same day appears twice in the data

## Verification done

Built and deployed the branch image to a production multi-tenant deployment with the bug reproducing reliably (300+ same-timestamp SiteChange events from a Dexcom-side data anomaly). After the fix, the dashboard, `/meals`, `/calendar`, and other previously-failing routes render cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)