### PR TITLE
perf: add lightweight basal-series endpoint to eliminate IOB/COB compute from reports

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Analytics/ChartDataController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/ChartDataController.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
 using Nocturne.Core.Contracts.Analytics;
+using Nocturne.Core.Contracts.Profiles.Resolvers;
+using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 
 namespace Nocturne.API.Controllers.V4.Analytics;
@@ -24,14 +26,26 @@ namespace Nocturne.API.Controllers.V4.Analytics;
 public class ChartDataController : ControllerBase
 {
     private readonly IChartDataService _chartDataService;
+    private readonly IBasalSeriesBuilder _basalSeriesBuilder;
+    private readonly ITempBasalRepository _tempBasalRepository;
+    private readonly ITherapySettingsResolver _therapySettingsResolver;
+    private readonly IBasalRateResolver _basalRateResolver;
     private readonly ILogger<ChartDataController> _logger;
 
     public ChartDataController(
         IChartDataService chartDataService,
+        IBasalSeriesBuilder basalSeriesBuilder,
+        ITempBasalRepository tempBasalRepository,
+        ITherapySettingsResolver therapySettingsResolver,
+        IBasalRateResolver basalRateResolver,
         ILogger<ChartDataController> logger
     )
     {
         _chartDataService = chartDataService;
+        _basalSeriesBuilder = basalSeriesBuilder;
+        _tempBasalRepository = tempBasalRepository;
+        _therapySettingsResolver = therapySettingsResolver;
+        _basalRateResolver = basalRateResolver;
         _logger = logger;
     }
 
@@ -80,6 +94,66 @@ public class ChartDataController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error calculating dashboard chart data");
+            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
+        }
+    }
+
+    /// <summary>
+    /// Gets the basal delivery series for a time window without running the
+    /// full IOB/COB compute pipeline. Fetches only temp basals and profile
+    /// data, making it significantly cheaper than the dashboard endpoint.
+    /// </summary>
+    /// <param name="startTime">Start of the requested window as a Unix timestamp in milliseconds.</param>
+    /// <param name="endTime">End of the requested window as a Unix timestamp in milliseconds.
+    /// Must be greater than <paramref name="startTime"/>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of <see cref="BasalPoint"/> representing basal delivery over time.</returns>
+    [HttpGet("basal-series")]
+    [RemoteQuery]
+    [ResponseCache(Duration = 60, VaryByQueryKeys = new[] { "*" })]
+    [ProducesResponseType(typeof(List<BasalPoint>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<List<BasalPoint>>> GetBasalSeries(
+        [FromQuery] long startTime,
+        [FromQuery] long endTime,
+        CancellationToken cancellationToken = default
+    )
+    {
+        try
+        {
+            if (endTime <= startTime)
+                return Problem(detail: "endTime must be greater than startTime", statusCode: 400, title: "Bad Request");
+
+            var defaultBasalRate = 1.0;
+            var hasData = await _therapySettingsResolver.HasDataAsync(cancellationToken);
+            if (hasData)
+                defaultBasalRate = await _basalRateResolver.GetBasalRateAsync(endTime, ct: cancellationToken);
+
+            var tempBasals = (await _tempBasalRepository.GetAsync(
+                from: DateTimeOffset.FromUnixTimeMilliseconds(startTime).UtcDateTime,
+                to: DateTimeOffset.FromUnixTimeMilliseconds(endTime).UtcDateTime,
+                device: null,
+                source: null,
+                limit: 131072,
+                offset: 0,
+                descending: false,
+                ct: cancellationToken
+            )).ToList();
+
+            var basalSeries = await _basalSeriesBuilder.BuildAsync(
+                tempBasals,
+                startTime,
+                endTime,
+                defaultBasalRate,
+                cancellationToken
+            );
+
+            return Ok(basalSeries);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error calculating basal series");
             return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
         }
     }

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/ChartDataController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/ChartDataController.cs
@@ -1,8 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
 using Nocturne.Core.Contracts.Analytics;
-using Nocturne.Core.Contracts.Profiles.Resolvers;
-using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 
 namespace Nocturne.API.Controllers.V4.Analytics;
@@ -26,26 +24,14 @@ namespace Nocturne.API.Controllers.V4.Analytics;
 public class ChartDataController : ControllerBase
 {
     private readonly IChartDataService _chartDataService;
-    private readonly IBasalSeriesBuilder _basalSeriesBuilder;
-    private readonly ITempBasalRepository _tempBasalRepository;
-    private readonly ITherapySettingsResolver _therapySettingsResolver;
-    private readonly IBasalRateResolver _basalRateResolver;
     private readonly ILogger<ChartDataController> _logger;
 
     public ChartDataController(
         IChartDataService chartDataService,
-        IBasalSeriesBuilder basalSeriesBuilder,
-        ITempBasalRepository tempBasalRepository,
-        ITherapySettingsResolver therapySettingsResolver,
-        IBasalRateResolver basalRateResolver,
         ILogger<ChartDataController> logger
     )
     {
         _chartDataService = chartDataService;
-        _basalSeriesBuilder = basalSeriesBuilder;
-        _tempBasalRepository = tempBasalRepository;
-        _therapySettingsResolver = therapySettingsResolver;
-        _basalRateResolver = basalRateResolver;
         _logger = logger;
     }
 
@@ -125,29 +111,7 @@ public class ChartDataController : ControllerBase
             if (endTime <= startTime)
                 return Problem(detail: "endTime must be greater than startTime", statusCode: 400, title: "Bad Request");
 
-            var defaultBasalRate = 1.0;
-            var hasData = await _therapySettingsResolver.HasDataAsync(cancellationToken);
-            if (hasData)
-                defaultBasalRate = await _basalRateResolver.GetBasalRateAsync(endTime, ct: cancellationToken);
-
-            var tempBasals = (await _tempBasalRepository.GetAsync(
-                from: DateTimeOffset.FromUnixTimeMilliseconds(startTime).UtcDateTime,
-                to: DateTimeOffset.FromUnixTimeMilliseconds(endTime).UtcDateTime,
-                device: null,
-                source: null,
-                limit: 131072,
-                offset: 0,
-                descending: false,
-                ct: cancellationToken
-            )).ToList();
-
-            var basalSeries = await _basalSeriesBuilder.BuildAsync(
-                tempBasals,
-                startTime,
-                endTime,
-                defaultBasalRate,
-                cancellationToken
-            );
+            var basalSeries = await _chartDataService.GetBasalSeriesAsync(startTime, endTime, cancellationToken);
 
             return Ok(basalSeries);
         }

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -481,6 +481,9 @@ public static class ServiceRegistrationExtensions
         >();
         services.AddScoped<IClockFaceService, ClockFaceService>();
         services.AddScoped<IWidgetSummaryService, WidgetSummaryService>();
+        // Basal series builder (used by chart data pipeline and reports endpoint)
+        services.AddScoped<IBasalSeriesBuilder, BasalSeriesBuilder>();
+
         // Chart data pipeline stages (order matters!)
         services.AddScoped<ProfileLoadStage>();
         services.AddScoped<DataFetchStage>();

--- a/src/API/Nocturne.API/Services/Analytics/ChartDataService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/ChartDataService.cs
@@ -192,7 +192,7 @@ public class ChartDataService : IChartDataService
         return tempBasals
             .Select(tb =>
             {
-                var origin = MapTempBasalOrigin(tb.Origin);
+                var origin = BasalSeriesBuilder.MapTempBasalOrigin(tb.Origin);
                 return new BasalDeliverySpanDto
                 {
                     Id = tb.LegacyId ?? tb.Id.ToString(),
@@ -226,21 +226,6 @@ public class ChartDataService : IChartDataService
             })
             .ToList();
     }
-
-    /// <summary>
-    /// Maps a TempBasalOrigin enum value to the corresponding BasalDeliveryOrigin enum value.
-    /// Both enums have identical members (Algorithm, Scheduled, Manual, Suspended, Inferred).
-    /// </summary>
-    internal static BasalDeliveryOrigin MapTempBasalOrigin(TempBasalOrigin origin) =>
-        origin switch
-        {
-            TempBasalOrigin.Algorithm => BasalDeliveryOrigin.Algorithm,
-            TempBasalOrigin.Scheduled => BasalDeliveryOrigin.Scheduled,
-            TempBasalOrigin.Manual => BasalDeliveryOrigin.Manual,
-            TempBasalOrigin.Suspended => BasalDeliveryOrigin.Suspended,
-            TempBasalOrigin.Inferred => BasalDeliveryOrigin.Inferred,
-            _ => BasalDeliveryOrigin.Scheduled,
-        };
 
     internal static List<SystemEventMarkerDto> MapSystemEvents(
         IEnumerable<SystemEvent>? systemEvents

--- a/src/API/Nocturne.API/Services/Analytics/ChartDataService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/ChartDataService.cs
@@ -2,6 +2,8 @@ using System.Text.Json;
 using Nocturne.API.Helpers;
 using Nocturne.API.Services.ChartData;
 using Nocturne.Core.Contracts.Analytics;
+using Nocturne.Core.Contracts.Profiles.Resolvers;
+using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities;
@@ -24,8 +26,14 @@ namespace Nocturne.API.Services.Analytics;
 /// <seealso cref="ChartDataContext"/>
 public class ChartDataService : IChartDataService
 {
+    private const int TempBasalQueryLimit = 131072;
+
     private readonly IEnumerable<IChartDataStage> _pipeline;
     private readonly IChartDataAssembler _assembler;
+    private readonly IBasalSeriesBuilder _basalSeriesBuilder;
+    private readonly ITempBasalRepository _tempBasalRepository;
+    private readonly ITherapySettingsResolver _therapySettingsResolver;
+    private readonly IBasalRateResolver _basalRateResolver;
     private readonly ILogger<ChartDataService> _logger;
 
     /// <summary>
@@ -33,15 +41,27 @@ public class ChartDataService : IChartDataService
     /// </summary>
     /// <param name="pipeline">The ordered sequence of <see cref="IChartDataStage"/> stages to execute.</param>
     /// <param name="assembler">The assembler that converts the completed context into the final DTO.</param>
+    /// <param name="basalSeriesBuilder">Builds basal delivery series from temp basals and profile rates.</param>
+    /// <param name="tempBasalRepository">Repository for fetching temp basal records.</param>
+    /// <param name="therapySettingsResolver">Resolves whether therapy settings (profile) data exists.</param>
+    /// <param name="basalRateResolver">Resolves the active basal rate at a point in time.</param>
     /// <param name="logger">The logger instance.</param>
     public ChartDataService(
         IEnumerable<IChartDataStage> pipeline,
         IChartDataAssembler assembler,
+        IBasalSeriesBuilder basalSeriesBuilder,
+        ITempBasalRepository tempBasalRepository,
+        ITherapySettingsResolver therapySettingsResolver,
+        IBasalRateResolver basalRateResolver,
         ILogger<ChartDataService> logger
     )
     {
         _pipeline = pipeline;
         _assembler = assembler;
+        _basalSeriesBuilder = basalSeriesBuilder;
+        _tempBasalRepository = tempBasalRepository;
+        _therapySettingsResolver = therapySettingsResolver;
+        _basalRateResolver = basalRateResolver;
         _logger = logger;
     }
 
@@ -68,6 +88,38 @@ public class ChartDataService : IChartDataService
         }
 
         return _assembler.Assemble(context);
+    }
+
+    /// <inheritdoc />
+    public async Task<List<BasalPoint>> GetBasalSeriesAsync(
+        long startTime,
+        long endTime,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var defaultBasalRate = 1.0;
+        var hasData = await _therapySettingsResolver.HasDataAsync(cancellationToken);
+        if (hasData)
+            defaultBasalRate = await _basalRateResolver.GetBasalRateAsync(endTime, ct: cancellationToken);
+
+        var tempBasals = (await _tempBasalRepository.GetAsync(
+            from: DateTimeOffset.FromUnixTimeMilliseconds(startTime).UtcDateTime,
+            to: DateTimeOffset.FromUnixTimeMilliseconds(endTime).UtcDateTime,
+            device: null,
+            source: null,
+            limit: TempBasalQueryLimit,
+            offset: 0,
+            descending: false,
+            ct: cancellationToken
+        )).ToList();
+
+        return await _basalSeriesBuilder.BuildAsync(
+            tempBasals,
+            startTime,
+            endTime,
+            defaultBasalRate,
+            cancellationToken
+        );
     }
 
     #region Internal Helpers

--- a/src/API/Nocturne.API/Services/ChartData/BasalSeriesBuilder.cs
+++ b/src/API/Nocturne.API/Services/ChartData/BasalSeriesBuilder.cs
@@ -1,0 +1,183 @@
+using Microsoft.Extensions.Logging;
+using Nocturne.API.Helpers;
+using Nocturne.Core.Contracts.Analytics;
+using Nocturne.Core.Contracts.Profiles.Resolvers;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.API.Services.ChartData;
+
+/// <summary>
+/// Builds basal delivery series from TempBasal records and profile-inferred rates.
+/// TempBasal records are the v4 source of truth for pump-confirmed basal delivery.
+/// Gaps in TempBasal coverage are filled at 5-minute resolution from the active
+/// basal rate schedule; when no TempBasal records exist the entire series is
+/// profile-derived.
+/// </summary>
+internal sealed class BasalSeriesBuilder(
+    ITherapySettingsResolver therapySettingsResolver,
+    IBasalRateResolver basalRateResolver,
+    ILogger<BasalSeriesBuilder> logger
+) : IBasalSeriesBuilder
+{
+    public async Task<List<BasalPoint>> BuildAsync(
+        List<TempBasal> tempBasals,
+        long startTime,
+        long endTime,
+        double defaultBasalRate,
+        CancellationToken ct = default
+    )
+    {
+        var series = new List<BasalPoint>();
+        var sorted = tempBasals.OrderBy(tb => tb.StartMills).ToList();
+
+        logger.LogDebug(
+            "Building basal series from {Count} TempBasal records",
+            sorted.Count
+        );
+
+        if (sorted.Count == 0)
+            return await BuildFromProfileAsync(startTime, endTime, defaultBasalRate, ct);
+
+        long currentTime = startTime;
+
+        var hasData = await therapySettingsResolver.HasDataAsync(ct);
+
+        foreach (var tb in sorted)
+        {
+            var tbStart = tb.StartMills;
+            var tbEnd = tb.EndMills ?? endTime;
+
+            if (tbEnd < startTime || tbStart > endTime)
+                continue;
+
+            tbStart = Math.Max(tbStart, startTime);
+            tbEnd = Math.Min(tbEnd, endTime);
+
+            if (tbStart > currentTime)
+            {
+                series.AddRange(
+                    await BuildFromProfileAsync(currentTime, tbStart, defaultBasalRate, ct)
+                );
+            }
+
+            var origin = MapTempBasalOrigin(tb.Origin);
+
+            var scheduledRate = tb.ScheduledRate
+                ?? (hasData
+                    ? await basalRateResolver.GetBasalRateAsync(tbStart, ct: ct)
+                    : defaultBasalRate);
+
+            series.Add(
+                new BasalPoint
+                {
+                    Timestamp = tbStart,
+                    Rate = origin == BasalDeliveryOrigin.Suspended ? 0 : tb.Rate,
+                    ScheduledRate = scheduledRate,
+                    Origin = origin,
+                    FillColor = ChartColorMapper.FillFromBasalOrigin(origin),
+                    StrokeColor = ChartColorMapper.StrokeFromBasalOrigin(origin),
+                }
+            );
+
+            currentTime = tbEnd;
+        }
+
+        if (currentTime < endTime)
+            series.AddRange(await BuildFromProfileAsync(currentTime, endTime, defaultBasalRate, ct));
+
+        if (series.Count == 0)
+        {
+            series.Add(
+                new BasalPoint
+                {
+                    Timestamp = startTime,
+                    Rate = defaultBasalRate,
+                    ScheduledRate = defaultBasalRate,
+                    Origin = BasalDeliveryOrigin.Scheduled,
+                    FillColor = ChartColorMapper.FillFromBasalOrigin(BasalDeliveryOrigin.Scheduled),
+                    StrokeColor = ChartColorMapper.StrokeFromBasalOrigin(
+                        BasalDeliveryOrigin.Scheduled
+                    ),
+                }
+            );
+        }
+
+        return series;
+    }
+
+    private async Task<List<BasalPoint>> BuildFromProfileAsync(
+        long startTime,
+        long endTime,
+        double defaultBasalRate,
+        CancellationToken ct = default
+    )
+    {
+        var series = new List<BasalPoint>();
+        const long intervalMs = 5 * 60 * 1000;
+        double? prevRate = null;
+
+        var hasData = await therapySettingsResolver.HasDataAsync(ct);
+
+        for (long t = startTime; t <= endTime; t += intervalMs)
+        {
+            var rate = hasData
+                ? await basalRateResolver.GetBasalRateAsync(t, ct: ct)
+                : defaultBasalRate;
+
+            if (prevRate == null || Math.Abs(rate - prevRate.Value) > 0.001)
+            {
+                series.Add(
+                    new BasalPoint
+                    {
+                        Timestamp = t,
+                        Rate = rate,
+                        ScheduledRate = rate,
+                        Origin = BasalDeliveryOrigin.Inferred,
+                        FillColor = ChartColorMapper.FillFromBasalOrigin(
+                            BasalDeliveryOrigin.Inferred
+                        ),
+                        StrokeColor = ChartColorMapper.StrokeFromBasalOrigin(
+                            BasalDeliveryOrigin.Inferred
+                        ),
+                    }
+                );
+                prevRate = rate;
+            }
+        }
+
+        if (series.Count == 0)
+        {
+            series.Add(
+                new BasalPoint
+                {
+                    Timestamp = startTime,
+                    Rate = defaultBasalRate,
+                    ScheduledRate = defaultBasalRate,
+                    Origin = BasalDeliveryOrigin.Inferred,
+                    FillColor = ChartColorMapper.FillFromBasalOrigin(BasalDeliveryOrigin.Inferred),
+                    StrokeColor = ChartColorMapper.StrokeFromBasalOrigin(
+                        BasalDeliveryOrigin.Inferred
+                    ),
+                }
+            );
+        }
+
+        return series;
+    }
+
+    /// <summary>
+    /// Maps a TempBasalOrigin enum value to the corresponding BasalDeliveryOrigin enum value.
+    /// Both enums have identical members (Algorithm, Scheduled, Manual, Suspended, Inferred).
+    /// </summary>
+    internal static BasalDeliveryOrigin MapTempBasalOrigin(TempBasalOrigin origin) =>
+        origin switch
+        {
+            TempBasalOrigin.Algorithm => BasalDeliveryOrigin.Algorithm,
+            TempBasalOrigin.Scheduled => BasalDeliveryOrigin.Scheduled,
+            TempBasalOrigin.Manual => BasalDeliveryOrigin.Manual,
+            TempBasalOrigin.Suspended => BasalDeliveryOrigin.Suspended,
+            TempBasalOrigin.Inferred => BasalDeliveryOrigin.Inferred,
+            _ => BasalDeliveryOrigin.Scheduled,
+        };
+}

--- a/src/API/Nocturne.API/Services/ChartData/Stages/IobCobComputeStage.cs
+++ b/src/API/Nocturne.API/Services/ChartData/Stages/IobCobComputeStage.cs
@@ -2,7 +2,7 @@ using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
-using Nocturne.API.Helpers;
+using Nocturne.Core.Contracts.Analytics;
 using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.Multitenancy;
@@ -31,8 +31,8 @@ namespace Nocturne.API.Services.ChartData.Stages;
 /// and interval. The tenant ID component prevents cross-tenant cache leakage.
 /// </para>
 /// <para>
-/// Basal series construction (<see cref="BuildBasalSeriesFromTempBasalsAsync"/>) uses v4
-/// <see cref="TempBasal"/> records as the source of truth and fills any gaps with
+/// Basal series construction is delegated to <see cref="IBasalSeriesBuilder"/>, which uses
+/// v4 <see cref="TempBasal"/> records as the source of truth and fills any gaps with
 /// profile-inferred rates at 5-minute resolution. When no TempBasal records exist the
 /// entire series is inferred from the profile. The y-axis maximum is clamped to at least
 /// 2.5× the default basal rate so the chart always shows meaningful scale.
@@ -47,8 +47,7 @@ namespace Nocturne.API.Services.ChartData.Stages;
 internal sealed class IobCobComputeStage(
     IIobCalculator iobCalculator,
     ICobCalculator cobCalculator,
-    ITherapySettingsResolver therapySettingsResolver,
-    IBasalRateResolver basalRateResolver,
+    IBasalSeriesBuilder basalSeriesBuilder,
     ITherapyTimelineResolver therapyTimelineResolver,
     IMemoryCache cache,
     ITenantAccessor tenantAccessor,
@@ -80,7 +79,7 @@ internal sealed class IobCobComputeStage(
             cancellationToken
         );
 
-        var basalSeries = await BuildBasalSeriesFromTempBasalsAsync(tempBasalList, startTime, endTime, defaultBasalRate, cancellationToken);
+        var basalSeries = await basalSeriesBuilder.BuildAsync(tempBasalList, startTime, endTime, defaultBasalRate, cancellationToken);
 
         var maxBasalRate = Math.Max(
             defaultBasalRate * 2.5,
@@ -300,169 +299,4 @@ internal sealed class IobCobComputeStage(
         return $"iobcob:{TenantCacheId}:{hash}:{roundedStart}:{roundedEnd}:{intervalMinutes}";
     }
 
-    /// <summary>
-    /// Build basal series from TempBasal records.
-    /// TempBasal records are the v4 source of truth for pump-confirmed basal delivery.
-    /// Falls back to profile-based rates when there are gaps in TempBasal data.
-    /// </summary>
-    internal async Task<List<BasalPoint>> BuildBasalSeriesFromTempBasalsAsync(
-        List<TempBasal> tempBasals,
-        long startTime,
-        long endTime,
-        double defaultBasalRate,
-        CancellationToken ct = default
-    )
-    {
-        var series = new List<BasalPoint>();
-        var sorted = tempBasals.OrderBy(tb => tb.StartMills).ToList();
-
-        logger.LogDebug(
-            "Building basal series from {Count} TempBasal records",
-            sorted.Count
-        );
-
-        if (sorted.Count == 0)
-            return await BuildBasalSeriesFromProfileAsync(startTime, endTime, defaultBasalRate, ct);
-
-        long currentTime = startTime;
-
-        var hasData = await therapySettingsResolver.HasDataAsync(ct);
-
-        foreach (var tb in sorted)
-        {
-            var tbStart = tb.StartMills;
-            var tbEnd = tb.EndMills ?? endTime;
-
-            if (tbEnd < startTime || tbStart > endTime)
-                continue;
-
-            tbStart = Math.Max(tbStart, startTime);
-            tbEnd = Math.Min(tbEnd, endTime);
-
-            if (tbStart > currentTime)
-            {
-                series.AddRange(
-                    await BuildBasalSeriesFromProfileAsync(currentTime, tbStart, defaultBasalRate, ct)
-                );
-            }
-
-            var origin = MapTempBasalOrigin(tb.Origin);
-
-            var scheduledRate = tb.ScheduledRate
-                ?? (hasData
-                    ? await basalRateResolver.GetBasalRateAsync(tbStart, ct: ct)
-                    : defaultBasalRate);
-
-            series.Add(
-                new BasalPoint
-                {
-                    Timestamp = tbStart,
-                    Rate = origin == BasalDeliveryOrigin.Suspended ? 0 : tb.Rate,
-                    ScheduledRate = scheduledRate,
-                    Origin = origin,
-                    FillColor = ChartColorMapper.FillFromBasalOrigin(origin),
-                    StrokeColor = ChartColorMapper.StrokeFromBasalOrigin(origin),
-                }
-            );
-
-            currentTime = tbEnd;
-        }
-
-        if (currentTime < endTime)
-            series.AddRange(await BuildBasalSeriesFromProfileAsync(currentTime, endTime, defaultBasalRate, ct));
-
-        if (series.Count == 0)
-        {
-            series.Add(
-                new BasalPoint
-                {
-                    Timestamp = startTime,
-                    Rate = defaultBasalRate,
-                    ScheduledRate = defaultBasalRate,
-                    Origin = BasalDeliveryOrigin.Scheduled,
-                    FillColor = ChartColorMapper.FillFromBasalOrigin(BasalDeliveryOrigin.Scheduled),
-                    StrokeColor = ChartColorMapper.StrokeFromBasalOrigin(
-                        BasalDeliveryOrigin.Scheduled
-                    ),
-                }
-            );
-        }
-
-        return series;
-    }
-
-    internal async Task<List<BasalPoint>> BuildBasalSeriesFromProfileAsync(
-        long startTime,
-        long endTime,
-        double defaultBasalRate,
-        CancellationToken ct = default
-    )
-    {
-        var series = new List<BasalPoint>();
-        const long intervalMs = 5 * 60 * 1000;
-        double? prevRate = null;
-
-        var hasData = await therapySettingsResolver.HasDataAsync(ct);
-
-        for (long t = startTime; t <= endTime; t += intervalMs)
-        {
-            var rate = hasData
-                ? await basalRateResolver.GetBasalRateAsync(t, ct: ct)
-                : defaultBasalRate;
-
-            if (prevRate == null || Math.Abs(rate - prevRate.Value) > 0.001)
-            {
-                series.Add(
-                    new BasalPoint
-                    {
-                        Timestamp = t,
-                        Rate = rate,
-                        ScheduledRate = rate,
-                        Origin = BasalDeliveryOrigin.Inferred,
-                        FillColor = ChartColorMapper.FillFromBasalOrigin(
-                            BasalDeliveryOrigin.Inferred
-                        ),
-                        StrokeColor = ChartColorMapper.StrokeFromBasalOrigin(
-                            BasalDeliveryOrigin.Inferred
-                        ),
-                    }
-                );
-                prevRate = rate;
-            }
-        }
-
-        if (series.Count == 0)
-        {
-            series.Add(
-                new BasalPoint
-                {
-                    Timestamp = startTime,
-                    Rate = defaultBasalRate,
-                    ScheduledRate = defaultBasalRate,
-                    Origin = BasalDeliveryOrigin.Inferred,
-                    FillColor = ChartColorMapper.FillFromBasalOrigin(BasalDeliveryOrigin.Inferred),
-                    StrokeColor = ChartColorMapper.StrokeFromBasalOrigin(
-                        BasalDeliveryOrigin.Inferred
-                    ),
-                }
-            );
-        }
-
-        return series;
-    }
-
-    /// <summary>
-    /// Maps a TempBasalOrigin enum value to the corresponding BasalDeliveryOrigin enum value.
-    /// Both enums have identical members (Algorithm, Scheduled, Manual, Suspended, Inferred).
-    /// </summary>
-    internal static BasalDeliveryOrigin MapTempBasalOrigin(TempBasalOrigin origin) =>
-        origin switch
-        {
-            TempBasalOrigin.Algorithm => BasalDeliveryOrigin.Algorithm,
-            TempBasalOrigin.Scheduled => BasalDeliveryOrigin.Scheduled,
-            TempBasalOrigin.Manual => BasalDeliveryOrigin.Manual,
-            TempBasalOrigin.Suspended => BasalDeliveryOrigin.Suspended,
-            TempBasalOrigin.Inferred => BasalDeliveryOrigin.Inferred,
-            _ => BasalDeliveryOrigin.Scheduled,
-        };
 }

--- a/src/Core/Nocturne.Core.Contracts/Analytics/IBasalSeriesBuilder.cs
+++ b/src/Core/Nocturne.Core.Contracts/Analytics/IBasalSeriesBuilder.cs
@@ -1,0 +1,29 @@
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.Core.Contracts.Analytics;
+
+/// <summary>
+/// Builds basal delivery series from TempBasal records and profile-inferred rates.
+/// Gaps in TempBasal coverage are filled at 5-minute resolution from the active
+/// basal rate schedule; when no TempBasal records exist the entire series is
+/// profile-derived.
+/// </summary>
+public interface IBasalSeriesBuilder
+{
+    /// <summary>
+    /// Build a basal delivery series for the given time window.
+    /// </summary>
+    /// <param name="tempBasals">Pump-confirmed TempBasal records (may be empty)</param>
+    /// <param name="startTime">Start of the time range in Unix milliseconds</param>
+    /// <param name="endTime">End of the time range in Unix milliseconds</param>
+    /// <param name="defaultBasalRate">Fallback basal rate when no profile data exists</param>
+    /// <param name="ct">Cancellation token</param>
+    Task<List<BasalPoint>> BuildAsync(
+        List<TempBasal> tempBasals,
+        long startTime,
+        long endTime,
+        double defaultBasalRate,
+        CancellationToken ct = default
+    );
+}

--- a/src/Core/Nocturne.Core.Contracts/Analytics/IChartDataService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Analytics/IChartDataService.cs
@@ -28,4 +28,18 @@ public interface IChartDataService
         int intervalMinutes,
         CancellationToken cancellationToken = default
     );
+
+    /// <summary>
+    /// Build the basal delivery series for a given time range without running the
+    /// full IOB/COB compute pipeline.
+    /// </summary>
+    /// <param name="startTime">Start of the time range in Unix milliseconds</param>
+    /// <param name="endTime">End of the time range in Unix milliseconds</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Basal delivery points covering the requested window</returns>
+    Task<List<BasalPoint>> GetBasalSeriesAsync(
+        long startTime,
+        long endTime,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/Web/packages/app/src/lib/api/reports.remote.ts
+++ b/src/Web/packages/app/src/lib/api/reports.remote.ts
@@ -281,8 +281,8 @@ export const getReportsData = query(
     const carbIntakes = allCarbIntakes!;
     const population = DiabetesPopulation.Type1Adult; // TODO: Get from user settings
 
-    // Get summary, analysis, averaged stats, and basal data in parallel
-    const [summary, analysis, averagedStats, chartData] = await Promise.all([
+    // Get summary, analysis, averaged stats, and basal series in parallel
+    const [summary, analysis, averagedStats, basalSeries] = await Promise.all([
       apiClient.statistics.getMultiPeriodStatistics(),
       apiClient.statistics.analyzeGlucoseDataExtended({
         entries,
@@ -291,11 +291,7 @@ export const getReportsData = query(
         population,
       }),
       apiClient.statistics.calculateAveragedStats(entries),
-      apiClient.chartData.getDashboardChartData(
-        startDate.getTime(),
-        endDate.getTime(),
-        5 // 5-minute intervals
-      ),
+      apiClient.chartData.getBasalSeries(startDate.getTime(), endDate.getTime()),
     ]);
 
     return {
@@ -305,7 +301,7 @@ export const getReportsData = query(
       summary,
       analysis,
       averagedStats,
-      basalSeries: chartData.basalSeries ?? ([] as BasalPoint[]),
+      basalSeries: basalSeries ?? [],
       dateRange: {
         from: startDate.toISOString(),
         to: endDate.toISOString(),

--- a/tests/Unit/Nocturne.API.Tests/Services/ChartData/Stages/IobCobComputeStageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ChartData/Stages/IobCobComputeStageTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.API.Services.ChartData;
 using Nocturne.API.Services.ChartData.Stages;
+using Nocturne.Core.Contracts.Analytics;
 using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Models;
@@ -17,8 +18,7 @@ public class IobCobComputeStageTests
 {
     private readonly Mock<IIobCalculator> _mockIobCalculator = new();
     private readonly Mock<ICobCalculator> _mockCobCalculator = new();
-    private readonly Mock<ITherapySettingsResolver> _mockTherapySettings = new();
-    private readonly Mock<IBasalRateResolver> _mockBasalRateResolver = new();
+    private readonly Mock<IBasalSeriesBuilder> _mockBasalSeriesBuilder = new();
     private readonly Mock<ITherapyTimelineResolver> _mockTherapyTimelineResolver = new();
     private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
     private readonly IobCobComputeStage _stage;
@@ -28,7 +28,24 @@ public class IobCobComputeStageTests
 
     public IobCobComputeStageTests()
     {
-        _mockTherapySettings.Setup(p => p.HasDataAsync(It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        _mockBasalSeriesBuilder
+            .Setup(b => b.BuildAsync(
+                It.IsAny<List<TempBasal>>(),
+                It.IsAny<long>(),
+                It.IsAny<long>(),
+                It.IsAny<double>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<TempBasal> _, long start, long _, double rate, CancellationToken _) =>
+                new List<BasalPoint>
+                {
+                    new()
+                    {
+                        Timestamp = start,
+                        Rate = rate,
+                        ScheduledRate = rate,
+                        Origin = BasalDeliveryOrigin.Inferred,
+                    },
+                });
 
         var defaultSnapshot = new TherapySnapshot(
             dia: 3.0,
@@ -48,8 +65,7 @@ public class IobCobComputeStageTests
         _stage = new IobCobComputeStage(
             _mockIobCalculator.Object,
             _mockCobCalculator.Object,
-            _mockTherapySettings.Object,
-            _mockBasalRateResolver.Object,
+            _mockBasalSeriesBuilder.Object,
             _mockTherapyTimelineResolver.Object,
             _cache,
             MockTenantAccessor.Create().Object,


### PR DESCRIPTION
## Summary

- **Extracts `IBasalSeriesBuilder`** service from `IobCobComputeStage` — moves `BuildBasalSeriesFromTempBasalsAsync`, `BuildBasalSeriesFromProfileAsync`, and `MapTempBasalOrigin` into a standalone, testable service
- **Adds `GET api/v4/ChartData/basal-series`** endpoint with `[RemoteQuery]` + 60s response cache — resolves default basal rate from profile, fetches temp basals, and delegates to the builder. No IOB/COB compute involved
- **Updates `getReportsData`** to call the new endpoint instead of `getDashboardChartData`, eliminating the full pipeline (11 data fetches + tick-by-tick IOB/COB computation) that was running just to extract `basalSeries`

### Why

`getReportsData` was calling `getDashboardChartData` solely to get the basal series. That triggered the full chart data pipeline: `DataFetchStage` (11 data types), `IobCobComputeStage` (O(ticks × active-window) with expensive per-treatment profile resolver calls and COB computing `CalculateTotalAsync` twice per carb intake per tick), and `DtoMappingStage`. For a 14-day window with many treatments, this was CPU-intensive enough to exceed Node's `UND_ERR_HEADERS_TIMEOUT`, causing the frontend to disconnect and pile up stale requests.

The basal series has **zero dependency on IOB/COB results** — it only needs temp basals + profile basal rates. This PR gives it a dedicated path.

## Test plan

- [ ] Run `aspire start` to regenerate NSwag client (adds `getBasalSeries` to TypeScript client)
- [ ] Verify reports page loads and basal series chart renders correctly
- [ ] Verify dashboard page still works (full pipeline unchanged, delegates to same `IBasalSeriesBuilder`)
- [ ] Run unit tests: `dotnet test --filter "Category!=Integration&Category!=Performance"`
- [ ] Check API directly: `GET /api/v4/ChartData/basal-series?startTime=X&endTime=Y` returns `BasalPoint[]`