### PR TITLE
perf(chart-data): build TherapyTimeline once per request, not twice

### DIFF
--- a/src/API/Nocturne.API/Services/Analytics/ChartDataService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/ChartDataService.cs
@@ -34,6 +34,7 @@ public class ChartDataService : IChartDataService
     private readonly ITempBasalRepository _tempBasalRepository;
     private readonly ITherapySettingsResolver _therapySettingsResolver;
     private readonly IBasalRateResolver _basalRateResolver;
+    private readonly ITherapyTimelineResolver _therapyTimelineResolver;
     private readonly ILogger<ChartDataService> _logger;
 
     /// <summary>
@@ -45,6 +46,7 @@ public class ChartDataService : IChartDataService
     /// <param name="tempBasalRepository">Repository for fetching temp basal records.</param>
     /// <param name="therapySettingsResolver">Resolves whether therapy settings (profile) data exists.</param>
     /// <param name="basalRateResolver">Resolves the active basal rate at a point in time.</param>
+    /// <param name="therapyTimelineResolver">Builds the therapy timeline that <see cref="IBasalSeriesBuilder"/> consumes.</param>
     /// <param name="logger">The logger instance.</param>
     public ChartDataService(
         IEnumerable<IChartDataStage> pipeline,
@@ -53,6 +55,7 @@ public class ChartDataService : IChartDataService
         ITempBasalRepository tempBasalRepository,
         ITherapySettingsResolver therapySettingsResolver,
         IBasalRateResolver basalRateResolver,
+        ITherapyTimelineResolver therapyTimelineResolver,
         ILogger<ChartDataService> logger
     )
     {
@@ -62,6 +65,7 @@ public class ChartDataService : IChartDataService
         _tempBasalRepository = tempBasalRepository;
         _therapySettingsResolver = therapySettingsResolver;
         _basalRateResolver = basalRateResolver;
+        _therapyTimelineResolver = therapyTimelineResolver;
         _logger = logger;
     }
 
@@ -113,11 +117,18 @@ public class ChartDataService : IChartDataService
             ct: cancellationToken
         )).ToList();
 
+        var timeline = await _therapyTimelineResolver.BuildAsync(
+            startTime,
+            endTime + 1,
+            ct: cancellationToken
+        );
+
         return await _basalSeriesBuilder.BuildAsync(
             tempBasals,
             startTime,
             endTime,
             defaultBasalRate,
+            timeline,
             cancellationToken
         );
     }

--- a/src/API/Nocturne.API/Services/ChartData/BasalSeriesBuilder.cs
+++ b/src/API/Nocturne.API/Services/ChartData/BasalSeriesBuilder.cs
@@ -16,7 +16,6 @@ namespace Nocturne.API.Services.ChartData;
 /// </summary>
 internal sealed class BasalSeriesBuilder(
     ITherapySettingsResolver therapySettingsResolver,
-    ITherapyTimelineResolver therapyTimelineResolver,
     ILogger<BasalSeriesBuilder> logger
 ) : IBasalSeriesBuilder
 {
@@ -25,11 +24,10 @@ internal sealed class BasalSeriesBuilder(
         long startTime,
         long endTime,
         double defaultBasalRate,
+        TherapyTimeline timeline,
         CancellationToken ct = default
     )
     {
-        // Build once — reused by both gap-fill and profile-only paths to avoid per-tick resolver round-trips.
-        var timeline = await therapyTimelineResolver.BuildAsync(startTime, endTime + 1, ct: ct);
         var hasData = await therapySettingsResolver.HasDataAsync(ct);
 
         var series = new List<BasalPoint>();

--- a/src/API/Nocturne.API/Services/ChartData/Stages/IobCobComputeStage.cs
+++ b/src/API/Nocturne.API/Services/ChartData/Stages/IobCobComputeStage.cs
@@ -69,14 +69,15 @@ internal sealed class IobCobComputeStage(
         var intervalMinutes = context.IntervalMinutes;
         var defaultBasalRate = context.DefaultBasalRate;
 
-        // Build once — reused by both IOB/COB and basal series to avoid per-tick resolver round-trips.
+        // Build once, then thread through both IOB/COB and the basal series so the resolver
+        // is hit a single time per chart-data request.
         var timeline = await therapyTimelineResolver.BuildAsync(startTime, endTime + 1, ct: cancellationToken);
 
         var (iobSeries, cobSeries, maxIob, maxCob) = BuildIobCobSeries(
             bolusList, carbIntakeList, startTime, endTime, intervalMinutes, tempBasalList, timeline, cancellationToken
         );
 
-        var basalSeries = await basalSeriesBuilder.BuildAsync(tempBasalList, startTime, endTime, defaultBasalRate, cancellationToken);
+        var basalSeries = await basalSeriesBuilder.BuildAsync(tempBasalList, startTime, endTime, defaultBasalRate, timeline, cancellationToken);
 
         var maxBasalRate = Math.Max(
             defaultBasalRate * 2.5,

--- a/src/Core/Nocturne.Core.Contracts/Analytics/IBasalSeriesBuilder.cs
+++ b/src/Core/Nocturne.Core.Contracts/Analytics/IBasalSeriesBuilder.cs
@@ -18,12 +18,18 @@ public interface IBasalSeriesBuilder
     /// <param name="startTime">Start of the time range in Unix milliseconds</param>
     /// <param name="endTime">End of the time range in Unix milliseconds</param>
     /// <param name="defaultBasalRate">Fallback basal rate when no profile data exists</param>
+    /// <param name="timeline">
+    /// Pre-built therapy timeline covering at least <c>[startTime, endTime + 1)</c>. Threaded in
+    /// from the caller so the resolver is hit once per chart-data request instead of once per
+    /// consumer.
+    /// </param>
     /// <param name="ct">Cancellation token</param>
     Task<List<BasalPoint>> BuildAsync(
         List<TempBasal> tempBasals,
         long startTime,
         long endTime,
         double defaultBasalRate,
+        TherapyTimeline timeline,
         CancellationToken ct = default
     );
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/ChartData/BasalSeriesBuilderTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ChartData/BasalSeriesBuilderTests.cs
@@ -1,5 +1,8 @@
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 using Nocturne.API.Services.ChartData;
+using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
 using Xunit;
@@ -40,5 +43,53 @@ public class BasalSeriesBuilderTests
         // Assert: rate comes from the timeline's basal schedule entry (1.2 U/hr), not the default
         result.Should().NotBeEmpty();
         result.Should().AllSatisfy(p => p.Rate.Should().BeApproximately(1.2, 0.001));
+    }
+
+    /// <summary>
+    /// The caller (e.g. IobCobComputeStage) builds a TherapyTimeline once and passes it
+    /// into BuildAsync. The builder must use that supplied timeline rather than calling
+    /// the resolver again — both for performance and to guarantee the basal series sees
+    /// the same therapy state as IOB/COB.
+    /// </summary>
+    [Fact]
+    public async Task BuildAsync_UsesSuppliedTimeline()
+    {
+        var startTime = TestMills;
+        var endTime = TestMills + 30 * 60 * 1000;
+        const double defaultBasalRate = 1.0;
+
+        var suppliedTimeline = new TherapyTimeline(new[]
+        {
+            new TherapySegment(startTime, endTime + 1,
+                new TherapySnapshot(
+                    dia: 3.0,
+                    peakMinutes: TherapySnapshot.DefaultPeakMinutes,
+                    carbsPerHour: TherapySnapshot.DefaultCarbsPerHour,
+                    timezone: null,
+                    ccpPercentage: null,
+                    ccpTimeshiftMs: 0,
+                    sensitivityEntries: null,
+                    carbRatioEntries: null,
+                    basalEntries: [new ScheduleEntry { TimeAsSeconds = 0, Value = 1.7 }]))
+        });
+
+        var therapySettings = new Mock<ITherapySettingsResolver>();
+        therapySettings.Setup(s => s.HasDataAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        var builder = new BasalSeriesBuilder(
+            therapySettings.Object,
+            NullLogger<BasalSeriesBuilder>.Instance);
+
+        var result = await builder.BuildAsync(
+            tempBasals: [],
+            startTime,
+            endTime,
+            defaultBasalRate,
+            suppliedTimeline,
+            CancellationToken.None);
+
+        // Output is driven by the supplied timeline's 1.7 U/hr schedule entry, not the default.
+        result.Should().NotBeEmpty();
+        result.Should().AllSatisfy(p => p.Rate.Should().BeApproximately(1.7, 0.001));
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/ChartData/Stages/IobCobComputeStageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ChartData/Stages/IobCobComputeStageTests.cs
@@ -34,8 +34,9 @@ public class IobCobComputeStageTests
                 It.IsAny<long>(),
                 It.IsAny<long>(),
                 It.IsAny<double>(),
+                It.IsAny<TherapyTimeline>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync((List<TempBasal> _, long start, long _, double rate, CancellationToken _) =>
+            .ReturnsAsync((List<TempBasal> _, long start, long _, double rate, TherapyTimeline _, CancellationToken _) =>
                 new List<BasalPoint>
                 {
                     new()


### PR DESCRIPTION
## Summary

- `IobCobComputeStage` built a `TherapyTimeline` at the top of `ExecuteAsync` with a "build once" comment, but `BasalSeriesBuilder.BuildAsync` then silently called the resolver again — defeating half the optimization the comment claimed.
- Thread the timeline through `IBasalSeriesBuilder.BuildAsync` as a parameter. `BasalSeriesBuilder` no longer depends on `ITherapyTimelineResolver`. The second caller (`ChartDataService.GetBasalSeriesAsync`) now builds the timeline locally before delegating.
- Fixes the duplicate-build bug flagged in a recent review of the chart-data pipeline.

## Test plan

- [x] `dotnet test tests/Unit/Nocturne.API.Tests/Nocturne.API.Tests.csproj -p:GenerateNSwagClient=false` — 3133 passing, only the pre-existing `DocumentProcessingServiceTests.ProcessDocuments_MemoryUsageBenchmarks` memory benchmark failure remains (unrelated).
- [x] New `BuildAsync_UsesSuppliedTimeline` parity test verifies the builder honours the caller-supplied timeline (1.7 U/hr schedule) instead of falling back to the default or re-resolving.