### PR TITLE
fix(web): cap onboarding-check API call and allow through on failure

### DIFF
--- a/src/Web/packages/app/src/lib/server/onboarding-check.test.ts
+++ b/src/Web/packages/app/src/lib/server/onboarding-check.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Cookies } from "@sveltejs/kit";
+import { checkOnboarding } from "./onboarding-check";
+
+function createCookies(initial: Record<string, string> = {}): {
+  cookies: Cookies;
+  store: Map<string, string>;
+} {
+  const store = new Map(Object.entries(initial));
+  const cookies = {
+    get: (name: string) => store.get(name),
+    set: (name: string, value: string) => {
+      store.set(name, value);
+    },
+    delete: (name: string) => {
+      store.delete(name);
+    },
+  } as unknown as Cookies;
+  return { cookies, store };
+}
+
+describe("checkOnboarding", () => {
+  it("returns isComplete: true from the cookie fast path without calling the API", async () => {
+    const { cookies } = createCookies({ "nocturne-setup-complete": "true" });
+    const getAuthStatus = vi.fn();
+
+    const result = await checkOnboarding(
+      cookies,
+      { passkey: { getAuthStatus } },
+      true,
+    );
+
+    expect(result).toEqual({ isComplete: true });
+    expect(getAuthStatus).not.toHaveBeenCalled();
+  });
+
+  it("returns isComplete: true and re-sets the cookie when the API confirms completion", async () => {
+    const { cookies, store } = createCookies();
+    const getAuthStatus = vi
+      .fn()
+      .mockResolvedValue({ onboardingCompleted: true });
+
+    const result = await checkOnboarding(
+      cookies,
+      { passkey: { getAuthStatus } },
+      true,
+    );
+
+    expect(result).toEqual({ isComplete: true });
+    expect(store.get("nocturne-setup-complete")).toBe("true");
+  });
+
+  it("returns isComplete: false when the API explicitly says onboarding is not done", async () => {
+    const { cookies, store } = createCookies();
+    const getAuthStatus = vi
+      .fn()
+      .mockResolvedValue({ onboardingCompleted: false });
+
+    const result = await checkOnboarding(
+      cookies,
+      { passkey: { getAuthStatus } },
+      true,
+    );
+
+    expect(result).toEqual({ isComplete: false });
+    expect(store.has("nocturne-setup-complete")).toBe(false);
+  });
+
+  it("passes an AbortSignal so a hung API can't block the load function (regression for #dashboard-hang)", async () => {
+    const { cookies } = createCookies();
+    const getAuthStatus = vi
+      .fn()
+      .mockResolvedValue({ onboardingCompleted: true });
+
+    await checkOnboarding(cookies, { passkey: { getAuthStatus } }, true);
+
+    expect(getAuthStatus).toHaveBeenCalledTimes(1);
+    const signal = getAuthStatus.mock.calls[0][0];
+    expect(signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("returns isComplete: true on API failure to avoid trapping users in a redirect loop", async () => {
+    const { cookies } = createCookies();
+    const getAuthStatus = vi.fn().mockRejectedValue(new Error("network down"));
+
+    const result = await checkOnboarding(
+      cookies,
+      { passkey: { getAuthStatus } },
+      true,
+    );
+
+    expect(result).toEqual({ isComplete: true });
+  });
+
+  it("returns isComplete: true when the request aborts (timeout)", async () => {
+    const { cookies } = createCookies();
+    const getAuthStatus = vi.fn().mockImplementation(
+      (signal?: AbortSignal) =>
+        new Promise((_resolve, reject) => {
+          signal?.addEventListener("abort", () =>
+            reject(new DOMException("aborted", "AbortError")),
+          );
+        }),
+    );
+
+    const result = await checkOnboarding(
+      cookies,
+      { passkey: { getAuthStatus } },
+      true,
+    );
+
+    expect(result).toEqual({ isComplete: true });
+  }, 10_000);
+});

--- a/src/Web/packages/app/src/lib/server/onboarding-check.ts
+++ b/src/Web/packages/app/src/lib/server/onboarding-check.ts
@@ -22,9 +22,11 @@ export async function checkOnboarding(
     return { isComplete: true };
   }
 
-  // Slow path — ask the API
+  // Slow path — ask the API. Bound the wait so a hung backend can't block the
+  // server-side load function indefinitely (which would leave the browser
+  // spinning forever on the root layout).
   try {
-    const status = await apiClient.passkey.getAuthStatus();
+    const status = await apiClient.passkey.getAuthStatus(AbortSignal.timeout(5000));
     if (status?.onboardingCompleted) {
       // Self-heal: re-set the cookie so subsequent loads are fast
       cookies.set(COOKIE_NAME, "true", {
@@ -36,11 +38,14 @@ export async function checkOnboarding(
       });
       return { isComplete: true };
     }
+    return { isComplete: false };
   } catch {
-    // API unreachable — allow through to avoid blocking authenticated users
+    // API unreachable or timed out — allow through rather than trapping users
+    // in a redirect loop. The setup layout invalidates this cookie on entry,
+    // so falling through to /setup here would just re-trigger the slow path
+    // on the next navigation.
+    return { isComplete: true };
   }
-
-  return { isComplete: false };
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the dashboard hanging indefinitely on first load when no `nocturne-setup-complete` cookie is present (fresh browser, incognito, returning user with an expired 30-day cookie).

Two bugs in `src/Web/packages/app/src/lib/server/onboarding-check.ts`:

- **No timeout on `getAuthStatus()`** — the call was awaited without an `AbortSignal`, even though the signature accepts one. When the backend hung, the SvelteKit server-side `load` blocked forever and the browser spun on a blank page.
- **Catch block contradicted its own comment** — the comment said "allow through to avoid blocking authenticated users", but `return { isComplete: false }` ran unconditionally after the try/catch, causing `(authenticated)/+layout.server.ts` to `redirect(303, "/setup")`. The setup layout then called `invalidateOnboardingCache()`, deleting the cookie so the next visit to `/` repeated the whole cycle.

Changes:
- Pass `AbortSignal.timeout(5000)` so the wait is bounded.
- Move `return { isComplete: false }` into the `try`, only reached when the API explicitly says onboarding isn't done.
- Return `isComplete: true` from the `catch` so a slow/dead API lets users through (matches the stated intent).

## Test plan

Added `onboarding-check.test.ts` covering:
- [x] Cookie fast path returns `isComplete: true` without touching the API
- [x] API returning `onboardingCompleted: true` sets the cookie and returns complete
- [x] API returning `onboardingCompleted: false` returns not-complete and does not set the cookie
- [x] An `AbortSignal` is passed to `getAuthStatus` (regression for the hang)
- [x] API rejection returns `isComplete: true` (no redirect loop)
- [x] Aborted request returns `isComplete: true`

Local `pnpm install` was blocked by file locks from running dev processes, so tests will run in CI. Manual verification: open an incognito window, navigate to `/`, confirm it no longer hangs.