### PR TITLE
Close treatment dialogs with browser back button

### DIFF
--- a/src/Web/packages/app/src/app.d.ts
+++ b/src/Web/packages/app/src/app.d.ts
@@ -92,7 +92,11 @@ declare global {
 		interface PageData extends Partial<BasePageData> {
 			[key: string]: any;
 		}
-		// interface PageState {}
+		// Shallow-routing state. Dialogs key their browser-history entries here
+		// (see useDialogHistory) so the back button can dismiss them.
+		interface PageState {
+			[key: string]: unknown;
+		}
 		// interface Platform {}
 	}
 }

--- a/src/Web/packages/app/src/lib/components/entries/EntryEditDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/entries/EntryEditDialog.svelte
@@ -6,6 +6,7 @@
   import * as Dialog from "$lib/components/ui/dialog";
   import * as Sheet from "$lib/components/ui/sheet";
   import { IsMobile } from "$lib/hooks/is-mobile.svelte";
+  import { useDialogHistory } from "$lib/hooks/dialog-history.svelte";
   import * as DropdownMenu from "$lib/components/ui/dropdown-menu";
   import { Separator } from "$lib/components/ui/separator";
   import { Button } from "$lib/components/ui/button";
@@ -79,6 +80,12 @@
 
   // On mobile, present the editor as a bottom sheet instead of a centered dialog.
   const isMobile = new IsMobile();
+
+  // Let the browser back button (and mobile back gesture) dismiss the dialog.
+  useDialogHistory(
+    () => open,
+    () => onClose(),
+  );
 
   let sections = $state<Sections>({
     bolus: null,

--- a/src/Web/packages/app/src/lib/components/treatments/TreatmentEditDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/treatments/TreatmentEditDialog.svelte
@@ -24,7 +24,11 @@
   import * as Dialog from "$lib/components/ui/dialog";
   import * as Sheet from "$lib/components/ui/sheet";
   import { IsMobile } from "$lib/hooks/is-mobile.svelte";
-  import { useDialogHistory } from "$lib/hooks/dialog-history.svelte";
+  import { untrack } from "svelte";
+  import {
+    useDialogHistory,
+    type DialogHistoryParam,
+  } from "$lib/hooks/dialog-history.svelte";
   import { Button } from "$lib/components/ui/button";
   import { Input } from "$lib/components/ui/input";
   import { Label } from "$lib/components/ui/label";
@@ -60,6 +64,12 @@
     onClose: () => void;
     onSave: (record: EntryRecord) => void;
     onDelete?: (record: EntryRecord) => void;
+    /**
+     * When set, the open dialog is reflected in this URL search param so it can
+     * be reloaded / deep-linked (the owning page resolves the param on load).
+     * Omit for plain back-button dismissal via an opaque history flag.
+     */
+    historyParam?: DialogHistoryParam;
   }
 
   let {
@@ -70,15 +80,19 @@
     onClose,
     onSave,
     onDelete,
+    historyParam,
   }: Props = $props();
 
   // On mobile, present the editor as a bottom sheet instead of a centered dialog.
   const isMobile = new IsMobile();
 
   // Let the browser back button (and mobile back gesture) dismiss the dialog.
+  // `historyParam` is stable config supplied at mount, so reading it once is
+  // intentional (untrack avoids the reactive-capture warning).
   useDialogHistory(
     () => open,
     () => onClose(),
+    { param: untrack(() => historyParam) },
   );
 
   // Override record for viewing linked records (null = use the `record` prop)

--- a/src/Web/packages/app/src/lib/components/treatments/TreatmentEditDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/treatments/TreatmentEditDialog.svelte
@@ -24,6 +24,7 @@
   import * as Dialog from "$lib/components/ui/dialog";
   import * as Sheet from "$lib/components/ui/sheet";
   import { IsMobile } from "$lib/hooks/is-mobile.svelte";
+  import { useDialogHistory } from "$lib/hooks/dialog-history.svelte";
   import { Button } from "$lib/components/ui/button";
   import { Input } from "$lib/components/ui/input";
   import { Label } from "$lib/components/ui/label";
@@ -73,6 +74,12 @@
 
   // On mobile, present the editor as a bottom sheet instead of a centered dialog.
   const isMobile = new IsMobile();
+
+  // Let the browser back button (and mobile back gesture) dismiss the dialog.
+  useDialogHistory(
+    () => open,
+    () => onClose(),
+  );
 
   // Override record for viewing linked records (null = use the `record` prop)
   let overrideRecord = $state<EntryRecord | null>(null);

--- a/src/Web/packages/app/src/lib/hooks/dialog-history.svelte.ts
+++ b/src/Web/packages/app/src/lib/hooks/dialog-history.svelte.ts
@@ -1,5 +1,27 @@
-import { pushState } from "$app/navigation";
+import { pushState, replaceState } from "$app/navigation";
 import { page } from "$app/state";
+
+/**
+ * Reflects an open dialog in a URL search param so it can be reloaded or
+ * deep-linked. The owning page writes the param value (via `value`) when the
+ * dialog opens and is responsible for reading the param on load and opening the
+ * dialog itself — {@link useDialogHistory} only keeps the param in sync.
+ */
+export interface DialogHistoryParam {
+  /** Search-param name that reflects the open dialog (e.g. "edit"). */
+  name: string;
+  /** Value written into the param when the dialog opens (e.g. "bolus:abc"). */
+  value: () => string;
+}
+
+export interface DialogHistoryOptions {
+  /**
+   * Reflect the open state in a URL search param instead of an opaque
+   * history-state flag, making the dialog reloadable / deep-linkable. Omit for
+   * transient dialogs that only need back-button dismissal.
+   */
+  param?: DialogHistoryParam;
+}
 
 /**
  * Syncs a dialog's open state with browser history so the back button (or the
@@ -7,51 +29,93 @@ import { page } from "$app/state";
  * from the page.
  *
  * When the dialog opens, a shallow-routing history entry is pushed via
- * SvelteKit's `pushState`. Popping that entry — by pressing back — clears the
- * flag from `page.state` and runs the dialog's `close` callback. Closing the
- * dialog any other way (Save, Cancel, Escape, overlay click) pops our entry
- * with `history.back()` so the history stack stays balanced.
+ * SvelteKit's `pushState`. Popping that entry — by pressing back — runs the
+ * dialog's `close` callback. Closing the dialog any other way (Save, Cancel,
+ * Escape, overlay click) pops our entry with `history.back()` so the history
+ * stack stays balanced.
  *
- * Call once during component init, e.g. inside a dialog component that owns the
- * `open`/`onClose` contract:
+ * By default the pushed entry carries an opaque `page.state` flag (the URL is
+ * unchanged). Pass {@link DialogHistoryOptions.param} to instead reflect the
+ * open state in a URL search param so the dialog survives a reload and can be
+ * deep-linked. When a dialog is opened from a param that is already present in
+ * the URL (a deep link or reload), the hook adopts that state and clears it
+ * with `replaceState` on close rather than calling `history.back()`, so closing
+ * never navigates the user off the site.
+ *
+ * Call once during component init:
  *
  *   useDialogHistory(() => open, onClose);
+ *   useDialogHistory(() => open, onClose, { param: { name: "edit", value } });
  *
  * @param isOpen Reactive getter for the dialog's open state.
  * @param close  Closes the dialog (and runs any associated cleanup). Invoked
  *               when the user pops our history entry via the back button.
  */
-export function useDialogHistory(isOpen: () => boolean, close: () => void) {
-  // Unique per instance so multiple dialogs on one page never collide, and so a
-  // stale flag left in history after a reload can't be mistaken for ours.
+export function useDialogHistory(
+  isOpen: () => boolean,
+  close: () => void,
+  options: DialogHistoryOptions = {},
+) {
+  const param = options.param;
+
+  // Unique per instance so multiple opaque dialogs on one page never collide,
+  // and so a stale flag left in history after a reload can't be mistaken for ours.
   const key = `dialog:${crypto.randomUUID()}`;
 
-  // Whether this dialog currently owns the topmost pushed history entry.
-  // Plain (non-reactive) bookkeeping — the effects react to `isOpen` and
-  // `page.state`, not to this flag.
-  let owns = false;
+  // Bookkeeping (plain, non-reactive): the effects react to `isOpen`,
+  // `page.state` and `page.url`, not to these flags.
+  // - `pushed`: we added a poppable history entry (close via history.back()).
+  // - `adopted`: the dialog opened from a param already in the URL on load
+  //   (deep link / reload), so there's no entry of ours to pop — close by
+  //   stripping the param with replaceState instead.
+  let pushed = false;
+  let adopted = false;
 
-  // Push our history entry when the dialog opens; pop it when the dialog is
-  // closed programmatically while our entry is still current.
+  // Whether the token that represents "this dialog is open" is currently present.
+  const present = () =>
+    param
+      ? page.url.searchParams.get(param.name) != null
+      : page.state[key] === true;
+
+  // Push our history entry when the dialog opens; remove it when the dialog is
+  // closed programmatically while our token is still current.
   $effect(() => {
     const open = isOpen();
-    const flagged = page.state[key] === true;
+    const here = present();
 
-    if (open && !owns) {
-      owns = true;
-      pushState("", { ...page.state, [key]: true });
-    } else if (!open && owns && flagged) {
-      owns = false;
-      history.back();
+    if (open && !pushed && !adopted) {
+      if (here) {
+        // Opened from a token already in the URL (deep link / reload).
+        adopted = true;
+      } else if (param) {
+        pushed = true;
+        const url = new URL(page.url);
+        url.searchParams.set(param.name, param.value());
+        pushState(url, { ...page.state });
+      } else {
+        pushed = true;
+        pushState("", { ...page.state, [key]: true });
+      }
+    } else if (!open && (pushed || adopted) && here) {
+      if (pushed) {
+        pushed = false;
+        history.back();
+      } else {
+        adopted = false;
+        const url = new URL(page.url);
+        url.searchParams.delete(param!.name);
+        replaceState(url, { ...page.state });
+      }
     }
   });
 
-  // Close the dialog when the user pops our entry (back button / gesture):
-  // SvelteKit reverts `page.state`, dropping our flag.
+  // Close the dialog when the user pops our token (back button / gesture):
+  // SvelteKit reverts `page.state` / `page.url`, dropping it.
   $effect(() => {
-    const flagged = page.state[key] === true;
-    if (!flagged && owns) {
-      owns = false;
+    const here = present();
+    if (!here && (pushed || adopted)) {
+      pushed = false;
+      adopted = false;
       if (isOpen()) close();
     }
   });

--- a/src/Web/packages/app/src/lib/hooks/dialog-history.svelte.ts
+++ b/src/Web/packages/app/src/lib/hooks/dialog-history.svelte.ts
@@ -1,0 +1,58 @@
+import { pushState } from "$app/navigation";
+import { page } from "$app/state";
+
+/**
+ * Syncs a dialog's open state with browser history so the back button (or the
+ * Android/mobile back gesture) closes the dialog instead of navigating away
+ * from the page.
+ *
+ * When the dialog opens, a shallow-routing history entry is pushed via
+ * SvelteKit's `pushState`. Popping that entry — by pressing back — clears the
+ * flag from `page.state` and runs the dialog's `close` callback. Closing the
+ * dialog any other way (Save, Cancel, Escape, overlay click) pops our entry
+ * with `history.back()` so the history stack stays balanced.
+ *
+ * Call once during component init, e.g. inside a dialog component that owns the
+ * `open`/`onClose` contract:
+ *
+ *   useDialogHistory(() => open, onClose);
+ *
+ * @param isOpen Reactive getter for the dialog's open state.
+ * @param close  Closes the dialog (and runs any associated cleanup). Invoked
+ *               when the user pops our history entry via the back button.
+ */
+export function useDialogHistory(isOpen: () => boolean, close: () => void) {
+  // Unique per instance so multiple dialogs on one page never collide, and so a
+  // stale flag left in history after a reload can't be mistaken for ours.
+  const key = `dialog:${crypto.randomUUID()}`;
+
+  // Whether this dialog currently owns the topmost pushed history entry.
+  // Plain (non-reactive) bookkeeping — the effects react to `isOpen` and
+  // `page.state`, not to this flag.
+  let owns = false;
+
+  // Push our history entry when the dialog opens; pop it when the dialog is
+  // closed programmatically while our entry is still current.
+  $effect(() => {
+    const open = isOpen();
+    const flagged = page.state[key] === true;
+
+    if (open && !owns) {
+      owns = true;
+      pushState("", { ...page.state, [key]: true });
+    } else if (!open && owns && flagged) {
+      owns = false;
+      history.back();
+    }
+  });
+
+  // Close the dialog when the user pops our entry (back button / gesture):
+  // SvelteKit reverts `page.state`, dropping our flag.
+  $effect(() => {
+    const flagged = page.state[key] === true;
+    if (!flagged && owns) {
+      owns = false;
+      if (isOpen()) close();
+    }
+  });
+}

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/treatments/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/treatments/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { page } from "$app/state";
+  import { replaceState } from "$app/navigation";
 
   interface TreatmentSummary {
     totals?: {
@@ -102,6 +103,41 @@
   let editRecord = $state<EntryRecord | null>(null);
   let editLoading = $state(false);
 
+  // Reflect the open edit dialog in the URL (?edit=<kind>:<id>) so it can be
+  // reloaded and deep-linked. The token is resolved against the loaded rows.
+  const EDIT_PARAM = "edit";
+  const editHistoryParam = {
+    name: EDIT_PARAM,
+    value: () =>
+      editRecord?.data.id ? `${editRecord.kind}:${editRecord.data.id}` : "",
+  };
+
+  // On load (or deep link), open the dialog for the record named in ?edit=.
+  // Runs once data is available; clears the param if the record isn't in range.
+  let restoredFromUrl = false;
+  $effect(() => {
+    if (restoredFromUrl || !reportsResource.current) return;
+    const token = page.url.searchParams.get(EDIT_PARAM);
+    if (!token) {
+      restoredFromUrl = true;
+      return;
+    }
+    const sep = token.indexOf(":");
+    const kind = sep === -1 ? token : token.slice(0, sep);
+    const id = sep === -1 ? "" : token.slice(sep + 1);
+    const found = allRows.find((r) => r.kind === kind && r.data.id === id);
+    restoredFromUrl = true;
+    if (found) {
+      editRecord = found;
+      editDialogOpen = true;
+    } else {
+      // Stale / out-of-range link: drop the param so the URL isn't misleading.
+      const url = new URL(page.url);
+      url.searchParams.delete(EDIT_PARAM);
+      replaceState(url, page.state);
+    }
+  });
+
   const editCorrelatedRecords = $derived.by(() => {
     if (!editRecord?.data.correlationId) return [];
     return allRows.filter(
@@ -164,13 +200,15 @@
   // Handlers
   function handleCategoryChange(category: EntryCategoryId | "all") {
     activeCategory = category;
-    const url = new URL(window.location.href);
+    const url = new URL(page.url);
     if (category === "all") {
       url.searchParams.delete("category");
     } else {
       url.searchParams.set("category", category);
     }
-    window.history.replaceState({}, "", url);
+    // Use SvelteKit shallow routing so `page.url` stays authoritative (the edit
+    // dialog reads it to keep its `?edit=` param in sync).
+    replaceState(url, page.state);
   }
 
   function handleSearch(e: Event) {
@@ -598,6 +636,7 @@
   record={editRecord}
   correlatedRecords={editCorrelatedRecords}
   isLoading={editLoading}
+  historyParam={editHistoryParam}
   onClose={handleEditClose}
   onSave={handleEditSave}
   onDelete={handleEditDelete}


### PR DESCRIPTION
Add a useDialogHistory hook that syncs a dialog's open state with browser
history via SvelteKit shallow routing. Opening a dialog pushes a history
entry; the back button (or mobile back gesture) pops it and runs the
dialog's close handler, while programmatic closes pop the entry to keep
history balanced.

Wired into EntryEditDialog and TreatmentEditDialog, so the entry/treatment
edit dialogs on the dashboard and in the treatments report can be dismissed
with browser back.