### PR TITLE
fix(di): resolve Nightscout connector config per-tenant, not from singleton

### DIFF
--- a/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
@@ -189,7 +189,7 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
         TConfig config;
         try
         {
-            config = await loader.LoadForTenantAsync(scope.ServiceProvider, stoppingToken);
+            config = await loader.LoadForTenantAsync(stoppingToken);
         }
         catch (InvalidOperationException ex)
         {

--- a/src/Connectors/Nocturne.Connectors.Core/Extensions/ConnectorServiceCollectionExtensions.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Extensions/ConnectorServiceCollectionExtensions.cs
@@ -124,7 +124,7 @@ public static class ConnectorServiceCollectionExtensions
                     options.DefaultServer));
 
             // Register config loader
-            services.AddSingleton<IConnectorConfigurationLoader<TConfig>, ConnectorConfigurationLoader<TConfig>>();
+            services.AddScoped<IConnectorConfigurationLoader<TConfig>, ConnectorConfigurationLoader<TConfig>>();
 
             // Register token cache (shared singleton across all connectors)
             services.TryAddSingleton<IConnectorTokenCache, ConnectorTokenCache>();
@@ -180,7 +180,7 @@ public static class ConnectorServiceCollectionExtensions
                     options.DefaultServer));
 
             // Register config loader
-            services.AddSingleton<IConnectorConfigurationLoader<TConfig>, ConnectorConfigurationLoader<TConfig>>();
+            services.AddScoped<IConnectorConfigurationLoader<TConfig>, ConnectorConfigurationLoader<TConfig>>();
 
             // Register token cache (shared singleton across all connectors)
             services.TryAddSingleton<IConnectorTokenCache, ConnectorTokenCache>();

--- a/src/Connectors/Nocturne.Connectors.Core/Interfaces/IConnectorConfigurationLoader.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Interfaces/IConnectorConfigurationLoader.cs
@@ -6,5 +6,5 @@ namespace Nocturne.Connectors.Core.Interfaces;
 /// </summary>
 public interface IConnectorConfigurationLoader<TConfig>
 {
-    Task<TConfig> LoadForTenantAsync(IServiceProvider scopeProvider, CancellationToken ct);
+    Task<TConfig> LoadForTenantAsync(CancellationToken ct);
 }

--- a/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorConfigurationLoader.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorConfigurationLoader.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
@@ -9,6 +8,7 @@ namespace Nocturne.Connectors.Core.Services;
 
 public class ConnectorConfigurationLoader<TConfig>(
     IConnectorRegistration<TConfig> registration,
+    IConnectorConfigurationService configService,
     ILogger<ConnectorConfigurationLoader<TConfig>> logger)
     : IConnectorConfigurationLoader<TConfig>
     where TConfig : BaseConnectorConfiguration, new()
@@ -18,15 +18,13 @@ public class ConnectorConfigurationLoader<TConfig>(
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
-    public async Task<TConfig> LoadForTenantAsync(IServiceProvider scopeProvider, CancellationToken ct)
+    public async Task<TConfig> LoadForTenantAsync(CancellationToken ct)
     {
         // Start from a fresh copy of the startup defaults
         var config = CloneDefaults(registration.Defaults);
 
         try
         {
-            var configService = scopeProvider.GetRequiredService<IConnectorConfigurationService>();
-
             var dbConfig = await configService.GetConfigurationAsync(registration.ConnectorName, ct);
             if (dbConfig?.Configuration != null)
                 ConnectorConfigurationBinder.ApplyJsonToConfig(dbConfig.Configuration, config);

--- a/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorSyncExecutor.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorSyncExecutor.cs
@@ -25,7 +25,7 @@ public abstract class ConnectorSyncExecutor<TService, TConfig> : IConnectorSyncE
     {
         var loader = scopeProvider.GetRequiredService<IConnectorConfigurationLoader<TConfig>>();
 
-        var config = await loader.LoadForTenantAsync(scopeProvider, ct);
+        var config = await loader.LoadForTenantAsync(ct);
 
         var service = scopeProvider.GetRequiredService<TService>();
         return await service.SyncDataAsync(request, config, ct, progressReporter);

--- a/src/Connectors/Nocturne.Connectors.Gluroo/GlurooConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Gluroo/GlurooConnectorInstaller.cs
@@ -25,7 +25,7 @@ public class GlurooConnectorInstaller : IConnectorInstaller
         // Server resolver — Gluroo URLs come from per-tenant config, not a server mapping
         services.AddSingleton<IConnectorServerResolver<GlurooConnectorConfiguration>>(
             new ConnectorServerResolver<GlurooConnectorConfiguration>(null, null, null));
-        services.AddSingleton<IConnectorConfigurationLoader<GlurooConnectorConfiguration>,
+        services.AddScoped<IConnectorConfigurationLoader<GlurooConnectorConfiguration>,
             ConnectorConfigurationLoader<GlurooConnectorConfiguration>>();
         services.TryAddSingleton<IConnectorTokenCache, ConnectorTokenCache>();
         services.TryAddSingleton<IConnectorCacheInvalidator>(sp => sp.GetRequiredService<IConnectorTokenCache>());

--- a/src/Connectors/Nocturne.Connectors.Gluroo/Services/GlurooConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Gluroo/Services/GlurooConnectorService.cs
@@ -15,9 +15,9 @@ public class GlurooConnectorService : NightscoutConnectorServiceBase<GlurooConne
         ILogger<GlurooConnectorService> logger,
         IRetryDelayStrategy retryDelayStrategy,
         IRateLimitingStrategy rateLimitingStrategy,
-        GlurooConnectorConfiguration config,
+        IConnectorRegistration<GlurooConnectorConfiguration> registration,
         IConnectorPublisher? publisher = null
-    ) : base(httpClient, serverResolver, logger, retryDelayStrategy, rateLimitingStrategy, config, publisher) { }
+    ) : base(httpClient, serverResolver, logger, retryDelayStrategy, rateLimitingStrategy, registration, publisher) { }
 
     protected override string ConnectorSource => DataSources.GlurooConnector;
     public override string ServiceName => "Gluroo Global Connect";

--- a/src/Connectors/Nocturne.Connectors.MyFitnessPal/MyFitnessPalConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.MyFitnessPal/MyFitnessPalConnectorInstaller.cs
@@ -25,7 +25,7 @@ public class MyFitnessPalConnectorInstaller : IConnectorInstaller
         // Server resolver — MyFitnessPal has a fixed URL, not a server mapping
         services.AddSingleton<IConnectorServerResolver<MyFitnessPalConnectorConfiguration>>(
             new ConnectorServerResolver<MyFitnessPalConnectorConfiguration>(null, null, null));
-        services.AddSingleton<IConnectorConfigurationLoader<MyFitnessPalConnectorConfiguration>,
+        services.AddScoped<IConnectorConfigurationLoader<MyFitnessPalConnectorConfiguration>,
             ConnectorConfigurationLoader<MyFitnessPalConnectorConfiguration>>();
         services.TryAddSingleton<IConnectorTokenCache, ConnectorTokenCache>();
         services.TryAddSingleton<IConnectorCacheInvalidator>(sp => sp.GetRequiredService<IConnectorTokenCache>());

--- a/src/Connectors/Nocturne.Connectors.MyLife/MyLifeConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/MyLifeConnectorInstaller.cs
@@ -26,7 +26,7 @@ public class MyLifeConnectorInstaller : IConnectorInstaller
         // Register server resolver, config loader, and token cache
         services.AddSingleton<IConnectorServerResolver<MyLifeConnectorConfiguration>>(
             new ConnectorServerResolver<MyLifeConnectorConfiguration>(null, null, null));
-        services.AddSingleton<IConnectorConfigurationLoader<MyLifeConnectorConfiguration>,
+        services.AddScoped<IConnectorConfigurationLoader<MyLifeConnectorConfiguration>,
             ConnectorConfigurationLoader<MyLifeConnectorConfiguration>>();
         services.TryAddSingleton<IConnectorTokenCache, ConnectorTokenCache>();
         services.TryAddSingleton<IConnectorCacheInvalidator>(sp => sp.GetRequiredService<IConnectorTokenCache>());

--- a/src/Connectors/Nocturne.Connectors.Nightscout/NightscoutConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/NightscoutConnectorInstaller.cs
@@ -20,8 +20,13 @@ public class NightscoutConnectorInstaller : IConnectorInstaller
             configuration,
             "Nightscout");
 
-        // Always register the configuration so write-back sinks can be resolved
-        // (they're referenced by ServiceRegistrationExtensions even when disabled)
+        // Direct singleton of the startup config. The connector service and write-back
+        // sinks no longer take this dependency (they go through IConnectorRegistration /
+        // IConnectorConfigurationLoader), but the compatibility proxy stack —
+        // RequestForwardingService, NightscoutTransitionController, CompatibilityController,
+        // CompatibilityProxyHealthCheck — still injects NightscoutConnectorConfiguration
+        // directly. Those should be migrated to the loader pattern as a followup, at which
+        // point this registration can be removed.
         services.AddSingleton(nightscoutConfig);
 
         if (!nightscoutConfig.Enabled)

--- a/src/Connectors/Nocturne.Connectors.Nightscout/NightscoutConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/NightscoutConnectorInstaller.cs
@@ -35,7 +35,7 @@ public class NightscoutConnectorInstaller : IConnectorInstaller
         // Server resolver — Nightscout URLs come from per-tenant config, not a server mapping
         services.AddSingleton<IConnectorServerResolver<NightscoutConnectorConfiguration>>(
             new ConnectorServerResolver<NightscoutConnectorConfiguration>(null, null, null));
-        services.AddSingleton<IConnectorConfigurationLoader<NightscoutConnectorConfiguration>,
+        services.AddScoped<IConnectorConfigurationLoader<NightscoutConnectorConfiguration>,
             ConnectorConfigurationLoader<NightscoutConnectorConfiguration>>();
         services.TryAddSingleton<IConnectorTokenCache, ConnectorTokenCache>();
         services.TryAddSingleton<IConnectorCacheInvalidator>(sp => sp.GetRequiredService<IConnectorTokenCache>());

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
@@ -15,7 +15,12 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
 {
     private readonly IRetryDelayStrategy _retryDelayStrategy;
     private readonly IRateLimitingStrategy _rateLimitingStrategy;
-    private readonly TConfig _config;
+
+    // Starts as the startup defaults (from IConnectorRegistration); replaced with the
+    // per-tenant config when AuthenticateWithConfigAsync runs at the start of a sync.
+    // Per-instance, no concurrency: connectors are resolved into a fresh DI scope per
+    // tenant sync, and SyncDataAsync is not invoked concurrently on the same instance.
+    private TConfig _currentConfig;
     private string? _apiSecretHash;
     private string? _resolvedBaseUrl;
 
@@ -25,14 +30,14 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         ILogger logger,
         IRetryDelayStrategy retryDelayStrategy,
         IRateLimitingStrategy rateLimitingStrategy,
-        TConfig config,
+        IConnectorRegistration<TConfig> registration,
         IConnectorPublisher? publisher = null
     )
         : base(httpClient, serverResolver, logger, publisher)
     {
         _retryDelayStrategy = retryDelayStrategy ?? throw new ArgumentNullException(nameof(retryDelayStrategy));
         _rateLimitingStrategy = rateLimitingStrategy ?? throw new ArgumentNullException(nameof(rateLimitingStrategy));
-        _config = config ?? throw new ArgumentNullException(nameof(config));
+        _currentConfig = registration?.Defaults ?? throw new ArgumentNullException(nameof(registration));
     }
 
     protected override string ConnectorSource => DataSources.NightscoutConnector;
@@ -55,13 +60,15 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
 
     public override async Task<bool> AuthenticateAsync()
     {
-        // Legacy no-config overload; uses the injected startup config.
+        // Legacy no-config overload; uses whatever config the service was last primed
+        // with (startup defaults until AuthenticateWithConfigAsync replaces it).
         // Per-tenant sync uses AuthenticateWithConfigAsync instead.
-        return await AuthenticateWithConfigAsync(_config);
+        return await AuthenticateWithConfigAsync(_currentConfig);
     }
 
     private async Task<bool> AuthenticateWithConfigAsync(TConfig config)
     {
+        _currentConfig = config;
         _resolvedBaseUrl = ResolveBaseUrl(config.Url);
 
         if (string.IsNullOrEmpty(config.ApiSecret))
@@ -385,7 +392,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
             allEntries.AddRange(entries);
 
             // If we got fewer than MaxCount, we've fetched everything in this range
-            if (entries.Length < _config.MaxCount)
+            if (entries.Length < _currentConfig.MaxCount)
                 break;
 
             // Find the oldest entry's date and paginate backwards
@@ -441,7 +448,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
 
             allTreatments.AddRange(treatments);
 
-            if (treatments.Length < _config.MaxCount)
+            if (treatments.Length < _currentConfig.MaxCount)
                 break;
 
             // Find the oldest treatment's created_at and paginate backwards.
@@ -516,7 +523,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
 
             allStatuses.AddRange(statuses);
 
-            if (statuses.Length < _config.MaxCount)
+            if (statuses.Length < _currentConfig.MaxCount)
                 break;
 
             var oldestDate = statuses
@@ -553,7 +560,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
     private async Task<IEnumerable<Food>> FetchFoodAsync()
     {
         var foods = await FetchDataAsync<Food[]>(
-            $"/api/v1/food.json?count={_config.MaxCount}",
+            $"/api/v1/food.json?count={_currentConfig.MaxCount}",
             "FetchFood");
 
         if (foods == null || foods.Length == 0)
@@ -589,7 +596,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
 
             allActivities.AddRange(activities);
 
-            if (activities.Length < _config.MaxCount)
+            if (activities.Length < _currentConfig.MaxCount)
                 break;
 
             var oldestDate = activities
@@ -653,7 +660,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
 
     private string BuildEntriesUrl(DateTime? from, DateTime? to)
     {
-        var url = $"/api/v1/entries.json?count={_config.MaxCount}";
+        var url = $"/api/v1/entries.json?count={_currentConfig.MaxCount}";
 
         if (from.HasValue)
         {
@@ -672,7 +679,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
 
     private string BuildTreatmentsUrl(DateTime? from, DateTime? to)
     {
-        var url = $"/api/v1/treatments.json?count={_config.MaxCount}";
+        var url = $"/api/v1/treatments.json?count={_currentConfig.MaxCount}";
 
         if (from.HasValue)
             url += $"&find[created_at][$gte]={from.Value.ToUniversalTime():o}";
@@ -685,7 +692,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
 
     private string BuildDeviceStatusUrl(DateTime? from, DateTime? to)
     {
-        var url = $"/api/v1/devicestatus.json?count={_config.MaxCount}";
+        var url = $"/api/v1/devicestatus.json?count={_currentConfig.MaxCount}";
 
         if (from.HasValue)
             url += $"&find[created_at][$gte]={from.Value.ToUniversalTime():o}";
@@ -698,7 +705,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
 
     private string BuildActivityUrl(DateTime? from, DateTime? to)
     {
-        var url = $"/api/v1/activity.json?count={_config.MaxCount}";
+        var url = $"/api/v1/activity.json?count={_currentConfig.MaxCount}";
 
         if (from.HasValue)
             url += $"&find[created_at][$gte]={from.Value.ToUniversalTime():o}";
@@ -725,7 +732,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
     {
         return new Dictionary<string, string>
         {
-            ["api-secret"] = _apiSecretHash ?? ComputeApiSecretHash(_config.ApiSecret)
+            ["api-secret"] = _apiSecretHash ?? ComputeApiSecretHash(_currentConfig.ApiSecret)
         };
     }
 
@@ -779,7 +786,7 @@ public class NightscoutConnectorService : NightscoutConnectorServiceBase<Nightsc
         ILogger<NightscoutConnectorService> logger,
         IRetryDelayStrategy retryDelayStrategy,
         IRateLimitingStrategy rateLimitingStrategy,
-        NightscoutConnectorConfiguration config,
+        IConnectorRegistration<NightscoutConnectorConfiguration> registration,
         IConnectorPublisher? publisher = null
-    ) : base(httpClient, serverResolver, logger, retryDelayStrategy, rateLimitingStrategy, config, publisher) { }
+    ) : base(httpClient, serverResolver, logger, retryDelayStrategy, rateLimitingStrategy, registration, publisher) { }
 }

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutActivityWriteBackSink.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutActivityWriteBackSink.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Nightscout.Configurations;
 using Nocturne.Core.Models;
 
@@ -9,10 +10,11 @@ namespace Nocturne.Connectors.Nightscout.Services.WriteBack;
 /// </summary>
 public class NightscoutActivityWriteBackSink(
     HttpClient httpClient,
-    NightscoutConnectorConfiguration config,
+    IConnectorConfigurationLoader<NightscoutConnectorConfiguration> configLoader,
+    IServiceProvider serviceProvider,
     NightscoutCircuitBreaker circuitBreaker,
     ILogger<NightscoutActivityWriteBackSink> logger)
-    : NightscoutWriteBackSink<Activity>(httpClient, config, circuitBreaker, logger)
+    : NightscoutWriteBackSink<Activity>(httpClient, configLoader, serviceProvider, circuitBreaker, logger)
 {
     protected override string Endpoint => "/api/v1/activity";
 }

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutActivityWriteBackSink.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutActivityWriteBackSink.cs
@@ -11,10 +11,9 @@ namespace Nocturne.Connectors.Nightscout.Services.WriteBack;
 public class NightscoutActivityWriteBackSink(
     HttpClient httpClient,
     IConnectorConfigurationLoader<NightscoutConnectorConfiguration> configLoader,
-    IServiceProvider serviceProvider,
     NightscoutCircuitBreaker circuitBreaker,
     ILogger<NightscoutActivityWriteBackSink> logger)
-    : NightscoutWriteBackSink<Activity>(httpClient, configLoader, serviceProvider, circuitBreaker, logger)
+    : NightscoutWriteBackSink<Activity>(httpClient, configLoader, circuitBreaker, logger)
 {
     protected override string Endpoint => "/api/v1/activity";
 }

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutDeviceStatusWriteBackSink.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutDeviceStatusWriteBackSink.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Nightscout.Configurations;
 using Nocturne.Core.Models;
 
@@ -9,10 +10,11 @@ namespace Nocturne.Connectors.Nightscout.Services.WriteBack;
 /// </summary>
 public class NightscoutDeviceStatusWriteBackSink(
     HttpClient httpClient,
-    NightscoutConnectorConfiguration config,
+    IConnectorConfigurationLoader<NightscoutConnectorConfiguration> configLoader,
+    IServiceProvider serviceProvider,
     NightscoutCircuitBreaker circuitBreaker,
     ILogger<NightscoutDeviceStatusWriteBackSink> logger)
-    : NightscoutWriteBackSink<DeviceStatus>(httpClient, config, circuitBreaker, logger)
+    : NightscoutWriteBackSink<DeviceStatus>(httpClient, configLoader, serviceProvider, circuitBreaker, logger)
 {
     protected override string Endpoint => "/api/v1/devicestatus";
 }

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutDeviceStatusWriteBackSink.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutDeviceStatusWriteBackSink.cs
@@ -11,10 +11,9 @@ namespace Nocturne.Connectors.Nightscout.Services.WriteBack;
 public class NightscoutDeviceStatusWriteBackSink(
     HttpClient httpClient,
     IConnectorConfigurationLoader<NightscoutConnectorConfiguration> configLoader,
-    IServiceProvider serviceProvider,
     NightscoutCircuitBreaker circuitBreaker,
     ILogger<NightscoutDeviceStatusWriteBackSink> logger)
-    : NightscoutWriteBackSink<DeviceStatus>(httpClient, configLoader, serviceProvider, circuitBreaker, logger)
+    : NightscoutWriteBackSink<DeviceStatus>(httpClient, configLoader, circuitBreaker, logger)
 {
     protected override string Endpoint => "/api/v1/devicestatus";
 }

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutEntryWriteBackSink.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutEntryWriteBackSink.cs
@@ -13,10 +13,9 @@ namespace Nocturne.Connectors.Nightscout.Services.WriteBack;
 public class NightscoutEntryWriteBackSink(
     HttpClient httpClient,
     IConnectorConfigurationLoader<NightscoutConnectorConfiguration> configLoader,
-    IServiceProvider serviceProvider,
     NightscoutCircuitBreaker circuitBreaker,
     ILogger<NightscoutEntryWriteBackSink> logger)
-    : NightscoutWriteBackSink<Entry>(httpClient, configLoader, serviceProvider, circuitBreaker, logger)
+    : NightscoutWriteBackSink<Entry>(httpClient, configLoader, circuitBreaker, logger)
 {
     protected override string Endpoint => "/api/v1/entries";
 

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutEntryWriteBackSink.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutEntryWriteBackSink.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Nightscout.Configurations;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Models;
@@ -11,10 +12,11 @@ namespace Nocturne.Connectors.Nightscout.Services.WriteBack;
 /// </summary>
 public class NightscoutEntryWriteBackSink(
     HttpClient httpClient,
-    NightscoutConnectorConfiguration config,
+    IConnectorConfigurationLoader<NightscoutConnectorConfiguration> configLoader,
+    IServiceProvider serviceProvider,
     NightscoutCircuitBreaker circuitBreaker,
     ILogger<NightscoutEntryWriteBackSink> logger)
-    : NightscoutWriteBackSink<Entry>(httpClient, config, circuitBreaker, logger)
+    : NightscoutWriteBackSink<Entry>(httpClient, configLoader, serviceProvider, circuitBreaker, logger)
 {
     protected override string Endpoint => "/api/v1/entries";
 

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutFoodWriteBackSink.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutFoodWriteBackSink.cs
@@ -11,10 +11,9 @@ namespace Nocturne.Connectors.Nightscout.Services.WriteBack;
 public class NightscoutFoodWriteBackSink(
     HttpClient httpClient,
     IConnectorConfigurationLoader<NightscoutConnectorConfiguration> configLoader,
-    IServiceProvider serviceProvider,
     NightscoutCircuitBreaker circuitBreaker,
     ILogger<NightscoutFoodWriteBackSink> logger)
-    : NightscoutWriteBackSink<Food>(httpClient, configLoader, serviceProvider, circuitBreaker, logger)
+    : NightscoutWriteBackSink<Food>(httpClient, configLoader, circuitBreaker, logger)
 {
     protected override string Endpoint => "/api/v1/food";
 }

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutFoodWriteBackSink.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutFoodWriteBackSink.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Nightscout.Configurations;
 using Nocturne.Core.Models;
 
@@ -9,10 +10,11 @@ namespace Nocturne.Connectors.Nightscout.Services.WriteBack;
 /// </summary>
 public class NightscoutFoodWriteBackSink(
     HttpClient httpClient,
-    NightscoutConnectorConfiguration config,
+    IConnectorConfigurationLoader<NightscoutConnectorConfiguration> configLoader,
+    IServiceProvider serviceProvider,
     NightscoutCircuitBreaker circuitBreaker,
     ILogger<NightscoutFoodWriteBackSink> logger)
-    : NightscoutWriteBackSink<Food>(httpClient, config, circuitBreaker, logger)
+    : NightscoutWriteBackSink<Food>(httpClient, configLoader, serviceProvider, circuitBreaker, logger)
 {
     protected override string Endpoint => "/api/v1/food";
 }

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutProfileWriteBackSink.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutProfileWriteBackSink.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Nightscout.Configurations;
 using Nocturne.Core.Models;
 
@@ -9,10 +10,11 @@ namespace Nocturne.Connectors.Nightscout.Services.WriteBack;
 /// </summary>
 public class NightscoutProfileWriteBackSink(
     HttpClient httpClient,
-    NightscoutConnectorConfiguration config,
+    IConnectorConfigurationLoader<NightscoutConnectorConfiguration> configLoader,
+    IServiceProvider serviceProvider,
     NightscoutCircuitBreaker circuitBreaker,
     ILogger<NightscoutProfileWriteBackSink> logger)
-    : NightscoutWriteBackSink<Profile>(httpClient, config, circuitBreaker, logger)
+    : NightscoutWriteBackSink<Profile>(httpClient, configLoader, serviceProvider, circuitBreaker, logger)
 {
     protected override string Endpoint => "/api/v1/profile";
 }

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutProfileWriteBackSink.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutProfileWriteBackSink.cs
@@ -11,10 +11,9 @@ namespace Nocturne.Connectors.Nightscout.Services.WriteBack;
 public class NightscoutProfileWriteBackSink(
     HttpClient httpClient,
     IConnectorConfigurationLoader<NightscoutConnectorConfiguration> configLoader,
-    IServiceProvider serviceProvider,
     NightscoutCircuitBreaker circuitBreaker,
     ILogger<NightscoutProfileWriteBackSink> logger)
-    : NightscoutWriteBackSink<Profile>(httpClient, configLoader, serviceProvider, circuitBreaker, logger)
+    : NightscoutWriteBackSink<Profile>(httpClient, configLoader, circuitBreaker, logger)
 {
     protected override string Endpoint => "/api/v1/profile";
 }

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutTreatmentWriteBackSink.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutTreatmentWriteBackSink.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Nightscout.Configurations;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Models;
@@ -11,10 +12,11 @@ namespace Nocturne.Connectors.Nightscout.Services.WriteBack;
 /// </summary>
 public class NightscoutTreatmentWriteBackSink(
     HttpClient httpClient,
-    NightscoutConnectorConfiguration config,
+    IConnectorConfigurationLoader<NightscoutConnectorConfiguration> configLoader,
+    IServiceProvider serviceProvider,
     NightscoutCircuitBreaker circuitBreaker,
     ILogger<NightscoutTreatmentWriteBackSink> logger)
-    : NightscoutWriteBackSink<Treatment>(httpClient, config, circuitBreaker, logger)
+    : NightscoutWriteBackSink<Treatment>(httpClient, configLoader, serviceProvider, circuitBreaker, logger)
 {
     protected override string Endpoint => "/api/v1/treatments";
 

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutTreatmentWriteBackSink.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutTreatmentWriteBackSink.cs
@@ -13,10 +13,9 @@ namespace Nocturne.Connectors.Nightscout.Services.WriteBack;
 public class NightscoutTreatmentWriteBackSink(
     HttpClient httpClient,
     IConnectorConfigurationLoader<NightscoutConnectorConfiguration> configLoader,
-    IServiceProvider serviceProvider,
     NightscoutCircuitBreaker circuitBreaker,
     ILogger<NightscoutTreatmentWriteBackSink> logger)
-    : NightscoutWriteBackSink<Treatment>(httpClient, configLoader, serviceProvider, circuitBreaker, logger)
+    : NightscoutWriteBackSink<Treatment>(httpClient, configLoader, circuitBreaker, logger)
 {
     protected override string Endpoint => "/api/v1/treatments";
 

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutWriteBackSink.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutWriteBackSink.cs
@@ -15,25 +15,21 @@ public abstract class NightscoutWriteBackSink<T> : IDataEventSink<T>
 {
     private readonly HttpClient _httpClient;
     private readonly IConnectorConfigurationLoader<NightscoutConnectorConfiguration> _configLoader;
-    private readonly IServiceProvider _serviceProvider;
     private readonly NightscoutCircuitBreaker _circuitBreaker;
     private readonly ILogger _logger;
 
-    // Cached per sink lifetime (which equals the request/sync scope, since sinks are
-    // resolved transiently from a scope). The loader reads per-tenant config from the
-    // DB; we don't want to repeat that for every entity write within a single request.
+    // Cached per sink instance. Sinks are transient (resolved from a scope per request),
+    // so this avoids repeated DB reads within a single request that writes multiple entities.
     private NightscoutConnectorConfiguration? _cachedConfig;
 
     protected NightscoutWriteBackSink(
         HttpClient httpClient,
         IConnectorConfigurationLoader<NightscoutConnectorConfiguration> configLoader,
-        IServiceProvider serviceProvider,
         NightscoutCircuitBreaker circuitBreaker,
         ILogger logger)
     {
         _httpClient = httpClient;
         _configLoader = configLoader;
-        _serviceProvider = serviceProvider;
         _circuitBreaker = circuitBreaker;
         _logger = logger;
     }
@@ -94,7 +90,7 @@ public abstract class NightscoutWriteBackSink<T> : IDataEventSink<T>
 
     private async Task<NightscoutConnectorConfiguration?> ResolveIfReadyAsync(CancellationToken ct)
     {
-        var config = _cachedConfig ??= await _configLoader.LoadForTenantAsync(_serviceProvider, ct);
+        var config = _cachedConfig ??= await _configLoader.LoadForTenantAsync(ct);
 
         if (!config.WriteBackEnabled)
             return null;

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutWriteBackSink.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutWriteBackSink.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
+using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Nightscout.Configurations;
 using Nocturne.Core.Contracts.Events;
 
@@ -13,18 +14,26 @@ namespace Nocturne.Connectors.Nightscout.Services.WriteBack;
 public abstract class NightscoutWriteBackSink<T> : IDataEventSink<T>
 {
     private readonly HttpClient _httpClient;
-    private readonly NightscoutConnectorConfiguration _config;
+    private readonly IConnectorConfigurationLoader<NightscoutConnectorConfiguration> _configLoader;
+    private readonly IServiceProvider _serviceProvider;
     private readonly NightscoutCircuitBreaker _circuitBreaker;
     private readonly ILogger _logger;
 
+    // Cached per sink lifetime (which equals the request/sync scope, since sinks are
+    // resolved transiently from a scope). The loader reads per-tenant config from the
+    // DB; we don't want to repeat that for every entity write within a single request.
+    private NightscoutConnectorConfiguration? _cachedConfig;
+
     protected NightscoutWriteBackSink(
         HttpClient httpClient,
-        NightscoutConnectorConfiguration config,
+        IConnectorConfigurationLoader<NightscoutConnectorConfiguration> configLoader,
+        IServiceProvider serviceProvider,
         NightscoutCircuitBreaker circuitBreaker,
         ILogger logger)
     {
         _httpClient = httpClient;
-        _config = config;
+        _configLoader = configLoader;
+        _serviceProvider = serviceProvider;
         _circuitBreaker = circuitBreaker;
         _logger = logger;
     }
@@ -41,35 +50,37 @@ public abstract class NightscoutWriteBackSink<T> : IDataEventSink<T>
 
     public async Task OnCreatedAsync(IReadOnlyList<T> items, CancellationToken ct = default)
     {
-        if (!ShouldProceed())
+        var config = await ResolveIfReadyAsync(ct);
+        if (config is null)
             return;
 
         var filtered = FilterItems(items);
         if (filtered.Count == 0)
             return;
 
-        // Batch into configured batch size
-        for (var i = 0; i < filtered.Count; i += _config.WriteBackBatchSize)
+        for (var i = 0; i < filtered.Count; i += config.WriteBackBatchSize)
         {
-            var batch = filtered.Skip(i).Take(_config.WriteBackBatchSize).ToList();
-            await SendAsync(HttpMethod.Post, Endpoint, batch, ct);
+            var batch = filtered.Skip(i).Take(config.WriteBackBatchSize).ToList();
+            await SendAsync(config, HttpMethod.Post, Endpoint, batch, ct);
         }
     }
 
     public async Task OnCreatedAsync(T item, CancellationToken ct = default)
     {
-        if (!ShouldProceed() || ShouldSkip(item))
+        var config = await ResolveIfReadyAsync(ct);
+        if (config is null || ShouldSkip(item))
             return;
 
-        await SendAsync(HttpMethod.Post, Endpoint, new[] { item }, ct);
+        await SendAsync(config, HttpMethod.Post, Endpoint, new[] { item }, ct);
     }
 
     public async Task OnUpdatedAsync(T item, CancellationToken ct = default)
     {
-        if (!ShouldProceed() || ShouldSkip(item))
+        var config = await ResolveIfReadyAsync(ct);
+        if (config is null || ShouldSkip(item))
             return;
 
-        await SendAsync(HttpMethod.Put, Endpoint, item, ct);
+        await SendAsync(config, HttpMethod.Put, Endpoint, item, ct);
     }
 
     public Task OnDeletedAsync(T? item, CancellationToken ct = default)
@@ -81,20 +92,22 @@ public abstract class NightscoutWriteBackSink<T> : IDataEventSink<T>
         return Task.CompletedTask;
     }
 
-    private bool ShouldProceed()
+    private async Task<NightscoutConnectorConfiguration?> ResolveIfReadyAsync(CancellationToken ct)
     {
-        if (!_config.WriteBackEnabled)
-            return false;
+        var config = _cachedConfig ??= await _configLoader.LoadForTenantAsync(_serviceProvider, ct);
+
+        if (!config.WriteBackEnabled)
+            return null;
 
         if (_circuitBreaker.IsOpen)
         {
             _logger.LogDebug(
                 "Nightscout write-back circuit breaker is open, skipping {Endpoint}",
                 Endpoint);
-            return false;
+            return null;
         }
 
-        return true;
+        return config;
     }
 
     private static string ResolveAbsoluteUrl(string configUrl, string endpoint)
@@ -118,6 +131,7 @@ public abstract class NightscoutWriteBackSink<T> : IDataEventSink<T>
     }
 
     private async Task SendAsync<TPayload>(
+        NightscoutConnectorConfiguration config,
         HttpMethod method,
         string endpoint,
         TPayload payload,
@@ -125,11 +139,11 @@ public abstract class NightscoutWriteBackSink<T> : IDataEventSink<T>
     {
         try
         {
-            var absoluteUrl = ResolveAbsoluteUrl(_config.Url, endpoint);
+            var absoluteUrl = ResolveAbsoluteUrl(config.Url, endpoint);
             using var request = new HttpRequestMessage(method, absoluteUrl);
             request.Headers.Add(
                 "api-secret",
-                NightscoutConnectorService.ComputeApiSecretHash(_config.ApiSecret));
+                NightscoutConnectorService.ComputeApiSecretHash(config.ApiSecret));
             request.Content = JsonContent.Create(payload);
 
             using var response = await _httpClient.SendAsync(request, ct);

--- a/src/Connectors/Nocturne.Connectors.NocturneRemote/NocturneRemoteConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.NocturneRemote/NocturneRemoteConnectorInstaller.cs
@@ -25,7 +25,7 @@ public class NocturneRemoteConnectorInstaller : IConnectorInstaller
         // Server resolver — URLs come from per-tenant config, not a server mapping
         services.AddSingleton<IConnectorServerResolver<NocturneRemoteConnectorConfiguration>>(
             new ConnectorServerResolver<NocturneRemoteConnectorConfiguration>(null, null, null));
-        services.AddSingleton<IConnectorConfigurationLoader<NocturneRemoteConnectorConfiguration>,
+        services.AddScoped<IConnectorConfigurationLoader<NocturneRemoteConnectorConfiguration>,
             ConnectorConfigurationLoader<NocturneRemoteConnectorConfiguration>>();
         services.TryAddSingleton<IConnectorTokenCache, ConnectorTokenCache>();
         services.TryAddSingleton<IConnectorCacheInvalidator>(sp => sp.GetRequiredService<IConnectorTokenCache>());

--- a/src/Web/pnpm-lock.yaml
+++ b/src/Web/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   svelte: ^5.37.0
   vite: ^6.3.5
 
-packageExtensionsChecksum: sha256-6F/1WkKxBVDJ8BZyE4tVp8Hz5H6dhFW1EHEBwWWMtEk=
+packageExtensionsChecksum: sha256-vJ0zYsojxAc/+KH1CJAifmsRxfze2q511/6WQBYHep0=
 
 importers:
 
@@ -6798,6 +6798,7 @@ snapshots:
       eventsource: 2.0.2
       fetch-cookie: 2.2.0
       node-fetch: 2.7.0(encoding@0.1.13)
+      tough-cookie: 6.0.1
       ws: 7.5.10
     transitivePeerDependencies:
       - bufferutil

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
@@ -426,7 +426,7 @@ public class ConnectorBackgroundServiceTests
     /// </summary>
     private sealed class TestConfigLoader(TestConnectorConfig config) : IConnectorConfigurationLoader<TestConnectorConfig>
     {
-        public Task<TestConnectorConfig> LoadForTenantAsync(IServiceProvider scopeProvider, CancellationToken ct)
+        public Task<TestConnectorConfig> LoadForTenantAsync(CancellationToken ct)
             => Task.FromResult(config);
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutConnectorPaginationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutConnectorPaginationTests.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Services;
 using Nocturne.Connectors.Nightscout.Configurations;
 using Nocturne.Connectors.Nightscout.Services;
 using Nocturne.Core.Models;
@@ -57,11 +58,11 @@ public class NightscoutConnectorPaginationTests
 
         return new NightscoutConnectorService(
             httpClient,
-            new Nocturne.Connectors.Core.Services.ConnectorServerResolver<NightscoutConnectorConfiguration>(null, null, null),
+            new ConnectorServerResolver<NightscoutConnectorConfiguration>(null, null, null),
             Mock.Of<ILogger<NightscoutConnectorService>>(),
             Mock.Of<IRetryDelayStrategy>(),
             Mock.Of<IRateLimitingStrategy>(),
-            config,
+            new ConnectorRegistration<NightscoutConnectorConfiguration>(config, "Nightscout"),
             publisher);
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutWriteBackSinkTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutWriteBackSinkTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Microsoft.Extensions.Logging;
+using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Nightscout.Configurations;
 using Nocturne.Connectors.Nightscout.Services.WriteBack;
 using Nocturne.Core.Constants;
@@ -34,9 +35,19 @@ public class NightscoutWriteBackSinkTests
 
         _sut = new NightscoutEntryWriteBackSink(
             httpClient,
-            _config,
+            CreateLoader(_config),
+            Mock.Of<IServiceProvider>(),
             _circuitBreaker,
             Mock.Of<ILogger<NightscoutEntryWriteBackSink>>());
+    }
+
+    private static IConnectorConfigurationLoader<NightscoutConnectorConfiguration> CreateLoader(
+        NightscoutConnectorConfiguration config)
+    {
+        var loader = new Mock<IConnectorConfigurationLoader<NightscoutConnectorConfiguration>>();
+        loader.Setup(l => l.LoadForTenantAsync(It.IsAny<IServiceProvider>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(config);
+        return loader.Object;
     }
 
     [Fact]
@@ -156,7 +167,8 @@ public class NightscoutWriteBackSinkTests
         };
         var sink = new NightscoutEntryWriteBackSink(
             httpClient,
-            _config,
+            CreateLoader(_config),
+            Mock.Of<IServiceProvider>(),
             _circuitBreaker,
             Mock.Of<ILogger<NightscoutEntryWriteBackSink>>());
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutWriteBackSinkTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutWriteBackSinkTests.cs
@@ -36,7 +36,6 @@ public class NightscoutWriteBackSinkTests
         _sut = new NightscoutEntryWriteBackSink(
             httpClient,
             CreateLoader(_config),
-            Mock.Of<IServiceProvider>(),
             _circuitBreaker,
             Mock.Of<ILogger<NightscoutEntryWriteBackSink>>());
     }
@@ -45,7 +44,7 @@ public class NightscoutWriteBackSinkTests
         NightscoutConnectorConfiguration config)
     {
         var loader = new Mock<IConnectorConfigurationLoader<NightscoutConnectorConfiguration>>();
-        loader.Setup(l => l.LoadForTenantAsync(It.IsAny<IServiceProvider>(), It.IsAny<CancellationToken>()))
+        loader.Setup(l => l.LoadForTenantAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(config);
         return loader.Object;
     }
@@ -168,7 +167,6 @@ public class NightscoutWriteBackSinkTests
         var sink = new NightscoutEntryWriteBackSink(
             httpClient,
             CreateLoader(_config),
-            Mock.Of<IServiceProvider>(),
             _circuitBreaker,
             Mock.Of<ILogger<NightscoutEntryWriteBackSink>>());
 


### PR DESCRIPTION
## Summary

- Fixes the root cause of the 500s that PR #234 worked around: write-back sinks and the connector service were injecting `NightscoutConnectorConfiguration` directly as a singleton, which holds empty startup defaults in multi-tenant prod — not the per-tenant config from the DB
- Write-back sinks now resolve config via `IConnectorConfigurationLoader<T>`, which loads per-tenant URL/secret/settings from the database
- `NightscoutConnectorServiceBase` takes `IConnectorRegistration<TConfig>` and replaces `_currentConfig` when `AuthenticateWithConfigAsync` runs, so pagination (`MaxCount`) and auth use correct per-tenant values
- Eliminates service-locator anti-pattern: `IConnectorConfigurationLoader<T>` is now scoped (not singleton), injecting `IConnectorConfigurationService` directly instead of receiving `IServiceProvider` at call time

## Impact

- Nightscout write-back correctly targets each tenant's upstream instance (URL + API secret from DB config)
- Connector sync pagination uses per-tenant `MaxCount` instead of startup defaults
- The bare `NightscoutConnectorConfiguration` singleton remains only for the compatibility proxy stack (follow-up to migrate those)
- Makes PR #234's `TryAddOptionalSink` workaround unnecessary — sink resolution no longer fails

## Test plan

- [x] `dotnet build` — 0 compilation errors
- [x] 24 relevant unit tests pass (write-back sinks, connector pagination, background service)
- [ ] After deploy: verify write-back targets correct tenant URLs in logs
- [ ] After deploy: confirm no `Unable to resolve service` errors in connector activation