### PR TITLE
fix(deploy): escape shell vars in Portainer inline init config

### DIFF
--- a/deploy/portainer/docker-compose.yaml
+++ b/deploy/portainer/docker-compose.yaml
@@ -188,20 +188,20 @@ configs:
 
       set -euo pipefail
 
-      : "${POSTGRES_DB:?POSTGRES_DB must be set}"
-      : "${POSTGRES_USER:?POSTGRES_USER must be set}"
-      : "${NOCTURNE_MIGRATOR_PASSWORD:?NOCTURNE_MIGRATOR_PASSWORD must be set}"
-      : "${NOCTURNE_APP_PASSWORD:?NOCTURNE_APP_PASSWORD must be set}"
-      : "${NOCTURNE_WEB_PASSWORD:?NOCTURNE_WEB_PASSWORD must be set}"
+      : "$${POSTGRES_DB:?POSTGRES_DB must be set}"
+      : "$${POSTGRES_USER:?POSTGRES_USER must be set}"
+      : "$${NOCTURNE_MIGRATOR_PASSWORD:?NOCTURNE_MIGRATOR_PASSWORD must be set}"
+      : "$${NOCTURNE_APP_PASSWORD:?NOCTURNE_APP_PASSWORD must be set}"
+      : "$${NOCTURNE_WEB_PASSWORD:?NOCTURNE_WEB_PASSWORD must be set}"
 
       psql \
-          --username "$POSTGRES_USER" \
-          --dbname "$POSTGRES_DB" \
+          --username "$$POSTGRES_USER" \
+          --dbname "$$POSTGRES_DB" \
           --set ON_ERROR_STOP=on \
-          --set DBNAME="$POSTGRES_DB" \
-          --set migrator_password="$NOCTURNE_MIGRATOR_PASSWORD" \
-          --set app_password="$NOCTURNE_APP_PASSWORD" \
-          --set web_password="$NOCTURNE_WEB_PASSWORD" \
+          --set DBNAME="$$POSTGRES_DB" \
+          --set migrator_password="$$NOCTURNE_MIGRATOR_PASSWORD" \
+          --set app_password="$$NOCTURNE_APP_PASSWORD" \
+          --set web_password="$$NOCTURNE_WEB_PASSWORD" \
           <<'SQL'
       CREATE ROLE nocturne_migrator LOGIN NOSUPERUSER NOBYPASSRLS NOCREATEDB NOCREATEROLE PASSWORD :'migrator_password';
       CREATE ROLE nocturne_app      LOGIN NOSUPERUSER NOBYPASSRLS NOCREATEDB NOCREATEROLE PASSWORD :'app_password';

--- a/src/Aspire/Nocturne.Aspire.Host/Publishing/PortainerComposePublisher.cs
+++ b/src/Aspire/Nocturne.Aspire.Host/Publishing/PortainerComposePublisher.cs
@@ -155,7 +155,10 @@ public static class PortainerComposePublisherExtensions
             throw new FileNotFoundException(
                 $"[portainer-publisher] Init script not found at: {initScriptPath}", initScriptPath);
 
-        var initScriptContent = File.ReadAllText(initScriptPath);
+        // Docker Compose interpolates `configs.*.content` when loading the file,
+        // so the script's runtime shell references (e.g. ${POSTGRES_DB:?...}) must
+        // be escaped to `$$` to survive parse-time and reach the container intact.
+        var initScriptContent = File.ReadAllText(initScriptPath).Replace("$", "$$");
 
         // Remove the ./init bind-mount.
         volumesList.Children.Remove(bindMountEntry);


### PR DESCRIPTION
## Summary
- Docker Compose interpolates the `configs.*.content` field when loading a stack file. The Postgres init script inlined into the Portainer bundle contains runtime shell references like `${POSTGRES_DB:?POSTGRES_DB must be set}`, which Compose resolved at parse time — aborting the deploy with `required variable POSTGRES_DB is missing a value`.
- Fix escapes `$` → `$$` when inlining the script in `PortainerComposePublisher`, so the references survive parse-time and reach the container intact. Regenerated `deploy/portainer/docker-compose.yaml` reflects the escaping.
- Only the Portainer inline-config path is affected; the `deploy/docker-compose` bundle bind-mounts the script from disk and never had this issue.

## Test plan
- [x] `dotnet build src/Aspire/Nocturne.Aspire.Host` succeeds (0 errors)
- [ ] Deploy the regenerated Portainer stack and confirm Postgres init runs and creates the `nocturne_migrator`/`nocturne_app`/`nocturne_web` roles