### PR TITLE
fix(web): make app layouts container-query responsive on mobile

### DIFF
--- a/src/Web/packages/app/src/lib/components/account/UserProfileCard.svelte
+++ b/src/Web/packages/app/src/lib/components/account/UserProfileCard.svelte
@@ -114,7 +114,7 @@
   });
 </script>
 
-<Card.Root>
+<Card.Root class="@container">
   <Card.Header>
     <div class="flex items-start gap-4">
       <div class="relative group">
@@ -180,7 +180,7 @@
         Account Details
       </h3>
 
-      <div class="grid gap-4 sm:grid-cols-2">
+      <div class="grid gap-4 @sm:grid-cols-2">
         <div class="space-y-1">
           <p class="text-sm text-muted-foreground">Subject ID</p>
           <p class="text-sm font-mono bg-muted px-2 py-1 rounded">
@@ -253,15 +253,15 @@
       {/if}
     </div>
   </Card.Content>
-  <Card.Footer class="flex flex-col sm:flex-row gap-2 border-t pt-6">
-    <Button variant="outline" href="/settings" class="w-full sm:w-auto">
+  <Card.Footer class="flex flex-col @sm:flex-row gap-2 border-t pt-6">
+    <Button variant="outline" href="/settings" class="w-full @sm:w-auto">
       <Settings class="mr-2 h-4 w-4" />
       Back to Settings
     </Button>
     <Button
       variant="destructive"
       onclick={onLogout}
-      class="w-full sm:w-auto"
+      class="w-full @sm:w-auto"
     >
       <LogOut class="mr-2 h-4 w-4" />
       Log Out

--- a/src/Web/packages/app/src/lib/components/alerts/AlertRuleRow.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/AlertRuleRow.svelte
@@ -61,7 +61,7 @@
 </script>
 
 <div
-  class="flex items-center gap-3 rounded-md border bg-background px-4 py-3 {!rule.isEnabled
+  class="@container flex items-center gap-3 rounded-md border bg-background px-4 py-3 {!rule.isEnabled
     ? 'opacity-60'
     : ''}"
 >
@@ -92,7 +92,7 @@
 
   <!-- Channel icons -->
   {#if rule.channels && rule.channels.length > 0}
-    <div class="hidden items-center gap-1 sm:flex" aria-label="Channels">
+    <div class="hidden items-center gap-1 @sm:flex" aria-label="Channels">
       {#each rule.channels.slice(0, 4) as ch (ch.id)}
         {@const meta = findChannelMeta(ch.channelType)}
         <span

--- a/src/Web/packages/app/src/lib/components/audit/AuditReadsTable.svelte
+++ b/src/Web/packages/app/src/lib/components/audit/AuditReadsTable.svelte
@@ -410,7 +410,7 @@
 {/snippet}
 
 {#snippet expandedDetailSnippet({ row }: { row: ReadAccessAuditDto })}
-  <div class="grid grid-cols-1 gap-3 px-4 py-3 text-sm sm:grid-cols-2">
+  <div class="@container grid grid-cols-1 gap-3 px-4 py-3 text-sm @sm:grid-cols-2">
     {#if row.authType}
       <div>
         <span class="font-medium text-muted-foreground">Auth Type</span>
@@ -428,7 +428,7 @@
     {#if row.queryParameters}
       {@const params = parseQueryParameters(row.queryParameters)}
       {#if Object.keys(params).length > 0}
-        <div class="sm:col-span-2">
+        <div class="@sm:col-span-2">
           <span class="font-medium text-muted-foreground"
             >Query Parameters</span
           >

--- a/src/Web/packages/app/src/lib/components/calendar/CalendarHeader.svelte
+++ b/src/Web/packages/app/src/lib/components/calendar/CalendarHeader.svelte
@@ -30,9 +30,9 @@
 </script>
 
 <div
-  class="border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60 sticky top-0 z-10"
+  class="@container border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60 sticky top-0 z-10"
 >
-  <div class="flex items-center justify-between p-4">
+  <div class="flex flex-wrap items-center justify-between gap-2 p-4">
     <div class="flex items-center gap-4">
       <Calendar class="h-6 w-6 text-muted-foreground" />
       <h1 class="text-2xl font-bold">Calendar</h1>
@@ -59,8 +59,8 @@
   </div>
 
   <!-- Legend and View Toggle -->
-  <div class="flex items-center justify-between px-4 pb-3">
-    <div class="flex items-center gap-6">
+  <div class="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 px-4 pb-3">
+    <div class="flex flex-wrap items-center gap-3 @xl:gap-6">
       <!-- View Mode Toggle -->
       <ToggleGroup.Root
         type="single"
@@ -95,7 +95,7 @@
       <!-- Mode-specific explanation -->
       {#if viewMode === "profile"}
         <div
-          class="flex items-center gap-3 text-xs text-muted-foreground border-l pl-4"
+          class="hidden @2xl:flex items-center gap-3 text-xs text-muted-foreground border-l pl-4"
         >
           <span>Daily glucose profile</span>
           <span>·</span>
@@ -103,7 +103,7 @@
         </div>
       {/if}
     </div>
-    <div class="text-sm text-muted-foreground">
+    <div class="hidden @xl:block text-sm text-muted-foreground">
       Click any day to view detailed report
     </div>
   </div>

--- a/src/Web/packages/app/src/lib/components/calendar/CalendarMonthSummary.svelte
+++ b/src/Web/packages/app/src/lib/components/calendar/CalendarMonthSummary.svelte
@@ -19,7 +19,8 @@
 </script>
 
 {#if monthSummary.totalReadings > 0}
-  <div class="mt-4 pt-4 border-t grid grid-cols-2 md:grid-cols-4 gap-4">
+  <div class="@container mt-4 pt-4 border-t">
+  <div class="grid grid-cols-2 @lg:grid-cols-4 gap-4">
     <div class="text-center">
       <div class="text-2xl font-bold text-glucose-in-range">
         {monthSummary.inRangePercent.toFixed(1)}%
@@ -51,5 +52,6 @@
         Avg TDD
       </div>
     </div>
+  </div>
   </div>
 {/if}

--- a/src/Web/packages/app/src/lib/components/calendar/CalendarSkeleton.svelte
+++ b/src/Web/packages/app/src/lib/components/calendar/CalendarSkeleton.svelte
@@ -44,7 +44,7 @@
   <!-- Calendar Grid Skeleton -->
   <div class="flex-1 p-4">
     <Card.Root class="h-full">
-      <Card.Content class="p-4 h-full flex flex-col">
+      <Card.Content class="@container p-4 h-full flex flex-col">
         <!-- Day of week headers -->
         <div class="grid grid-cols-7 gap-1 mb-2">
           {#each Array(7) as _}
@@ -71,7 +71,7 @@
         </div>
 
         <!-- Month Summary Skeleton -->
-        <div class="mt-4 pt-4 border-t grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div class="mt-4 pt-4 border-t grid grid-cols-2 @lg:grid-cols-4 gap-4">
           {#each Array(4) as _}
             <div class="text-center">
               <Skeleton class="h-8 w-16 mx-auto mb-1" />

--- a/src/Web/packages/app/src/lib/components/connectors/ConnectorDangerZone.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/ConnectorDangerZone.svelte
@@ -120,9 +120,9 @@
         Irreversible actions that affect this connector
       </CardDescription>
     </CardHeader>
-    <CardContent class="space-y-4">
+    <CardContent class="@container space-y-4">
       {#if hasExistingConfig}
-        <div class="flex items-center justify-between">
+        <div class="flex flex-col gap-3 @lg:flex-row @lg:items-center @lg:justify-between">
           <div>
             <p class="font-medium">Delete Configuration</p>
             <p class="text-sm text-muted-foreground">
@@ -131,6 +131,7 @@
             </p>
           </div>
           <Button
+            class="shrink-0"
             variant="destructive"
             onclick={() => {
               deleteConfigResult = null;
@@ -148,7 +149,7 @@
       {/if}
 
       {#if hasData}
-        <div class="flex items-center justify-between">
+        <div class="flex flex-col gap-3 @lg:flex-row @lg:items-center @lg:justify-between">
           <div>
             <p class="font-medium">Delete Synced Data</p>
             <p class="text-sm text-muted-foreground">
@@ -169,6 +170,7 @@
             {/if}
           </div>
           <Button
+            class="shrink-0"
             variant="destructive"
             disabled={!hasData}
             onclick={() => {

--- a/src/Web/packages/app/src/lib/components/connectors/ConnectorSelectionGrid.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/ConnectorSelectionGrid.svelte
@@ -40,14 +40,14 @@
     </CardContent>
   </Card>
 {:else if servicesOverview?.availableConnectors}
-  <div class="space-y-4">
+  <div class="@container space-y-4">
     <div>
       <h3 class="text-lg font-semibold">Choose a connector</h3>
       <p class="text-sm text-muted-foreground">
         Select a data source to configure
       </p>
     </div>
-    <div class="grid gap-3 sm:grid-cols-2">
+    <div class="grid gap-3 @xl:grid-cols-2">
       {#each servicesOverview.availableConnectors as connector}
         <button
           class="flex items-center gap-4 p-4 rounded-lg border hover:border-primary/50 hover:bg-accent/50 transition-colors text-left group {connector.isConfigured

--- a/src/Web/packages/app/src/lib/components/connectors/DataSourceSelectionView.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/DataSourceSelectionView.svelte
@@ -120,7 +120,7 @@
     </Card.Content>
   </Card.Root>
 {:else}
-  <div class="space-y-8">
+  <div class="@container space-y-8">
     <!-- Cloud Services (Connectors) -->
     {#if connectors.length > 0}
       <div class="space-y-3">
@@ -128,7 +128,7 @@
           <Cloud class="h-4 w-4" />
           Cloud Services
         </h2>
-        <div class="grid gap-3 sm:grid-cols-2">
+        <div class="grid gap-3 @xl:grid-cols-2">
           {#each connectors as connector (connector.id)}
             {@const configured = connector.isConfigured ?? false}
             <button
@@ -172,12 +172,12 @@
     <!-- Phone Apps (Uploaders) -->
     {#if uploaderApps.length > 0}
       <div class="space-y-3">
-        <div class="flex items-center justify-between">
+        <div class="flex flex-col gap-3 @lg:flex-row @lg:items-center @lg:justify-between">
           <h2 class="text-sm font-medium text-muted-foreground flex items-center gap-2">
             <Smartphone class="h-4 w-4" />
             Phone Apps
           </h2>
-          <div class="flex items-center gap-1">
+          <div class="flex flex-wrap items-center gap-1 shrink-0">
             <Button
               variant={platformFilter === "all" ? "default" : "outline"}
               size="sm"
@@ -210,7 +210,7 @@
           {#each groupedApps as group (group.category)}
             <div class="space-y-3">
               <h3 class="text-sm font-medium text-muted-foreground">{group.label}</h3>
-              <div class="grid gap-3 sm:grid-cols-2">
+              <div class="grid gap-3 @xl:grid-cols-2">
                 {#each group.apps as app (app.id)}
                   {@const detected = isDetected(app.id)}
                   <button

--- a/src/Web/packages/app/src/lib/components/connectors/ServerConnectorsCard.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/ServerConnectorsCard.svelte
@@ -96,9 +96,9 @@
   }
 </script>
 
-<Card>
+<Card class="@container">
   <CardHeader>
-    <div class="flex items-center justify-between">
+    <div class="flex flex-col gap-3 @lg:flex-row @lg:items-center @lg:justify-between">
       <div>
         <CardTitle class="flex items-center gap-2">
           <Cloud class="h-5 w-5" />
@@ -144,7 +144,7 @@
     </div>
   </CardHeader>
   <CardContent>
-    <div class="grid gap-3 sm:grid-cols-2">
+    <div class="grid gap-3 @xl:grid-cols-2">
       {#each availableConnectors as connector}
         {@const connectorStatusInfo = connectorStatuses.find(
           (cs) => cs.id === connector.id

--- a/src/Web/packages/app/src/lib/components/connectors/UploaderAppsCard.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/UploaderAppsCard.svelte
@@ -40,7 +40,7 @@
       Connect your CGM app or AID system to push data to Nocturne
     </CardDescription>
   </CardHeader>
-  <CardContent>
+  <CardContent class="@container">
     <Tabs.Root value="cgm">
       <Tabs.List class="grid w-full grid-cols-3">
         <Tabs.Trigger value="cgm">CGM Apps</Tabs.Trigger>
@@ -54,7 +54,7 @@
         { value: "other", apps: otherApps },
       ] as tab}
         <Tabs.Content value={tab.value} class="mt-4">
-          <div class="grid gap-3 sm:grid-cols-2">
+          <div class="grid gap-3 @xl:grid-cols-2">
             {#each tab.apps as uploader}
               {@const active = isUploaderActive(uploader)}
               <button

--- a/src/Web/packages/app/src/lib/components/dashboard/BGStatisticsCards.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/BGStatisticsCards.svelte
@@ -63,7 +63,8 @@
   }
 </script>
 
-<div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+<div class="@container">
+<div class="grid grid-cols-1 @lg:grid-cols-3 gap-4">
   <Card>
     <CardHeader class="pb-2">
       <CardTitle class="text-sm font-medium">BG Delta</CardTitle>
@@ -155,4 +156,5 @@
   {#if showWebSocketStatus}
     <WebSocketStatus />
   {/if}
+</div>
 </div>

--- a/src/Web/packages/app/src/lib/components/dashboard/DashboardSkeleton.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/DashboardSkeleton.svelte
@@ -3,9 +3,9 @@
   import { Card, CardContent, CardHeader } from "$lib/components/ui/card";
 </script>
 
-<div class="container mx-auto p-6 space-y-6">
+<div class="@container container mx-auto p-6 space-y-6">
   <!-- Header Skeleton -->
-  <div class="flex items-center justify-between">
+  <div class="flex flex-col gap-3 @lg:flex-row @lg:items-center @lg:justify-between">
     <div class="space-y-2">
       <Skeleton class="h-9 w-64" />
       <Skeleton class="h-4 w-96" />
@@ -17,7 +17,7 @@
   </div>
 
   <!-- Overall Status Cards Skeleton (4-card grid) -->
-  <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+  <div class="grid gap-4 @lg:grid-cols-2 @3xl:grid-cols-4">
     {#each Array(4) as _, i (i)}
       <Card>
         <CardHeader
@@ -35,7 +35,7 @@
   </div>
 
   <!-- Detailed Metrics Skeleton (2-column grid) -->
-  <div class="grid gap-6 md:grid-cols-2">
+  <div class="grid gap-6 @lg:grid-cols-2">
     <!-- Left Card -->
     <Card>
       <CardHeader>

--- a/src/Web/packages/app/src/lib/components/food/AddFoodDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/food/AddFoodDialog.svelte
@@ -142,7 +142,7 @@
 </script>
 
 <Dialog.Root bind:open {onOpenChange}>
-  <Dialog.Content class="max-w-2xl max-h-[90vh] overflow-y-auto">
+  <Dialog.Content class="@container max-w-2xl max-h-[90vh] overflow-y-auto">
     <Dialog.Header>
       <Dialog.Title>{dialogTitle}</Dialog.Title>
       <Dialog.Description>
@@ -158,7 +158,7 @@
         <input type="hidden" name="_id" value={editingFoodId} />
         <input type="hidden" name="type" value="food" />
         <!-- Name and Category row -->
-        <div class="grid gap-4 md:grid-cols-3">
+        <div class="grid gap-4 @lg:grid-cols-3">
           <div class="space-y-2">
             <Label for="food-name">Name</Label>
             <Input id="food-name" name="name" bind:value={foodName} />
@@ -184,7 +184,7 @@
           <h3 class="text-sm font-medium text-muted-foreground">
             Key Nutritional Info
           </h3>
-          <div class="grid gap-4 md:grid-cols-4">
+          <div class="grid gap-4 @lg:grid-cols-4">
             <div class="space-y-2">
               <Label for="food-carbs" class="text-base font-semibold">
                 Carbs (g)
@@ -224,7 +224,7 @@
           <h3 class="text-sm font-medium text-muted-foreground">
             Additional Macros
           </h3>
-          <div class="grid gap-4 md:grid-cols-3">
+          <div class="grid gap-4 @lg:grid-cols-3">
             <div class="space-y-2">
               <Label for="food-fat">Fat (g)</Label>
               <Input id="food-fat" name="n:fat" type="number" bind:value={foodFat} />
@@ -255,7 +255,7 @@
       <div class="space-y-4">
         <input type="hidden" name="type" value="food" />
         <!-- Name and Category row -->
-        <div class="grid gap-4 md:grid-cols-3">
+        <div class="grid gap-4 @lg:grid-cols-3">
           <div class="space-y-2">
             <Label for="food-name">Name</Label>
             <Input id="food-name" name="name" bind:value={foodName} />
@@ -281,7 +281,7 @@
           <h3 class="text-sm font-medium text-muted-foreground">
             Key Nutritional Info
           </h3>
-          <div class="grid gap-4 md:grid-cols-4">
+          <div class="grid gap-4 @lg:grid-cols-4">
             <div class="space-y-2">
               <Label for="food-carbs" class="text-base font-semibold">
                 Carbs (g)
@@ -321,7 +321,7 @@
           <h3 class="text-sm font-medium text-muted-foreground">
             Additional Macros
           </h3>
-          <div class="grid gap-4 md:grid-cols-3">
+          <div class="grid gap-4 @lg:grid-cols-3">
             <div class="space-y-2">
               <Label for="food-fat">Fat (g)</Label>
               <Input id="food-fat" name="n:fat" type="number" bind:value={foodFat} />

--- a/src/Web/packages/app/src/lib/components/layout/MobileHeader.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/MobileHeader.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
   import { tryGetRealtimeStore } from "$lib/stores/realtime-store.svelte";
   import { getDirectionInfo } from "$lib/utils";
+  import { formatGlucoseDelta } from "$lib/utils/formatting";
+  import { glucoseUnits } from "$lib/stores/appearance-store.svelte";
   import * as Sidebar from "$lib/components/ui/sidebar";
 
   const realtimeStore = tryGetRealtimeStore();
+
+  const units = $derived(glucoseUnits.current);
 
   // Scroll tracking state
   let lastScrollY = $state(0);
@@ -20,12 +24,6 @@
     if (bg > 250) return "bg-red-500";
     if (bg > 180) return "bg-orange-500";
     return "bg-green-500";
-  }
-
-  // Format delta with sign
-  function formatDelta(delta: number): string {
-    if (delta > 0) return `+${delta}`;
-    return String(delta);
   }
 
   // Handle scroll events
@@ -80,7 +78,7 @@
           {/if}
         </span>
         <span class="text-muted-foreground">
-          {formatDelta(realtimeStore.bgDelta)}
+          {formatGlucoseDelta(realtimeStore.bgDelta, units)}
         </span>
       </div>
     </div>

--- a/src/Web/packages/app/src/lib/components/meals/MealsFilterBar.svelte
+++ b/src/Web/packages/app/src/lib/components/meals/MealsFilterBar.svelte
@@ -58,13 +58,13 @@
 </script>
 
 <Card.Root>
-  <Card.Content class="space-y-4 p-4">
+  <Card.Content class="@container space-y-4 p-4">
     <!-- Row 1: Date picker inline -->
     <DateRangePicker defaultDays={1} onDateChange={handleDateChange} />
 
     <!-- Row 2: All filter controls -->
     <div
-      class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between"
+      class="flex flex-col gap-4 @lg:flex-row @lg:items-center @lg:justify-between"
     >
       <!-- Left side: All/Unattributed, Search, Food filter -->
       <div class="flex flex-wrap items-center gap-2">
@@ -89,7 +89,7 @@
         </div>
 
         <!-- Separator -->
-        <div class="hidden md:block h-6 w-px bg-border"></div>
+        <div class="hidden @lg:block h-6 w-px bg-border"></div>
 
         <!-- Search -->
         <div class="flex-1 min-w-[200px] max-w-sm">

--- a/src/Web/packages/app/src/lib/components/meals/MealsTable.svelte
+++ b/src/Web/packages/app/src/lib/components/meals/MealsTable.svelte
@@ -89,7 +89,7 @@
 </script>
 
 <Card.Root>
-  <Card.Content class="p-0">
+  <Card.Content class="@container p-0">
     {#if isLoading}
       <div class="flex items-center justify-center p-12">
         <Loader2 class="h-8 w-8 animate-spin text-muted-foreground" />
@@ -322,7 +322,7 @@
                             Foods ({meal.foods?.length})
                           </div>
                           <div
-                            class="grid gap-2 md:grid-cols-2 lg:grid-cols-3"
+                            class="grid gap-2 @xl:grid-cols-2 @4xl:grid-cols-3"
                           >
                             {#each meal.foods ?? [] as food}
                               <div class="rounded-lg border bg-card p-3 text-sm transition-colors group relative hover:bg-accent/50">

--- a/src/Web/packages/app/src/lib/components/members/CreateInviteCard.svelte
+++ b/src/Web/packages/app/src/lib/components/members/CreateInviteCard.svelte
@@ -119,7 +119,7 @@
       after signing in.
     </Card.Description>
   </Card.Header>
-  <Card.Content>
+  <Card.Content class="@container">
     {#if createdInviteUrl}
       <div class="space-y-4">
         <div
@@ -176,7 +176,7 @@
           description: "Roles control what they can see and do. Viewer for a quick glance, Caretaker if they help manage your diabetes.",
         })}>
           <Label>Roles</Label>
-          <div class="grid gap-2 sm:grid-cols-2">
+          <div class="grid gap-2 @sm:grid-cols-2">
             {#each roles as role (role.id)}
               <div class="flex items-center gap-2">
                 <Checkbox

--- a/src/Web/packages/app/src/lib/components/members/MemberCard.svelte
+++ b/src/Web/packages/app/src/lib/components/members/MemberCard.svelte
@@ -107,7 +107,7 @@
   }
 </script>
 
-<Card.Root>
+<Card.Root class="@container">
   <Card.Header>
     <div class="flex items-start justify-between gap-4">
       <div class="space-y-1 flex-1 min-w-0">
@@ -189,7 +189,7 @@
       <!-- Role selection -->
       <div class="space-y-2">
         <Label>Roles</Label>
-        <div class="grid gap-2 sm:grid-cols-2">
+        <div class="grid gap-2 @sm:grid-cols-2">
           {#each roles as role (role.id)}
             {@const isOwnerSelf = role.slug === "owner" && member.subjectId === currentSubjectId}
             {@const isOwnerRole = editingRoleIds.includes(role.id ?? '')}

--- a/src/Web/packages/app/src/lib/components/members/PendingRequestsList.svelte
+++ b/src/Web/packages/app/src/lib/components/members/PendingRequestsList.svelte
@@ -96,7 +96,7 @@
     {@const isDenying = denyingIds.has(request.id ?? "")}
     {@const isBusy = isApproving || isDenying}
     <Card.Root>
-      <Card.Content class="space-y-4 pt-6">
+      <Card.Content class="@container space-y-4 pt-6">
         <!-- Requester info -->
         <div class="flex items-start gap-3">
           <Avatar.Root class="h-10 w-10 shrink-0">
@@ -130,7 +130,7 @@
         <!-- Role selection -->
         <div class="space-y-2">
           <Label>Assign roles</Label>
-          <div class="grid gap-2 sm:grid-cols-2">
+          <div class="grid gap-2 @sm:grid-cols-2">
             {#each roles as role (role.id)}
               <div class="flex items-center gap-2">
                 <Checkbox

--- a/src/Web/packages/app/src/lib/components/patient/InsulinFormFields.svelte
+++ b/src/Web/packages/app/src/lib/components/patient/InsulinFormFields.svelte
@@ -82,9 +82,9 @@
   }
 </script>
 
-<div class="space-y-4">
+<div class="@container space-y-4">
   <!-- Category and Formulation Select -->
-  <div class="grid gap-4 sm:grid-cols-2">
+  <div class="grid gap-4 @sm:grid-cols-2">
     <div class="space-y-2">
       <Label for="insulin-category">Category</Label>
       <Select.Root
@@ -154,7 +154,7 @@
   </div>
 
   <!-- Name and Role Select -->
-  <div class="grid gap-4 sm:grid-cols-2">
+  <div class="grid gap-4 @sm:grid-cols-2">
     <div class="space-y-2">
       <Label for="insulin-name">Brand / Name</Label>
       <Input
@@ -189,7 +189,7 @@
   </div>
 
   <!-- DIA, Peak, Concentration -->
-  <div class="grid gap-4 sm:grid-cols-3">
+  <div class="grid gap-4 @sm:grid-cols-3">
     <div class="space-y-2">
       <Label for="insulin-dia">Duration of Insulin Action</Label>
       <div class="flex items-center gap-2">
@@ -239,7 +239,7 @@
 
   {#if showExtendedFields}
     <!-- Start/End Dates -->
-    <div class="grid gap-4 sm:grid-cols-2">
+    <div class="grid gap-4 @sm:grid-cols-2">
       <div class="space-y-2">
         <Label for="insulin-start">Start Date</Label>
         <Input

--- a/src/Web/packages/app/src/lib/components/patient/PatientClinicalForm.svelte
+++ b/src/Web/packages/app/src/lib/components/patient/PatientClinicalForm.svelte
@@ -22,6 +22,7 @@
 
 <form
   id="clinical-form"
+  class="@container"
   bind:this={formEl}
   {...state.guard.enhance()}
 >
@@ -39,7 +40,7 @@
     <input type="hidden" name="modifiedAt" value={state.record.modifiedAt instanceof Date ? state.record.modifiedAt.toISOString() : state.record.modifiedAt} />
   {/if}
 
-  <div class="grid gap-4 sm:grid-cols-2">
+  <div class="grid gap-4 @sm:grid-cols-2">
     <div class="space-y-2">
       <Label for="diabetes-type">Diabetes Type</Label>
       <Select.Root type="single" name="diabetesType" bind:value={state.diabetesType}>
@@ -111,7 +112,7 @@
       />
     </div>
 
-    <div class="space-y-2 sm:col-span-2">
+    <div class="space-y-2 @sm:col-span-2">
       <Label for="timezone">Timezone</Label>
       <Input
         id="timezone"

--- a/src/Web/packages/app/src/lib/components/patient/PatientDeviceManager.svelte
+++ b/src/Web/packages/app/src/lib/components/patient/PatientDeviceManager.svelte
@@ -200,8 +200,8 @@
           if (deviceList.createForm.result) resetInlineForm();
         })}
       >
-        <Card.Content class="space-y-4">
-          <div class="grid gap-4 sm:grid-cols-2">
+        <Card.Content class="@container space-y-4">
+          <div class="grid gap-4 @sm:grid-cols-2">
             <div class="space-y-2">
               <Label for="device-category">Device Category</Label>
               <Select.Root type="single" name="deviceCategory" bind:value={inlineCategory}>
@@ -379,7 +379,7 @@
         {#if editing?.id}
           <input type="hidden" name="id" value={editing.id} />
         {/if}
-        <div class="space-y-4 py-4">
+        <div class="@container space-y-4 py-4">
           <div class="space-y-2">
             <Label for="device-category">Category</Label>
             <Select.Root type="single" name="deviceCategory" bind:value={deviceCategory}>
@@ -394,7 +394,7 @@
             </Select.Root>
           </div>
 
-          <div class="grid gap-4 sm:grid-cols-2">
+          <div class="grid gap-4 @sm:grid-cols-2">
             <div class="space-y-2">
               <Label for="device-manufacturer">Manufacturer</Label>
               <Input
@@ -443,7 +443,7 @@
             />
           </div>
 
-          <div class="grid gap-4 sm:grid-cols-2">
+          <div class="grid gap-4 @sm:grid-cols-2">
             <div class="space-y-2">
               <Label for="device-start">Start Date</Label>
               <Input

--- a/src/Web/packages/app/src/lib/components/profile/ProfileEditDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/profile/ProfileEditDialog.svelte
@@ -174,7 +174,7 @@
 </script>
 
 <Dialog.Root bind:open onOpenChange={(isOpen) => !isOpen && handleClose()}>
-  <Dialog.Content class="max-w-3xl max-h-[85vh] overflow-hidden flex flex-col">
+  <Dialog.Content class="@container max-w-3xl max-h-[85vh] overflow-hidden flex flex-col">
     <Dialog.Header>
       <Dialog.Title class="flex items-center gap-2">
         <Edit class="h-5 w-5" />
@@ -351,7 +351,7 @@
               </div>
             </div>
 
-            <div class="grid md:grid-cols-2 gap-6">
+            <div class="grid @lg:grid-cols-2 gap-6">
               <!-- Target Low -->
               <div class="space-y-3">
                 <div class="flex items-center justify-between">

--- a/src/Web/packages/app/src/lib/components/reports/ApsStateCard.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/ApsStateCard.svelte
@@ -39,9 +39,9 @@
 </script>
 
 {#if snapshot}
-  <Card.Root>
+  <Card.Root class="@container">
     <Card.Header class="pb-2">
-      <div class="flex items-center justify-between">
+      <div class="flex flex-col gap-3 @lg:flex-row @lg:items-center @lg:justify-between">
         <Card.Title class="flex items-center gap-2 text-sm">
           <Brain class="h-4 w-4" />
           APS Decision at {snapshotTime}
@@ -49,8 +49,8 @@
         <Badge
           variant={isEnacted ? "default" : "outline"}
           class={isEnacted
-            ? "bg-green-600/20 text-green-400 border-green-600/40"
-            : ""}
+            ? "shrink-0 bg-green-600/20 text-green-400 border-green-600/40"
+            : "shrink-0"}
         >
           {#if isEnacted}
             <Check class="h-3 w-3 mr-1" />
@@ -62,7 +62,7 @@
       </div>
     </Card.Header>
     <Card.Content>
-      <div class="grid grid-cols-2 sm:grid-cols-4 gap-x-6 gap-y-3 text-sm">
+      <div class="grid grid-cols-2 @sm:grid-cols-4 gap-x-6 gap-y-3 text-sm">
         <!-- IOB -->
         <div>
           <div class="flex items-center gap-1 text-muted-foreground">

--- a/src/Web/packages/app/src/lib/components/reports/DailyInsulinSummary.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/DailyInsulinSummary.svelte
@@ -12,9 +12,9 @@
   let { treatmentSummary }: Props = $props();
 </script>
 
-<div class="mt-4 bg-blue-50 border border-blue-200 rounded-lg p-4">
+<div class="@container mt-4 bg-blue-50 border border-blue-200 rounded-lg p-4">
   <h4 class="text-sm font-semibold text-gray-700 mb-3">Daily Summary</h4>
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+  <div class="grid grid-cols-1 @lg:grid-cols-2 gap-4 text-sm">
     <div class="space-y-2">
       <div class="flex justify-between">
         <span class="text-gray-600">Bolus insulin:</span>

--- a/src/Web/packages/app/src/lib/components/reports/DailyStatistics.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/DailyStatistics.svelte
@@ -10,7 +10,8 @@
   let { dayData, thresholds }: Props = $props();
 </script>
 
-<div class="mt-4 grid grid-cols-2 md:grid-cols-3 gap-4 text-sm">
+<div class="@container mt-4">
+<div class="grid grid-cols-2 @lg:grid-cols-3 gap-4 text-sm">
   <div class="bg-gray-50 p-3 rounded">
     <div class="text-gray-600 text-xs">Average</div>
     <div
@@ -65,4 +66,5 @@
         (dayData.analytics?.timeInRange?.percentages?.veryHigh ?? 0)}%
     </div>
   </div>
+</div>
 </div>

--- a/src/Web/packages/app/src/lib/components/reports/DailySummaryTable.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/DailySummaryTable.svelte
@@ -22,7 +22,8 @@
   let { dailyDataPoints, thresholds }: Props = $props();
 </script>
 
-<div class="bg-white shadow-lg rounded-lg p-4 md:p-6">
+<div class="@container">
+<div class="bg-white shadow-lg rounded-lg p-4 @lg:p-6">
   <h2 class="text-xl font-semibold text-gray-700 mb-4">Daily Summary</h2>
   <Table>
     <TableCaption class="text-sm text-gray-500 mt-2">
@@ -122,4 +123,5 @@
       {/each}
     </TableBody>
   </Table>
+</div>
 </div>

--- a/src/Web/packages/app/src/lib/components/reports/PeriodAverages.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/PeriodAverages.svelte
@@ -15,11 +15,12 @@
   let { averages, thresholds }: Props = $props();
 </script>
 
-<div class="bg-white shadow-lg rounded-lg p-4 md:p-6 mb-6">
+<div class="@container mb-6">
+<div class="bg-white shadow-lg rounded-lg p-4 @lg:p-6">
   <h2 class="text-xl font-semibold text-gray-700 mb-4">Period Averages</h2>
   <div class="bg-green-50 border border-green-200 rounded-lg p-4 mb-4">
     <h3 class="text-sm font-semibold text-gray-700 mb-3">Glucose Management</h3>
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+    <div class="grid grid-cols-1 @lg:grid-cols-2 gap-4 text-sm">
       <div class="space-y-2">
         <div class="flex justify-between">
           <span class="text-gray-600">Time in Range average:</span>
@@ -48,7 +49,7 @@
     <h3 class="text-sm font-semibold text-gray-700 mb-3">
       Insulin & Nutrition
     </h3>
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+    <div class="grid grid-cols-1 @lg:grid-cols-2 gap-4 text-sm">
       <div class="space-y-2">
         <div class="flex justify-between">
           <span class="text-gray-600">TDD average:</span>
@@ -97,4 +98,5 @@
       </div>
     </div>
   </div>
+</div>
 </div>

--- a/src/Web/packages/app/src/lib/components/reports/ReportsSkeleton.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/ReportsSkeleton.svelte
@@ -3,7 +3,7 @@
   import { Card, CardContent, CardHeader } from "$lib/components/ui/card";
 </script>
 
-<div class="container mx-auto space-y-8 px-4 py-6">
+<div class="@container container mx-auto space-y-8 px-4 py-6">
   <!-- Header Skeleton -->
   <div class="space-y-3 text-center">
     <div class="flex items-center justify-center gap-2">
@@ -23,7 +23,7 @@
   </div>
 
   <!-- Score Cards Skeleton -->
-  <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+  <div class="grid grid-cols-1 gap-4 @xl:grid-cols-2 @5xl:grid-cols-4">
     {#each Array(4) as _}
       <Card>
         <CardHeader class="pb-2">
@@ -42,8 +42,8 @@
   </div>
 
   <!-- Charts Row Skeleton -->
-  <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
-    <Card class="lg:col-span-1">
+  <div class="grid grid-cols-1 gap-6 @4xl:grid-cols-3">
+    <Card class="@4xl:col-span-1">
       <CardHeader>
         <div class="flex items-center gap-2">
           <Skeleton class="h-5 w-5 rounded" />
@@ -56,7 +56,7 @@
       </CardContent>
     </Card>
 
-    <Card class="lg:col-span-2">
+    <Card class="@4xl:col-span-2">
       <CardHeader>
         <div class="flex items-center justify-between">
           <div>
@@ -76,7 +76,7 @@
   </div>
 
   <!-- Stats Grid Skeleton -->
-  <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+  <div class="grid grid-cols-2 gap-3 @sm:grid-cols-3 @3xl:grid-cols-6">
     {#each Array(6) as _}
       <Card class="p-4 text-center">
         <Skeleton class="h-8 w-16 mx-auto mb-2" />

--- a/src/Web/packages/app/src/lib/components/reports/RetrospectiveStats.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/RetrospectiveStats.svelte
@@ -58,7 +58,7 @@
 </script>
 
 {#if !retrospectiveQuery.current && !retrospectiveQuery.error}
-  <Card.Root class="border-2 border-primary/20 bg-primary/5">
+  <Card.Root class="@container border-2 border-primary/20 bg-primary/5">
     <Card.Header class="pb-2">
       <Card.Title class="flex items-center gap-2 text-base">
         <Activity class="h-4 w-4" />
@@ -67,7 +67,7 @@
     </Card.Header>
     <Card.Content>
       <!-- Skeleton loading state - matches the layout below -->
-      <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <div class="grid grid-cols-2 @lg:grid-cols-4 gap-4">
         {#each [1, 2, 3, 4] as _}
           <div
             class="flex flex-col items-center gap-1 p-3 rounded-lg bg-background/50"
@@ -120,7 +120,7 @@
   </Card.Root>
 {:else}
   {@const data = retrospectiveQuery.current}
-  <Card.Root class="border-2 border-primary/20 bg-primary/5">
+  <Card.Root class="@container border-2 border-primary/20 bg-primary/5">
     <Card.Header class="pb-2">
       <Card.Title class="flex items-center gap-2 text-base">
         <Activity class="h-4 w-4" />
@@ -128,7 +128,7 @@
       </Card.Title>
     </Card.Header>
     <Card.Content>
-      <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <div class="grid grid-cols-2 @lg:grid-cols-4 gap-4">
         <!-- Glucose -->
         <div
           class="flex flex-col items-center gap-1 p-3 rounded-lg bg-background/50"

--- a/src/Web/packages/app/src/lib/components/reports/SiteChangeImpactChart.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/SiteChangeImpactChart.svelte
@@ -141,7 +141,7 @@
     ]);
 </script>
 
-<div class="w-full">
+<div class="@container w-full">
   {#if analysis && analysis.hasSufficientData && chartData.length > 0}
     <div class="h-[400px] w-full">
       <AreaChart
@@ -242,7 +242,7 @@
 
     <!-- Summary Statistics -->
     {#if analysis.summary}
-      <div class="mt-6 grid grid-cols-2 gap-4 md:grid-cols-4">
+      <div class="mt-6 grid grid-cols-2 gap-4 @lg:grid-cols-4">
         <div class="rounded-lg bg-muted/50 p-3 text-center">
           <div class="text-sm text-muted-foreground">Avg Before</div>
           <div class="text-xl font-semibold">

--- a/src/Web/packages/app/src/lib/components/reports/TreatmentSummary.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/TreatmentSummary.svelte
@@ -52,11 +52,11 @@
   }
 </script>
 
-<div class="bg-white shadow-lg rounded-lg p-4 md:p-6 mb-6">
+<div class="@container bg-white shadow-lg rounded-lg p-4 @lg:p-6 mb-6">
   <h2 class="text-xl font-semibold text-gray-700 mb-4">
     Overall Treatment Summary
   </h2>
-  <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+  <div class="grid grid-cols-1 @4xl:grid-cols-3 gap-4">
     {#each dailyDataPoints as day}
       {@const totalInsulin = getTotalInsulin(day.treatmentSummary)}
       {@const totalCarbs = getTotalCarbs(day.treatmentSummary)}

--- a/src/Web/packages/app/src/lib/components/reports/year-overview/YearOverviewFilters.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/year-overview/YearOverviewFilters.svelte
@@ -23,8 +23,9 @@
   }>();
 </script>
 
+<div class="@container">
 <div
-  class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between"
+  class="mb-6 flex flex-col gap-4 @sm:flex-row @sm:items-center @sm:justify-between"
 >
   <div class="flex items-center gap-3">
     <div
@@ -122,4 +123,5 @@
       </Popover.Root>
     {/if}
   </div>
+</div>
 </div>

--- a/src/Web/packages/app/src/lib/components/settings/AlarmProfileDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/AlarmProfileDialog.svelte
@@ -174,13 +174,15 @@
       </Tabs>
     </div>
 
-    <DialogFooter class="border-t pt-4">
-      <div class="flex items-center justify-between w-full">
+    <DialogFooter class="border-t pt-4 @container">
+      <div
+        class="flex flex-col gap-3 @lg:flex-row @lg:items-center @lg:justify-between w-full"
+      >
         <div class="flex items-center gap-2">
           <Switch bind:checked={editedProfile.enabled} />
           <Label>Alarm Enabled</Label>
         </div>
-        <div class="flex gap-2">
+        <div class="flex flex-wrap gap-2">
           <Button variant="outline" onclick={onCancel}>Cancel</Button>
           <Button onclick={handleSave}>Save Alarm</Button>
         </div>

--- a/src/Web/packages/app/src/lib/components/settings/BrowserCapabilities.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/BrowserCapabilities.svelte
@@ -149,13 +149,13 @@
   {@const VibrationStatusIcon = vibrationStatus.icon}
   {@const wakelockStatus = getStatusIcon(capabilities.wakeLock)}
   {@const WakelockStatusIcon = wakelockStatus.icon}
-  <div class="space-y-4">
+  <div class="space-y-4 @container">
     <div class="flex items-center gap-2 text-sm font-medium">
       <Smartphone class="h-4 w-4" />
       Browser Capabilities
     </div>
 
-    <div class="grid gap-3 sm:grid-cols-2">
+    <div class="grid gap-3 @xl:grid-cols-2">
       <!-- Audio -->
       <button
         type="button"

--- a/src/Web/packages/app/src/lib/components/settings/DashboardWidgetConfigurator.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/DashboardWidgetConfigurator.svelte
@@ -123,7 +123,7 @@
       Customize the {maxWidgets} widgets shown above the glucose chart. Drag to reorder.
     </CardDescription>
   </CardHeader>
-  <CardContent class="space-y-4">
+  <CardContent class="space-y-4 @container">
     {#if true}
       {@const allAvailableWidgets = getAvailableWidgets()}
       {@const availableWidgets = allAvailableWidgets.filter(
@@ -191,7 +191,7 @@
           <span class="text-sm font-medium text-muted-foreground">
             Available Widgets {#if !canAddMore}(max {maxWidgets} reached){/if}
           </span>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          <div class="grid grid-cols-1 @sm:grid-cols-2 gap-2">
             {#each availableWidgets as widgetId (widgetId)}
               {@const Icon = getIcon(widgetId)}
               <button

--- a/src/Web/packages/app/src/lib/components/settings/HaloDialConfigurator.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/HaloDialConfigurator.svelte
@@ -80,9 +80,9 @@
     </CardTitle>
     <CardDescription>Configure the halo dial display</CardDescription>
   </CardHeader>
-  <CardContent class="space-y-4">
+  <CardContent class="space-y-4 @container">
     <!-- Section 1: Ring Settings -->
-    <div class="grid gap-4 sm:grid-cols-2">
+    <div class="grid gap-4 @sm:grid-cols-2">
       <div class="space-y-2">
         <Label>Color mode</Label>
         <Select.Root
@@ -160,7 +160,7 @@
     <Separator />
 
     <!-- Section 2: Center & Arcs -->
-    <div class="grid gap-4 sm:grid-cols-2">
+    <div class="grid gap-4 @sm:grid-cols-2">
       <div class="space-y-2">
         <Label>Center sub-element</Label>
         <Select.Root

--- a/src/Web/packages/app/src/lib/components/settings/SettingsPageSkeleton.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/SettingsPageSkeleton.svelte
@@ -29,7 +29,7 @@
           </div>
         </div>
       </CardHeader>
-      <CardContent class="space-y-4">
+      <CardContent class="space-y-4 @container">
         <!-- Vary the content based on card index for visual variety -->
         {#if i % 3 === 0}
           <!-- Toggle rows -->
@@ -49,7 +49,7 @@
           </div>
         {:else if i % 3 === 1}
           <!-- Grid of inputs -->
-          <div class="grid gap-4 sm:grid-cols-2">
+          <div class="grid gap-4 @sm:grid-cols-2">
             <div class="space-y-2">
               <Skeleton class="h-4 w-24" />
               <Skeleton class="h-10 w-full rounded-md" />

--- a/src/Web/packages/app/src/lib/components/settings/TitleFaviconSettings.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/TitleFaviconSettings.svelte
@@ -64,7 +64,7 @@
       Customize how glucose data appears in the browser tab
     </CardDescription>
   </CardHeader>
-  <CardContent class="space-y-6">
+  <CardContent class="space-y-6 @container">
     <!-- Master Enable -->
     <div class="flex items-center justify-between">
       <div class="space-y-0.5">
@@ -88,7 +88,7 @@
       <div class="space-y-4">
         <h4 class="text-sm font-medium">Title</h4>
 
-        <div class="grid gap-4 sm:grid-cols-2">
+        <div class="grid gap-4 @sm:grid-cols-2">
           <div class="flex items-center justify-between">
             <Label>Show BG value</Label>
             <Switch
@@ -158,7 +158,7 @@
         </div>
 
         {#if settings.faviconEnabled}
-          <div class="grid gap-4 sm:grid-cols-2 pl-4">
+          <div class="grid gap-4 @sm:grid-cols-2 pl-4">
             <div class="flex items-center justify-between">
               <Label>Show BG value in favicon</Label>
               <Switch

--- a/src/Web/packages/app/src/lib/components/settings/alarm-profile/AlarmAudioTab.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/alarm-profile/AlarmAudioTab.svelte
@@ -82,7 +82,7 @@
   ];
 </script>
 
-<div class="space-y-6">
+<div class="space-y-6 @container">
   <div class="flex items-center justify-between">
     <div class="flex items-center gap-3">
       <Volume2 class="h-5 w-5 text-muted-foreground" />
@@ -203,7 +203,7 @@
 
       {#if profile.audio.ascendingVolume}
         <div
-          class="grid gap-4 sm:grid-cols-3 p-4 bg-muted/50 rounded-lg"
+          class="grid gap-4 @sm:grid-cols-3 p-4 bg-muted/50 rounded-lg"
         >
           <div class="space-y-2">
             <Label class="text-sm">Start Volume</Label>

--- a/src/Web/packages/app/src/lib/components/settings/alarm-profile/AlarmGeneralTab.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/alarm-profile/AlarmGeneralTab.svelte
@@ -42,8 +42,8 @@
   const priorities: AlarmPriority[] = ["Low", "Normal", "High", "Critical"];
 </script>
 
-<div class="space-y-6">
-  <div class="grid gap-4 sm:grid-cols-2">
+<div class="space-y-6 @container">
+  <div class="grid gap-4 @sm:grid-cols-2">
     <div class="space-y-2">
       <Label for="name">Alarm Name</Label>
       <Input
@@ -62,7 +62,7 @@
     </div>
   </div>
 
-  <div class="grid gap-4 sm:grid-cols-2">
+  <div class="grid gap-4 @sm:grid-cols-2">
     <div class="space-y-2">
       <Label>Alarm Type</Label>
       <Select
@@ -123,7 +123,7 @@
 
   <div class="space-y-4">
     <h4 class="font-medium">Threshold Settings</h4>
-    <div class="grid gap-4 sm:grid-cols-2">
+    <div class="grid gap-4 @sm:grid-cols-2">
       <div class="space-y-2">
         <Label>
           {profile.alarmType === "StaleData"

--- a/src/Web/packages/app/src/lib/components/settings/alarm-profile/AlarmSnoozeTab.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/alarm-profile/AlarmSnoozeTab.svelte
@@ -34,14 +34,14 @@
   }
 </script>
 
-<div class="space-y-6">
+<div class="space-y-6 @container">
   <div class="space-y-4">
     <h4 class="font-medium flex items-center gap-2">
       <Timer class="h-4 w-4" />
       Snooze Settings
     </h4>
 
-    <div class="grid gap-4 sm:grid-cols-2">
+    <div class="grid gap-4 @sm:grid-cols-2">
       <div class="space-y-2">
         <Label>Default Snooze</Label>
         <div class="flex items-center gap-2">
@@ -120,7 +120,7 @@
     </div>
 
     {#if profile.reraise.enabled}
-      <div class="grid gap-4 sm:grid-cols-2 p-4 bg-muted/50 rounded-lg">
+      <div class="grid gap-4 @sm:grid-cols-2 p-4 bg-muted/50 rounded-lg">
         <div class="space-y-2">
           <Label>Re-raise every</Label>
           <div class="flex items-center gap-2">
@@ -169,7 +169,7 @@
           <br />
           For low alarms: extend if glucose is rising.
         </p>
-        <div class="grid gap-4 sm:grid-cols-3">
+        <div class="grid gap-4 @sm:grid-cols-3">
           <div class="space-y-2">
             <Label class="text-sm">Min Delta</Label>
             <div class="flex items-center gap-2">

--- a/src/Web/packages/app/src/lib/components/settings/alarm-profile/AlarmVisualTab.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/alarm-profile/AlarmVisualTab.svelte
@@ -33,7 +33,7 @@
   });
 </script>
 
-<div class="space-y-6">
+<div class="space-y-6 @container">
   <!-- Preview Section -->
   <div class="p-4 rounded-lg border bg-muted/30">
     <div class="flex items-center justify-between mb-3">
@@ -62,7 +62,7 @@
   </div>
 
   {#if profile.visual.screenFlash}
-    <div class="grid gap-4 sm:grid-cols-2 p-4 bg-muted/50 rounded-lg">
+    <div class="grid gap-4 @sm:grid-cols-2 p-4 bg-muted/50 rounded-lg">
       <div class="space-y-2">
         <Label>Flash Color</Label>
         <div class="flex items-center gap-2">

--- a/src/Web/packages/app/src/lib/components/trackers/TrackerEditorDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/trackers/TrackerEditorDialog.svelte
@@ -74,7 +74,7 @@
 </script>
 
 {#snippet definitionFormFields(prefix: string)}
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+  <div class="grid grid-cols-1 @lg:grid-cols-2 gap-4">
     <div class="space-y-2">
       <Label for="name">Name</Label>
       <Input
@@ -328,7 +328,7 @@
 {/snippet}
 
 <Dialog.Root bind:open>
-  <Dialog.Content class="max-w-2xl max-h-[90vh] overflow-y-auto">
+  <Dialog.Content class="@container max-w-2xl max-h-[90vh] overflow-y-auto">
     <Dialog.Header>
       <Dialog.Title>
         {isNewDefinition ? "New Tracker Definition" : "Edit Definition"}

--- a/src/Web/packages/app/src/lib/components/treatments/DataTablePagination.svelte
+++ b/src/Web/packages/app/src/lib/components/treatments/DataTablePagination.svelte
@@ -24,11 +24,12 @@
 </script>
 
 <!-- Pagination -->
-<div class="flex items-center justify-between px-2">
+<div class="@container">
+<div class="flex flex-col gap-3 @lg:flex-row @lg:items-center @lg:justify-between px-2">
   <div class="text-sm text-muted-foreground">
     {selectedCount} of {totalCount} row(s) selected
   </div>
-  <div class="flex items-center gap-6 lg:gap-8">
+  <div class="flex items-center gap-6 @3xl:gap-8">
     <div class="flex items-center gap-2">
       <p class="text-sm font-medium">Rows per page</p>
       <select
@@ -83,4 +84,5 @@
       </Button>
     </div>
   </div>
+</div>
 </div>

--- a/src/Web/packages/app/src/lib/components/treatments/DataTableToolbar.svelte
+++ b/src/Web/packages/app/src/lib/components/treatments/DataTableToolbar.svelte
@@ -17,8 +17,8 @@
 </script>
 
 <!-- Toolbar -->
-<div class="space-y-4">
-  <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+<div class="@container space-y-4">
+  <div class="flex flex-col gap-4 @sm:flex-row @sm:items-center @sm:justify-between">
     <!-- Search -->
     <div class="flex flex-1 items-center gap-2">
       <Input

--- a/src/Web/packages/app/src/lib/components/treatments/FoodNutritionalForm.svelte
+++ b/src/Web/packages/app/src/lib/components/treatments/FoodNutritionalForm.svelte
@@ -101,7 +101,7 @@
 
 <form
   id="food-form"
-  class="border-t pt-4 space-y-4"
+  class="@container border-t pt-4 space-y-4"
   {onsubmit}
 >
   <!-- Hidden fields for food record -->
@@ -114,7 +114,7 @@
   <input type="hidden" name="position" value="0" />
 
   <!-- Name and Category row -->
-  <div class="grid gap-4 md:grid-cols-3">
+  <div class="grid gap-4 @lg:grid-cols-3">
     <div class="space-y-2">
       <Label for="food-name">Name</Label>
       <Input id="food-name" name="name" bind:value={foodName} />
@@ -189,7 +189,7 @@
     </Collapsible.Trigger>
     <Collapsible.Content class="pt-3 space-y-4">
       <!-- Portion and unit row -->
-      <div class="grid gap-4 md:grid-cols-4">
+      <div class="grid gap-4 @lg:grid-cols-4">
         <div class="space-y-2">
           <Label for="food-portion">Portion Size</Label>
           <Input
@@ -299,7 +299,7 @@
       </div>
 
       <!-- Additional nutrients row -->
-      <div class="grid gap-4 md:grid-cols-3">
+      <div class="grid gap-4 @lg:grid-cols-3">
         <div class="space-y-2">
           <Label for="food-fat">Fat (g)</Label>
           <Input id="food-fat" name="fat" type="number" bind:value={foodFat} />

--- a/src/Web/packages/app/src/lib/components/treatments/TreatmentFoodEntryEditDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/treatments/TreatmentFoodEntryEditDialog.svelte
@@ -219,7 +219,7 @@
       <Dialog.Title>Edit Food Entry</Dialog.Title>
     </Dialog.Header>
 
-    <form class="space-y-4" onsubmit={handleSubmit}>
+    <form class="@container space-y-4" onsubmit={handleSubmit}>
 
       {#if entry}
         <!-- Show carbs context -->
@@ -268,7 +268,7 @@
           {/if}
         </div>
 
-        <div class="grid gap-4 md:grid-cols-2">
+        <div class="grid gap-4 @lg:grid-cols-2">
           {#if !isOtherEntry}
             <div class="space-y-2">
               <Label for="edit-portions">Portions</Label>
@@ -311,7 +311,7 @@
           </Button>
         {/if}
 
-        <div class="grid gap-4 md:grid-cols-2">
+        <div class="grid gap-4 @lg:grid-cols-2">
           <div class="space-y-2">
             <Label for="edit-offset">Time offset (min)</Label>
             <Input

--- a/src/Web/packages/app/src/lib/components/treatments/TreatmentPortionsForm.svelte
+++ b/src/Web/packages/app/src/lib/components/treatments/TreatmentPortionsForm.svelte
@@ -33,7 +33,7 @@
   }: Props = $props();
 </script>
 
-<div class="border-t pt-4 space-y-4">
+<div class="@container border-t pt-4 space-y-4">
   <div class="text-sm font-medium">How much did you eat?</div>
 
   <!-- Show remaining carbs context -->
@@ -49,7 +49,7 @@
   {/if}
 
   <!-- Bidirectional portion/carbs input -->
-  <div class="grid gap-4 md:grid-cols-3">
+  <div class="grid gap-4 @lg:grid-cols-3">
     {#if showPortions}
       <div class="space-y-2">
         <Label for="portions">Portions</Label>

--- a/src/Web/packages/app/src/lib/components/treatments/TreatmentStatsCard.svelte
+++ b/src/Web/packages/app/src/lib/components/treatments/TreatmentStatsCard.svelte
@@ -61,7 +61,8 @@
   );
 </script>
 
-<div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+<div class="@container">
+<div class="grid grid-cols-1 @4xl:grid-cols-3 gap-4">
   <!-- Total Records -->
   <Card.Root class="bg-card">
     <Card.Content class="p-4">
@@ -147,4 +148,5 @@
       </div>
     </Card.Content>
   </Card.Root>
+</div>
 </div>

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/+page.svelte
@@ -134,7 +134,7 @@
   <title>Alerts · Nocturne</title>
 </svelte:head>
 
-<div class="container mx-auto max-w-5xl p-4 lg:p-6 space-y-6">
+<div class="@container container mx-auto max-w-5xl p-4 @3xl:p-6 space-y-6">
   <!-- Header -->
   <div class="flex flex-wrap items-start justify-between gap-3">
     <div class="flex items-center gap-3">
@@ -196,7 +196,7 @@
     />
 
     <!-- Stat row -->
-    <div class="grid gap-3 sm:grid-cols-3">
+    <div class="grid gap-3 @md:grid-cols-3">
       <Card>
         <CardContent>
           <p class="text-xs uppercase tracking-wider text-muted-foreground">Rules enabled</p>

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/[id]/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/[id]/+page.svelte
@@ -256,7 +256,7 @@
   <title>{isNew ? "New alert" : state.name || "Alert"} · Nocturne</title>
 </svelte:head>
 
-<div class="container mx-auto p-4 lg:p-6 max-w-7xl">
+<div class="@container container mx-auto p-4 @3xl:p-6 max-w-7xl">
   <!-- Header -->
   <div class="mb-6 flex items-center justify-between gap-4">
     <div class="flex items-center gap-2 min-w-0">
@@ -314,7 +314,7 @@
     </div>
   {/if}
 
-  <div class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px] lg:items-start">
+  <div class="grid gap-6 @3xl:grid-cols-[minmax(0,1fr)_320px] @3xl:items-start">
     <!-- Main editor column -->
     <div class="space-y-6">
       {#if loading}

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/dnd/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/dnd/+page.svelte
@@ -92,8 +92,8 @@
   <title>Do Not Disturb · Alerts · Nocturne</title>
 </svelte:head>
 
-<div class="container mx-auto max-w-3xl p-4 lg:p-6 space-y-6">
-  <div class="flex items-center justify-between gap-2">
+<div class="@container container mx-auto max-w-3xl p-4 @3xl:p-6 space-y-6">
+  <div class="flex flex-col gap-3 @lg:flex-row @lg:items-center @lg:justify-between">
     <div class="flex items-center gap-2">
       <Button
         type="button"
@@ -113,7 +113,7 @@
         </p>
       </div>
     </div>
-    <Button onclick={save} disabled={saving || !seeded}>
+    <Button class="shrink-0" onclick={save} disabled={saving || !seeded}>
       {#if saving}
         <Loader2 class="h-4 w-4 mr-2 animate-spin" />
       {:else}
@@ -171,7 +171,7 @@
         />
       </div>
       {#if dndScheduleEnabled}
-        <div class="grid gap-4 sm:grid-cols-2">
+        <div class="grid gap-4 @sm:grid-cols-2">
           <div class="space-y-2">
             <Label for="dnd-start">From</Label>
             <Input

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/history/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/history/+page.svelte
@@ -20,7 +20,7 @@
 
 <svelte:head><title>Alert history · Nocturne</title></svelte:head>
 
-<div class="container mx-auto max-w-4xl p-4 lg:p-6 space-y-6">
+<div class="@container container mx-auto max-w-4xl p-4 @3xl:p-6 space-y-6">
   <div class="flex items-center gap-2">
     <Button
       type="button"

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/simulator/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/simulator/+page.svelte
@@ -19,7 +19,7 @@
   <title>Alert simulator · Nocturne</title>
 </svelte:head>
 
-<div class="container mx-auto max-w-4xl p-4 lg:p-6 space-y-6">
+<div class="@container container mx-auto max-w-4xl p-4 @3xl:p-6 space-y-6">
   <div class="flex items-center gap-2">
     <Button
       type="button"

--- a/src/Web/packages/app/src/routes/(authenticated)/compatibility/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/compatibility/+page.svelte
@@ -216,9 +216,9 @@
   }
 </script>
 
-<div class="container mx-auto p-6 space-y-6">
+<div class="@container container mx-auto p-6 space-y-6">
   <!-- Header -->
-  <div class="flex justify-between items-center">
+  <div class="flex flex-col gap-3 @lg:flex-row @lg:justify-between @lg:items-center">
     <h1 class="text-3xl font-bold">Compatibility Testing</h1>
     <div class="flex gap-2 items-center">
       <span class="text-sm text-gray-500">
@@ -238,7 +238,7 @@
   <!-- Configuration Card -->
   <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
     <h2 class="text-xl font-semibold mb-4">Configuration</h2>
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+    <div class="grid grid-cols-1 @lg:grid-cols-2 gap-4">
       <div>
         <p class="text-sm text-gray-500 dark:text-gray-400">Nightscout URL</p>
         <p class="font-mono text-sm">
@@ -253,7 +253,7 @@
   </div>
 
   <!-- Metrics Cards -->
-  <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+  <div class="grid grid-cols-1 @xl:grid-cols-2 @5xl:grid-cols-4 gap-4">
     <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
       <h3 class="text-sm text-gray-500 dark:text-gray-400 mb-2">
         Total Requests
@@ -289,7 +289,7 @@
   <!-- Filters -->
   <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
     <h2 class="text-xl font-semibold mb-4">Filters</h2>
-    <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+    <div class="grid grid-cols-1 @xl:grid-cols-2 @4xl:grid-cols-4 gap-4">
       <div>
         <label for="filterPath" class="block text-sm font-medium mb-1">
           Request Path

--- a/src/Web/packages/app/src/routes/(authenticated)/compatibility/[id]/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/compatibility/[id]/+page.svelte
@@ -97,7 +97,7 @@
   const matchType = $derived(getMatchTypeDisplay(analysis.overallMatch ?? 0));
 </script>
 
-<div class="container mx-auto p-6 space-y-6">
+<div class="@container container mx-auto p-6 space-y-6">
   <!-- Header with Back Button -->
   <div class="flex items-center gap-4">
     <button
@@ -112,7 +112,7 @@
   <!-- Overview Card -->
   <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
     <h2 class="text-xl font-semibold mb-4">Overview</h2>
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+    <div class="grid grid-cols-1 @lg:grid-cols-2 @3xl:grid-cols-3 gap-4">
       <div>
         <p class="text-sm text-gray-500 dark:text-gray-400">Correlation ID</p>
         <p class="font-mono text-sm">{analysis.correlationId}</p>
@@ -133,7 +133,7 @@
         <p class="text-sm text-gray-500 dark:text-gray-400">Request Method</p>
         <p class="font-mono font-semibold">{analysis.requestMethod}</p>
       </div>
-      <div class="md:col-span-2">
+      <div class="@lg:col-span-2">
         <p class="text-sm text-gray-500 dark:text-gray-400">Request Path</p>
         <p class="font-mono text-sm break-all">{analysis.requestPath}</p>
       </div>
@@ -141,7 +141,7 @@
   </div>
 
   <!-- Status Codes & Response Times -->
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+  <div class="grid grid-cols-1 @lg:grid-cols-2 gap-6">
     <!-- Status Codes -->
     <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
       <h2 class="text-xl font-semibold mb-4">Status Codes</h2>
@@ -220,7 +220,7 @@
   {#if analysis.selectedResponseTarget}
     <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
       <h2 class="text-xl font-semibold mb-4">Response Selection</h2>
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div class="grid grid-cols-1 @lg:grid-cols-2 gap-4">
         <div>
           <p class="text-sm text-gray-500 dark:text-gray-400">
             Selected Target
@@ -277,7 +277,7 @@
                   </span>
                 </div>
                 <p class="text-sm mb-2">{disc.description}</p>
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-2 mt-2">
+                <div class="grid grid-cols-1 @lg:grid-cols-2 gap-2 mt-2">
                   <div>
                     <p class="text-xs text-gray-500 dark:text-gray-400">
                       Nightscout Value
@@ -332,7 +332,7 @@
                   </span>
                 </div>
                 <p class="text-sm mb-2">{disc.description}</p>
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-2 mt-2">
+                <div class="grid grid-cols-1 @lg:grid-cols-2 gap-2 mt-2">
                   <div>
                     <p class="text-xs text-gray-500 dark:text-gray-400">
                       Nightscout Value
@@ -387,7 +387,7 @@
                   </span>
                 </div>
                 <p class="text-sm mb-2">{disc.description}</p>
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-2 mt-2">
+                <div class="grid grid-cols-1 @lg:grid-cols-2 gap-2 mt-2">
                   <div>
                     <p class="text-xs text-gray-500 dark:text-gray-400">
                       Nightscout Value

--- a/src/Web/packages/app/src/routes/(authenticated)/compatibility/test/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/compatibility/test/+page.svelte
@@ -388,16 +388,16 @@
   }
 </script>
 
-<div class="container mx-auto p-6 space-y-6">
+<div class="@container container mx-auto p-6 space-y-6">
   <!-- Header -->
-  <div class="flex justify-between items-center">
+  <div class="flex flex-col gap-3 @lg:flex-row @lg:justify-between @lg:items-center">
     <div>
       <h1 class="text-3xl font-bold">Manual Compatibility Test</h1>
       <p class="text-muted-foreground mt-1">
         Compare API responses between Nightscout and Nocturne
       </p>
     </div>
-    <Button variant="outline" href="/compatibility">
+    <Button variant="outline" href="/compatibility" class="shrink-0">
       <ArrowLeft class="h-4 w-4 mr-2" />
       Back to Dashboard
     </Button>
@@ -412,7 +412,7 @@
       </Card.Description>
     </Card.Header>
     <Card.Content class="space-y-4">
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div class="grid grid-cols-1 @lg:grid-cols-2 gap-4">
         <div class="space-y-2">
           <Label for="nightscoutUrl">Nightscout URL</Label>
           <Input
@@ -448,7 +448,7 @@
           </div>
         </div>
 
-        <div class="md:col-span-2 space-y-2">
+        <div class="@lg:col-span-2 space-y-2">
           <Label for="queryPath">Query Path</Label>
           <div class="flex gap-2">
             <Select.Root type="single" bind:value={method}>
@@ -470,7 +470,7 @@
         </div>
 
         {#if method === "POST"}
-          <div class="md:col-span-2 space-y-2">
+          <div class="@lg:col-span-2 space-y-2">
             <Label for="requestBody">Request Body (JSON)</Label>
             <Textarea
               id="requestBody"
@@ -544,7 +544,7 @@
   <!-- Results -->
   {#if result}
     <!-- Status Cards -->
-    <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+    <div class="grid grid-cols-1 @4xl:grid-cols-4 gap-4">
       <Card.Root>
         <Card.Content class="pt-6">
           <p class="text-sm text-muted-foreground mb-1">Nightscout Status</p>
@@ -620,7 +620,7 @@
     <!-- Diff View -->
     {#if showSideBySide}
       <!-- Side by Side Diff View -->
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div class="grid grid-cols-1 @lg:grid-cols-2 gap-4">
         <Card.Root>
           <Card.Header class="py-3">
             <Card.Title class="text-base text-red-600">

--- a/src/Web/packages/app/src/routes/(authenticated)/food/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/food/+page.svelte
@@ -31,9 +31,9 @@
   <title>Food Editor - Nocturne</title>
 </svelte:head>
 
-<div class="food-editor flex-1 overflow-auto p-5">
+<div class="food-editor @container flex-1 overflow-auto p-5">
   <!-- Header -->
-  <div class="mb-5 flex items-center justify-between">
+  <div class="mb-5 flex flex-col gap-3 @lg:flex-row @lg:items-center @lg:justify-between">
     <div>
       <h1 class="text-[22px] font-bold tracking-tight">Food Editor</h1>
       <div class="mt-0.5 text-xs text-muted-foreground">
@@ -44,7 +44,7 @@
         {/if}
       </div>
     </div>
-    <div class="flex gap-2">
+    <div class="flex flex-wrap gap-2">
       <Button variant="outline" size="sm"><Download class="h-3.5 w-3.5" /> Export</Button>
       <Button variant="outline" size="sm"><Upload class="h-3.5 w-3.5" /> Import CSV</Button>
       <Button size="sm" onclick={() => (state.composerOpen = true)}><Plus class="h-3.5 w-3.5" /> Add food</Button>
@@ -54,8 +54,8 @@
   <!-- Main card -->
   <div class="overflow-hidden rounded-[14px] border border-border bg-card">
     <!-- Toolbar -->
-    <div class="flex items-center gap-2.5 border-b border-border bg-card px-4 py-3.5">
-      <div class="flex h-[38px] flex-1 items-center gap-2 rounded-lg border border-border bg-white/[0.04] px-2.5 text-[13px] focus-within:border-ring focus-within:bg-white/[0.07]">
+    <div class="flex flex-wrap items-center gap-2.5 border-b border-border bg-card px-4 py-3.5">
+      <div class="flex h-[38px] min-w-[180px] flex-1 items-center gap-2 rounded-lg border border-border bg-white/[0.04] px-2.5 text-[13px] focus-within:border-ring focus-within:bg-white/[0.07]">
         <Search class="h-[15px] w-[15px] text-muted-foreground" />
         <input
           class="h-full flex-1 border-0 bg-transparent p-0 text-foreground outline-0"

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/+page.svelte
@@ -183,7 +183,7 @@
     </div>
   </div>
 {:else}
-  <div class="min-h-screen">
+  <div class="@container min-h-screen">
     <!-- Hero Section with Key Metrics -->
     <section
       class="relative overflow-hidden bg-linear-to-b from-slate-50 via-white to-transparent pb-8 pt-6 dark:from-slate-900 dark:via-slate-950 dark:to-transparent"
@@ -220,7 +220,7 @@
             })}
           </div>
           <h1
-            class="bg-linear-to-r from-slate-900 via-slate-700 to-slate-800 bg-clip-text text-4xl font-bold tracking-tight text-transparent dark:from-white dark:via-slate-200 dark:to-slate-300 md:text-5xl"
+            class="bg-linear-to-r from-slate-900 via-slate-700 to-slate-800 bg-clip-text text-4xl font-bold tracking-tight text-transparent dark:from-white dark:via-slate-200 dark:to-slate-300 @lg:text-5xl"
           >
             Your Glucose Report
           </h1>
@@ -248,18 +248,18 @@
                 )}
               ></div>
 
-              <div class="grid items-center gap-8 lg:grid-cols-[1fr,auto,1fr]">
+              <div class="grid items-center gap-8 @3xl:grid-cols-[1fr,auto,1fr]">
                 <!-- Left: Time in Range highlight -->
-                <div class="text-center lg:text-left">
+                <div class="text-center @3xl:text-left">
                   <div class="mb-1 text-sm font-medium text-muted-foreground">
                     Time in Range
                   </div>
                   <div
-                    class="flex items-baseline justify-center gap-2 lg:justify-start"
+                    class="flex items-baseline justify-center gap-2 @3xl:justify-start"
                   >
                     <span
                       class={cn(
-                        "bg-linear-to-r bg-clip-text text-6xl font-bold tabular-nums text-transparent md:text-7xl",
+                        "bg-linear-to-r bg-clip-text text-6xl font-bold tabular-nums text-transparent @lg:text-7xl",
                         getStatusColor(tirStatus)
                       )}
                     >
@@ -289,7 +289,7 @@
                 </div>
 
                 <!-- Right: Secondary metrics -->
-                <div class="grid grid-cols-2 gap-4 lg:gap-6">
+                <div class="grid grid-cols-2 gap-4 @3xl:gap-6">
                   <div
                     class="rounded-2xl bg-slate-50 p-4 text-center dark:bg-slate-800/50"
                   >
@@ -460,7 +460,7 @@
         </p>
       </div>
 
-      <div class="grid gap-6 md:grid-cols-2" {@attach coachmark({
+      <div class="grid gap-6 @3xl:grid-cols-2" {@attach coachmark({
         key: "setup-reports.categories",
         title: "Start with Executive Summary",
         description: "It combines your key metrics into a single page \u2014 great for clinic visits or sharing with your endo.",

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/agp/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/agp/+page.svelte
@@ -75,7 +75,7 @@
 </svelte:head>
 
 {#if reportsResource.current}
-<div class="container mx-auto px-4 py-6 space-y-8 max-w-7xl">
+<div class="@container container mx-auto px-4 py-6 space-y-8 max-w-7xl">
   <!-- Header with AGP Explanation -->
   <div class="space-y-4">
     <div class="flex items-center justify-between flex-wrap gap-4">
@@ -172,7 +172,7 @@
     {@const variability = analysis.glycemicVariability ?? {}}
 
     <!-- Quick Stats Grid -->
-    <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
+    <div class="grid grid-cols-2 @lg:grid-cols-4 @3xl:grid-cols-6 gap-4">
       <Card
         class="p-4 text-center border-2 border-green-200 dark:border-green-800 bg-green-50/50 dark:bg-green-950/30"
       >
@@ -231,13 +231,13 @@
           pattern
         </CardDescription>
       </CardHeader>
-      <CardContent class="h-80 md:h-96">
+      <CardContent class="h-80 @lg:h-96">
         <AmbulatoryGlucoseProfile averagedStats={data.averagedStats} />
       </CardContent>
     </Card>
 
     <!-- Time in Range Visual -->
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+    <div class="grid grid-cols-1 @3xl:grid-cols-2 gap-6">
       <Card class="border-2">
         <CardHeader>
           <CardTitle class="flex items-center gap-2">
@@ -373,7 +373,7 @@
   <!-- Clinical Context Footer -->
   <Card class="border bg-muted/30">
     <CardContent class="pt-6">
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-6 text-sm">
+      <div class="grid grid-cols-1 @3xl:grid-cols-3 gap-6 text-sm">
         <div>
           <h4 class="font-semibold mb-2">About This Report</h4>
           <p class="text-muted-foreground">

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/basal-analysis/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/basal-analysis/+page.svelte
@@ -84,7 +84,7 @@
 </svelte:head>
 
 {#if reportsResource.current}
-  <div class="container mx-auto max-w-7xl space-y-8 px-4 py-6">
+  <div class="@container container mx-auto max-w-7xl space-y-8 px-4 py-6">
     <!-- Header -->
     <div class="space-y-4">
       <div class="flex flex-wrap items-center justify-between gap-4">
@@ -169,7 +169,7 @@
     </Card>
 
     <!-- Key Stats Cards -->
-    <div class="grid grid-cols-2 gap-4 md:grid-cols-4">
+    <div class="grid grid-cols-2 gap-4 @lg:grid-cols-4">
       <Card class="border">
         <CardContent class="pt-6 text-center">
           <div class="text-2xl font-bold tabular-nums">
@@ -268,7 +268,7 @@
           </CardTitle>
         </CardHeader>
         <CardContent class="space-y-4">
-          <div class="grid gap-4 md:grid-cols-2">
+          <div class="grid gap-4 @3xl:grid-cols-2">
             <!-- Rate Range -->
             <div class="rounded-lg border bg-card p-4">
               <div class="flex items-start gap-3">

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/battery/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/battery/+page.svelte
@@ -128,16 +128,16 @@
 </svelte:head>
 
 {#if batteryResource.current}
-<div class="container mx-auto space-y-6 px-4 py-6">
+<div class="@container container mx-auto space-y-6 px-4 py-6">
   <!-- Header -->
-  <div class="flex items-center justify-between">
+  <div class="flex flex-col gap-3 @lg:flex-row @lg:items-center @lg:justify-between">
     <div>
       <h1 class="text-3xl font-bold">Battery Report</h1>
       <p class="text-muted-foreground">
         Device battery statistics and charge cycle history
       </p>
     </div>
-    <Button variant="outline" size="sm" onclick={fetchData}>
+    <Button variant="outline" size="sm" onclick={fetchData} class="shrink-0">
       <RefreshCw class="h-4 w-4 mr-2" />
       Refresh
     </Button>
@@ -192,7 +192,7 @@
     {/if}
 
     <!-- Statistics Cards -->
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+    <div class="grid grid-cols-1 @xl:grid-cols-2 @4xl:grid-cols-3 gap-4">
       {#each displayedStats as stat}
         {@const StatIcon = getBatteryIconComponent(
           stat?.level,

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/comparison/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/comparison/+page.svelte
@@ -359,7 +359,7 @@
   ]);
 </script>
 
-<div class="space-y-6">
+<div class="@container space-y-6">
   <!-- Period controls -->
   <Card.Root>
     <Card.Content class="space-y-4 p-4">
@@ -398,7 +398,7 @@
         </Button>
       </div>
 
-      <div class="grid gap-4 md:grid-cols-2">
+      <div class="grid gap-4 @xl:grid-cols-2">
         {#each sideConfigs as cfg (cfg.side)}
           {@const p = periods[cfg.side]}
           <div class="rounded-md border border-border bg-card p-3">
@@ -538,7 +538,7 @@
       </Card.Description>
     </Card.Header>
     <Card.Content>
-      <div class="grid gap-6 md:grid-cols-2">
+      <div class="grid gap-6 @xl:grid-cols-2">
         {#each tirColumns as col (col.key)}
           <div class="flex flex-col">
             <div class="mb-3 flex items-center gap-2">

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/+page.svelte
@@ -75,7 +75,7 @@
 </svelte:head>
 
 {#if suggestionsResource.current}
-	<div class="container mx-auto max-w-4xl space-y-6">
+	<div class="@container container mx-auto max-w-4xl space-y-6">
 		<!-- Header -->
 		<div class="flex items-center gap-3">
 			<div class="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
@@ -88,7 +88,7 @@
 		</div>
 
 		<!-- Summary Stats -->
-		<div class="grid gap-4 sm:grid-cols-3">
+		<div class="grid gap-4 @lg:grid-cols-3">
 			<Card>
 				<CardContent class="flex items-center gap-4 pt-6">
 					<div
@@ -187,7 +187,7 @@
 			<Card
 				class="border-amber-200 bg-amber-50/50 dark:border-amber-900/50 dark:bg-amber-900/10"
 			>
-				<CardContent class="flex items-center justify-between pt-6">
+				<CardContent class="flex flex-col gap-3 pt-6 @lg:flex-row @lg:items-center @lg:justify-between">
 					<div class="flex items-center gap-3">
 						<Clock class="h-5 w-5 text-amber-600 dark:text-amber-400" />
 						<div>
@@ -199,7 +199,7 @@
 							</p>
 						</div>
 					</div>
-					<Button href="/reports/data-quality/compression-lows" variant="default">
+					<Button href="/reports/data-quality/compression-lows" variant="default" class="shrink-0">
 						Review Now
 					</Button>
 				</CardContent>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/compression-lows/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/compression-lows/+page.svelte
@@ -283,8 +283,8 @@
 </svelte:head>
 
 {#if suggestionsResource.current}
-	<div class="container mx-auto space-y-6">
-		<div class="flex items-center justify-between">
+	<div class="@container container mx-auto space-y-6">
+		<div class="flex flex-col gap-3 @lg:flex-row @lg:items-center @lg:justify-between">
 			<div class="flex items-center gap-4">
 				<Button href="/reports/data-quality" variant="ghost" size="icon">
 					<ArrowLeft class="h-4 w-4" />
@@ -300,7 +300,7 @@
 					</p>
 				</div>
 			</div>
-			<div class="flex items-center gap-2">
+			<div class="flex shrink-0 items-center gap-2">
 				<span class="text-sm text-muted-foreground">Status:</span>
 				<Select
 					type="single"
@@ -386,7 +386,7 @@
 				</CardContent>
 			</Card>
 		{:else}
-			<div class="grid gap-6 lg:grid-cols-3">
+			<div class="grid gap-6 @3xl:grid-cols-3">
 				<!-- Suggestion List -->
 				<div class="max-h-[600px] space-y-2 overflow-y-auto pr-2">
 					{#each filteredSuggestions as suggestion, index (suggestion.id)}
@@ -433,7 +433,7 @@
 				</div>
 
 				<!-- Chart and Actions -->
-				<div class="lg:col-span-2">
+				<div class="@3xl:col-span-2">
 					{#if suggestionDetail}
 						<Card>
 							<CardHeader>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/day-in-review/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/day-in-review/+page.svelte
@@ -275,7 +275,7 @@
 {/snippet}
 
 {#if dayDataResource.current}
-<div class="space-y-6 p-4">
+<div class="@container space-y-6 p-4">
   <!-- Header with Navigation -->
   <Card.Root>
     <Card.Content class="p-4">
@@ -304,16 +304,16 @@
   </Card.Root>
 
   <!-- Summary Stats -->
-  <div class="grid md:grid-cols-3 gap-6">
+  <div class="grid @4xl:grid-cols-3 gap-6">
     <!-- Glucose Overview -->
-    <Card.Root class="md:col-span-2">
+    <Card.Root class="@4xl:col-span-2">
       <Card.Content class="p-4 space-y-4">
         <TIRStackedChart
           percentages={analysis?.timeInRange?.percentages}
           orientation="horizontal"
           compact
         />
-        <div class="grid grid-cols-2 sm:grid-cols-4 gap-x-6 gap-y-3 text-sm">
+        <div class="grid grid-cols-2 @lg:grid-cols-4 gap-x-6 gap-y-3 text-sm">
           <div>
             <div class="text-muted-foreground">Mean</div>
             <div class="font-medium tabular-nums">

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/heart-rate/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/heart-rate/+page.svelte
@@ -111,7 +111,7 @@
 
 {#await actogramResource then actogramData}
   {#if actogramData}
-  <div class="container mx-auto space-y-6 px-4 py-6 max-w-7xl">
+  <div class="@container container mx-auto space-y-6 px-4 py-6 max-w-7xl">
     <!-- Header -->
     <div>
       <h1 class="text-3xl font-bold">Heart Rate</h1>
@@ -121,7 +121,7 @@
     </div>
 
     <!-- Summary Cards -->
-    <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
+    <div class="grid grid-cols-2 @sm:grid-cols-4 gap-4">
       <Card>
         <CardHeader class="pb-2">
           <CardTitle class="text-sm font-medium text-muted-foreground">

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/insulin-delivery/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/insulin-delivery/+page.svelte
@@ -146,7 +146,7 @@
 </svelte:head>
 
 {#if reportsResource.current || multiPeriodStatsResource.current}
-<div class="container mx-auto max-w-7xl space-y-8 px-4 py-6">
+<div class="@container container mx-auto max-w-7xl space-y-8 px-4 py-6">
   <!-- Header -->
   <div class="space-y-4">
     <div class="flex flex-wrap items-center justify-between gap-4">
@@ -231,8 +231,8 @@
   </Card>
 
   <!-- Key Summary Stats -->
-  <div class="grid grid-cols-2 gap-4 md:grid-cols-5">
-    <Card class="border md:col-span-1">
+  <div class="grid grid-cols-2 gap-4 @lg:grid-cols-5">
+    <Card class="border @lg:col-span-1">
       <CardContent class="pt-6 text-center">
         <div class="text-3xl font-bold tabular-nums text-primary">
           {(insulinStats.tdd ?? 0).toFixed(1)}
@@ -356,7 +356,7 @@
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <div class="grid gap-4 md:grid-cols-3">
+        <div class="grid gap-4 @3xl:grid-cols-3">
           <div class="rounded-lg border bg-card p-4 text-center">
             <div class="text-3xl font-bold text-blue-600">
               {insulinStats.bolusCount ?? 0}

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/site-change-impact/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/site-change-impact/+page.svelte
@@ -76,7 +76,7 @@
 </svelte:head>
 
 {#if siteChangeResource.current}
-<div class="container mx-auto max-w-7xl space-y-8 px-4 py-6">
+<div class="@container container mx-auto max-w-7xl space-y-8 px-4 py-6">
   <!-- Header -->
   <div class="space-y-4">
     <div class="flex flex-wrap items-center justify-between gap-4">
@@ -185,7 +185,7 @@
         ages.
       </p>
 
-      <div class="grid gap-4 md:grid-cols-2">
+      <div class="grid gap-4 @lg:grid-cols-2">
         <div>
           <p class="font-medium">Before Site Change (Left)</p>
           <p class="text-blue-700/80 dark:text-blue-300/80">
@@ -228,7 +228,7 @@
         </CardTitle>
       </CardHeader>
       <CardContent class="space-y-4">
-        <div class="grid gap-4 md:grid-cols-2">
+        <div class="grid gap-4 @lg:grid-cols-2">
           {#if percentImprovement > 5}
             <div
               class="flex items-start gap-3 rounded-lg bg-green-50 p-4 dark:bg-green-950/30"

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/sleep/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/sleep/+page.svelte
@@ -116,7 +116,7 @@
 
 {#await actogramResource then actogramData}
   {#if actogramData}
-  <div class="container mx-auto space-y-6 px-4 py-6 max-w-7xl">
+  <div class="@container container mx-auto space-y-6 px-4 py-6 max-w-7xl">
     <!-- Header -->
     <div>
       <h1 class="text-3xl font-bold">Sleep & Overnight</h1>
@@ -126,7 +126,7 @@
     </div>
 
     <!-- Summary Cards -->
-    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+    <div class="grid grid-cols-1 @sm:grid-cols-3 gap-4">
       <Card>
         <CardHeader class="pb-2">
           <CardTitle class="text-sm font-medium text-muted-foreground">

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/steps/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/steps/+page.svelte
@@ -129,7 +129,7 @@
 
 {#await actogramResource then actogramData}
   {#if actogramData}
-  <div class="container mx-auto space-y-6 px-4 py-6 max-w-7xl">
+  <div class="@container container mx-auto space-y-6 px-4 py-6 max-w-7xl">
     <!-- Header -->
     <div>
       <h1 class="text-3xl font-bold">Step Count</h1>
@@ -139,7 +139,7 @@
     </div>
 
     <!-- Summary Cards -->
-    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+    <div class="grid grid-cols-1 @sm:grid-cols-3 gap-4">
       <Card>
         <CardHeader class="pb-2">
           <CardTitle class="text-sm font-medium text-muted-foreground">

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/treatments/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/treatments/+page.svelte
@@ -311,11 +311,11 @@
 
   <!-- Filters Panel -->
   <Card.Root>
-    <Card.Content class="p-4">
+    <Card.Content class="@container p-4">
       <div
-        class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between"
+        class="flex flex-col gap-4 @lg:flex-row @lg:items-end @lg:justify-between"
       >
-        <div class="flex flex-1 flex-col gap-4 md:flex-row md:items-end">
+        <div class="flex flex-1 flex-col gap-4 @lg:flex-row @lg:items-end">
           <div class="flex-1 max-w-sm">
             <Label for="search" class="text-sm font-medium">Search</Label>
             <Input

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/access-requests/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/access-requests/+page.svelte
@@ -125,7 +125,7 @@
   <title>Access Requests - Settings - Nocturne</title>
 </svelte:head>
 
-<div class="w-full py-6 space-y-6">
+<div class="@container w-full py-6 space-y-6">
   <div class="flex items-center gap-3">
     <div class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
       <UserPlus class="h-6 w-6 text-primary" />
@@ -209,7 +209,7 @@
             <!-- Role multi-select -->
             <div class="space-y-2">
               <Label>Roles</Label>
-              <div class="grid gap-2 sm:grid-cols-2">
+              <div class="grid gap-2 @sm:grid-cols-2">
                 {#each allRoles as role (role.id)}
                   <div class="flex items-center gap-2">
                     <Checkbox

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/account/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/account/+page.svelte
@@ -312,7 +312,7 @@
   <title>Account - Settings - Nocturne</title>
 </svelte:head>
 
-<div class="container mx-auto max-w-4xl p-6 space-y-6">
+<div class="@container container mx-auto max-w-4xl p-6 space-y-6">
   {#if user}
     <div class="flex items-center gap-3">
       <div class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
@@ -513,7 +513,7 @@
           <Button
             href="/auth/login"
             size="lg"
-            class="w-full sm:w-auto min-w-[200px] font-medium"
+            class="w-full @sm:w-auto min-w-[200px] font-medium"
           >
             <User class="mr-2 h-5 w-5" />
             Sign In with Nocturne

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
@@ -153,7 +153,7 @@
   <title>Appearance - Settings - Nocturne</title>
 </svelte:head>
 
-<div class="container mx-auto max-w-4xl p-6 space-y-6">
+<div class="@container container mx-auto max-w-4xl p-6 space-y-6">
   <!-- Header -->
   <div class="flex items-center gap-3">
     <div class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
@@ -190,7 +190,7 @@
         </CardDescription>
       </CardHeader>
       <CardContent class="space-y-4">
-        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <div class="grid gap-4 @xl:grid-cols-2 @5xl:grid-cols-4">
           <!-- Nocturne Theme -->
           <button
             type="button"
@@ -382,7 +382,7 @@
 
         <Separator />
 
-        <div class="grid gap-4 sm:grid-cols-2">
+        <div class="grid gap-4 @sm:grid-cols-2">
           <div class="space-y-2">
             <Label>Color scheme</Label>
             <Select
@@ -493,7 +493,7 @@
         </CardDescription>
       </CardHeader>
       <CardContent class="space-y-4">
-        <div class="grid gap-4 sm:grid-cols-2">
+        <div class="grid gap-4 @sm:grid-cols-2">
           <div class="space-y-2">
             <Label>Blood glucose units</Label>
             <Select
@@ -551,7 +551,7 @@
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <div class="grid gap-4 sm:grid-cols-2">
+        <div class="grid gap-4 @sm:grid-cols-2">
           <div class="space-y-1">
             <Label class="text-muted-foreground text-xs">Timezone</Label>
             <p class="font-medium">{browserTimezone}</p>
@@ -582,7 +582,7 @@
         <CardDescription>Configure chart display preferences</CardDescription>
       </CardHeader>
       <CardContent>
-        <div class="grid gap-4 sm:grid-cols-2">
+        <div class="grid gap-4 @sm:grid-cols-2">
           <div class="space-y-2">
             <FormLabel>Default chart range</FormLabel>
             <Select
@@ -615,7 +615,7 @@
         <Separator class="my-4" />
 
         <!-- Glucose line visual style -->
-        <div class="grid gap-4 sm:grid-cols-2">
+        <div class="grid gap-4 @sm:grid-cols-2">
           <!-- Line Color Mode -->
           <div class="space-y-2">
             <FormLabel>Line color mode</FormLabel>
@@ -781,7 +781,7 @@
         </CardDescription>
       </CardHeader>
       <CardContent class="space-y-4">
-        <div class="grid gap-4 sm:grid-cols-2">
+        <div class="grid gap-4 @xl:grid-cols-2">
           <button
             type="button"
             class="relative flex flex-col items-start gap-2 rounded-lg border-2 p-4 text-left transition-colors hover:bg-accent/50 {sidebarWidget.current === 'graph'
@@ -840,7 +840,7 @@
         </CardDescription>
       </CardHeader>
       <CardContent class="space-y-4">
-        <div class="grid gap-4 sm:grid-cols-2">
+        <div class="grid gap-4 @sm:grid-cols-2">
           <div class="space-y-2">
             <Label>Display preference</Label>
             <Select

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/audit/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/audit/+page.svelte
@@ -146,7 +146,7 @@
   <title>Audit Log - Settings - Nocturne</title>
 </svelte:head>
 
-<div class="container mx-auto max-w-4xl p-6 space-y-6">
+<div class="@container container mx-auto max-w-4xl p-6 space-y-6">
   <div class="flex items-center gap-3">
     <div class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
       <ScrollText class="h-6 w-6 text-primary" />
@@ -169,7 +169,7 @@
         </Card.Title>
       </Card.Header>
       <Card.Content>
-        <div class="grid gap-4 sm:grid-cols-3">
+        <div class="grid gap-4 @sm:grid-cols-3">
           <div class="flex items-center gap-3">
             <Switch
               checked={readAuditEnabled}
@@ -232,8 +232,8 @@
       <!-- Date Range Filter Card -->
       <Card.Root>
         <Card.Content class="p-4">
-          <div class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-            <div class="flex flex-1 flex-col gap-4 md:flex-row md:items-end">
+          <div class="flex flex-col gap-4 @lg:flex-row @lg:items-end @lg:justify-between">
+            <div class="flex flex-1 flex-col gap-4 @lg:flex-row @lg:items-end">
               <div class="space-y-1">
                 <Label for="m-from">From</Label>
                 <Input id="m-from" type="date" bind:value={mFrom} />
@@ -311,8 +311,8 @@
         <!-- Date Range Filter Card -->
         <Card.Root>
           <Card.Content class="p-4">
-            <div class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-              <div class="flex flex-1 flex-col gap-4 md:flex-row md:items-end">
+            <div class="flex flex-col gap-4 @lg:flex-row @lg:items-end @lg:justify-between">
+              <div class="flex flex-1 flex-col gap-4 @lg:flex-row @lg:items-end">
                 <div class="space-y-1">
                   <Label for="r-from">From</Label>
                   <Input id="r-from" type="date" bind:value={rFrom} />

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/data-quality/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/data-quality/+page.svelte
@@ -43,7 +43,7 @@
 	<title>Data Quality - Settings - Nocturne</title>
 </svelte:head>
 
-<div class="container mx-auto max-w-4xl p-6 space-y-6">
+<div class="@container container mx-auto max-w-4xl p-6 space-y-6">
 	<!-- Header -->
 	<div class="flex items-center gap-3">
 		<div class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
@@ -111,7 +111,7 @@
 					{/if}
 				</div>
 
-				<div class="grid gap-4 sm:grid-cols-2">
+				<div class="grid gap-4 @sm:grid-cols-2">
 					<div class="space-y-2">
 						<Label>Typical bedtime</Label>
 						<Select

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/migration/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/migration/+page.svelte
@@ -229,7 +229,7 @@
   <title>Data Migration - Settings - Nocturne</title>
 </svelte:head>
 
-<div class="container mx-auto max-w-4xl p-6 space-y-6">
+<div class="@container container mx-auto max-w-4xl p-6 space-y-6">
   <!-- Header -->
   <div class="flex items-center gap-3">
     <div class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
@@ -325,7 +325,7 @@
 
             <!-- API Mode Fields -->
             {#if mode === "Api"}
-              <div class="grid gap-4 md:grid-cols-2">
+              <div class="grid gap-4 @lg:grid-cols-2">
                 <div class="space-y-2">
                   <Label for="nightscout-url">Nightscout URL</Label>
                   <Input
@@ -376,7 +376,7 @@
                 Leave empty to import all data, or specify a range to import
                 partial data.
               </p>
-              <div class="grid gap-4 md:grid-cols-2">
+              <div class="grid gap-4 @lg:grid-cols-2">
                 <div class="space-y-2">
                   <Label for="date-start">Start Date</Label>
                   <Input

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/nightscout-transition/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/nightscout-transition/+page.svelte
@@ -104,7 +104,7 @@
 	<title>Nightscout Transition - Settings - Nocturne</title>
 </svelte:head>
 
-<div class="container mx-auto max-w-4xl p-6 space-y-6">
+<div class="@container container mx-auto max-w-4xl p-6 space-y-6">
 	<!-- Header -->
 	<div class="flex items-center gap-3">
 		<div class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
@@ -157,7 +157,7 @@
 			</CardHeader>
 			<CardContent class="space-y-4">
 				{#if Object.keys(status.migration.recordCounts).length > 0}
-					<div class="grid grid-cols-2 gap-3 sm:grid-cols-3">
+					<div class="grid grid-cols-2 gap-3 @sm:grid-cols-3">
 						{#each Object.entries(status.migration.recordCounts) as [dataType, count]}
 							<div class="rounded-lg border p-3">
 								<p class="text-sm text-muted-foreground capitalize">{dataType}</p>

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/profile/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/profile/+page.svelte
@@ -126,9 +126,9 @@
   {@const sensitivity = selectedProfileName ? getSensitivityForProfile(data, selectedProfileName) : null}
   {@const targetRange = selectedProfileName ? getTargetRangeForProfile(data, selectedProfileName) : null}
   {@const profileConfigured = (data?.basalSchedules ?? []).length > 0}
-  <div class="container mx-auto max-w-4xl p-6 space-y-6" {@attach coachmark({ key: "onboarding.therapy-profile", title: "Automatically synced", description: "Your basal rates, carb ratios, and sensitivity factors are imported from your uploader (AAPS, Loop, xDrip+). No manual entry needed.", completedWhen: () => profileConfigured })}>
+  <div class="@container container mx-auto max-w-4xl p-6 space-y-6" {@attach coachmark({ key: "onboarding.therapy-profile", title: "Automatically synced", description: "Your basal rates, carb ratios, and sensitivity factors are imported from your uploader (AAPS, Loop, xDrip+). No manual entry needed.", completedWhen: () => profileConfigured })}>
     <!-- Header -->
-    <div class="flex items-start justify-between">
+    <div class="flex flex-wrap items-start justify-between gap-2">
       <div class="flex items-center gap-3">
         <div
           class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10"
@@ -189,7 +189,7 @@
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <div class="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            <div class="grid gap-2 @xl:grid-cols-2 @4xl:grid-cols-3">
               {#each profileNames as profileName}
                 {@const profileTherapy = getTherapyForProfile(data, profileName)}
                 {@const isSelected = selectedProfileName === profileName}
@@ -223,7 +223,7 @@
                     {/if}
                   </div>
                   <div class="flex-1 min-w-0">
-                    <div class="flex items-center gap-2">
+                    <div class="flex flex-wrap items-center gap-2">
                       <span class="font-medium truncate">
                         {profileName}
                       </span>
@@ -315,7 +315,7 @@
             </div>
           </CardHeader>
           <CardContent>
-            <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            <div class="grid grid-cols-2 @xl:grid-cols-4 gap-4">
               <div class="space-y-1">
                 <span class="text-xs text-muted-foreground">Units</span>
                 <p class="font-medium">
@@ -345,7 +345,7 @@
         </Card>
 
         <!-- Schedule Cards Grid -->
-        <div class="grid gap-4 md:grid-cols-2">
+        <div class="grid gap-4 @3xl:grid-cols-2">
           {#if basal?.entries && basal.entries.length > 0}
             <ScheduleView
               title="Basal Rates"
@@ -401,7 +401,7 @@
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
+            <div class="grid grid-cols-2 @xl:grid-cols-4 gap-4 text-sm">
               <div>
                 <span class="text-muted-foreground">DIA</span>
                 <p class="font-medium">{therapy.dia ?? "-"} hours</p>

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/support/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/support/+page.svelte
@@ -181,7 +181,7 @@
   <title>Support & Community - Settings - Nocturne</title>
 </svelte:head>
 
-<div class="container mx-auto max-w-4xl p-6 space-y-6">
+<div class="@container container mx-auto max-w-4xl p-6 space-y-6">
   <!-- Header -->
   <div class="flex items-center gap-3">
     <div class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
@@ -246,7 +246,7 @@
       <CardDescription>Need help? Here's how to reach us</CardDescription>
     </CardHeader>
     <CardContent class="space-y-4">
-      <div class="grid gap-4 sm:grid-cols-2">
+      <div class="grid gap-4 @xl:grid-cols-2">
         {#await supportConfigQuery then supportConfig}
           {#each supportOptions as option}
             {#if option.template === "account" && supportConfig?.accountBilling?.mode === "redirect"}

--- a/src/Web/packages/app/src/routes/(authenticated)/tenants/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/tenants/+page.svelte
@@ -142,7 +142,7 @@
   }
 </script>
 
-<div class="container max-w-4xl space-y-6 p-6">
+<div class="@container container max-w-4xl space-y-6 p-6">
   <div class="flex items-center gap-3">
     <Building2 class="h-8 w-8 text-primary" />
     <div>
@@ -199,7 +199,7 @@
         </CardContent>
       </Card>
     {:else}
-      <div class="grid gap-4 md:grid-cols-2">
+      <div class="grid gap-4 @xl:grid-cols-2">
         {#each tenants as tenant (tenant.id)}
           <Card>
             <CardHeader class="pb-3">

--- a/src/Web/packages/app/src/routes/(authenticated)/tools/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/tools/+page.svelte
@@ -8,13 +8,13 @@
   import { Luggage } from "lucide-svelte";
 </script>
 
-<div class="container mx-auto p-6 max-w-5xl space-y-6">
+<div class="@container container mx-auto p-6 max-w-5xl space-y-6">
   <div>
     <h1 class="text-2xl font-bold tracking-tight">Tools</h1>
     <p class="text-muted-foreground">Utilities to help manage your diabetes.</p>
   </div>
 
-  <div class="grid gap-4 md:grid-cols-2">
+  <div class="grid gap-4 @xl:grid-cols-2">
     <a href="/tools/packing" class="block">
       <Card class="h-full hover:bg-muted/50 transition-colors cursor-pointer">
         <CardHeader>

--- a/src/Web/packages/app/src/routes/(authenticated)/tools/packing/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/tools/packing/+page.svelte
@@ -65,9 +65,9 @@
   );
 </script>
 
-<div class="container mx-auto p-6 max-w-3xl space-y-5">
+<div class="@container container mx-auto p-6 max-w-3xl space-y-5">
   <!-- Header with inline trip duration -->
-  <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+  <div class="flex flex-col gap-4 @sm:flex-row @sm:items-end @sm:justify-between">
     <div>
       <h1 class="text-2xl font-bold tracking-tight flex items-center gap-2">
         <Luggage class="h-6 w-6" />


### PR DESCRIPTION
Convert content-layout viewport breakpoints (sm/md/lg/xl) to Tailwind v4
container queries across authenticated app pages and components so layouts
respond to their actual content-area width rather than the viewport. The
collapsible sidebar made viewport breakpoints misfire, causing overflows
and clipped content on mobile and when the sidebar is open.

- Add localized @container contexts (page roots, cards, dialog bodies)
  rather than a global one, to avoid breaking fixed/full-screen overlays.
- Wrap non-wrapping flex rows (page headers, card action rows, toolbars,
  badge rows) so text and controls stack/wrap instead of overflowing.
- Fix MobileHeader delta showing an unrounded value by reusing the
  canonical formatGlucoseDelta formatter.
- Leave viewport breakpoints for genuinely viewport-bound chrome: mobile
  header/breadcrumbs, dialog/sheet panel widths, and fullscreen clock and
  alarm experiences.

https://claude.ai/code/session_0175t5Ts7vaDTXxzzs6jKZhf