### PR TITLE
fix(connectors): surface Tidepool auth failure as an unhealthy sync

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolConnectorService.cs
@@ -73,6 +73,24 @@ public class TidepoolConnectorService : BaseConnectorService<TidepoolConnectorCo
         var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes);
         var activeTypes = request.DataTypes.Where(t => enabledTypes.Contains(t)).ToHashSet();
 
+        // Authenticate up front. The data fetches below treat a missing token as "no data" and
+        // return null without raising an error, so without this gate an auth failure (e.g. bad
+        // credentials returning 401) would be recorded as a successful, healthy sync — masking a
+        // broken connector so it never surfaces as unhealthy. Fail the sync explicitly instead.
+        // The token is cached, so the fetches below reuse it rather than re-authenticating.
+        if (activeTypes.Count > 0)
+        {
+            var token = await _tokenProvider.GetValidTokenAsync(config, cancellationToken);
+            if (string.IsNullOrEmpty(token))
+            {
+                result.Success = false;
+                result.Errors.Add("Authentication failed");
+                result.EndTime = DateTimeOffset.UtcNow;
+                _logger.LogWarning("[{ConnectorSource}] Sync failed: authentication unsuccessful", ConnectorSource);
+                return result;
+            }
+        }
+
         // Handle Glucose (CBG + SMBG → SensorGlucose)
         if (activeTypes.Contains(SyncDataType.Glucose))
         {

--- a/tests/Unit/Nocturne.Connectors.Tidepool.Tests/Services/TidepoolConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Tidepool.Tests/Services/TidepoolConnectorServiceTests.cs
@@ -1,0 +1,74 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.Tidepool.Configurations;
+using Nocturne.Connectors.Tidepool.Services;
+using Nocturne.Core.Contracts.Multitenancy;
+using Xunit;
+
+namespace Nocturne.Connectors.Tidepool.Tests.Services;
+
+public class TidepoolConnectorServiceTests
+{
+    /// <summary>
+    /// When authentication fails, the sync must report failure (so the connector surfaces as
+    /// unhealthy) rather than silently returning a successful, empty result. Previously a missing
+    /// token made the data fetches return null without error, so a bad-credential tenant was
+    /// recorded as healthy and never alerted.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_ReportsFailure_WhenAuthenticationFails()
+    {
+        // Auth endpoint returns 401 → token provider yields no token.
+        var authHandler = new StubHandler(HttpStatusCode.Unauthorized,
+            "{\"code\":401,\"reason\":\"No user matched the given details\"}");
+        using var authClient = new HttpClient(authHandler);
+        using var dataClient = new HttpClient(); // never reached — auth fails first
+
+        var resolver = new ConnectorServerResolver<TidepoolConnectorConfiguration>(null, null, "api.tidepool.org");
+
+        var tenantAccessor = new Mock<ITenantAccessor>();
+        tenantAccessor.Setup(t => t.IsResolved).Returns(true);
+        tenantAccessor.Setup(t => t.TenantId).Returns(Guid.NewGuid());
+
+        var retryDelay = new Mock<IRetryDelayStrategy>();
+        retryDelay.Setup(r => r.ApplyRetryDelayAsync(It.IsAny<int>())).Returns(Task.CompletedTask);
+        var rateLimiting = new Mock<IRateLimitingStrategy>();
+        rateLimiting.Setup(r => r.ApplyDelayAsync(It.IsAny<int>())).Returns(Task.CompletedTask);
+
+        var tokenProvider = new TidepoolAuthTokenProvider(
+            authClient,
+            new ConnectorTokenCache(),
+            resolver,
+            tenantAccessor.Object,
+            NullLogger<TidepoolAuthTokenProvider>.Instance,
+            retryDelay.Object);
+
+        var service = new TidepoolConnectorService(
+            dataClient,
+            resolver,
+            NullLogger<TidepoolConnectorService>.Instance,
+            retryDelay.Object,
+            rateLimiting.Object,
+            tokenProvider);
+
+        var config = new TidepoolConnectorConfiguration { Username = "wrong@example.com", Password = "nope" };
+        var request = new SyncRequest { DataTypes = [SyncDataType.Glucose] };
+
+        var result = await service.SyncDataAsync(request, config, CancellationToken.None);
+
+        result.Success.Should().BeFalse("an authentication failure must mark the sync unhealthy");
+        result.Errors.Should().Contain(e => e.Contains("auth", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private sealed class StubHandler(HttpStatusCode status, string body) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(status) { Content = new StringContent(body) });
+    }
+}


### PR DESCRIPTION
## Problem

When a Tidepool sync failed to authenticate (e.g. a tenant with a wrong username → `401`), the data fetches returned `null` without raising an error, so `PerformSyncInternalAsync` returned `Success = true` with zero items. The background service then recorded `last_successful_sync = now` and `is_healthy = true`. A genuinely broken connector therefore reported **healthy** and never surfaced/alerted — the failure was silent.

(Observed in prod: tenant `as-notrune` 401's on every sync but shows `is_healthy = true`.)

## Fix

Authenticate up front in `TidepoolConnectorService.PerformSyncInternalAsync`: if no token can be acquired, fail the sync with an `"Authentication failed"` error so it surfaces as **unhealthy** instead of a vacuous success. The token is cached, so the subsequent data fetches reuse it (no double auth).

## Test
- `SyncDataAsync_ReportsFailure_WhenAuthenticationFails` — a 401 from the auth endpoint makes the sync report `Success = false`. **Verified to fail without the fix** (previously returned `Success = true`).

## Note
Other connectors share the "fetch returns null on missing token" pattern and would benefit from the same up-front auth gate; this PR covers Tidepool (the connector with a confirmed prod case). Follow-up could generalise it.