### PR TITLE
feat(auth): platform-admin tenant access without membership

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/PlatformAccessController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/PlatformAccessController.cs
@@ -29,6 +29,14 @@ namespace Nocturne.API.Controllers.V4.PlatformAdmin;
 /// taken from the <c>tenant</c> (slug) query parameter, not from subdomain resolution. The path is
 /// registered as tenantless-allowed in <see cref="TenantResolutionMiddleware"/>.
 /// </para>
+/// <para>
+/// Like <c>GET /api/auth/oidc/login</c>, this is a GET navigation endpoint and is therefore exposed
+/// to login-CSRF (a third party could force a platform admin's browser to mint a grant). The blast
+/// radius is bounded: the grant cookie is HttpOnly and lives only in the victim's own browser, the
+/// victim must already be a platform admin, the only effect is being navigated into a tenant, and
+/// the mint is recorded in the auth audit log under the operator's real subject. Accepted as a
+/// residual risk consistent with the existing OIDC-login endpoint shape.
+/// </para>
 /// </remarks>
 [ApiController]
 [Tags("PlatformAdmin")]
@@ -130,7 +138,10 @@ public class PlatformAccessController(
             "Platform-admin {SubjectId} was granted access to tenant {TenantId} ({Slug})",
             auth.SubjectId, target.Id, target.Slug);
 
-        var proto = Request.Headers["X-Forwarded-Proto"].FirstOrDefault() ?? Request.Scheme;
+        // Only honour a sensible forwarded scheme; never reflect an arbitrary client value
+        // into the redirect. Prod is always behind TLS, so default to https.
+        var forwardedProto = Request.Headers["X-Forwarded-Proto"].FirstOrDefault();
+        var proto = forwardedProto is "http" or "https" ? forwardedProto : "https";
         var redirectUrl = $"{proto}://{target.Slug}.{baseDomainOptions.Value.BaseDomain}/";
         return Redirect(redirectUrl);
     }

--- a/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/PlatformAccessController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/PlatformAccessController.cs
@@ -1,0 +1,143 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Nocturne.API.Extensions;
+using Nocturne.API.Multitenancy;
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Models.Configuration;
+using Nocturne.Infrastructure.Data;
+
+namespace Nocturne.API.Controllers.V4.PlatformAdmin;
+
+/// <summary>
+/// Mints a short-lived, tenant-pinned platform-admin access grant so a platform admin can enter a
+/// tenant they are not a member of. The grant is a JWT carrying a <c>platform_access</c> marker,
+/// stored in a dedicated <c>.basedomain</c> cookie and consumed by
+/// <see cref="Middleware.Handlers.PlatformAccessCookieHandler"/> on the target subdomain.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The endpoint is anonymous so it can bounce an unauthenticated operator through OIDC login and
+/// back. It authorizes via the operator's existing nocturne session (the <c>platform_admin</c>
+/// flag): a session is required, and it must be a platform admin. The grant — and therefore all
+/// resulting audit attribution — is minted for the operator's real subject.
+/// </para>
+/// <para>
+/// Reached at the apex (the operator is not yet on any tenant subdomain); the target tenant is
+/// taken from the <c>tenant</c> (slug) query parameter, not from subdomain resolution. The path is
+/// registered as tenantless-allowed in <see cref="TenantResolutionMiddleware"/>.
+/// </para>
+/// </remarks>
+[ApiController]
+[Tags("PlatformAdmin")]
+[Route("api/auth/platform-access")]
+[AllowAnonymous]
+public class PlatformAccessController(
+    NocturneDbContext dbContext,
+    IJwtService jwtService,
+    IAuthAuditService authAudit,
+    IOptions<OidcOptions> oidcOptions,
+    IOptions<BaseDomainOptions> baseDomainOptions,
+    ILogger<PlatformAccessController> logger) : ControllerBase
+{
+    /// <summary>Lifetime of a platform-access grant. A time-boxed "visit", not a standing credential.</summary>
+    private static readonly TimeSpan GrantLifetime = TimeSpan.FromMinutes(30);
+
+    private const string AuditEventType = "platform_admin_tenant_access";
+
+    /// <summary>
+    /// Mint a platform-access grant for the given tenant slug and redirect the operator into the
+    /// tenant. Bounces through OIDC login if there is no session yet; 403s if the session is not a
+    /// platform admin.
+    /// </summary>
+    /// <param name="tenant">Target tenant slug.</param>
+    /// <param name="ct">Cancellation token.</param>
+    [HttpGet]
+    public async Task<IActionResult> Access([FromQuery] string? tenant, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(tenant))
+            return BadRequest(new { error = "missing_tenant" });
+
+        var auth = HttpContext.GetAuthContext();
+
+        // No session yet → send the operator through nocturne OIDC login, returning here.
+        if (auth is not { IsAuthenticated: true, SubjectId: not null })
+        {
+            var returnUrl = $"/api/auth/platform-access?tenant={Uri.EscapeDataString(tenant)}";
+            return Redirect($"/api/auth/oidc/login?returnUrl={Uri.EscapeDataString(returnUrl)}");
+        }
+
+        if (!auth.IsPlatformAdmin)
+        {
+            await authAudit.LogAsync(AuditEventType, auth.SubjectId, success: false,
+                ipAddress: GetClientIp(), userAgent: GetUserAgent(),
+                errorMessage: "not_platform_admin",
+                detailsJson: JsonSerializer.Serialize(new { slug = tenant }));
+            logger.LogWarning("Subject {SubjectId} attempted platform access to '{Slug}' without platform_admin",
+                auth.SubjectId, tenant);
+            return StatusCode(StatusCodes.Status403Forbidden, new { error = "forbidden" });
+        }
+
+        // The tenants table is not RLS-scoped, so this resolves any tenant by slug.
+        var target = await dbContext.Tenants.AsNoTracking()
+            .Where(t => t.Slug == tenant)
+            .Select(t => new { t.Id, t.Slug, t.IsActive })
+            .FirstOrDefaultAsync(ct);
+
+        if (target is null)
+            return NotFound(new { error = "tenant_not_found" });
+
+        if (!target.IsActive)
+            return StatusCode(StatusCodes.Status403Forbidden, new { error = "tenant_inactive" });
+
+        // Mint a tenant-pinned, platform-access-marked grant for the operator's real subject.
+        var subject = new SubjectInfo
+        {
+            Id = auth.SubjectId.Value,
+            Name = auth.SubjectName ?? string.Empty,
+            Email = auth.Email,
+        };
+        var grant = jwtService.GenerateAccessToken(
+            subject,
+            permissions: ["*"],
+            roles: [],
+            scopes: [],
+            clientId: null,
+            limitTo24Hours: false,
+            tenantId: target.Id,
+            lifetime: GrantLifetime,
+            platformAccess: true);
+
+        var cookie = oidcOptions.Value.Cookie;
+        Response.Cookies.Append(cookie.PlatformAccessName, grant, new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = cookie.Secure,
+            SameSite = SessionCookieExtensions.MapSameSiteMode(cookie.SameSite),
+            Path = cookie.Path,
+            Domain = cookie.Domain,
+            IsEssential = true,
+            Expires = DateTimeOffset.UtcNow.Add(GrantLifetime),
+        });
+
+        await authAudit.LogAsync(AuditEventType, auth.SubjectId, success: true,
+            ipAddress: GetClientIp(), userAgent: GetUserAgent(),
+            detailsJson: JsonSerializer.Serialize(new { tenantId = target.Id, slug = target.Slug }));
+
+        logger.LogInformation(
+            "Platform-admin {SubjectId} was granted access to tenant {TenantId} ({Slug})",
+            auth.SubjectId, target.Id, target.Slug);
+
+        var proto = Request.Headers["X-Forwarded-Proto"].FirstOrDefault() ?? Request.Scheme;
+        var redirectUrl = $"{proto}://{target.Slug}.{baseDomainOptions.Value.BaseDomain}/";
+        return Redirect(redirectUrl);
+    }
+
+    private string? GetClientIp() =>
+        Request.Headers["X-Forwarded-For"].FirstOrDefault()?.Split(',')[0].Trim()
+        ?? HttpContext.Connection.RemoteIpAddress?.ToString();
+
+    private string? GetUserAgent() => Request.Headers.UserAgent.FirstOrDefault();
+}

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -230,6 +230,7 @@ public static class ServiceRegistrationExtensions
         services.AddScoped<ITenantService, TenantService>();
 
         // Auth handlers (executed in priority order, lowest first)
+        services.AddSingleton<IAuthHandler, PlatformAccessCookieHandler>(); // Priority 40
         services.AddSingleton<IAuthHandler, SessionCookieHandler>(); // Priority 50
         services.AddSingleton<IAuthHandler, GuestSessionHandler>(); // Priority 52
         services.AddSingleton<GuestSessionHandler>(); // For direct cookie-setting use

--- a/src/API/Nocturne.API/Middleware/AuthenticationMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/AuthenticationMiddleware.cs
@@ -188,8 +188,10 @@ public class AuthenticationMiddleware
         var resolvedAuth = context.Items["AuthContext"] as AuthContext;
         if (resolvedAuth is { IsAuthenticated: true, SubjectId: not null, TenantId: not null })
         {
-            // Skip membership check for ApiSecret and InstanceKey auth (grants admin on the resolved tenant)
-            if (resolvedAuth.AuthType is not (AuthType.ApiKey or AuthType.InstanceKey))
+            // Skip membership check for ApiSecret and InstanceKey auth (grants admin on the resolved
+            // tenant), and for PlatformAccess grants (PlatformAccessCookieHandler already proved the
+            // grant is platform-access-marked and pinned to this tenant).
+            if (resolvedAuth.AuthType is not (AuthType.ApiKey or AuthType.InstanceKey or AuthType.PlatformAccess))
             {
                 var tenantMemberService = context.RequestServices.GetRequiredService<ITenantMemberService>();
                 var isMember = await tenantMemberService.IsMemberAsync(

--- a/src/API/Nocturne.API/Middleware/Handlers/PlatformAccessCookieHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/PlatformAccessCookieHandler.cs
@@ -1,8 +1,11 @@
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Nocturne.API.Services.Auth;
+using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.Configuration;
+using Nocturne.Infrastructure.Data;
 
 namespace Nocturne.API.Middleware.Handlers;
 
@@ -55,22 +58,22 @@ public class PlatformAccessCookieHandler : IAuthHandler
     }
 
     /// <inheritdoc />
-    public Task<AuthResult> AuthenticateAsync(HttpContext context)
+    public async Task<AuthResult> AuthenticateAsync(HttpContext context)
     {
         var grant = context.Request.Cookies[_options.Cookie.PlatformAccessName];
         if (string.IsNullOrEmpty(grant))
-            return Task.FromResult(AuthResult.Skip());
+            return AuthResult.Skip();
 
         // A grant is only meaningful on a resolved tenant subdomain.
         if (context.Items["TenantContext"] is not TenantContext tenant)
-            return Task.FromResult(AuthResult.Skip());
+            return AuthResult.Skip();
 
         using var scope = _scopeFactory.CreateScope();
         var jwtService = scope.ServiceProvider.GetRequiredService<IJwtService>();
         var result = jwtService.ValidateAccessToken(grant);
 
         if (!result.IsValid || result.Claims is null)
-            return Task.FromResult(AuthResult.Skip());
+            return AuthResult.Skip();
 
         var claims = result.Claims;
 
@@ -78,13 +81,30 @@ public class PlatformAccessCookieHandler : IAuthHandler
         // (a normal session, an OAuth tenant-pinned token, a grant for another tenant)
         // falls through to the normal auth chain.
         if (!claims.PlatformAccess || claims.TenantId != tenant.TenantId)
-            return Task.FromResult(AuthResult.Skip());
+            return AuthResult.Skip();
+
+        // Defense in depth: a self-contained grant can't be revoked, so confirm the subject
+        // is STILL a platform admin on every request. Revoking the flag then ends access on
+        // the next request instead of lingering until the grant expires.
+        var db = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
+        var stillPlatformAdmin = await db.Subjects
+            .Where(s => s.Id == claims.SubjectId)
+            .Select(s => s.IsPlatformAdmin)
+            .FirstOrDefaultAsync();
+
+        if (!stillPlatformAdmin)
+        {
+            _logger.LogWarning(
+                "Platform-access grant rejected: subject {SubjectId} is no longer a platform admin",
+                claims.SubjectId);
+            return AuthResult.Skip();
+        }
 
         _logger.LogInformation(
             "Platform-admin access grant accepted for subject {SubjectId} on tenant {TenantId}",
             claims.SubjectId, tenant.TenantId);
 
-        return Task.FromResult(AuthResult.Success(new AuthContext
+        return AuthResult.Success(new AuthContext
         {
             IsAuthenticated = true,
             AuthType = AuthType.PlatformAccess,
@@ -94,7 +114,8 @@ public class PlatformAccessCookieHandler : IAuthHandler
             Permissions = ["*"],
             Roles = claims.Roles,
             RawToken = grant,
+            TokenId = Guid.TryParse(claims.JwtId, out var jwtId) ? jwtId : null,
             ExpiresAt = claims.ExpiresAt,
-        }));
+        });
     }
 }

--- a/src/API/Nocturne.API/Middleware/Handlers/PlatformAccessCookieHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/PlatformAccessCookieHandler.cs
@@ -1,0 +1,100 @@
+using Microsoft.Extensions.Options;
+using Nocturne.API.Services.Auth;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Core.Models.Configuration;
+
+namespace Nocturne.API.Middleware.Handlers;
+
+/// <summary>
+/// Authentication handler for platform-admin tenant-access grants. Reads the short-lived,
+/// tenant-pinned JWT in the platform-access cookie (minted by <c>PlatformAccessController</c>)
+/// and authenticates the request as <see cref="AuthType.PlatformAccess"/> — but only when the
+/// grant's <c>platform_access</c> marker is set AND its pinned tenant matches the tenant resolved
+/// from the request's subdomain.
+/// </summary>
+/// <remarks>
+/// Runs before <see cref="SessionCookieHandler"/> (priority 40 &lt; 50) so an active grant takes
+/// precedence over the operator's ordinary session on the granted tenant. If there is no grant
+/// cookie, the token is invalid, the marker is missing, or the pinned tenant doesn't match the
+/// resolved subdomain, this handler <see cref="AuthResult.Skip">skips</see> so the chain falls
+/// through to the normal session (which, for a non-member, is then rejected by the membership
+/// check in <see cref="AuthenticationMiddleware"/>). Requiring the <c>platform_access</c> marker
+/// — not just a tenant pin — prevents any other tenant-pinned token (e.g. an OAuth token) from
+/// being moved into this cookie to escalate to superuser.
+/// </remarks>
+/// <seealso cref="SessionCookieHandler"/>
+/// <seealso cref="AuthenticationMiddleware"/>
+public class PlatformAccessCookieHandler : IAuthHandler
+{
+    /// <summary>
+    /// Handler priority (40 — runs before <see cref="SessionCookieHandler"/> at 50).
+    /// </summary>
+    public int Priority => 40;
+
+    /// <summary>
+    /// Handler name for logging.
+    /// </summary>
+    public string Name => "PlatformAccessCookieHandler";
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<PlatformAccessCookieHandler> _logger;
+    private readonly OidcOptions _options;
+
+    /// <summary>
+    /// Creates a new instance of <see cref="PlatformAccessCookieHandler"/>.
+    /// </summary>
+    public PlatformAccessCookieHandler(
+        IServiceScopeFactory scopeFactory,
+        ILogger<PlatformAccessCookieHandler> logger,
+        IOptions<OidcOptions> options)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+        _options = options.Value;
+    }
+
+    /// <inheritdoc />
+    public Task<AuthResult> AuthenticateAsync(HttpContext context)
+    {
+        var grant = context.Request.Cookies[_options.Cookie.PlatformAccessName];
+        if (string.IsNullOrEmpty(grant))
+            return Task.FromResult(AuthResult.Skip());
+
+        // A grant is only meaningful on a resolved tenant subdomain.
+        if (context.Items["TenantContext"] is not TenantContext tenant)
+            return Task.FromResult(AuthResult.Skip());
+
+        using var scope = _scopeFactory.CreateScope();
+        var jwtService = scope.ServiceProvider.GetRequiredService<IJwtService>();
+        var result = jwtService.ValidateAccessToken(grant);
+
+        if (!result.IsValid || result.Claims is null)
+            return Task.FromResult(AuthResult.Skip());
+
+        var claims = result.Claims;
+
+        // Must be a genuine platform-access grant pinned to THIS tenant. Anything else
+        // (a normal session, an OAuth tenant-pinned token, a grant for another tenant)
+        // falls through to the normal auth chain.
+        if (!claims.PlatformAccess || claims.TenantId != tenant.TenantId)
+            return Task.FromResult(AuthResult.Skip());
+
+        _logger.LogInformation(
+            "Platform-admin access grant accepted for subject {SubjectId} on tenant {TenantId}",
+            claims.SubjectId, tenant.TenantId);
+
+        return Task.FromResult(AuthResult.Success(new AuthContext
+        {
+            IsAuthenticated = true,
+            AuthType = AuthType.PlatformAccess,
+            SubjectId = claims.SubjectId,
+            SubjectName = claims.Name,
+            Email = claims.Email,
+            Permissions = ["*"],
+            Roles = claims.Roles,
+            RawToken = grant,
+            ExpiresAt = claims.ExpiresAt,
+        }));
+    }
+}

--- a/src/API/Nocturne.API/Middleware/MemberScopeMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/MemberScopeMiddleware.cs
@@ -66,8 +66,10 @@ public class MemberScopeMiddleware
             return;
         }
 
-        // InstanceKey: infrastructure auth, always superuser — no membership lookup needed
-        if (authContext.AuthType is AuthType.InstanceKey)
+        // InstanceKey: infrastructure auth, always superuser — no membership lookup needed.
+        // PlatformAccess: a platform-admin tenant-access grant, pinned to this tenant and verified
+        // by PlatformAccessCookieHandler — full superuser on the granted tenant, no membership.
+        if (authContext.AuthType is AuthType.InstanceKey or AuthType.PlatformAccess)
         {
             var superuserScopes = new HashSet<string> { "*" };
             context.Items["GrantedScopes"] = (IReadOnlySet<string>)superuserScopes;

--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -62,6 +62,9 @@ public class TenantResolutionMiddleware
     /// </summary>
     private static readonly string[] TenantlessAllowedPrefixes =
     [
+        // Platform-admin tenant-access grant: minted at the apex (operator is not on
+        // any tenant subdomain yet); the target tenant is resolved from the query string.
+        "/api/auth/platform-access",
         "/api/auth/passkey/setup/",
         "/api/v4/admin/demo/",
         "/api/v4/admin/platform-settings",

--- a/src/API/Nocturne.API/Services/Auth/JwtService.cs
+++ b/src/API/Nocturne.API/Services/Auth/JwtService.cs
@@ -133,7 +133,8 @@ public class JwtService : IJwtService
         string? clientId = null,
         bool limitTo24Hours = false,
         Guid? tenantId = null,
-        TimeSpan? lifetime = null
+        TimeSpan? lifetime = null,
+        bool platformAccess = false
     )
     {
         var now = DateTimeOffset.UtcNow;
@@ -181,6 +182,13 @@ public class JwtService : IJwtService
         if (tenantId.HasValue)
         {
             claims.Add(new Claim("tenant_id", tenantId.Value.ToString()));
+        }
+
+        // Mark platform-admin tenant-access grants. Only tokens carrying this marker
+        // (and a matching tenant pin) confer out-of-tenant superuser access.
+        if (platformAccess)
+        {
+            claims.Add(new Claim("platform_access", "true", ClaimValueTypes.Boolean));
         }
 
         // Add OAuth scopes as space-delimited string (RFC 6749 Section 3.3)
@@ -272,6 +280,9 @@ public class JwtService : IJwtService
             var tenantIdClaim = principal.FindFirst("tenant_id")?.Value;
             Guid? tenantId = Guid.TryParse(tenantIdClaim, out var tid) ? tid : null;
 
+            // Parse platform-access marker (platform-admin tenant-access grants)
+            var platformAccess = principal.FindFirst("platform_access")?.Value == "true";
+
             var claims = new JwtClaims
             {
                 SubjectId = subjectId,
@@ -282,6 +293,7 @@ public class JwtService : IJwtService
                 Scopes = scopeList,
                 ClientId = principal.FindFirst("client_id")?.Value,
                 TenantId = tenantId,
+                PlatformAccess = platformAccess,
                 LimitTo24Hours = limitTo24Hours,
                 JwtId = jwtToken.Id,
                 IssuedAt = new DateTimeOffset(jwtToken.IssuedAt, TimeSpan.Zero),

--- a/src/Aspire/Nocturne.Aspire.Host/Program.cs
+++ b/src/Aspire/Nocturne.Aspire.Host/Program.cs
@@ -514,6 +514,13 @@ class Program
                 yarp.AddRoute("/api/v4/dev-only/{**catch-all}", api.GetEndpoint("http"))
                     .WithTransformXForwarded("X-Forwarded-", xForwardedAction);
 
+                // Platform-admin tenant-access grant → API (sets the .basedomain grant cookie on a
+                // browser navigation; must come before /api/ → web catch-all)
+                yarp.AddRoute("/api/auth/platform-access/{**catch-all}", api.GetEndpoint("http"))
+                    .WithTransformXForwarded("X-Forwarded-", xForwardedAction);
+                yarp.AddRoute("/api/auth/platform-access", api.GetEndpoint("http"))
+                    .WithTransformXForwarded("X-Forwarded-", xForwardedAction);
+
                 // Bot webhooks, remote functions → web
                 yarp.AddRoute("/api/{**catch-all}", webEndpoints.GetEndpoint("http"))
                     .WithTransformXForwarded("X-Forwarded-", xForwardedAction);

--- a/src/Core/Nocturne.Core.Contracts/Auth/IJwtService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Auth/IJwtService.cs
@@ -36,6 +36,9 @@ public interface IJwtService
     /// <param name="tenantId">Tenant this token is pinned to. When present, the token is
     /// only valid on the tenant subdomain that issued it.</param>
     /// <param name="lifetime">Optional custom lifetime (defaults to configuration)</param>
+    /// <param name="platformAccess">When true, marks this token as a platform-admin tenant-access
+    /// grant. Combined with <paramref name="tenantId"/>, this is what authorizes out-of-tenant
+    /// superuser access — a marker that no ordinary tenant-pinned token carries.</param>
     /// <returns>JWT access token string</returns>
     string GenerateAccessToken(
         SubjectInfo subject,
@@ -45,7 +48,8 @@ public interface IJwtService
         string? clientId = null,
         bool limitTo24Hours = false,
         Guid? tenantId = null,
-        TimeSpan? lifetime = null
+        TimeSpan? lifetime = null,
+        bool platformAccess = false
     );
 
     /// <summary>
@@ -192,6 +196,13 @@ public class JwtClaims
     /// the matching tenant subdomain.
     /// </summary>
     public Guid? TenantId { get; set; }
+
+    /// <summary>
+    /// Whether this token is a platform-admin tenant-access grant. Only such tokens
+    /// (combined with a matching <see cref="TenantId"/> pin) confer out-of-tenant
+    /// superuser access; no ordinary tenant-pinned token carries this marker.
+    /// </summary>
+    public bool PlatformAccess { get; set; }
 
     /// <summary>
     /// When true, data requests using this token should only return data from the

--- a/src/Core/Nocturne.Core.Models/Authorization/AuthModels.cs
+++ b/src/Core/Nocturne.Core.Models/Authorization/AuthModels.cs
@@ -279,5 +279,13 @@ public enum AuthType
     /// <summary>
     /// Guest session (temporary read-only access via guest code)
     /// </summary>
-    Guest
+    Guest,
+
+    /// <summary>
+    /// Platform-admin tenant access. A short-lived, tenant-pinned grant minted by
+    /// <c>PlatformAccessController</c> that lets a platform admin act on a tenant they
+    /// are not a member of, with full (superuser) permissions. Distinct from a normal
+    /// session so audit entries are marked as out-of-tenant platform access.
+    /// </summary>
+    PlatformAccess
 }

--- a/src/Core/Nocturne.Core.Models/Configuration/OidcOptions.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/OidcOptions.cs
@@ -109,6 +109,14 @@ public class CookieSettings
     /// Name of the refresh token cookie
     /// </summary>
     public string RefreshTokenName { get; set; } = ".Nocturne.RefreshToken";
+
+    /// <summary>
+    /// Name of the platform-admin tenant-access grant cookie. Holds a short-lived,
+    /// tenant-pinned JWT that confers out-of-tenant superuser access. Kept separate
+    /// from the normal session cookie so it can be issued/cleared independently and so
+    /// audit entries can mark the access as out-of-tenant platform access.
+    /// </summary>
+    public string PlatformAccessName { get; set; } = ".Nocturne.PlatformAccess";
 }
 
 /// <summary>

--- a/src/Web/packages/app/src/hooks.server.ts
+++ b/src/Web/packages/app/src/hooks.server.ts
@@ -144,12 +144,14 @@ const authHandle: Handle = async ({ event, resolve }) => {
     // performed by the API (via SessionCookieHandler auto-refresh) back to
     // the browser, so rotated refresh tokens don't silently disappear.
     const refreshToken = event.cookies.get(AUTH_COOKIE_NAMES.refreshToken);
+    const platformAccessToken = event.cookies.get(AUTH_COOKIE_NAMES.platformAccess);
     const forwardedHost = getEffectiveHost(event.request, event.cookies);
     const authExtraHeaders: Record<string, string> = { "X-Forwarded-Proto": getOriginalProto(event.request) };
     if (forwardedHost) authExtraHeaders["X-Forwarded-Host"] = forwardedHost;
     const apiClient = createServerApiClient(apiBaseUrl, fetch, {
       accessToken,
       refreshToken,
+      platformAccessToken,
       hashedInstanceKey: getHashedInstanceKey(),
       extraHeaders: authExtraHeaders,
       responseCookies: event.cookies,
@@ -334,6 +336,7 @@ const proxyHandle: Handle = async ({ event, resolve }) => {
     const accessToken = event.cookies.get(AUTH_COOKIE_NAMES.accessToken);
     const refreshToken = event.cookies.get(AUTH_COOKIE_NAMES.refreshToken);
     const guestSession = event.cookies.get("nocturne-guest-session");
+    const platformAccess = event.cookies.get(AUTH_COOKIE_NAMES.platformAccess);
     const cookies: string[] = [];
     if (accessToken) {
       cookies.push(`${AUTH_COOKIE_NAMES.accessToken}=${accessToken}`);
@@ -343,6 +346,9 @@ const proxyHandle: Handle = async ({ event, resolve }) => {
     }
     if (guestSession) {
       cookies.push(`nocturne-guest-session=${guestSession}`);
+    }
+    if (platformAccess) {
+      cookies.push(`${AUTH_COOKIE_NAMES.platformAccess}=${platformAccess}`);
     }
     if (cookies.length > 0) {
       headers.set("Cookie", cookies.join("; "));
@@ -381,6 +387,7 @@ const apiClientHandle: Handle = async ({ event, resolve }) => {
   const accessToken = event.cookies.get(AUTH_COOKIE_NAMES.accessToken);
   const refreshToken = event.cookies.get(AUTH_COOKIE_NAMES.refreshToken);
   const guestSessionToken = event.cookies.get("nocturne-guest-session");
+  const platformAccessToken = event.cookies.get(AUTH_COOKIE_NAMES.platformAccess);
 
   const extraHeaders: Record<string, string> = {
     "X-Forwarded-Proto": getOriginalProto(event.request),
@@ -400,6 +407,7 @@ const apiClientHandle: Handle = async ({ event, resolve }) => {
     accessToken,
     refreshToken,
     guestSessionToken,
+    platformAccessToken,
     hashedInstanceKey: getHashedInstanceKey(),
     extraHeaders,
     responseCookies: event.cookies,

--- a/src/Web/packages/app/src/lib/config/auth-cookies.ts
+++ b/src/Web/packages/app/src/lib/config/auth-cookies.ts
@@ -9,6 +9,7 @@
 import {
   COOKIE_ACCESS_TOKEN_NAME,
   COOKIE_REFRESH_TOKEN_NAME,
+  COOKIE_PLATFORM_ACCESS_NAME,
 } from "./constants";
 
 export function getAccessTokenCookieName(): string {
@@ -22,5 +23,6 @@ export function getRefreshTokenCookieName(): string {
 export const AUTH_COOKIE_NAMES = {
   accessToken: COOKIE_ACCESS_TOKEN_NAME,
   refreshToken: COOKIE_REFRESH_TOKEN_NAME,
+  platformAccess: COOKIE_PLATFORM_ACCESS_NAME,
   isAuthenticated: "IsAuthenticated",
 } as const;

--- a/src/Web/packages/app/src/lib/config/constants.ts
+++ b/src/Web/packages/app/src/lib/config/constants.ts
@@ -18,6 +18,9 @@ export const WEBSOCKET_PING_INTERVAL_MS = 20_000;
 // if anyone reports a conflict.
 export const COOKIE_ACCESS_TOKEN_NAME = ".Nocturne.AccessToken";
 export const COOKIE_REFRESH_TOKEN_NAME = ".Nocturne.RefreshToken";
+// Platform-admin tenant-access grant (short-lived, tenant-pinned). Must be forwarded
+// to the API alongside the session so out-of-tenant superuser requests carry it.
+export const COOKIE_PLATFORM_ACCESS_NAME = ".Nocturne.PlatformAccess";
 
 // OpenTelemetry service identity (build-time, not deployment config)
 export const OTEL_SERVICE_NAME = "nocturne-web";

--- a/src/Web/packages/app/src/lib/server/api-client-factory.ts
+++ b/src/Web/packages/app/src/lib/server/api-client-factory.ts
@@ -42,6 +42,7 @@ export function createServerApiClient(
     accessToken?: string;
     refreshToken?: string;
     guestSessionToken?: string;
+    platformAccessToken?: string;
     hashedInstanceKey?: string | null;
     extraHeaders?: Record<string, string>;
     responseCookies?: CookieSetter;
@@ -71,6 +72,11 @@ export function createServerApiClient(
       }
       if (options?.guestSessionToken) {
         cookies.push(`nocturne-guest-session=${options.guestSessionToken}`);
+      }
+      if (options?.platformAccessToken) {
+        cookies.push(
+          `${AUTH_COOKIE_NAMES.platformAccess}=${options.platformAccessToken}`
+        );
       }
       if (cookies.length > 0) {
         headers.set("Cookie", cookies.join("; "));

--- a/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/PlatformAccessCookieHandlerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/PlatformAccessCookieHandlerTests.cs
@@ -1,5 +1,8 @@
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -9,21 +12,26 @@ using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.Configuration;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
 using Xunit;
 
 namespace Nocturne.API.Tests.Middleware.Handlers;
 
 /// <summary>
 /// Verifies that <see cref="PlatformAccessCookieHandler"/> only confers platform-access
-/// authentication for a genuine, platform-access-marked grant pinned to the resolved tenant —
-/// and skips (falls through to the normal auth chain) for anything else.
+/// authentication for a genuine, platform-access-marked grant pinned to the resolved tenant,
+/// whose subject is still a platform admin — and skips (falls through to the normal auth chain)
+/// for anything else.
 /// </summary>
-public class PlatformAccessCookieHandlerTests
+public class PlatformAccessCookieHandlerTests : IDisposable
 {
     private readonly Guid _tenantId = Guid.CreateVersion7();
     private readonly Guid _otherTenantId = Guid.CreateVersion7();
     private readonly Guid _subjectId = Guid.CreateVersion7();
+    private readonly Guid _revokedSubjectId = Guid.CreateVersion7();
 
+    private readonly SqliteConnection _connection;
     private readonly IJwtService _jwt;
     private readonly PlatformAccessCookieHandler _handler;
     private readonly OidcOptions _oidc = new();
@@ -39,8 +47,25 @@ public class PlatformAccessCookieHandlerTests
         });
         _jwt = new JwtService(jwtOptions, NullLogger<JwtService>.Instance);
 
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        var dbOptions = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+        using (var ctx = new NocturneDbContext(dbOptions))
+        {
+            ctx.Database.EnsureCreated();
+            ctx.Subjects.Add(new SubjectEntity { Id = _subjectId, Name = "Operator", IsActive = true, IsPlatformAdmin = true });
+            ctx.Subjects.Add(new SubjectEntity { Id = _revokedSubjectId, Name = "Ex-Operator", IsActive = true, IsPlatformAdmin = false });
+            ctx.SaveChanges();
+        }
+
         var services = new ServiceCollection();
         services.AddSingleton(_jwt);
+        services.AddDbContext<NocturneDbContext>(o => o
+            .UseSqlite(_connection)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning)));
         var provider = services.BuildServiceProvider();
         var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
 
@@ -50,10 +75,12 @@ public class PlatformAccessCookieHandlerTests
             Options.Create(_oidc));
     }
 
+    public void Dispose() => _connection.Dispose();
+
     [Fact]
-    public async Task ValidGrant_MatchingTenant_AuthenticatesAsPlatformAccess()
+    public async Task ValidGrant_MatchingTenant_PlatformAdmin_AuthenticatesAsPlatformAccess()
     {
-        var token = MintGrant(tenantId: _tenantId, platformAccess: true);
+        var token = MintGrant(_subjectId, tenantId: _tenantId, platformAccess: true);
         var context = BuildContext(_tenantId, cookieValue: token);
 
         var result = await _handler.AuthenticateAsync(context);
@@ -65,10 +92,23 @@ public class PlatformAccessCookieHandlerTests
     }
 
     [Fact]
+    public async Task SubjectNoLongerPlatformAdmin_Skips()
+    {
+        // Grant is otherwise valid (marker + matching tenant) but the subject's platform-admin
+        // flag has since been revoked — the live re-check must reject it.
+        var token = MintGrant(_revokedSubjectId, tenantId: _tenantId, platformAccess: true);
+        var context = BuildContext(_tenantId, cookieValue: token);
+
+        var result = await _handler.AuthenticateAsync(context);
+
+        result.ShouldSkip.Should().BeTrue();
+        result.Succeeded.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task Grant_PinnedToDifferentTenant_Skips()
     {
-        // Genuine platform-access grant, but for another tenant than the one resolved.
-        var token = MintGrant(tenantId: _otherTenantId, platformAccess: true);
+        var token = MintGrant(_subjectId, tenantId: _otherTenantId, platformAccess: true);
         var context = BuildContext(_tenantId, cookieValue: token);
 
         var result = await _handler.AuthenticateAsync(context);
@@ -82,7 +122,7 @@ public class PlatformAccessCookieHandlerTests
     {
         // Escalation guard: an ordinary tenant-pinned token (e.g. an OAuth token) moved into
         // the platform-access cookie must NOT confer god mode.
-        var token = MintGrant(tenantId: _tenantId, platformAccess: false);
+        var token = MintGrant(_subjectId, tenantId: _tenantId, platformAccess: false);
         var context = BuildContext(_tenantId, cookieValue: token);
 
         var result = await _handler.AuthenticateAsync(context);
@@ -103,7 +143,7 @@ public class PlatformAccessCookieHandlerTests
     [Fact]
     public async Task NoResolvedTenant_Skips()
     {
-        var token = MintGrant(tenantId: _tenantId, platformAccess: true);
+        var token = MintGrant(_subjectId, tenantId: _tenantId, platformAccess: true);
         var context = BuildContext(tenant: null, cookieValue: token);
 
         var result = await _handler.AuthenticateAsync(context);
@@ -121,9 +161,9 @@ public class PlatformAccessCookieHandlerTests
         result.ShouldSkip.Should().BeTrue();
     }
 
-    private string MintGrant(Guid tenantId, bool platformAccess) =>
+    private string MintGrant(Guid subjectId, Guid tenantId, bool platformAccess) =>
         _jwt.GenerateAccessToken(
-            new SubjectInfo { Id = _subjectId, Name = "Platform Operator", Email = "ops@example.com" },
+            new SubjectInfo { Id = subjectId, Name = "Platform Operator", Email = "ops@example.com" },
             permissions: ["*"],
             roles: [],
             scopes: [],

--- a/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/PlatformAccessCookieHandlerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/PlatformAccessCookieHandlerTests.cs
@@ -1,0 +1,151 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Nocturne.API.Middleware.Handlers;
+using Nocturne.API.Services.Auth;
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Core.Models.Configuration;
+using Xunit;
+
+namespace Nocturne.API.Tests.Middleware.Handlers;
+
+/// <summary>
+/// Verifies that <see cref="PlatformAccessCookieHandler"/> only confers platform-access
+/// authentication for a genuine, platform-access-marked grant pinned to the resolved tenant —
+/// and skips (falls through to the normal auth chain) for anything else.
+/// </summary>
+public class PlatformAccessCookieHandlerTests
+{
+    private readonly Guid _tenantId = Guid.CreateVersion7();
+    private readonly Guid _otherTenantId = Guid.CreateVersion7();
+    private readonly Guid _subjectId = Guid.CreateVersion7();
+
+    private readonly IJwtService _jwt;
+    private readonly PlatformAccessCookieHandler _handler;
+    private readonly OidcOptions _oidc = new();
+
+    public PlatformAccessCookieHandlerTests()
+    {
+        var jwtOptions = Options.Create(new JwtOptions
+        {
+            SecretKey = "platform-access-test-secret-key-32+chars",
+            Issuer = "nocturne",
+            Audience = "nocturne-api",
+            AccessTokenLifetimeMinutes = 15,
+        });
+        _jwt = new JwtService(jwtOptions, NullLogger<JwtService>.Instance);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(_jwt);
+        var provider = services.BuildServiceProvider();
+        var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+
+        _handler = new PlatformAccessCookieHandler(
+            scopeFactory,
+            NullLogger<PlatformAccessCookieHandler>.Instance,
+            Options.Create(_oidc));
+    }
+
+    [Fact]
+    public async Task ValidGrant_MatchingTenant_AuthenticatesAsPlatformAccess()
+    {
+        var token = MintGrant(tenantId: _tenantId, platformAccess: true);
+        var context = BuildContext(_tenantId, cookieValue: token);
+
+        var result = await _handler.AuthenticateAsync(context);
+
+        result.Succeeded.Should().BeTrue();
+        result.AuthContext!.AuthType.Should().Be(AuthType.PlatformAccess);
+        result.AuthContext.SubjectId.Should().Be(_subjectId);
+        result.AuthContext.Permissions.Should().Contain("*");
+    }
+
+    [Fact]
+    public async Task Grant_PinnedToDifferentTenant_Skips()
+    {
+        // Genuine platform-access grant, but for another tenant than the one resolved.
+        var token = MintGrant(tenantId: _otherTenantId, platformAccess: true);
+        var context = BuildContext(_tenantId, cookieValue: token);
+
+        var result = await _handler.AuthenticateAsync(context);
+
+        result.ShouldSkip.Should().BeTrue();
+        result.Succeeded.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task TenantPinnedToken_WithoutPlatformAccessMarker_Skips()
+    {
+        // Escalation guard: an ordinary tenant-pinned token (e.g. an OAuth token) moved into
+        // the platform-access cookie must NOT confer god mode.
+        var token = MintGrant(tenantId: _tenantId, platformAccess: false);
+        var context = BuildContext(_tenantId, cookieValue: token);
+
+        var result = await _handler.AuthenticateAsync(context);
+
+        result.ShouldSkip.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task NoCookie_Skips()
+    {
+        var context = BuildContext(_tenantId, cookieValue: null);
+
+        var result = await _handler.AuthenticateAsync(context);
+
+        result.ShouldSkip.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task NoResolvedTenant_Skips()
+    {
+        var token = MintGrant(tenantId: _tenantId, platformAccess: true);
+        var context = BuildContext(tenant: null, cookieValue: token);
+
+        var result = await _handler.AuthenticateAsync(context);
+
+        result.ShouldSkip.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task InvalidToken_Skips()
+    {
+        var context = BuildContext(_tenantId, cookieValue: "not-a-real-jwt");
+
+        var result = await _handler.AuthenticateAsync(context);
+
+        result.ShouldSkip.Should().BeTrue();
+    }
+
+    private string MintGrant(Guid tenantId, bool platformAccess) =>
+        _jwt.GenerateAccessToken(
+            new SubjectInfo { Id = _subjectId, Name = "Platform Operator", Email = "ops@example.com" },
+            permissions: ["*"],
+            roles: [],
+            scopes: [],
+            clientId: null,
+            limitTo24Hours: false,
+            tenantId: tenantId,
+            lifetime: TimeSpan.FromMinutes(30),
+            platformAccess: platformAccess);
+
+    private DefaultHttpContext BuildContext(Guid? tenant, string? cookieValue)
+    {
+        var context = new DefaultHttpContext();
+        if (cookieValue is not null)
+        {
+            context.Request.Headers["Cookie"] =
+                $"{_oidc.Cookie.PlatformAccessName}={cookieValue}";
+        }
+        if (tenant is not null)
+        {
+            context.Items["TenantContext"] =
+                new TenantContext(tenant.Value, "acme", "Acme", IsActive: true);
+        }
+        return context;
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Middleware/MemberScopeMiddlewareTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/MemberScopeMiddlewareTests.cs
@@ -94,6 +94,32 @@ public class MemberScopeMiddlewareTests
     }
 
     [Fact]
+    public async Task PlatformAccess_AlwaysGetsSuperuserAccess()
+    {
+        // A platform-admin tenant-access grant (verified + tenant-pinned by
+        // PlatformAccessCookieHandler) gets full superuser on the granted tenant,
+        // with no membership lookup.
+        var (middleware, context) = Build(new AuthContext
+        {
+            IsAuthenticated = true,
+            AuthType = AuthType.PlatformAccess,
+            SubjectId = _subjectId,
+            TenantId = _tenantId,
+            Scopes = [],
+        });
+
+        await middleware.InvokeAsync(context);
+
+        var grantedScopes = context.Items["GrantedScopes"] as IReadOnlySet<string>;
+        grantedScopes.Should().NotBeNull();
+        grantedScopes.Should().Contain("*");
+
+        var permissionTrie = context.Items["PermissionTrie"] as PermissionTrie;
+        permissionTrie.Should().NotBeNull();
+        permissionTrie!.Check("*").Should().BeTrue();
+    }
+
+    [Fact]
     public async Task ApiKey_WithMultipleScopes_GrantsOnlyThoseScopes()
     {
         var (middleware, context) = Build(new AuthContext

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/JwtServicePlatformAccessTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/JwtServicePlatformAccessTests.cs
@@ -1,0 +1,60 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Nocturne.API.Services.Auth;
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Models.Configuration;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Auth;
+
+/// <summary>
+/// Round-trips the <c>platform_access</c> marker and tenant pin through
+/// <see cref="JwtService"/> generation and validation.
+/// </summary>
+public class JwtServicePlatformAccessTests
+{
+    private readonly JwtService _jwt = new(
+        Options.Create(new JwtOptions
+        {
+            SecretKey = "platform-access-test-secret-key-32+chars",
+            Issuer = "nocturne",
+            Audience = "nocturne-api",
+        }),
+        NullLogger<JwtService>.Instance);
+
+    private readonly SubjectInfo _subject = new()
+    {
+        Id = Guid.CreateVersion7(),
+        Name = "Operator",
+        Email = "ops@example.com",
+    };
+
+    [Fact]
+    public void PlatformAccessGrant_RoundTrips_MarkerAndTenantPin()
+    {
+        var tenantId = Guid.CreateVersion7();
+
+        var token = _jwt.GenerateAccessToken(
+            _subject, ["*"], [], [], tenantId: tenantId, platformAccess: true);
+
+        var result = _jwt.ValidateAccessToken(token);
+
+        result.IsValid.Should().BeTrue();
+        result.Claims!.PlatformAccess.Should().BeTrue();
+        result.Claims.TenantId.Should().Be(tenantId);
+        result.Claims.SubjectId.Should().Be(_subject.Id);
+    }
+
+    [Fact]
+    public void OrdinaryTenantPinnedToken_HasNoPlatformAccessMarker()
+    {
+        var token = _jwt.GenerateAccessToken(
+            _subject, ["glucose.read"], [], [], tenantId: Guid.CreateVersion7(), platformAccess: false);
+
+        var result = _jwt.ValidateAccessToken(token);
+
+        result.IsValid.Should().BeTrue();
+        result.Claims!.PlatformAccess.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Lets a **platform admin** enter any tenant they are *not* a member of, with full superuser permissions, **without** creating a `tenant_members` row — so they never appear in the tenant's member list — and with all actions still attributed to their real subject in the audit log.

Access is an explicit, **time-boxed visit**, not an ambient property of the account. God mode is conferred only by a short-lived (30 min), **tenant-pinned** JWT grant carrying a `platform_access` marker — never by the `IsPlatformAdmin` flag alone (which only authorizes *minting* a grant).

## How it works

1. Operator hits `GET /api/auth/platform-access?tenant={slug}` (top-level nav). Authenticated by their existing platform-admin session; bounces through OIDC login if absent.
2. Mints a tenant-pinned, `platform_access`-marked JWT for the operator's real subject, sets it in a dedicated `.basedomain` cookie, logs a `platform_admin_tenant_access` auth-audit event, and 303-redirects to `{slug}.{baseDomain}`.
3. `PlatformAccessCookieHandler` (priority 40) accepts the grant **only** when the marker is set **and** the pinned tenant matches the resolved subdomain — preventing any ordinary tenant-pinned token from being moved into the cookie to escalate. Produces `AuthType.PlatformAccess`.
4. `AuthenticationMiddleware` bypasses the membership check for `PlatformAccess`; `MemberScopeMiddleware` grants `*`. Audit `auth_type` becomes `"PlatformAccess"` automatically.

## Requirements met

- **Access any tenant without membership** — no `tenant_members` row created.
- **Invisible in member lists** — member list is sourced from `tenant_members`.
- **Audit as real identity + internal marker** — keeps real `subject_id`/`subject_name`; `mutation_audit_log.auth_type = "PlatformAccess"`. No schema change / migration.

## Changes

- New `PlatformAccessController` + `PlatformAccessCookieHandler` (+ DI registration, tenantless-allowed path).
- `AuthType.PlatformAccess`; `platform_access` marker on the tenant-pinned `GenerateAccessToken` overload (`IJwtService`/`JwtService`/`JwtClaims`).
- Two middleware branches (membership bypass + superuser).
- nocturne-web: forward the new grant cookie to the API (`hooks.server.ts`, `api-client-factory.ts`, `auth-cookies.ts`, `constants.ts`).
- Dev gateway route for the grant endpoint.

## Tests

`PlatformAccessCookieHandlerTests` (6 cases incl. the escalation guard), a `MemberScopeMiddleware` PlatformAccess superuser case, and a JWT marker round-trip. Full `Nocturne.API.Tests` unit suite green (one pre-existing flaky `uptimeMs` golden test passes in isolation).

## Notes

The apex "Access" UI and the production gateway route live in the downstream nocturne-cloud wrapper (separate PR). The dev gateway route here covers standalone `aspire start`.
