### PR TITLE
fix(migration): resilient, tenant-scoped Nightscout import + fix pnpm/Node build break

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/TenantAdmin/MigrationController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/TenantAdmin/MigrationController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
 using Nocturne.API.Services.Migration;
 using Nocturne.Core.Contracts.Connectors;
+using Nocturne.Core.Contracts.Multitenancy;
 
 namespace Nocturne.API.Controllers.V4.TenantAdmin;
 
@@ -17,6 +18,7 @@ public class MigrationController : ControllerBase
 {
     private readonly IMigrationJobService _migrationService;
     private readonly IConnectorConfigurationService _connectorConfigService;
+    private readonly ITenantAccessor _tenantAccessor;
     private readonly ILogger<MigrationController> _logger;
 
     /// <summary>
@@ -24,14 +26,17 @@ public class MigrationController : ControllerBase
     /// </summary>
     /// <param name="migrationService">Service for managing Nightscout data migration jobs.</param>
     /// <param name="connectorConfigService">Service for reading saved connector credentials.</param>
+    /// <param name="tenantAccessor">Resolves the current request's tenant, used to own and scope migration jobs.</param>
     /// <param name="logger">Logger instance.</param>
     public MigrationController(
         IMigrationJobService migrationService,
         IConnectorConfigurationService connectorConfigService,
+        ITenantAccessor tenantAccessor,
         ILogger<MigrationController> logger)
     {
         _migrationService = migrationService;
         _connectorConfigService = connectorConfigService;
+        _tenantAccessor = tenantAccessor;
         _logger = logger;
     }
 
@@ -77,7 +82,7 @@ public class MigrationController : ControllerBase
             }
         }
 
-        var jobInfo = await _migrationService.StartMigrationAsync(request, ct);
+        var jobInfo = await _migrationService.StartMigrationAsync(request, _tenantAccessor.Context, ct);
         return AcceptedAtAction(nameof(GetStatus), new { jobId = jobInfo.Id }, jobInfo);
     }
 
@@ -115,7 +120,7 @@ public class MigrationController : ControllerBase
             NightscoutApiSecret = apiSecret,
         };
 
-        var jobInfo = await _migrationService.StartMigrationAsync(request, ct);
+        var jobInfo = await _migrationService.StartMigrationAsync(request, _tenantAccessor.Context, ct);
         return AcceptedAtAction(nameof(GetStatus), new { jobId = jobInfo.Id }, jobInfo);
     }
 
@@ -128,7 +133,7 @@ public class MigrationController : ControllerBase
     {
         try
         {
-            var status = await _migrationService.GetStatusAsync(jobId);
+            var status = await _migrationService.GetStatusAsync(_tenantAccessor.TenantId, jobId);
             return Ok(status);
         }
         catch (KeyNotFoundException)
@@ -146,7 +151,7 @@ public class MigrationController : ControllerBase
     {
         try
         {
-            await _migrationService.CancelAsync(jobId);
+            await _migrationService.CancelAsync(_tenantAccessor.TenantId, jobId);
             return NoContent();
         }
         catch (KeyNotFoundException)
@@ -161,7 +166,7 @@ public class MigrationController : ControllerBase
     [ProducesResponseType(typeof(IReadOnlyList<MigrationJobInfo>), StatusCodes.Status200OK)]
     public async Task<ActionResult<IReadOnlyList<MigrationJobInfo>>> GetHistory()
     {
-        var history = await _migrationService.GetHistoryAsync();
+        var history = await _migrationService.GetHistoryAsync(_tenantAccessor.TenantId);
         return Ok(history);
     }
 

--- a/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
+++ b/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
@@ -6,6 +6,7 @@ using MongoDB.Bson;
 using MongoDB.Driver;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Models;
+using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
@@ -20,15 +21,16 @@ public interface IMigrationJobService
 {
     Task<MigrationJobInfo> StartMigrationAsync(
         StartMigrationRequest request,
+        TenantContext? tenantContext,
         CancellationToken ct = default
     );
 
-    /// <exception cref="KeyNotFoundException">Thrown when the migration job is not found.</exception>
-    Task<MigrationJobStatus> GetStatusAsync(Guid jobId);
+    /// <exception cref="KeyNotFoundException">Thrown when the migration job is not found for the given tenant.</exception>
+    Task<MigrationJobStatus> GetStatusAsync(Guid tenantId, Guid jobId);
 
-    /// <exception cref="KeyNotFoundException">Thrown when the migration job is not found.</exception>
-    Task CancelAsync(Guid jobId);
-    Task<IReadOnlyList<MigrationJobInfo>> GetHistoryAsync();
+    /// <exception cref="KeyNotFoundException">Thrown when the migration job is not found for the given tenant.</exception>
+    Task CancelAsync(Guid tenantId, Guid jobId);
+    Task<IReadOnlyList<MigrationJobInfo>> GetHistoryAsync(Guid tenantId);
     Task<TestMigrationConnectionResult> TestConnectionAsync(
         TestMigrationConnectionRequest request,
         CancellationToken ct = default
@@ -50,7 +52,7 @@ public class MigrationJobService : IMigrationJobService
     private readonly IServiceProvider _serviceProvider;
     private readonly IConfiguration _configuration;
     private readonly ConcurrentDictionary<Guid, MigrationJob> _jobs = new();
-    private readonly List<MigrationJobInfo> _history = [];
+    private readonly List<(Guid TenantId, MigrationJobInfo Info)> _history = [];
     private readonly object _historyLock = new();
 
     public MigrationJobService(
@@ -66,10 +68,12 @@ public class MigrationJobService : IMigrationJobService
 
     public async Task<MigrationJobInfo> StartMigrationAsync(
         StartMigrationRequest request,
+        TenantContext? tenantContext,
         CancellationToken ct = default
     )
     {
         var jobId = Guid.CreateVersion7();
+        var tenantId = tenantContext?.TenantId ?? Guid.Empty;
         var sourceDesc =
             request.Mode == MigrationMode.Api
                 ? request.NightscoutUrl
@@ -83,28 +87,32 @@ public class MigrationJobService : IMigrationJobService
             SourceDescription = sourceDesc,
         };
 
-        var job = new MigrationJob(jobId, request, jobInfo, _logger, _serviceProvider);
+        var job = new MigrationJob(jobId, tenantId, request, jobInfo, tenantContext, _logger, _serviceProvider);
         _jobs[jobId] = job;
 
         lock (_historyLock)
         {
-            _history.Add(jobInfo);
+            _history.Add((tenantId, jobInfo));
         }
 
-        // Start migration in background
+        // Start migration on a detached background task. This deliberately does NOT use the
+        // request's CancellationToken (HttpContext.RequestAborted): the migration is designed to
+        // outlive the HTTP request that kicked it off, and tying it to the request token would
+        // cancel/abort it as soon as that request completes. User-initiated cancellation flows
+        // through the job's own CancellationTokenSource via Cancel().
         _ = Task.Run(
             async () =>
             {
                 try
                 {
-                    await job.ExecuteAsync(ct);
+                    await job.ExecuteAsync(CancellationToken.None);
                 }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Migration job {JobId} failed", jobId);
                 }
             },
-            ct
+            CancellationToken.None
         );
 
         _logger.LogInformation(
@@ -117,9 +125,9 @@ public class MigrationJobService : IMigrationJobService
         return jobInfo;
     }
 
-    public Task<MigrationJobStatus> GetStatusAsync(Guid jobId)
+    public Task<MigrationJobStatus> GetStatusAsync(Guid tenantId, Guid jobId)
     {
-        if (_jobs.TryGetValue(jobId, out var job))
+        if (_jobs.TryGetValue(jobId, out var job) && job.TenantId == tenantId)
         {
             return Task.FromResult(job.GetStatus());
         }
@@ -127,9 +135,9 @@ public class MigrationJobService : IMigrationJobService
         throw new KeyNotFoundException($"Migration job {jobId} not found");
     }
 
-    public Task CancelAsync(Guid jobId)
+    public Task CancelAsync(Guid tenantId, Guid jobId)
     {
-        if (_jobs.TryGetValue(jobId, out var job))
+        if (_jobs.TryGetValue(jobId, out var job) && job.TenantId == tenantId)
         {
             job.Cancel();
             _logger.LogInformation("Cancelled migration job {JobId}", jobId);
@@ -139,11 +147,12 @@ public class MigrationJobService : IMigrationJobService
         throw new KeyNotFoundException($"Migration job {jobId} not found");
     }
 
-    public Task<IReadOnlyList<MigrationJobInfo>> GetHistoryAsync()
+    public Task<IReadOnlyList<MigrationJobInfo>> GetHistoryAsync(Guid tenantId)
     {
         lock (_historyLock)
         {
-            return Task.FromResult<IReadOnlyList<MigrationJobInfo>>(_history.ToList());
+            return Task.FromResult<IReadOnlyList<MigrationJobInfo>>(
+                _history.Where(h => h.TenantId == tenantId).Select(h => h.Info).ToList());
         }
     }
 
@@ -347,11 +356,16 @@ public class MigrationJobService : IMigrationJobService
 internal class MigrationJob
 {
     private readonly Guid _id;
+    private readonly Guid _tenantId;
     private readonly StartMigrationRequest _request;
     private readonly MigrationJobInfo _info;
+    private readonly TenantContext? _tenantContext;
     private readonly ILogger _logger;
     private readonly IServiceProvider _serviceProvider;
     private readonly CancellationTokenSource _cts = new();
+
+    /// <summary>The tenant that owns this migration job. Used to scope status/cancel lookups.</summary>
+    public Guid TenantId => _tenantId;
     private MigrationJobState _state = MigrationJobState.Pending;
     private string? _currentOperation;
     private string? _errorMessage;
@@ -363,17 +377,38 @@ internal class MigrationJob
 
     public MigrationJob(
         Guid id,
+        Guid tenantId,
         StartMigrationRequest request,
         MigrationJobInfo info,
+        TenantContext? tenantContext,
         ILogger logger,
         IServiceProvider serviceProvider
     )
     {
         _id = id;
+        _tenantId = tenantId;
         _request = request;
         _info = info;
+        _tenantContext = tenantContext;
         _logger = logger;
         _serviceProvider = serviceProvider;
+    }
+
+    /// <summary>
+    /// Creates a DI scope for migration work and propagates the owning tenant's context into it,
+    /// so that tenant-scoped services (NocturneDbContext, decomposers, repositories) resolve and
+    /// write under the correct tenant. The migration runs on a detached background task with no
+    /// ambient request scope, so the tenant must be re-applied explicitly here — mirroring the
+    /// pattern used by other background services (e.g. ConnectorBackgroundService).
+    /// </summary>
+    private IServiceScope CreateTenantScope()
+    {
+        var scope = _serviceProvider.CreateScope();
+        if (_tenantContext is not null)
+        {
+            scope.ServiceProvider.GetRequiredService<ITenantAccessor>().SetTenant(_tenantContext);
+        }
+        return scope;
     }
 
     public MigrationJobStatus GetStatus() =>
@@ -445,7 +480,7 @@ internal class MigrationJob
     {
         _currentOperation = "Connecting to Nightscout";
 
-        using var scope = _serviceProvider.CreateScope();
+        using var scope = CreateTenantScope();
         var httpClientFactory = scope.ServiceProvider.GetRequiredService<IHttpClientFactory>();
         var httpClient = httpClientFactory.CreateClient();
         httpClient.BaseAddress = new Uri(_request.NightscoutUrl!.TrimEnd('/'));
@@ -581,7 +616,7 @@ internal class MigrationJob
         DateTime? currentTo = null;
         const int pageSize = 10000;
 
-        using var scope = _serviceProvider.CreateScope();
+        using var scope = CreateTenantScope();
         var decomposer = scope.ServiceProvider.GetRequiredService<IEntryDecomposer>();
 
         while (true)
@@ -655,7 +690,7 @@ internal class MigrationJob
         DateTime? currentTo = null;
         const int pageSize = 10000;
 
-        using var scope = _serviceProvider.CreateScope();
+        using var scope = CreateTenantScope();
         var decomposer = scope.ServiceProvider.GetRequiredService<ITreatmentDecomposer>();
 
         while (true)
@@ -728,7 +763,7 @@ internal class MigrationJob
         DateTime? currentTo = null;
         const int pageSize = 10000;
 
-        using var scope = _serviceProvider.CreateScope();
+        using var scope = CreateTenantScope();
         var decomposer = scope.ServiceProvider.GetRequiredService<IDeviceStatusDecomposer>();
 
         while (true)
@@ -812,7 +847,7 @@ internal class MigrationJob
             UpdateCollectionProgress(collectionName, profiles.Length, 0, 0, false);
             UpdateOverallProgress();
 
-            using var scope = _serviceProvider.CreateScope();
+            using var scope = CreateTenantScope();
             var decomposer = scope.ServiceProvider.GetRequiredService<Nocturne.Core.Contracts.V4.IProfileDecomposer>();
 
             foreach (var profile in profiles)
@@ -964,7 +999,7 @@ internal class MigrationJob
         DateTime? currentTo = null;
         const int pageSize = 10000;
 
-        using var scope = _serviceProvider.CreateScope();
+        using var scope = CreateTenantScope();
         var decomposer = scope.ServiceProvider.GetRequiredService<IActivityDecomposer>();
 
         while (true)
@@ -1028,7 +1063,7 @@ internal class MigrationJob
         var client = new MongoClient(_request.MongoConnectionString);
         var database = client.GetDatabase(_request.MongoDatabaseName);
 
-        using var scope = _serviceProvider.CreateScope();
+        using var scope = CreateTenantScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
 
         // List available collections
@@ -1199,7 +1234,7 @@ internal class MigrationJob
         if (doc.Contains("_id"))
             status.Id = doc["_id"].AsObjectId.ToString();
 
-        using var scope = _serviceProvider.CreateScope();
+        using var scope = CreateTenantScope();
         var decomposer = scope.ServiceProvider.GetRequiredService<Core.Contracts.V4.IDeviceStatusDecomposer>();
         await decomposer.DecomposeAsync(status, ct);
     }
@@ -1244,7 +1279,7 @@ internal class MigrationJob
             LoopSettings = loopSettings,
         };
 
-        using var scope = _serviceProvider.CreateScope();
+        using var scope = CreateTenantScope();
         var decomposer = scope.ServiceProvider.GetRequiredService<Nocturne.Core.Contracts.V4.IProfileDecomposer>();
         await decomposer.DecomposeAsync(profile, ct);
     }

--- a/src/Web/package.json
+++ b/src/Web/package.json
@@ -13,7 +13,7 @@
     "test": "pnpm --recursive test",
     "clean": "pnpm --recursive clean && rm -rf node_modules",
     "generate-api-client": "cd ../API/Nocturne.API && nswag run nswag.json",
-    "generate-zod-schemas": "node --experimental-transform-types utils/generateZodSchemas/index.ts",
+    "generate-zod-schemas": "node utils/generateZodSchemas/index.ts",
     "generate-remote-functions": "npx openapi-remote-codegen",
     "generate-api": "pnpm run generate-api-client && pnpm run generate-zod-schemas && pnpm run generate-remote-functions",
     "translations:stage": "cd ../.. && git ls-files src/Web/locales/ | xargs git update-index --no-skip-worktree && git add src/Web/locales/",
@@ -31,31 +31,6 @@
   "engines": {
     "node": ">=24",
     "pnpm": ">=9"
-  },
-  "pnpm": {
-    "overrides": {
-      "@sveltejs/vite-plugin-svelte": "^5.0.3",
-      "svelte": "^5.37.0",
-      "vite": "^6.3.5"
-    },
-    "packageExtensions": {
-      "tiptap-extension-auto-joiner": {
-        "peerDependencies": {
-          "@tiptap/core": "*",
-          "@tiptap/pm": "*"
-        }
-      },
-      "@microsoft/signalr": {
-        "dependencies": {
-          "tough-cookie": "*"
-        }
-      }
-    },
-    "onlyBuiltDependencies": [
-      "@tailwindcss/oxide",
-      "esbuild",
-      "protobufjs"
-    ]
   },
   "dependencies": {
     "@wuchale/svelte": "^0.18.1",

--- a/src/Web/packages/app/src/routes/(unauthenticated)/setup/steps/ImportProgress.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/setup/steps/ImportProgress.svelte
@@ -134,6 +134,12 @@
 
       loading = false;
       let firstPoll = true;
+      let consecutiveFailures = 0;
+      // The migration runs server-side on a detached background task — it continues even if
+      // this screen is closed. A single failed status poll (a transient network blip, or the
+      // API being briefly busy importing a large dataset) must therefore NOT abort the UI.
+      // Tolerate a few consecutive failures before surfacing an error.
+      const MAX_CONSECUTIVE_FAILURES = 5;
 
       // Poll loop — update real data from backend
       // startedAt is set after the first successful poll of a live (non-complete) migration
@@ -141,6 +147,7 @@
         try {
           const status = await migrationRemote.getStatus(resolvedJobId);
           if (!active) break;
+          consecutiveFailures = 0; // a successful poll clears the transient-failure streak
 
           realProgress = status.progressPercentage ?? 0;
           currentOperation = status.currentOperation ?? null;
@@ -192,8 +199,14 @@
           await new Promise((resolve) => setTimeout(resolve, 2000));
         } catch {
           if (!active) break;
-          error = "Lost connection to migration status";
-          break;
+          consecutiveFailures++;
+          // Only give up — and tell the user — once polling has failed repeatedly. The import
+          // itself keeps running on the server regardless of what we show here.
+          if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+            error = "Lost connection to migration status";
+            break;
+          }
+          await new Promise((resolve) => setTimeout(resolve, 2000));
         }
       }
     }

--- a/src/Web/pnpm-workspace.yaml
+++ b/src/Web/pnpm-workspace.yaml
@@ -3,6 +3,32 @@ packages:
 
 enableGlobalVirtualStore: true
 
+# Build-script approval. pnpm v11+ gates dependency build scripts on `allowBuilds` (a per-package
+# boolean map) and will block `pnpm install` — exiting non-zero — until each is explicitly set,
+# which in turn breaks the API project's post-build codegen target (`pnpm run generate-zod-schemas`).
+# `onlyBuiltDependencies` is the equivalent allow-list honoured by pnpm 9/10 (engines allows >=9),
+# kept here for compatibility. Keep the two lists in sync.
+allowBuilds:
+  "@tailwindcss/oxide": true
+  esbuild: true
+  protobufjs: true
+
 onlyBuiltDependencies:
   - "@tailwindcss/oxide"
   - esbuild
+  - protobufjs
+
+# Migrated from the package.json "pnpm" field, which pnpm v11+ no longer reads.
+overrides:
+  "@sveltejs/vite-plugin-svelte": "^5.0.3"
+  svelte: "^5.37.0"
+  vite: "^6.3.5"
+
+packageExtensions:
+  tiptap-extension-auto-joiner:
+    peerDependencies:
+      "@tiptap/core": "*"
+      "@tiptap/pm": "*"
+  "@microsoft/signalr":
+    dependencies:
+      tough-cookie: "*"

--- a/tests/Unit/Nocturne.API.Tests/Migration/MigrationJobServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Migration/MigrationJobServiceTests.cs
@@ -1,0 +1,94 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Migration;
+using Nocturne.Core.Contracts.Multitenancy;
+
+namespace Nocturne.API.Tests.Migration;
+
+/// <summary>
+/// Tenant-isolation behaviour for <see cref="MigrationJobService"/>. A migration job is owned by
+/// the tenant that started it, and status/cancel lookups must be scoped to that tenant so one
+/// tenant cannot read or cancel another tenant's job by guessing its id.
+/// </summary>
+public class MigrationJobServiceTests
+{
+    private static MigrationJobService CreateService()
+    {
+        // The background migration task will fail fast when it tries to create a DI scope from this
+        // empty provider — that's fine and intentional: these tests only exercise job ownership and
+        // lookup, which happen synchronously in StartMigrationAsync before any background work runs.
+        var serviceProvider = new Mock<IServiceProvider>().Object;
+        return new MigrationJobService(
+            NullLogger<MigrationJobService>.Instance,
+            serviceProvider,
+            new ConfigurationBuilder().Build());
+    }
+
+    private static TenantContext Tenant(Guid id) => new(id, $"slug-{id:N}", "Test Tenant", true);
+
+    private static StartMigrationRequest ApiRequest() => new()
+    {
+        Mode = MigrationMode.Api,
+        NightscoutUrl = "https://example-nightscout.invalid",
+    };
+
+    [Fact]
+    public async Task GetStatusAsync_returns_status_for_owning_tenant()
+    {
+        var service = CreateService();
+        var tenant = Tenant(Guid.NewGuid());
+
+        var job = await service.StartMigrationAsync(ApiRequest(), tenant);
+
+        var status = await service.GetStatusAsync(tenant.TenantId, job.Id);
+
+        status.JobId.Should().Be(job.Id);
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_throws_for_a_different_tenant()
+    {
+        var service = CreateService();
+        var owner = Tenant(Guid.NewGuid());
+        var other = Tenant(Guid.NewGuid());
+
+        var job = await service.StartMigrationAsync(ApiRequest(), owner);
+
+        // A different tenant must not be able to read the job, even with the correct id.
+        await Assert.ThrowsAsync<KeyNotFoundException>(
+            () => service.GetStatusAsync(other.TenantId, job.Id));
+    }
+
+    [Fact]
+    public async Task CancelAsync_throws_for_a_different_tenant()
+    {
+        var service = CreateService();
+        var owner = Tenant(Guid.NewGuid());
+        var other = Tenant(Guid.NewGuid());
+
+        var job = await service.StartMigrationAsync(ApiRequest(), owner);
+
+        await Assert.ThrowsAsync<KeyNotFoundException>(
+            () => service.CancelAsync(other.TenantId, job.Id));
+
+        // The owning tenant can still cancel it.
+        await service.CancelAsync(owner.TenantId, job.Id);
+    }
+
+    [Fact]
+    public async Task GetHistoryAsync_only_returns_the_calling_tenants_jobs()
+    {
+        var service = CreateService();
+        var tenantA = Tenant(Guid.NewGuid());
+        var tenantB = Tenant(Guid.NewGuid());
+
+        var jobA = await service.StartMigrationAsync(ApiRequest(), tenantA);
+        await service.StartMigrationAsync(ApiRequest(), tenantB);
+
+        var historyA = await service.GetHistoryAsync(tenantA.TenantId);
+
+        historyA.Should().ContainSingle(h => h.Id == jobA.Id);
+        historyA.Should().OnlyContain(h => h.Id == jobA.Id);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the reported **"Connection lost to the Migration server"** error during the new-instance Nightscout migration flow (New instance → Migrate from NS → Fill Data → Apply), plus several issues found while investigating, and an unrelated build break in the API's post-build codegen.

### 1. Migration import is no longer aborted by a transient status poll
The setup wizard's import step (`ImportProgress.svelte`) polls `getStatus` and **aborted the whole UI on the very first failed poll** — showing "Lost connection to migration status" — even though the migration runs as a *detached background task* that keeps going and completes. That's why users saw the error but the data backfilled fine anyway. The loop now tolerates up to 5 consecutive poll failures (resetting on success) before surfacing an error, matching the resilient pattern used by the uploader-connection poller.

### 2. Background job no longer tied to the request's CancellationToken
`StartMigrationAsync` passed the controller's `CancellationToken` (`HttpContext.RequestAborted`) into the fire-and-forget `Task.Run`, so the import could be cancelled/aborted the moment the starting HTTP request completed. It now runs on `CancellationToken.None`; user-initiated cancellation still works via the job's own `CancellationTokenSource`.

### 3. Migration jobs are tenant-owned and tenant-correct
- `GetStatus`/`Cancel`/`History` are now scoped to the tenant that started the job, so a job can't be read or cancelled cross-tenant via its id.
- The background job propagates the tenant context into its DI scopes via `ITenantAccessor.SetTenant` (mirroring `ConnectorBackgroundService` / `CompressionLowDetectionService`). Previously it created scopes from the root provider with no tenant, so in multi-tenant deployments imported data was written under `Guid.Empty` instead of the owning tenant.

### 4. Fix post-build codegen break (`pnpm run generate-zod-schemas`)
Two stacked problems:
- **pnpm v11** no longer reads the `pnpm` field from `package.json`, dropping the build-script allow-list — so `pnpm install` exited non-zero on unapproved build scripts (`esbuild`, `protobufjs`). Since pnpm runs that check before `pnpm run <script>`, it broke the API project's post-build target. Settings are migrated to `pnpm-workspace.yaml` (`allowBuilds` for v11, `onlyBuiltDependencies` kept for v9/10), and `overrides`/`packageExtensions` moved alongside.
- The script used `node --experimental-transform-types`, a flag **removed in current Node** (engines requires ≥24, where TS type-stripping is the default). Flag dropped.

## Testing
- New `MigrationJobServiceTests` cover tenant ownership/scoping (status/cancel/history). 4/4 passing.
- `dotnet build` of the API succeeds with the full codegen chain (NSwag → Zod → remote functions).
- `pnpm install --frozen-lockfile`, `pnpm run generate-zod-schemas` both succeed.