### PR TITLE
perf(reports): compute report analytics server-side

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
@@ -323,6 +323,57 @@ public class StatisticsController : ControllerBase
     }
 
     /// <summary>
+    /// Extended glucose analytics for a date range, computed server-side. Fetches glucose,
+    /// manual boluses, and carb intakes for the window from the database and runs
+    /// <see cref="IStatisticsService.AnalyzeGlucoseDataExtended"/> plus
+    /// <see cref="IStatisticsService.CalculateAveragedStats"/>.
+    /// </summary>
+    /// <param name="startDate">Start of the window (inclusive, UTC).</param>
+    /// <param name="endDate">End of the window (exclusive, UTC).</param>
+    /// <param name="population">Diabetes population for clinical target assessment. Defaults to Type 1 adult.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The extended analytics and time-of-day averaged stats for the window.</returns>
+    [HttpGet("range-analytics")]
+    [RemoteQuery]
+    [ResponseCache(Duration = 60, VaryByQueryKeys = new[] { "*" })]
+    public async Task<ActionResult<ReportAnalysisResult>> GetRangeAnalytics(
+        [FromQuery] DateTime startDate,
+        [FromQuery] DateTime endDate,
+        [FromQuery] DiabetesPopulation population = DiabetesPopulation.Type1Adult,
+        CancellationToken cancellationToken = default
+    )
+    {
+        try
+        {
+            var startDt = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);
+            var endDt = DateTime.SpecifyKind(endDate, DateTimeKind.Utc);
+
+            // int.MaxValue limit mirrors ActogramReportService so dense tenants are never
+            // silently truncated (the cause of skewed report stats on high-frequency uploads).
+            var glucoseTask = _sensorGlucoseRepository.GetAsync(startDt, endDt, null, null, int.MaxValue, descending: false, ct: cancellationToken);
+            var bolusTask   = _bolusRepository.GetAsync(startDt, endDt, null, null, int.MaxValue, descending: false, kind: BolusKind.Manual, ct: cancellationToken);
+            var carbTask    = _carbIntakeRepository.GetAsync(startDt, endDt, null, null, int.MaxValue, descending: false, ct: cancellationToken);
+
+            await Task.WhenAll(glucoseTask, bolusTask, carbTask);
+
+            var entries = (await glucoseTask).ToList();
+            var boluses = await bolusTask;
+            var carbs   = await carbTask;
+
+            var result = new ReportAnalysisResult
+            {
+                Analysis = _statisticsService.AnalyzeGlucoseDataExtended(entries, boluses, carbs, population),
+                AveragedStats = _statisticsService.CalculateAveragedStats(entries).ToList(),
+            };
+            return Ok(result);
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    /// <summary>
     /// Calculate Glucose Management Indicator (GMI)
     /// </summary>
     /// <param name="meanGlucose">Mean glucose in mg/dL</param>
@@ -616,9 +667,9 @@ public class StatisticsController : ControllerBase
                 var startTimestamp = startDate;
                 var endTimestamp = endDate;
 
-                var glucoseTask = _sensorGlucoseRepository.GetAsync(from: (DateTime?)startTimestamp, to: (DateTime?)endTimestamp, device: null, source: null, limit: 10000, descending: false, ct: cancellationToken);
-                var bolusTask   = _bolusRepository.GetAsync(from: (DateTime?)startTimestamp, to: (DateTime?)endTimestamp, device: null, source: null, limit: 10000, descending: false, kind: BolusKind.Manual, ct: cancellationToken);
-                var carbTask    = _carbIntakeRepository.GetAsync(from: (DateTime?)startTimestamp, to: (DateTime?)endTimestamp, device: null, source: null, limit: 10000, descending: false, ct: cancellationToken);
+                var glucoseTask = _sensorGlucoseRepository.GetAsync(from: (DateTime?)startTimestamp, to: (DateTime?)endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, ct: cancellationToken);
+                var bolusTask   = _bolusRepository.GetAsync(from: (DateTime?)startTimestamp, to: (DateTime?)endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, kind: BolusKind.Manual, ct: cancellationToken);
+                var carbTask    = _carbIntakeRepository.GetAsync(from: (DateTime?)startTimestamp, to: (DateTime?)endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, ct: cancellationToken);
 
                 await Task.WhenAll(glucoseTask, bolusTask, carbTask);
 
@@ -647,8 +698,8 @@ public class StatisticsController : ControllerBase
 
                     // Fetch TempBasals and algorithm boluses for basal data
                     // Deduplicate by 30s window + rate to eliminate duplicates from multiple connectors
-                    var tempBasalTask = _tempBasalRepository.GetAsync(from: startTimestamp, to: endTimestamp, device: null, source: null, limit: 10000, descending: false, ct: cancellationToken);
-                    var algoTask      = _bolusRepository.GetAsync(from: startTimestamp, to: endTimestamp, device: null, source: null, limit: 10000, descending: false, kind: BolusKind.Algorithm, ct: cancellationToken);
+                    var tempBasalTask = _tempBasalRepository.GetAsync(from: startTimestamp, to: endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, ct: cancellationToken);
+                    var algoTask      = _bolusRepository.GetAsync(from: startTimestamp, to: endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, kind: BolusKind.Algorithm, ct: cancellationToken);
 
                     await Task.WhenAll(tempBasalTask, algoTask);
 

--- a/src/Core/Nocturne.Core.Models/StatisticsModels.cs
+++ b/src/Core/Nocturne.Core.Models/StatisticsModels.cs
@@ -1719,6 +1719,21 @@ public class ExtendedGlucoseAnalytics : GlucoseAnalytics
 }
 
 /// <summary>
+/// Bundled result of the server-side range-analytics endpoint: extended glucose
+/// analytics plus time-of-day averaged stats for the requested window.
+/// </summary>
+/// <seealso cref="ExtendedGlucoseAnalytics"/>
+/// <seealso cref="AveragedStats"/>
+public class ReportAnalysisResult
+{
+    /// <summary>Extended glucose analytics (TIR, GMI, GRI, variability, hypo/hyper, etc.).</summary>
+    public ExtendedGlucoseAnalytics Analysis { get; set; } = new();
+
+    /// <summary>Time-of-day averaged statistics for AGP-style charts.</summary>
+    public IEnumerable<AveragedStats> AveragedStats { get; set; } = [];
+}
+
+/// <summary>
 /// Data point for site change impact analysis
 /// Represents averaged glucose at a specific time offset from site change
 /// </summary>

--- a/src/Web/packages/app/src/lib/api/glucose-pagination.ts
+++ b/src/Web/packages/app/src/lib/api/glucose-pagination.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared server-side helper to page through all sensor glucose readings for a date
+ * range. Used by report remote functions that render raw readings.
+ */
+import { getRequestEvent } from "$app/server";
+
+type ApiClient = ReturnType<typeof getRequestEvent>["locals"]["apiClient"];
+
+const PAGE_SIZE = 10000;
+const SAFETY_LIMIT = 200000;
+
+/** Paginate through all sensor glucose readings for a date range. */
+export async function fetchAllGlucose(
+  apiClient: ApiClient,
+  startDate: Date,
+  endDate: Date
+) {
+  type GlucoseItem = NonNullable<
+    Awaited<ReturnType<typeof apiClient.sensorGlucose.getAll>>["data"]
+  >[number];
+  let all: GlucoseItem[] = [];
+  let offset = 0;
+  let hasMore = true;
+
+  while (hasMore) {
+    const batch = await apiClient.sensorGlucose.getAll(
+      startDate,
+      endDate,
+      PAGE_SIZE,
+      offset
+    );
+    all = all.concat(batch.data ?? []);
+
+    if ((batch.data?.length ?? 0) < PAGE_SIZE) {
+      hasMore = false;
+    } else {
+      offset += PAGE_SIZE;
+    }
+
+    if (offset >= SAFETY_LIMIT) {
+      console.warn(`Glucose fetch reached safety limit of ${SAFETY_LIMIT} records`);
+      hasMore = false;
+    }
+  }
+
+  return all;
+}

--- a/src/Web/packages/app/src/lib/api/idp.remote.ts
+++ b/src/Web/packages/app/src/lib/api/idp.remote.ts
@@ -6,7 +6,7 @@
 import { z } from "zod";
 import { getRequestEvent, query } from "$app/server";
 import { error } from "@sveltejs/kit";
-import { DiabetesPopulation } from "$lib/api";
+import { fetchAllGlucose } from "./glucose-pagination";
 
 /**
  * Input schema for date range queries. Uses nullish() to accept both null and
@@ -64,107 +64,29 @@ export const getIdpData = query(DateRangeSchema.optional(), async (input) => {
   const { apiClient } = locals;
   const { startDate, endDate } = calculateDateRange(input);
 
-  const pageSize = 1000;
-
-  // Fetch sensor glucose readings
-  const glucoseResult = await apiClient.sensorGlucose.getAll(
-    startDate,
-    endDate,
-    10000
-  );
-  const entries = glucoseResult.data ?? [];
-
-  // Paginate boluses
-  let allBoluses: Awaited<ReturnType<typeof apiClient.bolus.getAll>>["data"] =
-    [];
-  let offset = 0;
-  let hasMore = true;
-
-  while (hasMore) {
-    const batch = await apiClient.bolus.getAll(
-      startDate,
-      endDate,
-      pageSize,
-      offset
-    );
-    allBoluses = allBoluses!.concat(batch.data ?? []);
-
-    if ((batch.data?.length ?? 0) < pageSize) {
-      hasMore = false;
-    } else {
-      offset += pageSize;
-    }
-
-    if (offset >= 50000) {
-      console.warn("Bolus fetch reached safety limit of 50,000 records");
-      hasMore = false;
-    }
-  }
-
-  // Paginate carb intakes
-  let allCarbIntakes: Awaited<
-    ReturnType<typeof apiClient.nutrition.getCarbIntakes>
-  >["data"] = [];
-  offset = 0;
-  hasMore = true;
-
-  while (hasMore) {
-    const batch = await apiClient.nutrition.getCarbIntakes(
-      startDate,
-      endDate,
-      pageSize,
-      offset
-    );
-    allCarbIntakes = allCarbIntakes!.concat(batch.data ?? []);
-
-    if ((batch.data?.length ?? 0) < pageSize) {
-      hasMore = false;
-    } else {
-      offset += pageSize;
-    }
-
-    if (offset >= 50000) {
-      console.warn("CarbIntake fetch reached safety limit of 50,000 records");
-      hasMore = false;
-    }
-  }
-
-  const boluses = allBoluses!;
-  const carbIntakes = allCarbIntakes!;
-  const population = DiabetesPopulation.Type1Adult; // TODO: Get from user settings
-
-  // Fetch insulin delivery stats, profile summary, extended glucose analytics,
-  // averaged stats, and basal analysis in parallel
-  const [
-    insulinDeliveryStats,
-    profileSummary,
-    analysis,
-    averagedStats,
-    basalAnalysis,
-    aidSystemMetrics,
-  ] = await Promise.all([
-    apiClient.statistics.getInsulinDeliveryStatistics(startDate, endDate),
-    apiClient.profile.getProfileSummary(startDate, endDate),
-    apiClient.statistics.analyzeGlucoseDataExtended({
-      entries,
-      boluses,
-      carbIntakes,
-      population,
-    }),
-    apiClient.statistics.calculateAveragedStats(entries),
-    apiClient.statistics.getBasalAnalysis(startDate, endDate),
-    apiClient.statistics.getAidSystemMetrics(startDate, endDate),
+  // Raw readings (paginated) and boluses for the charts.
+  const [entries, bolusResult] = await Promise.all([
+    fetchAllGlucose(apiClient, startDate, endDate),
+    apiClient.bolus.getAll(startDate, endDate, 10000),
   ]);
+  const boluses = bolusResult.data ?? [];
+
+  // Insulin/profile/AID stats and server-side glucose analytics in parallel.
+  const [insulinDeliveryStats, profileSummary, rangeAnalytics, aidSystemMetrics] =
+    await Promise.all([
+      apiClient.statistics.getInsulinDeliveryStatistics(startDate, endDate),
+      apiClient.profile.getProfileSummary(startDate, endDate),
+      apiClient.statistics.getRangeAnalytics(startDate, endDate),
+      apiClient.statistics.getAidSystemMetrics(startDate, endDate),
+    ]);
 
   return {
     entries,
     boluses,
-    carbIntakes,
     insulinDeliveryStats,
     profileSummary,
-    analysis,
-    averagedStats,
-    basalAnalysis,
+    analysis: rangeAnalytics.analysis,
+    averagedStats: rangeAnalytics.averagedStats,
     aidSystemMetrics,
     dateRange: {
       from: startDate.toISOString(),

--- a/src/Web/packages/app/src/lib/api/reports.remote.ts
+++ b/src/Web/packages/app/src/lib/api/reports.remote.ts
@@ -6,7 +6,8 @@ import { z } from "zod";
 import { DiabetesPopulationSchema } from "$lib/api/generated/schemas";
 import { getRequestEvent, query } from "$app/server";
 import { error } from "@sveltejs/kit";
-import { DiabetesPopulation, type BasalPoint } from "$lib/api";
+import { DiabetesPopulation } from "$lib/api";
+import { fetchAllGlucose } from "./glucose-pagination";
 
 /**
  * Input schema for date range queries. Uses nullish() to accept both null and
@@ -53,37 +54,6 @@ function calculateDateRange(input?: DateRangeInput): {
   endDate.setHours(23, 59, 59, 999);
 
   return { startDate, endDate };
-}
-
-/** Paginate through all sensor glucose readings for a date range */
-async function fetchAllGlucose(
-  apiClient: ReturnType<typeof getRequestEvent>["locals"]["apiClient"],
-  startDate: Date,
-  endDate: Date
-) {
-  const pageSize = 1000;
-  type GlucoseItem = NonNullable<Awaited<ReturnType<typeof apiClient.sensorGlucose.getAll>>["data"]>[number];
-  let all: GlucoseItem[] = [];
-  let offset = 0;
-  let hasMore = true;
-
-  while (hasMore) {
-    const batch = await apiClient.sensorGlucose.getAll(startDate, endDate, pageSize, offset);
-    all = all.concat(batch.data ?? []);
-
-    if ((batch.data?.length ?? 0) < pageSize) {
-      hasMore = false;
-    } else {
-      offset += pageSize;
-    }
-
-    if (offset >= 200000) {
-      console.warn("Glucose fetch reached safety limit of 200,000 records");
-      hasMore = false;
-    }
-  }
-
-  return all;
 }
 
 /** Get sensor glucose readings for a date range */
@@ -207,8 +177,9 @@ export const getAnalysis = query(
 );
 
 /**
- * Combined query to get all reports data in one call This is the main entry
- * point for reports pages
+ * Reports data for pages that render raw readings (overview, executive summary, AGP,
+ * week-to-week): sensor glucose for the range plus server-computed extended analytics
+ * and averaged stats.
  */
 export const getReportsData = query(
   DateRangeSchema.optional(),
@@ -217,95 +188,71 @@ export const getReportsData = query(
     const { apiClient } = locals;
     const { startDate, endDate } = calculateDateRange(input);
 
-    const pageSize = 1000;
-
-    // Fetch all sensor glucose readings
-    const entries = await fetchAllGlucose(apiClient, startDate, endDate);
-
-    // Paginate boluses
-    let allBoluses: Awaited<ReturnType<typeof apiClient.bolus.getAll>>["data"] =
-      [];
-    let offset = 0;
-    let hasMore = true;
-
-    while (hasMore) {
-      const batch = await apiClient.bolus.getAll(
-        startDate,
-        endDate,
-        pageSize,
-        offset
-      );
-      allBoluses = allBoluses!.concat(batch.data ?? []);
-
-      if ((batch.data?.length ?? 0) < pageSize) {
-        hasMore = false;
-      } else {
-        offset += pageSize;
-      }
-
-      if (offset >= 50000) {
-        console.warn("Bolus fetch reached safety limit of 50,000 records");
-        hasMore = false;
-      }
-    }
-
-    // Paginate carb intakes
-    let allCarbIntakes: Awaited<
-      ReturnType<typeof apiClient.nutrition.getCarbIntakes>
-    >["data"] = [];
-    offset = 0;
-    hasMore = true;
-
-    while (hasMore) {
-      const batch = await apiClient.nutrition.getCarbIntakes(
-        startDate,
-        endDate,
-        pageSize,
-        offset
-      );
-      allCarbIntakes = allCarbIntakes!.concat(batch.data ?? []);
-
-      if ((batch.data?.length ?? 0) < pageSize) {
-        hasMore = false;
-      } else {
-        offset += pageSize;
-      }
-
-      if (offset >= 50000) {
-        console.warn("CarbIntake fetch reached safety limit of 50,000 records");
-        hasMore = false;
-      }
-    }
-
-    const boluses = allBoluses!;
-    const carbIntakes = allCarbIntakes!;
-    const population = DiabetesPopulation.Type1Adult; // TODO: Get from user settings
-
-    // Get summary, analysis, averaged stats, and basal series in parallel
-    const [summary, analysis, averagedStats, basalSeries] = await Promise.all([
-      apiClient.statistics.getMultiPeriodStatistics(),
-      apiClient.statistics.analyzeGlucoseDataExtended({
-        entries,
-        boluses,
-        carbIntakes,
-        population,
-      }),
-      apiClient.statistics.calculateAveragedStats(entries),
-      apiClient.chartData.getBasalSeries(startDate.getTime(), endDate.getTime()),
+    const [entries, { analysis, averagedStats }] = await Promise.all([
+      fetchAllGlucose(apiClient, startDate, endDate),
+      apiClient.statistics.getRangeAnalytics(startDate, endDate),
     ]);
 
     return {
       entries,
-      boluses,
-      carbIntakes,
-      summary,
       analysis,
       averagedStats,
-      basalSeries: basalSeries ?? [],
       dateRange: {
         from: startDate.toISOString(),
         to: endDate.toISOString(),
         lastUpdated: new Date().toISOString(),
+      },
+    };
+  }
+);
+
+/**
+ * Server-side extended analytics and averaged stats for a date range. Used by report
+ * pages that render only computed metrics (comparison, glucose distribution).
+ */
+export const getReportsAnalysis = query(
+  DateRangeSchema.optional(),
+  async (input) => {
+    const { locals } = getRequestEvent();
+    const { apiClient } = locals;
+    const { startDate, endDate } = calculateDateRange(input);
+
+    const { analysis, averagedStats } =
+      await apiClient.statistics.getRangeAnalytics(startDate, endDate);
+
+    return {
+      analysis,
+      averagedStats,
+      dateRange: {
+        from: startDate.toISOString(),
+        to: endDate.toISOString(),
+      },
+    };
+  }
+);
+
+/**
+ * Boluses and basal series for a date range, for the basal-analysis and
+ * insulin-delivery reports.
+ */
+export const getBasalReportData = query(
+  DateRangeSchema.optional(),
+  async (input) => {
+    const { locals } = getRequestEvent();
+    const { apiClient } = locals;
+    const { startDate, endDate } = calculateDateRange(input);
+
+    const [bolusResult, basalSeries] = await Promise.all([
+      apiClient.bolus.getAll(startDate, endDate, 10000),
+      apiClient.chartData.getBasalSeries(startDate.getTime(), endDate.getTime()),
+    ]);
+
+    return {
+      boluses: bolusResult.data ?? [],
+      basalSeries: basalSeries ?? [],
+      dateRange: {
+        from: startDate.toISOString(),
+        to: endDate.toISOString(),
       },
     };
   }

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/basal-analysis/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/basal-analysis/+page.svelte
@@ -22,7 +22,7 @@
   } from "lucide-svelte";
   import BasalRatePercentileChart from "$lib/components/reports/BasalRatePercentileChart.svelte";
   import InsulinDeliveryChart from "$lib/components/reports/InsulinDeliveryChart.svelte";
-  import { getReportsData } from "$api/reports.remote";
+  import { getBasalReportData } from "$api/reports.remote";
   import { requireDateParamsContext } from "$lib/hooks/date-params.svelte";
   import { contextResource } from "$lib/hooks/resource-context.svelte";
 
@@ -33,7 +33,7 @@
   // Use contextResource - it syncs to layout's ResourceGuard automatically
   // dateParams provides .date.from, .date.to, .date.dayCount derived from URL params
   const reportsResource = contextResource(
-    () => getReportsData(reportsParams.dateRangeInput),
+    () => getBasalReportData(reportsParams.dateRangeInput),
     { errorTitle: "Error Loading Basal Analysis", dateParams: reportsParams }
   );
 

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/comparison/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/comparison/+page.svelte
@@ -7,7 +7,7 @@
   import * as Select from "$lib/components/ui/select";
   import GlucoseRangeCalendarPicker from "$lib/components/alerts/GlucoseRangeCalendarPicker.svelte";
   import TIRStackedChart from "$lib/components/reports/TIRStackedChart.svelte";
-  import { getReportsData, type DateRangeInput } from "$api/reports.remote";
+  import { getReportsAnalysis, type DateRangeInput } from "$api/reports.remote";
   import { bg, bgLabel } from "$lib/utils/formatting";
   import { getResourceContext } from "$lib/hooks/resource-context.svelte";
 
@@ -114,8 +114,8 @@
   // Call queries directly in reactive context — SvelteKit query() returns a
   // reactive QueryResult, not a Promise. Using $derived ensures the queries
   // re-run when inputs change.
-  const queryA = $derived(getReportsData(inputA));
-  const queryB = $derived(getReportsData(inputB));
+  const queryA = $derived(getReportsAnalysis(inputA));
+  const queryB = $derived(getReportsAnalysis(inputB));
 
   // Sync to layout's ResourceContext using $effect.pre (matching contextResource's
   // approach). $effect.pre runs before DOM updates, which is critical: the layout's

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/glucose-distribution/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/glucose-distribution/+page.svelte
@@ -3,7 +3,7 @@
   import * as Card from "$lib/components/ui/card";
   import * as Table from "$lib/components/ui/table";
   import { Button } from "$lib/components/ui/button";
-  import { getReportsData } from "$api/reports.remote";
+  import { getReportsAnalysis } from "$api/reports.remote";
   import HourlyGlucoseDistributionChart from "$lib/components/reports/HourlyGlucoseDistributionChart.svelte";
   import ReliabilityBadge from "$lib/components/reports/ReliabilityBadge.svelte";
   import { requireDateParamsContext } from "$lib/hooks/date-params.svelte";
@@ -12,7 +12,7 @@
   const reportsParams = requireDateParamsContext(14);
 
   const reportsResource = contextResource(
-    () => getReportsData(reportsParams.dateRangeInput),
+    () => getReportsAnalysis(reportsParams.dateRangeInput),
     { errorTitle: "Error Loading Glucose Distribution" }
   );
 

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/idp/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/idp/+page.svelte
@@ -42,7 +42,6 @@
   const data = $derived({
     entries: reportsResource.current?.entries ?? [],
     boluses: reportsResource.current?.boluses ?? [],
-    carbIntakes: reportsResource.current?.carbIntakes ?? [],
     insulinDeliveryStats: reportsResource.current?.insulinDeliveryStats,
     profileSummary: reportsResource.current?.profileSummary,
     analysis: reportsResource.current?.analysis,

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/insulin-delivery/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/insulin-delivery/+page.svelte
@@ -25,7 +25,7 @@
   import InsulinDeliveryChart from "$lib/components/reports/InsulinDeliveryChart.svelte";
   import ReliabilityBadge from "$lib/components/reports/ReliabilityBadge.svelte";
   import type { InsulinDeliveryStatistics } from "$lib/api";
-  import { getReportsData } from "$api/reports.remote";
+  import { getBasalReportData } from "$api/reports.remote";
   import { getMultiPeriodStatistics, getDailyBasalBolusRatios } from "$api/generated/statistics.generated.remote";
   import { requireDateParamsContext } from "$lib/hooks/date-params.svelte";
   import { contextResource } from "$lib/hooks/resource-context.svelte";
@@ -36,7 +36,7 @@
 
   // Create primary resource with automatic layout registration
   const reportsResource = contextResource(
-    () => getReportsData(reportsParams.dateRangeInput),
+    () => getBasalReportData(reportsParams.dateRangeInput),
     { errorTitle: "Error Loading Insulin Delivery Data" }
   );
 

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/readings/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/readings/+page.svelte
@@ -1,22 +1,28 @@
 <script lang="ts">
   import { GlucoseChartCard } from "$lib/components/dashboard/glucose-chart";
-  import { getReportsData } from "$api/reports.remote";
   import { requireDateParamsContext } from "$lib/hooks/date-params.svelte";
-  import { contextResource } from "$lib/hooks/resource-context.svelte";
+  import { useResourceContext } from "$lib/hooks/resource-context.svelte";
 
   // Get shared date params from context (set by reports layout)
   // Default: 7 days for day-by-day readings view
   const reportsParams = requireDateParamsContext(7);
 
-  // Create resource with automatic layout registration
-  const reportsResource = contextResource(
-    () => getReportsData(reportsParams.dateRangeInput),
-    { errorTitle: "Error Loading Readings" }
-  );
+  // GlucoseChartCard self-fetches its own data; this page only supplies the range.
+  const dateRange = $derived.by(() => {
+    const { start, end } = reportsParams.getDateRange();
+    return { from: start, to: end };
+  });
+
+  // No page-level fetch, so report ready state to the layout ResourceGuard directly.
+  useResourceContext({
+    loading: () => false,
+    error: () => null,
+    hasData: () => true,
+    errorTitle: "Error Loading Readings",
+    refetch: () => {},
+  });
 </script>
 
-{#if reportsResource.current}
-  <div class="p-3 @md:p-6">
-    <GlucoseChartCard dateRange={reportsResource.current.dateRange} />
-  </div>
-{/if}
+<div class="p-3 @md:p-6">
+  <GlucoseChartCard {dateRange} />
+</div>

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsControllerTests.cs
@@ -1,0 +1,166 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Nocturne.API.Controllers.V4.Analytics;
+using Nocturne.Core.Contracts.Analytics;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Contracts.Profiles;
+using Nocturne.Core.Contracts.Profiles.Resolvers;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Cache.Abstractions;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4.Analytics;
+
+[Trait("Category", "Unit")]
+public class StatisticsControllerTests
+{
+    private readonly Mock<IStatisticsService> _statsServiceMock = new();
+    private readonly Mock<ISensorGlucoseRepository> _glucoseRepoMock = new();
+    private readonly Mock<IBolusRepository> _bolusRepoMock = new();
+    private readonly Mock<ICarbIntakeRepository> _carbIntakeRepoMock = new();
+
+    private StatisticsController CreateController()
+    {
+        var controller = new StatisticsController(
+            _statsServiceMock.Object,
+            Mock.Of<ICacheService>(),
+            Mock.Of<IProfileProjectionService>(),
+            Mock.Of<IBasalRateResolver>(),
+            Mock.Of<IBasalSegmentService>(),
+            Mock.Of<ITherapySettingsResolver>(),
+            _glucoseRepoMock.Object,
+            _bolusRepoMock.Object,
+            _carbIntakeRepoMock.Object,
+            Mock.Of<ITempBasalRepository>(),
+            Mock.Of<ITenantAccessor>(),
+            Mock.Of<IAidMetricsService>(),
+            Mock.Of<IPatientDeviceRepository>(),
+            Mock.Of<IApsSnapshotRepository>(),
+            Mock.Of<IDeviceEventRepository>(),
+            Mock.Of<ITargetRangeScheduleRepository>());
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        return controller;
+    }
+
+    private void SetupGlucose(IEnumerable<SensorGlucose> readings) =>
+        _glucoseRepoMock
+            .Setup(r => r.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(),
+                It.IsAny<bool>(), It.IsAny<DateTime?>(), It.IsAny<Guid?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(readings);
+
+    private void SetupEmptyTreatments()
+    {
+        _bolusRepoMock
+            .Setup(r => r.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(),
+                It.IsAny<bool>(), It.IsAny<BolusKind?>(),
+                It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Bolus>());
+
+        _carbIntakeRepoMock
+            .Setup(r => r.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(),
+                It.IsAny<bool>(), It.IsAny<DateTime?>(), It.IsAny<Guid?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CarbIntake>());
+    }
+
+    [Fact]
+    public async Task GetRangeAnalytics_FetchesUncapped_AndReturnsServiceResults()
+    {
+        // 12,000 readings — above the legacy 10,000 cap that truncated dense tenants.
+        var readings = Enumerable.Range(0, 12_000)
+            .Select(_ => new SensorGlucose())
+            .ToList();
+        var analysis = new ExtendedGlucoseAnalytics();
+        var averaged = new List<AveragedStats> { new() };
+
+        SetupGlucose(readings);
+        SetupEmptyTreatments();
+
+        List<SensorGlucose>? analysedEntries = null;
+        _statsServiceMock
+            .Setup(s => s.AnalyzeGlucoseDataExtended(
+                It.IsAny<IEnumerable<SensorGlucose>>(),
+                It.IsAny<IEnumerable<Bolus>>(),
+                It.IsAny<IEnumerable<CarbIntake>>(),
+                It.IsAny<DiabetesPopulation>(),
+                It.IsAny<ExtendedAnalysisConfig?>()))
+            .Callback<IEnumerable<SensorGlucose>, IEnumerable<Bolus>, IEnumerable<CarbIntake>, DiabetesPopulation, ExtendedAnalysisConfig?>(
+                (entries, _, _, _, _) => analysedEntries = entries.ToList())
+            .Returns(analysis);
+        _statsServiceMock
+            .Setup(s => s.CalculateAveragedStats(It.IsAny<IEnumerable<SensorGlucose>>()))
+            .Returns(averaged);
+
+        var controller = CreateController();
+
+        var result = await controller.GetRangeAnalytics(
+            new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 1, 15, 0, 0, 0, DateTimeKind.Utc));
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var payload = ok.Value.Should().BeOfType<ReportAnalysisResult>().Subject;
+        payload.Analysis.Should().BeSameAs(analysis);
+        payload.AveragedStats.Should().BeEquivalentTo(averaged);
+
+        // Every fetched reading reaches the analysis engine — nothing truncated.
+        analysedEntries.Should().HaveCount(12_000);
+
+        // The glucose fetch requests an uncapped limit.
+        _glucoseRepoMock.Verify(r => r.GetAsync(
+            It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+            It.IsAny<string?>(), It.IsAny<string?>(),
+            int.MaxValue, It.IsAny<int>(), It.IsAny<bool>(),
+            It.IsAny<bool>(), It.IsAny<DateTime?>(), It.IsAny<Guid?>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetRangeAnalytics_DefaultsToType1AdultPopulation()
+    {
+        SetupGlucose(new List<SensorGlucose>());
+        SetupEmptyTreatments();
+        _statsServiceMock
+            .Setup(s => s.AnalyzeGlucoseDataExtended(
+                It.IsAny<IEnumerable<SensorGlucose>>(),
+                It.IsAny<IEnumerable<Bolus>>(),
+                It.IsAny<IEnumerable<CarbIntake>>(),
+                It.IsAny<DiabetesPopulation>(),
+                It.IsAny<ExtendedAnalysisConfig?>()))
+            .Returns(new ExtendedGlucoseAnalytics());
+        _statsServiceMock
+            .Setup(s => s.CalculateAveragedStats(It.IsAny<IEnumerable<SensorGlucose>>()))
+            .Returns(new List<AveragedStats>());
+
+        var controller = CreateController();
+
+        await controller.GetRangeAnalytics(
+            new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 1, 15, 0, 0, 0, DateTimeKind.Utc));
+
+        _statsServiceMock.Verify(s => s.AnalyzeGlucoseDataExtended(
+            It.IsAny<IEnumerable<SensorGlucose>>(),
+            It.IsAny<IEnumerable<Bolus>>(),
+            It.IsAny<IEnumerable<CarbIntake>>(),
+            DiabetesPopulation.Type1Adult,
+            It.IsAny<ExtendedAnalysisConfig?>()), Times.Once);
+    }
+}


### PR DESCRIPTION
## Why

Most report pages had the SvelteKit server paginate **all** raw readings out of the API 1,000 at a time and then **POST them straight back** to be analysed — even though the API already holds every row. For dense tenants this meant dozens of sequential round-trips plus multi-MB POST bodies per report (the comparison report ran the whole pipeline twice). The DB itself was never the bottleneck (index-backed, fully cached, tens of ms).

## What

Add `GET /api/v4/statistics/range-analytics` (`GetRangeAnalytics`) — fetches glucose/manual-boluses/carbs for a window via the existing repositories and runs the existing pure `IStatisticsService.AnalyzeGlucoseDataExtended` + `CalculateAveragedStats`. Returns a new `ReportAnalysisResult` DTO.

Rewire the report data layer:
- **comparison**, **glucose-distribution** → `getReportsAnalysis` (analysis only)
- **basal-analysis**, **insulin-delivery** → `getBasalReportData` (boluses + basal series; no glucose)
- **getReportsData** → server-side analytics + paginated entries, page size 1k → 10k
- **idp** → paginate glucose (fixes the silent 10k truncation) + server-side analytics
- **readings** → drop the redundant fetch entirely; `GlucoseChartCard` self-fetches

Also:
- Raise the glucose fetch cap in `GetMultiPeriodStatistics` (was `limit: 10000`, silently truncating dense tenants).
- Extract the shared `fetchAllGlucose` paginator to `glucose-pagination.ts` (DRY).

## Tests

- New `StatisticsControllerTests`: asserts `GetRangeAnalytics` fetches uncapped (12k readings, none truncated), wires the service results into the response, and defaults to `Type1Adult`.
- Full Analytics-area unit suite green (446 tests). Frontend `pnpm check` clean for all changed files.

Generated API client files are intentionally not committed — CI regenerates them on build/merge.
