### PR TITLE
Improve dashboard mobile responsiveness

### DIFF
--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/GlucoseChartCard.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/GlucoseChartCard.svelte
@@ -7,6 +7,7 @@
     CardTitle,
   } from "$lib/components/ui/card";
   import { Badge } from "$lib/components/ui/badge";
+  import { IsMobile } from "$lib/hooks/is-mobile.svelte";
   import { getRealtimeStore } from "$lib/stores/realtime-store.svelte";
   import {
     predictionEnabled,
@@ -79,6 +80,9 @@
 
   const realtimeStore = getRealtimeStore();
   const displayDemoMode = $derived(demoMode ?? realtimeStore.demoMode);
+
+  // On mobile, drop the card chrome so the chart can use the full width.
+  const isMobile = new IsMobile();
 
   // ===== ENGINE =====
   // svelte-ignore state_referenced_locally
@@ -304,8 +308,8 @@
   );
 </script>
 
-<Card class="@container bg-card border-border">
-  <CardHeader class="pb-2 px-3 @md:px-6">
+{#snippet chartBody()}
+  <CardHeader class={isMobile.current ? "pb-2 px-1" : "pb-2 px-3 @md:px-6"}>
     <div class="flex items-center justify-between flex-wrap gap-2">
       <CardTitle class="flex items-center gap-2 text-card-foreground">
         Blood Glucose
@@ -329,7 +333,7 @@
     </div>
   </CardHeader>
 
-  <CardContent class="p-1 @md:p-2">
+  <CardContent class={isMobile.current ? "-mx-2 p-0" : "p-1 @md:p-2"}>
     <ZoomIndicator {isZoomed} brushXDomain={brushDomain} onResetZoom={resetZoom} />
 
     <div class={heightClass ?? "h-80 @md:h-[450px]"}>
@@ -421,7 +425,17 @@
       onToggleExpandedPumpModes={() => (expandedPumpModes = !expandedPumpModes)}
     />
   </CardContent>
-</Card>
+{/snippet}
+
+{#if isMobile.current}
+  <div class="@container">
+    {@render chartBody()}
+  </div>
+{:else}
+  <Card class="@container bg-card border-border">
+    {@render chartBody()}
+  </Card>
+{/if}
 
 <!-- Entry Edit Dialog -->
 <EntryEditDialog

--- a/src/Web/packages/app/src/lib/components/entries/CarbIntakeSection.svelte
+++ b/src/Web/packages/app/src/lib/components/entries/CarbIntakeSection.svelte
@@ -86,25 +86,23 @@
   {:else}
     <!-- Pending foods for new carb intakes -->
     <div class="rounded-lg border p-4 space-y-3">
-      <div class="flex items-center justify-between">
-        <div class="space-y-1">
-          <div class="text-sm font-semibold">Foods</div>
-          <div class="text-xs text-muted-foreground">
-            Link foods to this carb intake.
-          </div>
+      <div class="space-y-1">
+        <div class="text-sm font-semibold">Foods</div>
+        <div class="text-xs text-muted-foreground">
+          Link foods to this carb intake.
         </div>
-        <Button type="button" size="sm" onclick={() => (showAddFood = true)}>
-          <Plus class="mr-1 h-4 w-4" />
-          Add Food
-        </Button>
       </div>
 
       {#if pendingFoods.length === 0}
-        <div
-          class="rounded-md border border-dashed p-4 text-sm text-muted-foreground"
+        <Button
+          type="button"
+          variant="ghost"
+          onclick={() => (showAddFood = true)}
+          class="h-auto w-full justify-center rounded-md border border-dashed p-4 text-sm font-normal text-muted-foreground"
         >
-          No foods added yet.
-        </div>
+          <Plus class="mr-1.5 h-4 w-4" />
+          Add a food to this carb entry
+        </Button>
       {:else}
         <div class="space-y-2">
           {#each pendingFoods as food, index (index)}
@@ -138,6 +136,16 @@
             </Badge>
           </div>
         {/if}
+
+        <Button
+          type="button"
+          variant="ghost"
+          onclick={() => (showAddFood = true)}
+          class="h-auto w-full justify-center rounded-md border border-dashed p-3 text-sm font-normal text-muted-foreground"
+        >
+          <Plus class="mr-1.5 h-4 w-4" />
+          Add food
+        </Button>
       {/if}
     </div>
 

--- a/src/Web/packages/app/src/lib/components/entries/EntryEditDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/entries/EntryEditDialog.svelte
@@ -4,6 +4,8 @@
   import type { EntryRecord, EntryCategoryId } from "$lib/constants/entry-categories";
   import { ENTRY_CATEGORIES } from "$lib/constants/entry-categories";
   import * as Dialog from "$lib/components/ui/dialog";
+  import * as Sheet from "$lib/components/ui/sheet";
+  import { IsMobile } from "$lib/hooks/is-mobile.svelte";
   import * as DropdownMenu from "$lib/components/ui/dropdown-menu";
   import { Separator } from "$lib/components/ui/separator";
   import { Button } from "$lib/components/ui/button";
@@ -74,6 +76,9 @@
     correlatedRecords = [],
     onClose,
   }: Props = $props();
+
+  // On mobile, present the editor as a bottom sheet instead of a centered dialog.
+  const isMobile = new IsMobile();
 
   let sections = $state<Sections>({
     bolus: null,
@@ -544,8 +549,24 @@
   </form>
 {/if}
 
-<Dialog.Root bind:open onOpenChange={(o) => !o && onClose()}>
-  <Dialog.Content class="max-w-lg max-h-[85vh] overflow-y-auto">
+{#if isMobile.current}
+  <Sheet.Root bind:open onOpenChange={(o) => !o && onClose()}>
+    <Sheet.Content
+      side="bottom"
+      class="max-h-[90vh] overflow-y-auto rounded-t-xl p-6"
+    >
+      {@render dialogBody()}
+    </Sheet.Content>
+  </Sheet.Root>
+{:else}
+  <Dialog.Root bind:open onOpenChange={(o) => !o && onClose()}>
+    <Dialog.Content class="max-w-lg max-h-[85vh] overflow-y-auto">
+      {@render dialogBody()}
+    </Dialog.Content>
+  </Dialog.Root>
+{/if}
+
+{#snippet dialogBody()}
     <Dialog.Header>
       <Dialog.Title>
         {isEditing ? "Edit Entry" : "New Entry"}
@@ -684,5 +705,4 @@
         </Button>
       </Dialog.Footer>
     </div>
-  </Dialog.Content>
-</Dialog.Root>
+{/snippet}

--- a/src/Web/packages/app/src/lib/components/entries/FoodBreakdown.svelte
+++ b/src/Web/packages/app/src/lib/components/entries/FoodBreakdown.svelte
@@ -102,17 +102,11 @@
 </script>
 
 <div class="rounded-lg border p-4 space-y-4">
-  <div class="flex items-center justify-between">
-    <div class="space-y-1">
-      <div class="text-sm font-semibold">Food Breakdown</div>
-      <div class="text-xs text-muted-foreground">
-        Add foods to match carbs when it helps. Partial attribution is fine.
-      </div>
+  <div class="space-y-1">
+    <div class="text-sm font-semibold">Food Breakdown</div>
+    <div class="text-xs text-muted-foreground">
+      Add foods to match carbs when it helps. Partial attribution is fine.
     </div>
-    <Button type="button" size="sm" onclick={() => (showAddFood = true)}>
-      <Plus class="mr-1 h-4 w-4" />
-      Add Food
-    </Button>
   </div>
 
   {#if isLoading}
@@ -146,11 +140,15 @@
       </div>
 
       {#if !breakdown.foods || breakdown.foods.length === 0}
-        <div
-          class="rounded-md border border-dashed p-4 text-sm text-muted-foreground"
+        <Button
+          type="button"
+          variant="ghost"
+          onclick={() => (showAddFood = true)}
+          class="h-auto w-full justify-center rounded-md border border-dashed p-4 text-sm font-normal text-muted-foreground"
         >
-          No foods added yet.
-        </div>
+          <Plus class="mr-1.5 h-4 w-4" />
+          Add a food to this carb entry
+        </Button>
       {:else}
         <div class="space-y-2">
           {#each breakdown.foods as entry (entry.id)}
@@ -186,6 +184,15 @@
             </div>
           {/each}
         </div>
+        <Button
+          type="button"
+          variant="ghost"
+          onclick={() => (showAddFood = true)}
+          class="h-auto w-full justify-center rounded-md border border-dashed p-3 text-sm font-normal text-muted-foreground"
+        >
+          <Plus class="mr-1.5 h-4 w-4" />
+          Add food
+        </Button>
       {/if}
     </div>
   {/if}

--- a/src/Web/packages/app/src/lib/components/treatments/TreatmentEditDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/treatments/TreatmentEditDialog.svelte
@@ -22,6 +22,8 @@
     getEntryStyle,
   } from "$lib/constants/entry-categories";
   import * as Dialog from "$lib/components/ui/dialog";
+  import * as Sheet from "$lib/components/ui/sheet";
+  import { IsMobile } from "$lib/hooks/is-mobile.svelte";
   import { Button } from "$lib/components/ui/button";
   import { Input } from "$lib/components/ui/input";
   import { Label } from "$lib/components/ui/label";
@@ -68,6 +70,9 @@
     onSave,
     onDelete,
   }: Props = $props();
+
+  // On mobile, present the editor as a bottom sheet instead of a centered dialog.
+  const isMobile = new IsMobile();
 
   // Override record for viewing linked records (null = use the `record` prop)
   let overrideRecord = $state<EntryRecord | null>(null);
@@ -402,8 +407,24 @@
   }
 </script>
 
-<Dialog.Root bind:open onOpenChange={(o) => !o && onClose()}>
-  <Dialog.Content class="max-w-lg max-h-[90vh] overflow-y-auto">
+{#if isMobile.current}
+  <Sheet.Root bind:open onOpenChange={(o) => !o && onClose()}>
+    <Sheet.Content
+      side="bottom"
+      class="max-h-[90vh] overflow-y-auto rounded-t-xl p-6"
+    >
+      {@render dialogBody()}
+    </Sheet.Content>
+  </Sheet.Root>
+{:else}
+  <Dialog.Root bind:open onOpenChange={(o) => !o && onClose()}>
+    <Dialog.Content class="max-w-lg max-h-[90vh] overflow-y-auto">
+      {@render dialogBody()}
+    </Dialog.Content>
+  </Dialog.Root>
+{/if}
+
+{#snippet dialogBody()}
     {#if activeRecord && activeCategory && activeStyle && ActiveKindIcon}
       <Dialog.Header>
         <Dialog.Title class="flex items-center gap-2">
@@ -586,5 +607,4 @@
         </Dialog.Description>
       </Dialog.Header>
     {/if}
-  </Dialog.Content>
-</Dialog.Root>
+{/snippet}


### PR DESCRIPTION
- Glucose chart: drop the card chrome and tighten padding on mobile so the
  chart can use the full horizontal width.
- Carb food breakdown: move the add-food action into the empty-state slot as
  a ghost/dashed button ("Add a food to this carb entry" when empty, "Add
  food" when entries exist); applied to both the existing-record breakdown
  and the new-intake pending list.
- Entry and treatment edit dialogs: render as bottom sheets on mobile screen
  sizes, keeping the centered dialog on larger screens.