### PR TITLE
fix(portal): teal-dominant hero, orange Every accent, mobile chip fit

### DIFF
--- a/src/Web/packages/portal/src/lib/components/AuroraCanvas.svelte
+++ b/src/Web/packages/portal/src/lib/components/AuroraCanvas.svelte
@@ -23,8 +23,8 @@ uniform float u_t;
 uniform float u_intensity;
 
 const vec3 C_VLOW  = vec3(0.835, 0.149, 0.192);
-const vec3 C_LOW   = vec3(0.851, 0.455, 0.255);
-const vec3 C_IN    = vec3(0.165, 0.608, 0.608);
+const vec3 C_LOW   = vec3(0.165, 0.608, 0.608);
+const vec3 C_IN    = vec3(0.851, 0.455, 0.255);
 const vec3 C_TIGHT = vec3(0.298, 0.722, 0.420);
 const vec3 C_HIGH  = vec3(0.357, 0.435, 0.902);
 const vec3 C_BG    = vec3(0.039, 0.047, 0.071);

--- a/src/Web/packages/portal/src/lib/components/AuroraPool.svelte
+++ b/src/Web/packages/portal/src/lib/components/AuroraPool.svelte
@@ -494,17 +494,17 @@
   onpointermove={onPointerMove}
   onpointerup={onPointerUp}
 >
-  <!-- Mobile: static chip wrap (unchanged from original) -->
-  <div class="md:hidden absolute top-16 left-0 right-0 px-5">
-    <div class="flex flex-wrap gap-1.5 justify-center">
+  <!-- Mobile: static chip wrap -->
+  <div class="md:hidden absolute top-[72px] left-0 right-0 px-4">
+    <div class="flex flex-wrap gap-x-1.5 gap-y-2 justify-center">
       {#each CHIP_DEFS as def}
         <div
-          class="flex items-center gap-1.5 bg-[oklch(0.10_0.028_261/85%)] border border-[oklch(1_0_0/20%)] rounded-full py-1 pr-2.5 pl-1 backdrop-blur-sm"
+          class="flex items-center gap-1.5 bg-[oklch(0.10_0.028_261/85%)] border border-[oklch(1_0_0/20%)] rounded-full py-0.5 pr-2 pl-0.5 backdrop-blur-sm max-w-full"
         >
           <img
             src="/logos/{def.file}"
             alt=""
-            class="size-4 rounded object-cover"
+            class="size-3.5 rounded object-cover shrink-0"
           />
           <span class="text-[10px] font-semibold text-white whitespace-nowrap"
             >{def.name}</span

--- a/src/Web/packages/portal/src/routes/+page.svelte
+++ b/src/Web/packages/portal/src/routes/+page.svelte
@@ -91,12 +91,12 @@
             <span class="inline-flex items-center gap-2 font-mono text-[11px] tracking-[0.16em] uppercase text-[oklch(0.7_0.01_261)]">
                 <span class="eyebrow-dot size-1.5 rounded-full shrink-0 bg-glucose-in-range"></span>The new Nightscout API
             </span>
-            <h1 class="flex flex-col items-center text-[clamp(2.5rem,7vw,4.8rem)] font-bold leading-[1.06] tracking-[-0.025em] text-[oklch(0.97_0.005_261)] m-0 [text-shadow:0_2px_40px_oklch(0_0_0_/_60%)]">
+            <h1 class="flex flex-col items-center text-[clamp(2.5rem,7vw,4.8rem)] font-bold leading-[1.06] tracking-[-0.025em] text-[oklch(0.97_0.005_261)] m-0 [text-shadow:0_2px_8px_oklch(0_0_0_/_70%),0_4px_40px_oklch(0_0_0_/_80%)]">
                 <span>Every reading.</span>
-                <span><em class="text-glucose-in-range">Every</em> source.</span>
+                <span><em class="text-glucose-low">Every</em> source.</span>
                 <span>One dashboard.</span>
             </h1>
-            <p class="text-[1.05rem] leading-[1.65] text-[oklch(0.74_0.015_261)] max-w-[540px] m-0 [text-shadow:0_1px_20px_oklch(0_0_0_/_50%)]">
+            <p class="text-[1.05rem] leading-[1.65] text-[oklch(0.92_0.01_261)] max-w-[540px] m-0 [text-shadow:0_1px_3px_oklch(0_0_0_/_85%),0_2px_24px_oklch(0_0_0_/_70%)]">
                 Nocturne pulls every CGM, pump, and tracker you use into a single
                 self-hosted dashboard. Fast, multitenant, real-time, and built by
                 the diabetes community.


### PR DESCRIPTION
Swap C_LOW and C_IN in the aurora shader so the dominant noise band
renders teal instead of orange. Recolor the Every word to orange
(text-glucose-low) to keep an accent contrast on the now-teal field.

Mobile hero chips: add explicit row gap, tighten chip padding/icon
size, and reduce horizontal container padding so FreeStyle Libre,
Nightscout, and Tandem fit on one row without overlap on a 393px
viewport. Strengthen hero heading and body text shadows and brighten
body copy lightness to keep text readable over the aurora.