### PR TITLE
fix(devices): scope device unique index to tenant

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260603134703_MakeDevicesUniqueIndexTenantScoped.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260603134703_MakeDevicesUniqueIndexTenantScoped.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260603134703_MakeDevicesUniqueIndexTenantScoped")]
+    partial class MakeDevicesUniqueIndexTenantScoped
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260603134703_MakeDevicesUniqueIndexTenantScoped.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260603134703_MakeDevicesUniqueIndexTenantScoped.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeDevicesUniqueIndexTenantScoped : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_devices_category_type_serial",
+                table: "devices");
+
+            migrationBuilder.DropIndex(
+                name: "IX_devices_tenant_id",
+                table: "devices");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_devices_category_type_serial",
+                table: "devices",
+                columns: new[] { "tenant_id", "category", "type", "serial" },
+                unique: true,
+                filter: "deleted_at IS NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_devices_category_type_serial",
+                table: "devices");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_devices_category_type_serial",
+                table: "devices",
+                columns: new[] { "category", "type", "serial" },
+                unique: true,
+                filter: "deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_devices_tenant_id",
+                table: "devices",
+                column: "tenant_id");
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -1609,10 +1609,16 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             .HasDatabaseName("ix_temp_basals_tenant_start_timestamp")
             .IsDescending(false, true);
 
-        // Devices unique index (scoped to live records)
+        // Devices unique index (scoped to live records, per tenant).
+        // TenantId must be part of the key: devices are tenant-owned (FindByCategoryTypeAndSerialAsync
+        // is RLS-scoped to the current tenant) and the type/serial often carry shared, non-unique
+        // values — e.g. a pump's manufacturer/model ("Insulet"/"Omnipod 5") or the generic Loop
+        // uploader identity ("iPhone"/"unknown"). Without TenantId the constraint is global, so the
+        // first tenant to register such a device permanently blocks every other tenant's insert,
+        // surfacing as a 500 on devicestatus ingestion (and a network error in Loop).
         modelBuilder
             .Entity<DeviceEntity>()
-            .HasIndex(e => new { e.Category, e.Type, e.Serial })
+            .HasIndex(e => new { e.TenantId, e.Category, e.Type, e.Serial })
             .HasDatabaseName("ix_devices_category_type_serial")
             .IsUnique()
             .HasFilter("deleted_at IS NULL");

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/DeviceUniqueIndexTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/DeviceUniqueIndexTests.cs
@@ -1,0 +1,118 @@
+using FluentAssertions;
+using Npgsql;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests.Rls;
+
+/// <summary>
+/// Regression coverage for the <c>ix_devices_category_type_serial</c> unique index.
+///
+/// The index must be scoped by <c>tenant_id</c>. Devices are tenant-owned, and the
+/// (category, type, serial) triple is routinely shared across patients — a pump's
+/// manufacturer/model ("Insulet"/"Omnipod 5") or the generic Loop uploader identity
+/// ("iPhone"/"unknown"). When the index was global, the first tenant to register such a
+/// device permanently blocked every other tenant's insert, surfacing as a 500 on
+/// devicestatus ingestion (and a "network error" in Loop while adding the service).
+///
+/// Raw NpgsqlConnection (not EF) so the assertion is about what PostgreSQL actually
+/// enforces after the full migration chain runs, independent of the ORM.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("RLS completeness")]
+public class DeviceUniqueIndexTests
+{
+    private readonly RlsCompletenessFixture _fx;
+
+    public DeviceUniqueIndexTests(RlsCompletenessFixture fx)
+    {
+        _fx = fx;
+    }
+
+    [Fact]
+    public async Task TwoTenants_CanEachOwn_SameCategoryTypeSerialDevice()
+    {
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+
+        await using var conn = await _fx.OpenMigratorConnectionAsync();
+        await InsertTenantAsync(conn, tenantA);
+        await InsertTenantAsync(conn, tenantB);
+
+        // Two different patients running Loop on an iPhone produce the identical
+        // generic uploader identity. Both inserts must succeed.
+        await SetCurrentTenantAsync(conn, tenantA);
+        await InsertDeviceAsync(conn, tenantA, "Uploader", "iPhone", "unknown");
+
+        await SetCurrentTenantAsync(conn, tenantB);
+        var act = () => InsertDeviceAsync(conn, tenantB, "Uploader", "iPhone", "unknown");
+
+        await act.Should().NotThrowAsync(
+            "the device unique index is scoped per tenant; two tenants can legitimately own the " +
+            "same pump model or uploader identity without colliding");
+    }
+
+    [Fact]
+    public async Task SameTenant_CannotInsert_DuplicateLiveDevice()
+    {
+        var tenant = Guid.NewGuid();
+
+        await using var conn = await _fx.OpenMigratorConnectionAsync();
+        await InsertTenantAsync(conn, tenant);
+        await SetCurrentTenantAsync(conn, tenant);
+
+        await InsertDeviceAsync(conn, tenant, "InsulinPump", "Insulet", "Omnipod 5");
+        var act = () => InsertDeviceAsync(conn, tenant, "InsulinPump", "Insulet", "Omnipod 5");
+
+        var thrown = await act.Should().ThrowAsync<PostgresException>();
+        thrown.Which.SqlState.Should().Be(
+            "23505",
+            "within a single tenant the live (category, type, serial) device identity must remain unique");
+    }
+
+    private static async Task InsertTenantAsync(NpgsqlConnection conn, Guid tenantId)
+    {
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            INSERT INTO tenants
+                (id, slug, display_name, is_active, sys_created_at, sys_updated_at)
+            VALUES
+                (@id, @slug, 'device-index-test', true, now(), now())
+            """;
+        AddParam(cmd, "@id", tenantId);
+        AddParam(cmd, "@slug", $"dev-{tenantId:N}");
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private static async Task InsertDeviceAsync(
+        NpgsqlConnection conn, Guid tenantId, string category, string type, string serial)
+    {
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            INSERT INTO devices
+                (id, tenant_id, category, type, serial, first_seen_timestamp, last_seen_timestamp)
+            VALUES
+                (gen_random_uuid(), @tid, @category, @type, @serial, now(), now())
+            """;
+        AddParam(cmd, "@tid", tenantId);
+        AddParam(cmd, "@category", category);
+        AddParam(cmd, "@type", type);
+        AddParam(cmd, "@serial", serial);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private static async Task SetCurrentTenantAsync(NpgsqlConnection conn, Guid tenantId)
+    {
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT set_config('app.current_tenant_id', @tid, false)";
+        AddParam(cmd, "@tid", tenantId.ToString());
+        await cmd.ExecuteScalarAsync();
+    }
+
+    private static void AddParam(NpgsqlCommand cmd, string name, object value)
+    {
+        var p = cmd.CreateParameter();
+        p.ParameterName = name;
+        p.Value = value;
+        cmd.Parameters.Add(p);
+    }
+}


### PR DESCRIPTION
## Problem

`ix_devices_category_type_serial` is a **global** unique index on `(category, type, serial)` — it is not scoped by `tenant_id`:

```
CREATE UNIQUE INDEX ix_devices_category_type_serial
  ON public.devices (category, type, serial) WHERE (deleted_at IS NULL)
```

But devices are tenant-owned. `DeviceService` caches resolutions by `(tenantId, category, type, serial)` and `DeviceRepository.FindByCategoryTypeAndSerialAsync` only ever sees the current tenant's rows (RLS). Meanwhile the `(category, type, serial)` triple routinely carries values shared across patients:

- a pump's manufacturer/model — `InsulinPump / Insulet / Omnipod 5`
- the generic Loop-on-iPhone uploader identity — `Uploader / iPhone / unknown`

So the **first** tenant to register such a device owns it globally. Every other tenant's `DeviceStatusDecomposer` then tries to `INSERT` a row that already exists for someone else, hits a duplicate-key violation (`23505`), and the devicestatus request 500s:

```
DeviceStatusDecomposer.DecomposeUploaderAsync
  -> DeviceService.ResolveAsync(Uploader, "iPhone", "unknown")
    -> DeviceRepository.CreateAsync
      -> 23505 duplicate key value violates unique constraint "ix_devices_category_type_serial"
```

For Loop users this surfaces as a **network error while adding the Nightscout service** — glucose entries (which don't resolve a device) upload fine, but devicestatus fails, so Loop's setup verification reports a failure.

## Fix

Add `tenant_id` as the leading key column so the constraint is per-tenant — matching how the rest of the schema scopes tenant indexes (`new { e.TenantId, ... }`). EF drops the now-redundant standalone `IX_devices_tenant_id` (the composite index covers `tenant_id` lookups and the tenant FK); cascade-delete behaviour is unaffected.

## Test

Adds a Postgres-backed regression test (`DeviceUniqueIndexTests`) using the RLS fixture + full migration chain:

- two tenants can each own the same `(category, type, serial)` device
- uniqueness still holds within a single tenant (`23505`)

## Notes / follow-up

`DeviceService.ResolveAsync` is still a check-then-insert, so two *concurrent* devicestatus posts for the same brand-new device within one tenant could race on the first insert. That's far rarer and self-heals on the next post; this PR targets the persistent cross-tenant blocker. Worth a follow-up to make `ResolveAsync` resilient to the within-tenant race.