### PR TITLE
fix(migrations): make overlapping tenant-timestamp indexes idempotent

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260511000001_AddTenantTimestampIndexes.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260511000001_AddTenantTimestampIndexes.cs
@@ -10,28 +10,30 @@ namespace Nocturne.Infrastructure.Data.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.CreateIndex(
-                name: "ix_boluses_tenant_timestamp",
-                table: "boluses",
-                columns: new[] { "tenant_id", "timestamp" });
+            // These index names overlap with AddCompositePerformanceIndexes (20260511122202),
+            // which creates them with descending timestamp ordering. On databases that already
+            // ran the later migration, recreating them here would fail; on fresh databases
+            // the later migration would fail when it ran second. IF NOT EXISTS makes both
+            // paths a no-op when the index is already present.
+            migrationBuilder.Sql(
+                "CREATE INDEX IF NOT EXISTS ix_boluses_tenant_timestamp " +
+                "ON boluses (tenant_id, timestamp);");
 
-            migrationBuilder.CreateIndex(
-                name: "ix_carb_intakes_tenant_timestamp",
-                table: "carb_intakes",
-                columns: new[] { "tenant_id", "timestamp" });
+            migrationBuilder.Sql(
+                "CREATE INDEX IF NOT EXISTS ix_carb_intakes_tenant_timestamp " +
+                "ON carb_intakes (tenant_id, timestamp);");
 
-            migrationBuilder.CreateIndex(
-                name: "ix_temp_basals_tenant_start_timestamp",
-                table: "temp_basals",
-                columns: new[] { "tenant_id", "start_timestamp" });
+            migrationBuilder.Sql(
+                "CREATE INDEX IF NOT EXISTS ix_temp_basals_tenant_start_timestamp " +
+                "ON temp_basals (tenant_id, start_timestamp);");
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropIndex(name: "ix_boluses_tenant_timestamp",           table: "boluses");
-            migrationBuilder.DropIndex(name: "ix_carb_intakes_tenant_timestamp",      table: "carb_intakes");
-            migrationBuilder.DropIndex(name: "ix_temp_basals_tenant_start_timestamp", table: "temp_basals");
+            migrationBuilder.Sql("DROP INDEX IF EXISTS ix_boluses_tenant_timestamp;");
+            migrationBuilder.Sql("DROP INDEX IF EXISTS ix_carb_intakes_tenant_timestamp;");
+            migrationBuilder.Sql("DROP INDEX IF EXISTS ix_temp_basals_tenant_start_timestamp;");
         }
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260511122202_AddCompositePerformanceIndexes.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260511122202_AddCompositePerformanceIndexes.cs
@@ -16,11 +16,12 @@ namespace Nocturne.Infrastructure.Data.Migrations
                 columns: new[] { "tenant_id", "timestamp" },
                 descending: new[] { false, true });
 
-            migrationBuilder.CreateIndex(
-                name: "ix_temp_basals_tenant_start_timestamp",
-                table: "temp_basals",
-                columns: new[] { "tenant_id", "start_timestamp" },
-                descending: new[] { false, true });
+            // Idempotent: name overlaps with AddTenantTimestampIndexes (20260511000001),
+            // which creates the same index without descending ordering. Skip recreation
+            // if it already exists so both ordering choices work in sequence.
+            migrationBuilder.Sql(
+                "CREATE INDEX IF NOT EXISTS ix_temp_basals_tenant_start_timestamp " +
+                "ON temp_basals (tenant_id, start_timestamp DESC);");
 
             migrationBuilder.CreateIndex(
                 name: "ix_target_range_schedules_tenant_profile_timestamp",
@@ -40,17 +41,13 @@ namespace Nocturne.Infrastructure.Data.Migrations
                 columns: new[] { "tenant_id", "profile_name", "timestamp" },
                 descending: new[] { false, false, true });
 
-            migrationBuilder.CreateIndex(
-                name: "ix_carb_intakes_tenant_timestamp",
-                table: "carb_intakes",
-                columns: new[] { "tenant_id", "timestamp" },
-                descending: new[] { false, true });
+            migrationBuilder.Sql(
+                "CREATE INDEX IF NOT EXISTS ix_carb_intakes_tenant_timestamp " +
+                "ON carb_intakes (tenant_id, timestamp DESC);");
 
-            migrationBuilder.CreateIndex(
-                name: "ix_boluses_tenant_timestamp",
-                table: "boluses",
-                columns: new[] { "tenant_id", "timestamp" },
-                descending: new[] { false, true });
+            migrationBuilder.Sql(
+                "CREATE INDEX IF NOT EXISTS ix_boluses_tenant_timestamp " +
+                "ON boluses (tenant_id, timestamp DESC);");
 
             migrationBuilder.CreateIndex(
                 name: "ix_basal_schedules_tenant_profile_timestamp",
@@ -75,9 +72,7 @@ namespace Nocturne.Infrastructure.Data.Migrations
                 name: "ix_therapy_settings_tenant_timestamp",
                 table: "therapy_settings");
 
-            migrationBuilder.DropIndex(
-                name: "ix_temp_basals_tenant_start_timestamp",
-                table: "temp_basals");
+            migrationBuilder.Sql("DROP INDEX IF EXISTS ix_temp_basals_tenant_start_timestamp;");
 
             migrationBuilder.DropIndex(
                 name: "ix_target_range_schedules_tenant_profile_timestamp",
@@ -91,13 +86,8 @@ namespace Nocturne.Infrastructure.Data.Migrations
                 name: "ix_carb_ratio_schedules_tenant_profile_timestamp",
                 table: "carb_ratio_schedules");
 
-            migrationBuilder.DropIndex(
-                name: "ix_carb_intakes_tenant_timestamp",
-                table: "carb_intakes");
-
-            migrationBuilder.DropIndex(
-                name: "ix_boluses_tenant_timestamp",
-                table: "boluses");
+            migrationBuilder.Sql("DROP INDEX IF EXISTS ix_carb_intakes_tenant_timestamp;");
+            migrationBuilder.Sql("DROP INDEX IF EXISTS ix_boluses_tenant_timestamp;");
 
             migrationBuilder.DropIndex(
                 name: "ix_basal_schedules_tenant_profile_timestamp",


### PR DESCRIPTION
AddTenantTimestampIndexes (20260511000001) and AddCompositePerformanceIndexes
(20260511122202) both create ix_boluses_tenant_timestamp,
ix_carb_intakes_tenant_timestamp, and ix_temp_basals_tenant_start_timestamp.
The back-dated migration fails on existing databases where the later one
already ran, and the later one would fail on fresh databases where the
back-dated one runs first.

Switch the three conflicting CreateIndex calls in both migrations to raw
CREATE INDEX IF NOT EXISTS (and DROP INDEX IF EXISTS in the Down paths) so
the second creation is a no-op regardless of apply order.