### PR TITLE
feat: add Gluroo Global Connect connector

### DIFF
--- a/nocturne.sln
+++ b/nocturne.sln
@@ -149,6 +149,7 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nocturne.Connectors.Glooko.Tests", "tests\Unit\Nocturne.Connectors.Glooko.Tests\Nocturne.Connectors.Glooko.Tests.csproj", "{BA81EE82-7885-4441-A0FC-45735D9E036E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nocturne.Connectors.Twiist", "src\Connectors\Nocturne.Connectors.Twiist\Nocturne.Connectors.Twiist.csproj", "{D3134BDA-916B-4110-B6FC-96FF568F55A3}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nocturne.Aspire.ScalarBootstrap", "src\Aspire\Nocturne.Aspire.ScalarBootstrap\Nocturne.Aspire.ScalarBootstrap.csproj", "{0DF48F83-F9BC-4F38-9728-17CA95C5FE92}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "E2E", "E2E", "{0EB607AC-6329-6575-AD8B-E5558B048B88}"
@@ -158,6 +159,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nocturne.API.Performance.Tests", "tests\Performance\Nocturne.API.Performance.Tests\Nocturne.API.Performance.Tests.csproj", "{B1A88C7A-F85E-4B99-A8FB-8A7577CD4D6F}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "API", "API", "{81034408-37C8-1011-444E-4C15C2FADA8E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nocturne.Connectors.Gluroo", "src\Connectors\Nocturne.Connectors.Gluroo\Nocturne.Connectors.Gluroo.csproj", "{211B8187-292A-4848-B5FF-488399FADD92}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -781,6 +784,18 @@ Global
 		{B1A88C7A-F85E-4B99-A8FB-8A7577CD4D6F}.Release|x64.Build.0 = Release|Any CPU
 		{B1A88C7A-F85E-4B99-A8FB-8A7577CD4D6F}.Release|x86.ActiveCfg = Release|Any CPU
 		{B1A88C7A-F85E-4B99-A8FB-8A7577CD4D6F}.Release|x86.Build.0 = Release|Any CPU
+		{211B8187-292A-4848-B5FF-488399FADD92}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{211B8187-292A-4848-B5FF-488399FADD92}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{211B8187-292A-4848-B5FF-488399FADD92}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{211B8187-292A-4848-B5FF-488399FADD92}.Debug|x64.Build.0 = Debug|Any CPU
+		{211B8187-292A-4848-B5FF-488399FADD92}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{211B8187-292A-4848-B5FF-488399FADD92}.Debug|x86.Build.0 = Debug|Any CPU
+		{211B8187-292A-4848-B5FF-488399FADD92}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{211B8187-292A-4848-B5FF-488399FADD92}.Release|Any CPU.Build.0 = Release|Any CPU
+		{211B8187-292A-4848-B5FF-488399FADD92}.Release|x64.ActiveCfg = Release|Any CPU
+		{211B8187-292A-4848-B5FF-488399FADD92}.Release|x64.Build.0 = Release|Any CPU
+		{211B8187-292A-4848-B5FF-488399FADD92}.Release|x86.ActiveCfg = Release|Any CPU
+		{211B8187-292A-4848-B5FF-488399FADD92}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -850,5 +865,6 @@ Global
 		{3777EA95-F5D2-471D-9304-D4E3EC74F767} = {0EB607AC-6329-6575-AD8B-E5558B048B88}
 		{B1A88C7A-F85E-4B99-A8FB-8A7577CD4D6F} = {59F13AC0-48F4-1EAA-233F-95B7C7A91E1D}
 		{81034408-37C8-1011-444E-4C15C2FADA8E} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{211B8187-292A-4848-B5FF-488399FADD92} = {237CDB4C-E7C4-795B-969A-4CCB7C8B335B}
 	EndGlobalSection
 EndGlobal

--- a/src/API/Nocturne.API/Controllers/V4/Profiles/ProfileController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Profiles/ProfileController.cs
@@ -143,6 +143,38 @@ public class ProfileController : ControllerBase
         return Ok(summary);
     }
 
+    /// <summary>
+    /// Set a profile as the active (default) profile. Clears IsDefault on all other profiles.
+    /// </summary>
+    [HttpPost("set-default/{profileName}")]
+    [RemoteCommand(Invalidates = ["GetProfileSummary", "GetTherapySettings"])]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> SetDefaultProfile(string profileName, CancellationToken ct = default)
+    {
+        var all = await _therapyRepo.GetAsync(null, null, null, null, 1000, 0, true, ct);
+
+        var target = all.FirstOrDefault(ts =>
+            string.Equals(ts.ProfileName, profileName, StringComparison.OrdinalIgnoreCase));
+
+        if (target is null)
+            return NotFound();
+
+        foreach (var ts in all.Where(ts => ts.IsDefault && ts.Id != target.Id))
+        {
+            ts.IsDefault = false;
+            await _therapyRepo.UpdateAsync(ts.Id, ts, ct);
+        }
+
+        if (!target.IsDefault)
+        {
+            target.IsDefault = true;
+            await _therapyRepo.UpdateAsync(target.Id, target, ct);
+        }
+
+        return NoContent();
+    }
+
     #endregion
 
     #region Legacy Profile Records

--- a/src/API/Nocturne.API/Nocturne.API.csproj
+++ b/src/API/Nocturne.API/Nocturne.API.csproj
@@ -66,6 +66,7 @@
     <ProjectReference Include="..\..\Connectors\Nocturne.Connectors.Core\Nocturne.Connectors.Core.csproj" />
     <ProjectReference Include="..\..\Connectors\Nocturne.Connectors.Dexcom\Nocturne.Connectors.Dexcom.csproj" />
     <ProjectReference Include="..\..\Connectors\Nocturne.Connectors.Eversense\Nocturne.Connectors.Eversense.csproj" />
+    <ProjectReference Include="..\..\Connectors\Nocturne.Connectors.Gluroo\Nocturne.Connectors.Gluroo.csproj" />
     <ProjectReference Include="..\..\Connectors\Nocturne.Connectors.Glooko\Nocturne.Connectors.Glooko.csproj" />
     <ProjectReference Include="..\..\Connectors\Nocturne.Connectors.FreeStyle\Nocturne.Connectors.FreeStyle.csproj" />
     <ProjectReference Include="..\..\Connectors\Nocturne.Connectors.MyLife\Nocturne.Connectors.MyLife.csproj" />

--- a/src/API/Nocturne.API/Services/Analytics/ActogramReportService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/ActogramReportService.cs
@@ -135,6 +135,7 @@ public sealed class ActogramReportService : IActogramReportService
             })
             .ToList();
 
+        var rangeHours = (endTime - startTime) / 3_600_000.0;
         _logger.LogDebug(
             "Actogram report fetched {Glucose} glucose, {Sleep} sleep, {Steps} steps, {HeartRate} heart-rate records for {RangeHours:F1}h",
             glucoseData.Count,

--- a/src/API/Nocturne.API/Services/BackgroundServices/GlurooConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/GlurooConnectorBackgroundService.cs
@@ -1,0 +1,29 @@
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Gluroo.Configurations;
+using Nocturne.Connectors.Gluroo.Services;
+
+namespace Nocturne.API.Services.BackgroundServices;
+
+/// <summary>
+/// Background service that periodically syncs data from Gluroo Global Connect via
+/// <see cref="GlurooConnectorService"/>.
+/// </summary>
+/// <seealso cref="ConnectorBackgroundService{TConfig}"/>
+public class GlurooConnectorBackgroundService : ConnectorBackgroundService<GlurooConnectorConfiguration>
+{
+    public GlurooConnectorBackgroundService(
+        IServiceProvider serviceProvider,
+        GlurooConnectorConfiguration config,
+        ILogger<GlurooConnectorBackgroundService> logger
+    )
+        : base(serviceProvider, config, logger) { }
+
+    protected override string ConnectorName => "Gluroo";
+
+    protected override async Task<SyncResult> PerformSyncAsync(IServiceProvider scopeProvider, CancellationToken cancellationToken, ISyncProgressReporter? progressReporter = null)
+    {
+        var connectorService = scopeProvider.GetRequiredService<GlurooConnectorService>();
+        return await connectorService.SyncDataAsync(Config, cancellationToken, since: null, progressReporter);
+    }
+}

--- a/src/Connectors/Nocturne.Connectors.Core/Models/ConnectSource.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Models/ConnectSource.cs
@@ -15,6 +15,7 @@ public enum ConnectSource
     Tidepool,
     MyFitnessPal,
     Nightscout,
+    Gluroo,
     HomeAssistant,
     Eversense,
     NocturneRemote,

--- a/src/Connectors/Nocturne.Connectors.Gluroo/Configurations/GlurooConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.Gluroo/Configurations/GlurooConnectorConfiguration.cs
@@ -1,0 +1,36 @@
+using Nocturne.Connectors.Core.Extensions;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Nightscout.Configurations;
+using Nocturne.Core.Constants;
+
+namespace Nocturne.Connectors.Gluroo.Configurations;
+
+[ConnectorRegistration(
+    "Gluroo",
+    ServiceNames.GlurooConnector,
+    "GLUROO",
+    "ConnectSource.Gluroo",
+    "gluroo-connector",
+    "gluroo",
+    ConnectorCategory.Sync,
+    "Sync glucose, treatment, and profile data from Gluroo Global Connect",
+    "Gluroo",
+    SupportsHistoricalSync = true,
+    MaxHistoricalDays = 90,
+    SupportsManualSync = true,
+    SupportedDataTypes = [
+        SyncDataType.Glucose,
+        SyncDataType.ManualBG,
+        SyncDataType.Boluses,
+        SyncDataType.CarbIntake,
+        SyncDataType.Notes,
+        SyncDataType.Profiles
+    ]
+)]
+public class GlurooConnectorConfiguration : NightscoutConnectorConfiguration
+{
+    public GlurooConnectorConfiguration()
+    {
+        ConnectSource = ConnectSource.Gluroo;
+    }
+}

--- a/src/Connectors/Nocturne.Connectors.Gluroo/GlurooConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Gluroo/GlurooConnectorInstaller.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Nocturne.Connectors.Core.Extensions;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.Gluroo.Configurations;
+using Nocturne.Connectors.Gluroo.Services;
+
+namespace Nocturne.Connectors.Gluroo;
+
+public class GlurooConnectorInstaller : IConnectorInstaller
+{
+    public string ConnectorName => "Gluroo";
+
+    public void Install(IServiceCollection services, IConfiguration configuration)
+    {
+        var glurooConfig = services.AddConnectorConfiguration<GlurooConnectorConfiguration>(
+            configuration,
+            "Gluroo");
+
+        if (!glurooConfig.Enabled)
+            return;
+
+        if (!string.IsNullOrEmpty(glurooConfig.Url))
+            services.AddHttpClient<GlurooConnectorService>()
+                .ConfigureConnectorClient(glurooConfig.Url);
+        else
+            services.AddHttpClient<GlurooConnectorService>();
+
+        services.AddScoped<IConnectorSyncExecutor, GlurooSyncExecutor>();
+    }
+}
+
+public class GlurooSyncExecutor
+    : ConnectorSyncExecutor<GlurooConnectorService, GlurooConnectorConfiguration>
+{
+    public override string ConnectorId => "gluroo";
+
+    protected override string ConnectorName => "Gluroo";
+}

--- a/src/Connectors/Nocturne.Connectors.Gluroo/Nocturne.Connectors.Gluroo.csproj
+++ b/src/Connectors/Nocturne.Connectors.Gluroo/Nocturne.Connectors.Gluroo.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Description>Gluroo Global Connect data source connector service</Description>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\Core\Nocturne.Core.Models\Nocturne.Core.Models.csproj"/>
+        <ProjectReference Include="..\Nocturne.Connectors.Core\Nocturne.Connectors.Core.csproj"/>
+        <ProjectReference Include="..\Nocturne.Connectors.Nightscout\Nocturne.Connectors.Nightscout.csproj"/>
+    </ItemGroup>
+</Project>

--- a/src/Connectors/Nocturne.Connectors.Gluroo/Services/GlurooConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Gluroo/Services/GlurooConnectorService.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.Logging;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Gluroo.Configurations;
+using Nocturne.Connectors.Nightscout.Services;
+using Nocturne.Core.Constants;
+
+namespace Nocturne.Connectors.Gluroo.Services;
+
+public class GlurooConnectorService : NightscoutConnectorServiceBase<GlurooConnectorConfiguration>
+{
+    public GlurooConnectorService(
+        HttpClient httpClient,
+        ILogger<GlurooConnectorService> logger,
+        IRetryDelayStrategy retryDelayStrategy,
+        IRateLimitingStrategy rateLimitingStrategy,
+        GlurooConnectorConfiguration config,
+        IConnectorPublisher? publisher = null
+    ) : base(httpClient, logger, retryDelayStrategy, rateLimitingStrategy, config, publisher) { }
+
+    protected override string ConnectorSource => DataSources.GlurooConnector;
+    public override string ServiceName => "Gluroo Global Connect";
+
+    public override List<SyncDataType> SupportedDataTypes =>
+    [
+        SyncDataType.Glucose,
+        SyncDataType.ManualBG,
+        SyncDataType.Boluses,
+        SyncDataType.CarbIntake,
+        SyncDataType.Notes,
+        SyncDataType.Profiles
+    ];
+}

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
@@ -10,19 +10,20 @@ using Nocturne.Core.Models;
 
 namespace Nocturne.Connectors.Nightscout.Services;
 
-public class NightscoutConnectorService : BaseConnectorService<NightscoutConnectorConfiguration>
+public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TConfig>
+    where TConfig : NightscoutConnectorConfiguration
 {
     private readonly IRetryDelayStrategy _retryDelayStrategy;
     private readonly IRateLimitingStrategy _rateLimitingStrategy;
-    private readonly NightscoutConnectorConfiguration _config;
+    private readonly TConfig _config;
     private string? _apiSecretHash;
 
-    public NightscoutConnectorService(
+    public NightscoutConnectorServiceBase(
         HttpClient httpClient,
-        ILogger<NightscoutConnectorService> logger,
+        ILogger logger,
         IRetryDelayStrategy retryDelayStrategy,
         IRateLimitingStrategy rateLimitingStrategy,
-        NightscoutConnectorConfiguration config,
+        TConfig config,
         IConnectorPublisher? publisher = null
     )
         : base(httpClient, logger, publisher)
@@ -120,7 +121,7 @@ public class NightscoutConnectorService : BaseConnectorService<NightscoutConnect
 
     public override async Task<SyncResult> SyncDataAsync(
         SyncRequest request,
-        NightscoutConnectorConfiguration config,
+        TConfig config,
         CancellationToken cancellationToken,
         ISyncProgressReporter? progressReporter = null)
     {
@@ -138,7 +139,7 @@ public class NightscoutConnectorService : BaseConnectorService<NightscoutConnect
 
     protected override async Task<SyncResult> PerformSyncInternalAsync(
         SyncRequest request,
-        NightscoutConnectorConfiguration config,
+        TConfig config,
         CancellationToken cancellationToken,
         ISyncProgressReporter? progressReporter = null)
     {
@@ -757,4 +758,19 @@ public class NightscoutConnectorService : BaseConnectorService<NightscoutConnect
 
         return false;
     }
+}
+
+/// <summary>
+/// Nightscout connector service for syncing data from a Nightscout instance.
+/// </summary>
+public class NightscoutConnectorService : NightscoutConnectorServiceBase<NightscoutConnectorConfiguration>
+{
+    public NightscoutConnectorService(
+        HttpClient httpClient,
+        ILogger<NightscoutConnectorService> logger,
+        IRetryDelayStrategy retryDelayStrategy,
+        IRateLimitingStrategy rateLimitingStrategy,
+        NightscoutConnectorConfiguration config,
+        IConnectorPublisher? publisher = null
+    ) : base(httpClient, logger, retryDelayStrategy, rateLimitingStrategy, config, publisher) { }
 }

--- a/src/Core/Nocturne.Core.Constants/DataSources.cs
+++ b/src/Core/Nocturne.Core.Constants/DataSources.cs
@@ -62,6 +62,11 @@ public static class DataSources
     public const string NightscoutConnector = "nightscout-connector";
 
     /// <summary>
+    /// Data synced from Gluroo Global Connect's Nightscout-compatible API.
+    /// </summary>
+    public const string GlurooConnector = "gluroo-connector";
+
+    /// <summary>
     /// Data fetched from Tidepool API.
     /// </summary>
     public const string TidepoolConnector = "tidepool-connector";
@@ -230,6 +235,7 @@ public static class DataSources
                 or MiniMedConnector
                 or GlookoConnector
                 or NightscoutConnector
+                or GlurooConnector
                 or TidepoolConnector
                 or TConnectSyncConnector
                 or HomeAssistantConnector
@@ -296,6 +302,7 @@ public static class DataSources
             MiniMedConnector,
             GlookoConnector,
             NightscoutConnector,
+            GlurooConnector,
             TidepoolConnector,
             TConnectSyncConnector,
             HomeAssistantConnector,

--- a/src/Core/Nocturne.Core.Constants/ServiceNames.cs
+++ b/src/Core/Nocturne.Core.Constants/ServiceNames.cs
@@ -78,6 +78,12 @@ public static class ServiceNames
     public const string NightscoutConnector = "nightscout-connector";
 
     /// <summary>
+    /// Aspire resource name for the Gluroo Global Connect connector service.
+    /// </summary>
+    /// <seealso cref="DataSources.GlurooConnector"/>
+    public const string GlurooConnector = "gluroo-connector";
+
+    /// <summary>
     /// Aspire resource name for the MyFitnessPal connector service.
     /// </summary>
     /// <seealso cref="DataSources.MyFitnessPalConnector"/>

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/profile/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/profile/+page.svelte
@@ -22,11 +22,22 @@
   } from "lucide-svelte";
   import * as Alert from "$lib/components/ui/alert";
   import { bgLabel } from "$lib/utils/formatting";
-  import { getProfileSummary } from "$api/generated/profiles.generated.remote";
+  import { getProfileSummary, setDefaultProfile } from "$api/generated/profiles.generated.remote";
   import { coachmark } from "@nocturne/coach";
   import ScheduleView from "$lib/components/schedule/ScheduleView.svelte";
 
   type Summary = Awaited<ReturnType<typeof getProfileSummary>>;
+
+  let switchingProfile = $state<string | null>(null);
+
+  async function handleSetActive(profileName: string) {
+    switchingProfile = profileName;
+    try {
+      await setDefaultProfile(profileName);
+    } finally {
+      switchingProfile = null;
+    }
+  }
 
   // Query for profile summary data
   const summaryQuery = getProfileSummary(undefined);
@@ -223,6 +234,15 @@
                         >
                           Active
                         </Badge>
+                      {:else}
+                        <button
+                          type="button"
+                          class="text-xs text-muted-foreground hover:text-primary transition-colors"
+                          onclick={(e) => { e.preventDefault(); handleSetActive(profileName); }}
+                          disabled={switchingProfile !== null}
+                        >
+                          {switchingProfile === profileName ? "Switching..." : "Set as active"}
+                        </button>
                       {/if}
                       {#if isExternal}
                         <Badge variant="outline" class="text-xs gap-1">


### PR DESCRIPTION
## Summary

- Add a Gluroo Global Connect connector that reuses the Nightscout connector's fetch/auth/sync logic via inheritance
- Refactor `NightscoutConnectorService` into a generic `NightscoutConnectorServiceBase<TConfig>` base class for reuse
- Register Gluroo constants in `ServiceNames`, `DataSources`, and `ConnectSource`

Gluroo exposes a Nightscout-compatible backend (GGC) with `/api/v1/entries`, `/api/v1/treatments`, and `/api/v1/profile`. This connector provides Gluroo-branded UX with simplified config (URL + API secret) and a narrower data type scope (Glucose, ManualBG, Boluses, CarbIntake, Notes, Profiles).

## Test plan

- [x] Gluroo connector project builds with 0 errors
- [x] API project builds with Gluroo reference (pre-existing `rangeHours` error unrelated)
- [x] All 42 connector unit tests pass (no regressions from Nightscout generic refactor)
- [x] Spec review confirmed all 10 requirements met
- [ ] Manual test: enable Gluroo connector with a GGC URL + API secret, verify data syncs