### PR TITLE
fix(connectors): pin scoped DbContext to the synced tenant in background sync

### DIFF
--- a/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
@@ -252,6 +252,17 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
         var dbContext = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
         dbContext.AuditContext = SystemAuditContext.ForService($"connector:{ConnectorName}");
 
+        // Pin the RLS tenant on the scoped DbContext. NocturneDbContext is leased from a pool
+        // (AddPooledDbContextFactory) and its TenantId is NOT reset between leases, so a context
+        // can arrive carrying a previous lessee's tenant. On HTTP requests the auth handlers set
+        // dbContext.TenantId explicitly; background syncs have no such handler, so we must set it
+        // here. Setting ITenantAccessor alone does not retro-fit the already-leased context — the
+        // TenantConnectionInterceptor reads NocturneDbContext.TenantId to configure RLS on connection
+        // open. Without this, tenant-scoped reads (connector config + secrets) run under a stale or
+        // empty tenant and silently return nothing, so every connector authenticates with empty
+        // credentials and no data syncs.
+        dbContext.TenantId = tenantId;
+
         // Load per-tenant config via the loader
         var loader = scope.ServiceProvider.GetRequiredService<IConnectorConfigurationLoader<TConfig>>();
         TConfig config;

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
@@ -31,16 +31,19 @@ public class ConnectorBackgroundServiceTests
     {
         private readonly SyncResult _syncResult;
         private readonly Action? _onSync;
+        private readonly Action<IServiceProvider>? _onSyncScope;
 
         public TestConnectorBackgroundService(
             IServiceProvider serviceProvider,
             SyncResult syncResult,
             ILogger logger,
-            Action? onSync = null)
+            Action? onSync = null,
+            Action<IServiceProvider>? onSyncScope = null)
             : base(serviceProvider, logger)
         {
             _syncResult = syncResult;
             _onSync = onSync;
+            _onSyncScope = onSyncScope;
         }
 
         protected override string ConnectorName => "TestConnector";
@@ -52,6 +55,7 @@ public class ConnectorBackgroundServiceTests
             ISyncProgressReporter? progressReporter = null)
         {
             _onSync?.Invoke();
+            _onSyncScope?.Invoke(scopeProvider);
             return Task.FromResult(_syncResult);
         }
 
@@ -438,6 +442,57 @@ public class ConnectorBackgroundServiceTests
                 It.IsAny<CancellationToken>()),
             Times.Once,
             "Expected error message to be cleared on successful sync");
+    }
+
+    [Fact]
+    public async Task SyncForTenant_PinsScopedDbContextToSyncedTenant_ForRlsIsolation()
+    {
+        // Regression test for the connector-wide outage: NocturneDbContext is leased from a pool
+        // (AddPooledDbContextFactory) and its TenantId is NOT reset between leases. The background
+        // sync must set dbContext.TenantId to the tenant being synced — otherwise the
+        // TenantConnectionInterceptor applies a stale/empty RLS tenant, tenant-scoped reads
+        // (connector config + secrets) silently return nothing, and every connector authenticates
+        // with empty credentials. Before the fix the scoped context stayed at Guid.Empty here.
+        var (cleanup, connStr, tenantId) = CreateSqliteDbWithTenantId();
+        using var _ = cleanup;
+
+        var syncResult = new SyncResult { Success = true, Message = "OK" };
+
+        var configServiceMock = new Mock<IConnectorConfigurationService>();
+        configServiceMock
+            .Setup(x => x.GetConfigurationAsync("TestConnector", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConnectorConfigurationResponse
+            {
+                ConnectorName = "TestConnector",
+                IsActive = true,
+                Configuration = JsonDocument.Parse("{\"enabled\": true, \"syncIntervalMinutes\": 5}")
+            });
+        configServiceMock
+            .Setup(x => x.GetSecretsAsync("TestConnector", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, string>());
+        configServiceMock
+            .Setup(x => x.UpdateHealthStateAsync(
+                It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<string?>(), It.IsAny<DateTime?>(), It.IsAny<bool?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var config = new TestConnectorConfig { Enabled = true, SyncIntervalMinutes = 5 };
+        var serviceProvider = BuildServiceProvider(connStr, configServiceMock, config);
+
+        Guid? capturedTenantId = null;
+        var sut = new TestConnectorBackgroundService(
+            serviceProvider,
+            syncResult,
+            NullLogger<TestConnectorBackgroundService>.Instance,
+            onSyncScope: sp => capturedTenantId = sp.GetRequiredService<NocturneDbContext>().TenantId);
+
+        // Act
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+
+        // Assert — the scoped DbContext the connector services share must be pinned to the synced
+        // tenant so RLS scopes correctly.
+        Assert.Equal(tenantId, capturedTenantId);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

All connectors (Tidepool, CareLink, Glooko, Nightscout, LibreLinkUp, Gluroo, NocturneRemote, Dexcom, …) stopped syncing in production for every tenant. Symptoms: thousands of `Cannot update health state for connector X: configuration not found` warnings, and auth failures with empty credentials (e.g. Tidepool `{"code":400,"reason":"Missing id and/or password"}`).

## Root cause

`ConnectorBackgroundService.SyncForTenantAsync` set the tenant on `ITenantAccessor` but **never on the scoped `NocturneDbContext`**. That context is leased from a pool (`AddPooledDbContextFactory`) and its `TenantId` is **not reset between leases**, so a sync could run under a stale or empty tenant.

`TenantConnectionInterceptor` derives the RLS GUC (`app.current_tenant_id`) from `NocturneDbContext.TenantId` on connection open. With an empty/stale tenant, every tenant-scoped read — connector config and secrets — silently returned nothing, so the loader hydrated empty credentials and each connector failed to authenticate. It "worked" before by luck (pool reuse happening to carry a matching tenant); shifting pool-reuse patterns made it consistently broken.

On the HTTP path the auth handlers (`ApiKeyHandler`, `DirectGrantTokenHandler`) already pin `dbContext.TenantId`; the background loop was the one tenant-scoped path missing that step.

## Fix

Set `dbContext.TenantId = tenantId` in the per-tenant scope, matching the established pattern. One functional line in the shared base class → fixes every connector at once. Adds a regression test asserting the scoped context is pinned to the synced tenant (was `Guid.Empty` before the fix).

## Follow-ups (not in this PR)

1. **Silent failure**: when credentials are empty the sync returns null instead of throwing, so it logs "completed successfully" and health state never flags the outage — nothing alerted. Worth surfacing as a failure.
2. **Defense-in-depth**: reset pooled `NocturneDbContext.TenantId` to `Guid.Empty` on pool return so any future path that forgets to set it fails *closed* (no rows) rather than silently using a stale tenant — currently a latent cross-tenant hazard.