### PR TITLE
fix(web): provide react for the bot's resend adapter so the build is green

### DIFF
--- a/src/Web/packages/app/vite.config.ts
+++ b/src/Web/packages/app/vite.config.ts
@@ -4,6 +4,26 @@ import commonjs from "vite-plugin-commonjs";
 import lingo from 'vite-plugin-lingo';
 import tailwindcss from "@tailwindcss/vite";
 import { setupBridge } from "@nocturne/bridge";
+import { createRequire } from "node:module";
+import { dirname } from "node:path";
+
+// @resend/chat-sdk-adapter (via @nocturne/bot) renders email cards with React
+// (react-email). It declares react/react-dom as transitive peers, so pnpm
+// never co-locates React with the adapter in its store — a bundler or Node
+// resolving `react` from the adapter's path can't find it. Pin React to the
+// single hoisted copy (resolved at config-eval time, so it works the same on
+// Windows and CI Linux) and bundle the adapter into the SSR output (see
+// ssr.noExternal) so no unresolvable bare `react` import survives.
+//
+// Alias to the package *directories*, not their entry files: @rollup/plugin-alias
+// matches at path boundaries, so `react-dom` -> <dir> also rewrites subpaths like
+// `react-dom/server` -> <dir>/server (react-email needs that). Aliasing to a file
+// would turn `react-dom/server` into `<dir>/index.js/server` (ENOTDIR).
+const require = createRequire(import.meta.url);
+const reactAliases = {
+  react: dirname(require.resolve("react/package.json")),
+  "react-dom": dirname(require.resolve("react-dom/package.json")),
+};
 // WUCHALE-DISABLED: wuchale temporarily disabled — see also hooks.server.ts and +layout.ts
 // import { wuchale } from '@wuchale/vite-plugin'
 
@@ -13,6 +33,15 @@ export default defineConfig(({ mode }) => {
 
   return {
     assetsInclude: ["**/*.jpg", "**/*.png", "**/*.gif"],
+    resolve: {
+      alias: reactAliases,
+    },
+    ssr: {
+      // Bundle the Resend adapter (and its React deps) into the SSR output so
+      // there is no bare `react` import left for Node to resolve from pnpm's
+      // store path at prerender/runtime.
+      noExternal: ["@resend/chat-sdk-adapter"],
+    },
     plugins: [
       tailwindcss(),
       sveltekit(),

--- a/src/Web/packages/bot/package.json
+++ b/src/Web/packages/bot/package.json
@@ -22,6 +22,8 @@
     "@chat-adapter/state-pg": "4.29.0",
     "@chat-adapter/messenger": "4.29.0",
     "@resend/chat-sdk-adapter": "^0.2.2",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
     "winston": "^3.11.0"
   },
   "devDependencies": {

--- a/src/Web/pnpm-lock.yaml
+++ b/src/Web/pnpm-lock.yaml
@@ -299,6 +299,12 @@ importers:
       chat:
         specifier: 4.29.0
         version: 4.29.0(zod@4.4.3)
+      react:
+        specifier: ^19.2.0
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.6(react@19.2.6)
       winston:
         specifier: ^3.11.0
         version: 3.18.3
@@ -3203,6 +3209,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@valibot/to-json-schema@1.6.0':
     resolution: {integrity: sha512-d6rYyK5KVa2XdqamWgZ4/Nr+cXhxjy7lmpe6Iajw15J/jmU+gyxl2IEd1Otg1d7Rl3gOQL5reulnSypzBtYy1A==}
@@ -6260,6 +6267,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:


### PR DESCRIPTION
## Problem

`main`'s **Build and Publish with Aspire** has failed since the Resend feature landed (#281, last green run #280), so no fresh `:latest` images have published in ~2 days. #285/#293/#294 all hit the same wall.

**Root cause:** `@nocturne/bot` → `@resend/chat-sdk-adapter`, whose `card-renderer.js` imports `react`, `react/jsx-runtime`, and `react-email`. The adapter declares `react`/`react-dom` as **transitive peers**, so pnpm never co-locates React with the adapter in its content-addressable store. A bundler (or Node, at SSR prerender) resolving `react` *from the adapter's path* can't find it, so `vite build` of `@nocturne/app` fails → Web container build fails → "tag as latest" is skipped.

## Fix (verified locally)

- Declare `react` + `react-dom` as dependencies of `@nocturne/bot` (it consumes the adapter, so it must satisfy the peer); regenerate `pnpm-lock.yaml`.
- In the app's Vite config: alias `react`/`react-dom`/`jsx-runtime` to the single hoisted copy (resolved at config-eval time → identical on Windows and CI Linux), and add `@resend/chat-sdk-adapter` to `ssr.noExternal` so it's bundled into the SSR output and no unresolvable bare `react` import survives.

Verified with a local `build:sveltekit` at the same `--max-old-space-size=7168` heap the Docker build uses (`src/Web/Dockerfile`): exit 0, full `build/` output produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
