### PR TITLE
fix(web): never give up on WebSocket reconnection

### DIFF
--- a/src/Web/packages/app/src/lib/stores/realtime-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/realtime-store.svelte.ts
@@ -403,8 +403,9 @@ export class RealtimeStore {
   private setupEventHandlers(): void {
     this.websocketClient.on("connect", () => {
       toast.success("Connected to real-time data");
-      // Backfill any missed data on reconnection
-      this.performBackfillIfNeeded();
+      // Always force backfill on reconnection — any disconnection may have
+      // caused missed data, even if the gap was under 5 minutes.
+      this.performBackfillIfNeeded(true);
     });
 
     this.websocketClient.on("disconnect", () => {

--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
@@ -35,7 +35,7 @@
   // WebSocket config - defaults, can be overridden in production
   const config = {
     url: typeof window !== "undefined" ? window.location.origin : "",
-    reconnectAttempts: 10,
+    reconnectAttempts: Infinity,
     reconnectDelay: 5000,
     maxReconnectDelay: 30000,
     pingTimeout: 60000,


### PR DESCRIPTION
## Summary
- Change `reconnectAttempts` from `10` to `Infinity` so Socket.IO retries forever with exponential backoff (up to 30s) instead of permanently giving up after ~2-3 minutes of failed reconnects
- Force data backfill on every reconnect regardless of gap duration, since any disconnection may have caused missed CGM readings

## Context
On unstable networks (e.g. conference WiFi), WebSocket connections drop frequently. With only 10 reconnect attempts, the client gives up permanently and the UI goes stale — users have to manually refresh the page. The existing safety nets (visibility change, focus events) don't help when the page is actively displayed.

Production logs confirmed one tenant's WebSocket connections dropping every 10-94 minutes on conference WiFi, while other tenants on stable connections held WebSockets for 7-8+ hours without issue.

## Test plan
- [ ] Verify Socket.IO reconnects indefinitely by simulating network drops (e.g. DevTools network throttling / offline toggle)
- [ ] Confirm backfill toast appears on every reconnect, even after brief (<5 min) disconnections
- [ ] Verify no performance regression from forced backfill on rapid reconnect cycles (backfill skips if already syncing)