### PR TITLE
fix(ci): add concurrency control to API client regen workflow

### DIFF
--- a/.github/workflows/commit-generated-api-client.yml
+++ b/.github/workflows/commit-generated-api-client.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: commit-generated-api-client
+  cancel-in-progress: true
+
 env:
   DOTNET_VERSION: "10.0.x"
   NODE_VERSION: "24"


### PR DESCRIPTION
## Summary
- Adds `concurrency` group with `cancel-in-progress: true` to the Commit Generated API Client workflow
- Prevents race conditions when back-to-back pushes to main trigger concurrent regen runs that conflict on `schemas.ts` during rebase

## Test plan
- [x] Verified the workflow YAML is valid