### PR TITLE
fix(realtime): broadcast deduped V4 glucose inserts + emit on update/restore

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
@@ -111,6 +111,10 @@ public class SensorGlucoseController(
         try
         {
             var updated = await Repository.UpdateAsync(id, model, ct);
+
+            // V4 writes bypass the legacy entry sink; emit the realtime "entries" update here.
+            await glucoseEvents.OnUpdatedAsync(updated, ct);
+
             return Ok(updated);
         }
         catch (KeyNotFoundException)
@@ -196,5 +200,12 @@ public class SensorGlucoseController(
         await glucoseEvents.OnCreatedAsync(new[] { created }, ct);
 
         return created;
+    }
+
+    protected override async Task OnAfterRestoreAsync(SensorGlucose restored, CancellationToken ct)
+    {
+        // A restored reading reappears in the dataset; broadcast it as an "entries" create so the
+        // web client re-adds it. V4 restores bypass the legacy entry sink.
+        await glucoseEvents.OnCreatedAsync(new[] { restored }, ct);
     }
 }

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/GlucosePublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/GlucosePublisher.cs
@@ -81,12 +81,14 @@ internal sealed class GlucosePublisher : IGlucosePublisher
             if (recordList.Count == 0) return true;
 
             await StampPatientDeviceIdsAsync(recordList, source, cancellationToken);
-            await _sensorGlucoseRepository.BulkCreateAsync(recordList, cancellationToken);
+            var created = (await _sensorGlucoseRepository.BulkCreateAsync(recordList, cancellationToken)).ToList();
             await UpdateLastReadingAtAsync(cancellationToken);
             await EvaluateAlertsForSensorGlucoseAsync(recordList, cancellationToken);
 
-            // V4 writes bypass the legacy entry sink; emit the realtime "entries" create here.
-            await _sensorGlucoseEvents.OnCreatedAsync(recordList, cancellationToken);
+            // V4 writes bypass the legacy entry sink; emit the realtime "entries" create for the rows
+            // actually inserted. BulkCreateAsync dedupes by LegacyId, so connectors polling overlapping
+            // windows don't re-broadcast already-stored readings. Matches SensorGlucoseController.
+            await _sensorGlucoseEvents.OnCreatedAsync(created, cancellationToken);
 
             _logger.LogDebug("Published {Count} SensorGlucose records for {Source}", recordList.Count, source);
             return true;

--- a/src/API/Nocturne.API/Services/Glucose/SignalRSensorGlucoseEventSink.cs
+++ b/src/API/Nocturne.API/Services/Glucose/SignalRSensorGlucoseEventSink.cs
@@ -16,7 +16,7 @@ namespace Nocturne.API.Services.Glucose;
 /// V4-native glucose ingestion — the <c>POST /api/v4/glucose/sensor</c> controller and the connector
 /// <see cref="Nocturne.API.Services.ConnectorPublishing.GlucosePublisher"/> — writes directly to the
 /// SensorGlucose repository, bypassing the legacy <see cref="SignalREntryEventSink"/>, so without this
-/// sink those readings produce no real-time <c>create</c> event. Broadcasts as the <c>entries</c>
+/// sink those readings produce no real-time <c>create</c> or <c>update</c> event. Broadcasts as the <c>entries</c>
 /// collection (what the web client and the SignalR→Socket.IO bridge subscribe to). Entries written via
 /// the legacy path are decomposed to SensorGlucose by the decomposition pipeline, not this sink, so
 /// there is no double broadcast. Cache invalidation and options mirror <see cref="SignalREntryEventSink"/>.
@@ -51,12 +51,12 @@ public class SignalRSensorGlucoseEventSink : IDataEventSink<SensorGlucose>
         _logger = logger;
     }
 
-    private WriteEffectOptions BuildWriteOptions() => new()
+    private WriteEffectOptions BuildWriteOptions(bool broadcastDataUpdate = true) => new()
     {
         CacheKeysToRemove = [CacheKeyBuilder.BuildCurrentEntriesKey(TenantCacheId)],
         CachePatternsToClear = [CacheKeyBuilder.BuildRecentEntriesPattern(TenantCacheId)],
         DecomposeToV4 = false,
-        BroadcastDataUpdate = true,
+        BroadcastDataUpdate = broadcastDataUpdate,
     };
 
     public Task OnCreatedAsync(SensorGlucose item, CancellationToken ct = default) =>
@@ -75,6 +75,21 @@ public class SignalRSensorGlucoseEventSink : IDataEventSink<SensorGlucose>
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to process create side effects for {Count} sensor glucose readings", items.Count);
+        }
+    }
+
+    public async Task OnUpdatedAsync(SensorGlucose item, CancellationToken ct = default)
+    {
+        try
+        {
+            var entry = SensorGlucoseToEntryMapper.ToEntry(item);
+            // BroadcastDataUpdate=false mirrors SignalREntryEventSink.OnUpdatedAsync; the update path
+            // emits no dataUpdate regardless (IWriteSideEffects honours the flag only on create).
+            await _sideEffects.OnUpdatedAsync(CollectionName, entry, BuildWriteOptions(broadcastDataUpdate: false), ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to process update side effects for sensor glucose reading {Id}", item.Id);
         }
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/SensorGlucoseControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/SensorGlucoseControllerTests.cs
@@ -134,4 +134,55 @@ public class SensorGlucoseControllerTests
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
+
+    [Fact]
+    public async Task Update_BroadcastsRealtimeEvent_ForUpdatedReading()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var input = new UpsertSensorGlucoseRequest { Timestamp = DateTimeOffset.UtcNow, Mgdl = 95 };
+        var existing = new SensorGlucose { Id = id, Timestamp = input.Timestamp.UtcDateTime, Mgdl = 120 };
+        var updated = new SensorGlucose { Id = id, Timestamp = input.Timestamp.UtcDateTime, Mgdl = 95 };
+
+        _repoMock
+            .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        _repoMock
+            .Setup(r => r.UpdateAsync(id, It.IsAny<SensorGlucose>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(updated);
+
+        var controller = CreateController();
+
+        // Act
+        await controller.Update(id, input);
+
+        // Assert — an edited V4 reading must emit a real-time update so live dashboards reflect the change.
+        _eventsMock.Verify(
+            e => e.OnUpdatedAsync(updated, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Restore_BroadcastsRealtimeEvent_ForRestoredReading()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var restored = new SensorGlucose { Id = id, Timestamp = DateTime.UtcNow, Mgdl = 110 };
+
+        _repoMock
+            .Setup(r => r.RestoreAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(restored);
+
+        var controller = CreateController();
+
+        // Act
+        await controller.Restore(id);
+
+        // Assert — a restored reading reappears, so it must surface as a real-time create.
+        _eventsMock.Verify(
+            e => e.OnCreatedAsync(
+                It.Is<IReadOnlyList<SensorGlucose>>(l => l.Count == 1 && l[0] == restored),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/GlucosePublisherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/GlucosePublisherTests.cs
@@ -80,21 +80,28 @@ public class GlucosePublisherTests
         _mockPatientDeviceRepository
             .Setup(r => r.GetCurrentAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(Enumerable.Empty<PatientDevice>());
-        _mockSensorGlucoseRepository
-            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
 
         var records = new List<SensorGlucose>
         {
-            new() { Mgdl = 120, Timestamp = DateTime.UtcNow, DataSource = DataSources.DexcomConnector },
+            new() { Mgdl = 120, Timestamp = DateTime.UtcNow.AddMinutes(-5), DataSource = DataSources.DexcomConnector },
+            new() { Mgdl = 130, Timestamp = DateTime.UtcNow, DataSource = DataSources.DexcomConnector },
         };
+
+        // BulkCreateAsync dedupes by LegacyId and returns only the rows actually inserted — here a
+        // subset (the second reading); the first overlaps an already-stored reading from a prior poll.
+        var inserted = new List<SensorGlucose> { records[1] };
+        _mockSensorGlucoseRepository
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(inserted);
 
         var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector);
 
         result.Should().BeTrue();
+        // The broadcast must be the deduped insert result, not the raw input list, so already-stored
+        // readings from overlapping connector poll windows are not re-broadcast.
         _mockSensorGlucoseEvents.Verify(
             e => e.OnCreatedAsync(
-                It.Is<IReadOnlyList<SensorGlucose>>(l => l.Count == 1),
+                It.Is<IReadOnlyList<SensorGlucose>>(l => l.Count == 1 && l[0].Mgdl == 130),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }

--- a/tests/Unit/Nocturne.API.Tests/Services/Glucose/SignalRSensorGlucoseEventSinkTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Glucose/SignalRSensorGlucoseEventSinkTests.cs
@@ -65,6 +65,46 @@ public class SignalRSensorGlucoseEventSinkTests
     }
 
     [Fact]
+    public async Task OnUpdatedAsync_BroadcastsMappedEntry_OnTheEntriesCollection()
+    {
+        // Arrange
+        Entry? broadcast = null;
+        string? collection = null;
+        WriteEffectOptions? options = null;
+        _sideEffects
+            .Setup(s => s.OnUpdatedAsync(
+                It.IsAny<string>(),
+                It.IsAny<Entry>(),
+                It.IsAny<WriteEffectOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, Entry, WriteEffectOptions?, CancellationToken>(
+                (col, rec, opts, _) => { collection = col; broadcast = rec; options = opts; })
+            .Returns(Task.CompletedTask);
+
+        var reading = new SensorGlucose
+        {
+            Id = Guid.NewGuid(),
+            Timestamp = DateTime.UtcNow,
+            Mgdl = 95,
+        };
+
+        var sink = CreateSink();
+
+        // Act
+        await sink.OnUpdatedAsync(reading);
+
+        // Assert — an edited V4 glucose reading must surface as an "entries" update in Entry shape.
+        collection.Should().Be("entries");
+        broadcast.Should().NotBeNull();
+        broadcast!.Type.Should().Be("sgv");
+        broadcast.Sgv.Should().Be(95);
+        broadcast.Id.Should().Be(reading.Id.ToString());
+        // Parity with SignalREntryEventSink: updates pass BroadcastDataUpdate=false (the update path emits no dataUpdate anyway).
+        options.Should().NotBeNull();
+        options!.BroadcastDataUpdate.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task OnCreatedAsync_DoesNothing_ForEmptyBatch()
     {
         var sink = CreateSink();


### PR DESCRIPTION
## Summary

Closes two real-time broadcast gaps in the V4 SensorGlucose path. V4 glucose writes bypass the legacy Entry sink, so a dedicated `SignalRSensorGlucoseEventSink` re-broadcasts them on the `entries` collection that the web client and the SignalR→Socket.IO bridge subscribe to.

### 2a — Broadcast the deduped insert result, not the raw input
`GlucosePublisher.PublishSensorGlucoseAsync` broadcast its raw input list. `ISensorGlucoseRepository.BulkCreateAsync` dedupes by `LegacyId` (batch + DB level) and returns only the rows actually inserted. Connectors poll overlapping windows, so already-stored readings were re-broadcast — wasted traffic (the client dedupes by `(mills, sgv)`, so it was never wrong data, just noise). Now broadcasts the `BulkCreateAsync` return value, matching `SensorGlucoseController.CreateSensorGlucoseBulk`.

### 2b — Emit a real-time event on glucose Update / Restore
`SignalRSensorGlucoseEventSink` only implemented `OnCreatedAsync`, so V4 glucose edits and restores produced no real-time event.
- Added `OnUpdatedAsync`, broadcasting on the `entries` collection (mirrors `SignalREntryEventSink.OnUpdatedAsync`).
- `SensorGlucoseController.Update` now calls it; a new `OnAfterRestoreAsync` override broadcasts a restored reading as a **create** (a restored record reappears, and the web `handleCreate` re-adds it, deduping by id / `(mills, sgv)`).

**Delete** is intentionally out of scope: it isn't wired to the glucose sink, and the web client only applies create/update on these collections.

## Tests
- Updated `GlucosePublisherTests.PublishSensorGlucoseAsync_BroadcastsRealtimeEvent_ForPublishedReadings` — `BulkCreateAsync` returns a subset; asserts the broadcast is that subset.
- New `SignalRSensorGlucoseEventSinkTests.OnUpdatedAsync_BroadcastsMappedEntry_OnTheEntriesCollection`.
- New `SensorGlucoseControllerTests` cases for the `Update` and `Restore` broadcasts.

Build clean (0 errors); all targeted tests pass.