### PR TITLE
feat(portal): host Scalar API reference at /scalar

### DIFF
--- a/.github/workflows/portal-pages.yml
+++ b/.github/workflows/portal-pages.yml
@@ -58,6 +58,7 @@ jobs:
         env:
           VITE_DEMO_ENABLED: 'true'
           VITE_DEMO_WEB_URL: 'https://demo.nocturne.run'
+          VITE_SCALAR_API_URL: 'https://nocturne.run'
         run: pnpm run build
 
       - name: Upload artifact

--- a/src/Web/packages/portal/src/lib/components/DocsSidebar.svelte
+++ b/src/Web/packages/portal/src/lib/components/DocsSidebar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { page } from "$app/state";
-    import { Rocket, Download, Settings, Shield, Bell, ChevronRight, ChevronDown } from "@lucide/svelte";
+    import { Rocket, Download, Settings, Shield, Bell, Code2, ChevronRight, ChevronDown } from "@lucide/svelte";
 
     const navSections = [
         {
@@ -40,6 +40,13 @@
             icon: Settings,
             items: [
                 { href: "/docs/configuration", label: "Configuration Guide" },
+            ],
+        },
+        {
+            title: "API Reference",
+            icon: Code2,
+            items: [
+                { href: "/scalar", label: "Interactive API Docs" },
             ],
         },
     ];

--- a/src/Web/packages/portal/src/lib/components/SiteFooter.svelte
+++ b/src/Web/packages/portal/src/lib/components/SiteFooter.svelte
@@ -85,6 +85,14 @@
                             Configuration
                         </a>
                     </li>
+                    <li>
+                        <a
+                            href="/scalar"
+                            class="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                        >
+                            API Documentation
+                        </a>
+                    </li>
                 </ul>
             </div>
 

--- a/src/Web/packages/portal/src/lib/components/SiteHeader.svelte
+++ b/src/Web/packages/portal/src/lib/components/SiteHeader.svelte
@@ -12,6 +12,7 @@
     const baseNavLinks = [
         { href: "/features", label: "Features" },
         { href: "/docs", label: "Docs" },
+        { href: "/scalar", label: "API" },
         { href: "/get-involved", label: "Contribute" },
         { href: "/faq", label: "FAQ" },
     ];

--- a/src/Web/packages/portal/src/lib/config.ts
+++ b/src/Web/packages/portal/src/lib/config.ts
@@ -1,2 +1,6 @@
 export const DEMO_ENABLED = import.meta.env.VITE_DEMO_ENABLED === "true";
 export const DEMO_WEB_URL = import.meta.env.VITE_DEMO_WEB_URL || "";
+
+// Base URL of the hosted Nocturne API that serves the OpenAPI specs consumed by
+// the embedded Scalar reference at /scalar. Defaults to the production deployment.
+export const SCALAR_API_URL = import.meta.env.VITE_SCALAR_API_URL || "https://nocturne.run";

--- a/src/Web/packages/portal/src/routes/docs/+page.svelte
+++ b/src/Web/packages/portal/src/routes/docs/+page.svelte
@@ -94,8 +94,9 @@
             </div>
         </a>
 
-        <div
-            class="p-6 rounded-xl border border-border/60 bg-card/50 transition-colors"
+        <a
+            href="/scalar"
+            class="p-6 rounded-xl border border-border/60 bg-card/50 hover:bg-card hover:border-primary/30 transition-colors group"
         >
             <div class="flex items-start gap-4">
                 <div
@@ -105,23 +106,20 @@
                 </div>
                 <div class="flex-1">
                     <h2
-                        class="text-lg font-semibold mb-1 flex items-center gap-2"
+                        class="text-lg font-semibold mb-1 group-hover:text-primary transition-colors"
                     >
                         API Reference
                     </h2>
-                    <p class="text-sm text-muted-foreground mb-3">
+                    <p class="text-sm text-muted-foreground">
                         Interactive API documentation powered by Scalar. Explore
                         endpoints, test requests, and integrate with Nocturne.
                     </p>
-                    <p
-                        class="text-xs text-muted-foreground font-mono bg-muted/50 px-2 py-1 rounded inline-block"
-                    >
-                        Available at <span class="text-primary">/scalar</span> on
-                        your Nocturne API
-                    </p>
                 </div>
+                <ArrowRight
+                    class="w-5 h-5 text-muted-foreground group-hover:text-primary transition-colors"
+                />
             </div>
-        </div>
+        </a>
     </div>
 
     <div class="mt-12 p-6 rounded-xl border border-amber-500/30 bg-amber-500/5">

--- a/src/Web/packages/portal/src/routes/scalar/+page.svelte
+++ b/src/Web/packages/portal/src/routes/scalar/+page.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+    import { onMount } from "svelte";
+    import { SCALAR_API_URL } from "$lib/config";
+
+    // Pinned standalone build. Scalar is a Vue app, so it's loaded at runtime in
+    // the browser rather than bundled — keeps it out of the Svelte SSR/prerender
+    // graph (which can't resolve Vue's deps) and off the portal's dependency tree.
+    const SCALAR_SCRIPT = "https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.57.5";
+
+    type ScalarGlobal = {
+        createApiReference: (
+            el: HTMLElement,
+            config: Record<string, unknown>,
+        ) => { destroy?: () => void };
+    };
+
+    let container: HTMLDivElement;
+
+    onMount(() => {
+        let instance: { destroy?: () => void } | undefined;
+
+        const config = {
+            theme: "mars",
+            sources: [
+                {
+                    title: "Nocturne API",
+                    slug: "nocturne",
+                    url: `${SCALAR_API_URL}/openapi/nocturne.json`,
+                    default: true,
+                },
+                {
+                    title: "Nightscout API",
+                    slug: "nightscout",
+                    url: `${SCALAR_API_URL}/openapi/nightscout.json`,
+                },
+            ],
+        };
+
+        const script = document.createElement("script");
+        script.src = SCALAR_SCRIPT;
+        script.onload = () => {
+            const scalar = (window as unknown as { Scalar?: ScalarGlobal }).Scalar;
+            instance = scalar?.createApiReference(container, config);
+        };
+        document.head.appendChild(script);
+
+        return () => {
+            instance?.destroy?.();
+            script.remove();
+        };
+    });
+</script>
+
+<svelte:head>
+    <title>API Reference - Nocturne</title>
+    <meta
+        name="description"
+        content="Interactive Nocturne API documentation powered by Scalar — explore endpoints, test requests, and integrate with Nocturne."
+    />
+</svelte:head>
+
+<div bind:this={container} class="h-[calc(100vh-4rem)]"></div>


### PR DESCRIPTION
## What

Adds a `/scalar` route to the portal that hosts the **Scalar API reference**, so `getnocturne.dev/scalar` serves interactive API docs for the live Nocturne API.

## How

- The route loads Scalar's **pinned standalone bundle** (`@scalar/api-reference@1.57.5`) from jsDelivr at runtime in `onMount`, then calls `Scalar.createApiReference(...)`.
- It is deliberately **not** imported as an npm dependency: Scalar is a Vue app, and bundling it pulls Vue (via `vue-sonner`) into the Svelte SSR/prerender graph, which fails to build under `adapter-static`. Loading the script at runtime keeps Scalar entirely client-side and adds **zero weight** to the portal's dependency tree / lockfile.
- It reads the OpenAPI specs straight from the hosted API as two sources — `nocturne` (default) and `nightscout` — using the Mars theme to match the API's own Scalar UI.
- The API base URL is configurable via `VITE_SCALAR_API_URL` (defaults to `https://nocturne.run`); the GitHub Pages workflow sets it explicitly, mirroring the existing `VITE_DEMO_*` pattern.

## Discoverability

The page is linked from the docs index card, the docs sidebar (new "API Reference" section), the site header nav ("API"), and the footer ("API Documentation").

## Notes

- The specs are fetched cross-origin from the API, which already allows any CORS origin and exempts `/scalar` + `/openapi` from auth, so this works from the static Pages site. Scalar's "Test Request" hits the live API host per the spec's `servers`.
- Verified locally: `svelte-check` passes (0 errors) and the `adapter-static` production build prerenders the route cleanly.
