### PR TITLE
fix: wrap V4 repository transactions in execution strategy

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
@@ -260,37 +260,41 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
             .ToHashSet();
 
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-        if (legacyIds.Count > 0)
+        var strategy = ctx.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
         {
-            var existingIds = await ctx
-                .ApsSnapshots.AsNoTracking()
-                .Where(e => legacyIds.Contains(e.LegacyId!))
-                .Select(e => e.LegacyId)
-                .ToListAsync(ct);
+            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
 
-            var existingSet = existingIds.ToHashSet();
-            entities = entities
-                .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
-                .ToList();
-        }
+            if (legacyIds.Count > 0)
+            {
+                var existingIds = await ctx
+                    .ApsSnapshots.AsNoTracking()
+                    .Where(e => legacyIds.Contains(e.LegacyId!))
+                    .Select(e => e.LegacyId)
+                    .ToListAsync(ct);
 
-        if (entities.Count == 0)
-        {
+                var existingSet = existingIds.ToHashSet();
+                entities = entities
+                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                    .ToList();
+            }
+
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
+
+            const int batchSize = 500;
+            foreach (var batch in entities.Chunk(batchSize))
+            {
+                ctx.ApsSnapshots.AddRange(batch);
+                await ctx.SaveChangesAsync(ct);
+                ctx.ChangeTracker.Clear();
+            }
+
             await tx.CommitAsync(ct);
-            return [];
-        }
-
-        const int batchSize = 500;
-        foreach (var batch in entities.Chunk(batchSize))
-        {
-            ctx.ApsSnapshots.AddRange(batch);
-            await ctx.SaveChangesAsync(ct);
-            ctx.ChangeTracker.Clear();
-        }
-
-        await tx.CommitAsync(ct);
-        return entities.Select(ApsSnapshotMapper.ToDomainModel);
+            return entities.Select(ApsSnapshotMapper.ToDomainModel);
+        });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
@@ -218,73 +218,77 @@ public class BGCheckRepository : IBGCheckRepository
     )
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-        var entities = records.Select(BGCheckMapper.ToEntity).ToList();
-        if (entities.Count == 0)
+        var strategy = ctx.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
         {
-            await tx.CommitAsync(ct);
-            return [];
-        }
+            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
+            var entities = records.Select(BGCheckMapper.ToEntity).ToList();
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
 
-        // Batch-level dedup: keep first occurrence per LegacyId
-        entities = entities
-            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-            .Select(g => g.First())
-            .ToList();
-
-        // DB-level dedup: filter out records whose LegacyId already exists
-        var legacyIds = entities
-            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-            .Select(e => e.LegacyId!)
-            .ToHashSet();
-
-        if (legacyIds.Count > 0)
-        {
-            var existingIds = await ctx
-                .BGChecks.AsNoTracking()
-                .Where(e => legacyIds.Contains(e.LegacyId!))
-                .Select(e => e.LegacyId)
-                .ToListAsync(ct);
-
-            var existingSet = existingIds.ToHashSet();
+            // Batch-level dedup: keep first occurrence per LegacyId
             entities = entities
-                .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                .GroupBy(e => e.LegacyId ?? e.Id.ToString())
+                .Select(g => g.First())
                 .ToList();
-        }
 
-        if (entities.Count == 0)
-        {
+            // DB-level dedup: filter out records whose LegacyId already exists
+            var legacyIds = entities
+                .Where(e => !string.IsNullOrEmpty(e.LegacyId))
+                .Select(e => e.LegacyId!)
+                .ToHashSet();
+
+            if (legacyIds.Count > 0)
+            {
+                var existingIds = await ctx
+                    .BGChecks.AsNoTracking()
+                    .Where(e => legacyIds.Contains(e.LegacyId!))
+                    .Select(e => e.LegacyId)
+                    .ToListAsync(ct);
+
+                var existingSet = existingIds.ToHashSet();
+                entities = entities
+                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                    .ToList();
+            }
+
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
+
+            const int batchSize = 500;
+            foreach (var batch in entities.Chunk(batchSize))
+            {
+                ctx.BGChecks.AddRange(batch);
+                await ctx.SaveChangesAsync(ct);
+                ctx.ChangeTracker.Clear();
+            }
+
             await tx.CommitAsync(ct);
-            return [];
-        }
 
-        const int batchSize = 500;
-        foreach (var batch in entities.Chunk(batchSize))
-        {
-            ctx.BGChecks.AddRange(batch);
-            await ctx.SaveChangesAsync(ct);
-            ctx.ChangeTracker.Clear();
-        }
+            // Insert-time deduplication: link saved records to canonical groups
+            try
+            {
+                var dedupInputs = entities.Select(e => new DeduplicationInput(
+                    RecordId: e.Id,
+                    Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
+                    DataSource: e.DataSource ?? "unknown",
+                    Criteria: new MatchCriteria { GlucoseValue = e.Glucose, GlucoseTolerance = 1.0 }
+                )).ToList();
 
-        await tx.CommitAsync(ct);
+                await _deduplicationService.DeduplicateBatchAsync(RecordType.BGCheck, dedupInputs, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "BGCheck", entities.Count);
+            }
 
-        // Insert-time deduplication: link saved records to canonical groups
-        try
-        {
-            var dedupInputs = entities.Select(e => new DeduplicationInput(
-                RecordId: e.Id,
-                Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                DataSource: e.DataSource ?? "unknown",
-                Criteria: new MatchCriteria { GlucoseValue = e.Glucose, GlucoseTolerance = 1.0 }
-            )).ToList();
-
-            await _deduplicationService.DeduplicateBatchAsync(RecordType.BGCheck, dedupInputs, ct);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "BGCheck", entities.Count);
-        }
-
-        return entities.Select(BGCheckMapper.ToDomainModel);
+            return entities.Select(BGCheckMapper.ToDomainModel);
+        });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalScheduleRepository.cs
@@ -275,37 +275,41 @@ public class BasalScheduleRepository : IBasalScheduleRepository
             .ToHashSet();
 
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-        if (legacyIds.Count > 0)
+        var strategy = ctx.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
         {
-            var existingIds = await ctx
-                .BasalSchedules.AsNoTracking()
-                .Where(e => legacyIds.Contains(e.LegacyId!))
-                .Select(e => e.LegacyId)
-                .ToListAsync(ct);
+            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
 
-            var existingSet = existingIds.ToHashSet();
-            entities = entities
-                .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
-                .ToList();
-        }
+            if (legacyIds.Count > 0)
+            {
+                var existingIds = await ctx
+                    .BasalSchedules.AsNoTracking()
+                    .Where(e => legacyIds.Contains(e.LegacyId!))
+                    .Select(e => e.LegacyId)
+                    .ToListAsync(ct);
 
-        if (entities.Count == 0)
-        {
+                var existingSet = existingIds.ToHashSet();
+                entities = entities
+                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                    .ToList();
+            }
+
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
+
+            const int batchSize = 500;
+            foreach (var batch in entities.Chunk(batchSize))
+            {
+                ctx.BasalSchedules.AddRange(batch);
+                await ctx.SaveChangesAsync(ct);
+                ctx.ChangeTracker.Clear();
+            }
+
             await tx.CommitAsync(ct);
-            return [];
-        }
-
-        const int batchSize = 500;
-        foreach (var batch in entities.Chunk(batchSize))
-        {
-            ctx.BasalSchedules.AddRange(batch);
-            await ctx.SaveChangesAsync(ct);
-            ctx.ChangeTracker.Clear();
-        }
-
-        await tx.CommitAsync(ct);
-        return entities.Select(BasalScheduleMapper.ToDomainModel);
+            return entities.Select(BasalScheduleMapper.ToDomainModel);
+        });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
@@ -235,73 +235,77 @@ public class BolusCalculationRepository : IBolusCalculationRepository
     )
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-        var entities = records.Select(BolusCalculationMapper.ToEntity).ToList();
-        if (entities.Count == 0)
+        var strategy = ctx.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
         {
-            await tx.CommitAsync(ct);
-            return [];
-        }
+            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
+            var entities = records.Select(BolusCalculationMapper.ToEntity).ToList();
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
 
-        // Batch-level dedup: keep first occurrence per LegacyId
-        entities = entities
-            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-            .Select(g => g.First())
-            .ToList();
-
-        // DB-level dedup: filter out records whose LegacyId already exists
-        var legacyIds = entities
-            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-            .Select(e => e.LegacyId!)
-            .ToHashSet();
-
-        if (legacyIds.Count > 0)
-        {
-            var existingIds = await ctx
-                .BolusCalculations.AsNoTracking()
-                .Where(e => legacyIds.Contains(e.LegacyId!))
-                .Select(e => e.LegacyId)
-                .ToListAsync(ct);
-
-            var existingSet = existingIds.ToHashSet();
+            // Batch-level dedup: keep first occurrence per LegacyId
             entities = entities
-                .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                .GroupBy(e => e.LegacyId ?? e.Id.ToString())
+                .Select(g => g.First())
                 .ToList();
-        }
 
-        if (entities.Count == 0)
-        {
+            // DB-level dedup: filter out records whose LegacyId already exists
+            var legacyIds = entities
+                .Where(e => !string.IsNullOrEmpty(e.LegacyId))
+                .Select(e => e.LegacyId!)
+                .ToHashSet();
+
+            if (legacyIds.Count > 0)
+            {
+                var existingIds = await ctx
+                    .BolusCalculations.AsNoTracking()
+                    .Where(e => legacyIds.Contains(e.LegacyId!))
+                    .Select(e => e.LegacyId)
+                    .ToListAsync(ct);
+
+                var existingSet = existingIds.ToHashSet();
+                entities = entities
+                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                    .ToList();
+            }
+
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
+
+            const int batchSize = 500;
+            foreach (var batch in entities.Chunk(batchSize))
+            {
+                ctx.BolusCalculations.AddRange(batch);
+                await ctx.SaveChangesAsync(ct);
+                ctx.ChangeTracker.Clear();
+            }
+
             await tx.CommitAsync(ct);
-            return [];
-        }
 
-        const int batchSize = 500;
-        foreach (var batch in entities.Chunk(batchSize))
-        {
-            ctx.BolusCalculations.AddRange(batch);
-            await ctx.SaveChangesAsync(ct);
-            ctx.ChangeTracker.Clear();
-        }
+            // Insert-time deduplication: link saved records to canonical groups
+            try
+            {
+                var dedupInputs = entities.Select(e => new DeduplicationInput(
+                    RecordId: e.Id,
+                    Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
+                    DataSource: e.DataSource ?? "unknown",
+                    Criteria: new MatchCriteria { Carbs = e.CarbInput ?? 0, CarbsTolerance = 1.0 }
+                )).ToList();
 
-        await tx.CommitAsync(ct);
+                await _deduplicationService.DeduplicateBatchAsync(RecordType.BolusCalculation, dedupInputs, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "BolusCalculation", entities.Count);
+            }
 
-        // Insert-time deduplication: link saved records to canonical groups
-        try
-        {
-            var dedupInputs = entities.Select(e => new DeduplicationInput(
-                RecordId: e.Id,
-                Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                DataSource: e.DataSource ?? "unknown",
-                Criteria: new MatchCriteria { Carbs = e.CarbInput ?? 0, CarbsTolerance = 1.0 }
-            )).ToList();
-
-            await _deduplicationService.DeduplicateBatchAsync(RecordType.BolusCalculation, dedupInputs, ct);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "BolusCalculation", entities.Count);
-        }
-
-        return entities.Select(BolusCalculationMapper.ToDomainModel);
+            return entities.Select(BolusCalculationMapper.ToDomainModel);
+        });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
@@ -285,131 +285,135 @@ public class BolusRepository : IBolusRepository
     )
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-        var entities = records.Select(BolusMapper.ToEntity).ToList();
-        if (entities.Count == 0)
+        var strategy = ctx.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
         {
-            await tx.CommitAsync(ct);
-            return [];
-        }
-
-        // Intra-batch SyncIdentifier dedup: keep last occurrence per
-        // (DataSource, SyncIdentifier). Records without both keys keep a
-        // unique grouping key so they're not collapsed.
-        entities = entities
-            .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
-                ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
-                : $"id|{e.Id}")
-            .Select(g => g.Last())
-            .ToList();
-
-        // DB-level SyncIdentifier upsert: match any existing rows keyed by
-        // (DataSource, SyncIdentifier) and update them in place. Everything
-        // else falls through to the insert path below.
-        var syncKeyed = entities
-            .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
-            .ToList();
-
-        var updatedEntities = new List<BolusEntity>();
-        if (syncKeyed.Count > 0)
-        {
-            var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
-            var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
-
-            // Over-fetches by a Cartesian amount; the partial unique index
-            // on (tenant_id, data_source, sync_identifier) keeps this cheap.
-            var existingRows = await ctx.Boluses
-                .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
-                .ToListAsync(ct);
-
-            var existingByKey = existingRows
-                .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
-                .ToDictionary(g => g.Key, g => g.First());
-
-            var toInsert = new List<BolusEntity>();
-            foreach (var entity in entities)
+            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
+            var entities = records.Select(BolusMapper.ToEntity).ToList();
+            if (entities.Count == 0)
             {
-                var hasKey = !string.IsNullOrEmpty(entity.DataSource)
-                    && !string.IsNullOrEmpty(entity.SyncIdentifier);
-                if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
-                {
-                    // Update in place — mirror the single-record CreateAsync path via the mapper.
-                    var domain = BolusMapper.ToDomainModel(entity);
-                    BolusMapper.UpdateEntity(existing, domain);
-                    updatedEntities.Add(existing);
-                }
-                else
-                {
-                    toInsert.Add(entity);
-                }
+                await tx.CommitAsync(ct);
+                return [];
             }
 
-            if (updatedEntities.Count > 0)
-            {
-                // Persist updates before the insert-chunking loop clears the tracker.
-                await ctx.SaveChangesAsync(ct);
-            }
-
-            entities = toInsert;
-        }
-
-        // Batch-level dedup: keep first occurrence per LegacyId
-        entities = entities
-            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-            .Select(g => g.First())
-            .ToList();
-
-        // DB-level dedup: filter out records whose LegacyId already exists
-        var legacyIds = entities
-            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-            .Select(e => e.LegacyId!)
-            .ToHashSet();
-
-        if (legacyIds.Count > 0)
-        {
-            var existingIds = await ctx
-                .Boluses.AsNoTracking()
-                .Where(e => legacyIds.Contains(e.LegacyId!))
-                .Select(e => e.LegacyId)
-                .ToListAsync(ct);
-
-            var existingSet = existingIds.ToHashSet();
+            // Intra-batch SyncIdentifier dedup: keep last occurrence per
+            // (DataSource, SyncIdentifier). Records without both keys keep a
+            // unique grouping key so they're not collapsed.
             entities = entities
-                .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
+                    ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
+                    : $"id|{e.Id}")
+                .Select(g => g.Last())
                 .ToList();
-        }
 
-        if (entities.Count > 0)
-        {
-            const int batchSize = 500;
-            foreach (var batch in entities.Chunk(batchSize))
+            // DB-level SyncIdentifier upsert: match any existing rows keyed by
+            // (DataSource, SyncIdentifier) and update them in place. Everything
+            // else falls through to the insert path below.
+            var syncKeyed = entities
+                .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
+                .ToList();
+
+            var updatedEntities = new List<BolusEntity>();
+            if (syncKeyed.Count > 0)
             {
-                ctx.Boluses.AddRange(batch);
-                await ctx.SaveChangesAsync(ct);
-                ctx.ChangeTracker.Clear();
+                var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
+                var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
+
+                // Over-fetches by a Cartesian amount; the partial unique index
+                // on (tenant_id, data_source, sync_identifier) keeps this cheap.
+                var existingRows = await ctx.Boluses
+                    .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
+                    .ToListAsync(ct);
+
+                var existingByKey = existingRows
+                    .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
+                    .ToDictionary(g => g.Key, g => g.First());
+
+                var toInsert = new List<BolusEntity>();
+                foreach (var entity in entities)
+                {
+                    var hasKey = !string.IsNullOrEmpty(entity.DataSource)
+                        && !string.IsNullOrEmpty(entity.SyncIdentifier);
+                    if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
+                    {
+                        // Update in place — mirror the single-record CreateAsync path via the mapper.
+                        var domain = BolusMapper.ToDomainModel(entity);
+                        BolusMapper.UpdateEntity(existing, domain);
+                        updatedEntities.Add(existing);
+                    }
+                    else
+                    {
+                        toInsert.Add(entity);
+                    }
+                }
+
+                if (updatedEntities.Count > 0)
+                {
+                    // Persist updates before the insert-chunking loop clears the tracker.
+                    await ctx.SaveChangesAsync(ct);
+                }
+
+                entities = toInsert;
             }
 
-            // Insert-time deduplication: link saved records to canonical groups.
-            // Only runs on newly inserted entities — updated-in-place rows were
-            // already linked when first inserted.
-            try
-            {
-                var dedupInputs = entities.Select(e => new DeduplicationInput(
-                    RecordId: e.Id,
-                    Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    DataSource: e.DataSource ?? "unknown",
-                    Criteria: new MatchCriteria { Insulin = e.Insulin, InsulinTolerance = 0.05 }
-                )).ToList();
+            // Batch-level dedup: keep first occurrence per LegacyId
+            entities = entities
+                .GroupBy(e => e.LegacyId ?? e.Id.ToString())
+                .Select(g => g.First())
+                .ToList();
 
-                await _deduplicationService.DeduplicateBatchAsync(RecordType.Bolus, dedupInputs, ct);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "Bolus", entities.Count);
-            }
-        }
+            // DB-level dedup: filter out records whose LegacyId already exists
+            var legacyIds = entities
+                .Where(e => !string.IsNullOrEmpty(e.LegacyId))
+                .Select(e => e.LegacyId!)
+                .ToHashSet();
 
-        await tx.CommitAsync(ct);
-        return updatedEntities.Concat(entities).Select(BolusMapper.ToDomainModel);
+            if (legacyIds.Count > 0)
+            {
+                var existingIds = await ctx
+                    .Boluses.AsNoTracking()
+                    .Where(e => legacyIds.Contains(e.LegacyId!))
+                    .Select(e => e.LegacyId)
+                    .ToListAsync(ct);
+
+                var existingSet = existingIds.ToHashSet();
+                entities = entities
+                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                    .ToList();
+            }
+
+            if (entities.Count > 0)
+            {
+                const int batchSize = 500;
+                foreach (var batch in entities.Chunk(batchSize))
+                {
+                    ctx.Boluses.AddRange(batch);
+                    await ctx.SaveChangesAsync(ct);
+                    ctx.ChangeTracker.Clear();
+                }
+
+                // Insert-time deduplication: link saved records to canonical groups.
+                // Only runs on newly inserted entities — updated-in-place rows were
+                // already linked when first inserted.
+                try
+                {
+                    var dedupInputs = entities.Select(e => new DeduplicationInput(
+                        RecordId: e.Id,
+                        Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
+                        DataSource: e.DataSource ?? "unknown",
+                        Criteria: new MatchCriteria { Insulin = e.Insulin, InsulinTolerance = 0.05 }
+                    )).ToList();
+
+                    await _deduplicationService.DeduplicateBatchAsync(RecordType.Bolus, dedupInputs, ct);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "Bolus", entities.Count);
+                }
+            }
+
+            await tx.CommitAsync(ct);
+            return updatedEntities.Concat(entities).Select(BolusMapper.ToDomainModel);
+        });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CalibrationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CalibrationRepository.cs
@@ -258,37 +258,41 @@ public class CalibrationRepository : ICalibrationRepository
             .ToHashSet();
 
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-        if (legacyIds.Count > 0)
+        var strategy = ctx.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
         {
-            var existingIds = await ctx
-                .Calibrations.AsNoTracking()
-                .Where(e => legacyIds.Contains(e.LegacyId!))
-                .Select(e => e.LegacyId)
-                .ToListAsync(ct);
+            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
 
-            var existingSet = existingIds.ToHashSet();
-            entities = entities
-                .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
-                .ToList();
-        }
+            if (legacyIds.Count > 0)
+            {
+                var existingIds = await ctx
+                    .Calibrations.AsNoTracking()
+                    .Where(e => legacyIds.Contains(e.LegacyId!))
+                    .Select(e => e.LegacyId)
+                    .ToListAsync(ct);
 
-        if (entities.Count == 0)
-        {
+                var existingSet = existingIds.ToHashSet();
+                entities = entities
+                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                    .ToList();
+            }
+
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
+
+            const int batchSize = 500;
+            foreach (var batch in entities.Chunk(batchSize))
+            {
+                ctx.Calibrations.AddRange(batch);
+                await ctx.SaveChangesAsync(ct);
+                ctx.ChangeTracker.Clear();
+            }
+
             await tx.CommitAsync(ct);
-            return [];
-        }
-
-        const int batchSize = 500;
-        foreach (var batch in entities.Chunk(batchSize))
-        {
-            ctx.Calibrations.AddRange(batch);
-            await ctx.SaveChangesAsync(ct);
-            ctx.ChangeTracker.Clear();
-        }
-
-        await tx.CommitAsync(ct);
-        return entities.Select(CalibrationMapper.ToDomainModel);
+            return entities.Select(CalibrationMapper.ToDomainModel);
+        });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
@@ -292,131 +292,135 @@ public class CarbIntakeRepository : ICarbIntakeRepository
     )
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-        var entities = records.Select(CarbIntakeMapper.ToEntity).ToList();
-        if (entities.Count == 0)
+        var strategy = ctx.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
         {
-            await tx.CommitAsync(ct);
-            return [];
-        }
-
-        // Intra-batch SyncIdentifier dedup: keep last occurrence per
-        // (DataSource, SyncIdentifier). Records without both keys keep a
-        // unique grouping key so they're not collapsed.
-        entities = entities
-            .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
-                ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
-                : $"id|{e.Id}")
-            .Select(g => g.Last())
-            .ToList();
-
-        // DB-level SyncIdentifier upsert: match any existing rows keyed by
-        // (DataSource, SyncIdentifier) and update them in place. Everything
-        // else falls through to the insert path below.
-        var syncKeyed = entities
-            .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
-            .ToList();
-
-        var updatedEntities = new List<CarbIntakeEntity>();
-        if (syncKeyed.Count > 0)
-        {
-            var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
-            var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
-
-            // Over-fetches by a Cartesian amount; the partial unique index
-            // on (tenant_id, data_source, sync_identifier) keeps this cheap.
-            var existingRows = await ctx.CarbIntakes
-                .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
-                .ToListAsync(ct);
-
-            var existingByKey = existingRows
-                .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
-                .ToDictionary(g => g.Key, g => g.First());
-
-            var toInsert = new List<CarbIntakeEntity>();
-            foreach (var entity in entities)
+            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
+            var entities = records.Select(CarbIntakeMapper.ToEntity).ToList();
+            if (entities.Count == 0)
             {
-                var hasKey = !string.IsNullOrEmpty(entity.DataSource)
-                    && !string.IsNullOrEmpty(entity.SyncIdentifier);
-                if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
-                {
-                    // Update in place — mirror the single-record CreateAsync path via the mapper.
-                    var domain = CarbIntakeMapper.ToDomainModel(entity);
-                    CarbIntakeMapper.UpdateEntity(existing, domain);
-                    updatedEntities.Add(existing);
-                }
-                else
-                {
-                    toInsert.Add(entity);
-                }
+                await tx.CommitAsync(ct);
+                return [];
             }
 
-            if (updatedEntities.Count > 0)
-            {
-                // Persist updates before the insert-chunking loop clears the tracker.
-                await ctx.SaveChangesAsync(ct);
-            }
-
-            entities = toInsert;
-        }
-
-        // Batch-level dedup: keep first occurrence per LegacyId
-        entities = entities
-            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-            .Select(g => g.First())
-            .ToList();
-
-        // DB-level dedup: filter out records whose LegacyId already exists
-        var legacyIds = entities
-            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-            .Select(e => e.LegacyId!)
-            .ToHashSet();
-
-        if (legacyIds.Count > 0)
-        {
-            var existingIds = await ctx
-                .CarbIntakes.AsNoTracking()
-                .Where(e => legacyIds.Contains(e.LegacyId!))
-                .Select(e => e.LegacyId)
-                .ToListAsync(ct);
-
-            var existingSet = existingIds.ToHashSet();
+            // Intra-batch SyncIdentifier dedup: keep last occurrence per
+            // (DataSource, SyncIdentifier). Records without both keys keep a
+            // unique grouping key so they're not collapsed.
             entities = entities
-                .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
+                    ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
+                    : $"id|{e.Id}")
+                .Select(g => g.Last())
                 .ToList();
-        }
 
-        if (entities.Count > 0)
-        {
-            const int batchSize = 500;
-            foreach (var batch in entities.Chunk(batchSize))
+            // DB-level SyncIdentifier upsert: match any existing rows keyed by
+            // (DataSource, SyncIdentifier) and update them in place. Everything
+            // else falls through to the insert path below.
+            var syncKeyed = entities
+                .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
+                .ToList();
+
+            var updatedEntities = new List<CarbIntakeEntity>();
+            if (syncKeyed.Count > 0)
             {
-                ctx.CarbIntakes.AddRange(batch);
-                await ctx.SaveChangesAsync(ct);
-                ctx.ChangeTracker.Clear();
+                var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
+                var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
+
+                // Over-fetches by a Cartesian amount; the partial unique index
+                // on (tenant_id, data_source, sync_identifier) keeps this cheap.
+                var existingRows = await ctx.CarbIntakes
+                    .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
+                    .ToListAsync(ct);
+
+                var existingByKey = existingRows
+                    .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
+                    .ToDictionary(g => g.Key, g => g.First());
+
+                var toInsert = new List<CarbIntakeEntity>();
+                foreach (var entity in entities)
+                {
+                    var hasKey = !string.IsNullOrEmpty(entity.DataSource)
+                        && !string.IsNullOrEmpty(entity.SyncIdentifier);
+                    if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
+                    {
+                        // Update in place — mirror the single-record CreateAsync path via the mapper.
+                        var domain = CarbIntakeMapper.ToDomainModel(entity);
+                        CarbIntakeMapper.UpdateEntity(existing, domain);
+                        updatedEntities.Add(existing);
+                    }
+                    else
+                    {
+                        toInsert.Add(entity);
+                    }
+                }
+
+                if (updatedEntities.Count > 0)
+                {
+                    // Persist updates before the insert-chunking loop clears the tracker.
+                    await ctx.SaveChangesAsync(ct);
+                }
+
+                entities = toInsert;
             }
 
-            // Insert-time deduplication: link saved records to canonical groups.
-            // Only runs on newly inserted entities — updated-in-place rows were
-            // already linked when first inserted.
-            try
-            {
-                var dedupInputs = entities.Select(e => new DeduplicationInput(
-                    RecordId: e.Id,
-                    Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    DataSource: e.DataSource ?? "unknown",
-                    Criteria: new MatchCriteria { Carbs = e.Carbs, CarbsTolerance = 1.0 }
-                )).ToList();
+            // Batch-level dedup: keep first occurrence per LegacyId
+            entities = entities
+                .GroupBy(e => e.LegacyId ?? e.Id.ToString())
+                .Select(g => g.First())
+                .ToList();
 
-                await _deduplicationService.DeduplicateBatchAsync(RecordType.CarbIntake, dedupInputs, ct);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "CarbIntake", entities.Count);
-            }
-        }
+            // DB-level dedup: filter out records whose LegacyId already exists
+            var legacyIds = entities
+                .Where(e => !string.IsNullOrEmpty(e.LegacyId))
+                .Select(e => e.LegacyId!)
+                .ToHashSet();
 
-        await tx.CommitAsync(ct);
-        return updatedEntities.Concat(entities).Select(CarbIntakeMapper.ToDomainModel);
+            if (legacyIds.Count > 0)
+            {
+                var existingIds = await ctx
+                    .CarbIntakes.AsNoTracking()
+                    .Where(e => legacyIds.Contains(e.LegacyId!))
+                    .Select(e => e.LegacyId)
+                    .ToListAsync(ct);
+
+                var existingSet = existingIds.ToHashSet();
+                entities = entities
+                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                    .ToList();
+            }
+
+            if (entities.Count > 0)
+            {
+                const int batchSize = 500;
+                foreach (var batch in entities.Chunk(batchSize))
+                {
+                    ctx.CarbIntakes.AddRange(batch);
+                    await ctx.SaveChangesAsync(ct);
+                    ctx.ChangeTracker.Clear();
+                }
+
+                // Insert-time deduplication: link saved records to canonical groups.
+                // Only runs on newly inserted entities — updated-in-place rows were
+                // already linked when first inserted.
+                try
+                {
+                    var dedupInputs = entities.Select(e => new DeduplicationInput(
+                        RecordId: e.Id,
+                        Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
+                        DataSource: e.DataSource ?? "unknown",
+                        Criteria: new MatchCriteria { Carbs = e.Carbs, CarbsTolerance = 1.0 }
+                    )).ToList();
+
+                    await _deduplicationService.DeduplicateBatchAsync(RecordType.CarbIntake, dedupInputs, ct);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "CarbIntake", entities.Count);
+                }
+            }
+
+            await tx.CommitAsync(ct);
+            return updatedEntities.Concat(entities).Select(CarbIntakeMapper.ToDomainModel);
+        });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbRatioScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbRatioScheduleRepository.cs
@@ -269,37 +269,41 @@ public class CarbRatioScheduleRepository : ICarbRatioScheduleRepository
             .ToHashSet();
 
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-        if (legacyIds.Count > 0)
+        var strategy = ctx.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
         {
-            var existingIds = await ctx
-                .CarbRatioSchedules.AsNoTracking()
-                .Where(e => legacyIds.Contains(e.LegacyId!))
-                .Select(e => e.LegacyId)
-                .ToListAsync(ct);
+            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
 
-            var existingSet = existingIds.ToHashSet();
-            entities = entities
-                .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
-                .ToList();
-        }
+            if (legacyIds.Count > 0)
+            {
+                var existingIds = await ctx
+                    .CarbRatioSchedules.AsNoTracking()
+                    .Where(e => legacyIds.Contains(e.LegacyId!))
+                    .Select(e => e.LegacyId)
+                    .ToListAsync(ct);
 
-        if (entities.Count == 0)
-        {
+                var existingSet = existingIds.ToHashSet();
+                entities = entities
+                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                    .ToList();
+            }
+
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
+
+            const int batchSize = 500;
+            foreach (var batch in entities.Chunk(batchSize))
+            {
+                ctx.CarbRatioSchedules.AddRange(batch);
+                await ctx.SaveChangesAsync(ct);
+                ctx.ChangeTracker.Clear();
+            }
+
             await tx.CommitAsync(ct);
-            return [];
-        }
-
-        const int batchSize = 500;
-        foreach (var batch in entities.Chunk(batchSize))
-        {
-            ctx.CarbRatioSchedules.AddRange(batch);
-            await ctx.SaveChangesAsync(ct);
-            ctx.ChangeTracker.Clear();
-        }
-
-        await tx.CommitAsync(ct);
-        return entities.Select(CarbRatioScheduleMapper.ToDomainModel);
+            return entities.Select(CarbRatioScheduleMapper.ToDomainModel);
+        });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
@@ -250,74 +250,78 @@ public class DeviceEventRepository : IDeviceEventRepository
     )
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-        var entities = records.Select(DeviceEventMapper.ToEntity).ToList();
-        if (entities.Count == 0)
+        var strategy = ctx.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
         {
-            await tx.CommitAsync(ct);
-            return [];
-        }
+            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
+            var entities = records.Select(DeviceEventMapper.ToEntity).ToList();
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
 
-        // Batch-level dedup: keep first occurrence per LegacyId
-        entities = entities
-            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-            .Select(g => g.First())
-            .ToList();
-
-        // DB-level dedup: filter out records whose LegacyId already exists
-        var legacyIds = entities
-            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-            .Select(e => e.LegacyId!)
-            .ToHashSet();
-
-        if (legacyIds.Count > 0)
-        {
-            var existingIds = await ctx
-                .DeviceEvents.AsNoTracking()
-                .Where(e => legacyIds.Contains(e.LegacyId!))
-                .Select(e => e.LegacyId)
-                .ToListAsync(ct);
-
-            var existingSet = existingIds.ToHashSet();
+            // Batch-level dedup: keep first occurrence per LegacyId
             entities = entities
-                .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                .GroupBy(e => e.LegacyId ?? e.Id.ToString())
+                .Select(g => g.First())
                 .ToList();
-        }
 
-        if (entities.Count == 0)
-        {
+            // DB-level dedup: filter out records whose LegacyId already exists
+            var legacyIds = entities
+                .Where(e => !string.IsNullOrEmpty(e.LegacyId))
+                .Select(e => e.LegacyId!)
+                .ToHashSet();
+
+            if (legacyIds.Count > 0)
+            {
+                var existingIds = await ctx
+                    .DeviceEvents.AsNoTracking()
+                    .Where(e => legacyIds.Contains(e.LegacyId!))
+                    .Select(e => e.LegacyId)
+                    .ToListAsync(ct);
+
+                var existingSet = existingIds.ToHashSet();
+                entities = entities
+                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                    .ToList();
+            }
+
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
+
+            const int batchSize = 500;
+            foreach (var batch in entities.Chunk(batchSize))
+            {
+                ctx.DeviceEvents.AddRange(batch);
+                await ctx.SaveChangesAsync(ct);
+                ctx.ChangeTracker.Clear();
+            }
+
             await tx.CommitAsync(ct);
-            return [];
-        }
 
-        const int batchSize = 500;
-        foreach (var batch in entities.Chunk(batchSize))
-        {
-            ctx.DeviceEvents.AddRange(batch);
-            await ctx.SaveChangesAsync(ct);
-            ctx.ChangeTracker.Clear();
-        }
+            // Insert-time deduplication: link saved records to canonical groups
+            try
+            {
+                var dedupInputs = entities.Select(e => new DeduplicationInput(
+                    RecordId: e.Id,
+                    Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
+                    DataSource: e.DataSource ?? "unknown",
+                    Criteria: new MatchCriteria { EventType = e.EventType }
+                )).ToList();
 
-        await tx.CommitAsync(ct);
+                await _deduplicationService.DeduplicateBatchAsync(RecordType.DeviceEvent, dedupInputs, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "DeviceEvent", entities.Count);
+            }
 
-        // Insert-time deduplication: link saved records to canonical groups
-        try
-        {
-            var dedupInputs = entities.Select(e => new DeduplicationInput(
-                RecordId: e.Id,
-                Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                DataSource: e.DataSource ?? "unknown",
-                Criteria: new MatchCriteria { EventType = e.EventType }
-            )).ToList();
-
-            await _deduplicationService.DeduplicateBatchAsync(RecordType.DeviceEvent, dedupInputs, ct);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "DeviceEvent", entities.Count);
-        }
-
-        return entities.Select(DeviceEventMapper.ToDomainModel);
+            return entities.Select(DeviceEventMapper.ToDomainModel);
+        });
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceStatusExtrasRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceStatusExtrasRepository.cs
@@ -96,37 +96,41 @@ public class DeviceStatusExtrasRepository : IDeviceStatusExtrasRepository
             .ToHashSet();
 
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-        if (correlationIds.Count > 0)
+        var strategy = ctx.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
         {
-            var existingIds = await ctx
-                .DeviceStatusExtras.AsNoTracking()
-                .Where(e => correlationIds.Contains(e.CorrelationId))
-                .Select(e => e.CorrelationId)
-                .ToListAsync(ct);
+            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
 
-            var existingSet = existingIds.ToHashSet();
-            entities = entities
-                .Where(e => !existingSet.Contains(e.CorrelationId))
-                .ToList();
-        }
+            if (correlationIds.Count > 0)
+            {
+                var existingIds = await ctx
+                    .DeviceStatusExtras.AsNoTracking()
+                    .Where(e => correlationIds.Contains(e.CorrelationId))
+                    .Select(e => e.CorrelationId)
+                    .ToListAsync(ct);
 
-        if (entities.Count == 0)
-        {
+                var existingSet = existingIds.ToHashSet();
+                entities = entities
+                    .Where(e => !existingSet.Contains(e.CorrelationId))
+                    .ToList();
+            }
+
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
+
+            const int batchSize = 500;
+            foreach (var batch in entities.Chunk(batchSize))
+            {
+                ctx.DeviceStatusExtras.AddRange(batch);
+                await ctx.SaveChangesAsync(ct);
+                ctx.ChangeTracker.Clear();
+            }
+
             await tx.CommitAsync(ct);
-            return [];
-        }
-
-        const int batchSize = 500;
-        foreach (var batch in entities.Chunk(batchSize))
-        {
-            ctx.DeviceStatusExtras.AddRange(batch);
-            await ctx.SaveChangesAsync(ct);
-            ctx.ChangeTracker.Clear();
-        }
-
-        await tx.CommitAsync(ct);
-        return entities.Select(DeviceStatusExtrasMapper.ToDomainModel);
+            return entities.Select(DeviceStatusExtrasMapper.ToDomainModel);
+        });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/MeterGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/MeterGlucoseRepository.cs
@@ -258,37 +258,41 @@ public class MeterGlucoseRepository : IMeterGlucoseRepository
             .ToHashSet();
 
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-        if (legacyIds.Count > 0)
+        var strategy = ctx.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
         {
-            var existingIds = await ctx
-                .MeterGlucose.AsNoTracking()
-                .Where(e => legacyIds.Contains(e.LegacyId!))
-                .Select(e => e.LegacyId)
-                .ToListAsync(ct);
+            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
 
-            var existingSet = existingIds.ToHashSet();
-            entities = entities
-                .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
-                .ToList();
-        }
+            if (legacyIds.Count > 0)
+            {
+                var existingIds = await ctx
+                    .MeterGlucose.AsNoTracking()
+                    .Where(e => legacyIds.Contains(e.LegacyId!))
+                    .Select(e => e.LegacyId)
+                    .ToListAsync(ct);
 
-        if (entities.Count == 0)
-        {
+                var existingSet = existingIds.ToHashSet();
+                entities = entities
+                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                    .ToList();
+            }
+
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
+
+            const int batchSize = 500;
+            foreach (var batch in entities.Chunk(batchSize))
+            {
+                ctx.MeterGlucose.AddRange(batch);
+                await ctx.SaveChangesAsync(ct);
+                ctx.ChangeTracker.Clear();
+            }
+
             await tx.CommitAsync(ct);
-            return [];
-        }
-
-        const int batchSize = 500;
-        foreach (var batch in entities.Chunk(batchSize))
-        {
-            ctx.MeterGlucose.AddRange(batch);
-            await ctx.SaveChangesAsync(ct);
-            ctx.ChangeTracker.Clear();
-        }
-
-        await tx.CommitAsync(ct);
-        return entities.Select(MeterGlucoseMapper.ToDomainModel);
+            return entities.Select(MeterGlucoseMapper.ToDomainModel);
+        });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
@@ -232,73 +232,77 @@ public class NoteRepository : INoteRepository
     )
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-        var entities = records.Select(NoteMapper.ToEntity).ToList();
-        if (entities.Count == 0)
+        var strategy = ctx.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
         {
-            await tx.CommitAsync(ct);
-            return [];
-        }
+            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
+            var entities = records.Select(NoteMapper.ToEntity).ToList();
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
 
-        // Batch-level dedup: keep first occurrence per LegacyId
-        entities = entities
-            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-            .Select(g => g.First())
-            .ToList();
-
-        // DB-level dedup: filter out records whose LegacyId already exists
-        var legacyIds = entities
-            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-            .Select(e => e.LegacyId!)
-            .ToHashSet();
-
-        if (legacyIds.Count > 0)
-        {
-            var existingIds = await ctx
-                .Notes.AsNoTracking()
-                .Where(e => legacyIds.Contains(e.LegacyId!))
-                .Select(e => e.LegacyId)
-                .ToListAsync(ct);
-
-            var existingSet = existingIds.ToHashSet();
+            // Batch-level dedup: keep first occurrence per LegacyId
             entities = entities
-                .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                .GroupBy(e => e.LegacyId ?? e.Id.ToString())
+                .Select(g => g.First())
                 .ToList();
-        }
 
-        if (entities.Count == 0)
-        {
+            // DB-level dedup: filter out records whose LegacyId already exists
+            var legacyIds = entities
+                .Where(e => !string.IsNullOrEmpty(e.LegacyId))
+                .Select(e => e.LegacyId!)
+                .ToHashSet();
+
+            if (legacyIds.Count > 0)
+            {
+                var existingIds = await ctx
+                    .Notes.AsNoTracking()
+                    .Where(e => legacyIds.Contains(e.LegacyId!))
+                    .Select(e => e.LegacyId)
+                    .ToListAsync(ct);
+
+                var existingSet = existingIds.ToHashSet();
+                entities = entities
+                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                    .ToList();
+            }
+
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
+
+            const int batchSize = 500;
+            foreach (var batch in entities.Chunk(batchSize))
+            {
+                ctx.Notes.AddRange(batch);
+                await ctx.SaveChangesAsync(ct);
+                ctx.ChangeTracker.Clear();
+            }
+
             await tx.CommitAsync(ct);
-            return [];
-        }
 
-        const int batchSize = 500;
-        foreach (var batch in entities.Chunk(batchSize))
-        {
-            ctx.Notes.AddRange(batch);
-            await ctx.SaveChangesAsync(ct);
-            ctx.ChangeTracker.Clear();
-        }
+            // Insert-time deduplication: link saved records to canonical groups
+            try
+            {
+                var dedupInputs = entities.Select(e => new DeduplicationInput(
+                    RecordId: e.Id,
+                    Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
+                    DataSource: e.DataSource ?? "unknown",
+                    Criteria: new MatchCriteria()
+                )).ToList();
 
-        await tx.CommitAsync(ct);
+                await _deduplicationService.DeduplicateBatchAsync(RecordType.Note, dedupInputs, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "Note", entities.Count);
+            }
 
-        // Insert-time deduplication: link saved records to canonical groups
-        try
-        {
-            var dedupInputs = entities.Select(e => new DeduplicationInput(
-                RecordId: e.Id,
-                Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                DataSource: e.DataSource ?? "unknown",
-                Criteria: new MatchCriteria()
-            )).ToList();
-
-            await _deduplicationService.DeduplicateBatchAsync(RecordType.Note, dedupInputs, ct);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "Note", entities.Count);
-        }
-
-        return entities.Select(NoteMapper.ToDomainModel);
+            return entities.Select(NoteMapper.ToDomainModel);
+        });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
@@ -222,37 +222,41 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
             .ToHashSet();
 
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-        if (legacyIds.Count > 0)
+        var strategy = ctx.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
         {
-            var existingIds = await ctx
-                .PumpSnapshots.AsNoTracking()
-                .Where(e => legacyIds.Contains(e.LegacyId!))
-                .Select(e => e.LegacyId)
-                .ToListAsync(ct);
+            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
 
-            var existingSet = existingIds.ToHashSet();
-            entities = entities
-                .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
-                .ToList();
-        }
+            if (legacyIds.Count > 0)
+            {
+                var existingIds = await ctx
+                    .PumpSnapshots.AsNoTracking()
+                    .Where(e => legacyIds.Contains(e.LegacyId!))
+                    .Select(e => e.LegacyId)
+                    .ToListAsync(ct);
 
-        if (entities.Count == 0)
-        {
+                var existingSet = existingIds.ToHashSet();
+                entities = entities
+                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                    .ToList();
+            }
+
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
+
+            const int batchSize = 500;
+            foreach (var batch in entities.Chunk(batchSize))
+            {
+                ctx.PumpSnapshots.AddRange(batch);
+                await ctx.SaveChangesAsync(ct);
+                ctx.ChangeTracker.Clear();
+            }
+
             await tx.CommitAsync(ct);
-            return [];
-        }
-
-        const int batchSize = 500;
-        foreach (var batch in entities.Chunk(batchSize))
-        {
-            ctx.PumpSnapshots.AddRange(batch);
-            await ctx.SaveChangesAsync(ct);
-            ctx.ChangeTracker.Clear();
-        }
-
-        await tx.CommitAsync(ct);
-        return entities.Select(PumpSnapshotMapper.ToDomainModel);
+            return entities.Select(PumpSnapshotMapper.ToDomainModel);
+        });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensitivityScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensitivityScheduleRepository.cs
@@ -273,37 +273,41 @@ public class SensitivityScheduleRepository : ISensitivityScheduleRepository
             .ToHashSet();
 
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-        if (legacyIds.Count > 0)
+        var strategy = ctx.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
         {
-            var existingIds = await ctx
-                .SensitivitySchedules.AsNoTracking()
-                .Where(e => legacyIds.Contains(e.LegacyId!))
-                .Select(e => e.LegacyId)
-                .ToListAsync(ct);
+            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
 
-            var existingSet = existingIds.ToHashSet();
-            entities = entities
-                .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
-                .ToList();
-        }
+            if (legacyIds.Count > 0)
+            {
+                var existingIds = await ctx
+                    .SensitivitySchedules.AsNoTracking()
+                    .Where(e => legacyIds.Contains(e.LegacyId!))
+                    .Select(e => e.LegacyId)
+                    .ToListAsync(ct);
 
-        if (entities.Count == 0)
-        {
+                var existingSet = existingIds.ToHashSet();
+                entities = entities
+                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                    .ToList();
+            }
+
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
+
+            const int batchSize = 500;
+            foreach (var batch in entities.Chunk(batchSize))
+            {
+                ctx.SensitivitySchedules.AddRange(batch);
+                await ctx.SaveChangesAsync(ct);
+                ctx.ChangeTracker.Clear();
+            }
+
             await tx.CommitAsync(ct);
-            return [];
-        }
-
-        const int batchSize = 500;
-        foreach (var batch in entities.Chunk(batchSize))
-        {
-            ctx.SensitivitySchedules.AddRange(batch);
-            await ctx.SaveChangesAsync(ct);
-            ctx.ChangeTracker.Clear();
-        }
-
-        await tx.CommitAsync(ct);
-        return entities.Select(SensitivityScheduleMapper.ToDomainModel);
+            return entities.Select(SensitivityScheduleMapper.ToDomainModel);
+        });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -262,74 +262,78 @@ public class SensorGlucoseRepository : ISensorGlucoseRepository
     )
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-        var entities = records.Select(SensorGlucoseMapper.ToEntity).ToList();
-        if (entities.Count == 0)
+        var strategy = ctx.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
         {
-            await tx.CommitAsync(ct);
-            return [];
-        }
+            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
+            var entities = records.Select(SensorGlucoseMapper.ToEntity).ToList();
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
 
-        // Batch-level dedup: keep first occurrence per LegacyId
-        entities = entities
-            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-            .Select(g => g.First())
-            .ToList();
-
-        // DB-level dedup: filter out records whose LegacyId already exists
-        var legacyIds = entities
-            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-            .Select(e => e.LegacyId!)
-            .ToHashSet();
-
-        if (legacyIds.Count > 0)
-        {
-            var existingIds = await ctx
-                .SensorGlucose.AsNoTracking()
-                .Where(e => legacyIds.Contains(e.LegacyId!))
-                .Select(e => e.LegacyId)
-                .ToListAsync(ct);
-
-            var existingSet = existingIds.ToHashSet();
+            // Batch-level dedup: keep first occurrence per LegacyId
             entities = entities
-                .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                .GroupBy(e => e.LegacyId ?? e.Id.ToString())
+                .Select(g => g.First())
                 .ToList();
-        }
 
-        if (entities.Count == 0)
-        {
+            // DB-level dedup: filter out records whose LegacyId already exists
+            var legacyIds = entities
+                .Where(e => !string.IsNullOrEmpty(e.LegacyId))
+                .Select(e => e.LegacyId!)
+                .ToHashSet();
+
+            if (legacyIds.Count > 0)
+            {
+                var existingIds = await ctx
+                    .SensorGlucose.AsNoTracking()
+                    .Where(e => legacyIds.Contains(e.LegacyId!))
+                    .Select(e => e.LegacyId)
+                    .ToListAsync(ct);
+
+                var existingSet = existingIds.ToHashSet();
+                entities = entities
+                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                    .ToList();
+            }
+
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
+
+            const int batchSize = 500;
+            foreach (var batch in entities.Chunk(batchSize))
+            {
+                ctx.SensorGlucose.AddRange(batch);
+                await ctx.SaveChangesAsync(ct);
+                ctx.ChangeTracker.Clear();
+            }
+
             await tx.CommitAsync(ct);
-            return [];
-        }
 
-        const int batchSize = 500;
-        foreach (var batch in entities.Chunk(batchSize))
-        {
-            ctx.SensorGlucose.AddRange(batch);
-            await ctx.SaveChangesAsync(ct);
-            ctx.ChangeTracker.Clear();
-        }
+            // Insert-time deduplication: link saved records to canonical groups
+            try
+            {
+                var dedupInputs = entities.Select(e => new DeduplicationInput(
+                    RecordId: e.Id,
+                    Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
+                    DataSource: e.DataSource ?? "unknown",
+                    Criteria: new MatchCriteria { GlucoseValue = e.Mgdl, GlucoseTolerance = 1.0 }
+                )).ToList();
 
-        await tx.CommitAsync(ct);
+                await _deduplicationService.DeduplicateBatchAsync(RecordType.SensorGlucose, dedupInputs, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "SensorGlucose", entities.Count);
+            }
 
-        // Insert-time deduplication: link saved records to canonical groups
-        try
-        {
-            var dedupInputs = entities.Select(e => new DeduplicationInput(
-                RecordId: e.Id,
-                Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                DataSource: e.DataSource ?? "unknown",
-                Criteria: new MatchCriteria { GlucoseValue = e.Mgdl, GlucoseTolerance = 1.0 }
-            )).ToList();
-
-            await _deduplicationService.DeduplicateBatchAsync(RecordType.SensorGlucose, dedupInputs, ct);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "SensorGlucose", entities.Count);
-        }
-
-        return entities.Select(SensorGlucoseMapper.ToDomainModel);
+            return entities.Select(SensorGlucoseMapper.ToDomainModel);
+        });
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TargetRangeScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TargetRangeScheduleRepository.cs
@@ -273,37 +273,41 @@ public class TargetRangeScheduleRepository : ITargetRangeScheduleRepository
             .ToHashSet();
 
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-        if (legacyIds.Count > 0)
+        var strategy = ctx.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
         {
-            var existingIds = await ctx
-                .TargetRangeSchedules.AsNoTracking()
-                .Where(e => legacyIds.Contains(e.LegacyId!))
-                .Select(e => e.LegacyId)
-                .ToListAsync(ct);
+            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
 
-            var existingSet = existingIds.ToHashSet();
-            entities = entities
-                .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
-                .ToList();
-        }
+            if (legacyIds.Count > 0)
+            {
+                var existingIds = await ctx
+                    .TargetRangeSchedules.AsNoTracking()
+                    .Where(e => legacyIds.Contains(e.LegacyId!))
+                    .Select(e => e.LegacyId)
+                    .ToListAsync(ct);
 
-        if (entities.Count == 0)
-        {
+                var existingSet = existingIds.ToHashSet();
+                entities = entities
+                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                    .ToList();
+            }
+
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
+
+            const int batchSize = 500;
+            foreach (var batch in entities.Chunk(batchSize))
+            {
+                ctx.TargetRangeSchedules.AddRange(batch);
+                await ctx.SaveChangesAsync(ct);
+                ctx.ChangeTracker.Clear();
+            }
+
             await tx.CommitAsync(ct);
-            return [];
-        }
-
-        const int batchSize = 500;
-        foreach (var batch in entities.Chunk(batchSize))
-        {
-            ctx.TargetRangeSchedules.AddRange(batch);
-            await ctx.SaveChangesAsync(ct);
-            ctx.ChangeTracker.Clear();
-        }
-
-        await tx.CommitAsync(ct);
-        return entities.Select(TargetRangeScheduleMapper.ToDomainModel);
+            return entities.Select(TargetRangeScheduleMapper.ToDomainModel);
+        });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
@@ -204,74 +204,78 @@ public class TempBasalRepository : ITempBasalRepository
     )
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-        var entities = records.Select(TempBasalMapper.ToEntity).ToList();
-        if (entities.Count == 0)
+        var strategy = ctx.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
         {
-            await tx.CommitAsync(ct);
-            return [];
-        }
+            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
+            var entities = records.Select(TempBasalMapper.ToEntity).ToList();
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
 
-        // Batch-level dedup: keep first occurrence per LegacyId
-        entities = entities
-            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-            .Select(g => g.First())
-            .ToList();
-
-        // DB-level dedup: filter out records whose LegacyId already exists
-        var legacyIds = entities
-            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-            .Select(e => e.LegacyId!)
-            .ToHashSet();
-
-        if (legacyIds.Count > 0)
-        {
-            var existingIds = await ctx
-                .TempBasals.AsNoTracking()
-                .Where(e => legacyIds.Contains(e.LegacyId!))
-                .Select(e => e.LegacyId)
-                .ToListAsync(ct);
-
-            var existingSet = existingIds.ToHashSet();
+            // Batch-level dedup: keep first occurrence per LegacyId
             entities = entities
-                .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                .GroupBy(e => e.LegacyId ?? e.Id.ToString())
+                .Select(g => g.First())
                 .ToList();
-        }
 
-        if (entities.Count == 0)
-        {
+            // DB-level dedup: filter out records whose LegacyId already exists
+            var legacyIds = entities
+                .Where(e => !string.IsNullOrEmpty(e.LegacyId))
+                .Select(e => e.LegacyId!)
+                .ToHashSet();
+
+            if (legacyIds.Count > 0)
+            {
+                var existingIds = await ctx
+                    .TempBasals.AsNoTracking()
+                    .Where(e => legacyIds.Contains(e.LegacyId!))
+                    .Select(e => e.LegacyId)
+                    .ToListAsync(ct);
+
+                var existingSet = existingIds.ToHashSet();
+                entities = entities
+                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                    .ToList();
+            }
+
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
+
+            const int batchSize = 500;
+            foreach (var batch in entities.Chunk(batchSize))
+            {
+                ctx.TempBasals.AddRange(batch);
+                await ctx.SaveChangesAsync(ct);
+                ctx.ChangeTracker.Clear();
+            }
+
             await tx.CommitAsync(ct);
-            return [];
-        }
 
-        const int batchSize = 500;
-        foreach (var batch in entities.Chunk(batchSize))
-        {
-            ctx.TempBasals.AddRange(batch);
-            await ctx.SaveChangesAsync(ct);
-            ctx.ChangeTracker.Clear();
-        }
+            // Cross-connector deduplication: link saved records to canonical groups
+            try
+            {
+                var dedupInputs = entities.Select(e => new DeduplicationInput(
+                    RecordId: e.Id,
+                    Mills: new DateTimeOffset(e.StartTimestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
+                    DataSource: e.DataSource ?? "unknown",
+                    Criteria: new MatchCriteria { Rate = e.Rate, RateTolerance = 0.05 }
+                )).ToList();
 
-        await tx.CommitAsync(ct);
+                await _deduplicationService.DeduplicateBatchAsync(RecordType.TempBasal, dedupInputs, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "TempBasal", entities.Count);
+            }
 
-        // Cross-connector deduplication: link saved records to canonical groups
-        try
-        {
-            var dedupInputs = entities.Select(e => new DeduplicationInput(
-                RecordId: e.Id,
-                Mills: new DateTimeOffset(e.StartTimestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                DataSource: e.DataSource ?? "unknown",
-                Criteria: new MatchCriteria { Rate = e.Rate, RateTolerance = 0.05 }
-            )).ToList();
-
-            await _deduplicationService.DeduplicateBatchAsync(RecordType.TempBasal, dedupInputs, ct);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "TempBasal", entities.Count);
-        }
-
-        return entities.Select(TempBasalMapper.ToDomainModel);
+            return entities.Select(TempBasalMapper.ToDomainModel);
+        });
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TherapySettingsRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TherapySettingsRepository.cs
@@ -269,37 +269,41 @@ public class TherapySettingsRepository : ITherapySettingsRepository
             .ToHashSet();
 
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-        if (legacyIds.Count > 0)
+        var strategy = ctx.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
         {
-            var existingIds = await ctx
-                .TherapySettings.AsNoTracking()
-                .Where(e => legacyIds.Contains(e.LegacyId!))
-                .Select(e => e.LegacyId)
-                .ToListAsync(ct);
+            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
 
-            var existingSet = existingIds.ToHashSet();
-            entities = entities
-                .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
-                .ToList();
-        }
+            if (legacyIds.Count > 0)
+            {
+                var existingIds = await ctx
+                    .TherapySettings.AsNoTracking()
+                    .Where(e => legacyIds.Contains(e.LegacyId!))
+                    .Select(e => e.LegacyId)
+                    .ToListAsync(ct);
 
-        if (entities.Count == 0)
-        {
+                var existingSet = existingIds.ToHashSet();
+                entities = entities
+                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                    .ToList();
+            }
+
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
+
+            const int batchSize = 500;
+            foreach (var batch in entities.Chunk(batchSize))
+            {
+                ctx.TherapySettings.AddRange(batch);
+                await ctx.SaveChangesAsync(ct);
+                ctx.ChangeTracker.Clear();
+            }
+
             await tx.CommitAsync(ct);
-            return [];
-        }
-
-        const int batchSize = 500;
-        foreach (var batch in entities.Chunk(batchSize))
-        {
-            ctx.TherapySettings.AddRange(batch);
-            await ctx.SaveChangesAsync(ct);
-            ctx.ChangeTracker.Clear();
-        }
-
-        await tx.CommitAsync(ct);
-        return entities.Select(TherapySettingsMapper.ToDomainModel);
+            return entities.Select(TherapySettingsMapper.ToDomainModel);
+        });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
@@ -212,37 +212,41 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
             .ToHashSet();
 
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-        if (legacyIds.Count > 0)
+        var strategy = ctx.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
         {
-            var existingIds = await ctx
-                .UploaderSnapshots.AsNoTracking()
-                .Where(e => legacyIds.Contains(e.LegacyId!))
-                .Select(e => e.LegacyId)
-                .ToListAsync(ct);
+            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
 
-            var existingSet = existingIds.ToHashSet();
-            entities = entities
-                .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
-                .ToList();
-        }
+            if (legacyIds.Count > 0)
+            {
+                var existingIds = await ctx
+                    .UploaderSnapshots.AsNoTracking()
+                    .Where(e => legacyIds.Contains(e.LegacyId!))
+                    .Select(e => e.LegacyId)
+                    .ToListAsync(ct);
 
-        if (entities.Count == 0)
-        {
+                var existingSet = existingIds.ToHashSet();
+                entities = entities
+                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                    .ToList();
+            }
+
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
+
+            const int batchSize = 500;
+            foreach (var batch in entities.Chunk(batchSize))
+            {
+                ctx.UploaderSnapshots.AddRange(batch);
+                await ctx.SaveChangesAsync(ct);
+                ctx.ChangeTracker.Clear();
+            }
+
             await tx.CommitAsync(ct);
-            return [];
-        }
-
-        const int batchSize = 500;
-        foreach (var batch in entities.Chunk(batchSize))
-        {
-            ctx.UploaderSnapshots.AddRange(batch);
-            await ctx.SaveChangesAsync(ct);
-            ctx.ChangeTracker.Clear();
-        }
-
-        await tx.CommitAsync(ct);
-        return entities.Select(UploaderSnapshotMapper.ToDomainModel);
+            return entities.Select(UploaderSnapshotMapper.ToDomainModel);
+        });
     }
 }


### PR DESCRIPTION
## Summary
- All 19 V4 repository `BulkCreateAsync` methods now wrap their transaction block in `CreateExecutionStrategy().ExecuteAsync()`
- Fixes `NpgsqlRetryingExecutionStrategy does not support user-initiated transactions` error that was causing every connector publish to fail (Boluses, CarbIntake, BolusCalculations, DeviceEvents, StateSpans, etc.)
- Root cause: `EnableRetryOnFailure` was added to the DbContext config but the repositories still called `BeginTransactionAsync` directly

## Test plan
- [x] Solution builds with 0 errors, 0 warnings
- [ ] Connector sync completes without publish failures