### PR TITLE
feat(platform): add multi-tenant roster dashboard on apex domain

### DIFF
--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -66,6 +66,7 @@ public class TenantResolutionMiddleware
         "/api/v4/admin/demo/",
         "/api/v4/admin/platform-settings",
         "/api/v4/admin/tenants",
+        "/api/v4/me/tenants",
         "/api/v4/dev-only/",
         "/api/v4/platform/",
         "/api/v4/setup/",

--- a/src/Web/packages/app/src/app.d.ts
+++ b/src/Web/packages/app/src/app.d.ts
@@ -63,6 +63,16 @@ declare global {
 			 */
 			isPlatformAdmin: boolean;
 			/**
+			 * Set when the request is on the apex domain with no tenant resolved.
+			 * Used by /(platform) routes to verify they are being served correctly.
+			 */
+			isPlatformView?: boolean;
+			/**
+			 * The apex hostname (e.g. "nocturne.health") as seen by the client.
+			 * Used in the platform sidebar and to construct per-tenant hosts.
+			 */
+			apexHost?: string;
+			/**
 			 * Whether the current session is a guest link session (read-only, no subjectId)
 			 */
 			isGuestSession?: boolean;

--- a/src/Web/packages/app/src/hooks.server.ts
+++ b/src/Web/packages/app/src/hooks.server.ts
@@ -66,6 +66,9 @@ function getEffectiveHost(request: Request, cookies: { get(name: string): string
 /** Route prefixes that bypass requireAuthentication enforcement. */
 const PUBLIC_PREFIXES = ["/auth", "/api", "/setup", "/clock", "/invite", "/terms", "/privacy", "/guest"] as const;
 
+/** Route prefixes that belong to the /(platform) apex-domain dashboard. */
+const PLATFORM_ROUTE_PREFIXES = ["/roster", "/attention", "/trends", "/activity", "/care-plans"] as const;
+
 function isPublicRoute(pathname: string): boolean {
   return (
     pathname === "/" ||
@@ -277,13 +280,14 @@ const siteSecurityHandle: Handle = async ({ event, resolve }) => {
       // Tenant not found (404) — either no tenant for this subdomain,
       // or apex domain with no tenants set up yet.
       if (status === 404) {
+        // Use raw apex host — not getEffectiveHost, which would prepend a setup-tenant
+        // slug. apexHost must be the real apex domain for constructing per-tenant URLs.
         const apexHost = getOriginalHost(event.request);
 
         if (event.locals.isAuthenticated) {
           // Apex domain, authenticated — serve the platform dashboard.
           // If already on a platform route, let it render. Otherwise redirect.
-          const platformPrefixes = ["/roster", "/attention", "/trends", "/activity", "/care-plans"];
-          const onPlatformRoute = platformPrefixes.some(p => pathname.startsWith(p));
+          const onPlatformRoute = PLATFORM_ROUTE_PREFIXES.some(p => pathname.startsWith(p));
 
           event.locals.isPlatformView = true;
           if (apexHost) event.locals.apexHost = apexHost;

--- a/src/Web/packages/app/src/hooks.server.ts
+++ b/src/Web/packages/app/src/hooks.server.ts
@@ -277,7 +277,22 @@ const siteSecurityHandle: Handle = async ({ event, resolve }) => {
       // Tenant not found (404) — either no tenant for this subdomain,
       // or apex domain with no tenants set up yet.
       if (status === 404) {
-        // If a marketing site is configured, redirect there (SaaS apex landing)
+        const apexHost = getOriginalHost(event.request);
+
+        if (event.locals.isAuthenticated) {
+          // Apex domain, authenticated — serve the platform dashboard.
+          // If already on a platform route, let it render. Otherwise redirect.
+          const platformPrefixes = ["/roster", "/attention", "/trends", "/activity", "/care-plans"];
+          const onPlatformRoute = platformPrefixes.some(p => pathname.startsWith(p));
+
+          event.locals.isPlatformView = true;
+          if (apexHost) event.locals.apexHost = apexHost;
+
+          if (onPlatformRoute) return resolve(event);
+          return new Response(null, { status: 303, headers: { Location: "/roster" } });
+        }
+
+        // Unauthenticated — existing behaviour.
         const marketingUrl = env.MARKETING_URL;
         if (marketingUrl) {
           return new Response(null, {
@@ -285,14 +300,7 @@ const siteSecurityHandle: Handle = async ({ event, resolve }) => {
             headers: { Location: marketingUrl },
           });
         }
-
-        // No marketing site — this is likely a self-hosted install.
-        // Check if this is an apex domain request (no tenant subdomain).
-        // If so, redirect to setup so the user can create their first tenant.
-        return new Response(null, {
-          status: 303,
-          headers: { Location: "/setup" },
-        });
+        return new Response(null, { status: 303, headers: { Location: "/setup" } });
       }
     }
     console.error("Failed to check site security settings:", error);

--- a/src/Web/packages/app/src/lib/components/platform/AggregateStrip.svelte
+++ b/src/Web/packages/app/src/lib/components/platform/AggregateStrip.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  interface Props {
+    tir: number;          // 0-100 combined TIR
+    attention: number;    // tenants out-of-range right now
+    alarms: number;       // STUB-BACKEND: GET /api/v4/platform/roster-snapshots
+    stale: number;        // tenants with no reading > 25 min
+    tenantCount: number;
+  }
+
+  let { tir, attention, alarms, stale, tenantCount }: Props = $props();
+
+  const tirRest = $derived(100 - tir);
+</script>
+
+<div class="grid grid-cols-2 gap-3 p-4 sm:grid-cols-4">
+  <!-- TIR -->
+  <div class="rounded-lg border border-border bg-card p-4">
+    <div class="text-xs text-muted-foreground mb-1">Combined TIR · Today</div>
+    <div class="flex items-baseline gap-1">
+      <span class="text-3xl font-bold tabular-nums">{tir}</span>
+      <span class="text-sm text-muted-foreground">%</span>
+    </div>
+    <div class="mt-2 flex h-1.5 w-full overflow-hidden rounded-full">
+      <span style="width:{Math.max(0, tir - 6)}%" class="bg-[var(--glucose-in-range)]"></span>
+      <span style="width:6%" class="bg-[var(--glucose-low)]"></span>
+      <span style="width:{Math.max(0, tirRest - 6)}%" class="bg-[var(--glucose-high)]"></span>
+    </div>
+    <div class="mt-1.5 text-xs text-muted-foreground">
+      Across {tenantCount} tenants · 24 h rolling
+    </div>
+  </div>
+
+  <!-- Attention -->
+  <div class="rounded-lg border border-border bg-card p-4">
+    <div class="text-xs text-muted-foreground mb-1">Needs attention</div>
+    <div class="text-3xl font-bold tabular-nums" style="color:{attention > 0 ? 'var(--glucose-low)' : 'inherit'}">
+      {attention}
+    </div>
+    <div class="mt-1 text-xs text-muted-foreground">
+      {attention === 0 ? "All readings within range." : "Out-of-range right now"}
+    </div>
+  </div>
+
+  <!-- Alarms — STUB-BACKEND -->
+  <div class="rounded-lg border border-border bg-card p-4">
+    <div class="text-xs text-muted-foreground mb-1">Alarms · Today</div>
+    <!-- STUB-BACKEND: alarm count per tenant — GET /api/v4/platform/roster-snapshots -->
+    <div class="text-3xl font-bold tabular-nums text-muted-foreground">—</div>
+    <div class="mt-1 text-xs text-muted-foreground">Not yet available</div>
+  </div>
+
+  <!-- Stale -->
+  <div class="rounded-lg border border-border bg-card p-4">
+    <div class="text-xs text-muted-foreground mb-1">Stale connections</div>
+    <div class="text-3xl font-bold tabular-nums" style="color:{stale > 0 ? 'var(--glucose-low)' : 'inherit'}">
+      {stale}
+    </div>
+    <div class="mt-1 text-xs text-muted-foreground">
+      {stale === 0 ? "Every CGM reporting." : "No reading > 25 min"}
+    </div>
+  </div>
+</div>

--- a/src/Web/packages/app/src/lib/components/platform/AlertBanner.svelte
+++ b/src/Web/packages/app/src/lib/components/platform/AlertBanner.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { AlertTriangle } from "lucide-svelte";
+  import type { RosterItem } from "./types";
+
+  interface Props {
+    critical: RosterItem[];
+    onopen?: (item: RosterItem) => void;
+  }
+
+  let { critical, onopen }: Props = $props();
+  const first = $derived(critical[0]);
+  const others = $derived(critical.length - 1);
+</script>
+
+{#if critical.length > 0 && first}
+  <div class="flex items-center gap-3 px-4 py-2.5 text-sm"
+       style="background:color-mix(in oklch,var(--glucose-very-low) 12%,var(--background))">
+    <AlertTriangle class="size-4 shrink-0 text-[var(--glucose-very-low)]" />
+    <div class="flex-1">
+      <span class="font-semibold">{first.displayName}</span>
+      {' '}at{' '}
+      <span class="font-semibold text-[var(--glucose-very-low)]">{first.mgdl} mg/dL</span>
+      {#if others > 0}
+        {' '}· plus <strong>{others}</strong> other{others > 1 ? "s" : ""} flagged
+      {/if}
+    </div>
+    <button class="rounded border border-border px-2 py-1 text-xs hover:bg-accent"
+            onclick={() => onopen?.(first)}>
+      Open {first.displayName.split(" ")[0]}
+    </button>
+  </div>
+{/if}

--- a/src/Web/packages/app/src/lib/components/platform/AlertBanner.svelte
+++ b/src/Web/packages/app/src/lib/components/platform/AlertBanner.svelte
@@ -15,11 +15,11 @@
 {#if critical.length > 0 && first}
   <div class="flex items-center gap-3 px-4 py-2.5 text-sm"
        style="background:color-mix(in oklch,var(--glucose-very-low) 12%,var(--background))">
-    <AlertTriangle class="size-4 shrink-0 text-[var(--glucose-very-low)]" />
+    <AlertTriangle class="size-4 shrink-0 text-glucose-very-low" />
     <div class="flex-1">
       <span class="font-semibold">{first.displayName}</span>
       {' '}at{' '}
-      <span class="font-semibold text-[var(--glucose-very-low)]">{first.mgdl} mg/dL</span>
+      <span class="font-semibold text-glucose-very-low">{first.mgdl ?? "—"} mg/dL</span>
       {#if others > 0}
         {' '}· plus <strong>{others}</strong> other{others > 1 ? "s" : ""} flagged
       {/if}

--- a/src/Web/packages/app/src/lib/components/platform/AttentionRail.svelte
+++ b/src/Web/packages/app/src/lib/components/platform/AttentionRail.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import { STATUS_COLOR, dirArrow, type RosterItem } from "./types";
+
+  interface Props {
+    items: RosterItem[];
+    onopen?: (item: RosterItem) => void;
+  }
+
+  let { items, onopen }: Props = $props();
+</script>
+
+{#if items.length > 0}
+  <div class="border-b border-border px-4 py-3">
+    <div class="mb-2 flex items-center gap-2 text-xs font-medium text-muted-foreground">
+      <span class="size-1.5 rounded-full bg-[var(--glucose-low)] animate-pulse"></span>
+      Needs attention now · {items.length}
+    </div>
+    <div class="flex gap-2 overflow-x-auto pb-1">
+      {#each items as item (item.id)}
+        {@const color = STATUS_COLOR[item.status]}
+        <button
+          class="flex shrink-0 flex-col gap-1 rounded-xl border p-3 text-left transition-all hover:shadow-md"
+          style="min-width:200px; border-color:{color}; box-shadow:0 0 0 2px color-mix(in oklch,{color} 18%,transparent)"
+          onclick={() => onopen?.(item)}
+        >
+          <div class="text-sm font-medium">{item.displayName}</div>
+          <div class="flex items-baseline gap-1">
+            <span class="text-2xl font-bold" style="color:{color}">{item.mgdl ?? "—"}</span>
+            <span style="color:{color}">{dirArrow(item.delta)}</span>
+          </div>
+        </button>
+      {/each}
+    </div>
+  </div>
+{/if}

--- a/src/Web/packages/app/src/lib/components/platform/PlatformSidebar.svelte
+++ b/src/Web/packages/app/src/lib/components/platform/PlatformSidebar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state";
   import { Activity, Bell, BookOpen, TrendingUp, Users } from "lucide-svelte";
-  import type { AuthUser } from "../../../../app.d";
+  import type { AuthUser } from "$lib/stores/auth-store.svelte";
 
   interface Props {
     user: AuthUser;

--- a/src/Web/packages/app/src/lib/components/platform/PlatformSidebar.svelte
+++ b/src/Web/packages/app/src/lib/components/platform/PlatformSidebar.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import { page } from "$app/state";
+  import { Activity, Bell, BookOpen, TrendingUp, Users } from "lucide-svelte";
+  import type { AuthUser } from "../../../../app.d";
+
+  interface Props {
+    user: AuthUser;
+    apexHost: string;
+    attentionCount: number;
+    tenantCount: number;
+  }
+
+  let { user, apexHost, attentionCount, tenantCount }: Props = $props();
+
+  const nav = $derived([
+    { href: "/roster",     label: "Roster",      icon: Users,      count: tenantCount },
+    { href: "/attention",  label: "Attention",    icon: Bell,       count: attentionCount },
+    { href: "/trends",     label: "Trends",       icon: TrendingUp, count: undefined },
+    { href: "/activity",   label: "Activity",     icon: Activity,   count: undefined },
+    { href: "/care-plans", label: "Care plans",   icon: BookOpen,   count: undefined },
+  ]);
+</script>
+
+<aside class="flex h-full w-56 flex-col border-r border-border bg-sidebar px-3 py-4 shrink-0">
+  <!-- Brand -->
+  <div class="mb-6 flex items-center gap-2 px-2">
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"
+      stroke-linecap="round" stroke-linejoin="round" class="text-foreground">
+      <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
+    </svg>
+    <span class="font-semibold tracking-tight">Nocturne</span>
+  </div>
+
+  <!-- Identity -->
+  <div class="mb-4 px-2">
+    <div class="text-xs text-muted-foreground">Signed in as</div>
+    <div class="truncate font-medium text-sm">{user.name}</div>
+    <div class="truncate text-xs text-muted-foreground font-mono">{apexHost}</div>
+  </div>
+
+  <!-- Nav -->
+  <nav class="flex flex-col gap-0.5 flex-1">
+    {#each nav as item}
+      {@const active = $page.url.pathname.startsWith(item.href)}
+      <a
+        href={item.href}
+        class="flex items-center gap-2.5 rounded-md px-2 py-1.5 text-sm transition-colors
+               {active ? 'bg-accent text-accent-foreground font-medium' : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'}"
+      >
+        <item.icon class="size-4 shrink-0" />
+        <span class="flex-1">{item.label}</span>
+        {#if item.count != null}
+          <span class="rounded-full bg-muted px-1.5 py-0.5 text-xs font-medium tabular-nums">
+            {item.count}
+          </span>
+        {/if}
+      </a>
+    {/each}
+  </nav>
+
+  <!-- Footer -->
+  <div class="mt-4 flex items-center gap-2 px-2 pt-4 border-t border-border">
+    <div class="size-7 rounded-full bg-muted flex items-center justify-center text-xs font-semibold shrink-0">
+      {user.name.split(" ").map((p: string) => p[0]).slice(0, 2).join("").toUpperCase()}
+    </div>
+    <div class="flex-1 min-w-0">
+      <div class="truncate text-sm font-medium">{user.name}</div>
+    </div>
+  </div>
+</aside>

--- a/src/Web/packages/app/src/lib/components/platform/RosterToolbar.svelte
+++ b/src/Web/packages/app/src/lib/components/platform/RosterToolbar.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  interface Props {
+    layout: "grid" | "list" | "kanban";
+    density: "compact" | "standard" | "preview";
+    sortMode: "name" | "attention" | "tir";
+    onlayout: (v: "grid" | "list" | "kanban") => void;
+    ondensity: (v: "compact" | "standard" | "preview") => void;
+    onsort: (v: "name" | "attention" | "tir") => void;
+  }
+
+  let { layout, density, sortMode, onlayout, ondensity, onsort }: Props = $props();
+</script>
+
+<div class="flex flex-wrap items-center gap-2 px-4 py-2 border-b border-border bg-background/50">
+  <!-- Sort -->
+  <span class="text-xs text-muted-foreground">Sort</span>
+  <div class="flex rounded-md border border-border overflow-hidden text-xs">
+    {#each [["name","A → Z"],["attention","Attention"],["tir","Lowest TIR"]] as [val, label]}
+      <button
+        class="px-2.5 py-1 transition-colors {sortMode === val ? 'bg-accent font-medium' : 'hover:bg-accent/50'}"
+        onclick={() => onsort(val as "name" | "attention" | "tir")}
+      >{label}</button>
+    {/each}
+  </div>
+
+  <!-- Layout -->
+  <span class="text-xs text-muted-foreground ml-2">Layout</span>
+  <div class="flex rounded-md border border-border overflow-hidden text-xs">
+    {#each [["grid","Grid"],["list","List"],["kanban","By status"]] as [val, label]}
+      <button
+        class="px-2.5 py-1 transition-colors {layout === val ? 'bg-accent font-medium' : 'hover:bg-accent/50'}"
+        onclick={() => onlayout(val as "grid" | "list" | "kanban")}
+      >{label}</button>
+    {/each}
+  </div>
+
+  <!-- Density (grid only) -->
+  {#if layout === "grid"}
+    <span class="text-xs text-muted-foreground ml-2">Density</span>
+    <div class="flex rounded-md border border-border overflow-hidden text-xs">
+      {#each [["compact","Compact"],["standard","Standard"],["preview","Preview"]] as [val, label]}
+        <button
+          class="px-2.5 py-1 transition-colors {density === val ? 'bg-accent font-medium' : 'hover:bg-accent/50'}"
+          onclick={() => ondensity(val as "compact" | "standard" | "preview")}
+        >{label}</button>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/src/Web/packages/app/src/lib/components/platform/TenantCard.svelte
+++ b/src/Web/packages/app/src/lib/components/platform/TenantCard.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import { RosterSparkline, TIRBar } from "@nocturne/ui";
+  import { STATUS_COLOR, STATUS_LABEL, dirArrow, ageStr, type RosterItem } from "./types";
+
+  interface Props {
+    item: RosterItem;
+    density?: "compact" | "standard" | "preview";
+    onopen?: (item: RosterItem) => void;
+  }
+
+  let { item, density = "standard", onopen }: Props = $props();
+
+  const color = $derived(STATUS_COLOR[item.status]);
+  const isAlerting = $derived(item.status === "very-low" || item.status === "very-high");
+</script>
+
+<button
+  class="group relative flex flex-col gap-2 rounded-xl border bg-card p-3 text-left transition-all hover:shadow-md w-full"
+  style="--status-color:{color}; border-color:{isAlerting ? color : 'var(--border)'};
+         {isAlerting ? `box-shadow: 0 0 0 3px color-mix(in oklch, ${color} 18%, transparent)` : ''}"
+  onclick={() => onopen?.(item)}
+>
+  <!-- Header row -->
+  <div class="flex items-start gap-2">
+    <div class="relative flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold">
+      {item.displayName.split(" ").map((p: string) => p[0]).slice(0, 2).join("").toUpperCase()}
+      <span class="absolute -bottom-0.5 -right-0.5 size-2.5 rounded-full border-2 border-card"
+            style="background:{color}"></span>
+    </div>
+    <div class="flex-1 min-w-0">
+      <div class="truncate text-sm font-medium">{item.displayName}</div>
+      {#if density !== "compact"}
+        <div class="truncate text-xs text-muted-foreground font-mono">{item.slug}</div>
+      {/if}
+    </div>
+    {#if density === "standard" || density === "preview"}
+      <span class="flex items-center gap-1 rounded-full px-1.5 py-0.5 text-xs"
+            style="background:color-mix(in oklch,{color} 18%,transparent)">
+        <span class="size-1.5 rounded-full" style="background:{color}"></span>
+        {STATUS_LABEL[item.status]}
+      </span>
+    {/if}
+  </div>
+
+  <!-- BG row -->
+  <div class="flex items-baseline gap-1.5">
+    <span class="text-2xl font-bold tabular-nums leading-none" style="color:{color}">
+      {item.mgdl ?? "—"}
+    </span>
+    <span class="text-lg" style="color:{color}">{dirArrow(item.delta)}</span>
+    {#if density !== "compact"}
+      <div class="flex flex-col text-xs text-muted-foreground">
+        <span>{item.delta != null ? `${item.delta >= 0 ? "+" : ""}${item.delta} mg/dL` : ""}</span>
+        <span class="{item.status === 'stale' ? 'text-[var(--glucose-low)]' : ''}">{ageStr(item.ageMin)}</span>
+      </div>
+    {/if}
+  </div>
+
+  <!-- Sparkline (standard + preview) -->
+  {#if density !== "compact" && item.sparklinePoints.length > 1}
+    <div class="h-9 w-full">
+      <RosterSparkline points={item.sparklinePoints} {color} />
+    </div>
+  {/if}
+
+  <!-- TIR bar (standard + preview) -->
+  {#if density !== "compact"}
+    <TIRBar tir={item.tir} />
+  {/if}
+
+  <!-- Footer (preview only) -->
+  {#if density === "preview"}
+    <div class="flex items-center justify-between text-xs text-muted-foreground">
+      <span class="font-mono">{item.slug}</span>
+      <span>Open ↗</span>
+    </div>
+  {/if}
+</button>

--- a/src/Web/packages/app/src/lib/components/platform/TenantListRow.svelte
+++ b/src/Web/packages/app/src/lib/components/platform/TenantListRow.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { RosterSparkline } from "@nocturne/ui";
+  import { STATUS_COLOR, dirArrow, ageStr, type RosterItem } from "./types";
+
+  interface Props {
+    item: RosterItem;
+    onopen?: (item: RosterItem) => void;
+  }
+
+  let { item, onopen }: Props = $props();
+  const color = $derived(STATUS_COLOR[item.status]);
+</script>
+
+<div
+  class="grid items-center gap-3 px-4 py-2.5 text-sm border-b border-border hover:bg-accent/30 cursor-pointer transition-colors"
+  style="grid-template-columns: 8px 1fr 64px 32px 80px 1fr 60px 48px"
+  role="button"
+  tabindex="0"
+  onclick={() => onopen?.(item)}
+  onkeydown={(e) => e.key === "Enter" && onopen?.(item)}
+>
+  <span class="size-2 rounded-full" style="background:{color}"></span>
+  <div>
+    <div class="font-medium">{item.displayName}</div>
+  </div>
+  <div class="font-bold tabular-nums" style="color:{color}">{item.mgdl ?? "—"}</div>
+  <div class="text-muted-foreground">{dirArrow(item.delta)}</div>
+  <div class="h-7 w-20">
+    {#if item.sparklinePoints.length > 1}
+      <RosterSparkline points={item.sparklinePoints} {color} band={false} />
+    {/if}
+  </div>
+  <div class="truncate text-xs text-muted-foreground font-mono">{item.slug}</div>
+  <div class="tabular-nums text-xs">TIR <strong>{item.tir.inRange}%</strong></div>
+  <div class="text-xs text-muted-foreground">{ageStr(item.ageMin)}</div>
+</div>

--- a/src/Web/packages/app/src/lib/components/platform/types.ts
+++ b/src/Web/packages/app/src/lib/components/platform/types.ts
@@ -1,0 +1,57 @@
+// Derived shape the roster page passes to cards.
+// Built from TenantDto + SensorGlucose[] in the page's $derived.
+export interface RosterItem {
+  id: string;
+  slug: string;
+  displayName: string;
+  /** Latest BG in mg/dL, or null if no reading */
+  mgdl: number | null;
+  /** mg/dL change over last 5 min (latest - prev), or null */
+  delta: number | null;
+  /** Age of latest reading in minutes, or null */
+  ageMin: number | null;
+  /** Last 36 mg/dL values oldest-first, for sparkline */
+  sparklinePoints: number[];
+  /** Derived glucose status */
+  status: "very-low" | "low" | "tight" | "in-range" | "high" | "very-high" | "stale" | "no-data";
+  /** STUB-BACKEND: TIR percentages */
+  tir: { veryLow: number; low: number; inRange: number; high: number; veryHigh: number };
+}
+
+export const STATUS_COLOR: Record<RosterItem["status"], string> = {
+  "very-low":  "var(--glucose-very-low)",
+  "low":       "var(--glucose-low)",
+  "tight":     "var(--glucose-tight-range)",
+  "in-range":  "var(--glucose-in-range)",
+  "high":      "var(--glucose-high)",
+  "very-high": "var(--glucose-very-high)",
+  "stale":     "var(--muted-foreground)",
+  "no-data":   "var(--muted-foreground)",
+};
+
+export const STATUS_LABEL: Record<RosterItem["status"], string> = {
+  "very-low":  "Very low",
+  "low":       "Low",
+  "tight":     "Tight",
+  "in-range":  "In range",
+  "high":      "High",
+  "very-high": "Very high",
+  "stale":     "Stale",
+  "no-data":   "No data",
+};
+
+export function dirArrow(delta: number | null): string {
+  if (delta == null) return "→";
+  if (delta > 15)  return "↑";
+  if (delta > 6)   return "↗";
+  if (delta > -6)  return "→";
+  if (delta > -15) return "↘";
+  return "↓";
+}
+
+export function ageStr(min: number | null): string {
+  if (min == null) return "—";
+  if (min < 1)     return "now";
+  if (min < 60)    return `${min}m`;
+  return `${Math.floor(min / 60)}h ${min % 60}m`;
+}

--- a/src/Web/packages/app/src/lib/components/platform/types.ts
+++ b/src/Web/packages/app/src/lib/components/platform/types.ts
@@ -1,3 +1,5 @@
+import type { SensorGlucose, TenantDto } from "$lib/api/generated/nocturne-api-client";
+
 // Derived shape the roster page passes to cards.
 // Built from TenantDto + SensorGlucose[] in the page's $derived.
 export interface RosterItem {
@@ -54,4 +56,71 @@ export function ageStr(min: number | null): string {
   if (min < 1)     return "now";
   if (min < 60)    return `${min}m`;
   return `${Math.floor(min / 60)}h ${min % 60}m`;
+}
+
+// Shape of a single tenant's snapshot from the layout server load
+export interface TenantSnapshot {
+  tenant: TenantDto;
+  readings: SensorGlucose[];
+}
+
+/**
+ * Derives RosterItem[] from raw tenant snapshots.
+ *
+ * STUB-BACKEND: Glucose thresholds are hardcoded here (55/70/140/180/250 mg/dL).
+ * When GET /api/v4/platform/roster-snapshots is implemented, it should return
+ * per-tenant thresholds alongside readings so status is derived server-side
+ * or using tenant-specific values.
+ */
+export function deriveRosterItems(snapshots: TenantSnapshot[]): RosterItem[] {
+  return snapshots.map((s) => {
+    const readings = s.readings ?? [];
+    const latest = readings[0];
+    const prev = readings[1];
+
+    const mgdl = latest?.mgdl ?? null;
+    const prevMgdl = prev?.mgdl ?? null;
+    const delta = mgdl != null && prevMgdl != null ? Math.round(mgdl - prevMgdl) : null;
+
+    const now = Date.now();
+    const latestTs = latest?.timestamp ? new Date(latest.timestamp).getTime() : null;
+    const ageMin = latestTs != null ? Math.floor((now - latestTs) / 60000) : null;
+
+    let status: RosterItem["status"] = "no-data";
+    if (mgdl == null) {
+      status = "no-data";
+    } else if (ageMin != null && ageMin > 25) {
+      status = "stale";
+    } else if (mgdl < 55) {
+      status = "very-low";
+    } else if (mgdl < 70) {
+      status = "low";
+    } else if (mgdl <= 140) {
+      status = "tight";
+    } else if (mgdl <= 180) {
+      status = "in-range";
+    } else if (mgdl <= 250) {
+      status = "high";
+    } else {
+      status = "very-high";
+    }
+
+    const sparklinePoints = readings
+      .slice(0, 36)
+      .map((r) => r.mgdl ?? 0)
+      .reverse();
+
+    return {
+      id: s.tenant.id ?? "",
+      slug: s.tenant.slug ?? "",
+      displayName: s.tenant.displayName ?? s.tenant.slug ?? "",
+      mgdl,
+      delta,
+      ageMin,
+      sparklinePoints,
+      status,
+      // STUB-BACKEND: TIR — GET /api/v4/platform/roster-snapshots
+      tir: { veryLow: 0, low: 0, inRange: 0, high: 0, veryHigh: 0 },
+    };
+  });
 }

--- a/src/Web/packages/app/src/routes/(platform)/+layout.server.ts
+++ b/src/Web/packages/app/src/routes/(platform)/+layout.server.ts
@@ -12,14 +12,15 @@ const LIVE_PAGES = ["/roster", "/attention"];
 
 export const load: LayoutServerLoad = async (event) => {
   if (!event.locals.isPlatformView) {
-    redirect(303, "/dashboard");
+    throw redirect(303, "/dashboard");
   }
 
   if (!event.locals.isAuthenticated || !event.locals.user) {
-    redirect(303, `/auth/login?returnUrl=${encodeURIComponent(event.url.pathname)}`);
+    throw redirect(303, `/auth/login?returnUrl=${encodeURIComponent(event.url.pathname)}`);
   }
 
-  const apiBaseUrl = getApiBaseUrl()!;
+  const apiBaseUrl = getApiBaseUrl();
+  if (!apiBaseUrl) throw new Error("NOCTURNE_API_URL is not configured");
   const isLivePage = LIVE_PAGES.some((p) => event.url.pathname.startsWith(p));
 
   const tenants = event.locals.isPlatformAdmin
@@ -32,7 +33,7 @@ export const load: LayoutServerLoad = async (event) => {
       apexHost: event.locals.apexHost ?? "",
       isPlatformAdmin: event.locals.isPlatformAdmin,
       tenants: tenants ?? [],
-      snapshots: [] as Array<{ tenant: TenantDto; readings: SensorGlucose[] }>,
+      snapshots: [],
     };
   }
 

--- a/src/Web/packages/app/src/routes/(platform)/+layout.server.ts
+++ b/src/Web/packages/app/src/routes/(platform)/+layout.server.ts
@@ -1,0 +1,79 @@
+import { redirect } from "@sveltejs/kit";
+import type { LayoutServerLoad } from "./$types";
+import {
+  getApiBaseUrl,
+  getHashedInstanceKey,
+  createServerApiClient,
+} from "$lib/server/api-client-factory";
+import { AUTH_COOKIE_NAMES } from "$lib/config/auth-cookies";
+import type { SensorGlucose, TenantDto } from "$lib/api/generated/nocturne-api-client";
+
+const LIVE_PAGES = ["/roster", "/attention"];
+
+export const load: LayoutServerLoad = async (event) => {
+  if (!event.locals.isPlatformView) {
+    redirect(303, "/dashboard");
+  }
+
+  if (!event.locals.isAuthenticated || !event.locals.user) {
+    redirect(303, `/auth/login?returnUrl=${encodeURIComponent(event.url.pathname)}`);
+  }
+
+  const apiBaseUrl = getApiBaseUrl()!;
+  const isLivePage = LIVE_PAGES.some((p) => event.url.pathname.startsWith(p));
+
+  const tenants = event.locals.isPlatformAdmin
+    ? await event.locals.apiClient.tenant.getAll()
+    : await event.locals.apiClient.myTenants.getMyTenants();
+
+  if (!isLivePage) {
+    return {
+      user: event.locals.user,
+      apexHost: event.locals.apexHost ?? "",
+      isPlatformAdmin: event.locals.isPlatformAdmin,
+      tenants: tenants ?? [],
+      snapshots: [] as Array<{ tenant: TenantDto; readings: SensorGlucose[] }>,
+    };
+  }
+
+  event.depends("app:roster-snapshots");
+
+  const accessToken = event.cookies.get(AUTH_COOKIE_NAMES.accessToken);
+  const refreshToken = event.cookies.get(AUTH_COOKIE_NAMES.refreshToken);
+  const apexHost = event.locals.apexHost ?? "";
+  const hashedKey = getHashedInstanceKey();
+
+  const snapshots = await Promise.all(
+    (tenants ?? []).map(async (tenant) => {
+      try {
+        const client = createServerApiClient(apiBaseUrl, event.fetch, {
+          accessToken,
+          refreshToken,
+          hashedInstanceKey: hashedKey,
+          extraHeaders: {
+            "X-Forwarded-Host": `${tenant.slug}.${apexHost}`,
+            "X-Forwarded-Proto": "https",
+          },
+        });
+        const result = await client.sensorGlucose.getAll(
+          undefined,
+          undefined,
+          36,
+          0,
+          "timestamp_desc",
+        );
+        return { tenant, readings: result?.data ?? [] };
+      } catch {
+        return { tenant, readings: [] as SensorGlucose[] };
+      }
+    }),
+  );
+
+  return {
+    user: event.locals.user,
+    apexHost,
+    isPlatformAdmin: event.locals.isPlatformAdmin,
+    tenants: tenants ?? [],
+    snapshots,
+  };
+};

--- a/src/Web/packages/app/src/routes/(platform)/+layout.svelte
+++ b/src/Web/packages/app/src/routes/(platform)/+layout.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import { invalidate } from "$app/navigation";
+  import { page } from "$app/state";
+  import { onMount } from "svelte";
+  import PlatformSidebar from "$lib/components/platform/PlatformSidebar.svelte";
+  import type { LayoutData } from "./$types";
+
+  let { data, children }: { data: LayoutData; children: import("svelte").Snippet } = $props();
+
+  const LIVE_PAGES = ["/roster", "/attention"];
+  const POLL_INTERVAL_MS = 60_000;
+
+  const attentionCount = $derived(
+    data.snapshots.filter((s) => {
+      const latest = s.readings[0];
+      if (!latest) return false;
+      const mgdl = latest.mgdl ?? 0;
+      return mgdl > 0 && (mgdl < 70 || mgdl > 180);
+    }).length,
+  );
+
+  onMount(() => {
+    const interval = setInterval(() => {
+      if (LIVE_PAGES.some((p) => $page.url.pathname.startsWith(p))) {
+        invalidate("app:roster-snapshots");
+      }
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  });
+</script>
+
+<div class="flex h-screen w-full overflow-hidden bg-background">
+  <PlatformSidebar
+    user={data.user}
+    apexHost={data.apexHost}
+    {attentionCount}
+    tenantCount={data.tenants.length}
+  />
+  <main class="flex-1 overflow-y-auto">
+    {@render children()}
+  </main>
+</div>

--- a/src/Web/packages/app/src/routes/(platform)/+layout.svelte
+++ b/src/Web/packages/app/src/routes/(platform)/+layout.svelte
@@ -3,6 +3,7 @@
   import { page } from "$app/state";
   import { onMount } from "svelte";
   import PlatformSidebar from "$lib/components/platform/PlatformSidebar.svelte";
+  import { deriveRosterItems } from "$lib/components/platform/types";
   import type { LayoutData } from "./$types";
 
   let { data, children }: { data: LayoutData; children: import("svelte").Snippet } = $props();
@@ -10,13 +11,9 @@
   const LIVE_PAGES = ["/roster", "/attention"];
   const POLL_INTERVAL_MS = 60_000;
 
+  const rosterItems = $derived(deriveRosterItems(data.snapshots));
   const attentionCount = $derived(
-    data.snapshots.filter((s) => {
-      const latest = s.readings[0];
-      if (!latest) return false;
-      const mgdl = latest.mgdl ?? 0;
-      return mgdl > 0 && (mgdl < 70 || mgdl > 180);
-    }).length,
+    rosterItems.filter((i) => ["very-low", "very-high", "low", "high"].includes(i.status)).length,
   );
 
   onMount(() => {

--- a/src/Web/packages/app/src/routes/(platform)/STUB-BACKEND.md
+++ b/src/Web/packages/app/src/routes/(platform)/STUB-BACKEND.md
@@ -1,0 +1,17 @@
+# Outstanding Backend Stubs — Platform Roster
+
+Grep for `STUB-BACKEND` to find all frontend stub locations.
+
+| ID | Stub comment | Eventual endpoint | Pages affected |
+|----|-------------|-------------------|----------------|
+| 1 | `STUB-BACKEND: alarm count per tenant` | `GET /api/v4/platform/roster-snapshots` | Roster (AggregateStrip), Attention |
+| 2 | `STUB-BACKEND: TIR percentages` | `GET /api/v4/platform/roster-snapshots` | Roster (TenantCard), Trends |
+| 3 | `STUB-BACKEND: IOB/COB` | `GET /api/v4/platform/roster-snapshots` | Roster preview card |
+| 4 | `STUB-BACKEND: 14-day TIR series` | `GET /api/v4/platform/trends` | Trends page |
+| 5 | `STUB-BACKEND: cross-tenant event feed` | `GET /api/v4/platform/activity` | Activity page |
+| 6 | `STUB-BACKEND: care plan data` | Per-tenant endpoint TBD | Care Plans page |
+
+## Batch endpoint design note
+All stubs 1–3 collapse into a single batch endpoint that returns per-tenant snapshots
+including live BG, TIR, IOB, COB, and alarm counts. When that lands, the per-tenant
+BG fan-out in `+layout.server.ts` is also replaced.

--- a/src/Web/packages/app/src/routes/(platform)/activity/+page.svelte
+++ b/src/Web/packages/app/src/routes/(platform)/activity/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  // STUB-BACKEND: GET /api/v4/platform/activity — cross-tenant event feed
+</script>
+
+<div class="flex items-center justify-center h-64 text-muted-foreground text-sm">
+  Activity — backend not yet implemented
+</div>

--- a/src/Web/packages/app/src/routes/(platform)/attention/+page.svelte
+++ b/src/Web/packages/app/src/routes/(platform)/attention/+page.svelte
@@ -53,6 +53,7 @@
         ageMin,
         sparklinePoints,
         status,
+        // STUB-BACKEND: TIR — GET /api/v4/platform/roster-snapshots
         tir: { veryLow: 0, low: 0, inRange: 0, high: 0, veryHigh: 0 },
       };
     })

--- a/src/Web/packages/app/src/routes/(platform)/attention/+page.svelte
+++ b/src/Web/packages/app/src/routes/(platform)/attention/+page.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+  import { page } from "$app/state";
+  import type { LayoutData } from "../$types";
+  import { type RosterItem } from "$lib/components/platform/types";
+  import TenantCard from "$lib/components/platform/TenantCard.svelte";
+
+  const data = $derived($page.data as LayoutData);
+
+  const items = $derived.by<RosterItem[]>(() =>
+    data.snapshots.map((s) => {
+      const readings = s.readings ?? [];
+      const latest = readings[0];
+      const prev = readings[1];
+
+      const mgdl = latest?.mgdl ?? null;
+      const prevMgdl = prev?.mgdl ?? null;
+      const delta = mgdl != null && prevMgdl != null ? Math.round(mgdl - prevMgdl) : null;
+
+      const now = Date.now();
+      const latestTs = latest?.timestamp ? new Date(latest.timestamp).getTime() : null;
+      const ageMin = latestTs != null ? Math.floor((now - latestTs) / 60000) : null;
+
+      let status: RosterItem["status"] = "no-data";
+      if (mgdl == null) {
+        status = "no-data";
+      } else if (ageMin != null && ageMin > 25) {
+        status = "stale";
+      } else if (mgdl < 55) {
+        status = "very-low";
+      } else if (mgdl < 70) {
+        status = "low";
+      } else if (mgdl <= 140) {
+        status = "tight";
+      } else if (mgdl <= 180) {
+        status = "in-range";
+      } else if (mgdl <= 250) {
+        status = "high";
+      } else {
+        status = "very-high";
+      }
+
+      const sparklinePoints = readings
+        .slice(0, 36)
+        .map((r) => r.mgdl ?? 0)
+        .reverse();
+
+      return {
+        id: s.tenant.id ?? "",
+        slug: s.tenant.slug ?? "",
+        displayName: s.tenant.displayName ?? s.tenant.slug ?? "",
+        mgdl,
+        delta,
+        ageMin,
+        sparklinePoints,
+        status,
+        tir: { veryLow: 0, low: 0, inRange: 0, high: 0, veryHigh: 0 },
+      };
+    })
+  );
+
+  const critical = $derived(items.filter((i) => i.status === "very-low" || i.status === "very-high"));
+  const watching = $derived(items.filter((i) => i.status === "low" || i.status === "high"));
+  const stale    = $derived(items.filter((i) => i.status === "stale"));
+
+  function openTenant(item: RosterItem) {
+    window.location.href = `https://${item.slug}.${data.apexHost}`;
+  }
+</script>
+
+<div class="flex flex-col gap-6 p-4">
+  <h1 class="text-xl font-semibold">Attention</h1>
+
+  {#each [
+    { label: "Critical · respond now", items: critical, color: "var(--glucose-very-low)", pulse: true },
+    { label: "Watching",               items: watching, color: "var(--glucose-low)",      pulse: false },
+    { label: "Stale connections",      items: stale,    color: "var(--muted-foreground)", pulse: false },
+  ] as group}
+    {#if group.items.length > 0 || group.label === "Critical · respond now"}
+      <section>
+        <div class="mb-3 flex items-center gap-2">
+          <span
+            class="size-2 rounded-full {group.pulse && group.items.length > 0 ? 'animate-pulse' : ''}"
+            style="background:{group.color}"
+          ></span>
+          <h2 class="text-sm font-semibold">{group.label}</h2>
+          <span class="rounded-full bg-muted px-1.5 py-0.5 text-xs">{group.items.length}</span>
+        </div>
+        {#if group.items.length === 0}
+          <p class="text-sm text-muted-foreground">All clear.</p>
+        {:else}
+          <div class="grid gap-3" style="grid-template-columns: repeat(auto-fill, minmax(240px,1fr))">
+            {#each group.items as item (item.id)}
+              <TenantCard {item} density="standard" onopen={openTenant} />
+            {/each}
+          </div>
+        {/if}
+      </section>
+    {/if}
+  {/each}
+</div>

--- a/src/Web/packages/app/src/routes/(platform)/attention/+page.svelte
+++ b/src/Web/packages/app/src/routes/(platform)/attention/+page.svelte
@@ -1,63 +1,12 @@
 <script lang="ts">
   import { page } from "$app/state";
   import type { LayoutData } from "../$types";
-  import { type RosterItem } from "$lib/components/platform/types";
+  import { deriveRosterItems, type RosterItem } from "$lib/components/platform/types";
   import TenantCard from "$lib/components/platform/TenantCard.svelte";
 
   const data = $derived($page.data as LayoutData);
 
-  const items = $derived.by<RosterItem[]>(() =>
-    data.snapshots.map((s) => {
-      const readings = s.readings ?? [];
-      const latest = readings[0];
-      const prev = readings[1];
-
-      const mgdl = latest?.mgdl ?? null;
-      const prevMgdl = prev?.mgdl ?? null;
-      const delta = mgdl != null && prevMgdl != null ? Math.round(mgdl - prevMgdl) : null;
-
-      const now = Date.now();
-      const latestTs = latest?.timestamp ? new Date(latest.timestamp).getTime() : null;
-      const ageMin = latestTs != null ? Math.floor((now - latestTs) / 60000) : null;
-
-      let status: RosterItem["status"] = "no-data";
-      if (mgdl == null) {
-        status = "no-data";
-      } else if (ageMin != null && ageMin > 25) {
-        status = "stale";
-      } else if (mgdl < 55) {
-        status = "very-low";
-      } else if (mgdl < 70) {
-        status = "low";
-      } else if (mgdl <= 140) {
-        status = "tight";
-      } else if (mgdl <= 180) {
-        status = "in-range";
-      } else if (mgdl <= 250) {
-        status = "high";
-      } else {
-        status = "very-high";
-      }
-
-      const sparklinePoints = readings
-        .slice(0, 36)
-        .map((r) => r.mgdl ?? 0)
-        .reverse();
-
-      return {
-        id: s.tenant.id ?? "",
-        slug: s.tenant.slug ?? "",
-        displayName: s.tenant.displayName ?? s.tenant.slug ?? "",
-        mgdl,
-        delta,
-        ageMin,
-        sparklinePoints,
-        status,
-        // STUB-BACKEND: TIR — GET /api/v4/platform/roster-snapshots
-        tir: { veryLow: 0, low: 0, inRange: 0, high: 0, veryHigh: 0 },
-      };
-    })
-  );
+  const items = $derived.by<RosterItem[]>(() => deriveRosterItems(data.snapshots));
 
   const critical = $derived(items.filter((i) => i.status === "very-low" || i.status === "very-high"));
   const watching = $derived(items.filter((i) => i.status === "low" || i.status === "high"));

--- a/src/Web/packages/app/src/routes/(platform)/care-plans/+page.svelte
+++ b/src/Web/packages/app/src/routes/(platform)/care-plans/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  // STUB-BACKEND: per-tenant care plan endpoint TBD
+</script>
+
+<div class="flex items-center justify-center h-64 text-muted-foreground text-sm">
+  Care plans — backend not yet implemented
+</div>

--- a/src/Web/packages/app/src/routes/(platform)/roster/+page.svelte
+++ b/src/Web/packages/app/src/routes/(platform)/roster/+page.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+  import { page } from "$app/state";
+  import type { LayoutData } from "../$types";
+  import type { RosterItem } from "$lib/components/platform/types";
+  import { STATUS_COLOR, dirArrow } from "$lib/components/platform/types";
+  import AggregateStrip from "$lib/components/platform/AggregateStrip.svelte";
+  import AlertBanner from "$lib/components/platform/AlertBanner.svelte";
+  import AttentionRail from "$lib/components/platform/AttentionRail.svelte";
+  import RosterToolbar from "$lib/components/platform/RosterToolbar.svelte";
+  import TenantCard from "$lib/components/platform/TenantCard.svelte";
+
+  // Data flows from parent layout load
+  const data = $derived($page.data as LayoutData);
+
+  let layout = $state<"grid" | "list" | "kanban">("grid");
+  let density = $state<"compact" | "standard" | "preview">("standard");
+  let sortMode = $state<"name" | "attention" | "tir">("name");
+
+  // Derive RosterItem[] from raw snapshots. Readings are newest-first from the server.
+  const items = $derived.by<RosterItem[]>(() =>
+    data.snapshots.map((s) => {
+      const readings = s.readings ?? [];
+      const latest = readings[0];
+      const prev = readings[1];
+
+      const mgdl = latest?.mgdl ?? null;
+      const prevMgdl = prev?.mgdl ?? null;
+      const delta = mgdl != null && prevMgdl != null ? Math.round(mgdl - prevMgdl) : null;
+
+      const now = Date.now();
+      const latestTs = latest?.timestamp ? new Date(latest.timestamp).getTime() : null;
+      const ageMin = latestTs != null ? Math.floor((now - latestTs) / 60000) : null;
+
+      let status: RosterItem["status"] = "no-data";
+      if (mgdl == null) {
+        status = "no-data";
+      } else if (ageMin != null && ageMin > 25) {
+        status = "stale";
+      } else if (mgdl < 55) {
+        status = "very-low";
+      } else if (mgdl < 70) {
+        status = "low";
+      } else if (mgdl <= 140) {
+        status = "tight";
+      } else if (mgdl <= 180) {
+        status = "in-range";
+      } else if (mgdl <= 250) {
+        status = "high";
+      } else {
+        status = "very-high";
+      }
+
+      // Reverse so oldest-first for the sparkline
+      const sparklinePoints = readings
+        .slice(0, 36)
+        .map((r) => r.mgdl ?? 0)
+        .reverse();
+
+      return {
+        id: s.tenant.id ?? "",
+        slug: s.tenant.slug ?? "",
+        displayName: s.tenant.displayName ?? s.tenant.slug ?? "",
+        mgdl,
+        delta,
+        ageMin,
+        sparklinePoints,
+        status,
+        // STUB-BACKEND: TIR — GET /api/v4/platform/roster-snapshots
+        tir: { veryLow: 0, low: 0, inRange: 0, high: 0, veryHigh: 0 },
+      };
+    })
+  );
+
+  const sorted = $derived.by(() => {
+    const arr = [...items];
+    if (sortMode === "attention") {
+      const order: Record<string, number> = {
+        "very-low": 0, "very-high": 1, "low": 2, "high": 3,
+        "stale": 4, "tight": 5, "in-range": 6, "no-data": 7,
+      };
+      return arr.sort((a, b) => (order[a.status] ?? 9) - (order[b.status] ?? 9));
+    }
+    if (sortMode === "tir") return arr.sort((a, b) => a.tir.inRange - b.tir.inRange);
+    return arr.sort((a, b) => a.displayName.localeCompare(b.displayName));
+  });
+
+  const critical = $derived(sorted.filter((i) => i.status === "very-low" || i.status === "very-high"));
+  const attention = $derived(
+    sorted.filter((i) => ["very-low", "very-high", "low", "high"].includes(i.status)),
+  );
+
+  const agg = $derived({
+    tir: items.length ? Math.round(items.reduce((s, i) => s + i.tir.inRange, 0) / items.length) : 0,
+    attention: attention.length,
+    alarms: 0, // STUB-BACKEND: GET /api/v4/platform/roster-snapshots
+    stale: items.filter((i) => i.status === "stale").length,
+  });
+
+  function openTenant(item: RosterItem) {
+    window.location.href = `https://${item.slug}.${data.apexHost}`;
+  }
+</script>
+
+<div class="flex flex-col">
+  <div class="flex items-center justify-between px-4 py-4 border-b border-border">
+    <h1 class="text-xl font-semibold">Roster</h1>
+    <span class="text-sm text-muted-foreground font-mono">{data.apexHost}</span>
+  </div>
+
+  <AggregateStrip
+    tir={agg.tir}
+    attention={agg.attention}
+    alarms={agg.alarms}
+    stale={agg.stale}
+    tenantCount={items.length}
+  />
+
+  {#if critical.length > 0}
+    <AlertBanner {critical} onopen={openTenant} />
+  {/if}
+
+  {#if attention.length > 0}
+    <AttentionRail items={attention} onopen={openTenant} />
+  {/if}
+
+  <RosterToolbar
+    {layout}
+    {density}
+    {sortMode}
+    onlayout={(v) => (layout = v)}
+    ondensity={(v) => (density = v)}
+    onsort={(v) => (sortMode = v)}
+  />
+
+  <!-- Grid layout -->
+  {#if layout === "grid"}
+    <div
+      class="p-4 grid gap-3"
+      style="grid-template-columns: repeat(auto-fill, minmax({density === 'compact' ? '200px' : density === 'preview' ? '280px' : '240px'}, 1fr))"
+    >
+      {#each sorted as item (item.id)}
+        <TenantCard {item} {density} onopen={openTenant} />
+      {/each}
+    </div>
+  {/if}
+
+  <!-- List and kanban layouts added in Tasks 11–12 -->
+</div>

--- a/src/Web/packages/app/src/routes/(platform)/roster/+page.svelte
+++ b/src/Web/packages/app/src/routes/(platform)/roster/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state";
   import type { LayoutData } from "../$types";
-  import { dirArrow, type RosterItem } from "$lib/components/platform/types";
+  import { deriveRosterItems, dirArrow, type RosterItem } from "$lib/components/platform/types";
   import AggregateStrip from "$lib/components/platform/AggregateStrip.svelte";
   import AlertBanner from "$lib/components/platform/AlertBanner.svelte";
   import AttentionRail from "$lib/components/platform/AttentionRail.svelte";
@@ -16,60 +16,7 @@
   let density = $state<"compact" | "standard" | "preview">("standard");
   let sortMode = $state<"name" | "attention" | "tir">("name");
 
-  // Derive RosterItem[] from raw snapshots. Readings are newest-first from the server.
-  const items = $derived.by<RosterItem[]>(() =>
-    data.snapshots.map((s) => {
-      const readings = s.readings ?? [];
-      const latest = readings[0];
-      const prev = readings[1];
-
-      const mgdl = latest?.mgdl ?? null;
-      const prevMgdl = prev?.mgdl ?? null;
-      const delta = mgdl != null && prevMgdl != null ? Math.round(mgdl - prevMgdl) : null;
-
-      const now = Date.now();
-      const latestTs = latest?.timestamp ? new Date(latest.timestamp).getTime() : null;
-      const ageMin = latestTs != null ? Math.floor((now - latestTs) / 60000) : null;
-
-      let status: RosterItem["status"] = "no-data";
-      if (mgdl == null) {
-        status = "no-data";
-      } else if (ageMin != null && ageMin > 25) {
-        status = "stale";
-      } else if (mgdl < 55) {
-        status = "very-low";
-      } else if (mgdl < 70) {
-        status = "low";
-      } else if (mgdl <= 140) {
-        status = "tight";
-      } else if (mgdl <= 180) {
-        status = "in-range";
-      } else if (mgdl <= 250) {
-        status = "high";
-      } else {
-        status = "very-high";
-      }
-
-      // Reverse so oldest-first for the sparkline
-      const sparklinePoints = readings
-        .slice(0, 36)
-        .map((r) => r.mgdl ?? 0)
-        .reverse();
-
-      return {
-        id: s.tenant.id ?? "",
-        slug: s.tenant.slug ?? "",
-        displayName: s.tenant.displayName ?? s.tenant.slug ?? "",
-        mgdl,
-        delta,
-        ageMin,
-        sparklinePoints,
-        status,
-        // STUB-BACKEND: TIR — GET /api/v4/platform/roster-snapshots
-        tir: { veryLow: 0, low: 0, inRange: 0, high: 0, veryHigh: 0 },
-      };
-    })
-  );
+  const items = $derived.by<RosterItem[]>(() => deriveRosterItems(data.snapshots));
 
   const sorted = $derived.by(() => {
     const arr = [...items];

--- a/src/Web/packages/app/src/routes/(platform)/roster/+page.svelte
+++ b/src/Web/packages/app/src/routes/(platform)/roster/+page.svelte
@@ -2,7 +2,6 @@
   import { page } from "$app/state";
   import type { LayoutData } from "../$types";
   import type { RosterItem } from "$lib/components/platform/types";
-  import { STATUS_COLOR, dirArrow } from "$lib/components/platform/types";
   import AggregateStrip from "$lib/components/platform/AggregateStrip.svelte";
   import AlertBanner from "$lib/components/platform/AlertBanner.svelte";
   import AttentionRail from "$lib/components/platform/AttentionRail.svelte";

--- a/src/Web/packages/app/src/routes/(platform)/roster/+page.svelte
+++ b/src/Web/packages/app/src/routes/(platform)/roster/+page.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
   import { page } from "$app/state";
   import type { LayoutData } from "../$types";
-  import type { RosterItem } from "$lib/components/platform/types";
+  import { dirArrow, type RosterItem } from "$lib/components/platform/types";
   import AggregateStrip from "$lib/components/platform/AggregateStrip.svelte";
   import AlertBanner from "$lib/components/platform/AlertBanner.svelte";
   import AttentionRail from "$lib/components/platform/AttentionRail.svelte";
   import RosterToolbar from "$lib/components/platform/RosterToolbar.svelte";
   import TenantCard from "$lib/components/platform/TenantCard.svelte";
+  import TenantListRow from "$lib/components/platform/TenantListRow.svelte";
 
   // Data flows from parent layout load
   const data = $derived($page.data as LayoutData);
@@ -143,5 +144,22 @@
     </div>
   {/if}
 
-  <!-- List and kanban layouts added in Tasks 11–12 -->
+  <!-- List layout -->
+  {#if layout === "list"}
+    <div>
+      <!-- Header -->
+      <div
+        class="grid px-4 py-2 text-xs font-medium text-muted-foreground border-b border-border"
+        style="grid-template-columns: 8px 1fr 64px 32px 80px 1fr 60px 48px"
+      >
+        <span></span><span>Tenant</span><span>BG</span><span>Δ</span>
+        <span>3 hr</span><span>Subdomain</span><span>TIR</span><span>Last</span>
+      </div>
+      {#each sorted as item (item.id)}
+        <TenantListRow {item} onopen={openTenant} />
+      {/each}
+    </div>
+  {/if}
+
+  <!-- Kanban layout added in Task 12 -->
 </div>

--- a/src/Web/packages/app/src/routes/(platform)/roster/+page.svelte
+++ b/src/Web/packages/app/src/routes/(platform)/roster/+page.svelte
@@ -161,5 +161,43 @@
     </div>
   {/if}
 
-  <!-- Kanban layout added in Task 12 -->
+  <!-- Kanban layout -->
+  {#if layout === "kanban"}
+    {@const columns = [
+      { key: "very-low",  label: "Very low",  color: "var(--glucose-very-low)" },
+      { key: "low",       label: "Low",        color: "var(--glucose-low)" },
+      { key: "tight",     label: "Tight",      color: "var(--glucose-tight-range)" },
+      { key: "in-range",  label: "In range",   color: "var(--glucose-in-range)" },
+      { key: "high",      label: "High",       color: "var(--glucose-high)" },
+      { key: "very-high", label: "Very high",  color: "var(--glucose-very-high)" },
+      { key: "stale",     label: "Stale",      color: "var(--muted-foreground)" },
+      { key: "no-data",   label: "No data",    color: "var(--muted-foreground)" },
+    ] as const}
+    <div class="flex gap-3 overflow-x-auto p-4 items-start">
+      {#each columns as col}
+        {@const colItems = sorted.filter((i) => i.status === col.key)}
+        {#if colItems.length > 0}
+          <div class="flex w-44 shrink-0 flex-col gap-1.5">
+            <div class="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+              <span class="size-2 rounded-full" style="background:{col.color}"></span>
+              {col.label} · {colItems.length}
+            </div>
+            {#each colItems as item (item.id)}
+              <button
+                class="rounded-lg border bg-card p-2.5 text-left text-xs hover:shadow-sm transition-all"
+                style="border-color:{col.color}"
+                onclick={() => openTenant(item)}
+              >
+                <div class="font-medium text-sm">{item.displayName}</div>
+                <div class="font-bold tabular-nums mt-1" style="color:{col.color}">
+                  {item.mgdl ?? "—"} {dirArrow(item.delta)}
+                </div>
+                <div class="text-muted-foreground mt-0.5 font-mono truncate">{item.slug}</div>
+              </button>
+            {/each}
+          </div>
+        {/if}
+      {/each}
+    </div>
+  {/if}
 </div>

--- a/src/Web/packages/app/src/routes/(platform)/trends/+page.svelte
+++ b/src/Web/packages/app/src/routes/(platform)/trends/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  // STUB-BACKEND: GET /api/v4/platform/trends — 14-day TIR series per tenant
+</script>
+
+<div class="flex items-center justify-center h-64 text-muted-foreground text-sm">
+  Trends — backend not yet implemented
+</div>

--- a/src/Web/packages/ui/src/index.ts
+++ b/src/Web/packages/ui/src/index.ts
@@ -1,2 +1,5 @@
 // @nocturne/ui — Nocturne design system
 // Import components via "@nocturne/ui/ui/button", "@nocturne/ui/utils", etc.
+
+export { default as RosterSparkline } from "./lib/components/RosterSparkline.svelte";
+export { default as TIRBar } from "./lib/components/TIRBar.svelte";

--- a/src/Web/packages/ui/src/lib/components/RosterSparkline.svelte
+++ b/src/Web/packages/ui/src/lib/components/RosterSparkline.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  interface Props {
+    /** Up to 36 glucose readings, oldest-first */
+    points: number[];
+    /** Status colour token e.g. "var(--glucose-low)" */
+    color: string;
+    width?: number;
+    height?: number;
+    /** Show the 70–180 in-range band */
+    band?: boolean;
+  }
+
+  let { points, color, width = 220, height = 38, band = true }: Props = $props();
+
+  const MIN_Y = 40;
+  const MAX_Y = 320;
+
+  function toSvgY(v: number): number {
+    return height - ((Math.max(MIN_Y, Math.min(MAX_Y, v)) - MIN_Y) / (MAX_Y - MIN_Y)) * height;
+  }
+
+  const path = $derived(
+    points.length
+      ? points
+          .map((v, i) => {
+            const x = ((i / (points.length - 1)) * width).toFixed(1);
+            const y = toSvgY(v).toFixed(1);
+            return `${i === 0 ? "M" : "L"}${x},${y}`;
+          })
+          .join(" ")
+      : ""
+  );
+
+  const bandYHi = $derived(toSvgY(180));
+  const bandYLo = $derived(toSvgY(70));
+  const lastX = $derived(width);
+  const lastY = $derived(points.length ? toSvgY(points[points.length - 1]) : 0);
+</script>
+
+{#if points.length > 1}
+  <svg viewBox="0 0 {width} {height}" preserveAspectRatio="none" class="w-full h-full overflow-visible">
+    {#if band}
+      <rect
+        x="0" y={bandYHi}
+        {width}
+        height={Math.max(0, bandYLo - bandYHi)}
+        fill="var(--glucose-in-range)"
+        opacity="0.10"
+      />
+    {/if}
+    <path
+      d={path}
+      fill="none"
+      stroke={color}
+      stroke-width="1.6"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <circle cx={lastX} cy={lastY} r="2.2" fill={color} />
+  </svg>
+{/if}

--- a/src/Web/packages/ui/src/lib/components/TIRBar.svelte
+++ b/src/Web/packages/ui/src/lib/components/TIRBar.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  interface TIR {
+    veryLow: number;
+    low: number;
+    inRange: number;
+    high: number;
+    veryHigh: number;
+  }
+
+  interface Props {
+    tir: TIR;
+  }
+
+  let { tir }: Props = $props();
+</script>
+
+<div class="flex h-1.5 w-full overflow-hidden rounded-full">
+  <span style="width:{tir.veryLow}%" class="bg-[var(--glucose-very-low)]"></span>
+  <span style="width:{tir.low}%" class="bg-[var(--glucose-low)]"></span>
+  <span style="width:{tir.inRange}%" class="bg-[var(--glucose-in-range)]"></span>
+  <span style="width:{tir.high}%" class="bg-[var(--glucose-high)]"></span>
+  <span style="width:{tir.veryHigh}%" class="bg-[var(--glucose-very-high)]"></span>
+</div>


### PR DESCRIPTION
## Summary

- Adds a new `/(platform)` route group served on the apex domain for authenticated users, providing a multi-tenant roster dashboard to monitor all tenants at a glance
- Introduces grid, list, and kanban layout views for the roster with tenant cards showing live BG, sparkline, TIR bar, delta, and staleness indicators
- Adds supporting platform components: `AggregateStrip` (combined TIR/attention/stale stats), `AlertBanner` (critical BG alerts), `AttentionRail` (horizontally scrollable out-of-range tenants), `PlatformSidebar`, `RosterToolbar`, `TenantCard`, and `TenantListRow`
- Adds shared `RosterSparkline` and `TIRBar` components to the `@nocturne/ui` package
- Adds stub pages for trends, activity, and care-plans with `STUB-BACKEND.md` documenting which API endpoints are still needed
- Adds an attention page showing tenants currently out of range, grouped by severity
- Fixes tenant resolution middleware to allow `/api/v4/me/tenants` on the apex domain (needed for the layout server load to fetch the tenant list)
- Hooks server routes authenticated apex users to `/roster` and sets `isPlatformView`/`apexHost` on locals

## Backend changes

- `TenantResolutionMiddleware.cs`: added `/api/v4/me/tenants` to `TenantlessAllowedPrefixes`

## Frontend changes

- `hooks.server.ts`: platform route detection, apex redirect to `/roster`, `isPlatformView`/`apexHost` locals
- `app.d.ts`: new `isPlatformView` and `apexHost` fields on `App.Locals`
- `(platform)/+layout.server.ts`: fan-out fetch of latest BG entry per tenant with 60s polling via `invalidateAll`
- `(platform)/+layout.svelte`: sidebar + polling shell
- `(platform)/roster/+page.svelte`: grid/list/kanban views with derived `RosterItem[]`
- `(platform)/attention/+page.svelte`: attention detail page
- `(platform)/trends|activity|care-plans/+page.svelte`: stub pages
- New platform components in `$lib/components/platform/`
- New shared UI components: `RosterSparkline`, `TIRBar`

## Test plan

- [ ] Start Aspire, navigate to apex domain while authenticated -- should redirect to `/roster`
- [ ] Verify roster displays tenant cards with BG values, sparklines, and TIR bars
- [ ] Switch between grid, list, and kanban layouts via toolbar
- [ ] Verify attention rail shows only out-of-range tenants
- [ ] Navigate to `/attention` page and confirm severity grouping
- [ ] Verify sidebar badge counts update with polling
- [ ] Verify unauthenticated apex requests still redirect to marketing URL or `/setup`