### PR TITLE
fix(auth): make refresh-token rotation atomic to stop spurious sign-outs

### DIFF
--- a/src/API/Nocturne.API/Services/Auth/RefreshTokenService.cs
+++ b/src/API/Nocturne.API/Services/Auth/RefreshTokenService.cs
@@ -112,6 +112,15 @@ public class RefreshTokenService : IRefreshTokenService
         return record.SubjectId;
     }
 
+    /// <summary>
+    /// Window during which reuse of a just-rotated refresh token is treated as a benign
+    /// concurrent-request race rather than token theft. An SSR web app fans out several
+    /// parallel requests per navigation (page load, preload, proxied API and remote-function
+    /// calls) that all carry the same refresh-token cookie, so a client can legitimately
+    /// present a token that another in-flight request rotated moments earlier.
+    /// </summary>
+    private static readonly TimeSpan RotationGracePeriod = TimeSpan.FromSeconds(60);
+
     /// <inheritdoc />
     public async Task<string?> RotateRefreshTokenAsync(
         string oldRefreshToken,
@@ -122,36 +131,23 @@ public class RefreshTokenService : IRefreshTokenService
 
         var oldRecord = await _repository.FindByHashAsync(tokenHash);
 
-        if (oldRecord == null || oldRecord.RevokedAt != null || oldRecord.ExpiresAt < DateTime.UtcNow)
+        if (oldRecord == null || oldRecord.ExpiresAt < DateTime.UtcNow)
         {
-            if (oldRecord != null && oldRecord.RevokedAt != null && oldRecord.ReplacedByTokenId.HasValue)
-            {
-                // Check if this is a race condition (concurrent requests using the
-                // same token shortly after rotation) vs actual token theft.
-                // A 30-second grace period prevents nuking all tokens when parallel
-                // requests (SSR + preload, two tabs, page load + API call) both
-                // attempt to refresh with the same token.
-                var timeSinceRevocation = DateTime.UtcNow - oldRecord.RevokedAt.Value;
-                if (timeSinceRevocation < TimeSpan.FromSeconds(30))
-                {
-                    _logger.LogDebug(
-                        "Refresh token reuse within grace period ({Elapsed:F1}s) for subject {SubjectId}. " +
-                        "Likely a concurrent request — skipping family revocation.",
-                        timeSinceRevocation.TotalSeconds, oldRecord.SubjectId);
-                    throw new TokenRotationRaceException();
-                }
-
-                // Outside grace period — this looks like actual token theft
-                _logger.LogWarning(
-                    "Refresh token reuse detected for subject {SubjectId}. Revoking all tokens in the family.",
-                    oldRecord.SubjectId);
-
-                await _repository.RevokeAllForSubjectAsync(oldRecord.SubjectId, "Token reuse detected");
-            }
+            // Unknown or expired token — nothing to rotate.
             return null;
         }
 
-        // Create new refresh token
+        if (oldRecord.RevokedAt != null)
+        {
+            // Already revoked: decide whether this is a benign concurrent/stale-client
+            // reuse or genuine token theft.
+            return await HandleReuseOfRevokedTokenAsync(oldRecord);
+        }
+
+        // Token is currently active. Mint the replacement up front, then atomically claim the
+        // rotation: of N concurrent requests carrying this token, only one can flip the row
+        // from active to revoked. This stops the family forking into many siblings (which
+        // later surface as "reuse" and trigger a whole-session revocation).
         var newRefreshToken = _jwtService.GenerateRefreshToken();
         var newTokenHash = _jwtService.HashRefreshToken(newRefreshToken);
 
@@ -170,8 +166,17 @@ public class RefreshTokenService : IRefreshTokenService
             ReplacedByTokenId: null,
             LastUsedAt: null);
 
-        // Revoke old token and link to new one
-        await _repository.RevokeAsync(oldRecord.Id, "Rotated", newRecord.Id);
+        var claimed = await _repository.TryMarkRotatedAsync(oldRecord.Id, newRecord.Id);
+        if (!claimed)
+        {
+            // A concurrent request rotated this token between our read and our claim. Treat
+            // it as a benign race: don't create a second successor (no fork) and don't revoke
+            // the family — the request that won carries the new cookie back to the client.
+            _logger.LogDebug(
+                "Lost refresh-token rotation race for subject {SubjectId} — a concurrent request rotated first.",
+                oldRecord.SubjectId);
+            throw new TokenRotationRaceException();
+        }
 
         await _repository.CreateAsync(newRecord);
 
@@ -180,6 +185,41 @@ public class RefreshTokenService : IRefreshTokenService
             oldRecord.SubjectId, oldRecord.Id, newRecord.Id);
 
         return newRefreshToken;
+    }
+
+    /// <summary>
+    /// Handles presentation of an already-revoked refresh token. Reuse of a rotated token
+    /// within <see cref="RotationGracePeriod"/> is a concurrent-request race (the client had
+    /// not yet received the rotated cookie); beyond it, reuse signals the token leaked and the
+    /// whole family is revoked. Tokens revoked for any other reason are simply rejected.
+    /// </summary>
+    private async Task<string?> HandleReuseOfRevokedTokenAsync(RefreshTokenRecord oldRecord)
+    {
+        // Only a rotated token (one that links to a successor) participates in reuse handling;
+        // a token revoked by logout, manual revocation, or a prior family revocation is rejected.
+        if (!oldRecord.ReplacedByTokenId.HasValue)
+        {
+            return null;
+        }
+
+        var timeSinceRevocation = DateTime.UtcNow - oldRecord.RevokedAt!.Value;
+        if (timeSinceRevocation < RotationGracePeriod)
+        {
+            _logger.LogDebug(
+                "Refresh token reuse within grace period ({Elapsed:F1}s) for subject {SubjectId} — " +
+                "concurrent request, skipping family revocation.",
+                timeSinceRevocation.TotalSeconds, oldRecord.SubjectId);
+            throw new TokenRotationRaceException();
+        }
+
+        // Outside the grace period — this looks like actual token theft.
+        _logger.LogWarning(
+            "Refresh token reuse detected for subject {SubjectId} ({Elapsed:F0}s after rotation). " +
+            "Revoking all tokens in the family.",
+            oldRecord.SubjectId, timeSinceRevocation.TotalSeconds);
+
+        await _repository.RevokeAllForSubjectAsync(oldRecord.SubjectId, "Token reuse detected");
+        return null;
     }
 
     /// <inheritdoc />

--- a/src/Core/Nocturne.Core.Contracts/Auth/IFirstPartyTokenRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/Auth/IFirstPartyTokenRepository.cs
@@ -9,6 +9,17 @@ public interface IFirstPartyTokenRepository
     Task CreateAsync(RefreshTokenRecord record, CancellationToken ct = default);
     Task<RefreshTokenRecord?> FindByHashAsync(string tokenHash, CancellationToken ct = default);
     Task RevokeAsync(Guid tokenId, string reason, Guid? replacedByTokenId = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Atomically marks an active token as rotated — revokes it and links it to its
+    /// replacement — but only if it is still active (not yet revoked). Returns true if this
+    /// caller performed the rotation, false if a concurrent request already rotated it.
+    /// The single conditional UPDATE lets exactly one of several parallel refresh requests
+    /// win, which prevents the token family from forking under the concurrent requests an
+    /// SSR app issues per navigation (page load, preload, proxied API and remote-function
+    /// calls all carry the same refresh-token cookie).
+    /// </summary>
+    Task<bool> TryMarkRotatedAsync(Guid tokenId, Guid replacedByTokenId, CancellationToken ct = default);
     Task<int> RevokeAllForSubjectAsync(Guid subjectId, string reason, CancellationToken ct = default);
     Task<int> RevokeByOidcSessionAsync(string oidcSessionId, string reason, CancellationToken ct = default);
     Task UpdateLastUsedAsync(string tokenHash, CancellationToken ct = default);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/EfFirstPartyTokenRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/EfFirstPartyTokenRepository.cs
@@ -79,6 +79,30 @@ public class EfFirstPartyTokenRepository : IFirstPartyTokenRepository
     }
 
     /// <inheritdoc />
+    public async Task<bool> TryMarkRotatedAsync(
+        Guid tokenId,
+        Guid replacedByTokenId,
+        CancellationToken ct = default)
+    {
+        var now = DateTime.UtcNow;
+
+        // Single atomic UPDATE ... WHERE id = @id AND revoked_at IS NULL. The database admits
+        // exactly one concurrent caller while the row is still active, so parallel refresh
+        // requests cannot each mint a successor and fork the token chain.
+        var affected = await _context.RefreshTokens
+            .Where(t => t.Id == tokenId && t.RevokedAt == null)
+            .ExecuteUpdateAsync(
+                s => s
+                    .SetProperty(t => t.RevokedAt, now)
+                    .SetProperty(t => t.RevokedReason, "Rotated")
+                    .SetProperty(t => t.ReplacedByTokenId, (Guid?)replacedByTokenId)
+                    .SetProperty(t => t.UpdatedAt, now),
+                ct);
+
+        return affected == 1;
+    }
+
+    /// <inheritdoc />
     public async Task<int> RevokeAllForSubjectAsync(
         Guid subjectId,
         string reason,

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/RefreshTokenServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/RefreshTokenServiceTests.cs
@@ -131,7 +131,7 @@ public class RefreshTokenServiceTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task RotateRefreshTokenAsync_ValidToken_RevokesOldCreatesNew()
+    public async Task RotateRefreshTokenAsync_ValidToken_AtomicallyClaimsRotationAndCreatesNew()
     {
         // Arrange
         var oldTokenId = Guid.CreateVersion7();
@@ -145,6 +145,10 @@ public class RefreshTokenServiceTests
                 revokedAt: null,
                 expiresAt: DateTime.UtcNow.AddHours(1)));
 
+        // This caller wins the atomic rotation claim.
+        _repository.Setup(r => r.TryMarkRotatedAsync(oldTokenId, It.IsAny<Guid>(), default))
+            .ReturnsAsync(true);
+
         var service = CreateService();
 
         // Act
@@ -153,17 +157,55 @@ public class RefreshTokenServiceTests
         // Assert
         result.Should().Be("new-token");
 
-        _repository.Verify(r => r.RevokeAsync(
+        // Rotation is claimed atomically (not via the unconditional RevokeAsync).
+        _repository.Verify(r => r.TryMarkRotatedAsync(
             oldTokenId,
-            "Rotated",
-            It.IsAny<Guid?>(),
+            It.IsAny<Guid>(),
             default));
+        _repository.Verify(
+            r => r.RevokeAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid?>(), default),
+            Times.Never);
 
         _repository.Verify(r => r.CreateAsync(
             It.Is<RefreshTokenRecord>(rec =>
                 rec.TokenHash == "hash-new" &&
                 rec.SubjectId == _subjectId),
             default));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task RotateRefreshTokenAsync_LostAtomicClaim_ThrowsRaceWithoutForkingOrNuking()
+    {
+        // Arrange — token reads as active, but a concurrent request wins the atomic claim,
+        // so TryMarkRotatedAsync reports we lost the race. This is the SSR fan-out case
+        // (many parallel requests carrying the same cookie) that previously forked the
+        // token family into many siblings.
+        var oldTokenId = Guid.CreateVersion7();
+        _jwtService.Setup(j => j.HashRefreshToken("old-token")).Returns("hash-old");
+        _jwtService.Setup(j => j.GenerateRefreshToken()).Returns("new-token");
+        _jwtService.Setup(j => j.HashRefreshToken("new-token")).Returns("hash-new");
+
+        _repository.Setup(r => r.FindByHashAsync("hash-old", default))
+            .ReturnsAsync(MakeRecord(
+                id: oldTokenId,
+                revokedAt: null,
+                expiresAt: DateTime.UtcNow.AddHours(1)));
+
+        _repository.Setup(r => r.TryMarkRotatedAsync(oldTokenId, It.IsAny<Guid>(), default))
+            .ReturnsAsync(false);
+
+        var service = CreateService();
+
+        // Act & Assert — benign race: throws rather than authenticating with a forked token.
+        await service.Invoking(s => s.RotateRefreshTokenAsync("old-token"))
+            .Should().ThrowAsync<TokenRotationRaceException>();
+
+        // No second successor is created (no fork) and no session-wide revocation happens.
+        _repository.Verify(r => r.CreateAsync(It.IsAny<RefreshTokenRecord>(), default), Times.Never);
+        _repository.Verify(
+            r => r.RevokeAllForSubjectAsync(It.IsAny<Guid>(), It.IsAny<string>(), default),
+            Times.Never);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

Users report being signed out of the web app constantly — login "won't stick." Production data shows why: in the first-party `refresh_tokens` table, **415 of 679 tokens were revoked with reason `Token reuse detected`** (vs 244 normal `Rotated`), recurring almost daily over a month, with single revocation events nuking **6–18 tokens that were all minted within the same millisecond**.

`Token reuse detected` triggers `RevokeAllForSubjectAsync`, which revokes **every** token the subject holds → the user is signed out on all devices.

## Root cause: non-atomic rotation forks the token family under concurrency

Access tokens are short-lived (15 min) and rotation is on. The SvelteKit SSR app fans out many parallel server requests per navigation (session validation + permissions + proxied `/api/*` + remote-function calls), **all carrying the same refresh-token cookie**. When the access token has expired, each of those requests independently calls `RotateRefreshTokenAsync`.

`RotateRefreshTokenAsync` was a read-then-write:

1. `FindByHashAsync` → read old token (sees `RevokedAt == null`)
2. `RevokeAsync(old, "Rotated", newId)` + `CreateAsync(new)`

With no atomicity between (1) and (2), N concurrent requests all pass the "is it revoked?" check and each mint a successor — **one token forks into N siblings in the same instant**. The browser keeps only one cookie; the orphaned siblings (and the parent) linger and, once one is presented more than the grace period after revocation, trip reuse detection → `RevokeAllForSubjectAsync` → full sign-out. Then it repeats on the next cycle.

The existing 30s grace window only masked the *fast* race; it did nothing about the fork, and converted a benign concurrent refresh into a catastrophic all-device logout.

## Fix

Make rotation atomic so the family cannot fork:

- **`IFirstPartyTokenRepository.TryMarkRotatedAsync`** — revoke + link-to-successor as a single conditional `UPDATE … WHERE id = @id AND revoked_at IS NULL` (`ExecuteUpdateAsync`). The database admits exactly one concurrent caller while the row is active.
- **`RotateRefreshTokenAsync`** now claims the rotation atomically. The winner mints the single successor; losers throw `TokenRotationRaceException` (already handled as a benign skip by `SessionCookieHandler`) — **no second successor, no family revocation**.
- Reuse-vs-theft handling factored into `HandleReuseOfRevokedTokenAsync`; grace window widened 30s → 60s for slow mobile/retry clients. Genuine post-grace reuse still revokes the family (theft detection preserved).

## Tests

- Updated the happy-path rotation test to assert the atomic claim (no unconditional `RevokeAsync`).
- Added `RotateRefreshTokenAsync_LostAtomicClaim_ThrowsRaceWithoutForkingOrNuking` — the direct regression test: a lost claim must not create a sibling and must not revoke the family.
- Post-grace reuse-detection tests pass unchanged.
- **433/433 auth unit tests green.**

## Notes / possible follow-ups

- `oidc_session_id` is NULL on every row in production, so the theft response can't currently be scoped to a single session/device — a follow-up could populate it and revoke per-session instead of per-subject to further reduce blast radius.
