### PR TITLE
fix(api): isolate the response cache per tenant and per credential

### DIFF
--- a/src/API/Nocturne.API/Filters/TenantCacheVaryFilter.cs
+++ b/src/API/Nocturne.API/Filters/TenantCacheVaryFilter.cs
@@ -1,0 +1,50 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Net.Http.Headers;
+using Nocturne.Core.Contracts.Multitenancy;
+
+namespace Nocturne.API.Filters;
+
+/// <summary>
+/// Makes shared-cacheable (<c>public</c>) responses on tenant-scoped endpoints vary by the
+/// <c>Cookie</c> header.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Multitenancy.TenantResolutionMiddleware"/> resolves the tenant from
+/// <c>X-Forwarded-Host</c>, and <c>UseResponseCaching</c> runs after <c>UseForwardedHeaders</c>
+/// so its cache key already includes the per-tenant host. This filter adds <c>Vary: Cookie</c>
+/// so anonymous, public-access, and authenticated requests resolve to distinct cache entries —
+/// without it the shared cache would serve one caller's cached response to another with
+/// different credentials (an authenticated read could be returned to an anonymous caller, and
+/// vice versa).
+/// </para>
+/// <para>
+/// Only applied when a tenant is resolved and the response is already marked <c>public</c>;
+/// it never makes anything more cacheable than the endpoint already declared.
+/// </para>
+/// </remarks>
+public class TenantCacheVaryFilter : IAsyncResultFilter
+{
+    public Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next)
+    {
+        var httpContext = context.HttpContext;
+
+        if (httpContext.Items["TenantContext"] is TenantContext)
+        {
+            var cacheControl = httpContext.Response.Headers.CacheControl.ToString();
+            if (cacheControl.Contains("public", StringComparison.OrdinalIgnoreCase))
+            {
+                var vary = httpContext.Response.Headers.Vary;
+                var alreadyVariesByCookie = vary.Any(v =>
+                    v is not null && v.Contains("Cookie", StringComparison.OrdinalIgnoreCase));
+                if (!alreadyVariesByCookie)
+                {
+                    httpContext.Response.Headers.Append(HeaderNames.Vary, "Cookie");
+                }
+            }
+        }
+
+        return next();
+    }
+}

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -157,6 +157,7 @@ builder.Services.AddScoped<ReadAccessAuditFilter>();
 builder.Services.AddControllers(options =>
 {
     options.Filters.Add<NightscoutJsonFilter>();
+    options.Filters.Add<TenantCacheVaryFilter>();
     options.Filters.AddService<ReadAccessAuditFilter>();
 })
 .ConfigureApplicationPartManager(manager =>
@@ -318,10 +319,15 @@ var app = builder.Build();
 // Configure middleware pipeline
 app.UseExceptionHandler();
 app.UseStatusCodePages();
-app.UseResponseCaching();
 app.UseCors();
 app.UseStaticFiles();
 app.UseForwardedHeaders();
+
+// Response caching must run after UseForwardedHeaders so its cache key uses the per-tenant
+// Host (rewritten from X-Forwarded-Host) rather than the constant gateway destination host
+// (the gateway suppresses the original Host). Paired with TenantCacheVaryFilter (Vary: Cookie),
+// this keeps tenant-scoped responses isolated per tenant and per credential in the shared cache.
+app.UseResponseCaching();
 
 // Strip .json suffixes before routing so /api/v1/treatments.json matches
 // the TreatmentsController route /api/v1/treatments. Must run before

--- a/tests/Unit/Nocturne.API.Tests/Filters/TenantCacheVaryFilterTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Filters/TenantCacheVaryFilterTests.cs
@@ -1,0 +1,81 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Nocturne.API.Filters;
+using Nocturne.Core.Contracts.Multitenancy;
+
+namespace Nocturne.API.Tests.Filters;
+
+public class TenantCacheVaryFilterTests
+{
+    private static readonly TenantContext TestTenant = new(Guid.CreateVersion7(), "test", "Test Tenant", true);
+
+    private static async Task<HttpContext> RunAsync(
+        TenantContext? tenant,
+        string? cacheControl,
+        string? existingVary = null)
+    {
+        var httpContext = new DefaultHttpContext();
+        if (tenant != null)
+            httpContext.Items["TenantContext"] = tenant;
+        if (cacheControl != null)
+            httpContext.Response.Headers.CacheControl = cacheControl;
+        if (existingVary != null)
+            httpContext.Response.Headers.Vary = existingVary;
+
+        var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+        var executingContext = new ResultExecutingContext(
+            actionContext, new List<IFilterMetadata>(), new OkResult(), controller: null!);
+        ResultExecutionDelegate next = () => Task.FromResult(
+            new ResultExecutedContext(actionContext, new List<IFilterMetadata>(), new OkResult(), controller: null!));
+
+        await new TenantCacheVaryFilter().OnResultExecutionAsync(executingContext, next);
+        return httpContext;
+    }
+
+    [Fact]
+    public async Task AddsVaryCookie_ForPublicTenantScopedResponse()
+    {
+        var http = await RunAsync(TestTenant, "public,max-age=60");
+        http.Response.Headers.Vary.ToString().Should().Contain("Cookie");
+    }
+
+    [Fact]
+    public async Task DoesNotAddVary_WhenNoTenantResolved()
+    {
+        var http = await RunAsync(tenant: null, "public,max-age=60");
+        http.Response.Headers.Vary.ToString().Should().NotContain("Cookie");
+    }
+
+    [Fact]
+    public async Task DoesNotAddVary_WhenResponseNotPublic()
+    {
+        var http = await RunAsync(TestTenant, "private,max-age=60");
+        http.Response.Headers.Vary.ToString().Should().NotContain("Cookie");
+    }
+
+    [Fact]
+    public async Task DoesNotAddVary_WhenNoCacheControl()
+    {
+        var http = await RunAsync(TestTenant, cacheControl: null);
+        http.Response.Headers.Vary.ToString().Should().NotContain("Cookie");
+    }
+
+    [Fact]
+    public async Task DoesNotDuplicateCookie_WhenAlreadyPresent()
+    {
+        var http = await RunAsync(TestTenant, "public,max-age=60", existingVary: "Cookie");
+        http.Response.Headers.Vary.Count(v => v != null && v.Contains("Cookie")).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task PreservesExistingVary_WhenAddingCookie()
+    {
+        var http = await RunAsync(TestTenant, "public,max-age=60", existingVary: "If-Modified-Since");
+        var vary = http.Response.Headers.Vary.ToString();
+        vary.Should().Contain("If-Modified-Since");
+        vary.Should().Contain("Cookie");
+    }
+}


### PR DESCRIPTION
## Problem
`[ResponseCache(Duration=N, public, VaryByQueryKeys=["*"])]` is applied to many tenant-scoped reads — v1 `entries`, **v4 `glucose/sensor`**, treatments, statistics, chart-data, profiles, etc. Combined with the server-side `ResponseCachingMiddleware`, this leaked tenant data, two ways:

- **Cross-tenant:** `UseResponseCaching` ran *before* `UseForwardedHeaders`, so the cache keyed on the raw `Host`. The YARP gateway suppresses the original Host and forwards the constant destination (`http://nocturne-api`) — the tenant rides only in `X-Forwarded-Host`, which the cache ignored. So all tenants collapsed onto one cache key.
- **Auth bypass:** the cache key ignored the cookie, and the middleware runs before authentication, so a cached authenticated `200` could be served to a later anonymous request to the same URL.

Both were confirmed empirically with standalone repros: the response cache served an authed read to an anonymous caller (`Age` header present), and YARP was verified to replace the original Host with the destination host.

## Fix
- **Move `UseResponseCaching` after `UseForwardedHeaders`** so the cache key uses the per-tenant Host (rewritten from `X-Forwarded-Host`) instead of the constant gateway destination.
- **Add `TenantCacheVaryFilter`** — sets `Vary: Cookie` on `public` tenant-scoped responses, so anonymous, public-access, and authenticated requests resolve to **distinct** cache entries. A cached response is never served across credentials.

Net effect (validated with a standalone `ResponseCaching` repro):
- tenant A's entry is never served to tenant B (per-tenant key),
- an authenticated request is never served the anonymous cache, and vice-versa (Vary: Cookie),
- **public-dashboard caching is preserved** — anonymous requests still share one entry per tenant; authenticated requests cache per credential.

## Tests
Unit tests cover the filter (adds `Vary: Cookie` only for public tenant-scoped responses; no-ops otherwise; no duplicates; preserves existing `Vary`). The pipeline-ordering half is validated by the standalone repro.

> Note: I could not run the full integration suite — the Aspire AppHost currently fails to start on `main` (`InvalidOperationException: Step 'mermaid-publish' depends on unknown step 'publish-compose'`), which blocks all integration tests and `aspire start`. That's a separate, pre-existing issue.

Related: bridge probe hardening in #320 (the bridge was one entry point into this same cache).