### PR TITLE
feat: universal soft delete for all v4 entities

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Base/V4CrudControllerBase.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Base/V4CrudControllerBase.cs
@@ -128,6 +128,22 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
         }
     }
 
+    /// <summary>Lists soft-deleted records available for restoration, ordered by deletion date (newest first).</summary>
+    /// <param name="limit">Maximum number of records to return. Defaults to `100`.</param>
+    /// <param name="offset">Number of records to skip for pagination. Defaults to `0`.</param>
+    /// <param name="ct">Cancellation token.</param>
+    [HttpGet("deleted")]
+    [RemoteQuery]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public virtual async Task<ActionResult<PaginatedResponse<TModel>>> ListDeleted(
+        [FromQuery] int limit = 100, [FromQuery] int offset = 0,
+        CancellationToken ct = default)
+    {
+        var data = await Repository.GetDeletedAsync(limit, offset, ct);
+        var total = await Repository.CountDeletedAsync(ct);
+        return Ok(new PaginatedResponse<TModel> { Data = data, Pagination = new PaginationInfo(limit, offset, total) });
+    }
+
     /// <summary>Restores a soft-deleted record by ID.</summary>
     /// <param name="id">The unique identifier of the soft-deleted record.</param>
     /// <param name="ct">Cancellation token.</param>

--- a/src/API/Nocturne.API/Controllers/V4/Base/V4CrudControllerBase.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Base/V4CrudControllerBase.cs
@@ -128,6 +128,42 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
         }
     }
 
+    /// <summary>Restores a soft-deleted record by ID.</summary>
+    /// <param name="id">The unique identifier of the soft-deleted record.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <remarks>Returns `200 OK` with the restored record, or `404 Not Found` if no soft-deleted record with the given <paramref name="id"/> exists.</remarks>
+    [HttpPost("{id:guid}/restore")]
+    [RemoteCommand]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public virtual async Task<ActionResult<TModel>> Restore(Guid id, CancellationToken ct = default)
+    {
+        try
+        {
+            var restored = await Repository.RestoreAsync(id, ct);
+            await OnAfterRestoreAsync(restored, ct);
+            return Ok(restored);
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound();
+        }
+    }
+
+    /// <summary>Restores multiple soft-deleted records by their IDs.</summary>
+    /// <param name="ids">The unique identifiers of the soft-deleted records.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <remarks>Returns `200 OK` with the restored records. IDs that don't match a soft-deleted record are silently ignored.</remarks>
+    [HttpPost("restore")]
+    [RemoteCommand]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public virtual async Task<ActionResult<IEnumerable<TModel>>> BulkRestore(
+        [FromBody] Guid[] ids, CancellationToken ct = default)
+    {
+        var restored = await Repository.BulkRestoreAsync(ids, ct);
+        return Ok(restored);
+    }
+
     /// <summary>
     /// Hook called after a record is successfully created. Override to add post-creation side effects
     /// such as alert evaluation or SignalR broadcasting.
@@ -136,4 +172,12 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The record, potentially enriched by the hook.</returns>
     protected virtual Task<TModel> OnAfterCreateAsync(TModel created, CancellationToken ct) => Task.FromResult(created);
+
+    /// <summary>
+    /// Hook called after a record is restored. Override to add post-restore side effects
+    /// such as SignalR broadcasting.
+    /// </summary>
+    /// <param name="restored">The restored record.</param>
+    /// <param name="ct">Cancellation token.</param>
+    protected virtual Task OnAfterRestoreAsync(TModel restored, CancellationToken ct) => Task.CompletedTask;
 }

--- a/src/API/Nocturne.API/Controllers/V4/Base/V4ReadOnlyControllerBase.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Base/V4ReadOnlyControllerBase.cs
@@ -71,4 +71,20 @@ public abstract class V4ReadOnlyControllerBase<TModel, TRepository>(TRepository 
         var result = await Repository.GetByIdAsync(id, ct);
         return result is null ? NotFound() : Ok(result);
     }
+
+    /// <summary>Lists soft-deleted records available for restoration, ordered by deletion date (newest first).</summary>
+    /// <param name="limit">Maximum number of records to return. Defaults to `100`.</param>
+    /// <param name="offset">Number of records to skip for pagination. Defaults to `0`.</param>
+    /// <param name="ct">Cancellation token.</param>
+    [HttpGet("deleted")]
+    [RemoteQuery]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public virtual async Task<ActionResult<PaginatedResponse<TModel>>> ListDeleted(
+        [FromQuery] int limit = 100, [FromQuery] int offset = 0,
+        CancellationToken ct = default)
+    {
+        var data = await Repository.GetDeletedAsync(limit, offset, ct);
+        var total = await Repository.CountDeletedAsync(ct);
+        return Ok(new PaginatedResponse<TModel> { Data = data, Pagination = new PaginationInfo(limit, offset, total) });
+    }
 }

--- a/src/API/Nocturne.API/Controllers/V4/Base/V4ReadOnlyControllerBase.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Base/V4ReadOnlyControllerBase.cs
@@ -71,20 +71,4 @@ public abstract class V4ReadOnlyControllerBase<TModel, TRepository>(TRepository 
         var result = await Repository.GetByIdAsync(id, ct);
         return result is null ? NotFound() : Ok(result);
     }
-
-    /// <summary>Lists soft-deleted records available for restoration, ordered by deletion date (newest first).</summary>
-    /// <param name="limit">Maximum number of records to return. Defaults to `100`.</param>
-    /// <param name="offset">Number of records to skip for pagination. Defaults to `0`.</param>
-    /// <param name="ct">Cancellation token.</param>
-    [HttpGet("deleted")]
-    [RemoteQuery]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    public virtual async Task<ActionResult<PaginatedResponse<TModel>>> ListDeleted(
-        [FromQuery] int limit = 100, [FromQuery] int offset = 0,
-        CancellationToken ct = default)
-    {
-        var data = await Repository.GetDeletedAsync(limit, offset, ct);
-        var total = await Repository.CountDeletedAsync(ct);
-        return Ok(new PaginatedResponse<TModel> { Data = data, Pagination = new PaginationInfo(limit, offset, total) });
-    }
 }

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -10,6 +10,7 @@ using Nocturne.API.Authorization;
 using Nocturne.API.Configuration;
 using Nocturne.API.Services.Audit;
 using Nocturne.API.Services.Auth;
+using Nocturne.API.Services.BackgroundServices;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.API.Extensions;
 using Nocturne.API.Filters;
@@ -146,6 +147,7 @@ builder.Services.AddResponseCaching();
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<IAuditContext, AuditContext>();
 builder.Services.AddHostedService<AuditRetentionService>();
+builder.Services.AddHostedService<SoftDeleteCleanupService>();
 
 // Add native API services for strangler pattern
 // Note: NightscoutJsonFilter is added globally to apply null-omission and

--- a/src/API/Nocturne.API/Services/BackgroundServices/SoftDeleteCleanupService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/SoftDeleteCleanupService.cs
@@ -1,0 +1,177 @@
+using Microsoft.EntityFrameworkCore;
+using Nocturne.Infrastructure.Data;
+
+namespace Nocturne.API.Services.BackgroundServices;
+
+/// <summary>
+/// Background service that hard-deletes soft-deleted records past their retention period.
+/// Runs every 24 hours, deleting in batches to avoid WAL bloat.
+/// </summary>
+public class SoftDeleteCleanupService(
+    IDbContextFactory<NocturneDbContext> contextFactory,
+    IConfiguration configuration,
+    ILogger<SoftDeleteCleanupService> logger) : BackgroundService
+{
+    private static readonly TimeSpan InitialDelay = TimeSpan.FromMinutes(10);
+    private static readonly TimeSpan Interval = TimeSpan.FromHours(24);
+    private const int BatchSize = 10_000;
+    private const int MinRetentionDays = 7;
+
+    private int DefaultRetentionDays =>
+        configuration.GetValue("DataRetention:SoftDeleteRetentionDays", 30);
+
+    /// <summary>
+    /// All v4 tables with a deleted_at column.
+    /// </summary>
+    private static readonly string[] V4Tables =
+    [
+        "aps_snapshots", "basal_schedules", "bg_checks", "bolus_calculations",
+        "boluses", "calibrations", "carb_intakes", "carb_ratio_schedules",
+        "decomposition_batches", "device_events", "device_status_extras",
+        "devices", "meter_glucose", "notes", "patient_devices",
+        "patient_insulins", "patient_records", "pump_snapshots",
+        "sensitivity_schedules", "sensor_glucose", "target_range_schedules",
+        "temp_basals", "therapy_settings", "uploader_snapshots"
+    ];
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await Task.Delay(InitialDelay, stoppingToken);
+
+        using var timer = new PeriodicTimer(Interval);
+
+        do
+        {
+            try
+            {
+                await PurgeExpiredRecordsAsync(stoppingToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogWarning(ex, "Soft-delete cleanup failed; will retry next cycle");
+            }
+        }
+        while (await timer.WaitForNextTickAsync(stoppingToken));
+    }
+
+    /// <summary>
+    /// Iterates all tenants and hard-deletes soft-deleted records past their retention period.
+    /// </summary>
+    internal async Task PurgeExpiredRecordsAsync(CancellationToken ct)
+    {
+        await using var configContext = await contextFactory.CreateDbContextAsync(ct);
+
+        // Get per-tenant retention config
+        var configs = await configContext.TenantDataRetentionConfig
+            .Select(c => new { c.TenantId, c.SoftDeleteRetentionDays })
+            .ToListAsync(ct);
+
+        // Also get all tenants that might have soft-deleted records but no config
+        var allTenantIds = await configContext.Tenants
+            .Select(t => t.Id)
+            .ToListAsync(ct);
+
+        var configMap = configs.ToDictionary(c => c.TenantId, c => c.SoftDeleteRetentionDays);
+
+        foreach (var tenantId in allTenantIds)
+        {
+            try
+            {
+                var retentionDays = configMap.GetValueOrDefault(tenantId) ?? DefaultRetentionDays;
+                retentionDays = Math.Max(retentionDays, MinRetentionDays); // Enforce minimum
+                var cutoff = DateTime.UtcNow.AddDays(-retentionDays);
+
+                var totalDeleted = 0;
+
+                foreach (var table in V4Tables)
+                {
+                    var tableDeleted = await PurgeBatchedAsync(tenantId, table, cutoff, ct);
+                    totalDeleted += tableDeleted;
+                }
+
+                // Clean up orphaned linked_records
+                await CleanupOrphanedLinkedRecordsAsync(tenantId, ct);
+
+                if (totalDeleted > 0)
+                {
+                    logger.LogInformation(
+                        "Soft-delete cleanup for tenant {TenantId}: hard-deleted {Count} expired records (retention: {Days} days)",
+                        tenantId, totalDeleted, retentionDays);
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogWarning(ex,
+                    "Soft-delete cleanup failed for tenant {TenantId}; continuing with next tenant",
+                    tenantId);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Deletes records from the specified table with deleted_at before the cutoff, in batches
+    /// of <see cref="BatchSize"/> to avoid WAL bloat and long-running transactions.
+    /// </summary>
+    /// <returns>Total number of records deleted.</returns>
+    private async Task<int> PurgeBatchedAsync(
+        Guid tenantId, string table, DateTime cutoff, CancellationToken ct)
+    {
+        var totalDeleted = 0;
+        int batchDeleted;
+
+        do
+        {
+            await using var db = await contextFactory.CreateDbContextAsync(ct);
+
+            // Set RLS context for the tenant-scoped table
+            await db.Database.ExecuteSqlRawAsync(
+                "SELECT set_config('app.current_tenant_id', {0}, false)",
+                [tenantId.ToString()], ct);
+
+            // Delete a batch using ctid for efficient sub-select.
+            // Table name is from our code (not user input) so interpolation is safe.
+#pragma warning disable EF1002
+            batchDeleted = await db.Database.ExecuteSqlRawAsync(
+                $"DELETE FROM {table} WHERE ctid IN (SELECT ctid FROM {table} WHERE deleted_at < {{0}} LIMIT {BatchSize})",
+                [cutoff], ct);
+#pragma warning restore EF1002
+
+            totalDeleted += batchDeleted;
+        }
+        while (batchDeleted >= BatchSize);
+
+        return totalDeleted;
+    }
+
+    /// <summary>
+    /// Removes linked_records that reference hard-deleted records. Best-effort: orphans don't
+    /// cause incorrect behavior, just stale dedup metadata.
+    /// </summary>
+    private async Task CleanupOrphanedLinkedRecordsAsync(Guid tenantId, CancellationToken ct)
+    {
+        await using var db = await contextFactory.CreateDbContextAsync(ct);
+
+        await db.Database.ExecuteSqlRawAsync(
+            "SELECT set_config('app.current_tenant_id', {0}, false)",
+            [tenantId.ToString()], ct);
+
+        // RecordType enum values are stored lowercase (e.g. "sensorglucose", "bolus")
+        var dedupTypes = new Dictionary<string, string>
+        {
+            ["sensorglucose"] = "sensor_glucose",
+            ["bolus"] = "boluses",
+            ["carbintake"] = "carb_intakes",
+            ["bgcheck"] = "bg_checks",
+            ["tempbasal"] = "temp_basals"
+        };
+
+        foreach (var (recordType, sourceTable) in dedupTypes)
+        {
+#pragma warning disable EF1002
+            await db.Database.ExecuteSqlRawAsync(
+                $"DELETE FROM linked_records WHERE record_type = {{0}} AND record_id NOT IN (SELECT id FROM {sourceTable})",
+                [recordType], ct);
+#pragma warning restore EF1002
+        }
+    }
+}

--- a/src/API/Nocturne.API/Services/BackgroundServices/SoftDeleteCleanupService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/SoftDeleteCleanupService.cs
@@ -63,6 +63,7 @@ public class SoftDeleteCleanupService(
 
         // Get per-tenant retention config
         var configs = await configContext.TenantDataRetentionConfig
+            .IgnoreQueryFilters()
             .Select(c => new { c.TenantId, c.SoftDeleteRetentionDays })
             .ToListAsync(ct);
 

--- a/src/API/Nocturne.API/Services/V4/EntryDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/EntryDecomposer.cs
@@ -1,3 +1,4 @@
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Models;
@@ -259,15 +260,31 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
     /// <inheritdoc />
     public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
-        var deleted = 0;
-        deleted += await _sensorGlucoseRepository.DeleteByLegacyIdAsync(legacyId, ct);
-        deleted += await _meterGlucoseRepository.DeleteByLegacyIdAsync(legacyId, ct);
-        deleted += await _calibrationRepository.DeleteByLegacyIdAsync(legacyId, ct);
+        var strategy = _dbContext.Database.CreateExecutionStrategy();
 
-        if (deleted > 0)
-            _logger.LogDebug("Deleted {Count} v4 records for legacy entry {LegacyId}", deleted, legacyId);
+        return await strategy.ExecuteAsync(async () =>
+        {
+            await using var tx = await _dbContext.Database.BeginTransactionAsync(ct);
+            var now = DateTime.UtcNow;
+            var deleted = 0;
 
-        return deleted;
+            deleted += await _dbContext.SensorGlucose
+                .Where(e => e.LegacyId == legacyId)
+                .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, now), ct);
+            deleted += await _dbContext.MeterGlucose
+                .Where(e => e.LegacyId == legacyId)
+                .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, now), ct);
+            deleted += await _dbContext.Calibrations
+                .Where(e => e.LegacyId == legacyId)
+                .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, now), ct);
+
+            await tx.CommitAsync(ct);
+
+            if (deleted > 0)
+                _logger.LogDebug("Soft-deleted {Count} v4 records for legacy entry {LegacyId}", deleted, legacyId);
+
+            return deleted;
+        });
     }
 
     /// <inheritdoc />

--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -11,6 +11,7 @@ using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Models;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Entities.V4;
 
 using V4Models = Nocturne.Core.Models.V4;
@@ -1584,7 +1585,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
 
     private static async Task<int> DeleteEntitiesByTimeRange<T>(
         Microsoft.EntityFrameworkCore.DbSet<T> dbSet, DateTime? from, DateTime? to, CancellationToken ct)
-        where T : class
+        where T : class, ISoftDeletable
     {
         var query = dbSet.AsQueryable();
 
@@ -1636,6 +1637,6 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             }
         }
 
-        return await query.ExecuteDeleteAsync(ct);
+        return await query.ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 }

--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -1501,19 +1501,43 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
     /// <inheritdoc />
     public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
-        var deleted = 0;
-        deleted += await _bolusRepository.DeleteByLegacyIdAsync(legacyId, ct);
-        deleted += await _tempBasalRepository.DeleteByLegacyIdAsync(legacyId, ct);
-        deleted += await _carbIntakeRepository.DeleteByLegacyIdAsync(legacyId, ct);
-        deleted += await _bgCheckRepository.DeleteByLegacyIdAsync(legacyId, ct);
-        deleted += await _noteRepository.DeleteByLegacyIdAsync(legacyId, ct);
-        deleted += await _deviceEventRepository.DeleteByLegacyIdAsync(legacyId, ct);
-        deleted += await _bolusCalculationRepository.DeleteByLegacyIdAsync(legacyId, ct);
+        var strategy = _dbContext.Database.CreateExecutionStrategy();
 
-        if (deleted > 0)
-            _logger.LogDebug("Deleted {Count} v4 records for legacy treatment {LegacyId}", deleted, legacyId);
+        return await strategy.ExecuteAsync(async () =>
+        {
+            await using var tx = await _dbContext.Database.BeginTransactionAsync(ct);
+            var now = DateTime.UtcNow;
+            var deleted = 0;
 
-        return deleted;
+            deleted += await _dbContext.Boluses
+                .Where(e => e.LegacyId == legacyId)
+                .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, now), ct);
+            deleted += await _dbContext.TempBasals
+                .Where(e => e.LegacyId == legacyId)
+                .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, now), ct);
+            deleted += await _dbContext.CarbIntakes
+                .Where(e => e.LegacyId == legacyId)
+                .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, now), ct);
+            deleted += await _dbContext.BGChecks
+                .Where(e => e.LegacyId == legacyId)
+                .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, now), ct);
+            deleted += await _dbContext.Notes
+                .Where(e => e.LegacyId == legacyId)
+                .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, now), ct);
+            deleted += await _dbContext.DeviceEvents
+                .Where(e => e.LegacyId == legacyId)
+                .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, now), ct);
+            deleted += await _dbContext.BolusCalculations
+                .Where(e => e.LegacyId == legacyId)
+                .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, now), ct);
+
+            await tx.CommitAsync(ct);
+
+            if (deleted > 0)
+                _logger.LogDebug("Soft-deleted {Count} v4 records for legacy treatment {LegacyId}", deleted, legacyId);
+
+            return deleted;
+        });
     }
 
     /// <inheritdoc />

--- a/src/API/Nocturne.API/appsettings.example.json
+++ b/src/API/Nocturne.API/appsettings.example.json
@@ -78,6 +78,12 @@
   // ApiToken, UserKey via user-secrets.
   "Pushover": {},
 
+  // Soft-delete data retention
+  "DataRetention": {
+    "SoftDeleteRetentionDays": 30,
+    "MinimumRetentionDays": 7
+  },
+
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IV4Repository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IV4Repository.cs
@@ -61,6 +61,39 @@ public interface IV4Repository<T> where T : class, IV4Record
     Task DeleteAsync(Guid id, CancellationToken ct = default);
 
     /// <summary>
+    /// Restore a soft-deleted record by clearing its DeletedAt timestamp.
+    /// </summary>
+    /// <param name="id">UUID v7 identifier of the soft-deleted record.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The restored record.</returns>
+    /// <exception cref="KeyNotFoundException">If no soft-deleted record with the given ID exists.</exception>
+    Task<T> RestoreAsync(Guid id, CancellationToken ct = default);
+
+    /// <summary>
+    /// Restore multiple soft-deleted records by clearing their DeletedAt timestamps.
+    /// </summary>
+    /// <param name="ids">UUID v7 identifiers of the soft-deleted records.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The restored records (only those that were actually soft-deleted).</returns>
+    Task<IEnumerable<T>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default);
+
+    /// <summary>
+    /// Retrieve soft-deleted records for the "trash" view, ordered by deletion date (newest first).
+    /// </summary>
+    /// <param name="limit">Maximum number of records to return.</param>
+    /// <param name="offset">Number of records to skip for pagination.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Soft-deleted records ordered by DeletedAt descending.</returns>
+    Task<IEnumerable<T>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default);
+
+    /// <summary>
+    /// Count soft-deleted records.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Number of soft-deleted records.</returns>
+    Task<int> CountDeletedAsync(CancellationToken ct = default);
+
+    /// <summary>
     /// Count records within an optional time range.
     /// </summary>
     /// <param name="from">Inclusive start of the time window, or <c>null</c> for no lower bound.</param>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TenantDataRetentionConfigEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TenantDataRetentionConfigEntity.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Nocturne.Infrastructure.Data.Entities;
+
+/// <summary>
+/// Per-tenant configuration for soft-delete data retention.
+/// </summary>
+[Table("tenant_data_retention_config")]
+public class TenantDataRetentionConfigEntity : ITenantScoped
+{
+    [Key]
+    public Guid Id { get; set; }
+
+    [Column("tenant_id")]
+    public Guid TenantId { get; set; }
+
+    /// <summary>
+    /// Number of days to retain soft-deleted records before hard-deleting.
+    /// Null = use global default. Minimum enforced: 7 days.
+    /// </summary>
+    [Column("soft_delete_retention_days")]
+    public int? SoftDeleteRetentionDays { get; set; }
+
+    [Column("created_at")]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    [Column("updated_at")]
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/ApsSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/ApsSnapshotEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.ApsSnapshot
 /// </summary>
 [Table("aps_snapshots")]
-public class ApsSnapshotEntity : ITenantScoped
+public class ApsSnapshotEntity : ITenantScoped, ISoftDeletable
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.
@@ -231,4 +231,11 @@ public class ApsSnapshotEntity : ITenantScoped
     /// </summary>
     [Column("additional_properties", TypeName = "jsonb")]
     public string? AdditionalPropertiesJson { get; set; }
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BGCheckEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BGCheckEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.BGCheck
 /// </summary>
 [Table("bg_checks")]
-public class BGCheckEntity : ITenantScoped
+public class BGCheckEntity : ITenantScoped, ISoftDeletable
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.
@@ -114,4 +114,11 @@ public class BGCheckEntity : ITenantScoped
     /// </summary>
     [Column("additional_properties", TypeName = "jsonb")]
     public string? AdditionalPropertiesJson { get; set; }
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalScheduleEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.BasalSchedule
 /// </summary>
 [Table("basal_schedules")]
-public class BasalScheduleEntity : ITenantScoped, IAuditable
+public class BasalScheduleEntity : ITenantScoped, IAuditable, ISoftDeletable
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.
@@ -102,4 +102,12 @@ public class BasalScheduleEntity : ITenantScoped, IAuditable
     /// </summary>
     [Column("additional_properties", TypeName = "jsonb")]
     public string? AdditionalPropertiesJson { get; set; }
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [AuditIgnored]
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusCalculationEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusCalculationEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.BolusCalculation
 /// </summary>
 [Table("bolus_calculations")]
-public class BolusCalculationEntity : ITenantScoped, IAuditable
+public class BolusCalculationEntity : ITenantScoped, IAuditable, ISoftDeletable
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.
@@ -169,4 +169,12 @@ public class BolusCalculationEntity : ITenantScoped, IAuditable
     /// </summary>
     [Column("additional_properties", TypeName = "jsonb")]
     public string? AdditionalPropertiesJson { get; set; }
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [AuditIgnored]
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.Bolus
 /// </summary>
 [Table("boluses")]
-public class BolusEntity : ITenantScoped, IAuditable
+public class BolusEntity : ITenantScoped, IAuditable, ISoftDeletable
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.
@@ -190,4 +190,12 @@ public class BolusEntity : ITenantScoped, IAuditable
     /// </summary>
     [Column("additional_properties", TypeName = "jsonb")]
     public string? AdditionalPropertiesJson { get; set; }
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [AuditIgnored]
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CalibrationEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CalibrationEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.Calibration
 /// </summary>
 [Table("calibrations")]
-public class CalibrationEntity : ITenantScoped
+public class CalibrationEntity : ITenantScoped, ISoftDeletable
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.
@@ -105,4 +105,11 @@ public class CalibrationEntity : ITenantScoped
     /// </summary>
     [Column("additional_properties", TypeName = "jsonb")]
     public string? AdditionalPropertiesJson { get; set; }
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbIntakeEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbIntakeEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.CarbIntake
 /// </summary>
 [Table("carb_intakes")]
-public class CarbIntakeEntity : ITenantScoped, IAuditable
+public class CarbIntakeEntity : ITenantScoped, IAuditable, ISoftDeletable
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.
@@ -114,4 +114,12 @@ public class CarbIntakeEntity : ITenantScoped, IAuditable
     /// </summary>
     [Column("additional_properties", TypeName = "jsonb")]
     public string? AdditionalPropertiesJson { get; set; }
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [AuditIgnored]
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbRatioScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbRatioScheduleEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.CarbRatioSchedule
 /// </summary>
 [Table("carb_ratio_schedules")]
-public class CarbRatioScheduleEntity : ITenantScoped
+public class CarbRatioScheduleEntity : ITenantScoped, ISoftDeletable
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.
@@ -100,4 +100,11 @@ public class CarbRatioScheduleEntity : ITenantScoped
     /// </summary>
     [Column("additional_properties", TypeName = "jsonb")]
     public string? AdditionalPropertiesJson { get; set; }
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DecompositionBatchEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DecompositionBatchEntity.cs
@@ -9,7 +9,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Deleting a batch cascades to all sibling V4 records.
 /// </summary>
 [Table("decomposition_batches")]
-public class DecompositionBatchEntity : ITenantScoped
+public class DecompositionBatchEntity : ITenantScoped, ISoftDeletable
 {
     /// <summary>Primary key (UUID v7).</summary>
     [Key]
@@ -39,4 +39,11 @@ public class DecompositionBatchEntity : ITenantScoped
     /// </summary>
     [Column("created_at")]
     public DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceEntity.cs
@@ -11,7 +11,6 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.Device
 /// </summary>
 [Table("devices")]
-[Index(nameof(Category), nameof(Type), nameof(Serial), IsUnique = true)]
 public class DeviceEntity : ITenantScoped, ISoftDeletable
 {
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceEntity.cs
@@ -12,7 +12,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// </summary>
 [Table("devices")]
 [Index(nameof(Category), nameof(Type), nameof(Serial), IsUnique = true)]
-public class DeviceEntity : ITenantScoped
+public class DeviceEntity : ITenantScoped, ISoftDeletable
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.
@@ -64,4 +64,11 @@ public class DeviceEntity : ITenantScoped
     /// </summary>
     [Column("additional_properties", TypeName = "jsonb")]
     public string? AdditionalPropertiesJson { get; set; }
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceEventEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceEventEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.DeviceEvent
 /// </summary>
 [Table("device_events")]
-public class DeviceEventEntity : ITenantScoped, IAuditable
+public class DeviceEventEntity : ITenantScoped, IAuditable, ISoftDeletable
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.
@@ -122,4 +122,12 @@ public class DeviceEventEntity : ITenantScoped, IAuditable
     /// </summary>
     [Column("additional_properties", TypeName = "jsonb")]
     public string? AdditionalPropertiesJson { get; set; }
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [AuditIgnored]
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceStatusExtrasEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceStatusExtrasEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.DeviceStatusExtras
 /// </summary>
 [Table("device_status_extras")]
-public class DeviceStatusExtrasEntity : ITenantScoped, IAuditable
+public class DeviceStatusExtrasEntity : ITenantScoped, IAuditable, ISoftDeletable
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.
@@ -53,4 +53,12 @@ public class DeviceStatusExtrasEntity : ITenantScoped, IAuditable
     /// </summary>
     [Column("sys_updated_at")]
     public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [AuditIgnored]
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/MeterGlucoseEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/MeterGlucoseEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.MeterGlucose
 /// </summary>
 [Table("meter_glucose")]
-public class MeterGlucoseEntity : ITenantScoped
+public class MeterGlucoseEntity : ITenantScoped, ISoftDeletable
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.
@@ -93,4 +93,11 @@ public class MeterGlucoseEntity : ITenantScoped
     /// </summary>
     [Column("additional_properties", TypeName = "jsonb")]
     public string? AdditionalPropertiesJson { get; set; }
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/NoteEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/NoteEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.Note
 /// </summary>
 [Table("notes")]
-public class NoteEntity : ITenantScoped
+public class NoteEntity : ITenantScoped, ISoftDeletable
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.
@@ -114,4 +114,11 @@ public class NoteEntity : ITenantScoped
     /// </summary>
     [Column("additional_properties", TypeName = "jsonb")]
     public string? AdditionalPropertiesJson { get; set; }
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PatientDeviceEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PatientDeviceEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.PatientDevice
 /// </summary>
 [Table("patient_devices")]
-public class PatientDeviceEntity : ITenantScoped
+public class PatientDeviceEntity : ITenantScoped, ISoftDeletable
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.
@@ -108,4 +108,11 @@ public class PatientDeviceEntity : ITenantScoped
     /// </summary>
     [Column("sys_updated_at")]
     public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PatientInsulinEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PatientInsulinEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.PatientInsulin
 /// </summary>
 [Table("patient_insulins")]
-public class PatientInsulinEntity : ITenantScoped
+public class PatientInsulinEntity : ITenantScoped, ISoftDeletable
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.
@@ -119,4 +119,11 @@ public class PatientInsulinEntity : ITenantScoped
     /// </summary>
     [Column("sys_updated_at")]
     public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PatientRecordEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PatientRecordEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.PatientRecord
 /// </summary>
 [Table("patient_records")]
-public class PatientRecordEntity : ITenantScoped
+public class PatientRecordEntity : ITenantScoped, ISoftDeletable
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.
@@ -82,4 +82,11 @@ public class PatientRecordEntity : ITenantScoped
     /// </summary>
     [Column("sys_updated_at")]
     public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PumpSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PumpSnapshotEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.PumpSnapshot
 /// </summary>
 [Table("pump_snapshots")]
-public class PumpSnapshotEntity : ITenantScoped
+public class PumpSnapshotEntity : ITenantScoped, ISoftDeletable
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.
@@ -162,4 +162,11 @@ public class PumpSnapshotEntity : ITenantScoped
     /// </summary>
     [Column("additional_properties", TypeName = "jsonb")]
     public string? AdditionalPropertiesJson { get; set; }
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensitivityScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensitivityScheduleEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.SensitivitySchedule
 /// </summary>
 [Table("sensitivity_schedules")]
-public class SensitivityScheduleEntity : ITenantScoped
+public class SensitivityScheduleEntity : ITenantScoped, ISoftDeletable
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.
@@ -100,4 +100,11 @@ public class SensitivityScheduleEntity : ITenantScoped
     /// </summary>
     [Column("additional_properties", TypeName = "jsonb")]
     public string? AdditionalPropertiesJson { get; set; }
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensorGlucoseEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensorGlucoseEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.SensorGlucose
 /// </summary>
 [Table("sensor_glucose")]
-public class SensorGlucoseEntity : ITenantScoped, IAuditable
+public class SensorGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.
@@ -157,4 +157,12 @@ public class SensorGlucoseEntity : ITenantScoped, IAuditable
     /// </summary>
     [Column("additional_properties", TypeName = "jsonb")]
     public string? AdditionalPropertiesJson { get; set; }
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [AuditIgnored]
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TargetRangeScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TargetRangeScheduleEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.TargetRangeSchedule
 /// </summary>
 [Table("target_range_schedules")]
-public class TargetRangeScheduleEntity : ITenantScoped
+public class TargetRangeScheduleEntity : ITenantScoped, ISoftDeletable
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.
@@ -100,4 +100,11 @@ public class TargetRangeScheduleEntity : ITenantScoped
     /// </summary>
     [Column("additional_properties", TypeName = "jsonb")]
     public string? AdditionalPropertiesJson { get; set; }
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TempBasalEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TempBasalEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.TempBasal
 /// </summary>
 [Table("temp_basals")]
-public class TempBasalEntity : ITenantScoped, IAuditable
+public class TempBasalEntity : ITenantScoped, IAuditable, ISoftDeletable
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.
@@ -145,4 +145,12 @@ public class TempBasalEntity : ITenantScoped, IAuditable
     /// </summary>
     [Column("additional_properties", TypeName = "jsonb")]
     public string? AdditionalPropertiesJson { get; set; }
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [AuditIgnored]
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TherapySettingsEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TherapySettingsEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.TherapySettings
 /// </summary>
 [Table("therapy_settings")]
-public class TherapySettingsEntity : ITenantScoped
+public class TherapySettingsEntity : ITenantScoped, ISoftDeletable
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.
@@ -200,4 +200,11 @@ public class TherapySettingsEntity : ITenantScoped
     /// </summary>
     [Column("additional_properties", TypeName = "jsonb")]
     public string? AdditionalPropertiesJson { get; set; }
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/UploaderSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/UploaderSnapshotEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.UploaderSnapshot
 /// </summary>
 [Table("uploader_snapshots")]
-public class UploaderSnapshotEntity : ITenantScoped
+public class UploaderSnapshotEntity : ITenantScoped, ISoftDeletable
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.
@@ -117,4 +117,11 @@ public class UploaderSnapshotEntity : ITenantScoped
     /// </summary>
     [Column("additional_properties", TypeName = "jsonb")]
     public string? AdditionalPropertiesJson { get; set; }
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/AuditedBulkDeleteExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/AuditedBulkDeleteExtensions.cs
@@ -153,7 +153,7 @@ public static class AuditedBulkDeleteExtensions
                     TenantId = context.TenantId,
                     EntityType = entityTypeName,
                     EntityId = (Guid)entry.Property("Id").CurrentValue!,
-                    Action = "soft_delete",
+                    Action = "delete",
                     ChangesJson = JsonSerializer.Serialize(snapshot, JsonOptions),
                     SubjectId = auditContext?.SubjectId,
                     AuthType = auditContext?.AuthType,

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/AuditedBulkDeleteExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/AuditedBulkDeleteExtensions.cs
@@ -98,4 +98,99 @@ public static class AuditedBulkDeleteExtensions
             return deletedCount;
         });
     }
+
+    /// <summary>
+    /// Executes a bulk soft delete with audit trail. Queries affected records,
+    /// writes audit entries, then sets <c>DeletedAt</c> — all in one transaction.
+    /// </summary>
+    public static async Task<int> AuditedSoftDeleteAsync<T>(
+        this NocturneDbContext context,
+        IQueryable<T> query,
+        IAuditContext? auditContext,
+        CancellationToken ct = default) where T : class, IAuditable, ISoftDeletable
+    {
+        var strategy = context.Database.CreateExecutionStrategy();
+
+        return await strategy.ExecuteAsync(async () =>
+        {
+            await using var transaction = await context.Database.BeginTransactionAsync(ct);
+
+            // Query affected records for audit snapshot
+            var affectedRecords = await query.ToListAsync(ct);
+
+            if (affectedRecords.Count == 0)
+            {
+                await transaction.CommitAsync(ct);
+                return 0;
+            }
+
+            var now = DateTime.UtcNow;
+            var entityTypeName = typeof(T).Name.Replace("Entity", "");
+
+            var auditEntries = affectedRecords.Select(record =>
+            {
+                var entry = context.Entry(record);
+                var snapshot = new Dictionary<string, object?>();
+
+                foreach (var prop in entry.Properties)
+                {
+                    if (prop.Metadata.IsPrimaryKey())
+                        continue;
+
+                    var property = typeof(T).GetProperty(prop.Metadata.Name,
+                        BindingFlags.Public | BindingFlags.Instance);
+
+                    if (property?.GetCustomAttribute<AuditIgnoredAttribute>() is not null)
+                        continue;
+
+                    var isRedacted = property?.GetCustomAttribute<AuditRedactedAttribute>() is not null;
+                    snapshot[prop.Metadata.Name] = isRedacted ? "[redacted]" : prop.CurrentValue;
+                }
+
+                return new MutationAuditLogEntity
+                {
+                    Id = Guid.CreateVersion7(),
+                    TenantId = context.TenantId,
+                    EntityType = entityTypeName,
+                    EntityId = (Guid)entry.Property("Id").CurrentValue!,
+                    Action = "soft_delete",
+                    ChangesJson = JsonSerializer.Serialize(snapshot, JsonOptions),
+                    SubjectId = auditContext?.SubjectId,
+                    AuthType = auditContext?.AuthType,
+                    IpAddress = auditContext?.IpAddress,
+                    TokenId = auditContext?.TokenId,
+                    CorrelationId = auditContext?.CorrelationId,
+                    Endpoint = auditContext?.Endpoint,
+                    CreatedAt = now
+                };
+            }).ToList();
+
+            // Detach the loaded entities so they don't interfere with the bulk update
+            foreach (var record in affectedRecords)
+                context.Entry(record).State = EntityState.Detached;
+
+            // Write audit entries
+            context.Set<MutationAuditLogEntity>().AddRange(auditEntries);
+            await context.SaveChangesAsync(ct);
+
+            // Execute bulk soft delete
+            var deletedCount = await query.ExecuteUpdateAsync(
+                s => s.SetProperty(e => e.DeletedAt, now), ct);
+
+            await transaction.CommitAsync(ct);
+            return deletedCount;
+        });
+    }
+
+    /// <summary>
+    /// Executes a bulk soft delete without audit trail by setting <c>DeletedAt</c> on all matching rows.
+    /// </summary>
+    public static async Task<int> SoftDeleteAsync<T>(
+        this NocturneDbContext context,
+        IQueryable<T> query,
+        CancellationToken ct = default) where T : class, ISoftDeletable
+    {
+        return await query.ExecuteUpdateAsync(
+            s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
+    }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260514052027_AddSoftDeleteToV4Entities.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260514052027_AddSoftDeleteToV4Entities.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260514052027_AddSoftDeleteToV4Entities")]
+    partial class AddSoftDeleteToV4Entities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260514052027_AddSoftDeleteToV4Entities.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260514052027_AddSoftDeleteToV4Entities.cs
@@ -341,11 +341,50 @@ namespace Nocturne.Infrastructure.Data.Migrations
                 columns: new[] { "tenant_id", "legacy_id" },
                 unique: true,
                 filter: "legacy_id IS NOT NULL AND deleted_at IS NULL");
+
+            // Partial indexes for efficient soft-delete cleanup queries
+            var tables = new[]
+            {
+                "aps_snapshots", "basal_schedules", "bg_checks", "bolus_calculations",
+                "boluses", "calibrations", "carb_intakes", "carb_ratio_schedules",
+                "decomposition_batches", "device_events", "device_status_extras",
+                "devices", "meter_glucose", "notes", "patient_devices",
+                "patient_insulins", "patient_records", "pump_snapshots",
+                "sensitivity_schedules", "sensor_glucose", "target_range_schedules",
+                "temp_basals", "therapy_settings", "uploader_snapshots"
+            };
+
+            foreach (var table in tables)
+            {
+                migrationBuilder.CreateIndex(
+                    name: $"ix_{table}_deleted_at",
+                    table: table,
+                    column: "deleted_at",
+                    filter: "deleted_at IS NOT NULL");
+            }
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            var tables = new[]
+            {
+                "aps_snapshots", "basal_schedules", "bg_checks", "bolus_calculations",
+                "boluses", "calibrations", "carb_intakes", "carb_ratio_schedules",
+                "decomposition_batches", "device_events", "device_status_extras",
+                "devices", "meter_glucose", "notes", "patient_devices",
+                "patient_insulins", "patient_records", "pump_snapshots",
+                "sensitivity_schedules", "sensor_glucose", "target_range_schedules",
+                "temp_basals", "therapy_settings", "uploader_snapshots"
+            };
+
+            foreach (var table in tables)
+            {
+                migrationBuilder.DropIndex(
+                    name: $"ix_{table}_deleted_at",
+                    table: table);
+            }
+
             migrationBuilder.DropIndex(
                 name: "ix_therapy_settings_tenant_legacy_id",
                 table: "therapy_settings");

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260514052027_AddSoftDeleteToV4Entities.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260514052027_AddSoftDeleteToV4Entities.cs
@@ -1,0 +1,631 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSoftDeleteToV4Entities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_therapy_settings_tenant_legacy_id",
+                table: "therapy_settings");
+
+            migrationBuilder.DropIndex(
+                name: "ix_temp_basals_tenant_legacy_id",
+                table: "temp_basals");
+
+            migrationBuilder.DropIndex(
+                name: "ix_target_range_schedules_tenant_legacy_id",
+                table: "target_range_schedules");
+
+            migrationBuilder.DropIndex(
+                name: "ix_sensor_glucose_tenant_legacy_id",
+                table: "sensor_glucose");
+
+            migrationBuilder.DropIndex(
+                name: "ix_sensitivity_schedules_tenant_legacy_id",
+                table: "sensitivity_schedules");
+
+            migrationBuilder.DropIndex(
+                name: "ix_patient_records_tenant_id",
+                table: "patient_records");
+
+            migrationBuilder.DropIndex(
+                name: "ix_notes_tenant_legacy_id",
+                table: "notes");
+
+            migrationBuilder.DropIndex(
+                name: "IX_devices_category_type_serial",
+                table: "devices");
+
+            migrationBuilder.DropIndex(
+                name: "ix_device_events_tenant_legacy_id",
+                table: "device_events");
+
+            migrationBuilder.DropIndex(
+                name: "ix_carb_ratio_schedules_tenant_legacy_id",
+                table: "carb_ratio_schedules");
+
+            migrationBuilder.DropIndex(
+                name: "ix_carb_intakes_tenant_legacy_id",
+                table: "carb_intakes");
+
+            migrationBuilder.DropIndex(
+                name: "ix_carb_intakes_tenant_source_sync_id",
+                table: "carb_intakes");
+
+            migrationBuilder.DropIndex(
+                name: "ix_boluses_tenant_legacy_id",
+                table: "boluses");
+
+            migrationBuilder.DropIndex(
+                name: "ix_boluses_tenant_source_sync_id",
+                table: "boluses");
+
+            migrationBuilder.DropIndex(
+                name: "ix_bolus_calculations_tenant_legacy_id",
+                table: "bolus_calculations");
+
+            migrationBuilder.DropIndex(
+                name: "ix_bg_checks_tenant_legacy_id",
+                table: "bg_checks");
+
+            migrationBuilder.DropIndex(
+                name: "ix_basal_schedules_tenant_legacy_id",
+                table: "basal_schedules");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "uploader_snapshots",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "therapy_settings",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "temp_basals",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "target_range_schedules",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "sensor_glucose",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "sensitivity_schedules",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "pump_snapshots",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "patient_records",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "patient_insulins",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "patient_devices",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "notes",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "meter_glucose",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "devices",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "device_status_extras",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "device_events",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "decomposition_batches",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "carb_ratio_schedules",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "carb_intakes",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "calibrations",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "boluses",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "bolus_calculations",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "bg_checks",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "basal_schedules",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "aps_snapshots",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_therapy_settings_tenant_legacy_id",
+                table: "therapy_settings",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_temp_basals_tenant_legacy_id",
+                table: "temp_basals",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_target_range_schedules_tenant_legacy_id",
+                table: "target_range_schedules",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_sensor_glucose_tenant_legacy_id",
+                table: "sensor_glucose",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_sensitivity_schedules_tenant_legacy_id",
+                table: "sensitivity_schedules",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_patient_records_tenant_id",
+                table: "patient_records",
+                column: "tenant_id",
+                unique: true,
+                filter: "deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_notes_tenant_legacy_id",
+                table: "notes",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_devices_category_type_serial",
+                table: "devices",
+                columns: new[] { "category", "type", "serial" },
+                unique: true,
+                filter: "deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_device_events_tenant_legacy_id",
+                table: "device_events",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_carb_ratio_schedules_tenant_legacy_id",
+                table: "carb_ratio_schedules",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_carb_intakes_tenant_legacy_id",
+                table: "carb_intakes",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_carb_intakes_tenant_source_sync_id",
+                table: "carb_intakes",
+                columns: new[] { "tenant_id", "data_source", "sync_identifier" },
+                unique: true,
+                filter: "sync_identifier IS NOT NULL AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_boluses_tenant_legacy_id",
+                table: "boluses",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_boluses_tenant_source_sync_id",
+                table: "boluses",
+                columns: new[] { "tenant_id", "data_source", "sync_identifier" },
+                unique: true,
+                filter: "sync_identifier IS NOT NULL AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_bolus_calculations_tenant_legacy_id",
+                table: "bolus_calculations",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_bg_checks_tenant_legacy_id",
+                table: "bg_checks",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_basal_schedules_tenant_legacy_id",
+                table: "basal_schedules",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL AND deleted_at IS NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_therapy_settings_tenant_legacy_id",
+                table: "therapy_settings");
+
+            migrationBuilder.DropIndex(
+                name: "ix_temp_basals_tenant_legacy_id",
+                table: "temp_basals");
+
+            migrationBuilder.DropIndex(
+                name: "ix_target_range_schedules_tenant_legacy_id",
+                table: "target_range_schedules");
+
+            migrationBuilder.DropIndex(
+                name: "ix_sensor_glucose_tenant_legacy_id",
+                table: "sensor_glucose");
+
+            migrationBuilder.DropIndex(
+                name: "ix_sensitivity_schedules_tenant_legacy_id",
+                table: "sensitivity_schedules");
+
+            migrationBuilder.DropIndex(
+                name: "ix_patient_records_tenant_id",
+                table: "patient_records");
+
+            migrationBuilder.DropIndex(
+                name: "ix_notes_tenant_legacy_id",
+                table: "notes");
+
+            migrationBuilder.DropIndex(
+                name: "ix_devices_category_type_serial",
+                table: "devices");
+
+            migrationBuilder.DropIndex(
+                name: "ix_device_events_tenant_legacy_id",
+                table: "device_events");
+
+            migrationBuilder.DropIndex(
+                name: "ix_carb_ratio_schedules_tenant_legacy_id",
+                table: "carb_ratio_schedules");
+
+            migrationBuilder.DropIndex(
+                name: "ix_carb_intakes_tenant_legacy_id",
+                table: "carb_intakes");
+
+            migrationBuilder.DropIndex(
+                name: "ix_carb_intakes_tenant_source_sync_id",
+                table: "carb_intakes");
+
+            migrationBuilder.DropIndex(
+                name: "ix_boluses_tenant_legacy_id",
+                table: "boluses");
+
+            migrationBuilder.DropIndex(
+                name: "ix_boluses_tenant_source_sync_id",
+                table: "boluses");
+
+            migrationBuilder.DropIndex(
+                name: "ix_bolus_calculations_tenant_legacy_id",
+                table: "bolus_calculations");
+
+            migrationBuilder.DropIndex(
+                name: "ix_bg_checks_tenant_legacy_id",
+                table: "bg_checks");
+
+            migrationBuilder.DropIndex(
+                name: "ix_basal_schedules_tenant_legacy_id",
+                table: "basal_schedules");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "uploader_snapshots");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "therapy_settings");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "temp_basals");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "target_range_schedules");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "sensor_glucose");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "sensitivity_schedules");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "pump_snapshots");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "patient_records");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "patient_insulins");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "patient_devices");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "notes");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "meter_glucose");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "devices");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "device_status_extras");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "device_events");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "decomposition_batches");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "carb_ratio_schedules");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "carb_intakes");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "calibrations");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "boluses");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "bolus_calculations");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "bg_checks");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "basal_schedules");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "aps_snapshots");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_therapy_settings_tenant_legacy_id",
+                table: "therapy_settings",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_temp_basals_tenant_legacy_id",
+                table: "temp_basals",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_target_range_schedules_tenant_legacy_id",
+                table: "target_range_schedules",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_sensor_glucose_tenant_legacy_id",
+                table: "sensor_glucose",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_sensitivity_schedules_tenant_legacy_id",
+                table: "sensitivity_schedules",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_patient_records_tenant_id",
+                table: "patient_records",
+                column: "tenant_id",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_notes_tenant_legacy_id",
+                table: "notes",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_devices_category_type_serial",
+                table: "devices",
+                columns: new[] { "category", "type", "serial" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_device_events_tenant_legacy_id",
+                table: "device_events",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_carb_ratio_schedules_tenant_legacy_id",
+                table: "carb_ratio_schedules",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_carb_intakes_tenant_legacy_id",
+                table: "carb_intakes",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_carb_intakes_tenant_source_sync_id",
+                table: "carb_intakes",
+                columns: new[] { "tenant_id", "data_source", "sync_identifier" },
+                unique: true,
+                filter: "sync_identifier IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_boluses_tenant_legacy_id",
+                table: "boluses",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_boluses_tenant_source_sync_id",
+                table: "boluses",
+                columns: new[] { "tenant_id", "data_source", "sync_identifier" },
+                unique: true,
+                filter: "sync_identifier IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_bolus_calculations_tenant_legacy_id",
+                table: "bolus_calculations",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_bg_checks_tenant_legacy_id",
+                table: "bg_checks",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_basal_schedules_tenant_legacy_id",
+                table: "basal_schedules",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL");
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260514053840_AddTenantDataRetentionConfig.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260514053840_AddTenantDataRetentionConfig.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260514053840_AddTenantDataRetentionConfig")]
+    partial class AddTenantDataRetentionConfig
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260514053840_AddTenantDataRetentionConfig.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260514053840_AddTenantDataRetentionConfig.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTenantDataRetentionConfig : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "tenant_data_retention_config",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    tenant_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    soft_delete_retention_days = table.Column<int>(type: "integer", nullable: true),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_tenant_data_retention_config", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_tenant_data_retention_config_tenants_tenant_id",
+                        column: x => x.tenant_id,
+                        principalTable: "tenants",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_tenant_data_retention_config_tenant_id",
+                table: "tenant_data_retention_config",
+                column: "tenant_id",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "tenant_data_retention_config");
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -1280,7 +1280,7 @@ public class NocturneDbContext : DbContext
             .HasIndex(e => new { e.TenantId, e.LegacyId })
             .HasDatabaseName("ix_sensor_glucose_tenant_legacy_id")
             .IsUnique()
-            .HasFilter("legacy_id IS NOT NULL");
+            .HasFilter("legacy_id IS NOT NULL AND deleted_at IS NULL");
 
         modelBuilder
             .Entity<SensorGlucoseEntity>()
@@ -1352,7 +1352,7 @@ public class NocturneDbContext : DbContext
             .HasIndex(e => new { e.TenantId, e.LegacyId })
             .HasDatabaseName("ix_boluses_tenant_legacy_id")
             .IsUnique()
-            .HasFilter("legacy_id IS NOT NULL");
+            .HasFilter("legacy_id IS NOT NULL AND deleted_at IS NULL");
 
         modelBuilder
             .Entity<BolusEntity>()
@@ -1369,7 +1369,7 @@ public class NocturneDbContext : DbContext
             .HasIndex(e => new { e.TenantId, e.DataSource, e.SyncIdentifier })
             .HasDatabaseName("ix_boluses_tenant_source_sync_id")
             .IsUnique()
-            .HasFilter("sync_identifier IS NOT NULL");
+            .HasFilter("sync_identifier IS NOT NULL AND deleted_at IS NULL");
 
         // CarbIntakes indexes
         modelBuilder
@@ -1383,7 +1383,7 @@ public class NocturneDbContext : DbContext
             .HasIndex(e => new { e.TenantId, e.LegacyId })
             .HasDatabaseName("ix_carb_intakes_tenant_legacy_id")
             .IsUnique()
-            .HasFilter("legacy_id IS NOT NULL");
+            .HasFilter("legacy_id IS NOT NULL AND deleted_at IS NULL");
 
         modelBuilder
             .Entity<CarbIntakeEntity>()
@@ -1400,7 +1400,7 @@ public class NocturneDbContext : DbContext
             .HasIndex(e => new { e.TenantId, e.DataSource, e.SyncIdentifier })
             .HasDatabaseName("ix_carb_intakes_tenant_source_sync_id")
             .IsUnique()
-            .HasFilter("sync_identifier IS NOT NULL");
+            .HasFilter("sync_identifier IS NOT NULL AND deleted_at IS NULL");
 
         // BGChecks indexes
         modelBuilder
@@ -1414,7 +1414,7 @@ public class NocturneDbContext : DbContext
             .HasIndex(e => new { e.TenantId, e.LegacyId })
             .HasDatabaseName("ix_bg_checks_tenant_legacy_id")
             .IsUnique()
-            .HasFilter("legacy_id IS NOT NULL");
+            .HasFilter("legacy_id IS NOT NULL AND deleted_at IS NULL");
 
         modelBuilder
             .Entity<BGCheckEntity>()
@@ -1433,7 +1433,7 @@ public class NocturneDbContext : DbContext
             .HasIndex(e => new { e.TenantId, e.LegacyId })
             .HasDatabaseName("ix_notes_tenant_legacy_id")
             .IsUnique()
-            .HasFilter("legacy_id IS NOT NULL");
+            .HasFilter("legacy_id IS NOT NULL AND deleted_at IS NULL");
 
         modelBuilder
             .Entity<NoteEntity>()
@@ -1452,7 +1452,7 @@ public class NocturneDbContext : DbContext
             .HasIndex(e => new { e.TenantId, e.LegacyId })
             .HasDatabaseName("ix_device_events_tenant_legacy_id")
             .IsUnique()
-            .HasFilter("legacy_id IS NOT NULL");
+            .HasFilter("legacy_id IS NOT NULL AND deleted_at IS NULL");
 
         modelBuilder
             .Entity<DeviceEventEntity>()
@@ -1471,7 +1471,7 @@ public class NocturneDbContext : DbContext
             .HasIndex(e => new { e.TenantId, e.LegacyId })
             .HasDatabaseName("ix_bolus_calculations_tenant_legacy_id")
             .IsUnique()
-            .HasFilter("legacy_id IS NOT NULL");
+            .HasFilter("legacy_id IS NOT NULL AND deleted_at IS NULL");
 
         modelBuilder
             .Entity<BolusCalculationEntity>()
@@ -1538,7 +1538,7 @@ public class NocturneDbContext : DbContext
             .HasIndex(e => new { e.TenantId, e.LegacyId })
             .HasDatabaseName("ix_temp_basals_tenant_legacy_id")
             .IsUnique()
-            .HasFilter("legacy_id IS NOT NULL");
+            .HasFilter("legacy_id IS NOT NULL AND deleted_at IS NULL");
 
         modelBuilder
             .Entity<TempBasalEntity>()
@@ -1551,7 +1551,13 @@ public class NocturneDbContext : DbContext
             .HasDatabaseName("ix_temp_basals_tenant_start_timestamp")
             .IsDescending(false, true);
 
-        // Devices unique index is handled by [Index] attribute on entity
+        // Devices unique index (scoped to live records)
+        modelBuilder
+            .Entity<DeviceEntity>()
+            .HasIndex(e => new { e.Category, e.Type, e.Serial })
+            .HasDatabaseName("ix_devices_category_type_serial")
+            .IsUnique()
+            .HasFilter("deleted_at IS NULL");
 
         // V4 Profile Decomposition indexes
 
@@ -1567,7 +1573,7 @@ public class NocturneDbContext : DbContext
             .HasIndex(e => new { e.TenantId, e.LegacyId })
             .HasDatabaseName("ix_therapy_settings_tenant_legacy_id")
             .IsUnique()
-            .HasFilter("legacy_id IS NOT NULL");
+            .HasFilter("legacy_id IS NOT NULL AND deleted_at IS NULL");
 
         modelBuilder
             .Entity<TherapySettingsEntity>()
@@ -1597,7 +1603,7 @@ public class NocturneDbContext : DbContext
             .HasIndex(e => new { e.TenantId, e.LegacyId })
             .HasDatabaseName("ix_basal_schedules_tenant_legacy_id")
             .IsUnique()
-            .HasFilter("legacy_id IS NOT NULL");
+            .HasFilter("legacy_id IS NOT NULL AND deleted_at IS NULL");
 
         modelBuilder
             .Entity<BasalScheduleEntity>()
@@ -1627,7 +1633,7 @@ public class NocturneDbContext : DbContext
             .HasIndex(e => new { e.TenantId, e.LegacyId })
             .HasDatabaseName("ix_carb_ratio_schedules_tenant_legacy_id")
             .IsUnique()
-            .HasFilter("legacy_id IS NOT NULL");
+            .HasFilter("legacy_id IS NOT NULL AND deleted_at IS NULL");
 
         modelBuilder
             .Entity<CarbRatioScheduleEntity>()
@@ -1657,7 +1663,7 @@ public class NocturneDbContext : DbContext
             .HasIndex(e => new { e.TenantId, e.LegacyId })
             .HasDatabaseName("ix_sensitivity_schedules_tenant_legacy_id")
             .IsUnique()
-            .HasFilter("legacy_id IS NOT NULL");
+            .HasFilter("legacy_id IS NOT NULL AND deleted_at IS NULL");
 
         modelBuilder
             .Entity<SensitivityScheduleEntity>()
@@ -1687,7 +1693,7 @@ public class NocturneDbContext : DbContext
             .HasIndex(e => new { e.TenantId, e.LegacyId })
             .HasDatabaseName("ix_target_range_schedules_tenant_legacy_id")
             .IsUnique()
-            .HasFilter("legacy_id IS NOT NULL");
+            .HasFilter("legacy_id IS NOT NULL AND deleted_at IS NULL");
 
         modelBuilder
             .Entity<TargetRangeScheduleEntity>()
@@ -1715,11 +1721,12 @@ public class NocturneDbContext : DbContext
             .HasIndex(tm => tm.SubjectId)
             .HasDatabaseName("ix_tenant_members_subject_id");
 
-        // PatientRecord: unique constraint — one record per tenant
+        // PatientRecord: unique constraint — one record per tenant (scoped to live records)
         modelBuilder.Entity<PatientRecordEntity>()
             .HasIndex(e => e.TenantId)
             .HasDatabaseName("ix_patient_records_tenant_id")
-            .IsUnique();
+            .IsUnique()
+            .HasFilter("deleted_at IS NULL");
 
         // PatientDevice: query by tenant + current status
         modelBuilder.Entity<PatientDeviceEntity>()

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -496,6 +496,11 @@ public class NocturneDbContext : DbContext
     public DbSet<TenantAuditConfigEntity> TenantAuditConfig { get; set; }
 
     /// <summary>
+    /// Gets or sets the TenantDataRetentionConfig table for per-tenant soft-delete retention
+    /// </summary>
+    public DbSet<TenantDataRetentionConfigEntity> TenantDataRetentionConfig { get; set; }
+
+    /// <summary>
     /// Configure the database model and relationships
     /// </summary>
     /// <param name="modelBuilder">The model builder to configure</param>
@@ -1893,6 +1898,10 @@ public class NocturneDbContext : DbContext
             .Entity<TenantAuditConfigEntity>()
             .Property(a => a.Id)
             .HasValueGenerator<GuidV7ValueGenerator>();
+        modelBuilder
+            .Entity<TenantDataRetentionConfigEntity>()
+            .Property(a => a.Id)
+            .HasValueGenerator<GuidV7ValueGenerator>();
 
         // Tracker entity UUID generators
         modelBuilder
@@ -2484,6 +2493,17 @@ public class NocturneDbContext : DbContext
             entity.HasIndex(e => e.TenantId)
                 .IsUnique()
                 .HasDatabaseName("ix_tenant_audit_config_tenant_id");
+        });
+
+        // Configure Tenant Data Retention Config entity defaults and indexes
+        modelBuilder.Entity<TenantDataRetentionConfigEntity>(entity =>
+        {
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+            entity.HasIndex(e => e.TenantId)
+                .IsUnique()
+                .HasDatabaseName("ix_tenant_data_retention_config_tenant_id");
         });
 
         // Configure LinkedRecordEntity defaults

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
@@ -121,8 +121,57 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.ApsSnapshots.FindAsync([id], ct)
             ?? throw new KeyNotFoundException($"ApsSnapshot {id} not found");
-        ctx.ApsSnapshots.Remove(entity);
+        entity.DeletedAt = DateTime.UtcNow;
         await ctx.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApsSnapshot> RestoreAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entity = await ctx.ApsSnapshots.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Soft-deleted ApsSnapshot {id} not found");
+        entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return ApsSnapshotMapper.ToDomainModel(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<ApsSnapshot>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var idSet = ids.ToHashSet();
+        var entities = await ctx.ApsSnapshots.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
+            .ToListAsync(ct);
+        foreach (var entity in entities)
+            entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return entities.Select(ApsSnapshotMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<ApsSnapshot>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entities = await ctx.ApsSnapshots.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .OrderByDescending(e => e.DeletedAt)
+            .Skip(offset).Take(limit)
+            .AsNoTracking()
+            .ToListAsync(ct);
+        return entities.Select(ApsSnapshotMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        return await ctx.ApsSnapshots.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .CountAsync(ct);
     }
 
     /// <summary>
@@ -195,7 +244,7 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
         await using var ctx = await _contextFactory.CreateAsync(ct);
         return await ctx.ApsSnapshots
             .Where(e => e.LegacyId == legacyId)
-            .ExecuteDeleteAsync(ct);
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 
     /// <inheritdoc />

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
@@ -316,25 +316,19 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
 
             if (legacyIds.Count > 0)
             {
-                var existingIds = await ctx
-                    .ApsSnapshots.IgnoreQueryFilters().AsNoTracking()
+                var existingRecords = await ctx.ApsSnapshots.IgnoreQueryFilters().AsNoTracking()
                     .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
-                    .Select(e => e.LegacyId)
+                    .Select(e => new { e.LegacyId, IsSoftDeleted = e.DeletedAt != null })
                     .ToListAsync(ct);
 
-                var existingSet = existingIds.ToHashSet();
-
-                var softDeletedCount = await ctx
-                    .ApsSnapshots.IgnoreQueryFilters().AsNoTracking()
-                    .Where(e => e.TenantId == ctx.TenantId)
-                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
-                    .CountAsync(ct);
+                var existingSet = existingRecords.Select(r => r.LegacyId).ToHashSet();
+                var softDeletedCount = existingRecords.Count(r => r.IsSoftDeleted);
 
                 if (softDeletedCount > 0)
                     _logger.LogInformation(
-                        "Skipped {Count} previously-deleted ApsSnapshot records during import",
-                        softDeletedCount);
+                        "Skipped {Count} previously-deleted {Type} records during import",
+                        softDeletedCount, "ApsSnapshot");
 
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
@@ -317,12 +317,25 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
             if (legacyIds.Count > 0)
             {
                 var existingIds = await ctx
-                    .ApsSnapshots.AsNoTracking()
+                    .ApsSnapshots.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
                     .Select(e => e.LegacyId)
                     .ToListAsync(ct);
 
                 var existingSet = existingIds.ToHashSet();
+
+                var softDeletedCount = await ctx
+                    .ApsSnapshots.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
+                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
+                    .CountAsync(ct);
+
+                if (softDeletedCount > 0)
+                    _logger.LogInformation(
+                        "Skipped {Count} previously-deleted ApsSnapshot records during import",
+                        softDeletedCount);
+
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
                     .ToList();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
@@ -153,8 +153,57 @@ public class BGCheckRepository : IBGCheckRepository
         var entity =
             await ctx.BGChecks.FindAsync([id], ct)
             ?? throw new KeyNotFoundException($"BGCheck {id} not found");
-        ctx.BGChecks.Remove(entity);
+        entity.DeletedAt = DateTime.UtcNow;
         await ctx.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<BGCheck> RestoreAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entity = await ctx.BGChecks.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Soft-deleted BGCheck {id} not found");
+        entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return BGCheckMapper.ToDomainModel(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<BGCheck>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var idSet = ids.ToHashSet();
+        var entities = await ctx.BGChecks.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
+            .ToListAsync(ct);
+        foreach (var entity in entities)
+            entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return entities.Select(BGCheckMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<BGCheck>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entities = await ctx.BGChecks.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .OrderByDescending(e => e.DeletedAt)
+            .Skip(offset).Take(limit)
+            .AsNoTracking()
+            .ToListAsync(ct);
+        return entities.Select(BGCheckMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        return await ctx.BGChecks.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .CountAsync(ct);
     }
 
     /// <summary>
@@ -203,7 +252,8 @@ public class BGCheckRepository : IBGCheckRepository
     public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.BGChecks.Where(e => e.LegacyId == legacyId).ExecuteDeleteAsync(ct);
+        return await ctx.BGChecks.Where(e => e.LegacyId == legacyId)
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
@@ -294,12 +294,25 @@ public class BGCheckRepository : IBGCheckRepository
             if (legacyIds.Count > 0)
             {
                 var existingIds = await ctx
-                    .BGChecks.AsNoTracking()
+                    .BGChecks.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
                     .Select(e => e.LegacyId)
                     .ToListAsync(ct);
 
                 var existingSet = existingIds.ToHashSet();
+
+                var softDeletedCount = await ctx
+                    .BGChecks.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
+                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
+                    .CountAsync(ct);
+
+                if (softDeletedCount > 0)
+                    _logger.LogInformation(
+                        "Skipped {Count} previously-deleted BGCheck records during import",
+                        softDeletedCount);
+
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
                     .ToList();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
@@ -293,25 +293,19 @@ public class BGCheckRepository : IBGCheckRepository
 
             if (legacyIds.Count > 0)
             {
-                var existingIds = await ctx
-                    .BGChecks.IgnoreQueryFilters().AsNoTracking()
+                var existingRecords = await ctx.BGChecks.IgnoreQueryFilters().AsNoTracking()
                     .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
-                    .Select(e => e.LegacyId)
+                    .Select(e => new { e.LegacyId, IsSoftDeleted = e.DeletedAt != null })
                     .ToListAsync(ct);
 
-                var existingSet = existingIds.ToHashSet();
-
-                var softDeletedCount = await ctx
-                    .BGChecks.IgnoreQueryFilters().AsNoTracking()
-                    .Where(e => e.TenantId == ctx.TenantId)
-                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
-                    .CountAsync(ct);
+                var existingSet = existingRecords.Select(r => r.LegacyId).ToHashSet();
+                var softDeletedCount = existingRecords.Count(r => r.IsSoftDeleted);
 
                 if (softDeletedCount > 0)
                     _logger.LogInformation(
-                        "Skipped {Count} previously-deleted BGCheck records during import",
-                        softDeletedCount);
+                        "Skipped {Count} previously-deleted {Type} records during import",
+                        softDeletedCount, "BGCheck");
 
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalScheduleRepository.cs
@@ -332,12 +332,25 @@ public class BasalScheduleRepository : IBasalScheduleRepository
             if (legacyIds.Count > 0)
             {
                 var existingIds = await ctx
-                    .BasalSchedules.AsNoTracking()
+                    .BasalSchedules.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
                     .Select(e => e.LegacyId)
                     .ToListAsync(ct);
 
                 var existingSet = existingIds.ToHashSet();
+
+                var softDeletedCount = await ctx
+                    .BasalSchedules.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
+                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
+                    .CountAsync(ct);
+
+                if (softDeletedCount > 0)
+                    _logger.LogInformation(
+                        "Skipped {Count} previously-deleted BasalSchedule records during import",
+                        softDeletedCount);
+
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
                     .ToList();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalScheduleRepository.cs
@@ -331,25 +331,19 @@ public class BasalScheduleRepository : IBasalScheduleRepository
 
             if (legacyIds.Count > 0)
             {
-                var existingIds = await ctx
-                    .BasalSchedules.IgnoreQueryFilters().AsNoTracking()
+                var existingRecords = await ctx.BasalSchedules.IgnoreQueryFilters().AsNoTracking()
                     .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
-                    .Select(e => e.LegacyId)
+                    .Select(e => new { e.LegacyId, IsSoftDeleted = e.DeletedAt != null })
                     .ToListAsync(ct);
 
-                var existingSet = existingIds.ToHashSet();
-
-                var softDeletedCount = await ctx
-                    .BasalSchedules.IgnoreQueryFilters().AsNoTracking()
-                    .Where(e => e.TenantId == ctx.TenantId)
-                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
-                    .CountAsync(ct);
+                var existingSet = existingRecords.Select(r => r.LegacyId).ToHashSet();
+                var softDeletedCount = existingRecords.Count(r => r.IsSoftDeleted);
 
                 if (softDeletedCount > 0)
                     _logger.LogInformation(
-                        "Skipped {Count} previously-deleted BasalSchedule records during import",
-                        softDeletedCount);
+                        "Skipped {Count} previously-deleted {Type} records during import",
+                        softDeletedCount, "BasalSchedule");
 
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalScheduleRepository.cs
@@ -179,8 +179,57 @@ public class BasalScheduleRepository : IBasalScheduleRepository
         var entity =
             await ctx.BasalSchedules.FindAsync([id], ct)
             ?? throw new KeyNotFoundException($"BasalSchedule {id} not found");
-        ctx.BasalSchedules.Remove(entity);
+        entity.DeletedAt = DateTime.UtcNow;
         await ctx.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<BasalSchedule> RestoreAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entity = await ctx.BasalSchedules.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Soft-deleted BasalSchedule {id} not found");
+        entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return BasalScheduleMapper.ToDomainModel(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<BasalSchedule>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var idSet = ids.ToHashSet();
+        var entities = await ctx.BasalSchedules.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
+            .ToListAsync(ct);
+        foreach (var entity in entities)
+            entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return entities.Select(BasalScheduleMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<BasalSchedule>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entities = await ctx.BasalSchedules.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .OrderByDescending(e => e.DeletedAt)
+            .Skip(offset).Take(limit)
+            .AsNoTracking()
+            .ToListAsync(ct);
+        return entities.Select(BasalScheduleMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        return await ctx.BasalSchedules.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .CountAsync(ct);
     }
 
     /// <summary>
@@ -192,7 +241,7 @@ public class BasalScheduleRepository : IBasalScheduleRepository
     public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.AuditedExecuteDeleteAsync(
+        return await ctx.AuditedSoftDeleteAsync(
             ctx.BasalSchedules.Where(e => e.LegacyId == legacyId), _auditContext, ct);
     }
 
@@ -205,7 +254,7 @@ public class BasalScheduleRepository : IBasalScheduleRepository
     public async Task<int> DeleteByLegacyIdPrefixAsync(string prefix, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.AuditedExecuteDeleteAsync(
+        return await ctx.AuditedSoftDeleteAsync(
             ctx.BasalSchedules.Where(e => e.LegacyId != null && e.LegacyId.StartsWith(prefix)),
             _auditContext, ct);
     }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
@@ -309,25 +309,19 @@ public class BolusCalculationRepository : IBolusCalculationRepository
 
             if (legacyIds.Count > 0)
             {
-                var existingIds = await ctx
-                    .BolusCalculations.IgnoreQueryFilters().AsNoTracking()
+                var existingRecords = await ctx.BolusCalculations.IgnoreQueryFilters().AsNoTracking()
                     .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
-                    .Select(e => e.LegacyId)
+                    .Select(e => new { e.LegacyId, IsSoftDeleted = e.DeletedAt != null })
                     .ToListAsync(ct);
 
-                var existingSet = existingIds.ToHashSet();
-
-                var softDeletedCount = await ctx
-                    .BolusCalculations.IgnoreQueryFilters().AsNoTracking()
-                    .Where(e => e.TenantId == ctx.TenantId)
-                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
-                    .CountAsync(ct);
+                var existingSet = existingRecords.Select(r => r.LegacyId).ToHashSet();
+                var softDeletedCount = existingRecords.Count(r => r.IsSoftDeleted);
 
                 if (softDeletedCount > 0)
                     _logger.LogInformation(
-                        "Skipped {Count} previously-deleted BolusCalculation records during import",
-                        softDeletedCount);
+                        "Skipped {Count} previously-deleted {Type} records during import",
+                        softDeletedCount, "BolusCalculation");
 
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
@@ -310,12 +310,25 @@ public class BolusCalculationRepository : IBolusCalculationRepository
             if (legacyIds.Count > 0)
             {
                 var existingIds = await ctx
-                    .BolusCalculations.AsNoTracking()
+                    .BolusCalculations.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
                     .Select(e => e.LegacyId)
                     .ToListAsync(ct);
 
                 var existingSet = existingIds.ToHashSet();
+
+                var softDeletedCount = await ctx
+                    .BolusCalculations.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
+                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
+                    .CountAsync(ct);
+
+                if (softDeletedCount > 0)
+                    _logger.LogInformation(
+                        "Skipped {Count} previously-deleted BolusCalculation records during import",
+                        softDeletedCount);
+
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
                     .ToList();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
@@ -169,8 +169,57 @@ public class BolusCalculationRepository : IBolusCalculationRepository
         var entity =
             await ctx.BolusCalculations.FindAsync([id], ct)
             ?? throw new KeyNotFoundException($"BolusCalculation {id} not found");
-        ctx.BolusCalculations.Remove(entity);
+        entity.DeletedAt = DateTime.UtcNow;
         await ctx.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<BolusCalculation> RestoreAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entity = await ctx.BolusCalculations.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Soft-deleted BolusCalculation {id} not found");
+        entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return BolusCalculationMapper.ToDomainModel(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<BolusCalculation>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var idSet = ids.ToHashSet();
+        var entities = await ctx.BolusCalculations.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
+            .ToListAsync(ct);
+        foreach (var entity in entities)
+            entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return entities.Select(BolusCalculationMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<BolusCalculation>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entities = await ctx.BolusCalculations.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .OrderByDescending(e => e.DeletedAt)
+            .Skip(offset).Take(limit)
+            .AsNoTracking()
+            .ToListAsync(ct);
+        return entities.Select(BolusCalculationMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        return await ctx.BolusCalculations.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .CountAsync(ct);
     }
 
     /// <summary>
@@ -219,7 +268,7 @@ public class BolusCalculationRepository : IBolusCalculationRepository
     public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.AuditedExecuteDeleteAsync(
+        return await ctx.AuditedSoftDeleteAsync(
             ctx.BolusCalculations.Where(e => e.LegacyId == legacyId), _auditContext, ct);
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
@@ -420,25 +420,19 @@ public class BolusRepository : IBolusRepository
 
             if (legacyIds.Count > 0)
             {
-                var existingIds = await ctx
-                    .Boluses.IgnoreQueryFilters().AsNoTracking()
+                var existingRecords = await ctx.Boluses.IgnoreQueryFilters().AsNoTracking()
                     .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
-                    .Select(e => e.LegacyId)
+                    .Select(e => new { e.LegacyId, IsSoftDeleted = e.DeletedAt != null })
                     .ToListAsync(ct);
 
-                var existingSet = existingIds.ToHashSet();
-
-                var softDeletedCount = await ctx
-                    .Boluses.IgnoreQueryFilters().AsNoTracking()
-                    .Where(e => e.TenantId == ctx.TenantId)
-                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
-                    .CountAsync(ct);
+                var existingSet = existingRecords.Select(r => r.LegacyId).ToHashSet();
+                var softDeletedCount = existingRecords.Count(r => r.IsSoftDeleted);
 
                 if (softDeletedCount > 0)
                     _logger.LogInformation(
-                        "Skipped {Count} previously-deleted Bolus records during import",
-                        softDeletedCount);
+                        "Skipped {Count} previously-deleted {Type} records during import",
+                        softDeletedCount, "Bolus");
 
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
@@ -370,7 +370,8 @@ public class BolusRepository : IBolusRepository
 
                 // Over-fetches by a Cartesian amount; the partial unique index
                 // on (tenant_id, data_source, sync_identifier) keeps this cheap.
-                var existingRows = await ctx.Boluses
+                var existingRows = await ctx.Boluses.IgnoreQueryFilters()
+                    .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
                     .ToListAsync(ct);
 
@@ -420,12 +421,25 @@ public class BolusRepository : IBolusRepository
             if (legacyIds.Count > 0)
             {
                 var existingIds = await ctx
-                    .Boluses.AsNoTracking()
+                    .Boluses.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
                     .Select(e => e.LegacyId)
                     .ToListAsync(ct);
 
                 var existingSet = existingIds.ToHashSet();
+
+                var softDeletedCount = await ctx
+                    .Boluses.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
+                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
+                    .CountAsync(ct);
+
+                if (softDeletedCount > 0)
+                    _logger.LogInformation(
+                        "Skipped {Count} previously-deleted Bolus records during import",
+                        softDeletedCount);
+
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
                     .ToList();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
@@ -204,8 +204,57 @@ public class BolusRepository : IBolusRepository
         var entity =
             await ctx.Boluses.FindAsync([id], ct)
             ?? throw new KeyNotFoundException($"Bolus {id} not found");
-        ctx.Boluses.Remove(entity);
+        entity.DeletedAt = DateTime.UtcNow;
         await ctx.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<Bolus> RestoreAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entity = await ctx.Boluses.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Soft-deleted Bolus {id} not found");
+        entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return BolusMapper.ToDomainModel(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<Bolus>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var idSet = ids.ToHashSet();
+        var entities = await ctx.Boluses.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
+            .ToListAsync(ct);
+        foreach (var entity in entities)
+            entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return entities.Select(BolusMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<Bolus>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entities = await ctx.Boluses.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .OrderByDescending(e => e.DeletedAt)
+            .Skip(offset).Take(limit)
+            .AsNoTracking()
+            .ToListAsync(ct);
+        return entities.Select(BolusMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        return await ctx.Boluses.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .CountAsync(ct);
     }
 
     /// <summary>
@@ -254,7 +303,7 @@ public class BolusRepository : IBolusRepository
     public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.AuditedExecuteDeleteAsync(
+        return await ctx.AuditedSoftDeleteAsync(
             ctx.Boluses.Where(e => e.LegacyId == legacyId), _auditContext, ct);
     }
 
@@ -268,7 +317,7 @@ public class BolusRepository : IBolusRepository
     public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.AuditedExecuteDeleteAsync(
+        return await ctx.AuditedSoftDeleteAsync(
             ctx.Boluses.Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier),
             _auditContext, ct);
     }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CalibrationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CalibrationRepository.cs
@@ -314,25 +314,19 @@ public class CalibrationRepository : ICalibrationRepository
 
             if (legacyIds.Count > 0)
             {
-                var existingIds = await ctx
-                    .Calibrations.IgnoreQueryFilters().AsNoTracking()
+                var existingRecords = await ctx.Calibrations.IgnoreQueryFilters().AsNoTracking()
                     .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
-                    .Select(e => e.LegacyId)
+                    .Select(e => new { e.LegacyId, IsSoftDeleted = e.DeletedAt != null })
                     .ToListAsync(ct);
 
-                var existingSet = existingIds.ToHashSet();
-
-                var softDeletedCount = await ctx
-                    .Calibrations.IgnoreQueryFilters().AsNoTracking()
-                    .Where(e => e.TenantId == ctx.TenantId)
-                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
-                    .CountAsync(ct);
+                var existingSet = existingRecords.Select(r => r.LegacyId).ToHashSet();
+                var softDeletedCount = existingRecords.Count(r => r.IsSoftDeleted);
 
                 if (softDeletedCount > 0)
                     _logger.LogInformation(
-                        "Skipped {Count} previously-deleted Calibration records during import",
-                        softDeletedCount);
+                        "Skipped {Count} previously-deleted {Type} records during import",
+                        softDeletedCount, "Calibration");
 
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CalibrationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CalibrationRepository.cs
@@ -122,8 +122,57 @@ public class CalibrationRepository : ICalibrationRepository
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.Calibrations.FindAsync([id], ct)
             ?? throw new KeyNotFoundException($"Calibration {id} not found");
-        ctx.Calibrations.Remove(entity);
+        entity.DeletedAt = DateTime.UtcNow;
         await ctx.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<Calibration> RestoreAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entity = await ctx.Calibrations.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Soft-deleted Calibration {id} not found");
+        entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return CalibrationMapper.ToDomainModel(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<Calibration>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var idSet = ids.ToHashSet();
+        var entities = await ctx.Calibrations.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
+            .ToListAsync(ct);
+        foreach (var entity in entities)
+            entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return entities.Select(CalibrationMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<Calibration>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entities = await ctx.Calibrations.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .OrderByDescending(e => e.DeletedAt)
+            .Skip(offset).Take(limit)
+            .AsNoTracking()
+            .ToListAsync(ct);
+        return entities.Select(CalibrationMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        return await ctx.Calibrations.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .CountAsync(ct);
     }
 
     /// <summary>
@@ -169,7 +218,7 @@ public class CalibrationRepository : ICalibrationRepository
         await using var ctx = await _contextFactory.CreateAsync(ct);
         return await ctx.Calibrations
             .Where(e => e.LegacyId == legacyId)
-            .ExecuteDeleteAsync(ct);
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 
     /// <summary>
@@ -213,7 +262,7 @@ public class CalibrationRepository : ICalibrationRepository
         await using var ctx = await _contextFactory.CreateAsync(ct);
         return await ctx.Calibrations
             .Where(e => e.DataSource == source)
-            .ExecuteDeleteAsync(ct);
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 
     /// <summary>
@@ -233,7 +282,7 @@ public class CalibrationRepository : ICalibrationRepository
         if (to.HasValue)
             query = query.Where(e => e.Timestamp < to.Value);
 
-        return await query.ExecuteDeleteAsync(ct);
+        return await query.ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 
     /// <inheritdoc />

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CalibrationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CalibrationRepository.cs
@@ -315,12 +315,25 @@ public class CalibrationRepository : ICalibrationRepository
             if (legacyIds.Count > 0)
             {
                 var existingIds = await ctx
-                    .Calibrations.AsNoTracking()
+                    .Calibrations.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
                     .Select(e => e.LegacyId)
                     .ToListAsync(ct);
 
                 var existingSet = existingIds.ToHashSet();
+
+                var softDeletedCount = await ctx
+                    .Calibrations.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
+                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
+                    .CountAsync(ct);
+
+                if (softDeletedCount > 0)
+                    _logger.LogInformation(
+                        "Skipped {Count} previously-deleted Calibration records during import",
+                        softDeletedCount);
+
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
                     .ToList();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
@@ -427,25 +427,19 @@ public class CarbIntakeRepository : ICarbIntakeRepository
 
             if (legacyIds.Count > 0)
             {
-                var existingIds = await ctx
-                    .CarbIntakes.IgnoreQueryFilters().AsNoTracking()
+                var existingRecords = await ctx.CarbIntakes.IgnoreQueryFilters().AsNoTracking()
                     .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
-                    .Select(e => e.LegacyId)
+                    .Select(e => new { e.LegacyId, IsSoftDeleted = e.DeletedAt != null })
                     .ToListAsync(ct);
 
-                var existingSet = existingIds.ToHashSet();
-
-                var softDeletedCount = await ctx
-                    .CarbIntakes.IgnoreQueryFilters().AsNoTracking()
-                    .Where(e => e.TenantId == ctx.TenantId)
-                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
-                    .CountAsync(ct);
+                var existingSet = existingRecords.Select(r => r.LegacyId).ToHashSet();
+                var softDeletedCount = existingRecords.Count(r => r.IsSoftDeleted);
 
                 if (softDeletedCount > 0)
                     _logger.LogInformation(
-                        "Skipped {Count} previously-deleted CarbIntake records during import",
-                        softDeletedCount);
+                        "Skipped {Count} previously-deleted {Type} records during import",
+                        softDeletedCount, "CarbIntake");
 
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
@@ -211,8 +211,57 @@ public class CarbIntakeRepository : ICarbIntakeRepository
         var entity =
             await ctx.CarbIntakes.FindAsync([id], ct)
             ?? throw new KeyNotFoundException($"CarbIntake {id} not found");
-        ctx.CarbIntakes.Remove(entity);
+        entity.DeletedAt = DateTime.UtcNow;
         await ctx.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<CarbIntake> RestoreAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entity = await ctx.CarbIntakes.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Soft-deleted CarbIntake {id} not found");
+        entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return CarbIntakeMapper.ToDomainModel(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<CarbIntake>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var idSet = ids.ToHashSet();
+        var entities = await ctx.CarbIntakes.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
+            .ToListAsync(ct);
+        foreach (var entity in entities)
+            entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return entities.Select(CarbIntakeMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<CarbIntake>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entities = await ctx.CarbIntakes.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .OrderByDescending(e => e.DeletedAt)
+            .Skip(offset).Take(limit)
+            .AsNoTracking()
+            .ToListAsync(ct);
+        return entities.Select(CarbIntakeMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        return await ctx.CarbIntakes.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .CountAsync(ct);
     }
 
     /// <summary>
@@ -261,7 +310,7 @@ public class CarbIntakeRepository : ICarbIntakeRepository
     public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.AuditedExecuteDeleteAsync(
+        return await ctx.AuditedSoftDeleteAsync(
             ctx.CarbIntakes.Where(e => e.LegacyId == legacyId), _auditContext, ct);
     }
 
@@ -275,7 +324,7 @@ public class CarbIntakeRepository : ICarbIntakeRepository
     public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.AuditedExecuteDeleteAsync(
+        return await ctx.AuditedSoftDeleteAsync(
             ctx.CarbIntakes.Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier),
             _auditContext, ct);
     }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
@@ -377,7 +377,8 @@ public class CarbIntakeRepository : ICarbIntakeRepository
 
                 // Over-fetches by a Cartesian amount; the partial unique index
                 // on (tenant_id, data_source, sync_identifier) keeps this cheap.
-                var existingRows = await ctx.CarbIntakes
+                var existingRows = await ctx.CarbIntakes.IgnoreQueryFilters()
+                    .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
                     .ToListAsync(ct);
 
@@ -427,12 +428,25 @@ public class CarbIntakeRepository : ICarbIntakeRepository
             if (legacyIds.Count > 0)
             {
                 var existingIds = await ctx
-                    .CarbIntakes.AsNoTracking()
+                    .CarbIntakes.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
                     .Select(e => e.LegacyId)
                     .ToListAsync(ct);
 
                 var existingSet = existingIds.ToHashSet();
+
+                var softDeletedCount = await ctx
+                    .CarbIntakes.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
+                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
+                    .CountAsync(ct);
+
+                if (softDeletedCount > 0)
+                    _logger.LogInformation(
+                        "Skipped {Count} previously-deleted CarbIntake records during import",
+                        softDeletedCount);
+
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
                     .ToList();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbRatioScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbRatioScheduleRepository.cs
@@ -326,25 +326,19 @@ public class CarbRatioScheduleRepository : ICarbRatioScheduleRepository
 
             if (legacyIds.Count > 0)
             {
-                var existingIds = await ctx
-                    .CarbRatioSchedules.IgnoreQueryFilters().AsNoTracking()
+                var existingRecords = await ctx.CarbRatioSchedules.IgnoreQueryFilters().AsNoTracking()
                     .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
-                    .Select(e => e.LegacyId)
+                    .Select(e => new { e.LegacyId, IsSoftDeleted = e.DeletedAt != null })
                     .ToListAsync(ct);
 
-                var existingSet = existingIds.ToHashSet();
-
-                var softDeletedCount = await ctx
-                    .CarbRatioSchedules.IgnoreQueryFilters().AsNoTracking()
-                    .Where(e => e.TenantId == ctx.TenantId)
-                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
-                    .CountAsync(ct);
+                var existingSet = existingRecords.Select(r => r.LegacyId).ToHashSet();
+                var softDeletedCount = existingRecords.Count(r => r.IsSoftDeleted);
 
                 if (softDeletedCount > 0)
                     _logger.LogInformation(
-                        "Skipped {Count} previously-deleted CarbRatioSchedule records during import",
-                        softDeletedCount);
+                        "Skipped {Count} previously-deleted {Type} records during import",
+                        softDeletedCount, "CarbRatioSchedule");
 
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbRatioScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbRatioScheduleRepository.cs
@@ -174,8 +174,57 @@ public class CarbRatioScheduleRepository : ICarbRatioScheduleRepository
         var entity =
             await ctx.CarbRatioSchedules.FindAsync([id], ct)
             ?? throw new KeyNotFoundException($"CarbRatioSchedule {id} not found");
-        ctx.CarbRatioSchedules.Remove(entity);
+        entity.DeletedAt = DateTime.UtcNow;
         await ctx.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<CarbRatioSchedule> RestoreAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entity = await ctx.CarbRatioSchedules.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Soft-deleted CarbRatioSchedule {id} not found");
+        entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return CarbRatioScheduleMapper.ToDomainModel(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<CarbRatioSchedule>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var idSet = ids.ToHashSet();
+        var entities = await ctx.CarbRatioSchedules.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
+            .ToListAsync(ct);
+        foreach (var entity in entities)
+            entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return entities.Select(CarbRatioScheduleMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<CarbRatioSchedule>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entities = await ctx.CarbRatioSchedules.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .OrderByDescending(e => e.DeletedAt)
+            .Skip(offset).Take(limit)
+            .AsNoTracking()
+            .ToListAsync(ct);
+        return entities.Select(CarbRatioScheduleMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        return await ctx.CarbRatioSchedules.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .CountAsync(ct);
     }
 
     /// <summary>
@@ -187,7 +236,8 @@ public class CarbRatioScheduleRepository : ICarbRatioScheduleRepository
     public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.CarbRatioSchedules.Where(e => e.LegacyId == legacyId).ExecuteDeleteAsync(ct);
+        return await ctx.CarbRatioSchedules.Where(e => e.LegacyId == legacyId)
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 
     /// <summary>
@@ -201,7 +251,7 @@ public class CarbRatioScheduleRepository : ICarbRatioScheduleRepository
         await using var ctx = await _contextFactory.CreateAsync(ct);
         return await ctx
             .CarbRatioSchedules.Where(e => e.LegacyId != null && e.LegacyId.StartsWith(prefix))
-            .ExecuteDeleteAsync(ct);
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbRatioScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbRatioScheduleRepository.cs
@@ -327,12 +327,25 @@ public class CarbRatioScheduleRepository : ICarbRatioScheduleRepository
             if (legacyIds.Count > 0)
             {
                 var existingIds = await ctx
-                    .CarbRatioSchedules.AsNoTracking()
+                    .CarbRatioSchedules.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
                     .Select(e => e.LegacyId)
                     .ToListAsync(ct);
 
                 var existingSet = existingIds.ToHashSet();
+
+                var softDeletedCount = await ctx
+                    .CarbRatioSchedules.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
+                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
+                    .CountAsync(ct);
+
+                if (softDeletedCount > 0)
+                    _logger.LogInformation(
+                        "Skipped {Count} previously-deleted CarbRatioSchedule records during import",
+                        softDeletedCount);
+
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
                     .ToList();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
@@ -169,8 +169,57 @@ public class DeviceEventRepository : IDeviceEventRepository
         var entity =
             await ctx.DeviceEvents.FindAsync([id], ct)
             ?? throw new KeyNotFoundException($"DeviceEvent {id} not found");
-        ctx.DeviceEvents.Remove(entity);
+        entity.DeletedAt = DateTime.UtcNow;
         await ctx.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<DeviceEvent> RestoreAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entity = await ctx.DeviceEvents.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Soft-deleted DeviceEvent {id} not found");
+        entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return DeviceEventMapper.ToDomainModel(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<DeviceEvent>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var idSet = ids.ToHashSet();
+        var entities = await ctx.DeviceEvents.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
+            .ToListAsync(ct);
+        foreach (var entity in entities)
+            entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return entities.Select(DeviceEventMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<DeviceEvent>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entities = await ctx.DeviceEvents.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .OrderByDescending(e => e.DeletedAt)
+            .Skip(offset).Take(limit)
+            .AsNoTracking()
+            .ToListAsync(ct);
+        return entities.Select(DeviceEventMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        return await ctx.DeviceEvents.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .CountAsync(ct);
     }
 
     /// <summary>
@@ -219,7 +268,7 @@ public class DeviceEventRepository : IDeviceEventRepository
     public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.AuditedExecuteDeleteAsync(
+        return await ctx.AuditedSoftDeleteAsync(
             ctx.DeviceEvents.Where(e => e.LegacyId == legacyId), _auditContext, ct);
     }
 
@@ -233,7 +282,7 @@ public class DeviceEventRepository : IDeviceEventRepository
     public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.AuditedExecuteDeleteAsync(
+        return await ctx.AuditedSoftDeleteAsync(
             ctx.DeviceEvents.Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier),
             _auditContext, ct);
     }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
@@ -324,25 +324,19 @@ public class DeviceEventRepository : IDeviceEventRepository
 
             if (legacyIds.Count > 0)
             {
-                var existingIds = await ctx
-                    .DeviceEvents.IgnoreQueryFilters().AsNoTracking()
+                var existingRecords = await ctx.DeviceEvents.IgnoreQueryFilters().AsNoTracking()
                     .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
-                    .Select(e => e.LegacyId)
+                    .Select(e => new { e.LegacyId, IsSoftDeleted = e.DeletedAt != null })
                     .ToListAsync(ct);
 
-                var existingSet = existingIds.ToHashSet();
-
-                var softDeletedCount = await ctx
-                    .DeviceEvents.IgnoreQueryFilters().AsNoTracking()
-                    .Where(e => e.TenantId == ctx.TenantId)
-                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
-                    .CountAsync(ct);
+                var existingSet = existingRecords.Select(r => r.LegacyId).ToHashSet();
+                var softDeletedCount = existingRecords.Count(r => r.IsSoftDeleted);
 
                 if (softDeletedCount > 0)
                     _logger.LogInformation(
-                        "Skipped {Count} previously-deleted DeviceEvent records during import",
-                        softDeletedCount);
+                        "Skipped {Count} previously-deleted {Type} records during import",
+                        softDeletedCount, "DeviceEvent");
 
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
@@ -325,12 +325,25 @@ public class DeviceEventRepository : IDeviceEventRepository
             if (legacyIds.Count > 0)
             {
                 var existingIds = await ctx
-                    .DeviceEvents.AsNoTracking()
+                    .DeviceEvents.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
                     .Select(e => e.LegacyId)
                     .ToListAsync(ct);
 
                 var existingSet = existingIds.ToHashSet();
+
+                var softDeletedCount = await ctx
+                    .DeviceEvents.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
+                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
+                    .CountAsync(ct);
+
+                if (softDeletedCount > 0)
+                    _logger.LogInformation(
+                        "Skipped {Count} previously-deleted DeviceEvent records during import",
+                        softDeletedCount);
+
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
                     .ToList();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceStatusExtrasRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceStatusExtrasRepository.cs
@@ -72,7 +72,7 @@ public class DeviceStatusExtrasRepository : IDeviceStatusExtrasRepository
         await using var ctx = await _contextFactory.CreateAsync(ct);
         return await ctx.DeviceStatusExtras
             .Where(e => e.CorrelationId == correlationId)
-            .ExecuteDeleteAsync(ct);
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 
     /// <inheritdoc />
@@ -103,25 +103,19 @@ public class DeviceStatusExtrasRepository : IDeviceStatusExtrasRepository
 
             if (correlationIds.Count > 0)
             {
-                var existingIds = await ctx
-                    .DeviceStatusExtras.IgnoreQueryFilters().AsNoTracking()
+                var existingRecords = await ctx.DeviceStatusExtras.IgnoreQueryFilters().AsNoTracking()
                     .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => correlationIds.Contains(e.CorrelationId))
-                    .Select(e => e.CorrelationId)
+                    .Select(e => new { e.CorrelationId, IsSoftDeleted = e.DeletedAt != null })
                     .ToListAsync(ct);
 
-                var existingSet = existingIds.ToHashSet();
-
-                var softDeletedCount = await ctx
-                    .DeviceStatusExtras.IgnoreQueryFilters().AsNoTracking()
-                    .Where(e => e.TenantId == ctx.TenantId)
-                    .Where(e => correlationIds.Contains(e.CorrelationId) && e.DeletedAt != null)
-                    .CountAsync(ct);
+                var existingSet = existingRecords.Select(r => r.CorrelationId).ToHashSet();
+                var softDeletedCount = existingRecords.Count(r => r.IsSoftDeleted);
 
                 if (softDeletedCount > 0)
                     _logger.LogInformation(
-                        "Skipped {Count} previously-deleted DeviceStatusExtras records during import",
-                        softDeletedCount);
+                        "Skipped {Count} previously-deleted {Type} records during import",
+                        softDeletedCount, "DeviceStatusExtras");
 
                 entities = entities
                     .Where(e => !existingSet.Contains(e.CorrelationId))

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceStatusExtrasRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceStatusExtrasRepository.cs
@@ -104,12 +104,25 @@ public class DeviceStatusExtrasRepository : IDeviceStatusExtrasRepository
             if (correlationIds.Count > 0)
             {
                 var existingIds = await ctx
-                    .DeviceStatusExtras.AsNoTracking()
+                    .DeviceStatusExtras.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => correlationIds.Contains(e.CorrelationId))
                     .Select(e => e.CorrelationId)
                     .ToListAsync(ct);
 
                 var existingSet = existingIds.ToHashSet();
+
+                var softDeletedCount = await ctx
+                    .DeviceStatusExtras.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
+                    .Where(e => correlationIds.Contains(e.CorrelationId) && e.DeletedAt != null)
+                    .CountAsync(ct);
+
+                if (softDeletedCount > 0)
+                    _logger.LogInformation(
+                        "Skipped {Count} previously-deleted DeviceStatusExtras records during import",
+                        softDeletedCount);
+
                 entities = entities
                     .Where(e => !existingSet.Contains(e.CorrelationId))
                     .ToList();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/MeterGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/MeterGlucoseRepository.cs
@@ -314,25 +314,19 @@ public class MeterGlucoseRepository : IMeterGlucoseRepository
 
             if (legacyIds.Count > 0)
             {
-                var existingIds = await ctx
-                    .MeterGlucose.IgnoreQueryFilters().AsNoTracking()
+                var existingRecords = await ctx.MeterGlucose.IgnoreQueryFilters().AsNoTracking()
                     .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
-                    .Select(e => e.LegacyId)
+                    .Select(e => new { e.LegacyId, IsSoftDeleted = e.DeletedAt != null })
                     .ToListAsync(ct);
 
-                var existingSet = existingIds.ToHashSet();
-
-                var softDeletedCount = await ctx
-                    .MeterGlucose.IgnoreQueryFilters().AsNoTracking()
-                    .Where(e => e.TenantId == ctx.TenantId)
-                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
-                    .CountAsync(ct);
+                var existingSet = existingRecords.Select(r => r.LegacyId).ToHashSet();
+                var softDeletedCount = existingRecords.Count(r => r.IsSoftDeleted);
 
                 if (softDeletedCount > 0)
                     _logger.LogInformation(
-                        "Skipped {Count} previously-deleted MeterGlucose records during import",
-                        softDeletedCount);
+                        "Skipped {Count} previously-deleted {Type} records during import",
+                        softDeletedCount, "MeterGlucose");
 
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/MeterGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/MeterGlucoseRepository.cs
@@ -122,8 +122,57 @@ public class MeterGlucoseRepository : IMeterGlucoseRepository
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.MeterGlucose.FindAsync([id], ct)
             ?? throw new KeyNotFoundException($"MeterGlucose {id} not found");
-        ctx.MeterGlucose.Remove(entity);
+        entity.DeletedAt = DateTime.UtcNow;
         await ctx.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<MeterGlucose> RestoreAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entity = await ctx.MeterGlucose.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Soft-deleted MeterGlucose {id} not found");
+        entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return MeterGlucoseMapper.ToDomainModel(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<MeterGlucose>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var idSet = ids.ToHashSet();
+        var entities = await ctx.MeterGlucose.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
+            .ToListAsync(ct);
+        foreach (var entity in entities)
+            entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return entities.Select(MeterGlucoseMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<MeterGlucose>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entities = await ctx.MeterGlucose.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .OrderByDescending(e => e.DeletedAt)
+            .Skip(offset).Take(limit)
+            .AsNoTracking()
+            .ToListAsync(ct);
+        return entities.Select(MeterGlucoseMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        return await ctx.MeterGlucose.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .CountAsync(ct);
     }
 
     /// <summary>
@@ -169,7 +218,7 @@ public class MeterGlucoseRepository : IMeterGlucoseRepository
         await using var ctx = await _contextFactory.CreateAsync(ct);
         return await ctx.MeterGlucose
             .Where(e => e.LegacyId == legacyId)
-            .ExecuteDeleteAsync(ct);
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 
     /// <summary>
@@ -213,7 +262,7 @@ public class MeterGlucoseRepository : IMeterGlucoseRepository
         await using var ctx = await _contextFactory.CreateAsync(ct);
         return await ctx.MeterGlucose
             .Where(e => e.DataSource == source)
-            .ExecuteDeleteAsync(ct);
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 
     /// <summary>
@@ -233,7 +282,7 @@ public class MeterGlucoseRepository : IMeterGlucoseRepository
         if (to.HasValue)
             query = query.Where(e => e.Timestamp < to.Value);
 
-        return await query.ExecuteDeleteAsync(ct);
+        return await query.ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 
     /// <inheritdoc />

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/MeterGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/MeterGlucoseRepository.cs
@@ -315,12 +315,25 @@ public class MeterGlucoseRepository : IMeterGlucoseRepository
             if (legacyIds.Count > 0)
             {
                 var existingIds = await ctx
-                    .MeterGlucose.AsNoTracking()
+                    .MeterGlucose.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
                     .Select(e => e.LegacyId)
                     .ToListAsync(ct);
 
                 var existingSet = existingIds.ToHashSet();
+
+                var softDeletedCount = await ctx
+                    .MeterGlucose.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
+                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
+                    .CountAsync(ct);
+
+                if (softDeletedCount > 0)
+                    _logger.LogInformation(
+                        "Skipped {Count} previously-deleted MeterGlucose records during import",
+                        softDeletedCount);
+
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
                     .ToList();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
@@ -153,8 +153,57 @@ public class NoteRepository : INoteRepository
         var entity =
             await ctx.Notes.FindAsync([id], ct)
             ?? throw new KeyNotFoundException($"Note {id} not found");
-        ctx.Notes.Remove(entity);
+        entity.DeletedAt = DateTime.UtcNow;
         await ctx.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<Note> RestoreAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entity = await ctx.Notes.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Soft-deleted Note {id} not found");
+        entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return NoteMapper.ToDomainModel(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<Note>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var idSet = ids.ToHashSet();
+        var entities = await ctx.Notes.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
+            .ToListAsync(ct);
+        foreach (var entity in entities)
+            entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return entities.Select(NoteMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<Note>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entities = await ctx.Notes.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .OrderByDescending(e => e.DeletedAt)
+            .Skip(offset).Take(limit)
+            .AsNoTracking()
+            .ToListAsync(ct);
+        return entities.Select(NoteMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        return await ctx.Notes.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .CountAsync(ct);
     }
 
     /// <summary>
@@ -203,7 +252,8 @@ public class NoteRepository : INoteRepository
     public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.Notes.Where(e => e.LegacyId == legacyId).ExecuteDeleteAsync(ct);
+        return await ctx.Notes.Where(e => e.LegacyId == legacyId)
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 
     /// <summary>
@@ -217,7 +267,7 @@ public class NoteRepository : INoteRepository
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         return await ctx.Notes.Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier)
-            .ExecuteDeleteAsync(ct);
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
@@ -308,12 +308,25 @@ public class NoteRepository : INoteRepository
             if (legacyIds.Count > 0)
             {
                 var existingIds = await ctx
-                    .Notes.AsNoTracking()
+                    .Notes.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
                     .Select(e => e.LegacyId)
                     .ToListAsync(ct);
 
                 var existingSet = existingIds.ToHashSet();
+
+                var softDeletedCount = await ctx
+                    .Notes.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
+                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
+                    .CountAsync(ct);
+
+                if (softDeletedCount > 0)
+                    _logger.LogInformation(
+                        "Skipped {Count} previously-deleted Note records during import",
+                        softDeletedCount);
+
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
                     .ToList();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
@@ -307,25 +307,19 @@ public class NoteRepository : INoteRepository
 
             if (legacyIds.Count > 0)
             {
-                var existingIds = await ctx
-                    .Notes.IgnoreQueryFilters().AsNoTracking()
+                var existingRecords = await ctx.Notes.IgnoreQueryFilters().AsNoTracking()
                     .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
-                    .Select(e => e.LegacyId)
+                    .Select(e => new { e.LegacyId, IsSoftDeleted = e.DeletedAt != null })
                     .ToListAsync(ct);
 
-                var existingSet = existingIds.ToHashSet();
-
-                var softDeletedCount = await ctx
-                    .Notes.IgnoreQueryFilters().AsNoTracking()
-                    .Where(e => e.TenantId == ctx.TenantId)
-                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
-                    .CountAsync(ct);
+                var existingSet = existingRecords.Select(r => r.LegacyId).ToHashSet();
+                var softDeletedCount = existingRecords.Count(r => r.IsSoftDeleted);
 
                 if (softDeletedCount > 0)
                     _logger.LogInformation(
-                        "Skipped {Count} previously-deleted Note records during import",
-                        softDeletedCount);
+                        "Skipped {Count} previously-deleted {Type} records during import",
+                        softDeletedCount, "Note");
 
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PatientDeviceRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PatientDeviceRepository.cs
@@ -159,7 +159,56 @@ public class PatientDeviceRepository : IPatientDeviceRepository
         var entity = await ctx.PatientDevices.FindAsync([id], ct)
             ?? throw new KeyNotFoundException($"PatientDevice {id} not found");
 
-        ctx.PatientDevices.Remove(entity);
+        entity.DeletedAt = DateTime.UtcNow;
         await ctx.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<PatientDevice> RestoreAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entity = await ctx.PatientDevices.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Soft-deleted PatientDevice {id} not found");
+        entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return PatientDeviceMapper.ToDomainModel(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<PatientDevice>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var idSet = ids.ToHashSet();
+        var entities = await ctx.PatientDevices.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
+            .ToListAsync(ct);
+        foreach (var entity in entities)
+            entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return entities.Select(PatientDeviceMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<PatientDevice>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entities = await ctx.PatientDevices.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .OrderByDescending(e => e.DeletedAt)
+            .Skip(offset).Take(limit)
+            .AsNoTracking()
+            .ToListAsync(ct);
+        return entities.Select(PatientDeviceMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        return await ctx.PatientDevices.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .CountAsync(ct);
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PatientInsulinRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PatientInsulinRepository.cs
@@ -119,8 +119,57 @@ public class PatientInsulinRepository : IPatientInsulinRepository
         var entity = await ctx.PatientInsulins.FindAsync([id], ct)
             ?? throw new KeyNotFoundException($"PatientInsulin {id} not found");
 
-        ctx.PatientInsulins.Remove(entity);
+        entity.DeletedAt = DateTime.UtcNow;
         await ctx.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<PatientInsulin> RestoreAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entity = await ctx.PatientInsulins.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Soft-deleted PatientInsulin {id} not found");
+        entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return PatientInsulinMapper.ToDomainModel(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<PatientInsulin>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var idSet = ids.ToHashSet();
+        var entities = await ctx.PatientInsulins.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
+            .ToListAsync(ct);
+        foreach (var entity in entities)
+            entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return entities.Select(PatientInsulinMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<PatientInsulin>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entities = await ctx.PatientInsulins.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .OrderByDescending(e => e.DeletedAt)
+            .Skip(offset).Take(limit)
+            .AsNoTracking()
+            .ToListAsync(ct);
+        return entities.Select(PatientInsulinMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        return await ctx.PatientInsulins.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .CountAsync(ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
@@ -279,12 +279,25 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
             if (legacyIds.Count > 0)
             {
                 var existingIds = await ctx
-                    .PumpSnapshots.AsNoTracking()
+                    .PumpSnapshots.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
                     .Select(e => e.LegacyId)
                     .ToListAsync(ct);
 
                 var existingSet = existingIds.ToHashSet();
+
+                var softDeletedCount = await ctx
+                    .PumpSnapshots.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
+                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
+                    .CountAsync(ct);
+
+                if (softDeletedCount > 0)
+                    _logger.LogInformation(
+                        "Skipped {Count} previously-deleted PumpSnapshot records during import",
+                        softDeletedCount);
+
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
                     .ToList();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
@@ -145,8 +145,57 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.PumpSnapshots.FindAsync([id], ct)
             ?? throw new KeyNotFoundException($"PumpSnapshot {id} not found");
-        ctx.PumpSnapshots.Remove(entity);
+        entity.DeletedAt = DateTime.UtcNow;
         await ctx.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<PumpSnapshot> RestoreAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entity = await ctx.PumpSnapshots.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Soft-deleted PumpSnapshot {id} not found");
+        entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return PumpSnapshotMapper.ToDomainModel(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<PumpSnapshot>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var idSet = ids.ToHashSet();
+        var entities = await ctx.PumpSnapshots.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
+            .ToListAsync(ct);
+        foreach (var entity in entities)
+            entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return entities.Select(PumpSnapshotMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<PumpSnapshot>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entities = await ctx.PumpSnapshots.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .OrderByDescending(e => e.DeletedAt)
+            .Skip(offset).Take(limit)
+            .AsNoTracking()
+            .ToListAsync(ct);
+        return entities.Select(PumpSnapshotMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        return await ctx.PumpSnapshots.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .CountAsync(ct);
     }
 
     /// <summary>
@@ -197,7 +246,7 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
         await using var ctx = await _contextFactory.CreateAsync(ct);
         return await ctx.PumpSnapshots
             .Where(e => e.LegacyId == legacyId)
-            .ExecuteDeleteAsync(ct);
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 
     /// <inheritdoc />

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
@@ -278,25 +278,19 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
 
             if (legacyIds.Count > 0)
             {
-                var existingIds = await ctx
-                    .PumpSnapshots.IgnoreQueryFilters().AsNoTracking()
+                var existingRecords = await ctx.PumpSnapshots.IgnoreQueryFilters().AsNoTracking()
                     .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
-                    .Select(e => e.LegacyId)
+                    .Select(e => new { e.LegacyId, IsSoftDeleted = e.DeletedAt != null })
                     .ToListAsync(ct);
 
-                var existingSet = existingIds.ToHashSet();
-
-                var softDeletedCount = await ctx
-                    .PumpSnapshots.IgnoreQueryFilters().AsNoTracking()
-                    .Where(e => e.TenantId == ctx.TenantId)
-                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
-                    .CountAsync(ct);
+                var existingSet = existingRecords.Select(r => r.LegacyId).ToHashSet();
+                var softDeletedCount = existingRecords.Count(r => r.IsSoftDeleted);
 
                 if (softDeletedCount > 0)
                     _logger.LogInformation(
-                        "Skipped {Count} previously-deleted PumpSnapshot records during import",
-                        softDeletedCount);
+                        "Skipped {Count} previously-deleted {Type} records during import",
+                        softDeletedCount, "PumpSnapshot");
 
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensitivityScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensitivityScheduleRepository.cs
@@ -331,12 +331,25 @@ public class SensitivityScheduleRepository : ISensitivityScheduleRepository
             if (legacyIds.Count > 0)
             {
                 var existingIds = await ctx
-                    .SensitivitySchedules.AsNoTracking()
+                    .SensitivitySchedules.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
                     .Select(e => e.LegacyId)
                     .ToListAsync(ct);
 
                 var existingSet = existingIds.ToHashSet();
+
+                var softDeletedCount = await ctx
+                    .SensitivitySchedules.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
+                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
+                    .CountAsync(ct);
+
+                if (softDeletedCount > 0)
+                    _logger.LogInformation(
+                        "Skipped {Count} previously-deleted SensitivitySchedule records during import",
+                        softDeletedCount);
+
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
                     .ToList();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensitivityScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensitivityScheduleRepository.cs
@@ -178,8 +178,57 @@ public class SensitivityScheduleRepository : ISensitivityScheduleRepository
         var entity =
             await ctx.SensitivitySchedules.FindAsync([id], ct)
             ?? throw new KeyNotFoundException($"SensitivitySchedule {id} not found");
-        ctx.SensitivitySchedules.Remove(entity);
+        entity.DeletedAt = DateTime.UtcNow;
         await ctx.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<SensitivitySchedule> RestoreAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entity = await ctx.SensitivitySchedules.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Soft-deleted SensitivitySchedule {id} not found");
+        entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return SensitivityScheduleMapper.ToDomainModel(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<SensitivitySchedule>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var idSet = ids.ToHashSet();
+        var entities = await ctx.SensitivitySchedules.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
+            .ToListAsync(ct);
+        foreach (var entity in entities)
+            entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return entities.Select(SensitivityScheduleMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<SensitivitySchedule>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entities = await ctx.SensitivitySchedules.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .OrderByDescending(e => e.DeletedAt)
+            .Skip(offset).Take(limit)
+            .AsNoTracking()
+            .ToListAsync(ct);
+        return entities.Select(SensitivityScheduleMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        return await ctx.SensitivitySchedules.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .CountAsync(ct);
     }
 
     /// <summary>
@@ -191,7 +240,8 @@ public class SensitivityScheduleRepository : ISensitivityScheduleRepository
     public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.SensitivitySchedules.Where(e => e.LegacyId == legacyId).ExecuteDeleteAsync(ct);
+        return await ctx.SensitivitySchedules.Where(e => e.LegacyId == legacyId)
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 
     /// <summary>
@@ -205,7 +255,7 @@ public class SensitivityScheduleRepository : ISensitivityScheduleRepository
         await using var ctx = await _contextFactory.CreateAsync(ct);
         return await ctx
             .SensitivitySchedules.Where(e => e.LegacyId != null && e.LegacyId.StartsWith(prefix))
-            .ExecuteDeleteAsync(ct);
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensitivityScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensitivityScheduleRepository.cs
@@ -330,25 +330,19 @@ public class SensitivityScheduleRepository : ISensitivityScheduleRepository
 
             if (legacyIds.Count > 0)
             {
-                var existingIds = await ctx
-                    .SensitivitySchedules.IgnoreQueryFilters().AsNoTracking()
+                var existingRecords = await ctx.SensitivitySchedules.IgnoreQueryFilters().AsNoTracking()
                     .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
-                    .Select(e => e.LegacyId)
+                    .Select(e => new { e.LegacyId, IsSoftDeleted = e.DeletedAt != null })
                     .ToListAsync(ct);
 
-                var existingSet = existingIds.ToHashSet();
-
-                var softDeletedCount = await ctx
-                    .SensitivitySchedules.IgnoreQueryFilters().AsNoTracking()
-                    .Where(e => e.TenantId == ctx.TenantId)
-                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
-                    .CountAsync(ct);
+                var existingSet = existingRecords.Select(r => r.LegacyId).ToHashSet();
+                var softDeletedCount = existingRecords.Count(r => r.IsSoftDeleted);
 
                 if (softDeletedCount > 0)
                     _logger.LogInformation(
-                        "Skipped {Count} previously-deleted SensitivitySchedule records during import",
-                        softDeletedCount);
+                        "Skipped {Count} previously-deleted {Type} records during import",
+                        softDeletedCount, "SensitivitySchedule");
 
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -196,8 +196,57 @@ public class SensorGlucoseRepository : ISensorGlucoseRepository
         var entity =
             await ctx.SensorGlucose.FindAsync([id], ct)
             ?? throw new KeyNotFoundException($"SensorGlucose {id} not found");
-        ctx.SensorGlucose.Remove(entity);
+        entity.DeletedAt = DateTime.UtcNow;
         await ctx.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<SensorGlucose> RestoreAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entity = await ctx.SensorGlucose.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Soft-deleted SensorGlucose {id} not found");
+        entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return SensorGlucoseMapper.ToDomainModel(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<SensorGlucose>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var idSet = ids.ToHashSet();
+        var entities = await ctx.SensorGlucose.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
+            .ToListAsync(ct);
+        foreach (var entity in entities)
+            entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return entities.Select(SensorGlucoseMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<SensorGlucose>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entities = await ctx.SensorGlucose.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .OrderByDescending(e => e.DeletedAt)
+            .Skip(offset).Take(limit)
+            .AsNoTracking()
+            .ToListAsync(ct);
+        return entities.Select(SensorGlucoseMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        return await ctx.SensorGlucose.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .CountAsync(ct);
     }
 
     /// <summary>
@@ -246,7 +295,7 @@ public class SensorGlucoseRepository : ISensorGlucoseRepository
     public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.AuditedExecuteDeleteAsync(
+        return await ctx.AuditedSoftDeleteAsync(
             ctx.SensorGlucose.Where(e => e.LegacyId == legacyId), _auditContext, ct);
     }
 
@@ -396,7 +445,7 @@ public class SensorGlucoseRepository : ISensorGlucoseRepository
     public async Task<int> DeleteBySourceAsync(string source, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.AuditedExecuteDeleteAsync(
+        return await ctx.AuditedSoftDeleteAsync(
             ctx.SensorGlucose.Where(e => e.DataSource == source), _auditContext, ct);
     }
 
@@ -417,6 +466,6 @@ public class SensorGlucoseRepository : ISensorGlucoseRepository
         if (to.HasValue)
             query = query.Where(e => e.Timestamp < to.Value);
 
-        return await ctx.AuditedExecuteDeleteAsync(query, _auditContext, ct);
+        return await ctx.AuditedSoftDeleteAsync(query, _auditContext, ct);
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -336,25 +336,19 @@ public class SensorGlucoseRepository : ISensorGlucoseRepository
 
             if (legacyIds.Count > 0)
             {
-                var existingIds = await ctx
-                    .SensorGlucose.IgnoreQueryFilters().AsNoTracking()
+                var existingRecords = await ctx.SensorGlucose.IgnoreQueryFilters().AsNoTracking()
                     .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
-                    .Select(e => e.LegacyId)
+                    .Select(e => new { e.LegacyId, IsSoftDeleted = e.DeletedAt != null })
                     .ToListAsync(ct);
 
-                var existingSet = existingIds.ToHashSet();
-
-                var softDeletedCount = await ctx
-                    .SensorGlucose.IgnoreQueryFilters().AsNoTracking()
-                    .Where(e => e.TenantId == ctx.TenantId)
-                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
-                    .CountAsync(ct);
+                var existingSet = existingRecords.Select(r => r.LegacyId).ToHashSet();
+                var softDeletedCount = existingRecords.Count(r => r.IsSoftDeleted);
 
                 if (softDeletedCount > 0)
                     _logger.LogInformation(
-                        "Skipped {Count} previously-deleted SensorGlucose records during import",
-                        softDeletedCount);
+                        "Skipped {Count} previously-deleted {Type} records during import",
+                        softDeletedCount, "SensorGlucose");
 
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -337,12 +337,25 @@ public class SensorGlucoseRepository : ISensorGlucoseRepository
             if (legacyIds.Count > 0)
             {
                 var existingIds = await ctx
-                    .SensorGlucose.AsNoTracking()
+                    .SensorGlucose.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
                     .Select(e => e.LegacyId)
                     .ToListAsync(ct);
 
                 var existingSet = existingIds.ToHashSet();
+
+                var softDeletedCount = await ctx
+                    .SensorGlucose.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
+                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
+                    .CountAsync(ct);
+
+                if (softDeletedCount > 0)
+                    _logger.LogInformation(
+                        "Skipped {Count} previously-deleted SensorGlucose records during import",
+                        softDeletedCount);
+
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
                     .ToList();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TargetRangeScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TargetRangeScheduleRepository.cs
@@ -178,8 +178,57 @@ public class TargetRangeScheduleRepository : ITargetRangeScheduleRepository
         var entity =
             await ctx.TargetRangeSchedules.FindAsync([id], ct)
             ?? throw new KeyNotFoundException($"TargetRangeSchedule {id} not found");
-        ctx.TargetRangeSchedules.Remove(entity);
+        entity.DeletedAt = DateTime.UtcNow;
         await ctx.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<TargetRangeSchedule> RestoreAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entity = await ctx.TargetRangeSchedules.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Soft-deleted TargetRangeSchedule {id} not found");
+        entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return TargetRangeScheduleMapper.ToDomainModel(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<TargetRangeSchedule>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var idSet = ids.ToHashSet();
+        var entities = await ctx.TargetRangeSchedules.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
+            .ToListAsync(ct);
+        foreach (var entity in entities)
+            entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return entities.Select(TargetRangeScheduleMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<TargetRangeSchedule>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entities = await ctx.TargetRangeSchedules.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .OrderByDescending(e => e.DeletedAt)
+            .Skip(offset).Take(limit)
+            .AsNoTracking()
+            .ToListAsync(ct);
+        return entities.Select(TargetRangeScheduleMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        return await ctx.TargetRangeSchedules.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .CountAsync(ct);
     }
 
     /// <summary>
@@ -191,7 +240,8 @@ public class TargetRangeScheduleRepository : ITargetRangeScheduleRepository
     public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.TargetRangeSchedules.Where(e => e.LegacyId == legacyId).ExecuteDeleteAsync(ct);
+        return await ctx.TargetRangeSchedules.Where(e => e.LegacyId == legacyId)
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 
     /// <summary>
@@ -205,7 +255,7 @@ public class TargetRangeScheduleRepository : ITargetRangeScheduleRepository
         await using var ctx = await _contextFactory.CreateAsync(ct);
         return await ctx
             .TargetRangeSchedules.Where(e => e.LegacyId != null && e.LegacyId.StartsWith(prefix))
-            .ExecuteDeleteAsync(ct);
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TargetRangeScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TargetRangeScheduleRepository.cs
@@ -330,25 +330,19 @@ public class TargetRangeScheduleRepository : ITargetRangeScheduleRepository
 
             if (legacyIds.Count > 0)
             {
-                var existingIds = await ctx
-                    .TargetRangeSchedules.IgnoreQueryFilters().AsNoTracking()
+                var existingRecords = await ctx.TargetRangeSchedules.IgnoreQueryFilters().AsNoTracking()
                     .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
-                    .Select(e => e.LegacyId)
+                    .Select(e => new { e.LegacyId, IsSoftDeleted = e.DeletedAt != null })
                     .ToListAsync(ct);
 
-                var existingSet = existingIds.ToHashSet();
-
-                var softDeletedCount = await ctx
-                    .TargetRangeSchedules.IgnoreQueryFilters().AsNoTracking()
-                    .Where(e => e.TenantId == ctx.TenantId)
-                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
-                    .CountAsync(ct);
+                var existingSet = existingRecords.Select(r => r.LegacyId).ToHashSet();
+                var softDeletedCount = existingRecords.Count(r => r.IsSoftDeleted);
 
                 if (softDeletedCount > 0)
                     _logger.LogInformation(
-                        "Skipped {Count} previously-deleted TargetRangeSchedule records during import",
-                        softDeletedCount);
+                        "Skipped {Count} previously-deleted {Type} records during import",
+                        softDeletedCount, "TargetRangeSchedule");
 
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TargetRangeScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TargetRangeScheduleRepository.cs
@@ -331,12 +331,25 @@ public class TargetRangeScheduleRepository : ITargetRangeScheduleRepository
             if (legacyIds.Count > 0)
             {
                 var existingIds = await ctx
-                    .TargetRangeSchedules.AsNoTracking()
+                    .TargetRangeSchedules.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
                     .Select(e => e.LegacyId)
                     .ToListAsync(ct);
 
                 var existingSet = existingIds.ToHashSet();
+
+                var softDeletedCount = await ctx
+                    .TargetRangeSchedules.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
+                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
+                    .CountAsync(ct);
+
+                if (softDeletedCount > 0)
+                    _logger.LogInformation(
+                        "Skipped {Count} previously-deleted TargetRangeSchedule records during import",
+                        softDeletedCount);
+
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
                     .ToList();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
@@ -157,8 +157,57 @@ public class TempBasalRepository : ITempBasalRepository
         var entity =
             await ctx.TempBasals.FindAsync([id], ct)
             ?? throw new KeyNotFoundException($"TempBasal {id} not found");
-        ctx.TempBasals.Remove(entity);
+        entity.DeletedAt = DateTime.UtcNow;
         await ctx.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<TempBasal> RestoreAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entity = await ctx.TempBasals.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Soft-deleted TempBasal {id} not found");
+        entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return TempBasalMapper.ToDomainModel(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<TempBasal>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var idSet = ids.ToHashSet();
+        var entities = await ctx.TempBasals.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
+            .ToListAsync(ct);
+        foreach (var entity in entities)
+            entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return entities.Select(TempBasalMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<TempBasal>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entities = await ctx.TempBasals.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .OrderByDescending(e => e.DeletedAt)
+            .Skip(offset).Take(limit)
+            .AsNoTracking()
+            .ToListAsync(ct);
+        return entities.Select(TempBasalMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        return await ctx.TempBasals.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .CountAsync(ct);
     }
 
     /// <summary>
@@ -170,7 +219,7 @@ public class TempBasalRepository : ITempBasalRepository
     public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.AuditedExecuteDeleteAsync(
+        return await ctx.AuditedSoftDeleteAsync(
             ctx.TempBasals.Where(e => e.LegacyId == legacyId), _auditContext, ct);
     }
 
@@ -294,7 +343,7 @@ public class TempBasalRepository : ITempBasalRepository
     )
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.AuditedExecuteDeleteAsync(
+        return await ctx.AuditedSoftDeleteAsync(
             ctx.TempBasals.Where(e => e.DataSource == source && e.StartTimestamp >= from && e.StartTimestamp <= to),
             _auditContext, ct);
     }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
@@ -278,25 +278,19 @@ public class TempBasalRepository : ITempBasalRepository
 
             if (legacyIds.Count > 0)
             {
-                var existingIds = await ctx
-                    .TempBasals.IgnoreQueryFilters().AsNoTracking()
+                var existingRecords = await ctx.TempBasals.IgnoreQueryFilters().AsNoTracking()
                     .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
-                    .Select(e => e.LegacyId)
+                    .Select(e => new { e.LegacyId, IsSoftDeleted = e.DeletedAt != null })
                     .ToListAsync(ct);
 
-                var existingSet = existingIds.ToHashSet();
-
-                var softDeletedCount = await ctx
-                    .TempBasals.IgnoreQueryFilters().AsNoTracking()
-                    .Where(e => e.TenantId == ctx.TenantId)
-                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
-                    .CountAsync(ct);
+                var existingSet = existingRecords.Select(r => r.LegacyId).ToHashSet();
+                var softDeletedCount = existingRecords.Count(r => r.IsSoftDeleted);
 
                 if (softDeletedCount > 0)
                     _logger.LogInformation(
-                        "Skipped {Count} previously-deleted TempBasal records during import",
-                        softDeletedCount);
+                        "Skipped {Count} previously-deleted {Type} records during import",
+                        softDeletedCount, "TempBasal");
 
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
@@ -279,12 +279,25 @@ public class TempBasalRepository : ITempBasalRepository
             if (legacyIds.Count > 0)
             {
                 var existingIds = await ctx
-                    .TempBasals.AsNoTracking()
+                    .TempBasals.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
                     .Select(e => e.LegacyId)
                     .ToListAsync(ct);
 
                 var existingSet = existingIds.ToHashSet();
+
+                var softDeletedCount = await ctx
+                    .TempBasals.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
+                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
+                    .CountAsync(ct);
+
+                if (softDeletedCount > 0)
+                    _logger.LogInformation(
+                        "Skipped {Count} previously-deleted TempBasal records during import",
+                        softDeletedCount);
+
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
                     .ToList();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TherapySettingsRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TherapySettingsRepository.cs
@@ -326,25 +326,19 @@ public class TherapySettingsRepository : ITherapySettingsRepository
 
             if (legacyIds.Count > 0)
             {
-                var existingIds = await ctx
-                    .TherapySettings.IgnoreQueryFilters().AsNoTracking()
+                var existingRecords = await ctx.TherapySettings.IgnoreQueryFilters().AsNoTracking()
                     .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
-                    .Select(e => e.LegacyId)
+                    .Select(e => new { e.LegacyId, IsSoftDeleted = e.DeletedAt != null })
                     .ToListAsync(ct);
 
-                var existingSet = existingIds.ToHashSet();
-
-                var softDeletedCount = await ctx
-                    .TherapySettings.IgnoreQueryFilters().AsNoTracking()
-                    .Where(e => e.TenantId == ctx.TenantId)
-                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
-                    .CountAsync(ct);
+                var existingSet = existingRecords.Select(r => r.LegacyId).ToHashSet();
+                var softDeletedCount = existingRecords.Count(r => r.IsSoftDeleted);
 
                 if (softDeletedCount > 0)
                     _logger.LogInformation(
-                        "Skipped {Count} previously-deleted TherapySettings records during import",
-                        softDeletedCount);
+                        "Skipped {Count} previously-deleted {Type} records during import",
+                        softDeletedCount, "TherapySettings");
 
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TherapySettingsRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TherapySettingsRepository.cs
@@ -174,8 +174,57 @@ public class TherapySettingsRepository : ITherapySettingsRepository
         var entity =
             await ctx.TherapySettings.FindAsync([id], ct)
             ?? throw new KeyNotFoundException($"TherapySettings {id} not found");
-        ctx.TherapySettings.Remove(entity);
+        entity.DeletedAt = DateTime.UtcNow;
         await ctx.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<TherapySettings> RestoreAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entity = await ctx.TherapySettings.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Soft-deleted TherapySettings {id} not found");
+        entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return TherapySettingsMapper.ToDomainModel(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<TherapySettings>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var idSet = ids.ToHashSet();
+        var entities = await ctx.TherapySettings.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
+            .ToListAsync(ct);
+        foreach (var entity in entities)
+            entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return entities.Select(TherapySettingsMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<TherapySettings>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entities = await ctx.TherapySettings.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .OrderByDescending(e => e.DeletedAt)
+            .Skip(offset).Take(limit)
+            .AsNoTracking()
+            .ToListAsync(ct);
+        return entities.Select(TherapySettingsMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        return await ctx.TherapySettings.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .CountAsync(ct);
     }
 
     /// <summary>
@@ -187,7 +236,8 @@ public class TherapySettingsRepository : ITherapySettingsRepository
     public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.TherapySettings.Where(e => e.LegacyId == legacyId).ExecuteDeleteAsync(ct);
+        return await ctx.TherapySettings.Where(e => e.LegacyId == legacyId)
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 
     /// <summary>
@@ -201,7 +251,7 @@ public class TherapySettingsRepository : ITherapySettingsRepository
         await using var ctx = await _contextFactory.CreateAsync(ct);
         return await ctx
             .TherapySettings.Where(e => e.LegacyId != null && e.LegacyId.StartsWith(prefix))
-            .ExecuteDeleteAsync(ct);
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TherapySettingsRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TherapySettingsRepository.cs
@@ -327,12 +327,25 @@ public class TherapySettingsRepository : ITherapySettingsRepository
             if (legacyIds.Count > 0)
             {
                 var existingIds = await ctx
-                    .TherapySettings.AsNoTracking()
+                    .TherapySettings.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
                     .Select(e => e.LegacyId)
                     .ToListAsync(ct);
 
                 var existingSet = existingIds.ToHashSet();
+
+                var softDeletedCount = await ctx
+                    .TherapySettings.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
+                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
+                    .CountAsync(ct);
+
+                if (softDeletedCount > 0)
+                    _logger.LogInformation(
+                        "Skipped {Count} previously-deleted TherapySettings records during import",
+                        softDeletedCount);
+
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
                     .ToList();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
@@ -121,8 +121,57 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.UploaderSnapshots.FindAsync([id], ct)
             ?? throw new KeyNotFoundException($"UploaderSnapshot {id} not found");
-        ctx.UploaderSnapshots.Remove(entity);
+        entity.DeletedAt = DateTime.UtcNow;
         await ctx.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<UploaderSnapshot> RestoreAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entity = await ctx.UploaderSnapshots.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Soft-deleted UploaderSnapshot {id} not found");
+        entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return UploaderSnapshotMapper.ToDomainModel(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<UploaderSnapshot>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var idSet = ids.ToHashSet();
+        var entities = await ctx.UploaderSnapshots.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
+            .ToListAsync(ct);
+        foreach (var entity in entities)
+            entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return entities.Select(UploaderSnapshotMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<UploaderSnapshot>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entities = await ctx.UploaderSnapshots.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .OrderByDescending(e => e.DeletedAt)
+            .Skip(offset).Take(limit)
+            .AsNoTracking()
+            .ToListAsync(ct);
+        return entities.Select(UploaderSnapshotMapper.ToDomainModel);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        return await ctx.UploaderSnapshots.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .CountAsync(ct);
     }
 
     /// <summary>
@@ -173,7 +222,7 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
         await using var ctx = await _contextFactory.CreateAsync(ct);
         return await ctx.UploaderSnapshots
             .Where(e => e.LegacyId == legacyId)
-            .ExecuteDeleteAsync(ct);
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 
     /// <inheritdoc />

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
@@ -268,25 +268,19 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
 
             if (legacyIds.Count > 0)
             {
-                var existingIds = await ctx
-                    .UploaderSnapshots.IgnoreQueryFilters().AsNoTracking()
+                var existingRecords = await ctx.UploaderSnapshots.IgnoreQueryFilters().AsNoTracking()
                     .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
-                    .Select(e => e.LegacyId)
+                    .Select(e => new { e.LegacyId, IsSoftDeleted = e.DeletedAt != null })
                     .ToListAsync(ct);
 
-                var existingSet = existingIds.ToHashSet();
-
-                var softDeletedCount = await ctx
-                    .UploaderSnapshots.IgnoreQueryFilters().AsNoTracking()
-                    .Where(e => e.TenantId == ctx.TenantId)
-                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
-                    .CountAsync(ct);
+                var existingSet = existingRecords.Select(r => r.LegacyId).ToHashSet();
+                var softDeletedCount = existingRecords.Count(r => r.IsSoftDeleted);
 
                 if (softDeletedCount > 0)
                     _logger.LogInformation(
-                        "Skipped {Count} previously-deleted UploaderSnapshot records during import",
-                        softDeletedCount);
+                        "Skipped {Count} previously-deleted {Type} records during import",
+                        softDeletedCount, "UploaderSnapshot");
 
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
@@ -269,12 +269,25 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
             if (legacyIds.Count > 0)
             {
                 var existingIds = await ctx
-                    .UploaderSnapshots.AsNoTracking()
+                    .UploaderSnapshots.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
                     .Where(e => legacyIds.Contains(e.LegacyId!))
                     .Select(e => e.LegacyId)
                     .ToListAsync(ct);
 
                 var existingSet = existingIds.ToHashSet();
+
+                var softDeletedCount = await ctx
+                    .UploaderSnapshots.IgnoreQueryFilters().AsNoTracking()
+                    .Where(e => e.TenantId == ctx.TenantId)
+                    .Where(e => legacyIds.Contains(e.LegacyId!) && e.DeletedAt != null)
+                    .CountAsync(ct);
+
+                if (softDeletedCount > 0)
+                    _logger.LogInformation(
+                        "Skipped {Count} previously-deleted UploaderSnapshot records during import",
+                        softDeletedCount);
+
                 entities = entities
                     .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
                     .ToList();


### PR DESCRIPTION
## Summary

- All 24 v4 entities implement `ISoftDeletable` — deletes set `DeletedAt` instead of removing rows
- Connectors see through soft-deleted records via `IgnoreQueryFilters()` to prevent re-importing user-deleted data
- V4 gets restore (`POST {id}/restore`, `POST restore`), bulk restore, and trash listing (`GET deleted`) endpoints
- Decomposition pipeline deletes (v1/v3 legacy path) wrapped in shared transactions for atomicity
- `SoftDeleteCleanupService` hard-deletes expired records per-tenant (default 30 days, min 7, configurable via `TenantDataRetentionConfig`)
- `AuditedSoftDeleteAsync` extension for bulk soft-delete with audit trail
- Unique indexes updated to `WHERE deleted_at IS NULL` to allow re-creation after hard-delete cleanup
- 24 partial indexes on `deleted_at` for efficient cleanup queries

## Motivation

When a user deletes a treatment or entry, connectors re-download the same data and re-add it. Soft delete retains the record so the connector dedup check sees it and skips re-import.

## Migration

Two migrations:
1. `AddSoftDeleteToV4Entities` — adds `deleted_at` column to all 24 v4 tables, updates unique index filters, adds partial indexes
2. `AddTenantDataRetentionConfig` — new `tenant_data_retention_config` table for per-tenant retention settings

## Test plan

- [ ] Existing unit tests pass (3,389 verified locally)
- [ ] Delete a v4 record via API — confirm it's soft-deleted (exists in DB with `DeletedAt` set, invisible via GET)
- [ ] `GET /api/v4/{entity}/deleted` returns the soft-deleted record
- [ ] `POST /api/v4/{entity}/{id}/restore` restores it (visible via GET again)
- [ ] Connector import with same LegacyId as soft-deleted record — confirm skipped with log message
- [ ] v1/v3 legacy delete transparently soft-deletes
- [ ] Cleanup service purges records past retention window
- [ ] Per-tenant retention config overrides global default