### PR TITLE
feat(connectors): Glooko pump mode series + manual BG fix

### DIFF
--- a/src/API/Nocturne.API/Helpers/ChartColorMapper.cs
+++ b/src/API/Nocturne.API/Helpers/ChartColorMapper.cs
@@ -20,6 +20,7 @@ public static class ChartColorMapper
             "Exercise" => ChartColor.PumpModeExercise,
             "Suspended" => ChartColor.PumpModeSuspended,
             "Off" => ChartColor.PumpModeOff,
+            "Liberty" => ChartColor.PumpModeLiberty,
             _ => ChartColor.PumpModeManual,
         };
 

--- a/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConstants.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConstants.cs
@@ -83,6 +83,29 @@ public static class GlookoConstants
     /// </summary>
     public static readonly string[] V3CgmBackfillSeries = ["cgmHigh", "cgmNormal", "cgmLow"];
 
+    /// <summary>
+    ///     Pump mode series requested from the v3 graph/data endpoint.
+    ///     Device-family-prefixed series covering CamAPS FX, Control-IQ, Omnipod 5, Basal-iQ, and generic pumps.
+    /// </summary>
+    public static readonly string[] V3PumpModeSeries =
+    [
+        // CamAPS FX
+        "pumpCamapsAutomaticMode", "pumpCamapsManualMode", "pumpCamapsBoostMode",
+        "pumpCamapsEaseOffMode", "pumpCamapsLibertyMode",
+        "pumpCamapsPumpDeliverySuspendedMode",
+        "pumpCamapsNoPumpConnectivityMode", "pumpCamapsBluetoothTurnedOffMode", "pumpCamapsNoCgmMode",
+        // Control-IQ
+        "pumpControliqAutomaticMode", "pumpControliqManualMode",
+        "pumpControliqSleepMode", "pumpControliqExerciseMode",
+        // Omnipod 5
+        "pumpOp5AutomaticMode", "pumpOp5ManualMode",
+        "pumpOp5LimitedMode", "pumpOp5HypoprotectMode",
+        // Basal-iQ
+        "pumpBasaliqAutomaticMode", "pumpBasaliqManualMode",
+        // Generic
+        "pumpGenericAutomaticMode", "pumpGenericManualMode",
+    ];
+
     // -- HTTP -----------------------------------------------------------------
 
     /// <summary>

--- a/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoStateSpanMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoStateSpanMapper.cs
@@ -140,6 +140,131 @@ public class GlookoStateSpanMapper
         return stateSpans;
     }
 
+    public List<StateSpan> TransformV3PumpModeToStateSpans(GlookoV3GraphResponse graphData)
+    {
+        var stateSpans = new List<StateSpan>();
+
+        if (graphData?.Series == null)
+            return stateSpans;
+
+        var series = graphData.Series;
+
+        // PumpMode mappings
+        MapPumpModeSeries(stateSpans, series.PumpCamapsAutomaticMode, "camaps_automatic", PumpModeState.Automatic);
+        MapPumpModeSeries(stateSpans, series.PumpCamapsManualMode, "camaps_manual", PumpModeState.Manual);
+        MapPumpModeSeries(stateSpans, series.PumpCamapsBoostMode, "camaps_boost", PumpModeState.Boost);
+        MapPumpModeSeries(stateSpans, series.PumpCamapsEaseOffMode, "camaps_easeoff", PumpModeState.EaseOff);
+        MapPumpModeSeries(stateSpans, series.PumpCamapsLibertyMode, "camaps_liberty", PumpModeState.Liberty);
+        MapPumpModeSeries(stateSpans, series.PumpCamapsPumpDeliverySuspendedMode, "camaps_suspended", PumpModeState.Suspended);
+        MapPumpModeSeries(stateSpans, series.PumpControliqAutomaticMode, "controliq_automatic", PumpModeState.Automatic);
+        MapPumpModeSeries(stateSpans, series.PumpControliqManualMode, "controliq_manual", PumpModeState.Manual);
+        MapPumpModeSeries(stateSpans, series.PumpControliqSleepMode, "controliq_sleep", PumpModeState.Sleep);
+        MapPumpModeSeries(stateSpans, series.PumpControliqExerciseMode, "controliq_exercise", PumpModeState.Exercise);
+        MapPumpModeSeries(stateSpans, series.PumpOp5AutomaticMode, "op5_automatic", PumpModeState.Automatic);
+        MapPumpModeSeries(stateSpans, series.PumpOp5ManualMode, "op5_manual", PumpModeState.Manual);
+        MapPumpModeSeries(stateSpans, series.PumpOp5LimitedMode, "op5_limited", PumpModeState.Limited);
+        MapPumpModeSeries(stateSpans, series.PumpOp5HypoprotectMode, "op5_hypoprotect", PumpModeState.Limited);
+        MapPumpModeSeries(stateSpans, series.PumpBasaliqAutomaticMode, "basaliq_automatic", PumpModeState.Automatic);
+        MapPumpModeSeries(stateSpans, series.PumpBasaliqManualMode, "basaliq_manual", PumpModeState.Manual);
+        MapPumpModeSeries(stateSpans, series.PumpGenericAutomaticMode, "generic_automatic", PumpModeState.Automatic);
+        MapPumpModeSeries(stateSpans, series.PumpGenericManualMode, "generic_manual", PumpModeState.Manual);
+
+        // PumpConnectivity mappings
+        MapPumpConnectivitySeries(stateSpans, series.PumpCamapsNoPumpConnectivityMode, "camaps_no_pump", PumpConnectivityState.Disconnected);
+        MapPumpConnectivitySeries(stateSpans, series.PumpCamapsBluetoothTurnedOffMode, "camaps_bt_off", PumpConnectivityState.BluetoothOff);
+        MapPumpConnectivitySeries(stateSpans, series.PumpCamapsNoCgmMode, "camaps_no_cgm", PumpConnectivityState.Disconnected);
+
+        _logger.LogInformation(
+            "[{ConnectorSource}] Transformed {Count} pump mode/connectivity state spans from v3 data",
+            _connectorSource,
+            stateSpans.Count
+        );
+
+        return stateSpans;
+    }
+
+    private void MapPumpModeSeries(
+        List<StateSpan> stateSpans,
+        GlookoV3PumpModeDataPoint[]? dataPoints,
+        string glookoType,
+        PumpModeState state)
+    {
+        if (dataPoints == null)
+            return;
+
+        foreach (var point in dataPoints)
+        {
+            if (point.Interpolated)
+                continue;
+
+            var startTimestamp = _timeMapper.GetCorrectedGlookoTime(point.X);
+            var durationSeconds = point.Duration ?? 0;
+            var endTimestamp =
+                durationSeconds > 0
+                    ? startTimestamp.AddSeconds(durationSeconds)
+                    : (DateTime?)null;
+
+            stateSpans.Add(
+                new StateSpan
+                {
+                    OriginalId = $"glooko_pumpmode_{glookoType}_{point.X}",
+                    Category = StateSpanCategory.PumpMode,
+                    State = state.ToString(),
+                    StartTimestamp = startTimestamp,
+                    EndTimestamp = endTimestamp,
+                    Source = _connectorSource,
+                    Metadata = new Dictionary<string, object>
+                    {
+                        { "label", point.Type ?? glookoType },
+                        { "glookoType", glookoType },
+                        { "durationSeconds", durationSeconds }
+                    }
+                }
+            );
+        }
+    }
+
+    private void MapPumpConnectivitySeries(
+        List<StateSpan> stateSpans,
+        GlookoV3PumpModeDataPoint[]? dataPoints,
+        string glookoType,
+        PumpConnectivityState state)
+    {
+        if (dataPoints == null)
+            return;
+
+        foreach (var point in dataPoints)
+        {
+            if (point.Interpolated)
+                continue;
+
+            var startTimestamp = _timeMapper.GetCorrectedGlookoTime(point.X);
+            var durationSeconds = point.Duration ?? 0;
+            var endTimestamp =
+                durationSeconds > 0
+                    ? startTimestamp.AddSeconds(durationSeconds)
+                    : (DateTime?)null;
+
+            stateSpans.Add(
+                new StateSpan
+                {
+                    OriginalId = $"glooko_pumpconn_{glookoType}_{point.X}",
+                    Category = StateSpanCategory.PumpConnectivity,
+                    State = state.ToString(),
+                    StartTimestamp = startTimestamp,
+                    EndTimestamp = endTimestamp,
+                    Source = _connectorSource,
+                    Metadata = new Dictionary<string, object>
+                    {
+                        { "label", point.Type ?? glookoType },
+                        { "glookoType", glookoType },
+                        { "durationSeconds", durationSeconds }
+                    }
+                }
+            );
+        }
+    }
+
     public List<StateSpan> TransformV2ToStateSpans(GlookoBatchData batchData)
     {
         var stateSpans = new List<StateSpan>();

--- a/src/Connectors/Nocturne.Connectors.Glooko/Models/GlookoV3Models.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Models/GlookoV3Models.cs
@@ -87,6 +87,37 @@ public class GlookoV3Series
 
     // Target ranges
     [JsonPropertyName("bgTargets")] public GlookoV3TargetDataPoint[]? BgTargets { get; set; }
+
+    // Pump mode series — CamAPS FX
+    [JsonPropertyName("pumpCamapsAutomaticMode")] public GlookoV3PumpModeDataPoint[]? PumpCamapsAutomaticMode { get; set; }
+    [JsonPropertyName("pumpCamapsManualMode")] public GlookoV3PumpModeDataPoint[]? PumpCamapsManualMode { get; set; }
+    [JsonPropertyName("pumpCamapsBoostMode")] public GlookoV3PumpModeDataPoint[]? PumpCamapsBoostMode { get; set; }
+    [JsonPropertyName("pumpCamapsEaseOffMode")] public GlookoV3PumpModeDataPoint[]? PumpCamapsEaseOffMode { get; set; }
+    [JsonPropertyName("pumpCamapsLibertyMode")] public GlookoV3PumpModeDataPoint[]? PumpCamapsLibertyMode { get; set; }
+    [JsonPropertyName("pumpCamapsPumpDeliverySuspendedMode")] public GlookoV3PumpModeDataPoint[]? PumpCamapsPumpDeliverySuspendedMode { get; set; }
+    [JsonPropertyName("pumpCamapsNoPumpConnectivityMode")] public GlookoV3PumpModeDataPoint[]? PumpCamapsNoPumpConnectivityMode { get; set; }
+    [JsonPropertyName("pumpCamapsBluetoothTurnedOffMode")] public GlookoV3PumpModeDataPoint[]? PumpCamapsBluetoothTurnedOffMode { get; set; }
+    [JsonPropertyName("pumpCamapsNoCgmMode")] public GlookoV3PumpModeDataPoint[]? PumpCamapsNoCgmMode { get; set; }
+
+    // Pump mode series — Control-IQ
+    [JsonPropertyName("pumpControliqAutomaticMode")] public GlookoV3PumpModeDataPoint[]? PumpControliqAutomaticMode { get; set; }
+    [JsonPropertyName("pumpControliqManualMode")] public GlookoV3PumpModeDataPoint[]? PumpControliqManualMode { get; set; }
+    [JsonPropertyName("pumpControliqSleepMode")] public GlookoV3PumpModeDataPoint[]? PumpControliqSleepMode { get; set; }
+    [JsonPropertyName("pumpControliqExerciseMode")] public GlookoV3PumpModeDataPoint[]? PumpControliqExerciseMode { get; set; }
+
+    // Pump mode series — Omnipod 5
+    [JsonPropertyName("pumpOp5AutomaticMode")] public GlookoV3PumpModeDataPoint[]? PumpOp5AutomaticMode { get; set; }
+    [JsonPropertyName("pumpOp5ManualMode")] public GlookoV3PumpModeDataPoint[]? PumpOp5ManualMode { get; set; }
+    [JsonPropertyName("pumpOp5LimitedMode")] public GlookoV3PumpModeDataPoint[]? PumpOp5LimitedMode { get; set; }
+    [JsonPropertyName("pumpOp5HypoprotectMode")] public GlookoV3PumpModeDataPoint[]? PumpOp5HypoprotectMode { get; set; }
+
+    // Pump mode series — Basal-iQ
+    [JsonPropertyName("pumpBasaliqAutomaticMode")] public GlookoV3PumpModeDataPoint[]? PumpBasaliqAutomaticMode { get; set; }
+    [JsonPropertyName("pumpBasaliqManualMode")] public GlookoV3PumpModeDataPoint[]? PumpBasaliqManualMode { get; set; }
+
+    // Pump mode series — Generic
+    [JsonPropertyName("pumpGenericAutomaticMode")] public GlookoV3PumpModeDataPoint[]? PumpGenericAutomaticMode { get; set; }
+    [JsonPropertyName("pumpGenericManualMode")] public GlookoV3PumpModeDataPoint[]? PumpGenericManualMode { get; set; }
 }
 
 /// <summary>
@@ -378,4 +409,34 @@ public class GlookoV3TargetDataPoint : GlookoV3DataPointBase
     [JsonPropertyName("low")] public double? Low { get; set; }
 
     [JsonPropertyName("high")] public double? High { get; set; }
+}
+
+/// <summary>
+///     Pump mode data point (CamAPS, Control-IQ, Op5, Basal-iQ, generic)
+/// </summary>
+public class GlookoV3PumpModeDataPoint : GlookoV3DataPointBase
+{
+    /// <summary>
+    ///     Mode type string (e.g., "automatic", "ease_off", "boost", "no_pump_connectivity")
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    /// <summary>
+    ///     Duration in seconds
+    /// </summary>
+    [JsonPropertyName("duration")]
+    public int? Duration { get; set; }
+
+    /// <summary>
+    ///     ISO 8601 end timestamp
+    /// </summary>
+    [JsonPropertyName("endTimestamp")]
+    public string? EndTimestamp { get; set; }
+
+    /// <summary>
+    ///     Whether this is an interpolated graph point (not a real event)
+    /// </summary>
+    [JsonPropertyName("interpolated")]
+    public bool Interpolated { get; set; }
 }

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -55,6 +55,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     public override List<SyncDataType> SupportedDataTypes =>
     [
         SyncDataType.Glucose,
+        SyncDataType.ManualBG,
         SyncDataType.Boluses,
         SyncDataType.CarbIntake,
         SyncDataType.StateSpans,
@@ -243,9 +244,11 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     {
         var patientCode = _userData?.GlookoCode;
 
-        var series = _syncConfig!.V3IncludeCgmBackfill
-            ? GlookoConstants.V3GraphSeries.Concat(GlookoConstants.V3CgmBackfillSeries)
-            : GlookoConstants.V3GraphSeries;
+        var series = GlookoConstants.V3GraphSeries
+            .Concat(GlookoConstants.V3PumpModeSeries);
+
+        if (_syncConfig!.V3IncludeCgmBackfill)
+            series = series.Concat(GlookoConstants.V3CgmBackfillSeries);
 
         var seriesParams = string.Join("&", series.Select(s => $"series[]={s}"));
 
@@ -549,6 +552,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         if (activeTypes.Contains(SyncDataType.StateSpans))
         {
             var stateSpans = _stateSpanMapper.TransformV3ToStateSpans(v3Data);
+            stateSpans.AddRange(_stateSpanMapper.TransformV3PumpModeToStateSpans(v3Data));
             if (stateSpans.Count > 0)
                 await PublishStateSpanDataAsync(stateSpans, config, cancellationToken);
 

--- a/src/Core/Nocturne.Core.Models/ChartColor.cs
+++ b/src/Core/Nocturne.Core.Models/ChartColor.cs
@@ -74,6 +74,9 @@ public enum ChartColor
     [EnumMember(Value = "pump-mode-off"), JsonStringEnumMemberName("pump-mode-off")]
     PumpModeOff,
 
+    [EnumMember(Value = "pump-mode-liberty"), JsonStringEnumMemberName("pump-mode-liberty")]
+    PumpModeLiberty,
+
     // System events
     [EnumMember(Value = "system-event-alarm"), JsonStringEnumMemberName("system-event-alarm")]
     SystemEventAlarm,

--- a/src/Core/Nocturne.Core.Models/StateSpanEnums.cs
+++ b/src/Core/Nocturne.Core.Models/StateSpanEnums.cs
@@ -103,6 +103,11 @@ public enum PumpModeState
     Exercise,
 
     /// <summary>
+    /// Liberty mode (CamAPS FX)
+    /// </summary>
+    Liberty,
+
+    /// <summary>
     /// Insulin delivery suspended
     /// </summary>
     Suspended,

--- a/src/Web/packages/app/src/lib/components/icons/LibertyModeIcon.svelte
+++ b/src/Web/packages/app/src/lib/components/icons/LibertyModeIcon.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import Waves from "lucide-svelte/icons/waves";
+  import type { IconProps } from "./types";
+
+  let { class: className = "", ...rest }: IconProps = $props();
+</script>
+
+<!-- Liberty mode - relaxed closed-loop -->
+<Waves class={className} {...rest} />

--- a/src/Web/packages/app/src/lib/components/icons/PumpModeIcon.svelte
+++ b/src/Web/packages/app/src/lib/components/icons/PumpModeIcon.svelte
@@ -7,6 +7,7 @@
   import SuspendedModeIcon from "./SuspendedModeIcon.svelte";
   import LimitedModeIcon from "./LimitedModeIcon.svelte";
   import EaseOffModeIcon from "./EaseOffModeIcon.svelte";
+  import LibertyModeIcon from "./LibertyModeIcon.svelte";
 
   interface Props {
     state: string;
@@ -41,6 +42,8 @@
   <LimitedModeIcon class={className} {size} {strokeWidth} {color} />
 {:else if state === "EaseOff"}
   <EaseOffModeIcon class={className} {size} {strokeWidth} {color} />
+{:else if state === "Liberty"}
+  <LibertyModeIcon class={className} {size} {strokeWidth} {color} />
 {:else}
   <!-- Default to manual mode icon for unknown states -->
   <ManualModeIcon class={className} {size} {strokeWidth} {color} />

--- a/src/Web/packages/app/src/routes/(authenticated)/time-spans/data.remote.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/time-spans/data.remote.ts
@@ -64,6 +64,7 @@ function getPumpModeColor(state: string): string {
     Exercise: "var(--pump-mode-exercise)",
     Suspended: "var(--pump-mode-suspended)",
     Off: "var(--pump-mode-off)",
+    Liberty: "var(--pump-mode-liberty)",
   };
   return stateColors[state] ?? "var(--muted-foreground)";
 }

--- a/src/Web/packages/app/src/styles/aaps-theme.css
+++ b/src/Web/packages/app/src/styles/aaps-theme.css
@@ -73,6 +73,7 @@
   --pump-mode-exercise: oklch(0.6 0.14 175);    /* AAPS teal */
   --pump-mode-suspended: oklch(0.55 0.25 29);   /* Red */
   --pump-mode-off: oklch(0.4 0.02 240);         /* Dark grey */
+  --pump-mode-liberty: oklch(0.65 0.13 200);   /* Cyan - liberty */
 
   /* System Event Severity */
   --system-event-alarm: oklch(0.55 0.25 29);    /* Red */

--- a/src/Web/packages/app/src/styles/classic-theme.css
+++ b/src/Web/packages/app/src/styles/classic-theme.css
@@ -73,6 +73,7 @@
   --pump-mode-exercise: oklch(0.6 0.15 195);
   --pump-mode-suspended: oklch(0.55 0.25 29);
   --pump-mode-off: oklch(0.4 0.01 250);
+  --pump-mode-liberty: oklch(0.7 0.13 200);
 
   /* System Event Severity */
   --system-event-alarm: oklch(0.55 0.25 29);

--- a/src/Web/packages/app/src/styles/nocturne-theme.css
+++ b/src/Web/packages/app/src/styles/nocturne-theme.css
@@ -55,6 +55,7 @@
     0.6 0.22 30
   ); /* Red-orange - insulin suspended */
   --pump-mode-off: oklch(0.4 0.05 270); /* Dark gray - pump off */
+  --pump-mode-liberty: oklch(0.65 0.13 200); /* Cyan - liberty mode */
 
   /* System Event Severity */
   --system-event-alarm: oklch(0.577 0.245 27.325); /* Red - critical alarm */

--- a/src/Web/packages/glucose-chart/src/themes/nocturne.css
+++ b/src/Web/packages/glucose-chart/src/themes/nocturne.css
@@ -56,6 +56,7 @@
     0.6 0.22 30
   ); /* Red-orange - insulin suspended */
   --pump-mode-off: oklch(0.4 0.05 270); /* Dark gray - pump off */
+  --pump-mode-liberty: oklch(0.65 0.13 200); /* Cyan - liberty mode */
 
   /* System Event Severity */
   --system-event-alarm: oklch(0.577 0.245 27.325); /* Red - critical alarm */

--- a/src/Web/packages/ui/src/styles/aaps-theme.css
+++ b/src/Web/packages/ui/src/styles/aaps-theme.css
@@ -73,6 +73,7 @@
   --pump-mode-exercise: oklch(0.6 0.14 175);    /* AAPS teal */
   --pump-mode-suspended: oklch(0.55 0.25 29);   /* Red */
   --pump-mode-off: oklch(0.4 0.02 240);         /* Dark grey */
+  --pump-mode-liberty: oklch(0.65 0.13 200);   /* Cyan - liberty */
 
   /* System Event Severity */
   --system-event-alarm: oklch(0.55 0.25 29);    /* Red */

--- a/src/Web/packages/ui/src/styles/classic-theme.css
+++ b/src/Web/packages/ui/src/styles/classic-theme.css
@@ -73,6 +73,7 @@
   --pump-mode-exercise: oklch(0.6 0.15 195);
   --pump-mode-suspended: oklch(0.55 0.25 29);
   --pump-mode-off: oklch(0.4 0.01 250);
+  --pump-mode-liberty: oklch(0.7 0.13 200);
 
   /* System Event Severity */
   --system-event-alarm: oklch(0.55 0.25 29);

--- a/src/Web/packages/ui/src/styles/nocturne-theme.css
+++ b/src/Web/packages/ui/src/styles/nocturne-theme.css
@@ -55,6 +55,7 @@
     0.6 0.22 30
   ); /* Red-orange - insulin suspended */
   --pump-mode-off: oklch(0.4 0.05 270); /* Dark gray - pump off */
+  --pump-mode-liberty: oklch(0.65 0.13 200); /* Cyan - liberty mode */
 
   /* System Event Severity */
   --system-event-alarm: oklch(0.577 0.245 27.325); /* Red - critical alarm */

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Mappers/GlookoStateSpanMapperPumpModeTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Mappers/GlookoStateSpanMapperPumpModeTests.cs
@@ -1,0 +1,159 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Connectors.Glooko.Configurations;
+using Nocturne.Connectors.Glooko.Mappers;
+using Nocturne.Connectors.Glooko.Models;
+using Nocturne.Core.Models;
+using Xunit;
+
+namespace Nocturne.Connectors.Glooko.Tests.Mappers;
+
+public class GlookoStateSpanMapperPumpModeTests
+{
+    private const string ConnectorSource = "glooko_test";
+    private readonly GlookoStateSpanMapper _mapper;
+
+    public GlookoStateSpanMapperPumpModeTests()
+    {
+        var config = new GlookoConnectorConfiguration { TimezoneOffset = 0 };
+        var timeMapper = new GlookoTimeMapper(config, NullLogger.Instance);
+        _mapper = new GlookoStateSpanMapper(ConnectorSource, timeMapper, NullLogger.Instance);
+    }
+
+    [Fact]
+    public void TransformV3PumpModeToStateSpans_MapsEaseOff()
+    {
+        var response = BuildResponse("PumpCamapsEaseOffMode", "ease_off", 3600);
+
+        var spans = _mapper.TransformV3PumpModeToStateSpans(response);
+
+        spans.Should().HaveCount(1);
+        var span = spans[0];
+        span.Category.Should().Be(StateSpanCategory.PumpMode);
+        span.State.Should().Be("EaseOff");
+        span.EndTimestamp.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void TransformV3PumpModeToStateSpans_MapsLiberty()
+    {
+        var response = BuildResponse("PumpCamapsLibertyMode", "liberty", 7200);
+
+        var spans = _mapper.TransformV3PumpModeToStateSpans(response);
+
+        spans.Should().HaveCount(1);
+        var span = spans[0];
+        span.Category.Should().Be(StateSpanCategory.PumpMode);
+        span.State.Should().Be("Liberty");
+    }
+
+    [Fact]
+    public void TransformV3PumpModeToStateSpans_MapsControlIqSleep()
+    {
+        var response = BuildResponse("PumpControliqSleepMode", "sleep", 28800);
+
+        var spans = _mapper.TransformV3PumpModeToStateSpans(response);
+
+        spans.Should().HaveCount(1);
+        spans[0].State.Should().Be("Sleep");
+    }
+
+    [Fact]
+    public void TransformV3PumpModeToStateSpans_MapsOp5Limited()
+    {
+        var response = BuildResponse("PumpOp5LimitedMode", "limited", 1800);
+
+        var spans = _mapper.TransformV3PumpModeToStateSpans(response);
+
+        spans.Should().HaveCount(1);
+        spans[0].State.Should().Be("Limited");
+    }
+
+    [Fact]
+    public void TransformV3PumpModeToStateSpans_SkipsInterpolatedPoints()
+    {
+        var series = new GlookoV3Series();
+        SetSeriesProperty(series, "PumpCamapsAutomaticMode", [
+            new GlookoV3PumpModeDataPoint { X = 1000, Type = "automatic", Duration = 3600, Interpolated = true },
+            new GlookoV3PumpModeDataPoint { X = 2000, Type = "automatic", Duration = 3600, Interpolated = false },
+            new GlookoV3PumpModeDataPoint { X = 3000, Type = "automatic", Duration = 3600, Interpolated = true },
+        ]);
+
+        var spans = _mapper.TransformV3PumpModeToStateSpans(new GlookoV3GraphResponse { Series = series });
+
+        spans.Should().HaveCount(1);
+        spans[0].OriginalId.Should().Contain("2000");
+    }
+
+    [Fact]
+    public void TransformV3PumpModeToStateSpans_MapsConnectivity()
+    {
+        var response = BuildResponse("PumpCamapsNoPumpConnectivityMode", "no_pump_connectivity", 600);
+
+        var spans = _mapper.TransformV3PumpModeToStateSpans(response);
+
+        spans.Should().HaveCount(1);
+        var span = spans[0];
+        span.Category.Should().Be(StateSpanCategory.PumpConnectivity);
+        span.State.Should().Be("Disconnected");
+    }
+
+    [Fact]
+    public void TransformV3PumpModeToStateSpans_MapsBluetoothOff()
+    {
+        var response = BuildResponse("PumpCamapsBluetoothTurnedOffMode", "bluetooth_turned_off", 300);
+
+        var spans = _mapper.TransformV3PumpModeToStateSpans(response);
+
+        spans.Should().HaveCount(1);
+        var span = spans[0];
+        span.Category.Should().Be(StateSpanCategory.PumpConnectivity);
+        span.State.Should().Be("BluetoothOff");
+    }
+
+    [Fact]
+    public void TransformV3PumpModeToStateSpans_NullSeriesReturnsEmpty()
+    {
+        var response = new GlookoV3GraphResponse { Series = null };
+
+        var spans = _mapper.TransformV3PumpModeToStateSpans(response);
+
+        spans.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(0)]
+    public void TransformV3PumpModeToStateSpans_NullOrZeroDuration_ProducesNullEndTimestamp(int? duration)
+    {
+        var response = BuildResponse("PumpCamapsAutomaticMode", "automatic", duration);
+
+        var spans = _mapper.TransformV3PumpModeToStateSpans(response);
+
+        spans.Should().HaveCount(1);
+        spans[0].EndTimestamp.Should().BeNull(
+            because: "a null or zero duration means the span has no known end");
+    }
+
+    private static GlookoV3GraphResponse BuildResponse(string seriesProperty, string type, int? duration)
+    {
+        var series = new GlookoV3Series();
+        SetSeriesProperty(series, seriesProperty, [
+            new GlookoV3PumpModeDataPoint
+            {
+                X = 1779230416,
+                Type = type,
+                Duration = duration,
+                Interpolated = false,
+            }
+        ]);
+        return new GlookoV3GraphResponse { Series = series };
+    }
+
+    private static void SetSeriesProperty(GlookoV3Series series, string name, GlookoV3PumpModeDataPoint[] value)
+    {
+        var prop = typeof(GlookoV3Series).GetProperty(name)
+            ?? throw new ArgumentException($"No property {name} on GlookoV3Series");
+        prop.SetValue(series, value);
+    }
+}


### PR DESCRIPTION
## Summary

- **Pump mode time-series**: The Glooko connector now requests 21 device-specific pump mode series from the V3 graph API and maps them to `PumpMode` and `PumpConnectivity` StateSpan records. Covers CamAPS FX (Automatic, Manual, Boost, EaseOff, Liberty, Suspended + connectivity states), Control-IQ (Automatic, Manual, Sleep, Exercise), Omnipod 5 (Automatic, Manual, Limited, Hypoprotect), Basal-iQ, and generic pumps.
- **Liberty enum**: New `PumpModeState.Liberty` for CamAPS FX with full-stack support (chart color, CSS variable in all 7 themes, `LibertyModeIcon` component).
- **Manual BG fix**: `SyncDataType.ManualBG` was missing from `SupportedDataTypes`, so finger-stick BG readings were mapped but silently dropped at publish time.

## Test plan

- [x] 10 new unit tests for pump mode mapping (EaseOff, Liberty, Control-IQ Sleep, Op5 Limited, interpolation filtering, connectivity, BluetoothOff, null series, null/zero duration)
- [x] All 25 Glooko connector tests pass
- [x] Connector project builds cleanly
- [ ] Trigger a Glooko sync and verify pump mode StateSpans appear in the time-spans page
- [ ] Verify manual BG readings appear after sync