### PR TITLE
fix(bridge): authenticate Socket.IO handshakes against per-tenant read policy

### DIFF
--- a/src/Web/packages/app/vite.config.ts
+++ b/src/Web/packages/app/vite.config.ts
@@ -84,6 +84,7 @@ export default defineConfig(({ mode }) => {
               },
             },
             instanceKey: INSTANCE_KEY,
+            baseDomain: env.BASE_DOMAIN || undefined,
           })
             .then((bridge) => {
               console.log("✓ WebSocket bridge initialized successfully");

--- a/src/Web/packages/bridge/package.json
+++ b/src/Web/packages/bridge/package.json
@@ -15,6 +15,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "clean": "rimraf dist",
+    "test": "vitest run",
     "prepublishOnly": "pnpm run build"
   },
   "keywords": [
@@ -36,7 +37,8 @@
     "@types/node": "^20.10.6",
     "@types/tough-cookie": "^4.0.5",
     "rimraf": "^5.0.5",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^4.1.6"
   },
   "engines": {
     "node": ">=24"

--- a/src/Web/packages/bridge/src/lib/socketio-server.test.ts
+++ b/src/Web/packages/bridge/src/lib/socketio-server.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createServer } from 'http';
+import SocketIOServer, { pickHandshakeHost, resolveTenantSlug } from './socketio-server.js';
+import type { TenantAuthorizer } from './tenant-authorizer.js';
+
+describe('resolveTenantSlug', () => {
+  const base = 'nocturne.run';
+
+  it('resolves a subdomain to its slug', () => {
+    expect(resolveTenantSlug('rhys.nocturne.run', base, [])).toBe('rhys');
+  });
+
+  it('resolves the apex domain to the sole tenant', () => {
+    expect(resolveTenantSlug('nocturne.run', base, ['only'])).toBe('only');
+  });
+
+  it('returns null on the apex when more than one tenant exists', () => {
+    expect(resolveTenantSlug('nocturne.run', base, ['a', 'b'])).toBeNull();
+  });
+
+  it('returns null on the apex when no tenants are known yet', () => {
+    expect(resolveTenantSlug('nocturne.run', base, [])).toBeNull();
+  });
+
+  it('returns null for a foreign domain', () => {
+    expect(resolveTenantSlug('evil.com', base, ['only'])).toBeNull();
+  });
+
+  it('ignores a port on the host', () => {
+    expect(resolveTenantSlug('rhys.nocturne.run:443', base, [])).toBe('rhys');
+  });
+});
+
+describe('pickHandshakeHost', () => {
+  it('prefers X-Forwarded-Host over Host', () => {
+    expect(pickHandshakeHost({ 'x-forwarded-host': 'rhys.nocturne.run', host: 'web:5173' })).toBe(
+      'rhys.nocturne.run',
+    );
+  });
+
+  it('falls back to Host when no forwarded host is present', () => {
+    expect(pickHandshakeHost({ host: 'rhys.nocturne.run' })).toBe('rhys.nocturne.run');
+  });
+
+  it('takes the first value when the forwarded host is repeated', () => {
+    expect(pickHandshakeHost({ 'x-forwarded-host': ['a.nocturne.run', 'b.nocturne.run'] })).toBe(
+      'a.nocturne.run',
+    );
+  });
+
+  it('returns undefined when no host header is present', () => {
+    expect(pickHandshakeHost({})).toBeUndefined();
+  });
+});
+
+type HandshakeHeaders = Record<string, string | string[] | undefined>;
+
+function makeServer(
+  authorize: boolean | Error,
+  tenantSlugs: string[] = [],
+): { server: SocketIOServer; isAuthorized: ReturnType<typeof vi.fn> } {
+  const isAuthorized =
+    authorize instanceof Error
+      ? vi.fn(async () => {
+          throw authorize;
+        })
+      : vi.fn(async () => authorize);
+  const authorizer = { isAuthorized } as unknown as TenantAuthorizer;
+  const server = new SocketIOServer(createServer(), {}, 'nocturne.run', tenantSlugs, authorizer);
+  return { server, isAuthorized };
+}
+
+function fakeSocket(headers: HandshakeHeaders) {
+  return { id: 'sock1', handshake: { headers }, data: {} as Record<string, unknown> };
+}
+
+describe('SocketIOServer.authorizeHandshake', () => {
+  it('rejects when the host resolves to no tenant', async () => {
+    const { server, isAuthorized } = makeServer(true);
+    const next = vi.fn();
+
+    await server.authorizeHandshake(fakeSocket({ host: 'evil.com' }) as never, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(next.mock.calls[0][0].message).toBe('tenant_unresolved');
+    expect(isAuthorized).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unauthorized connection to a private tenant', async () => {
+    const { server, isAuthorized } = makeServer(false);
+    const next = vi.fn();
+    const socket = fakeSocket({ 'x-forwarded-host': 'rhys.nocturne.run', cookie: 'session=bad' });
+
+    await server.authorizeHandshake(socket as never, next);
+
+    expect(isAuthorized).toHaveBeenCalledWith('rhys.nocturne.run', 'session=bad');
+    expect(next.mock.calls[0][0].message).toBe('unauthorized');
+    expect(socket.data.tenantSlug).toBeUndefined();
+  });
+
+  it('admits an authorized connection and tags the socket with its tenant', async () => {
+    const { server } = makeServer(true);
+    const next = vi.fn();
+    const socket = fakeSocket({ 'x-forwarded-host': 'rhys.nocturne.run', cookie: 'session=good' });
+
+    await server.authorizeHandshake(socket as never, next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(socket.data.tenantSlug).toBe('rhys');
+  });
+
+  it('admits a public-tenant connection that carries no cookie', async () => {
+    const { server, isAuthorized } = makeServer(true);
+    const next = vi.fn();
+    const socket = fakeSocket({ 'x-forwarded-host': 'public.nocturne.run' });
+
+    await server.authorizeHandshake(socket as never, next);
+
+    expect(isAuthorized).toHaveBeenCalledWith('public.nocturne.run', undefined);
+    expect(next).toHaveBeenCalledWith();
+    expect(socket.data.tenantSlug).toBe('public');
+  });
+
+  it('admits an apex connection for the sole tenant', async () => {
+    const { server } = makeServer(true, ['only']);
+    const next = vi.fn();
+    const socket = fakeSocket({ host: 'nocturne.run' });
+
+    await server.authorizeHandshake(socket as never, next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(socket.data.tenantSlug).toBe('only');
+  });
+
+  it('rejects with no admission when authorization throws (fails closed)', async () => {
+    const { server } = makeServer(new Error('boom'));
+    const next = vi.fn();
+    const socket = fakeSocket({ 'x-forwarded-host': 'rhys.nocturne.run', cookie: 'session=x' });
+
+    await server.authorizeHandshake(socket as never, next);
+
+    expect(next.mock.calls[0][0].message).toBe('authorization_error');
+    expect(socket.data.tenantSlug).toBeUndefined();
+  });
+});

--- a/src/Web/packages/bridge/src/lib/socketio-server.ts
+++ b/src/Web/packages/bridge/src/lib/socketio-server.ts
@@ -2,6 +2,7 @@ import { Server as SocketIOServerClass, Socket } from 'socket.io';
 import { Server as HttpServer } from 'http';
 import logger from './logger.js';
 import type { ClientInfo, AlarmData, ServerStats } from '../types.js';
+import type { TenantAuthorizer } from './tenant-authorizer.js';
 
 interface SocketIOConfig {
   cors?: {
@@ -14,29 +15,76 @@ interface SocketIOConfig {
   pingInterval?: number;
 }
 
+/** Pick the host the connection arrived on: the proxy-forwarded host if present
+ *  (X-Forwarded-Host), otherwise the Host header. Returns the first value when a
+ *  header is repeated.
+ *
+ *  Trust model: X-Forwarded-Host is NOT sanitized at the edge — the YARP gateway
+ *  forwards it as-is and nothing overwrites it, so a client can set it to any
+ *  value. Safety does not depend on trusting this header. The chosen host is
+ *  replayed to the API authorization probe together with the client's OWN cookie,
+ *  and the API applies its per-tenant read policy: a spoofed host only re-points
+ *  the probe at another tenant, and a private tenant still rejects a non-member
+ *  cookie, so spoofing can expose only data that is already public. The API
+ *  resolves tenants from the same header in TenantResolutionMiddleware, so the
+ *  bridge adds no new trust assumption. */
+export function pickHandshakeHost(
+  headers: Record<string, string | string[] | undefined>,
+): string | undefined {
+  const value = headers['x-forwarded-host'] ?? headers['host'];
+  const single = Array.isArray(value) ? value[0] : value;
+  return single || undefined;
+}
+
+/** Resolve the tenant slug a host belongs to. A subdomain resolves to its slug;
+ *  the apex domain resolves to the sole tenant when exactly one exists, mirroring
+ *  the API's tenant resolution so a single tenant served on the root domain works
+ *  without a subdomain. Returns null when the host is foreign or the apex can't be
+ *  resolved to a single tenant. */
+export function resolveTenantSlug(
+  host: string | undefined,
+  baseDomain: string,
+  tenantSlugs: string[],
+): string | null {
+  if (!host) return null;
+
+  const hostname = host.split(':')[0];
+  const baseDomainHost = baseDomain.split(':')[0];
+
+  if (hostname.endsWith(`.${baseDomainHost}`)) {
+    const slug = hostname.slice(0, -(baseDomainHost.length + 1));
+    return slug || null;
+  }
+
+  if (hostname === baseDomainHost && tenantSlugs.length === 1) {
+    return tenantSlugs[0];
+  }
+
+  return null;
+}
+
 class SocketIOServer {
   private io: SocketIOServerClass | null = null;
   private httpServer: HttpServer;
   private clients: Map<string, ClientInfo> = new Map();
   private config: SocketIOConfig;
-  private baseDomain?: string;
+  private baseDomain: string;
   private tenantSlugs: string[];
+  private authorizer?: TenantAuthorizer;
 
   constructor(
     httpServer: HttpServer,
     config: SocketIOConfig = {},
-    baseDomain?: string,
+    baseDomain: string,
     tenantSlugs: string[] = [],
+    authorizer?: TenantAuthorizer,
   ) {
     this.httpServer = httpServer;
     this.baseDomain = baseDomain;
     this.tenantSlugs = tenantSlugs;
+    this.authorizer = authorizer;
     this.config = {
-      cors: config.cors || {
-        origin: '*',
-        methods: ['GET', 'POST'],
-        credentials: true
-      },
+      cors: config.cors ?? { origin: '*', methods: ['GET', 'POST'], credentials: true },
       transports: config.transports || ['websocket', 'polling'],
       pingTimeout: config.pingTimeout || 60000,
       pingInterval: config.pingInterval || 25000
@@ -54,6 +102,7 @@ class SocketIOServer {
           pingInterval: this.config.pingInterval
         });
 
+        this.setupHandshakeAuth();
         this.setupEventHandlers();
 
         logger.info('Socket.IO server attached to HTTP server');
@@ -64,6 +113,48 @@ class SocketIOServer {
         reject(error);
       }
     });
+  }
+
+  /** Authorize every handshake before it can join a tenant room. The tenant is
+   *  resolved from the connection's Host, then the connection is authorized
+   *  against the API's per-tenant read policy (see TenantAuthorizer) by
+   *  forwarding the same Host and session cookie. Unauthorized handshakes are
+   *  rejected so the socket never receives broadcasts. */
+  private setupHandshakeAuth(): void {
+    if (!this.io) return;
+    this.io.use((socket, next) => this.authorizeHandshake(socket, next));
+  }
+
+  /** Resolve the tenant for a handshake and authorize it. Sets
+   *  `socket.data.tenantSlug` for room assignment on success; calls `next` with
+   *  an error to reject. Exposed for unit testing. */
+  async authorizeHandshake(socket: Socket, next: (err?: Error) => void): Promise<void> {
+    try {
+      const host = pickHandshakeHost(socket.handshake.headers);
+      const tenantSlug = resolveTenantSlug(host, this.baseDomain, this.tenantSlugs);
+      if (!tenantSlug) {
+        logger.warn(`Rejecting connection ${socket.id}: no resolvable tenant`);
+        return next(new Error('tenant_unresolved'));
+      }
+
+      if (!this.authorizer) {
+        logger.error(`Rejecting connection ${socket.id}: no authorizer configured`);
+        return next(new Error('authorization_unavailable'));
+      }
+
+      const authorized = await this.authorizer.isAuthorized(host!, socket.handshake.headers['cookie']);
+      if (!authorized) {
+        logger.warn(`Rejecting connection ${socket.id}: unauthorized for tenant ${tenantSlug}`);
+        return next(new Error('unauthorized'));
+      }
+
+      socket.data.tenantSlug = tenantSlug;
+      next();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`Rejecting connection ${socket.id}: authorization error: ${message}`);
+      next(new Error('authorization_error'));
+    }
   }
 
   private setupEventHandlers(): void {
@@ -82,16 +173,12 @@ class SocketIOServer {
       logger.info(`Client connected: ${clientId} from ${clientInfo.address}`);
       logger.debug(`Total connected clients: ${this.clients.size}`);
 
-      // In multi-tenant mode, join the client to a tenant-specific room
-      // based on the X-Forwarded-Host header set by the reverse proxy.
-      if (this.baseDomain) {
-        const tenantSlug = this.extractTenantSlug(socket);
-        if (tenantSlug) {
-          socket.join(`tenant:${tenantSlug}`);
-          logger.info(`Client ${clientId} joined tenant room: ${tenantSlug}`);
-        } else {
-          logger.warn(`Client ${clientId} connected without resolvable tenant`);
-        }
+      // Join the client to the tenant room resolved and authorized during the
+      // handshake (see setupHandshakeAuth).
+      const tenantSlug = socket.data.tenantSlug as string | undefined;
+      if (tenantSlug) {
+        socket.join(`tenant:${tenantSlug}`);
+        logger.info(`Client ${clientId} joined tenant room: ${tenantSlug}`);
       }
 
       // Handle client disconnection
@@ -101,24 +188,6 @@ class SocketIOServer {
         logger.debug(`Total connected clients: ${this.clients.size}`);
       });
 
-      // Handle client authentication if needed
-      socket.on('authenticate', () => {
-        logger.debug(`Client ${clientId} attempting authentication`);
-        // TODO: Implement authentication logic if required
-        socket.emit('authenticated', { success: true });
-      });
-
-      // Handle client joining rooms (for targeted messaging)
-      socket.on('join', (room: string) => {
-        socket.join(room);
-        logger.debug(`Client ${clientId} joined room: ${room}`);
-      });
-
-      socket.on('leave', (room: string) => {
-        socket.leave(room);
-        logger.debug(`Client ${clientId} left room: ${room}`);
-      });
-
       // Send initial connection acknowledgment
       socket.emit('connect_ack', {
         clientId: clientId,
@@ -126,35 +195,6 @@ class SocketIOServer {
         version: '1.0.0'
       });
     });
-  }
-
-  /** Extract tenant slug from the Socket.IO handshake headers.
-   *  Checks X-Forwarded-Host first (set by YARP's X-Forwarded transform),
-   *  then falls back to Host (preserved by RequestHeaderOriginalHost).
-   *  Apex-domain connections fall back to the sole tenant when exactly one
-   *  exists, mirroring the API's TenantResolutionMiddleware behavior so
-   *  self-hosted single-tenant deployments work without a subdomain. */
-  private extractTenantSlug(socket: Socket): string | null {
-    if (!this.baseDomain) return null;
-
-    const forwardedHost = socket.handshake.headers['x-forwarded-host'];
-    const rawHost = socket.handshake.headers['host'];
-    const candidate = Array.isArray(forwardedHost) ? forwardedHost[0] : (forwardedHost || rawHost);
-    if (!candidate) return null;
-
-    const hostname = candidate.split(':')[0];
-    const baseDomainHost = this.baseDomain.split(':')[0];
-
-    if (hostname.endsWith(`.${baseDomainHost}`)) {
-      const slug = hostname.slice(0, -(baseDomainHost.length + 1));
-      return slug || null;
-    }
-
-    if (hostname === baseDomainHost && this.tenantSlugs.length === 1) {
-      return this.tenantSlugs[0];
-    }
-
-    return null;
   }
 
   /** Return the Socket.IO emit target: tenant room if scoped, or all clients. */

--- a/src/Web/packages/bridge/src/lib/tenant-authorizer.test.ts
+++ b/src/Web/packages/bridge/src/lib/tenant-authorizer.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TenantAuthorizer, type FetchLike } from './tenant-authorizer.js';
+
+function authorizerWith(fetchImpl: FetchLike): TenantAuthorizer {
+  return new TenantAuthorizer({
+    apiBaseUrl: 'http://api:8080/',
+    fetch: fetchImpl,
+    timeoutMs: 1000,
+  });
+}
+
+describe('TenantAuthorizer.isAuthorized', () => {
+  it('authorizes when the read probe returns 200 (authed member or public tenant)', async () => {
+    const fetch = vi.fn(async () => ({ ok: true, status: 200 }));
+    const auth = authorizerWith(fetch as unknown as FetchLike);
+
+    await expect(auth.isAuthorized('rhys.nocturne.run', 'session=abc')).resolves.toBe(true);
+  });
+
+  it('rejects when the read probe returns 401 (private tenant, no/invalid credentials)', async () => {
+    const fetch = vi.fn(async () => ({ ok: false, status: 401 }));
+    const auth = authorizerWith(fetch as unknown as FetchLike);
+
+    await expect(auth.isAuthorized('rhys.nocturne.run', undefined)).resolves.toBe(false);
+  });
+
+  it('rejects a cookie scoped to another tenant (API membership check fails -> 401)', async () => {
+    const fetch = vi.fn(async () => ({ ok: false, status: 401 }));
+    const auth = authorizerWith(fetch as unknown as FetchLike);
+
+    await expect(
+      auth.isAuthorized('rhys.nocturne.run', 'session=for-another-tenant'),
+    ).resolves.toBe(false);
+  });
+
+  it('probes the read endpoint /api/v1/entries, forwarding the original Host and cookie', async () => {
+    const fetch = vi.fn(async () => ({ ok: true, status: 200 }));
+    const auth = authorizerWith(fetch as unknown as FetchLike);
+
+    await auth.isAuthorized('rhys.nocturne.run', 'session=abc');
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, init] = fetch.mock.calls[0] as [string, { headers?: Record<string, string> }];
+    expect(url).toBe('http://api:8080/api/v1/entries?count=1');
+    expect(init.headers?.['X-Forwarded-Host']).toBe('rhys.nocturne.run');
+    expect(init.headers?.['Cookie']).toBe('session=abc');
+  });
+
+  it('omits the Cookie header when the handshake carries no cookie (public path)', async () => {
+    const fetch = vi.fn(async () => ({ ok: true, status: 200 }));
+    const auth = authorizerWith(fetch as unknown as FetchLike);
+
+    await auth.isAuthorized('public.nocturne.run', undefined);
+
+    const [, init] = fetch.mock.calls[0] as [string, { headers?: Record<string, string> }];
+    expect(init.headers && 'Cookie' in init.headers).toBe(false);
+  });
+
+  it('fails closed when the probe throws (e.g. the API is unreachable)', async () => {
+    const fetch = vi.fn(async () => {
+      throw new Error('network down');
+    });
+    const auth = authorizerWith(fetch as unknown as FetchLike);
+
+    await expect(auth.isAuthorized('rhys.nocturne.run', 'session=abc')).resolves.toBe(false);
+  });
+});

--- a/src/Web/packages/bridge/src/lib/tenant-authorizer.ts
+++ b/src/Web/packages/bridge/src/lib/tenant-authorizer.ts
@@ -1,0 +1,80 @@
+import logger from './logger.js';
+
+/** Minimal fetch surface used by the authorizer, for injection in tests. */
+export type FetchLike = (
+  url: string,
+  init?: { method?: string; headers?: Record<string, string>; signal?: AbortSignal },
+) => Promise<{ ok: boolean; status: number }>;
+
+export interface TenantAuthorizerConfig {
+  /** Base URL of the Nocturne API (e.g. "http://api:8080"), no trailing slash required. */
+  apiBaseUrl: string;
+  /** Injected fetch implementation. Defaults to the global fetch. */
+  fetch?: FetchLike;
+  /** Per-request timeout in milliseconds. */
+  timeoutMs?: number;
+}
+
+/**
+ * Authorizes a Socket.IO handshake for a tenant's live data stream by replaying
+ * the browser's read against the API. It forwards the handshake's original Host
+ * (the same header the REST read path receives) and session cookie to a read of
+ * `GET /api/v1/entries?count=1`. That endpoint carries the same
+ * `[Authorize(Policy = HasPermissions)]` gate as every data read, so probing it
+ * mirrors the read policy exactly and cannot drift from it — including for
+ * public-read tenants, which the API admits unauthenticated. The Loop probe
+ * `/api/v1/experiments/test` is NOT equivalent: its `[RequireRead]` filter
+ * rejects every unauthenticated request before checking permissions, so it
+ * would deny public dashboards. The API resolves the tenant from the Host —
+ * subdomain or apex single-tenant — and applies its standard read policy:
+ *   - authenticated member of the tenant -> 200
+ *   - public-read tenant -> 200 even without a cookie
+ *   - private tenant without valid credentials -> 401
+ *   - cookie scoped to a different tenant -> fails the API's membership check
+ *     and falls through to the resolved tenant's public access, so it is
+ *     rejected unless that tenant is public-read
+ * A data-less tenant still returns 200 with an empty array, so an authorized
+ * connection is never rejected for lack of entries.
+ */
+export class TenantAuthorizer {
+  private readonly probeUrl: string;
+  private readonly fetch: FetchLike;
+  private readonly timeoutMs: number;
+
+  constructor(config: TenantAuthorizerConfig) {
+    this.probeUrl = `${config.apiBaseUrl.replace(/\/+$/, '')}/api/v1/entries?count=1`;
+    this.fetch = config.fetch ?? (globalThis.fetch as unknown as FetchLike);
+    this.timeoutMs = config.timeoutMs ?? 5000;
+  }
+
+  /**
+   * Returns true if a connection carrying the given Host and cookie header is
+   * allowed to read the data of the tenant that Host resolves to.
+   */
+  async isAuthorized(host: string, cookieHeader: string | undefined): Promise<boolean> {
+    const headers: Record<string, string> = { 'X-Forwarded-Host': host };
+    if (cookieHeader) headers['Cookie'] = cookieHeader;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const response = await this.fetch(this.probeUrl, {
+        method: 'GET',
+        headers,
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        logger.warn(
+          `Socket.IO authorization denied for host ${host}: API returned ${response.status}`,
+        );
+      }
+      return response.ok;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn(`Socket.IO authorization probe failed for host ${host}: ${message}`);
+      return false;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/src/Web/packages/bridge/src/setup.test.ts
+++ b/src/Web/packages/bridge/src/setup.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createServer } from 'http';
+import { setupBridge } from './setup.js';
+
+describe('setupBridge fail-closed', () => {
+  beforeEach(() => {
+    // buildConfig falls back to process.env.BASE_DOMAIN; clear it so the
+    // absent-baseDomain case is exercised regardless of the host environment.
+    vi.stubEnv('BASE_DOMAIN', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('throws when BASE_DOMAIN is absent so no unauthenticated path is started', async () => {
+    await expect(
+      setupBridge(createServer(), {
+        signalr: { hubUrl: 'http://api:8080/hubs/data' },
+        instanceKey: 'test-key',
+      }),
+    ).rejects.toThrow(/BASE_DOMAIN/);
+  });
+});

--- a/src/Web/packages/bridge/src/setup.ts
+++ b/src/Web/packages/bridge/src/setup.ts
@@ -5,7 +5,13 @@ import { buildConfig } from './lib/config-builder.js';
 import SocketIOServer from './lib/socketio-server.js';
 import SignalRClient from './lib/signalr-client.js';
 import MessageTranslator from './lib/message-translator.js';
+import { TenantAuthorizer } from './lib/tenant-authorizer.js';
 import logger from './lib/logger.js';
+
+/** Derive the API base URL from a SignalR hub URL (".../hubs/data" -> "..."). */
+function apiBaseFromHubUrl(hubUrl: string): string {
+  return hubUrl.replace(/\/hubs\/\w+$/, '');
+}
 
 interface TenantInfo {
   slug: string;
@@ -69,6 +75,16 @@ export async function setupBridge(
 
   const config = buildConfig(userConfig);
 
+  // BASE_DOMAIN is how the bridge resolves which tenant a connection belongs to
+  // and authorizes it against the API's read policy. Without it the bridge can't
+  // scope or authorize Socket.IO traffic, so it refuses to start rather than
+  // broadcast tenant data unauthenticated. Callers catch this and keep the web
+  // app running with real-time updates disabled.
+  if (!config.baseDomain) {
+    throw new Error('BASE_DOMAIN is required to run the WebSocket bridge');
+  }
+  const baseDomain = config.baseDomain;
+
   logger.info(`SignalR DataHub URL: ${config.signalr.hubUrl}`);
   if (config.signalr.alarmHubUrl) {
     logger.info(`SignalR AlarmHub URL: ${config.signalr.alarmHubUrl}`);
@@ -77,61 +93,38 @@ export async function setupBridge(
     logger.info(`SignalR ConfigHub URL: ${config.signalr.configHubUrl}`);
   }
 
-  // Start the Socket.IO server eagerly — it doesn't need tenant info to
-  // accept browser connections.  Tenant room assignment uses the Host
-  // header, not the pre-discovered slug list (the list is only needed for
-  // the apex-domain single-tenant fallback).
+  // Authorize each Socket.IO handshake against the API's per-tenant read policy
+  // before it joins a tenant room.
+  const authorizer = new TenantAuthorizer({
+    apiBaseUrl: apiBaseFromHubUrl(config.signalr.hubUrl),
+  });
+
+  // Start the Socket.IO server eagerly — it doesn't need tenant info to accept
+  // browser connections. Tenant room assignment uses the Host header; the slug
+  // list is only needed for the apex-domain single-tenant case and is filled in
+  // once tenant discovery completes.
   const socketIOServer = new SocketIOServer(
     httpServer,
     config.socketio,
-    config.baseDomain,
+    baseDomain,
+    [],
+    authorizer,
   );
 
   await socketIOServer.start();
   logger.info('Socket.IO server started');
 
-  if (!config.baseDomain) {
-    // Single-tenant mode (backward compatible): one SignalR connection, no tenant scoping
-    const messageTranslator = new MessageTranslator(socketIOServer);
-    const signalRClient = new SignalRClient(messageTranslator, {
-      hubUrl: config.signalr.hubUrl,
-      alarmHubUrl: config.signalr.alarmHubUrl,
-      configHubUrl: config.signalr.configHubUrl,
-      reconnectAttempts: config.signalr.reconnectAttempts,
-      reconnectDelay: config.signalr.reconnectDelay,
-      maxReconnectDelay: config.signalr.maxReconnectDelay,
-      instanceKey: config.instanceKey,
-    });
-
-    await signalRClient.connect();
-    logger.info('SignalR client connected');
-    logger.info('WebSocket Bridge setup completed successfully');
-
-    return {
-      io: socketIOServer.getIO()!,
-      disconnect: async () => {
-        await signalRClient.disconnect();
-        await socketIOServer.stop();
-      },
-      isConnected: () => signalRClient.isConnected(),
-      getStats: () => ({
-        ...socketIOServer.getStats(),
-        signalrConnected: signalRClient.isConnected(),
-      }),
-    };
-  }
-
-  // Multi-tenant mode: discover tenants and connect SignalR clients in the
-  // background so a slow or temporarily-unavailable API doesn't prevent the
-  // Socket.IO server from accepting browser connections.
-  logger.info(`Multi-tenant mode enabled (baseDomain: ${config.baseDomain})`);
+  // Discover tenants and connect their SignalR clients in the background so a
+  // slow or temporarily-unavailable API doesn't prevent the Socket.IO server
+  // from accepting browser connections.
+  logger.info(`Bridge tenant discovery starting (baseDomain: ${baseDomain})`);
 
   const instanceKeyHash = createHash('sha1')
     .update(config.instanceKey)
     .digest('hex')
     .toLowerCase();
 
-  const apiBaseUrl = config.signalr.hubUrl.replace(/\/hubs\/\w+$/, '');
+  const apiBaseUrl = apiBaseFromHubUrl(config.signalr.hubUrl);
   const clients: SignalRClient[] = [];
   let cancelled = false;
 
@@ -146,7 +139,7 @@ export async function setupBridge(
 
         for (const slug of tenantSlugs) {
           if (cancelled) return;
-          const client = createTenantClient(socketIOServer, config, slug, config.baseDomain!);
+          const client = createTenantClient(socketIOServer, config, slug, baseDomain);
           clients.push(client);
           await client.connect();
           logger.info(`SignalR client connected for tenant: ${slug}`);

--- a/src/Web/packages/bridge/src/types.ts
+++ b/src/Web/packages/bridge/src/types.ts
@@ -25,10 +25,11 @@ export interface BridgeConfig {
     format?: string;
   };
   instanceKey: string;
-  /** Base domain for multi-tenant mode (e.g. "nocturne.run"). When set, the
-   *  bridge discovers active tenants from the API and creates a SignalR
-   *  connection per tenant with the correct X-Forwarded-Host header. Socket.IO
-   *  clients are routed to tenant-specific rooms. */
+  /** Base domain the bridge runs under (e.g. "nocturne.run"). Required at
+   *  runtime: the bridge discovers active tenants from the API, opens a SignalR
+   *  connection per tenant, and routes Socket.IO clients to tenant rooms keyed by
+   *  the Host they connect on. Kept optional in the type because it is sourced
+   *  from the environment; setupBridge throws when it is absent. */
   baseDomain?: string;
 }
 

--- a/src/Web/packages/bridge/vitest.config.ts
+++ b/src/Web/packages/bridge/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/src/Web/pnpm-lock.yaml
+++ b/src/Web/pnpm-lock.yaml
@@ -346,6 +346,9 @@ importers:
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@20.19.25)(@vitest/browser-playwright@4.1.6)(happy-dom@20.9.0)(vite@8.0.12(@types/node@20.19.25)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))
 
   packages/cms:
     devDependencies:
@@ -9469,6 +9472,20 @@ snapshots:
       - utf-8-validate
       - vite
 
+  '@vitest/browser-playwright@4.1.6(playwright@1.60.0)(vite@8.0.12(@types/node@20.19.25)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))(vitest@4.1.6)':
+    dependencies:
+      '@vitest/browser': 4.1.6(vite@8.0.12(@types/node@20.19.25)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))(vitest@4.1.6)
+      '@vitest/mocker': 4.1.6(vite@8.0.12(@types/node@20.19.25)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))
+      playwright: 1.60.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@20.19.25)(@vitest/browser-playwright@4.1.6)(happy-dom@20.9.0)(vite@8.0.12(@types/node@20.19.25)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
   '@vitest/browser@4.1.6(vite@6.4.1(@types/node@25.7.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.9.0))(vitest@4.1.6)':
     dependencies:
       '@blazediff/core': 1.9.1
@@ -9485,6 +9502,24 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+
+  '@vitest/browser@4.1.6(vite@8.0.12(@types/node@20.19.25)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))(vitest@4.1.6)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.6(vite@8.0.12(@types/node@20.19.25)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))
+      '@vitest/utils': 4.1.6
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@20.19.25)(@vitest/browser-playwright@4.1.6)(happy-dom@20.9.0)(vite@8.0.12(@types/node@20.19.25)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))
+      ws: 8.20.1
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -9518,6 +9553,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 6.4.1(@types/node@25.7.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.6(vite@8.0.12(@types/node@20.19.25)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.12(@types/node@20.19.25)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -13224,6 +13267,21 @@ snapshots:
       tsx: 4.20.6
       yaml: 2.9.0
 
+  vite@8.0.12(@types/node@20.19.25)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rolldown: 1.0.0
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 20.19.25
+      esbuild: 0.28.0
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.20.6
+      yaml: 2.9.0
+
   vite@8.0.12(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -13315,6 +13373,36 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@20.19.25)(@vitest/browser-playwright@4.1.6)(happy-dom@20.9.0)(vite@8.0.12(@types/node@20.19.25)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.6
+      '@vitest/mocker': 4.1.6(vite@8.0.12(@types/node@20.19.25)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/runner': 4.1.6
+      '@vitest/snapshot': 4.1.6
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.12(@types/node@20.19.25)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 20.19.25
+      '@vitest/browser-playwright': 4.1.6(playwright@1.60.0)(vite@8.0.12(@types/node@20.19.25)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))(vitest@4.1.6)
+      happy-dom: 20.9.0
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(@vitest/browser-playwright@4.1.6)(happy-dom@20.9.0)(vite@6.4.1(@types/node@25.7.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
## Problem
The bridge's Socket.IO server accepted any connection and joined it to a tenant room from the `X-Forwarded-Host` header with **no authentication** — anyone could connect to `wss://<tenant>.../socket.io` and receive that tenant's live glucose / treatments / devicestatus stream unauthenticated (PHI exposure). The API's SignalR hubs are authenticated; only the browser ↔ bridge hop was open.

## Fix
Authorize every Socket.IO handshake before it joins a tenant room. The bridge forwards the connection's original `Host` and session cookie to `GET /api/v1/entries?count=1` — which carries the same `[Authorize(Policy = HasPermissions)]` gate as every data read — and admits the socket only on a 2xx. This mirrors the REST read policy exactly and cannot drift from it:

- authenticated member → 200 → admitted
- public-read tenant, no cookie → 200 → admitted (public dashboards keep working)
- private tenant, no/invalid cookie → 401 → rejected
- cookie scoped to another tenant → API membership check fails → rejected (unless the host tenant is public)

Other changes:
- **Fail closed on missing `BASE_DOMAIN`**: `setupBridge` throws rather than serve tenant data unauthenticated. Both callers already catch and keep the web app running with realtime disabled. Removes the previous unauthenticated single-tenant broadcast path.
- Removes the client-triggered `join` / `authenticate` socket events (a prior bypass).
- Dev: `vite.config.ts` forwards `BASE_DOMAIN` so local realtime works once it is set.
- Adds vitest to `@nocturne/bridge` with tests for the handshake gate, tenant resolution (subdomain + apex single-tenant), the authorizer, and fail-closed behavior.

## Security review
Reviewed in two adversarial passes (verdict: SHIP). Verified: no room-join / broadcast bypass; fail-closed on missing `BASE_DOMAIN` and on probe timeout / throw / unreachable; cross-tenant rejected; apex single-tenant matches `TenantResolutionMiddleware.GetSoleTenantAsync`. Host-spoofing is contained to already-public data — the cookie is replayed to the API's per-tenant gate, so a spoofed host cannot read a private tenant; the bridge adds no new trust assumption beyond what the API already makes for tenant resolution.

## Follow-up (pre-existing, out of scope)
`GET /api/v1/entries` emits `Cache-Control: public, max-age=60` without `Vary: Cookie`. No cross-tenant risk (host is part of the cache key), but within a single private tenant a shared-cache hit could in principle serve an authed read to an unauthenticated requester. Worth hardening separately.