### PR TITLE
fix(auth): allow apex-initiated OIDC login (tenantless)

### DIFF
--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -52,6 +52,12 @@ public class TenantResolutionMiddleware
         "/api/metadata",
         "/api/v4/chat-identity/directory/resolve",
         "/api/v4/chat-identity/directory/pending-links",
+        // OIDC login can be initiated from the apex (no subdomain) — e.g. the
+        // platform-access grant bounces an unauthenticated operator here. OIDC is
+        // centralized at the apex (the registered redirect_uri is the apex callback),
+        // so login must not be tenant-gated. On a subdomain the tenant still resolves
+        // normally; this only allows the apex (tenantless) case through.
+        "/api/auth/oidc/login",
     ];
 
     /// <summary>


### PR DESCRIPTION
`GET /api/auth/oidc/login` returns 404 on the apex domain because it isn't tenantless-allowed — with multiple tenants `TenantResolutionMiddleware` can't resolve one. Normal logins start from a tenant subdomain so they don't hit this, but the new platform-access grant endpoint (nightscout/nocturne#302) bounces an unauthenticated operator to apex `/api/auth/oidc/login`, which 404s.

OIDC is already centralized at the apex (the registered `redirect_uri` is the apex callback), so apex-initiated login is well-defined. This adds `/api/auth/oidc/login` to `TenantlessAllowedPaths`. On a subdomain the tenant still resolves normally; this only allows the apex (tenantless) case through. Verified in prod: apex login 404s today, subdomain login 302s.