### PR TITLE
fix: bypass setup middleware for demo tenants

### DIFF
--- a/src/API/Nocturne.API/Middleware/TenantSetupMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/TenantSetupMiddleware.cs
@@ -69,6 +69,13 @@ public class TenantSetupMiddleware
             return;
         }
 
+        // Demo tenants bypass setup requirements — they have no owner credentials by design
+        if (tenantAccessor.Context?.IsDemo == true)
+        {
+            await _next(context);
+            return;
+        }
+
         // Endpoints marked [AllowDuringSetup] bypass both the setup check and the
         // recovery check — these are the bootstrap endpoints (passkey/TOTP setup,
         // OIDC bootstrap login, admin provisioning, metadata).

--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -185,7 +185,7 @@ public class TenantResolutionMiddleware
         if (tenant == null)
             return null;
 
-        var tenantContext = new TenantContext(tenant.Id, tenant.Slug, tenant.DisplayName, tenant.IsActive);
+        var tenantContext = new TenantContext(tenant.Id, tenant.Slug, tenant.DisplayName, tenant.IsActive, tenant.IsDemo);
         _cache.Set(cacheKey, tenantContext, CacheDuration);
         return tenantContext;
     }
@@ -225,7 +225,7 @@ public class TenantResolutionMiddleware
             return null;
 
         var tenant = tenants[0];
-        var tenantContext = new TenantContext(tenant.Id, tenant.Slug, tenant.DisplayName, tenant.IsActive);
+        var tenantContext = new TenantContext(tenant.Id, tenant.Slug, tenant.DisplayName, tenant.IsActive, tenant.IsDemo);
         _cache.Set(cacheKey, tenantContext, CacheDuration);
         return tenantContext;
     }

--- a/src/Core/Nocturne.Core.Contracts/Multitenancy/TenantContext.cs
+++ b/src/Core/Nocturne.Core.Contracts/Multitenancy/TenantContext.cs
@@ -9,4 +9,4 @@ namespace Nocturne.Core.Contracts.Multitenancy;
 /// <param name="DisplayName">The human-readable display name of the tenant.</param>
 /// <param name="IsActive">Whether the tenant is currently active and accepting data.</param>
 /// <seealso cref="ITenantAccessor"/>
-public record TenantContext(Guid TenantId, string Slug, string DisplayName, bool IsActive);
+public record TenantContext(Guid TenantId, string Slug, string DisplayName, bool IsActive, bool IsDemo = false);


### PR DESCRIPTION
## Summary
- Add `IsDemo` to `TenantContext` record and populate it during tenant resolution
- Skip the `TenantSetupMiddleware` check for demo tenants (they have no owner credentials by design)
- Fixes demo data service getting 503 when trying to write entries to the demo tenant

## Context
The demo tenant is `is_demo = true` in the DB but the setup middleware requires passkey/OIDC credentials to exist before allowing API access. Demo tenants don't have (and shouldn't need) owner credentials.