### PR TITLE
fix(connectors): don't sync connectors for tenants that never configured them

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorConfigurationLoader.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorConfigurationLoader.cs
@@ -27,7 +27,18 @@ public class ConnectorConfigurationLoader<TConfig>(
         {
             var dbConfig = await configService.GetConfigurationAsync(registration.ConnectorName, ct);
             if (dbConfig?.Configuration != null)
+            {
                 ConnectorConfigurationBinder.ApplyJsonToConfig(dbConfig.Configuration, config);
+            }
+            else
+            {
+                // No per-tenant configuration row exists, so this connector is not configured for
+                // this tenant and must not sync. registration.Defaults sets Enabled = true (a C#
+                // property initializer, not a deliberate opt-in); without this, every connector
+                // would poll every tenant with empty credentials — producing auth failures and
+                // "configuration not found" health-state noise across all tenants.
+                config.Enabled = false;
+            }
 
             var secrets = await configService.GetSecretsAsync(registration.ConnectorName, ct);
             if (secrets.Count > 0)

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/ConnectorConfigurationLoaderTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/ConnectorConfigurationLoaderTests.cs
@@ -1,0 +1,80 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Core.Contracts.Connectors;
+using Xunit;
+
+namespace Nocturne.Connectors.Core.Tests.Services;
+
+/// <summary>
+///     Regression tests for <see cref="ConnectorConfigurationLoader{TConfig}"/>.
+///     A connector must only run for a tenant that has actually configured it. The startup
+///     defaults carry <c>Enabled = true</c> (a property initializer), so when a tenant has no
+///     config row the loader must explicitly disable the connector — otherwise every connector
+///     polls every tenant with empty credentials, producing auth failures and
+///     "configuration not found" health-state noise across all tenants.
+/// </summary>
+public class ConnectorConfigurationLoaderTests
+{
+    private const string ConnectorName = "TestConnector";
+
+    private static ConnectorConfigurationLoader<LoaderTestConfig> CreateLoader(
+        Mock<IConnectorConfigurationService> configService)
+    {
+        var registration = new ConnectorRegistration<LoaderTestConfig>(new LoaderTestConfig(), ConnectorName);
+        return new ConnectorConfigurationLoader<LoaderTestConfig>(
+            registration,
+            configService.Object,
+            NullLogger<ConnectorConfigurationLoader<LoaderTestConfig>>.Instance);
+    }
+
+    [Fact]
+    public async Task LoadForTenantAsync_DisablesConnector_WhenTenantHasNoConfigRow()
+    {
+        var configService = new Mock<IConnectorConfigurationService>();
+        configService
+            .Setup(s => s.GetConfigurationAsync(ConnectorName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ConnectorConfigurationResponse?)null);
+        configService
+            .Setup(s => s.GetSecretsAsync(ConnectorName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, string>());
+
+        var config = await CreateLoader(configService).LoadForTenantAsync(CancellationToken.None);
+
+        config.Enabled.Should().BeFalse(
+            "a connector with no per-tenant config row must not run, even though the defaults set Enabled = true");
+    }
+
+    [Fact]
+    public async Task LoadForTenantAsync_LoadsConfig_WhenTenantHasConfigRow()
+    {
+        var configService = new Mock<IConnectorConfigurationService>();
+        configService
+            .Setup(s => s.GetConfigurationAsync(ConnectorName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConnectorConfigurationResponse
+            {
+                ConnectorName = ConnectorName,
+                Configuration = JsonDocument.Parse("{\"enabled\": true, \"username\": \"user@example.com\"}")
+            });
+        configService
+            .Setup(s => s.GetSecretsAsync(ConnectorName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, string>());
+
+        var config = await CreateLoader(configService).LoadForTenantAsync(CancellationToken.None);
+
+        config.Enabled.Should().BeTrue("a configured, enabled tenant must still sync");
+        config.Username.Should().Be("user@example.com", "the stored configuration must be applied");
+    }
+
+    private sealed class LoaderTestConfig : BaseConnectorConfiguration
+    {
+        public LoaderTestConfig() => ConnectSource = ConnectSource.Dexcom;
+
+        public string Username { get; set; } = string.Empty;
+
+        protected override void ValidateSourceSpecificConfiguration() { }
+    }
+}


### PR DESCRIPTION
## Problem

In production, every connector was being polled for **every** active tenant — including tenants that never configured that connector. Each such sync authenticated with **empty credentials** (e.g. Tidepool `400 Missing id and/or password`, CareLink/Glooko "Authentication failed") and then logged `Cannot update health state for connector {X}: configuration not found` — thousands of times an hour.

## Root cause

`ConnectorConfigurationLoader.LoadForTenantAsync` starts from `registration.Defaults`, and `BaseConnectorConfiguration.Enabled` defaults to `true` (a property initializer, not an opt-in). It only overwrites fields when a per-tenant config row exists:

```csharp
var dbConfig = await configService.GetConfigurationAsync(registration.ConnectorName, ct);
if (dbConfig?.Configuration != null)
    ConnectorConfigurationBinder.ApplyJsonToConfig(dbConfig.Configuration, config);
```

When `GetConfigurationAsync` returns `null` (tenant never configured the connector), the loader returns `Enabled = true` with empty credentials, so `ConnectorBackgroundService.SyncForTenantAsync` passes the `!config.Enabled` gate and runs a doomed sync.

## Evidence

`connector_configurations` had rows for only 8 connector slugs (dexcom, glooko, gluroo, homeassistant, myfitnesspal, mylife, nightscout, tidepool), yet `configuration not found` fired for connectors with **zero** rows — CareLink, FreeStyle LibreLinkUp, NocturneRemote, Eversense — proving the loop ran for unconfigured (tenant, connector) pairs.

## Fix

When no per-tenant config row exists, set `config.Enabled = false` so the connector is skipped for that tenant. Configured tenants are unaffected. Adds `ConnectorConfigurationLoaderTests` covering both paths (verified to fail without the fix).