### PR TITLE
fix(aspire): skip publish-only steps in run mode

### DIFF
--- a/src/Aspire/Nocturne.Aspire.Host/Program.cs
+++ b/src/Aspire/Nocturne.Aspire.Host/Program.cs
@@ -623,8 +623,17 @@ class Program
                 .PublishAsDockerComposeService((_, _) => { });
         }
 
-        builder.AddMermaidDiagramPublisher();
-        builder.AddPortainerComposePublisher();
+        // Mermaid + Portainer publishers add pipeline steps that depend on
+        // `publish-compose`, which is registered only in publish mode by
+        // AddDockerComposeEnvironment. Registering them in run mode leaves
+        // their dependency dangling and crashes `aspire start` /
+        // `aspire run` with "Step 'mermaid-publish' depends on unknown step
+        // 'publish-compose'".
+        if (!builder.ExecutionContext.IsRunMode)
+        {
+            builder.AddMermaidDiagramPublisher();
+            builder.AddPortainerComposePublisher();
+        }
 
         var app = builder.Build();
         await app.RunAsync();


### PR DESCRIPTION
## Summary
\`aspire start\` and \`aspire run\` currently crash on a clean checkout with:

\`\`\`
System.InvalidOperationException:
  Step 'mermaid-publish' depends on unknown step 'publish-compose'
\`\`\`

\`AddMermaidDiagramPublisher\` and \`AddPortainerComposePublisher\` each register pipeline steps that \`dependsOn: \"publish-compose\"\`. That step is added by \`AddDockerComposeEnvironment\` **only in publish mode**, so in run mode it doesn't exist and the pipeline validator throws on startup.

This is also why \`Nocturne.E2E.Tests.Bootstrap.TenantSetupTests.SeedingTenantSucceeds\` fails at AppHost startup with the same exception — it never gets to actually exercise its assertions.

## Fix
Gate both publisher registrations on \`!builder.ExecutionContext.IsRunMode\`. They're publish-time artifacts (\`.mmd\` diagrams + Portainer bundle) and have no business running in dev. This mirrors the \`IsRunMode\` checks already used throughout \`Program.cs\` for dev-only resources.

## Test plan
- [x] \`dotnet build\` clean on the AppHost project
- [x] \`aspire start\` boots without the pipeline exception (verified locally against a wiped postgres volume + fresh tenant via \`dev-only/admin/seed-tenant\`)
- [ ] \`Nocturne.E2E.Tests.Bootstrap.TenantSetupTests\` runs (CI will confirm)
- [ ] \`aspire publish\` still emits the \`.mmd\` files and Portainer bundle (publishers still registered when \`IsRunMode == false\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)