### PR TITLE
fix(web): defer remote-function .run() calls out of render context

### DIFF
--- a/src/Web/packages/app/src/lib/components/dashboard/halo-dial/HaloDial.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/halo-dial/HaloDial.svelte
@@ -105,14 +105,18 @@
       return;
     }
     let active = true;
-    getPredictions({})
-      .run()
-      .then((data) => {
-        if (active) predictions = data;
-      })
-      .catch(() => {
-        if (active) predictions = null;
-      });
+    // Defer out of render context — `.run()` rejects when called during render.
+    queueMicrotask(() => {
+      if (!active) return;
+      getPredictions({})
+        .run()
+        .then((data) => {
+          if (active) predictions = data;
+        })
+        .catch(() => {
+          if (active) predictions = null;
+        });
+    });
     return () => {
       active = false;
     };

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/year-overview/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/year-overview/+page.svelte
@@ -21,7 +21,7 @@
   import { getUnitLabel } from "$lib/utils/formatting";
   import { glucoseUnits } from "$lib/stores/appearance-store.svelte";
   import { getDateParamsContext } from "$lib/hooks/date-params.svelte";
-  import { untrack, tick } from "svelte";
+  import { onMount, untrack, tick } from "svelte";
   import { fade } from "svelte/transition";
 
   const reportsParams = getDateParamsContext();
@@ -433,14 +433,9 @@
   // Lifecycle
   // =========================================================================
 
-  $effect(() => {
-    if (browser && !metadataLoaded && !metadataLoading) {
-      loadMetadata();
-    }
-  });
-
-  $effect(() => {
-    if (metadataLoaded && sortedYears.length > 0) {
+  onMount(async () => {
+    await loadMetadata();
+    if (sortedYears.length > 0) {
       loadYearData(sortedYears[0]);
     }
   });
@@ -463,7 +458,7 @@
     const prevKey = [...prevDataSources].sort().join(",");
     if (currentKey !== prevKey && metadataLoaded) {
       prevDataSources = [...selectedDataSources];
-      clearAndReload();
+      queueMicrotask(() => clearAndReload());
     }
   });
 


### PR DESCRIPTION
Calling .run() on a remote function during render is rejected by the
SvelteKit runtime. When the rejection lands inside an $effect with a
loading/loaded gate, the gate prematurely clears and the effect re-fires,
producing effect_update_depth_exceeded on /reports/year-overview.

- year-overview/+page.svelte: convert the metadata + initial-year
  bootstrap effects into a single onMount; defer the data-source filter
  refetch with queueMicrotask so its .run() fires after render commits.
- halo-dial/HaloDial.svelte: wrap the predictions .run() chain in
  queueMicrotask, preserving the active-flag cancellation. Predictions
  were silently failing to load.

Matches the precedent in auth-store.svelte.ts:138.


—

NOTE i have not tested this yet, i can spin it up on my test instance tomorrow if you want