### PR TITLE
Update URL for Trio in DataSourceService

### DIFF
--- a/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
@@ -505,7 +505,7 @@ public class DataSourceService : IDataSourceService
                 Platform = UploaderPlatform.iOS,
                 Category = UploaderCategory.AidSystem,
                 Icon = "trio",
-                Url = "https://diy-trio.org",
+                Url = "https://triodocs.org",
             },
             new()
             {


### PR DESCRIPTION
From "https://diy-trio.org" to "https://triodocs.org", as the former URL is no longer used.