### PR TITLE
fix(dexcom): accept Trend as either int or string

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Dexcom/Converters/DexcomTrendConverter.cs
+++ b/src/Connectors/Nocturne.Connectors.Dexcom/Converters/DexcomTrendConverter.cs
@@ -1,0 +1,43 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.Connectors.Dexcom.Converters;
+
+/// Dexcom Share returns Trend as either a numeric code (0-9) or a string name
+/// ("Flat", "FortyFiveDown", ...). Both shapes have been observed in the wild;
+/// reject neither.
+internal sealed class DexcomTrendConverter : JsonConverter<GlucoseDirection>
+{
+    public override GlucoseDirection Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options
+    )
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.Number
+                when reader.TryGetInt32(out var ordinal)
+                    && Enum.IsDefined(typeof(GlucoseDirection), ordinal):
+                return (GlucoseDirection)ordinal;
+
+            case JsonTokenType.String
+                when Enum.TryParse<GlucoseDirection>(
+                    reader.GetString(),
+                    ignoreCase: true,
+                    out var named
+                ):
+                return named;
+
+            default:
+                return GlucoseDirection.NotComputable;
+        }
+    }
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        GlucoseDirection value,
+        JsonSerializerOptions options
+    ) => writer.WriteStringValue(value.ToString());
+}

--- a/src/Connectors/Nocturne.Connectors.Dexcom/Mappers/DexcomSensorGlucoseMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Dexcom/Mappers/DexcomSensorGlucoseMapper.cs
@@ -8,20 +8,6 @@ namespace Nocturne.Connectors.Dexcom.Mappers;
 
 public class DexcomSensorGlucoseMapper(ILogger logger)
 {
-    private static readonly Dictionary<int, GlucoseDirection> TrendDirections = new()
-    {
-        { 0, GlucoseDirection.None },
-        { 1, GlucoseDirection.DoubleUp },
-        { 2, GlucoseDirection.SingleUp },
-        { 3, GlucoseDirection.FortyFiveUp },
-        { 4, GlucoseDirection.Flat },
-        { 5, GlucoseDirection.FortyFiveDown },
-        { 6, GlucoseDirection.SingleDown },
-        { 7, GlucoseDirection.DoubleDown },
-        { 8, GlucoseDirection.NotComputable },
-        { 9, GlucoseDirection.RateOutOfRange }
-    };
-
     private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
     public IEnumerable<SensorGlucose> MapBatchData(DexcomEntry[]? batchData)
@@ -48,7 +34,7 @@ public class DexcomSensorGlucoseMapper(ILogger logger)
                 return null;
             }
 
-            var direction = TrendDirections.GetValueOrDefault(dexcomEntry.Trend, GlucoseDirection.NotComputable);
+            var direction = dexcomEntry.Trend;
             var mgdl = (double)dexcomEntry.Value;
 
             return new SensorGlucose

--- a/src/Connectors/Nocturne.Connectors.Dexcom/Models/DexcomEntry.cs
+++ b/src/Connectors/Nocturne.Connectors.Dexcom/Models/DexcomEntry.cs
@@ -1,10 +1,17 @@
+using System.Text.Json.Serialization;
+using Nocturne.Connectors.Dexcom.Converters;
+using Nocturne.Core.Models.V4;
+
 namespace Nocturne.Connectors.Dexcom.Models;
 
 public class DexcomEntry
 {
     public string Dt { get; set; } = string.Empty;
     public string St { get; set; } = string.Empty;
-    public int Trend { get; set; }
+
+    [JsonConverter(typeof(DexcomTrendConverter))]
+    public GlucoseDirection Trend { get; set; }
+
     public int Value { get; set; }
     public string Wt { get; set; } = string.Empty;
 }


### PR DESCRIPTION
## Problem

The Dexcom connector has been failing to ingest glucose readings for self-hosted instances. Symptom on the dashboard: BG widget stuck at the last good reading from days prior; APS-snapshot data (e.g. Trio loop pills, glucose chart values) still flows because that path is independent.

API logs show the connector hitting Dexcom Share successfully (HTTP 200) but failing to deserialize the response on the very first array element:

[dexcom-connector] JSON parsing error during FetchDexcomData
System.Text.Json.JsonException: The JSON value could not be converted to System.Int32.
Path: $[0].Trend | LineNumber: 0 | BytePositionInLine: 113.
---> Cannot get the value of a token type 'String' as a number.



The retry/exception wrapper logs `Background sync completed successfully` after swallowing the failure, so the service appears healthy in coarse monitoring while writing zero rows.

## Root cause

Dexcom Share is returning `Trend` as a string (`"Flat"`, `"FortyFiveDown"`, …) for at least some accounts. The connector's transport model `DexcomEntry.Trend` is typed `int`, so deserialization throws on the first record and the entire batch is discarded.

`git log` on `DexcomEntry.cs` shows the field has always been `int` — this is a Dexcom-side response format change, not a regression introduced by Nocturne.

## Fix

Defensive: accept either shape.

- New `DexcomTrendConverter : JsonConverter<GlucoseDirection>` in `Connectors.Dexcom/Converters/`:
  - `JsonTokenType.Number` → cast to `GlucoseDirection` (preserves legacy 0–9 ordinal mapping).
  - `JsonTokenType.String` → `Enum.TryParse` (handles new `"Flat"`, `"FortyFiveDown"`, … form).
  - Anything else / unknown value → `GlucoseDirection.NotComputable`.
- `DexcomEntry.Trend` retyped from `int` to `GlucoseDirection` with `[JsonConverter(typeof(DexcomTrendConverter))]` overriding the enum-level `JsonStringEnumConverter` for this property only.
- `DexcomSensorGlucoseMapper` no longer needs its `Dictionary<int, GlucoseDirection>` lookup; the converter has already produced a `GlucoseDirection`.

This works because `GlucoseDirection` enum names already match Dexcom's string vocabulary exactly and the enum's ordinal values match the legacy numeric codes 1:1, so no manual mapping table is required.

## Compatibility

- Legacy numeric Trend responses still parse correctly via the ordinal cast.
- Unknown trend values now degrade to `NotComputable` instead of crashing the entire batch.
- No database schema or API surface changes.

## Test plan

- [ ] Build succeeds: `dotnet build src/Connectors/Nocturne.Connectors.Dexcom/Nocturne.Connectors.Dexcom.csproj`
- [ ] Self-hosted instance with a Dexcom Share connector configured: verify new entries appear in the `entries` table and the dashboard's "last reading" timestamp updates within ~5 minutes of deploy.
- [ ] Connector logs no longer show the `JsonException: ... Path: $[0].Trend` error.
- [ ] Manual: deserialize a fixture array containing both numeric (`"Trend": 4`) and string (`"Trend": "Flat"`) forms and confirm both produce `GlucoseDirection.Flat`.

Closes the production-data-staleness issue for Dexcom Share users.