### PR TITLE
fix(connectors): sync tenants concurrently so one tenant can't block others

### DIFF
--- a/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
@@ -44,6 +44,20 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
     private static readonly TimeSpan NudgeDebounceWindow = TimeSpan.FromSeconds(10);
 
     /// <summary>
+    /// Maximum number of tenants this connector syncs concurrently. Tenants sync in parallel so one
+    /// tenant's slow or failing sync never blocks another's; this only caps resource use (DB
+    /// connections, outbound requests). Overridable for tests.
+    /// </summary>
+    protected virtual int MaxConcurrentTenantSyncs => 8;
+
+    /// <summary>
+    /// Maximum wall-clock time a single tenant's sync may run before it is cancelled. Bounds how long
+    /// one stuck or failing tenant — e.g. a hung network call or an auth-retry storm against bad
+    /// credentials — can hold a concurrency slot. Overridable for tests.
+    /// </summary>
+    protected virtual TimeSpan PerTenantSyncTimeout => TimeSpan.FromMinutes(3);
+
+    /// <summary>
     /// Initialises a new <see cref="ConnectorBackgroundService{TConfig}"/>.
     /// </summary>
     /// <param name="serviceProvider">Root DI service provider; a new scope is created per tenant sync.</param>
@@ -225,19 +239,45 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
             .Select(t => new { t.Id, t.Slug, t.DisplayName })
             .ToListAsync(stoppingToken);
 
-        foreach (var tenant in tenants)
-        {
-            try
+        // Sync tenants concurrently so each tenant is independent: one tenant's slow or failing sync
+        // must never delay or block another's. Each tenant already runs in its own DI scope (own
+        // DbContext, own tenant context), so concurrent execution is isolated. MaxConcurrentTenantSyncs
+        // only caps resource use (DB connections, outbound requests), and PerTenantSyncTimeout bounds
+        // how long any single tenant can hold a slot.
+        await Parallel.ForEachAsync(
+            tenants,
+            new ParallelOptions
             {
-                await SyncForTenantAsync(tenant.Id, tenant.Slug, tenant.DisplayName, stoppingToken);
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
+                MaxDegreeOfParallelism = MaxConcurrentTenantSyncs,
+                CancellationToken = stoppingToken
+            },
+            async (tenant, ct) =>
             {
-                Logger.LogError(ex,
-                    "Error syncing {ConnectorName} for tenant {TenantSlug}",
-                    ConnectorName, tenant.Slug);
-            }
-        }
+                using var tenantCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                tenantCts.CancelAfter(PerTenantSyncTimeout);
+
+                try
+                {
+                    await SyncForTenantAsync(tenant.Id, tenant.Slug, tenant.DisplayName, tenantCts.Token);
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    throw; // The service itself is shutting down — propagate to stop the loop.
+                }
+                catch (OperationCanceledException)
+                {
+                    // Per-tenant timeout fired. Abandon this tenant so it frees its slot for others.
+                    Logger.LogWarning(
+                        "{ConnectorName} sync for tenant {TenantSlug} exceeded {Timeout} and was cancelled",
+                        ConnectorName, tenant.Slug, PerTenantSyncTimeout);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(ex,
+                        "Error syncing {ConnectorName} for tenant {TenantSlug}",
+                        ConnectorName, tenant.Slug);
+                }
+            });
     }
 
     private async Task SyncForTenantAsync(Guid tenantId, string tenantSlug, string displayName, CancellationToken stoppingToken)

--- a/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolAuthTokenProvider.cs
+++ b/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolAuthTokenProvider.cs
@@ -48,9 +48,9 @@ public class TidepoolAuthTokenProvider(
                     attempt + 1,
                     maxRetries);
 
-                var (token, userId) = await LoginAsync(config, cancellationToken);
+                var (token, userId, shouldRetry) = await LoginAsync(config, cancellationToken);
                 if (string.IsNullOrEmpty(token))
-                    return (null, true);
+                    return (null, shouldRetry);
 
                 authUserId = userId;
                 return (token, false);
@@ -78,7 +78,7 @@ public class TidepoolAuthTokenProvider(
         return (sessionToken, expiresAt, metadata.Count > 0 ? metadata : null);
     }
 
-    private async Task<(string? Token, string? UserId)> LoginAsync(TidepoolConnectorConfiguration config, CancellationToken cancellationToken)
+    private async Task<(string? Token, string? UserId, bool ShouldRetry)> LoginAsync(TidepoolConnectorConfiguration config, CancellationToken cancellationToken)
     {
         using var request = new HttpRequestMessage(HttpMethod.Post,
             _serverResolver.BuildUrl(config, "/auth/login"));
@@ -92,8 +92,11 @@ public class TidepoolAuthTokenProvider(
 
         if (!response.IsSuccessStatusCode)
         {
-            await HandleErrorResponseAsync(response, "Tidepool authentication", cancellationToken);
-            return (null, null);
+            // Honour the retryable verdict: a 401/400 (bad/missing credentials) is non-retryable, so
+            // don't burn three attempts with multi-minute backoff — that blocks every other tenant of
+            // this connector. Transient errors (5xx, 429) still return true and retry.
+            var shouldRetry = await HandleErrorResponseAsync(response, "Tidepool authentication", cancellationToken);
+            return (null, null, shouldRetry);
         }
 
         // Session token is in the response header
@@ -101,14 +104,14 @@ public class TidepoolAuthTokenProvider(
         {
             _logger.LogError("Tidepool authentication response missing {Header} header",
                 TidepoolConstants.Headers.SessionToken);
-            return (null, null);
+            return (null, null, true);
         }
 
         var token = tokenValues.FirstOrDefault();
         if (string.IsNullOrEmpty(token))
         {
             _logger.LogError("Tidepool authentication returned empty session token");
-            return (null, null);
+            return (null, null, true);
         }
 
         // Extract user ID from response body
@@ -126,6 +129,6 @@ public class TidepoolAuthTokenProvider(
             _logger.LogWarning("Tidepool authentication response did not contain a user ID");
         }
 
-        return (token, userId);
+        return (token, userId, false);
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
@@ -32,31 +32,53 @@ public class ConnectorBackgroundServiceTests
         private readonly SyncResult _syncResult;
         private readonly Action? _onSync;
         private readonly Action<IServiceProvider>? _onSyncScope;
+        private readonly Action? _onSyncCompleted;
+        private readonly TimeSpan? _perTenantTimeout;
+        private readonly int _hangFirstNCalls;
+        private int _callCount;
 
         public TestConnectorBackgroundService(
             IServiceProvider serviceProvider,
             SyncResult syncResult,
             ILogger logger,
             Action? onSync = null,
-            Action<IServiceProvider>? onSyncScope = null)
+            Action<IServiceProvider>? onSyncScope = null,
+            TimeSpan? perTenantTimeout = null,
+            int hangFirstNCalls = 0,
+            Action? onSyncCompleted = null)
             : base(serviceProvider, logger)
         {
             _syncResult = syncResult;
             _onSync = onSync;
             _onSyncScope = onSyncScope;
+            _perTenantTimeout = perTenantTimeout;
+            _hangFirstNCalls = hangFirstNCalls;
+            _onSyncCompleted = onSyncCompleted;
         }
 
         protected override string ConnectorName => "TestConnector";
 
-        protected override Task<SyncResult> PerformSyncAsync(
+        protected override TimeSpan PerTenantSyncTimeout => _perTenantTimeout ?? base.PerTenantSyncTimeout;
+
+        /// <summary>Number of times PerformSyncAsync has been entered (across all tenants).</summary>
+        public int CallCount => _callCount;
+
+        protected override async Task<SyncResult> PerformSyncAsync(
             IServiceProvider scopeProvider,
             TestConnectorConfig config,
             CancellationToken cancellationToken,
             ISyncProgressReporter? progressReporter = null)
         {
+            var n = Interlocked.Increment(ref _callCount);
             _onSync?.Invoke();
             _onSyncScope?.Invoke(scopeProvider);
-            return Task.FromResult(_syncResult);
+
+            // Simulate a stuck tenant (e.g. an auth-retry storm) that respects cancellation.
+            if (n <= _hangFirstNCalls)
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+
+            _onSyncCompleted?.Invoke();
+            return _syncResult;
         }
 
         /// <summary>
@@ -122,6 +144,44 @@ public class ConnectorBackgroundServiceTests
             DateTime.UtcNow.ToString("O"), DateTime.UtcNow.ToString("O"));
 
         return (cleanup, connectionString, tenantId);
+    }
+
+    /// <summary>
+    /// Sets up an in-memory SQLite NocturneDbContext with two active tenants.
+    /// </summary>
+    private static (IDisposable cleanup, string connectionString) CreateSqliteDbWithTwoTenants()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"ConnectorBgTest_{Guid.NewGuid():N}.db");
+        var connectionString = $"Data Source={dbPath}";
+        var cleanup = new TempFileCleanup(dbPath);
+
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(connectionString)
+            .Options;
+
+        using var context = new NocturneDbContext(options);
+        context.Database.ExecuteSqlRaw(@"
+            CREATE TABLE tenants (
+                Id TEXT PRIMARY KEY,
+                slug TEXT NOT NULL,
+                display_name TEXT NOT NULL,
+                is_active INTEGER NOT NULL DEFAULT 1,
+                last_reading_at TEXT,
+                allow_access_requests INTEGER NOT NULL DEFAULT 1,
+                onboarding_completed_at TEXT,
+                sys_created_at TEXT NOT NULL,
+                sys_updated_at TEXT NOT NULL
+            )");
+
+        foreach (var slug in new[] { "tenant-a", "tenant-b" })
+        {
+            context.Database.ExecuteSqlRaw(
+                "INSERT INTO tenants (Id, slug, display_name, is_active, allow_access_requests, sys_created_at, sys_updated_at) VALUES ({0}, {1}, {2}, 1, 1, {3}, {4})",
+                Guid.NewGuid().ToString(), slug, slug,
+                DateTime.UtcNow.ToString("O"), DateTime.UtcNow.ToString("O"));
+        }
+
+        return (cleanup, connectionString);
     }
 
     private static IServiceProvider BuildServiceProvider(
@@ -493,6 +553,92 @@ public class ConnectorBackgroundServiceTests
         // Assert — the scoped DbContext the connector services share must be pinned to the synced
         // tenant so RLS scopes correctly.
         Assert.Equal(tenantId, capturedTenantId);
+    }
+
+    [Fact]
+    public async Task SyncAllTenants_RunsTenantsConcurrently_OneStuckTenantDoesNotBlockOthers()
+    {
+        // Tenants must sync independently: a tenant whose sync hangs (e.g. an auth-retry storm against
+        // bad credentials) must not delay or block any other tenant of the connector.
+        var (cleanup, connStr) = CreateSqliteDbWithTwoTenants();
+        using var _ = cleanup;
+
+        var configServiceMock = BuildEnabledConfigMock();
+        var config = new TestConnectorConfig { Enabled = true, SyncIntervalMinutes = 5 };
+        var serviceProvider = BuildServiceProvider(connStr, configServiceMock, config);
+
+        var secondTenantDone = new TaskCompletionSource();
+        using var cts = new CancellationTokenSource();
+
+        // The first tenant to start hangs. A long per-tenant timeout ensures this test measures
+        // concurrency, not the timeout cutting the hang short.
+        var sut = new TestConnectorBackgroundService(
+            serviceProvider,
+            new SyncResult { Success = true },
+            NullLogger<TestConnectorBackgroundService>.Instance,
+            perTenantTimeout: TimeSpan.FromSeconds(30),
+            hangFirstNCalls: 1,
+            onSyncCompleted: () => secondTenantDone.TrySetResult());
+
+        var run = sut.ExecuteOnceAsync(cts.Token);
+        try
+        {
+            var winner = await Task.WhenAny(secondTenantDone.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+            winner.Should().Be(secondTenantDone.Task,
+                "the second tenant must sync concurrently while the first tenant is stuck");
+        }
+        finally
+        {
+            cts.Cancel();
+            try { await run; } catch (OperationCanceledException) { }
+        }
+    }
+
+    [Fact]
+    public async Task SyncForTenant_IsCancelled_WhenItExceedsPerTenantTimeout()
+    {
+        // A stuck tenant must be cancelled at PerTenantSyncTimeout so it cannot hold a slot forever.
+        var (cleanup, connStr, _) = CreateSqliteDbWithTenantId();
+        using var _c = cleanup;
+
+        var configServiceMock = BuildEnabledConfigMock();
+        var config = new TestConnectorConfig { Enabled = true, SyncIntervalMinutes = 5 };
+        var serviceProvider = BuildServiceProvider(connStr, configServiceMock, config);
+
+        var sut = new TestConnectorBackgroundService(
+            serviceProvider,
+            new SyncResult { Success = true },
+            NullLogger<TestConnectorBackgroundService>.Instance,
+            perTenantTimeout: TimeSpan.FromMilliseconds(300),
+            hangFirstNCalls: 1);
+
+        var run = sut.ExecuteOnceAsync(CancellationToken.None);
+        var winner = await Task.WhenAny(run, Task.Delay(TimeSpan.FromSeconds(10)));
+
+        winner.Should().Be(run,
+            "a tenant exceeding PerTenantSyncTimeout must be cancelled so the cycle completes");
+        await run;
+    }
+
+    /// <summary>Config-service mock that reports the test connector as configured and enabled.</summary>
+    private static Mock<IConnectorConfigurationService> BuildEnabledConfigMock()
+    {
+        var mock = new Mock<IConnectorConfigurationService>();
+        mock.Setup(x => x.GetConfigurationAsync("TestConnector", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConnectorConfigurationResponse
+            {
+                ConnectorName = "TestConnector",
+                IsActive = true,
+                Configuration = JsonDocument.Parse("{\"enabled\": true, \"syncIntervalMinutes\": 5}")
+            });
+        mock.Setup(x => x.GetSecretsAsync("TestConnector", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, string>());
+        mock.Setup(x => x.UpdateHealthStateAsync(
+                It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<string?>(), It.IsAny<DateTime?>(), It.IsAny<bool?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        return mock;
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Connectors.Tidepool.Tests/Services/TidepoolAuthTokenProviderTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Tidepool.Tests/Services/TidepoolAuthTokenProviderTests.cs
@@ -1,0 +1,70 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.Tidepool.Configurations;
+using Nocturne.Connectors.Tidepool.Services;
+using Nocturne.Core.Contracts.Multitenancy;
+using Xunit;
+
+namespace Nocturne.Connectors.Tidepool.Tests.Services;
+
+public class TidepoolAuthTokenProviderTests
+{
+    /// <summary>
+    /// A non-retryable auth failure (e.g. a 401 from bad credentials) must fail after a single
+    /// attempt. Retrying it 3× with multi-minute backoff wastes a connector concurrency slot and
+    /// delays the connector — which is what previously let one bad-credential tenant stall others.
+    /// </summary>
+    [Fact]
+    public async Task GetValidTokenAsync_DoesNotRetry_OnNonRetryableAuthError()
+    {
+        var handler = new CountingHandler(
+            HttpStatusCode.Unauthorized,
+            "{\"code\":401,\"reason\":\"No user matched the given details\"}");
+        using var httpClient = new HttpClient(handler);
+
+        var tenantAccessor = new Mock<ITenantAccessor>();
+        tenantAccessor.Setup(t => t.IsResolved).Returns(true);
+        tenantAccessor.Setup(t => t.TenantId).Returns(Guid.NewGuid());
+
+        var retryDelay = new Mock<IRetryDelayStrategy>();
+        retryDelay.Setup(r => r.ApplyRetryDelayAsync(It.IsAny<int>())).Returns(Task.CompletedTask);
+
+        var provider = new TidepoolAuthTokenProvider(
+            httpClient,
+            new ConnectorTokenCache(),
+            new ConnectorServerResolver<TidepoolConnectorConfiguration>(null, null, "api.tidepool.org"),
+            tenantAccessor.Object,
+            NullLogger<TidepoolAuthTokenProvider>.Instance,
+            retryDelay.Object);
+
+        var config = new TidepoolConnectorConfiguration { Username = "wrong@example.com", Password = "nope" };
+
+        var token = await provider.GetValidTokenAsync(config, CancellationToken.None);
+
+        token.Should().BeNull();
+        handler.CallCount.Should().Be(1,
+            "a non-retryable 401 must fail fast, not burn three attempts with backoff");
+        retryDelay.Verify(r => r.ApplyRetryDelayAsync(It.IsAny<int>()), Times.Never,
+            "no backoff delay should be applied for a non-retryable error");
+    }
+
+    private sealed class CountingHandler(HttpStatusCode status, string body) : HttpMessageHandler
+    {
+        private int _callCount;
+        public int CallCount => _callCount;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _callCount);
+            return Task.FromResult(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body)
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Problem

A connector's tenants were synced **sequentially**, and a failed auth retried **3× with multi-minute backoff**. Together, one tenant with bad credentials (e.g. a wrong Tidepool username → `401`) held the connector's loop for ~7 minutes every cycle and **starved every other tenant of that connector**. In prod, one user's typo'd Tidepool username stopped another user's Tidepool from ever syncing.

(John's Dexcom and Tidepool should run independently of Sarah's Dexcom, Tidepool, and Glooko — regardless of whether any of them fail.)

## Fix

**1. Concurrent per-tenant sync** — `ConnectorBackgroundService.SyncAllTenantsAsync` now uses `Parallel.ForEachAsync` (bounded by `MaxConcurrentTenantSyncs`, default 8) instead of a sequential `foreach`. Each tenant already runs in its own DI scope (own `DbContext`, own tenant context), so concurrent execution is isolated. A slow or failing tenant no longer delays any other.

**2. Per-tenant timeout** — `PerTenantSyncTimeout` (default 3 min) bounds how long any single tenant can hold a concurrency slot, so a genuinely stuck tenant (hung socket, retry storm) can't occupy a slot forever.

**3. Fail-fast auth (Tidepool)** — `TidepoolAuthTokenProvider` now honours the retryable verdict that `HandleErrorResponseAsync` already computes, so a non-retryable `401`/`400` fails after **one** attempt instead of three with backoff. (Other connectors' token providers share this pattern; the concurrency + timeout guard protects them now, and they can adopt the same one-line fix.)

## Tests
- `SyncAllTenants_RunsTenantsConcurrently_OneStuckTenantDoesNotBlockOthers` — a second tenant syncs while the first is stuck. **Verified to fail when forced sequential (`MaxConcurrentTenantSyncs = 1`).**
- `SyncForTenant_IsCancelled_WhenItExceedsPerTenantTimeout` — a stuck tenant is cancelled at the timeout so the cycle completes.
- `GetValidTokenAsync_DoesNotRetry_OnNonRetryableAuthError` — a 401 results in a single attempt, no backoff.