### PR TITLE
fix: make write-back sinks optional when connector is disabled

### DIFF
--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -394,12 +394,18 @@ public static class ServiceRegistrationExtensions
         services.AddScoped<ITreatmentCache, Nocturne.API.Services.Treatments.TreatmentCacheAdapter>();
         services.AddScoped<SignalRTreatmentEventSink>();
         services.AddScoped<IDataEventSink<Treatment>>(sp =>
-            new CompositeDataEventSink<Treatment>(
-                [
-                    sp.GetRequiredService<SignalRTreatmentEventSink>(),
-                    sp.GetRequiredService<NightscoutTreatmentWriteBackSink>()
-                ],
-                sp.GetService<ILogger<CompositeDataEventSink<Treatment>>>()));
+        {
+            var sinks = new List<IDataEventSink<Treatment>>
+            {
+                sp.GetRequiredService<SignalRTreatmentEventSink>(),
+            };
+            var writeBack = sp.GetService<NightscoutTreatmentWriteBackSink>();
+            if (writeBack is not null) sinks.Add(writeBack);
+
+            return new CompositeDataEventSink<Treatment>(
+                sinks,
+                sp.GetService<ILogger<CompositeDataEventSink<Treatment>>>());
+        });
         services.AddScoped<IWriteSideEffects, WriteSideEffectsService>();
         services.AddScoped<IEntryService, EntryService>();
         services.AddScoped<IEntryStore, Nocturne.API.Services.Entries.EntryReadService>();
@@ -410,8 +416,9 @@ public static class ServiceRegistrationExtensions
             var sinks = new List<IDataEventSink<Entry>>
             {
                 sp.GetRequiredService<SignalREntryEventSink>(),
-                sp.GetRequiredService<NightscoutEntryWriteBackSink>()
             };
+            var writeBack = sp.GetService<NightscoutEntryWriteBackSink>();
+            if (writeBack is not null) sinks.Add(writeBack);
 
             return new CompositeDataEventSink<Entry>(
                 sinks,
@@ -420,9 +427,14 @@ public static class ServiceRegistrationExtensions
         services.AddScoped<IStateSpanService, StateSpanService>();
         services.AddScoped<DeviceStatusProjectionService>();
         services.AddScoped<IDataEventSink<DeviceStatus>>(sp =>
-            new CompositeDataEventSink<DeviceStatus>(
-                [sp.GetRequiredService<NightscoutDeviceStatusWriteBackSink>()],
-                sp.GetService<ILogger<CompositeDataEventSink<DeviceStatus>>>()));
+        {
+            var sinks = new List<IDataEventSink<DeviceStatus>>();
+            var writeBack = sp.GetService<NightscoutDeviceStatusWriteBackSink>();
+            if (writeBack is not null) sinks.Add(writeBack);
+            return new CompositeDataEventSink<DeviceStatus>(
+                sinks,
+                sp.GetService<ILogger<CompositeDataEventSink<DeviceStatus>>>());
+        });
         services.AddScoped<IBatteryService, BatteryService>();
         services.AddScoped<IProfileWriteService, ProfileWriteService>();
         services.AddScoped<IActiveProfileResolver, ActiveProfileResolver>();
@@ -436,16 +448,26 @@ public static class ServiceRegistrationExtensions
         services.AddScoped<ITempBasalResolver, TempBasalResolver>();
         services.AddScoped<IProfileProjectionService, ProfileProjectionService>();
         services.AddScoped<IDataEventSink<Profile>>(sp =>
-            new CompositeDataEventSink<Profile>(
-                [sp.GetRequiredService<NightscoutProfileWriteBackSink>()],
-                sp.GetService<ILogger<CompositeDataEventSink<Profile>>>()));
+        {
+            var sinks = new List<IDataEventSink<Profile>>();
+            var writeBack = sp.GetService<NightscoutProfileWriteBackSink>();
+            if (writeBack is not null) sinks.Add(writeBack);
+            return new CompositeDataEventSink<Profile>(
+                sinks,
+                sp.GetService<ILogger<CompositeDataEventSink<Profile>>>());
+        });
 
         // Food services
         services.AddScoped<IFoodService, FoodService>();
         services.AddScoped<IDataEventSink<Food>>(sp =>
-            new CompositeDataEventSink<Food>(
-                [sp.GetRequiredService<NightscoutFoodWriteBackSink>()],
-                sp.GetService<ILogger<CompositeDataEventSink<Food>>>()));
+        {
+            var sinks = new List<IDataEventSink<Food>>();
+            var writeBack = sp.GetService<NightscoutFoodWriteBackSink>();
+            if (writeBack is not null) sinks.Add(writeBack);
+            return new CompositeDataEventSink<Food>(
+                sinks,
+                sp.GetService<ILogger<CompositeDataEventSink<Food>>>());
+        });
         services.AddScoped<IConnectorFoodEntryService, ConnectorFoodEntryService>();
         services.AddScoped<ITreatmentFoodService, TreatmentFoodService>();
         services.AddScoped<IUserFoodFavoriteService, UserFoodFavoriteService>();
@@ -455,9 +477,14 @@ public static class ServiceRegistrationExtensions
         // Activity and health metric services
         services.AddScoped<IActivityService, ActivityService>();
         services.AddScoped<IDataEventSink<Activity>>(sp =>
-            new CompositeDataEventSink<Activity>(
-                [sp.GetRequiredService<NightscoutActivityWriteBackSink>()],
-                sp.GetService<ILogger<CompositeDataEventSink<Activity>>>()));
+        {
+            var sinks = new List<IDataEventSink<Activity>>();
+            var writeBack = sp.GetService<NightscoutActivityWriteBackSink>();
+            if (writeBack is not null) sinks.Add(writeBack);
+            return new CompositeDataEventSink<Activity>(
+                sinks,
+                sp.GetService<ILogger<CompositeDataEventSink<Activity>>>());
+        });
         services.AddScoped<IHeartRateService, HeartRateService>();
         services.AddScoped<IBodyWeightService, BodyWeightService>();
         services.AddScoped<IStepCountService, StepCountService>();

--- a/src/API/Nocturne.API/Middleware/TenantSetupMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/TenantSetupMiddleware.cs
@@ -69,6 +69,13 @@ public class TenantSetupMiddleware
             return;
         }
 
+        // Demo tenants bypass setup requirements — they have no owner credentials by design
+        if (tenantAccessor.Context?.IsDemo == true)
+        {
+            await _next(context);
+            return;
+        }
+
         // Endpoints marked [AllowDuringSetup] bypass both the setup check and the
         // recovery check — these are the bootstrap endpoints (passkey/TOTP setup,
         // OIDC bootstrap login, admin provisioning, metadata).

--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -185,7 +185,7 @@ public class TenantResolutionMiddleware
         if (tenant == null)
             return null;
 
-        var tenantContext = new TenantContext(tenant.Id, tenant.Slug, tenant.DisplayName, tenant.IsActive);
+        var tenantContext = new TenantContext(tenant.Id, tenant.Slug, tenant.DisplayName, tenant.IsActive, tenant.IsDemo);
         _cache.Set(cacheKey, tenantContext, CacheDuration);
         return tenantContext;
     }
@@ -225,7 +225,7 @@ public class TenantResolutionMiddleware
             return null;
 
         var tenant = tenants[0];
-        var tenantContext = new TenantContext(tenant.Id, tenant.Slug, tenant.DisplayName, tenant.IsActive);
+        var tenantContext = new TenantContext(tenant.Id, tenant.Slug, tenant.DisplayName, tenant.IsActive, tenant.IsDemo);
         _cache.Set(cacheKey, tenantContext, CacheDuration);
         return tenantContext;
     }

--- a/src/Core/Nocturne.Core.Contracts/Multitenancy/TenantContext.cs
+++ b/src/Core/Nocturne.Core.Contracts/Multitenancy/TenantContext.cs
@@ -9,4 +9,4 @@ namespace Nocturne.Core.Contracts.Multitenancy;
 /// <param name="DisplayName">The human-readable display name of the tenant.</param>
 /// <param name="IsActive">Whether the tenant is currently active and accepting data.</param>
 /// <seealso cref="ITenantAccessor"/>
-public record TenantContext(Guid TenantId, string Slug, string DisplayName, bool IsActive);
+public record TenantContext(Guid TenantId, string Slug, string DisplayName, bool IsActive, bool IsDemo = false);

--- a/src/Services/Nocturne.Services.Demo/Program.cs
+++ b/src/Services/Nocturne.Services.Demo/Program.cs
@@ -35,11 +35,17 @@ public class Program
         // Configure HTTP clients for API communication
         var apiUrl = builder.Configuration["DemoService:ApiUrl"] ?? "http://localhost:5000";
         var demoHost = builder.Configuration["DemoService:DemoHost"] ?? "demo.localhost";
+        var instanceKey = builder.Configuration["DemoService:InstanceKey"] ?? "";
+        var instanceKeyHash = !string.IsNullOrEmpty(instanceKey)
+            ? Nocturne.Connectors.Core.Utilities.HashUtils.Sha1Hex(instanceKey)
+            : "";
 
         builder.Services.AddHttpClient("DemoAdmin", client =>
         {
             client.BaseAddress = new Uri(apiUrl.TrimEnd('/') + "/");
             client.Timeout = TimeSpan.FromMinutes(5); // Backfill can be slow
+            if (!string.IsNullOrEmpty(instanceKeyHash))
+                client.DefaultRequestHeaders.Add("X-Instance-Key", instanceKeyHash);
         });
 
         builder.Services.AddHttpClient("DemoTenant", client =>
@@ -47,6 +53,8 @@ public class Program
             client.BaseAddress = new Uri(apiUrl.TrimEnd('/') + "/");
             client.DefaultRequestHeaders.Host = demoHost;
             client.Timeout = TimeSpan.FromMinutes(5);
+            if (!string.IsNullOrEmpty(instanceKeyHash))
+                client.DefaultRequestHeaders.Add("X-Instance-Key", instanceKeyHash);
         });
 
         // Register the API client


### PR DESCRIPTION
## Summary
- Switch composite data event sinks from `GetRequiredService` to `GetService` for Nightscout write-back sinks
- When the Nightscout connector is disabled, its write-back sinks aren't registered — using `GetRequiredService` caused 500 errors on all entry/treatment writes

## Root cause
`NightscoutConnectorInstaller.Install()` conditionally registers write-back sinks only when `Enabled = true`, but `ServiceRegistrationExtensions` unconditionally resolved them.