### PR TITLE
Implement bulk delete for activities

### DIFF
--- a/src/API/Nocturne.API/Services/Health/ActivityService.cs
+++ b/src/API/Nocturne.API/Services/Health/ActivityService.cs
@@ -351,9 +351,59 @@ public class ActivityService : IActivityService
         {
             _logger.LogDebug("Bulk deleting activity records with filter: {Find}", find);
 
-            // TODO: Implement bulk delete for activities stored as StateSpans
-            _logger.LogWarning("Bulk delete for activities is not implemented yet");
-            return await Task.FromResult(0L);
+            // Regular activities are stored as StateSpans and are the only source
+            // addressable by the type-based `find` filter. Heart rate and step count
+            // sensor data live in dedicated tables and are not bulk-deletable here.
+            var activities = await _stateSpanService.GetActivitiesAsync(
+                type: find,
+                count: int.MaxValue,
+                skip: 0,
+                cancellationToken: cancellationToken
+            );
+
+            long deletedCount = 0;
+            foreach (var activity in activities)
+            {
+                if (string.IsNullOrEmpty(activity.Id))
+                    continue;
+
+                // Clean up any decomposed records linked to this legacy activity id.
+                try
+                {
+                    await _activityDecomposer.DeleteByLegacyIdAsync(
+                        activity.Id,
+                        cancellationToken
+                    );
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(
+                        ex,
+                        "Failed to delete decomposed records for legacy activity {Id}",
+                        activity.Id
+                    );
+                }
+
+                if (await _stateSpanService.DeleteActivityAsync(activity.Id, cancellationToken))
+                    deletedCount++;
+            }
+
+            if (deletedCount > 0)
+            {
+                await _signalRBroadcastService.BroadcastStorageDeleteAsync(
+                    "activity",
+                    new { collection = "activity", count = deletedCount }
+                );
+
+                await _events.OnBulkDeletedAsync(deletedCount, cancellationToken);
+
+                _logger.LogDebug(
+                    "Successfully bulk deleted {Count} activity records",
+                    deletedCount
+                );
+            }
+
+            return deletedCount;
         }
         catch (Exception ex)
         {

--- a/tests/Unit/Nocturne.API.Tests/Services/Health/ActivityServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Health/ActivityServiceTests.cs
@@ -531,10 +531,20 @@ public class ActivityServiceTests
     [Fact]
     [Trait("Category", "Unit")]
     [Trait("Category", "Parity")]
-    public async Task DeleteMultipleActivitiesAsync_WithoutFilter_ReturnsZero()
+    public async Task DeleteMultipleActivitiesAsync_WithoutFilter_DeletesAllStateSpanActivities()
     {
         // Arrange
-        // DeleteMultipleActivitiesAsync is not implemented yet, so it returns 0
+        var activities = new List<Activity>
+        {
+            new Activity { Id = "1", Type = "exercise", Mills = 1 },
+            new Activity { Id = "2", Type = "meal", Mills = 2 },
+        };
+        _mockStateSpanService
+            .Setup(s => s.GetActivitiesAsync(null, int.MaxValue, 0, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(activities);
+        _mockStateSpanService
+            .Setup(s => s.DeleteActivityAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
 
         // Act
         var result = await _activityService.DeleteMultipleActivitiesAsync(
@@ -542,17 +552,42 @@ public class ActivityServiceTests
         );
 
         // Assert
-        Assert.Equal(0L, result);
+        Assert.Equal(2L, result);
+        _mockStateSpanService.Verify(
+            s => s.DeleteActivityAsync("1", It.IsAny<CancellationToken>()),
+            Times.Once
+        );
+        _mockStateSpanService.Verify(
+            s => s.DeleteActivityAsync("2", It.IsAny<CancellationToken>()),
+            Times.Once
+        );
+        _mockActivityDecomposer.Verify(
+            d => d.DeleteByLegacyIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2)
+        );
+        _mockSignalRBroadcastService.Verify(
+            s => s.BroadcastStorageDeleteAsync("activity", It.IsAny<object>()),
+            Times.Once
+        );
     }
 
     [Fact]
     [Trait("Category", "Unit")]
     [Trait("Category", "Parity")]
-    public async Task DeleteMultipleActivitiesAsync_WithFilter_ReturnsZero()
+    public async Task DeleteMultipleActivitiesAsync_WithFilter_PassesFilterAndCountsDeleted()
     {
         // Arrange
         var find = "{\"type\":\"exercise\"}";
-        // DeleteMultipleActivitiesAsync is not implemented yet, so it returns 0
+        var activities = new List<Activity>
+        {
+            new Activity { Id = "1", Type = "exercise", Mills = 1 },
+        };
+        _mockStateSpanService
+            .Setup(s => s.GetActivitiesAsync(find, int.MaxValue, 0, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(activities);
+        _mockStateSpanService
+            .Setup(s => s.DeleteActivityAsync("1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
 
         // Act
         var result = await _activityService.DeleteMultipleActivitiesAsync(
@@ -561,7 +596,34 @@ public class ActivityServiceTests
         );
 
         // Assert
+        Assert.Equal(1L, result);
+        _mockStateSpanService.Verify(
+            s => s.GetActivitiesAsync(find, int.MaxValue, 0, It.IsAny<CancellationToken>()),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Parity")]
+    public async Task DeleteMultipleActivitiesAsync_WithNoMatches_ReturnsZeroAndDoesNotBroadcast()
+    {
+        // Arrange
+        _mockStateSpanService
+            .Setup(s => s.GetActivitiesAsync(null, int.MaxValue, 0, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Enumerable.Empty<Activity>());
+
+        // Act
+        var result = await _activityService.DeleteMultipleActivitiesAsync(
+            cancellationToken: CancellationToken.None
+        );
+
+        // Assert
         Assert.Equal(0L, result);
+        _mockSignalRBroadcastService.Verify(
+            s => s.BroadcastStorageDeleteAsync(It.IsAny<string>(), It.IsAny<object>()),
+            Times.Never
+        );
     }
 
     [Fact]
@@ -570,15 +632,14 @@ public class ActivityServiceTests
     public async Task DeleteMultipleActivitiesAsync_WithException_ThrowsException()
     {
         // Arrange
-        // Since the method currently just returns Task.FromResult(0L), it won't throw
-        // But we'll test what happens if it's modified to throw
+        _mockStateSpanService
+            .Setup(s => s.GetActivitiesAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Database error"));
 
         // Act & Assert
-        // For now, this should pass since the method doesn't actually throw
-        var result = await _activityService.DeleteMultipleActivitiesAsync(
-            cancellationToken: CancellationToken.None
+        await Assert.ThrowsAsync<Exception>(() =>
+            _activityService.DeleteMultipleActivitiesAsync(cancellationToken: CancellationToken.None)
         );
-        Assert.Equal(0L, result);
     }
 
     [Fact]


### PR DESCRIPTION
Replace the unimplemented DeleteMultipleActivitiesAsync stub in ActivityService
with a real implementation. Regular activities are stored as StateSpans, which
are the only source addressable by the type-based find filter, so the method
enumerates matching StateSpan activities, cleans up any decomposed (heart rate /
step count) records linked by legacy id, deletes each, and fires a single bulk
SignalR broadcast plus OnBulkDeletedAsync event. Heart rate and step count
sensor data live in dedicated tables and are not bulk-deletable via this path.

Update ActivityServiceTests to cover the new behavior (delete all, filter
pass-through, no-match no-broadcast, and exception propagation).