### PR TITLE
feat: add Resend email provider for alert delivery

### DIFF
--- a/src/API/Nocturne.API/Services/Alerts/Providers/ChatBotProvider.cs
+++ b/src/API/Nocturne.API/Services/Alerts/Providers/ChatBotProvider.cs
@@ -29,6 +29,7 @@ internal sealed class ChatBotProvider(
         ChannelType.TelegramDm,
         ChannelType.TelegramGroup,
         ChannelType.WhatsAppDm,
+        ChannelType.ResendEmail,
     ];
 
     /// <summary>

--- a/src/API/Nocturne.API/Services/Platform/BotHealthService.cs
+++ b/src/API/Nocturne.API/Services/Platform/BotHealthService.cs
@@ -23,6 +23,7 @@ public sealed class BotHealthService
         ["slack"] = ChannelType.SlackDm,
         ["telegram"] = ChannelType.Telegram,
         ["whatsapp"] = ChannelType.WhatsApp,
+        ["resend"] = ChannelType.ResendEmail,
     };
 
     private static readonly HashSet<ChannelType> AlwaysAvailable =

--- a/src/API/Nocturne.API/Services/PlatformSettingsService.cs
+++ b/src/API/Nocturne.API/Services/PlatformSettingsService.cs
@@ -60,6 +60,13 @@ public class PlatformSettingsService
             new("phoneNumberId", "Phone Number ID", true),
             new("verifyToken", "Verify Token", true),
         ],
+        ["resend"] =
+        [
+            new("apiKey", "API Key", true),
+            new("fromAddress", "From Address", true),
+            new("fromName", "From Name", false),
+            new("webhookSecret", "Webhook Secret", false),
+        ],
     };
 
     public PlatformSettingsService(NocturneDbContext db, ISecretEncryptionService encryption)

--- a/src/Core/Nocturne.Core.Models/Alerts/ChannelType.cs
+++ b/src/Core/Nocturne.Core.Models/Alerts/ChannelType.cs
@@ -63,4 +63,8 @@ public enum ChannelType
     /// <summary>Home Assistant integration delivery via dedicated SignalR hub.</summary>
     [EnumMember(Value = "home_assistant"), JsonStringEnumMemberName("home_assistant")]
     HomeAssistant,
+
+    /// <summary>Email delivery via Resend.</summary>
+    [EnumMember(Value = "resend_email"), JsonStringEnumMemberName("resend_email")]
+    ResendEmail,
 }

--- a/src/Web/packages/app/src/lib/components/admin/IntegrationsTabContent.svelte
+++ b/src/Web/packages/app/src/lib/components/admin/IntegrationsTabContent.svelte
@@ -21,6 +21,7 @@
     slack: "Slack",
     telegram: "Telegram",
     whatsapp: "WhatsApp",
+    resend: "Resend (Email)",
   };
 
   let { platforms, onSave, onDelete } = $props<{

--- a/src/Web/packages/app/src/lib/components/alerts/channelMeta.ts
+++ b/src/Web/packages/app/src/lib/components/alerts/channelMeta.ts
@@ -148,6 +148,17 @@ export const CHANNEL_META: ChannelMetaEntry[] = [
     destinationPlaceholder: "+15551234567",
     destinationRequired: true,
   },
+  {
+    type: ChannelType.ResendEmail,
+    label: "Email",
+    description: "Send alerts to an email address via Resend",
+    logo: "/logos/email.jpg",
+    platform: "resend",
+    destinationInput: "text",
+    destinationLabel: "Email Address",
+    destinationPlaceholder: "user@example.com",
+    destinationRequired: true,
+  },
 ];
 
 const CHANNEL_META_BY_TYPE: Map<string, ChannelMetaEntry> = new Map(

--- a/src/Web/packages/app/src/lib/server/bot/index.ts
+++ b/src/Web/packages/app/src/lib/server/bot/index.ts
@@ -77,6 +77,16 @@ const platformBuilders: Record<string, PlatformConfigBuilder> = {
 		}),
 		fromEnv: () => false, // WhatsApp has no env var fallback
 	},
+	resend: {
+		fromDb: (fields) => ({
+			enabled: true,
+			fromAddress: fields["fromAddress"],
+			fromName: fields["fromName"],
+			apiKey: fields["apiKey"],
+			webhookSecret: fields["webhookSecret"],
+		}),
+		fromEnv: () => !!(env.RESEND_API_KEY && env.RESEND_FROM_ADDRESS),
+	},
 };
 
 function buildPlatformConfig(
@@ -103,6 +113,7 @@ async function initBot(): Promise<Bot> {
 			slack: buildPlatformConfig("slack", dbCredentials),
 			telegram: buildPlatformConfig("telegram", dbCredentials),
 			whatsapp: buildPlatformConfig("whatsapp", dbCredentials),
+			resend: buildPlatformConfig("resend", dbCredentials),
 		},
 		// The bot adapter expects a postgresql:// URL, not the .NET-style
 		// ConnectionStrings__nocturne-postgres value (which is

--- a/src/Web/packages/app/src/routes/api/v4/webhooks/resend/+server.ts
+++ b/src/Web/packages/app/src/routes/api/v4/webhooks/resend/+server.ts
@@ -1,0 +1,7 @@
+import type { RequestHandler } from "./$types";
+import { getBot } from "$lib/server/bot";
+
+export const POST: RequestHandler = async ({ request }) => {
+	const bot = await getBot();
+	return bot.webhooks.resend(request);
+};

--- a/src/Web/packages/bot/package.json
+++ b/src/Web/packages/bot/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nocturne/bot",
   "version": "1.0.0",
-  "description": "Multi-platform messaging bot for Nocturne (Discord, Telegram, Slack, WhatsApp)",
+  "description": "Multi-platform messaging bot for Nocturne (Discord, Telegram, Slack, WhatsApp, Resend)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
@@ -20,6 +20,7 @@
     "@chat-adapter/telegram": "4.20.2",
     "@chat-adapter/whatsapp": "4.20.2",
     "@chat-adapter/state-pg": "4.20.2",
+    "@resend/chat-sdk-adapter": "4.20.2",
     "winston": "^3.11.0"
   },
   "devDependencies": {

--- a/src/Web/packages/bot/src/alerts/deliver.ts
+++ b/src/Web/packages/bot/src/alerts/deliver.ts
@@ -5,18 +5,29 @@ import { createLogger } from "../lib/logger.js";
 
 const logger = createLogger();
 
+const DIRECT_CHANNEL_TYPES = new Set([
+  "discord_dm",
+  "slack_dm",
+  "telegram_dm",
+  "whatsapp_dm",
+  "resend_email",
+]);
+
 export class AlertDeliveryHandler {
   constructor(
     private bot: Chat,
     private api: BotApiClient,
   ) {}
 
+  private isDirect(channelType: string): boolean {
+    return DIRECT_CHANNEL_TYPES.has(channelType);
+  }
+
   async deliver(event: AlertDispatchEvent): Promise<void> {
     const { deliveryId, channelType, destination, payload } = event;
 
     try {
-      const isDM = channelType.endsWith("_dm");
-      const target = isDM
+      const target = this.isDirect(channelType)
         ? await this.bot.openDM(destination)
         : this.bot.channel(destination);
 

--- a/src/Web/packages/bot/src/bot.ts
+++ b/src/Web/packages/bot/src/bot.ts
@@ -3,6 +3,7 @@ import { createDiscordAdapter } from "@chat-adapter/discord";
 import { createSlackAdapter } from "@chat-adapter/slack";
 import { createTelegramAdapter } from "@chat-adapter/telegram";
 import { createWhatsAppAdapter } from "@chat-adapter/whatsapp";
+import { createResendAdapter } from "@resend/chat-sdk-adapter";
 import { createPostgresState } from "@chat-adapter/state-pg";
 import { createLogger } from "./lib/logger.js";
 
@@ -18,6 +19,10 @@ export interface PlatformCredentials {
   appSecret?: string;
   phoneNumberId?: string;
   verifyToken?: string;
+  fromAddress?: string;
+  fromName?: string;
+  apiKey?: string;
+  webhookSecret?: string;
 }
 
 export interface BotOptions {
@@ -26,6 +31,7 @@ export interface BotOptions {
     slack?: PlatformCredentials | boolean;
     telegram?: PlatformCredentials | boolean;
     whatsapp?: PlatformCredentials | boolean;
+    resend?: PlatformCredentials | boolean;
   };
   postgresUrl: string;
 }
@@ -89,6 +95,24 @@ export function createBot(options: BotOptions): Chat {
       logger.warn(
         "WhatsApp requires explicit credentials configured via the admin UI — skipping env var fallback",
       );
+    }
+  }
+
+  const resend = platforms.resend;
+  if (resend) {
+    if (typeof resend === "object") {
+      logger.info("Enabling Resend adapter");
+      adapters.resend = createResendAdapter({
+        fromAddress: resend.fromAddress!,
+        fromName: resend.fromName,
+        apiKey: resend.apiKey!,
+        webhookSecret: resend.webhookSecret,
+      });
+    } else {
+      adapters.resend = createResendAdapter({
+        fromAddress: process.env.RESEND_FROM_ADDRESS!,
+        fromName: process.env.RESEND_FROM_NAME,
+      }); // apiKey + webhookSecret auto-load from env
     }
   }
 

--- a/src/Web/packages/portal/src/content/docs/alerts-email.svx
+++ b/src/Web/packages/portal/src/content/docs/alerts-email.svx
@@ -1,0 +1,102 @@
+---
+title: Email Alerts (Resend)
+---
+
+<script>
+  import Callout from '@nocturne/cms/components/Callout.svelte';
+</script>
+
+# Email Alerts
+
+Nocturne can deliver glucose alerts directly to email using [Resend](https://resend.com),
+an email API provider. Resend's free tier includes 3,000 emails per month and 100 emails
+per day -- more than enough for most alert configurations.
+
+## 1. Create a Resend account
+
+1. Go to [resend.com](https://resend.com) and sign up
+2. Verify your email address
+
+## 2. Add and verify a sending domain
+
+1. In the Resend dashboard, go to **Domains**
+2. Click **Add Domain** and enter the domain you want to send from (e.g. `alerts.your-instance.com`)
+3. Add the DNS records Resend provides (typically a few TXT and MX records)
+4. Wait for verification -- this usually takes a few minutes but can take up to 48 hours
+
+<Callout type="info" title="Free tier sending domain">
+  On the free tier you can also send from Resend's shared domain
+  (<code>onboarding@resend.dev</code>) for testing, but a verified custom domain
+  is strongly recommended for production use to avoid deliverability issues.
+</Callout>
+
+## 3. Create an API key
+
+1. In the Resend dashboard, go to **API Keys**
+2. Click **Create API Key**
+3. Give it a name (e.g. `Nocturne Alerts`) and select **Sending access** permission
+4. Copy the key immediately
+
+<Callout type="warning" title="Save the API key now">
+  Resend only displays the full API key once. If you lose it, you'll need to
+  create a new one.
+</Callout>
+
+## 4. Configure Nocturne
+
+### Option A: Admin UI
+
+1. Sign in to your Nocturne instance as an admin
+2. Go to **Settings > Admin > Platform Settings**
+3. Find or add the **Resend** provider and fill in:
+
+| Field | Value |
+|-------|-------|
+| **From Address** | The email address to send from (e.g. `alerts@your-instance.com`) |
+| **From Name** | Display name in the From header (e.g. `Nocturne Alerts`) |
+| **API Key** | The API key from step 3 |
+| **Webhook Secret** | _(optional)_ Webhook signing secret for inbound email replies |
+
+4. Enable the provider and click **Save**
+
+### Option B: Environment variables
+
+Set these in your `.env` or container environment:
+
+| Variable | Value |
+|----------|-------|
+| `RESEND_API_KEY` | Your Resend API key |
+| `RESEND_FROM_ADDRESS` | Sender address (e.g. `alerts@your-instance.com`) |
+| `RESEND_FROM_NAME` | _(optional)_ Display name (e.g. `Nocturne Alerts`) |
+| `RESEND_WEBHOOK_SECRET` | _(optional)_ Webhook signing secret |
+
+Then restart Nocturne for the changes to take effect.
+
+## 5. Set up an alert rule
+
+1. Go to **Settings > Alerts**
+2. Create or edit an alert rule
+3. Under **Delivery channels**, add an **Email** channel
+4. Enter the recipient email address
+5. Save the rule
+
+## 6. Test it
+
+1. Trigger a test alert from **Settings > Alerts** (or wait for a real glucose excursion)
+2. Check the recipient's inbox for the alert email
+3. Verify that the **Acknowledge** link in the email works
+
+<Callout type="tip" title="Check spam folders">
+  If the test email doesn't arrive, check the spam/junk folder. Using a verified
+  custom domain with proper DNS records (SPF, DKIM) greatly improves deliverability.
+</Callout>
+
+## Inbound replies (optional)
+
+If you'd like users to reply to alert emails (e.g. to acknowledge an alert via email),
+set up a Resend inbound webhook:
+
+1. In the Resend dashboard, go to **Webhooks**
+2. Add a webhook pointing to `https://your-instance.com/api/v4/webhooks/resend`
+3. Copy the **signing secret** and add it as `RESEND_WEBHOOK_SECRET` in your config
+4. Enable the webhook

--- a/src/Web/packages/portal/src/lib/components/DocsSidebar.svelte
+++ b/src/Web/packages/portal/src/lib/components/DocsSidebar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { page } from "$app/state";
-    import { Rocket, Download, Settings, Shield, ChevronRight, ChevronDown } from "@lucide/svelte";
+    import { Rocket, Download, Settings, Shield, Bell, ChevronRight, ChevronDown } from "@lucide/svelte";
 
     const navSections = [
         {
@@ -26,6 +26,13 @@
             items: [
                 { href: "/docs/authentication/google", label: "Sign in with Google" },
                 { href: "/docs/authentication/github", label: "Sign in with GitHub" },
+            ],
+        },
+        {
+            title: "Alerts",
+            icon: Bell,
+            items: [
+                { href: "/docs/alerts/email", label: "Email (Resend)" },
             ],
         },
         {

--- a/src/Web/packages/portal/src/routes/docs/alerts/email/+page.svelte
+++ b/src/Web/packages/portal/src/routes/docs/alerts/email/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+    import Content from "../../../../content/docs/alerts-email.svx";
+</script>
+
+<div class="max-w-3xl">
+    <Content />
+</div>


### PR DESCRIPTION
Wire up the Resend Chat SDK adapter as a new alert delivery channel, allowing glucose alerts to be sent directly to email addresses. The implementation follows the same pattern as the existing Discord, Slack, Telegram, and WhatsApp providers.