### PR TITLE
feat(mylife): emit Profile state_span from pump-settings sync

### DIFF
--- a/src/Connectors/Nocturne.Connectors.MyLife/Mappers/MyLifePumpSettingsMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Mappers/MyLifePumpSettingsMapper.cs
@@ -62,6 +62,62 @@ internal static class MyLifePumpSettingsMapper
         return profiles;
     }
 
+    /// <summary>
+    /// Maps MyLife pump settings readouts to Profile state_spans tracking the active basal program
+    /// over time. Readouts are grouped by device serial number and sorted chronologically;
+    /// consecutive readouts produce abutting spans, with the most recent left open-ended.
+    /// Readouts with a null/empty ActiveBasalProgramName are skipped (the next readout still
+    /// closes the prior span).
+    /// </summary>
+    internal static List<StateSpan> MapToStateSpans(
+        IReadOnlyList<MyLifePumpSettingsReadout> readouts,
+        string connectorSource)
+    {
+        var stateSpans = new List<StateSpan>();
+
+        var byDevice = readouts.GroupBy(r => r.DeviceSerialNumber ?? string.Empty);
+
+        foreach (var device in byDevice)
+        {
+            var ordered = device.OrderBy(r => r.UploadDateTime).ToList();
+
+            for (var i = 0; i < ordered.Count; i++)
+            {
+                var readout = ordered[i];
+                var profileName = readout.ActiveBasalProgramName;
+                if (string.IsNullOrWhiteSpace(profileName))
+                    continue;
+
+                var startMills = MyLifeMapperHelpers.ToUnixMilliseconds(readout.UploadDateTime);
+                var startTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(startMills).UtcDateTime;
+
+                DateTime? endTimestamp = null;
+                if (i < ordered.Count - 1)
+                {
+                    var nextMills = MyLifeMapperHelpers.ToUnixMilliseconds(ordered[i + 1].UploadDateTime);
+                    endTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(nextMills).UtcDateTime;
+                }
+
+                var deviceKey = string.IsNullOrEmpty(device.Key) ? "unknown" : device.Key;
+                stateSpans.Add(new StateSpan
+                {
+                    OriginalId = $"mylife_active_profile_{deviceKey}_{startMills}",
+                    Category = StateSpanCategory.Profile,
+                    State = ProfileState.Active.ToString(),
+                    StartTimestamp = startTimestamp,
+                    EndTimestamp = endTimestamp,
+                    Source = connectorSource,
+                    Metadata = new Dictionary<string, object>
+                    {
+                        { "profileName", profileName }
+                    }
+                });
+            }
+        }
+
+        return stateSpans;
+    }
+
     private static List<TimeValue> MapBasalEntries(List<MyLifeBasalProgramEntry>? entries)
     {
         if (entries == null || entries.Count == 0)

--- a/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
@@ -67,9 +67,10 @@ public class MyLifeConnectorService(
     }
 
     /// <summary>
-    /// Fetches pump settings from MyLife and maps them to Profile records.
+    /// Fetches pump settings readouts from MyLife. Returns an empty list when no valid session
+    /// is established.
     /// </summary>
-    public async Task<IEnumerable<Profile>> FetchPumpSettingsProfileAsync(
+    private async Task<IReadOnlyList<MyLifePumpSettingsReadout>> FetchPumpSettingsReadoutsAsync(
         CancellationToken cancellationToken)
     {
         var session = sessionCache.Get(tenantAccessor.TenantId);
@@ -81,13 +82,21 @@ public class MyLifeConnectorService(
             return [];
         }
 
-        var readouts = await syncService.FetchPumpSettingsAsync(
+        return await syncService.FetchPumpSettingsAsync(
             session.ServiceUrl,
             session.AuthToken,
             session.PatientId,
             cancellationToken
         );
+    }
 
+    /// <summary>
+    /// Fetches pump settings from MyLife and maps them to Profile records.
+    /// </summary>
+    public async Task<IEnumerable<Profile>> FetchPumpSettingsProfileAsync(
+        CancellationToken cancellationToken)
+    {
+        var readouts = await FetchPumpSettingsReadoutsAsync(cancellationToken);
         return MyLifePumpSettingsMapper.MapToProfiles(readouts);
     }
 
@@ -255,12 +264,24 @@ public class MyLifeConnectorService(
                 UpdatePreviousTail(previousTail, batch.Events, overlapMs);
             }
 
-            // Publish Profile records from pump settings (separate SOAP call)
+            // Publish Profile records and active-profile state spans from pump settings
+            // (one SOAP call, two derived data shapes).
             if (activeTypes.Contains(SyncDataType.Profiles))
             {
-                var profiles = (await FetchPumpSettingsProfileAsync(cancellationToken)).ToList();
+                var readouts = await FetchPumpSettingsReadoutsAsync(cancellationToken);
+
+                var profiles = MyLifePumpSettingsMapper.MapToProfiles(readouts);
                 await PublishRecordTypeAsync(result, SyncDataType.Profiles, activeTypes,
                     profiles, PublishProfileDataAsync, config, cancellationToken);
+
+                var profileStateSpans = MyLifePumpSettingsMapper.MapToStateSpans(readouts, ConnectorSource);
+                if (profileStateSpans.Count > 0)
+                {
+                    await PublishStateSpanDataAsync(profileStateSpans, config, cancellationToken);
+                    _logger.LogInformation(
+                        "Published {Count} profile state spans from pump settings",
+                        profileStateSpans.Count);
+                }
             }
         }
         catch (Exception ex)

--- a/tests/Unit/Nocturne.Connectors.MyLife.Tests/Mappers/MyLifePumpSettingsMapperStateSpanTests.cs
+++ b/tests/Unit/Nocturne.Connectors.MyLife.Tests/Mappers/MyLifePumpSettingsMapperStateSpanTests.cs
@@ -1,0 +1,175 @@
+using FluentAssertions;
+using Nocturne.Connectors.MyLife.Mappers;
+using Nocturne.Connectors.MyLife.Models;
+using Nocturne.Core.Models;
+using Xunit;
+
+namespace Nocturne.Connectors.MyLife.Tests.Mappers;
+
+public class MyLifePumpSettingsMapperStateSpanTests
+{
+    private const string ConnectorSource = "mylife-connector";
+
+    private static long Ticks(int year, int month, int day, int hour = 0, int minute = 0)
+    {
+        var mills = new DateTimeOffset(year, month, day, hour, minute, 0, TimeSpan.Zero).ToUnixTimeMilliseconds();
+        return mills * 10_000;
+    }
+
+    private static MyLifePumpSettingsReadout Readout(
+        string id,
+        long uploadTicks,
+        string? activeBasalProgramName,
+        string? deviceSerialNumber = "SN-1")
+    {
+        return new MyLifePumpSettingsReadout
+        {
+            Id = id,
+            UploadDateTime = uploadTicks,
+            ActiveBasalProgramName = activeBasalProgramName,
+            DeviceSerialNumber = deviceSerialNumber,
+        };
+    }
+
+    [Fact]
+    public void MapToStateSpans_SingleReadoutWithProgram_EmitsOpenEndedSpan()
+    {
+        var readouts = new[]
+        {
+            Readout("r1", Ticks(2026, 4, 1, 10), "Morning"),
+        };
+
+        var spans = MyLifePumpSettingsMapper.MapToStateSpans(readouts, ConnectorSource);
+
+        spans.Should().HaveCount(1);
+        var span = spans[0];
+        span.Category.Should().Be(StateSpanCategory.Profile);
+        span.State.Should().Be(ProfileState.Active.ToString());
+        span.Source.Should().Be(ConnectorSource);
+        span.StartTimestamp.Should().Be(new DateTime(2026, 4, 1, 10, 0, 0, DateTimeKind.Utc));
+        span.EndTimestamp.Should().BeNull();
+        span.Metadata.Should().ContainKey("profileName")
+            .WhoseValue.Should().Be("Morning");
+        span.OriginalId.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void MapToStateSpans_MultipleReadouts_EmitsAbuttingSpansWithLastOpenEnded()
+    {
+        var readouts = new[]
+        {
+            Readout("r1", Ticks(2026, 4, 1, 10), "A"),
+            Readout("r2", Ticks(2026, 4, 2, 10), "B"),
+            Readout("r3", Ticks(2026, 4, 3, 10), "A"),
+        };
+
+        var spans = MyLifePumpSettingsMapper.MapToStateSpans(readouts, ConnectorSource)
+            .OrderBy(s => s.StartTimestamp)
+            .ToList();
+
+        spans.Should().HaveCount(3);
+
+        spans[0].StartTimestamp.Should().Be(new DateTime(2026, 4, 1, 10, 0, 0, DateTimeKind.Utc));
+        spans[0].EndTimestamp.Should().Be(new DateTime(2026, 4, 2, 10, 0, 0, DateTimeKind.Utc));
+        spans[0].Metadata!["profileName"].Should().Be("A");
+
+        spans[1].StartTimestamp.Should().Be(new DateTime(2026, 4, 2, 10, 0, 0, DateTimeKind.Utc));
+        spans[1].EndTimestamp.Should().Be(new DateTime(2026, 4, 3, 10, 0, 0, DateTimeKind.Utc));
+        spans[1].Metadata!["profileName"].Should().Be("B");
+
+        spans[2].StartTimestamp.Should().Be(new DateTime(2026, 4, 3, 10, 0, 0, DateTimeKind.Utc));
+        spans[2].EndTimestamp.Should().BeNull();
+        spans[2].Metadata!["profileName"].Should().Be("A");
+    }
+
+    [Fact]
+    public void MapToStateSpans_ReadoutsArrivingOutOfOrder_AreSortedChronologically()
+    {
+        var readouts = new[]
+        {
+            Readout("r3", Ticks(2026, 4, 3, 10), "C"),
+            Readout("r1", Ticks(2026, 4, 1, 10), "A"),
+            Readout("r2", Ticks(2026, 4, 2, 10), "B"),
+        };
+
+        var spans = MyLifePumpSettingsMapper.MapToStateSpans(readouts, ConnectorSource)
+            .OrderBy(s => s.StartTimestamp)
+            .ToList();
+
+        spans.Should().HaveCount(3);
+        spans[0].EndTimestamp.Should().Be(spans[1].StartTimestamp);
+        spans[1].EndTimestamp.Should().Be(spans[2].StartTimestamp);
+        spans[2].EndTimestamp.Should().BeNull();
+    }
+
+    [Fact]
+    public void MapToStateSpans_NullOrEmptyActiveBasalProgram_SkipsSpan()
+    {
+        var readouts = new[]
+        {
+            Readout("r1", Ticks(2026, 4, 1, 10), "A"),
+            Readout("r2", Ticks(2026, 4, 2, 10), null),
+            Readout("r3", Ticks(2026, 4, 3, 10), ""),
+        };
+
+        var spans = MyLifePumpSettingsMapper.MapToStateSpans(readouts, ConnectorSource);
+
+        spans.Should().HaveCount(1);
+        spans[0].Metadata!["profileName"].Should().Be("A");
+        spans[0].EndTimestamp.Should().Be(
+            new DateTime(2026, 4, 2, 10, 0, 0, DateTimeKind.Utc),
+            because: "the next readout's timestamp closes the prior span even when its program is null");
+    }
+
+    [Fact]
+    public void MapToStateSpans_MultipleDevices_EmitsIndependentSpansPerDevice()
+    {
+        var readouts = new[]
+        {
+            Readout("r1", Ticks(2026, 4, 1, 10), "A", deviceSerialNumber: "SN-1"),
+            Readout("r2", Ticks(2026, 4, 2, 10), "B", deviceSerialNumber: "SN-1"),
+            Readout("r3", Ticks(2026, 4, 1, 10), "X", deviceSerialNumber: "SN-2"),
+        };
+
+        var spans = MyLifePumpSettingsMapper.MapToStateSpans(readouts, ConnectorSource);
+
+        spans.Should().HaveCount(3);
+
+        var sn1 = spans.Where(s => s.OriginalId!.Contains("SN-1"))
+            .OrderBy(s => s.StartTimestamp).ToList();
+        sn1.Should().HaveCount(2);
+        sn1[0].EndTimestamp.Should().Be(sn1[1].StartTimestamp);
+        sn1[1].EndTimestamp.Should().BeNull();
+
+        var sn2 = spans.Where(s => s.OriginalId!.Contains("SN-2")).ToList();
+        sn2.Should().HaveCount(1);
+        sn2[0].Metadata!["profileName"].Should().Be("X");
+        sn2[0].EndTimestamp.Should().BeNull();
+    }
+
+    [Fact]
+    public void MapToStateSpans_OriginalIdsAreStableAcrossRuns()
+    {
+        var readouts = new[]
+        {
+            Readout("r1", Ticks(2026, 4, 1, 10), "A"),
+            Readout("r2", Ticks(2026, 4, 2, 10), "B"),
+        };
+
+        var first = MyLifePumpSettingsMapper.MapToStateSpans(readouts, ConnectorSource)
+            .Select(s => s.OriginalId).OrderBy(id => id).ToList();
+        var second = MyLifePumpSettingsMapper.MapToStateSpans(readouts, ConnectorSource)
+            .Select(s => s.OriginalId).OrderBy(id => id).ToList();
+
+        first.Should().Equal(second);
+        first.Should().OnlyHaveUniqueItems();
+    }
+
+    [Fact]
+    public void MapToStateSpans_EmptyList_ReturnsEmpty()
+    {
+        var spans = MyLifePumpSettingsMapper.MapToStateSpans(Array.Empty<MyLifePumpSettingsReadout>(), ConnectorSource);
+
+        spans.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds \`MyLifePumpSettingsMapper.MapToStateSpans\`, which groups pump-settings readouts by \`DeviceSerialNumber\` and emits one \`Profile\` state_span per readout from \`ActiveBasalProgramName\`. Consecutive readouts within a device produce abutting spans; the most recent is open-ended. Null/empty \`ActiveBasalProgramName\` is skipped (the next readout still closes the prior span). \`OriginalId\` is stable per device + start mills so re-sync upserts cleanly.
- Refactors \`MyLifeConnectorService\` to share a single pump-settings fetch (\`FetchPumpSettingsReadoutsAsync\`) between profile records and the new state_spans, so the SOAP call isn't doubled.

## Why

Same gap that #244 fixed for Glooko. \`MyLifePumpSettingsMapper.MapToProfiles\` (\`src/Connectors/Nocturne.Connectors.MyLife/Mappers/MyLifePumpSettingsMapper.cs:43-46\`) reads \`ActiveBasalProgramName\` and stores it on \`Profile.DefaultProfile\`, but no Profile-category \`StateSpan\` is ever emitted. \`ActiveProfileResolver.GetActiveProfileNameAsync\` (\`src/API/Nocturne.API/Services/Profiles/Resolvers/ActiveProfileResolver.cs:104-107\`) therefore returns \`null\` for MyLife users whose pump never explicitly switches programs, callers fall back to the literal \`\"Default\"\`, and \`BasalRateResolver\` returns hardcoded \`1.0 U/hr\`.

This PR mirrors #244's approach for MyLife.

## Test plan

- [x] Unit tests added in \`MyLifePumpSettingsMapperStateSpanTests\` (7 tests):
  - Single readout with program → open-ended span
  - Three readouts → abutting spans, last open-ended
  - Out-of-order readouts sorted chronologically
  - Null/empty \`ActiveBasalProgramName\` skipped, prior span still closed
  - Two devices → independent spans keyed by \`DeviceSerialNumber\`
  - Stable \`OriginalId\` across runs
  - Empty list → empty
- [x] \`dotnet test tests/Unit/Nocturne.Connectors.MyLife.Tests\` — 29/29 pass (7 new + 22 pre-existing).
- [ ] Production verification on a MyLife tenant after deploy — confirm \`state_spans WHERE category = 'Profile' AND source = 'mylife-connector'\` count > 0, and that \`temp_basals.scheduled_rate\` resolves to the programmed basal rather than the 1.0 fallback.

## Out of scope

- Same caveat as #244: re-syncing against tenants with pre-existing soft-deleted \`temp_basals\` may need a SQL purge first, due to the dedup-vs-replace gap tracked in #245.

## Related

- #244 (Glooko equivalent)
- #245 (temp_basals dedup gap)