### PR TITLE
fix: map Nightscout "date" field on Entry to resolve 1970 timestamps

### DIFF
--- a/src/Core/Nocturne.Core.Models/Entry.cs
+++ b/src/Core/Nocturne.Core.Models/Entry.cs
@@ -39,6 +39,11 @@ public class Entry : ProcessableDocumentBase
             if (_mills != 0)
                 return _mills;
 
+            // Nightscout returns "date" (Unix ms) as the primary timestamp on entries.
+            // "mills" is only added by some clients, so fall back to "date" first.
+            if (_dateMills != 0)
+                return _dateMills;
+
             // If mills is not set but date is available, calculate it
             if (_date.HasValue)
             {
@@ -69,6 +74,19 @@ public class Entry : ProcessableDocumentBase
         set => _mills = value;
     }
     private long _mills;
+
+    /// <summary>
+    /// Captures the Nightscout "date" field (Unix milliseconds).
+    /// Nightscout entries use "date" as their primary timestamp; "mills" is not always present.
+    /// </summary>
+    [JsonPropertyName("date")]
+    [JsonConverter(typeof(FlexibleLongConverter))]
+    public long DateMills
+    {
+        get => _dateMills;
+        set => _dateMills = value;
+    }
+    private long _dateMills;
 
     /// <summary>
     /// Gets or sets the date and time when this glucose reading was taken.

--- a/tests/Unit/Nocturne.Core.Models.Tests/Serializers/NightscoutDataCompatibilityTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/Serializers/NightscoutDataCompatibilityTests.cs
@@ -321,6 +321,64 @@ public class NightscoutDataCompatibilityTests
     }
 
     // ========================================================================
+    // Bug — Entry "date" field (Unix ms) not mapped to Mills
+    //
+    // Nightscout v1 entries API returns "date" (Unix milliseconds) as the
+    // primary timestamp, but the Entry model maps Mills from "mills" only.
+    // "date" falls into AdditionalProperties and Mills returns 0 (epoch 1970).
+    // When "dateString" is also absent, the migrator imports BG data at 1970.
+    // ========================================================================
+
+    [Fact]
+    public void Entry_Mills_ResolvesFromDateFieldWhenMillsMissing()
+    {
+        // Nightscout entry with "date" but no "mills" and no "dateString"
+        var json = """{"sgv": 120, "type": "sgv", "date": 1507507102681}""";
+
+        var entry = JsonSerializer.Deserialize<Entry>(json);
+
+        entry.Should().NotBeNull();
+        entry!.Mills.Should().Be(1507507102681,
+            "Mills should resolve from the Nightscout 'date' field when 'mills' is absent");
+    }
+
+    [Fact]
+    public void Entry_Mills_PrefersMillsOverDateField()
+    {
+        // When both "mills" and "date" are present, "mills" wins
+        var json = """{"sgv": 120, "mills": 1507507102681, "date": 9999999999999}""";
+
+        var entry = JsonSerializer.Deserialize<Entry>(json);
+
+        entry!.Mills.Should().Be(1507507102681,
+            "Mills should use the 'mills' value when both 'mills' and 'date' are present");
+    }
+
+    [Fact]
+    public void Entry_Mills_ResolvesFromDateFieldInFullRecord()
+    {
+        // Real-world Nightscout entry from AAPS — has "date" but no "mills"
+        var json = """
+        {
+            "sgv": 108,
+            "filtered": 142941.16575,
+            "unfiltered": 142941.16575,
+            "direction": "Flat",
+            "device": "xDrip-LibreAlarm",
+            "noise": 0,
+            "type": "sgv",
+            "date": 1507507102681,
+            "_id": "59dabbb7c7d5afdddbc99300"
+        }
+        """;
+
+        var entry = JsonSerializer.Deserialize<Entry>(json);
+
+        entry!.Mills.Should().Be(1507507102681,
+            "full Nightscout entry with 'date' field should resolve Mills correctly");
+    }
+
+    // ========================================================================
     // Issues #2, #3 — Entry glucose/rawbg fields (LOW)
     //
     // Some entries have a "glucose" field (duplicate of sgv) and "rawbg" from


### PR DESCRIPTION
## Summary

- The Nightscout v1 entries API returns `"date"` (Unix milliseconds) as the primary timestamp, but `Entry` only mapped `"mills"` — which Nightscout doesn't send. The `"date"` field silently fell into `[JsonExtensionData]` and was never used.
- When `"dateString"` was also absent (common with AAPS/LibreAlarm entries), `Mills` returned `0` → epoch 1970 timestamps on all migrated BG data.
- `Treatment` and `DeviceStatus` both already had `[JsonPropertyName("date")]` — `Entry` was the only document type missing it.

## Fix

Added `DateMills` property with `[JsonPropertyName("date")]` to capture the Nightscout `"date"` field, and inserted it into the `Mills` getter fallback chain.

## Test plan

- [x] New test: `Entry_Mills_ResolvesFromDateFieldWhenMillsMissing` — entry with only `"date"`, no `"mills"` or `"dateString"`
- [x] New test: `Entry_Mills_PrefersMillsOverDateField` — `"mills"` takes precedence when both present
- [x] New test: `Entry_Mills_ResolvesFromDateFieldInFullRecord` — real-world LibreAlarm entry shape
- [x] All 192 model tests pass