### PR TITLE
Make alerts UI responsive and align settings gutters

### DIFF
--- a/src/Web/packages/app/src/lib/components/alerts/AlertRuleRow.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/AlertRuleRow.svelte
@@ -117,21 +117,6 @@
 
   <!-- Per-row actions -->
   <div class="flex items-center gap-1 shrink-0">
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon"
-      class="h-8 w-8"
-      onclick={onTestFire}
-      disabled={isTesting || !rule.isEnabled}
-      title="Test fire — sends a real notification"
-    >
-      {#if isTesting}
-        <Loader2 class="h-4 w-4 animate-spin" />
-      {:else}
-        <Zap class="h-4 w-4" />
-      {/if}
-    </Button>
     <Switch
       checked={rule.isEnabled ?? false}
       onCheckedChange={onToggleEnabled}
@@ -156,6 +141,17 @@
       <DropdownMenu.Content align="end">
         <DropdownMenu.Item onclick={onEdit}>
           <Pencil class="h-4 w-4 mr-2" /> Edit
+        </DropdownMenu.Item>
+        <DropdownMenu.Item
+          onclick={onTestFire}
+          disabled={isTesting || !rule.isEnabled}
+        >
+          {#if isTesting}
+            <Loader2 class="h-4 w-4 mr-2 animate-spin" />
+          {:else}
+            <Zap class="h-4 w-4 mr-2" />
+          {/if}
+          Test fire
         </DropdownMenu.Item>
         <DropdownMenu.Separator />
         <AlertDialog.Root>

--- a/src/Web/packages/app/src/lib/components/alerts/ReplayPanel.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/ReplayPanel.svelte
@@ -15,6 +15,7 @@
     Info,
     AlertCircle,
     Calendar as CalendarIcon,
+    CalendarDays,
     CheckCircle2,
     BellOff,
     Bell,
@@ -190,6 +191,23 @@
       day: "numeric",
     });
   }
+
+  // Link to the Day in Review report for the day under replay. Prefers the
+  // explicitly picked date; falls back to the day of the result window so the
+  // link still works for a rolling last-24h / brushed window.
+  let dayInReviewHref = $derived.by<string | undefined>(() => {
+    let ymd: string | undefined;
+    if (selectedDate) {
+      ymd = selectedDate.toString();
+    } else if (result?.windowStart) {
+      const d = new Date(result.windowStart);
+      if (!Number.isNaN(d.getTime())) {
+        const pad = (n: number) => String(n).padStart(2, "0");
+        ymd = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+      }
+    }
+    return ymd ? `/reports/day-in-review?date=${ymd}` : undefined;
+  });
 
   function clearDate(): void {
     selectedDate = undefined;
@@ -471,7 +489,7 @@
 
 {#snippet replayTooltipExtras({ time }: { time: Date })}
   {@const nearby = eventsNear(time)}
-  {#each nearby as m (`${m.ev.ruleId ?? "x"}:${m.tMs}`)}
+  {#each nearby as m, i (`${m.ev.ruleId ?? "x"}:${m.tMs}:${m.ev.kind ?? ""}:${i}`)}
     <Tooltip.Item
       label={kindLabel(m.ev)}
       value={m.ev.ruleName ?? "(unnamed rule)"}
@@ -541,6 +559,18 @@
         <Loader2 class="h-3.5 w-3.5 animate-spin" />
         Running…
       </span>
+    {/if}
+
+    {#if dayInReviewHref}
+      <Button
+        variant="outline"
+        href={dayInReviewHref}
+        class="ml-auto h-8 gap-2 font-normal"
+        title="Open Day in Review for this day"
+      >
+        <CalendarDays class="h-3.5 w-3.5 text-muted-foreground" />
+        <span class="hidden @sm:inline">Day in review</span>
+      </Button>
     {/if}
   </div>
 
@@ -628,7 +658,7 @@
             <div
               class="flex-1 min-h-0 overflow-y-auto rounded-md border divide-y"
             >
-              {#each firedMarkers as m (`${m.ev.ruleId ?? "x"}:${m.tMs}`)}
+              {#each firedMarkers as m, i (`${m.ev.ruleId ?? "x"}:${m.tMs}:${m.ev.kind ?? ""}:${i}`)}
                 {@const dimmed = currentTimeMs != null && m.tMs > currentTimeMs}
                 {@const isResolved =
                   m.ev.kind === AlertReplayEventKind.AutoResolved}

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/+page.svelte
@@ -134,7 +134,7 @@
   <title>Alerts · Nocturne</title>
 </svelte:head>
 
-<div class="@container container mx-auto max-w-5xl p-4 @3xl:p-6 space-y-6">
+<div class="@container container mx-auto max-w-5xl p-3 @md:p-6 space-y-6">
   <!-- Header -->
   <div class="flex flex-wrap items-start justify-between gap-3">
     <div class="flex items-center gap-3">
@@ -231,12 +231,12 @@
     {#if activeAlerts.length > 0}
       <Card class="border-destructive/40 bg-destructive/5">
         <CardHeader>
-          <div class="flex items-center justify-between">
-            <CardTitle class="flex items-center gap-2 text-destructive">
-              <AlertTriangle class="h-5 w-5" />
-              Active alerts ({activeAlerts.length})
+          <div class="flex flex-col gap-2 @sm:flex-row @sm:items-center @sm:justify-between">
+            <CardTitle class="flex min-w-0 items-center gap-2 text-destructive">
+              <AlertTriangle class="h-5 w-5 shrink-0" />
+              <span class="truncate">Active alerts ({activeAlerts.length})</span>
             </CardTitle>
-            <Button variant="outline" size="sm" onclick={handleAcknowledge} disabled={acknowledging}>
+            <Button class="@sm:shrink-0" variant="outline" size="sm" onclick={handleAcknowledge} disabled={acknowledging}>
               {#if acknowledging}
                 <Loader2 class="h-4 w-4 mr-2 animate-spin" />
               {:else}
@@ -257,7 +257,7 @@
                 </p>
               </div>
               {#if a.acknowledgedAt}
-                <Badge variant="secondary">Acknowledged</Badge>
+                <Badge variant="secondary" class="shrink-0">Acknowledged</Badge>
               {/if}
             </div>
           {/each}

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/[id]/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/[id]/+page.svelte
@@ -41,6 +41,7 @@
     Loader2,
     History as HistoryIcon,
     PlayCircle,
+    CalendarDays,
   } from "lucide-svelte";
 
   import RuleBuilder from "$lib/components/alerts/RuleBuilder.svelte";
@@ -197,6 +198,14 @@
     return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
   }
 
+  // Link to the Day in Review report for the calendar day a firing occurred.
+  function dayInReviewHref(at: Date | string | undefined): string | undefined {
+    if (!at) return undefined;
+    const d = at instanceof Date ? at : new Date(at);
+    if (Number.isNaN(d.getTime())) return undefined;
+    return `/reports/day-in-review?date=${ymd(d)}`;
+  }
+
   function formatHistoryRow(at: Date | string | undefined): string {
     if (!at) return "—";
     const d = at instanceof Date ? at : new Date(at);
@@ -256,7 +265,7 @@
   <title>{isNew ? "New alert" : state.name || "Alert"} · Nocturne</title>
 </svelte:head>
 
-<div class="@container container mx-auto p-4 @3xl:p-6 max-w-7xl">
+<div class="@container container mx-auto p-3 @md:p-6 max-w-7xl">
   <!-- Header -->
   <div class="mb-6 flex items-center justify-between gap-4">
     <div class="flex items-center gap-2 min-w-0">
@@ -575,24 +584,41 @@
             {:else}
               <div class="max-h-72 overflow-y-auto space-y-1">
                 {#each history as h (h.id)}
-                  <button
-                    type="button"
-                    class="flex w-full items-center gap-2 rounded-md border bg-background px-2 py-1.5 text-left text-xs hover:bg-muted"
-                    onclick={() => openReplay(h.startedAt)}
+                  <div
+                    class="flex items-center gap-1 rounded-md border bg-background pr-1 hover:bg-muted"
                   >
-                    <span
-                      class="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500"
-                      aria-hidden="true"
-                    ></span>
-                    <span class="flex-1 min-w-0 truncate tabular-nums">
-                      {formatHistoryRow(h.startedAt)}
-                    </span>
-                    {#if h.acknowledgedAt}
-                      <span class="text-[10px] text-muted-foreground shrink-0">
-                        ack
+                    <button
+                      type="button"
+                      class="flex min-w-0 flex-1 items-center gap-2 px-2 py-1.5 text-left text-xs"
+                      onclick={() => openReplay(h.startedAt)}
+                      title="Replay this day in the simulator"
+                    >
+                      <span
+                        class="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500"
+                        aria-hidden="true"
+                      ></span>
+                      <span class="min-w-0 flex-1 truncate tabular-nums">
+                        {formatHistoryRow(h.startedAt)}
                       </span>
+                      {#if h.acknowledgedAt}
+                        <span class="text-[10px] text-muted-foreground shrink-0">
+                          ack
+                        </span>
+                      {/if}
+                    </button>
+                    {#if dayInReviewHref(h.startedAt)}
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        class="h-6 w-6 shrink-0 text-muted-foreground"
+                        href={dayInReviewHref(h.startedAt)}
+                        title="Open day in review"
+                        aria-label="Open day in review"
+                      >
+                        <CalendarDays class="h-3.5 w-3.5" />
+                      </Button>
                     {/if}
-                  </button>
+                  </div>
                 {/each}
               </div>
             {/if}
@@ -605,9 +631,9 @@
 
 <Dialog.Root bind:open={replayOpen}>
   <Dialog.Content
-    class="flex max-h-[90vh] max-w-6xl w-6xl flex-col sm:max-w-[95vw]"
+    class="flex h-[90vh] max-h-[90vh] w-[calc(100vw-1rem)] max-w-6xl flex-col gap-0 overflow-hidden p-0 sm:w-[95vw]"
   >
-    <Dialog.Header>
+    <Dialog.Header class="border-b px-4 py-3">
       <Dialog.Title class="flex items-center gap-2">
         <PlayCircle class="h-4 w-4" /> Replay
       </Dialog.Title>
@@ -617,7 +643,7 @@
       </Dialog.Description>
     </Dialog.Header>
 
-    <div class="flex-1 min-h-0 overflow-hidden py-2">
+    <div class="@container min-h-0 flex-1 overflow-hidden p-3 @md:p-4">
       <ReplayPanel
         initialCustomDate={replayInitialDate}
         rule={buildReplayRule}

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/dnd/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/dnd/+page.svelte
@@ -92,7 +92,7 @@
   <title>Do Not Disturb · Alerts · Nocturne</title>
 </svelte:head>
 
-<div class="@container container mx-auto max-w-3xl p-4 @3xl:p-6 space-y-6">
+<div class="@container container mx-auto max-w-3xl p-3 @md:p-6 space-y-6">
   <div class="flex flex-col gap-3 @lg:flex-row @lg:items-center @lg:justify-between">
     <div class="flex items-center gap-2">
       <Button

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/history/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/history/+page.svelte
@@ -20,7 +20,7 @@
 
 <svelte:head><title>Alert history · Nocturne</title></svelte:head>
 
-<div class="@container container mx-auto max-w-4xl p-4 @3xl:p-6 space-y-6">
+<div class="@container container mx-auto max-w-4xl p-3 @md:p-6 space-y-6">
   <div class="flex items-center gap-2">
     <Button
       type="button"

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/simulator/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/simulator/+page.svelte
@@ -19,7 +19,7 @@
   <title>Alert simulator · Nocturne</title>
 </svelte:head>
 
-<div class="@container container mx-auto max-w-4xl p-4 @3xl:p-6 space-y-6">
+<div class="@container container mx-auto max-w-4xl p-3 @md:p-6 space-y-6">
   <div class="flex items-center gap-2">
     <Button
       type="button"

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/account/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/account/+page.svelte
@@ -312,7 +312,7 @@
   <title>Account - Settings - Nocturne</title>
 </svelte:head>
 
-<div class="@container container mx-auto max-w-4xl p-6 space-y-6">
+<div class="@container container mx-auto max-w-4xl p-3 @md:p-6 space-y-6">
   {#if user}
     <div class="flex items-center gap-3">
       <div class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/admin/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/admin/+page.svelte
@@ -408,7 +408,7 @@
   <title>Administration - Settings - Nocturne</title>
 </svelte:head>
 
-<div class="container mx-auto p-6 max-w-5xl">
+<div class="@container container mx-auto p-3 @md:p-6 max-w-5xl">
   <!-- Header -->
   <div class="flex items-center gap-3">
     <div class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/admin/tenants/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/admin/tenants/+page.svelte
@@ -108,7 +108,7 @@
   }
 </script>
 
-<div class="container mx-auto max-w-4xl p-6 space-y-6">
+<div class="@container container mx-auto max-w-4xl p-3 @md:p-6 space-y-6">
   <div class="flex items-center gap-3">
     <Building2 class="h-8 w-8 text-primary" />
     <div>

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/alarms/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/alarms/+page.svelte
@@ -8,6 +8,6 @@
   });
 </script>
 
-<div class="container mx-auto max-w-4xl p-6">
+<div class="@container container mx-auto max-w-4xl p-3 @md:p-6">
   <p class="text-muted-foreground">Redirecting to Alerts...</p>
 </div>

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
@@ -153,7 +153,7 @@
   <title>Appearance - Settings - Nocturne</title>
 </svelte:head>
 
-<div class="@container container mx-auto max-w-4xl p-6 space-y-6">
+<div class="@container container mx-auto max-w-4xl p-3 @md:p-6 space-y-6">
   <!-- Header -->
   <div class="flex items-center gap-3">
     <div class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/audit/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/audit/+page.svelte
@@ -146,7 +146,7 @@
   <title>Audit Log - Settings - Nocturne</title>
 </svelte:head>
 
-<div class="@container container mx-auto max-w-4xl p-6 space-y-6">
+<div class="@container container mx-auto max-w-4xl p-3 @md:p-6 space-y-6">
   <div class="flex items-center gap-3">
     <div class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
       <ScrollText class="h-6 w-6 text-primary" />

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/+page.svelte
@@ -377,7 +377,7 @@
   <title>Connectors & Apps - Settings - Nocturne</title>
 </svelte:head>
 
-<div class="container mx-auto max-w-4xl p-6 space-y-6">
+<div class="@container container mx-auto max-w-4xl p-3 @md:p-6 space-y-6">
   <!-- Header -->
   <div class="flex items-start justify-between">
     <div class="flex items-center gap-3">

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/[connector]/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/[connector]/+page.svelte
@@ -22,7 +22,7 @@
   <title>{connectorName} - Connectors - Settings - Nocturne</title>
 </svelte:head>
 
-<div class="container mx-auto p-6 max-w-3xl space-y-6">
+<div class="@container container mx-auto p-3 @md:p-6 max-w-3xl space-y-6">
   <div>
     <Button
       variant="ghost"

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/data-quality/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/data-quality/+page.svelte
@@ -43,7 +43,7 @@
 	<title>Data Quality - Settings - Nocturne</title>
 </svelte:head>
 
-<div class="@container container mx-auto max-w-4xl p-6 space-y-6">
+<div class="@container container mx-auto max-w-4xl p-3 @md:p-6 space-y-6">
 	<!-- Header -->
 	<div class="flex items-center gap-3">
 		<div class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/integrations/discord/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/integrations/discord/+page.svelte
@@ -121,7 +121,7 @@
 	);
 </script>
 
-<div class="container mx-auto max-w-2xl p-6 space-y-6">
+<div class="@container container mx-auto max-w-2xl p-3 @md:p-6 space-y-6">
 	<div>
 		<h1 class="text-2xl font-bold">Discord Integration</h1>
 		<p class="text-muted-foreground">

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/members/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/members/+page.svelte
@@ -157,7 +157,7 @@
   <title>Members - Settings - Nocturne</title>
 </svelte:head>
 
-<div class="container mx-auto max-w-4xl p-6 space-y-6" {@attach coachmark({ key: "onboarding.sharing", title: "Share with a caretaker", description: "Share your glucose data with a parent, partner, or clinician.", completedWhen: () => sharingConfigured })}>
+<div class="@container container mx-auto max-w-4xl p-3 @md:p-6 space-y-6" {@attach coachmark({ key: "onboarding.sharing", title: "Share with a caretaker", description: "Share your glucose data with a parent, partner, or clinician.", completedWhen: () => sharingConfigured })}>
   <div class="flex items-center gap-3">
     <div class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
       <Users class="h-6 w-6 text-primary" />

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/migration/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/migration/+page.svelte
@@ -229,7 +229,7 @@
   <title>Data Migration - Settings - Nocturne</title>
 </svelte:head>
 
-<div class="@container container mx-auto max-w-4xl p-6 space-y-6">
+<div class="@container container mx-auto max-w-4xl p-3 @md:p-6 space-y-6">
   <!-- Header -->
   <div class="flex items-center gap-3">
     <div class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/nightscout-transition/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/nightscout-transition/+page.svelte
@@ -104,7 +104,7 @@
 	<title>Nightscout Transition - Settings - Nocturne</title>
 </svelte:head>
 
-<div class="@container container mx-auto max-w-4xl p-6 space-y-6">
+<div class="@container container mx-auto max-w-4xl p-3 @md:p-6 space-y-6">
 	<!-- Header -->
 	<div class="flex items-center gap-3">
 		<div class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/patient/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/patient/+page.svelte
@@ -40,7 +40,7 @@
   <title>Patient Record - Settings - Nocturne</title>
 </svelte:head>
 
-<div class="container mx-auto max-w-4xl p-6 space-y-6">
+<div class="@container container mx-auto max-w-4xl p-3 @md:p-6 space-y-6">
   <div class="flex items-center gap-3">
     <div class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
       <HeartPulse class="h-6 w-6 text-primary" />

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/profile/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/profile/+page.svelte
@@ -111,7 +111,7 @@
 </svelte:head>
 
 {#await summaryQuery}
-  <div class="container mx-auto max-w-4xl p-6 space-y-6">
+  <div class="@container container mx-auto max-w-4xl p-3 @md:p-6 space-y-6">
     <div class="flex items-center justify-center h-64">
       <div class="animate-pulse text-muted-foreground">Loading profiles...</div>
     </div>
@@ -126,7 +126,7 @@
   {@const sensitivity = selectedProfileName ? getSensitivityForProfile(data, selectedProfileName) : null}
   {@const targetRange = selectedProfileName ? getTargetRangeForProfile(data, selectedProfileName) : null}
   {@const profileConfigured = (data?.basalSchedules ?? []).length > 0}
-  <div class="@container container mx-auto max-w-4xl p-6 space-y-6" {@attach coachmark({ key: "onboarding.therapy-profile", title: "Automatically synced", description: "Your basal rates, carb ratios, and sensitivity factors are imported from your uploader (AAPS, Loop, xDrip+). No manual entry needed.", completedWhen: () => profileConfigured })}>
+  <div class="@container container mx-auto max-w-4xl p-3 @md:p-6 space-y-6" {@attach coachmark({ key: "onboarding.therapy-profile", title: "Automatically synced", description: "Your basal rates, carb ratios, and sensitivity factors are imported from your uploader (AAPS, Loop, xDrip+). No manual entry needed.", completedWhen: () => profileConfigured })}>
     <!-- Header -->
     <div class="flex flex-wrap items-start justify-between gap-2">
       <div class="flex items-center gap-3">
@@ -436,7 +436,7 @@
     {/if}
   </div>
 {:catch error}
-  <div class="container mx-auto max-w-4xl p-6 space-y-6">
+  <div class="@container container mx-auto max-w-4xl p-3 @md:p-6 space-y-6">
     <Card class="border-destructive">
       <CardContent class="py-8">
         <div class="text-center space-y-2">

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/roles/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/roles/+page.svelte
@@ -173,7 +173,7 @@
   <title>Roles - Settings - Nocturne</title>
 </svelte:head>
 
-<div class="container mx-auto max-w-4xl p-6 space-y-6">
+<div class="@container container mx-auto max-w-4xl p-3 @md:p-6 space-y-6">
   {#if !canManageRoles}
     <Card.Root>
       <Card.Content

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/support/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/support/+page.svelte
@@ -181,7 +181,7 @@
   <title>Support & Community - Settings - Nocturne</title>
 </svelte:head>
 
-<div class="@container container mx-auto max-w-4xl p-6 space-y-6">
+<div class="@container container mx-auto max-w-4xl p-3 @md:p-6 space-y-6">
   <!-- Header -->
   <div class="flex items-center gap-3">
     <div class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/therapy/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/therapy/+page.svelte
@@ -13,7 +13,7 @@
   <title>Therapy - Settings - Nocturne</title>
 </svelte:head>
 
-<div class="container mx-auto max-w-4xl p-6 space-y-6">
+<div class="@container container mx-auto max-w-4xl p-3 @md:p-6 space-y-6">
   <div class="flex items-center justify-center py-12">
     <p class="text-muted-foreground">Redirecting to Profile...</p>
   </div>

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/trackers/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/trackers/+page.svelte
@@ -441,7 +441,7 @@
   <title>Notifications & Trackers - Settings - Nocturne</title>
 </svelte:head>
 
-<div class="container mx-auto max-w-4xl p-6 space-y-6">
+<div class="@container container mx-auto max-w-4xl p-3 @md:p-6 space-y-6">
   <!-- Header -->
   <div class="flex items-center gap-3">
     <div class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">


### PR DESCRIPTION
- Move the per-rule "Test fire" action into the three-dot menu so the
  rule row no longer crams a button/toggle/menu on narrow screens.
- Make the replay dialog responsive: fluid width (calc(100vw-1rem) /
  95vw) capped at max-w-6xl, fixed 90vh height, and zero outer padding
  with a bordered header so the panel cards get more room.
- Fix the each-key duplicate error when replaying a historic firing by
  including the event kind and index in marker keys (a fired + resolved
  event can share rule id and timestamp).
- Add Day in Review links: a toolbar button in the replay panel for the
  day under replay, and a per-row link in the historic firings list.
- Stack the "Active alerts" card header on narrow containers and keep
  badges/buttons from clipping.
- Align settings and alerts page gutters with reports and the dashboard
  (p-3 @md:p-6) and ensure @container is present for the queries.