### PR TITLE
fix(portal): hero chip overlap, aurora seam, and subheading legibility

### DIFF
--- a/src/Web/packages/portal/src/lib/components/AuroraCanvas.svelte
+++ b/src/Web/packages/portal/src/lib/components/AuroraCanvas.svelte
@@ -55,7 +55,8 @@ void main(){
   vec2 q=vec2(fbm(p*1.4+vec2(0.,t)),fbm(p*1.4+vec2(5.2,-t*0.8)));
   vec2 r=vec2(fbm(p*2.1+1.8*q+vec2(1.7,9.2)+t*1.3),fbm(p*2.1+1.8*q+vec2(8.3,2.8)-t*1.1));
   float n=fbm(p*1.6+2.2*r);
-  float band=smoothstep(0.0,0.55,1.0-abs(p.y*1.15+0.05));
+  float yb=p.y*1.15+0.05;
+  float band=smoothstep(0.0,0.55,1.0-yb*yb);
   float v=pow(n,1.15)*(0.55+0.6*band);
   vec3 col=ramp(v);
   float vign=smoothstep(0.95,0.2,length(p*vec2(0.55,1.05)));

--- a/src/Web/packages/portal/src/routes/+page.svelte
+++ b/src/Web/packages/portal/src/routes/+page.svelte
@@ -75,11 +75,11 @@
     <div class="absolute bottom-0 inset-x-0 h-[280px] pointer-events-none bg-gradient-to-b from-transparent to-background" aria-hidden="true"></div>
 
     <div class="absolute inset-0 pt-16 pointer-events-none">
-        <div class="absolute top-[calc(4rem+20px)] left-6 flex flex-col gap-0.5 font-mono text-[9px] tracking-[0.12em] uppercase text-[oklch(0.6_0.01_261)]">
+        <div class="absolute top-[calc(4rem+20px)] left-6 hidden md:flex flex-col gap-0.5 font-mono text-[9px] tracking-[0.12em] uppercase text-[oklch(0.6_0.01_261)]">
             <span>NCTRN / HOMEPAGE</span>
             <span>v0.4 &middot; public preview</span>
         </div>
-        <div class="absolute top-[calc(4rem+20px)] right-6 flex flex-col gap-0.5 font-mono text-[9px] tracking-[0.12em] uppercase text-[oklch(0.6_0.01_261)] text-right">
+        <div class="absolute top-[calc(4rem+20px)] right-6 hidden md:flex flex-col gap-0.5 font-mono text-[9px] tracking-[0.12em] uppercase text-[oklch(0.6_0.01_261)] text-right">
             <span>5,250 d &middot; running</span>
             <span>22 connectors</span>
         </div>
@@ -88,7 +88,7 @@
             bind:this={textBlockEl}
             class="absolute bottom-[200px] left-1/2 -translate-x-1/2 w-[min(760px,90vw)] text-center flex flex-col items-center gap-5"
         >
-            <span class="inline-flex items-center gap-2 font-mono text-[11px] tracking-[0.16em] uppercase text-[oklch(0.7_0.01_261)]">
+            <span class="inline-flex items-center gap-2 font-mono text-[11px] tracking-[0.16em] uppercase text-[oklch(0.94_0.012_261)] [text-shadow:0_1px_3px_oklch(0_0_0_/_90%),0_2px_12px_oklch(0_0_0_/_75%)]">
                 <span class="eyebrow-dot size-1.5 rounded-full shrink-0 bg-glucose-in-range"></span>The new Nightscout API
             </span>
             <h1 class="flex flex-col items-center text-[clamp(2.5rem,7vw,4.8rem)] font-bold leading-[1.06] tracking-[-0.025em] text-[oklch(0.97_0.005_261)] m-0 [text-shadow:0_2px_8px_oklch(0_0_0_/_70%),0_4px_40px_oklch(0_0_0_/_80%)]">


### PR DESCRIPTION
- Hide the corner meta labels on mobile so they no longer bleed through
  behind the static connector chip row.
- Replace the abs()-based aurora band with a smooth parabola, removing the
  derivative kink that rendered as a horizontal crease in the WebGL shader.
- Brighten the hero eyebrow and add a text-shadow so "The new Nightscout
  API" stays legible over the bright aurora background.

https://claude.ai/code/session_01EvZ5omrnEqAszuuYVLcArb