### PR TITLE
fix(#188): respect time format preference across frontend

### DIFF
--- a/src/Web/packages/app/src/lib/components/WebSocketStatus.svelte
+++ b/src/Web/packages/app/src/lib/components/WebSocketStatus.svelte
@@ -3,7 +3,7 @@
   import { Card, CardContent } from "$lib/components/ui/card";
   import { Button } from "$lib/components/ui/button";
   import { getRealtimeStore } from "$lib/stores/realtime-store.svelte";
-  import { formatTime } from "$lib/utils";
+  import { time } from "$lib/utils/formatting";
 
   const realtimeStore = getRealtimeStore();
 
@@ -125,7 +125,7 @@
         <p class="font-medium text-destructive">Connection Error:</p>
         <p class="text-muted-foreground">{connectionError.message}</p>
         <p class="text-muted-foreground">
-          {formatTime(new Date(connectionError.timestamp))}
+          {time(new Date(connectionError.timestamp))}
         </p>
       </div>
     {/if}

--- a/src/Web/packages/app/src/lib/components/alerts/PlaybackStrip.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/PlaybackStrip.svelte
@@ -4,7 +4,7 @@
   import { Play, Pause, RotateCcw } from "lucide-svelte";
   import { AlertReplayEventKind, type AlertRuleSeverity } from "$api-clients";
   import { severityVar } from "./severity";
-  import { formatDateTime } from "./alertTime";
+  import { formatDateTimeCompact } from "$lib/utils/formatting";
 
   interface EventTick {
     tMs: number;
@@ -165,6 +165,6 @@
   <span
     class="font-mono text-xs text-muted-foreground tabular-nums shrink-0 w-32 text-right"
   >
-    {currentDate ? formatDateTime(currentDate) : ""}
+    {currentDate ? formatDateTimeCompact(currentDate) : ""}
   </span>
 </div>

--- a/src/Web/packages/app/src/lib/components/alerts/ReplayPanel.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/ReplayPanel.svelte
@@ -32,7 +32,8 @@
     type ReplayRuleDefinition,
   } from "$api-clients";
   import { severityLabel, severityVar } from "./severity";
-  import { formatTime, formatRange } from "./alertTime";
+  import { formatRange } from "./alertTime";
+  import { time } from "$lib/utils/formatting";
   import { createChartDataEngine } from "$lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte";
   import GlucoseChartShell from "$lib/components/dashboard/glucose-chart/GlucoseChartShell.svelte";
   import GlucoseTrack from "$lib/components/dashboard/glucose-chart/tracks/GlucoseTrack.svelte";
@@ -659,7 +660,7 @@
                   <span
                     class="font-mono text-xs text-muted-foreground tabular-nums w-16 shrink-0"
                   >
-                    {formatTime(m.ev.at)}
+                    {m.ev.at ? time(new Date(m.ev.at)) : ""}
                   </span>
                   <Badge variant="outline" class="shrink-0">
                     {kindLabel(m.ev)}

--- a/src/Web/packages/app/src/lib/components/alerts/alertTime.test.ts
+++ b/src/Web/packages/app/src/lib/components/alerts/alertTime.test.ts
@@ -1,37 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
-  formatTime,
-  formatDateTime,
   formatRange,
   formatTimeSince,
   formatDuration,
 } from "./alertTime";
 
 describe("alertTime", () => {
-  describe("formatTime", () => {
-    it("returns non-empty string for valid date", () => {
-      expect(formatTime(new Date("2025-03-05T14:32:00Z"))).not.toBe("");
-    });
-    it("accepts ISO string", () => {
-      expect(formatTime("2025-03-05T14:32:00Z")).not.toBe("");
-    });
-    it("returns empty string when undefined", () => {
-      expect(formatTime(undefined)).toBe("");
-    });
-    it("returns empty string for invalid date string", () => {
-      expect(formatTime("not-a-date")).toBe("");
-    });
-  });
-
-  describe("formatDateTime", () => {
-    it("returns non-empty string for valid date", () => {
-      expect(formatDateTime(new Date("2025-03-05T14:32:00Z"))).not.toBe("");
-    });
-    it("returns empty string when undefined", () => {
-      expect(formatDateTime(undefined)).toBe("");
-    });
-  });
-
   describe("formatRange", () => {
     it("returns empty string when either side missing", () => {
       expect(formatRange(undefined, new Date())).toBe("");

--- a/src/Web/packages/app/src/lib/components/alerts/alertTime.ts
+++ b/src/Web/packages/app/src/lib/components/alerts/alertTime.ts
@@ -3,10 +3,12 @@
  *
  * All helpers accept Date | string | undefined and return "" on missing
  * or unparseable input (call sites supply their own dash fallback when
- * they want one). formatTime / formatDateTime fall back to ISO if the
- * runtime's Intl rejects the options, matching the behaviour the
- * helpers had when they lived inside ReplayPanel.
+ * they want one). Generic time/date-time formatting now lives in
+ * "$lib/utils/formatting"; only alert-specific relative/duration
+ * formatters remain here.
  */
+
+import { formatDateTimeCompact } from "$lib/utils/formatting";
 
 function toDate(at: Date | string | undefined): Date | null {
   if (!at) return null;
@@ -15,43 +17,13 @@ function toDate(at: Date | string | undefined): Date | null {
   return d;
 }
 
-/** "14:32" — locale time. */
-export function formatTime(at: Date | string | undefined): string {
-  const d = toDate(at);
-  if (!d) return "";
-  try {
-    return new Intl.DateTimeFormat(undefined, {
-      hour: "2-digit",
-      minute: "2-digit",
-    }).format(d);
-  } catch {
-    return d.toISOString();
-  }
-}
-
-/** "Mar 5, 14:32" — short date + time. */
-export function formatDateTime(at: Date | string | undefined): string {
-  const d = toDate(at);
-  if (!d) return "";
-  try {
-    return new Intl.DateTimeFormat(undefined, {
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    }).format(d);
-  } catch {
-    return d.toISOString();
-  }
-}
-
-/** "Mar 5, 14:32 — Mar 5, 15:00" — formatDateTime range. Empty when either side missing. */
+/** "Mar 5, 14:32 — Mar 5, 15:00" — compact date-time range. Empty when either side missing. */
 export function formatRange(
   start: Date | string | undefined,
   end: Date | string | undefined
 ): string {
   if (!start || !end) return "";
-  return `${formatDateTime(start)} — ${formatDateTime(end)}`;
+  return `${formatDateTimeCompact(start)} — ${formatDateTimeCompact(end)}`;
 }
 
 /** Relative: "Just now", "12m ago", "3h 5m ago", "2d ago". */

--- a/src/Web/packages/app/src/lib/components/dashboard/BGStatisticsCards.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/BGStatisticsCards.svelte
@@ -13,8 +13,8 @@
     BatteryWarning,
     Zap,
   } from "lucide-svelte";
-  import { formatTime, timeAgo } from "$lib/utils";
-  import { formatGlucoseDelta, getUnitLabel } from "$lib/utils/formatting";
+  import { timeAgo } from "$lib/utils";
+  import { formatGlucoseDelta, getUnitLabel, time } from "$lib/utils/formatting";
   import { getRealtimeStore } from "$lib/stores/realtime-store.svelte";
   import { glucoseUnits } from "$lib/stores/appearance-store.svelte";
   import WebSocketStatus from "$lib/components/WebSocketStatus.svelte";
@@ -87,7 +87,7 @@
           {timeAgo(displayLastUpdated)}
         </div>
         <p class="text-xs text-muted-foreground">
-          {formatTime(displayLastUpdated)}
+          {time(displayLastUpdated)}
         </p>
       </CardContent>
     </Card>
@@ -131,7 +131,7 @@
           </div>
         {:else}
           <p class="text-xs text-muted-foreground">
-            {formatTime(displayLastUpdated)}
+            {time(displayLastUpdated)}
           </p>
         {/if}
       </CardContent>
@@ -146,7 +146,7 @@
           {timeAgo(displayLastUpdated)}
         </div>
         <p class="text-xs text-muted-foreground">
-          {formatTime(displayLastUpdated)}
+          {time(displayLastUpdated)}
         </p>
       </CardContent>
     </Card>

--- a/src/Web/packages/app/src/lib/components/dashboard/MiniOverviewChart.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/MiniOverviewChart.svelte
@@ -12,6 +12,7 @@
   import { curveMonotoneX } from "d3";
   import type { BrushContextValue } from "layerchart";
   import RotateCcw from "lucide-svelte/icons/rotate-ccw";
+  import { time, formatDateTimeCompact } from "$lib/utils/formatting";
 
   interface GlucosePoint {
     time: Date;
@@ -76,29 +77,14 @@
         selectedXDomain[1].getTime() !== fullXDomain[1].getTime())
   );
 
-  // Format time for handle labels
-  function formatTime(date: Date): string {
-    return date.toLocaleTimeString([], {
-      hour: "numeric",
-      minute: "2-digit",
-    });
-  }
-
   // Format date for longer displays
   function formatDateTime(date: Date): string {
     const now = new Date();
     const isToday = date.toDateString() === now.toDateString();
-
     if (isToday) {
-      return formatTime(date);
+      return time(date);
     }
-
-    return date.toLocaleDateString([], {
-      month: "short",
-      day: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-    });
+    return formatDateTimeCompact(date);
   }
 
   // Handle brush end - update selection
@@ -202,7 +188,7 @@
             <Axis
               placement="bottom"
               ticks={4}
-              format={(v) => (v instanceof Date ? formatTime(v) : String(v))}
+              format={(v) => (v instanceof Date ? time(v) : String(v))}
               tickLabelProps={{ class: "text-[9px] fill-muted-foreground" }}
             />
           </Svg>

--- a/src/Web/packages/app/src/lib/components/dashboard/RecentEntriesCard.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/RecentEntriesCard.svelte
@@ -2,13 +2,13 @@
   import type { Entry } from "$lib/api";
   import { Card, CardContent, CardHeader } from "$lib/components/ui/card";
 
-  import { formatTime } from "$lib/utils";
   import { getRealtimeStore } from "$lib/stores/realtime-store.svelte";
   import { glucoseUnits } from "$lib/stores/appearance-store.svelte";
   import {
     formatGlucoseValue,
     formatGlucoseDelta,
     getUnitLabel,
+    time,
   } from "$lib/utils/formatting";
   import { getDirectionInfo } from "$lib/utils";
 
@@ -52,7 +52,7 @@
                   {/if}
                 </div>
                 <div class="text-sm text-muted-foreground">
-                  {formatTime(entry.mills!)}
+                  {time(entry.mills!)}
                 </div>
               </div>
             </div>

--- a/src/Web/packages/app/src/lib/components/dashboard/RecentTreatmentsCard.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/RecentTreatmentsCard.svelte
@@ -8,7 +8,7 @@
     CardTitle,
   } from "$lib/components/ui/card";
   import { Badge } from "$lib/components/ui/badge";
-  import { formatTime } from "$lib/utils";
+  import { time } from "$lib/utils/formatting";
   import { getRealtimeStore } from "$lib/stores/realtime-store.svelte";
   import { EntryEditDialog } from "$lib/components/entries";
 
@@ -118,7 +118,7 @@
                     {/if}
                   </div>
                   <div class="text-sm text-muted-foreground">
-                    {formatTime(entry.data.mills!)}
+                    {time(entry.data.mills!)}
                   </div>
                 </div>
               </div>

--- a/src/Web/packages/app/src/lib/components/dashboard/state-spans-timeline/state-spans-timeline.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/state-spans-timeline/state-spans-timeline.svelte
@@ -5,6 +5,7 @@
   import { BasalRateTrack } from "$lib/components/charts";
   import type { ProcessedSpan } from "../../../../routes/(authenticated)/time-spans/data.remote";
   import { BasalDeliveryOrigin } from "$lib/api";
+  import { formatDateTimeCompact } from "$lib/utils/formatting";
 
   interface BasalDeliveryChartData {
     id: string;
@@ -122,15 +123,6 @@
     return `${minutes}m`;
   }
 
-  // Format time for tooltip
-  function formatTime(date: Date): string {
-    return date.toLocaleString(undefined, {
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-  }
 </script>
 
 <div class="relative w-full" style="height: {chartHeight}px;">
@@ -282,7 +274,7 @@
       >
         <div class="font-medium">{hoveredSpan.profileName ?? hoveredSpan.state}</div>
         <div class="text-xs text-muted-foreground mt-1">
-          <div>{formatTime(hoveredSpan.startTime)} - {formatTime(hoveredSpan.endTime)}</div>
+          <div>{formatDateTimeCompact(hoveredSpan.startTime)} - {formatDateTimeCompact(hoveredSpan.endTime)}</div>
           <div>Duration: {formatDuration(hoveredSpan.startTime, hoveredSpan.endTime)}</div>
         </div>
       </div>

--- a/src/Web/packages/app/src/lib/components/dashboard/widgets/BgDeltaWidget.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/widgets/BgDeltaWidget.svelte
@@ -2,8 +2,8 @@
   import WidgetCard from "./WidgetCard.svelte";
   import { getRealtimeStore } from "$lib/stores/realtime-store.svelte";
   import { glucoseUnits } from "$lib/stores/appearance-store.svelte";
-  import { formatGlucoseDelta, getUnitLabel } from "$lib/utils/formatting";
-  import { timeAgo, formatTime } from "$lib/utils";
+  import { formatGlucoseDelta, getUnitLabel, time } from "$lib/utils/formatting";
+  import { timeAgo } from "$lib/utils";
   import { onMount } from "svelte";
   import {
     BatteryCharging,
@@ -97,7 +97,7 @@
         {timeAgo(displayLastUpdated)}
       </span>
       <span class="text-xs text-muted-foreground">
-        {formatTime(displayLastUpdated)}
+        {time(displayLastUpdated)}
       </span>
     </div>
   {:else}
@@ -109,7 +109,7 @@
           {timeAgo(displayLastUpdated)}
         </span>
         <span class="text-xs text-muted-foreground">
-          {formatTime(displayLastUpdated)}
+          {time(displayLastUpdated)}
         </span>
       </div>
     {:then currentStatus}
@@ -145,7 +145,7 @@
           </span>
         {:else}
           <span class="text-xs text-muted-foreground">
-            {formatTime(displayLastUpdated)}
+            {time(displayLastUpdated)}
           </span>
         {/if}
       </div>
@@ -157,7 +157,7 @@
           {timeAgo(displayLastUpdated)}
         </span>
         <span class="text-xs text-muted-foreground">
-          {formatTime(displayLastUpdated)}
+          {time(displayLastUpdated)}
         </span>
       </div>
     {/await}

--- a/src/Web/packages/app/src/lib/components/dashboard/widgets/LastUpdatedWidget.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/widgets/LastUpdatedWidget.svelte
@@ -8,7 +8,8 @@
     BatteryWarning,
     Zap,
   } from "lucide-svelte";
-  import { formatTime, timeAgo } from "$lib/utils";
+  import { timeAgo } from "$lib/utils";
+  import { time } from "$lib/utils/formatting";
   import { getRealtimeStore } from "$lib/stores/realtime-store.svelte";
   import { getCurrentBatteryStatus } from "$api/generated/batteries.generated.remote";
 
@@ -52,7 +53,7 @@
       {timeAgo(displayLastUpdated)}
     </div>
     <p class="text-xs text-muted-foreground">
-      {formatTime(displayLastUpdated)}
+      {time(displayLastUpdated)}
     </p>
   </WidgetCard>
 {:then currentStatus}
@@ -89,7 +90,7 @@
       </div>
     {:else}
       <p class="text-xs text-muted-foreground">
-        {formatTime(displayLastUpdated)}
+        {time(displayLastUpdated)}
       </p>
     {/if}
   </WidgetCard>
@@ -99,7 +100,7 @@
       {timeAgo(displayLastUpdated)}
     </div>
     <p class="text-xs text-muted-foreground">
-      {formatTime(displayLastUpdated)}
+      {time(displayLastUpdated)}
     </p>
   </WidgetCard>
 {/await}

--- a/src/Web/packages/app/src/lib/components/dashboard/widgets/MealsWidget.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/widgets/MealsWidget.svelte
@@ -2,7 +2,7 @@
   import WidgetCard from "./WidgetCard.svelte";
   import { Badge } from "$lib/components/ui/badge";
   import { getRealtimeStore } from "$lib/stores/realtime-store.svelte";
-  import { formatTime } from "$lib/utils";
+  import { time } from "$lib/utils/formatting";
   import { UtensilsCrossed } from "lucide-svelte";
 
   const realtimeStore = getRealtimeStore();
@@ -36,7 +36,7 @@
       </div>
       <div class="text-xs text-muted-foreground">
         {#if lastMealTime}
-          Last: {formatTime(lastMealTime)}
+          Last: {time(lastMealTime)}
         {/if}
       </div>
       <div class="flex flex-wrap gap-1 mt-1">

--- a/src/Web/packages/app/src/lib/components/meals/MealsTable.svelte
+++ b/src/Web/packages/app/src/lib/components/meals/MealsTable.svelte
@@ -18,6 +18,7 @@
   import CarbBreakdownBar from "$lib/components/treatments/CarbBreakdownBar.svelte";
   import FoodEntryDetails from "$lib/components/treatments/FoodEntryDetails.svelte";
   import { getMealNameForTime } from "$lib/constants/meal-times";
+  import { time } from "$lib/utils/formatting";
 
   interface MealsByDay {
     date: string;
@@ -68,14 +69,6 @@
     onDismissSuggestion,
     onReviewSuggestion,
   }: Props = $props();
-
-  function formatTime(mills: number | undefined): string {
-    if (!mills) return "—";
-    return new Date(mills).toLocaleTimeString(undefined, {
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-  }
 
   function getMealLabel(meal: MealEvent): string {
     const foods = meal.foods ?? [];
@@ -242,7 +235,7 @@
                   </Table.Cell>
                   <Table.Cell class="py-3">
                     <div class="text-lg font-semibold tabular-nums">
-                      {formatTime(meal.carbIntakes?.[0]?.mills)}
+                      {meal.carbIntakes?.[0]?.mills ? time(meal.carbIntakes[0].mills) : "—"}
                     </div>
                   </Table.Cell>
                   <Table.Cell class="py-3">

--- a/src/Web/packages/app/src/lib/components/reports/RetrospectiveTimeScrubber.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/RetrospectiveTimeScrubber.svelte
@@ -3,6 +3,7 @@
   import { Button } from "$lib/components/ui/button";
   import { Play, Pause, SkipBack, SkipForward } from "lucide-svelte";
   import { onDestroy } from "svelte";
+  import { time } from "$lib/utils/formatting";
 
   interface Props {
     /** The date being reviewed */
@@ -62,15 +63,6 @@
     const newTime = sliderToTime(value);
     currentTime = newTime;
     onTimeChange?.(newTime);
-  }
-
-  // Format time for display
-  function formatTime(date: Date): string {
-    return date.toLocaleTimeString(undefined, {
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: true,
-    });
   }
 
   // Format time label for slider
@@ -169,7 +161,7 @@
     </div>
     <div class="text-center">
       <div class="text-2xl font-bold tabular-nums">
-        {formatTime(currentTime)}
+        {time(currentTime)}
       </div>
       <div class="text-xs text-muted-foreground">
         Scrub time to see data at that moment

--- a/src/Web/packages/app/src/lib/test-stubs/app-environment-node.ts
+++ b/src/Web/packages/app/src/lib/test-stubs/app-environment-node.ts
@@ -1,0 +1,8 @@
+/**
+ * Stub for $app/environment in node test environment.
+ * `browser` is false so store side-effects (DOM access) are skipped.
+ */
+export const browser = false;
+export const building = false;
+export const dev = false;
+export const version = "test";

--- a/src/Web/packages/app/src/lib/utils/formatting.test.ts
+++ b/src/Web/packages/app/src/lib/utils/formatting.test.ts
@@ -18,6 +18,8 @@ vi.mock("runed", () => ({
 }));
 vi.mock("$lib/stores/appearance-store.svelte", () => ({
 	glucoseUnits: { current: "mg/dl" },
+	timeFormat: { current: "12" },
+	preferredLanguage: { current: "en" },
 }));
 
 // Dynamic import so mocks are established first

--- a/src/Web/packages/app/src/lib/utils/formatting.ts
+++ b/src/Web/packages/app/src/lib/utils/formatting.ts
@@ -8,7 +8,7 @@
  * - Insulin/carb/percentage display formatting
  */
 
-import { glucoseUnits, type GlucoseUnits } from "$lib/stores/appearance-store.svelte";
+import { glucoseUnits, timeFormat, preferredLanguage, type GlucoseUnits } from "$lib/stores/appearance-store.svelte";
 import type { Treatment } from "$lib/api";
 
 // Re-export for backward compatibility
@@ -193,6 +193,36 @@ export function bgThresholds(): {
 }
 
 // =============================================================================
+// Time Formatting (auto-detect format from global preference)
+// =============================================================================
+
+/** The user's preferred locale for Intl formatting */
+function locale(): string {
+  return preferredLanguage.current;
+}
+
+/** Whether the user prefers 12-hour time */
+function hour12(): boolean {
+  return timeFormat.current !== "24";
+}
+
+/**
+ * Format a time using the global time format and language preferences
+ * @param date - Date object or Unix milliseconds
+ * @param compact - If true, use numeric minutes in 12h mode
+ * @returns Formatted time string (e.g. "2:30 pm" or "14:30")
+ */
+export function time(date: Date | number, compact?: boolean): string {
+  const d = typeof date === "number" ? new Date(date) : date;
+  const options: Intl.DateTimeFormatOptions = {
+    hour: "numeric",
+    minute: compact && hour12() ? "numeric" : "2-digit",
+    hour12: hour12(),
+  };
+  return d.toLocaleTimeString(locale(), options);
+}
+
+// =============================================================================
 // Date Formatting
 // =============================================================================
 
@@ -204,7 +234,11 @@ export function bgThresholds(): {
 export function formatDateTime(dateStr: string | undefined): string {
   if (!dateStr) return "—";
   const date = new Date(dateStr);
-  return date.toLocaleDateString() + " " + date.toLocaleTimeString();
+  return date.toLocaleDateString(locale()) + " " + date.toLocaleTimeString(locale(), {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: hour12(),
+  });
 }
 
 /**
@@ -214,7 +248,7 @@ export function formatDateTime(dateStr: string | undefined): string {
  */
 export function formatDate(date: Date | string | undefined): string {
   if (!date) return "N/A";
-  return new Date(date).toLocaleString();
+  return new Date(date).toLocaleString(locale());
 }
 
 /**
@@ -225,12 +259,13 @@ export function formatDate(date: Date | string | undefined): string {
 export function formatDateDetailed(dateString: string | undefined): string {
   if (!dateString) return "Unknown";
   try {
-    return new Date(dateString).toLocaleDateString(undefined, {
+    return new Date(dateString).toLocaleDateString(locale(), {
       year: "numeric",
       month: "long",
       day: "numeric",
       hour: "2-digit",
       minute: "2-digit",
+      hour12: hour12(),
     });
   } catch {
     return dateString;
@@ -258,14 +293,15 @@ export function formatDateForInput(dateStr: string | undefined): string {
  * @param dateStr - ISO date string or undefined
  * @returns Compact formatted date and time, or "—"
  */
-export function formatDateTimeCompact(dateStr: string | undefined): string {
-  if (!dateStr) return "—";
-  const date = new Date(dateStr);
-  return date.toLocaleDateString(undefined, {
+export function formatDateTimeCompact(date: Date | string | number | undefined): string {
+  if (date == null) return "—";
+  const d = date instanceof Date ? date : new Date(date);
+  return d.toLocaleDateString(locale(), {
     month: "short",
     day: "numeric",
     hour: "2-digit",
     minute: "2-digit",
+    hour12: hour12(),
   });
 }
 

--- a/src/Web/packages/app/src/lib/utils/index.ts
+++ b/src/Web/packages/app/src/lib/utils/index.ts
@@ -47,14 +47,14 @@ export function formatTime(
 
   if (timeFormat === 24) {
     options.hour12 = false;
-    return date.toLocaleTimeString("en-US", options);
+    return date.toLocaleTimeString(undefined, options);
   }
 
   if (compact) {
     options.minute = "numeric";
   }
 
-  return date.toLocaleTimeString("en-US", options).toLowerCase();
+  return date.toLocaleTimeString(undefined, options).toLowerCase();
 }
 
 /** Calculate BG trend direction based on raw delta value */

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/history/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/history/+page.svelte
@@ -11,7 +11,8 @@
     CardTitle,
   } from "$lib/components/ui/card";
   import { ArrowLeft, History as HistoryIcon, Loader2 } from "lucide-svelte";
-  import { formatDuration, formatDateTime } from "$lib/components/alerts/alertTime";
+  import { formatDuration } from "$lib/components/alerts/alertTime";
+  import { formatDateTimeCompact } from "$lib/utils/formatting";
 
   let page = $state(1);
   const historyQuery = $derived(getAlertHistory({ page, pageSize: 25 }));
@@ -125,7 +126,7 @@
         {/if}
       </div>
       <div class="text-xs text-muted-foreground">
-        {formatDateTime(h.startedAt) || "—"}{#if h.endedAt} → {formatDateTime(h.endedAt) || "—"}{/if} · {formatDuration(h.startedAt, h.endedAt) || "—"}
+        {formatDateTimeCompact(h.startedAt) || "—"}{#if h.endedAt} → {formatDateTimeCompact(h.endedAt) || "—"}{/if} · {formatDuration(h.startedAt, h.endedAt) || "—"}
       </div>
     </div>
   </div>

--- a/src/Web/packages/app/src/routes/(authenticated)/compatibility/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/compatibility/+page.svelte
@@ -7,6 +7,7 @@
     getCompatibilityMetrics,
     getCompatibilityAnalyses,
   } from "./data.remote";
+  import { formatDateTimeCompact } from "$lib/utils/formatting";
   import type { AnalysisListItemDto } from "$lib/api";
 
   // Get filter params from URL
@@ -207,11 +208,6 @@
       : activeAnalyses.filter((a) => !isCompatible(a.overallMatch))
   );
 
-  // Format timestamp
-  function formatTime(timestamp: string | Date | undefined) {
-    if (!timestamp) return "N/A";
-    return new Date(timestamp).toLocaleString();
-  }
 
   // Format duration
   function formatDuration(ms: number) {
@@ -226,7 +222,7 @@
     <h1 class="text-3xl font-bold">Compatibility Testing</h1>
     <div class="flex gap-2 items-center">
       <span class="text-sm text-gray-500">
-        Last update: {formatTime(lastUpdate.toISOString())}
+        Last update: {formatDateTimeCompact(lastUpdate.toISOString())}
       </span>
       <button
         onclick={togglePolling}
@@ -424,7 +420,7 @@
               onclick={() => goto(`/compatibility/${analysis.id}`)}
             >
               <td class="px-6 py-4 whitespace-nowrap text-sm">
-                {formatTime(analysis.analysisTimestamp)}
+                {formatDateTimeCompact(analysis.analysisTimestamp)}
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-sm font-mono">
                 {analysis.requestMethod}

--- a/src/Web/packages/app/src/routes/(authenticated)/compatibility/[id]/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/compatibility/[id]/+page.svelte
@@ -2,6 +2,7 @@
   import { page } from "$app/state";
   import { goto } from "$app/navigation";
   import { getAnalysisDetail } from "../data.remote";
+  import { formatDateTimeCompact } from "$lib/utils/formatting";
 
   // Get ID from route params (guaranteed to exist in [id] route)
   const analysisId = $derived(page.params.id ?? "");
@@ -78,11 +79,6 @@
     return types[type] || "Unknown";
   }
 
-  // Format timestamp
-  function formatTime(timestamp: Date | string | undefined) {
-    if (!timestamp) return "N/A";
-    return new Date(timestamp).toLocaleString();
-  }
 
   // Format duration
   function formatDuration(ms: number) {
@@ -123,7 +119,7 @@
       </div>
       <div>
         <p class="text-sm text-gray-500 dark:text-gray-400">Timestamp</p>
-        <p class="text-sm">{formatTime(analysis.analysisTimestamp)}</p>
+        <p class="text-sm">{formatDateTimeCompact(analysis.analysisTimestamp)}</p>
       </div>
       <div>
         <p class="text-sm text-gray-500 dark:text-gray-400">Overall Match</p>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/compression-lows/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/compression-lows/+page.svelte
@@ -32,6 +32,7 @@
 	import AlertTriangle from 'lucide-svelte/icons/triangle-alert';
 	import History from 'lucide-svelte/icons/history';
 	import ArrowLeft from 'lucide-svelte/icons/arrow-left';
+	import { time } from '$lib/utils/formatting';
 	import type { CompressionLowSuggestion } from '$lib/api';
 
 	// Create resource with automatic layout registration - load ALL suggestions
@@ -248,10 +249,6 @@
 		return 'outline';
 	}
 
-	function formatTime(mills: number | Date): string {
-		const date = mills instanceof Date ? mills : new Date(mills);
-		return date.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
-	}
 
 	function formatNightOf(nightOf: string | Date): string {
 		const date = nightOf instanceof Date ? nightOf : new Date(nightOf);
@@ -421,7 +418,7 @@
 											{suggestion.nightOf ? formatNightOf(suggestion.nightOf) : 'Unknown date'}
 										</p>
 										<p class="text-sm text-muted-foreground">
-											{formatTime(suggestion.startMills ?? 0)} - {formatTime(
+											{time(suggestion.startMills ?? 0)} - {time(
 												suggestion.endMills ?? 0
 											)}
 										</p>
@@ -511,7 +508,7 @@
 											{isPending ? 'Selected Range' : 'Exclusion Range'}
 										</p>
 										<p class="font-medium">
-											{formatTime(brushDomain[0])} - {formatTime(brushDomain[1])}
+											{time(brushDomain[0])} - {time(brushDomain[1])}
 										</p>
 										{#if isPending}
 											<p class="text-sm text-muted-foreground">

--- a/src/Web/packages/app/vitest.config.ts
+++ b/src/Web/packages/app/vitest.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       $routes: new URL("./src/routes", import.meta.url).pathname,
       // mode-watcher only exports under "svelte" condition — stub for node tests
       "mode-watcher": new URL("./src/lib/test-stubs/mode-watcher.ts", import.meta.url).pathname,
+      "$app/environment": new URL("./src/lib/test-stubs/app-environment-node.ts", import.meta.url).pathname,
     },
   },
 });


### PR DESCRIPTION
## Summary

Closes #188

- Add `time()` convenience function to `formatting.ts` that reads the user's 12h/24h preference from the appearance store (matching the existing `bg()` pattern for glucose units)
- Also respects the user's language preference for locale-aware formatting (e.g. French time separators)
- Fix hardcoded `"en-US"` locale in `formatTime` — now uses browser locale
- Update `formatDateTime`, `formatDateDetailed`, `formatDateTimeCompact` to respect both preferences
- Migrate all dashboard widgets/cards and 7 local `formatTime()` duplicates to the centralized `time()` function
- Eliminate redundant `formatTime`/`formatDateTime` from `alertTime.ts`
- Net: -53 lines (replaced duplicated formatting logic with centralized functions)

## Test plan

- [x] `pnpm run check` — 0 errors (466 files)
- [x] `formatting.test.ts` — 46 tests pass
- [x] `alertTime.test.ts` — 12 tests pass
- [ ] Manual: toggle 12h/24h in Settings > Appearance, verify dashboard times update immediately
- [ ] Manual: change language preference, verify time formatting uses locale conventions