### PR TITLE
fix(web): stop coach mark bottom sheet stretching to fill viewport on mobile

### DIFF
--- a/src/Web/packages/coach/src/lib/popover/Popover.svelte
+++ b/src/Web/packages/coach/src/lib/popover/Popover.svelte
@@ -27,6 +27,19 @@
 
   let spotlightClipPath = $state("");
 
+  // Mobile renders the popover as a bottom sheet anchored by CSS. Track the
+  // breakpoint so we can suppress floating-ui's inline positioning there.
+  let isMobile = $state(false);
+
+  $effect(() => {
+    if (typeof window === "undefined") return;
+    const mq = window.matchMedia("(max-width: 640px)");
+    isMobile = mq.matches;
+    const onChange = (e: MediaQueryListEvent) => (isMobile = e.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  });
+
   const activeKey = $derived(ctx.activeKey);
   const mountedSteps = $derived(activeKey ? ctx.getMountedSteps(activeKey) : []);
   const currentRegistration = $derived(mountedSteps[currentLocalStep] ?? null);
@@ -150,6 +163,15 @@
         if (!currentRegistration || !popoverEl) return;
 
         updateSpotlightRect(currentRegistration.element);
+
+        // On mobile the popover is a bottom sheet positioned entirely by CSS.
+        // Applying floating-ui's inline top/left would override the CSS top:auto
+        // and fight bottom:0, stretching the sheet to fill the viewport.
+        if (isMobile) {
+          popoverEl.style.left = "";
+          popoverEl.style.top = "";
+          return;
+        }
 
         computePosition(currentRegistration.element, popoverEl, {
           strategy: "fixed",


### PR DESCRIPTION
On mobile the coach mark popover is anchored as a bottom sheet via CSS
(top:auto; bottom:0). floating-ui kept writing inline top/left coordinates,
which overrode top:auto and combined with bottom:0 to stretch the sheet over
the whole viewport, leaving the content stranded at the top with a large
empty gap. Suppress floating-ui's inline positioning while in the mobile
breakpoint so the CSS bottom-sheet anchors apply cleanly.

https://claude.ai/code/session_015iJH7XmQiTCCGqYbo2zpmv