### PR TITLE
feat(treatments): manual treatment creation incl. long-acting injections

### DIFF
--- a/src/Web/packages/app/e2e/basal-injection.spec.ts
+++ b/src/Web/packages/app/e2e/basal-injection.spec.ts
@@ -2,99 +2,65 @@ import { expect, test } from "@playwright/test";
 
 test.describe("basal injection entry flow", () => {
 	test("logs a long-acting basal injection end-to-end", async ({ page }) => {
-		// Navigate to the treatments report page (where the Add Treatment action leads)
+		// The treatments report page is where manual treatment creation lives.
 		await page.goto("/reports/treatments");
 
-		// Wait for the page to be fully loaded
+		// Wait for the page to be fully loaded.
 		await expect(page.getByRole("heading", { level: 1 })).toBeVisible({ timeout: 10_000 });
 
-		// Open the treatment data table's add/edit dialog.
-		// The TreatmentsDataTable should have a way to create a new entry.
-		// Click the row or button that opens TreatmentEditDialog for a new basalInjection.
-		// In the treatments page, there should be category tabs — click "Long-acting injection".
-		const basalTab = page.getByRole("tab", { name: /long.acting injection/i });
-		if (await basalTab.isVisible({ timeout: 3_000 })) {
-			await basalTab.click();
-		}
+		// Open the "Add Treatment" kind picker and choose the long-acting injection.
+		await page.getByRole("button", { name: /add treatment/i }).click();
+		await page
+			.getByRole("menuitem", { name: /long.acting injection/i })
+			.click();
 
-		// Look for an "Add" / "New" / "+" button to create a new treatment entry
-		const addButton = page
-			.getByRole("button", { name: /add|new|create/i })
-			.first();
-		await expect(addButton).toBeVisible({ timeout: 5_000 });
-		await addButton.click();
+		// --- BasalInjectionFormFields (inside TreatmentEditDialog) ---
 
-		// The TreatmentEditDialog should open. If it presents an event type
-		// selector, choose "Long-acting injection" (basalInjection category).
-		const eventTypeSelect = page.getByText(/long.acting injection/i).first();
-		if (await eventTypeSelect.isVisible({ timeout: 3_000 })) {
-			await eventTypeSelect.click();
-		}
-
-		// --- BasalInjectionFormFields ---
-
-		// Select a basal insulin from the dropdown.
-		// The Select.Trigger shows "Select insulin..." as placeholder text.
+		// Select a basal insulin from the dropdown. The Select.Trigger shows
+		// "Select insulin..." as placeholder text until one is chosen.
 		const insulinTrigger = page.getByText("Select insulin...");
 		await expect(insulinTrigger).toBeVisible({ timeout: 5_000 });
 		await insulinTrigger.click();
 
-		// Wait for the dropdown content to appear, then pick the first option.
-		// In a real environment this would be a configured patient insulin like "Tresiba".
-		const firstInsulinOption = page
-			.getByRole("option")
-			.first();
+		// Pick the first available basal insulin option (e.g. a configured "Tresiba").
+		const firstInsulinOption = page.getByRole("option").first();
 		await expect(firstInsulinOption).toBeVisible({ timeout: 5_000 });
 		const insulinName = await firstInsulinOption.textContent();
 		await firstInsulinOption.click();
 
-		// Enter units (20u)
+		// Enter units (20U).
 		const unitsInput = page.locator("#basal-units");
 		await expect(unitsInput).toBeVisible();
 		await unitsInput.fill("20");
 
-		// Optionally add a note
+		// Optionally add a note.
 		const notesField = page.locator("#basal-notes");
 		if (await notesField.isVisible({ timeout: 1_000 })) {
 			await notesField.fill("Evening dose");
 		}
 
-		// Submit the form — the Save button in the dialog footer
-		const saveButton = page.getByRole("button", { name: /save/i });
-		await expect(saveButton).toBeEnabled();
+		// Submit via the dialog's create button.
+		const createButton = page.getByRole("button", { name: /create record/i });
+		await expect(createButton).toBeEnabled();
+		await createButton.click();
 
-		// Intercept the SvelteKit form action response (remote functions submit to the page route)
-		const saveResponsePromise = page.waitForResponse(
-			(resp) =>
-				resp.url().includes("/reports/treatments") &&
-				resp.request().method() === "POST",
-			{ timeout: 10_000 },
-		);
-
-		await saveButton.click();
-
-		// Wait for the API response to confirm the save went through
-		const saveResponse = await saveResponsePromise;
-		expect(saveResponse.ok()).toBe(true);
-
-		// The dialog should close after a successful save
+		// The dialog should close after a successful save.
 		await expect(page.locator("#basal-units")).not.toBeVisible({
-			timeout: 5_000,
+			timeout: 10_000,
 		});
 
 		// The treatments table should now show the new basal injection entry.
-		// RecentTreatmentsCard / TreatmentsDataTable renders "20u basal" for
-		// basalInjection entries, and the insulin name as detail text.
-		const newRow = page.getByText("20u basal");
-		await expect(newRow).toBeVisible({ timeout: 10_000 });
+		// TreatmentsDataTable renders the units (e.g. "20U") in the value column,
+		// with the insulin name as detail text.
+		await expect(page.getByText("20U").first()).toBeVisible({ timeout: 10_000 });
 
-		// The insulin name should appear alongside the entry
+		// The insulin name should appear alongside the entry.
 		if (insulinName) {
 			const trimmedName = insulinName.trim().split("\n")[0].trim();
 			if (trimmedName) {
-				await expect(
-					page.getByText(trimmedName).first(),
-				).toBeVisible({ timeout: 5_000 });
+				await expect(page.getByText(trimmedName).first()).toBeVisible({
+					timeout: 5_000,
+				});
 			}
 		}
 	});

--- a/src/Web/packages/app/src/lib/components/entries/BasalInjectionSection.svelte
+++ b/src/Web/packages/app/src/lib/components/entries/BasalInjectionSection.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+  import type { BasalInjection, PatientInsulin, InsulinCategory } from "$lib/api";
+  import * as Select from "$lib/components/ui/select";
+  import { Input } from "$lib/components/ui/input";
+  import { Label } from "$lib/components/ui/label";
+  import { Textarea } from "$lib/components/ui/textarea";
+  import { Button } from "$lib/components/ui/button";
+  import { Syringe, X, AlertTriangle } from "lucide-svelte";
+  import * as patientRemote from "$api/generated/patientRecords.generated.remote";
+  import { insulinCategoryLabels } from "$lib/components/patient/labels";
+
+  interface Props {
+    injection: Partial<BasalInjection>;
+    onRemove?: () => void;
+  }
+
+  let { injection = $bindable(), onRemove }: Props = $props();
+
+  // Long-acting injections reference a configured PatientInsulin (Basal/Both
+  // role). The hidden form submits insulinContext.patientInsulinId; the server
+  // resolves the full TreatmentInsulinContext snapshot at write time.
+  const insulinsResource = patientRemote.getInsulins();
+  let patientInsulins = $derived(
+    (insulinsResource.current ?? []) as PatientInsulin[],
+  );
+
+  let eligibleInsulins = $derived(
+    patientInsulins.filter(
+      (i) => i.isCurrent && (i.role === "Basal" || i.role === "Both"),
+    ),
+  );
+
+  let selectedId = $derived(injection.insulinContext?.patientInsulinId);
+  let selectedInsulin = $derived(
+    eligibleInsulins.find((i) => i.id === selectedId),
+  );
+  let isPremix = $derived(selectedInsulin?.role === "Both");
+  let isHighDose = $derived(
+    typeof injection.units === "number" && injection.units > 100,
+  );
+
+  function handleInsulinSelect(next: string) {
+    const insulin = eligibleInsulins.find((i) => i.id === next);
+    if (!insulin?.id) {
+      injection.insulinContext = undefined;
+      return;
+    }
+    injection.insulinContext = {
+      patientInsulinId: insulin.id,
+      insulinName: insulin.name,
+      dia: insulin.dia,
+      peak: insulin.peak,
+      curve: insulin.curve,
+      concentration: insulin.concentration,
+    };
+  }
+</script>
+
+<div class="space-y-3">
+  <div class="flex items-center justify-between">
+    <div class="flex items-center gap-2 text-sm font-medium">
+      <Syringe class="h-4 w-4 text-indigo-500" />
+      Long-acting injection
+    </div>
+    {#if onRemove}
+      <Button variant="ghost" size="icon" class="h-6 w-6" onclick={onRemove}>
+        <X class="h-3.5 w-3.5" />
+      </Button>
+    {/if}
+  </div>
+
+  <div class="space-y-1.5">
+    <Label>Basal Insulin</Label>
+    <Select.Root
+      type="single"
+      value={selectedId ?? ""}
+      onValueChange={handleInsulinSelect}
+    >
+      <Select.Trigger>
+        {selectedInsulin?.name ?? "Select insulin..."}
+      </Select.Trigger>
+      <Select.Content>
+        {#each eligibleInsulins as insulin (insulin.id)}
+          <Select.Item value={insulin.id ?? ""}>
+            <div>
+              <div>{insulin.name}</div>
+              <div class="text-xs text-muted-foreground">
+                {insulinCategoryLabels[
+                  insulin.insulinCategory as InsulinCategory
+                ] ?? insulin.insulinCategory}
+              </div>
+            </div>
+          </Select.Item>
+        {/each}
+      </Select.Content>
+    </Select.Root>
+    {#if isPremix}
+      <div
+        class="flex items-start gap-1.5 text-xs text-amber-600 dark:text-amber-500"
+      >
+        <AlertTriangle class="h-3.5 w-3.5 mt-0.5 shrink-0" />
+        <span>
+          This insulin is used for both bolus and basal &mdash; log the basal
+          portion only.
+        </span>
+      </div>
+    {/if}
+  </div>
+
+  <div class="space-y-1.5">
+    <Label for="basal-section-units">Units (U)</Label>
+    <Input
+      id="basal-section-units"
+      type="number"
+      step="0.5"
+      min="0"
+      max="500"
+      bind:value={injection.units}
+    />
+    {#if isHighDose}
+      <div
+        class="flex items-start gap-1.5 text-xs text-amber-600 dark:text-amber-500"
+      >
+        <AlertTriangle class="h-3.5 w-3.5 mt-0.5 shrink-0" />
+        <span>Confirm the dose &mdash; this is higher than typical.</span>
+      </div>
+    {/if}
+  </div>
+
+  <div class="space-y-1.5">
+    <Label for="basal-section-notes">Notes</Label>
+    <Textarea
+      id="basal-section-notes"
+      bind:value={injection.notes}
+      placeholder="Optional notes..."
+      rows={2}
+    />
+  </div>
+</div>

--- a/src/Web/packages/app/src/lib/components/entries/EntryEditDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/entries/EntryEditDialog.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Bolus, CarbIntake, BGCheck, Note, DeviceEvent } from "$lib/api";
+  import type { Bolus, CarbIntake, BGCheck, Note, DeviceEvent, BasalInjection } from "$lib/api";
   import { BolusType, GlucoseType, GlucoseUnit, DeviceEventType } from "$lib/api";
   import type { EntryRecord, EntryCategoryId } from "$lib/constants/entry-categories";
   import { ENTRY_CATEGORIES } from "$lib/constants/entry-categories";
@@ -17,6 +17,7 @@
   import BGCheckSection from "./BGCheckSection.svelte";
   import NoteSection from "./NoteSection.svelte";
   import DeviceEventSection from "./DeviceEventSection.svelte";
+  import BasalInjectionSection from "./BasalInjectionSection.svelte";
   import {
     Plus,
     Trash2,
@@ -55,6 +56,11 @@
     update as updateDeviceEventForm,
     remove as deleteDeviceEvent,
   } from "$api/generated/deviceEvents.generated.remote";
+  import {
+    create as createBasalInjectionForm,
+    update as updateBasalInjectionForm,
+    remove as deleteBasalInjection,
+  } from "$api/generated/basalInjections.generated.remote";
 
   interface Sections {
     bolus: Partial<Bolus> | null;
@@ -62,6 +68,7 @@
     bgCheck: Partial<BGCheck> | null;
     note: Partial<Note> | null;
     deviceEvent: Partial<DeviceEvent> | null;
+    basalInjection: Partial<BasalInjection> | null;
   }
 
   interface Props {
@@ -93,6 +100,7 @@
     bgCheck: null,
     note: null,
     deviceEvent: null,
+    basalInjection: null,
   });
 
   let mills = $state<number>(Date.now());
@@ -105,6 +113,7 @@
   let bgCheckFormRef = $state<HTMLFormElement | null>(null);
   let noteFormRef = $state<HTMLFormElement | null>(null);
   let deviceEventFormRef = $state<HTMLFormElement | null>(null);
+  let basalInjectionFormRef = $state<HTMLFormElement | null>(null);
 
   // Track form completion per section
   let bolusFormDone = $state(false);
@@ -112,6 +121,7 @@
   let bgCheckFormDone = $state(false);
   let noteFormDone = $state(false);
   let deviceEventFormDone = $state(false);
+  let basalInjectionFormDone = $state(false);
   let saveError = $state<string | null>(null);
   let isSaving = $state(false);
 
@@ -162,6 +172,11 @@
     existingDeviceEventRecord?.data.id ? updateDeviceEventForm : createDeviceEventForm,
   );
 
+  const existingBasalInjectionRecord = $derived(findExistingRecord("basalInjection"));
+  const activeBasalInjectionForm = $derived(
+    existingBasalInjectionRecord?.data.id ? updateBasalInjectionForm : createBasalInjectionForm,
+  );
+
   // Aggregate pending state across all forms
   const formsPending = $derived(
     !!createBolusForm.pending ||
@@ -173,7 +188,9 @@
     !!createNoteForm.pending ||
     !!updateNoteForm.pending ||
     !!createDeviceEventForm.pending ||
-    !!updateDeviceEventForm.pending,
+    !!updateDeviceEventForm.pending ||
+    !!createBasalInjectionForm.pending ||
+    !!updateBasalInjectionForm.pending,
   );
 
   const sectionIcons: Record<EntryCategoryId, typeof Syringe> = {
@@ -182,6 +199,7 @@
     bgCheck: Droplet,
     note: FileText,
     deviceEvent: Smartphone,
+    basalInjection: Syringe,
   };
 
   // Populate sections from entry and correlated records when dialog opens
@@ -196,6 +214,7 @@
         bgCheck: null,
         note: null,
         deviceEvent: null,
+        basalInjection: null,
       };
 
       // Populate primary entry
@@ -217,6 +236,7 @@
         bgCheck: null,
         note: null,
         deviceEvent: null,
+        basalInjection: null,
       };
       mills = Date.now();
       carbsPendingFoods = [];
@@ -239,6 +259,9 @@
         break;
       case "deviceEvent":
         target.deviceEvent = { ...record.data };
+        break;
+      case "basalInjection":
+        target.basalInjection = { ...record.data };
         break;
     }
   }
@@ -284,6 +307,7 @@
     bgCheckFormDone = sections.bgCheck == null;
     noteFormDone = sections.note == null;
     deviceEventFormDone = sections.deviceEvent == null;
+    basalInjectionFormDone = sections.basalInjection == null;
 
     // Submit all active forms
     if (sections.bolus != null && bolusFormRef) {
@@ -301,10 +325,13 @@
     if (sections.deviceEvent != null && deviceEventFormRef) {
       deviceEventFormRef.requestSubmit();
     }
+    if (sections.basalInjection != null && basalInjectionFormRef) {
+      basalInjectionFormRef.requestSubmit();
+    }
   }
 
   function checkAllDone() {
-    if (bolusFormDone && carbsFormDone && bgCheckFormDone && noteFormDone && deviceEventFormDone) {
+    if (bolusFormDone && carbsFormDone && bgCheckFormDone && noteFormDone && deviceEventFormDone && basalInjectionFormDone) {
       if (!saveError) {
         toast.success(isEditing ? "Entry updated" : "Entry created");
         open = false;
@@ -318,7 +345,7 @@
 
   // Watch for form completion
   $effect(() => {
-    if (isSaving && bolusFormDone && carbsFormDone && bgCheckFormDone && noteFormDone && deviceEventFormDone) {
+    if (isSaving && bolusFormDone && carbsFormDone && bgCheckFormDone && noteFormDone && deviceEventFormDone && basalInjectionFormDone) {
       checkAllDone();
     }
   });
@@ -346,6 +373,9 @@
         case "deviceEvent":
           promises.push(deleteDeviceEvent(entry.data.id));
           break;
+        case "basalInjection":
+          promises.push(deleteBasalInjection(entry.data.id));
+          break;
       }
 
       // Delete correlated records
@@ -366,6 +396,9 @@
             break;
           case "deviceEvent":
             promises.push(deleteDeviceEvent(record.data.id));
+            break;
+          case "basalInjection":
+            promises.push(deleteBasalInjection(record.data.id));
             break;
         }
       }
@@ -556,6 +589,43 @@
   </form>
 {/if}
 
+<!-- Hidden basal injection form -->
+{#if sections.basalInjection != null}
+  {@const correlationId = activeSectionCount > 1 ? crypto.randomUUID() : undefined}
+  <form
+    bind:this={basalInjectionFormRef}
+    class="hidden"
+    {...activeBasalInjectionForm.enhance(async ({ submit }) => {
+      await submit();
+      if (activeBasalInjectionForm.result) {
+        basalInjectionFormDone = true;
+      } else {
+        saveError = "Failed to save basal injection";
+        basalInjectionFormDone = true;
+      }
+    })}
+  >
+    {#if existingBasalInjectionRecord?.data.id}
+      <input type="hidden" name="id" value={existingBasalInjectionRecord.data.id} />
+    {/if}
+    <input type="hidden" name="n:mills" value={mills} />
+    {#if correlationId}
+      <input type="hidden" name="correlationId" value={correlationId} />
+    {/if}
+    {#if sections.basalInjection?.insulinContext?.patientInsulinId}
+      <input
+        type="hidden"
+        name="patientInsulinId"
+        value={sections.basalInjection.insulinContext.patientInsulinId}
+      />
+    {/if}
+    <input type="hidden" name="n:units" value={sections.basalInjection?.units ?? 0} />
+    {#if sections.basalInjection?.notes}
+      <input type="hidden" name="notes" value={sections.basalInjection.notes} />
+    {/if}
+  </form>
+{/if}
+
 {#if isMobile.current}
   <Sheet.Root bind:open onOpenChange={(o) => !o && onClose()}>
     <Sheet.Content
@@ -642,6 +712,13 @@
             bind:deviceEvent={sections.deviceEvent}
             onRemove={activeSectionCount > 1
               ? () => removeSection("deviceEvent")
+              : undefined}
+          />
+        {:else if key === "basalInjection" && sections.basalInjection != null}
+          <BasalInjectionSection
+            bind:injection={sections.basalInjection}
+            onRemove={activeSectionCount > 1
+              ? () => removeSection("basalInjection")
               : undefined}
           />
         {/if}

--- a/src/Web/packages/app/src/lib/components/treatments/TreatmentCategoryTabs.svelte
+++ b/src/Web/packages/app/src/lib/components/treatments/TreatmentCategoryTabs.svelte
@@ -21,6 +21,7 @@
     bgCheck: Droplet,
     note: FileText,
     deviceEvent: Smartphone,
+    basalInjection: Syringe,
   } as const;
 </script>
 

--- a/src/Web/packages/app/src/lib/components/treatments/TreatmentEditDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/treatments/TreatmentEditDialog.svelte
@@ -327,6 +327,10 @@
     activeRecord ? kindIcon[activeRecord.kind] : null
   );
 
+  // A record without an id is being created rather than edited. Drives the
+  // title/description/button copy and suppresses edit-only chrome.
+  let isCreate = $derived(!activeRecord?.data.id);
+
   function handleSubmit() {
     if (!activeRecord) return;
 
@@ -456,10 +460,12 @@
             <ActiveKindIcon class="mr-1 h-3.5 w-3.5" />
             {activeCategory.name}
           </Badge>
-          Edit Record
+          {isCreate ? "Add Record" : "Edit Record"}
         </Dialog.Title>
         <Dialog.Description>
-          Edit the details of this {activeCategory.name.toLowerCase()} record.
+          {isCreate
+            ? `Log a new ${activeCategory.name.toLowerCase()} record.`
+            : `Edit the details of this ${activeCategory.name.toLowerCase()} record.`}
         </Dialog.Description>
       </Dialog.Header>
 
@@ -471,6 +477,7 @@
         class="space-y-4"
       >
         <!-- Read-only metadata -->
+        {#if !isCreate}
         <div
           class="flex flex-wrap gap-4 text-sm text-muted-foreground bg-muted/30 rounded-lg p-3"
         >
@@ -491,6 +498,7 @@
             </div>
           {/if}
         </div>
+        {/if}
 
         <!-- Date and Time -->
         <div class="space-y-2">
@@ -557,7 +565,11 @@
             Cancel
           </Button>
           <Button type="submit" disabled={isLoading}>
-            {isLoading ? "Saving..." : "Save Changes"}
+            {isLoading
+              ? "Saving..."
+              : isCreate
+                ? "Create Record"
+                : "Save Changes"}
           </Button>
         </Dialog.Footer>
       </form>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/treatments/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/treatments/+page.svelte
@@ -59,6 +59,7 @@
     updateEntry,
     createEntry,
   } from "./data.remote";
+  import { toCreateEntryInput, toUpdateEntryInput } from "./entry-request";
 
   // Get shared date params from context (set by reports layout)
   const reportsParams = requireDateParamsContext(7);
@@ -287,17 +288,10 @@
     editLoading = true;
     try {
       if (record.data.id) {
-        await updateEntry({
-          kind: record.kind,
-          id: record.data.id,
-          data: record.data as Record<string, unknown>,
-        });
+        await updateEntry(toUpdateEntryInput(record));
         toast.success("Record updated successfully");
       } else {
-        await createEntry({
-          kind: record.kind,
-          data: record.data as Record<string, unknown>,
-        });
+        await createEntry(toCreateEntryInput(record));
         toast.success("Record created successfully");
       }
       editDialogOpen = false;

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/treatments/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/treatments/+page.svelte
@@ -29,7 +29,17 @@
   import { Badge } from "$lib/components/ui/badge";
   import * as Card from "$lib/components/ui/card";
   import * as Alert from "$lib/components/ui/alert";
-  import { Calendar, X } from "lucide-svelte";
+  import * as DropdownMenu from "$lib/components/ui/dropdown-menu";
+  import {
+    Calendar,
+    X,
+    Plus,
+    Syringe,
+    Utensils,
+    Droplet,
+    FileText,
+    Smartphone,
+  } from "lucide-svelte";
   import {
     formatInsulinDisplay,
     formatCarbDisplay,
@@ -47,6 +57,7 @@
     deleteEntryForm,
     bulkDeleteEntries,
     updateEntry,
+    createEntry,
   } from "./data.remote";
 
   // Get shared date params from context (set by reports layout)
@@ -64,6 +75,7 @@
       bgChecks: reportsResource.current?.bgChecks,
       notes: reportsResource.current?.notes,
       deviceEvents: reportsResource.current?.deviceEvents,
+      basalInjections: reportsResource.current?.basalInjections,
     })
   );
   const dateRange = $derived(
@@ -182,6 +194,11 @@
             if (r.data.eventType) searchable.push(r.data.eventType);
             if (r.data.notes) searchable.push(r.data.notes);
             break;
+          case "basalInjection":
+            if (r.data.insulinContext?.insulinName)
+              searchable.push(r.data.insulinContext.insulinName);
+            if (r.data.notes) searchable.push(r.data.notes);
+            break;
         }
 
         if (r.data.dataSource) searchable.push(r.data.dataSource);
@@ -236,6 +253,31 @@
     editDialogOpen = true;
   }
 
+  // Build an empty record of the chosen kind to open the dialog in "create"
+  // mode. The dialog keys off the absent id to switch its title/buttons and the
+  // save handler routes id-less records to createEntry.
+  function makeBlankRecord(kind: EntryCategoryId): EntryRecord {
+    const data = {
+      mills: Date.now(),
+      utcOffset: -new Date().getTimezoneOffset(),
+    } as EntryRecord["data"];
+    return { kind, data } as EntryRecord;
+  }
+
+  function handleAddTreatment(kind: EntryCategoryId) {
+    editRecord = makeBlankRecord(kind);
+    editDialogOpen = true;
+  }
+
+  const addKindIcons: Record<EntryCategoryId, typeof Plus> = {
+    bolus: Syringe,
+    carbs: Utensils,
+    bgCheck: Droplet,
+    note: FileText,
+    deviceEvent: Smartphone,
+    basalInjection: Syringe,
+  };
+
   function handleEditClose() {
     editDialogOpen = false;
     editRecord = null;
@@ -244,18 +286,28 @@
   async function handleEditSave(record: EntryRecord) {
     editLoading = true;
     try {
-      await updateEntry({
-        kind: record.kind,
-        id: record.data.id!,
-        data: record.data as Record<string, unknown>,
-      });
-      toast.success("Record updated successfully");
+      if (record.data.id) {
+        await updateEntry({
+          kind: record.kind,
+          id: record.data.id,
+          data: record.data as Record<string, unknown>,
+        });
+        toast.success("Record updated successfully");
+      } else {
+        await createEntry({
+          kind: record.kind,
+          data: record.data as Record<string, unknown>,
+        });
+        toast.success("Record created successfully");
+      }
       editDialogOpen = false;
       editRecord = null;
       reportsResource.refresh();
     } catch (error) {
-      console.error("Update error:", error);
-      toast.error("Failed to update record");
+      console.error("Save error:", error);
+      toast.error(
+        record.data.id ? "Failed to update record" : "Failed to create record",
+      );
     } finally {
       editLoading = false;
     }
@@ -302,6 +354,10 @@
           : "Note";
       case "deviceEvent":
         return record.data.eventType ?? "Device Event";
+      case "basalInjection":
+        return record.data.units
+          ? `${record.data.units}U basal`
+          : "Long-acting injection";
     }
   }
 </script>
@@ -373,6 +429,27 @@
               Clear filters
             </Button>
           {/if}
+          <DropdownMenu.Root>
+            <DropdownMenu.Trigger>
+              {#snippet child({ props })}
+                <Button {...props} size="sm">
+                  <Plus class="mr-1 h-4 w-4" />
+                  Add Treatment
+                </Button>
+              {/snippet}
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content align="end">
+              {#each Object.entries(ENTRY_CATEGORIES) as [id, cat]}
+                {@const Icon = addKindIcons[id as EntryCategoryId]}
+                <DropdownMenu.Item
+                  onclick={() => handleAddTreatment(id as EntryCategoryId)}
+                >
+                  <Icon class="mr-2 h-4 w-4 {cat.colorClass}" />
+                  {cat.name}
+                </DropdownMenu.Item>
+              {/each}
+            </DropdownMenu.Content>
+          </DropdownMenu.Root>
         </div>
       </div>
 
@@ -639,6 +716,6 @@
   historyParam={editHistoryParam}
   onClose={handleEditClose}
   onSave={handleEditSave}
-  onDelete={handleEditDelete}
+  onDelete={editRecord?.data.id ? handleEditDelete : undefined}
 />
 {/if}

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/treatments/data.remote.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/treatments/data.remote.ts
@@ -5,7 +5,28 @@
 import { z } from 'zod';
 import { getRequestEvent, form, command, query } from '$app/server';
 import { invalid } from '@sveltejs/kit';
-import type { Bolus, CarbIntake, BGCheck, Note, DeviceEvent, BasalInjection } from '$lib/api';
+import type {
+	CreateBolusRequest,
+	UpdateBolusRequest,
+	CreateCarbIntakeRequest,
+	UpdateCarbIntakeRequest,
+	UpsertBGCheckRequest,
+	UpsertNoteRequest,
+	UpsertDeviceEventRequest,
+	CreateBasalInjectionRequest,
+	UpdateBasalInjectionRequest,
+} from '$lib/api';
+import {
+	CreateBolusRequestSchema,
+	UpdateBolusRequestSchema,
+	CreateCarbIntakeRequestSchema,
+	UpdateCarbIntakeRequestSchema,
+	UpsertBGCheckRequestSchema,
+	UpsertNoteRequestSchema,
+	UpsertDeviceEventRequestSchema,
+	CreateBasalInjectionRequestSchema,
+	UpdateBasalInjectionRequestSchema,
+} from '$lib/api/generated/schemas';
 import { getProfileSummary } from '$api/generated/profiles.generated.remote';
 import { getLocalDayBoundariesUtc } from '$lib/utils/timezone';
 
@@ -212,31 +233,37 @@ export const bulkDeleteEntries = command(
 );
 
 /**
- * Update a single entry (v4: dispatches to the correct endpoint by kind)
+ * Update a single entry (v4: dispatches to the correct endpoint by kind).
+ *
+ * Input is validated per kind against the backend-generated request schemas
+ * (the same schemas the auto-generated per-kind remote forms use), so the
+ * payload is guaranteed to match the API contract before dispatch. The caller
+ * maps the dialog's domain record onto the request DTO via `toUpdateEntryInput`.
  */
 export const updateEntry = command(
-	z.object({
-		kind: z.enum(['bolus', 'carbs', 'bgCheck', 'note', 'deviceEvent', 'basalInjection']),
-		id: z.string().min(1),
-		data: z.record(z.string(), z.unknown()),
-	}),
-	async ({ kind, id, data }) => {
-		const { locals } = getRequestEvent();
-		const { apiClient } = locals;
-
-		switch (kind) {
+	z.discriminatedUnion('kind', [
+		z.object({ kind: z.literal('bolus'), id: z.string().min(1), data: UpdateBolusRequestSchema }),
+		z.object({ kind: z.literal('carbs'), id: z.string().min(1), data: UpdateCarbIntakeRequestSchema }),
+		z.object({ kind: z.literal('bgCheck'), id: z.string().min(1), data: UpsertBGCheckRequestSchema }),
+		z.object({ kind: z.literal('note'), id: z.string().min(1), data: UpsertNoteRequestSchema }),
+		z.object({ kind: z.literal('deviceEvent'), id: z.string().min(1), data: UpsertDeviceEventRequestSchema }),
+		z.object({ kind: z.literal('basalInjection'), id: z.string().min(1), data: UpdateBasalInjectionRequestSchema }),
+	]),
+	async (input) => {
+		const { apiClient } = getRequestEvent().locals;
+		switch (input.kind) {
 			case 'bolus':
-				return await apiClient.bolus.update(id, data as Bolus);
+				return await apiClient.bolus.update(input.id, input.data as UpdateBolusRequest);
 			case 'carbs':
-				return await apiClient.nutrition.updateCarbIntake(id, data as CarbIntake);
+				return await apiClient.nutrition.updateCarbIntake(input.id, input.data as UpdateCarbIntakeRequest);
 			case 'bgCheck':
-				return await apiClient.bGCheck.update(id, data as BGCheck);
+				return await apiClient.bGCheck.update(input.id, input.data as UpsertBGCheckRequest);
 			case 'note':
-				return await apiClient.note.update(id, data as Note);
+				return await apiClient.note.update(input.id, input.data as UpsertNoteRequest);
 			case 'deviceEvent':
-				return await apiClient.deviceEvent.update(id, data as DeviceEvent);
+				return await apiClient.deviceEvent.update(input.id, input.data as UpsertDeviceEventRequest);
 			case 'basalInjection':
-				return await apiClient.basalInjection.update(id, data as BasalInjection);
+				return await apiClient.basalInjection.update(input.id, input.data as UpdateBasalInjectionRequest);
 		}
 	}
 );
@@ -249,83 +276,34 @@ export const updateEntry = command(
  * upstream device, so a first-class manual create flow is required. The same
  * dispatcher handles every kind for consistency.
  *
- * `data` is the v4 domain shape produced by the edit dialog; we map it onto the
- * create-request shape, converting the mills-first timestamp to an ISO instant.
+ * Input is validated per kind against the backend-generated request schemas, so
+ * the payload matches the API contract before dispatch. The caller maps the
+ * dialog's domain record onto the request DTO via `toCreateEntryInput`.
  */
 export const createEntry = command(
-	z.object({
-		kind: z.enum(['bolus', 'carbs', 'bgCheck', 'note', 'deviceEvent', 'basalInjection']),
-		data: z.record(z.string(), z.unknown()),
-	}),
-	async ({ kind, data }) => {
-		const { locals } = getRequestEvent();
-		const { apiClient } = locals;
-
-		const d = data as Record<string, any>;
-		const mills = typeof d.mills === 'number' ? d.mills : Date.now();
-		const timestamp = new Date(mills);
-		const utcOffset = typeof d.utcOffset === 'number' ? d.utcOffset : undefined;
-		const app = 'Nocturne Web';
-
-		switch (kind) {
+	z.discriminatedUnion('kind', [
+		z.object({ kind: z.literal('bolus'), data: CreateBolusRequestSchema }),
+		z.object({ kind: z.literal('carbs'), data: CreateCarbIntakeRequestSchema }),
+		z.object({ kind: z.literal('bgCheck'), data: UpsertBGCheckRequestSchema }),
+		z.object({ kind: z.literal('note'), data: UpsertNoteRequestSchema }),
+		z.object({ kind: z.literal('deviceEvent'), data: UpsertDeviceEventRequestSchema }),
+		z.object({ kind: z.literal('basalInjection'), data: CreateBasalInjectionRequestSchema }),
+	]),
+	async (input) => {
+		const { apiClient } = getRequestEvent().locals;
+		switch (input.kind) {
 			case 'bolus':
-				return await apiClient.bolus.create({
-					timestamp,
-					utcOffset,
-					app,
-					insulin: d.insulin,
-					programmed: d.programmed,
-					delivered: d.delivered,
-					bolusType: d.bolusType,
-					duration: d.duration,
-					automatic: d.automatic,
-					insulinType: d.insulinType,
-					patientInsulinId: d.insulinContext?.patientInsulinId ?? d.patientInsulinId,
-				});
+				return await apiClient.bolus.create(input.data as CreateBolusRequest);
 			case 'carbs':
-				return await apiClient.nutrition.createCarbIntake({
-					timestamp,
-					utcOffset,
-					app,
-					carbs: d.carbs,
-					carbTime: d.carbTime,
-					absorptionTime: d.absorptionTime,
-				});
+				return await apiClient.nutrition.createCarbIntake(input.data as CreateCarbIntakeRequest);
 			case 'bgCheck':
-				return await apiClient.bGCheck.create({
-					timestamp,
-					utcOffset,
-					app,
-					glucose: d.glucose ?? d.mgdl,
-					units: d.units,
-					glucoseType: d.glucoseType,
-				});
+				return await apiClient.bGCheck.create(input.data as UpsertBGCheckRequest);
 			case 'note':
-				return await apiClient.note.create({
-					timestamp,
-					utcOffset,
-					app,
-					text: d.text,
-					eventType: d.eventType,
-					isAnnouncement: d.isAnnouncement,
-				});
+				return await apiClient.note.create(input.data as UpsertNoteRequest);
 			case 'deviceEvent':
-				return await apiClient.deviceEvent.create({
-					timestamp,
-					utcOffset,
-					app,
-					eventType: d.eventType,
-					notes: d.notes,
-				});
+				return await apiClient.deviceEvent.create(input.data as UpsertDeviceEventRequest);
 			case 'basalInjection':
-				return await apiClient.basalInjection.create({
-					timestamp,
-					utcOffset,
-					app,
-					patientInsulinId: d.insulinContext?.patientInsulinId ?? d.patientInsulinId,
-					units: d.units,
-					notes: d.notes,
-				});
+				return await apiClient.basalInjection.create(input.data as CreateBasalInjectionRequest);
 		}
 	}
 );

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/treatments/data.remote.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/treatments/data.remote.ts
@@ -5,7 +5,7 @@
 import { z } from 'zod';
 import { getRequestEvent, form, command, query } from '$app/server';
 import { invalid } from '@sveltejs/kit';
-import type { Bolus, CarbIntake, BGCheck, Note, DeviceEvent } from '$lib/api';
+import type { Bolus, CarbIntake, BGCheck, Note, DeviceEvent, BasalInjection } from '$lib/api';
 import { getProfileSummary } from '$api/generated/profiles.generated.remote';
 import { getLocalDayBoundariesUtc } from '$lib/utils/timezone';
 
@@ -58,20 +58,28 @@ export const getTreatmentsData = query(
 		const profile = await getProfileSummary(undefined);
 		const timezone = profile?.therapySettings?.[0]?.timezone;
 		const { startDate, endDate } = calculateDateRange(input, timezone);
-		const [bolusResponse, carbResponse, bgCheckResponse, noteResponse, deviceEventResponse] =
-			await Promise.all([
-				apiClient.bolus.getAll(startDate, endDate, 10000),
-				apiClient.nutrition.getCarbIntakes(startDate, endDate, 10000),
-				apiClient.bGCheck.getAll(startDate, endDate, 10000),
-				apiClient.note.getAll(startDate, endDate, 10000),
-				apiClient.deviceEvent.getAll(startDate, endDate, 10000),
-			]);
+		const [
+			bolusResponse,
+			carbResponse,
+			bgCheckResponse,
+			noteResponse,
+			deviceEventResponse,
+			basalInjectionResponse,
+		] = await Promise.all([
+			apiClient.bolus.getAll(startDate, endDate, 10000),
+			apiClient.nutrition.getCarbIntakes(startDate, endDate, 10000),
+			apiClient.bGCheck.getAll(startDate, endDate, 10000),
+			apiClient.note.getAll(startDate, endDate, 10000),
+			apiClient.deviceEvent.getAll(startDate, endDate, 10000),
+			apiClient.basalInjection.getAll(startDate, endDate, 10000),
+		]);
 
 		const boluses = bolusResponse.data ?? [];
 		const carbIntakes = carbResponse.data ?? [];
 		const bgChecks = bgCheckResponse.data ?? [];
 		const notes = noteResponse.data ?? [];
 		const deviceEvents = deviceEventResponse.data ?? [];
+		const basalInjections = basalInjectionResponse.data ?? [];
 
 		const treatmentSummary =
 			boluses.length > 0 || carbIntakes.length > 0
@@ -84,6 +92,7 @@ export const getTreatmentsData = query(
 			bgChecks,
 			notes,
 			deviceEvents,
+			basalInjections,
 			treatmentSummary,
 			dateRange: {
 				from: startDate.toISOString(),
@@ -99,7 +108,7 @@ export const getTreatmentsData = query(
 export const deleteEntryForm = form(
 	z.object({
 		entryId: z.string().min(1, 'Entry ID is required'),
-		entryKind: z.enum(['bolus', 'carbs', 'bgCheck', 'note', 'deviceEvent']),
+		entryKind: z.enum(['bolus', 'carbs', 'bgCheck', 'note', 'deviceEvent', 'basalInjection']),
 	}),
 	async ({ entryId, entryKind }, issue) => {
 		const { locals } = getRequestEvent();
@@ -122,6 +131,9 @@ export const deleteEntryForm = form(
 				case 'deviceEvent':
 					await apiClient.deviceEvent.delete(entryId);
 					break;
+				case 'basalInjection':
+					await apiClient.basalInjection.delete(entryId);
+					break;
 			}
 
 			return {
@@ -143,7 +155,7 @@ export const bulkDeleteEntries = command(
 	z.array(
 		z.object({
 			id: z.string(),
-			kind: z.enum(['bolus', 'carbs', 'bgCheck', 'note', 'deviceEvent']),
+			kind: z.enum(['bolus', 'carbs', 'bgCheck', 'note', 'deviceEvent', 'basalInjection']),
 		})
 	),
 	async (items) => {
@@ -170,6 +182,9 @@ export const bulkDeleteEntries = command(
 						break;
 					case 'deviceEvent':
 						await apiClient.deviceEvent.delete(item.id);
+						break;
+					case 'basalInjection':
+						await apiClient.basalInjection.delete(item.id);
 						break;
 				}
 				deletedIds.push(item.id);
@@ -201,7 +216,7 @@ export const bulkDeleteEntries = command(
  */
 export const updateEntry = command(
 	z.object({
-		kind: z.enum(['bolus', 'carbs', 'bgCheck', 'note', 'deviceEvent']),
+		kind: z.enum(['bolus', 'carbs', 'bgCheck', 'note', 'deviceEvent', 'basalInjection']),
 		id: z.string().min(1),
 		data: z.record(z.string(), z.unknown()),
 	}),
@@ -220,6 +235,97 @@ export const updateEntry = command(
 				return await apiClient.note.update(id, data as Note);
 			case 'deviceEvent':
 				return await apiClient.deviceEvent.update(id, data as DeviceEvent);
+			case 'basalInjection':
+				return await apiClient.basalInjection.update(id, data as BasalInjection);
+		}
+	}
+);
+
+/**
+ * Create a single entry (v4: dispatches to the correct endpoint by kind).
+ *
+ * Manual entry path for the treatments page. Most treatment kinds normally
+ * arrive from a connected app, but long-acting (basal) injections have no
+ * upstream device, so a first-class manual create flow is required. The same
+ * dispatcher handles every kind for consistency.
+ *
+ * `data` is the v4 domain shape produced by the edit dialog; we map it onto the
+ * create-request shape, converting the mills-first timestamp to an ISO instant.
+ */
+export const createEntry = command(
+	z.object({
+		kind: z.enum(['bolus', 'carbs', 'bgCheck', 'note', 'deviceEvent', 'basalInjection']),
+		data: z.record(z.string(), z.unknown()),
+	}),
+	async ({ kind, data }) => {
+		const { locals } = getRequestEvent();
+		const { apiClient } = locals;
+
+		const d = data as Record<string, any>;
+		const mills = typeof d.mills === 'number' ? d.mills : Date.now();
+		const timestamp = new Date(mills);
+		const utcOffset = typeof d.utcOffset === 'number' ? d.utcOffset : undefined;
+		const app = 'Nocturne Web';
+
+		switch (kind) {
+			case 'bolus':
+				return await apiClient.bolus.create({
+					timestamp,
+					utcOffset,
+					app,
+					insulin: d.insulin,
+					programmed: d.programmed,
+					delivered: d.delivered,
+					bolusType: d.bolusType,
+					duration: d.duration,
+					automatic: d.automatic,
+					insulinType: d.insulinType,
+					patientInsulinId: d.insulinContext?.patientInsulinId ?? d.patientInsulinId,
+				});
+			case 'carbs':
+				return await apiClient.nutrition.createCarbIntake({
+					timestamp,
+					utcOffset,
+					app,
+					carbs: d.carbs,
+					carbTime: d.carbTime,
+					absorptionTime: d.absorptionTime,
+				});
+			case 'bgCheck':
+				return await apiClient.bGCheck.create({
+					timestamp,
+					utcOffset,
+					app,
+					glucose: d.glucose ?? d.mgdl,
+					units: d.units,
+					glucoseType: d.glucoseType,
+				});
+			case 'note':
+				return await apiClient.note.create({
+					timestamp,
+					utcOffset,
+					app,
+					text: d.text,
+					eventType: d.eventType,
+					isAnnouncement: d.isAnnouncement,
+				});
+			case 'deviceEvent':
+				return await apiClient.deviceEvent.create({
+					timestamp,
+					utcOffset,
+					app,
+					eventType: d.eventType,
+					notes: d.notes,
+				});
+			case 'basalInjection':
+				return await apiClient.basalInjection.create({
+					timestamp,
+					utcOffset,
+					app,
+					patientInsulinId: d.insulinContext?.patientInsulinId ?? d.patientInsulinId,
+					units: d.units,
+					notes: d.notes,
+				});
 		}
 	}
 );

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/treatments/entry-request.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/treatments/entry-request.ts
@@ -1,0 +1,224 @@
+/**
+ * Maps the edit dialog's v4 *domain* record (mills-first, with a resolved
+ * insulinContext) onto the backend-generated *request* DTO shapes consumed by
+ * `createEntry` / `updateEntry`. Those commands validate the result against the
+ * generated Zod schemas, which are strict (unknown keys are rejected) and
+ * expect an ISO `timestamp` rather than `mills` — so the shaping happens here,
+ * once, in one place.
+ */
+import type { EntryRecord } from "$lib/constants/entry-categories";
+
+const APP = "Nocturne Web";
+
+/** Fields shared by every v4 request DTO. */
+function common(data: EntryRecord["data"]) {
+  const mills = data.mills ?? Date.now();
+  return {
+    timestamp: new Date(mills).toISOString(),
+    utcOffset:
+      typeof data.utcOffset === "number"
+        ? data.utcOffset
+        : -new Date(mills).getTimezoneOffset(),
+    app: APP,
+  };
+}
+
+/** Build the `{ kind, data }` payload for `createEntry`. */
+export function toCreateEntryInput(record: EntryRecord) {
+  switch (record.kind) {
+    case "bolus": {
+      const d = record.data;
+      return {
+        kind: "bolus" as const,
+        data: {
+          ...common(d),
+          insulin: d.insulin,
+          programmed: d.programmed,
+          delivered: d.delivered,
+          bolusType: d.bolusType ?? undefined,
+          duration: d.duration,
+          automatic: d.automatic,
+          insulinType: d.insulinType || undefined,
+          patientInsulinId: d.insulinContext?.patientInsulinId,
+          correlationId: d.correlationId,
+        },
+      };
+    }
+    case "carbs": {
+      const d = record.data;
+      return {
+        kind: "carbs" as const,
+        data: {
+          ...common(d),
+          carbs: d.carbs,
+          carbTime: d.carbTime,
+          absorptionTime: d.absorptionTime,
+          correlationId: d.correlationId,
+        },
+      };
+    }
+    case "bgCheck": {
+      const d = record.data;
+      return {
+        kind: "bgCheck" as const,
+        data: {
+          ...common(d),
+          glucose: d.glucose,
+          units: d.units,
+          glucoseType: d.glucoseType,
+        },
+      };
+    }
+    case "note": {
+      const d = record.data;
+      return {
+        kind: "note" as const,
+        data: {
+          ...common(d),
+          text: d.text || undefined,
+          eventType: d.eventType || undefined,
+          isAnnouncement: d.isAnnouncement,
+        },
+      };
+    }
+    case "deviceEvent": {
+      const d = record.data;
+      return {
+        kind: "deviceEvent" as const,
+        data: {
+          ...common(d),
+          eventType: d.eventType,
+          notes: d.notes || undefined,
+        },
+      };
+    }
+    case "basalInjection": {
+      const d = record.data;
+      return {
+        kind: "basalInjection" as const,
+        data: {
+          ...common(d),
+          patientInsulinId: d.insulinContext?.patientInsulinId,
+          units: d.units,
+          notes: d.notes || undefined,
+          correlationId: d.correlationId,
+        },
+      };
+    }
+  }
+}
+
+/**
+ * Provenance/dedup metadata to carry across an update. The V4 update endpoints
+ * replace the record from the request body, so omitting these would blank out
+ * the originating device/source on records that came from a connector.
+ */
+function preserved(data: EntryRecord["data"]) {
+  return {
+    device: data.device || undefined,
+    dataSource: data.dataSource || undefined,
+    syncIdentifier: data.syncIdentifier || undefined,
+  };
+}
+
+/** Build the `{ kind, id, data }` payload for `updateEntry`. */
+export function toUpdateEntryInput(record: EntryRecord) {
+  const id = record.data.id ?? "";
+  switch (record.kind) {
+    case "bolus": {
+      const d = record.data;
+      // UpdateBolusRequest intentionally omits bolusType (delivery pattern is
+      // immutable once recorded), so it is not carried over.
+      return {
+        kind: "bolus" as const,
+        id,
+        data: {
+          ...common(d),
+          ...preserved(d),
+          insulin: d.insulin,
+          programmed: d.programmed,
+          delivered: d.delivered,
+          duration: d.duration,
+          automatic: d.automatic,
+          insulinType: d.insulinType || undefined,
+          patientInsulinId: d.insulinContext?.patientInsulinId,
+          unabsorbed: d.unabsorbed,
+          bolusCalculationId: d.bolusCalculationId,
+          apsSnapshotId: d.apsSnapshotId,
+          correlationId: d.correlationId,
+        },
+      };
+    }
+    case "carbs": {
+      const d = record.data;
+      return {
+        kind: "carbs" as const,
+        id,
+        data: {
+          ...common(d),
+          ...preserved(d),
+          carbs: d.carbs,
+          carbTime: d.carbTime,
+          absorptionTime: d.absorptionTime,
+          correlationId: d.correlationId,
+        },
+      };
+    }
+    case "bgCheck": {
+      const d = record.data;
+      return {
+        kind: "bgCheck" as const,
+        id,
+        data: {
+          ...common(d),
+          ...preserved(d),
+          glucose: d.glucose,
+          units: d.units,
+          glucoseType: d.glucoseType,
+        },
+      };
+    }
+    case "note": {
+      const d = record.data;
+      return {
+        kind: "note" as const,
+        id,
+        data: {
+          ...common(d),
+          ...preserved(d),
+          text: d.text || undefined,
+          eventType: d.eventType || undefined,
+          isAnnouncement: d.isAnnouncement,
+        },
+      };
+    }
+    case "deviceEvent": {
+      const d = record.data;
+      return {
+        kind: "deviceEvent" as const,
+        id,
+        data: {
+          ...common(d),
+          ...preserved(d),
+          eventType: d.eventType,
+          notes: d.notes || undefined,
+        },
+      };
+    }
+    case "basalInjection": {
+      const d = record.data;
+      return {
+        kind: "basalInjection" as const,
+        id,
+        data: {
+          ...common(d),
+          ...preserved(d),
+          patientInsulinId: d.insulinContext?.patientInsulinId,
+          units: d.units,
+          notes: d.notes || undefined,
+          correlationId: d.correlationId,
+        },
+      };
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Started from a question about the "Long-acting injection" option that had no icon, and grew into making long-acting (basal) injections a first-class, manually-creatable treatment everywhere they should be.

The investigation found:
1. **Missing icon** — `TreatmentCategoryTabs` iterated over all `ENTRY_CATEGORIES` but its local icon map omitted `basalInjection`, so the tab rendered a blank icon.
2. **Not wired up on the treatments page** — the `basalInjection` kind existed in the backend, edit dialog, data table and chart markers, but the treatments page never *fetched*, *displayed*, *updated* or *deleted* basal injections, and there was no way to **create** any treatment from the UI. That matters most for basal injections because — unlike boluses/carbs/BG checks that typically arrive from a connected app — there is no app in the loop for a long-acting injection.
3. **Broken in the dashboard dialog** — the canonical `EntryEditDialog` (used across the dashboard) iterated all categories for its "Add Section" menu but its `Sections` map omitted `basalInjection`, so it offered a non-functional, icon-less item.

## Changes

**Icon fix**
- `TreatmentCategoryTabs.svelte`: add `basalInjection: Syringe` to the category icon map.

**Manual creation on the treatments page (all kinds)**
- `data.remote.ts`: fetch basal injections in `getTreatmentsData`; new `createEntry` command dispatching by kind to the V4 create endpoints (mills → timestamp); wire `basalInjection` into the `updateEntry` / `deleteEntryForm` / `bulkDeleteEntries` dispatchers.
- `+page.svelte`: merge basal injections into the table; "Add Treatment" kind picker opening `TreatmentEditDialog` in create mode; id-less saves → `createEntry`, id-bearing → `updateEntry`; delete omitted for new records; cover `basalInjection` in the search and delete-description switches.
- `TreatmentEditDialog.svelte`: create mode (title/description/button copy, hide edit-only metadata), reusing the existing per-kind form fields incl. the basal insulin selector.

**Dashboard entry dialog**
- New `BasalInjectionSection.svelte` (basal-eligible insulin selector + units + notes).
- `EntryEditDialog.svelte`: wire `basalInjection` as a first-class section with full parity to the others (Sections map, icon, populate/find, create/update/delete remotes, pending + completion tracking, hidden form, render case).

**Tests**
- Firmed up the placeholder `e2e/basal-injection.spec.ts` to drive the real treatments-page flow: Add Treatment → Long-acting injection → select insulin → units → Create, then assert the row appears.

## Verification
- `pnpm run check`: the new/changed code is clean and the changes **remove 7 pre-existing type errors** (3 on the treatments page, 4 in the dashboard dialog) that stemmed from `EntryRecord` / `Sections` already including `basalInjection` while the switches/maps did not. The only remaining errors in touched files are pre-existing (unused imports in `TreatmentEditDialog`) or the known fresh-container `packages/ui` type-generation cascade (implicit-any on `child({ props })` / Input `onchange` — identical patterns exist in the canonical dialogs and resolve once the UI package types are generated in CI).
- Component/e2e tests need the UI-package build / running stack, which isn't available in this environment, so the e2e flow is written but not executed here.

## Notes
- The dashboard `EntryEditDialog` create/edit forms use a flat hidden-field convention shared by all section kinds; `basalInjection` is wired with exact parity to its siblings. A separate, pre-existing question about whether that convention fully satisfies the generated nested `{ id, request }` update schema is out of scope here and affects all kinds equally.

https://claude.ai/code/session_016mtmCCUvUPXQfVuVfnsgVX