### PR TITLE
fix(bridge): bypass the API response cache when authorizing handshakes

### DIFF
--- a/src/Web/packages/bridge/src/lib/tenant-authorizer.test.ts
+++ b/src/Web/packages/bridge/src/lib/tenant-authorizer.test.ts
@@ -44,6 +44,9 @@ describe('TenantAuthorizer.isAuthorized', () => {
     expect(url).toBe('http://api:8080/api/v1/entries?count=1');
     expect(init.headers?.['X-Forwarded-Host']).toBe('rhys.nocturne.run');
     expect(init.headers?.['Cookie']).toBe('session=abc');
+    // Must bypass the API response cache, or a cached authed 200 could authorize an
+    // unauthenticated handshake (the cache keys on the constant internal Host).
+    expect(init.headers?.['Cache-Control']).toBe('no-cache, no-store');
   });
 
   it('omits the Cookie header when the handshake carries no cookie (public path)', async () => {

--- a/src/Web/packages/bridge/src/lib/tenant-authorizer.ts
+++ b/src/Web/packages/bridge/src/lib/tenant-authorizer.ts
@@ -52,7 +52,17 @@ export class TenantAuthorizer {
    * allowed to read the data of the tenant that Host resolves to.
    */
   async isAuthorized(host: string, cookieHeader: string | undefined): Promise<boolean> {
-    const headers: Record<string, string> = { 'X-Forwarded-Host': host };
+    const headers: Record<string, string> = {
+      'X-Forwarded-Host': host,
+      // Bypass the API's server-side response cache. UseResponseCaching runs before
+      // authentication and keys on the raw Host, which is the same constant internal
+      // host for every tenant's probe — so without this, an authorized probe's cached
+      // 200 would be replayed to authorize a later unauthenticated handshake. 'no-cache'
+      // forces the cache to revalidate so the request reaches the auth pipeline;
+      // 'no-store' keeps this probe out of the cache. ('no-store' alone does NOT bypass
+      // the lookup.)
+      'Cache-Control': 'no-cache, no-store',
+    };
     if (cookieHeader) headers['Cookie'] = cookieHeader;
 
     const controller = new AbortController();


### PR DESCRIPTION
## Problem
Follow-up to #318. The Socket.IO handshake authorizer probes `GET /api/v1/entries?count=1`, which carries `[ResponseCache(Duration=60, public)]`. `UseResponseCaching` runs **before** authentication and keys on the raw `Host`. The bridge calls the API at one **constant internal host** for every tenant (the tenant rides in `X-Forwarded-Host`, which the cache ignores), so all tenants' probes collapse onto a single cache key.

Effect: a logged-in user's probe seeds a cached `200`; within the 60s TTL an **unauthenticated** socket to the same (or another) tenant gets that cached `200` and is **admitted to a private tenant's live stream** — bypassing the auth added in #318, across tenants.

This was confirmed empirically (a standalone ASP.NET repro reproduced the auth-bypass; `Age` header present on the anonymous response).

## Fix
Send `Cache-Control: no-cache, no-store` on the probe request so it always reaches the auth pipeline and never reads or writes the shared response cache. Verified in the repro: `no-cache` bypasses the cache lookup (anonymous → 401); `no-store` alone does **not** (still served from cache), so both are sent.

Tests updated to assert the probe carries the cache-bypass header. Existing bridge tests still pass (23/23).

## Note (out of scope)
The underlying API-level issue remains: `[ResponseCache(public)]` on tenant-scoped reads (v1 entries, **v4 glucose/sensor**, treatments, stats, …) combined with `UseResponseCaching` running before `UseForwardedHeaders` and YARP not preserving the per-tenant `Host` means the response cache provides no tenant isolation for any internal consumer using the constant backend host. That deserves a separate API fix (don't mark tenant-scoped reads `public`, key the cache by tenant, or move caching after auth).