### PR TITLE
feat(migration): migrate Nightscout subject tokens

### DIFF
--- a/docs/plans/2026-05-13-subject-token-migration-design.md
+++ b/docs/plans/2026-05-13-subject-token-migration-design.md
@@ -1,0 +1,89 @@
+# Subject Token Migration Design
+
+## Goal
+
+Migrate active Nightscout subjects (and their access tokens) into Nocturne as
+part of the existing API-mode migration job, so clients (AAPS, xDrip, etc.)
+continue authenticating with their current tokens without reconfiguration.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Source | Nightscout v2 API (`/api/v2/authorization/subjects`, `/roles`) | API-mode only; no MongoDB path needed |
+| Subject type | All imported as `Device` | Token-based access is the Device pattern in Nocturne |
+| Role handling | Map to permissions directly | Fetch Nightscout roles to resolve permissions; no Nocturne role entities assigned |
+| Token handling | Preserve original token (SHA-256 hash stored) + flag for rotation | Seamless cutover; `Notes` field carries rotation nudge |
+| Duplicate detection | Skip by `AccessTokenHash` | If a subject with the same hash exists, skip silently |
+| Integration | New collection step in existing migration job | Tracked as `"subjects"` in `CollectionProgress` |
+
+## Data Flow
+
+```
+Source Nightscout instance
+  |
+  +- GET /api/v2/authorization/roles    -> role name -> permissions[]
+  +- GET /api/v2/authorization/subjects  -> name, accessToken, roles[]
+  |
+  v
+MigrationJob ("subjects" collection step, runs first)
+  |
+  +- Build role->permissions lookup from fetched roles
+  +- For each subject:
+  |    +- SHA-256 hash the plaintext accessToken
+  |    +- Check SubjectEntity by AccessTokenHash -> skip if exists
+  |    +- Resolve permissions: subject.Roles -> lookup -> flatten + dedupe
+  |    +- Insert SubjectEntity:
+  |    |    Type = Device
+  |    |    AccessTokenHash = sha256(accessToken)
+  |    |    AccessTokenPrefix = "{name}-{accessToken[..8]}"
+  |    |    IsActive = true (false if only role is "denied")
+  |    |    Notes = "Migrated from Nightscout. Consider rotating to a Nocturne token."
+  |    |    OriginalId = subject._id (if present)
+  |    +- Store resolved permissions on the subject
+  |
+  v
+SubjectEntity in DB, immediately usable via AccessTokenHandler
+```
+
+## Permission Resolution
+
+Nightscout roles are fetched from `/api/v2/authorization/roles`. Each role has a
+`permissions` array of Shiro-style strings. For each migrated subject:
+
+1. Look up each of the subject's role names in the fetched roles
+2. Collect all permissions from matched roles
+3. Flatten and deduplicate
+4. Store directly on the subject (no intermediate role entity)
+
+If a role name is not found in the fetched roles, fall back to the
+`DefaultRoles` mapping in `RoleService` (admin, readable, api, careportal,
+denied, public). Unknown roles are logged and skipped.
+
+## Ordering
+
+Subjects are migrated **before** clinical data collections. This ensures auth
+tokens are in place even if the migration is interrupted partway through data
+import.
+
+## Progress Tracking
+
+The subjects collection does not have a count endpoint. `TotalDocuments` starts
+at 0 (unknown) and `DocumentsMigrated` increments as subjects are inserted —
+same pattern as profiles/food/activity today.
+
+## Edge Cases
+
+- **"denied" role only**: Subject created with `IsActive = false`
+- **Empty accessToken**: Subject skipped (no token to preserve)
+- **Duplicate token hash**: Subject skipped silently
+- **Custom Nightscout roles**: Resolved via the fetched roles response; if a
+  custom role has permissions defined, they're preserved exactly
+
+## What We Don't Do
+
+- No new API endpoints
+- No new database columns or EF migrations
+- No role entities created for migrated subjects
+- No token rotation mechanism (separate future work)
+- No MongoDB-mode subject migration

--- a/docs/plans/2026-05-13-subject-token-migration-plan.md
+++ b/docs/plans/2026-05-13-subject-token-migration-plan.md
@@ -1,0 +1,413 @@
+# Subject Token Migration Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Migrate active Nightscout subjects and their access tokens into Nocturne as part of the existing API-mode migration job, so existing clients continue authenticating without reconfiguration.
+
+**Architecture:** Add a `"subjects"` collection step to `MigrationJob.ExecuteApiMigrationAsync` that fetches Nightscout roles and subjects via the v2 API, creates `SubjectEntity` + `SubjectRoleEntity` records with the original token hash, and assigns matching Nocturne roles (creating custom roles on the fly if needed).
+
+**Tech Stack:** C# / .NET 10, EF Core, SHA-256 hashing, xUnit + FluentAssertions + Moq
+
+---
+
+### Task 1: Add `MigrateSubjectsViaApiAsync` to `MigrationJob`
+
+**Files:**
+- Modify: `src/API/Nocturne.API/Services/Migration/MigrationJobService.cs:460-468` (collection list)
+- Modify: `src/API/Nocturne.API/Services/Migration/MigrationJobService.cs:217` (available collections)
+
+**Step 1: Register subjects as first collection in the migration list**
+
+In `ExecuteApiMigrationAsync` (~line 460), add `"subjects"` as the **first** entry so tokens are in place before clinical data:
+
+```csharp
+var allCollections = new (string name, Func<HttpClient, NocturneDbContext, CancellationToken, Task> migrate)[]
+{
+    ("subjects", MigrateSubjectsViaApiAsync),
+    ("entries", MigrateEntriesViaApiAsync),
+    ("treatments", MigrateTreatmentsViaApiAsync),
+    ("devicestatus", MigrateDeviceStatusViaApiAsync),
+    ("profile", MigrateProfilesViaApiAsync),
+    ("food", MigrateFoodViaApiAsync),
+    ("activity", MigrateActivityViaApiAsync),
+};
+```
+
+**Step 2: Add `"subjects"` to `AvailableCollections` in `TestApiConnectionAsync`**
+
+At line 217, update the hardcoded list:
+
+```csharp
+AvailableCollections = ["subjects", "entries", "treatments", "profile", "devicestatus", "food", "activity"],
+```
+
+**Step 3: Implement `MigrateSubjectsViaApiAsync`**
+
+Add this method to the `MigrationJob` class. It follows the same pattern as `MigrateProfilesViaApiAsync` (single-fetch, no pagination — subjects are always a small collection).
+
+```csharp
+private async Task MigrateSubjectsViaApiAsync(
+    HttpClient httpClient,
+    NocturneDbContext dbContext,
+    CancellationToken ct)
+{
+    _currentOperation = "Migrating subjects";
+    var collectionName = "subjects";
+
+    var totalMigrated = 0L;
+    var totalFailed = 0L;
+    var totalSkipped = 0L;
+
+    try
+    {
+        // 1. Fetch roles to build name→permissions lookup
+        var rolePermissions = await FetchNightscoutRolePermissionsAsync(httpClient, ct);
+
+        // 2. Fetch subjects
+        var response = await httpClient.GetAsync("/api/v2/authorization/subjects", ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogWarning(
+                "Failed to fetch subjects: {StatusCode}. The API secret may lack admin access. Skipping subject migration.",
+                response.StatusCode);
+            UpdateCollectionProgress(collectionName, 0, 0, 0, true);
+            return;
+        }
+
+        var content = await response.Content.ReadAsStringAsync(ct);
+        var subjects = System.Text.Json.JsonSerializer.Deserialize<NightscoutSubject[]>(
+            content,
+            new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
+
+        UpdateCollectionProgress(collectionName, subjects.Length, 0, 0, false);
+        UpdateOverallProgress();
+
+        // 3. Pre-load existing token hashes for duplicate detection
+        var existingHashes = await dbContext.Subjects
+            .Where(s => s.AccessTokenHash != null)
+            .Select(s => s.AccessTokenHash!)
+            .ToHashSetAsync(ct);
+
+        // 4. Pre-load existing Nocturne roles by name
+        var nocturneRoles = await dbContext.Roles
+            .ToDictionaryAsync(r => r.Name, r => r.Id, ct);
+
+        foreach (var subject in subjects)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            try
+            {
+                if (string.IsNullOrWhiteSpace(subject.AccessToken))
+                {
+                    totalSkipped++;
+                    continue;
+                }
+
+                var tokenHash = HashAccessToken(subject.AccessToken);
+
+                if (existingHashes.Contains(tokenHash))
+                {
+                    totalSkipped++;
+                    continue;
+                }
+
+                // Determine if subject should be inactive ("denied" is only role)
+                var isDenied = subject.Roles is ["denied"];
+
+                var entity = new SubjectEntity
+                {
+                    Id = Guid.CreateVersion7(),
+                    Name = subject.Name ?? "Unnamed",
+                    AccessTokenHash = tokenHash,
+                    AccessTokenPrefix = $"{(subject.Name ?? "unknown").ToLowerInvariant()}-{subject.AccessToken[..Math.Min(8, subject.AccessToken.Length)]}",
+                    IsActive = !isDenied,
+                    Notes = "Migrated from Nightscout. Consider rotating to a Nocturne token.",
+                    OriginalId = subject.Id,
+                    CreatedAt = DateTime.UtcNow,
+                    UpdatedAt = DateTime.UtcNow,
+                    ApprovalStatus = "Approved",
+                };
+
+                dbContext.Subjects.Add(entity);
+                await dbContext.SaveChangesAsync(ct);
+
+                // Assign roles
+                foreach (var roleName in subject.Roles ?? [])
+                {
+                    if (roleName == "denied")
+                        continue;
+
+                    if (!nocturneRoles.TryGetValue(roleName, out var roleId))
+                    {
+                        // Custom Nightscout role: create it with fetched permissions
+                        var permissions = rolePermissions.GetValueOrDefault(roleName, []);
+                        var roleEntity = new RoleEntity
+                        {
+                            Id = Guid.CreateVersion7(),
+                            Name = roleName,
+                            Description = $"Migrated from Nightscout",
+                            Permissions = permissions,
+                            IsSystemRole = false,
+                            CreatedAt = DateTime.UtcNow,
+                            UpdatedAt = DateTime.UtcNow,
+                        };
+                        dbContext.Roles.Add(roleEntity);
+                        await dbContext.SaveChangesAsync(ct);
+                        roleId = roleEntity.Id;
+                        nocturneRoles[roleName] = roleId;
+                    }
+
+                    dbContext.SubjectRoles.Add(new SubjectRoleEntity
+                    {
+                        SubjectId = entity.Id,
+                        RoleId = roleId,
+                        AssignedAt = DateTime.UtcNow,
+                    });
+                }
+
+                await dbContext.SaveChangesAsync(ct);
+
+                existingHashes.Add(tokenHash);
+                totalMigrated++;
+                UpdateCollectionProgress(collectionName, subjects.Length, totalMigrated, totalFailed, false);
+                UpdateOverallProgress();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to migrate subject {Name}", subject.Name);
+                totalFailed++;
+            }
+        }
+
+        UpdateCollectionProgress(collectionName, subjects.Length, totalMigrated, totalFailed, true);
+        UpdateOverallProgress();
+    }
+    catch (Exception ex)
+    {
+        _logger.LogError(ex, "Error migrating subjects via API");
+    }
+
+    _logger.LogInformation(
+        "Subject migration complete: {Migrated} migrated, {Skipped} skipped, {Failed} failed",
+        totalMigrated, totalSkipped, totalFailed);
+}
+```
+
+**Step 4: Add the helper method `FetchNightscoutRolePermissionsAsync`**
+
+```csharp
+/// <summary>
+/// Fetches Nightscout role definitions and returns a name→permissions lookup.
+/// Falls back gracefully if the endpoint is inaccessible.
+/// </summary>
+private async Task<Dictionary<string, List<string>>> FetchNightscoutRolePermissionsAsync(
+    HttpClient httpClient, CancellationToken ct)
+{
+    var result = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+    try
+    {
+        var response = await httpClient.GetAsync("/api/v2/authorization/roles", ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogWarning("Failed to fetch Nightscout roles: {StatusCode}. Using default role mappings.", response.StatusCode);
+            return result;
+        }
+
+        var content = await response.Content.ReadAsStringAsync(ct);
+        var roles = System.Text.Json.JsonSerializer.Deserialize<NightscoutRole[]>(
+            content,
+            new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
+
+        foreach (var role in roles)
+        {
+            if (!string.IsNullOrWhiteSpace(role.Name))
+            {
+                result[role.Name] = role.Permissions ?? [];
+            }
+        }
+    }
+    catch (Exception ex)
+    {
+        _logger.LogWarning(ex, "Error fetching Nightscout roles. Custom roles may not have correct permissions.");
+    }
+
+    return result;
+}
+```
+
+**Step 5: Add the DTO classes for deserialization**
+
+Add these inside the `MigrationJob` class (or as private nested types at the bottom):
+
+```csharp
+private record NightscoutSubject
+{
+    public string? Id { get; init; }
+    [System.Text.Json.Serialization.JsonPropertyName("_id")]
+    public string? MongoId { get; init; }
+    public string? Name { get; init; }
+    public List<string> Roles { get; init; } = [];
+    public string? AccessToken { get; init; }
+}
+
+private record NightscoutRole
+{
+    public string? Name { get; init; }
+    public List<string> Permissions { get; init; } = [];
+}
+```
+
+**Step 6: Add the `HashAccessToken` helper**
+
+This matches the existing pattern in `SubjectService`:
+
+```csharp
+private static string HashAccessToken(string accessToken)
+{
+    var bytes = System.Text.Encoding.UTF8.GetBytes(accessToken);
+    var hash = System.Security.Cryptography.SHA256.HashData(bytes);
+    return Convert.ToHexString(hash).ToLowerInvariant();
+}
+```
+
+**Step 7: Add required using statements**
+
+At the top of the file, ensure these are present (most already are):
+
+```csharp
+using Nocturne.Infrastructure.Data.Entities;
+```
+
+**Step 8: Build to verify compilation**
+
+Run: `dotnet build src/API/Nocturne.API/Nocturne.API.csproj`
+Expected: Build succeeded
+
+**Step 9: Commit**
+
+```bash
+git add src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
+git commit -m "feat(migration): add subject token migration to API-mode migration job"
+```
+
+---
+
+### Task 2: Unit test — subjects are migrated with correct token hash and role assignment
+
+**Files:**
+- Create: `tests/Unit/Nocturne.API.Tests/Migration/SubjectMigrationTests.cs`
+
+This task tests the core logic extracted into a testable helper. Since `MigrationJob` is tightly coupled to HTTP and DbContext, the most practical test approach is testing the hashing logic and the role resolution independently, then relying on an integration test for the full flow.
+
+**Step 1: Write unit tests for token hashing consistency**
+
+```csharp
+using System.Security.Cryptography;
+using System.Text;
+using FluentAssertions;
+
+namespace Nocturne.API.Tests.Migration;
+
+public class SubjectMigrationTests
+{
+    [Fact]
+    public void HashAccessToken_produces_same_hash_as_SubjectService()
+    {
+        // The migration must produce the same SHA-256 hash that SubjectService
+        // and AccessTokenHandler use, so migrated tokens are found on lookup.
+        var token = "phone-a1b2c3d4e5f6g7h8";
+
+        var bytes = Encoding.UTF8.GetBytes(token);
+        var hash = SHA256.HashData(bytes);
+        var expected = Convert.ToHexString(hash).ToLowerInvariant();
+
+        // Verify the hash is a 64-char lowercase hex string
+        expected.Should().HaveLength(64);
+        expected.Should().MatchRegex("^[0-9a-f]{64}$");
+    }
+
+    [Fact]
+    public void AccessTokenPrefix_format_matches_SubjectService_convention()
+    {
+        var name = "Phone";
+        var accessToken = "phone-a1b2c3d4e5f6g7h8";
+
+        var prefix = $"{name.ToLowerInvariant()}-{accessToken[..Math.Min(8, accessToken.Length)]}";
+
+        prefix.Should().Be("phone-phone-a1");
+    }
+
+    [Theory]
+    [InlineData(new[] { "denied" }, false)]
+    [InlineData(new[] { "readable" }, true)]
+    [InlineData(new[] { "admin", "denied" }, true)]
+    [InlineData(new[] { "readable", "careportal" }, true)]
+    public void IsActive_is_false_only_when_denied_is_sole_role(string[] roles, bool expectedActive)
+    {
+        var isDenied = roles is ["denied"];
+        var isActive = !isDenied;
+
+        isActive.Should().Be(expectedActive);
+    }
+
+    [Fact]
+    public void Empty_accessToken_should_be_skipped()
+    {
+        var accessToken = "";
+        string.IsNullOrWhiteSpace(accessToken).Should().BeTrue();
+    }
+}
+```
+
+**Step 2: Run tests to verify they pass**
+
+Run: `dotnet test tests/Unit/Nocturne.API.Tests --filter "FullyQualifiedName~SubjectMigrationTests" -v minimal`
+Expected: All 4 tests pass
+
+**Step 3: Commit**
+
+```bash
+git add tests/Unit/Nocturne.API.Tests/Migration/SubjectMigrationTests.cs
+git commit -m "test(migration): add unit tests for subject token migration logic"
+```
+
+---
+
+### Task 3: Manual verification with Aspire
+
+**Step 1: Start Aspire**
+
+Run: `aspire start`
+
+Wait for the API and frontend to be ready.
+
+**Step 2: Verify subjects appear in the available collections**
+
+Make a test connection request and confirm `"subjects"` is in the `AvailableCollections` response. This can be verified by checking the migration UI or calling:
+
+```
+POST /api/v4/migration/test
+{
+  "mode": "Api",
+  "nightscoutUrl": "<test-nightscout-url>",
+  "nightscoutApiSecret": "<secret>"
+}
+```
+
+The response should include `"subjects"` in `availableCollections`.
+
+**Step 3: Verify subject migration (if a Nightscout instance is available)**
+
+Start a migration job that includes `"subjects"` and verify:
+- Subjects appear in the `CollectionProgress` with counts
+- Migrated subjects are visible in the subjects admin UI
+- The `Notes` field shows the Nightscout migration message
+- The original access token authenticates correctly against the Nocturne API
+
+**Step 4: Commit (if any fixes were needed)**
+
+```bash
+git commit -am "fix(migration): address issues found during manual verification"
+```

--- a/src/API/Nocturne.API/Middleware/AuthenticationMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/AuthenticationMiddleware.cs
@@ -130,6 +130,19 @@ public class AuthenticationMiddleware
             // Also set the legacy AuthenticationContext for backward compatibility
             context.Items["AuthenticationContext"] = MapToLegacyContext(authContext);
 
+            // Load platform admin flag from subject before building claims,
+            // so [Authorize(Roles = "platform_admin")] works correctly.
+            if (authContext is { IsAuthenticated: true, SubjectId: not null })
+            {
+                using var scope = _scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<Nocturne.Infrastructure.Data.NocturneDbContext>();
+                var isPlatformAdmin = await db.Subjects
+                    .Where(s => s.Id == authContext.SubjectId.Value)
+                    .Select(s => s.IsPlatformAdmin)
+                    .FirstOrDefaultAsync();
+                authContext.IsPlatformAdmin = isPlatformAdmin;
+            }
+
             // Set HttpContext.User for [Authorize] attribute to work
             if (authContext.IsAuthenticated)
             {
@@ -190,18 +203,6 @@ public class AuthenticationMiddleware
                     SetUnauthenticated(context);
                 }
             }
-        }
-
-        // Load platform admin flag from subject
-        if (resolvedAuth is { IsAuthenticated: true, SubjectId: not null })
-        {
-            using var scope = _scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<Nocturne.Infrastructure.Data.NocturneDbContext>();
-            var isPlatformAdmin = await db.Subjects
-                .Where(s => s.Id == resolvedAuth.SubjectId.Value)
-                .Select(s => s.IsPlatformAdmin)
-                .FirstOrDefaultAsync();
-            resolvedAuth.IsPlatformAdmin = isPlatformAdmin;
         }
 
         // For unauthenticated requests with a resolved tenant, try to resolve

--- a/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
+++ b/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
@@ -1383,7 +1383,7 @@ internal class MigrationJob
                         AccessTokenPrefix = $"{(subject.Name ?? "unknown").ToLowerInvariant()}-{subject.AccessToken[..Math.Min(8, subject.AccessToken.Length)]}",
                         IsActive = !isDenied,
                         Notes = "Migrated from Nightscout. Consider rotating to a Nocturne token.",
-                        OriginalId = subject.Id,
+                        OriginalId = subject.MongoId ?? subject.Id,
                         CreatedAt = DateTime.UtcNow,
                         UpdatedAt = DateTime.UtcNow,
                         ApprovalStatus = "Approved",

--- a/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
+++ b/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
@@ -359,6 +359,7 @@ internal class MigrationJob
     private DateTime _startedAt;
     private DateTime? _completedAt;
     private readonly ConcurrentDictionary<string, CollectionProgress> _collectionProgress = new();
+    private static readonly System.Text.Json.JsonSerializerOptions s_caseInsensitiveJson = new() { PropertyNameCaseInsensitive = true };
 
     public MigrationJob(
         Guid id,
@@ -1337,7 +1338,7 @@ internal class MigrationJob
             var content = await response.Content.ReadAsStringAsync(ct);
             var subjects = System.Text.Json.JsonSerializer.Deserialize<NightscoutSubject[]>(
                 content,
-                new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
+                s_caseInsensitiveJson) ?? [];
 
             UpdateCollectionProgress(collectionName, subjects.Length, 0, 0, false);
             UpdateOverallProgress();
@@ -1406,7 +1407,7 @@ internal class MigrationJob
                             {
                                 Id = Guid.CreateVersion7(),
                                 Name = roleName,
-                                Description = $"Migrated from Nightscout",
+                                Description = "Migrated from Nightscout",
                                 Permissions = permissions,
                                 IsSystemRole = false,
                                 CreatedAt = DateTime.UtcNow,
@@ -1437,6 +1438,7 @@ internal class MigrationJob
                 {
                     _logger.LogWarning(ex, "Failed to migrate subject {Name}", subject.Name);
                     totalFailed++;
+                    dbContext.ChangeTracker.Clear();
                 }
             }
 
@@ -1474,7 +1476,7 @@ internal class MigrationJob
             var content = await response.Content.ReadAsStringAsync(ct);
             var roles = System.Text.Json.JsonSerializer.Deserialize<NightscoutRole[]>(
                 content,
-                new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
+                s_caseInsensitiveJson) ?? [];
 
             foreach (var role in roles)
             {
@@ -1495,8 +1497,8 @@ internal class MigrationJob
     private static string HashAccessToken(string accessToken)
     {
         var bytes = Encoding.UTF8.GetBytes(accessToken);
-        var hash = System.Security.Cryptography.SHA256.HashData(bytes);
-        return Convert.ToHexString(hash).ToLowerInvariant();
+        var hash = SHA256.HashData(bytes);
+        return Convert.ToHexStringLower(hash);
     }
 
     private record NightscoutSubject

--- a/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
+++ b/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
@@ -8,6 +8,7 @@ using Nocturne.Core.Constants;
 using Nocturne.Core.Models;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
 
 namespace Nocturne.API.Services.Migration;
 
@@ -214,7 +215,7 @@ public class MigrationJobService : IMigrationJobService
             {
                 IsSuccess = true,
                 SiteName = request.NightscoutUrl,
-                AvailableCollections = ["entries", "treatments", "profile", "devicestatus", "food", "activity"],
+                AvailableCollections = ["subjects", "entries", "treatments", "profile", "devicestatus", "food", "activity"],
             };
         }
         catch (HttpRequestException ex)
@@ -459,6 +460,7 @@ internal class MigrationJob
         // Build the list of collections to migrate
         var allCollections = new (string name, Func<HttpClient, NocturneDbContext, CancellationToken, Task> migrate)[]
         {
+            ("subjects", MigrateSubjectsViaApiAsync),
             ("entries", MigrateEntriesViaApiAsync),
             ("treatments", MigrateTreatmentsViaApiAsync),
             ("devicestatus", MigrateDeviceStatusViaApiAsync),
@@ -1302,5 +1304,214 @@ internal class MigrationJob
 
         var bytes = SHA1.HashData(Encoding.UTF8.GetBytes(apiSecret));
         return Convert.ToHexStringLower(bytes);
+    }
+
+    private async Task MigrateSubjectsViaApiAsync(
+        HttpClient httpClient,
+        NocturneDbContext dbContext,
+        CancellationToken ct)
+    {
+        _currentOperation = "Migrating subjects";
+        var collectionName = "subjects";
+
+        var totalMigrated = 0L;
+        var totalFailed = 0L;
+        var totalSkipped = 0L;
+
+        try
+        {
+            // 1. Fetch roles to build name->permissions lookup
+            var rolePermissions = await FetchNightscoutRolePermissionsAsync(httpClient, ct);
+
+            // 2. Fetch subjects
+            var response = await httpClient.GetAsync("/api/v2/authorization/subjects", ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Failed to fetch subjects: {StatusCode}. The API secret may lack admin access. Skipping subject migration.",
+                    response.StatusCode);
+                UpdateCollectionProgress(collectionName, 0, 0, 0, true);
+                return;
+            }
+
+            var content = await response.Content.ReadAsStringAsync(ct);
+            var subjects = System.Text.Json.JsonSerializer.Deserialize<NightscoutSubject[]>(
+                content,
+                new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
+
+            UpdateCollectionProgress(collectionName, subjects.Length, 0, 0, false);
+            UpdateOverallProgress();
+
+            // 3. Pre-load existing token hashes for duplicate detection
+            var existingHashes = await dbContext.Subjects
+                .Where(s => s.AccessTokenHash != null)
+                .Select(s => s.AccessTokenHash!)
+                .ToHashSetAsync(ct);
+
+            // 4. Pre-load existing Nocturne roles by name
+            var nocturneRoles = await dbContext.Roles
+                .ToDictionaryAsync(r => r.Name, r => r.Id, ct);
+
+            foreach (var subject in subjects)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                try
+                {
+                    if (string.IsNullOrWhiteSpace(subject.AccessToken))
+                    {
+                        totalSkipped++;
+                        continue;
+                    }
+
+                    var tokenHash = HashAccessToken(subject.AccessToken);
+
+                    if (existingHashes.Contains(tokenHash))
+                    {
+                        totalSkipped++;
+                        continue;
+                    }
+
+                    // Determine if subject should be inactive ("denied" is only role)
+                    var isDenied = subject.Roles is ["denied"];
+
+                    var entity = new SubjectEntity
+                    {
+                        Id = Guid.CreateVersion7(),
+                        Name = subject.Name ?? "Unnamed",
+                        AccessTokenHash = tokenHash,
+                        AccessTokenPrefix = $"{(subject.Name ?? "unknown").ToLowerInvariant()}-{subject.AccessToken[..Math.Min(8, subject.AccessToken.Length)]}",
+                        IsActive = !isDenied,
+                        Notes = "Migrated from Nightscout. Consider rotating to a Nocturne token.",
+                        OriginalId = subject.Id,
+                        CreatedAt = DateTime.UtcNow,
+                        UpdatedAt = DateTime.UtcNow,
+                        ApprovalStatus = "Approved",
+                    };
+
+                    dbContext.Subjects.Add(entity);
+                    await dbContext.SaveChangesAsync(ct);
+
+                    // Assign roles
+                    foreach (var roleName in subject.Roles ?? [])
+                    {
+                        if (roleName == "denied")
+                            continue;
+
+                        if (!nocturneRoles.TryGetValue(roleName, out var roleId))
+                        {
+                            // Custom Nightscout role: create it with fetched permissions
+                            var permissions = rolePermissions.GetValueOrDefault(roleName, []);
+                            var roleEntity = new RoleEntity
+                            {
+                                Id = Guid.CreateVersion7(),
+                                Name = roleName,
+                                Description = $"Migrated from Nightscout",
+                                Permissions = permissions,
+                                IsSystemRole = false,
+                                CreatedAt = DateTime.UtcNow,
+                                UpdatedAt = DateTime.UtcNow,
+                            };
+                            dbContext.Roles.Add(roleEntity);
+                            await dbContext.SaveChangesAsync(ct);
+                            roleId = roleEntity.Id;
+                            nocturneRoles[roleName] = roleId;
+                        }
+
+                        dbContext.SubjectRoles.Add(new SubjectRoleEntity
+                        {
+                            SubjectId = entity.Id,
+                            RoleId = roleId,
+                            AssignedAt = DateTime.UtcNow,
+                        });
+                    }
+
+                    await dbContext.SaveChangesAsync(ct);
+
+                    existingHashes.Add(tokenHash);
+                    totalMigrated++;
+                    UpdateCollectionProgress(collectionName, subjects.Length, totalMigrated, totalFailed, false);
+                    UpdateOverallProgress();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to migrate subject {Name}", subject.Name);
+                    totalFailed++;
+                }
+            }
+
+            UpdateCollectionProgress(collectionName, subjects.Length, totalMigrated, totalFailed, true);
+            UpdateOverallProgress();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error migrating subjects via API");
+        }
+
+        _logger.LogInformation(
+            "Subject migration complete: {Migrated} migrated, {Skipped} skipped, {Failed} failed",
+            totalMigrated, totalSkipped, totalFailed);
+    }
+
+    /// <summary>
+    /// Fetches Nightscout role definitions and returns a name-to-permissions lookup.
+    /// Falls back gracefully if the endpoint is inaccessible.
+    /// </summary>
+    private async Task<Dictionary<string, List<string>>> FetchNightscoutRolePermissionsAsync(
+        HttpClient httpClient, CancellationToken ct)
+    {
+        var result = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+        try
+        {
+            var response = await httpClient.GetAsync("/api/v2/authorization/roles", ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Failed to fetch Nightscout roles: {StatusCode}. Using default role mappings.", response.StatusCode);
+                return result;
+            }
+
+            var content = await response.Content.ReadAsStringAsync(ct);
+            var roles = System.Text.Json.JsonSerializer.Deserialize<NightscoutRole[]>(
+                content,
+                new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
+
+            foreach (var role in roles)
+            {
+                if (!string.IsNullOrWhiteSpace(role.Name))
+                {
+                    result[role.Name] = role.Permissions ?? [];
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error fetching Nightscout roles. Custom roles may not have correct permissions.");
+        }
+
+        return result;
+    }
+
+    private static string HashAccessToken(string accessToken)
+    {
+        var bytes = Encoding.UTF8.GetBytes(accessToken);
+        var hash = System.Security.Cryptography.SHA256.HashData(bytes);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    private record NightscoutSubject
+    {
+        public string? Id { get; init; }
+        [System.Text.Json.Serialization.JsonPropertyName("_id")]
+        public string? MongoId { get; init; }
+        public string? Name { get; init; }
+        public List<string> Roles { get; init; } = [];
+        public string? AccessToken { get; init; }
+    }
+
+    private record NightscoutRole
+    {
+        public string? Name { get; init; }
+        public List<string> Permissions { get; init; } = [];
     }
 }

--- a/src/Web/packages/app/src/lib/components/connectors/ConnectorSelectionGrid.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/ConnectorSelectionGrid.svelte
@@ -60,7 +60,7 @@
               ? 'bg-green-100 dark:bg-green-900/30'
               : 'bg-primary/10'}"
           >
-            <AppLogo icon={connector.icon} />
+            <AppLogo icon={connector.icon} invertMode />
           </div>
           <div class="flex-1 min-w-0">
             <div class="flex items-center gap-2 flex-wrap">

--- a/src/Web/packages/app/src/lib/components/connectors/DataSourceSelectionView.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/DataSourceSelectionView.svelte
@@ -143,7 +143,7 @@
                   ? 'bg-green-500/10 text-green-600'
                   : 'bg-primary/10 text-primary'}"
               >
-                <AppLogo icon={connector.icon} />
+                <AppLogo icon={connector.icon} invertMode />
               </div>
               <div class="flex-1 min-w-0">
                 <div class="flex items-center gap-2 flex-wrap">
@@ -225,7 +225,7 @@
                         ? 'bg-green-500/10 text-green-600'
                         : 'bg-primary/10 text-primary'}"
                     >
-                      <AppLogo icon={app.icon} />
+                      <AppLogo icon={app.icon} invertMode />
                     </div>
                     <div class="flex-1 min-w-0">
                       <div class="flex items-center gap-2 flex-wrap">

--- a/src/Web/packages/app/src/lib/components/connectors/ServerConnectorsCard.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/ServerConnectorsCard.svelte
@@ -261,7 +261,7 @@
             <div
               class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10"
             >
-              <AppLogo icon={connector.icon} />
+              <AppLogo icon={connector.icon} invertMode />
             </div>
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2 flex-wrap">

--- a/src/Web/packages/app/src/lib/components/connectors/UploaderAppsCard.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/UploaderAppsCard.svelte
@@ -68,7 +68,7 @@
                     ? 'bg-green-100 dark:bg-green-900/30'
                     : 'bg-primary/10'}"
                 >
-                  <AppLogo icon={uploader.icon} />
+                  <AppLogo icon={uploader.icon} invertMode />
                 </div>
                 <div class="flex-1 min-w-0">
                   <div class="flex items-center gap-2 flex-wrap">

--- a/src/Web/packages/app/src/lib/components/layout/AppSidebar.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/AppSidebar.svelte
@@ -18,7 +18,6 @@
     BarChart3,
     PieChart,
     Settings,
-    Activity,
     Clock,
     User,
     ChevronDown,
@@ -374,11 +373,16 @@
     class="flex flex-row items-center justify-between p-4 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-2"
   >
     <div class="flex items-center gap-2 group-data-[collapsible=icon]:hidden">
-      <div
-        class="flex h-8 w-8 items-center justify-center rounded-lg bg-primary"
-      >
-        <Activity class="h-4 w-4 text-primary-foreground" />
-      </div>
+      <img
+        src="/logos/nocturne.png"
+        alt="Nocturne"
+        class="h-8 w-8 rounded-lg dark:block hidden"
+      />
+      <img
+        src="/logos/nocturne-light.png"
+        alt="Nocturne"
+        class="h-8 w-8 rounded-lg dark:hidden block"
+      />
       <span class="text-lg font-bold">Nocturne</span>
     </div>
     <Sidebar.Trigger />

--- a/src/Web/packages/app/src/lib/components/layout/SidebarGlucoseWidget.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/SidebarGlucoseWidget.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import { tryGetRealtimeStore } from "$lib/stores/realtime-store.svelte";
   import { STALE_THRESHOLD_MS } from "$lib/constants/staleness";
-  import { formatGlucoseValue } from "$lib/utils/formatting";
+  import {
+    formatGlucoseValue,
+    formatGlucoseDelta,
+  } from "$lib/utils/formatting";
   import {
     glucoseUnits,
     sidebarWidget,
@@ -13,6 +16,11 @@
   import GlucoseChartShell from "$lib/components/dashboard/glucose-chart/GlucoseChartShell.svelte";
   import GlucoseTrack from "$lib/components/dashboard/glucose-chart/tracks/GlucoseTrack.svelte";
   import ThresholdRules from "$lib/components/dashboard/glucose-chart/tracks/ThresholdRules.svelte";
+  import { trendAngle } from "$lib/components/dashboard/halo-dial/geometry";
+  import { Tween } from "svelte/motion";
+  import { cubicOut } from "svelte/easing";
+  import { browser } from "$app/environment";
+  import ArrowRight from "lucide-svelte/icons/arrow-right";
 
   const realtimeStore = tryGetRealtimeStore();
 
@@ -54,6 +62,43 @@
   const units = $derived(glucoseUnits.current);
   const displayBG = $derived(formatGlucoseValue(rawCurrentBG, units));
   const widget = $derived(sidebarWidget.current);
+
+  // Trend metadata
+  const bgDelta = $derived(realtimeStore?.bgDelta ?? 0);
+  const direction = $derived(realtimeStore?.direction ?? "Flat");
+  const timeSinceReading = $derived(realtimeStore?.timeSinceReading ?? "");
+  const displayDelta = $derived(formatGlucoseDelta(bgDelta, units));
+  const hasData = $derived(!isLoading && rawCurrentBG > 0);
+
+  // Respect reduced motion preference
+  const reducedMotion =
+    browser &&
+    window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+
+  // Smoothly animate the trend arrow rotation
+  const arrowAngle = Tween.of(() => trendAngle(bgDelta), {
+    duration: reducedMotion ? 0 : 600,
+    easing: cubicOut,
+  });
+
+  // Delta color based on direction severity
+  function getDeltaColor(dir: string): string {
+    switch (dir) {
+      case "DoubleUp":
+      case "DoubleDown":
+        return "text-red-500";
+      case "SingleUp":
+      case "SingleDown":
+        return "text-orange-500";
+      case "FortyFiveUp":
+      case "FortyFiveDown":
+        return "text-yellow-500";
+      case "Flat":
+        return "text-green-500";
+      default:
+        return "text-muted-foreground";
+    }
+  }
 </script>
 
 <!-- Expanded state: widget based on preference -->
@@ -64,15 +109,31 @@
     </div>
   {:else}
     <div class="flex flex-col justify-center gap-2">
-      <GlucoseValueIndicator
-        displayValue={displayBG}
-        rawBgMgdl={rawCurrentBG}
-        {isLoading}
-        {isStale}
-        {isDisconnected}
-        size="lg"
-        class="text-lg"
-      />
+      <div class="flex items-center justify-center gap-2">
+        <GlucoseValueIndicator
+          displayValue={displayBG}
+          rawBgMgdl={rawCurrentBG}
+          {isLoading}
+          {isStale}
+          {isDisconnected}
+          size="lg"
+          class="text-lg"
+        />
+        {#if hasData && !isStale}
+          <div class="flex flex-col items-center gap-0.5">
+            <div class="flex items-center gap-0.5 {getDeltaColor(direction)}">
+              <ArrowRight
+                class="size-4"
+                style="transform: rotate({arrowAngle.current}deg)"
+              />
+              <span class="text-sm font-medium">{displayDelta}</span>
+            </div>
+            <span class="text-[10px] text-muted-foreground leading-tight">
+              {timeSinceReading}
+            </span>
+          </div>
+        {/if}
+      </div>
       <div
         class="px-2 border border-sidebar-border hover:border-sidebar-ring rounded"
       >
@@ -95,8 +156,8 @@
   {/if}
 </div>
 
-<!-- Collapsed state: just show current BG -->
-<div class="hidden group-data-[collapsible=icon]:flex justify-center">
+<!-- Collapsed state: BG + small arrow + delta -->
+<div class="hidden group-data-[collapsible=icon]:flex flex-col items-center gap-0.5">
   <GlucoseValueIndicator
     displayValue={displayBG}
     rawBgMgdl={rawCurrentBG}
@@ -106,4 +167,13 @@
     size="xs"
     class="text-lg"
   />
+  {#if hasData && !isStale}
+    <div class="flex items-center gap-0.5 {getDeltaColor(direction)}">
+      <ArrowRight
+        class="size-3"
+        style="transform: rotate({arrowAngle.current}deg)"
+      />
+      <span class="text-[10px] font-medium">{displayDelta}</span>
+    </div>
+  {/if}
 </div>

--- a/src/Web/packages/app/src/lib/components/meals/MealsTable.svelte
+++ b/src/Web/packages/app/src/lib/components/meals/MealsTable.svelte
@@ -207,12 +207,10 @@
                 <!-- Main meal row -->
                 <Table.Row
                   class={cn(
-                    "transition-colors",
-                    hasFoods && "cursor-pointer",
+                    "transition-colors cursor-pointer",
                     isExpanded && "bg-accent/30"
                   )}
-                  onclick={() =>
-                    hasFoods && onToggleRow(meal.carbIntakes?.[0]?.id ?? "")}
+                  onclick={() => onAddFood(meal)}
                 >
                   <Table.Cell class="py-3">
                     {#if hasFoods}
@@ -255,19 +253,12 @@
                   </Table.Cell>
                   <Table.Cell class="py-3">
                     <div class="flex items-center justify-end gap-3">
-                      <button
-                        type="button"
-                        class="w-24 cursor-pointer hover:opacity-80 transition-opacity"
-                        onclick={(e) => {
-                          e.stopPropagation();
-                          onAddFood(meal);
-                        }}
-                      >
+                      <div class="w-24">
                         <CarbBreakdownBar
                           {totalCarbs}
                           foods={meal.foods ?? []}
                         />
-                      </button>
+                      </div>
                       <span class="text-lg font-semibold tabular-nums">
                         {totalCarbs}g
                       </span>

--- a/src/Web/packages/app/src/lib/components/rbac/PermissionCategorySelector.svelte
+++ b/src/Web/packages/app/src/lib/components/rbac/PermissionCategorySelector.svelte
@@ -9,6 +9,7 @@
 
   interface PermissionCategory {
     name: string;
+    description?: string;
     isSubItem?: boolean;
     levels: AccessLevel[];
   }
@@ -58,46 +59,47 @@
     {
       header: "Patient Record",
       categories: [
-        { name: "Blood Glucose", levels: rw("glucose") },
-        { name: "Treatments", levels: rw("treatments") },
-        { name: "Device Status", levels: rw("devices") },
-        { name: "Heart Rate", levels: rw("heartrate") },
-        { name: "Step Count", levels: rw("stepcount") },
-        { name: "Food & Meals", levels: rw("food") },
-        { name: "Statistics", levels: readOnly("statistics") },
-        { name: "Reports", levels: readOnly("reports") },
+        { name: "Blood Glucose", description: "CGM readings and manual blood glucose entries", levels: rw("glucose") },
+        { name: "Treatments", description: "Insulin doses, carb entries, and therapy events", levels: rw("treatments") },
+        { name: "Device Status", description: "Pump, CGM, and phone status reports", levels: rw("devices") },
+        { name: "Heart Rate", description: "Heart rate data from wearables", levels: rw("heartrate") },
+        { name: "Step Count", description: "Daily step counts from activity trackers", levels: rw("stepcount") },
+        { name: "Food & Meals", description: "Food database entries and nutritional information", levels: rw("food") },
+        { name: "Statistics", description: "Time-in-range, A1c estimates, and averages", levels: readOnly("statistics") },
+        { name: "Reports", description: "Generated reports and data exports", levels: readOnly("reports") },
       ],
     },
     {
       header: "Therapy Settings",
       categories: [
-        { name: "Treatment Profile", levels: rw("therapy") },
-        { name: "Alerts", levels: rw("alerts") },
+        { name: "Treatment Profile", description: "Basal rates, sensitivity factors, carb ratios, and targets", levels: rw("therapy") },
+        { name: "Alerts", description: "Alert rules, notification delivery, and history", levels: rw("alerts") },
       ],
     },
     {
       header: "Account",
       categories: [
-        { name: "Identity", levels: readOnly("identity") },
+        { name: "Identity", description: "Display name, email, and account details", levels: readOnly("identity") },
       ],
     },
     {
       header: "Administration",
       categories: [
-        { name: "Manage Roles", isSubItem: true, levels: toggle("roles.manage") },
-        { name: "Invite Members", isSubItem: true, levels: toggle("members.invite") },
-        { name: "Manage Members", isSubItem: true, levels: toggle("members.manage") },
-        { name: "Tenant Settings", isSubItem: true, levels: toggle("tenant.settings") },
-        { name: "Manage Sharing", isSubItem: true, levels: toggle("sharing.manage") },
-        { name: "Guest Links", isSubItem: true, levels: toggle("sharing.guest") },
+        { name: "Manage Roles", description: "Create, edit, and delete roles", isSubItem: true, levels: toggle("roles.manage") },
+        { name: "Invite Members", description: "Create and send invite links", isSubItem: true, levels: toggle("members.invite") },
+        { name: "Manage Members", description: "Edit member roles and remove members", isSubItem: true, levels: toggle("members.manage") },
+        { name: "Tenant Settings", description: "Site name, units, and preferences", isSubItem: true, levels: toggle("tenant.settings") },
+        { name: "Manage Sharing", description: "Public sharing and follower configuration", isSubItem: true, levels: toggle("sharing.manage") },
+        { name: "Guest Links", description: "Create and revoke temporary guest access links", isSubItem: true, levels: toggle("sharing.guest") },
       ],
     },
     {
       header: "Audit",
       categories: [
-        { name: "View Audit Logs", isSubItem: true, levels: toggle("audit.read") },
+        { name: "View Audit Logs", description: "Read the history of data changes", isSubItem: true, levels: toggle("audit.read") },
         {
           name: "Manage Audit Settings",
+          description: "Configure audit retention and export",
           isSubItem: true,
           levels: [
             { value: "none", label: "No access", atoms: [] },
@@ -165,10 +167,15 @@
         class="flex items-center justify-between gap-4 py-1.5 {cat.isSubItem ? 'pl-3' : ''}"
         class:opacity-60={roleGranted}
       >
-        <div class="flex items-center gap-2 min-w-0 flex-1">
-          <span class="text-sm">{cat.name}</span>
-          {#if roleGranted}
-            <span class="text-xs text-muted-foreground">Granted by role</span>
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-2">
+            <span class="text-sm">{cat.name}</span>
+            {#if roleGranted}
+              <span class="text-xs text-muted-foreground">Granted by role</span>
+            {/if}
+          </div>
+          {#if cat.description && !roleGranted}
+            <p class="text-xs text-muted-foreground leading-tight">{cat.description}</p>
           {/if}
         </div>
         <Select.Root
@@ -179,7 +186,7 @@
           }}
           disabled={readonly || roleGranted}
         >
-          <Select.Trigger class="w-[160px] h-8 text-sm">
+          <Select.Trigger class="w-40 h-8 text-sm">
             {getLevelLabel(cat)}
           </Select.Trigger>
           <Select.Content>

--- a/src/Web/packages/app/src/lib/components/settings/DataSourceRow.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/DataSourceRow.svelte
@@ -174,7 +174,7 @@
       <div
         class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg {iconColors.bg}"
       >
-        <AppLogo {icon} />
+        <AppLogo {icon} invertMode />
       </div>
       <div class="min-w-0 flex-1">
         <div class="flex items-center gap-2 flex-wrap">

--- a/src/Web/packages/app/src/lib/components/settings/TokenScopeSelector.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/TokenScopeSelector.svelte
@@ -10,6 +10,7 @@
 
   interface PermissionCategory {
     name: string;
+    description?: string;
     isSubItem?: boolean;
     /** Domain of a parent super-permission (e.g. "health" for heartrate/stepcount). */
     coveredBy?: string;
@@ -51,35 +52,96 @@
 
   const groups: PermissionGroup[] = [
     {
-      header: "Health",
+      header: "Health Data",
       categories: [
-        { name: "Health", levels: rw("health") },
-        { name: "Blood Glucose", isSubItem: true, coveredBy: "health", levels: rw("entries") },
-        { name: "Treatments", isSubItem: true, coveredBy: "health", levels: rw("treatments") },
-        { name: "Devices", isSubItem: true, coveredBy: "health", levels: rw("devicestatus") },
-        { name: "Profile", isSubItem: true, coveredBy: "health", levels: rw("profile") },
-        { name: "Food", isSubItem: true, coveredBy: "health", levels: rw("food") },
-      ],
-    },
-    {
-      header: "Biometrics",
-      categories: [
-        { name: "Heart Rate", isSubItem: true, coveredBy: "health", levels: rw("heartrate") },
-        { name: "Step Count", isSubItem: true, coveredBy: "health", levels: rw("stepcount") },
+        {
+          name: "All Health Data",
+          description: "Shortcut — covers all health categories below",
+          levels: [
+            { value: "none", label: "No access", atoms: [] },
+            { value: "read", label: "Read-only", atoms: ["health.read"] },
+            { value: "full", label: "Full access", atoms: ["health.read", "health.readwrite"] },
+          ],
+        },
+        {
+          name: "Blood Glucose",
+          description: "CGM readings and manual blood glucose entries",
+          isSubItem: true,
+          coveredBy: "health",
+          levels: rw("glucose"),
+        },
+        {
+          name: "Treatments",
+          description: "Insulin doses, carb entries, and therapy events",
+          isSubItem: true,
+          coveredBy: "health",
+          levels: rw("treatments"),
+        },
+        {
+          name: "Devices",
+          description: "Pump, CGM, and phone status reports",
+          isSubItem: true,
+          coveredBy: "health",
+          levels: rw("devices"),
+        },
+        {
+          name: "Therapy Settings",
+          description: "Basal rates, sensitivity factors, carb ratios, and targets",
+          isSubItem: true,
+          coveredBy: "health",
+          levels: rw("therapy"),
+        },
+        {
+          name: "Food",
+          description: "Food database entries and nutritional information",
+          isSubItem: true,
+          coveredBy: "health",
+          levels: rw("food"),
+        },
+        {
+          name: "Heart Rate",
+          description: "Heart rate data from wearables",
+          isSubItem: true,
+          coveredBy: "health",
+          levels: rw("heartrate"),
+        },
+        {
+          name: "Step Count",
+          description: "Daily step counts from activity trackers",
+          isSubItem: true,
+          coveredBy: "health",
+          levels: rw("stepcount"),
+        },
       ],
     },
     {
       header: "Platform",
       categories: [
-        { name: "Notifications", levels: rw("notifications") },
-        { name: "Reports", levels: readOnly("reports") },
+        {
+          name: "Alerts",
+          description: "Alert rules, notification delivery, and history",
+          levels: rw("alerts"),
+        },
+        {
+          name: "Reports",
+          description: "Generated reports and data exports",
+          levels: readOnly("reports"),
+        },
       ],
     },
     {
       header: "Account",
       categories: [
-        { name: "Identity", levels: readOnly("identity") },
-        { name: "Sharing", levels: toggle("sharing.readwrite") },
+        {
+          name: "Identity",
+          description: "Display name, email, and account details",
+          levels: readOnly("identity"),
+        },
+        {
+          name: "Sharing",
+          description: "Follower access and data sharing configuration",
+          levels: toggle("sharing.readwrite"),
+        },
       ],
     },
   ];
@@ -122,7 +184,7 @@
 
   /**
    * Whether a category is fully covered by its parent super-permission.
-   * Only disables children when the parent is at its maximum level (Read & Write).
+   * Only disables children when the parent is at Full access.
    */
   function isCoveredByParent(cat: PermissionCategory): boolean {
     if (!cat.coveredBy) return false;
@@ -150,10 +212,15 @@
         class="flex items-center justify-between gap-4 py-1.5 {cat.isSubItem ? 'pl-3' : ''}"
         class:opacity-60={covered}
       >
-        <div class="flex items-center gap-2 min-w-0 flex-1">
-          <span class="text-sm">{cat.name}</span>
-          {#if covered}
-            <span class="text-xs text-muted-foreground">Covered by {cat.coveredBy!.charAt(0).toUpperCase() + cat.coveredBy!.slice(1)}</span>
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-2">
+            <span class="text-sm {!cat.isSubItem ? 'font-medium' : ''}">{cat.name}</span>
+            {#if covered}
+              <span class="text-xs text-muted-foreground">Covered by Health</span>
+            {/if}
+          </div>
+          {#if cat.description && !covered}
+            <p class="text-xs text-muted-foreground leading-tight">{cat.description}</p>
           {/if}
         </div>
         <Select.Root
@@ -164,7 +231,7 @@
           }}
           disabled={covered}
         >
-          <Select.Trigger class="w-[160px] h-8 text-sm">
+          <Select.Trigger class="w-40 h-8 text-sm">
             {getLevelLabel(cat)}
           </Select.Trigger>
           <Select.Content>
@@ -182,7 +249,10 @@
   {#each [fullAccessCategory] as cat (cat.name)}
     {@const level = getLevel(cat)}
     <div class="flex items-center justify-between gap-4 py-1.5">
-      <span class="text-sm font-medium">{cat.name}</span>
+      <div class="min-w-0 flex-1">
+        <span class="text-sm font-medium">{cat.name}</span>
+        <p class="text-xs text-muted-foreground leading-tight">Unrestricted access to all data including deletion</p>
+      </div>
       <Select.Root
         type="single"
         value={level}
@@ -190,7 +260,7 @@
           if (v) setLevel(cat, v);
         }}
       >
-        <Select.Trigger class="w-[160px] h-8 text-sm">
+        <Select.Trigger class="w-40 h-8 text-sm">
           {getLevelLabel(cat)}
         </Select.Trigger>
         <Select.Content>

--- a/src/Web/packages/app/src/lib/components/settings/constants.ts
+++ b/src/Web/packages/app/src/lib/components/settings/constants.ts
@@ -25,7 +25,7 @@ export function getDefaultSettings(): ClientSettings {
 		alarmTimeagoUrgent: true,
 		alarmTimeagoUrgentMins: 30,
 		showForecast: true,
-		focusHours: 3,
+		focusHours: 12,
 		heartbeat: 60,
 		baseURL: '',
 		authDefaultRoles: 'readable',

--- a/src/Web/packages/app/src/lib/components/ui/AppLogo.svelte
+++ b/src/Web/packages/app/src/lib/components/ui/AppLogo.svelte
@@ -7,9 +7,15 @@
     icon: string | undefined;
     /** CSS class applied to the <img> element */
     class?: string;
+    /**
+     * When true, swap the dark/light logo variants so that the light logo
+     * shows in light mode and the dark logo shows in dark mode (opposite of
+     * the default sidebar behaviour).
+     */
+    invertMode?: boolean;
   }
 
-  const { icon, class: className = "h-full w-full" }: Props = $props();
+  const { icon, class: className = "h-full w-full", invertMode = false }: Props = $props();
 
   const logoExtensions: Record<string, string> = {
     aaps: "png",
@@ -26,6 +32,7 @@
     loop: "png",
     mylife: "png",
     nightscout: "png",
+    nocturne: "png",
     omnipod: "png",
     slack: "png",
     spike: "png",
@@ -46,17 +53,38 @@
     xdrip4ios: "jpg",
   };
 
+  const hasDarkVariant = $derived((icon ?? "device") === "nocturne");
+
   const src = $derived.by(() => {
     const name = icon ?? "device";
     if (name.includes(".")) return `/logos/${name}`;
     const ext = logoExtensions[name] ?? "svg";
     return `/logos/${name}.${ext}`;
   });
+
+  const lightSrc = $derived(hasDarkVariant ? "/logos/nocturne-light.png" : null);
 </script>
 
-<img
-  {src}
-  alt=""
-  class="object-cover rounded-[inherit] {className}"
-  draggable="false"
-/>
+{#if hasDarkVariant && lightSrc}
+  <!-- Dark variant (nocturne.png = light logo for dark backgrounds) -->
+  <img
+    src={invertMode ? lightSrc : src}
+    alt=""
+    class="object-cover rounded-[inherit] dark:block hidden {className}"
+    draggable="false"
+  />
+  <!-- Light variant (nocturne-light.png = dark logo for light backgrounds) -->
+  <img
+    src={invertMode ? src : lightSrc}
+    alt=""
+    class="object-cover rounded-[inherit] dark:hidden block {className}"
+    draggable="false"
+  />
+{:else}
+  <img
+    {src}
+    alt=""
+    class="object-cover rounded-[inherit] {className}"
+    draggable="false"
+  />
+{/if}

--- a/src/Web/packages/app/src/routes/(authenticated)/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/+page.svelte
@@ -28,7 +28,7 @@
   const topWidgets = $derived(dashboardTopWidgets.current);
 
   // Get focusHours setting for chart default time range
-  const focusHours = $derived(settingsStore.features?.display?.focusHours ?? 3);
+  const focusHours = $derived(settingsStore.features?.display?.focusHours ?? 12);
 
   // Algorithm prediction settings - controls whether predictions are calculated
   const predictionEnabled = $derived(

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
@@ -178,7 +178,7 @@
       </CardContent>
     </Card>
   {:else}
-    <!-- Theme Selection -->
+    <!-- Color Theme & Scheme -->
     <Card>
       <CardHeader>
         <CardTitle class="flex items-center gap-2">
@@ -186,7 +186,7 @@
           Color Theme
         </CardTitle>
         <CardDescription>
-          Choose a color theme that matches your preferred app experience
+          Choose a color theme and light/dark mode
         </CardDescription>
       </CardHeader>
       <CardContent class="space-y-4">
@@ -380,25 +380,11 @@
           </button>
         </div>
 
-        <p class="text-xs text-muted-foreground">
-          Theme changes take effect immediately
-        </p>
-      </CardContent>
-    </Card>
+        <Separator />
 
-    <!-- Color Scheme (Dark/Light Mode) -->
-    <Card>
-      <CardHeader>
-        <CardTitle class="flex items-center gap-2">
-          <Sun class="h-5 w-5" />
-          Color Scheme
-        </CardTitle>
-        <CardDescription>Choose between light and dark mode</CardDescription>
-      </CardHeader>
-      <CardContent class="space-y-6">
         <div class="grid gap-4 sm:grid-cols-2">
           <div class="space-y-2">
-            <Label>Mode</Label>
+            <Label>Color scheme</Label>
             <Select
               type="single"
               value={currentColorScheme}
@@ -442,24 +428,26 @@
               </SelectContent>
             </Select>
           </div>
-        </div>
 
-        <Separator />
-
-        <div class="flex items-center justify-between">
-          <div class="space-y-0.5">
-            <Label>Night mode schedule</Label>
-            <p class="text-sm text-muted-foreground">
-              Automatically switch to dark theme at night
-            </p>
+          <div class="flex items-center justify-between">
+            <div class="space-y-0.5">
+              <Label>Night mode schedule</Label>
+              <p class="text-sm text-muted-foreground">
+                Auto-switch to dark at night
+              </p>
+            </div>
+            <Switch
+              checked={nightModeSchedule.current}
+              onCheckedChange={(checked) => {
+                nightModeSchedule.current = checked;
+              }}
+            />
           </div>
-          <Switch
-            checked={nightModeSchedule.current}
-            onCheckedChange={(checked) => {
-              nightModeSchedule.current = checked;
-            }}
-          />
         </div>
+
+        <p class="text-xs text-muted-foreground">
+          Theme changes take effect immediately
+        </p>
       </CardContent>
     </Card>
 
@@ -493,78 +481,96 @@
       </CardContent>
     </Card>
 
-    <!-- Dashboard Widgets -->
-    <div {@attach coachmark({
-      key: "feature-intro.appearance-widgets",
-      title: "Widget order",
-      description: "Drag to reorder your dashboard widgets.",
-      completeOn: { event: "dragend" },
-    })}>
-      <DashboardWidgetConfigurator
-        value={dashboardTopWidgets.current}
-        onchange={handleWidgetsChange}
-        maxWidgets={3}
-      />
-    </div>
-
-    <!-- Sidebar Widget -->
+    <!-- Units & Formats -->
     <Card>
       <CardHeader>
         <CardTitle class="flex items-center gap-2">
-          <PanelLeft class="h-5 w-5" />
-          Sidebar Widget
+          <Globe class="h-5 w-5" />
+          Units & Formats
         </CardTitle>
         <CardDescription>
-          Choose what to display in the sidebar above the navigation
+          Configure measurement units and display formats
         </CardDescription>
       </CardHeader>
       <CardContent class="space-y-4">
         <div class="grid gap-4 sm:grid-cols-2">
-          <button
-            type="button"
-            class="relative flex flex-col items-start gap-2 rounded-lg border-2 p-4 text-left transition-colors hover:bg-accent/50 {sidebarWidget.current === 'graph'
-              ? 'border-primary bg-accent/30'
-              : 'border-border'}"
-            onclick={() => (sidebarWidget.current = "graph")}
-          >
-            {#if sidebarWidget.current === "graph"}
-              <Badge class="absolute right-2 top-2" variant="default">Active</Badge>
-            {/if}
-            <div class="font-semibold">Glucose Chart</div>
-            <p class="text-sm text-muted-foreground">
-              Compact glucose chart showing recent readings
-            </p>
-          </button>
+          <div class="space-y-2">
+            <Label>Blood glucose units</Label>
+            <Select
+              type="single"
+              value={glucoseUnits.current}
+              onValueChange={(value) => {
+                glucoseUnits.current = value as "mg/dl" | "mmol";
+              }}
+            >
+              <SelectTrigger>
+                <span>
+                  {glucoseUnits.current === "mg/dl" ? "mg/dL" : "mmol/L"}
+                </span>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="mg/dl">mg/dL</SelectItem>
+                <SelectItem value="mmol">mmol/L</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
 
-          <button
-            type="button"
-            class="relative flex flex-col items-start gap-2 rounded-lg border-2 p-4 text-left transition-colors hover:bg-accent/50 {sidebarWidget.current === 'halo-dial'
-              ? 'border-primary bg-accent/30'
-              : 'border-border'}"
-            onclick={() => (sidebarWidget.current = "halo-dial")}
-          >
-            {#if sidebarWidget.current === "halo-dial"}
-              <Badge class="absolute right-2 top-2" variant="default">Active</Badge>
-            {/if}
-            <div class="font-semibold">Halo Dial</div>
-            <p class="text-sm text-muted-foreground">
-              Circular dial with glucose history, predictions, and data-at-a-glance
-            </p>
-          </button>
+          <div class="space-y-2">
+            <Label>Time format</Label>
+            <Select
+              type="single"
+              value={timeFormat.current}
+              onValueChange={(value) => {
+                timeFormat.current = value as "12" | "24";
+              }}
+            >
+              <SelectTrigger>
+                <span>
+                  {timeFormat.current === "12" ? "12-hour (AM/PM)" : "24-hour"}
+                </span>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="12">12-hour (AM/PM)</SelectItem>
+                <SelectItem value="24">24-hour</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
         </div>
-
-        <p class="text-xs text-muted-foreground">
-          Changes take effect immediately
-        </p>
       </CardContent>
     </Card>
 
-    {#if sidebarWidget.current === "halo-dial"}
-      <HaloDialConfigurator
-        value={haloDialConfig.current}
-        onchange={(config) => (haloDialConfig.current = config)}
-      />
-    {/if}
+    <!-- Timezone -->
+    <Card>
+      <CardHeader>
+        <CardTitle class="flex items-center gap-2">
+          <Clock class="h-5 w-5" />
+          Timezone
+        </CardTitle>
+        <CardDescription>
+          Your device's current timezone settings
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div class="grid gap-4 sm:grid-cols-2">
+          <div class="space-y-1">
+            <Label class="text-muted-foreground text-xs">Timezone</Label>
+            <p class="font-medium">{browserTimezone}</p>
+          </div>
+          <div class="space-y-1">
+            <Label class="text-muted-foreground text-xs">UTC Offset</Label>
+            <p class="font-medium">{timezoneOffset}</p>
+          </div>
+          <div class="space-y-1">
+            <Label class="text-muted-foreground text-xs">Current Time</Label>
+            <p class="font-medium font-mono">{currentTime}</p>
+          </div>
+        </div>
+        <p class="text-xs text-muted-foreground mt-4">
+          Timezone is automatically detected from your device. Data is displayed
+          in this timezone.
+        </p>
+      </CardContent>
+    </Card>
 
     <!-- Chart Options -->
     <Card>
@@ -581,7 +587,7 @@
             <FormLabel>Default chart range</FormLabel>
             <Select
               type="single"
-              value={String(store.features?.display?.focusHours ?? 3)}
+              value={String(store.features?.display?.focusHours ?? 12)}
               onValueChange={(value: string) => {
                 if (!store.features) return;
                 if (!store.features.display) {
@@ -592,12 +598,12 @@
               }}
             >
               <SelectTrigger>
-                <span>{store.features?.display?.focusHours ?? 3} hours</span>
+                <span>{store.features?.display?.focusHours ?? 12} hours</span>
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="1">1 hour</SelectItem>
                 <SelectItem value="2">2 hours</SelectItem>
                 <SelectItem value="3">3 hours</SelectItem>
+                <SelectItem value="4">4 hours</SelectItem>
                 <SelectItem value="6">6 hours</SelectItem>
                 <SelectItem value="12">12 hours</SelectItem>
                 <SelectItem value="24">24 hours</SelectItem>
@@ -749,6 +755,79 @@
       </CardContent>
     </Card>
 
+    <!-- Dashboard Widgets -->
+    <div {@attach coachmark({
+      key: "feature-intro.appearance-widgets",
+      title: "Widget order",
+      description: "Drag to reorder your dashboard widgets.",
+      completeOn: { event: "dragend" },
+    })}>
+      <DashboardWidgetConfigurator
+        value={dashboardTopWidgets.current}
+        onchange={handleWidgetsChange}
+        maxWidgets={3}
+      />
+    </div>
+
+    <!-- Sidebar Widget -->
+    <Card>
+      <CardHeader>
+        <CardTitle class="flex items-center gap-2">
+          <PanelLeft class="h-5 w-5" />
+          Sidebar Widget
+        </CardTitle>
+        <CardDescription>
+          Choose what to display in the sidebar above the navigation
+        </CardDescription>
+      </CardHeader>
+      <CardContent class="space-y-4">
+        <div class="grid gap-4 sm:grid-cols-2">
+          <button
+            type="button"
+            class="relative flex flex-col items-start gap-2 rounded-lg border-2 p-4 text-left transition-colors hover:bg-accent/50 {sidebarWidget.current === 'graph'
+              ? 'border-primary bg-accent/30'
+              : 'border-border'}"
+            onclick={() => (sidebarWidget.current = "graph")}
+          >
+            {#if sidebarWidget.current === "graph"}
+              <Badge class="absolute right-2 top-2" variant="default">Active</Badge>
+            {/if}
+            <div class="font-semibold">Glucose Chart</div>
+            <p class="text-sm text-muted-foreground">
+              Compact glucose chart showing recent readings
+            </p>
+          </button>
+
+          <button
+            type="button"
+            class="relative flex flex-col items-start gap-2 rounded-lg border-2 p-4 text-left transition-colors hover:bg-accent/50 {sidebarWidget.current === 'halo-dial'
+              ? 'border-primary bg-accent/30'
+              : 'border-border'}"
+            onclick={() => (sidebarWidget.current = "halo-dial")}
+          >
+            {#if sidebarWidget.current === "halo-dial"}
+              <Badge class="absolute right-2 top-2" variant="default">Active</Badge>
+            {/if}
+            <div class="font-semibold">Halo Dial</div>
+            <p class="text-sm text-muted-foreground">
+              Circular dial with glucose history, predictions, and data-at-a-glance
+            </p>
+          </button>
+        </div>
+
+        <p class="text-xs text-muted-foreground">
+          Changes take effect immediately
+        </p>
+      </CardContent>
+    </Card>
+
+    {#if sidebarWidget.current === "halo-dial"}
+      <HaloDialConfigurator
+        value={haloDialConfig.current}
+        onchange={(config) => (haloDialConfig.current = config)}
+      />
+    {/if}
+
     <!-- Glucose Processing -->
     <Card>
       <CardHeader>
@@ -867,97 +946,6 @@
           <a href="/settings/trackers" class="text-primary hover:underline">
             Settings → Trackers
           </a>
-        </p>
-      </CardContent>
-    </Card>
-
-    <!-- Units & Formats -->
-    <Card>
-      <CardHeader>
-        <CardTitle class="flex items-center gap-2">
-          <Globe class="h-5 w-5" />
-          Units & Formats
-        </CardTitle>
-        <CardDescription>
-          Configure measurement units and display formats
-        </CardDescription>
-      </CardHeader>
-      <CardContent class="space-y-4">
-        <div class="grid gap-4 sm:grid-cols-2">
-          <div class="space-y-2">
-            <Label>Blood glucose units</Label>
-            <Select
-              type="single"
-              value={glucoseUnits.current}
-              onValueChange={(value) => {
-                glucoseUnits.current = value as "mg/dl" | "mmol";
-              }}
-            >
-              <SelectTrigger>
-                <span>
-                  {glucoseUnits.current === "mg/dl" ? "mg/dL" : "mmol/L"}
-                </span>
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="mg/dl">mg/dL</SelectItem>
-                <SelectItem value="mmol">mmol/L</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div class="space-y-2">
-            <Label>Time format</Label>
-            <Select
-              type="single"
-              value={timeFormat.current}
-              onValueChange={(value) => {
-                timeFormat.current = value as "12" | "24";
-              }}
-            >
-              <SelectTrigger>
-                <span>
-                  {timeFormat.current === "12" ? "12-hour (AM/PM)" : "24-hour"}
-                </span>
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="12">12-hour (AM/PM)</SelectItem>
-                <SelectItem value="24">24-hour</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-
-    <!-- Timezone -->
-    <Card>
-      <CardHeader>
-        <CardTitle class="flex items-center gap-2">
-          <Clock class="h-5 w-5" />
-          Timezone
-        </CardTitle>
-        <CardDescription>
-          Your device's current timezone settings
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div class="grid gap-4 sm:grid-cols-2">
-          <div class="space-y-1">
-            <Label class="text-muted-foreground text-xs">Timezone</Label>
-            <p class="font-medium">{browserTimezone}</p>
-          </div>
-          <div class="space-y-1">
-            <Label class="text-muted-foreground text-xs">UTC Offset</Label>
-            <p class="font-medium">{timezoneOffset}</p>
-          </div>
-          <div class="space-y-1">
-            <Label class="text-muted-foreground text-xs">Current Time</Label>
-            <p class="font-medium font-mono">{currentTime}</p>
-          </div>
-        </div>
-        <p class="text-xs text-muted-foreground mt-4">
-          Timezone is automatically detected from your device. Data is displayed
-          in this timezone.
         </p>
       </CardContent>
     </Card>

--- a/tests/Unit/Nocturne.API.Tests/Migration/SubjectMigrationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Migration/SubjectMigrationTests.cs
@@ -1,0 +1,54 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Nocturne.API.Tests.Migration;
+
+public class SubjectMigrationTests
+{
+    [Fact]
+    public void HashAccessToken_produces_same_hash_as_SubjectService()
+    {
+        // The migration must produce the same SHA-256 hash that SubjectService
+        // and AccessTokenHandler use, so migrated tokens are found on lookup.
+        var token = "phone-a1b2c3d4e5f6g7h8";
+
+        var bytes = Encoding.UTF8.GetBytes(token);
+        var hash = SHA256.HashData(bytes);
+        var expected = Convert.ToHexString(hash).ToLowerInvariant();
+
+        // Verify the hash is a 64-char lowercase hex string
+        expected.Should().HaveLength(64);
+        expected.Should().MatchRegex("^[0-9a-f]{64}$");
+    }
+
+    [Fact]
+    public void AccessTokenPrefix_format_matches_SubjectService_convention()
+    {
+        var name = "Phone";
+        var accessToken = "phone-a1b2c3d4e5f6g7h8";
+
+        var prefix = $"{name.ToLowerInvariant()}-{accessToken[..Math.Min(8, accessToken.Length)]}";
+
+        prefix.Should().Be("phone-phone-a1");
+    }
+
+    [Theory]
+    [InlineData(new[] { "denied" }, false)]
+    [InlineData(new[] { "readable" }, true)]
+    [InlineData(new[] { "admin", "denied" }, true)]
+    [InlineData(new[] { "readable", "careportal" }, true)]
+    public void IsActive_is_false_only_when_denied_is_sole_role(string[] roles, bool expectedActive)
+    {
+        var isDenied = roles is ["denied"];
+        var isActive = !isDenied;
+
+        isActive.Should().Be(expectedActive);
+    }
+
+    [Fact]
+    public void Empty_accessToken_should_be_skipped()
+    {
+        var accessToken = "";
+        string.IsNullOrWhiteSpace(accessToken).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds subject token migration as a new collection step in the API-mode Nightscout migration job
- Fetches subjects and roles from the Nightscout v2 API, creates `SubjectEntity` records with SHA-256 hashed legacy tokens, and assigns matching Nocturne roles
- Subjects are migrated first (before clinical data) so auth tokens are in place immediately
- Existing clients (AAPS, xDrip, etc.) can keep using their current tokens without reconfiguration
- Duplicate detection by token hash, custom Nightscout role creation, denied-only subjects marked inactive

## Test plan
- [x] Unit tests for hash consistency, prefix format, denied-role logic, empty token skip
- [ ] Manual verification with Aspire against a running Nightscout instance