### PR TITLE
feat(portal): render mermaid diagrams in hosted Scalar

### DIFF
--- a/src/Web/packages/portal/src/routes/scalar/+page.svelte
+++ b/src/Web/packages/portal/src/routes/scalar/+page.svelte
@@ -44,9 +44,26 @@
         };
         document.head.appendChild(script);
 
+        // Diagrams embedded in the OpenAPI descriptions are rendered by the API's
+        // own mermaid lazy-loader, served alongside the specs. Reusing it (rather
+        // than forking a copy into the portal) keeps rendering in sync with the API.
+        // It observes the document, so load order relative to Scalar doesn't matter.
+        const mermaidCss = document.createElement("link");
+        mermaidCss.rel = "stylesheet";
+        mermaidCss.href = `${SCALAR_API_URL}/scalar/mermaid-loader.css`;
+        document.head.appendChild(mermaidCss);
+
+        const mermaid = document.createElement("script");
+        mermaid.type = "module";
+        mermaid.crossOrigin = "anonymous";
+        mermaid.src = `${SCALAR_API_URL}/scalar/mermaid-loader.js`;
+        document.head.appendChild(mermaid);
+
         return () => {
             instance?.destroy?.();
             script.remove();
+            mermaidCss.remove();
+            mermaid.remove();
         };
     });
 </script>


### PR DESCRIPTION
Follow-up to #297.

The OpenAPI descriptions contain ` ```mermaid ` diagrams, which the API's own Scalar renders via a lazy-loader served at `/scalar/mermaid-loader.{js,css}`. The portal-hosted Scalar from #297 was missing it, so those diagrams showed as raw code fences.

This injects that same loader into the portal's `/scalar` route, pulling it **from the API origin** (`nocturne.run`) rather than forking a third copy:

- `nocturne.run` serves the loader with `Access-Control-Allow-Origin` reflecting the portal origin and `Content-Type: text/javascript`, so the cross-origin ES module loads cleanly.
- Reusing the deployed asset keeps the portal's diagram rendering automatically in sync with the API — no duplicated JS/CSS to drift.
- The loader observes the document, so load order relative to the Scalar bundle doesn't matter; both are appended in `onMount` and removed on destroy.

Base URL follows the existing `VITE_SCALAR_API_URL` config (defaults to `https://nocturne.run`).

Verified locally: `svelte-check` passes (0 errors) and the `adapter-static` build prerenders `/scalar` cleanly.
