### PR TITLE
fix(web): make reports overview hero mobile-responsive

### DIFF
--- a/src/Web/packages/app/src/lib/components/reports/ReliabilityBadge.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/ReliabilityBadge.svelte
@@ -1,19 +1,27 @@
 <script lang="ts">
   import { Info } from "lucide-svelte";
   import { Badge } from "$lib/components/ui/badge";
+  import { cn } from "$lib/utils";
   import type { StatisticReliability } from "$lib/api";
 
-  let { reliability } = $props<{ reliability?: StatisticReliability | null }>();
+  let { reliability, class: className } = $props<{
+    reliability?: StatisticReliability | null;
+    class?: string;
+  }>();
 </script>
 
 {#if reliability && reliability.meetsReliabilityCriteria === false}
   <Badge
     variant="outline"
-    class="text-amber-600 bg-amber-50 border-amber-200 dark:text-amber-400 dark:bg-amber-950/30 dark:border-amber-800 gap-1.5 h-auto whitespace-normal text-left py-1.5"
+    class={cn(
+      "h-auto max-w-full items-start gap-1.5 whitespace-normal break-words border-amber-200 bg-amber-50 py-1 text-left text-[11px] leading-snug text-amber-600 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-400",
+      className
+    )}
   >
-    <Info class="size-3 shrink-0" />
-    <span>
-      Based on {reliability.daysOfData ?? 0} days of data ({reliability.recommendedMinimumDays ?? 14} recommended)
+    <Info class="mt-px size-3 shrink-0" />
+    <span class="min-w-0">
+      Based on {reliability.daysOfData ?? 0} days of data ({reliability.recommendedMinimumDays ??
+        14} recommended)
     </span>
   </Badge>
 {/if}

--- a/src/Web/packages/app/src/lib/components/reports/ReportsSkeleton.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/ReportsSkeleton.svelte
@@ -3,7 +3,7 @@
   import { Card, CardContent, CardHeader } from "$lib/components/ui/card";
 </script>
 
-<div class="@container container mx-auto space-y-8 px-4 py-6">
+<div class="@container container mx-auto space-y-6 px-4 py-6 @lg:space-y-8">
   <!-- Header Skeleton -->
   <div class="space-y-3 text-center">
     <div class="flex items-center justify-center gap-2">

--- a/src/Web/packages/app/src/lib/components/reports/ReportsSkeleton.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/ReportsSkeleton.svelte
@@ -3,7 +3,7 @@
   import { Card, CardContent, CardHeader } from "$lib/components/ui/card";
 </script>
 
-<div class="@container container mx-auto space-y-6 px-4 py-6 @lg:space-y-8">
+<div class="@container container mx-auto space-y-6 p-3 @md:p-6 @lg:space-y-8">
   <!-- Header Skeleton -->
   <div class="space-y-3 text-center">
     <div class="flex items-center justify-center gap-2">

--- a/src/Web/packages/app/src/lib/components/treatments/TreatmentCategoryTabs.svelte
+++ b/src/Web/packages/app/src/lib/components/treatments/TreatmentCategoryTabs.svelte
@@ -29,8 +29,7 @@
   onValueChange={(v) => onChange(v as EntryCategoryId | "all")}
 >
   <Tabs.List
-    class="grid w-full h-auto gap-2 bg-transparent p-0"
-    style="grid-template-columns: repeat({Object.keys(ENTRY_CATEGORIES).length + 1}, minmax(0, 1fr));"
+    class="grid h-auto w-full grid-cols-[repeat(auto-fit,minmax(4.5rem,1fr))] gap-2 bg-transparent p-0"
   >
     <Tabs.Trigger
       value="all"

--- a/src/Web/packages/app/src/routes/(authenticated)/calendar/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/calendar/+page.svelte
@@ -416,7 +416,7 @@
     </div>
 
     {#if trackersLoading}
-      <div class="flex-1 p-4">
+      <div class="flex-1 p-3 sm:p-4">
         <Card.Root class="h-full">
           <Card.Content class="p-4 h-full flex items-center justify-center">
             <div class="text-muted-foreground">Loading data...</div>
@@ -424,9 +424,9 @@
         </Card.Root>
       </div>
     {:else if trackersError}
-      <div class="flex-1 p-4">
+      <div class="flex-1 p-3 sm:p-4">
         <Card.Root class="h-full">
-          <Card.Content class="p-4 h-full flex flex-col">
+          <Card.Content class="p-2 sm:p-4 h-full flex flex-col">
             <div class="grid grid-cols-7 gap-1 mb-2">
               {#each DAY_NAMES as dayName}
                 <div
@@ -444,9 +444,9 @@
         </Card.Root>
       </div>
     {:else}
-      <div class="flex-1 p-4">
+      <div class="flex-1 p-3 sm:p-4">
         <Card.Root class="h-full">
-          <Card.Content class="p-4 h-full flex flex-col">
+          <Card.Content class="p-2 sm:p-4 h-full flex flex-col">
             <div class="grid grid-cols-7 gap-1 mb-2">
               {#each DAY_NAMES as dayName}
                 <div

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/+layout.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/+layout.svelte
@@ -74,7 +74,7 @@
         <div
                 class="sticky top-14 md:top-0 z-20 border-b border-border bg-card/95 backdrop-blur supports-backdrop-filter:bg-card/60"
         >
-            <div class="flex h-14 items-center justify-between gap-2 px-4">
+            <div class="flex h-14 items-center justify-between gap-2 px-3 @md:px-6">
                 <div class="flex items-center gap-2">
                     <!-- Report info -->
                     <div class="flex items-center gap-3">
@@ -104,7 +104,7 @@
     {/if}
 
     <!-- Main Content -->
-    <main class="relative px-6 py-6">
+    <main class="relative">
         {#if useResourceGuard}
             <ResourceGuard
                 loading={resourceCtx.loading}

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/+page.svelte
@@ -200,7 +200,7 @@
         ></div>
       </div>
 
-      <div class="container relative mx-auto max-w-6xl px-4">
+      <div class="container relative mx-auto max-w-6xl px-3">
         <!-- Header -->
         <div
           class="mb-8 text-center"
@@ -427,7 +427,7 @@
     </section>
 
     <!-- Quick Actions -->
-    <section class="container mx-auto max-w-6xl px-4 py-6">
+    <section class="container mx-auto max-w-6xl px-3 py-6">
       <div
         class="flex flex-wrap items-center justify-center gap-3"
         in:fly={{ y: 20, duration: 500, delay: 450, easing: cubicOut }}
@@ -459,7 +459,7 @@
     </section>
 
     <!-- Report Categories -->
-    <section class="container mx-auto max-w-6xl px-4 pb-16 pt-8">
+    <section class="container mx-auto max-w-6xl px-3 pb-16 pt-8">
       <div
         class="mb-10 text-center"
         in:fly={{ y: 20, duration: 500, delay: 500, easing: cubicOut }}
@@ -567,7 +567,7 @@
     </section>
 
     <!-- Footer Note -->
-    <section class="container mx-auto max-w-6xl px-4 pb-12">
+    <section class="container mx-auto max-w-6xl px-3 pb-12">
       <div
         class="rounded-2xl bg-slate-50 p-6 text-center dark:bg-slate-900/50"
         in:fade={{ duration: 400, delay: 800 }}

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/+page.svelte
@@ -238,7 +238,7 @@
             in:fly={{ y: 30, duration: 700, delay: 200, easing: cubicOut }}
           >
             <div
-              class="relative overflow-hidden rounded-3xl bg-white p-8 shadow-xl shadow-slate-200/50 dark:bg-slate-900 dark:shadow-none dark:ring-1 dark:ring-white/10"
+              class="relative overflow-hidden rounded-3xl bg-white p-5 shadow-xl shadow-slate-200/50 @lg:p-6 @3xl:p-8 dark:bg-slate-900 dark:shadow-none dark:ring-1 dark:ring-white/10"
             >
               <!-- Gradient accent bar -->
               <div
@@ -248,7 +248,9 @@
                 )}
               ></div>
 
-              <div class="grid items-center gap-8 @3xl:grid-cols-[1fr,auto,1fr]">
+              <div
+                class="grid items-center gap-6 @3xl:grid-cols-[1fr_auto_1fr] @3xl:gap-8"
+              >
                 <!-- Left: Time in Range highlight -->
                 <div class="text-center @3xl:text-left">
                   <div class="mb-1 text-sm font-medium text-muted-foreground">
@@ -277,7 +279,7 @@
 
                 <!-- Center: TIR Chart -->
                 <div
-                  class="flex justify-center h-96"
+                  class="flex h-64 justify-center @sm:h-72 @3xl:h-96"
                   in:scale={{
                     start: 0.9,
                     duration: 600,
@@ -289,78 +291,84 @@
                 </div>
 
                 <!-- Right: Secondary metrics -->
-                <div class="grid grid-cols-2 gap-4 @3xl:gap-6">
-                  <div
-                    class="rounded-2xl bg-slate-50 p-4 text-center dark:bg-slate-800/50"
-                  >
+                <div class="space-y-4">
+                  <div class="grid grid-cols-2 gap-3 @sm:gap-4 @3xl:gap-6">
                     <div
-                      class="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+                      class="min-w-0 rounded-2xl bg-slate-50 p-4 text-center dark:bg-slate-800/50"
                     >
-                      Est. A1C
+                      <div
+                        class="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+                      >
+                        Est. A1C
+                      </div>
+                      <div
+                        class="mt-1 text-3xl font-bold tabular-nums text-slate-900 dark:text-slate-100"
+                      >
+                        {variability?.estimatedA1c?.toFixed(1) ?? "–"}
+                        <span class="text-lg font-normal text-muted-foreground">
+                          %
+                        </span>
+                      </div>
                     </div>
                     <div
-                      class="mt-1 text-3xl font-bold tabular-nums text-slate-900 dark:text-slate-100"
+                      class="min-w-0 rounded-2xl bg-slate-50 p-4 text-center dark:bg-slate-800/50"
                     >
-                      {variability?.estimatedA1c?.toFixed(1) ?? "–"}
-                      <span class="text-lg font-normal text-muted-foreground">
-                        %
-                      </span>
+                      <div
+                        class="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+                      >
+                        Variability
+                      </div>
+                      <div
+                        class="mt-1 text-3xl font-bold tabular-nums text-slate-900 dark:text-slate-100"
+                      >
+                        {variability?.coefficientOfVariation?.toFixed(0) ?? "–"}
+                        <span class="text-lg font-normal text-muted-foreground">
+                          %
+                        </span>
+                      </div>
                     </div>
-                    <ReliabilityBadge reliability={analysis?.reliability} />
+                    <div
+                      class="min-w-0 rounded-2xl bg-slate-50 p-4 text-center dark:bg-slate-800/50"
+                    >
+                      <div
+                        class="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+                      >
+                        Average
+                      </div>
+                      <div
+                        class="mt-1 text-3xl font-bold tabular-nums text-slate-900 dark:text-slate-100"
+                      >
+                        {stats?.mean
+                          ? formatGlucoseValue(stats.mean, units)
+                          : "–"}
+                        <span class="text-sm font-normal text-muted-foreground">
+                          {glucoseFormatting.unitLabel}
+                        </span>
+                      </div>
+                    </div>
+                    <div
+                      class="min-w-0 rounded-2xl bg-slate-50 p-4 text-center dark:bg-slate-800/50"
+                    >
+                      <div
+                        class="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+                      >
+                        Time Low
+                      </div>
+                      <div
+                        class="mt-1 text-3xl font-bold tabular-nums text-slate-900 dark:text-slate-100"
+                      >
+                        {((tir?.low ?? 0) + (tir?.veryLow ?? 0)).toFixed(1)}
+                        <span class="text-lg font-normal text-muted-foreground">
+                          %
+                        </span>
+                      </div>
+                    </div>
                   </div>
-                  <div
-                    class="rounded-2xl bg-slate-50 p-4 text-center dark:bg-slate-800/50"
-                  >
-                    <div
-                      class="text-xs font-medium uppercase tracking-wide text-muted-foreground"
-                    >
-                      Variability
+                  {#if analysis?.reliability?.meetsReliabilityCriteria === false}
+                    <div class="flex justify-center">
+                      <ReliabilityBadge reliability={analysis.reliability} />
                     </div>
-                    <div
-                      class="mt-1 text-3xl font-bold tabular-nums text-slate-900 dark:text-slate-100"
-                    >
-                      {variability?.coefficientOfVariation?.toFixed(0) ?? "–"}
-                      <span class="text-lg font-normal text-muted-foreground">
-                        %
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="rounded-2xl bg-slate-50 p-4 text-center dark:bg-slate-800/50"
-                  >
-                    <div
-                      class="text-xs font-medium uppercase tracking-wide text-muted-foreground"
-                    >
-                      Average
-                    </div>
-                    <div
-                      class="mt-1 text-3xl font-bold tabular-nums text-slate-900 dark:text-slate-100"
-                    >
-                      {stats?.mean
-                        ? formatGlucoseValue(stats.mean, units)
-                        : "–"}
-                      <span class="text-sm font-normal text-muted-foreground">
-                        {glucoseFormatting.unitLabel}
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    class="rounded-2xl bg-slate-50 p-4 text-center dark:bg-slate-800/50"
-                  >
-                    <div
-                      class="text-xs font-medium uppercase tracking-wide text-muted-foreground"
-                    >
-                      Time Low
-                    </div>
-                    <div
-                      class="mt-1 text-3xl font-bold tabular-nums text-slate-900 dark:text-slate-100"
-                    >
-                      {((tir?.low ?? 0) + (tir?.veryLow ?? 0)).toFixed(1)}
-                      <span class="text-lg font-normal text-muted-foreground">
-                        %
-                      </span>
-                    </div>
-                  </div>
+                  {/if}
                 </div>
               </div>
             </div>
@@ -368,13 +376,15 @@
 
           <!-- AGP Preview -->
           <div
-            class="rounded-2xl bg-white p-6 shadow-lg shadow-slate-200/30 dark:bg-slate-900/80 dark:shadow-none dark:ring-1 dark:ring-white/5"
+            class="rounded-2xl bg-white p-4 shadow-lg shadow-slate-200/30 @sm:p-6 dark:bg-slate-900/80 dark:shadow-none dark:ring-1 dark:ring-white/5"
             in:fly={{ y: 30, duration: 600, delay: 350, easing: cubicOut }}
           >
-            <div class="mb-4 flex items-center justify-between">
-              <div>
+            <div
+              class="mb-4 flex flex-col gap-3 @sm:flex-row @sm:items-center @sm:justify-between"
+            >
+              <div class="min-w-0">
                 <h2 class="flex items-center gap-2 text-lg font-semibold">
-                  <Activity class="h-5 w-5 text-muted-foreground" />
+                  <Activity class="h-5 w-5 shrink-0 text-muted-foreground" />
                   Your Typical Day
                 </h2>
                 <p class="text-sm text-muted-foreground">
@@ -385,13 +395,13 @@
                 href="/reports/agp"
                 variant="ghost"
                 size="sm"
-                class="gap-1.5"
+                class="shrink-0 gap-1.5 self-start @sm:self-auto"
               >
                 Full Report
                 <ArrowRight class="h-4 w-4" />
               </Button>
             </div>
-            <div class="h-56">
+            <div class="h-64">
               <AmbulatoryGlucoseProfile {averagedStats} />
             </div>
           </div>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/agp/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/agp/+page.svelte
@@ -75,7 +75,7 @@
 </svelte:head>
 
 {#if reportsResource.current}
-<div class="@container container mx-auto px-4 py-6 space-y-8 max-w-7xl">
+<div class="@container container mx-auto space-y-8 p-3 @md:p-6 max-w-7xl">
   <!-- Header with AGP Explanation -->
   <div class="space-y-4">
     <div class="flex items-center justify-between flex-wrap gap-4">

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/basal-analysis/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/basal-analysis/+page.svelte
@@ -84,7 +84,7 @@
 </svelte:head>
 
 {#if reportsResource.current}
-  <div class="@container container mx-auto max-w-7xl space-y-8 px-4 py-6">
+  <div class="@container container mx-auto max-w-7xl space-y-8 p-3 @md:p-6">
     <!-- Header -->
     <div class="space-y-4">
       <div class="flex flex-wrap items-center justify-between gap-4">

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/battery/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/battery/+page.svelte
@@ -128,7 +128,7 @@
 </svelte:head>
 
 {#if batteryResource.current}
-<div class="@container container mx-auto space-y-6 px-4 py-6">
+<div class="@container container mx-auto space-y-6 p-3 @md:p-6">
   <!-- Header -->
   <div class="flex flex-col gap-3 @lg:flex-row @lg:items-center @lg:justify-between">
     <div>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/comparison/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/comparison/+page.svelte
@@ -359,7 +359,7 @@
   ]);
 </script>
 
-<div class="@container space-y-6">
+<div class="@container space-y-6 p-3 @md:p-6">
   <!-- Period controls -->
   <Card.Root>
     <Card.Content class="space-y-4 p-4">
@@ -490,17 +490,16 @@
       <div class="space-y-1">
         {#each diffRows as row (row.key)}
           <div
-            class="grid items-center gap-4 rounded border border-border bg-card px-3 py-2.5"
-            style="grid-template-columns: minmax(140px, 1fr) 90px 90px minmax(120px, 2fr) 100px;"
+            class="flex flex-wrap items-center gap-x-3 gap-y-1.5 rounded border border-border bg-card px-3 py-2.5 @2xl:grid @2xl:flex-nowrap @2xl:gap-4 @2xl:[grid-template-columns:minmax(140px,1fr)_90px_90px_minmax(120px,2fr)_100px]"
           >
-            <div class="text-sm font-medium">{row.label}</div>
-            <div class="text-right font-mono text-sm tabular-nums text-muted-foreground">
+            <div class="w-full text-sm font-medium @2xl:w-auto">{row.label}</div>
+            <div class="font-mono text-sm tabular-nums text-muted-foreground @2xl:text-right">
               {valueText(row.key, row.av)}
             </div>
-            <div class="text-right font-mono text-sm font-semibold tabular-nums">
+            <div class="font-mono text-sm font-semibold tabular-nums @2xl:text-right">
               {valueText(row.key, row.bv)}
             </div>
-            <div class="relative h-2 overflow-hidden rounded-full bg-muted">
+            <div class="relative order-last h-2 w-full overflow-hidden rounded-full bg-muted @2xl:order-none @2xl:w-auto">
               <div class="absolute top-0 bottom-0 left-1/2 w-px bg-border"></div>
               <div
                 class="absolute top-0 bottom-0 rounded-full transition-all duration-200"
@@ -508,7 +507,7 @@
               ></div>
             </div>
             <div
-              class="text-right font-mono text-xs font-semibold tabular-nums"
+              class="ml-auto font-mono text-xs font-semibold tabular-nums @2xl:ml-0 @2xl:text-right"
               style="color: {row.verdict === 'better'
                 ? 'var(--glucose-in-range)'
                 : row.verdict === 'worse'

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/+page.svelte
@@ -75,7 +75,7 @@
 </svelte:head>
 
 {#if suggestionsResource.current}
-	<div class="@container container mx-auto max-w-4xl space-y-6">
+	<div class="@container container mx-auto max-w-4xl space-y-6 p-3 @md:p-6">
 		<!-- Header -->
 		<div class="flex items-center gap-3">
 			<div class="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/compression-lows/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/compression-lows/+page.svelte
@@ -283,7 +283,7 @@
 </svelte:head>
 
 {#if suggestionsResource.current}
-	<div class="@container container mx-auto space-y-6">
+	<div class="@container container mx-auto space-y-6 p-3 @md:p-6">
 		<div class="flex flex-col gap-3 @lg:flex-row @lg:items-center @lg:justify-between">
 			<div class="flex items-center gap-4">
 				<Button href="/reports/data-quality" variant="ghost" size="icon">

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/day-in-review/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/day-in-review/+page.svelte
@@ -275,30 +275,51 @@
 {/snippet}
 
 {#if dayDataResource.current}
-<div class="@container space-y-6 p-4">
+<div class="@container space-y-6 p-3 @md:p-6">
   <!-- Header with Navigation -->
   <Card.Root>
     <Card.Content class="p-4">
-      <div class="flex flex-wrap items-center justify-between gap-4">
-        <Button variant="ghost" size="sm" onclick={goBackToMonthView}>
+      <div
+        class="flex flex-col gap-3 @2xl:flex-row @2xl:flex-wrap @2xl:items-center @2xl:justify-between"
+      >
+        <Button
+          variant="ghost"
+          size="sm"
+          class="self-start @2xl:self-auto"
+          onclick={goBackToMonthView}
+        >
           <ArrowLeft class="h-4 w-4 mr-2" />
           Back to Month View
         </Button>
 
-        <div class="flex items-center gap-2">
-          <Button variant="outline" size="icon" onclick={goToPreviousDay}>
+        <div class="flex items-center justify-center gap-2">
+          <Button
+            variant="outline"
+            size="icon"
+            class="shrink-0"
+            onclick={goToPreviousDay}
+          >
             <ChevronLeft class="h-4 w-4" />
           </Button>
-          <div class="flex items-center gap-2 min-w-[280px] justify-center">
-            <Calendar class="h-4 w-4 text-muted-foreground" />
-            <span class="text-lg font-medium">{dateDisplay}</span>
+          <div
+            class="flex min-w-0 items-center justify-center gap-2 px-1 @2xl:min-w-[220px]"
+          >
+            <Calendar class="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span class="truncate text-base font-medium @2xl:text-lg">
+              {dateDisplay}
+            </span>
           </div>
-          <Button variant="outline" size="icon" onclick={goToNextDay}>
+          <Button
+            variant="outline"
+            size="icon"
+            class="shrink-0"
+            onclick={goToNextDay}
+          >
             <ChevronRight class="h-4 w-4" />
           </Button>
         </div>
 
-        <div class="w-[100px]"><!-- Spacer for alignment --></div>
+        <div class="hidden @2xl:block @2xl:w-[100px]"><!-- Spacer for alignment --></div>
       </div>
     </Card.Content>
   </Card.Root>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/executive-summary/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/executive-summary/+page.svelte
@@ -124,7 +124,7 @@
 </svelte:head>
 
 {#if reportsResource.current}
-  <div class="@container container mx-auto px-4 py-6 space-y-8 max-w-6xl">
+  <div class="@container container mx-auto space-y-8 p-3 @md:p-6 max-w-6xl">
     <!-- Print-Friendly Header -->
     <div class="print:block hidden text-center mb-8">
       <h1 class="text-2xl font-bold">Diabetes Management Report</h1>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/glucose-distribution/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/glucose-distribution/+page.svelte
@@ -97,7 +97,7 @@
 
 {#if reportsResource.current}
   {@const report = reportsResource.current}
-  <div class="@container space-y-6 p-4">
+  <div class="@container space-y-6 p-3 @md:p-6">
     <Card.Root>
       <Card.Header>
         <Card.Title class="flex items-center gap-2">

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/heart-rate/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/heart-rate/+page.svelte
@@ -111,7 +111,7 @@
 
 {#await actogramResource then actogramData}
   {#if actogramData}
-  <div class="@container container mx-auto space-y-6 px-4 py-6 max-w-7xl">
+  <div class="@container container mx-auto space-y-6 p-3 @md:p-6 max-w-7xl">
     <!-- Header -->
     <div>
       <h1 class="text-3xl font-bold">Heart Rate</h1>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/idp/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/idp/+page.svelte
@@ -83,7 +83,7 @@
 </svelte:head>
 
 {#if reportsResource.current}
-<div class="@container container mx-auto px-4 py-6 space-y-8 max-w-7xl">
+<div class="@container container mx-auto space-y-8 p-3 @md:p-6 max-w-7xl">
   <!-- Header -->
   <div class="space-y-4">
     <div class="flex items-center justify-between flex-wrap gap-4">

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/insulin-delivery/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/insulin-delivery/+page.svelte
@@ -146,7 +146,7 @@
 </svelte:head>
 
 {#if reportsResource.current || multiPeriodStatsResource.current}
-<div class="@container container mx-auto max-w-7xl space-y-8 px-4 py-6">
+<div class="@container container mx-auto max-w-7xl space-y-8 p-3 @md:p-6">
   <!-- Header -->
   <div class="space-y-4">
     <div class="flex flex-wrap items-center justify-between gap-4">

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/readings/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/readings/+page.svelte
@@ -16,7 +16,7 @@
 </script>
 
 {#if reportsResource.current}
-  <GlucoseChartCard
-    dateRange={reportsResource.current.dateRange}
-  />
+  <div class="p-3 @md:p-6">
+    <GlucoseChartCard dateRange={reportsResource.current.dateRange} />
+  </div>
 {/if}

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/site-change-impact/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/site-change-impact/+page.svelte
@@ -76,7 +76,7 @@
 </svelte:head>
 
 {#if siteChangeResource.current}
-<div class="@container container mx-auto max-w-7xl space-y-8 px-4 py-6">
+<div class="@container container mx-auto max-w-7xl space-y-8 p-3 @md:p-6">
   <!-- Header -->
   <div class="space-y-4">
     <div class="flex flex-wrap items-center justify-between gap-4">

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/sleep/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/sleep/+page.svelte
@@ -116,7 +116,7 @@
 
 {#await actogramResource then actogramData}
   {#if actogramData}
-  <div class="@container container mx-auto space-y-6 px-4 py-6 max-w-7xl">
+  <div class="@container container mx-auto space-y-6 p-3 @md:p-6 max-w-7xl">
     <!-- Header -->
     <div>
       <h1 class="text-3xl font-bold">Sleep & Overnight</h1>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/steps/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/steps/+page.svelte
@@ -129,7 +129,7 @@
 
 {#await actogramResource then actogramData}
   {#if actogramData}
-  <div class="@container container mx-auto space-y-6 px-4 py-6 max-w-7xl">
+  <div class="@container container mx-auto space-y-6 p-3 @md:p-6 max-w-7xl">
     <!-- Header -->
     <div>
       <h1 class="text-3xl font-bold">Step Count</h1>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/treatments/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/treatments/+page.svelte
@@ -277,7 +277,7 @@
 </svelte:head>
 
 {#if reportsResource.current}
-<div class="container mx-auto space-y-6 px-4 py-6">
+<div class="@container container mx-auto space-y-6 p-3 @md:p-6">
   <!-- Header -->
   <div class="space-y-2">
     <div

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/week-to-week/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/week-to-week/+page.svelte
@@ -108,7 +108,7 @@
 </script>
 
 {#if reportsResource.current}
-<div class="space-y-6 p-4">
+<div class="@container space-y-6 p-3 @md:p-6">
   <!-- Controls -->
   <Card.Root>
     <Card.Content class="p-4">


### PR DESCRIPTION
The reports overview hero crowded on mobile: the TIR chart used a fixed
h-96, the data-reliability badge overflowed its cramped stat card, and the
"Your Typical Day" header wrapped its title word-by-word next to the
Full Report button. Scale the chart height by container size, move the
reliability note to a centered row below the metrics, stack the section
header on narrow containers, and tighten card padding/spacing. Also fixes
the hero's comma-separated grid-cols arbitrary value (invalid CSS) so the
intended 3-column desktop layout actually applies.

https://claude.ai/code/session_01XUUcHmWcwJCg2iwuNyNycQ