### PR TITLE
fix(web): alert overflow, sticky-header clipping, empty armed strip

### DIFF
--- a/src/Web/packages/app/src/lib/components/alerts/RuleBuilderRow.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/RuleBuilderRow.svelte
@@ -232,7 +232,7 @@
       >
         {label}
       </span>
-      <div class="flex-1">
+      <div class="min-w-0 flex-1">
         <RuleBuilder bind:node={parent.composite!.conditions[index]} {availableRules} nested />
       </div>
       <DropdownMenu.Root>
@@ -268,7 +268,7 @@
   <!-- Leaf row (possibly wrapped in NOT/SUSTAINED) -->
   <div
     role="listitem"
-    class="group/row flex items-center gap-2 rounded-md border bg-background px-2 py-1.5 transition-opacity"
+    class="group/row flex flex-wrap items-center gap-2 rounded-md border bg-background px-2 py-1.5 transition-opacity"
     class:opacity-50={isDragSource}
     draggable="true"
     ondragstart={startDrag}

--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
@@ -208,8 +208,8 @@
   <CoachParamHandler />
   <Sidebar.Provider>
     <AppSidebar user={data.user} tenantCount={data.tenantCount} effectivePermissions={data.effectivePermissions} isPlatformAdmin={data.isPlatformAdmin} isGuestSession={data.isGuestSession} />
-    <MobileHeader />
     <Sidebar.Inset>
+      <MobileHeader />
       {#if data.isDemo}
         <DemoBanner nextResetAt={data.nextResetAt} />
       {/if}

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/+page.svelte
@@ -188,12 +188,14 @@
       return Number.isFinite(t) && t >= cutoff;
     }).length}
 
-    <!-- Armed status strip -->
-    <ArmedStatusStrip
-      state={armedState}
-      onDisableDnd={armedState === "dnd" && dnd ? () => handleDisableDnd(dnd) : undefined}
-      {disablingDnd}
-    />
+    <!-- Armed status strip — only meaningful once at least one rule exists. -->
+    {#if totalCount > 0}
+      <ArmedStatusStrip
+        state={armedState}
+        onDisableDnd={armedState === "dnd" && dnd ? () => handleDisableDnd(dnd) : undefined}
+        {disablingDnd}
+      />
+    {/if}
 
     <!-- Stat row -->
     <div class="grid gap-3 @md:grid-cols-3">

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/[id]/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/[id]/+page.svelte
@@ -314,9 +314,9 @@
     </div>
   {/if}
 
-  <div class="grid gap-6 @3xl:grid-cols-[minmax(0,1fr)_320px] @3xl:items-start">
+  <div class="grid grid-cols-1 gap-6 @3xl:grid-cols-[minmax(0,1fr)_320px] @3xl:items-start">
     <!-- Main editor column -->
-    <div class="space-y-6">
+    <div class="min-w-0 space-y-6">
       {#if loading}
         <Card>
           <CardHeader>
@@ -509,7 +509,7 @@
     </div>
 
     <!-- Right rail: test alert + historic firings -->
-    <aside class="lg:sticky lg:top-6 self-start space-y-4">
+    <aside class="min-w-0 lg:sticky lg:top-6 self-start space-y-4">
       <Card>
         <CardHeader>
           <CardTitle class="text-base">Test alert</CardTitle>


### PR DESCRIPTION
Address three mobile/container-query issues on the alerts surface:

- Editor overflow: the rule editor grid had no base column, so on mobile
  it fell back to an implicit auto grid track that grew to its content's
  max-content. RuleBuilderRow's leaf/group rows are non-wrapping flex with
  many shrink-0 controls (untouched by #260), so the track — and every
  card stacked in it — blew past the viewport. Cap the mobile column with
  grid-cols-1 (minmax(0,1fr)), add min-w-0 to the columns, and let the
  condition rows flex-wrap so controls reflow instead of overflowing.

- Sticky header clipping: MobileHeader renders a fixed bar plus an h-14
  spacer, but it sat as a sibling of Sidebar.Inset inside the flex-row
  wrapper, where the spacer collapsed to zero width and reserved no
  vertical space — page headings slid under the fixed header. Move
  MobileHeader inside the inset's flex-column so the spacer offsets content.

- Empty armed strip: hide the "All channels healthy. Alerts are armed."
  status strip when no alert rules exist.