### PR TITLE
feat(v1): add /api/v1/experiments/test endpoint for Loop compatibility

### DIFF
--- a/src/API/Nocturne.API/Controllers/V1/ExperimentsController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/ExperimentsController.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
+
+namespace Nocturne.API.Controllers.V1;
+
+/// <summary>
+/// Provides the Nightscout <c>/api/v1/experiments/test</c> endpoint used by AID apps —
+/// notably Loop — to verify their API secret while adding the Nightscout service.
+/// </summary>
+/// <remarks>
+/// Loop's connection check issues an authenticated <c>GET /api/v1/experiments/test</c> and
+/// treats only a 200 as success (401 means "bad secret"). Without this endpoint Nocturne
+/// returns 404, so Loop reports a network error and aborts setup even though entries and
+/// devicestatus uploads succeed. Mirrors reference Nightscout, which gates the endpoint on
+/// read permission and returns <c>{ status: "ok" }</c>.
+/// </remarks>
+[ApiController]
+[Tags("V1")]
+[Route("api/v1")]
+public class ExperimentsController : ControllerBase
+{
+    /// <summary>
+    /// Confirms the request carries valid, authorized credentials.
+    /// </summary>
+    /// <returns>200 with <c>{ status: "ok" }</c> when authorized; 401 otherwise.</returns>
+    [HttpGet("experiments/test")]
+    [RequireRead]
+    [NightscoutEndpoint("/api/v1/experiments/test")]
+    [ProducesResponseType(200)]
+    [ProducesResponseType(401)]
+    public IActionResult Test()
+    {
+        return Ok(new { status = "ok" });
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260603134703_MakeDevicesUniqueIndexTenantScoped.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260603134703_MakeDevicesUniqueIndexTenantScoped.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260603134703_MakeDevicesUniqueIndexTenantScoped")]
+    partial class MakeDevicesUniqueIndexTenantScoped
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260603134703_MakeDevicesUniqueIndexTenantScoped.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260603134703_MakeDevicesUniqueIndexTenantScoped.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeDevicesUniqueIndexTenantScoped : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_devices_category_type_serial",
+                table: "devices");
+
+            migrationBuilder.DropIndex(
+                name: "IX_devices_tenant_id",
+                table: "devices");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_devices_category_type_serial",
+                table: "devices",
+                columns: new[] { "tenant_id", "category", "type", "serial" },
+                unique: true,
+                filter: "deleted_at IS NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_devices_category_type_serial",
+                table: "devices");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_devices_category_type_serial",
+                table: "devices",
+                columns: new[] { "category", "type", "serial" },
+                unique: true,
+                filter: "deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_devices_tenant_id",
+                table: "devices",
+                column: "tenant_id");
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -1609,10 +1609,16 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             .HasDatabaseName("ix_temp_basals_tenant_start_timestamp")
             .IsDescending(false, true);
 
-        // Devices unique index (scoped to live records)
+        // Devices unique index (scoped to live records, per tenant).
+        // TenantId must be part of the key: devices are tenant-owned (FindByCategoryTypeAndSerialAsync
+        // is RLS-scoped to the current tenant) and the type/serial often carry shared, non-unique
+        // values — e.g. a pump's manufacturer/model ("Insulet"/"Omnipod 5") or the generic Loop
+        // uploader identity ("iPhone"/"unknown"). Without TenantId the constraint is global, so the
+        // first tenant to register such a device permanently blocks every other tenant's insert,
+        // surfacing as a 500 on devicestatus ingestion (and a network error in Loop).
         modelBuilder
             .Entity<DeviceEntity>()
-            .HasIndex(e => new { e.Category, e.Type, e.Serial })
+            .HasIndex(e => new { e.TenantId, e.Category, e.Type, e.Serial })
             .HasDatabaseName("ix_devices_category_type_serial")
             .IsUnique()
             .HasFilter("deleted_at IS NULL");

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/DeviceUniqueIndexTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/DeviceUniqueIndexTests.cs
@@ -1,0 +1,118 @@
+using FluentAssertions;
+using Npgsql;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests.Rls;
+
+/// <summary>
+/// Regression coverage for the <c>ix_devices_category_type_serial</c> unique index.
+///
+/// The index must be scoped by <c>tenant_id</c>. Devices are tenant-owned, and the
+/// (category, type, serial) triple is routinely shared across patients — a pump's
+/// manufacturer/model ("Insulet"/"Omnipod 5") or the generic Loop uploader identity
+/// ("iPhone"/"unknown"). When the index was global, the first tenant to register such a
+/// device permanently blocked every other tenant's insert, surfacing as a 500 on
+/// devicestatus ingestion (and a "network error" in Loop while adding the service).
+///
+/// Raw NpgsqlConnection (not EF) so the assertion is about what PostgreSQL actually
+/// enforces after the full migration chain runs, independent of the ORM.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("RLS completeness")]
+public class DeviceUniqueIndexTests
+{
+    private readonly RlsCompletenessFixture _fx;
+
+    public DeviceUniqueIndexTests(RlsCompletenessFixture fx)
+    {
+        _fx = fx;
+    }
+
+    [Fact]
+    public async Task TwoTenants_CanEachOwn_SameCategoryTypeSerialDevice()
+    {
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+
+        await using var conn = await _fx.OpenMigratorConnectionAsync();
+        await InsertTenantAsync(conn, tenantA);
+        await InsertTenantAsync(conn, tenantB);
+
+        // Two different patients running Loop on an iPhone produce the identical
+        // generic uploader identity. Both inserts must succeed.
+        await SetCurrentTenantAsync(conn, tenantA);
+        await InsertDeviceAsync(conn, tenantA, "Uploader", "iPhone", "unknown");
+
+        await SetCurrentTenantAsync(conn, tenantB);
+        var act = () => InsertDeviceAsync(conn, tenantB, "Uploader", "iPhone", "unknown");
+
+        await act.Should().NotThrowAsync(
+            "the device unique index is scoped per tenant; two tenants can legitimately own the " +
+            "same pump model or uploader identity without colliding");
+    }
+
+    [Fact]
+    public async Task SameTenant_CannotInsert_DuplicateLiveDevice()
+    {
+        var tenant = Guid.NewGuid();
+
+        await using var conn = await _fx.OpenMigratorConnectionAsync();
+        await InsertTenantAsync(conn, tenant);
+        await SetCurrentTenantAsync(conn, tenant);
+
+        await InsertDeviceAsync(conn, tenant, "InsulinPump", "Insulet", "Omnipod 5");
+        var act = () => InsertDeviceAsync(conn, tenant, "InsulinPump", "Insulet", "Omnipod 5");
+
+        var thrown = await act.Should().ThrowAsync<PostgresException>();
+        thrown.Which.SqlState.Should().Be(
+            "23505",
+            "within a single tenant the live (category, type, serial) device identity must remain unique");
+    }
+
+    private static async Task InsertTenantAsync(NpgsqlConnection conn, Guid tenantId)
+    {
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            INSERT INTO tenants
+                (id, slug, display_name, is_active, sys_created_at, sys_updated_at)
+            VALUES
+                (@id, @slug, 'device-index-test', true, now(), now())
+            """;
+        AddParam(cmd, "@id", tenantId);
+        AddParam(cmd, "@slug", $"dev-{tenantId:N}");
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private static async Task InsertDeviceAsync(
+        NpgsqlConnection conn, Guid tenantId, string category, string type, string serial)
+    {
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            INSERT INTO devices
+                (id, tenant_id, category, type, serial, first_seen_timestamp, last_seen_timestamp)
+            VALUES
+                (gen_random_uuid(), @tid, @category, @type, @serial, now(), now())
+            """;
+        AddParam(cmd, "@tid", tenantId);
+        AddParam(cmd, "@category", category);
+        AddParam(cmd, "@type", type);
+        AddParam(cmd, "@serial", serial);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private static async Task SetCurrentTenantAsync(NpgsqlConnection conn, Guid tenantId)
+    {
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT set_config('app.current_tenant_id', @tid, false)";
+        AddParam(cmd, "@tid", tenantId.ToString());
+        await cmd.ExecuteScalarAsync();
+    }
+
+    private static void AddParam(NpgsqlCommand cmd, string name, object value)
+    {
+        var p = cmd.CreateParameter();
+        p.ParameterName = name;
+        p.Value = value;
+        cmd.Parameters.Add(p);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/ExperimentsControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/ExperimentsControllerTests.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using Nocturne.API.Tests.Infrastructure;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers;
+
+/// <summary>
+/// Covers the Nightscout <c>/api/v1/experiments/test</c> endpoint that Loop's connection
+/// check relies on: a valid API secret must return 200 (Loop treats anything else as a
+/// failed connection), and an unauthenticated request must return 401.
+/// </summary>
+public class ExperimentsControllerTests : IClassFixture<AuthenticationTestFactory>
+{
+    private readonly AuthenticationTestFactory _factory;
+
+    public ExperimentsControllerTests(AuthenticationTestFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task ExperimentsTest_ValidApiSecret_Returns200Ok()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add(
+            "api-secret",
+            ComputeSha1Hash(AuthenticationTestFactory.ApiSecret));
+
+        var response = await client.GetAsync("/api/v1/experiments/test", CancellationToken.None);
+        var content = await response.Content.ReadAsStringAsync(CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("ok", content);
+    }
+
+    [Fact]
+    public async Task ExperimentsTest_NoAuthentication_Returns401()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/experiments/test", CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    private static string ComputeSha1Hash(string input)
+    {
+        using var sha1 = SHA1.Create();
+        var hashBytes = sha1.ComputeHash(Encoding.UTF8.GetBytes(input));
+        return BitConverter.ToString(hashBytes).Replace("-", "").ToLowerInvariant();
+    }
+}


### PR DESCRIPTION
## Problem

Loop's "add Nightscout service" flow verifies the connection by issuing an authenticated `GET /api/v1/experiments/test` and treats **only a 200 as success** (401 = bad secret). Nocturne doesn't implement the endpoint, so it returns **404** — Loop reports a network error and aborts setup, even though `entries` and `devicestatus` uploads succeed.

Observed in prod (gateway log) for a tenant trying to connect Loop:

```
GET  /api/v1/experiments/test → 404   (repeated — Loop retries the check)
POST /api/v1/devicestatus     → 200
POST /api/v1/entries          → 201
```

This is the classic symptom: data flows briefly, but the service can't be added, and cancelling the error tears the connection down.

## Fix

Add `GET /api/v1/experiments/test`, gated on read permission, returning `{ status: "ok" }` — mirroring reference Nightscout (which gates it on `api:experiments:read`). A valid api-secret authenticates as full-access (`*`), so it returns 200; an unauthenticated request returns 401.

`WebApplicationFactory` tests cover both cases (200 with valid api-secret, 401 unauthenticated).

## Note

This branch stacks on #312 (tenant-scoped device index) — that fix turned `devicestatus` from a 500 into a 200; this PR fixes the verification endpoint that gates Loop setup. Both are needed for a working Loop connection. Merge #312 first (or merge this and it carries both).