### PR TITLE
fix(aspire): only register publish-only pipeline steps in publish mode

### DIFF
--- a/src/Aspire/Nocturne.Aspire.Host/Program.cs
+++ b/src/Aspire/Nocturne.Aspire.Host/Program.cs
@@ -638,8 +638,15 @@ class Program
                 .PublishAsDockerComposeService((_, _) => { });
         }
 
-        builder.AddMermaidDiagramPublisher();
-        builder.AddPortainerComposePublisher();
+        // These steps depend on the "publish-compose" pipeline step, which only
+        // exists in publish mode: AddDockerComposeEnvironment does not add the
+        // environment resource (the step's provider) to the model in run mode, so
+        // registering them in run mode fails pipeline validation during startup.
+        if (builder.ExecutionContext.IsPublishMode)
+        {
+            builder.AddMermaidDiagramPublisher();
+            builder.AddPortainerComposePublisher();
+        }
 
         var app = builder.Build();
         await app.RunAsync();


### PR DESCRIPTION
The Mermaid and Portainer compose publishers register pipeline steps that depend on `publish-compose`, which only exists in **publish** mode (`AddDockerComposeEnvironment` doesn't add the environment resource in run mode). Registering them in run mode failed pipeline validation at startup:

```
InvalidOperationException: Step 'mermaid-publish' depends on unknown step 'publish-compose'
```

This broke `aspire start` and all integration tests. Fix: guard `AddMermaidDiagramPublisher()` / `AddPortainerComposePublisher()` behind `builder.ExecutionContext.IsPublishMode`.