### PR TITLE
fix(connectors): reclassify Tandem Control-IQ temp basals from Scheduled to Algorithm

### DIFF
--- a/src/API/Nocturne.API/Services/ConnectorPublishing/TreatmentPublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/TreatmentPublisher.cs
@@ -1,4 +1,5 @@
 using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
@@ -23,6 +24,8 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
     private readonly IBGCheckRepository _bgCheckRepository;
     private readonly IBolusCalculationRepository _bolusCalculationRepository;
     private readonly ITempBasalRepository _tempBasalRepository;
+    private readonly IBasalRateResolver _basalRateResolver;
+    private readonly ITherapySettingsResolver _therapySettingsResolver;
     private readonly ILogger<TreatmentPublisher> _logger;
 
     public TreatmentPublisher(
@@ -33,6 +36,8 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
         IBGCheckRepository bgCheckRepository,
         IBolusCalculationRepository bolusCalculationRepository,
         ITempBasalRepository tempBasalRepository,
+        IBasalRateResolver basalRateResolver,
+        ITherapySettingsResolver therapySettingsResolver,
         ILogger<TreatmentPublisher> logger)
     {
         _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
@@ -42,6 +47,8 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
         _bgCheckRepository = bgCheckRepository ?? throw new ArgumentNullException(nameof(bgCheckRepository));
         _bolusCalculationRepository = bolusCalculationRepository ?? throw new ArgumentNullException(nameof(bolusCalculationRepository));
         _tempBasalRepository = tempBasalRepository ?? throw new ArgumentNullException(nameof(tempBasalRepository));
+        _basalRateResolver = basalRateResolver ?? throw new ArgumentNullException(nameof(basalRateResolver));
+        _therapySettingsResolver = therapySettingsResolver ?? throw new ArgumentNullException(nameof(therapySettingsResolver));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -167,6 +174,14 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
             await _tempBasalRepository.DeleteBySourceAndDateRangeAsync(
                 source, minTimestamp, maxTimestamp, cancellationToken);
 
+            var reclassifiedCount = await ReclassifyScheduledAlgorithmicBasalsAsync(
+                recordList, cancellationToken);
+            if (reclassifiedCount > 0)
+                _logger.LogInformation(
+                    "Reclassified {Count}/{Total} TempBasal records from Scheduled to Algorithm "
+                    + "(rate differs from programmed basal schedule) for {Source}",
+                    reclassifiedCount, recordList.Count, source);
+
             await _tempBasalRepository.BulkCreateAsync(recordList, cancellationToken);
             _logger.LogDebug("Published {Count} TempBasal records for {Source}", recordList.Count, source);
             return true;
@@ -177,6 +192,55 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
             _logger.LogError(ex, "Failed to publish TempBasal records for {Source}", source);
             return false;
         }
+    }
+
+    /// <summary>
+    /// Connectors that flatten algorithm-driven adjustments (e.g. Tandem Control-IQ via Glooko's
+    /// ScheduledBasal stream) emit <see cref="TempBasalOrigin.Scheduled"/> records whose
+    /// <see cref="TempBasal.Rate"/> reflects what the pump actually delivered, not the user's
+    /// programmed basal profile. Compare each Scheduled record's rate against the resolved
+    /// schedule rate; when they diverge, reclassify as <see cref="TempBasalOrigin.Algorithm"/>
+    /// so downstream chart code emits the correct overlay. In either case, overwrite
+    /// <see cref="TempBasal.ScheduledRate"/> with the resolved programmed rate (some connectors
+    /// copy Rate into ScheduledRate, which makes the chart's reference line track the algorithm).
+    /// </summary>
+    private async Task<int> ReclassifyScheduledAlgorithmicBasalsAsync(
+        List<TempBasal> records,
+        CancellationToken cancellationToken)
+    {
+        // Floating-point noise guard. Real pump precision is ≥0.025 U/hr; algorithm-driven
+        // adjustments differ by far more.
+        const double rateTolerance = 0.005;
+
+        var scheduledRecords = records
+            .Where(r => r.Origin == TempBasalOrigin.Scheduled)
+            .ToList();
+        if (scheduledRecords.Count == 0) return 0;
+
+        // Without therapy settings on file, the resolver falls back to a hardcoded default and
+        // would mass-reclassify every record. Skip — we don't yet know what the schedule is.
+        if (!await _therapySettingsResolver.HasDataAsync(cancellationToken))
+            return 0;
+
+        var minMills = scheduledRecords.Min(r => r.StartMills);
+        var maxMills = scheduledRecords.Max(r => r.StartMills);
+
+        var resolve = await _basalRateResolver.BuildResolverAsync(minMills, maxMills, cancellationToken);
+
+        var reclassified = 0;
+        foreach (var record in scheduledRecords)
+        {
+            var programmedRate = resolve(record.StartMills);
+            record.ScheduledRate = programmedRate;
+
+            if (Math.Abs(record.Rate - programmedRate) > rateTolerance)
+            {
+                record.Origin = TempBasalOrigin.Algorithm;
+                reclassified++;
+            }
+        }
+
+        return reclassified;
     }
 
     public async Task<bool> PublishDecompositionBatchesAsync(

--- a/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoTempBasalMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoTempBasalMapper.cs
@@ -126,7 +126,13 @@ public class GlookoTempBasalMapper
                 );
             }
 
-        // ScheduledBasal -> TempBasal with actual rate, origin=Scheduled
+        // ScheduledBasal -> TempBasal with actual delivered rate, origin=Scheduled.
+        // Tandem Control-IQ (and similar algorithmic pumps) report algorithm-driven adjustments
+        // through this same stream — the connector cannot tell algorithm output from a true
+        // schedule rate without consulting the user's programmed basal_schedules. The
+        // ingest-side publisher reclassifies these to Algorithm and resolves the correct
+        // ScheduledRate when the delivered rate diverges from the programmed schedule, so we
+        // leave ScheduledRate null here rather than asserting "delivered == scheduled".
         if (series.ScheduledBasal != null)
             foreach (var basal in series.ScheduledBasal.Where(b => !b.Interpolated))
             {
@@ -146,7 +152,7 @@ public class GlookoTempBasalMapper
                         StartTimestamp = startTimestamp,
                         EndTimestamp = endTimestamp,
                         Rate = rate,
-                        ScheduledRate = rate,
+                        ScheduledRate = null,
                         Origin = TempBasalOrigin.Scheduled,
                         Device = null,
                         App = null,
@@ -222,7 +228,9 @@ public class GlookoTempBasalMapper
                 );
             }
 
-        // ScheduledBasals -> origin=Scheduled
+        // ScheduledBasals -> origin=Scheduled. See note on the v3 path above:
+        // ScheduledRate is left null so the publisher can resolve it from the user's
+        // programmed basal_schedules and reclassify algorithm-driven adjustments.
         if (batchData.ScheduledBasals != null)
             foreach (var basal in batchData.ScheduledBasals)
             {
@@ -258,7 +266,7 @@ public class GlookoTempBasalMapper
                         StartTimestamp = startTimestamp,
                         EndTimestamp = endTimestamp,
                         Rate = rate,
-                        ScheduledRate = rate,
+                        ScheduledRate = null,
                         Origin = TempBasalOrigin.Scheduled,
                         Device = null,
                         App = null,

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/TreatmentPublisherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/TreatmentPublisherTests.cs
@@ -4,9 +4,11 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.API.Services.ConnectorPublishing;
+using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data;
 using Xunit;
 
@@ -21,6 +23,8 @@ public class TreatmentPublisherTests
     private readonly Mock<IBGCheckRepository> _mockBGCheckRepository;
     private readonly Mock<IBolusCalculationRepository> _mockBolusCalculationRepository;
     private readonly Mock<ITempBasalRepository> _mockTempBasalRepository;
+    private readonly Mock<IBasalRateResolver> _mockBasalRateResolver;
+    private readonly Mock<ITherapySettingsResolver> _mockTherapySettingsResolver;
     private readonly TreatmentPublisher _publisher;
 
     public TreatmentPublisherTests()
@@ -31,6 +35,16 @@ public class TreatmentPublisherTests
         _mockBGCheckRepository = new Mock<IBGCheckRepository>();
         _mockBolusCalculationRepository = new Mock<IBolusCalculationRepository>();
         _mockTempBasalRepository = new Mock<ITempBasalRepository>();
+        _mockBasalRateResolver = new Mock<IBasalRateResolver>();
+        _mockTherapySettingsResolver = new Mock<ITherapySettingsResolver>();
+
+        // Default: resolver returns a constant 1.0 U/hr. Individual tests override as needed.
+        _mockBasalRateResolver
+            .Setup(r => r.BuildResolverAsync(It.IsAny<long>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Func<long, double>)(_ => 1.0));
+        _mockTherapySettingsResolver
+            .Setup(r => r.HasDataAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
 
         var dbOptions = new DbContextOptionsBuilder<NocturneDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
@@ -45,6 +59,8 @@ public class TreatmentPublisherTests
             _mockBGCheckRepository.Object,
             _mockBolusCalculationRepository.Object,
             _mockTempBasalRepository.Object,
+            _mockBasalRateResolver.Object,
+            _mockTherapySettingsResolver.Object,
             NullLogger<TreatmentPublisher>.Instance
         );
     }
@@ -118,5 +134,168 @@ public class TreatmentPublisherTests
         var result = await _publisher.GetLatestTreatmentTimestampAsync("test-source");
 
         result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task PublishTempBasalsAsync_ReclassifiesScheduledToAlgorithm_WhenRateDiffersFromProgrammed()
+    {
+        // Programmed schedule is a steady 1.0 U/hr, but the pump delivered 0.4 (low-temp).
+        // A connector that flattens algorithmic adjustments emits these as Scheduled.
+        _mockBasalRateResolver
+            .Setup(r => r.BuildResolverAsync(It.IsAny<long>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Func<long, double>)(_ => 1.0));
+
+        var startTs = new DateTime(2026, 5, 14, 12, 0, 0, DateTimeKind.Utc);
+        var records = new List<TempBasal>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                StartTimestamp = startTs,
+                EndTimestamp = startTs.AddMinutes(5),
+                Rate = 0.4,
+                ScheduledRate = 0.4, // connector copied Rate into ScheduledRate
+                Origin = TempBasalOrigin.Scheduled,
+                DataSource = "glooko-connector",
+            }
+        };
+
+        var result = await _publisher.PublishTempBasalsAsync(records, "glooko-connector");
+
+        result.Should().BeTrue();
+        records[0].Origin.Should().Be(TempBasalOrigin.Algorithm);
+        records[0].ScheduledRate.Should().Be(1.0);
+        records[0].Rate.Should().Be(0.4);
+        _mockTempBasalRepository.Verify(
+            r => r.BulkCreateAsync(records, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task PublishTempBasalsAsync_KeepsScheduledOrigin_WhenRateMatchesProgrammed()
+    {
+        _mockBasalRateResolver
+            .Setup(r => r.BuildResolverAsync(It.IsAny<long>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Func<long, double>)(_ => 1.0));
+
+        var records = new List<TempBasal>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                StartTimestamp = new DateTime(2026, 5, 14, 12, 0, 0, DateTimeKind.Utc),
+                Rate = 1.0,
+                ScheduledRate = 1.0,
+                Origin = TempBasalOrigin.Scheduled,
+                DataSource = "glooko-connector",
+            }
+        };
+
+        var result = await _publisher.PublishTempBasalsAsync(records, "glooko-connector");
+
+        result.Should().BeTrue();
+        records[0].Origin.Should().Be(TempBasalOrigin.Scheduled);
+        records[0].ScheduledRate.Should().Be(1.0);
+    }
+
+    [Fact]
+    public async Task PublishTempBasalsAsync_DoesNotReclassify_WithinFloatingPointTolerance()
+    {
+        // 0.025 U/hr is the typical pump rate increment. Below that should not trigger reclassification.
+        _mockBasalRateResolver
+            .Setup(r => r.BuildResolverAsync(It.IsAny<long>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Func<long, double>)(_ => 1.0));
+
+        var records = new List<TempBasal>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                StartTimestamp = new DateTime(2026, 5, 14, 12, 0, 0, DateTimeKind.Utc),
+                Rate = 1.0 + 1e-6, // pure floating-point noise
+                ScheduledRate = 1.0,
+                Origin = TempBasalOrigin.Scheduled,
+                DataSource = "glooko-connector",
+            }
+        };
+
+        var result = await _publisher.PublishTempBasalsAsync(records, "glooko-connector");
+
+        result.Should().BeTrue();
+        records[0].Origin.Should().Be(TempBasalOrigin.Scheduled);
+    }
+
+    [Fact]
+    public async Task PublishTempBasalsAsync_DoesNotTouchAlreadyAlgorithmOrManualOrigins()
+    {
+        _mockBasalRateResolver
+            .Setup(r => r.BuildResolverAsync(It.IsAny<long>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Func<long, double>)(_ => 1.0));
+
+        var ts = new DateTime(2026, 5, 14, 12, 0, 0, DateTimeKind.Utc);
+        var records = new List<TempBasal>
+        {
+            new() { Id = Guid.NewGuid(), StartTimestamp = ts, Rate = 0.5, ScheduledRate = 1.0, Origin = TempBasalOrigin.Algorithm },
+            new() { Id = Guid.NewGuid(), StartTimestamp = ts.AddMinutes(5), Rate = 0.5, ScheduledRate = 1.0, Origin = TempBasalOrigin.Manual },
+            new() { Id = Guid.NewGuid(), StartTimestamp = ts.AddMinutes(10), Rate = 0, ScheduledRate = null, Origin = TempBasalOrigin.Suspended },
+        };
+
+        var result = await _publisher.PublishTempBasalsAsync(records, "loop-connector");
+
+        result.Should().BeTrue();
+        records[0].Origin.Should().Be(TempBasalOrigin.Algorithm);
+        records[0].ScheduledRate.Should().Be(1.0); // untouched
+        records[1].Origin.Should().Be(TempBasalOrigin.Manual);
+        records[1].ScheduledRate.Should().Be(1.0); // untouched
+        records[2].Origin.Should().Be(TempBasalOrigin.Suspended);
+        records[2].ScheduledRate.Should().BeNull(); // untouched
+    }
+
+    [Fact]
+    public async Task PublishTempBasalsAsync_SkipsReclassification_WhenNoTherapyData()
+    {
+        // First-sync scenario: no basal_schedules on file yet, so we can't determine what was
+        // programmed. Leave records as-is rather than mass-reclassifying against the fallback default.
+        _mockTherapySettingsResolver
+            .Setup(r => r.HasDataAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var records = new List<TempBasal>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                StartTimestamp = new DateTime(2026, 5, 14, 12, 0, 0, DateTimeKind.Utc),
+                Rate = 0.4,
+                ScheduledRate = 0.4,
+                Origin = TempBasalOrigin.Scheduled,
+            }
+        };
+
+        var result = await _publisher.PublishTempBasalsAsync(records, "glooko-connector");
+
+        result.Should().BeTrue();
+        records[0].Origin.Should().Be(TempBasalOrigin.Scheduled);
+        records[0].ScheduledRate.Should().Be(0.4); // untouched
+        _mockBasalRateResolver.Verify(
+            r => r.BuildResolverAsync(It.IsAny<long>(), It.IsAny<long>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task PublishTempBasalsAsync_NoOpResolverCall_WhenNoScheduledRecords()
+    {
+        var ts = new DateTime(2026, 5, 14, 12, 0, 0, DateTimeKind.Utc);
+        var records = new List<TempBasal>
+        {
+            new() { Id = Guid.NewGuid(), StartTimestamp = ts, Rate = 0.5, Origin = TempBasalOrigin.Algorithm },
+        };
+
+        var result = await _publisher.PublishTempBasalsAsync(records, "loop-connector");
+
+        result.Should().BeTrue();
+        _mockBasalRateResolver.Verify(
+            r => r.BuildResolverAsync(It.IsAny<long>(), It.IsAny<long>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 }


### PR DESCRIPTION
## Summary

Glooko serves Tandem Control-IQ algorithmic basal adjustments through the same `ScheduledBasal` stream it uses for true profile rates. `GlookoTempBasalMapper` preserved every record as `Origin = Scheduled` with `ScheduledRate = Rate`, so on the chart:

- The dashed "scheduled profile" reference line tracked Control-IQ's output rather than the user's programmed schedule.
- `MapTempBasalSpans` filters on `Origin == Manual`, so the colored "TEMP BASAL" overlay never rendered for hours of algorithmic activity — those swathes blended into the default-profile area.

Verified on production data: a Tandem + Control-IQ user had 39,831 `Origin = Scheduled` records over months with `rate == scheduled_rate` for 754/754 in the last 7 days, while their programmed schedule was a flat 0.41 U/hr and the algorithm delivered between 0 and 1.58 U/hr.

## Fix

Reclassify at the ingest boundary in `TreatmentPublisher.PublishTempBasalsAsync`:

1. For each `Origin = Scheduled` record, resolve the user's programmed rate at `StartMills` via `IBasalRateResolver.BuildResolverAsync` (single batched lookup per publish).
2. Overwrite `ScheduledRate` with the resolved programmed rate so the chart's reference line tracks the real schedule.
3. If the delivered `Rate` diverges from the programmed rate beyond a 0.005 U/hr floating-point tolerance, flip `Origin` to `Algorithm`.
4. Guarded by `ITherapySettingsResolver.HasDataAsync` — a first sync with no schedule on file would otherwise mass-reclassify against the hardcoded default.

Also drop the misleading `ScheduledRate = Rate` from `GlookoTempBasalMapper` (v2 + v3 ScheduledBasal paths). The publisher is now the source of truth.

## Test plan

- [x] Unit: 5 new tests in `TreatmentPublisherTests` (reclassify when divergent, keep Scheduled when matched, FP tolerance, don't touch Algorithm/Manual/Suspended, skip on no-therapy-data)
- [x] `dotnet test` on `Nocturne.API.Tests`: 1239 unit tests pass
- [x] `dotnet test` filtered to Glooko: 8 pass
- [ ] Validate on production tenant after deploy (Glooko re-sync replaces records via `DeleteBySourceAndDateRangeAsync`)