### PR TITLE
fix(demo): authenticate demo service API requests with instance key

### DIFF
--- a/src/API/Nocturne.API/Middleware/TenantSetupMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/TenantSetupMiddleware.cs
@@ -69,6 +69,13 @@ public class TenantSetupMiddleware
             return;
         }
 
+        // Demo tenants bypass setup requirements — they have no owner credentials by design
+        if (tenantAccessor.Context?.IsDemo == true)
+        {
+            await _next(context);
+            return;
+        }
+
         // Endpoints marked [AllowDuringSetup] bypass both the setup check and the
         // recovery check — these are the bootstrap endpoints (passkey/TOTP setup,
         // OIDC bootstrap login, admin provisioning, metadata).

--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -185,7 +185,7 @@ public class TenantResolutionMiddleware
         if (tenant == null)
             return null;
 
-        var tenantContext = new TenantContext(tenant.Id, tenant.Slug, tenant.DisplayName, tenant.IsActive);
+        var tenantContext = new TenantContext(tenant.Id, tenant.Slug, tenant.DisplayName, tenant.IsActive, tenant.IsDemo);
         _cache.Set(cacheKey, tenantContext, CacheDuration);
         return tenantContext;
     }
@@ -225,7 +225,7 @@ public class TenantResolutionMiddleware
             return null;
 
         var tenant = tenants[0];
-        var tenantContext = new TenantContext(tenant.Id, tenant.Slug, tenant.DisplayName, tenant.IsActive);
+        var tenantContext = new TenantContext(tenant.Id, tenant.Slug, tenant.DisplayName, tenant.IsActive, tenant.IsDemo);
         _cache.Set(cacheKey, tenantContext, CacheDuration);
         return tenantContext;
     }

--- a/src/Core/Nocturne.Core.Contracts/Multitenancy/TenantContext.cs
+++ b/src/Core/Nocturne.Core.Contracts/Multitenancy/TenantContext.cs
@@ -9,4 +9,4 @@ namespace Nocturne.Core.Contracts.Multitenancy;
 /// <param name="DisplayName">The human-readable display name of the tenant.</param>
 /// <param name="IsActive">Whether the tenant is currently active and accepting data.</param>
 /// <seealso cref="ITenantAccessor"/>
-public record TenantContext(Guid TenantId, string Slug, string DisplayName, bool IsActive);
+public record TenantContext(Guid TenantId, string Slug, string DisplayName, bool IsActive, bool IsDemo = false);

--- a/src/Services/Nocturne.Services.Demo/Program.cs
+++ b/src/Services/Nocturne.Services.Demo/Program.cs
@@ -35,11 +35,17 @@ public class Program
         // Configure HTTP clients for API communication
         var apiUrl = builder.Configuration["DemoService:ApiUrl"] ?? "http://localhost:5000";
         var demoHost = builder.Configuration["DemoService:DemoHost"] ?? "demo.localhost";
+        var instanceKey = builder.Configuration["DemoService:InstanceKey"] ?? "";
+        var instanceKeyHash = !string.IsNullOrEmpty(instanceKey)
+            ? Nocturne.Connectors.Core.Utilities.HashUtils.Sha1Hex(instanceKey)
+            : "";
 
         builder.Services.AddHttpClient("DemoAdmin", client =>
         {
             client.BaseAddress = new Uri(apiUrl.TrimEnd('/') + "/");
             client.Timeout = TimeSpan.FromMinutes(5); // Backfill can be slow
+            if (!string.IsNullOrEmpty(instanceKeyHash))
+                client.DefaultRequestHeaders.Add("X-Instance-Key", instanceKeyHash);
         });
 
         builder.Services.AddHttpClient("DemoTenant", client =>
@@ -47,6 +53,8 @@ public class Program
             client.BaseAddress = new Uri(apiUrl.TrimEnd('/') + "/");
             client.DefaultRequestHeaders.Host = demoHost;
             client.Timeout = TimeSpan.FromMinutes(5);
+            if (!string.IsNullOrEmpty(instanceKeyHash))
+                client.DefaultRequestHeaders.Add("X-Instance-Key", instanceKeyHash);
         });
 
         // Register the API client


### PR DESCRIPTION
## Summary
- Add `X-Instance-Key` header (SHA1-hashed) to both `DemoAdmin` and `DemoTenant` HTTP clients
- The demo service was getting 401 Unauthorized when writing entries because V1 endpoints require auth
- Reads `DemoService:InstanceKey` from configuration (passed by Aspire AppHost)

## Follow-up
- Migrate from V1 entries/treatments to V4 bulk endpoints (separate PR)