### PR TITLE
feat: event-driven connector sync + cross-connector dedup reconciliation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -64,6 +64,7 @@
     <PackageVersion Include="MongoDB.Driver" Version="3.5.0" />
     <PackageVersion Include="MongoDB.Bson" Version="3.5.0" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <PackageVersion Include="SocketIOClient" Version="4.0.4" />
     <PackageVersion Include="StackExchange.Redis" Version="2.9.32" />
     <PackageVersion Include="System.Text.Json" Version="10.0.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -730,6 +730,9 @@ public static class ServiceRegistrationExtensions
         // Background sweep
         services.AddHostedService<AlertSweepService>();
 
+        // Periodic watermark-driven deduplication reconciliation across active tenants
+        services.AddHostedService<Nocturne.API.Services.BackgroundServices.DeduplicationReconciliationBackgroundService>();
+
         return services;
     }
 

--- a/src/API/Nocturne.API/Nocturne.API.csproj
+++ b/src/API/Nocturne.API/Nocturne.API.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="ShiroTrie" />
     <PackageReference Include="SixLabors.ImageSharp" />
+    <PackageReference Include="SocketIOClient" />
     <PackageReference Include="Wasmtime" />
     <PackageReference Include="YamlDotNet" />
     <PackageReference Include="Yarp.ReverseProxy" />

--- a/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
@@ -36,6 +36,14 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
     private readonly ConcurrentDictionary<Guid, DateTime> _lastSyncByTenant = new();
 
     /// <summary>
+    /// Tracks the last time a nudge (immediate sync request) was accepted per tenant,
+    /// used to debounce rapid consecutive calls.
+    /// </summary>
+    private readonly ConcurrentDictionary<Guid, DateTime> _lastNudgeByTenant = new();
+
+    private static readonly TimeSpan NudgeDebounceWindow = TimeSpan.FromSeconds(10);
+
+    /// <summary>
     /// Initialises a new <see cref="ConnectorBackgroundService{TConfig}"/>.
     /// </summary>
     /// <param name="serviceProvider">Root DI service provider; a new scope is created per tenant sync.</param>
@@ -47,6 +55,28 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
     {
         ServiceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
         Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Requests an immediate sync for the specified tenant on the next poll cycle.
+    /// Removes the tenant's last-sync timestamp so the interval check passes immediately.
+    /// Calls within <see cref="NudgeDebounceWindow"/> of a previous nudge for the same
+    /// tenant are silently ignored to prevent event storms.
+    /// </summary>
+    /// <param name="tenantId">The tenant to sync immediately.</param>
+    protected void RequestImmediateSync(Guid tenantId)
+    {
+        var now = DateTime.UtcNow;
+
+        if (_lastNudgeByTenant.TryGetValue(tenantId, out var lastNudge) && now - lastNudge < NudgeDebounceWindow)
+            return;
+
+        _lastNudgeByTenant[tenantId] = now;
+        _lastSyncByTenant.TryRemove(tenantId, out _);
+
+        Logger.LogDebug(
+            "Immediate sync requested for {ConnectorName} tenant {TenantId}",
+            ConnectorName, tenantId);
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
@@ -85,6 +85,20 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
     protected abstract string ConnectorName { get; }
 
     /// <summary>
+    /// Called once after the initial startup delay, before the poll loop begins.
+    /// Override to start real-time listeners (e.g. webhooks, SSE, WebSocket connections).
+    /// The default implementation is a no-op.
+    /// </summary>
+    protected virtual Task StartRealtimeListenersAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <summary>
+    /// Called when the service is shutting down, after the poll loop exits.
+    /// Override to tear down any real-time listeners started in <see cref="StartRealtimeListenersAsync"/>.
+    /// The default implementation is a no-op.
+    /// </summary>
+    protected virtual Task StopRealtimeListenersAsync() => Task.CompletedTask;
+
+    /// <summary>
     /// Performs a single sync operation using the connector service.
     /// Services should be resolved from the provided <paramref name="scopeProvider"/>
     /// which has the tenant context already set.
@@ -149,6 +163,18 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
 
         try
         {
+            try
+            {
+                await StartRealtimeListenersAsync(stoppingToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                Logger.LogWarning(
+                    ex,
+                    "Failed to start real-time listeners for {ConnectorName}, falling back to polling",
+                    ConnectorName);
+            }
+
             // Poll every minute; each tenant is only synced when its own
             // SyncIntervalMinutes has elapsed since its last sync.
             using var timer = new PeriodicTimer(TimeSpan.FromMinutes(1));
@@ -171,6 +197,18 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
         }
         finally
         {
+            try
+            {
+                await StopRealtimeListenersAsync();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(
+                    ex,
+                    "Failed to stop real-time listeners for {ConnectorName}",
+                    ConnectorName);
+            }
+
             Logger.LogInformation(
                 "{ConnectorName} connector background service stopped",
                 ConnectorName);

--- a/src/API/Nocturne.API/Services/BackgroundServices/DeduplicationReconciliationBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/DeduplicationReconciliationBackgroundService.cs
@@ -1,0 +1,111 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Nocturne.Core.Contracts.Infrastructure;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Infrastructure.Data;
+
+namespace Nocturne.API.Services.BackgroundServices;
+
+/// <summary>
+/// Periodically drives watermark-based deduplication reconciliation for every active tenant.
+/// On each tick it enumerates active tenants and calls
+/// <see cref="IDeduplicationService.ReconcileNewLinksAsync(int, int, CancellationToken)"/> for each,
+/// merging duplicate canonical groups created since the tenant's last watermark.
+/// </summary>
+/// <remarks>
+/// Single-instance deployment only. If the API is ever scaled out, gate per-tenant reconcile with a
+/// Postgres advisory lock (pg_advisory_xact_lock) so instances don't both reconcile the same tenant.
+/// </remarks>
+internal sealed class DeduplicationReconciliationBackgroundService : BackgroundService
+{
+    private static readonly TimeSpan Interval = TimeSpan.FromMinutes(2);
+    private static readonly int BatchSize = 5000;
+    private static readonly int MaxBatchesPerTick = 4;
+
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<DeduplicationReconciliationBackgroundService> _logger;
+
+    /// <summary>
+    /// Initialises a new <see cref="DeduplicationReconciliationBackgroundService"/>.
+    /// </summary>
+    /// <param name="serviceProvider">Root DI service provider; a new scope is created per tenant.</param>
+    /// <param name="logger">Logger instance.</param>
+    public DeduplicationReconciliationBackgroundService(
+        IServiceProvider serviceProvider,
+        ILogger<DeduplicationReconciliationBackgroundService> logger)
+    {
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Wait briefly to let the application fully start
+        await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken);
+
+        _logger.LogInformation("Deduplication reconciliation background service started");
+
+        try
+        {
+            using var timer = new PeriodicTimer(Interval);
+
+            do
+            {
+                try
+                {
+                    await ReconcileAllTenantsAsync(stoppingToken);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    _logger.LogError(ex, "Error during deduplication reconciliation cycle");
+                }
+            } while (await timer.WaitForNextTickAsync(stoppingToken));
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("Deduplication reconciliation background service stopping");
+        }
+    }
+
+    /// <summary>
+    /// Loads active tenants and reconciles each one sequentially. Per-tenant failures are logged
+    /// and swallowed so a single tenant's error does not abort the sweep.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    internal async Task ReconcileAllTenantsAsync(CancellationToken ct)
+    {
+        using var lookupScope = _serviceProvider.CreateScope();
+        var factory = lookupScope.ServiceProvider.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
+        await using var lookupContext = await factory.CreateDbContextAsync(ct);
+        var tenants = await lookupContext.Tenants.AsNoTracking()
+            .Where(t => t.IsActive)
+            .Select(t => new { t.Id, t.Slug, t.DisplayName })
+            .ToListAsync(ct);
+
+        foreach (var tenant in tenants)
+        {
+            try
+            {
+                using var scope = _serviceProvider.CreateScope();
+
+                var tenantAccessor = scope.ServiceProvider.GetRequiredService<ITenantAccessor>();
+                tenantAccessor.SetTenant(new TenantContext(tenant.Id, tenant.Slug, tenant.DisplayName, true));
+
+                var dedup = scope.ServiceProvider.GetRequiredService<IDeduplicationService>();
+                var result = await dedup.ReconcileNewLinksAsync(BatchSize, MaxBatchesPerTick, ct);
+
+                _logger.LogDebug(
+                    "Reconciled deduplication for tenant {TenantSlug}: {GroupsMerged} groups merged",
+                    tenant.Slug, result.GroupsMerged);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogError(ex,
+                    "Error reconciling deduplication for tenant {TenantSlug}",
+                    tenant.Slug);
+            }
+        }
+    }
+}

--- a/src/API/Nocturne.API/Services/BackgroundServices/NightscoutConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/NightscoutConnectorBackgroundService.cs
@@ -1,17 +1,26 @@
+using Microsoft.EntityFrameworkCore;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
 using Nocturne.Connectors.Nightscout.Configurations;
 using Nocturne.Connectors.Nightscout.Services;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Infrastructure.Data;
+using System.Collections.Concurrent;
+using SocketIOClient;
 
 namespace Nocturne.API.Services.BackgroundServices;
 
 /// <summary>
 /// Background service that periodically syncs data from a legacy Nightscout instance via
 /// <see cref="NightscoutConnectorService"/>, enabling migration or mirroring workflows.
+/// Optionally connects to each tenant's Nightscout Socket.IO endpoint to trigger
+/// immediate syncs when upstream data changes.
 /// </summary>
 /// <seealso cref="ConnectorBackgroundService{TConfig}"/>
 public class NightscoutConnectorBackgroundService : ConnectorBackgroundService<NightscoutConnectorConfiguration>
 {
+    private readonly ConcurrentDictionary<Guid, SocketIO> _socketClients = new();
+
     /// <param name="serviceProvider">Service provider used to create a DI scope per sync cycle.</param>
     /// <param name="logger">Logger instance for this background service.</param>
     public NightscoutConnectorBackgroundService(
@@ -26,5 +35,112 @@ public class NightscoutConnectorBackgroundService : ConnectorBackgroundService<N
     {
         var connectorService = scopeProvider.GetRequiredService<NightscoutConnectorService>();
         return await connectorService.SyncDataAsync(config, cancellationToken, since: null, progressReporter);
+    }
+
+    /// <inheritdoc />
+    protected override async Task StartRealtimeListenersAsync(CancellationToken cancellationToken)
+    {
+        using var scope = ServiceProvider.CreateScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
+        await using var context = await factory.CreateDbContextAsync(cancellationToken);
+
+        var tenants = await context.Tenants.AsNoTracking()
+            .Where(t => t.IsActive)
+            .Select(t => new { t.Id, t.Slug, t.DisplayName })
+            .ToListAsync(cancellationToken);
+
+        foreach (var tenant in tenants)
+        {
+            try
+            {
+                using var tenantScope = ServiceProvider.CreateScope();
+
+                var tenantAccessor = tenantScope.ServiceProvider.GetRequiredService<ITenantAccessor>();
+                tenantAccessor.SetTenant(new TenantContext(tenant.Id, tenant.Slug, tenant.DisplayName, true));
+
+                var loader = tenantScope.ServiceProvider
+                    .GetRequiredService<IConnectorConfigurationLoader<NightscoutConnectorConfiguration>>();
+
+                NightscoutConnectorConfiguration config;
+                try
+                {
+                    config = await loader.LoadForTenantAsync(cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogWarning(
+                        ex,
+                        "Failed to load Nightscout config for tenant {TenantSlug}, skipping real-time listener",
+                        tenant.Slug);
+                    continue;
+                }
+
+                if (!config.Enabled || string.IsNullOrWhiteSpace(config.Url))
+                    continue;
+
+                var client = new SocketIO(new Uri(config.Url), new SocketIOOptions
+                {
+                    Reconnection = true,
+                    ReconnectionAttempts = int.MaxValue,
+                    ReconnectionDelayMax = 30_000,
+                });
+
+                var tenantId = tenant.Id;
+                foreach (var evt in new[] { "dataUpdate", "create", "update" })
+                    client.On(evt, _ => { RequestImmediateSync(tenantId); return Task.CompletedTask; });
+
+                try
+                {
+                    await client.ConnectAsync(cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogWarning(
+                        ex,
+                        "Failed to connect Socket.IO for tenant {TenantSlug} at {Url}, will rely on polling",
+                        tenant.Slug, config.Url);
+
+                    client.Dispose();
+                    continue;
+                }
+
+                _socketClients.TryAdd(tenantId, client);
+
+                Logger.LogInformation(
+                    "Started real-time listener for Nightscout tenant {TenantSlug}",
+                    tenant.Slug);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(
+                    ex,
+                    "Unexpected error starting real-time listener for tenant {TenantSlug}",
+                    tenant.Slug);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task StopRealtimeListenersAsync()
+    {
+        foreach (var (tenantId, client) in _socketClients)
+        {
+            try
+            {
+                await client.DisconnectAsync();
+                client.Dispose();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(
+                    ex,
+                    "Error disconnecting Socket.IO client for tenant {TenantId}",
+                    tenantId);
+            }
+        }
+
+        _socketClients.Clear();
+
+        Logger.LogInformation("Stopped all Nightscout real-time listeners");
     }
 }

--- a/src/API/Nocturne.API/Services/BackgroundServices/NocturneRemoteConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/NocturneRemoteConnectorBackgroundService.cs
@@ -1,17 +1,26 @@
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.EntityFrameworkCore;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
 using Nocturne.Connectors.NocturneRemote.Configurations;
 using Nocturne.Connectors.NocturneRemote.Services;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Infrastructure.Data;
+using System.Collections.Concurrent;
 
 namespace Nocturne.API.Services.BackgroundServices;
 
 /// <summary>
 /// Background service that periodically pulls data from a remote Nocturne V4 instance via
 /// <see cref="NocturneRemoteConnectorService"/>.
+/// Optionally connects to each tenant's Nocturne SignalR hub to trigger
+/// immediate syncs when upstream data changes.
 /// </summary>
 /// <seealso cref="ConnectorBackgroundService{TConfig}"/>
 public class NocturneRemoteConnectorBackgroundService : ConnectorBackgroundService<NocturneRemoteConnectorConfiguration>
 {
+    private readonly ConcurrentDictionary<Guid, HubConnection> _hubConnections = new();
+
     /// <param name="serviceProvider">Service provider used to create a DI scope per sync cycle.</param>
     /// <param name="logger">Logger instance for this background service.</param>
     public NocturneRemoteConnectorBackgroundService(
@@ -26,5 +35,124 @@ public class NocturneRemoteConnectorBackgroundService : ConnectorBackgroundServi
     {
         var connectorService = scopeProvider.GetRequiredService<NocturneRemoteConnectorService>();
         return await connectorService.SyncDataAsync(config, cancellationToken, since: null, progressReporter);
+    }
+
+    /// <inheritdoc />
+    protected override async Task StartRealtimeListenersAsync(CancellationToken cancellationToken)
+    {
+        using var scope = ServiceProvider.CreateScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
+        await using var context = await factory.CreateDbContextAsync(cancellationToken);
+
+        var tenants = await context.Tenants.AsNoTracking()
+            .Where(t => t.IsActive)
+            .Select(t => new { t.Id, t.Slug, t.DisplayName })
+            .ToListAsync(cancellationToken);
+
+        foreach (var tenant in tenants)
+        {
+            try
+            {
+                using var tenantScope = ServiceProvider.CreateScope();
+
+                var tenantAccessor = tenantScope.ServiceProvider.GetRequiredService<ITenantAccessor>();
+                tenantAccessor.SetTenant(new TenantContext(tenant.Id, tenant.Slug, tenant.DisplayName, true));
+
+                var loader = tenantScope.ServiceProvider
+                    .GetRequiredService<IConnectorConfigurationLoader<NocturneRemoteConnectorConfiguration>>();
+
+                NocturneRemoteConnectorConfiguration config;
+                try
+                {
+                    config = await loader.LoadForTenantAsync(cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogWarning(
+                        ex,
+                        "Failed to load NocturneRemote config for tenant {TenantSlug}, skipping real-time listener",
+                        tenant.Slug);
+                    continue;
+                }
+
+                if (!config.Enabled || string.IsNullOrWhiteSpace(config.Url))
+                    continue;
+
+                var hubUrl = $"{config.Url.TrimEnd('/')}/hubs/data";
+                var tenantId = tenant.Id;
+
+                var connection = new HubConnectionBuilder()
+                    .WithUrl(hubUrl, options =>
+                    {
+                        options.Headers.Add("Authorization", $"Bearer {config.Token}");
+                    })
+                    .WithAutomaticReconnect(new InfiniteRetryPolicy())
+                    .Build();
+
+                foreach (var evt in new[] { "dataUpdate", "create", "update" })
+                    connection.On<object>(evt, _ => RequestImmediateSync(tenantId));
+
+                try
+                {
+                    await connection.StartAsync(cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogWarning(
+                        ex,
+                        "Failed to connect SignalR for tenant {TenantSlug} at {Url}, will rely on polling",
+                        tenant.Slug, hubUrl);
+
+                    await connection.DisposeAsync();
+                    continue;
+                }
+
+                _hubConnections.TryAdd(tenantId, connection);
+
+                Logger.LogInformation(
+                    "Started real-time listener for NocturneRemote tenant {TenantSlug}",
+                    tenant.Slug);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(
+                    ex,
+                    "Unexpected error starting real-time listener for tenant {TenantSlug}",
+                    tenant.Slug);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task StopRealtimeListenersAsync()
+    {
+        foreach (var (tenantId, connection) in _hubConnections)
+        {
+            try
+            {
+                await connection.StopAsync();
+                await connection.DisposeAsync();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(
+                    ex,
+                    "Error disconnecting SignalR client for tenant {TenantId}",
+                    tenantId);
+            }
+        }
+
+        _hubConnections.Clear();
+
+        Logger.LogInformation("Stopped all NocturneRemote real-time listeners");
+    }
+
+    private sealed class InfiniteRetryPolicy : IRetryPolicy
+    {
+        public TimeSpan? NextRetryDelay(RetryContext retryContext)
+        {
+            var delay = Math.Min(1000 * Math.Pow(2, retryContext.PreviousRetryCount), 30_000);
+            return TimeSpan.FromMilliseconds(delay);
+        }
     }
 }

--- a/src/Core/Nocturne.Core.Contracts/Infrastructure/IDeduplicationService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Infrastructure/IDeduplicationService.cs
@@ -119,4 +119,12 @@ public interface IDeduplicationService
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>True if the job was cancelled, false if not found or already completed</returns>
     Task<bool> CancelJobAsync(Guid jobId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reconcile newly-created linked_records for the current tenant in bounded chunks,
+    /// merging duplicate canonical groups. Processes links with SysCreatedAt at or after
+    /// the tenant's watermark (minus a small overlap), advancing the watermark per batch.
+    /// Stops when caught up or after maxBatches. Returns groups merged and whether caught up.
+    /// </summary>
+    Task<ReconcileResult> ReconcileNewLinksAsync(int batchSize, int maxBatches, CancellationToken cancellationToken = default);
 }

--- a/src/Core/Nocturne.Core.Models/DeduplicationModels.cs
+++ b/src/Core/Nocturne.Core.Models/DeduplicationModels.cs
@@ -107,6 +107,12 @@ public record DeduplicationInput(Guid RecordId, long Mills, string DataSource, M
 public record DeduplicationBatchResult(int Processed, int GroupsCreated, int RecordsLinked, int DuplicateGroups);
 
 /// <summary>
+/// Result of a watermark-bounded reconcile pass: the number of duplicate groups merged
+/// and whether the pass caught up to the end of the newly-created links.
+/// </summary>
+public record ReconcileResult(int GroupsMerged, bool CaughtUp);
+
+/// <summary>
 /// Progress information for deduplication job
 /// </summary>
 public record DeduplicationProgress

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/DedupReconcileStateEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/DedupReconcileStateEntity.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Nocturne.Infrastructure.Data.Entities;
+
+/// <summary>
+/// PostgreSQL entity recording how far dedup reconciliation has processed for a tenant.
+/// One row per tenant, keyed on the ingestion time (<c>linked_records.sys_created_at</c>)
+/// of the last reconciled link.
+/// </summary>
+[Table("dedup_reconcile_state")]
+public class DedupReconcileStateEntity : ITenantScoped
+{
+    /// <summary>
+    /// The unique identifier of the tenant this state belongs to. Primary key — one row per tenant.
+    /// </summary>
+    [Key]
+    [Column("tenant_id")]
+    public Guid TenantId { get; set; }
+
+    /// <summary>
+    /// Ingestion time (<c>linked_records.sys_created_at</c>) of the last reconciled link.
+    /// Reconciliation resumes from records created after this point.
+    /// </summary>
+    [Column("last_reconciled_link_created_at")]
+    public DateTime LastReconciledLinkCreatedAt { get; set; }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260531103636_AddDedupReconcileState.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260531103636_AddDedupReconcileState.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260531103636_AddDedupReconcileState")]
+    partial class AddDedupReconcileState
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260531103636_AddDedupReconcileState.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260531103636_AddDedupReconcileState.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDedupReconcileState : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "dedup_reconcile_state",
+                columns: table => new
+                {
+                    tenant_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    last_reconciled_link_created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_dedup_reconcile_state", x => x.tenant_id);
+                    table.ForeignKey(
+                        name: "FK_dedup_reconcile_state_tenants_tenant_id",
+                        column: x => x.tenant_id,
+                        principalTable: "tenants",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.Sql("ALTER TABLE dedup_reconcile_state ENABLE ROW LEVEL SECURITY;");
+            migrationBuilder.Sql("ALTER TABLE dedup_reconcile_state FORCE ROW LEVEL SECURITY;");
+            migrationBuilder.Sql(
+                """
+                CREATE POLICY tenant_isolation ON dedup_reconcile_state
+                    USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid)
+                    WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid);
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP POLICY IF EXISTS tenant_isolation ON dedup_reconcile_state;");
+            migrationBuilder.Sql("ALTER TABLE dedup_reconcile_state DISABLE ROW LEVEL SECURITY;");
+            migrationBuilder.DropTable(
+                name: "dedup_reconcile_state");
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -207,6 +207,11 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
     /// </summary>
     public DbSet<LinkedRecordEntity> LinkedRecords { get; set; }
 
+    /// <summary>
+    /// Gets or sets the DedupReconcileState table tracking per-tenant reconciliation watermarks
+    /// </summary>
+    public DbSet<DedupReconcileStateEntity> DedupReconcileState { get; set; }
+
     // Connector Configuration entities
 
     /// <summary>
@@ -2563,6 +2568,12 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
         {
             entity.Property(e => e.IsPrimary).HasDefaultValue(false);
             entity.Property(e => e.SysCreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
+        });
+
+        // Configure DedupReconcileStateEntity — one row per tenant, PK on tenant id.
+        modelBuilder.Entity<DedupReconcileStateEntity>(entity =>
+        {
+            entity.HasKey(e => e.TenantId);
         });
 
         // Configure InAppNotification entity

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
@@ -279,6 +279,13 @@ public class CarbIntakeRepository : ICarbIntakeRepository
             query = query.Where(e => e.Timestamp >= from.Value);
         if (to.HasValue)
             query = query.Where(e => e.Timestamp <= to.Value);
+
+        // Exclude non-primary duplicates from cross-connector deduplication so the
+        // count matches the rows GetAsync returns (otherwise pagination totals are
+        // inflated by duplicate meals imported from multiple connectors).
+        query = query.Where(b => !ctx.LinkedRecords
+            .Any(lr => lr.RecordType == "carbintake" && !lr.IsPrimary && lr.RecordId == b.Id));
+
         return await query.CountAsync(ct);
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
@@ -32,23 +32,6 @@ public class DeduplicationService : IDeduplicationService
     private static readonly TimeSpan ReconcileOverlap = TimeSpan.FromMinutes(2);
 
     /// <summary>
-    /// Record types that participate in deduplication, in the order
-    /// <see cref="DeduplicateAllAsync"/> processes them.
-    /// </summary>
-    private static readonly RecordType[] DedupableTypes =
-    [
-        RecordType.SensorGlucose,
-        RecordType.Bolus,
-        RecordType.CarbIntake,
-        RecordType.BGCheck,
-        RecordType.DeviceEvent,
-        RecordType.Note,
-        RecordType.BolusCalculation,
-        RecordType.TempBasal,
-        RecordType.StateSpan
-    ];
-
-    /// <summary>
     /// A record's match criteria paired with its soft-deleted status, keyed by record id
     /// when returned from <see cref="LoadRecordInfoAsync"/>.
     /// </summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
@@ -1599,4 +1599,43 @@ public class DeduplicationService : IDeduplicationService
             .OrderByDescending(GetBasalTypePriority)
             .First();
     }
+
+    /// <summary>
+    /// Returns the current tenant's reconciliation watermark — the ingestion time of the last
+    /// reconciled link — or <see cref="DateTime.MinValue"/> if reconciliation has never run.
+    /// </summary>
+    internal async Task<DateTime> GetWatermarkAsync(CancellationToken ct)
+    {
+        var state = await _context.DedupReconcileState
+            .Where(s => s.TenantId == _context.TenantId)
+            .FirstOrDefaultAsync(ct);
+
+        return state?.LastReconciledLinkCreatedAt ?? DateTime.MinValue;
+    }
+
+    /// <summary>
+    /// Upserts the current tenant's reconciliation watermark, inserting a row if none exists
+    /// or updating the existing one otherwise.
+    /// </summary>
+    internal async Task SetWatermarkAsync(DateTime value, CancellationToken ct)
+    {
+        var state = await _context.DedupReconcileState
+            .Where(s => s.TenantId == _context.TenantId)
+            .FirstOrDefaultAsync(ct);
+
+        if (state is null)
+        {
+            _context.DedupReconcileState.Add(new DedupReconcileStateEntity
+            {
+                TenantId = _context.TenantId,
+                LastReconciledLinkCreatedAt = value
+            });
+        }
+        else
+        {
+            state.LastReconciledLinkCreatedAt = value;
+        }
+
+        await _context.SaveChangesAsync(ct);
+    }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
@@ -735,7 +735,9 @@ public class DeduplicationService : IDeduplicationService
         // Re-read from a little before the watermark so links whose SysCreatedAt straddled the
         // previous batch's boundary aren't missed. Re-processing is idempotent: once a region is
         // merged, MergeDuplicateGroupsAsync finds nothing more to collapse there.
-        var cutoff = watermark - ReconcileOverlap;
+        // A fresh tenant (deploy-day backfill) has no watermark yet, so it defaults to
+        // DateTime.MinValue — subtracting the overlap would underflow, so skip it and start at MinValue.
+        var cutoff = watermark == DateTime.MinValue ? DateTime.MinValue : watermark - ReconcileOverlap;
 
         var merged = 0;
         var caughtUp = false;
@@ -760,8 +762,18 @@ public class DeduplicationService : IDeduplicationService
             // and merge each type's candidate canonical groups.
             foreach (var group in batch.GroupBy(l => l.RecordType))
             {
-                var type = Enum.Parse<RecordType>(group.Key, ignoreCase: true);
+                // RecordType is a free-form string column whose surface is broader than the enum.
+                // A legacy/typo'd value must not throw and block all further batches for this tenant.
+                if (!Enum.TryParse<RecordType>(group.Key, ignoreCase: true, out var type))
+                {
+                    _logger.LogWarning(
+                        "Skipping linked_records group with unknown RecordType '{RecordType}' during reconcile",
+                        group.Key);
+                    continue;
+                }
+
                 var candidateCanonicalIds = group.Select(l => l.CanonicalId).ToHashSet();
+                // GroupsMerged is the reduction in group count (k canonicals -> 1 == k-1), matching MergeDuplicateGroupsAsync.
                 merged += await MergeDuplicateGroupsAsync(type, candidateCanonicalIds, cancellationToken);
             }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
@@ -612,6 +612,12 @@ public class DeduplicationService : IDeduplicationService
     /// underlying record is soft-deleted. Soft-deleted rows are included via
     /// <c>IgnoreQueryFilters</c>; record types without a <c>DeletedAt</c> column report
     /// <see cref="RecordInfo.IsDeleted"/> as <see langword="false"/>.
+    /// <para>
+    /// The global query filter combines tenant scoping (<c>TenantId == this.TenantId</c>) with
+    /// the soft-delete predicate (<c>DeletedAt == null</c>) and <c>IgnoreQueryFilters</c> drops
+    /// both. To bypass only the soft-delete filter, each query re-applies the tenant predicate
+    /// (<c>e.TenantId == _context.TenantId</c>) explicitly so cross-tenant rows can never leak in.
+    /// </para>
     /// </summary>
     private async Task<Dictionary<Guid, RecordInfo>> LoadRecordInfoAsync(
         RecordType recordType, HashSet<Guid> ids, CancellationToken ct)
@@ -624,56 +630,56 @@ public class DeduplicationService : IDeduplicationService
             case RecordType.SensorGlucose:
             {
                 var records = await _context.SensorGlucose.IgnoreQueryFilters()
-                    .Where(e => ids.Contains(e.Id)).ToListAsync(ct);
+                    .Where(e => e.TenantId == _context.TenantId && ids.Contains(e.Id)).ToListAsync(ct);
                 return records.ToDictionary(e => e.Id,
                     e => new RecordInfo(BuildCriteria(e), e.DeletedAt != null));
             }
             case RecordType.Bolus:
             {
                 var records = await _context.Boluses.IgnoreQueryFilters()
-                    .Where(b => ids.Contains(b.Id)).ToListAsync(ct);
+                    .Where(b => b.TenantId == _context.TenantId && ids.Contains(b.Id)).ToListAsync(ct);
                 return records.ToDictionary(b => b.Id,
                     b => new RecordInfo(BuildCriteria(b), b.DeletedAt != null));
             }
             case RecordType.CarbIntake:
             {
                 var records = await _context.CarbIntakes.IgnoreQueryFilters()
-                    .Where(c => ids.Contains(c.Id)).ToListAsync(ct);
+                    .Where(c => c.TenantId == _context.TenantId && ids.Contains(c.Id)).ToListAsync(ct);
                 return records.ToDictionary(c => c.Id,
                     c => new RecordInfo(BuildCriteria(c), c.DeletedAt != null));
             }
             case RecordType.BGCheck:
             {
                 var records = await _context.BGChecks.IgnoreQueryFilters()
-                    .Where(bg => ids.Contains(bg.Id)).ToListAsync(ct);
+                    .Where(bg => bg.TenantId == _context.TenantId && ids.Contains(bg.Id)).ToListAsync(ct);
                 return records.ToDictionary(bg => bg.Id,
                     bg => new RecordInfo(BuildCriteria(bg), bg.DeletedAt != null));
             }
             case RecordType.DeviceEvent:
             {
                 var records = await _context.DeviceEvents.IgnoreQueryFilters()
-                    .Where(d => ids.Contains(d.Id)).ToListAsync(ct);
+                    .Where(d => d.TenantId == _context.TenantId && ids.Contains(d.Id)).ToListAsync(ct);
                 return records.ToDictionary(d => d.Id,
                     d => new RecordInfo(BuildCriteria(d), d.DeletedAt != null));
             }
             case RecordType.Note:
             {
                 var records = await _context.Notes.IgnoreQueryFilters()
-                    .Where(n => ids.Contains(n.Id)).ToListAsync(ct);
+                    .Where(n => n.TenantId == _context.TenantId && ids.Contains(n.Id)).ToListAsync(ct);
                 return records.ToDictionary(n => n.Id,
                     n => new RecordInfo(BuildNoteCriteria(), n.DeletedAt != null));
             }
             case RecordType.BolusCalculation:
             {
                 var records = await _context.BolusCalculations.IgnoreQueryFilters()
-                    .Where(bc => ids.Contains(bc.Id)).ToListAsync(ct);
+                    .Where(bc => bc.TenantId == _context.TenantId && ids.Contains(bc.Id)).ToListAsync(ct);
                 return records.ToDictionary(bc => bc.Id,
                     bc => new RecordInfo(BuildCriteria(bc), bc.DeletedAt != null));
             }
             case RecordType.TempBasal:
             {
                 var records = await _context.TempBasals.IgnoreQueryFilters()
-                    .Where(t => ids.Contains(t.Id)).ToListAsync(ct);
+                    .Where(t => t.TenantId == _context.TenantId && ids.Contains(t.Id)).ToListAsync(ct);
                 return records.ToDictionary(t => t.Id,
                     t => new RecordInfo(BuildCriteria(t), t.DeletedAt != null));
             }
@@ -681,7 +687,7 @@ public class DeduplicationService : IDeduplicationService
             {
                 // StateSpanEntity has no DeletedAt column, so IsDeleted is always false.
                 var records = await _context.StateSpans.IgnoreQueryFilters()
-                    .Where(s => ids.Contains(s.Id)).ToListAsync(ct);
+                    .Where(s => s.TenantId == _context.TenantId && ids.Contains(s.Id)).ToListAsync(ct);
                 return records.ToDictionary(s => s.Id,
                     s => new RecordInfo(BuildCriteria(s), false));
             }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
@@ -25,6 +25,13 @@ public class DeduplicationService : IDeduplicationService
     private static readonly long MatchingWindowMillis = (long)MatchingWindow.TotalMilliseconds;
 
     /// <summary>
+    /// How far before the watermark each reconcile chunk re-reads. Covers links whose
+    /// SysCreatedAt straddles a previous batch boundary; re-processing them is idempotent
+    /// because <see cref="MergeDuplicateGroupsAsync"/> is a no-op once a region is merged.
+    /// </summary>
+    private static readonly TimeSpan ReconcileOverlap = TimeSpan.FromMinutes(2);
+
+    /// <summary>
     /// Record types that participate in deduplication, in the order
     /// <see cref="DeduplicateAllAsync"/> processes them.
     /// </summary>
@@ -578,30 +585,37 @@ public class DeduplicationService : IDeduplicationService
     {
         var recordTypeStr = recordType.ToString().ToLowerInvariant();
 
-        // 1. Load primary linked_records for this type, ordered by source timestamp.
-        var primaries = await _context.LinkedRecords
-            .Where(lr => lr.RecordType == recordTypeStr && lr.IsPrimary)
-            .OrderBy(lr => lr.SourceTimestamp)
-            .ToListAsync(ct);
-
-        // When restricted to candidates, keep only candidate groups plus their event-window
-        // neighbours (other primaries within MatchingWindowMillis), so merges that involve a
-        // candidate are still discovered.
-        if (candidateCanonicalIds != null)
+        List<LinkedRecordEntity> primaries;
+        if (candidateCanonicalIds == null)
         {
-            var relevant = new HashSet<Guid>();
-            foreach (var p in primaries)
-            {
-                if (!candidateCanonicalIds.Contains(p.CanonicalId))
-                    continue;
-                relevant.Add(p.CanonicalId);
-                foreach (var other in primaries)
-                {
-                    if (Math.Abs(other.SourceTimestamp - p.SourceTimestamp) <= MatchingWindowMillis)
-                        relevant.Add(other.CanonicalId);
-                }
-            }
-            primaries = primaries.Where(p => relevant.Contains(p.CanonicalId)).ToList();
+            // Full reconcile: load every primary of this type, ordered by source timestamp.
+            primaries = await _context.LinkedRecords
+                .Where(lr => lr.RecordType == recordTypeStr && lr.IsPrimary)
+                .OrderBy(lr => lr.SourceTimestamp)
+                .ToListAsync(ct);
+        }
+        else
+        {
+            // Candidate-bounded reconcile: never load all primaries. Load only the candidate
+            // canonicals' primary links to learn their event timestamps, then DB-bound the
+            // neighbour query to [minCandidateTs - window, maxCandidateTs + window]. This keeps
+            // the candidate path O(candidates + window-slice) rather than O(all primaries).
+            var candidatePrimaries = await _context.LinkedRecords
+                .Where(lr => lr.RecordType == recordTypeStr && lr.IsPrimary
+                             && candidateCanonicalIds.Contains(lr.CanonicalId))
+                .ToListAsync(ct);
+
+            if (candidatePrimaries.Count == 0)
+                return 0;
+
+            var minTs = candidatePrimaries.Min(p => p.SourceTimestamp) - MatchingWindowMillis;
+            var maxTs = candidatePrimaries.Max(p => p.SourceTimestamp) + MatchingWindowMillis;
+
+            primaries = await _context.LinkedRecords
+                .Where(lr => lr.RecordType == recordTypeStr && lr.IsPrimary
+                             && lr.SourceTimestamp >= minTs && lr.SourceTimestamp <= maxTs)
+                .OrderBy(lr => lr.SourceTimestamp)
+                .ToListAsync(ct);
         }
 
         if (primaries.Count < 2)
@@ -708,6 +722,72 @@ public class DeduplicationService : IDeduplicationService
         }
 
         return merged;
+    }
+
+    /// <inheritdoc />
+    public async Task<ReconcileResult> ReconcileNewLinksAsync(
+        int batchSize,
+        int maxBatches,
+        CancellationToken cancellationToken = default)
+    {
+        var watermark = await GetWatermarkAsync(cancellationToken);
+
+        // Re-read from a little before the watermark so links whose SysCreatedAt straddled the
+        // previous batch's boundary aren't missed. Re-processing is idempotent: once a region is
+        // merged, MergeDuplicateGroupsAsync finds nothing more to collapse there.
+        var cutoff = watermark - ReconcileOverlap;
+
+        var merged = 0;
+        var caughtUp = false;
+        var previousMaxCreated = DateTime.MinValue;
+
+        for (var batchNo = 0; batchNo < maxBatches; batchNo++)
+        {
+            // Tenant-scoped automatically via the global query filter.
+            var batch = await _context.LinkedRecords
+                .Where(lr => lr.SysCreatedAt >= cutoff)
+                .OrderBy(lr => lr.SysCreatedAt)
+                .Take(batchSize)
+                .ToListAsync(cancellationToken);
+
+            if (batch.Count == 0)
+            {
+                caughtUp = true;
+                break;
+            }
+
+            // Reconcile per record type: parse the lowercased RecordType string back to the enum
+            // and merge each type's candidate canonical groups.
+            foreach (var group in batch.GroupBy(l => l.RecordType))
+            {
+                var type = Enum.Parse<RecordType>(group.Key, ignoreCase: true);
+                var candidateCanonicalIds = group.Select(l => l.CanonicalId).ToHashSet();
+                merged += await MergeDuplicateGroupsAsync(type, candidateCanonicalIds, cancellationToken);
+            }
+
+            var maxCreated = batch.Max(l => l.SysCreatedAt);
+            await SetWatermarkAsync(maxCreated, cancellationToken);
+
+            // Forward-progress guard: if the batch's max SysCreatedAt did not advance past the
+            // previous batch (e.g. many links share the same instant and a full batch sits on one
+            // boundary), re-reading from cutoff would loop forever — so stop here.
+            if (batchNo > 0 && maxCreated <= previousMaxCreated)
+            {
+                caughtUp = true;
+                break;
+            }
+            previousMaxCreated = maxCreated;
+            cutoff = maxCreated - ReconcileOverlap;
+
+            // A partial batch means we've drained everything at/after the cutoff.
+            if (batch.Count < batchSize)
+            {
+                caughtUp = true;
+                break;
+            }
+        }
+
+        return new ReconcileResult(merged, caughtUp);
     }
 
     private async Task<bool> RecordExistsAsync(string recordType, Guid recordId, CancellationToken ct)
@@ -1619,12 +1699,21 @@ public class DeduplicationService : IDeduplicationService
     /// </summary>
     internal async Task SetWatermarkAsync(DateTime value, CancellationToken ct)
     {
+        // Npgsql requires Kind=Utc to persist a timestamptz; SQLite tests won't catch a bad caller.
+        value = value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+        };
+
         var state = await _context.DedupReconcileState
             .Where(s => s.TenantId == _context.TenantId)
             .FirstOrDefaultAsync(ct);
 
         if (state is null)
         {
+            // single-threaded per tenant; PK guards accidental concurrent insert
             _context.DedupReconcileState.Add(new DedupReconcileStateEntity
             {
                 TenantId = _context.TenantId,

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
@@ -554,6 +554,162 @@ public class DeduplicationService : IDeduplicationService
             DuplicateGroups: duplicateGroups);
     }
 
+    /// <summary>
+    /// Collapses duplicate canonical groups for a record type within the current tenant.
+    /// Two groups merge when their primary records fall within <see cref="MatchingWindowMillis"/>
+    /// of each other and their <see cref="MatchCriteria"/> match; merging is transitive
+    /// (union-find) and source-agnostic, mirroring insert-time <see cref="DeduplicateBatchAsync"/>
+    /// semantics. For each merged super-group the surviving primary is the earliest-timestamp
+    /// non-deleted record (falling back to earliest-overall when every record is soft-deleted);
+    /// all linked rows are re-pointed to the survivor's canonical id and <c>IsPrimary</c> is set
+    /// on exactly the survivor.
+    /// </summary>
+    /// <param name="recordType">The record type whose canonical groups are reconciled.</param>
+    /// <param name="candidateCanonicalIds">
+    /// When non-null, only canonical groups in this set plus their event-window neighbours are
+    /// considered; when null, all primaries of the type are considered.
+    /// </param>
+    /// <param name="ct">A token to cancel the operation.</param>
+    /// <returns>The number of duplicate groups collapsed (merges that reduced group count).</returns>
+    internal async Task<int> MergeDuplicateGroupsAsync(
+        RecordType recordType,
+        IReadOnlySet<Guid>? candidateCanonicalIds,
+        CancellationToken ct)
+    {
+        var recordTypeStr = recordType.ToString().ToLowerInvariant();
+
+        // 1. Load primary linked_records for this type, ordered by source timestamp.
+        var primaries = await _context.LinkedRecords
+            .Where(lr => lr.RecordType == recordTypeStr && lr.IsPrimary)
+            .OrderBy(lr => lr.SourceTimestamp)
+            .ToListAsync(ct);
+
+        // When restricted to candidates, keep only candidate groups plus their event-window
+        // neighbours (other primaries within MatchingWindowMillis), so merges that involve a
+        // candidate are still discovered.
+        if (candidateCanonicalIds != null)
+        {
+            var relevant = new HashSet<Guid>();
+            foreach (var p in primaries)
+            {
+                if (!candidateCanonicalIds.Contains(p.CanonicalId))
+                    continue;
+                relevant.Add(p.CanonicalId);
+                foreach (var other in primaries)
+                {
+                    if (Math.Abs(other.SourceTimestamp - p.SourceTimestamp) <= MatchingWindowMillis)
+                        relevant.Add(other.CanonicalId);
+                }
+            }
+            primaries = primaries.Where(p => relevant.Contains(p.CanonicalId)).ToList();
+        }
+
+        if (primaries.Count < 2)
+            return 0;
+
+        // 2. Load criteria + deleted status for the primary record ids.
+        var primaryIds = primaries.Select(p => p.RecordId).ToHashSet();
+        var info = await LoadRecordInfoAsync(recordType, primaryIds, ct);
+
+        // 3. Sorted sliding-window union-find over primaries by canonical id.
+        var parent = new Dictionary<Guid, Guid>();
+        Guid Find(Guid x)
+        {
+            if (!parent.TryGetValue(x, out var p) || p.Equals(x))
+            {
+                parent[x] = x;
+                return x;
+            }
+            var root = Find(p);
+            parent[x] = root;
+            return root;
+        }
+        void Union(Guid a, Guid b)
+        {
+            var ra = Find(a);
+            var rb = Find(b);
+            if (!ra.Equals(rb))
+                parent[ra] = rb;
+        }
+
+        foreach (var p in primaries)
+            parent[p.CanonicalId] = p.CanonicalId;
+
+        for (int i = 0; i < primaries.Count; i++)
+        {
+            if (!info.TryGetValue(primaries[i].RecordId, out var infoI))
+                continue;
+            for (int j = i + 1; j < primaries.Count
+                 && primaries[j].SourceTimestamp - primaries[i].SourceTimestamp <= MatchingWindowMillis; j++)
+            {
+                if (!info.TryGetValue(primaries[j].RecordId, out var infoJ))
+                    continue;
+                if (CriteriaMatch(recordType, infoI.Criteria, infoJ.Criteria))
+                    Union(primaries[i].CanonicalId, primaries[j].CanonicalId);
+            }
+        }
+
+        // 4. Group canonical ids by union root; only roots spanning >1 distinct canonical merge.
+        var groupsByRoot = new Dictionary<Guid, HashSet<Guid>>();
+        foreach (var p in primaries)
+        {
+            var root = Find(p.CanonicalId);
+            if (!groupsByRoot.TryGetValue(root, out var set))
+            {
+                set = new HashSet<Guid>();
+                groupsByRoot[root] = set;
+            }
+            set.Add(p.CanonicalId);
+        }
+
+        var merged = 0;
+        foreach (var canonicals in groupsByRoot.Values)
+        {
+            if (canonicals.Count < 2)
+                continue;
+
+            // Load every linked row in the merged canonicals (soft-deleted records included).
+            var rows = await _context.LinkedRecords
+                .Where(lr => lr.RecordType == recordTypeStr && canonicals.Contains(lr.CanonicalId))
+                .ToListAsync(ct);
+            if (rows.Count == 0)
+                continue;
+
+            // Load deleted status for all record ids in the super-group.
+            var rowIds = rows.Select(r => r.RecordId).ToHashSet();
+            var rowInfo = await LoadRecordInfoAsync(recordType, rowIds, ct);
+
+            // Survivor = earliest-timestamp non-deleted record; fall back to earliest-overall
+            // only if every record in the group is soft-deleted.
+            bool IsDeleted(LinkedRecordEntity r) =>
+                rowInfo.TryGetValue(r.RecordId, out var ri) && ri.IsDeleted;
+
+            var survivor = rows
+                .Where(r => !IsDeleted(r))
+                .OrderBy(r => r.SourceTimestamp)
+                .FirstOrDefault()
+                ?? rows.OrderBy(r => r.SourceTimestamp).First();
+
+            // Re-point every row to the survivor's canonical id and fix the IsPrimary invariant.
+            foreach (var r in rows)
+            {
+                r.CanonicalId = survivor.CanonicalId;
+                r.IsPrimary = ReferenceEquals(r, survivor);
+            }
+
+            // Collapsing N canonicals into 1 removes (N-1) groups.
+            merged += canonicals.Count - 1;
+        }
+
+        if (merged > 0)
+        {
+            await _context.SaveChangesAsync(ct);
+            _context.ChangeTracker.Clear();
+        }
+
+        return merged;
+    }
+
     private async Task<bool> RecordExistsAsync(string recordType, Guid recordId, CancellationToken ct)
     {
         return recordType switch

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.Infrastructure;
 using Nocturne.Core.Models;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Mappers;
 
 namespace Nocturne.Infrastructure.Data.Services;
@@ -22,6 +23,29 @@ public class DeduplicationService : IDeduplicationService
 
     private static readonly TimeSpan MatchingWindow = TimeSpan.FromSeconds(30);
     private static readonly long MatchingWindowMillis = (long)MatchingWindow.TotalMilliseconds;
+
+    /// <summary>
+    /// Record types that participate in deduplication, in the order
+    /// <see cref="DeduplicateAllAsync"/> processes them.
+    /// </summary>
+    private static readonly RecordType[] DedupableTypes =
+    [
+        RecordType.SensorGlucose,
+        RecordType.Bolus,
+        RecordType.CarbIntake,
+        RecordType.BGCheck,
+        RecordType.DeviceEvent,
+        RecordType.Note,
+        RecordType.BolusCalculation,
+        RecordType.TempBasal,
+        RecordType.StateSpan
+    ];
+
+    /// <summary>
+    /// A record's match criteria paired with its soft-deleted status, keyed by record id
+    /// when returned from <see cref="LoadRecordInfoAsync"/>.
+    /// </summary>
+    internal sealed record RecordInfo(MatchCriteria Criteria, bool IsDeleted);
 
     private static readonly ConcurrentDictionary<Guid, DeduplicationJobStatus> _runningJobs = new();
     private static readonly ConcurrentDictionary<Guid, CancellationTokenSource> _jobCancellations = new();
@@ -546,6 +570,134 @@ public class DeduplicationService : IDeduplicationService
         };
     }
 
+    // --- Per-type MatchCriteria builders ---
+    // Single source of truth for each record type's MatchCriteria. Both the inline
+    // dedup pass (DeduplicateAllAsync) and the reconciliation loader (LoadRecordInfoAsync)
+    // call these so the criteria definitions cannot drift between the two code paths.
+
+    private static MatchCriteria BuildCriteria(SensorGlucoseEntity e) =>
+        new() { GlucoseValue = e.Mgdl, GlucoseTolerance = 5.0 };
+
+    private static MatchCriteria BuildCriteria(BolusEntity b) =>
+        new() { Insulin = b.Insulin, InsulinTolerance = 0.05 };
+
+    private static MatchCriteria BuildCriteria(CarbIntakeEntity c) =>
+        new() { Carbs = c.Carbs, CarbsTolerance = 1.0 };
+
+    private static MatchCriteria BuildCriteria(BGCheckEntity bg) =>
+        new() { GlucoseValue = bg.Glucose, GlucoseTolerance = 5.0 };
+
+    private static MatchCriteria BuildCriteria(DeviceEventEntity d) =>
+        new() { EventType = d.EventType };
+
+    private static MatchCriteria BuildNoteCriteria() =>
+        new();
+
+    private static MatchCriteria BuildCriteria(BolusCalculationEntity bc) =>
+        new() { Carbs = bc.CarbInput ?? 0, CarbsTolerance = 1.0 };
+
+    private static MatchCriteria BuildCriteria(TempBasalEntity t) =>
+        new() { Rate = t.Rate, RateTolerance = 0.05 };
+
+    private static MatchCriteria BuildCriteria(StateSpanEntity s) =>
+        new()
+        {
+            Category = Enum.TryParse<StateSpanCategory>(s.Category, ignoreCase: true, out var cat)
+                ? cat : null,
+            State = s.State
+        };
+
+    /// <summary>
+    /// Loads, for each requested record id, its <see cref="MatchCriteria"/> and whether the
+    /// underlying record is soft-deleted. Soft-deleted rows are included via
+    /// <c>IgnoreQueryFilters</c>; record types without a <c>DeletedAt</c> column report
+    /// <see cref="RecordInfo.IsDeleted"/> as <see langword="false"/>.
+    /// </summary>
+    private async Task<Dictionary<Guid, RecordInfo>> LoadRecordInfoAsync(
+        RecordType recordType, HashSet<Guid> ids, CancellationToken ct)
+    {
+        if (ids.Count == 0)
+            return new Dictionary<Guid, RecordInfo>();
+
+        switch (recordType)
+        {
+            case RecordType.SensorGlucose:
+            {
+                var records = await _context.SensorGlucose.IgnoreQueryFilters()
+                    .Where(e => ids.Contains(e.Id)).ToListAsync(ct);
+                return records.ToDictionary(e => e.Id,
+                    e => new RecordInfo(BuildCriteria(e), e.DeletedAt != null));
+            }
+            case RecordType.Bolus:
+            {
+                var records = await _context.Boluses.IgnoreQueryFilters()
+                    .Where(b => ids.Contains(b.Id)).ToListAsync(ct);
+                return records.ToDictionary(b => b.Id,
+                    b => new RecordInfo(BuildCriteria(b), b.DeletedAt != null));
+            }
+            case RecordType.CarbIntake:
+            {
+                var records = await _context.CarbIntakes.IgnoreQueryFilters()
+                    .Where(c => ids.Contains(c.Id)).ToListAsync(ct);
+                return records.ToDictionary(c => c.Id,
+                    c => new RecordInfo(BuildCriteria(c), c.DeletedAt != null));
+            }
+            case RecordType.BGCheck:
+            {
+                var records = await _context.BGChecks.IgnoreQueryFilters()
+                    .Where(bg => ids.Contains(bg.Id)).ToListAsync(ct);
+                return records.ToDictionary(bg => bg.Id,
+                    bg => new RecordInfo(BuildCriteria(bg), bg.DeletedAt != null));
+            }
+            case RecordType.DeviceEvent:
+            {
+                var records = await _context.DeviceEvents.IgnoreQueryFilters()
+                    .Where(d => ids.Contains(d.Id)).ToListAsync(ct);
+                return records.ToDictionary(d => d.Id,
+                    d => new RecordInfo(BuildCriteria(d), d.DeletedAt != null));
+            }
+            case RecordType.Note:
+            {
+                var records = await _context.Notes.IgnoreQueryFilters()
+                    .Where(n => ids.Contains(n.Id)).ToListAsync(ct);
+                return records.ToDictionary(n => n.Id,
+                    n => new RecordInfo(BuildNoteCriteria(), n.DeletedAt != null));
+            }
+            case RecordType.BolusCalculation:
+            {
+                var records = await _context.BolusCalculations.IgnoreQueryFilters()
+                    .Where(bc => ids.Contains(bc.Id)).ToListAsync(ct);
+                return records.ToDictionary(bc => bc.Id,
+                    bc => new RecordInfo(BuildCriteria(bc), bc.DeletedAt != null));
+            }
+            case RecordType.TempBasal:
+            {
+                var records = await _context.TempBasals.IgnoreQueryFilters()
+                    .Where(t => ids.Contains(t.Id)).ToListAsync(ct);
+                return records.ToDictionary(t => t.Id,
+                    t => new RecordInfo(BuildCriteria(t), t.DeletedAt != null));
+            }
+            case RecordType.StateSpan:
+            {
+                // StateSpanEntity has no DeletedAt column, so IsDeleted is always false.
+                var records = await _context.StateSpans.IgnoreQueryFilters()
+                    .Where(s => ids.Contains(s.Id)).ToListAsync(ct);
+                return records.ToDictionary(s => s.Id,
+                    s => new RecordInfo(BuildCriteria(s), false));
+            }
+            default:
+                return new Dictionary<Guid, RecordInfo>();
+        }
+    }
+
+    /// <summary>
+    /// Internal test seam over <see cref="LoadRecordInfoAsync"/>. Exposed to the
+    /// test assembly via <c>InternalsVisibleTo</c>; not part of the public API.
+    /// </summary>
+    internal Task<Dictionary<Guid, RecordInfo>> LoadRecordInfoForTestAsync(
+        RecordType recordType, HashSet<Guid> ids, CancellationToken ct = default)
+        => LoadRecordInfoAsync(recordType, ids, ct);
+
     private async Task<Func<Guid, MatchCriteria, bool>> LoadMatcherAsync(
         RecordType recordType, HashSet<Guid> ids, CancellationToken ct)
     {
@@ -815,7 +967,7 @@ public class DeduplicationService : IDeduplicationService
                     e.Id,
                     new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
                     e.DataSource ?? "unknown",
-                    new MatchCriteria { GlucoseValue = e.Mgdl, GlucoseTolerance = 5.0 }),
+                    BuildCriteria(e)),
                 "SensorGlucose", totalRecords, processed, progress, cancellationToken);
             processed += sensorGlucoseResult.processed;
             groupsCreated += sensorGlucoseResult.groups;
@@ -830,7 +982,7 @@ public class DeduplicationService : IDeduplicationService
                     b.Id,
                     new DateTimeOffset(b.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
                     b.DataSource ?? "unknown",
-                    new MatchCriteria { Insulin = b.Insulin, InsulinTolerance = 0.05 }),
+                    BuildCriteria(b)),
                 "Boluses", totalRecords, processed, progress, cancellationToken);
             processed += bolusResult.processed;
             groupsCreated += bolusResult.groups;
@@ -845,7 +997,7 @@ public class DeduplicationService : IDeduplicationService
                     c.Id,
                     new DateTimeOffset(c.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
                     c.DataSource ?? "unknown",
-                    new MatchCriteria { Carbs = c.Carbs, CarbsTolerance = 1.0 }),
+                    BuildCriteria(c)),
                 "CarbIntakes", totalRecords, processed, progress, cancellationToken);
             processed += carbIntakeResult.processed;
             groupsCreated += carbIntakeResult.groups;
@@ -860,7 +1012,7 @@ public class DeduplicationService : IDeduplicationService
                     bg.Id,
                     new DateTimeOffset(bg.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
                     bg.DataSource ?? "unknown",
-                    new MatchCriteria { GlucoseValue = bg.Glucose, GlucoseTolerance = 5.0 }),
+                    BuildCriteria(bg)),
                 "BGChecks", totalRecords, processed, progress, cancellationToken);
             processed += bgCheckResult.processed;
             groupsCreated += bgCheckResult.groups;
@@ -875,7 +1027,7 @@ public class DeduplicationService : IDeduplicationService
                     d.Id,
                     new DateTimeOffset(d.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
                     d.DataSource ?? "unknown",
-                    new MatchCriteria { EventType = d.EventType }),
+                    BuildCriteria(d)),
                 "DeviceEvents", totalRecords, processed, progress, cancellationToken);
             processed += deviceEventResult.processed;
             groupsCreated += deviceEventResult.groups;
@@ -890,7 +1042,7 @@ public class DeduplicationService : IDeduplicationService
                     n.Id,
                     new DateTimeOffset(n.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
                     n.DataSource ?? "unknown",
-                    new MatchCriteria()),
+                    BuildNoteCriteria()),
                 "Notes", totalRecords, processed, progress, cancellationToken);
             processed += noteResult.processed;
             groupsCreated += noteResult.groups;
@@ -905,7 +1057,7 @@ public class DeduplicationService : IDeduplicationService
                     bc.Id,
                     new DateTimeOffset(bc.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
                     bc.DataSource ?? "unknown",
-                    new MatchCriteria { Carbs = bc.CarbInput ?? 0, CarbsTolerance = 1.0 }),
+                    BuildCriteria(bc)),
                 "BolusCalculations", totalRecords, processed, progress, cancellationToken);
             processed += bolusCalcResult.processed;
             groupsCreated += bolusCalcResult.groups;
@@ -920,7 +1072,7 @@ public class DeduplicationService : IDeduplicationService
                     t.Id,
                     new DateTimeOffset(t.StartTimestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
                     t.DataSource ?? "unknown",
-                    new MatchCriteria { Rate = t.Rate, RateTolerance = 0.05 }),
+                    BuildCriteria(t)),
                 "TempBasals", totalRecords, processed, progress, cancellationToken);
             processed += tempBasalResult.processed;
             groupsCreated += tempBasalResult.groups;
@@ -935,12 +1087,7 @@ public class DeduplicationService : IDeduplicationService
                     s.Id,
                     new DateTimeOffset(s.StartTimestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
                     s.Source ?? "unknown",
-                    new MatchCriteria
-                    {
-                        Category = Enum.TryParse<StateSpanCategory>(s.Category, ignoreCase: true, out var cat)
-                            ? cat : null,
-                        State = s.State
-                    }),
+                    BuildCriteria(s)),
                 "StateSpans", totalRecords, processed, progress, cancellationToken);
             processed += stateSpanResult.processed;
             groupsCreated += stateSpanResult.groups;

--- a/src/Web/packages/app/package.json
+++ b/src/Web/packages/app/package.json
@@ -46,6 +46,7 @@
     "format": "prettier --write ."
   },
   "devDependencies": {
+    "@eslint/js": "^10.3.0",
     "@internationalized/date": "^3.12.1",
     "@lucide/svelte": "^1.14.0",
     "@playwright/test": "^1.60.0",

--- a/src/Web/packages/app/src/lib/stores/realtime-store-harness.svelte
+++ b/src/Web/packages/app/src/lib/stores/realtime-store-harness.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  // Test-only harness: exercises createRealtimeStore inside a real component
+  // lifecycle so setContext() is valid. Hands the created store back to the test.
+  import { createRealtimeStore } from "./realtime-store.svelte";
+  import type { RealtimeStore } from "./realtime-store.svelte";
+
+  let { onstore }: { onstore: (store: RealtimeStore) => void } = $props();
+
+  onstore(
+    createRealtimeStore({
+      url: "",
+      reconnectAttempts: 0,
+      reconnectDelay: 0,
+      maxReconnectDelay: 0,
+      pingTimeout: 0,
+      pingInterval: 0,
+    })
+  );
+</script>

--- a/src/Web/packages/app/src/lib/stores/realtime-store.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/stores/realtime-store.svelte.test.ts
@@ -1,0 +1,27 @@
+import { render } from "vitest-browser-svelte";
+import { describe, it, expect } from "vitest";
+import Harness from "./realtime-store-harness.svelte";
+import type { RealtimeStore } from "./realtime-store.svelte";
+
+describe("createRealtimeStore singleton lifecycle", () => {
+  it("returns the same singleton across mounts until destroy(), then a fresh one", () => {
+    let first!: RealtimeStore;
+    render(Harness, { props: { onstore: (s: RealtimeStore) => (first = s) } });
+
+    // A second mount reuses the module-level singleton.
+    let cached!: RealtimeStore;
+    render(Harness, { props: { onstore: (s: RealtimeStore) => (cached = s) } });
+    expect(cached).toBe(first);
+
+    // Tearing the store down must clear the singleton so a later mount
+    // (e.g. re-entering the authenticated layout) starts from clean state
+    // rather than inheriting stale realtime data.
+    first.destroy();
+
+    let afterDestroy!: RealtimeStore;
+    render(Harness, {
+      props: { onstore: (s: RealtimeStore) => (afterDestroy = s) },
+    });
+    expect(afterDestroy).not.toBe(first);
+  });
+});

--- a/src/Web/packages/app/src/lib/stores/realtime-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/realtime-store.svelte.ts
@@ -803,6 +803,13 @@ export class RealtimeStore {
       }
     }
     this.websocketClient.destroy();
+
+    // Clear the module-level singleton so the next createRealtimeStore() builds
+    // a fresh store rather than resurrecting this torn-down instance with stale
+    // realtime state (e.g. when re-entering the authenticated layout).
+    if (singletonStore === this) {
+      singletonStore = null;
+    }
   }
 
   /**

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
@@ -30,14 +30,17 @@ public class ConnectorBackgroundServiceTests
     private class TestConnectorBackgroundService : ConnectorBackgroundService<TestConnectorConfig>
     {
         private readonly SyncResult _syncResult;
+        private readonly Action? _onSync;
 
         public TestConnectorBackgroundService(
             IServiceProvider serviceProvider,
             SyncResult syncResult,
-            ILogger logger)
+            ILogger logger,
+            Action? onSync = null)
             : base(serviceProvider, logger)
         {
             _syncResult = syncResult;
+            _onSync = onSync;
         }
 
         protected override string ConnectorName => "TestConnector";
@@ -48,6 +51,7 @@ public class ConnectorBackgroundServiceTests
             CancellationToken cancellationToken,
             ISyncProgressReporter? progressReporter = null)
         {
+            _onSync?.Invoke();
             return Task.FromResult(_syncResult);
         }
 
@@ -61,12 +65,27 @@ public class ConnectorBackgroundServiceTests
                 .GetMethod("SyncAllTenantsAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
             await (Task)method.Invoke(this, [ct])!;
         }
+
+        /// <summary>
+        /// Exposes the protected RequestImmediateSync for testing.
+        /// </summary>
+        public new void RequestImmediateSync(Guid tenantId) => base.RequestImmediateSync(tenantId);
     }
 
     /// <summary>
     /// Sets up an in-memory SQLite NocturneDbContext with one active tenant.
     /// </summary>
     private static (IDisposable cleanup, string connectionString) CreateSqliteDb()
+    {
+        var (cleanup, connectionString, _) = CreateSqliteDbWithTenantId();
+        return (cleanup, connectionString);
+    }
+
+    /// <summary>
+    /// Sets up an in-memory SQLite NocturneDbContext with one active tenant,
+    /// returning the tenant ID for tests that need to target a specific tenant.
+    /// </summary>
+    private static (IDisposable cleanup, string connectionString, Guid tenantId) CreateSqliteDbWithTenantId()
     {
         // Use a temp file so factory-created contexts can share the same data
         var dbPath = Path.Combine(Path.GetTempPath(), $"ConnectorBgTest_{Guid.NewGuid():N}.db");
@@ -98,7 +117,7 @@ public class ConnectorBackgroundServiceTests
             tenantId.ToString(), "test-tenant", "Test Tenant",
             DateTime.UtcNow.ToString("O"), DateTime.UtcNow.ToString("O"));
 
-        return (cleanup, connectionString);
+        return (cleanup, connectionString, tenantId);
     }
 
     private static IServiceProvider BuildServiceProvider(
@@ -419,6 +438,113 @@ public class ConnectorBackgroundServiceTests
                 It.IsAny<CancellationToken>()),
             Times.Once,
             "Expected error message to be cleared on successful sync");
+    }
+
+    [Fact]
+    public async Task RequestImmediateSync_CausesNextPollToSyncImmediately()
+    {
+        // Arrange
+        var (cleanup, connStr, tenantId) = CreateSqliteDbWithTenantId();
+        using var _ = cleanup;
+
+        var syncCount = 0;
+        var syncResult = new SyncResult { Success = true, Message = "OK" };
+
+        var configServiceMock = new Mock<IConnectorConfigurationService>();
+        configServiceMock
+            .Setup(x => x.GetConfigurationAsync("TestConnector", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConnectorConfigurationResponse
+            {
+                ConnectorName = "TestConnector",
+                IsActive = true,
+                Configuration = JsonDocument.Parse("{\"enabled\": true, \"syncIntervalMinutes\": 60}")
+            });
+        configServiceMock
+            .Setup(x => x.GetSecretsAsync("TestConnector", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, string>());
+        configServiceMock
+            .Setup(x => x.UpdateHealthStateAsync(
+                It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<string?>(), It.IsAny<DateTime?>(), It.IsAny<bool?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var config = new TestConnectorConfig { Enabled = true, SyncIntervalMinutes = 60 };
+        var serviceProvider = BuildServiceProvider(connStr, configServiceMock, config);
+
+        var sut = new TestConnectorBackgroundService(
+            serviceProvider,
+            syncResult,
+            NullLogger<TestConnectorBackgroundService>.Instance,
+            onSync: () => syncCount++);
+
+        // Act — first poll triggers the initial sync
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+        Assert.Equal(1, syncCount);
+
+        // Second poll should NOT sync (60-minute interval hasn't elapsed)
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+        Assert.Equal(1, syncCount);
+
+        // Request immediate sync, then poll again — it should sync immediately
+        sut.RequestImmediateSync(tenantId);
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+        Assert.Equal(2, syncCount);
+    }
+
+    [Fact]
+    public async Task RequestImmediateSync_DebouncesPreviouslyNudgedTenant()
+    {
+        // Arrange
+        var (cleanup, connStr, tenantId) = CreateSqliteDbWithTenantId();
+        using var _ = cleanup;
+
+        var syncCount = 0;
+        var syncResult = new SyncResult { Success = true, Message = "OK" };
+
+        var configServiceMock = new Mock<IConnectorConfigurationService>();
+        configServiceMock
+            .Setup(x => x.GetConfigurationAsync("TestConnector", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConnectorConfigurationResponse
+            {
+                ConnectorName = "TestConnector",
+                IsActive = true,
+                Configuration = JsonDocument.Parse("{\"enabled\": true, \"syncIntervalMinutes\": 60}")
+            });
+        configServiceMock
+            .Setup(x => x.GetSecretsAsync("TestConnector", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, string>());
+        configServiceMock
+            .Setup(x => x.UpdateHealthStateAsync(
+                It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<string?>(), It.IsAny<DateTime?>(), It.IsAny<bool?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var config = new TestConnectorConfig { Enabled = true, SyncIntervalMinutes = 60 };
+        var serviceProvider = BuildServiceProvider(connStr, configServiceMock, config);
+
+        var sut = new TestConnectorBackgroundService(
+            serviceProvider,
+            syncResult,
+            NullLogger<TestConnectorBackgroundService>.Instance,
+            onSync: () => syncCount++);
+
+        // Act — initial sync
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+        Assert.Equal(1, syncCount);
+
+        // First nudge should succeed and cause a sync
+        sut.RequestImmediateSync(tenantId);
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+        Assert.Equal(2, syncCount);
+
+        // Second nudge within the debounce window should be ignored
+        sut.RequestImmediateSync(tenantId);
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+        // Sync count should remain at 2 because the nudge was debounced
+        // and the 60-minute interval hasn't elapsed
+        Assert.Equal(2, syncCount);
     }
 
     /// <summary>

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/DeduplicationReconciliationBackgroundServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/DeduplicationReconciliationBackgroundServiceTests.cs
@@ -1,0 +1,170 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.BackgroundServices;
+using Nocturne.Core.Contracts.Infrastructure;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models;
+using Nocturne.Infrastructure.Data;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.BackgroundServices;
+
+public class DeduplicationReconciliationBackgroundServiceTests
+{
+    /// <summary>
+    /// Sets up an in-memory SQLite NocturneDbContext seeded with two active tenants
+    /// and one inactive tenant, returning the connection string.
+    /// </summary>
+    private static (IDisposable cleanup, string connectionString) CreateSqliteDb()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"DedupReconcileBgTest_{Guid.NewGuid():N}.db");
+        var connectionString = $"Data Source={dbPath}";
+        var cleanup = new TempFileCleanup(dbPath);
+
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(connectionString)
+            .Options;
+
+        using var context = new NocturneDbContext(options);
+        context.Database.ExecuteSqlRaw(@"
+            CREATE TABLE tenants (
+                Id TEXT PRIMARY KEY,
+                slug TEXT NOT NULL,
+                display_name TEXT NOT NULL,
+                is_active INTEGER NOT NULL DEFAULT 1,
+                last_reading_at TEXT,
+                allow_access_requests INTEGER NOT NULL DEFAULT 1,
+                onboarding_completed_at TEXT,
+                sys_created_at TEXT NOT NULL,
+                sys_updated_at TEXT NOT NULL
+            )");
+
+        void Insert(string slug, bool active) =>
+            context.Database.ExecuteSqlRaw(
+                "INSERT INTO tenants (Id, slug, display_name, is_active, allow_access_requests, sys_created_at, sys_updated_at) VALUES ({0}, {1}, {2}, {3}, 1, {4}, {5})",
+                Guid.NewGuid().ToString(), slug, slug, active ? 1 : 0,
+                DateTime.UtcNow.ToString("O"), DateTime.UtcNow.ToString("O"));
+
+        Insert("active-one", true);
+        Insert("active-two", true);
+        Insert("inactive-one", false);
+
+        return (cleanup, connectionString);
+    }
+
+    private static IServiceProvider BuildServiceProvider(
+        string connectionString,
+        Mock<IDeduplicationService> dedupMock)
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IDbContextFactory<NocturneDbContext>>(
+            new SqliteDbContextFactory(connectionString));
+
+        services.AddScoped(sp =>
+        {
+            var factory = sp.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
+            return factory.CreateDbContext();
+        });
+
+        services.AddScoped<ITenantAccessor>(_ =>
+        {
+            var mock = new Mock<ITenantAccessor>();
+            mock.Setup(t => t.SetTenant(It.IsAny<TenantContext>()));
+            return mock.Object;
+        });
+
+        services.AddScoped(_ => dedupMock.Object);
+
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task ReconcileAllTenantsAsync_CallsReconcileOncePerActiveTenant()
+    {
+        // Arrange
+        var (cleanup, connStr) = CreateSqliteDb();
+        using var _ = cleanup;
+
+        var dedupMock = new Mock<IDeduplicationService>();
+        dedupMock
+            .Setup(d => d.ReconcileNewLinksAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ReconcileResult(0, true));
+
+        var serviceProvider = BuildServiceProvider(connStr, dedupMock);
+
+        var sut = new DeduplicationReconciliationBackgroundService(
+            serviceProvider,
+            NullLogger<DeduplicationReconciliationBackgroundService>.Instance);
+
+        // Act
+        await sut.ReconcileAllTenantsAsync(CancellationToken.None);
+
+        // Assert — once per ACTIVE tenant (2), not the inactive one
+        dedupMock.Verify(
+            d => d.ReconcileNewLinksAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task ReconcileAllTenantsAsync_OneTenantThrows_OtherTenantsStillReconciled()
+    {
+        // Arrange
+        var (cleanup, connStr) = CreateSqliteDb();
+        using var _ = cleanup;
+
+        var callCount = 0;
+        var dedupMock = new Mock<IDeduplicationService>();
+        dedupMock
+            .Setup(d => d.ReconcileNewLinksAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                callCount++;
+                // First active tenant throws; the loop must continue to the second.
+                if (callCount == 1)
+                    throw new InvalidOperationException("boom");
+                return Task.FromResult(new ReconcileResult(0, true));
+            });
+
+        var serviceProvider = BuildServiceProvider(connStr, dedupMock);
+
+        var sut = new DeduplicationReconciliationBackgroundService(
+            serviceProvider,
+            NullLogger<DeduplicationReconciliationBackgroundService>.Instance);
+
+        // Act — must not throw despite the first tenant failing
+        await sut.ReconcileAllTenantsAsync(CancellationToken.None);
+
+        // Assert — both active tenants were attempted
+        dedupMock.Verify(
+            d => d.ReconcileNewLinksAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    /// <summary>
+    /// Simple IDbContextFactory that creates NocturneDbContext instances against a SQLite database file.
+    /// </summary>
+    private sealed class SqliteDbContextFactory(string connectionString) : IDbContextFactory<NocturneDbContext>
+    {
+        public NocturneDbContext CreateDbContext()
+        {
+            var options = new DbContextOptionsBuilder<NocturneDbContext>()
+                .UseSqlite(connectionString)
+                .Options;
+            return new NocturneDbContext(options);
+        }
+    }
+
+    /// <summary>
+    /// Deletes a temporary SQLite database file on dispose.
+    /// </summary>
+    private sealed class TempFileCleanup(string path) : IDisposable
+    {
+        public void Dispose()
+        {
+            try { File.Delete(path); } catch (IOException) { } catch (UnauthorizedAccessException) { }
+        }
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/NightscoutRealtimeListenerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/NightscoutRealtimeListenerTests.cs
@@ -1,0 +1,272 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.BackgroundServices;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Nightscout.Configurations;
+using Nocturne.Connectors.Nightscout.Services;
+using Nocturne.Core.Contracts.Connectors;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Infrastructure.Data;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.BackgroundServices;
+
+public class NightscoutRealtimeListenerTests
+{
+    /// <summary>
+    /// StartRealtimeListenersAsync should complete without throwing when there
+    /// are no active tenants in the database.
+    /// </summary>
+    [Fact]
+    public async Task StartRealtimeListenersAsync_NoTenants_DoesNotThrow()
+    {
+        // Arrange — empty database (no tenants)
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: false);
+        using var _ = cleanup;
+
+        var serviceProvider = BuildServiceProvider(connectionString);
+        var sut = new NightscoutConnectorBackgroundService(
+            serviceProvider,
+            NullLogger<NightscoutConnectorBackgroundService>.Instance);
+
+        // Act & Assert — should not throw
+        await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// StopRealtimeListenersAsync should be safe to call even when no listeners
+    /// have been started (i.e. the socket client dictionary is empty).
+    /// </summary>
+    [Fact]
+    public async Task StopRealtimeListenersAsync_NoListenersStarted_DoesNotThrow()
+    {
+        // Arrange
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: false);
+        using var _ = cleanup;
+
+        var serviceProvider = BuildServiceProvider(connectionString);
+        var sut = new NightscoutConnectorBackgroundService(
+            serviceProvider,
+            NullLogger<NightscoutConnectorBackgroundService>.Instance);
+
+        // Act & Assert — should not throw
+        await InvokeStopRealtimeListenersAsync(sut);
+    }
+
+    /// <summary>
+    /// StopRealtimeListenersAsync should be safe to call multiple times in a row.
+    /// </summary>
+    [Fact]
+    public async Task StopRealtimeListenersAsync_CalledTwice_DoesNotThrow()
+    {
+        // Arrange
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: false);
+        using var _ = cleanup;
+
+        var serviceProvider = BuildServiceProvider(connectionString);
+        var sut = new NightscoutConnectorBackgroundService(
+            serviceProvider,
+            NullLogger<NightscoutConnectorBackgroundService>.Instance);
+
+        // Act & Assert — should not throw on repeated calls
+        await InvokeStopRealtimeListenersAsync(sut);
+        await InvokeStopRealtimeListenersAsync(sut);
+    }
+
+    /// <summary>
+    /// When a tenant exists but the connector config is disabled, StartRealtimeListenersAsync
+    /// should skip that tenant without throwing.
+    /// </summary>
+    [Fact]
+    public async Task StartRealtimeListenersAsync_DisabledConnector_SkipsTenant()
+    {
+        // Arrange — one tenant with a disabled connector config
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: true);
+        using var _ = cleanup;
+
+        var config = new NightscoutConnectorConfiguration
+        {
+            Enabled = false,
+            Url = "http://nightscout.example.com",
+        };
+
+        var serviceProvider = BuildServiceProvider(connectionString, config);
+        var sut = new NightscoutConnectorBackgroundService(
+            serviceProvider,
+            NullLogger<NightscoutConnectorBackgroundService>.Instance);
+
+        // Act & Assert — should skip the tenant without throwing
+        await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// When a tenant exists but the connector config has no URL, StartRealtimeListenersAsync
+    /// should skip that tenant without throwing.
+    /// </summary>
+    [Fact]
+    public async Task StartRealtimeListenersAsync_EmptyUrl_SkipsTenant()
+    {
+        // Arrange — one tenant with no URL configured
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: true);
+        using var _ = cleanup;
+
+        var config = new NightscoutConnectorConfiguration
+        {
+            Enabled = true,
+            Url = "",
+        };
+
+        var serviceProvider = BuildServiceProvider(connectionString, config);
+        var sut = new NightscoutConnectorBackgroundService(
+            serviceProvider,
+            NullLogger<NightscoutConnectorBackgroundService>.Instance);
+
+        // Act & Assert — should skip the tenant without throwing
+        await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
+    }
+
+    #region Helpers
+
+    /// <summary>
+    /// Invokes the protected StartRealtimeListenersAsync via reflection.
+    /// </summary>
+    private static async Task InvokeStartRealtimeListenersAsync(
+        NightscoutConnectorBackgroundService sut,
+        CancellationToken cancellationToken)
+    {
+        var method = typeof(ConnectorBackgroundService<NightscoutConnectorConfiguration>)
+            .GetMethod("StartRealtimeListenersAsync",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        await (Task)method.Invoke(sut, [cancellationToken])!;
+    }
+
+    /// <summary>
+    /// Invokes the protected StopRealtimeListenersAsync via reflection.
+    /// </summary>
+    private static async Task InvokeStopRealtimeListenersAsync(
+        NightscoutConnectorBackgroundService sut)
+    {
+        var method = typeof(ConnectorBackgroundService<NightscoutConnectorConfiguration>)
+            .GetMethod("StopRealtimeListenersAsync",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        await (Task)method.Invoke(sut, [])!;
+    }
+
+    /// <summary>
+    /// Creates an in-memory SQLite database, optionally seeding one active tenant.
+    /// </summary>
+    private static (IDisposable cleanup, string connectionString) CreateSqliteDb(bool addTenant)
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"NsRealtimeTest_{Guid.NewGuid():N}.db");
+        var connectionString = $"Data Source={dbPath}";
+        var cleanup = new TempFileCleanup(dbPath);
+
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(connectionString)
+            .Options;
+
+        using var context = new NocturneDbContext(options);
+        context.Database.ExecuteSqlRaw(@"
+            CREATE TABLE tenants (
+                Id TEXT PRIMARY KEY,
+                slug TEXT NOT NULL,
+                display_name TEXT NOT NULL,
+                is_active INTEGER NOT NULL DEFAULT 1,
+                last_reading_at TEXT,
+                allow_access_requests INTEGER NOT NULL DEFAULT 1,
+                onboarding_completed_at TEXT,
+                sys_created_at TEXT NOT NULL,
+                sys_updated_at TEXT NOT NULL
+            )");
+
+        if (addTenant)
+        {
+            var tenantId = Guid.NewGuid();
+            context.Database.ExecuteSqlRaw(
+                "INSERT INTO tenants (Id, slug, display_name, is_active, allow_access_requests, sys_created_at, sys_updated_at) VALUES ({0}, {1}, {2}, 1, 1, {3}, {4})",
+                tenantId.ToString(), "test-tenant", "Test Tenant",
+                DateTime.UtcNow.ToString("O"), DateTime.UtcNow.ToString("O"));
+        }
+
+        return (cleanup, connectionString);
+    }
+
+    /// <summary>
+    /// Builds a service provider wired up for the NightscoutConnectorBackgroundService.
+    /// When <paramref name="config"/> is null, no config loader is registered (used for
+    /// the "no tenants" scenario where it's never resolved).
+    /// </summary>
+    private static IServiceProvider BuildServiceProvider(
+        string connectionString,
+        NightscoutConnectorConfiguration? config = null)
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IDbContextFactory<NocturneDbContext>>(
+            new SqliteDbContextFactory(connectionString));
+
+        services.AddScoped(sp =>
+        {
+            var factory = sp.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
+            return factory.CreateDbContext();
+        });
+
+        services.AddScoped<ITenantAccessor>(_ =>
+        {
+            var mock = new Mock<ITenantAccessor>();
+            mock.Setup(t => t.IsResolved).Returns(true);
+            mock.Setup(t => t.TenantId).Returns(Guid.NewGuid());
+            mock.Setup(t => t.SetTenant(It.IsAny<TenantContext>()));
+            return mock.Object;
+        });
+
+        if (config != null)
+        {
+            services.AddScoped<IConnectorConfigurationLoader<NightscoutConnectorConfiguration>>(
+                _ => new StaticConfigLoader(config));
+        }
+        else
+        {
+            // Register a loader that throws — it should never be called for empty tenant lists
+            services.AddScoped<IConnectorConfigurationLoader<NightscoutConnectorConfiguration>>(
+                _ => throw new InvalidOperationException("Config loader should not be called when there are no tenants"));
+        }
+
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class StaticConfigLoader(NightscoutConnectorConfiguration config)
+        : IConnectorConfigurationLoader<NightscoutConnectorConfiguration>
+    {
+        public Task<NightscoutConnectorConfiguration> LoadForTenantAsync(CancellationToken ct)
+            => Task.FromResult(config);
+    }
+
+    private sealed class SqliteDbContextFactory(string connectionString)
+        : IDbContextFactory<NocturneDbContext>
+    {
+        public NocturneDbContext CreateDbContext()
+        {
+            var options = new DbContextOptionsBuilder<NocturneDbContext>()
+                .UseSqlite(connectionString)
+                .Options;
+            return new NocturneDbContext(options);
+        }
+    }
+
+    private sealed class TempFileCleanup(string path) : IDisposable
+    {
+        public void Dispose()
+        {
+            try { File.Delete(path); }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
+    }
+
+    #endregion
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/NocturneRemoteRealtimeListenerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/NocturneRemoteRealtimeListenerTests.cs
@@ -1,0 +1,270 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.BackgroundServices;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.NocturneRemote.Configurations;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Infrastructure.Data;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.BackgroundServices;
+
+public class NocturneRemoteRealtimeListenerTests
+{
+    /// <summary>
+    /// StartRealtimeListenersAsync should complete without throwing when there
+    /// are no active tenants in the database.
+    /// </summary>
+    [Fact]
+    public async Task StartRealtimeListenersAsync_NoTenants_DoesNotThrow()
+    {
+        // Arrange — empty database (no tenants)
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: false);
+        using var _ = cleanup;
+
+        var serviceProvider = BuildServiceProvider(connectionString);
+        var sut = new NocturneRemoteConnectorBackgroundService(
+            serviceProvider,
+            NullLogger<NocturneRemoteConnectorBackgroundService>.Instance);
+
+        // Act & Assert — should not throw
+        await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// StopRealtimeListenersAsync should be safe to call even when no listeners
+    /// have been started (i.e. the hub connection dictionary is empty).
+    /// </summary>
+    [Fact]
+    public async Task StopRealtimeListenersAsync_NoListenersStarted_DoesNotThrow()
+    {
+        // Arrange
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: false);
+        using var _ = cleanup;
+
+        var serviceProvider = BuildServiceProvider(connectionString);
+        var sut = new NocturneRemoteConnectorBackgroundService(
+            serviceProvider,
+            NullLogger<NocturneRemoteConnectorBackgroundService>.Instance);
+
+        // Act & Assert — should not throw
+        await InvokeStopRealtimeListenersAsync(sut);
+    }
+
+    /// <summary>
+    /// StopRealtimeListenersAsync should be safe to call multiple times in a row.
+    /// </summary>
+    [Fact]
+    public async Task StopRealtimeListenersAsync_CalledTwice_DoesNotThrow()
+    {
+        // Arrange
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: false);
+        using var _ = cleanup;
+
+        var serviceProvider = BuildServiceProvider(connectionString);
+        var sut = new NocturneRemoteConnectorBackgroundService(
+            serviceProvider,
+            NullLogger<NocturneRemoteConnectorBackgroundService>.Instance);
+
+        // Act & Assert — should not throw on repeated calls
+        await InvokeStopRealtimeListenersAsync(sut);
+        await InvokeStopRealtimeListenersAsync(sut);
+    }
+
+    /// <summary>
+    /// When a tenant exists but the connector config is disabled, StartRealtimeListenersAsync
+    /// should skip that tenant without throwing.
+    /// </summary>
+    [Fact]
+    public async Task StartRealtimeListenersAsync_DisabledConnector_SkipsTenant()
+    {
+        // Arrange — one tenant with a disabled connector config
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: true);
+        using var _ = cleanup;
+
+        var config = new NocturneRemoteConnectorConfiguration
+        {
+            Enabled = false,
+            Url = "http://remote.example.com",
+            Token = "test-token",
+        };
+
+        var serviceProvider = BuildServiceProvider(connectionString, config);
+        var sut = new NocturneRemoteConnectorBackgroundService(
+            serviceProvider,
+            NullLogger<NocturneRemoteConnectorBackgroundService>.Instance);
+
+        // Act & Assert — should skip the tenant without throwing
+        await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// When a tenant exists but the connector config has no URL, StartRealtimeListenersAsync
+    /// should skip that tenant without throwing.
+    /// </summary>
+    [Fact]
+    public async Task StartRealtimeListenersAsync_EmptyUrl_SkipsTenant()
+    {
+        // Arrange — one tenant with no URL configured
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: true);
+        using var _ = cleanup;
+
+        var config = new NocturneRemoteConnectorConfiguration
+        {
+            Enabled = true,
+            Url = "",
+            Token = "test-token",
+        };
+
+        var serviceProvider = BuildServiceProvider(connectionString, config);
+        var sut = new NocturneRemoteConnectorBackgroundService(
+            serviceProvider,
+            NullLogger<NocturneRemoteConnectorBackgroundService>.Instance);
+
+        // Act & Assert — should skip the tenant without throwing
+        await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
+    }
+
+    #region Helpers
+
+    /// <summary>
+    /// Invokes the protected StartRealtimeListenersAsync via reflection.
+    /// </summary>
+    private static async Task InvokeStartRealtimeListenersAsync(
+        NocturneRemoteConnectorBackgroundService sut,
+        CancellationToken cancellationToken)
+    {
+        var method = typeof(ConnectorBackgroundService<NocturneRemoteConnectorConfiguration>)
+            .GetMethod("StartRealtimeListenersAsync",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        await (Task)method.Invoke(sut, [cancellationToken])!;
+    }
+
+    /// <summary>
+    /// Invokes the protected StopRealtimeListenersAsync via reflection.
+    /// </summary>
+    private static async Task InvokeStopRealtimeListenersAsync(
+        NocturneRemoteConnectorBackgroundService sut)
+    {
+        var method = typeof(ConnectorBackgroundService<NocturneRemoteConnectorConfiguration>)
+            .GetMethod("StopRealtimeListenersAsync",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        await (Task)method.Invoke(sut, [])!;
+    }
+
+    /// <summary>
+    /// Creates an in-memory SQLite database, optionally seeding one active tenant.
+    /// </summary>
+    private static (IDisposable cleanup, string connectionString) CreateSqliteDb(bool addTenant)
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"NrRealtimeTest_{Guid.NewGuid():N}.db");
+        var connectionString = $"Data Source={dbPath}";
+        var cleanup = new TempFileCleanup(dbPath);
+
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(connectionString)
+            .Options;
+
+        using var context = new NocturneDbContext(options);
+        context.Database.ExecuteSqlRaw(@"
+            CREATE TABLE tenants (
+                Id TEXT PRIMARY KEY,
+                slug TEXT NOT NULL,
+                display_name TEXT NOT NULL,
+                is_active INTEGER NOT NULL DEFAULT 1,
+                last_reading_at TEXT,
+                allow_access_requests INTEGER NOT NULL DEFAULT 1,
+                onboarding_completed_at TEXT,
+                sys_created_at TEXT NOT NULL,
+                sys_updated_at TEXT NOT NULL
+            )");
+
+        if (addTenant)
+        {
+            var tenantId = Guid.NewGuid();
+            context.Database.ExecuteSqlRaw(
+                "INSERT INTO tenants (Id, slug, display_name, is_active, allow_access_requests, sys_created_at, sys_updated_at) VALUES ({0}, {1}, {2}, 1, 1, {3}, {4})",
+                tenantId.ToString(), "test-tenant", "Test Tenant",
+                DateTime.UtcNow.ToString("O"), DateTime.UtcNow.ToString("O"));
+        }
+
+        return (cleanup, connectionString);
+    }
+
+    /// <summary>
+    /// Builds a service provider wired up for the NocturneRemoteConnectorBackgroundService.
+    /// When <paramref name="config"/> is null, no config loader is registered (used for
+    /// the "no tenants" scenario where it's never resolved).
+    /// </summary>
+    private static IServiceProvider BuildServiceProvider(
+        string connectionString,
+        NocturneRemoteConnectorConfiguration? config = null)
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IDbContextFactory<NocturneDbContext>>(
+            new SqliteDbContextFactory(connectionString));
+
+        services.AddScoped(sp =>
+        {
+            var factory = sp.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
+            return factory.CreateDbContext();
+        });
+
+        services.AddScoped<ITenantAccessor>(_ =>
+        {
+            var mock = new Mock<ITenantAccessor>();
+            mock.Setup(t => t.IsResolved).Returns(true);
+            mock.Setup(t => t.TenantId).Returns(Guid.NewGuid());
+            mock.Setup(t => t.SetTenant(It.IsAny<TenantContext>()));
+            return mock.Object;
+        });
+
+        if (config != null)
+        {
+            services.AddScoped<IConnectorConfigurationLoader<NocturneRemoteConnectorConfiguration>>(
+                _ => new StaticConfigLoader(config));
+        }
+        else
+        {
+            // Register a loader that throws — it should never be called for empty tenant lists
+            services.AddScoped<IConnectorConfigurationLoader<NocturneRemoteConnectorConfiguration>>(
+                _ => throw new InvalidOperationException("Config loader should not be called when there are no tenants"));
+        }
+
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class StaticConfigLoader(NocturneRemoteConnectorConfiguration config)
+        : IConnectorConfigurationLoader<NocturneRemoteConnectorConfiguration>
+    {
+        public Task<NocturneRemoteConnectorConfiguration> LoadForTenantAsync(CancellationToken ct)
+            => Task.FromResult(config);
+    }
+
+    private sealed class SqliteDbContextFactory(string connectionString)
+        : IDbContextFactory<NocturneDbContext>
+    {
+        public NocturneDbContext CreateDbContext()
+        {
+            var options = new DbContextOptionsBuilder<NocturneDbContext>()
+                .UseSqlite(connectionString)
+                .Options;
+            return new NocturneDbContext(options);
+        }
+    }
+
+    private sealed class TempFileCleanup(string path) : IDisposable
+    {
+        public void Dispose()
+        {
+            try { File.Delete(path); }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
+    }
+
+    #endregion
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/CarbIntakeRepositoryTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/CarbIntakeRepositoryTests.cs
@@ -197,6 +197,66 @@ public class CarbIntakeRepositoryTests : IDisposable
     }
 
     [Fact]
+    public async Task CountAsync_ExcludesNonPrimaryDuplicates()
+    {
+        var timestamp = DateTime.UtcNow;
+
+        // The same meal imported by two connectors (e.g. MyLife pump data that
+        // also flows through Glooko) — two distinct rows.
+        var primary = await _repo.CreateAsync(new CarbIntake
+        {
+            Timestamp = timestamp,
+            DataSource = "mylife-connector",
+            LegacyId = "mylife-1",
+            Carbs = 50.0,
+        });
+        var duplicate = await _repo.CreateAsync(new CarbIntake
+        {
+            Timestamp = timestamp,
+            DataSource = "glooko-connector",
+            LegacyId = "glooko-1",
+            Carbs = 50.0,
+        });
+
+        // Dedup links them into one canonical group; the Glooko row is non-primary.
+        var canonicalId = Guid.CreateVersion7();
+        var mills = new DateTimeOffset(timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
+        _context.LinkedRecords.AddRange(
+            new LinkedRecordEntity
+            {
+                Id = Guid.CreateVersion7(),
+                TenantId = TestTenantId,
+                CanonicalId = canonicalId,
+                RecordType = "carbintake",
+                RecordId = primary.Id,
+                SourceTimestamp = mills,
+                DataSource = "mylife-connector",
+                IsPrimary = true,
+            },
+            new LinkedRecordEntity
+            {
+                Id = Guid.CreateVersion7(),
+                TenantId = TestTenantId,
+                CanonicalId = canonicalId,
+                RecordType = "carbintake",
+                RecordId = duplicate.Id,
+                SourceTimestamp = mills,
+                DataSource = "glooko-connector",
+                IsPrimary = false,
+            });
+        await _context.SaveChangesAsync();
+
+        // GetAsync already drops the non-primary duplicate; CountAsync must agree
+        // so pagination totals match the returned rows.
+        var fetched = (await _repo.GetAsync(
+            from: null, to: null, device: null, source: null)).ToList();
+        var count = await _repo.CountAsync(from: null, to: null);
+
+        fetched.Should().HaveCount(1);
+        count.Should().Be(1);
+    }
+
+    [Fact]
     public async Task BulkCreateAsync_WithIntraBatchSyncIdentifierCollision_DeduplicatesToLatest()
     {
         var timestamp = DateTime.UtcNow;

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationReconcileTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationReconcileTests.cs
@@ -75,4 +75,33 @@ public class DeduplicationReconcileTests : IDisposable
         info[live].IsDeleted.Should().BeFalse();
         info[gone].IsDeleted.Should().BeTrue();
     }
+
+    [Fact]
+    public async Task LoadRecordInfoAsync_CarbIntake_ExcludesOtherTenants()
+    {
+        var mine = Guid.CreateVersion7();
+        var theirs = Guid.CreateVersion7();
+        var otherTenant = Guid.Parse("00000000-0000-0000-0000-000000000002");
+
+        // The cross-tenant row references a real tenant, so seed it (bypassing the
+        // query filter) to satisfy the FK constraint without it leaking into _context.
+        using (var seedContext = new NocturneDbContext(_contextOptions))
+        {
+            seedContext.TenantId = otherTenant;
+            seedContext.Tenants.Add(new TenantEntity { Id = otherTenant, Slug = "other" });
+            seedContext.SaveChanges();
+        }
+
+        // Seed a record for the current tenant and one belonging to a different tenant.
+        // IgnoreQueryFilters bypasses the soft-delete filter, so tenant scoping must be
+        // re-applied explicitly; otherwise the cross-tenant row leaks into the result.
+        _context.CarbIntakes.Add(new CarbIntakeEntity { Id = mine, TenantId = TestTenantId, Carbs = 10, Timestamp = DateTime.UtcNow });
+        _context.CarbIntakes.Add(new CarbIntakeEntity { Id = theirs, TenantId = otherTenant, Carbs = 99, Timestamp = DateTime.UtcNow });
+        await _context.SaveChangesAsync();
+
+        var info = await _service.LoadRecordInfoForTestAsync(RecordType.CarbIntake, new HashSet<Guid> { mine, theirs });
+
+        info.Should().ContainKey(mine);
+        info.Should().NotContainKey(theirs);
+    }
 }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationReconcileTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationReconcileTests.cs
@@ -180,6 +180,34 @@ public class DeduplicationReconcileTests : IDisposable
         links.Single(l => l.IsPrimary).RecordId.Should().Be(live); // earliest non-deleted
     }
 
+    [Fact]
+    public async Task Watermark_RoundTrips_DefaultsToMinValue()
+    {
+        (await _service.GetWatermarkAsync(CancellationToken.None)).Should().Be(DateTime.MinValue);
+
+        var t = new DateTime(2026, 5, 30, 12, 0, 0, DateTimeKind.Utc);
+        await _service.SetWatermarkAsync(t, CancellationToken.None);
+
+        (await _service.GetWatermarkAsync(CancellationToken.None)).Should().Be(t);
+    }
+
+    [Fact]
+    public async Task Watermark_SetTwice_Updates()
+    {
+        var t1 = new DateTime(2026, 5, 30, 12, 0, 0, DateTimeKind.Utc);
+        var t2 = new DateTime(2026, 5, 31, 9, 30, 0, DateTimeKind.Utc);
+
+        await _service.SetWatermarkAsync(t1, CancellationToken.None);
+        await _service.SetWatermarkAsync(t2, CancellationToken.None);
+
+        (await _service.GetWatermarkAsync(CancellationToken.None)).Should().Be(t2);
+
+        // Upsert must update the single row, not create a duplicate.
+        var rows = await _context.DedupReconcileState.IgnoreQueryFilters()
+            .Where(s => s.TenantId == TestTenantId).CountAsync();
+        rows.Should().Be(1);
+    }
+
     /// <summary>
     /// Inserts a <see cref="CarbIntakeEntity"/> for the test tenant and returns its id.
     /// </summary>

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationReconcileTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationReconcileTests.cs
@@ -11,10 +11,11 @@ using Nocturne.Infrastructure.Data.Services;
 namespace Nocturne.Infrastructure.Data.Tests.Services;
 
 /// <summary>
-/// Tests for the reusable per-record criteria + deleted-status loader used by
-/// dedup reconciliation. Verifies that <see cref="DeduplicationService"/> can
-/// load each record's <see cref="MatchCriteria"/> alongside its soft-deleted
-/// status, keyed by record id, even for soft-deleted rows.
+/// Tests for dedup reconciliation in <see cref="DeduplicationService"/>: the reusable
+/// per-record criteria + deleted-status loader (<see cref="MatchCriteria"/> plus soft-deleted
+/// status keyed by record id), merging duplicate canonical groups (full and candidate-bounded,
+/// including transitive chains), the per-tenant reconciliation watermark round-trip, and the
+/// watermark-bounded chunked reconcile pass over newly-created links.
 /// </summary>
 [Trait("Category", "Unit")]
 [Trait("Category", "Deduplication")]
@@ -181,6 +182,128 @@ public class DeduplicationReconcileTests : IDisposable
     }
 
     [Fact]
+    public async Task MergeDuplicateGroupsAsync_MergesTransitiveThreeGroupChain()
+    {
+        var t = DateTime.UtcNow;
+        // Three groups 20s apart: endpoints are 40s apart (> the 30s window) but connect
+        // transitively through the middle group, so all three must collapse to one.
+        var a = await AddCarb(t, "mylife-connector", 50);
+        var b = await AddCarb(t.AddSeconds(20), "glooko-connector", 50);
+        var c = await AddCarb(t.AddSeconds(40), "libre-connector", 50);
+        AddPrimaryLink(RecordType.CarbIntake, a, ToMills(t), "mylife-connector");
+        AddPrimaryLink(RecordType.CarbIntake, b, ToMills(t.AddSeconds(20)), "glooko-connector");
+        AddPrimaryLink(RecordType.CarbIntake, c, ToMills(t.AddSeconds(40)), "libre-connector");
+        await _context.SaveChangesAsync();
+
+        var merged = await _service.MergeDuplicateGroupsAsync(RecordType.CarbIntake, null, CancellationToken.None);
+
+        merged.Should().Be(2);
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(1);
+        links.Count(l => l.IsPrimary).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task MergeDuplicateGroupsAsync_CandidatePath_MergesCandidateWithNeighbour()
+    {
+        var t = DateTime.UtcNow;
+        var mylife = await AddCarb(t, "mylife-connector", 50);
+        var glooko = await AddCarb(t.AddSeconds(20), "glooko-connector", 50);
+        AddPrimaryLink(RecordType.CarbIntake, mylife, ToMills(t), "mylife-connector");
+        var glookoCanonical = AddPrimaryLink(RecordType.CarbIntake, glooko, ToMills(t.AddSeconds(20)), "glooko-connector");
+        await _context.SaveChangesAsync();
+
+        var merged = await _service.MergeDuplicateGroupsAsync(
+            RecordType.CarbIntake,
+            new HashSet<Guid> { glookoCanonical },
+            CancellationToken.None);
+
+        merged.Should().Be(1);
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task MergeDuplicateGroupsAsync_CandidatePath_LeavesUnrelatedPairAlone()
+    {
+        var t = DateTime.UtcNow;
+        // Candidate group plus its in-window neighbour (these should merge).
+        var candA = await AddCarb(t, "mylife-connector", 50);
+        var candB = await AddCarb(t.AddSeconds(20), "glooko-connector", 50);
+        var candCanonical = AddPrimaryLink(RecordType.CarbIntake, candA, ToMills(t), "mylife-connector");
+        AddPrimaryLink(RecordType.CarbIntake, candB, ToMills(t.AddSeconds(20)), "glooko-connector");
+
+        // A SEPARATE unrelated matching pair far away in time — must NOT be touched.
+        var farT = t.AddHours(5);
+        var farA = await AddCarb(farT, "mylife-connector", 80);
+        var farB = await AddCarb(farT.AddSeconds(20), "glooko-connector", 80);
+        AddPrimaryLink(RecordType.CarbIntake, farA, ToMills(farT), "mylife-connector");
+        AddPrimaryLink(RecordType.CarbIntake, farB, ToMills(farT.AddSeconds(20)), "glooko-connector");
+        await _context.SaveChangesAsync();
+
+        var merged = await _service.MergeDuplicateGroupsAsync(
+            RecordType.CarbIntake,
+            new HashSet<Guid> { candCanonical },
+            CancellationToken.None);
+
+        // Only the candidate region was reconciled: 1 merge, and the far pair is untouched.
+        merged.Should().Be(1);
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        // candidate pair collapsed to 1 canonical; far pair still 2 distinct canonicals => 3 total.
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(3);
+        // The far pair still has its two separate primaries.
+        var farLinks = links.Where(l => l.RecordId == farA || l.RecordId == farB).ToList();
+        farLinks.Select(l => l.CanonicalId).Distinct().Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task ReconcileNewLinksAsync_MergesGroupsWithRecentLinks()
+    {
+        var now = DateTime.UtcNow;
+        await _service.SetWatermarkAsync(now.AddHours(-1), CancellationToken.None);
+
+        var t = now.AddMinutes(-5);
+        var mylife = await AddCarb(t, "mylife-connector", 50);
+        var glooko = await AddCarb(t.AddSeconds(20), "glooko-connector", 50);
+        AddPrimaryLink(RecordType.CarbIntake, mylife, ToMills(t), "mylife-connector");
+        AddPrimaryLink(RecordType.CarbIntake, glooko, ToMills(t.AddSeconds(20)), "glooko-connector");
+        await _context.SaveChangesAsync();
+        await SetAllLinkSysCreatedAt(now);
+
+        var result = await _service.ReconcileNewLinksAsync(5000, 10, CancellationToken.None);
+
+        result.GroupsMerged.Should().Be(1);
+        result.CaughtUp.Should().BeTrue();
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(1);
+
+        var watermark = await _service.GetWatermarkAsync(CancellationToken.None);
+        watermark.Should().BeCloseTo(now, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task ReconcileNewLinksAsync_IgnoresLinksBeforeWatermark()
+    {
+        var now = DateTime.UtcNow;
+        await _service.SetWatermarkAsync(now, CancellationToken.None);
+
+        // Links created an hour ago — well before (watermark - overlap), so out of scope.
+        var t = now.AddHours(-1);
+        var mylife = await AddCarb(t, "mylife-connector", 50);
+        var glooko = await AddCarb(t.AddSeconds(20), "glooko-connector", 50);
+        AddPrimaryLink(RecordType.CarbIntake, mylife, ToMills(t), "mylife-connector");
+        AddPrimaryLink(RecordType.CarbIntake, glooko, ToMills(t.AddSeconds(20)), "glooko-connector");
+        await _context.SaveChangesAsync();
+        await SetAllLinkSysCreatedAt(now.AddHours(-1));
+
+        var result = await _service.ReconcileNewLinksAsync(5000, 10, CancellationToken.None);
+
+        result.GroupsMerged.Should().Be(0);
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(2);
+    }
+
+    [Fact]
     public async Task Watermark_RoundTrips_DefaultsToMinValue()
     {
         (await _service.GetWatermarkAsync(CancellationToken.None)).Should().Be(DateTime.MinValue);
@@ -228,15 +351,17 @@ public class DeduplicationReconcileTests : IDisposable
     }
 
     /// <summary>
-    /// Adds a primary <see cref="LinkedRecordEntity"/> with a fresh canonical id for the test tenant.
+    /// Adds a primary <see cref="LinkedRecordEntity"/> with a fresh canonical id for the test tenant
+    /// and returns that canonical id (handy for candidate-bounded reconcile tests).
     /// </summary>
-    private void AddPrimaryLink(RecordType recordType, Guid recordId, long mills, string source)
+    private Guid AddPrimaryLink(RecordType recordType, Guid recordId, long mills, string source)
     {
+        var canonicalId = Guid.CreateVersion7();
         _context.LinkedRecords.Add(new LinkedRecordEntity
         {
             Id = Guid.CreateVersion7(),
             TenantId = TestTenantId,
-            CanonicalId = Guid.CreateVersion7(),
+            CanonicalId = canonicalId,
             RecordType = recordType.ToString().ToLowerInvariant(),
             RecordId = recordId,
             SourceTimestamp = mills,
@@ -244,6 +369,24 @@ public class DeduplicationReconcileTests : IDisposable
             IsPrimary = true,
             SysCreatedAt = DateTime.UtcNow
         });
+        return canonicalId;
+    }
+
+    /// <summary>
+    /// Overrides <see cref="LinkedRecordEntity.SysCreatedAt"/> on all of the tenant's links.
+    /// The SaveChanges interceptor stamps SysCreatedAt = now only on <c>Added</c> rows, so the
+    /// initializer value is ignored on insert; updating already-persisted rows lets tests pin a
+    /// deterministic ingestion time for the watermark-bounded reconcile pass.
+    /// </summary>
+    private async Task SetAllLinkSysCreatedAt(DateTime sysCreatedAt)
+    {
+        var utc = DateTime.SpecifyKind(sysCreatedAt, DateTimeKind.Utc);
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().ToListAsync();
+        foreach (var link in links)
+        {
+            link.SysCreatedAt = utc;
+        }
+        await _context.SaveChangesAsync();
     }
 
     /// <summary>

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationReconcileTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationReconcileTests.cs
@@ -1,0 +1,78 @@
+using System.Data.Common;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Contracts.Infrastructure;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Services;
+
+namespace Nocturne.Infrastructure.Data.Tests.Services;
+
+/// <summary>
+/// Tests for the reusable per-record criteria + deleted-status loader used by
+/// dedup reconciliation. Verifies that <see cref="DeduplicationService"/> can
+/// load each record's <see cref="MatchCriteria"/> alongside its soft-deleted
+/// status, keyed by record id, even for soft-deleted rows.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Category", "Deduplication")]
+public class DeduplicationReconcileTests : IDisposable
+{
+    private static readonly Guid TestTenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+    private readonly DbConnection _connection;
+    private readonly DbContextOptions<NocturneDbContext> _contextOptions;
+    private readonly NocturneDbContext _context;
+    private readonly DeduplicationService _service;
+
+    public DeduplicationReconcileTests()
+    {
+        // In-memory SQLite database for testing — mirrors CarbIntakeRepositoryTests.
+        _connection = new SqliteConnection("Filename=:memory:");
+        _connection.Open();
+
+        _contextOptions = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        // Create the database schema and seed the tenant.
+        using (var seedContext = new NocturneDbContext(_contextOptions))
+        {
+            seedContext.TenantId = TestTenantId;
+            seedContext.Database.EnsureCreated();
+            seedContext.Tenants.Add(new TenantEntity { Id = TestTenantId, Slug = "test" });
+            seedContext.SaveChanges();
+        }
+
+        _context = new NocturneDbContext(_contextOptions);
+        _context.TenantId = TestTenantId;
+
+        _service = new DeduplicationService(
+            _context,
+            new Mock<IServiceScopeFactory>().Object,
+            NullLogger<DeduplicationService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task LoadRecordInfoAsync_CarbIntake_ReturnsCriteriaAndDeletedFlag()
+    {
+        var live = Guid.CreateVersion7();
+        var gone = Guid.CreateVersion7();
+        _context.CarbIntakes.Add(new CarbIntakeEntity { Id = live, TenantId = TestTenantId, Carbs = 42, Timestamp = DateTime.UtcNow });
+        _context.CarbIntakes.Add(new CarbIntakeEntity { Id = gone, TenantId = TestTenantId, Carbs = 42, Timestamp = DateTime.UtcNow, DeletedAt = DateTime.UtcNow });
+        await _context.SaveChangesAsync();
+
+        var info = await _service.LoadRecordInfoForTestAsync(RecordType.CarbIntake, new HashSet<Guid> { live, gone });
+
+        info[live].Criteria.Carbs.Should().Be(42);
+        info[live].IsDeleted.Should().BeFalse();
+        info[gone].IsDeleted.Should().BeTrue();
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationReconcileTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationReconcileTests.cs
@@ -1,8 +1,10 @@
 using System.Data.Common;
 using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Nocturne.Core.Contracts.Infrastructure;
+using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Services;
 
@@ -104,4 +106,121 @@ public class DeduplicationReconcileTests : IDisposable
         info.Should().ContainKey(mine);
         info.Should().NotContainKey(theirs);
     }
+
+    [Fact]
+    public async Task MergeDuplicateGroupsAsync_MergesTwoPrimaryGroupsForSameMeal()
+    {
+        var t = DateTime.UtcNow;
+        var mylife = await AddCarb(t, "mylife-connector", 50);
+        var glooko = await AddCarb(t.AddSeconds(20), "glooko-connector", 50);
+        AddPrimaryLink(RecordType.CarbIntake, mylife, ToMills(t), "mylife-connector");
+        AddPrimaryLink(RecordType.CarbIntake, glooko, ToMills(t.AddSeconds(20)), "glooko-connector");
+        await _context.SaveChangesAsync();
+
+        var merged = await _service.MergeDuplicateGroupsAsync(RecordType.CarbIntake, null, CancellationToken.None);
+
+        merged.Should().Be(1);
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(1);
+        links.Count(l => l.IsPrimary).Should().Be(1);
+        links.Single(l => l.IsPrimary).RecordId.Should().Be(mylife); // earliest, non-deleted
+    }
+
+    [Fact]
+    public async Task MergeDuplicateGroupsAsync_DoesNotMergeDifferentValues()
+    {
+        var t = DateTime.UtcNow;
+        var mylife = await AddCarb(t, "mylife-connector", 50);
+        var glooko = await AddCarb(t.AddSeconds(20), "glooko-connector", 80);
+        AddPrimaryLink(RecordType.CarbIntake, mylife, ToMills(t), "mylife-connector");
+        AddPrimaryLink(RecordType.CarbIntake, glooko, ToMills(t.AddSeconds(20)), "glooko-connector");
+        await _context.SaveChangesAsync();
+
+        var merged = await _service.MergeDuplicateGroupsAsync(RecordType.CarbIntake, null, CancellationToken.None);
+
+        merged.Should().Be(0);
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task MergeDuplicateGroupsAsync_DoesNotMergeOutsideWindow()
+    {
+        var t = DateTime.UtcNow;
+        var mylife = await AddCarb(t, "mylife-connector", 50);
+        var glooko = await AddCarb(t.AddSeconds(90), "glooko-connector", 50);
+        AddPrimaryLink(RecordType.CarbIntake, mylife, ToMills(t), "mylife-connector");
+        AddPrimaryLink(RecordType.CarbIntake, glooko, ToMills(t.AddSeconds(90)), "glooko-connector");
+        await _context.SaveChangesAsync();
+
+        var merged = await _service.MergeDuplicateGroupsAsync(RecordType.CarbIntake, null, CancellationToken.None);
+
+        merged.Should().Be(0);
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task MergeDuplicateGroupsAsync_PrefersNonDeletedAsPrimary()
+    {
+        var t = DateTime.UtcNow;
+        // Earliest record is soft-deleted; the later non-deleted record must become the surviving primary.
+        var deleted = await AddCarb(t, "mylife-connector", 50, deletedAt: DateTime.UtcNow);
+        var live = await AddCarb(t.AddSeconds(20), "glooko-connector", 50);
+        AddPrimaryLink(RecordType.CarbIntake, deleted, ToMills(t), "mylife-connector");
+        AddPrimaryLink(RecordType.CarbIntake, live, ToMills(t.AddSeconds(20)), "glooko-connector");
+        await _context.SaveChangesAsync();
+
+        var merged = await _service.MergeDuplicateGroupsAsync(RecordType.CarbIntake, null, CancellationToken.None);
+
+        merged.Should().Be(1);
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(1);
+        links.Count(l => l.IsPrimary).Should().Be(1);
+        links.Single(l => l.IsPrimary).RecordId.Should().Be(live); // earliest non-deleted
+    }
+
+    /// <summary>
+    /// Inserts a <see cref="CarbIntakeEntity"/> for the test tenant and returns its id.
+    /// </summary>
+    private async Task<Guid> AddCarb(DateTime timestamp, string dataSource, double carbs, DateTime? deletedAt = null)
+    {
+        var id = Guid.CreateVersion7();
+        _context.CarbIntakes.Add(new CarbIntakeEntity
+        {
+            Id = id,
+            TenantId = TestTenantId,
+            Carbs = carbs,
+            Timestamp = timestamp,
+            DataSource = dataSource,
+            DeletedAt = deletedAt
+        });
+        await _context.SaveChangesAsync();
+        return id;
+    }
+
+    /// <summary>
+    /// Adds a primary <see cref="LinkedRecordEntity"/> with a fresh canonical id for the test tenant.
+    /// </summary>
+    private void AddPrimaryLink(RecordType recordType, Guid recordId, long mills, string source)
+    {
+        _context.LinkedRecords.Add(new LinkedRecordEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TestTenantId,
+            CanonicalId = Guid.CreateVersion7(),
+            RecordType = recordType.ToString().ToLowerInvariant(),
+            RecordId = recordId,
+            SourceTimestamp = mills,
+            DataSource = source,
+            IsPrimary = true,
+            SysCreatedAt = DateTime.UtcNow
+        });
+    }
+
+    /// <summary>
+    /// Converts a UTC <see cref="DateTime"/> to Unix milliseconds, matching the link source timestamp.
+    /// </summary>
+    private static long ToMills(DateTime d) =>
+        new DateTimeOffset(d, TimeSpan.Zero).ToUnixTimeMilliseconds();
 }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationReconcileTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationReconcileTests.cs
@@ -304,6 +304,73 @@ public class DeduplicationReconcileTests : IDisposable
     }
 
     [Fact]
+    public async Task ReconcileNewLinksAsync_SkipsUnknownRecordType()
+    {
+        var now = DateTime.UtcNow;
+        await _service.SetWatermarkAsync(now.AddHours(-1), CancellationToken.None);
+
+        // A valid mergeable pair that should still collapse despite a bogus row in the batch.
+        var t = now.AddMinutes(-5);
+        var mylife = await AddCarb(t, "mylife-connector", 50);
+        var glooko = await AddCarb(t.AddSeconds(20), "glooko-connector", 50);
+        AddPrimaryLink(RecordType.CarbIntake, mylife, ToMills(t), "mylife-connector");
+        AddPrimaryLink(RecordType.CarbIntake, glooko, ToMills(t.AddSeconds(20)), "glooko-connector");
+
+        // A linked_records row whose free-form RecordType is not a member of the RecordType enum.
+        // Enum.Parse on this string would throw and take down the whole reconcile batch loop.
+        _context.LinkedRecords.Add(new LinkedRecordEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TestTenantId,
+            CanonicalId = Guid.CreateVersion7(),
+            RecordType = "bogustype",
+            RecordId = Guid.CreateVersion7(),
+            SourceTimestamp = ToMills(t),
+            DataSource = "mylife-connector",
+            IsPrimary = true,
+            SysCreatedAt = DateTime.UtcNow
+        });
+        await _context.SaveChangesAsync();
+        await SetAllLinkSysCreatedAt(now);
+
+        var act = async () => await _service.ReconcileNewLinksAsync(5000, 10, CancellationToken.None);
+
+        var result = await act.Should().NotThrowAsync();
+        // The valid pair still merges, and the call returns normally.
+        result.Subject.GroupsMerged.Should().Be(1);
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ReconcileNewLinksAsync_FreshTenant_DefaultWatermark_ReconcilesWithoutThrowing()
+    {
+        // Fresh tenant: no watermark seeded, so GetWatermarkAsync returns DateTime.MinValue.
+        // cutoff = watermark - ReconcileOverlap would underflow (ArgumentOutOfRangeException).
+        (await _service.GetWatermarkAsync(CancellationToken.None)).Should().Be(DateTime.MinValue);
+
+        var now = DateTime.UtcNow;
+        var t = now.AddMinutes(-5);
+        var mylife = await AddCarb(t, "mylife-connector", 50);
+        var glooko = await AddCarb(t.AddSeconds(20), "glooko-connector", 50);
+        AddPrimaryLink(RecordType.CarbIntake, mylife, ToMills(t), "mylife-connector");
+        AddPrimaryLink(RecordType.CarbIntake, glooko, ToMills(t.AddSeconds(20)), "glooko-connector");
+        await _context.SaveChangesAsync();
+        await SetAllLinkSysCreatedAt(now);
+
+        var act = async () => await _service.ReconcileNewLinksAsync(5000, 10, CancellationToken.None);
+
+        var result = await act.Should().NotThrowAsync();
+        result.Subject.GroupsMerged.Should().Be(1);
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(1);
+
+        // The watermark advances past MinValue.
+        var watermark = await _service.GetWatermarkAsync(CancellationToken.None);
+        watermark.Should().BeCloseTo(now, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
     public async Task Watermark_RoundTrips_DefaultsToMinValue()
     {
         (await _service.GetWatermarkAsync(CancellationToken.None)).Should().Be(DateTime.MinValue);


### PR DESCRIPTION
## Summary

This branch combines two related bodies of work around connector data flow:

**1. Event-driven connector sync** (pre-existing commits on this branch)
- SignalR realtime listener for the Nocturne Remote connector and a Socket.IO listener for the Nightscout connector, so an upstream change triggers an immediate (debounced) sync instead of waiting for the poll interval.
- `RequestImmediateSync` + realtime-listener lifecycle hooks on `ConnectorBackgroundService`.

**2. Cross-connector dedup reconciliation** (this session's work)
When two connectors import the same event — e.g. a MyLife pump whose data also flows through Glooko — insert-time dedup can leave two separate canonical groups (both `IsPrimary`), so the dashboard COB double-counts the same meal. This adds a self-healing watermark-driven sweep:
- `MergeDuplicateGroupsAsync` — window + criteria union-find that merges duplicate canonical groups; earliest **non-deleted** record becomes the sole primary, others demoted/re-pointed. Transitive + source-agnostic, matching insert-time semantics.
- `ReconcileNewLinksAsync` — chunked, watermark-bounded pass keyed on `linked_records.SysCreatedAt` (ingestion time), so back-dated catch-up imports are covered. Idempotent; bounded per tick.
- Per-tenant watermark state (`dedup_reconcile_state`, RLS-protected) + `DeduplicationReconciliationBackgroundService` (every 2 min, sequential per active tenant). First sweep auto-heals existing duplicates.
- Prereq fixes: `CarbIntakeRepository.CountAsync` now applies the same non-primary filter as `GetAsync`; realtime store singleton reset on `destroy()`; declare the missing `@eslint/js` devDependency.

Single-instance deployment assumed; a code comment notes swapping to a Postgres advisory lock if the API is ever scaled out.

## Test plan
- [x] `Nocturne.Infrastructure.Data.Tests` green locally (331/331, incl. 30 new dedup/reconcile tests)
- [x] `Nocturne.API.Tests` green except 2 pre-existing flakes unrelated to this work (a StatusService test-ordering flake that passes in isolation; a DocumentProcessing memory-usage benchmark)
- [ ] CI green
- [ ] Post-deploy: confirm a tenant's non-primary `carbintake` link count rises toward the MyLife/Glooko overlap and an overlap-day COB no longer doubles