### PR TITLE
fix(portal): mobile responsiveness on features page and docs

### DIFF
--- a/src/Web/packages/portal/src/lib/components/features/FeaturePillars.svelte
+++ b/src/Web/packages/portal/src/lib/components/features/FeaturePillars.svelte
@@ -51,7 +51,7 @@
     ] as const;
 </script>
 
-<section class="max-w-[1200px] mx-auto px-6 border-t border-border">
+<section class="max-w-[1200px] mx-auto px-6 border-t border-border overflow-x-clip">
     <!-- Section header -->
     <div class="pt-20 pb-14">
         <div class="font-mono text-[11px] tracking-[0.14em] uppercase text-muted-foreground mb-4">What it can do</div>
@@ -67,7 +67,7 @@
                     {flip ? 'md:grid-cols-[1.05fr_1fr]' : 'md:grid-cols-[1fr_1.05fr]'}">
 
             <!-- Text side -->
-            <div class="flex flex-col gap-5 {flip ? 'md:order-2' : 'md:order-1'}">
+            <div class="flex flex-col gap-5 min-w-0 {flip ? 'md:order-2' : 'md:order-1'}">
                 <!-- BigEyebrow -->
                 <div class="flex items-center gap-3 text-[17px] font-semibold tracking-[0.02em] uppercase"
                      style:color={p.color}>
@@ -101,7 +101,7 @@
             </div>
 
             <!-- Demo side -->
-            <div class="relative {flip ? 'md:order-1' : 'md:order-2'}">
+            <div class="relative min-w-0 {flip ? 'md:order-1' : 'md:order-2'}">
                 <!-- Radial glow -->
                 <div class="absolute -inset-10 rounded-3xl pointer-events-none"
                      style="background: radial-gradient(60% 60% at 50% 50%, color-mix(in oklch, {p.color}, transparent 82%), transparent 70%); filter: blur(20px);"

--- a/src/Web/packages/portal/src/lib/components/features/ReportsDemo.svelte
+++ b/src/Web/packages/portal/src/lib/components/features/ReportsDemo.svelte
@@ -29,21 +29,21 @@
     let current = $derived(REPORTS[idx]);
 </script>
 
+<div class="@container" style:height="{height}px">
 <div
-    class="rounded-[14px] overflow-hidden border border-white/10 bg-[oklch(0.10_0.025_261)] grid"
-    style:height="{height}px"
-    style="grid-template-columns: 168px 1fr"
+    class="h-full rounded-[14px] overflow-hidden border border-white/10 bg-[oklch(0.10_0.025_261)] grid
+        grid-cols-[96px_minmax(0,1fr)] @sm:grid-cols-[130px_minmax(0,1fr)] @lg:grid-cols-[168px_minmax(0,1fr)]"
 >
     <!-- Sidebar list -->
     <div class="bg-[oklch(0.15_0.03_261)] border-r border-white/[0.08] py-3 overflow-hidden flex flex-col">
         {#each REPORTS as r, i (r.kind)}
             <div
-                class="px-4 py-2 text-[13px] flex items-center justify-between transition-all duration-300 border-l-[3px] shrink-0
+                class="px-3 @sm:px-4 py-2 text-[12px] @sm:text-[13px] flex items-center justify-between gap-1 transition-all duration-300 border-l-[3px] shrink-0
                     {i === idx
                         ? 'text-foreground bg-glucose-in-range/[0.14] border-glucose-in-range font-semibold'
                         : 'text-[oklch(0.65_0.02_261)] border-transparent font-medium'}"
             >
-                <span>{r.short}</span>
+                <span class="truncate">{r.short}</span>
                 {#if i === idx}
                     <Check class="size-3 text-glucose-in-range shrink-0" />
                 {/if}
@@ -52,7 +52,7 @@
     </div>
 
     <!-- Preview pane -->
-    <div class="p-[18px] flex flex-col gap-2.5 min-h-0">
+    <div class="p-3 @sm:p-[18px] flex flex-col gap-2.5 min-h-0 min-w-0">
         <div class="flex items-baseline justify-between gap-2 shrink-0">
             <div class="min-w-0">
                 <div class="text-[17px] font-bold text-foreground truncate">{current.name}</div>
@@ -223,4 +223,5 @@
             {/if}
         </div>
     </div>
+</div>
 </div>

--- a/src/Web/packages/portal/src/routes/docs/+layout.svelte
+++ b/src/Web/packages/portal/src/routes/docs/+layout.svelte
@@ -57,3 +57,14 @@
         </main>
     </div>
 </div>
+
+<style>
+    /* Markdown tables can hold long, unbreakable strings (callback URLs, paths).
+       Let them scroll horizontally on narrow screens instead of forcing the
+       whole page to overflow. */
+    article.prose :global(table) {
+        display: block;
+        max-width: 100%;
+        overflow-x: auto;
+    }
+</style>

--- a/src/Web/packages/portal/src/routes/features/+page.svelte
+++ b/src/Web/packages/portal/src/routes/features/+page.svelte
@@ -95,7 +95,7 @@
     };
 </script>
 
-<div class="max-w-[1200px] mx-auto px-6">
+<div class="max-w-[1200px] mx-auto px-6 overflow-x-clip">
 
     <!-- Hero -->
     <div class="pt-20 pb-16 border-b border-border relative overflow-hidden">
@@ -132,7 +132,7 @@
                         {flip ? 'md:grid-cols-[1.05fr_1fr]' : 'md:grid-cols-[1fr_1.05fr]'}">
 
             <!-- Text -->
-            <div class="flex flex-col gap-5 {flip ? 'md:order-2' : 'md:order-1'}">
+            <div class="flex flex-col gap-5 min-w-0 {flip ? 'md:order-2' : 'md:order-1'}">
                 <!-- Eyebrow -->
                 <div class="flex items-center gap-3 text-[17px] font-semibold tracking-[0.02em] uppercase"
                      style:color={p.color}>
@@ -167,7 +167,7 @@
             </div>
 
             <!-- Demo -->
-            <div class="relative {flip ? 'md:order-1' : 'md:order-2'}">
+            <div class="relative min-w-0 {flip ? 'md:order-1' : 'md:order-2'}">
                 <div class="absolute -inset-10 rounded-3xl pointer-events-none"
                      style="background: radial-gradient(60% 60% at 50% 50%, color-mix(in oklch, {p.color}, transparent 80%), transparent 70%); filter: blur(24px);"
                      aria-hidden="true"></div>


### PR DESCRIPTION
The Reports demo used a fixed 168px sidebar and a non-shrinking preview
track, giving the card a ~429px intrinsic min-width. On mobile this forced
the whole pillar column wider than the viewport, cutting off the report
preview (and pushing the page into horizontal scroll). It appears on both
/features and the home page (via FeaturePillars).

- ReportsDemo: drive the layout with container queries (@container). The
  sidebar steps 96px -> 130px -> 168px as the demo container widens, the
  preview track uses minmax(0,1fr) + min-w-0 so it can shrink, and sidebar
  /preview padding and label sizing scale down on narrow containers. Desktop
  rendering is unchanged.
- Pillars (features/+page.svelte + FeaturePillars): add min-w-0 to the grid
  columns so the text/demo can shrink, and overflow-x-clip on the section so
  the decorative -inset-10 glow no longer triggers page horizontal scroll.
- Docs layout: let markdown tables scroll horizontally instead of overflowing
  the page (long callback URLs in the GitHub auth table overflowed at <=320px).

Verified no horizontal overflow across all portal routes at 320/360/390px,
and desktop (1280px) layout unchanged.