### PR TITLE
fix(migrations): backfill oauth_refresh_tokens.tenant_id under per-tenant RLS context

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260514100536_AddTenantIdToOAuthRefreshTokens.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260514100536_AddTenantIdToOAuthRefreshTokens.cs
@@ -18,13 +18,27 @@ namespace Nocturne.Infrastructure.Data.Migrations
                 type: "uuid",
                 nullable: true);
 
-            // Backfill from the parent grant
+            // Backfill from the parent grant. The migrator role is NOBYPASSRLS,
+            // so reading oauth_grants requires setting app.current_tenant_id per
+            // tenant — without it, FORCE RLS on oauth_grants silently filters
+            // every row and the subsequent NOT NULL alter fails.
             migrationBuilder.Sql(
                 """
-                UPDATE oauth_refresh_tokens rt
-                SET tenant_id = g.tenant_id
-                FROM oauth_grants g
-                WHERE rt.grant_id = g.id;
+                DO $$
+                DECLARE
+                    r RECORD;
+                BEGIN
+                    FOR r IN SELECT id FROM tenants
+                    LOOP
+                        PERFORM set_config('app.current_tenant_id', r.id::text, true);
+
+                        UPDATE oauth_refresh_tokens rt
+                        SET tenant_id = g.tenant_id
+                        FROM oauth_grants g
+                        WHERE rt.grant_id = g.id
+                          AND g.tenant_id = r.id;
+                    END LOOP;
+                END $$;
                 """);
 
             // Make NOT NULL now that all rows are backfilled


### PR DESCRIPTION
## Summary

`AddTenantIdToOAuthRefreshTokens` runs the backfill `UPDATE` as `nocturne_migrator`, which is `NOBYPASSRLS`. With `FORCE ROW LEVEL SECURITY` on `oauth_grants` and no `app.current_tenant_id` set, the join silently matches **zero** rows on any deployment that already has `oauth_refresh_tokens` data. Every `tenant_id` stays `NULL`, the next `AlterColumn ... nullable: false` fails with:

```
Npgsql.PostgresException: 23502: column "tenant_id" of relation "oauth_refresh_tokens" contains null values
```

…and `nocturne-api` crash-loops on startup. Fresh deployments (empty `oauth_refresh_tokens`) didn't hit this — the failure only surfaces against existing data.

## Fix

Wrap the backfill in a `DO $$ ... LOOP` that iterates `tenants` and calls `set_config('app.current_tenant_id', ..., true)` per iteration, matching the pattern already established in `MigrateApiSecretsToDirectGrants`. Schema-only steps (AddColumn / AlterColumn / CreateIndex / AddForeignKey / ENABLE/FORCE RLS / CREATE POLICY) are unaffected by RLS and stay outside the loop.

This aligns with the guidance in `CLAUDE.md`:

> Data migrations cannot SELECT or UPDATE tenant-scoped tables without first setting the tenant context. […] If a data migration needs to touch multiple tenants, loop over tenants and set the GUC per iteration.

## Test plan

- [x] Reproduced on a production deployment with **2,770** `oauth_refresh_tokens` across **6** tenants / **20** grants — original migration failed every restart.
- [x] After truncating `oauth_refresh_tokens` and re-running, the migration applied cleanly (verified the empty-table path).
- [ ] Re-run on a populated DB with the fixed migration to confirm rows are backfilled (recommended in CI).
- [ ] `dotnet test --filter "Category!=Integration&Category!=Performance"` (no behavioural change to existing tests; migration files aren't covered by unit tests).