### PR TITLE
fix(auth): scope refresh-token reuse revocation to a single session

### DIFF
--- a/src/API/Nocturne.API/Services/Auth/RefreshTokenService.cs
+++ b/src/API/Nocturne.API/Services/Auth/RefreshTokenService.cs
@@ -191,7 +191,7 @@ public class RefreshTokenService : IRefreshTokenService
     /// Handles presentation of an already-revoked refresh token. Reuse of a rotated token
     /// within <see cref="RotationGracePeriod"/> is a concurrent-request race (the client had
     /// not yet received the rotated cookie); beyond it, reuse signals the token leaked and the
-    /// whole family is revoked. Tokens revoked for any other reason are simply rejected.
+    /// token family is revoked. Tokens revoked for any other reason are simply rejected.
     /// </summary>
     private async Task<string?> HandleReuseOfRevokedTokenAsync(RefreshTokenRecord oldRecord)
     {
@@ -212,13 +212,29 @@ public class RefreshTokenService : IRefreshTokenService
             throw new TokenRotationRaceException();
         }
 
-        // Outside the grace period — this looks like actual token theft.
-        _logger.LogWarning(
-            "Refresh token reuse detected for subject {SubjectId} ({Elapsed:F0}s after rotation). " +
-            "Revoking all tokens in the family.",
-            oldRecord.SubjectId, timeSinceRevocation.TotalSeconds);
+        // Outside the grace period — this looks like actual token theft. Revoke the affected
+        // session's chain rather than every session the subject has, so one compromised (or
+        // misbehaving) device doesn't sign the user out everywhere. Tokens issued before
+        // sessions were tagged have no session id; fall back to a subject-wide revocation.
+        if (!string.IsNullOrEmpty(oldRecord.OidcSessionId))
+        {
+            _logger.LogWarning(
+                "Refresh token reuse detected for subject {SubjectId} ({Elapsed:F0}s after rotation). " +
+                "Revoking session {OidcSessionId}.",
+                oldRecord.SubjectId, timeSinceRevocation.TotalSeconds, oldRecord.OidcSessionId);
 
-        await _repository.RevokeAllForSubjectAsync(oldRecord.SubjectId, "Token reuse detected");
+            await _repository.RevokeByOidcSessionAsync(oldRecord.OidcSessionId, "Token reuse detected");
+        }
+        else
+        {
+            _logger.LogWarning(
+                "Refresh token reuse detected for subject {SubjectId} ({Elapsed:F0}s after rotation), " +
+                "no session id on token — revoking all of the subject's tokens.",
+                oldRecord.SubjectId, timeSinceRevocation.TotalSeconds);
+
+            await _repository.RevokeAllForSubjectAsync(oldRecord.SubjectId, "Token reuse detected");
+        }
+
         return null;
     }
 

--- a/src/API/Nocturne.API/Services/Auth/SessionService.cs
+++ b/src/API/Nocturne.API/Services/Auth/SessionService.cs
@@ -40,9 +40,18 @@ public class SessionService : ISessionService
             Email = subject.Email,
         };
 
+        // Tag the session with a stable id so a token chain can be revoked on its own.
+        // Prefer the identity provider's session id (`sid`) when present — it ties us to the
+        // provider's session for front-channel logout — otherwise mint our own. Most providers
+        // (e.g. Google) omit `sid`, and the passkey/TOTP/setup paths have none, so without this
+        // the id would be null and reuse detection could only revoke a subject's entire fleet.
+        var oidcSessionId = string.IsNullOrEmpty(context.OidcSessionId)
+            ? Guid.CreateVersion7().ToString("N")
+            : context.OidcSessionId;
+
         var accessToken = _jwtService.GenerateAccessToken(subjectInfo, permissions, roles);
         var refreshToken = await _refreshTokenService.CreateRefreshTokenAsync(
-            subjectId, context.OidcSessionId, context.DeviceDescription,
+            subjectId, oidcSessionId, context.DeviceDescription,
             context.IpAddress, context.UserAgent);
         var expiresIn = (int)_jwtService.GetAccessTokenLifetime().TotalSeconds;
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/RefreshTokenServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/RefreshTokenServiceTests.cs
@@ -210,9 +210,39 @@ public class RefreshTokenServiceTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task RotateRefreshTokenAsync_ReuseOutsideGracePeriod_RevokesFamily()
+    public async Task RotateRefreshTokenAsync_ReuseOutsideGracePeriod_WithSessionId_RevokesOnlyThatSession()
     {
-        // Arrange — revoked token reused after 5 minutes (well past grace period)
+        // Arrange — revoked token (tagged with a session id) reused well past the grace period.
+        _jwtService.Setup(j => j.HashRefreshToken("stolen")).Returns("hash-stolen");
+
+        _repository.Setup(r => r.FindByHashAsync("hash-stolen", default))
+            .ReturnsAsync(MakeRecord(
+                revokedAt: DateTime.UtcNow.AddMinutes(-5),
+                expiresAt: DateTime.UtcNow.AddHours(1),
+                replacedByTokenId: Guid.CreateVersion7(),
+                oidcSessionId: "session-abc"));
+
+        var service = CreateService();
+
+        // Act
+        await service.RotateRefreshTokenAsync("stolen");
+
+        // Assert — only the affected session's chain is revoked, not every session the subject has.
+        _repository.Verify(r => r.RevokeByOidcSessionAsync(
+            "session-abc",
+            "Token reuse detected",
+            default));
+        _repository.Verify(
+            r => r.RevokeAllForSubjectAsync(It.IsAny<Guid>(), It.IsAny<string>(), default),
+            Times.Never);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task RotateRefreshTokenAsync_ReuseOutsideGracePeriod_NoSessionId_RevokesAllForSubject()
+    {
+        // Arrange — a legacy token issued before sessions were tagged (no session id),
+        // reused well past the grace period, falls back to a subject-wide revocation.
         _jwtService.Setup(j => j.HashRefreshToken("stolen")).Returns("hash-stolen");
 
         _repository.Setup(r => r.FindByHashAsync("hash-stolen", default))
@@ -231,6 +261,9 @@ public class RefreshTokenServiceTests
             _subjectId,
             "Token reuse detected",
             default));
+        _repository.Verify(
+            r => r.RevokeByOidcSessionAsync(It.IsAny<string>(), It.IsAny<string>(), default),
+            Times.Never);
     }
 
     [Fact]
@@ -311,12 +344,13 @@ public class RefreshTokenServiceTests
         Guid? id = null,
         DateTime? revokedAt = null,
         DateTime? expiresAt = null,
-        Guid? replacedByTokenId = null) =>
+        Guid? replacedByTokenId = null,
+        string? oidcSessionId = null) =>
         new(
             Id: id ?? Guid.CreateVersion7(),
             TokenHash: "hash",
             SubjectId: _subjectId,
-            OidcSessionId: null,
+            OidcSessionId: oidcSessionId,
             DeviceDescription: null,
             IpAddress: null,
             UserAgent: null,

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/SessionServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/SessionServiceTests.cs
@@ -128,6 +128,54 @@ public class SessionServiceTests
 
     [Fact]
     [Trait("Category", "Unit")]
+    public async Task IssueSessionAsync_NoProviderSessionId_GeneratesOne()
+    {
+        // Arrange — the identity provider supplied no session id (Google omits `sid`; the
+        // passkey/TOTP/setup paths have none). Without a generated id the token chain could
+        // only be revoked subject-wide.
+        var contextWithoutSession = _context with { OidcSessionId = null };
+        string? capturedSessionId = null;
+        _refreshTokenService.Setup(r => r.CreateRefreshTokenAsync(
+                _subjectId, It.IsAny<string?>(), contextWithoutSession.DeviceDescription,
+                contextWithoutSession.IpAddress, contextWithoutSession.UserAgent))
+            .Callback<Guid, string?, string?, string?, string?>(
+                (_, sid, _, _, _) => capturedSessionId = sid)
+            .ReturnsAsync(TestRefreshToken);
+
+        var service = CreateService();
+
+        // Act
+        await service.IssueSessionAsync(_subjectId, contextWithoutSession);
+
+        // Assert — a stable session id is minted so the chain can be revoked on its own.
+        capturedSessionId.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task IssueSessionAsync_ProviderSessionId_IsPreserved()
+    {
+        // Arrange — when the provider does supply a session id, keep it (ties us to the
+        // provider's session for front-channel logout).
+        string? capturedSessionId = null;
+        _refreshTokenService.Setup(r => r.CreateRefreshTokenAsync(
+                _subjectId, It.IsAny<string?>(), _context.DeviceDescription,
+                _context.IpAddress, _context.UserAgent))
+            .Callback<Guid, string?, string?, string?, string?>(
+                (_, sid, _, _, _) => capturedSessionId = sid)
+            .ReturnsAsync(TestRefreshToken);
+
+        var service = CreateService();
+
+        // Act
+        await service.IssueSessionAsync(_subjectId, _context);
+
+        // Assert
+        capturedSessionId.Should().Be("oidc-session-123");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
     public async Task IssueSessionAsync_ExpiresInSeconds_MatchesJwtLifetime()
     {
         // Arrange


### PR DESCRIPTION
Follow-up to #326. That PR stopped refresh-token rotation from forking under SSR concurrency; this one limits the blast radius when reuse *is* detected.

## Problem

When reuse is detected outside the grace window, `HandleReuseOfRevokedTokenAsync` calls `RevokeAllForSubjectAsync` — revoking **every** token the subject holds, so a single compromised or misbehaving device signs the user out on all of them.

`refresh_tokens.oidc_session_id` exists precisely to scope this, but in production it is **null on every row**: Google (the only configured provider) does not emit a `sid` claim, and the passkey / TOTP / setup login paths never set one. So per-session revocation was impossible.

## Change

- **`SessionService.IssueSessionAsync`** mints a stable session id when the provider supplies none. This is the single choke point every login path flows through (OIDC, passkey, TOTP, setup, dev-admin), so one change covers them all. The provider's `sid` is preferred when present, keeping us tied to the provider session for front-channel logout.
- Rotation already copies `OidcSessionId` onto each successor, so an entire token chain shares one session id.
- **Reuse detection** now revokes only the affected session's chain via `RevokeByOidcSessionAsync`, falling back to `RevokeAllForSubjectAsync` for legacy tokens that predate session tagging (still null).

No migration — the column already exists; this only populates it going forward.

## Tests

- `IssueSessionAsync_NoProviderSessionId_GeneratesOne` / `_ProviderSessionId_IsPreserved`
- `RotateRefreshTokenAsync_ReuseOutsideGracePeriod_WithSessionId_RevokesOnlyThatSession`
- `RotateRefreshTokenAsync_ReuseOutsideGracePeriod_NoSessionId_RevokesAllForSubject` (fallback)
- **436/436 auth unit tests green.**
