### PR TITLE
fix(stats): clip overlapping TempBasals to fix 4-7x basal overcount for loop/AID users

### DIFF
--- a/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
@@ -1931,9 +1931,9 @@ public class StatisticsService : IStatisticsService
         var tempBasalInsulin = 0.0;
         var scheduledBasalInsulin = 0.0;
         var additionalBasalInsulin = 0.0;
-        foreach (var tb in tempBasals)
+        foreach (var (tb, effectiveEndMills) in ClipOverlappingTempBasals(tempBasals))
         {
-            var insulin = GetTempBasalInsulin(tb);
+            var insulin = GetTempBasalInsulin(tb, effectiveEndMills);
             if (insulin <= 0)
                 continue;
             tempBasalInsulin += insulin;
@@ -1941,8 +1941,7 @@ public class StatisticsService : IStatisticsService
             // Split into scheduled vs additional using ScheduledRate when available
             if (tb.ScheduledRate.HasValue)
             {
-                var endMills = tb.EndMills ?? tb.StartMills + (5 * 60 * 1000);
-                var durationHours = (endMills - tb.StartMills) / (1000.0 * 60 * 60);
+                var durationHours = (effectiveEndMills - tb.StartMills) / (1000.0 * 60 * 60);
                 var scheduled = tb.ScheduledRate.Value * durationHours;
                 scheduledBasalInsulin += scheduled;
                 additionalBasalInsulin += insulin - scheduled;
@@ -2011,10 +2010,10 @@ public class StatisticsService : IStatisticsService
             dailyData[dateKey] = (currentBasal, currentBolus + bolus.Insulin);
         }
 
-        // Process TempBasals
-        foreach (var tb in tempBasals)
+        // Process TempBasals — clip overlapping records (loop systems write every ~5 min with longer declared duration)
+        foreach (var (tb, effectiveEndMills) in ClipOverlappingTempBasals(tempBasals))
         {
-            var basalInsulin = GetTempBasalInsulin(tb);
+            var basalInsulin = GetTempBasalInsulin(tb, effectiveEndMills);
             if (basalInsulin <= 0)
                 continue;
 

--- a/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
@@ -2104,7 +2104,7 @@ public class StatisticsService : IStatisticsService
     )
     {
         var tz = userTimeZone ?? TimeZoneInfo.Utc;
-        var tempBasalList = tempBasals.ToList();
+        var tempBasalList = ClipOverlappingTempBasals(tempBasals);
         var dayCount = Math.Max(1, (int)Math.Ceiling((endDate - startDate).TotalDays));
 
         var allRates = new List<double>();
@@ -2118,15 +2118,16 @@ public class StatisticsService : IStatisticsService
         var hourlyRates = new List<(double Rate, long WeightMs)>[24];
         for (int h = 0; h < 24; h++) hourlyRates[h] = new();
 
-        foreach (var tb in tempBasalList)
+        foreach (var (tb, effectiveEndMills) in tempBasalList)
         {
+            // Skip zero-duration records (e.g. exact cross-source duplicates clipped to zero)
+            if (effectiveEndMills <= tb.StartMills)
+                continue;
+
             var rate = tb.Rate;
             allRates.Add(rate);
-            totalDelivered += GetTempBasalInsulin(tb);
+            totalDelivered += GetTempBasalInsulin(tb, effectiveEndMills);
 
-            // Effective interval: open-ended TempBasals fall back to a 5-min slice (matches
-            // GetTempBasalInsulin's convention), so the weight isn't zero.
-            var effectiveEndMills = tb.EndMills ?? tb.StartMills + 5 * 60_000L;
             DistributeAcrossHourOfDay(tb.StartMills, effectiveEndMills, rate, tz, hourlyRates);
 
             if (tb.Origin != TempBasalOrigin.Scheduled && tb.Origin != TempBasalOrigin.Inferred)

--- a/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
@@ -1857,12 +1857,57 @@ public class StatisticsService : IStatisticsService
     }
 
     /// <summary>
-    /// Calculate the insulin delivered (units) for a single TempBasal record.
-    /// duration = (EndMills ?? StartMills + 5 min) - StartMills, converted to hours.
+    /// Groups TempBasals by device, sorts each group by start time, and clips each record's
+    /// effective end to the next record's start within the same device group. This corrects
+    /// the over-counting that occurs with loop/AID systems (Trio, AndroidAPS, Loop) that
+    /// write a new TempBasal every ~5 minutes with a 30–120 min declared duration — each new
+    /// record cancels the previous on the pump, so only the actual inter-record window was
+    /// delivered.
     /// </summary>
-    internal static double GetTempBasalInsulin(TempBasal tb)
+    /// <remarks>
+    /// Grouping is by <c>DeviceId?.ToString() ?? Device ?? string.Empty</c> so records from
+    /// different physical devices (e.g. Tidepool history alongside Trio loop data) are clipped
+    /// independently. Records from different devices must not truncate each other.
+    ///
+    /// The last record in each device group keeps its declared end unchanged.
+    /// Zero-duration records (identical start times, or clipped to their own start) are
+    /// returned with <c>EffectiveEndMills == StartMills</c> and are discarded by the
+    /// <c>insulin &lt;= 0</c> guards in callers.
+    /// </remarks>
+    internal static IReadOnlyList<(TempBasal Tb, long EffectiveEndMills)> ClipOverlappingTempBasals(
+        IEnumerable<TempBasal> tempBasals)
     {
-        var endMills = tb.EndMills ?? tb.StartMills + (5 * 60 * 1000); // Default 5 min
+        var result = new List<(TempBasal Tb, long EffectiveEndMills)>();
+
+        var groups = tempBasals
+            .GroupBy(tb => tb.DeviceId?.ToString() ?? tb.Device ?? string.Empty);
+
+        foreach (var group in groups)
+        {
+            var sorted = group.OrderBy(tb => tb.StartMills).ToList();
+            for (int i = 0; i < sorted.Count; i++)
+            {
+                var tb = sorted[i];
+                var declaredEnd = tb.EndMills ?? tb.StartMills + (5 * 60_000L);
+                var effectiveEnd = i < sorted.Count - 1
+                    ? Math.Min(declaredEnd, sorted[i + 1].StartMills)
+                    : declaredEnd;
+                result.Add((tb, effectiveEnd));
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Calculate the insulin delivered (units) for a single TempBasal record.
+    /// When <paramref name="effectiveEndMills"/> is provided (from
+    /// <see cref="ClipOverlappingTempBasals"/>), it overrides the record's declared end.
+    /// Otherwise falls back to <c>EndMills ?? StartMills + 5 min</c>.
+    /// </summary>
+    internal static double GetTempBasalInsulin(TempBasal tb, long? effectiveEndMills = null)
+    {
+        var endMills = effectiveEndMills ?? tb.EndMills ?? tb.StartMills + (5 * 60 * 1000);
         var durationHours = (endMills - tb.StartMills) / (1000.0 * 60 * 60);
         return tb.Rate * durationHours;
     }

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceTDDTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceTDDTests.cs
@@ -639,6 +639,118 @@ public class StatisticsServiceTDDTests
 
     #endregion
 
+    #region ClipOverlappingTempBasals
+
+    [Fact]
+    public void Clip_NonOverlapping_ShouldBeUnchanged()
+    {
+        // 3 hourly records, perfectly adjacent — clip is a no-op
+        var records = new[]
+        {
+            MakeTempBasal(rate: 1.0, durationMinutes: 60, mills: Day1Mills),
+            MakeTempBasal(rate: 0.8, durationMinutes: 60, mills: Day1Mills + 3_600_000L),
+            MakeTempBasal(rate: 1.2, durationMinutes: 60, mills: Day1Mills + 7_200_000L),
+        };
+
+        var clipped = StatisticsService.ClipOverlappingTempBasals(records);
+
+        clipped.Should().HaveCount(3);
+        for (int i = 0; i < clipped.Count; i++)
+            clipped[i].EffectiveEndMills.Should().Be(records[i].EndMills!.Value,
+                $"non-overlapping record {i} should be unchanged");
+    }
+
+    [Fact]
+    public void Clip_LastRecord_ShouldUseOriginalEnd()
+    {
+        var record = MakeTempBasal(rate: 1.0, durationMinutes: 30, mills: Day1Mills);
+
+        var clipped = StatisticsService.ClipOverlappingTempBasals(new[] { record });
+
+        clipped.Should().HaveCount(1);
+        clipped[0].EffectiveEndMills.Should().Be(record.EndMills!.Value);
+    }
+
+    [Fact]
+    public void Clip_Overlapping_ShouldTruncateToNextStart()
+    {
+        // 3 records starting every 5 min, each with 30-min duration
+        var t0 = Day1Mills;
+        var t1 = Day1Mills + 5 * 60_000L;
+        var t2 = Day1Mills + 10 * 60_000L;
+        var records = new[]
+        {
+            MakeTempBasal(rate: 1.0, durationMinutes: 30, mills: t0),
+            MakeTempBasal(rate: 1.0, durationMinutes: 30, mills: t1),
+            MakeTempBasal(rate: 1.0, durationMinutes: 30, mills: t2),
+        };
+
+        var clipped = StatisticsService.ClipOverlappingTempBasals(records);
+
+        clipped.Should().HaveCount(3);
+        clipped[0].EffectiveEndMills.Should().Be(t1, "first record clipped to second's start");
+        clipped[1].EffectiveEndMills.Should().Be(t2, "second record clipped to third's start");
+        clipped[2].EffectiveEndMills.Should().Be(records[2].EndMills!.Value, "last record unchanged");
+    }
+
+    [Fact]
+    public void Clip_MultipleDeviceGroups_ShouldClipWithinGroupOnly()
+    {
+        // Device A: one 60-min record at t0
+        // Device B: one 60-min record at t0 + 5 min
+        // Device A's record must NOT be clipped by Device B's record
+        var t0 = Day1Mills;
+        var tB = Day1Mills + 5 * 60_000L;
+
+        var recordA = new TempBasal
+        {
+            StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(t0).UtcDateTime,
+            EndTimestamp   = DateTimeOffset.FromUnixTimeMilliseconds(t0 + 60 * 60_000L).UtcDateTime,
+            Rate           = 1.0,
+            Origin         = TempBasalOrigin.Algorithm,
+            Device         = "PumpA",
+        };
+        var recordB = new TempBasal
+        {
+            StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(tB).UtcDateTime,
+            EndTimestamp   = DateTimeOffset.FromUnixTimeMilliseconds(tB + 60 * 60_000L).UtcDateTime,
+            Rate           = 1.0,
+            Origin         = TempBasalOrigin.Algorithm,
+            Device         = "PumpB",
+        };
+
+        var clipped = StatisticsService.ClipOverlappingTempBasals(new[] { recordA, recordB });
+
+        clipped.Should().HaveCount(2);
+        var a = clipped.Single(c => c.Tb.Device == "PumpA");
+        var b = clipped.Single(c => c.Tb.Device == "PumpB");
+
+        a.EffectiveEndMills.Should().Be(recordA.EndMills!.Value,
+            "device A is not clipped by device B");
+        b.EffectiveEndMills.Should().Be(recordB.EndMills!.Value,
+            "device B is not clipped by device A");
+    }
+
+    [Fact]
+    public void Clip_ExactSameStart_ZeroDuration()
+    {
+        // Two records with identical start (exact cross-source duplicate)
+        var records = new[]
+        {
+            MakeTempBasal(rate: 1.0, durationMinutes: 30, mills: Day1Mills),
+            MakeTempBasal(rate: 1.0, durationMinutes: 30, mills: Day1Mills), // same device (null), same start
+        };
+
+        var clipped = StatisticsService.ClipOverlappingTempBasals(records);
+
+        clipped.Should().HaveCount(2);
+        // Whichever sorts first gets EffectiveEnd = Day1Mills (zero duration)
+        clipped.Should().Contain(c => c.EffectiveEndMills == c.Tb.StartMills,
+            "one duplicate collapses to zero duration");
+    }
+
+    #endregion
+
     #region Helper Methods
 
     private static Bolus MakeBolus(double insulin, long? mills = null, bool automatic = false)

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceTDDTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceTDDTests.cs
@@ -95,8 +95,8 @@ public class StatisticsServiceTDDTests
     {
         var tempBasals = new[]
         {
-            MakeTempBasal(rate: 1.0, durationMinutes: 30, mills: Day1Mills), // 0.5U
-            MakeTempBasal(rate: 0.8, durationMinutes: 60, mills: Day1Mills), // 0.8U
+            MakeTempBasal(rate: 1.0, durationMinutes: 30, mills: Day1Mills),                       // 0.5U
+            MakeTempBasal(rate: 0.8, durationMinutes: 60, mills: Day1Mills + 30 * 60_000L), // 0.8U
         };
 
         var result = _sut.CalculateInsulinDeliveryStatistics(
@@ -274,6 +274,58 @@ public class StatisticsServiceTDDTests
         delivery.TotalBasal.Should().BeGreaterThan(0);
         delivery.BolusCount.Should().Be(11, "3 meals + 8 SMBs = 11 boluses");
     }
+
+    #region LoopSystem Overlap
+
+    [Fact]
+    public void LoopSystem_OverlappingTempBasals_ShouldClipToActualDelivery()
+    {
+        // Trio pattern: 12 records at 1.0 U/hr, 30-min declared duration, every 5 min.
+        // Naive:  12 × 0.5 hr × 1.0 = 6.0 U.
+        // Clipped: 11 × (5/60) hr × 1.0 + 1 × 0.5 hr × 1.0 = 0.917 + 0.5 = 1.417 U
+        //          (last record keeps its declared 30-min end — see Task 4 follow-up bug)
+        var tempBasals = Enumerable.Range(0, 12)
+            .Select(i => MakeTempBasal(
+                rate: 1.0,
+                durationMinutes: 30,
+                mills: Day1Mills + i * 5 * 60_000L))
+            .ToArray();
+
+        var delivery = _sut.CalculateInsulinDeliveryStatistics(
+            Array.Empty<Bolus>(), Array.Empty<Bolus>(), tempBasals,
+            Array.Empty<CarbIntake>(), StartDate, EndDate);
+
+        var ratios = _sut.CalculateDailyBasalBolusRatios(
+            Array.Empty<Bolus>(), Array.Empty<Bolus>(), tempBasals);
+
+        delivery.TotalBasal.Should().BeApproximately(1.417, 0.01,
+            "11 clipped to 5-min windows + last record at full 30 min = 1.417 U, not 6.0 U (naive)");
+        ratios.DailyData.Sum(d => d.Basal).Should().BeApproximately(1.417, 0.01,
+            "daily ratios should also use clipped durations");
+    }
+
+    [Fact]
+    public void LoopSystem_VaryingRates_ShouldUseEachRecordsOwnRate()
+    {
+        // Alternating 0.5 and 2.0 U/hr, every 5 min, 30-min declared duration.
+        // Last record (index 11) is 2.0 U/hr and keeps its declared 30-min end.
+        // Clipped: 6 × 0.5 × (5/60) + 5 × 2.0 × (5/60) + 1 × 2.0 × 0.5 = 0.25 + 0.833 + 1.0 = 2.083 U
+        var tempBasals = Enumerable.Range(0, 12)
+            .Select(i => MakeTempBasal(
+                rate: i % 2 == 0 ? 0.5 : 2.0,
+                durationMinutes: 30,
+                mills: Day1Mills + i * 5 * 60_000L))
+            .ToArray();
+
+        var delivery = _sut.CalculateInsulinDeliveryStatistics(
+            Array.Empty<Bolus>(), Array.Empty<Bolus>(), tempBasals,
+            Array.Empty<CarbIntake>(), StartDate, EndDate);
+
+        delivery.TotalBasal.Should().BeApproximately(2.083, 0.01,
+            "each clipped window uses its own record's rate; naive would be 7.5 U");
+    }
+
+    #endregion
 
     [Fact]
     public void RealisticPattern_Omnipod_BolusOnlyTreatments_ShouldReportBolusCorrectly()


### PR DESCRIPTION
## Summary

- Loop/AID systems (Trio, AndroidAPS, Loop) write a new TempBasal every ~5 min with a 30–120 min declared duration. Each new record cancels the previous on the pump, so the naive `rate × declared_duration` sum overcounted by 4–7× for affected users (e.g. 33.1 U calculated vs ~7.2 U actual for one Trio user).
- Adds `ClipOverlappingTempBasals` static helper in `StatisticsService` that groups records by device, sorts by start time, and clips each record's effective end to the next record's start within the same device group.
- Wires clipping into all three calculation paths: `CalculateInsulinDeliveryStatistics`, `CalculateDailyBasalBolusRatios`, and `CalculateBasalAnalysis`.

## Test Plan

- [x] 5 unit tests for `ClipOverlappingTempBasals` covering non-overlapping, single record, overlapping, multi-device isolation, and zero-duration (exact duplicate) cases
- [x] 2 regression tests: `LoopSystem_OverlappingTempBasals_ShouldClipToActualDelivery` and `LoopSystem_VaryingRates_ShouldUseEachRecordsOwnRate`
- [x] Full unit test suite: 3131 passed, 0 new failures
- [ ] Verify defiantt1d on production after deploy — basal TDD should be ~12 U/day, not ~33+ U/day

## Follow-up

nightscout/nocturne#237 — last record in each device group still uses its declared end rather than `min(declaredEnd, endDateMills)`, causing a small tail overcount per query. Independent of this fix.