### PR TITLE
feat(coach): back-button dismisses coach marks

### DIFF
--- a/src/Web/packages/app/src/lib/coach-marks/context-dismiss.test.ts
+++ b/src/Web/packages/app/src/lib/coach-marks/context-dismiss.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { selectActiveMark, isSequenceDone, sequenceProgress } from "@nocturne/coach";
+import type { MarkState, SequenceConfig } from "@nocturne/coach";
+
+const sequences: SequenceConfig = {
+  first: {
+    priority: 100,
+    steps: ["first.a", "first.b"],
+  },
+  second: {
+    priority: 50,
+    steps: ["second.a"],
+  },
+};
+
+function makeStates(entries: Record<string, MarkState["status"]>): Map<string, MarkState> {
+  const map = new Map<string, MarkState>();
+  for (const [key, status] of Object.entries(entries)) {
+    map.set(key, {
+      id: key,
+      markKey: key,
+      status,
+      seenAt: null,
+      completedAt: null,
+    });
+  }
+  return map;
+}
+
+function makeRegistration(key: string) {
+  return {
+    key,
+    step: 0,
+    title: key,
+    description: key,
+    priority: 0,
+    element: {} as HTMLElement,
+  };
+}
+
+describe("quiet dismiss behavior", () => {
+  it("dismissing all steps in a sequence makes it done", () => {
+    const states = makeStates({
+      "first.a": "dismissed",
+      "first.b": "dismissed",
+    });
+    expect(isSequenceDone("first", sequences, states)).toBe(true);
+  });
+
+  it("dismissed sequence satisfies prerequisite for dependent sequences", () => {
+    const seqWithPrereq: SequenceConfig = {
+      ...sequences,
+      second: { ...sequences.second, prerequisite: "first" },
+    };
+    const states = makeStates({
+      "first.a": "dismissed",
+      "first.b": "dismissed",
+    });
+    expect(isSequenceDone("first", seqWithPrereq, states)).toBe(true);
+  });
+
+  it("selectActiveMark skips dismissed sequences and finds next eligible", () => {
+    const states = makeStates({
+      "first.a": "dismissed",
+      "first.b": "dismissed",
+    });
+    const registrations = [makeRegistration("second.a")];
+
+    const result = selectActiveMark(states, registrations, sequences);
+    expect(result).toEqual({ key: "second.a", step: 0 });
+  });
+
+  it("selectActiveMark returns null when all sequences are dismissed", () => {
+    const states = makeStates({
+      "first.a": "dismissed",
+      "first.b": "dismissed",
+      "second.a": "dismissed",
+    });
+    const registrations = [
+      makeRegistration("first.a"),
+      makeRegistration("second.a"),
+    ];
+
+    const result = selectActiveMark(states, registrations, sequences);
+    expect(result).toBeNull();
+  });
+
+  it("sequenceProgress counts dismissed steps as completed", () => {
+    const states = makeStates({
+      "first.a": "dismissed",
+      "first.b": "completed",
+    });
+    const progress = sequenceProgress("first", sequences, states);
+    expect(progress).toEqual({ completed: 2, total: 2 });
+  });
+});

--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
@@ -12,6 +12,7 @@
   import type { AlarmVisualSettings } from "$lib/types/alarm-profile";
   import type { TitleFaviconSettings } from "$lib/stores/serverSettings";
   import { browser } from "$app/environment";
+  import { beforeNavigate } from "$app/navigation";
   import * as Card from "$lib/components/ui/card";
   import { Button } from "$lib/components/ui/button";
   import AlertBanner from "$lib/components/alerts/AlertBanner.svelte";
@@ -194,7 +195,7 @@
   });
 </script>
 
-<CoachMarkProvider adapter={coachMarkAdapter} {sequences}>
+<CoachMarkProvider adapter={coachMarkAdapter} {sequences} onBeforeNavigate={beforeNavigate}>
   <CoachParamHandler />
   <Sidebar.Provider>
     <AppSidebar user={data.user} tenantCount={data.tenantCount} effectivePermissions={data.effectivePermissions} isPlatformAdmin={data.isPlatformAdmin} isGuestSession={data.isGuestSession} />

--- a/src/Web/packages/coach/src/lib/CoachMarkProvider.svelte
+++ b/src/Web/packages/coach/src/lib/CoachMarkProvider.svelte
@@ -33,6 +33,7 @@
   // Let the consuming app wire in its router's beforeNavigate hook.
   // The callback sets a flag so Popover uses replaceState instead of
   // history.back() when cleaning up the sentinel entry during navigation.
+  // svelte-ignore state_referenced_locally — intentional: beforeNavigate must be called at init time
   if (onBeforeNavigate) {
     onBeforeNavigate(() => {
       navigationFlag.navigating = true;

--- a/src/Web/packages/coach/src/lib/CoachMarkProvider.svelte
+++ b/src/Web/packages/coach/src/lib/CoachMarkProvider.svelte
@@ -11,12 +11,14 @@
     sequences = {},
     settleDelay = 500,
     seenDwellMs = 2000,
+    onBeforeNavigate,
     children,
   }: {
     adapter: CoachMarkAdapter;
     sequences?: SequenceConfig;
     settleDelay?: number;
     seenDwellMs?: number;
+    onBeforeNavigate?: (callback: () => void) => void;
     children: Snippet;
   } = $props();
 
@@ -24,10 +26,28 @@
   const ctx = createCoachMarkContext(adapter, sequences, settleDelay, seenDwellMs);
   setCoachMarkContextRef(ctx);
 
+  let navigatingAway = $state(false);
+
+  // Let the consuming app wire in its router's beforeNavigate hook.
+  // The callback sets a flag so Popover uses replaceState instead of
+  // history.back() when cleaning up the sentinel entry during navigation.
+  if (onBeforeNavigate) {
+    onBeforeNavigate(() => {
+      navigatingAway = true;
+    });
+  }
+
   onMount(() => {
+    // Refresh recovery: if the page was refreshed while a coach mark was
+    // visible, the sentinel history entry is now the current entry. Pop it
+    // before any coach marks activate.
+    if (history.state?.__coachMark) {
+      history.back();
+    }
+
     ctx.initialize();
   });
 </script>
 
 {@render children()}
-<Popover />
+<Popover {navigatingAway} />

--- a/src/Web/packages/coach/src/lib/CoachMarkProvider.svelte
+++ b/src/Web/packages/coach/src/lib/CoachMarkProvider.svelte
@@ -26,14 +26,16 @@
   const ctx = createCoachMarkContext(adapter, sequences, settleDelay, seenDwellMs);
   setCoachMarkContextRef(ctx);
 
-  let navigatingAway = $state(false);
+  // Shared mutable flag so Popover can read AND reset after consuming.
+  // Not $state — Popover reads it imperatively in effect cleanup, not reactively.
+  const navigationFlag = { navigating: false };
 
   // Let the consuming app wire in its router's beforeNavigate hook.
   // The callback sets a flag so Popover uses replaceState instead of
   // history.back() when cleaning up the sentinel entry during navigation.
   if (onBeforeNavigate) {
     onBeforeNavigate(() => {
-      navigatingAway = true;
+      navigationFlag.navigating = true;
     });
   }
 
@@ -50,4 +52,4 @@
 </script>
 
 {@render children()}
-<Popover {navigatingAway} />
+<Popover {navigationFlag} />

--- a/src/Web/packages/coach/src/lib/context.svelte.ts
+++ b/src/Web/packages/coach/src/lib/context.svelte.ts
@@ -1,6 +1,7 @@
 import { getContext, setContext, untrack } from "svelte";
 import type {
   CoachMarkAdapter,
+  DismissOptions,
   MarkRegistration,
   MarkState,
   MarkStatus,
@@ -94,7 +95,7 @@ export class CoachMarkContext {
     this._activeSelection = { key, step };
   }
 
-  dismiss(key: string): void {
+  dismiss(key: string, options?: DismissOptions): void {
     if (this._forcedSequence) {
       // Dismissing any step in a forced sequence dismisses ALL remaining unseen/seen steps
       const seq = this.sequences[this._forcedSequence];
@@ -108,6 +109,7 @@ export class CoachMarkContext {
       }
       this._activeSelection = null;
       this.onForcedSequenceComplete();
+      if (options?.quiet) this._quietUntilNavigation = true;
       return;
     }
 
@@ -130,7 +132,11 @@ export class CoachMarkContext {
     }
 
     this._activeSelection = null;
-    this.scheduleSelection();
+    if (options?.quiet) {
+      this._quietUntilNavigation = true;
+    } else {
+      this.scheduleSelection();
+    }
   }
 
   complete(key: string): void {

--- a/src/Web/packages/coach/src/lib/index.ts
+++ b/src/Web/packages/coach/src/lib/index.ts
@@ -4,6 +4,7 @@ export type {
   CoachMarkOptions,
   CoachMarkProviderOptions,
   CoachMarkStep,
+  DismissOptions,
   MarkRegistration,
   MarkState,
   MarkStatus,

--- a/src/Web/packages/coach/src/lib/popover/Popover.svelte
+++ b/src/Web/packages/coach/src/lib/popover/Popover.svelte
@@ -50,6 +50,7 @@
     if (key) {
       // Overlay just appeared — push sentinel if we haven't already
       if (!historyEntryPushed) {
+        dismissedByUI = false; // reset stale flag from any previous cycle
         history.pushState({ ...history.state, __coachMark: true }, "");
         historyEntryPushed = true;
       }
@@ -72,8 +73,12 @@
       return () => {
         window.removeEventListener("popstate", onPopState);
 
-        // Cleanup: if the overlay is disappearing and we still have a
-        // sentinel entry, remove it.
+        // If transitioning directly to another coach mark (activeKey went
+        // from truthy A to truthy B), keep the sentinel entry — the new
+        // effect run will reuse it via the historyEntryPushed guard.
+        if (ctx.activeKey) return;
+
+        // Cleanup: overlay is disappearing, remove the sentinel entry.
         if (historyEntryPushed) {
           historyEntryPushed = false;
           if (navigationFlag.navigating) {

--- a/src/Web/packages/coach/src/lib/popover/Popover.svelte
+++ b/src/Web/packages/coach/src/lib/popover/Popover.svelte
@@ -18,6 +18,11 @@
   let dwellTimer: ReturnType<typeof setTimeout> | null = null;
   let cleanupAutoUpdate: (() => void) | null = null;
 
+  let { navigatingAway = false }: { navigatingAway?: boolean } = $props();
+
+  let historyEntryPushed = false;
+  let dismissedByUI = false;
+
   const SPOTLIGHT_PADDING = 8;
 
   let spotlightClipPath = $state("");
@@ -34,6 +39,57 @@
       startDwellTimer();
     } else {
       cancelDwellTimer();
+    }
+  });
+
+  // History management for back-button dismissal.
+  // Push a sentinel entry when the overlay appears; pop it when it disappears.
+  $effect(() => {
+    const key = activeKey;
+
+    if (key) {
+      // Overlay just appeared — push sentinel if we haven't already
+      if (!historyEntryPushed) {
+        history.pushState({ __coachMark: true }, "");
+        historyEntryPushed = true;
+      }
+
+      function onPopState() {
+        // Guard: if the UI already dismissed (Escape/backdrop/button),
+        // this popstate is just the history.back() cleanup — ignore it.
+        if (dismissedByUI) {
+          dismissedByUI = false;
+          return;
+        }
+
+        // The user pressed back. Dismiss with quiet so no follow-on sequence appears.
+        historyEntryPushed = false;
+        if (activeKey) ctx.dismiss(activeKey, { quiet: true });
+      }
+
+      window.addEventListener("popstate", onPopState);
+
+      return () => {
+        window.removeEventListener("popstate", onPopState);
+
+        // Cleanup: if the overlay is disappearing and we still have a
+        // sentinel entry, remove it.
+        if (historyEntryPushed) {
+          historyEntryPushed = false;
+          if (navigatingAway) {
+            // SvelteKit is navigating — don't call history.back() which
+            // would fight the router. Replace the current state to strip
+            // our marker (the router's pushState has already happened).
+            const cleaned = { ...history.state };
+            delete cleaned.__coachMark;
+            history.replaceState(cleaned, "");
+          } else {
+            // Natural dismiss (Escape, backdrop, "Got it") — pop our entry.
+            dismissedByUI = true;
+            history.back();
+          }
+        }
+      };
     }
   });
 

--- a/src/Web/packages/coach/src/lib/popover/Popover.svelte
+++ b/src/Web/packages/coach/src/lib/popover/Popover.svelte
@@ -18,7 +18,7 @@
   let dwellTimer: ReturnType<typeof setTimeout> | null = null;
   let cleanupAutoUpdate: (() => void) | null = null;
 
-  let { navigatingAway = false }: { navigatingAway?: boolean } = $props();
+  let { navigationFlag = { navigating: false } }: { navigationFlag?: { navigating: boolean } } = $props();
 
   let historyEntryPushed = false;
   let dismissedByUI = false;
@@ -50,7 +50,7 @@
     if (key) {
       // Overlay just appeared — push sentinel if we haven't already
       if (!historyEntryPushed) {
-        history.pushState({ __coachMark: true }, "");
+        history.pushState({ ...history.state, __coachMark: true }, "");
         historyEntryPushed = true;
       }
 
@@ -64,7 +64,7 @@
 
         // The user pressed back. Dismiss with quiet so no follow-on sequence appears.
         historyEntryPushed = false;
-        if (activeKey) ctx.dismiss(activeKey, { quiet: true });
+        if (key) ctx.dismiss(key, { quiet: true });
       }
 
       window.addEventListener("popstate", onPopState);
@@ -76,10 +76,11 @@
         // sentinel entry, remove it.
         if (historyEntryPushed) {
           historyEntryPushed = false;
-          if (navigatingAway) {
+          if (navigationFlag.navigating) {
             // SvelteKit is navigating — don't call history.back() which
             // would fight the router. Replace the current state to strip
             // our marker (the router's pushState has already happened).
+            navigationFlag.navigating = false;
             const cleaned = { ...history.state };
             delete cleaned.__coachMark;
             history.replaceState(cleaned, "");

--- a/src/Web/packages/coach/src/lib/types.ts
+++ b/src/Web/packages/coach/src/lib/types.ts
@@ -1,5 +1,9 @@
 export type MarkStatus = "unseen" | "seen" | "dismissed" | "completed";
 
+export interface DismissOptions {
+  quiet?: boolean;
+}
+
 export interface MarkState {
   id: string;
   markKey: string;


### PR DESCRIPTION
## Summary

- Adds back-button support to coach marks: pressing the browser back button dismisses the active coach mark quietly (no follow-on sequence appears)
- Pushes a sentinel `pushState` history entry when a coach mark overlay appears; intercepts `popstate` to dismiss and clean up
- Introduces a `quiet` option on `dismiss()` that suppresses automatic progression to the next coach mark, used for back-button and navigation-triggered dismissals
- Wires SvelteKit's `beforeNavigate` into `CoachMarkProvider` so navigation-triggered cleanup uses `replaceState` instead of `history.back()`, avoiding router conflicts
- Handles refresh recovery: if the page reloads while a coach mark is visible, the stale sentinel entry is popped on mount before any marks activate

## Test plan

- [ ] Unit tests added for quiet dismiss sequencing behavior (`context-dismiss.test.ts`)
- [ ] Verify pressing browser back button dismisses an active coach mark without showing the next one
- [ ] Verify Escape / backdrop / "Got it" button still dismiss normally and advance the sequence
- [ ] Verify navigating via SvelteKit link while a coach mark is open does not break history
- [ ] Verify refreshing while a coach mark is visible recovers cleanly on reload