### PR TITLE
fix(connectors): resilient deserialization + per-type catch-up cursors for Nightscout

### DIFF
--- a/src/API/Nocturne.API/Configuration/ScalarExtensionsDocumentTransformer.cs
+++ b/src/API/Nocturne.API/Configuration/ScalarExtensionsDocumentTransformer.cs
@@ -13,7 +13,7 @@ public sealed class ScalarExtensionsDocumentTransformer : IOpenApiDocumentTransf
 {
     private static readonly Dictionary<string, string[]> NocturneTagGroups = new()
     {
-        ["Concepts"] = ["Idempotency"],
+        ["Concepts"] = ["Syncing"],
         ["Authentication & Identity"] = ["Authentication", "OIDC Discovery", "Identity"],
         ["Health Data"] = ["Glucose", "Treatments", "Health", "Devices", "State Spans"],
         ["Insights & Alerting"] = ["Analytics", "Current Therapy State", "Monitoring"],
@@ -72,7 +72,7 @@ public sealed class ScalarExtensionsDocumentTransformer : IOpenApiDocumentTransf
     {
         var used = new HashSet<string>(StringComparer.Ordinal);
 
-        // Document-level tags include standalone conceptual pages (e.g. Idempotency)
+        // Document-level tags include standalone conceptual pages (e.g. Syncing)
         // added by TagDescriptionDocumentTransformer, which runs before this one.
         if (document.Tags is not null)
             foreach (var tag in document.Tags)

--- a/src/API/Nocturne.API/Configuration/TagDescriptionDocumentTransformer.cs
+++ b/src/API/Nocturne.API/Configuration/TagDescriptionDocumentTransformer.cs
@@ -33,7 +33,7 @@ public sealed class TagDescriptionDocumentTransformer : IOpenApiDocumentTransfor
     /// Conceptual guide tags that have no operations of their own but still render as
     /// a standalone sidebar page from their description. Added to the Nocturne document only.
     /// </summary>
-    private static readonly string[] StandaloneDocTags = ["Idempotency"];
+    private static readonly string[] StandaloneDocTags = ["Syncing"];
 
     private static readonly Dictionary<string, string> Descriptions = new()
     {
@@ -213,12 +213,41 @@ public sealed class TagDescriptionDocumentTransformer : IOpenApiDocumentTransfor
             This is reference data — it is not tenant-specific and cannot be modified via the API.
             """,
 
-        ["Idempotency"] = """
+        ["Syncing"] = """
+            How Nocturne ingests data from connectors, how it resumes where it left off, and why re-syncing the same data never creates duplicates.
+
+            ## How connectors sync
+
+            Each connector (Nightscout, Dexcom, Glooko, …) runs as a per-tenant background service. The poller wakes on the tenant's configured interval (and, for Nightscout, immediately on real-time socket events from the upstream instance) and pulls any new data since it last ran. There is no stored cursor — Nocturne derives the resume point from the **latest record already stored** for each data type.
+
+            ## Per-type catch-up cursors
+
+            A connection carries several independent streams — glucose, treatments (boluses/carbs/manual BG), device status, activity — and each resumes from **its own** latest record, not a single shared cursor. This matters because one stream can legitimately lag another: a closed-loop user produces a glucose reading every 5 minutes but may bolus only a few times a day. Tying every stream to the glucose cursor would strand the slower streams permanently once glucose caught up.
+
+            - On a normal background sync each enabled type fetches from `latest_stored_record − 5min` (a small overlap absorbs clock drift).
+            - When a type has **no** data yet, it performs an initial backfill over a bounded window (currently 6 months) so a new connection fills in recent history.
+            - Profiles and food are small and fetched in full on every sync rather than windowed.
+
+            ## Resilient ingestion
+
+            Real-world uploader payloads are messy: numeric fields arrive as JSON strings (`"insulin":"1.5"`), booleans as `"true"`/`1`, direction as an integer. Connector deserialization tolerates these variants so one oddly-typed record can't throw and abort an entire page — which would otherwise drop a whole stream's backfill while a sibling stream (e.g. glucose) succeeded.
+
+            ## Re-syncing and cursor reset
+
+            Two endpoints force data in on demand, both reusing the stored connector credentials:
+
+            - **Manual sync** — `POST /api/v4/services/connectors/{id}/sync` with a `SyncRequest`. Supplying `to` switches the connector into *explicit-range* mode: it fetches exactly `from`…`to` for the requested `dataTypes`, bypassing the catch-up cursors. Use this to backfill a specific window of a specific type (e.g. treatments only) without re-pulling everything.
+            - **Cursor reset** — `POST /api/v4/services/connectors/{id}/reset-cursor`. Re-pulls history (all types, or a subset) from the beginning, or from an optional `from`. Use this after fixing a connector bug to push corrected data to a tenant.
+
+            Both are safe to re-run because of idempotency, below.
+
+            ## Idempotency
+
             How Nocturne guarantees that writing the same record twice never creates a duplicate — and why there are two separate keys for it.
 
             Diabetes data is written by two very different kinds of client, and **both retry**. A phone app may resend a `POST` after a flaky network; a background connector re-fetches overlapping time windows on every sync. To make writes safe to repeat, every V4 record carries an idempotency key and the database enforces uniqueness on it. Which key is used depends on **who is writing**.
 
-            ## Two channels
+            ### Two channels
 
             | Channel | Key | Who sets it | Why |
             | --- | --- | --- | --- |
@@ -227,19 +256,19 @@ public sealed class TagDescriptionDocumentTransformer : IOpenApiDocumentTransfor
 
             A given record normally carries **one** of these keys, not both.
 
-            ### `syncIdentifier` — client-owned
+            #### `syncIdentifier` — client-owned
 
             Clients that integrate over the REST API supply their own stable identifier on each write, scoped by `dataSource`. On create, if a record with the same `(dataSource, syncIdentifier)` already exists, the endpoint returns the existing record unchanged — an idempotent upsert — instead of inserting a duplicate. Enforced by a unique index on `(tenant_id, data_source, sync_identifier)`.
 
             Use this when **you** control the writer and can guarantee a stable ID that survives retries.
 
-            ### `legacyId` — content-derived
+            #### `legacyId` — content-derived
 
             Connectors pull from upstream platforms that rarely expose a stable per-record ID — Glooko's graph series, for example, are just timestamped points. Rather than a source ID, the connector derives a deterministic fingerprint from the record's own immutable content (event type + timestamp + salient fields). Re-syncing the same window regenerates an identical `legacyId`, so the second write is recognised as a duplicate. Enforced by a unique index on `(tenant_id, legacy_id)`.
 
             `legacyId` also doubles as migration traceability: it ties a V4 record back to the original Nightscout/Mongo document it was decomposed from.
 
-            ## Guidance for writers
+            ### Guidance for writers
 
             - **Building a client or uploader?** Always send `dataSource` + `syncIdentifier`, and reuse the same `syncIdentifier` when retrying the same logical record.
             - **Building a connector?** Derive a stable `legacyId` from immutable content. The repository bulk-create paths dedupe on it automatically.

--- a/src/API/Nocturne.API/Controllers/V4/Platform/ServicesController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/ServicesController.cs
@@ -436,6 +436,55 @@ public class ServicesController : ControllerBase
     }
 
     /// <summary>
+    /// Reset a connector's sync cursor for the current tenant and re-pull historical data.
+    /// </summary>
+    /// <remarks>
+    /// Nocturne does not persist a sync cursor — each data type resumes from the latest record
+    /// already stored. This endpoint forces a fresh ingest of history by running an explicit-range
+    /// sync (an upper bound of "now" bypasses the per-type catch-up cursors), so the effect is a
+    /// cursor reset. Re-ingested records are deduplicated on their idempotency keys (see the
+    /// "Syncing" guide), so it is safe to run after fixing a connector bug to push corrected data
+    /// to a tenant.
+    /// </remarks>
+    /// <param name="id">Connector ID (e.g., "nightscout", "dexcom").</param>
+    /// <param name="request">Optional lower bound and data-type filter. Omit <c>from</c> to re-pull all available history; omit <c>dataTypes</c> to reset every supported type.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Sync result with success status and details.</returns>
+    [HttpPost("connectors/{id}/reset-cursor")]
+    [RemoteCommand]
+    [ProducesResponseType(typeof(Nocturne.Connectors.Core.Models.SyncResult), 200)]
+    [ProducesResponseType(400)]
+    public async Task<
+        ActionResult<Nocturne.Connectors.Core.Models.SyncResult>
+    > ResetConnectorCursor(
+        string id,
+        [FromBody] ResetCursorRequest request,
+        CancellationToken cancellationToken
+    )
+    {
+        if (string.IsNullOrWhiteSpace(id))
+            return Problem(detail: "Connector ID is required", statusCode: 400, title: "Bad Request");
+
+        // Setting To forces "explicit range" mode in the connectors, bypassing the per-type
+        // catch-up cursors so history is genuinely re-pulled rather than resumed from the latest
+        // stored record. A null From means no lower bound — re-pull everything available.
+        var syncRequest = new Nocturne.Connectors.Core.Models.SyncRequest
+        {
+            From = request.From,
+            To = DateTime.UtcNow,
+            DataTypes = request.DataTypes ?? [],
+        };
+
+        _logger.LogInformation(
+            "Cursor reset requested for connector {ConnectorId} (from {From})",
+            id,
+            request.From?.ToString("o") ?? "beginning");
+
+        var result = await _connectorSyncService.TriggerSyncAsync(id, syncRequest, cancellationToken);
+        return Ok(result);
+    }
+
+    /// <summary>
     /// Get sync status for a specific connector, including latest timestamps and connector state.
     /// Used by connectors on startup to determine where to resume syncing from.
     /// </summary>
@@ -547,6 +596,24 @@ public class ServicesController : ControllerBase
         return $"{request.Scheme}://{request.Host}";
     }
 
+}
+
+/// <summary>
+/// Request body for resetting a connector's sync cursor and re-pulling history.
+/// </summary>
+public class ResetCursorRequest
+{
+    /// <summary>
+    /// Optional lower bound for the re-pull. When null, no lower bound is applied and all
+    /// available history is re-ingested.
+    /// </summary>
+    public DateTime? From { get; init; }
+
+    /// <summary>
+    /// Optional set of data types to reset. When null or empty, every data type the connector
+    /// supports is re-pulled.
+    /// </summary>
+    public List<Nocturne.Connectors.Core.Models.SyncDataType>? DataTypes { get; init; }
 }
 
 /// <summary>

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/DevicePublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/DevicePublisher.cs
@@ -15,15 +15,18 @@ internal sealed class DevicePublisher : IDevicePublisher
 {
     private readonly IDeviceStatusDecomposer _decomposer;
     private readonly IDeviceEventRepository _deviceEventRepository;
+    private readonly IApsSnapshotRepository _apsSnapshotRepository;
     private readonly ILogger<DevicePublisher> _logger;
 
     public DevicePublisher(
         IDeviceStatusDecomposer decomposer,
         IDeviceEventRepository deviceEventRepository,
+        IApsSnapshotRepository apsSnapshotRepository,
         ILogger<DevicePublisher> logger)
     {
         _decomposer = decomposer ?? throw new ArgumentNullException(nameof(decomposer));
         _deviceEventRepository = deviceEventRepository ?? throw new ArgumentNullException(nameof(deviceEventRepository));
+        _apsSnapshotRepository = apsSnapshotRepository ?? throw new ArgumentNullException(nameof(apsSnapshotRepository));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -69,4 +72,15 @@ internal sealed class DevicePublisher : IDevicePublisher
             return false;
         }
     }
+
+    /// <summary>
+    /// Returns the timestamp of the most recent device-status record for the current tenant,
+    /// using the <c>aps_snapshots</c> watermark — the dominant loop/openaps/pump device-status
+    /// source after decomposition. Like <see cref="ITreatmentPublisher.GetLatestTreatmentTimestampAsync"/>,
+    /// this is not source-filtered and returns the global latest for the tenant.
+    /// </summary>
+    public async Task<DateTime?> GetLatestDeviceStatusTimestampAsync(
+        string source,
+        CancellationToken cancellationToken = default)
+        => await _apsSnapshotRepository.GetLatestTimestampAsync(null, cancellationToken);
 }

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/MetadataPublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/MetadataPublisher.cs
@@ -183,4 +183,35 @@ internal sealed class MetadataPublisher : IMetadataPublisher
             return false;
         }
     }
+
+    /// <summary>
+    /// Returns the timestamp of the most recent activity record for the current tenant,
+    /// or <c>null</c> if none exist. Activities are stored across decomposed sources (StateSpans,
+    /// HeartRate, StepCount); <see cref="IActivityService.GetActivitiesAsync"/> merges them and
+    /// orders newest-first, so requesting a single record yields the global latest. Like
+    /// <see cref="ITreatmentPublisher.GetLatestTreatmentTimestampAsync"/>, this is not source-filtered.
+    /// </summary>
+    public async Task<DateTime?> GetLatestActivityTimestampAsync(
+        string source,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Filter by source to support multi-connector catch-up. Currently returns global latest.
+        var latest = (await _activityService.GetActivitiesAsync(
+                count: 1,
+                skip: 0,
+                cancellationToken: cancellationToken))
+            .FirstOrDefault();
+
+        if (latest == null)
+            return null;
+
+        if (!string.IsNullOrEmpty(latest.CreatedAt)
+            && DateTime.TryParse(latest.CreatedAt, out var createdAt))
+            return createdAt;
+
+        if (latest.Mills > 0)
+            return DateTimeOffset.FromUnixTimeMilliseconds(latest.Mills).UtcDateTime;
+
+        return null;
+    }
 }

--- a/src/Connectors/Nocturne.Connectors.Core/Interfaces/IDevicePublisher.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Interfaces/IDevicePublisher.cs
@@ -14,4 +14,12 @@ public interface IDevicePublisher
         IEnumerable<DeviceEvent> records,
         string source,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the timestamp of the most recent device-status record for the current tenant,
+    /// used by connectors to resume catch-up from where they left off, or <c>null</c> if none exist.
+    /// </summary>
+    Task<DateTime?> GetLatestDeviceStatusTimestampAsync(
+        string source,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Connectors/Nocturne.Connectors.Core/Interfaces/IMetadataPublisher.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Interfaces/IMetadataPublisher.cs
@@ -39,4 +39,12 @@ public interface IMetadataPublisher
         IEnumerable<Note> records,
         string source,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the timestamp of the most recent activity record for the current tenant,
+    /// used by connectors to resume catch-up from where they left off, or <c>null</c> if none exist.
+    /// </summary>
+    Task<DateTime?> GetLatestActivityTimestampAsync(
+        string source,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -161,6 +161,64 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     }
 
     /// <summary>
+    ///     Get the timestamp of the most recent device status from the Nocturne API
+    ///     This enables independent "catch up" for device status, decoupled from glucose
+    /// </summary>
+    private async Task<DateTime?> FetchLatestDeviceStatusTimestampAsync(TConfig config)
+    {
+        if (_publisher is not { IsAvailable: true })
+        {
+            _logger.LogDebug(
+                "API data submitter not available, cannot fetch latest device status timestamp"
+            );
+            return null;
+        }
+
+        try
+        {
+            return await _publisher.Device.GetLatestDeviceStatusTimestampAsync(ConnectorSource);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to fetch latest device status timestamp for {ConnectorSource}",
+                ConnectorSource
+            );
+            return null;
+        }
+    }
+
+    /// <summary>
+    ///     Get the timestamp of the most recent activity record from the Nocturne API
+    ///     This enables independent "catch up" for activity, decoupled from glucose
+    /// </summary>
+    private async Task<DateTime?> FetchLatestActivityTimestampAsync(TConfig config)
+    {
+        if (_publisher is not { IsAvailable: true })
+        {
+            _logger.LogDebug(
+                "API data submitter not available, cannot fetch latest activity timestamp"
+            );
+            return null;
+        }
+
+        try
+        {
+            return await _publisher.Metadata.GetLatestActivityTimestampAsync(ConnectorSource);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to fetch latest activity timestamp for {ConnectorSource}",
+                ConnectorSource
+            );
+            return null;
+        }
+    }
+
+    /// <summary>
     ///     Calculate the optimal "since" timestamp for fetching glucose entries
     ///     Uses catch-up logic to fetch from the most recent entry, or falls back to default lookback
     /// </summary>
@@ -197,9 +255,34 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     }
 
     /// <summary>
-    ///     Helper method to calculate the since timestamp from a latest timestamp
+    ///     Calculate an independent catch-up "since" timestamp for device status.
+    ///     Returns the most recent device-status timestamp (minus a small overlap), or
+    ///     <c>null</c> when none exists — letting the caller decide its own fallback
+    ///     rather than forcing a full initial-window re-fetch of high-volume telemetry.
     /// </summary>
-    private DateTime CalculateSinceFromTimestamp(DateTime? latestTimestamp, string dataType)
+    protected async Task<DateTime?> CalculateDeviceStatusCatchUpSinceAsync(TConfig config)
+    {
+        var latest = await FetchLatestDeviceStatusTimestampAsync(config);
+        return TryCalculateCatchUpSince(latest, "device status");
+    }
+
+    /// <summary>
+    ///     Calculate an independent catch-up "since" timestamp for activity.
+    ///     Returns the most recent activity timestamp (minus a small overlap), or
+    ///     <c>null</c> when none exists so the caller can choose its own fallback.
+    /// </summary>
+    protected async Task<DateTime?> CalculateActivityCatchUpSinceAsync(TConfig config)
+    {
+        var latest = await FetchLatestActivityTimestampAsync(config);
+        return TryCalculateCatchUpSince(latest, "activity");
+    }
+
+    /// <summary>
+    ///     Applies the catch-up overlap to a latest-record timestamp: returns the timestamp
+    ///     minus a small overlap (to absorb clock drift), or <c>null</c> when there is no
+    ///     usable prior timestamp.
+    /// </summary>
+    private DateTime? TryCalculateCatchUpSince(DateTime? latestTimestamp, string dataType)
     {
         if (latestTimestamp.HasValue && latestTimestamp.Value > DateTime.MinValue.AddMinutes(10))
         {
@@ -214,6 +297,19 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             );
             return sinceWithOverlap;
         }
+
+        return null;
+    }
+
+    /// <summary>
+    ///     Helper method to calculate the since timestamp from a latest timestamp.
+    ///     Falls back to a 6-month initial window when no prior data exists.
+    /// </summary>
+    private DateTime CalculateSinceFromTimestamp(DateTime? latestTimestamp, string dataType)
+    {
+        var catchUpSince = TryCalculateCatchUpSince(latestTimestamp, dataType);
+        if (catchUpSince.HasValue)
+            return catchUpSince.Value;
 
         // Fallback to 6 months for initial sync if no existing data found
         var fallbackSince = DateTime.UtcNow.AddMonths(-6);

--- a/src/Connectors/Nocturne.Connectors.Core/Utilities/JsonDefaults.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Utilities/JsonDefaults.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Nocturne.Core.Models.Serializers;
 
 namespace Nocturne.Connectors.Core.Utilities;
 
@@ -11,9 +12,34 @@ public static class JsonDefaults
     /// <summary>
     ///     Default options for deserializing API responses.
     ///     Case-insensitive to handle varying API response formats.
+    ///
+    ///     The flexible converters let numeric and boolean fields arrive in whatever
+    ///     JSON shape a given uploader emits — numbers as strings (e.g. <c>"insulin":"1.5"</c>,
+    ///     <c>"carbs":"45"</c>, <c>"duration":"30"</c>) and booleans as strings/ints
+    ///     (e.g. <c>"isValid":"true"</c>, <c>"bolusing":1</c>). Without them a single oddly-typed
+    ///     value throws a <see cref="JsonException"/> that aborts the whole page fetch —
+    ///     observed dropping entire treatment backfills while clean numeric glucose
+    ///     entries synced fine. Real-world Nightscout collections (treatments and
+    ///     especially the deeply-nested devicestatus pump/loop/openaps payloads) are the
+    ///     worst offenders. Registering the converters here applies them to every type
+    ///     these options touch (top-level and nested); property-level <c>[JsonConverter]</c>
+    ///     attributes on the models still take precedence where present.
     /// </summary>
     public static readonly JsonSerializerOptions CaseInsensitive = new()
     {
-        PropertyNameCaseInsensitive = true
+        PropertyNameCaseInsensitive = true,
+        Converters =
+        {
+            new FlexibleDoubleConverter(),
+            new FlexibleNullableDoubleConverter(),
+            new FlexibleDecimalConverter(),
+            new FlexibleNullableDecimalConverter(),
+            new FlexibleIntConverter(),
+            new FlexibleNullableIntConverter(),
+            new FlexibleLongConverter(),
+            new FlexibleNullableLongConverter(),
+            new FlexibleNonNullableBooleanJsonConverter(),
+            new FlexibleBooleanJsonConverter(),
+        },
     };
 }

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
@@ -181,7 +181,16 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes);
         var activeTypes = request.DataTypes.Where(t => enabledTypes.Contains(t)).ToList();
 
+        // For open-ended background catch-up (no explicit upper bound), each data type
+        // resolves its own "since" from its OWN latest stored record rather than reusing
+        // the glucose-derived request.From. Otherwise a single type that fell behind (or
+        // failed once) would be permanently stranded behind the glucose cursor. Explicit
+        // ranged syncs (request.To set, e.g. a manual re-import) honour request.From/To as-is.
+        var openEnded = request.To is null;
+
         // Handle Glucose
+        // Glucose keeps request.From — for background syncs the framework already derived
+        // it from the latest glucose entry, so it is glucose's own independent cursor.
         if (activeTypes.Contains(SyncDataType.Glucose))
         {
             try
@@ -219,7 +228,12 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         {
             try
             {
-                var treatments = await FetchTreatmentsAsync(request.From, request.To);
+                // Treatments track their own cursor (latest treatment, else 6-month initial
+                // backfill) so historical boluses/carbs are filled even once glucose is current.
+                var treatmentFrom = openEnded
+                    ? await CalculateTreatmentSinceTimestampAsync(config)
+                    : request.From;
+                var treatments = await FetchTreatmentsAsync(treatmentFrom, request.To);
                 var treatmentList = treatments.ToList();
                 if (treatmentList.Count > 0)
                 {
@@ -289,7 +303,13 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         {
             try
             {
-                var deviceStatuses = await FetchDeviceStatusAsync(request.From, request.To);
+                // Device status tracks its own cursor when a watermark is available; if none
+                // exists yet it falls back to request.From (current behaviour) rather than
+                // re-fetching the full initial window of this high-volume telemetry every sync.
+                var deviceStatusFrom = openEnded
+                    ? await CalculateDeviceStatusCatchUpSinceAsync(config) ?? request.From
+                    : request.From;
+                var deviceStatuses = await FetchDeviceStatusAsync(deviceStatusFrom, request.To);
                 var deviceStatusList = deviceStatuses.ToList();
                 result.ItemsSynced[SyncDataType.DeviceStatus] = deviceStatusList.Count;
                 if (deviceStatusList.Count > 0)
@@ -348,7 +368,12 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         {
             try
             {
-                var activities = await FetchActivityAsync(request.From, request.To);
+                // Activity tracks its own cursor when a watermark is available, else falls
+                // back to request.From.
+                var activityFrom = openEnded
+                    ? await CalculateActivityCatchUpSinceAsync(config) ?? request.From
+                    : request.From;
+                var activities = await FetchActivityAsync(activityFrom, request.To);
                 var activityList = activities.ToList();
                 result.ItemsSynced[SyncDataType.Activity] = activityList.Count;
                 if (activityList.Count > 0)

--- a/src/Core/Nocturne.Core.Models/Serializers/FlexibleNumberConverters.cs
+++ b/src/Core/Nocturne.Core.Models/Serializers/FlexibleNumberConverters.cs
@@ -192,3 +192,94 @@ public class FlexibleNullableDoubleConverter : JsonConverter<double?>
         }
     }
 }
+
+/// <summary>
+/// JSON converter that handles flexible decimal serialization for Nightscout compatibility.
+/// Nightscout may send numeric values as either numbers or strings depending on the context.
+/// </summary>
+/// <seealso cref="FlexibleNullableDecimalConverter"/>
+/// <seealso cref="FlexibleDoubleConverter"/>
+public class FlexibleDecimalConverter : JsonConverter<decimal>
+{
+    public override decimal Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options
+    )
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.Number:
+                return reader.GetDecimal();
+
+            case JsonTokenType.String:
+                var stringValue = reader.GetString();
+                if (string.IsNullOrWhiteSpace(stringValue))
+                    return 0;
+
+                if (decimal.TryParse(stringValue, out var result))
+                    return result;
+
+                return 0;
+
+            case JsonTokenType.Null:
+                return 0;
+
+            default:
+                return 0;
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, decimal value, JsonSerializerOptions options)
+    {
+        writer.WriteNumberValue(value);
+    }
+}
+
+/// <summary>
+/// JSON converter that handles flexible nullable decimal serialization for Nightscout compatibility.
+/// </summary>
+/// <seealso cref="FlexibleDecimalConverter"/>
+public class FlexibleNullableDecimalConverter : JsonConverter<decimal?>
+{
+    public override decimal? Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options
+    )
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.Number:
+                return reader.GetDecimal();
+
+            case JsonTokenType.String:
+                var stringValue = reader.GetString();
+                if (string.IsNullOrWhiteSpace(stringValue))
+                    return null;
+
+                if (decimal.TryParse(stringValue, out var result))
+                    return result;
+
+                return null;
+
+            case JsonTokenType.Null:
+                return null;
+
+            default:
+                return null;
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, decimal? value, JsonSerializerOptions options)
+    {
+        if (value.HasValue)
+        {
+            writer.WriteNumberValue(value.Value);
+        }
+        else
+        {
+            writer.WriteNullValue();
+        }
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Platform/ServicesControllerResetCursorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Platform/ServicesControllerResetCursorTests.cs
@@ -1,0 +1,75 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Nocturne.API.Controllers.V4.Platform;
+using Nocturne.API.Services.Connectors;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Core.Contracts.Connectors;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4.Platform;
+
+/// <summary>
+/// Tests for the connector cursor-reset endpoint. The key behaviour is that it forces an
+/// explicit-range re-pull (sets <see cref="SyncRequest.To"/>), which bypasses the per-type
+/// catch-up cursors so history is genuinely re-ingested rather than resumed from the latest
+/// stored record.
+/// </summary>
+public class ServicesControllerResetCursorTests
+{
+    private static ServicesController CreateController(IConnectorSyncService syncService) =>
+        new(
+            Mock.Of<IDataSourceService>(),
+            Mock.Of<IConnectorHealthService>(),
+            syncService,
+            Mock.Of<ILogger<ServicesController>>(),
+            Mock.Of<IConfiguration>());
+
+    [Fact]
+    public async Task ResetConnectorCursor_SetsUpperBound_ToForceExplicitRangeRePull()
+    {
+        SyncRequest? captured = null;
+        var syncService = new Mock<IConnectorSyncService>();
+        syncService
+            .Setup(s => s.TriggerSyncAsync("nightscout", It.IsAny<SyncRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<string, SyncRequest, CancellationToken>((_, r, _) => captured = r)
+            .ReturnsAsync(new SyncResult { Success = true });
+
+        var from = new DateTime(2025, 12, 27, 0, 0, 0, DateTimeKind.Utc);
+        var controller = CreateController(syncService.Object);
+
+        var result = await controller.ResetConnectorCursor(
+            "nightscout",
+            new ResetCursorRequest { From = from, DataTypes = [SyncDataType.Boluses, SyncDataType.CarbIntake] },
+            CancellationToken.None);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        captured.Should().NotBeNull();
+        captured!.To.Should().NotBeNull(
+            "an explicit upper bound is what switches the connector out of catch-up mode into a full re-pull");
+        captured.From.Should().Be(from, "the requested lower bound is passed through verbatim");
+        captured.DataTypes.Should().BeEquivalentTo([SyncDataType.Boluses, SyncDataType.CarbIntake]);
+    }
+
+    [Fact]
+    public async Task ResetConnectorCursor_EmptyRequest_RePullsAllTypesFromBeginning()
+    {
+        SyncRequest? captured = null;
+        var syncService = new Mock<IConnectorSyncService>();
+        syncService
+            .Setup(s => s.TriggerSyncAsync(It.IsAny<string>(), It.IsAny<SyncRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<string, SyncRequest, CancellationToken>((_, r, _) => captured = r)
+            .ReturnsAsync(new SyncResult { Success = true });
+
+        var controller = CreateController(syncService.Object);
+
+        await controller.ResetConnectorCursor("nightscout", new ResetCursorRequest(), CancellationToken.None);
+
+        captured.Should().NotBeNull();
+        captured!.From.Should().BeNull("a null lower bound means re-pull all available history");
+        captured.To.Should().NotBeNull();
+        captured.DataTypes.Should().BeEmpty("an empty data-type set means reset every supported type");
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/DevicePublisherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/DevicePublisherTests.cs
@@ -16,16 +16,19 @@ public class DevicePublisherTests
 {
     private readonly Mock<IDeviceStatusDecomposer> _mockDecomposer;
     private readonly Mock<IDeviceEventRepository> _mockDeviceEventRepository;
+    private readonly Mock<IApsSnapshotRepository> _mockApsSnapshotRepository;
     private readonly DevicePublisher _publisher;
 
     public DevicePublisherTests()
     {
         _mockDecomposer = new Mock<IDeviceStatusDecomposer>();
         _mockDeviceEventRepository = new Mock<IDeviceEventRepository>();
+        _mockApsSnapshotRepository = new Mock<IApsSnapshotRepository>();
 
         _publisher = new DevicePublisher(
             _mockDecomposer.Object,
             _mockDeviceEventRepository.Object,
+            _mockApsSnapshotRepository.Object,
             NullLogger<DevicePublisher>.Instance
         );
     }

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutPerTypeCursorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutPerTypeCursorTests.cs
@@ -1,0 +1,223 @@
+using System.Globalization;
+using System.Net;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.Nightscout.Configurations;
+using Nocturne.Connectors.Nightscout.Services;
+using Nocturne.Core.Models;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Connectors;
+
+/// <summary>
+/// Verifies that each data type resolves its own catch-up cursor on open-ended (background)
+/// syncs, rather than reusing the glucose-derived <see cref="SyncRequest.From"/>. Regression
+/// guard for the bug where treatments (boluses/carbs) were permanently stranded behind the
+/// glucose cursor: once glucose was current, treatments only ever fetched the last few minutes
+/// and historical treatments never backfilled.
+/// </summary>
+public class NightscoutPerTypeCursorTests
+{
+    private const int MaxCount = 100;
+
+    private static NightscoutConnectorService CreateService(
+        HttpMessageHandler handler,
+        NightscoutConnectorConfiguration config,
+        DateTime? latestEntry = null,
+        DateTime? latestTreatment = null,
+        DateTime? latestDeviceStatus = null,
+        DateTime? latestActivity = null)
+    {
+        var glucose = new Mock<IGlucosePublisher>();
+        glucose.Setup(p => p.GetLatestEntryTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(latestEntry);
+        glucose.Setup(p => p.PublishEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var treatments = new Mock<ITreatmentPublisher>();
+        treatments.Setup(p => p.GetLatestTreatmentTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(latestTreatment);
+        treatments.Setup(p => p.PublishTreatmentsAsync(It.IsAny<IEnumerable<Treatment>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var device = new Mock<IDevicePublisher>();
+        device.Setup(p => p.GetLatestDeviceStatusTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(latestDeviceStatus);
+        device.Setup(p => p.PublishDeviceStatusAsync(It.IsAny<IEnumerable<DeviceStatus>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var metadata = new Mock<IMetadataPublisher>();
+        metadata.Setup(p => p.GetLatestActivityTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(latestActivity);
+
+        var publisher = new Mock<IConnectorPublisher>();
+        publisher.Setup(p => p.IsAvailable).Returns(true);
+        publisher.Setup(p => p.Glucose).Returns(glucose.Object);
+        publisher.Setup(p => p.Treatments).Returns(treatments.Object);
+        publisher.Setup(p => p.Device).Returns(device.Object);
+        publisher.Setup(p => p.Metadata).Returns(metadata.Object);
+
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri(config.Url) };
+
+        return new NightscoutConnectorService(
+            httpClient,
+            new ConnectorServerResolver<NightscoutConnectorConfiguration>(null, null, null),
+            Mock.Of<ILogger<NightscoutConnectorService>>(),
+            Mock.Of<IRetryDelayStrategy>(),
+            Mock.Of<IRateLimitingStrategy>(),
+            new ConnectorRegistration<NightscoutConnectorConfiguration>(config, "Nightscout"),
+            publisher.Object);
+    }
+
+    private static NightscoutConnectorConfiguration Config() => new()
+    {
+        Url = "https://nightscout.example.com",
+        ApiSecret = "test-secret",
+        MaxCount = MaxCount,
+    };
+
+    /// <summary>Extracts the <c>find[created_at][$gte]</c> lower bound from a recorded request URL.</summary>
+    private static DateTime ExtractGte(string url)
+    {
+        var decoded = Uri.UnescapeDataString(url);
+        var match = Regex.Match(decoded, @"\$gte\]=([^&]+)");
+        match.Success.Should().BeTrue($"request URL should carry a created_at lower bound: {decoded}");
+        return DateTime.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)
+            .ToUniversalTime();
+    }
+
+    private static string TreatmentsUrl(SequentialMockHandler handler) =>
+        handler.RequestUrls.Single(u => u.Contains("treatments.json"));
+
+    private static string DeviceStatusUrl(SequentialMockHandler handler) =>
+        handler.RequestUrls.Single(u => u.Contains("devicestatus.json"));
+
+    [Fact]
+    public async Task Treatments_OpenEndedSync_UseOwnCursor_NotGlucoseCursor()
+    {
+        // Glucose is fully caught up (latest entry ~now), but no treatments exist yet.
+        var now = DateTime.UtcNow;
+        var handler = new SequentialMockHandler();
+        handler.Enqueue(JsonResponse(Array.Empty<Entry>()));      // auth check
+        handler.Enqueue(JsonResponse(Array.Empty<Treatment>()));  // treatments page (empty)
+
+        var config = Config();
+        var service = CreateService(handler, config, latestEntry: now, latestTreatment: null);
+
+        // Open-ended background sync: From is the glucose-derived cursor (~now), To is null.
+        var request = new SyncRequest
+        {
+            From = now.AddMinutes(-5),
+            To = null,
+            DataTypes = [SyncDataType.Boluses],
+        };
+
+        var result = await service.SyncDataAsync(request, config, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        var gte = ExtractGte(TreatmentsUrl(handler));
+        gte.Should().BeBefore(now.AddMonths(-3),
+            "with no treatments yet, treatments must backfill from their own initial window (~6 months), " +
+            "not from the recent glucose cursor");
+    }
+
+    [Fact]
+    public async Task Treatments_OpenEndedSync_WithExistingTreatments_CatchUpFromOwnLatest()
+    {
+        var now = DateTime.UtcNow;
+        var treatmentLatest = now.AddDays(-2);
+        var handler = new SequentialMockHandler();
+        handler.Enqueue(JsonResponse(Array.Empty<Entry>()));
+        handler.Enqueue(JsonResponse(Array.Empty<Treatment>()));
+
+        var config = Config();
+        var service = CreateService(handler, config, latestEntry: now, latestTreatment: treatmentLatest);
+
+        var request = new SyncRequest { From = now.AddMinutes(-5), To = null, DataTypes = [SyncDataType.Boluses] };
+
+        await service.SyncDataAsync(request, config, CancellationToken.None);
+
+        var gte = ExtractGte(TreatmentsUrl(handler));
+        // Catch-up resumes from the latest treatment minus a small overlap, independent of glucose.
+        gte.Should().BeCloseTo(treatmentLatest.AddMinutes(-5), TimeSpan.FromMinutes(1));
+    }
+
+    [Fact]
+    public async Task Treatments_ExplicitRange_HonoursRequestFrom()
+    {
+        var from = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var handler = new SequentialMockHandler();
+        handler.Enqueue(JsonResponse(Array.Empty<Entry>()));
+        handler.Enqueue(JsonResponse(Array.Empty<Treatment>()));
+
+        var config = Config();
+        var service = CreateService(handler, config, latestTreatment: null);
+
+        // Explicit range (To set) — e.g. a manual re-import — must be honoured verbatim.
+        var request = new SyncRequest
+        {
+            From = from,
+            To = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            DataTypes = [SyncDataType.Boluses],
+        };
+
+        await service.SyncDataAsync(request, config, CancellationToken.None);
+
+        var gte = ExtractGte(TreatmentsUrl(handler));
+        gte.Should().BeCloseTo(from, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task DeviceStatus_OpenEndedSync_NoWatermark_FallsBackToRequestFrom()
+    {
+        // No device-status watermark available → must fall back to request.From (current behaviour),
+        // never re-fetching the full initial window of high-volume telemetry every sync.
+        var from = DateTime.UtcNow.AddHours(-1);
+        var handler = new SequentialMockHandler();
+        handler.Enqueue(JsonResponse(Array.Empty<Entry>()));
+        handler.Enqueue(JsonResponse(Array.Empty<DeviceStatus>()));
+
+        var config = Config();
+        var service = CreateService(handler, config, latestDeviceStatus: null);
+
+        var request = new SyncRequest { From = from, To = null, DataTypes = [SyncDataType.DeviceStatus] };
+
+        await service.SyncDataAsync(request, config, CancellationToken.None);
+
+        var gte = ExtractGte(DeviceStatusUrl(handler));
+        gte.Should().BeCloseTo(from, TimeSpan.FromSeconds(1));
+    }
+
+    private static HttpResponseMessage JsonResponse<T>(T data) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                JsonSerializer.Serialize(data), System.Text.Encoding.UTF8, "application/json"),
+        };
+
+    private sealed class SequentialMockHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses = new();
+        public List<string> RequestUrls { get; } = [];
+
+        public void Enqueue(HttpResponseMessage response) => _responses.Enqueue(response);
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestUrls.Add(request.RequestUri?.PathAndQuery ?? "");
+            return Task.FromResult(_responses.Count == 0
+                ? new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("[]", System.Text.Encoding.UTF8, "application/json"),
+                }
+                : _responses.Dequeue());
+        }
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutTreatmentDeserializationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutTreatmentDeserializationTests.cs
@@ -1,0 +1,148 @@
+using System.Text.Json;
+using FluentAssertions;
+using Nocturne.Connectors.Core.Utilities;
+using Nocturne.Core.Models;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Connectors;
+
+/// <summary>
+/// Regression tests for the connector treatment-ingestion path.
+///
+/// Many real-world Nightscout uploaders emit numeric treatment fields as JSON
+/// strings (e.g. <c>"insulin":"1.5"</c>, <c>"carbs":"45"</c>, <c>"duration":"30"</c>). The
+/// connector deserializes treatment pages with <see cref="JsonDefaults.CaseInsensitive"/>;
+/// before flexible numeric converters were registered there, a single string-encoded
+/// number threw a <see cref="JsonException"/> that aborted the entire page fetch. Because
+/// glucose entries (clean numeric) are fetched separately and succeeded, affected tenants
+/// ended up with full glucose history but no treatment (bolus/carb/basal) backfill.
+/// </summary>
+public class NightscoutTreatmentDeserializationTests
+{
+    [Fact]
+    public void Treatments_WithStringEncodedNumbers_DeserializeWithoutThrowing()
+    {
+        // A treatments page as emitted by an uploader that stringifies numeric fields.
+        var json = """
+        [
+            {
+                "eventType": "Meal Bolus",
+                "insulin": "1.5",
+                "carbs": "45",
+                "duration": "0",
+                "created_at": "2026-01-15T08:30:00.000Z"
+            },
+            {
+                "eventType": "Temp Basal",
+                "absolute": "0.75",
+                "rate": "0.75",
+                "duration": "30",
+                "created_at": "2026-01-15T09:00:00.000Z"
+            }
+        ]
+        """;
+
+        var act = () => JsonSerializer.Deserialize<Treatment[]>(json, JsonDefaults.CaseInsensitive);
+
+        act.Should().NotThrow<JsonException>();
+
+        var treatments = JsonSerializer.Deserialize<Treatment[]>(json, JsonDefaults.CaseInsensitive);
+        treatments.Should().HaveCount(2);
+
+        treatments![0].EventType.Should().Be("Meal Bolus");
+        treatments[0].Insulin.Should().Be(1.5);
+        treatments[0].Carbs.Should().Be(45);
+
+        treatments[1].EventType.Should().Be("Temp Basal");
+        treatments[1].Absolute.Should().Be(0.75);
+        treatments[1].Rate.Should().Be(0.75);
+        treatments[1].Duration.Should().Be(30);
+    }
+
+    [Fact]
+    public void Treatments_WithNumericTypedNumbers_StillDeserialize()
+    {
+        // The common case must keep working: native JSON numbers.
+        var json = """
+        [
+            {
+                "eventType": "Correction Bolus",
+                "insulin": 1.2,
+                "carbs": 0,
+                "created_at": "2026-01-15T10:00:00.000Z"
+            }
+        ]
+        """;
+
+        var treatments = JsonSerializer.Deserialize<Treatment[]>(json, JsonDefaults.CaseInsensitive);
+
+        treatments.Should().ContainSingle();
+        treatments![0].Insulin.Should().Be(1.2);
+    }
+
+    [Theory]
+    [InlineData("\"1.5\"", 1.5)]
+    [InlineData("2.25", 2.25)]
+    [InlineData("\"\"", null)]
+    [InlineData("null", null)]
+    public void JsonDefaults_CoercesStringEncodedDecimals(string jsonValue, double? expected)
+    {
+        // Defensive coverage for any connector-deserialized model carrying decimal fields
+        // (the numeric converters apply to every type these options touch).
+        var result = JsonSerializer.Deserialize<decimal?>(jsonValue, JsonDefaults.CaseInsensitive);
+
+        result.Should().Be(expected.HasValue ? (decimal)expected.Value : null);
+    }
+
+    [Fact]
+    public void Treatments_WithStringOrIntBooleans_DeserializeWithoutThrowing()
+    {
+        // Uploaders variously send booleans as "true"/"false", 1/0, or native bools.
+        // The model's bool/bool? fields (isValid, automatic, ...) lack per-property converters,
+        // so the connector's flexible boolean converters must absorb these.
+        var json = """
+        [
+            { "eventType": "SMB", "automatic": "true", "isValid": 1, "created_at": "2026-01-15T08:30:00.000Z" },
+            { "eventType": "Meal Bolus", "automatic": false, "isValid": "0", "created_at": "2026-01-15T09:00:00.000Z" }
+        ]
+        """;
+
+        var act = () => JsonSerializer.Deserialize<Treatment[]>(json, JsonDefaults.CaseInsensitive);
+
+        act.Should().NotThrow<JsonException>();
+        var treatments = JsonSerializer.Deserialize<Treatment[]>(json, JsonDefaults.CaseInsensitive);
+        treatments.Should().HaveCount(2);
+        treatments![0].Automatic.Should().Be(true);
+    }
+
+    [Fact]
+    public void DeviceStatus_WithStringTypedNumbersAndBooleans_DeserializeWithoutThrowing()
+    {
+        // Device status is the most heterogeneous Nightscout collection (pump/loop/openaps).
+        // Numbers and booleans in the nested payload routinely arrive as strings; the registered
+        // converters apply to nested types too.
+        var json = """
+        [
+            {
+                "device": "openaps://pi",
+                "isCharging": "true",
+                "uploader": { "battery": "82", "batteryVoltage": "4.1" },
+                "pump": {
+                    "reservoir": "120.5",
+                    "battery": { "percent": "75", "voltage": "1.45" },
+                    "status": { "bolusing": "false", "suspended": 0 }
+                },
+                "created_at": "2026-01-15T08:30:00.000Z"
+            }
+        ]
+        """;
+
+        var act = () => JsonSerializer.Deserialize<DeviceStatus[]>(json, JsonDefaults.CaseInsensitive);
+
+        act.Should().NotThrow<JsonException>();
+        var statuses = JsonSerializer.Deserialize<DeviceStatus[]>(json, JsonDefaults.CaseInsensitive);
+        statuses.Should().ContainSingle();
+        statuses![0].Pump!.Reservoir.Should().Be(120.5);
+        statuses[0].IsCharging.Should().Be(true);
+    }
+}


### PR DESCRIPTION
## Problem

Across roughly half of production Nightscout-connected tenants, **glucose synced fully but historical treatments (boluses/carbs) never arrived**. Two independent root causes:

1. **Fragile deserialization.** Real-world Nightscout uploaders send numeric fields as JSON strings (`"insulin":"1.5"`, `"carbs":"45"`) and booleans as strings/ints. `Treatment` and the deeply-nested `DeviceStatus` (pump/loop/openaps) payloads carried `double?`/`bool?` fields with no flexible converter, so `System.Text.Json` threw `JsonException`. `ExecuteWithRetryAsync` swallows that and returns `null`, so the **entire treatment page fetch aborted** — while glucose entries (clean numerics, fetched separately) synced fine.

2. **Shared catch-up cursor.** Every data type reused a single glucose-derived `since` (`request.From`). Once glucose was current, treatments only ever fetched the last few minutes, so historical treatments could never backfill.

## Changes

- **Defensive deserialization** — register the existing `Flexible{Double,NullableDouble,Decimal,NullableDecimal,Int,NullableInt,Long,NullableLong}Converter` plus `Flexible{,NonNullable}BooleanJsonConverter` in the connectors' shared `JsonDefaults.CaseInsensitive`. Options-level converters apply to every type these options touch (top-level and nested) for all connectors; property-level `[JsonConverter]` attributes still take precedence. (`FlexibleDecimal*` converters are new.)
- **Independent per-type catch-up cursors** — `NightscoutConnectorService.PerformSyncInternalAsync` now, for open-ended background syncs (`request.To == null`), resolves each type's window from its **own** latest record: treatments via `CalculateTreatmentSinceTimestampAsync` (6-month initial backfill when empty); device status / activity via new `CalculateDeviceStatusCatchUpSinceAsync` / `CalculateActivityCatchUpSinceAsync`, backed by new `IDevicePublisher.GetLatestDeviceStatusTimestampAsync` / `IMetadataPublisher.GetLatestActivityTimestampAsync`. When no watermark exists they fall back to `request.From` (never worse than before). Explicit ranged syncs (`To` set) honour `From`/`To` verbatim.
- **`POST /api/v4/services/connectors/{id}/reset-cursor`** — forces an explicit-range re-pull (sets `To=now`, bypassing catch-up) to push corrected/missing data to a tenant after a fix; deduped on idempotency keys.
- **Docs** — renamed the Scalar "Idempotency" reference page to **"Syncing"** and documented the sync model (per-type cursors, initial backfill, resilient ingestion, manual sync / cursor reset), keeping idempotency as a subsection.

## Tests

New unit tests cover string/bool/decimal coercion and nested device-status payloads through the real connector options, per-type cursor selection (decoupled-from-glucose, own-latest catch-up, explicit-range honoured, device-status fallback), and the reset-cursor request shaping. All connector + publishing + serializer tests pass.

## Notes / follow-ups

- `reset-cursor` runs synchronously (mirrors the sibling `sync` endpoint); a background-job variant is the right call before fanning out across tenants.
- Device-status watermark is sourced from `aps_snapshots` only (misses pump/uploader-only device status); the `?? request.From` fallback prevents any regression, but unioning the other snapshot tables is a worthwhile follow-up.
