### PR TITLE
feat(admin): cross-tenant connector cursor reset UI + endpoint (nocturne-cloud#17)

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/ConnectorAdminController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/ConnectorAdminController.cs
@@ -1,0 +1,111 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using OpenApi.Remote.Attributes;
+using Nocturne.API.Services.Connectors;
+using Nocturne.Connectors.Core.Models;
+
+namespace Nocturne.API.Controllers.V4.PlatformAdmin;
+
+/// <summary>
+/// Platform-admin controller for cross-tenant connector operations.
+/// </summary>
+/// <remarks>
+/// The per-tenant connector endpoints (<c>/api/v4/services/connectors/...</c>) only act on the
+/// caller's own tenant context. After fixing an upstream connector bug, an operator needs to push
+/// corrected/missing historical data to affected tenants — across every connector, for any tenant.
+/// These endpoints set the tenant context to a target tenant on the admin's behalf and reuse the
+/// existing sync path. Restricted to users with the <c>platform_admin</c> role.
+/// </remarks>
+/// <seealso cref="IConnectorCursorResetService"/>
+[ApiController]
+[Tags("PlatformAdmin")]
+[Route("api/v4/admin/connectors")]
+[Produces("application/json")]
+[Authorize(Roles = "platform_admin")]
+public class ConnectorAdminController : ControllerBase
+{
+    private readonly IConnectorCursorResetService _cursorResetService;
+    private readonly ILogger<ConnectorAdminController> _logger;
+
+    /// <summary>Initializes a new instance of <see cref="ConnectorAdminController"/>.</summary>
+    public ConnectorAdminController(
+        IConnectorCursorResetService cursorResetService,
+        ILogger<ConnectorAdminController> logger)
+    {
+        _cursorResetService = cursorResetService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// List the connectors a target tenant has configured, with their last-sync and health state.
+    /// </summary>
+    /// <remarks>
+    /// Lets an admin inspect the data gap (last successful sync, health, last error) before deciding
+    /// to reset cursors.
+    /// </remarks>
+    /// <param name="tenantId">The target tenant.</param>
+    /// <param name="ct">Cancellation token.</param>
+    [HttpGet("{tenantId:guid}")]
+    [RemoteQuery]
+    [ProducesResponseType(typeof(TenantConnectorsDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<TenantConnectorsDto>> GetTenantConnectors(
+        Guid tenantId, CancellationToken ct)
+    {
+        var result = await _cursorResetService.GetTenantConnectorsAsync(tenantId, ct);
+        return result is null
+            ? Problem(detail: $"Tenant not found: {tenantId}", statusCode: 404, title: "Not Found")
+            : Ok(result);
+    }
+
+    /// <summary>
+    /// Reset the sync cursor for every connector configured on a target tenant, forcing a re-pull
+    /// of history. Use after fixing a connector bug to push corrected data to an affected tenant.
+    /// </summary>
+    /// <remarks>
+    /// First cut runs synchronously and returns a per-connector <see cref="SyncResult"/>. A full
+    /// re-pull can take minutes per connector, so this can block for a while on data-heavy tenants.
+    /// TODO: move to a background job with progress polling (cf. the migration job model) before
+    /// fanning out across many tenants at once.
+    /// </remarks>
+    /// <param name="tenantId">The target tenant whose connectors should be re-pulled.</param>
+    /// <param name="request">Optional lower bound and data-type filter, mirroring the per-tenant reset endpoint.</param>
+    /// <param name="ct">Cancellation token.</param>
+    [HttpPost("{tenantId:guid}/reset-cursors")]
+    [RemoteCommand(Invalidates = ["GetTenantConnectors"])]
+    [ProducesResponseType(typeof(TenantCursorResetResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<TenantCursorResetResult>> ResetTenantCursors(
+        Guid tenantId,
+        [FromBody] AdminResetCursorsRequest request,
+        CancellationToken ct)
+    {
+        _logger.LogInformation(
+            "Platform admin cursor reset requested for tenant {TenantId} (from {From})",
+            tenantId, request.From?.ToString("o") ?? "beginning");
+
+        var result = await _cursorResetService.ResetTenantCursorsAsync(
+            tenantId, request.From, request.DataTypes, ct);
+
+        return result is null
+            ? Problem(detail: $"Tenant not found: {tenantId}", statusCode: 404, title: "Not Found")
+            : Ok(result);
+    }
+}
+
+/// <summary>
+/// Request body for a cross-tenant cursor reset. Mirrors the per-tenant
+/// <c>ResetCursorRequest</c> shape.
+/// </summary>
+public class AdminResetCursorsRequest
+{
+    /// <summary>
+    /// Optional lower bound for the re-pull. When null, all available history is re-ingested.
+    /// </summary>
+    public DateTime? From { get; init; }
+
+    /// <summary>
+    /// Optional set of data types to reset. When null or empty, every supported data type is reset.
+    /// </summary>
+    public List<SyncDataType>? DataTypes { get; init; }
+}

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -751,6 +751,7 @@ public static class ServiceRegistrationExtensions
         services.AddScoped<IConnectorConfigurationService, ConnectorConfigurationService>();
         services.AddScoped<PlatformSettingsService>();
         services.AddScoped<IConnectorSyncService, ConnectorSyncService>();
+        services.AddScoped<IConnectorCursorResetService, ConnectorCursorResetService>();
 
         // Connector runtime
         services.AddBaseConnectorServices();

--- a/src/API/Nocturne.API/Services/Connectors/ConnectorCursorResetService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/ConnectorCursorResetService.cs
@@ -140,25 +140,44 @@ public class ConnectorCursorResetService : IConnectorCursorResetService
 
         var results = new List<ConnectorCursorResetResult>(configs.Count);
 
+        // Loop-invariant: setting To forces "explicit range" mode in the connectors, bypassing the
+        // per-type catch-up cursors so history is genuinely re-pulled. A null From means no lower bound.
+        var request = new SyncRequest
+        {
+            From = from,
+            To = DateTime.UtcNow,
+            DataTypes = dataTypes ?? [],
+        };
+
         foreach (var config in configs)
         {
             ct.ThrowIfCancellationRequested();
-
-            // Setting To forces "explicit range" mode in the connectors, bypassing the per-type
-            // catch-up cursors so history is genuinely re-pulled. A null From means no lower bound.
-            var request = new SyncRequest
-            {
-                From = from,
-                To = DateTime.UtcNow,
-                DataTypes = dataTypes ?? [],
-            };
 
             _logger.LogInformation(
                 "Resetting cursor for connector {ConnectorName} in tenant {TenantSlug} (from {From})",
                 config.ConnectorName, tenant.Slug, from?.ToString("o") ?? "beginning");
 
-            var result = await _syncService.TriggerSyncAsync(config.ConnectorName, request, ct);
-            results.Add(new ConnectorCursorResetResult(config.ConnectorName, result));
+            // Isolate each connector: one failing must not abort the rest of the tenant's fan-out,
+            // and the response should carry one entry per configured connector. Cancellation still
+            // propagates so a cancelled request stops cleanly.
+            try
+            {
+                var result = await _syncService.TriggerSyncAsync(config.ConnectorName, request, ct);
+                results.Add(new ConnectorCursorResetResult(config.ConnectorName, result));
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "Cursor reset failed for connector {ConnectorName} in tenant {TenantSlug}",
+                    config.ConnectorName, tenant.Slug);
+                results.Add(new ConnectorCursorResetResult(
+                    config.ConnectorName,
+                    new SyncResult { Success = false, Message = ex.Message }));
+            }
         }
 
         _logger.LogInformation(

--- a/src/API/Nocturne.API/Services/Connectors/ConnectorCursorResetService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/ConnectorCursorResetService.cs
@@ -119,8 +119,16 @@ public class ConnectorCursorResetService : IConnectorCursorResetService
         }
 
         // Switch the ambient tenant context to the target tenant so that RLS-scoped queries and the
-        // sync executors operate under the right tenant. This is the same mechanism the dev-only
-        // sync-all endpoint and the migration background jobs use.
+        // sync executors operate under the right tenant.
+        //
+        // The TenantConnectionInterceptor sets the RLS GUC from NocturneDbContext.TenantId on each
+        // connection open (and RESETs it on close), so the *DbContext's* TenantId is what actually
+        // scopes our own queries below — updating ITenantAccessor alone does not retro-fit the
+        // already-created _db. Set it explicitly, otherwise the ConnectorConfigurations query runs
+        // under the admin's (or empty) tenant and silently finds no connectors. SetTenantGucAsync is
+        // belt-and-suspenders for the current connection; SetTenant propagates to the executor scope
+        // that IConnectorSyncService.TriggerSyncAsync creates.
+        _db.TenantId = tenantId;
         await SetTenantGucAsync(tenantId, ct);
         _tenantAccessor.SetTenant(new TenantContext(
             tenant.Id, tenant.Slug, tenant.DisplayName, tenant.IsActive, tenant.IsDemo));
@@ -169,6 +177,9 @@ public class ConnectorCursorResetService : IConnectorCursorResetService
         if (tenant is null)
             return null;
 
+        // See ResetTenantCursorsAsync: the interceptor scopes connections by DbContext.TenantId,
+        // so set it on _db before the RLS-scoped query below.
+        _db.TenantId = tenantId;
         await SetTenantGucAsync(tenantId, ct);
 
         var connectors = await _db.ConnectorConfigurations.AsNoTracking()

--- a/src/API/Nocturne.API/Services/Connectors/ConnectorCursorResetService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/ConnectorCursorResetService.cs
@@ -1,0 +1,202 @@
+using Microsoft.EntityFrameworkCore;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Infrastructure.Data;
+
+namespace Nocturne.API.Services.Connectors;
+
+/// <summary>
+/// Resets connector sync cursors for an arbitrary tenant, fanning out across every connector
+/// that tenant has configured. Intended for platform-admin use after an upstream connector fix,
+/// when corrected/missing historical data must be re-pushed to affected tenants.
+/// </summary>
+/// <remarks>
+/// Nocturne does not persist a sync cursor — each data type resumes from the latest record already
+/// stored. A "cursor reset" is therefore an explicit-range sync with an upper bound of "now", which
+/// bypasses the per-type catch-up cursors and forces a genuine re-pull of history. Re-ingested
+/// records dedupe on their idempotency keys, so re-running is safe.
+/// </remarks>
+/// <seealso cref="IConnectorSyncService"/>
+public interface IConnectorCursorResetService
+{
+    /// <summary>
+    /// Resets the cursor for every configured connector belonging to <paramref name="tenantId"/>.
+    /// </summary>
+    /// <param name="tenantId">The target tenant whose connectors should be re-pulled.</param>
+    /// <param name="from">Optional lower bound. When null, all available history is re-ingested.</param>
+    /// <param name="dataTypes">Optional data-type filter. When null/empty, every supported type is reset.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// A per-connector result, or null when the target tenant does not exist.
+    /// </returns>
+    Task<TenantCursorResetResult?> ResetTenantCursorsAsync(
+        Guid tenantId,
+        DateTime? from,
+        List<SyncDataType>? dataTypes,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Lists the connectors configured for <paramref name="tenantId"/> with their last-sync and
+    /// health state, so an admin can see the data gap before/after a reset.
+    /// </summary>
+    /// <param name="tenantId">The target tenant.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The configured connectors, or null when the target tenant does not exist.</returns>
+    Task<TenantConnectorsDto?> GetTenantConnectorsAsync(Guid tenantId, CancellationToken ct);
+}
+
+/// <summary>Sync/health summary for a single configured connector.</summary>
+/// <param name="ConnectorName">The connector name (e.g. <c>nightscout</c>).</param>
+/// <param name="IsHealthy">Whether the connector last reported healthy.</param>
+/// <param name="LastSuccessfulSync">When the connector last completed a successful sync.</param>
+/// <param name="LastSyncAttempt">When the connector last attempted a sync.</param>
+/// <param name="LastErrorMessage">The most recent error message, if any.</param>
+public record TenantConnectorSummary(
+    string ConnectorName,
+    bool IsHealthy,
+    DateTime? LastSuccessfulSync,
+    DateTime? LastSyncAttempt,
+    string? LastErrorMessage);
+
+/// <summary>A tenant and the connectors it has configured.</summary>
+/// <param name="TenantId">The tenant id.</param>
+/// <param name="TenantSlug">The tenant slug, for display.</param>
+/// <param name="Connectors">One entry per configured connector.</param>
+public record TenantConnectorsDto(
+    Guid TenantId,
+    string TenantSlug,
+    IReadOnlyList<TenantConnectorSummary> Connectors);
+
+/// <summary>Per-connector outcome of a tenant-wide cursor reset.</summary>
+/// <param name="ConnectorName">The connector that was reset (e.g. <c>nightscout</c>).</param>
+/// <param name="Result">The sync result returned by the connector executor.</param>
+public record ConnectorCursorResetResult(string ConnectorName, SyncResult Result);
+
+/// <summary>Aggregate result of resetting every connector for a single tenant.</summary>
+/// <param name="TenantId">The tenant that was processed.</param>
+/// <param name="TenantSlug">The tenant's slug, for display.</param>
+/// <param name="Connectors">One entry per configured connector.</param>
+public record TenantCursorResetResult(
+    Guid TenantId,
+    string TenantSlug,
+    IReadOnlyList<ConnectorCursorResetResult> Connectors);
+
+/// <inheritdoc cref="IConnectorCursorResetService"/>
+public class ConnectorCursorResetService : IConnectorCursorResetService
+{
+    private readonly NocturneDbContext _db;
+    private readonly IConnectorSyncService _syncService;
+    private readonly ITenantAccessor _tenantAccessor;
+    private readonly ILogger<ConnectorCursorResetService> _logger;
+
+    /// <summary>Initializes a new instance of <see cref="ConnectorCursorResetService"/>.</summary>
+    public ConnectorCursorResetService(
+        NocturneDbContext db,
+        IConnectorSyncService syncService,
+        ITenantAccessor tenantAccessor,
+        ILogger<ConnectorCursorResetService> logger)
+    {
+        _db = db;
+        _syncService = syncService;
+        _tenantAccessor = tenantAccessor;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<TenantCursorResetResult?> ResetTenantCursorsAsync(
+        Guid tenantId,
+        DateTime? from,
+        List<SyncDataType>? dataTypes,
+        CancellationToken ct)
+    {
+        var tenant = await _db.Tenants.AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == tenantId, ct);
+
+        if (tenant is null)
+        {
+            _logger.LogWarning("Cursor reset requested for unknown tenant {TenantId}", tenantId);
+            return null;
+        }
+
+        // Switch the ambient tenant context to the target tenant so that RLS-scoped queries and the
+        // sync executors operate under the right tenant. This is the same mechanism the dev-only
+        // sync-all endpoint and the migration background jobs use.
+        await SetTenantGucAsync(tenantId, ct);
+        _tenantAccessor.SetTenant(new TenantContext(
+            tenant.Id, tenant.Slug, tenant.DisplayName, tenant.IsActive, tenant.IsDemo));
+
+        var configs = await _db.ConnectorConfigurations.AsNoTracking()
+            .Where(c => c.TenantId == tenantId)
+            .OrderBy(c => c.ConnectorName)
+            .ToListAsync(ct);
+
+        var results = new List<ConnectorCursorResetResult>(configs.Count);
+
+        foreach (var config in configs)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            // Setting To forces "explicit range" mode in the connectors, bypassing the per-type
+            // catch-up cursors so history is genuinely re-pulled. A null From means no lower bound.
+            var request = new SyncRequest
+            {
+                From = from,
+                To = DateTime.UtcNow,
+                DataTypes = dataTypes ?? [],
+            };
+
+            _logger.LogInformation(
+                "Resetting cursor for connector {ConnectorName} in tenant {TenantSlug} (from {From})",
+                config.ConnectorName, tenant.Slug, from?.ToString("o") ?? "beginning");
+
+            var result = await _syncService.TriggerSyncAsync(config.ConnectorName, request, ct);
+            results.Add(new ConnectorCursorResetResult(config.ConnectorName, result));
+        }
+
+        _logger.LogInformation(
+            "Cursor reset complete for tenant {TenantSlug}: {ConnectorCount} connectors processed",
+            tenant.Slug, results.Count);
+
+        return new TenantCursorResetResult(tenant.Id, tenant.Slug, results);
+    }
+
+    /// <inheritdoc />
+    public async Task<TenantConnectorsDto?> GetTenantConnectorsAsync(Guid tenantId, CancellationToken ct)
+    {
+        var tenant = await _db.Tenants.AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == tenantId, ct);
+
+        if (tenant is null)
+            return null;
+
+        await SetTenantGucAsync(tenantId, ct);
+
+        var connectors = await _db.ConnectorConfigurations.AsNoTracking()
+            .Where(c => c.TenantId == tenantId)
+            .OrderBy(c => c.ConnectorName)
+            .Select(c => new TenantConnectorSummary(
+                c.ConnectorName,
+                c.IsHealthy,
+                c.LastSuccessfulSync,
+                c.LastSyncAttempt,
+                c.LastErrorMessage))
+            .ToListAsync(ct);
+
+        return new TenantConnectorsDto(tenant.Id, tenant.Slug, connectors);
+    }
+
+    /// <summary>
+    /// Sets the PostgreSQL RLS GUC for the target tenant. No-op on non-relational providers
+    /// (e.g. the EF Core in-memory provider used by unit tests), where RLS does not apply.
+    /// </summary>
+    private async Task SetTenantGucAsync(Guid tenantId, CancellationToken ct)
+    {
+        if (!_db.Database.IsRelational())
+            return;
+
+        await _db.Database.ExecuteSqlRawAsync(
+            "SELECT set_config('app.current_tenant_id', {0}, false)",
+            [tenantId.ToString()],
+            ct);
+    }
+}

--- a/src/Web/packages/app/src/lib/components/layout/AppSidebar.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/AppSidebar.svelte
@@ -47,6 +47,7 @@
     PlayCircle,
     History as HistoryIcon,
     SlidersHorizontal,
+    RefreshCw,
   } from "lucide-svelte";
   import { getSidebarReportItems } from "$lib/navigation/report-navigation";
   import type { AuthUser } from "$lib/stores/auth-store.svelte";
@@ -313,7 +314,10 @@
           icon: HeartHandshake,
         },
         ...(isPlatformAdmin
-          ? [{ title: "Tenant Management", href: "/settings/admin/tenants", icon: Building2 }]
+          ? [
+              { title: "Tenant Management", href: "/settings/admin/tenants", icon: Building2 },
+              { title: "Reset Connector Cursors", href: "/settings/admin/connector-cursors", icon: RefreshCw },
+            ]
           : []),
       ],
     });

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/admin/connector-cursors.remote.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/admin/connector-cursors.remote.ts
@@ -1,0 +1,104 @@
+/**
+ * Platform-admin connector cursor-reset remote functions.
+ *
+ * Server-side wrappers around the cross-tenant connector admin endpoints
+ * (`/api/v4/admin/connectors/...`). These are hand-authored (rather than
+ * generated) because they call the API through SvelteKit's `event.fetch`,
+ * which routes via the `/api` proxy so auth cookies, the instance key, and the
+ * X-Forwarded-Host (tenant resolution) headers are all forwarded automatically.
+ */
+
+import { z } from "zod";
+import { command, query, getRequestEvent } from "$app/server";
+import { error } from "@sveltejs/kit";
+
+/** Mirrors the backend SyncDataType enum (string-serialised). */
+const syncDataTypeSchema = z.enum([
+  "Glucose",
+  "ManualBG",
+  "Calibrations",
+  "Boluses",
+  "CarbIntake",
+  "BGChecks",
+  "BolusCalculations",
+  "Notes",
+  "DeviceEvents",
+  "StateSpans",
+  "Profiles",
+  "DeviceStatus",
+  "Activity",
+  "Food",
+]);
+
+export type SyncDataType = z.infer<typeof syncDataTypeSchema>;
+
+export interface TenantConnectorSummary {
+  connectorName: string;
+  isHealthy: boolean;
+  lastSuccessfulSync: string | null;
+  lastSyncAttempt: string | null;
+  lastErrorMessage: string | null;
+}
+
+export interface TenantConnectorsDto {
+  tenantId: string;
+  tenantSlug: string;
+  connectors: TenantConnectorSummary[];
+}
+
+export interface SyncResult {
+  success: boolean;
+  message: string;
+  itemsSynced?: Record<string, number>;
+  errors?: string[];
+}
+
+export interface ConnectorCursorResetResult {
+  connectorName: string;
+  result: SyncResult;
+}
+
+export interface TenantCursorResetResult {
+  tenantId: string;
+  tenantSlug: string;
+  connectors: ConnectorCursorResetResult[];
+}
+
+async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const { fetch } = getRequestEvent();
+  const res = await fetch(path, init);
+  if (!res.ok) {
+    let detail = res.statusText;
+    try {
+      const body = await res.json();
+      detail = body?.detail ?? body?.error ?? detail;
+    } catch {
+      // non-JSON body; keep statusText
+    }
+    throw error(res.status, detail);
+  }
+  return (await res.json()) as T;
+}
+
+/** Lists the connectors a target tenant has configured, with last-sync/health state. */
+export const getTenantConnectors = query(z.string().uuid(), async (tenantId) =>
+  apiFetch<TenantConnectorsDto>(`/api/v4/admin/connectors/${tenantId}`),
+);
+
+/**
+ * Resets the cursor for every connector configured on the target tenant,
+ * forcing a re-pull of history. Returns a per-connector SyncResult.
+ */
+export const resetTenantCursors = command(
+  z.object({
+    tenantId: z.string().uuid(),
+    from: z.string().datetime().nullish(),
+    dataTypes: z.array(syncDataTypeSchema).nullish(),
+  }),
+  async ({ tenantId, from, dataTypes }) =>
+    apiFetch<TenantCursorResetResult>(`/api/v4/admin/connectors/${tenantId}/reset-cursors`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ from: from ?? null, dataTypes: dataTypes ?? null }),
+    }),
+);

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/admin/connector-cursors/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/admin/connector-cursors/+page.svelte
@@ -1,0 +1,333 @@
+<script lang="ts">
+  import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+  } from "$lib/components/ui/card";
+  import { Button } from "$lib/components/ui/button";
+  import { Badge } from "$lib/components/ui/badge";
+  import { Input } from "$lib/components/ui/input";
+  import { Label } from "$lib/components/ui/label";
+  import * as Select from "$lib/components/ui/select";
+  import * as Alert from "$lib/components/ui/alert";
+  import * as AlertDialog from "$lib/components/ui/alert-dialog";
+  import {
+    RefreshCw,
+    Loader2,
+    AlertTriangle,
+    CheckCircle2,
+    XCircle,
+    Plug,
+    Building2,
+  } from "lucide-svelte";
+  import * as tenantRemote from "$api/generated/tenants.generated.remote";
+  import {
+    getTenantConnectors,
+    resetTenantCursors,
+    type TenantConnectorsDto,
+    type TenantCursorResetResult,
+  } from "../connector-cursors.remote";
+  import type { TenantDto } from "$api";
+
+  // Tenant list (platform admin)
+  let tenants = $state<TenantDto[]>([]);
+  let tenantsLoading = $state(true);
+  let tenantsError = $state<string | null>(null);
+
+  // Selected tenant + its connectors
+  let selectedTenantId = $state<string | undefined>(undefined);
+  let connectors = $state<TenantConnectorsDto | null>(null);
+  let connectorsLoading = $state(false);
+  let connectorsError = $state<string | null>(null);
+
+  // Reset options
+  let fromDate = $state<string>(""); // yyyy-MM-dd (optional lower bound)
+
+  // Reset execution
+  let confirmOpen = $state(false);
+  let resetting = $state(false);
+  let resetResult = $state<TenantCursorResetResult | null>(null);
+  let resetError = $state<string | null>(null);
+
+  const selectedTenant = $derived(
+    tenants.find((t) => t.id === selectedTenantId),
+  );
+
+  async function loadTenants() {
+    tenantsLoading = true;
+    tenantsError = null;
+    try {
+      tenants = (await tenantRemote.getAll()) ?? [];
+    } catch (err) {
+      console.error("Failed to load tenants:", err);
+      tenantsError = "Failed to load tenants.";
+    } finally {
+      tenantsLoading = false;
+    }
+  }
+
+  $effect(() => {
+    loadTenants();
+  });
+
+  async function onTenantChange(value: string | undefined) {
+    selectedTenantId = value;
+    connectors = null;
+    resetResult = null;
+    resetError = null;
+    if (!value) return;
+
+    connectorsLoading = true;
+    connectorsError = null;
+    try {
+      connectors = await getTenantConnectors(value);
+    } catch (err) {
+      console.error("Failed to load connectors:", err);
+      connectorsError = "Failed to load this tenant's connectors.";
+    } finally {
+      connectorsLoading = false;
+    }
+  }
+
+  async function runReset() {
+    if (!selectedTenantId) return;
+    resetting = true;
+    resetError = null;
+    resetResult = null;
+    try {
+      // Convert the optional date-only lower bound to an ISO instant.
+      const fromIso = fromDate ? new Date(`${fromDate}T00:00:00Z`).toISOString() : null;
+      resetResult = await resetTenantCursors({
+        tenantId: selectedTenantId,
+        from: fromIso,
+        dataTypes: null, // first cut resets every supported type
+      });
+      // Refresh the connector list so the admin sees updated sync timestamps.
+      connectors = await getTenantConnectors(selectedTenantId);
+    } catch (err) {
+      console.error("Cursor reset failed:", err);
+      resetError = "Cursor reset failed. Check the server logs for details.";
+    } finally {
+      resetting = false;
+      confirmOpen = false;
+    }
+  }
+
+  function formatTimestamp(value: string | null | undefined): string {
+    if (!value) return "Never";
+    return new Date(value).toLocaleString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
+
+  const hasConnectors = $derived((connectors?.connectors.length ?? 0) > 0);
+</script>
+
+<svelte:head>
+  <title>Reset Connector Cursors - Administration - Nocturne</title>
+</svelte:head>
+
+<div class="@container container mx-auto max-w-4xl space-y-6 p-3 @md:p-6">
+  <div class="flex items-center gap-3">
+    <div class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
+      <RefreshCw class="h-6 w-6 text-primary" />
+    </div>
+    <div>
+      <h1 class="text-2xl font-bold tracking-tight">Reset Connector Cursors</h1>
+      <p class="text-muted-foreground">
+        Re-pull a tenant's connector history after fixing a connector bug
+      </p>
+    </div>
+  </div>
+
+  <Alert.Root>
+    <AlertTriangle class="h-4 w-4" />
+    <Alert.Title>Heads up</Alert.Title>
+    <Alert.Description>
+      This forces a full re-pull of history for every configured connector on
+      the selected tenant. Re-ingested records dedupe on their idempotency keys,
+      so it is safe to re-run, but a large re-pull can take several minutes and
+      runs synchronously.
+    </Alert.Description>
+  </Alert.Root>
+
+  <!-- Tenant picker -->
+  <Card>
+    <CardHeader>
+      <CardTitle class="flex items-center gap-2">
+        <Building2 class="h-5 w-5" />
+        Target tenant
+      </CardTitle>
+      <CardDescription>Pick the tenant whose connectors you want to reset</CardDescription>
+    </CardHeader>
+    <CardContent class="space-y-4">
+      {#if tenantsLoading}
+        <div class="flex items-center gap-2 text-muted-foreground">
+          <Loader2 class="h-4 w-4 animate-spin" />
+          Loading tenants...
+        </div>
+      {:else if tenantsError}
+        <Alert.Root variant="destructive">
+          <AlertTriangle class="h-4 w-4" />
+          <Alert.Description>{tenantsError}</Alert.Description>
+        </Alert.Root>
+      {:else}
+        <div class="space-y-2">
+          <Label for="tenant-select">Tenant</Label>
+          <Select.Root
+            type="single"
+            value={selectedTenantId}
+            onValueChange={onTenantChange}
+          >
+            <Select.Trigger id="tenant-select" class="w-full">
+              {selectedTenant
+                ? `${selectedTenant.displayName} (${selectedTenant.slug})`
+                : "Select a tenant"}
+            </Select.Trigger>
+            <Select.Content>
+              {#each tenants as t (t.id)}
+                <Select.Item value={t.id ?? ""} label={`${t.displayName} (${t.slug})`} />
+              {/each}
+            </Select.Content>
+          </Select.Root>
+        </div>
+
+        <div class="space-y-2">
+          <Label for="from-date">Lower bound (optional)</Label>
+          <Input id="from-date" type="date" bind:value={fromDate} class="w-full" />
+          <p class="text-xs text-muted-foreground">
+            Leave empty to re-pull all available history.
+          </p>
+        </div>
+      {/if}
+    </CardContent>
+  </Card>
+
+  <!-- Connectors + current sync status -->
+  {#if selectedTenantId}
+    <Card>
+      <CardHeader class="flex flex-row items-center justify-between">
+        <div>
+          <CardTitle class="flex items-center gap-2">
+            <Plug class="h-5 w-5" />
+            Connectors
+          </CardTitle>
+          <CardDescription>Current sync status for {selectedTenant?.slug}</CardDescription>
+        </div>
+        <Button
+          onclick={() => (confirmOpen = true)}
+          disabled={!hasConnectors || connectorsLoading || resetting}
+        >
+          {#if resetting}
+            <Loader2 class="mr-2 h-4 w-4 animate-spin" />
+          {:else}
+            <RefreshCw class="mr-2 h-4 w-4" />
+          {/if}
+          Reset cursors
+        </Button>
+      </CardHeader>
+      <CardContent class="space-y-3">
+        {#if connectorsLoading}
+          <div class="flex items-center gap-2 text-muted-foreground">
+            <Loader2 class="h-4 w-4 animate-spin" />
+            Loading connectors...
+          </div>
+        {:else if connectorsError}
+          <Alert.Root variant="destructive">
+            <AlertTriangle class="h-4 w-4" />
+            <Alert.Description>{connectorsError}</Alert.Description>
+          </Alert.Root>
+        {:else if !hasConnectors}
+          <p class="text-sm text-muted-foreground">
+            This tenant has no configured connectors.
+          </p>
+        {:else}
+          {#each connectors!.connectors as c (c.connectorName)}
+            {@const resultForConnector = resetResult?.connectors.find(
+              (r) => r.connectorName === c.connectorName,
+            )}
+            <div class="rounded-lg border p-3">
+              <div class="flex items-center justify-between">
+                <div class="flex items-center gap-2 font-medium">
+                  {c.connectorName}
+                  {#if c.isHealthy}
+                    <Badge variant="secondary">Healthy</Badge>
+                  {:else}
+                    <Badge variant="destructive">Unhealthy</Badge>
+                  {/if}
+                </div>
+                {#if resultForConnector}
+                  {#if resultForConnector.result.success}
+                    <span class="flex items-center gap-1 text-sm text-green-600">
+                      <CheckCircle2 class="h-4 w-4" /> Reset
+                    </span>
+                  {:else}
+                    <span class="flex items-center gap-1 text-sm text-destructive">
+                      <XCircle class="h-4 w-4" /> Failed
+                    </span>
+                  {/if}
+                {/if}
+              </div>
+              <div class="mt-2 grid grid-cols-2 gap-2 text-xs text-muted-foreground">
+                <div>
+                  <span class="font-medium">Last successful sync:</span>
+                  {formatTimestamp(c.lastSuccessfulSync)}
+                </div>
+                <div>
+                  <span class="font-medium">Last attempt:</span>
+                  {formatTimestamp(c.lastSyncAttempt)}
+                </div>
+              </div>
+              {#if c.lastErrorMessage}
+                <p class="mt-1 text-xs text-destructive">{c.lastErrorMessage}</p>
+              {/if}
+              {#if resultForConnector}
+                <p class="mt-1 text-xs">{resultForConnector.result.message}</p>
+              {/if}
+            </div>
+          {/each}
+        {/if}
+
+        {#if resetError}
+          <Alert.Root variant="destructive">
+            <AlertTriangle class="h-4 w-4" />
+            <Alert.Description>{resetError}</Alert.Description>
+          </Alert.Root>
+        {/if}
+      </CardContent>
+    </Card>
+  {/if}
+</div>
+
+<!-- Confirmation -->
+<AlertDialog.Root bind:open={confirmOpen}>
+  <AlertDialog.Content>
+    <AlertDialog.Header>
+      <AlertDialog.Title>Reset cursors for {selectedTenant?.slug}?</AlertDialog.Title>
+      <AlertDialog.Description>
+        This re-pulls history for all {connectors?.connectors.length ?? 0}
+        connector(s) configured on this tenant
+        {#if fromDate}
+          from {fromDate}
+        {:else}
+          from the beginning
+        {/if}. The request runs synchronously and may take a while.
+      </AlertDialog.Description>
+    </AlertDialog.Header>
+    <AlertDialog.Footer>
+      <AlertDialog.Cancel disabled={resetting}>Cancel</AlertDialog.Cancel>
+      <AlertDialog.Action onclick={runReset} disabled={resetting}>
+        {#if resetting}
+          <Loader2 class="mr-2 h-4 w-4 animate-spin" />
+        {/if}
+        Reset cursors
+      </AlertDialog.Action>
+    </AlertDialog.Footer>
+  </AlertDialog.Content>
+</AlertDialog.Root>

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/PlatformAdmin/ConnectorAdminControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/PlatformAdmin/ConnectorAdminControllerTests.cs
@@ -1,0 +1,170 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Nocturne.API.Controllers.V4.PlatformAdmin;
+using Nocturne.API.Services.Connectors;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4.PlatformAdmin;
+
+/// <summary>
+/// Tests for the platform-admin cross-tenant cursor-reset endpoint and its backing service.
+/// The key behaviours are:
+/// <list type="bullet">
+///   <item>the action sets the tenant context to the <em>target</em> tenant (not the caller's);</item>
+///   <item>it fans out across <em>every</em> connector that tenant has configured;</item>
+///   <item>each per-connector sync forces a full re-pull (<see cref="SyncRequest.To"/> is set).</item>
+/// </list>
+/// The EF Core in-memory provider is used so the RLS GUC (a PostgreSQL-only function) is skipped.
+/// </summary>
+public class ConnectorAdminControllerTests
+{
+    private readonly Guid _targetTenantId = Guid.CreateVersion7();
+
+    private NocturneDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseInMemoryDatabase($"connector-admin-{Guid.NewGuid()}")
+            .Options;
+
+        // The DbContext's TenantId drives the per-tenant global query filter, so it must match the
+        // target tenant for that tenant's connector configurations to be visible.
+        var db = new NocturneDbContext(options) { TenantId = _targetTenantId };
+
+        db.Tenants.Add(new TenantEntity
+        {
+            Id = _targetTenantId,
+            Slug = "erik",
+            DisplayName = "Erik",
+            IsActive = true,
+        });
+
+        db.ConnectorConfigurations.AddRange(
+            new ConnectorConfigurationEntity
+            {
+                Id = Guid.CreateVersion7(),
+                TenantId = _targetTenantId,
+                ConnectorName = "nightscout",
+                IsHealthy = true,
+            },
+            new ConnectorConfigurationEntity
+            {
+                Id = Guid.CreateVersion7(),
+                TenantId = _targetTenantId,
+                ConnectorName = "dexcom",
+                IsHealthy = false,
+                LastErrorMessage = "boom",
+            });
+
+        db.SaveChanges();
+        return db;
+    }
+
+    private static ConnectorAdminController CreateController(IConnectorCursorResetService service) =>
+        new(service, Mock.Of<ILogger<ConnectorAdminController>>());
+
+    [Fact]
+    public async Task ResetTenantCursors_FansOutAcrossEveryConnector_WithUpperBoundSet()
+    {
+        var db = CreateDb();
+        var captured = new List<(string ConnectorId, SyncRequest Request)>();
+        var syncService = new Mock<IConnectorSyncService>();
+        syncService
+            .Setup(s => s.TriggerSyncAsync(It.IsAny<string>(), It.IsAny<SyncRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<string, SyncRequest, CancellationToken>((id, r, _) => captured.Add((id, r)))
+            .ReturnsAsync(new SyncResult { Success = true });
+
+        var tenantAccessor = new Mock<ITenantAccessor>();
+        TenantContext? setContext = null;
+        tenantAccessor.Setup(a => a.SetTenant(It.IsAny<TenantContext>()))
+            .Callback<TenantContext>(c => setContext = c);
+
+        var service = new ConnectorCursorResetService(
+            db, syncService.Object, tenantAccessor.Object,
+            Mock.Of<ILogger<ConnectorCursorResetService>>());
+        var controller = CreateController(service);
+
+        var from = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var result = await controller.ResetTenantCursors(
+            _targetTenantId,
+            new AdminResetCursorsRequest { From = from, DataTypes = [SyncDataType.Boluses] },
+            CancellationToken.None);
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var payload = ok.Value.Should().BeOfType<TenantCursorResetResult>().Subject;
+
+        // Fans out across BOTH configured connectors.
+        captured.Should().HaveCount(2);
+        captured.Select(c => c.ConnectorId).Should().BeEquivalentTo(["nightscout", "dexcom"]);
+        payload.Connectors.Should().HaveCount(2);
+
+        // Every request forces a full re-pull (To set), passing through the requested filters.
+        captured.Should().OnlyContain(c => c.Request.To != null);
+        captured.Should().OnlyContain(c => c.Request.From == from);
+        captured.Should().OnlyContain(c => c.Request.DataTypes.Contains(SyncDataType.Boluses));
+
+        // The tenant context is switched to the TARGET tenant on the admin's behalf.
+        setContext.Should().NotBeNull();
+        setContext!.TenantId.Should().Be(_targetTenantId);
+        setContext.Slug.Should().Be("erik");
+    }
+
+    [Fact]
+    public async Task ResetTenantCursors_UnknownTenant_Returns404_AndDoesNotSync()
+    {
+        var db = CreateDb();
+        var syncService = new Mock<IConnectorSyncService>();
+        var service = new ConnectorCursorResetService(
+            db, syncService.Object, Mock.Of<ITenantAccessor>(),
+            Mock.Of<ILogger<ConnectorCursorResetService>>());
+        var controller = CreateController(service);
+
+        var result = await controller.ResetTenantCursors(
+            Guid.CreateVersion7(), new AdminResetCursorsRequest(), CancellationToken.None);
+
+        result.Result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(404);
+        syncService.Verify(
+            s => s.TriggerSyncAsync(It.IsAny<string>(), It.IsAny<SyncRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetTenantConnectors_ReturnsConfiguredConnectorsWithHealth()
+    {
+        var db = CreateDb();
+        var service = new ConnectorCursorResetService(
+            db, Mock.Of<IConnectorSyncService>(), Mock.Of<ITenantAccessor>(),
+            Mock.Of<ILogger<ConnectorCursorResetService>>());
+        var controller = CreateController(service);
+
+        var result = await controller.GetTenantConnectors(_targetTenantId, CancellationToken.None);
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var payload = ok.Value.Should().BeOfType<TenantConnectorsDto>().Subject;
+        payload.TenantSlug.Should().Be("erik");
+        payload.Connectors.Should().HaveCount(2);
+        payload.Connectors.Should().Contain(c => c.ConnectorName == "dexcom" && !c.IsHealthy && c.LastErrorMessage == "boom");
+    }
+
+    [Fact]
+    public async Task GetTenantConnectors_UnknownTenant_Returns404()
+    {
+        var db = CreateDb();
+        var service = new ConnectorCursorResetService(
+            db, Mock.Of<IConnectorSyncService>(), Mock.Of<ITenantAccessor>(),
+            Mock.Of<ILogger<ConnectorCursorResetService>>());
+        var controller = CreateController(service);
+
+        var result = await controller.GetTenantConnectors(Guid.CreateVersion7(), CancellationToken.None);
+
+        result.Result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(404);
+    }
+}


### PR DESCRIPTION
## What

Adds a platform-admin affordance to **reset connector sync cursors for any tenant**, fanning out across **every** connector that tenant has configured. This closes the recurring operational loop described in nocturne-cloud#17: after fixing an upstream connector bug, an operator must re-push corrected/missing historical data to affected tenants — previously API-only, per-connector, per-tenant.

## Backend

- **`IConnectorCursorResetService`** (`src/API/Nocturne.API/Services/Connectors/ConnectorCursorResetService.cs`)
  - Sets the ambient tenant context to the **target** tenant (RLS GUC `set_config('app.current_tenant_id', ...)` + `ITenantAccessor.SetTenant`), the same mechanism used by the dev-only `sync-all` endpoint and the migration background jobs.
  - Enumerates the tenant's `connector_configurations` and reuses the existing `IConnectorSyncService.TriggerSyncAsync` per connector with **`To = now`**, which forces an explicit-range re-pull (bypasses the per-type catch-up cursors) — i.e. a cursor reset. Re-ingested records dedupe on their idempotency keys, so it is safe to re-run.
  - The RLS GUC is only set on relational providers (`IsRelational()`), so the service is unit-testable on the EF Core in-memory provider.
- **`ConnectorAdminController`** (`[Authorize(Roles = "platform_admin")]`, `/api/v4/admin/connectors`)
  - `GET /{tenantId}` — lists the target tenant's connectors with health + last-sync timestamps (so the admin can see the gap before/after).
  - `POST /{tenantId}/reset-cursors` — resets all of them; optional `from` lower bound and `dataTypes` filter, mirroring the per-tenant `ResetCursorRequest` shape. Returns a per-connector `SyncResult`.

## Design decisions / open items

- **Synchronous first cut.** Like the existing dev `sync-all`, the endpoint runs the fan-out synchronously and returns per-connector `SyncResult`s, which directly satisfies the "surface per-connector results" acceptance criterion. A full re-pull can take minutes per connector, so there is a clear `TODO` to move this to a background job with progress polling (cf. the migration job model) before fanning out across *many* tenants at once. Kept synchronous here to land a working, reviewable slice.
- **Route placement.** Lives under the existing platform-admin route group (`/api/v4/admin/...`) alongside `TenantController`, and the UI under `/settings/admin/...` behind the existing platform-admin layout guard.
- **Single-tenant per request** for now (the "multi-select / all affected tenants" mode from the issue is a natural follow-up once this is async).

## Frontend

- New platform-admin screen at `/settings/admin/connector-cursors` (`src/Web/packages/app/src/routes/(authenticated)/settings/admin/connector-cursors/`): pick a tenant + optional lower-bound date, view each connector's sync status/health, "Reset cursors" with an `AlertDialog` confirmation, and per-connector success/failure feedback.
- Sidebar link added for platform admins next to "Tenant Management".
- Remote functions (`connector-cursors.remote.ts`) call the endpoints through SvelteKit's `event.fetch` → `/api` proxy (forwards auth + instance key + tenant host). Hand-authored rather than generated since this PR is built with `-p:GenerateNSwagClient=false`; the generated client + zod will pick these up on the next codegen run. Lucide icons, shadcn-svelte, strings on the frontend.

## Tests

`tests/Unit/Nocturne.API.Tests/Controllers/V4/PlatformAdmin/ConnectorAdminControllerTests.cs`:
- fans out across **all** configured connectors with `To` set and the requested `from`/`dataTypes` passed through;
- switches the tenant context to the **target** tenant;
- `404` for an unknown tenant (and does not sync);
- `GetTenantConnectors` returns connectors with health/error state.

All 4 new tests pass; the 2 existing `ServicesControllerResetCursorTests` still pass.

## Verification

- `dotnet build src/API/Nocturne.API/Nocturne.API.csproj -p:GenerateNSwagClient=false` → 0 errors.
- `dotnet test tests/Unit/Nocturne.API.Tests --filter "ResetCursor|ConnectorAdmin"` → 6 passed.
- `pnpm run check` shows no errors in the new frontend files (the repo's existing baseline errors stem from the generated client / `@nocturne/bot` / UI package types not being built in this environment).

Implements the backend + UI for the cross-tenant cursor reset (nocturne-cloud#17).