### PR TITLE
feat(clock): bouncing screensaver mode for fullscreen clock face

### DIFF
--- a/src/Core/Nocturne.Core.Models/ClockFaceModels.cs
+++ b/src/Core/Nocturne.Core.Models/ClockFaceModels.cs
@@ -313,6 +313,12 @@ public class ClockSettings
     /// </summary>
     [JsonPropertyName("backgroundOpacity")]
     public int BackgroundOpacity { get; set; } = 100;
+
+    /// <summary>
+    /// Enable bouncing screensaver mode on fullscreen views.
+    /// </summary>
+    [JsonPropertyName("screensaverMode")]
+    public bool ScreensaverMode { get; set; }
 }
 
 /// <summary>

--- a/src/Web/packages/app/src/lib/clock-builder/types.ts
+++ b/src/Web/packages/app/src/lib/clock-builder/types.ts
@@ -297,4 +297,5 @@ export const DEFAULT_SETTINGS: ClockSettings = {
   staleMinutes: 13,
   alwaysShowTime: false,
   backgroundOpacity: 100,
+  screensaverMode: false,
 };

--- a/src/Web/packages/app/src/lib/components/clock-builder/DisplaySettings.svelte
+++ b/src/Web/packages/app/src/lib/components/clock-builder/DisplaySettings.svelte
@@ -101,6 +101,13 @@
           onCheckedChange={(v) => updateSetting("alwaysShowTime", !!v)}
         />
       </div>
+      <div class="flex items-center justify-between">
+        <Label>Screensaver mode (bouncing)</Label>
+        <Checkbox
+          checked={settings.screensaverMode ?? false}
+          onCheckedChange={(v) => updateSetting("screensaverMode", !!v)}
+        />
+      </div>
       <Separator />
       <Button
         variant="outline"

--- a/src/Web/packages/app/src/lib/components/clock/ClockFaceRenderer.svelte
+++ b/src/Web/packages/app/src/lib/components/clock/ClockFaceRenderer.svelte
@@ -25,6 +25,14 @@
     TrackerDefinitionDto,
   } from "$lib/api";
   import { getDefinitions } from "$api/generated/trackers.generated.remote";
+  import {
+    advance,
+    angleToVel,
+    computeAngleToCorner,
+    randomNonAxialAngle,
+    type Vec2,
+  } from "$lib/components/clock/screensaver-math";
+  import ScreensaverPulse from "$lib/components/clock/ScreensaverPulse.svelte";
 
   interface Props {
     config: ClockFaceConfig;
@@ -34,9 +42,17 @@
     showCharts?: boolean;
     /** Additional CSS class for the container */
     class?: string;
+    /** Enable bouncing screensaver mode. Only honour from fullscreen views. */
+    screensaver?: boolean;
   }
 
-  let { config, scale = 1, showCharts = true, class: className = "" }: Props = $props();
+  let {
+    config,
+    scale = 1,
+    showCharts = true,
+    class: className = "",
+    screensaver = false,
+  }: Props = $props();
 
   const realtimeStore = getRealtimeStore();
 
@@ -262,12 +278,139 @@
       ? (100 - (config.settings.backgroundOpacity ?? 100)) / 100
       : 0
   );
+
+  // Screensaver bouncing state
+  const SCREENSAVER_SPEED = 60; // px/sec
+  const CORNER_HIT_MIN_MS = 10 * 60 * 1000;
+  const CORNER_HIT_MAX_MS = 20 * 60 * 1000;
+  const CORNER_ARM_LEAD_MS = 30 * 1000;
+
+  let bouncerRef: HTMLDivElement | null = $state(null);
+  let blockSize = $state({ w: 0, h: 0 });
+  let viewportSize = $state({ w: 0, h: 0 });
+  let pos = $state<Vec2>({ x: 0, y: 0 });
+  let vel = $state<Vec2>({ x: 0, y: 0 });
+  let pulses = $state<{ id: number; x: number; y: number }[]>([]);
+  let pulseSeq = 0;
+
+  let nextCornerHitAt = 0;
+  let armedForCorner = false;
+
+  function scheduleNextCornerHit() {
+    const span = CORNER_HIT_MAX_MS - CORNER_HIT_MIN_MS;
+    nextCornerHitAt = Date.now() + CORNER_HIT_MIN_MS + Math.random() * span;
+    armedForCorner = false;
+  }
+
+  function emitPulse(x: number, y: number) {
+    const id = ++pulseSeq;
+    pulses = [...pulses, { id, x, y }];
+    setTimeout(() => {
+      pulses = pulses.filter((p) => p.id !== id);
+    }, 1300);
+  }
+
+  function pickCorner(): Vec2 {
+    const maxX = Math.max(0, viewportSize.w - blockSize.w);
+    const maxY = Math.max(0, viewportSize.h - blockSize.h);
+    const corners: Vec2[] = [
+      { x: 0, y: 0 },
+      { x: maxX, y: 0 },
+      { x: 0, y: maxY },
+      { x: maxX, y: maxY },
+    ];
+    return corners[Math.floor(Math.random() * corners.length)];
+  }
+
+  function armForCorner() {
+    const target = pickCorner();
+    vel = computeAngleToCorner(pos, target, SCREENSAVER_SPEED);
+    armedForCorner = true;
+  }
+
+  $effect(() => {
+    if (!browser || !screensaver) return;
+
+    const updateViewport = () => {
+      viewportSize = { w: window.innerWidth, h: window.innerHeight };
+    };
+    updateViewport();
+    window.addEventListener("resize", updateViewport);
+
+    let ro: ResizeObserver | null = null;
+    if (bouncerRef) {
+      ro = new ResizeObserver((entries) => {
+        const e = entries[0];
+        if (!e) return;
+        const r = e.contentRect;
+        blockSize = { w: r.width, h: r.height };
+      });
+      ro.observe(bouncerRef);
+    }
+
+    const angle = randomNonAxialAngle(Math.random);
+    vel = angleToVel(angle, SCREENSAVER_SPEED);
+    pos = {
+      x: Math.random() * Math.max(0, viewportSize.w - blockSize.w),
+      y: Math.random() * Math.max(0, viewportSize.h - blockSize.h),
+    };
+    scheduleNextCornerHit();
+
+    let raf = 0;
+    let lastT = 0;
+
+    const tick = (t: number) => {
+      if (document.visibilityState !== "visible") {
+        lastT = 0;
+        raf = requestAnimationFrame(tick);
+        return;
+      }
+      if (lastT === 0) lastT = t;
+      const dt = Math.min(0.05, (t - lastT) / 1000);
+      lastT = t;
+
+      const now = Date.now();
+      if (!armedForCorner && now >= nextCornerHitAt - CORNER_ARM_LEAD_MS) {
+        armForCorner();
+      }
+
+      const result = advance(
+        pos,
+        vel,
+        {
+          blockW: blockSize.w,
+          blockH: blockSize.h,
+          viewportW: viewportSize.w,
+          viewportH: viewportSize.h,
+        },
+        dt
+      );
+
+      pos = result.pos;
+      vel = result.vel;
+
+      const hitX = result.hitLeft || result.hitRight;
+      const hitY = result.hitTop || result.hitBottom;
+      if (hitX && hitY) {
+        const cx = result.hitLeft ? 0 : viewportSize.w;
+        const cy = result.hitTop ? 0 : viewportSize.h;
+        emitPulse(cx, cy);
+        if (armedForCorner) scheduleNextCornerHit();
+      }
+
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("resize", updateViewport);
+      ro?.disconnect();
+    };
+  });
 </script>
 
-<div
-  class="{className} relative flex flex-col items-center justify-center overflow-hidden"
-  style={bgStyle}
->
+{#snippet body()}
   <!-- Background overlay for image opacity -->
   {#if config?.settings?.backgroundImage}
     <div
@@ -444,4 +587,31 @@
       </div>
     {/each}
   </div>
-</div>
+{/snippet}
+
+{#if screensaver}
+  <div class="{className} fixed inset-0 overflow-hidden bg-black">
+    <div
+      bind:this={bouncerRef}
+      class="absolute"
+      style="transform: translate3d({pos.x}px, {pos.y}px, 0); will-change: transform;"
+    >
+      <div
+        class="relative flex flex-col items-center justify-center overflow-hidden"
+        style={bgStyle}
+      >
+        {@render body()}
+      </div>
+    </div>
+    {#each pulses as p (p.id)}
+      <ScreensaverPulse x={p.x} y={p.y} />
+    {/each}
+  </div>
+{:else}
+  <div
+    class="{className} relative flex flex-col items-center justify-center overflow-hidden"
+    style={bgStyle}
+  >
+    {@render body()}
+  </div>
+{/if}

--- a/src/Web/packages/app/src/lib/components/clock/ClockFaceRenderer.svelte
+++ b/src/Web/packages/app/src/lib/components/clock/ClockFaceRenderer.svelte
@@ -322,12 +322,6 @@
     return corners[Math.floor(Math.random() * corners.length)];
   }
 
-  function armForCorner() {
-    const target = pickCorner();
-    vel = computeAngleToCorner(pos, target, SCREENSAVER_SPEED);
-    armedForCorner = true;
-  }
-
   $effect(() => {
     if (!browser || !screensaver || !bouncerRef) return;
     const ro = new ResizeObserver((entries) => {
@@ -350,14 +344,11 @@
 
     const angle = randomNonAxialAngle(Math.random);
     vel = angleToVel(angle, SCREENSAVER_SPEED);
-    pos = {
-      x: Math.random() * Math.max(0, viewportSize.w - blockSize.w),
-      y: Math.random() * Math.max(0, viewportSize.h - blockSize.h),
-    };
     scheduleNextCornerHit();
 
     let raf = 0;
     let lastT = 0;
+    let positioned = false;
 
     const tick = (t: number) => {
       if (document.visibilityState !== "visible") {
@@ -365,13 +356,25 @@
         raf = requestAnimationFrame(tick);
         return;
       }
+      if (blockSize.w <= 0 || blockSize.h <= 0) {
+        lastT = 0;
+        raf = requestAnimationFrame(tick);
+        return;
+      }
+      if (!positioned) {
+        pos = {
+          x: Math.random() * Math.max(0, viewportSize.w - blockSize.w),
+          y: Math.random() * Math.max(0, viewportSize.h - blockSize.h),
+        };
+        positioned = true;
+      }
       if (lastT === 0) lastT = t;
       const dt = Math.min(0.05, (t - lastT) / 1000);
       lastT = t;
 
       const now = Date.now();
       if (!armedForCorner && now >= nextCornerHitAt - CORNER_ARM_LEAD_MS) {
-        armForCorner();
+        armedForCorner = true;
       }
 
       const result = advance(
@@ -391,6 +394,15 @@
 
       const hitX = result.hitLeft || result.hitRight;
       const hitY = result.hitTop || result.hitBottom;
+
+      if (armedForCorner && (hitX || hitY) && !(hitX && hitY)) {
+        // Just bounced off one wall. Steer the new trajectory to a corner
+        // from the post-bounce position so the direction change is hidden
+        // inside the bounce.
+        const target = pickCorner();
+        vel = computeAngleToCorner(pos, target, SCREENSAVER_SPEED);
+      }
+
       if (hitX && hitY) {
         const cx = result.hitLeft ? 0 : viewportSize.w;
         const cy = result.hitTop ? 0 : viewportSize.h;

--- a/src/Web/packages/app/src/lib/components/clock/ClockFaceRenderer.svelte
+++ b/src/Web/packages/app/src/lib/components/clock/ClockFaceRenderer.svelte
@@ -32,7 +32,7 @@
     randomNonAxialAngle,
     type Vec2,
   } from "$lib/components/clock/screensaver-math";
-  import ScreensaverPulse from "$lib/components/clock/ScreensaverPulse.svelte";
+  import ScreensaverPulse, { PULSE_DURATION_MS } from "$lib/components/clock/ScreensaverPulse.svelte";
 
   interface Props {
     config: ClockFaceConfig;
@@ -307,7 +307,7 @@
     pulses = [...pulses, { id, x, y }];
     setTimeout(() => {
       pulses = pulses.filter((p) => p.id !== id);
-    }, 1300);
+    }, PULSE_DURATION_MS + 100);
   }
 
   function pickCorner(): Vec2 {
@@ -329,6 +329,17 @@
   }
 
   $effect(() => {
+    if (!browser || !screensaver || !bouncerRef) return;
+    const ro = new ResizeObserver((entries) => {
+      const e = entries[0];
+      if (!e) return;
+      blockSize = { w: e.contentRect.width, h: e.contentRect.height };
+    });
+    ro.observe(bouncerRef);
+    return () => ro.disconnect();
+  });
+
+  $effect(() => {
     if (!browser || !screensaver) return;
 
     const updateViewport = () => {
@@ -336,17 +347,6 @@
     };
     updateViewport();
     window.addEventListener("resize", updateViewport);
-
-    let ro: ResizeObserver | null = null;
-    if (bouncerRef) {
-      ro = new ResizeObserver((entries) => {
-        const e = entries[0];
-        if (!e) return;
-        const r = e.contentRect;
-        blockSize = { w: r.width, h: r.height };
-      });
-      ro.observe(bouncerRef);
-    }
 
     const angle = randomNonAxialAngle(Math.random);
     vel = angleToVel(angle, SCREENSAVER_SPEED);
@@ -405,7 +405,6 @@
     return () => {
       cancelAnimationFrame(raf);
       window.removeEventListener("resize", updateViewport);
-      ro?.disconnect();
     };
   });
 </script>

--- a/src/Web/packages/app/src/lib/components/clock/ScreensaverPulse.svelte
+++ b/src/Web/packages/app/src/lib/components/clock/ScreensaverPulse.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  interface Props {
+    /** Viewport coordinate where the corner hit occurred. */
+    x: number;
+    y: number;
+  }
+
+  let { x, y }: Props = $props();
+</script>
+
+<svg
+  class="pointer-events-none fixed inset-0 z-30 h-full w-full"
+  aria-hidden="true"
+>
+  <circle
+    cx={x}
+    cy={y}
+    fill="none"
+    stroke="white"
+    stroke-width="2"
+    class="pulse"
+  />
+</svg>
+
+<style>
+  .pulse {
+    animation: screensaver-pulse 1200ms ease-out forwards;
+  }
+  @keyframes screensaver-pulse {
+    from {
+      r: 0;
+      opacity: 0.6;
+    }
+    to {
+      r: 30vmax;
+      opacity: 0;
+    }
+  }
+</style>

--- a/src/Web/packages/app/src/lib/components/clock/ScreensaverPulse.svelte
+++ b/src/Web/packages/app/src/lib/components/clock/ScreensaverPulse.svelte
@@ -1,3 +1,8 @@
+<script module lang="ts">
+  /** Duration of the corner-hit pulse animation, in milliseconds. Must match the CSS keyframe below. */
+  export const PULSE_DURATION_MS = 1200;
+</script>
+
 <script lang="ts">
   interface Props {
     /** Viewport coordinate where the corner hit occurred. */

--- a/src/Web/packages/app/src/lib/components/clock/screensaver-math.test.ts
+++ b/src/Web/packages/app/src/lib/components/clock/screensaver-math.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import {
+  advance,
+  reflect,
+  computeAngleToCorner,
+  type Vec2,
+  type Bounds,
+} from "./screensaver-math";
+
+const bounds = (w: number, h: number): Bounds => ({
+  blockW: 100,
+  blockH: 50,
+  viewportW: w,
+  viewportH: h,
+});
+
+describe("advance", () => {
+  it("moves position by velocity * dt", () => {
+    const next = advance(
+      { x: 10, y: 20 },
+      { x: 60, y: 0 },
+      bounds(1000, 1000),
+      1 // 1 second
+    );
+    expect(next.pos).toEqual({ x: 70, y: 20 });
+    expect(next.vel).toEqual({ x: 60, y: 0 });
+    expect(next.hitLeft).toBe(false);
+    expect(next.hitRight).toBe(false);
+    expect(next.hitTop).toBe(false);
+    expect(next.hitBottom).toBe(false);
+  });
+
+  it("reflects off right wall and clamps inside bounds", () => {
+    const next = advance(
+      { x: 880, y: 20 },
+      { x: 60, y: 0 },
+      bounds(1000, 1000),
+      1
+    );
+    expect(next.pos.x).toBe(900);
+    expect(next.vel.x).toBeLessThan(0);
+    expect(next.hitRight).toBe(true);
+  });
+
+  it("reflects off left wall", () => {
+    const next = advance(
+      { x: 20, y: 100 },
+      { x: -60, y: 0 },
+      bounds(1000, 1000),
+      1
+    );
+    expect(next.pos.x).toBe(0);
+    expect(next.vel.x).toBeGreaterThan(0);
+    expect(next.hitLeft).toBe(true);
+  });
+
+  it("reflects off top wall", () => {
+    const next = advance(
+      { x: 100, y: 10 },
+      { x: 0, y: -30 },
+      bounds(1000, 1000),
+      1
+    );
+    expect(next.pos.y).toBe(0);
+    expect(next.vel.y).toBeGreaterThan(0);
+    expect(next.hitTop).toBe(true);
+  });
+
+  it("reflects off bottom wall", () => {
+    const next = advance(
+      { x: 100, y: 940 },
+      { x: 0, y: 30 },
+      bounds(1000, 1000),
+      1
+    );
+    expect(next.pos.y).toBe(950);
+    expect(next.vel.y).toBeLessThan(0);
+    expect(next.hitBottom).toBe(true);
+  });
+
+  it("detects a corner hit when both axes clamp in the same frame", () => {
+    const next = advance(
+      { x: 880, y: 940 },
+      { x: 60, y: 30 },
+      bounds(1000, 1000),
+      1
+    );
+    expect(next.pos).toEqual({ x: 900, y: 950 });
+    expect(next.hitRight).toBe(true);
+    expect(next.hitBottom).toBe(true);
+  });
+});
+
+describe("computeAngleToCorner", () => {
+  it("produces a velocity that lands on the target corner from a wall start", () => {
+    const speed = 60;
+    const vel = computeAngleToCorner(
+      { x: 0, y: 300 },
+      { x: 900, y: 950 },
+      speed
+    );
+
+    expect(vel.x).toBeGreaterThan(0);
+    expect(vel.y).toBeGreaterThan(0);
+
+    const mag = Math.hypot(vel.x, vel.y);
+    expect(mag).toBeCloseTo(speed, 5);
+
+    const dx = 900 - 0;
+    const dy = 950 - 300;
+    const t = Math.hypot(dx, dy) / speed;
+    const arrival = { x: 0 + vel.x * t, y: 300 + vel.y * t };
+    expect(arrival.x).toBeCloseTo(900, 3);
+    expect(arrival.y).toBeCloseTo(950, 3);
+  });
+});
+
+describe("reflect", () => {
+  it("flips x for vertical walls", () => {
+    expect(reflect({ x: 5, y: 3 }, "x")).toEqual({ x: -5, y: 3 });
+  });
+  it("flips y for horizontal walls", () => {
+    expect(reflect({ x: 5, y: 3 }, "y")).toEqual({ x: 5, y: -3 });
+  });
+});

--- a/src/Web/packages/app/src/lib/components/clock/screensaver-math.ts
+++ b/src/Web/packages/app/src/lib/components/clock/screensaver-math.ts
@@ -1,0 +1,107 @@
+export interface Vec2 {
+  x: number;
+  y: number;
+}
+
+export interface Bounds {
+  blockW: number;
+  blockH: number;
+  viewportW: number;
+  viewportH: number;
+}
+
+export interface AdvanceResult {
+  pos: Vec2;
+  vel: Vec2;
+  hitLeft: boolean;
+  hitRight: boolean;
+  hitTop: boolean;
+  hitBottom: boolean;
+}
+
+export function reflect(v: Vec2, axis: "x" | "y"): Vec2 {
+  return axis === "x" ? { x: -v.x, y: v.y } : { x: v.x, y: -v.y };
+}
+
+export function advance(
+  pos: Vec2,
+  vel: Vec2,
+  bounds: Bounds,
+  dtSec: number
+): AdvanceResult {
+  const maxX = Math.max(0, bounds.viewportW - bounds.blockW);
+  const maxY = Math.max(0, bounds.viewportH - bounds.blockH);
+
+  let nx = pos.x + vel.x * dtSec;
+  let ny = pos.y + vel.y * dtSec;
+  let vx = vel.x;
+  let vy = vel.y;
+
+  let hitLeft = false;
+  let hitRight = false;
+  let hitTop = false;
+  let hitBottom = false;
+
+  if (nx <= 0) {
+    nx = 0;
+    vx = Math.abs(vx);
+    hitLeft = true;
+  } else if (nx >= maxX) {
+    nx = maxX;
+    vx = -Math.abs(vx);
+    hitRight = true;
+  }
+
+  if (ny <= 0) {
+    ny = 0;
+    vy = Math.abs(vy);
+    hitTop = true;
+  } else if (ny >= maxY) {
+    ny = maxY;
+    vy = -Math.abs(vy);
+    hitBottom = true;
+  }
+
+  return {
+    pos: { x: nx, y: ny },
+    vel: { x: vx, y: vy },
+    hitLeft,
+    hitRight,
+    hitTop,
+    hitBottom,
+  };
+}
+
+/**
+ * Compute a velocity vector of magnitude `speed` that, from `from`, points at `target`.
+ * Used to rig the trajectory after a wall bounce so the block lands on a corner.
+ */
+export function computeAngleToCorner(from: Vec2, target: Vec2, speed: number): Vec2 {
+  const dx = target.x - from.x;
+  const dy = target.y - from.y;
+  const mag = Math.hypot(dx, dy);
+  if (mag === 0) return { x: speed, y: 0 };
+  return { x: (dx / mag) * speed, y: (dy / mag) * speed };
+}
+
+/**
+ * Generate a random unit angle that's at least `minDegFromAxis` degrees away from any cardinal axis,
+ * so the bouncer doesn't slide imperceptibly along an edge.
+ */
+export function randomNonAxialAngle(
+  random: () => number,
+  minDegFromAxis = 5
+): number {
+  const minRad = (minDegFromAxis * Math.PI) / 180;
+  let angle = random() * Math.PI * 2;
+  for (const axis of [0, Math.PI / 2, Math.PI, (3 * Math.PI) / 2, 2 * Math.PI]) {
+    if (Math.abs(angle - axis) < minRad) {
+      angle = axis + minRad * (random() > 0.5 ? 1 : -1);
+    }
+  }
+  return angle;
+}
+
+export function angleToVel(angle: number, speed: number): Vec2 {
+  return { x: Math.cos(angle) * speed, y: Math.sin(angle) * speed };
+}

--- a/src/Web/packages/app/src/routes/(unauthenticated)/clock/[id]/+page.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/clock/[id]/+page.svelte
@@ -146,25 +146,28 @@
   <!-- Clock Display -->
   <ClockFaceRenderer
     config={clockConfig}
+    screensaver={clockConfig.settings?.screensaverMode ?? false}
     class="fixed inset-0 h-screen w-screen transition-colors duration-500"
   />
 
-  <!-- Show time if configured or stale -->
-  {#if showTime}
-    <div class="fixed bottom-20 left-1/2 z-20 -translate-x-1/2">
-      <div class="flex items-center gap-2 text-2xl text-white/80">
-        <ClockIcon class="size-6" />
-        {formatTime()}
+  {#if !(clockConfig.settings?.screensaverMode ?? false)}
+    <!-- Show time if configured or stale -->
+    {#if showTime}
+      <div class="fixed bottom-20 left-1/2 z-20 -translate-x-1/2">
+        <div class="flex items-center gap-2 text-2xl text-white/80">
+          <ClockIcon class="size-6" />
+          {formatTime()}
+        </div>
       </div>
-    </div>
-  {/if}
+    {/if}
 
-  <!-- Stale indicator -->
-  {#if isStale}
-    <div class="fixed bottom-8 left-1/2 z-20 -translate-x-1/2">
-      <Badge variant="outline" class="border-white/50 px-4 py-2 text-white">
-        Data is {timeSince} old
-      </Badge>
-    </div>
+    <!-- Stale indicator -->
+    {#if isStale}
+      <div class="fixed bottom-8 left-1/2 z-20 -translate-x-1/2">
+        <Badge variant="outline" class="border-white/50 px-4 py-2 text-white">
+          Data is {timeSince} old
+        </Badge>
+      </div>
+    {/if}
   {/if}
 {/if}


### PR DESCRIPTION
## Summary

- Adds a **Screensaver mode (bouncing)** toggle to the clock builder's Display Settings popover — a single `bool` on `ClockSettings` (`screensaverMode`), serialized as JSON in the existing clock face config (no EF migration needed)
- On the fullscreen `/clock/[id]` route, when enabled, the composed clock face block drifts around a black full-viewport surface at 60 px/s, reflecting off all four walls
- Every 10–20 minutes the bouncer is silently rigged to arrive at a corner on its next wall bounce; hitting a corner triggers a white expanding-ring CSS animation (`ScreensaverPulse.svelte`)
- Bouncer logic lives in a pure, side-effect-free math module (`screensaver-math.ts`) covered by unit tests
- Dashboard widget and clock builder preview are unaffected — the `screensaver` prop is only passed truthy from the fullscreen route

## Changes

| Area | File(s) |
|------|---------|
| Backend model | `ClockFaceModels.cs` — `ScreensaverMode: bool` added to `ClockSettings` |
| Math module + tests | `screensaver-math.ts` + `screensaver-math.test.ts` (9 vitest tests) |
| Pulse component | `ScreensaverPulse.svelte` — fixed SVG overlay, one-shot CSS keyframe animation, exports `PULSE_DURATION_MS` |
| Renderer | `ClockFaceRenderer.svelte` — `screensaver?: boolean` prop, rAF loop, ResizeObserver, corner-hit rigging |
| Builder UI | `DisplaySettings.svelte` — checkbox row; `types.ts` — default `false` |
| Fullscreen route | `(unauthenticated)/clock/[id]/+page.svelte` — passes prop, hides stale/time badges in screensaver mode |

## Test plan

- [ ] Start Aspire, open a clock face in the builder, enable **Screensaver mode (bouncing)** in Display Settings
- [ ] Visit `/clock/<id>` fullscreen — confirm block bounces, walls reflect correctly, no teleport/drift
- [ ] Resize the browser window — block stays within bounds
- [ ] Switch to another tab and back — no position jump on resume
- [ ] Wait for a corner hit (or temporarily reduce `CORNER_HIT_MIN_MS` to a few seconds in `ClockFaceRenderer.svelte`) — confirm the expanding ring appears at the corner
- [ ] Confirm the dashboard widget and clock builder preview are unaffected (no bouncing)