### PR TITLE
fix(ci): stage api-client.generated.ts in commit-generated-api-client

### DIFF
--- a/.github/workflows/commit-generated-api-client.yml
+++ b/.github/workflows/commit-generated-api-client.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add src/Web/packages/app/src/lib/api/generated/**
+          git add src/Web/packages/app/src/lib/api/generated src/Web/packages/app/src/lib/api/api-client.generated.ts
           if git diff --cached --quiet; then
             echo "No changes to commit"
             exit 0


### PR DESCRIPTION
## Problem

The **Commit Generated API Client** workflow has been failing on every push to `main`:

```
[main abe1cbe] chore: regenerate API client [skip ci]
 6 files changed, 1241 insertions(+), 119 deletions(-)
error: cannot pull with rebase: You have unstaged changes.
error: Please commit or stash them.
##[error]Process completed with exit code 128.
```

The commit step staged only `src/Web/packages/app/src/lib/api/generated/**`, but the build also regenerates `src/Web/packages/app/src/lib/api/api-client.generated.ts` — one directory *above* `generated/`. That file was left unstaged, so the subsequent `git pull --rebase origin main` aborted. Net effect: the committed generated client drifts from source.

## Fix

Stage the generated directory *and* `api-client.generated.ts`. Using the directory form (rather than the `generated/**` glob) also reliably picks up newly added remotes such as `connectorAdmins.generated.remote.ts`.

```diff
-          git add src/Web/packages/app/src/lib/api/generated/**
+          git add src/Web/packages/app/src/lib/api/generated src/Web/packages/app/src/lib/api/api-client.generated.ts
```
