### PR TITLE
fix: pump mode stuck on Suspended for Nightscout-ingested data

### DIFF
--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -273,6 +273,11 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         if (produceDeviceEvent)
         {
             await DecomposeDeviceEventAsync(treatment, result, parsedDeviceEventType, ct);
+
+            if (parsedDeviceEventType is DeviceEventType.PumpSuspend or DeviceEventType.PumpResume)
+            {
+                await DecomposePumpSuspensionFromTreatmentAsync(treatment, parsedDeviceEventType, result, ct);
+            }
         }
 
         // After all decompositions, link records via FKs
@@ -475,6 +480,64 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             var created = await _deviceEventRepository.CreateAsync(model, ct);
             result.CreatedRecords.Add(created);
             _logger.LogDebug("Created DeviceEvent from legacy treatment {LegacyId}", treatment.Id);
+        }
+    }
+
+    /// <summary>
+    /// Opens or closes a <see cref="StateSpanCategory.PumpMode"/> /
+    /// <see cref="PumpModeState.Suspended"/> state span when a treatment-sourced
+    /// PumpSuspend or PumpResume device event is decomposed.
+    /// </summary>
+    private async Task DecomposePumpSuspensionFromTreatmentAsync(
+        Treatment treatment,
+        DeviceEventType deviceEventType,
+        V4Models.DecompositionResult result,
+        CancellationToken ct)
+    {
+        var timestamp = DateTimeOffset.FromUnixTimeMilliseconds(treatment.Mills).UtcDateTime;
+
+        if (deviceEventType == DeviceEventType.PumpSuspend)
+        {
+            var span = new StateSpan
+            {
+                Category = StateSpanCategory.PumpMode,
+                State = PumpModeState.Suspended.ToString(),
+                StartTimestamp = timestamp,
+                EndTimestamp = null,
+                Source = treatment.DataSource ?? treatment.EnteredBy ?? "nightscout",
+                OriginalId = $"pump-suspended-tx:{treatment.Id}",
+            };
+
+            var upserted = await _stateSpanService.UpsertStateSpanAsync(span, ct);
+            result.CreatedRecords.Add(upserted);
+            _logger.LogDebug(
+                "Opened PumpMode/Suspended StateSpan from treatment {LegacyId}",
+                treatment.Id);
+        }
+        else if (deviceEventType == DeviceEventType.PumpResume)
+        {
+            var openSpans = await _stateSpanService.GetStateSpansAsync(
+                category: StateSpanCategory.PumpMode,
+                state: PumpModeState.Suspended.ToString(),
+                active: true,
+                count: 1,
+                cancellationToken: ct);
+
+            var openSpan = openSpans.FirstOrDefault();
+            if (openSpan is null)
+            {
+                _logger.LogWarning(
+                    "PumpResume treatment {LegacyId} but no open PumpMode/Suspended StateSpan to close",
+                    treatment.Id);
+                return;
+            }
+
+            openSpan.EndTimestamp = timestamp;
+            var closed = await _stateSpanService.UpsertStateSpanAsync(openSpan, ct);
+            result.UpdatedRecords.Add(closed);
+            _logger.LogDebug(
+                "Closed PumpMode/Suspended StateSpan {SpanId} from treatment {LegacyId}",
+                openSpan.Id, treatment.Id);
         }
     }
 

--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -521,6 +521,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
                 state: PumpModeState.Suspended.ToString(),
                 active: true,
                 count: 1,
+                descending: true,
                 cancellationToken: ct);
 
             var openSpan = openSpans.FirstOrDefault();

--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -1123,6 +1123,8 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         // Track treatments that produce both bolus AND bolusCalculation for post-insert linking
         var bolusCalcLinkTreatmentIds = new HashSet<string>();
 
+        var pumpSuspendResumeTreatments = new List<(Treatment Treatment, DeviceEventType EventType)>();
+
         foreach (var treatment in treatments)
         {
             var eventType = treatment.EventType?.Trim();
@@ -1268,6 +1270,11 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
                     V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
                 model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
                 deviceEventList.Add(model);
+
+                if (parsedDeviceEventType is DeviceEventType.PumpSuspend or DeviceEventType.PumpResume)
+                {
+                    pumpSuspendResumeTreatments.Add((treatment, parsedDeviceEventType));
+                }
             }
 
             // Track for post-insert linking
@@ -1384,6 +1391,12 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         {
             var created = await _tempBasalRepository.BulkCreateAsync(tempBasalList, ct);
             result.CreatedRecords.AddRange(created);
+        }
+
+        // Post-insert pump suspend/resume pass: sequential, order-dependent
+        foreach (var (treatment, eventType) in pumpSuspendResumeTreatments.OrderBy(t => t.Treatment.Mills))
+        {
+            await DecomposePumpSuspensionFromTreatmentAsync(treatment, eventType, result, ct);
         }
 
         // Upsert remaining state spans (Override, TemporaryTarget — ProfileSwitch already done in pre-pass)

--- a/src/Connectors/Nocturne.Connectors.Core/Constants/TreatmentTypes.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Constants/TreatmentTypes.cs
@@ -49,6 +49,16 @@ public static class TreatmentTypes
     public const string PumpAlarm = "Pump Alarm";
 
     /// <summary>
+    /// Pump insulin delivery suspended.
+    /// </summary>
+    public const string PumpSuspend = "Pump Suspend";
+
+    /// <summary>
+    /// Pump insulin delivery resumed.
+    /// </summary>
+    public const string PumpResume = "Pump Resume";
+
+    /// <summary>
     /// Reservoir/cartridge change.
     /// </summary>
     public const string ReservoirChange = "Reservoir Change";
@@ -169,5 +179,7 @@ public static class TreatmentTypes
         [ReservoirChangeEvent] = DeviceEventType.ReservoirChange,
         [CannulaChange] = DeviceEventType.CannulaChange,
         [TransmitterSensorInsert] = DeviceEventType.TransmitterSensorInsert,
+        [PumpSuspend] = DeviceEventType.PumpSuspend,
+        [PumpResume] = DeviceEventType.PumpResume,
     };
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/StateSpanRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/StateSpanRepository.cs
@@ -29,6 +29,7 @@ public class StateSpanRepository : IStateSpanRepository
         nameof(StateSpanCategory.Override),
         nameof(StateSpanCategory.TemporaryTarget),
         nameof(StateSpanCategory.Profile),
+        nameof(StateSpanCategory.PumpMode),
     };
 
     /// <summary>

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
@@ -1796,6 +1796,8 @@ public class TreatmentDecomposerTests : IDisposable
     [InlineData("Reservoir Change", DeviceEventType.ReservoirChange)]
     [InlineData("Cannula Change", DeviceEventType.CannulaChange)]
     [InlineData("Transmitter Sensor Insert", DeviceEventType.TransmitterSensorInsert)]
+    [InlineData("Pump Suspend", DeviceEventType.PumpSuspend)]
+    [InlineData("Pump Resume", DeviceEventType.PumpResume)]
     public async Task DecomposeAsync_DeviceEventTypes_CreatesDeviceEvent(string eventType, DeviceEventType expectedType)
     {
         // Arrange
@@ -1814,7 +1816,8 @@ public class TreatmentDecomposerTests : IDisposable
         var result = await _decomposer.DecomposeAsync(treatment);
 
         // Assert — DeviceEvent + Note (because Notes is non-empty)
-        result.CreatedRecords.Should().HaveCount(2);
+        result.CreatedRecords.OfType<V4Models.DeviceEvent>().Should().HaveCount(1);
+        result.CreatedRecords.OfType<V4Models.Note>().Should().HaveCount(1);
         var deviceEvent = result.CreatedRecords.OfType<V4Models.DeviceEvent>().Single();
         deviceEvent.LegacyId.Should().Be(treatment.Id);
         deviceEvent.Mills.Should().Be(1700000000000);
@@ -1882,6 +1885,137 @@ public class TreatmentDecomposerTests : IDisposable
         // Assert
         var deviceEvent = result.CreatedRecords[0].Should().BeOfType<V4Models.DeviceEvent>().Subject;
         deviceEvent.Notes.Should().BeNull();
+    }
+
+    #endregion
+
+    #region Pump Suspend/Resume → DeviceEvent + PumpMode StateSpan
+
+    [Fact]
+    public async Task DecomposeAsync_PumpSuspend_CreatesDeviceEventAndOpensSuspendedStateSpan()
+    {
+        // Arrange
+        var expectedStateSpan = new StateSpan
+        {
+            Id = "ss-pump-suspend",
+            Category = StateSpanCategory.PumpMode,
+            State = PumpModeState.Suspended.ToString(),
+            StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(1700000000000).UtcDateTime,
+        };
+
+        _stateSpanServiceMock
+            .Setup(s => s.UpsertStateSpanAsync(It.IsAny<StateSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedStateSpan);
+
+        var treatment = new Treatment
+        {
+            Id = "pump-suspend-1",
+            EventType = "Pump Suspend",
+            Mills = 1700000000000,
+            Notes = "User suspended pump",
+            EnteredBy = "AAPS",
+            DataSource = "nightscout",
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeAsync(treatment);
+
+        // Assert — DeviceEvent + Note + StateSpan
+        var deviceEvent = result.CreatedRecords.OfType<V4Models.DeviceEvent>().Single();
+        deviceEvent.EventType.Should().Be(DeviceEventType.PumpSuspend);
+        deviceEvent.LegacyId.Should().Be("pump-suspend-1");
+
+        result.CreatedRecords.OfType<V4Models.Note>().Should().HaveCount(1);
+
+        _stateSpanServiceMock.Verify(
+            s => s.UpsertStateSpanAsync(
+                It.Is<StateSpan>(ss =>
+                    ss.Category == StateSpanCategory.PumpMode
+                    && ss.State == "Suspended"
+                    && ss.EndTimestamp == null
+                    && ss.OriginalId == "pump-suspended-tx:pump-suspend-1"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DecomposeAsync_PumpResume_ClosesOpenSuspendedStateSpan()
+    {
+        // Arrange — an open Suspended state span exists
+        var openSpan = new StateSpan
+        {
+            Id = "ss-open-suspend",
+            Category = StateSpanCategory.PumpMode,
+            State = PumpModeState.Suspended.ToString(),
+            StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(1699999990000).UtcDateTime,
+            EndTimestamp = null,
+        };
+
+        _stateSpanServiceMock
+            .Setup(s => s.GetStateSpansAsync(
+                StateSpanCategory.PumpMode, PumpModeState.Suspended.ToString(),
+                null, null, null, true,
+                It.IsAny<int>(), It.IsAny<int>(), true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { openSpan });
+
+        _stateSpanServiceMock
+            .Setup(s => s.UpsertStateSpanAsync(It.IsAny<StateSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StateSpan ss, CancellationToken _) => ss);
+
+        var treatment = new Treatment
+        {
+            Id = "pump-resume-1",
+            EventType = "Pump Resume",
+            Mills = 1700000000000,
+            Notes = "User resumed pump",
+            EnteredBy = "AAPS",
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeAsync(treatment);
+
+        // Assert — DeviceEvent created, StateSpan closed
+        var deviceEvent = result.CreatedRecords.OfType<V4Models.DeviceEvent>().Single();
+        deviceEvent.EventType.Should().Be(DeviceEventType.PumpResume);
+
+        _stateSpanServiceMock.Verify(
+            s => s.UpsertStateSpanAsync(
+                It.Is<StateSpan>(ss =>
+                    ss.Id == "ss-open-suspend"
+                    && ss.EndTimestamp == DateTimeOffset.FromUnixTimeMilliseconds(1700000000000).UtcDateTime),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        result.UpdatedRecords.OfType<StateSpan>().Should().Contain(ss => ss.Id == "ss-open-suspend");
+    }
+
+    [Fact]
+    public async Task DecomposeAsync_PumpResume_NoOpenSpan_CreatesDeviceEventOnly()
+    {
+        // Arrange — no open state span
+        _stateSpanServiceMock
+            .Setup(s => s.GetStateSpansAsync(
+                StateSpanCategory.PumpMode, PumpModeState.Suspended.ToString(),
+                null, null, null, true,
+                It.IsAny<int>(), It.IsAny<int>(), true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<StateSpan>());
+
+        var treatment = new Treatment
+        {
+            Id = "pump-resume-no-span",
+            EventType = "Pump Resume",
+            Mills = 1700000000000,
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeAsync(treatment);
+
+        // Assert — DeviceEvent created, no StateSpan upserted
+        result.CreatedRecords.OfType<V4Models.DeviceEvent>().Should().HaveCount(1);
+
+        _stateSpanServiceMock.Verify(
+            s => s.UpsertStateSpanAsync(It.IsAny<StateSpan>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     #endregion

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/StateSpanRepositoryTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/StateSpanRepositoryTests.cs
@@ -266,26 +266,21 @@ public class StateSpanRepositoryTests : IDisposable
     [Fact]
     public async Task GetCurrentPumpModeAsync_ExcludesNonPrimaryDeduplicatedSpans()
     {
-        await _repository.UpsertStateSpanAsync(new StateSpan
-        {
-            Category = StateSpanCategory.PumpMode,
-            State = PumpModeState.Automatic.ToString(),
-            StartTimestamp = new DateTime(2026, 1, 1, 9, 0, 0, DateTimeKind.Utc),
-            EndTimestamp = null,
-            Source = "primary",
-            OriginalId = "pm-primary",
-        });
-        await _repository.UpsertStateSpanAsync(new StateSpan
-        {
-            Category = StateSpanCategory.PumpMode,
-            State = PumpModeState.Manual.ToString(),
-            StartTimestamp = new DateTime(2026, 1, 1, 11, 0, 0, DateTimeKind.Utc),
-            EndTimestamp = null,
-            Source = "duplicate",
-            OriginalId = "pm-duplicate",
-        });
+        // Insert entities directly to bypass exclusive-category auto-close logic;
+        // this test verifies the deduplication query filter, not upsert behavior.
+        var primaryEntity = SpanEntity(
+            _context.TenantId, StateSpanCategory.PumpMode, PumpModeState.Automatic.ToString(),
+            new DateTime(2026, 1, 1, 9, 0, 0, DateTimeKind.Utc), null);
+        primaryEntity.OriginalId = "pm-primary";
+        primaryEntity.Source = "primary";
 
-        var duplicateEntity = _context.StateSpans.Single(s => s.OriginalId == "pm-duplicate");
+        var duplicateEntity = SpanEntity(
+            _context.TenantId, StateSpanCategory.PumpMode, PumpModeState.Manual.ToString(),
+            new DateTime(2026, 1, 1, 11, 0, 0, DateTimeKind.Utc), null);
+        duplicateEntity.OriginalId = "pm-duplicate";
+        duplicateEntity.Source = "duplicate";
+
+        _context.StateSpans.AddRange(primaryEntity, duplicateEntity);
         _context.LinkedRecords.Add(new LinkedRecordEntity
         {
             Id = Guid.NewGuid(),


### PR DESCRIPTION
## Summary

Fixes #205 — pump mode is always shown as "Suspended" for users whose data is ingested from Nightscout.

**Root cause:** Two gaps in the treatment decomposition pipeline:
1. `DeviceEventTypeMap` was missing `"Pump Suspend"` / `"Pump Resume"` entries, so these treatments fell through to the Note branch
2. `TreatmentDecomposer` never created `PumpMode/Suspended` state spans from treatments — only `DeviceStatusDecomposer` (snapshot transitions) and Glooko did

**Changes:**
- Make `PumpMode` an exclusive `StateSpan` category — a pump can only be in one mode at a time, preventing duplicate open spans from different data sources
- Add `"Pump Suspend"` / `"Pump Resume"` to `DeviceEventTypeMap` so they're recognised as device events
- Open/close `PumpMode/Suspended` state spans when these treatments are decomposed (both single and batch paths)
- Cross-source span closing works naturally — a treatment-sourced resume can close a snapshot-sourced suspend and vice versa

## Test plan

- [x] 130/130 TreatmentDecomposer unit tests passing
- [x] PumpSuspend treatment creates DeviceEvent + opens PumpMode/Suspended StateSpan
- [x] PumpResume treatment creates DeviceEvent + closes open PumpMode/Suspended StateSpan
- [x] PumpResume with no open span logs warning, creates DeviceEvent only
- [x] Existing DeviceEvent theory updated with PumpSuspend/PumpResume entries