### PR TITLE
feat(glooko): emit Profile state_span from device-settings sync

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoProfileMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoProfileMapper.cs
@@ -82,7 +82,7 @@ public class GlookoProfileMapper
 
             for (var i = 0; i < ordered.Count; i++)
             {
-                var (key, parsed, settings) = ordered[i];
+                var (_, parsed, settings) = ordered[i];
                 var profileName = settings.BasalSettings?.ActiveBasalProgram;
                 if (string.IsNullOrWhiteSpace(profileName))
                     continue;

--- a/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoProfileMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoProfileMapper.cs
@@ -59,6 +59,74 @@ public class GlookoProfileMapper
         return profiles;
     }
 
+    /// <summary>
+    ///     Emits a Profile state_span per device per settings snapshot, derived from
+    ///     <c>BasalSettings.ActiveBasalProgram</c>. Consecutive snapshots produce abutting spans;
+    ///     the most recent snapshot's span is open-ended. Snapshots with a null/empty active program
+    ///     are skipped (the next snapshot's timestamp still closes the prior span).
+    /// </summary>
+    public List<StateSpan> TransformDeviceSettingsToStateSpans(GlookoV3DeviceSettingsResponse response)
+    {
+        var stateSpans = new List<StateSpan>();
+
+        if (response.DeviceSettings?.Pumps == null)
+            return stateSpans;
+
+        foreach (var (deviceGuid, settingsSnapshots) in response.DeviceSettings.Pumps)
+        {
+            var ordered = settingsSnapshots
+                .Select(kv => (Key: kv.Key, Parsed: TryParseTimestamp(kv.Key), Settings: kv.Value))
+                .Where(x => x.Parsed.HasValue)
+                .OrderBy(x => x.Parsed!.Value)
+                .ToList();
+
+            for (var i = 0; i < ordered.Count; i++)
+            {
+                var (key, parsed, settings) = ordered[i];
+                var profileName = settings.BasalSettings?.ActiveBasalProgram;
+                if (string.IsNullOrWhiteSpace(profileName))
+                    continue;
+
+                var startTimestamp = parsed!.Value;
+                DateTime? endTimestamp = i < ordered.Count - 1 ? ordered[i + 1].Parsed : null;
+                var startMills = new DateTimeOffset(startTimestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
+
+                stateSpans.Add(new StateSpan
+                {
+                    OriginalId = $"glooko_active_profile_{deviceGuid}_{startMills}",
+                    Category = StateSpanCategory.Profile,
+                    State = ProfileState.Active.ToString(),
+                    StartTimestamp = startTimestamp,
+                    EndTimestamp = endTimestamp,
+                    Source = _connectorSource,
+                    Metadata = new Dictionary<string, object>
+                    {
+                        { "profileName", profileName }
+                    }
+                });
+            }
+        }
+
+        _logger.LogInformation(
+            "[{ConnectorSource}] Transformed {Count} profile state spans from device settings",
+            _connectorSource,
+            stateSpans.Count
+        );
+
+        return stateSpans;
+    }
+
+    private static DateTime? TryParseTimestamp(string timestamp)
+    {
+        if (string.IsNullOrWhiteSpace(timestamp))
+            return null;
+        return DateTime.TryParse(
+            timestamp,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.RoundtripKind,
+            out var parsed) ? parsed : null;
+    }
+
     private Profile? MapSettingsToProfile(GlookoV3PumpSettings settings, string timestamp)
     {
         if (settings.PumpProfilesBasal == null && settings.ProfilesBolus == null)

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -353,6 +353,14 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                             _logger.LogInformation("[{ConnectorSource}] Published {Count} profiles from device settings",
                                 ConnectorSource, profiles.Count);
                         }
+
+                        var profileStateSpans = _profileMapper.TransformDeviceSettingsToStateSpans(deviceSettings);
+                        if (profileStateSpans.Count > 0)
+                        {
+                            await PublishStateSpanDataAsync(profileStateSpans, config, cancellationToken);
+                            _logger.LogInformation("[{ConnectorSource}] Published {Count} profile state spans from device settings",
+                                ConnectorSource, profileStateSpans.Count);
+                        }
                     }
                 }
                 catch (Exception profileEx)

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Mappers/GlookoProfileMapperStateSpanTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Mappers/GlookoProfileMapperStateSpanTests.cs
@@ -1,0 +1,200 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Nocturne.Connectors.Glooko.Mappers;
+using Nocturne.Connectors.Glooko.Models;
+using Nocturne.Core.Models;
+using Xunit;
+
+namespace Nocturne.Connectors.Glooko.Tests.Mappers;
+
+public class GlookoProfileMapperStateSpanTests
+{
+    private const string ConnectorSource = "glooko-connector";
+    private readonly GlookoProfileMapper _mapper;
+
+    public GlookoProfileMapperStateSpanTests()
+    {
+        _mapper = new GlookoProfileMapper(ConnectorSource, Mock.Of<ILogger>());
+    }
+
+    private static GlookoV3DeviceSettingsResponse Build(
+        params (string DeviceGuid, (string Timestamp, string? ActiveBasalProgram)[] Snapshots)[] devices)
+    {
+        var pumps = new Dictionary<string, Dictionary<string, GlookoV3PumpSettings>>();
+        foreach (var (deviceGuid, snapshots) in devices)
+        {
+            var byTs = new Dictionary<string, GlookoV3PumpSettings>();
+            foreach (var (ts, program) in snapshots)
+            {
+                byTs[ts] = new GlookoV3PumpSettings
+                {
+                    SyncTimestamp = ts,
+                    BasalSettings = new GlookoV3BasalSettings
+                    {
+                        ActiveBasalProgram = program
+                    }
+                };
+            }
+            pumps[deviceGuid] = byTs;
+        }
+
+        return new GlookoV3DeviceSettingsResponse
+        {
+            DeviceSettings = new GlookoV3DeviceSettings { Pumps = pumps }
+        };
+    }
+
+    [Fact]
+    public void TransformDeviceSettingsToStateSpans_SingleSnapshotWithProgram_EmitsOpenEndedSpan()
+    {
+        var response = Build(
+            ("device-1", [("2026-04-01T10:00:00Z", "A")])
+        );
+
+        var spans = _mapper.TransformDeviceSettingsToStateSpans(response);
+
+        spans.Should().HaveCount(1);
+        var span = spans[0];
+        span.Category.Should().Be(StateSpanCategory.Profile);
+        span.State.Should().Be(ProfileState.Active.ToString());
+        span.Source.Should().Be(ConnectorSource);
+        span.StartTimestamp.Should().Be(new DateTime(2026, 4, 1, 10, 0, 0, DateTimeKind.Utc));
+        span.EndTimestamp.Should().BeNull();
+        span.Metadata.Should().ContainKey("profileName")
+            .WhoseValue.Should().Be("A");
+        span.OriginalId.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void TransformDeviceSettingsToStateSpans_MultipleSnapshots_EmitsAbuttingSpansWithLastOpenEnded()
+    {
+        var response = Build(
+            ("device-1",
+            [
+                ("2026-04-01T10:00:00Z", "A"),
+                ("2026-04-02T10:00:00Z", "B"),
+                ("2026-04-03T10:00:00Z", "A"),
+            ])
+        );
+
+        var spans = _mapper.TransformDeviceSettingsToStateSpans(response)
+            .OrderBy(s => s.StartTimestamp)
+            .ToList();
+
+        spans.Should().HaveCount(3);
+
+        spans[0].StartTimestamp.Should().Be(new DateTime(2026, 4, 1, 10, 0, 0, DateTimeKind.Utc));
+        spans[0].EndTimestamp.Should().Be(new DateTime(2026, 4, 2, 10, 0, 0, DateTimeKind.Utc));
+        spans[0].Metadata!["profileName"].Should().Be("A");
+
+        spans[1].StartTimestamp.Should().Be(new DateTime(2026, 4, 2, 10, 0, 0, DateTimeKind.Utc));
+        spans[1].EndTimestamp.Should().Be(new DateTime(2026, 4, 3, 10, 0, 0, DateTimeKind.Utc));
+        spans[1].Metadata!["profileName"].Should().Be("B");
+
+        spans[2].StartTimestamp.Should().Be(new DateTime(2026, 4, 3, 10, 0, 0, DateTimeKind.Utc));
+        spans[2].EndTimestamp.Should().BeNull();
+        spans[2].Metadata!["profileName"].Should().Be("A");
+    }
+
+    [Fact]
+    public void TransformDeviceSettingsToStateSpans_SnapshotsArrivingOutOfOrder_AreSortedChronologically()
+    {
+        var response = Build(
+            ("device-1",
+            [
+                ("2026-04-03T10:00:00Z", "C"),
+                ("2026-04-01T10:00:00Z", "A"),
+                ("2026-04-02T10:00:00Z", "B"),
+            ])
+        );
+
+        var spans = _mapper.TransformDeviceSettingsToStateSpans(response)
+            .OrderBy(s => s.StartTimestamp)
+            .ToList();
+
+        spans.Should().HaveCount(3);
+        spans[0].EndTimestamp.Should().Be(spans[1].StartTimestamp);
+        spans[1].EndTimestamp.Should().Be(spans[2].StartTimestamp);
+        spans[2].EndTimestamp.Should().BeNull();
+    }
+
+    [Fact]
+    public void TransformDeviceSettingsToStateSpans_NullOrEmptyActiveBasalProgram_SkipsSpan()
+    {
+        var response = Build(
+            ("device-1",
+            [
+                ("2026-04-01T10:00:00Z", "A"),
+                ("2026-04-02T10:00:00Z", null),
+                ("2026-04-03T10:00:00Z", ""),
+            ])
+        );
+
+        var spans = _mapper.TransformDeviceSettingsToStateSpans(response);
+
+        spans.Should().HaveCount(1);
+        spans[0].Metadata!["profileName"].Should().Be("A");
+        spans[0].EndTimestamp.Should().Be(new DateTime(2026, 4, 2, 10, 0, 0, DateTimeKind.Utc),
+            because: "the next snapshot's timestamp closes the prior span even when its program is null");
+    }
+
+    [Fact]
+    public void TransformDeviceSettingsToStateSpans_MultipleDevices_EmitsIndependentSpansPerDevice()
+    {
+        var response = Build(
+            ("device-1",
+            [
+                ("2026-04-01T10:00:00Z", "A"),
+                ("2026-04-02T10:00:00Z", "B"),
+            ]),
+            ("device-2",
+            [
+                ("2026-04-01T10:00:00Z", "X"),
+            ])
+        );
+
+        var spans = _mapper.TransformDeviceSettingsToStateSpans(response);
+
+        spans.Should().HaveCount(3);
+
+        var device1Spans = spans.Where(s => s.OriginalId!.Contains("device-1")).ToList();
+        device1Spans.Should().HaveCount(2);
+        device1Spans.Select(s => s.Metadata!["profileName"]).Should().BeEquivalentTo(new object[] { "A", "B" });
+
+        var device2Spans = spans.Where(s => s.OriginalId!.Contains("device-2")).ToList();
+        device2Spans.Should().HaveCount(1);
+        device2Spans[0].Metadata!["profileName"].Should().Be("X");
+        device2Spans[0].EndTimestamp.Should().BeNull();
+    }
+
+    [Fact]
+    public void TransformDeviceSettingsToStateSpans_OriginalIdsAreStableAcrossRuns()
+    {
+        var response = Build(
+            ("device-1",
+            [
+                ("2026-04-01T10:00:00Z", "A"),
+                ("2026-04-02T10:00:00Z", "B"),
+            ])
+        );
+
+        var first = _mapper.TransformDeviceSettingsToStateSpans(response)
+            .Select(s => s.OriginalId).OrderBy(id => id).ToList();
+        var second = _mapper.TransformDeviceSettingsToStateSpans(response)
+            .Select(s => s.OriginalId).OrderBy(id => id).ToList();
+
+        first.Should().Equal(second);
+        first.Should().OnlyHaveUniqueItems();
+    }
+
+    [Fact]
+    public void TransformDeviceSettingsToStateSpans_NullPumps_ReturnsEmpty()
+    {
+        var response = new GlookoV3DeviceSettingsResponse { DeviceSettings = null };
+
+        var spans = _mapper.TransformDeviceSettingsToStateSpans(response);
+
+        spans.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `GlookoProfileMapper.TransformDeviceSettingsToStateSpans`, which emits a `Profile` state_span per pump per settings snapshot from `BasalSettings.ActiveBasalProgram`. Consecutive snapshots produce abutting spans; the most recent is open-ended. Snapshots with null/empty `ActiveBasalProgram` are skipped (the next snapshot still closes the prior span). `OriginalId` is stable per device + start mills so re-sync upserts cleanly.
- Wires it into `GlookoConnectorService.PerformSyncInternalAsync` alongside the existing profile publish, so a single device-settings fetch yields both `Profile` objects and matching active-profile state_spans.

## Why

`ActiveProfileResolver.GetActiveProfileNameAsync` returns `null` for users whose pump never explicitly switches profiles, because the only writer of `state_spans WHERE category = 'Profile'` is `GlookoStateSpanMapper.TransformV3ToStateSpans`, which iterates Glooko's v3 `series.ProfileChange` — empty for users on a single program. Callers fall back to the literal `"Default"`, which usually doesn't match any `basal_schedules.profile_name`, so `BasalRateResolver` returns hardcoded `1.0 U/hr`.

Production confirmation: a Tandem Control-IQ tenant with `BasalSettings.ActiveBasalProgram = "A"` and `basal_schedules` for profile `A` (0.41 U/hr) had every chart datapoint resolved against the `1.0` fallback. The active program name is already available in the device-settings snapshot — this PR just propagates it to a state_span the resolver can read.

## Implementation notes

- Lives on `GlookoProfileMapper` (not `GlookoStateSpanMapper`) since the input is `GlookoV3DeviceSettingsResponse`, not `GlookoV3GraphResponse`, and the mapper already reads `ActiveBasalProgram` for `DefaultProfile` selection.
- Mirrors the existing `ProfileChange` template in `GlookoStateSpanMapper.cs` (category, state, metadata `{ profileName }`, source).
- Multi-device safe — spans are keyed by device GUID via the `OriginalId`.
- Idempotent — `MetadataPublisher.PublishStateSpansAsync` upserts by `OriginalId`.

## Test plan

- [x] Unit tests added in `GlookoProfileMapperStateSpanTests` (7 tests):
  - Single snapshot with program → open-ended span
  - Three snapshots → abutting spans, last open-ended
  - Out-of-order keys sorted chronologically
  - Null/empty `ActiveBasalProgram` skipped, prior span still closed
  - Two devices → independent spans keyed by device GUID
  - Stable `OriginalId` across runs
  - Null `Pumps` → empty
- [x] `dotnet test tests/Unit/Nocturne.Connectors.Glooko.Tests` — 15/15 pass.
- [ ] Production verification on Glooko-Tandem tenant after deploy (see below).

## Production verification (post-deploy)

After deploying, on tenant `019dce87-06a9-76f0-96c0-c9d745602b16`:

```sql
SELECT set_config('app.current_tenant_id', '019dce87-06a9-76f0-96c0-c9d745602b16', false);
SELECT COUNT(*) FROM state_spans WHERE category = 'Profile';  -- expect > 0
SELECT origin, MIN(scheduled_rate), MAX(scheduled_rate)
FROM temp_basals
WHERE deleted_at IS NULL AND data_source = 'glooko-connector'
GROUP BY origin;
-- expect scheduled_rate ~0.41 (programmed Tandem rate), not 1.0
```

Re-trigger Glooko sync (note: hits the dedup-vs-replace gap from PR #223 caveat #3 — may need to SQL-purge `temp_basals WHERE data_source = 'glooko-connector'` first):

```bash
curl -sS -X POST "https://<host>/api/v4/services/connectors/glooko/sync" \
  -H "X-Instance-Key: $NOCTURNE_INSTANCE_KEY" \
  -H "Content-Type: application/json" -d "{}"
```

## Out of scope

- Dedup-vs-replace gap in `TempBasalRepository.BulkCreateAsync` (separate issue).
- Extending `MapTempBasalSpans` to emit overlay bands for `Origin == Algorithm` (separate UX call).
- Other connectors (MyLife, Nightscout, etc.) that may have the same "active program known, never written as state_span" gap — to investigate separately.

Background: PR #223.