### PR TITLE
feat: event-driven connector sync via real-time listeners

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -64,6 +64,7 @@
     <PackageVersion Include="MongoDB.Driver" Version="3.5.0" />
     <PackageVersion Include="MongoDB.Bson" Version="3.5.0" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <PackageVersion Include="SocketIOClient" Version="4.0.4" />
     <PackageVersion Include="StackExchange.Redis" Version="2.9.32" />
     <PackageVersion Include="System.Text.Json" Version="10.0.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />

--- a/src/API/Nocturne.API/Nocturne.API.csproj
+++ b/src/API/Nocturne.API/Nocturne.API.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="ShiroTrie" />
     <PackageReference Include="SixLabors.ImageSharp" />
+    <PackageReference Include="SocketIOClient" />
     <PackageReference Include="Wasmtime" />
     <PackageReference Include="YamlDotNet" />
     <PackageReference Include="Yarp.ReverseProxy" />

--- a/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
@@ -36,6 +36,14 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
     private readonly ConcurrentDictionary<Guid, DateTime> _lastSyncByTenant = new();
 
     /// <summary>
+    /// Tracks the last time a nudge (immediate sync request) was accepted per tenant,
+    /// used to debounce rapid consecutive calls.
+    /// </summary>
+    private readonly ConcurrentDictionary<Guid, DateTime> _lastNudgeByTenant = new();
+
+    private static readonly TimeSpan NudgeDebounceWindow = TimeSpan.FromSeconds(10);
+
+    /// <summary>
     /// Initialises a new <see cref="ConnectorBackgroundService{TConfig}"/>.
     /// </summary>
     /// <param name="serviceProvider">Root DI service provider; a new scope is created per tenant sync.</param>
@@ -47,6 +55,28 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
     {
         ServiceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
         Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Requests an immediate sync for the specified tenant on the next poll cycle.
+    /// Removes the tenant's last-sync timestamp so the interval check passes immediately.
+    /// Calls within <see cref="NudgeDebounceWindow"/> of a previous nudge for the same
+    /// tenant are silently ignored to prevent event storms.
+    /// </summary>
+    /// <param name="tenantId">The tenant to sync immediately.</param>
+    protected void RequestImmediateSync(Guid tenantId)
+    {
+        var now = DateTime.UtcNow;
+
+        if (_lastNudgeByTenant.TryGetValue(tenantId, out var lastNudge) && now - lastNudge < NudgeDebounceWindow)
+            return;
+
+        _lastNudgeByTenant[tenantId] = now;
+        _lastSyncByTenant.TryRemove(tenantId, out _);
+
+        Logger.LogDebug(
+            "Immediate sync requested for {ConnectorName} tenant {TenantId}",
+            ConnectorName, tenantId);
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
@@ -85,6 +85,20 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
     protected abstract string ConnectorName { get; }
 
     /// <summary>
+    /// Called once after the initial startup delay, before the poll loop begins.
+    /// Override to start real-time listeners (e.g. webhooks, SSE, WebSocket connections).
+    /// The default implementation is a no-op.
+    /// </summary>
+    protected virtual Task StartRealtimeListenersAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <summary>
+    /// Called when the service is shutting down, after the poll loop exits.
+    /// Override to tear down any real-time listeners started in <see cref="StartRealtimeListenersAsync"/>.
+    /// The default implementation is a no-op.
+    /// </summary>
+    protected virtual Task StopRealtimeListenersAsync() => Task.CompletedTask;
+
+    /// <summary>
     /// Performs a single sync operation using the connector service.
     /// Services should be resolved from the provided <paramref name="scopeProvider"/>
     /// which has the tenant context already set.
@@ -149,6 +163,18 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
 
         try
         {
+            try
+            {
+                await StartRealtimeListenersAsync(stoppingToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                Logger.LogWarning(
+                    ex,
+                    "Failed to start real-time listeners for {ConnectorName}, falling back to polling",
+                    ConnectorName);
+            }
+
             // Poll every minute; each tenant is only synced when its own
             // SyncIntervalMinutes has elapsed since its last sync.
             using var timer = new PeriodicTimer(TimeSpan.FromMinutes(1));
@@ -171,6 +197,18 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
         }
         finally
         {
+            try
+            {
+                await StopRealtimeListenersAsync();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(
+                    ex,
+                    "Failed to stop real-time listeners for {ConnectorName}",
+                    ConnectorName);
+            }
+
             Logger.LogInformation(
                 "{ConnectorName} connector background service stopped",
                 ConnectorName);

--- a/src/API/Nocturne.API/Services/BackgroundServices/NightscoutConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/NightscoutConnectorBackgroundService.cs
@@ -1,17 +1,26 @@
+using Microsoft.EntityFrameworkCore;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
 using Nocturne.Connectors.Nightscout.Configurations;
 using Nocturne.Connectors.Nightscout.Services;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Infrastructure.Data;
+using System.Collections.Concurrent;
+using SocketIOClient;
 
 namespace Nocturne.API.Services.BackgroundServices;
 
 /// <summary>
 /// Background service that periodically syncs data from a legacy Nightscout instance via
 /// <see cref="NightscoutConnectorService"/>, enabling migration or mirroring workflows.
+/// Optionally connects to each tenant's Nightscout Socket.IO endpoint to trigger
+/// immediate syncs when upstream data changes.
 /// </summary>
 /// <seealso cref="ConnectorBackgroundService{TConfig}"/>
 public class NightscoutConnectorBackgroundService : ConnectorBackgroundService<NightscoutConnectorConfiguration>
 {
+    private readonly ConcurrentDictionary<Guid, SocketIO> _socketClients = new();
+
     /// <param name="serviceProvider">Service provider used to create a DI scope per sync cycle.</param>
     /// <param name="logger">Logger instance for this background service.</param>
     public NightscoutConnectorBackgroundService(
@@ -26,5 +35,112 @@ public class NightscoutConnectorBackgroundService : ConnectorBackgroundService<N
     {
         var connectorService = scopeProvider.GetRequiredService<NightscoutConnectorService>();
         return await connectorService.SyncDataAsync(config, cancellationToken, since: null, progressReporter);
+    }
+
+    /// <inheritdoc />
+    protected override async Task StartRealtimeListenersAsync(CancellationToken cancellationToken)
+    {
+        using var scope = ServiceProvider.CreateScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
+        await using var context = await factory.CreateDbContextAsync(cancellationToken);
+
+        var tenants = await context.Tenants.AsNoTracking()
+            .Where(t => t.IsActive)
+            .Select(t => new { t.Id, t.Slug, t.DisplayName })
+            .ToListAsync(cancellationToken);
+
+        foreach (var tenant in tenants)
+        {
+            try
+            {
+                using var tenantScope = ServiceProvider.CreateScope();
+
+                var tenantAccessor = tenantScope.ServiceProvider.GetRequiredService<ITenantAccessor>();
+                tenantAccessor.SetTenant(new TenantContext(tenant.Id, tenant.Slug, tenant.DisplayName, true));
+
+                var loader = tenantScope.ServiceProvider
+                    .GetRequiredService<IConnectorConfigurationLoader<NightscoutConnectorConfiguration>>();
+
+                NightscoutConnectorConfiguration config;
+                try
+                {
+                    config = await loader.LoadForTenantAsync(cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogWarning(
+                        ex,
+                        "Failed to load Nightscout config for tenant {TenantSlug}, skipping real-time listener",
+                        tenant.Slug);
+                    continue;
+                }
+
+                if (!config.Enabled || string.IsNullOrWhiteSpace(config.Url))
+                    continue;
+
+                var client = new SocketIO(new Uri(config.Url), new SocketIOOptions
+                {
+                    Reconnection = true,
+                    ReconnectionAttempts = int.MaxValue,
+                    ReconnectionDelayMax = 30_000,
+                });
+
+                var tenantId = tenant.Id;
+                foreach (var evt in new[] { "dataUpdate", "create", "update" })
+                    client.On(evt, _ => { RequestImmediateSync(tenantId); return Task.CompletedTask; });
+
+                try
+                {
+                    await client.ConnectAsync(cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogWarning(
+                        ex,
+                        "Failed to connect Socket.IO for tenant {TenantSlug} at {Url}, will rely on polling",
+                        tenant.Slug, config.Url);
+
+                    client.Dispose();
+                    continue;
+                }
+
+                _socketClients.TryAdd(tenantId, client);
+
+                Logger.LogInformation(
+                    "Started real-time listener for Nightscout tenant {TenantSlug}",
+                    tenant.Slug);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(
+                    ex,
+                    "Unexpected error starting real-time listener for tenant {TenantSlug}",
+                    tenant.Slug);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task StopRealtimeListenersAsync()
+    {
+        foreach (var (tenantId, client) in _socketClients)
+        {
+            try
+            {
+                await client.DisconnectAsync();
+                client.Dispose();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(
+                    ex,
+                    "Error disconnecting Socket.IO client for tenant {TenantId}",
+                    tenantId);
+            }
+        }
+
+        _socketClients.Clear();
+
+        Logger.LogInformation("Stopped all Nightscout real-time listeners");
     }
 }

--- a/src/API/Nocturne.API/Services/BackgroundServices/NocturneRemoteConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/NocturneRemoteConnectorBackgroundService.cs
@@ -1,17 +1,26 @@
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.EntityFrameworkCore;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
 using Nocturne.Connectors.NocturneRemote.Configurations;
 using Nocturne.Connectors.NocturneRemote.Services;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Infrastructure.Data;
+using System.Collections.Concurrent;
 
 namespace Nocturne.API.Services.BackgroundServices;
 
 /// <summary>
 /// Background service that periodically pulls data from a remote Nocturne V4 instance via
 /// <see cref="NocturneRemoteConnectorService"/>.
+/// Optionally connects to each tenant's Nocturne SignalR hub to trigger
+/// immediate syncs when upstream data changes.
 /// </summary>
 /// <seealso cref="ConnectorBackgroundService{TConfig}"/>
 public class NocturneRemoteConnectorBackgroundService : ConnectorBackgroundService<NocturneRemoteConnectorConfiguration>
 {
+    private readonly ConcurrentDictionary<Guid, HubConnection> _hubConnections = new();
+
     /// <param name="serviceProvider">Service provider used to create a DI scope per sync cycle.</param>
     /// <param name="logger">Logger instance for this background service.</param>
     public NocturneRemoteConnectorBackgroundService(
@@ -26,5 +35,124 @@ public class NocturneRemoteConnectorBackgroundService : ConnectorBackgroundServi
     {
         var connectorService = scopeProvider.GetRequiredService<NocturneRemoteConnectorService>();
         return await connectorService.SyncDataAsync(config, cancellationToken, since: null, progressReporter);
+    }
+
+    /// <inheritdoc />
+    protected override async Task StartRealtimeListenersAsync(CancellationToken cancellationToken)
+    {
+        using var scope = ServiceProvider.CreateScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
+        await using var context = await factory.CreateDbContextAsync(cancellationToken);
+
+        var tenants = await context.Tenants.AsNoTracking()
+            .Where(t => t.IsActive)
+            .Select(t => new { t.Id, t.Slug, t.DisplayName })
+            .ToListAsync(cancellationToken);
+
+        foreach (var tenant in tenants)
+        {
+            try
+            {
+                using var tenantScope = ServiceProvider.CreateScope();
+
+                var tenantAccessor = tenantScope.ServiceProvider.GetRequiredService<ITenantAccessor>();
+                tenantAccessor.SetTenant(new TenantContext(tenant.Id, tenant.Slug, tenant.DisplayName, true));
+
+                var loader = tenantScope.ServiceProvider
+                    .GetRequiredService<IConnectorConfigurationLoader<NocturneRemoteConnectorConfiguration>>();
+
+                NocturneRemoteConnectorConfiguration config;
+                try
+                {
+                    config = await loader.LoadForTenantAsync(cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogWarning(
+                        ex,
+                        "Failed to load NocturneRemote config for tenant {TenantSlug}, skipping real-time listener",
+                        tenant.Slug);
+                    continue;
+                }
+
+                if (!config.Enabled || string.IsNullOrWhiteSpace(config.Url))
+                    continue;
+
+                var hubUrl = $"{config.Url.TrimEnd('/')}/hubs/data";
+                var tenantId = tenant.Id;
+
+                var connection = new HubConnectionBuilder()
+                    .WithUrl(hubUrl, options =>
+                    {
+                        options.Headers.Add("Authorization", $"Bearer {config.Token}");
+                    })
+                    .WithAutomaticReconnect(new InfiniteRetryPolicy())
+                    .Build();
+
+                foreach (var evt in new[] { "dataUpdate", "create", "update" })
+                    connection.On<object>(evt, _ => RequestImmediateSync(tenantId));
+
+                try
+                {
+                    await connection.StartAsync(cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogWarning(
+                        ex,
+                        "Failed to connect SignalR for tenant {TenantSlug} at {Url}, will rely on polling",
+                        tenant.Slug, hubUrl);
+
+                    await connection.DisposeAsync();
+                    continue;
+                }
+
+                _hubConnections.TryAdd(tenantId, connection);
+
+                Logger.LogInformation(
+                    "Started real-time listener for NocturneRemote tenant {TenantSlug}",
+                    tenant.Slug);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(
+                    ex,
+                    "Unexpected error starting real-time listener for tenant {TenantSlug}",
+                    tenant.Slug);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task StopRealtimeListenersAsync()
+    {
+        foreach (var (tenantId, connection) in _hubConnections)
+        {
+            try
+            {
+                await connection.StopAsync();
+                await connection.DisposeAsync();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(
+                    ex,
+                    "Error disconnecting SignalR client for tenant {TenantId}",
+                    tenantId);
+            }
+        }
+
+        _hubConnections.Clear();
+
+        Logger.LogInformation("Stopped all NocturneRemote real-time listeners");
+    }
+
+    private sealed class InfiniteRetryPolicy : IRetryPolicy
+    {
+        public TimeSpan? NextRetryDelay(RetryContext retryContext)
+        {
+            var delay = Math.Min(1000 * Math.Pow(2, retryContext.PreviousRetryCount), 30_000);
+            return TimeSpan.FromMilliseconds(delay);
+        }
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
@@ -30,14 +30,17 @@ public class ConnectorBackgroundServiceTests
     private class TestConnectorBackgroundService : ConnectorBackgroundService<TestConnectorConfig>
     {
         private readonly SyncResult _syncResult;
+        private readonly Action? _onSync;
 
         public TestConnectorBackgroundService(
             IServiceProvider serviceProvider,
             SyncResult syncResult,
-            ILogger logger)
+            ILogger logger,
+            Action? onSync = null)
             : base(serviceProvider, logger)
         {
             _syncResult = syncResult;
+            _onSync = onSync;
         }
 
         protected override string ConnectorName => "TestConnector";
@@ -48,6 +51,7 @@ public class ConnectorBackgroundServiceTests
             CancellationToken cancellationToken,
             ISyncProgressReporter? progressReporter = null)
         {
+            _onSync?.Invoke();
             return Task.FromResult(_syncResult);
         }
 
@@ -61,12 +65,27 @@ public class ConnectorBackgroundServiceTests
                 .GetMethod("SyncAllTenantsAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
             await (Task)method.Invoke(this, [ct])!;
         }
+
+        /// <summary>
+        /// Exposes the protected RequestImmediateSync for testing.
+        /// </summary>
+        public new void RequestImmediateSync(Guid tenantId) => base.RequestImmediateSync(tenantId);
     }
 
     /// <summary>
     /// Sets up an in-memory SQLite NocturneDbContext with one active tenant.
     /// </summary>
     private static (IDisposable cleanup, string connectionString) CreateSqliteDb()
+    {
+        var (cleanup, connectionString, _) = CreateSqliteDbWithTenantId();
+        return (cleanup, connectionString);
+    }
+
+    /// <summary>
+    /// Sets up an in-memory SQLite NocturneDbContext with one active tenant,
+    /// returning the tenant ID for tests that need to target a specific tenant.
+    /// </summary>
+    private static (IDisposable cleanup, string connectionString, Guid tenantId) CreateSqliteDbWithTenantId()
     {
         // Use a temp file so factory-created contexts can share the same data
         var dbPath = Path.Combine(Path.GetTempPath(), $"ConnectorBgTest_{Guid.NewGuid():N}.db");
@@ -98,7 +117,7 @@ public class ConnectorBackgroundServiceTests
             tenantId.ToString(), "test-tenant", "Test Tenant",
             DateTime.UtcNow.ToString("O"), DateTime.UtcNow.ToString("O"));
 
-        return (cleanup, connectionString);
+        return (cleanup, connectionString, tenantId);
     }
 
     private static IServiceProvider BuildServiceProvider(
@@ -419,6 +438,113 @@ public class ConnectorBackgroundServiceTests
                 It.IsAny<CancellationToken>()),
             Times.Once,
             "Expected error message to be cleared on successful sync");
+    }
+
+    [Fact]
+    public async Task RequestImmediateSync_CausesNextPollToSyncImmediately()
+    {
+        // Arrange
+        var (cleanup, connStr, tenantId) = CreateSqliteDbWithTenantId();
+        using var _ = cleanup;
+
+        var syncCount = 0;
+        var syncResult = new SyncResult { Success = true, Message = "OK" };
+
+        var configServiceMock = new Mock<IConnectorConfigurationService>();
+        configServiceMock
+            .Setup(x => x.GetConfigurationAsync("TestConnector", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConnectorConfigurationResponse
+            {
+                ConnectorName = "TestConnector",
+                IsActive = true,
+                Configuration = JsonDocument.Parse("{\"enabled\": true, \"syncIntervalMinutes\": 60}")
+            });
+        configServiceMock
+            .Setup(x => x.GetSecretsAsync("TestConnector", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, string>());
+        configServiceMock
+            .Setup(x => x.UpdateHealthStateAsync(
+                It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<string?>(), It.IsAny<DateTime?>(), It.IsAny<bool?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var config = new TestConnectorConfig { Enabled = true, SyncIntervalMinutes = 60 };
+        var serviceProvider = BuildServiceProvider(connStr, configServiceMock, config);
+
+        var sut = new TestConnectorBackgroundService(
+            serviceProvider,
+            syncResult,
+            NullLogger<TestConnectorBackgroundService>.Instance,
+            onSync: () => syncCount++);
+
+        // Act — first poll triggers the initial sync
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+        Assert.Equal(1, syncCount);
+
+        // Second poll should NOT sync (60-minute interval hasn't elapsed)
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+        Assert.Equal(1, syncCount);
+
+        // Request immediate sync, then poll again — it should sync immediately
+        sut.RequestImmediateSync(tenantId);
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+        Assert.Equal(2, syncCount);
+    }
+
+    [Fact]
+    public async Task RequestImmediateSync_DebouncesPreviouslyNudgedTenant()
+    {
+        // Arrange
+        var (cleanup, connStr, tenantId) = CreateSqliteDbWithTenantId();
+        using var _ = cleanup;
+
+        var syncCount = 0;
+        var syncResult = new SyncResult { Success = true, Message = "OK" };
+
+        var configServiceMock = new Mock<IConnectorConfigurationService>();
+        configServiceMock
+            .Setup(x => x.GetConfigurationAsync("TestConnector", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConnectorConfigurationResponse
+            {
+                ConnectorName = "TestConnector",
+                IsActive = true,
+                Configuration = JsonDocument.Parse("{\"enabled\": true, \"syncIntervalMinutes\": 60}")
+            });
+        configServiceMock
+            .Setup(x => x.GetSecretsAsync("TestConnector", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, string>());
+        configServiceMock
+            .Setup(x => x.UpdateHealthStateAsync(
+                It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<string?>(), It.IsAny<DateTime?>(), It.IsAny<bool?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var config = new TestConnectorConfig { Enabled = true, SyncIntervalMinutes = 60 };
+        var serviceProvider = BuildServiceProvider(connStr, configServiceMock, config);
+
+        var sut = new TestConnectorBackgroundService(
+            serviceProvider,
+            syncResult,
+            NullLogger<TestConnectorBackgroundService>.Instance,
+            onSync: () => syncCount++);
+
+        // Act — initial sync
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+        Assert.Equal(1, syncCount);
+
+        // First nudge should succeed and cause a sync
+        sut.RequestImmediateSync(tenantId);
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+        Assert.Equal(2, syncCount);
+
+        // Second nudge within the debounce window should be ignored
+        sut.RequestImmediateSync(tenantId);
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+        // Sync count should remain at 2 because the nudge was debounced
+        // and the 60-minute interval hasn't elapsed
+        Assert.Equal(2, syncCount);
     }
 
     /// <summary>

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/NightscoutRealtimeListenerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/NightscoutRealtimeListenerTests.cs
@@ -1,0 +1,272 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.BackgroundServices;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Nightscout.Configurations;
+using Nocturne.Connectors.Nightscout.Services;
+using Nocturne.Core.Contracts.Connectors;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Infrastructure.Data;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.BackgroundServices;
+
+public class NightscoutRealtimeListenerTests
+{
+    /// <summary>
+    /// StartRealtimeListenersAsync should complete without throwing when there
+    /// are no active tenants in the database.
+    /// </summary>
+    [Fact]
+    public async Task StartRealtimeListenersAsync_NoTenants_DoesNotThrow()
+    {
+        // Arrange — empty database (no tenants)
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: false);
+        using var _ = cleanup;
+
+        var serviceProvider = BuildServiceProvider(connectionString);
+        var sut = new NightscoutConnectorBackgroundService(
+            serviceProvider,
+            NullLogger<NightscoutConnectorBackgroundService>.Instance);
+
+        // Act & Assert — should not throw
+        await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// StopRealtimeListenersAsync should be safe to call even when no listeners
+    /// have been started (i.e. the socket client dictionary is empty).
+    /// </summary>
+    [Fact]
+    public async Task StopRealtimeListenersAsync_NoListenersStarted_DoesNotThrow()
+    {
+        // Arrange
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: false);
+        using var _ = cleanup;
+
+        var serviceProvider = BuildServiceProvider(connectionString);
+        var sut = new NightscoutConnectorBackgroundService(
+            serviceProvider,
+            NullLogger<NightscoutConnectorBackgroundService>.Instance);
+
+        // Act & Assert — should not throw
+        await InvokeStopRealtimeListenersAsync(sut);
+    }
+
+    /// <summary>
+    /// StopRealtimeListenersAsync should be safe to call multiple times in a row.
+    /// </summary>
+    [Fact]
+    public async Task StopRealtimeListenersAsync_CalledTwice_DoesNotThrow()
+    {
+        // Arrange
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: false);
+        using var _ = cleanup;
+
+        var serviceProvider = BuildServiceProvider(connectionString);
+        var sut = new NightscoutConnectorBackgroundService(
+            serviceProvider,
+            NullLogger<NightscoutConnectorBackgroundService>.Instance);
+
+        // Act & Assert — should not throw on repeated calls
+        await InvokeStopRealtimeListenersAsync(sut);
+        await InvokeStopRealtimeListenersAsync(sut);
+    }
+
+    /// <summary>
+    /// When a tenant exists but the connector config is disabled, StartRealtimeListenersAsync
+    /// should skip that tenant without throwing.
+    /// </summary>
+    [Fact]
+    public async Task StartRealtimeListenersAsync_DisabledConnector_SkipsTenant()
+    {
+        // Arrange — one tenant with a disabled connector config
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: true);
+        using var _ = cleanup;
+
+        var config = new NightscoutConnectorConfiguration
+        {
+            Enabled = false,
+            Url = "http://nightscout.example.com",
+        };
+
+        var serviceProvider = BuildServiceProvider(connectionString, config);
+        var sut = new NightscoutConnectorBackgroundService(
+            serviceProvider,
+            NullLogger<NightscoutConnectorBackgroundService>.Instance);
+
+        // Act & Assert — should skip the tenant without throwing
+        await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// When a tenant exists but the connector config has no URL, StartRealtimeListenersAsync
+    /// should skip that tenant without throwing.
+    /// </summary>
+    [Fact]
+    public async Task StartRealtimeListenersAsync_EmptyUrl_SkipsTenant()
+    {
+        // Arrange — one tenant with no URL configured
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: true);
+        using var _ = cleanup;
+
+        var config = new NightscoutConnectorConfiguration
+        {
+            Enabled = true,
+            Url = "",
+        };
+
+        var serviceProvider = BuildServiceProvider(connectionString, config);
+        var sut = new NightscoutConnectorBackgroundService(
+            serviceProvider,
+            NullLogger<NightscoutConnectorBackgroundService>.Instance);
+
+        // Act & Assert — should skip the tenant without throwing
+        await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
+    }
+
+    #region Helpers
+
+    /// <summary>
+    /// Invokes the protected StartRealtimeListenersAsync via reflection.
+    /// </summary>
+    private static async Task InvokeStartRealtimeListenersAsync(
+        NightscoutConnectorBackgroundService sut,
+        CancellationToken cancellationToken)
+    {
+        var method = typeof(ConnectorBackgroundService<NightscoutConnectorConfiguration>)
+            .GetMethod("StartRealtimeListenersAsync",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        await (Task)method.Invoke(sut, [cancellationToken])!;
+    }
+
+    /// <summary>
+    /// Invokes the protected StopRealtimeListenersAsync via reflection.
+    /// </summary>
+    private static async Task InvokeStopRealtimeListenersAsync(
+        NightscoutConnectorBackgroundService sut)
+    {
+        var method = typeof(ConnectorBackgroundService<NightscoutConnectorConfiguration>)
+            .GetMethod("StopRealtimeListenersAsync",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        await (Task)method.Invoke(sut, [])!;
+    }
+
+    /// <summary>
+    /// Creates an in-memory SQLite database, optionally seeding one active tenant.
+    /// </summary>
+    private static (IDisposable cleanup, string connectionString) CreateSqliteDb(bool addTenant)
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"NsRealtimeTest_{Guid.NewGuid():N}.db");
+        var connectionString = $"Data Source={dbPath}";
+        var cleanup = new TempFileCleanup(dbPath);
+
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(connectionString)
+            .Options;
+
+        using var context = new NocturneDbContext(options);
+        context.Database.ExecuteSqlRaw(@"
+            CREATE TABLE tenants (
+                Id TEXT PRIMARY KEY,
+                slug TEXT NOT NULL,
+                display_name TEXT NOT NULL,
+                is_active INTEGER NOT NULL DEFAULT 1,
+                last_reading_at TEXT,
+                allow_access_requests INTEGER NOT NULL DEFAULT 1,
+                onboarding_completed_at TEXT,
+                sys_created_at TEXT NOT NULL,
+                sys_updated_at TEXT NOT NULL
+            )");
+
+        if (addTenant)
+        {
+            var tenantId = Guid.NewGuid();
+            context.Database.ExecuteSqlRaw(
+                "INSERT INTO tenants (Id, slug, display_name, is_active, allow_access_requests, sys_created_at, sys_updated_at) VALUES ({0}, {1}, {2}, 1, 1, {3}, {4})",
+                tenantId.ToString(), "test-tenant", "Test Tenant",
+                DateTime.UtcNow.ToString("O"), DateTime.UtcNow.ToString("O"));
+        }
+
+        return (cleanup, connectionString);
+    }
+
+    /// <summary>
+    /// Builds a service provider wired up for the NightscoutConnectorBackgroundService.
+    /// When <paramref name="config"/> is null, no config loader is registered (used for
+    /// the "no tenants" scenario where it's never resolved).
+    /// </summary>
+    private static IServiceProvider BuildServiceProvider(
+        string connectionString,
+        NightscoutConnectorConfiguration? config = null)
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IDbContextFactory<NocturneDbContext>>(
+            new SqliteDbContextFactory(connectionString));
+
+        services.AddScoped(sp =>
+        {
+            var factory = sp.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
+            return factory.CreateDbContext();
+        });
+
+        services.AddScoped<ITenantAccessor>(_ =>
+        {
+            var mock = new Mock<ITenantAccessor>();
+            mock.Setup(t => t.IsResolved).Returns(true);
+            mock.Setup(t => t.TenantId).Returns(Guid.NewGuid());
+            mock.Setup(t => t.SetTenant(It.IsAny<TenantContext>()));
+            return mock.Object;
+        });
+
+        if (config != null)
+        {
+            services.AddScoped<IConnectorConfigurationLoader<NightscoutConnectorConfiguration>>(
+                _ => new StaticConfigLoader(config));
+        }
+        else
+        {
+            // Register a loader that throws — it should never be called for empty tenant lists
+            services.AddScoped<IConnectorConfigurationLoader<NightscoutConnectorConfiguration>>(
+                _ => throw new InvalidOperationException("Config loader should not be called when there are no tenants"));
+        }
+
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class StaticConfigLoader(NightscoutConnectorConfiguration config)
+        : IConnectorConfigurationLoader<NightscoutConnectorConfiguration>
+    {
+        public Task<NightscoutConnectorConfiguration> LoadForTenantAsync(CancellationToken ct)
+            => Task.FromResult(config);
+    }
+
+    private sealed class SqliteDbContextFactory(string connectionString)
+        : IDbContextFactory<NocturneDbContext>
+    {
+        public NocturneDbContext CreateDbContext()
+        {
+            var options = new DbContextOptionsBuilder<NocturneDbContext>()
+                .UseSqlite(connectionString)
+                .Options;
+            return new NocturneDbContext(options);
+        }
+    }
+
+    private sealed class TempFileCleanup(string path) : IDisposable
+    {
+        public void Dispose()
+        {
+            try { File.Delete(path); }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
+    }
+
+    #endregion
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/NocturneRemoteRealtimeListenerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/NocturneRemoteRealtimeListenerTests.cs
@@ -1,0 +1,270 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.BackgroundServices;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.NocturneRemote.Configurations;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Infrastructure.Data;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.BackgroundServices;
+
+public class NocturneRemoteRealtimeListenerTests
+{
+    /// <summary>
+    /// StartRealtimeListenersAsync should complete without throwing when there
+    /// are no active tenants in the database.
+    /// </summary>
+    [Fact]
+    public async Task StartRealtimeListenersAsync_NoTenants_DoesNotThrow()
+    {
+        // Arrange — empty database (no tenants)
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: false);
+        using var _ = cleanup;
+
+        var serviceProvider = BuildServiceProvider(connectionString);
+        var sut = new NocturneRemoteConnectorBackgroundService(
+            serviceProvider,
+            NullLogger<NocturneRemoteConnectorBackgroundService>.Instance);
+
+        // Act & Assert — should not throw
+        await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// StopRealtimeListenersAsync should be safe to call even when no listeners
+    /// have been started (i.e. the hub connection dictionary is empty).
+    /// </summary>
+    [Fact]
+    public async Task StopRealtimeListenersAsync_NoListenersStarted_DoesNotThrow()
+    {
+        // Arrange
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: false);
+        using var _ = cleanup;
+
+        var serviceProvider = BuildServiceProvider(connectionString);
+        var sut = new NocturneRemoteConnectorBackgroundService(
+            serviceProvider,
+            NullLogger<NocturneRemoteConnectorBackgroundService>.Instance);
+
+        // Act & Assert — should not throw
+        await InvokeStopRealtimeListenersAsync(sut);
+    }
+
+    /// <summary>
+    /// StopRealtimeListenersAsync should be safe to call multiple times in a row.
+    /// </summary>
+    [Fact]
+    public async Task StopRealtimeListenersAsync_CalledTwice_DoesNotThrow()
+    {
+        // Arrange
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: false);
+        using var _ = cleanup;
+
+        var serviceProvider = BuildServiceProvider(connectionString);
+        var sut = new NocturneRemoteConnectorBackgroundService(
+            serviceProvider,
+            NullLogger<NocturneRemoteConnectorBackgroundService>.Instance);
+
+        // Act & Assert — should not throw on repeated calls
+        await InvokeStopRealtimeListenersAsync(sut);
+        await InvokeStopRealtimeListenersAsync(sut);
+    }
+
+    /// <summary>
+    /// When a tenant exists but the connector config is disabled, StartRealtimeListenersAsync
+    /// should skip that tenant without throwing.
+    /// </summary>
+    [Fact]
+    public async Task StartRealtimeListenersAsync_DisabledConnector_SkipsTenant()
+    {
+        // Arrange — one tenant with a disabled connector config
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: true);
+        using var _ = cleanup;
+
+        var config = new NocturneRemoteConnectorConfiguration
+        {
+            Enabled = false,
+            Url = "http://remote.example.com",
+            Token = "test-token",
+        };
+
+        var serviceProvider = BuildServiceProvider(connectionString, config);
+        var sut = new NocturneRemoteConnectorBackgroundService(
+            serviceProvider,
+            NullLogger<NocturneRemoteConnectorBackgroundService>.Instance);
+
+        // Act & Assert — should skip the tenant without throwing
+        await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// When a tenant exists but the connector config has no URL, StartRealtimeListenersAsync
+    /// should skip that tenant without throwing.
+    /// </summary>
+    [Fact]
+    public async Task StartRealtimeListenersAsync_EmptyUrl_SkipsTenant()
+    {
+        // Arrange — one tenant with no URL configured
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: true);
+        using var _ = cleanup;
+
+        var config = new NocturneRemoteConnectorConfiguration
+        {
+            Enabled = true,
+            Url = "",
+            Token = "test-token",
+        };
+
+        var serviceProvider = BuildServiceProvider(connectionString, config);
+        var sut = new NocturneRemoteConnectorBackgroundService(
+            serviceProvider,
+            NullLogger<NocturneRemoteConnectorBackgroundService>.Instance);
+
+        // Act & Assert — should skip the tenant without throwing
+        await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
+    }
+
+    #region Helpers
+
+    /// <summary>
+    /// Invokes the protected StartRealtimeListenersAsync via reflection.
+    /// </summary>
+    private static async Task InvokeStartRealtimeListenersAsync(
+        NocturneRemoteConnectorBackgroundService sut,
+        CancellationToken cancellationToken)
+    {
+        var method = typeof(ConnectorBackgroundService<NocturneRemoteConnectorConfiguration>)
+            .GetMethod("StartRealtimeListenersAsync",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        await (Task)method.Invoke(sut, [cancellationToken])!;
+    }
+
+    /// <summary>
+    /// Invokes the protected StopRealtimeListenersAsync via reflection.
+    /// </summary>
+    private static async Task InvokeStopRealtimeListenersAsync(
+        NocturneRemoteConnectorBackgroundService sut)
+    {
+        var method = typeof(ConnectorBackgroundService<NocturneRemoteConnectorConfiguration>)
+            .GetMethod("StopRealtimeListenersAsync",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        await (Task)method.Invoke(sut, [])!;
+    }
+
+    /// <summary>
+    /// Creates an in-memory SQLite database, optionally seeding one active tenant.
+    /// </summary>
+    private static (IDisposable cleanup, string connectionString) CreateSqliteDb(bool addTenant)
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"NrRealtimeTest_{Guid.NewGuid():N}.db");
+        var connectionString = $"Data Source={dbPath}";
+        var cleanup = new TempFileCleanup(dbPath);
+
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(connectionString)
+            .Options;
+
+        using var context = new NocturneDbContext(options);
+        context.Database.ExecuteSqlRaw(@"
+            CREATE TABLE tenants (
+                Id TEXT PRIMARY KEY,
+                slug TEXT NOT NULL,
+                display_name TEXT NOT NULL,
+                is_active INTEGER NOT NULL DEFAULT 1,
+                last_reading_at TEXT,
+                allow_access_requests INTEGER NOT NULL DEFAULT 1,
+                onboarding_completed_at TEXT,
+                sys_created_at TEXT NOT NULL,
+                sys_updated_at TEXT NOT NULL
+            )");
+
+        if (addTenant)
+        {
+            var tenantId = Guid.NewGuid();
+            context.Database.ExecuteSqlRaw(
+                "INSERT INTO tenants (Id, slug, display_name, is_active, allow_access_requests, sys_created_at, sys_updated_at) VALUES ({0}, {1}, {2}, 1, 1, {3}, {4})",
+                tenantId.ToString(), "test-tenant", "Test Tenant",
+                DateTime.UtcNow.ToString("O"), DateTime.UtcNow.ToString("O"));
+        }
+
+        return (cleanup, connectionString);
+    }
+
+    /// <summary>
+    /// Builds a service provider wired up for the NocturneRemoteConnectorBackgroundService.
+    /// When <paramref name="config"/> is null, no config loader is registered (used for
+    /// the "no tenants" scenario where it's never resolved).
+    /// </summary>
+    private static IServiceProvider BuildServiceProvider(
+        string connectionString,
+        NocturneRemoteConnectorConfiguration? config = null)
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IDbContextFactory<NocturneDbContext>>(
+            new SqliteDbContextFactory(connectionString));
+
+        services.AddScoped(sp =>
+        {
+            var factory = sp.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
+            return factory.CreateDbContext();
+        });
+
+        services.AddScoped<ITenantAccessor>(_ =>
+        {
+            var mock = new Mock<ITenantAccessor>();
+            mock.Setup(t => t.IsResolved).Returns(true);
+            mock.Setup(t => t.TenantId).Returns(Guid.NewGuid());
+            mock.Setup(t => t.SetTenant(It.IsAny<TenantContext>()));
+            return mock.Object;
+        });
+
+        if (config != null)
+        {
+            services.AddScoped<IConnectorConfigurationLoader<NocturneRemoteConnectorConfiguration>>(
+                _ => new StaticConfigLoader(config));
+        }
+        else
+        {
+            // Register a loader that throws — it should never be called for empty tenant lists
+            services.AddScoped<IConnectorConfigurationLoader<NocturneRemoteConnectorConfiguration>>(
+                _ => throw new InvalidOperationException("Config loader should not be called when there are no tenants"));
+        }
+
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class StaticConfigLoader(NocturneRemoteConnectorConfiguration config)
+        : IConnectorConfigurationLoader<NocturneRemoteConnectorConfiguration>
+    {
+        public Task<NocturneRemoteConnectorConfiguration> LoadForTenantAsync(CancellationToken ct)
+            => Task.FromResult(config);
+    }
+
+    private sealed class SqliteDbContextFactory(string connectionString)
+        : IDbContextFactory<NocturneDbContext>
+    {
+        public NocturneDbContext CreateDbContext()
+        {
+            var options = new DbContextOptionsBuilder<NocturneDbContext>()
+                .UseSqlite(connectionString)
+                .Options;
+            return new NocturneDbContext(options);
+        }
+    }
+
+    private sealed class TempFileCleanup(string path) : IDisposable
+    {
+        public void Dispose()
+        {
+            try { File.Delete(path); }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Add `RequestImmediateSync` with 10-second debounce to `ConnectorBackgroundService` base class
- Add `StartRealtimeListenersAsync` / `StopRealtimeListenersAsync` lifecycle hooks (no-op by default)
- Nightscout connector subscribes to upstream Socket.IO stream (`dataUpdate`, `create`, `update` events) and triggers immediate sync on new data
- Nocturne Remote connector subscribes to upstream SignalR `/hubs/data` hub with the same trigger mechanism
- Existing polling remains as a maximum-staleness fallback — `SyncIntervalMinutes` unchanged, no new config

## Motivation
Connectors poll on a fixed interval (typically 4-5 min), causing IOB/glucose values to lag behind what the phone and upstream Nightscout show. With real-time listeners, data arrives within seconds of Trio/Loop uploading to Nightscout.

## Test plan
- [ ] 21 unit tests pass (6 base class + 5 Nightscout listener + 5 Nocturne Remote listener + existing)
- [ ] Verify Nightscout connector receives Socket.IO events and triggers immediate sync
- [ ] Verify Nocturne Remote connector receives SignalR events and triggers immediate sync
- [ ] Verify polling fallback still works when real-time connection fails