### PR TITLE
feat(alerts): Home Assistant as first-class alert delivery target

### DIFF
--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -689,6 +689,7 @@ public static class ServiceRegistrationExtensions
         services.AddScoped<Nocturne.API.Services.Alerts.Providers.InAppProvider>();
         services.AddScoped<Nocturne.API.Services.Alerts.Providers.WebhookProvider>();
         services.AddScoped<Nocturne.API.Services.Alerts.Providers.ChatBotProvider>();
+        services.AddScoped<Nocturne.API.Services.Alerts.Providers.HomeAssistantProvider>();
         services.AddHttpClient("ChatBot");
 
         // Chat identity

--- a/src/API/Nocturne.API/Hubs/HomeAssistantHub.cs
+++ b/src/API/Nocturne.API/Hubs/HomeAssistantHub.cs
@@ -20,7 +20,7 @@ public class HomeAssistantHub : TenantAwareHub
     /// <summary>
     /// Tracks active HA instance connection counts. Key is the tenant-scoped group name for
     /// "ha:{instanceId}", value is the number of active connections in that group.
-    /// Used by <see cref="HomeAssistantProvider"/> to gate delivery marking.
+    /// Used by <see cref="Services.Alerts.Providers.HomeAssistantProvider"/> to gate delivery marking.
     /// </summary>
     private static readonly ConcurrentDictionary<string, int> _instanceConnectionCounts = new();
 

--- a/src/API/Nocturne.API/Hubs/HomeAssistantHub.cs
+++ b/src/API/Nocturne.API/Hubs/HomeAssistantHub.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text.Json;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -17,24 +18,68 @@ namespace Nocturne.API.Hubs;
 public class HomeAssistantHub : TenantAwareHub
 {
     /// <summary>
+    /// Tracks active HA instance connection counts. Key is the tenant-scoped group name for
+    /// "ha:{instanceId}", value is the number of active connections in that group.
+    /// Used by <see cref="HomeAssistantProvider"/> to gate delivery marking.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, int> _instanceConnectionCounts = new();
+
+    /// <summary>
     /// Subscribe the calling connection to glucose relay and per-instance alert groups.
     /// Also performs catch-up delivery for any failed HA deliveries targeting this instance.
     /// </summary>
     /// <param name="instanceId">The Home Assistant instance identifier (matches channel Destination).</param>
     public async Task Subscribe(string instanceId)
     {
+        var ct = Context.ConnectionAborted;
+
         if (string.IsNullOrWhiteSpace(instanceId))
             throw new HubException("instanceId must not be empty.");
 
         var tenantId = TenantContext?.TenantId
             ?? throw new HubException("No tenant context resolved.");
 
-        // Join tenant-scoped glucose relay and per-instance groups
-        await Groups.AddToGroupAsync(Context.ConnectionId, TenantGroup("ha-glucose"));
-        await Groups.AddToGroupAsync(Context.ConnectionId, TenantGroup($"ha:{instanceId}"));
+        // Join tenant-scoped glucose relay, per-instance, and alert groups
+        await Groups.AddToGroupAsync(Context.ConnectionId, TenantGroup("ha-glucose"), ct);
+        await Groups.AddToGroupAsync(Context.ConnectionId, TenantGroup($"ha:{instanceId}"), ct);
+        await Groups.AddToGroupAsync(Context.ConnectionId, TenantGroup("ha-alerts"), ct);
+
+        // Track connection count for this instance and store instanceId for cleanup on disconnect
+        var instanceGroupKey = FormatTenantGroup(tenantId.ToString(), $"ha:{instanceId}");
+        _instanceConnectionCounts.AddOrUpdate(instanceGroupKey, 1, (_, count) => count + 1);
+        Context.Items["ha_instance_id"] = instanceId;
 
         // Catch-up: re-dispatch failed deliveries for this instance
-        await CatchUpFailedDeliveriesAsync(tenantId, instanceId);
+        await CatchUpFailedDeliveriesAsync(tenantId, instanceId, ct);
+    }
+
+    /// <summary>
+    /// Decrements the connection count for the instance this connection was subscribed to.
+    /// </summary>
+    public override async Task OnDisconnectedAsync(Exception? exception)
+    {
+        var instanceId = Context.Items.TryGetValue("ha_instance_id", out var val) ? val as string : null;
+        if (instanceId is not null)
+        {
+            var tenantId = TenantContext?.TenantId.ToString();
+            if (tenantId is not null)
+            {
+                var groupKey = FormatTenantGroup(tenantId, $"ha:{instanceId}");
+                _instanceConnectionCounts.AddOrUpdate(groupKey, 0, (_, count) => Math.Max(0, count - 1));
+            }
+        }
+
+        await base.OnDisconnectedAsync(exception);
+    }
+
+    /// <summary>
+    /// Returns whether a specific HA instance currently has at least one active SignalR connection.
+    /// Used by <see cref="Services.Alerts.Providers.HomeAssistantProvider"/> to decide whether to mark delivery as delivered.
+    /// </summary>
+    public static bool IsInstanceConnected(string tenantId, string instanceId)
+    {
+        var key = FormatTenantGroup(tenantId, $"ha:{instanceId}");
+        return _instanceConnectionCounts.TryGetValue(key, out var count) && count > 0;
     }
 
     /// <summary>
@@ -45,26 +90,31 @@ public class HomeAssistantHub : TenantAwareHub
     /// <param name="acknowledgedBy">Display name or identifier of the person acknowledging.</param>
     public async Task Acknowledge(Guid excursionId, string acknowledgedBy)
     {
+        var ct = Context.ConnectionAborted;
+
         var tenantId = TenantContext?.TenantId
             ?? throw new HubException("No tenant context resolved.");
 
         // Gate 1: OAuth scope check — require "alerts.readwrite"
-        var scopeClaim = Context.User?.FindFirst("scope")?.Value;
-        if (scopeClaim is null || !scopeClaim.Split(' ').Contains("alerts.readwrite"))
-            throw new HubException("Insufficient scope: alerts.readwrite is required.");
+        var scopes = Context.User?.FindAll("scope")
+            .SelectMany(c => c.Value.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+            .ToHashSet() ?? new HashSet<string>();
+
+        if (!scopes.Contains("alerts.readwrite"))
+            throw new HubException("Insufficient permissions: alerts.readwrite scope required.");
 
         // Gate 2: Channel config check — find HA channels for this excursion's rule and verify allow_ack
         var services = Context.GetHttpContext()!.RequestServices;
         var contextFactory = services.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
 
-        await using var db = await contextFactory.CreateDbContextAsync(CancellationToken.None);
+        await using var db = await contextFactory.CreateDbContextAsync(ct);
         db.TenantId = tenantId;
 
         var excursion = await db.AlertExcursions
             .AsNoTracking()
             .Where(e => e.Id == excursionId && e.TenantId == tenantId)
             .Select(e => new { e.AlertRuleId })
-            .FirstOrDefaultAsync(CancellationToken.None);
+            .FirstOrDefaultAsync(ct);
 
         if (excursion is null)
             throw new HubException("Excursion not found.");
@@ -75,7 +125,7 @@ public class HomeAssistantHub : TenantAwareHub
                         && c.TenantId == tenantId
                         && c.ChannelType == ChannelType.HomeAssistant)
             .Select(c => c.Metadata)
-            .ToListAsync(CancellationToken.None);
+            .ToListAsync(ct);
 
         var allowAck = haChannels.Any(metadata =>
         {
@@ -99,21 +149,22 @@ public class HomeAssistantHub : TenantAwareHub
 
         // Both gates passed — acknowledge
         var ackService = services.GetRequiredService<IAlertAcknowledgementService>();
-        await ackService.AcknowledgeExcursionAsync(tenantId, excursionId, acknowledgedBy, broadcast: true, CancellationToken.None);
+        await ackService.AcknowledgeExcursionAsync(tenantId, excursionId, acknowledgedBy, broadcast: true, ct);
     }
 
-    private async Task CatchUpFailedDeliveriesAsync(Guid tenantId, string instanceId)
+    private async Task CatchUpFailedDeliveriesAsync(Guid tenantId, string instanceId, CancellationToken ct)
     {
         var services = Context.GetHttpContext()!.RequestServices;
         var contextFactory = services.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
 
-        await using var db = await contextFactory.CreateDbContextAsync(CancellationToken.None);
+        await using var db = await contextFactory.CreateDbContextAsync(ct);
         db.TenantId = tenantId;
 
         // Find failed HA deliveries for this instance that belong to open excursions
         var failedDeliveries = await db.AlertDeliveries
             .Include(d => d.AlertInstance)
                 .ThenInclude(i => i!.AlertExcursion)
+            .Include(d => d.AlertRuleChannel)
             .Where(d => d.TenantId == tenantId
                         && d.ChannelType == ChannelType.HomeAssistant
                         && d.Destination == instanceId
@@ -121,17 +172,30 @@ public class HomeAssistantHub : TenantAwareHub
                         && d.AlertInstance != null
                         && d.AlertInstance.AlertExcursion != null
                         && d.AlertInstance.AlertExcursion.EndedAt == null)
-            .ToListAsync(CancellationToken.None);
+            .ToListAsync(ct);
 
         foreach (var delivery in failedDeliveries)
         {
             try
             {
-                // Re-dispatch the payload to the caller
+                // Re-dispatch the payload to the caller, including allow_ack from channel metadata
                 var payload = JsonSerializer.Deserialize<AlertPayload>(delivery.Payload);
                 if (payload is not null)
                 {
-                    await Clients.Caller.SendCoreAsync("alert_dispatch", [payload], CancellationToken.None);
+                    var allowAck = false;
+                    if (!string.IsNullOrEmpty(delivery.AlertRuleChannel?.Metadata))
+                    {
+                        try
+                        {
+                            using var doc = JsonDocument.Parse(delivery.AlertRuleChannel.Metadata);
+                            allowAck = doc.RootElement.TryGetProperty("allow_ack", out var prop)
+                                       && prop.ValueKind == JsonValueKind.True;
+                        }
+                        catch (JsonException) { }
+                    }
+
+                    var channelMeta = new { allowAck };
+                    await Clients.Caller.SendCoreAsync("alert_dispatch", new object[] { payload, channelMeta }, ct);
 
                     // Mark as delivered
                     delivery.Status = "delivered";
@@ -146,7 +210,7 @@ public class HomeAssistantHub : TenantAwareHub
 
         if (failedDeliveries.Count > 0)
         {
-            await db.SaveChangesAsync(CancellationToken.None);
+            await db.SaveChangesAsync(ct);
         }
     }
 }

--- a/src/API/Nocturne.API/Hubs/HomeAssistantHub.cs
+++ b/src/API/Nocturne.API/Hubs/HomeAssistantHub.cs
@@ -1,0 +1,152 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using Nocturne.Core.Contracts.Alerts;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Alerts;
+using Nocturne.Infrastructure.Data;
+
+namespace Nocturne.API.Hubs;
+
+/// <summary>
+/// SignalR hub for Home Assistant integration. HA instances subscribe to receive
+/// real-time glucose relays and alert dispatches, and can acknowledge excursions
+/// when the channel is configured to allow it.
+/// Mounted at /hubs/home-assistant.
+/// </summary>
+public class HomeAssistantHub : TenantAwareHub
+{
+    /// <summary>
+    /// Subscribe the calling connection to glucose relay and per-instance alert groups.
+    /// Also performs catch-up delivery for any failed HA deliveries targeting this instance.
+    /// </summary>
+    /// <param name="instanceId">The Home Assistant instance identifier (matches channel Destination).</param>
+    public async Task Subscribe(string instanceId)
+    {
+        if (string.IsNullOrWhiteSpace(instanceId))
+            throw new HubException("instanceId must not be empty.");
+
+        var tenantId = TenantContext?.TenantId
+            ?? throw new HubException("No tenant context resolved.");
+
+        // Join tenant-scoped glucose relay and per-instance groups
+        await Groups.AddToGroupAsync(Context.ConnectionId, TenantGroup("ha-glucose"));
+        await Groups.AddToGroupAsync(Context.ConnectionId, TenantGroup($"ha:{instanceId}"));
+
+        // Catch-up: re-dispatch failed deliveries for this instance
+        await CatchUpFailedDeliveriesAsync(tenantId, instanceId);
+    }
+
+    /// <summary>
+    /// Acknowledge a specific excursion from the Home Assistant side.
+    /// Requires the "alerts.readwrite" OAuth scope and the channel's metadata must have allow_ack enabled.
+    /// </summary>
+    /// <param name="excursionId">The excursion to acknowledge.</param>
+    /// <param name="acknowledgedBy">Display name or identifier of the person acknowledging.</param>
+    public async Task Acknowledge(Guid excursionId, string acknowledgedBy)
+    {
+        var tenantId = TenantContext?.TenantId
+            ?? throw new HubException("No tenant context resolved.");
+
+        // Gate 1: OAuth scope check — require "alerts.readwrite"
+        var scopeClaim = Context.User?.FindFirst("scope")?.Value;
+        if (scopeClaim is null || !scopeClaim.Split(' ').Contains("alerts.readwrite"))
+            throw new HubException("Insufficient scope: alerts.readwrite is required.");
+
+        // Gate 2: Channel config check — find HA channels for this excursion's rule and verify allow_ack
+        var services = Context.GetHttpContext()!.RequestServices;
+        var contextFactory = services.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
+
+        await using var db = await contextFactory.CreateDbContextAsync(CancellationToken.None);
+        db.TenantId = tenantId;
+
+        var excursion = await db.AlertExcursions
+            .AsNoTracking()
+            .Where(e => e.Id == excursionId && e.TenantId == tenantId)
+            .Select(e => new { e.AlertRuleId })
+            .FirstOrDefaultAsync(CancellationToken.None);
+
+        if (excursion is null)
+            throw new HubException("Excursion not found.");
+
+        var haChannels = await db.AlertRuleChannels
+            .AsNoTracking()
+            .Where(c => c.AlertRuleId == excursion.AlertRuleId
+                        && c.TenantId == tenantId
+                        && c.ChannelType == ChannelType.HomeAssistant)
+            .Select(c => c.Metadata)
+            .ToListAsync(CancellationToken.None);
+
+        var allowAck = haChannels.Any(metadata =>
+        {
+            if (string.IsNullOrEmpty(metadata))
+                return false;
+
+            try
+            {
+                using var doc = JsonDocument.Parse(metadata);
+                return doc.RootElement.TryGetProperty("allow_ack", out var prop)
+                       && prop.ValueKind == JsonValueKind.True;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+        });
+
+        if (!allowAck)
+            throw new HubException("Acknowledgement is not permitted for this alert channel.");
+
+        // Both gates passed — acknowledge
+        var ackService = services.GetRequiredService<IAlertAcknowledgementService>();
+        await ackService.AcknowledgeExcursionAsync(tenantId, excursionId, acknowledgedBy, broadcast: true, CancellationToken.None);
+    }
+
+    private async Task CatchUpFailedDeliveriesAsync(Guid tenantId, string instanceId)
+    {
+        var services = Context.GetHttpContext()!.RequestServices;
+        var contextFactory = services.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
+
+        await using var db = await contextFactory.CreateDbContextAsync(CancellationToken.None);
+        db.TenantId = tenantId;
+
+        // Find failed HA deliveries for this instance that belong to open excursions
+        var failedDeliveries = await db.AlertDeliveries
+            .Include(d => d.AlertInstance)
+                .ThenInclude(i => i!.AlertExcursion)
+            .Where(d => d.TenantId == tenantId
+                        && d.ChannelType == ChannelType.HomeAssistant
+                        && d.Destination == instanceId
+                        && d.Status == "failed"
+                        && d.AlertInstance != null
+                        && d.AlertInstance.AlertExcursion != null
+                        && d.AlertInstance.AlertExcursion.EndedAt == null)
+            .ToListAsync(CancellationToken.None);
+
+        foreach (var delivery in failedDeliveries)
+        {
+            try
+            {
+                // Re-dispatch the payload to the caller
+                var payload = JsonSerializer.Deserialize<AlertPayload>(delivery.Payload);
+                if (payload is not null)
+                {
+                    await Clients.Caller.SendCoreAsync("alert_dispatch", [payload], CancellationToken.None);
+
+                    // Mark as delivered
+                    delivery.Status = "delivered";
+                    delivery.DeliveredAt = DateTime.UtcNow;
+                }
+            }
+            catch (JsonException)
+            {
+                // Payload is malformed — skip this delivery
+            }
+        }
+
+        if (failedDeliveries.Count > 0)
+        {
+            await db.SaveChangesAsync(CancellationToken.None);
+        }
+    }
+}

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -390,6 +390,7 @@ app.MapHub<DataHub>("/hubs/data");
 app.MapHub<AlarmHub>("/hubs/alarms");
 app.MapHub<AlertHub>("/hubs/alerts");
 app.MapHub<ConfigHub>("/hubs/config");
+app.MapHub<HomeAssistantHub>("/hubs/home-assistant");
 
 // Serve OpenAPI specs at /openapi/{documentName}.json
 app.MapOpenApi();

--- a/src/API/Nocturne.API/Services/Alerts/AlertDeliveryService.cs
+++ b/src/API/Nocturne.API/Services/Alerts/AlertDeliveryService.cs
@@ -100,11 +100,13 @@ internal sealed class AlertDeliveryService(
 
         // Hand each persisted row to its provider. Provider failures are caught and recorded
         // on the delivery row; one bad webhook does not abort the rest of the batch.
-        foreach (var delivery in deliveryRows)
+        for (var i = 0; i < deliveryRows.Count; i++)
         {
+            var delivery = deliveryRows[i];
+            var channelMetadata = channels[i].Metadata;
             try
             {
-                await DispatchToProviderAsync(delivery, payload, ct);
+                await DispatchToProviderAsync(delivery, payload, channelMetadata, ct);
             }
             catch (Exception ex)
             {
@@ -208,11 +210,13 @@ internal sealed class AlertDeliveryService(
         }
         await db.SaveChangesAsync(ct);
 
-        foreach (var delivery in deliveryRows)
+        for (var i = 0; i < deliveryRows.Count; i++)
         {
+            var delivery = deliveryRows[i];
+            var channelMetadata = channels[i].Metadata;
             try
             {
-                await DispatchToProviderAsync(delivery, payload, ct);
+                await DispatchToProviderAsync(delivery, payload, channelMetadata, ct);
             }
             catch (Exception ex)
             {
@@ -250,7 +254,7 @@ internal sealed class AlertDeliveryService(
                     ChannelType = channel.ChannelType,
                     Destination = channel.Destination,
                 };
-                await DispatchToProviderAsync(fauxDelivery, payload, ct);
+                await DispatchToProviderAsync(fauxDelivery, payload, channel.Metadata, ct);
             }
             catch (Exception ex)
             {
@@ -286,7 +290,7 @@ internal sealed class AlertDeliveryService(
         await db.SaveChangesAsync(ct);
     }
 
-    private async Task DispatchToProviderAsync(AlertDeliveryEntity delivery, AlertPayload payload, CancellationToken ct)
+    private async Task DispatchToProviderAsync(AlertDeliveryEntity delivery, AlertPayload payload, string? channelMetadata, CancellationToken ct)
     {
         switch (delivery.ChannelType)
         {
@@ -329,8 +333,31 @@ internal sealed class AlertDeliveryService(
                 var haProvider = serviceProvider.GetService<Providers.HomeAssistantProvider>();
                 if (haProvider is not null)
                 {
-                    await haProvider.SendAsync(delivery.TenantId, delivery.Destination, payload, ct);
-                    await MarkDeliveredAsync(delivery.Id, null, null, ct);
+                    object? channelMeta = null;
+                    if (!string.IsNullOrEmpty(channelMetadata))
+                    {
+                        try
+                        {
+                            using var doc = System.Text.Json.JsonDocument.Parse(channelMetadata);
+                            var allowAck = doc.RootElement.TryGetProperty("allow_ack", out var prop)
+                                           && prop.ValueKind == System.Text.Json.JsonValueKind.True;
+                            channelMeta = new { allowAck };
+                        }
+                        catch (System.Text.Json.JsonException)
+                        {
+                            channelMeta = new { allowAck = false };
+                        }
+                    }
+                    else
+                    {
+                        channelMeta = new { allowAck = false };
+                    }
+
+                    var delivered = await haProvider.SendAsync(delivery.TenantId, delivery.Destination, payload, channelMeta, ct);
+                    if (delivered)
+                        await MarkDeliveredAsync(delivery.Id, null, null, ct);
+                    else
+                        await MarkFailedAsync(delivery.Id, "No Home Assistant instance connected", ct);
                 }
                 break;
 

--- a/src/API/Nocturne.API/Services/Alerts/AlertDeliveryService.cs
+++ b/src/API/Nocturne.API/Services/Alerts/AlertDeliveryService.cs
@@ -325,6 +325,15 @@ internal sealed class AlertDeliveryService(
                 }
                 break;
 
+            case ChannelType.HomeAssistant:
+                var haProvider = serviceProvider.GetService<Providers.HomeAssistantProvider>();
+                if (haProvider is not null)
+                {
+                    await haProvider.SendAsync(delivery.TenantId, delivery.Destination, payload, ct);
+                    await MarkDeliveredAsync(delivery.Id, null, null, ct);
+                }
+                break;
+
             default:
                 logger.LogWarning("Unsupported channel type '{ChannelType}' for delivery {DeliveryId}",
                     delivery.ChannelType, delivery.Id);

--- a/src/API/Nocturne.API/Services/Alerts/Providers/HomeAssistantProvider.cs
+++ b/src/API/Nocturne.API/Services/Alerts/Providers/HomeAssistantProvider.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.SignalR;
+using Nocturne.API.Hubs;
+using Nocturne.Core.Models;
+
+namespace Nocturne.API.Services.Alerts.Providers;
+
+/// <summary>
+/// Delivers alert payloads to a specific Home Assistant instance via the
+/// HomeAssistantHub's per-instance SignalR group.
+/// </summary>
+internal sealed class HomeAssistantProvider(
+    IHubContext<HomeAssistantHub> hubContext,
+    ILogger<HomeAssistantProvider> logger)
+{
+    /// <summary>
+    /// Sends an alert payload to the HA instance identified by <paramref name="destination"/>
+    /// (the OAuth client ID). Targets the SignalR group "ha:{destination}" within the tenant.
+    /// </summary>
+    public async Task SendAsync(Guid tenantId, string destination, AlertPayload payload, CancellationToken ct)
+    {
+        var group = TenantAwareHub.FormatTenantGroup(tenantId.ToString(), $"ha:{destination}");
+
+        try
+        {
+            await hubContext.Clients.Group(group)
+                .SendCoreAsync("alert_dispatch", new object[] { payload }, ct);
+
+            logger.LogDebug(
+                "HA alert dispatched to instance {Destination} for alert instance {InstanceId}",
+                destination, payload.InstanceId);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Failed to dispatch HA alert to instance {Destination} for alert instance {InstanceId}",
+                destination, payload.InstanceId);
+            throw;
+        }
+    }
+}

--- a/src/API/Nocturne.API/Services/Alerts/Providers/HomeAssistantProvider.cs
+++ b/src/API/Nocturne.API/Services/Alerts/Providers/HomeAssistantProvider.cs
@@ -15,19 +15,29 @@ internal sealed class HomeAssistantProvider(
     /// <summary>
     /// Sends an alert payload to the HA instance identified by <paramref name="destination"/>
     /// (the OAuth client ID). Targets the SignalR group "ha:{destination}" within the tenant.
+    /// Returns <c>true</c> if the instance is connected and the message was sent;
+    /// <c>false</c> if no connection is registered for the instance.
     /// </summary>
-    public async Task SendAsync(Guid tenantId, string destination, AlertPayload payload, CancellationToken ct)
+    public async Task<bool> SendAsync(Guid tenantId, string destination, AlertPayload payload, object? channelMeta, CancellationToken ct)
     {
+        if (!HomeAssistantHub.IsInstanceConnected(tenantId.ToString(), destination))
+        {
+            logger.LogDebug("HA instance {Destination} not connected, skipping dispatch", destination);
+            return false;
+        }
+
         var group = TenantAwareHub.FormatTenantGroup(tenantId.ToString(), $"ha:{destination}");
 
         try
         {
             await hubContext.Clients.Group(group)
-                .SendCoreAsync("alert_dispatch", new object[] { payload }, ct);
+                .SendCoreAsync("alert_dispatch", new object[] { payload, channelMeta ?? new { allowAck = false } }, ct);
 
             logger.LogDebug(
                 "HA alert dispatched to instance {Destination} for alert instance {InstanceId}",
                 destination, payload.InstanceId);
+
+            return true;
         }
         catch (Exception ex)
         {

--- a/src/API/Nocturne.API/Services/Realtime/SignalRBroadcastService.cs
+++ b/src/API/Nocturne.API/Services/Realtime/SignalRBroadcastService.cs
@@ -566,7 +566,7 @@ public class SignalRBroadcastService : ISignalRBroadcastService
         try
         {
             await _homeAssistantHubContext
-                .Clients.Group(TenantGroup("ha-glucose"))
+                .Clients.Group(TenantGroup("ha-alerts"))
                 .SendCoreAsync(eventName, new[] { payload });
         }
         catch (Exception ex)

--- a/src/API/Nocturne.API/Services/Realtime/SignalRBroadcastService.cs
+++ b/src/API/Nocturne.API/Services/Realtime/SignalRBroadcastService.cs
@@ -112,13 +112,19 @@ public interface ISignalRBroadcastService
     /// Broadcast sync progress event to subscribers via ConfigHub
     /// </summary>
     Task BroadcastSyncProgressAsync(SyncProgressEvent progress);
+
+    /// <summary>
+    /// Broadcast glucose reading to Home Assistant subscribers via HomeAssistantHub
+    /// </summary>
+    Task BroadcastHomeAssistantGlucoseAsync(object glucoseData);
 }
 
 /// <summary>
 /// Concrete implementation of <see cref="ISignalRBroadcastService"/> that routes broadcasts
-/// to tenant-scoped groups across four hubs: <see cref="DataHub"/> (data and storage events),
+/// to tenant-scoped groups across five hubs: <see cref="DataHub"/> (data and storage events),
 /// <see cref="AlarmHub"/> (notifications and alarms), <see cref="ConfigHub"/> (configuration
-/// changes and sync progress), and <see cref="AlertHub"/> (alert engine events).
+/// changes and sync progress), <see cref="AlertHub"/> (alert engine events), and
+/// <see cref="HomeAssistantHub"/> (glucose relay and alert event relay to HA instances).
 /// </summary>
 /// <remarks>
 /// Group names are always prefixed with the tenant ID via <see cref="TenantAwareHub.FormatTenantGroup"/>
@@ -130,12 +136,14 @@ public interface ISignalRBroadcastService
 /// <seealso cref="AlarmHub"/>
 /// <seealso cref="ConfigHub"/>
 /// <seealso cref="AlertHub"/>
+/// <seealso cref="HomeAssistantHub"/>
 public class SignalRBroadcastService : ISignalRBroadcastService
 {
     private readonly IHubContext<DataHub> _dataHubContext;
     private readonly IHubContext<AlarmHub> _alarmHubContext;
     private readonly IHubContext<ConfigHub> _configHubContext;
     private readonly IHubContext<AlertHub> _alertHubContext;
+    private readonly IHubContext<HomeAssistantHub> _homeAssistantHubContext;
     private readonly ITenantAccessor _tenantAccessor;
     private readonly ILogger<SignalRBroadcastService> _logger;
 
@@ -146,6 +154,7 @@ public class SignalRBroadcastService : ISignalRBroadcastService
     /// <param name="alarmHubContext">Hub context for <see cref="AlarmHub"/> — notifications, alarms, and announcements.</param>
     /// <param name="configHubContext">Hub context for <see cref="ConfigHub"/> — configuration changes and sync progress.</param>
     /// <param name="alertHubContext">Hub context for <see cref="AlertHub"/> — alert engine dispatch, resolution, and acknowledgement events.</param>
+    /// <param name="homeAssistantHubContext">Hub context for <see cref="HomeAssistantHub"/> — glucose relay and alert event relay to Home Assistant instances.</param>
     /// <param name="tenantAccessor">Provides the current tenant context for scoping group names.</param>
     /// <param name="logger">The logger instance.</param>
     public SignalRBroadcastService(
@@ -153,6 +162,7 @@ public class SignalRBroadcastService : ISignalRBroadcastService
         IHubContext<AlarmHub> alarmHubContext,
         IHubContext<ConfigHub> configHubContext,
         IHubContext<AlertHub> alertHubContext,
+        IHubContext<HomeAssistantHub> homeAssistantHubContext,
         ITenantAccessor tenantAccessor,
         ILogger<SignalRBroadcastService> logger
     )
@@ -161,6 +171,7 @@ public class SignalRBroadcastService : ISignalRBroadcastService
         _alarmHubContext = alarmHubContext;
         _configHubContext = configHubContext;
         _alertHubContext = alertHubContext;
+        _homeAssistantHubContext = homeAssistantHubContext;
         _tenantAccessor = tenantAccessor;
         _logger = logger;
     }
@@ -200,6 +211,9 @@ public class SignalRBroadcastService : ISignalRBroadcastService
                 .Clients.Group(group)
                 .SendCoreAsync("dataUpdate", new[] { data });
             _logger.LogInformation("Data update broadcast completed successfully");
+
+            // Relay to Home Assistant subscribers
+            await BroadcastHomeAssistantGlucoseAsync(data);
         }
         catch (Exception ex)
         {
@@ -546,6 +560,34 @@ public class SignalRBroadcastService : ISignalRBroadcastService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error broadcasting alert event {EventName}", eventName);
+        }
+
+        // Also relay to Home Assistant subscribers
+        try
+        {
+            await _homeAssistantHubContext
+                .Clients.Group(TenantGroup("ha-glucose"))
+                .SendCoreAsync(eventName, new[] { payload });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error relaying alert event {EventName} to HA", eventName);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task BroadcastHomeAssistantGlucoseAsync(object glucoseData)
+    {
+        try
+        {
+            _logger.LogDebug("Broadcasting glucose_reading to HA subscribers");
+            await _homeAssistantHubContext
+                .Clients.Group(TenantGroup("ha-glucose"))
+                .SendCoreAsync("glucose_reading", new[] { glucoseData });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error broadcasting glucose_reading to HA");
         }
     }
 

--- a/src/Core/Nocturne.Core.Models/AlertSnapshots.cs
+++ b/src/Core/Nocturne.Core.Models/AlertSnapshots.cs
@@ -21,7 +21,8 @@ public record AlertRuleChannelSnapshot(
     Nocturne.Core.Models.Alerts.ChannelType ChannelType,
     string Destination,
     string? DestinationLabel,
-    int SortOrder);
+    int SortOrder,
+    string? Metadata = null);
 
 /// <summary>
 /// Immutable snapshot of a live alert instance.

--- a/src/Core/Nocturne.Core.Models/Alerts/ChannelType.cs
+++ b/src/Core/Nocturne.Core.Models/Alerts/ChannelType.cs
@@ -59,4 +59,8 @@ public enum ChannelType
     /// <summary>WhatsApp direct message to a user.</summary>
     [EnumMember(Value = "whatsapp_dm"), JsonStringEnumMemberName("whatsapp_dm")]
     WhatsAppDm,
+
+    /// <summary>Home Assistant integration delivery via dedicated SignalR hub.</summary>
+    [EnumMember(Value = "home_assistant"), JsonStringEnumMemberName("home_assistant")]
+    HomeAssistant,
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/AlertRuleChannelEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/AlertRuleChannelEntity.cs
@@ -53,6 +53,13 @@ public class AlertRuleChannelEntity : ITenantScoped
     [Column("created_at")]
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
+    /// <summary>
+    /// Channel-specific configuration stored as JSONB. Schema varies by channel type.
+    /// For home_assistant: { "allow_ack": bool, "delivery_methods": string[], "critical_push": bool }
+    /// </summary>
+    [Column("metadata", TypeName = "jsonb")]
+    public string? Metadata { get; set; }
+
     // Navigation
 
     /// <summary>Navigation back to the owning rule.</summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260514094424_AddAlertRuleChannelMetadata.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260514094424_AddAlertRuleChannelMetadata.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260514094424_AddAlertRuleChannelMetadata")]
+    partial class AddAlertRuleChannelMetadata
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -2615,10 +2618,6 @@ namespace Nocturne.Infrastructure.Data.Migrations
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("revoked_at");
 
-                    b.Property<Guid>("TenantId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("tenant_id");
-
                     b.Property<string>("TokenHash")
                         .IsRequired()
                         .HasMaxLength(64)
@@ -2638,8 +2637,6 @@ namespace Nocturne.Infrastructure.Data.Migrations
                     b.HasIndex("RevokedAt")
                         .HasDatabaseName("ix_oauth_refresh_tokens_revoked_at")
                         .HasFilter("revoked_at IS NULL");
-
-                    b.HasIndex("TenantId");
 
                     b.HasIndex("TokenHash")
                         .IsUnique()
@@ -4818,106 +4815,6 @@ namespace Nocturne.Infrastructure.Data.Migrations
                         .HasFilter("legacy_id IS NOT NULL AND deleted_at IS NULL");
 
                     b.ToTable("bg_checks");
-                });
-
-            modelBuilder.Entity("Nocturne.Infrastructure.Data.Entities.V4.BasalInjectionEntity", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid")
-                        .HasColumnName("id");
-
-                    b.Property<string>("AdditionalPropertiesJson")
-                        .HasColumnType("jsonb")
-                        .HasColumnName("additional_properties");
-
-                    b.Property<string>("App")
-                        .HasMaxLength(256)
-                        .HasColumnType("character varying(256)")
-                        .HasColumnName("app");
-
-                    b.Property<Guid?>("CorrelationId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("correlation_id");
-
-                    b.Property<string>("DataSource")
-                        .HasMaxLength(256)
-                        .HasColumnType("character varying(256)")
-                        .HasColumnName("data_source");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("deleted_at");
-
-                    b.Property<string>("Device")
-                        .HasMaxLength(256)
-                        .HasColumnType("character varying(256)")
-                        .HasColumnName("device");
-
-                    b.Property<string>("InsulinContextJson")
-                        .IsRequired()
-                        .HasColumnType("jsonb")
-                        .HasColumnName("insulin_context");
-
-                    b.Property<string>("LegacyId")
-                        .HasMaxLength(64)
-                        .HasColumnType("character varying(64)")
-                        .HasColumnName("legacy_id");
-
-                    b.Property<string>("Notes")
-                        .HasMaxLength(4096)
-                        .HasColumnType("character varying(4096)")
-                        .HasColumnName("notes");
-
-                    b.Property<string>("SyncIdentifier")
-                        .HasMaxLength(256)
-                        .HasColumnType("character varying(256)")
-                        .HasColumnName("sync_identifier");
-
-                    b.Property<DateTime>("SysCreatedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("sys_created_at");
-
-                    b.Property<DateTime>("SysUpdatedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("sys_updated_at");
-
-                    b.Property<Guid>("TenantId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("tenant_id");
-
-                    b.Property<DateTime>("Timestamp")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("timestamp");
-
-                    b.Property<double>("Units")
-                        .HasColumnType("double precision")
-                        .HasColumnName("units");
-
-                    b.Property<int?>("UtcOffset")
-                        .HasColumnType("integer")
-                        .HasColumnName("utc_offset");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CorrelationId")
-                        .HasDatabaseName("ix_basal_injections_correlation_id");
-
-                    b.HasIndex("Timestamp")
-                        .IsDescending()
-                        .HasDatabaseName("ix_basal_injections_timestamp");
-
-                    b.HasIndex("TenantId", "LegacyId")
-                        .IsUnique()
-                        .HasDatabaseName("ix_basal_injections_tenant_legacy_id")
-                        .HasFilter("legacy_id IS NOT NULL");
-
-                    b.HasIndex("TenantId", "DataSource", "SyncIdentifier")
-                        .IsUnique()
-                        .HasDatabaseName("ix_basal_injections_tenant_source_sync_id")
-                        .HasFilter("sync_identifier IS NOT NULL AND deleted_at IS NULL");
-
-                    b.ToTable("basal_injections");
                 });
 
             modelBuilder.Entity("Nocturne.Infrastructure.Data.Entities.V4.BasalScheduleEntity", b =>
@@ -7528,12 +7425,6 @@ namespace Nocturne.Infrastructure.Data.Migrations
                         .HasForeignKey("ReplacedById")
                         .OnDelete(DeleteBehavior.SetNull);
 
-                    b.HasOne("Nocturne.Infrastructure.Data.Entities.TenantEntity", null)
-                        .WithMany()
-                        .HasForeignKey("TenantId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
                     b.Navigation("Grant");
 
                     b.Navigation("ReplacedBy");
@@ -7901,15 +7792,6 @@ namespace Nocturne.Infrastructure.Data.Migrations
                         .HasForeignKey("CorrelationId")
                         .OnDelete(DeleteBehavior.Cascade);
 
-                    b.HasOne("Nocturne.Infrastructure.Data.Entities.TenantEntity", null)
-                        .WithMany()
-                        .HasForeignKey("TenantId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-                });
-
-            modelBuilder.Entity("Nocturne.Infrastructure.Data.Entities.V4.BasalInjectionEntity", b =>
-                {
                     b.HasOne("Nocturne.Infrastructure.Data.Entities.TenantEntity", null)
                         .WithMany()
                         .HasForeignKey("TenantId")

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260514094424_AddAlertRuleChannelMetadata.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260514094424_AddAlertRuleChannelMetadata.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAlertRuleChannelMetadata : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "metadata",
+                table: "alert_rule_channels",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "metadata",
+                table: "alert_rule_channels");
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/AlertRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/AlertRepository.cs
@@ -57,7 +57,7 @@ public class AlertRepository : IAlertRepository
             .OrderBy(c => c.SortOrder)
             .Select(c => new AlertRuleChannelSnapshot(
                 c.Id, c.AlertRuleId, c.ChannelType,
-                c.Destination, c.DestinationLabel, c.SortOrder))
+                c.Destination, c.DestinationLabel, c.SortOrder, c.Metadata))
             .ToListAsync(ct);
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantIsolationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantIsolationTests.cs
@@ -297,9 +297,15 @@ public class TenantIsolationTests
         mockAlertHub.Setup(x => x.Clients).Returns(alertClients.Object);
         alertClients.Setup(x => x.Group(It.IsAny<string>())).Returns(alertProxy.Object);
 
+        var mockHaHub = new Mock<IHubContext<HomeAssistantHub>>();
+        var haClients = new Mock<IHubClients>();
+        var haProxy = new Mock<IClientProxy>();
+        mockHaHub.Setup(x => x.Clients).Returns(haClients.Object);
+        haClients.Setup(x => x.Group(It.IsAny<string>())).Returns(haProxy.Object);
+
         var service = new SignalRBroadcastService(
             mockDataHub.Object, mockAlarmHub.Object, mockConfigHub.Object, mockAlertHub.Object,
-            mockAccessor.Object, mockLogger.Object);
+            mockHaHub.Object, mockAccessor.Object, mockLogger.Object);
 
         return (service, dataClients, alarmClients, configClients, dataProxy, alarmProxy, configProxy);
     }

--- a/tests/Unit/Nocturne.API.Tests/Services/Realtime/SignalRBroadcastServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Realtime/SignalRBroadcastServiceTests.cs
@@ -20,6 +20,7 @@ public class SignalRBroadcastServiceTests
     private readonly Mock<IHubContext<AlarmHub>> _mockAlarmHubContext;
     private readonly Mock<IHubContext<ConfigHub>> _mockConfigHubContext;
     private readonly Mock<IHubContext<AlertHub>> _mockAlertHubContext;
+    private readonly Mock<IHubContext<HomeAssistantHub>> _mockHomeAssistantHubContext;
     private readonly Mock<ILogger<SignalRBroadcastService>> _mockLogger;
     private readonly Mock<IHubClients> _mockDataClients;
     private readonly Mock<IHubClients> _mockAlarmClients;
@@ -37,6 +38,7 @@ public class SignalRBroadcastServiceTests
         _mockAlarmHubContext = new Mock<IHubContext<AlarmHub>>();
         _mockConfigHubContext = new Mock<IHubContext<ConfigHub>>();
         _mockAlertHubContext = new Mock<IHubContext<AlertHub>>();
+        _mockHomeAssistantHubContext = new Mock<IHubContext<HomeAssistantHub>>();
         _mockLogger = new Mock<ILogger<SignalRBroadcastService>>();
         _mockDataClients = new Mock<IHubClients>();
         _mockAlarmClients = new Mock<IHubClients>();
@@ -63,12 +65,17 @@ public class SignalRBroadcastServiceTests
         _mockAlertClients
             .Setup(x => x.Group(It.IsAny<string>()))
             .Returns(_mockAlertGroupProxy.Object);
+        var mockHaClients = new Mock<IHubClients>();
+        var mockHaProxy = new Mock<IClientProxy>();
+        _mockHomeAssistantHubContext.Setup(x => x.Clients).Returns(mockHaClients.Object);
+        mockHaClients.Setup(x => x.Group(It.IsAny<string>())).Returns(mockHaProxy.Object);
 
         _service = new SignalRBroadcastService(
             _mockDataHubContext.Object,
             _mockAlarmHubContext.Object,
             _mockConfigHubContext.Object,
             _mockAlertHubContext.Object,
+            _mockHomeAssistantHubContext.Object,
             MockTenantAccessor.Create().Object,
             _mockLogger.Object
         );


### PR DESCRIPTION
## Summary

- Adds `home_assistant` as a new `ChannelType` alongside the existing 12 channels
- Introduces `HomeAssistantHub` at `/hubs/home-assistant` — a dedicated SignalR hub that multiplexes real-time glucose readings and alert events to connected HA instances, with per-instance group targeting and failed-delivery catch-up on reconnect
- Adds `HomeAssistantProvider` that delivers alert payloads to specific HA instances via SignalR, tracking connection state to correctly mark deliveries as failed (rather than delivered) when no client is connected
- Adds `metadata` JSONB column to `alert_rule_channels` for channel-specific config (`allow_ack`, `delivery_methods`, `critical_push`)
- Relays glucose `dataUpdate` broadcasts and alert resolved/acknowledged events to HA subscribers through the new hub
- Two-gate ack validation: OAuth `alerts.readwrite` scope + per-channel `allow_ack` config

## Design

See design doc and implementation plan in the nocturne-homeassistant repo: `docs/plans/2026-05-14-home-assistant-alert-delivery-design.md`

Companion PR: ryceg/nocturne-homeassistant (feat/home-assistant-alert-delivery)

## Test Plan

- [ ] Build passes: `dotnet build src/API/Nocturne.API/` — 0 errors
- [ ] Apply EF migration: `dotnet ef database update --project src/Infrastructure/Nocturne.Infrastructure.Data/ --startup-project src/API/Nocturne.API/`
- [ ] Verify `home_assistant` appears in generated OpenAPI spec
- [ ] Connect HA integration to dev instance, confirm Subscribe joins correct groups
- [ ] Fire a test alert on a rule with `home_assistant` channel — confirm delivery status reflects connection state
- [ ] Ack from HA — confirm two-gate validation, audit trail shows `homeassistant:*`
- [ ] Disconnect HA, fire alert — confirm `failed` delivery, reconnect and confirm catch-up dispatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)