### PR TITLE
fix(auth): allow apex OIDC callback (tenantless)

### DIFF
--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -58,6 +58,12 @@ public class TenantResolutionMiddleware
         // so login must not be tenant-gated. On a subdomain the tenant still resolves
         // normally; this only allows the apex (tenantless) case through.
         "/api/auth/oidc/login",
+        // The OIDC callback is the registered redirect_uri (apex). For apex-initiated
+        // logins the state carries no TenantSlug, so OidcCallbackRedirectMiddleware
+        // can't bounce it to a subdomain and it must process here. The session it
+        // issues is subject-scoped (no tenant needed). Subdomain-originated callbacks
+        // are already redirected to their subdomain before reaching this point.
+        "/api/auth/oidc/callback",
     ];
 
     /// <summary>


### PR DESCRIPTION
Follow-up to #303. The OIDC callback (`/api/auth/oidc/callback`) is the registered `redirect_uri` and lands on the apex. For apex-initiated logins (the platform-access grant bounce, nightscout/nocturne#302) the OIDC `state` carries no `TenantSlug`, so `OidcCallbackRedirectMiddleware` can't bounce it to a subdomain and it falls through to `TenantResolutionMiddleware`, which 404s on the apex when multiple tenants exist.

`OidcController.Callback` has no tenant dependency — it validates the state cookie, exchanges the code, sets the (subject-scoped, `.basedomain`) session, and redirects to `returnUrl`. So it can process at the apex. Adds `/api/auth/oidc/callback` to `TenantlessAllowedPaths`. Subdomain-originated callbacks are still redirected to their subdomain before reaching this point, so the normal login flow is unaffected.

Verified in prod: apex login now 302s (from #303) but the apex callback 404s; this closes the last gap in the apex OIDC flow.