### PR TITLE
Change default alarm title/favicon flash duration from 500ms to 1s

### DIFF
--- a/src/Core/Nocturne.Core.Models/Configuration/AlarmProfileConfiguration.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/AlarmProfileConfiguration.cs
@@ -292,7 +292,7 @@ public class AlarmVisualSettings
     /// Flash frequency in milliseconds
     /// </summary>
     [JsonPropertyName("flashIntervalMs")]
-    public int FlashIntervalMs { get; set; } = 500;
+    public int FlashIntervalMs { get; set; } = 2000;
 
     /// <summary>
     /// Whether to show a persistent banner until acknowledged

--- a/src/Core/Nocturne.Core.Models/Configuration/AlarmProfileConfiguration.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/AlarmProfileConfiguration.cs
@@ -292,7 +292,7 @@ public class AlarmVisualSettings
     /// Flash frequency in milliseconds
     /// </summary>
     [JsonPropertyName("flashIntervalMs")]
-    public int FlashIntervalMs { get; set; } = 2000;
+    public int FlashIntervalMs { get; set; } = 1000;
 
     /// <summary>
     /// Whether to show a persistent banner until acknowledged

--- a/src/Web/packages/app/src/lib/services/title-favicon-service.svelte.ts
+++ b/src/Web/packages/app/src/lib/services/title-favicon-service.svelte.ts
@@ -166,7 +166,7 @@ export class TitleFaviconService {
     this.flashInterval = setInterval(() => {
       this.isFlashOn = !this.isFlashOn;
       this.applyFlashState();
-    }, visualSettings.flashIntervalMs || 500);
+    }, visualSettings.flashIntervalMs || 2000);
 
     // Apply initial flash state
     this.applyFlashState();

--- a/src/Web/packages/app/src/lib/services/title-favicon-service.svelte.ts
+++ b/src/Web/packages/app/src/lib/services/title-favicon-service.svelte.ts
@@ -166,7 +166,7 @@ export class TitleFaviconService {
     this.flashInterval = setInterval(() => {
       this.isFlashOn = !this.isFlashOn;
       this.applyFlashState();
-    }, visualSettings.flashIntervalMs || 2000);
+    }, visualSettings.flashIntervalMs || 1000);
 
     // Apply initial flash state
     this.applyFlashState();

--- a/src/Web/packages/app/src/lib/types/alarm-profile.ts
+++ b/src/Web/packages/app/src/lib/types/alarm-profile.ts
@@ -424,7 +424,7 @@ export function createDefaultAlarmProfile(
     visual: {
       screenFlash: type === "UrgentHigh" || type === "UrgentLow",
       flashColor: defaults.flashColor,
-      flashIntervalMs: 500,
+      flashIntervalMs: 2000,
       persistentBanner: true,
       wakeScreen: true,
       showEmergencyContacts: type === "UrgentHigh" || type === "UrgentLow",

--- a/src/Web/packages/app/src/lib/types/alarm-profile.ts
+++ b/src/Web/packages/app/src/lib/types/alarm-profile.ts
@@ -424,7 +424,7 @@ export function createDefaultAlarmProfile(
     visual: {
       screenFlash: type === "UrgentHigh" || type === "UrgentLow",
       flashColor: defaults.flashColor,
-      flashIntervalMs: 2000,
+      flashIntervalMs: 1000,
       persistentBanner: true,
       wakeScreen: true,
       showEmergencyContacts: type === "UrgentHigh" || type === "UrgentLow",

--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
@@ -187,7 +187,7 @@
           const alarmVisual: AlarmVisualSettings = {
             screenFlash: true,
             flashColor: "",
-            flashIntervalMs: 2000,
+            flashIntervalMs: 1000,
             persistentBanner: true,
             wakeScreen: true,
             showEmergencyContacts: false,

--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
@@ -187,7 +187,7 @@
           const alarmVisual: AlarmVisualSettings = {
             screenFlash: true,
             flashColor: "",
-            flashIntervalMs: 500,
+            flashIntervalMs: 2000,
             persistentBanner: true,
             wakeScreen: true,
             showEmergencyContacts: false,


### PR DESCRIPTION
The previous 500ms cadence made the tab title and favicon flicker twice per second during HIGH/LOW alarms, which was IMO too aggressive as a default given that it seems to occur regardless of whether the tab is focused or not. Let me know if you disagree.