### PR TITLE
fix(web): correct @eslint/js version + lockfile to unblock CI build

### DIFF
--- a/src/Web/packages/app/package.json
+++ b/src/Web/packages/app/package.json
@@ -46,7 +46,7 @@
     "format": "prettier --write ."
   },
   "devDependencies": {
-    "@eslint/js": "^10.3.0",
+    "@eslint/js": "^10.0.1",
     "@internationalized/date": "^3.12.1",
     "@lucide/svelte": "^1.14.0",
     "@playwright/test": "^1.60.0",

--- a/src/Web/pnpm-lock.yaml
+++ b/src/Web/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.3.0(jiti@2.7.0))
       '@internationalized/date':
         specifier: ^3.12.1
         version: 3.12.1
@@ -1062,6 +1065,15 @@ packages:
   '@eslint/core@1.2.1':
     resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/js@10.0.1':
+    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^10.0.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
 
   '@eslint/object-schema@3.0.5':
     resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
@@ -6618,6 +6630,10 @@ snapshots:
   '@eslint/core@1.2.1':
     dependencies:
       '@types/json-schema': 7.0.15
+
+  '@eslint/js@10.0.1(eslint@10.3.0(jiti@2.7.0))':
+    optionalDependencies:
+      eslint: 10.3.0(jiti@2.7.0)
 
   '@eslint/object-schema@3.0.5': {}
 


### PR DESCRIPTION
Follow-up to #279. The merged branch added `@eslint/js@^10.3.0` to package.json, but @eslint/js's latest is 10.0.1 (it doesn't track eslint's version), so the spec was unresolvable and `pnpm install --frozen-lockfile` failed in CI — breaking 'Build and Publish with Aspire' (no image). This corrects the spec to `^10.0.1` and adds the matching lockfile entry. Lockfile-only change; peers cleanly with the installed eslint@10.3.0.