### PR TITLE
fix(auth): give tenant superuser members a wildcard permission trie (fixes authenticated realtime)

### DIFF
--- a/src/API/Nocturne.API/Middleware/MemberScopeMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/MemberScopeMiddleware.cs
@@ -143,8 +143,19 @@ public class MemberScopeMiddleware
 
         if (effectivePermissions.Contains("*"))
         {
-            // Superuser — grant all scopes directly
+            // Superuser — grant all scopes AND a wildcard permission trie. Both must be set:
+            // GrantedScopes drives RequireScope checks, while the PermissionTrie drives the
+            // HasPermissions policy (the legacy v1 endpoints). Session tokens carry only the
+            // subject's global role permissions — empty for a normal tenant owner/admin whose
+            // permissions come from membership — so the trie built by AuthenticationMiddleware
+            // is empty. Without rebuilding it here, HasPermissions-gated endpoints would 403
+            // for a tenant superuser on their own tenant (matching the InstanceKey/PlatformAccess
+            // branch above, which sets both).
             context.Items["GrantedScopes"] = (IReadOnlySet<string>)effectivePermissions;
+
+            var superuserTrie = new PermissionTrie();
+            superuserTrie.Add(["*"]);
+            context.Items["PermissionTrie"] = superuserTrie;
         }
         else
         {

--- a/tests/Unit/Nocturne.API.Tests/Middleware/MemberScopeMiddlewareTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/MemberScopeMiddlewareTests.cs
@@ -1,8 +1,13 @@
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Nocturne.API.Middleware;
+using Nocturne.API.Tests.Infrastructure;
 using Nocturne.Core.Models.Authorization;
+using Nocturne.Infrastructure.Data;
 using Xunit;
 
 namespace Nocturne.API.Tests.Middleware;
@@ -148,6 +153,59 @@ public class MemberScopeMiddlewareTests
         permissionTrie.Check("api:treatments:read").Should().BeTrue();
         permissionTrie.Check("api:treatments:create").Should().BeTrue();
         permissionTrie.Check("api:profile:read").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task TenantMemberWithWildcardRole_GetsSuperuserPermissionTrie()
+    {
+        // Arrange — a tenant owner whose membership role grants "*", but whose session token
+        // carries no permissions. Session tokens are minted from the subject's GLOBAL roles,
+        // which are empty for a normal owner (their access comes from tenant membership), so
+        // AuthenticationMiddleware leaves an empty PermissionTrie. The superuser branch must
+        // rebuild it, or HasPermissions-gated endpoints (the legacy v1 API, e.g. the realtime
+        // /api/v1/entries probe) would 403 for the owner on their own tenant.
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
+
+        using (var seed = new NocturneDbContext(options))
+        {
+            seed.Database.EnsureCreated();
+            // Seeds the default tenant with TestSubjectId as owner (the "*" wildcard role).
+            TestDatabaseSeeder.Seed(seed);
+        }
+
+        var services = new ServiceCollection();
+        services.AddScoped(_ => new NocturneDbContext(options));
+        using var provider = services.BuildServiceProvider();
+
+        var context = new DefaultHttpContext { RequestServices = provider };
+        context.Items["AuthContext"] = new AuthContext
+        {
+            IsAuthenticated = true,
+            AuthType = AuthType.SessionCookie,
+            SubjectId = TestDatabaseSeeder.TestSubjectId,
+            TenantId = TestDatabaseSeeder.TenantId,
+            Permissions = [], // session JWT carries no permissions
+        };
+        // As AuthenticationMiddleware would set it for a token with no permissions.
+        context.Items["PermissionTrie"] = new PermissionTrie();
+        context.Items["GrantedScopes"] = (IReadOnlySet<string>)new HashSet<string>();
+
+        var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert — a non-empty wildcard trie so the HasPermissions policy succeeds.
+        var permissionTrie = context.Items["PermissionTrie"] as PermissionTrie;
+        permissionTrie.Should().NotBeNull();
+        permissionTrie!.IsEmpty.Should().BeFalse();
+        permissionTrie.Check("*").Should().BeTrue();
+
+        var grantedScopes = context.Items["GrantedScopes"] as IReadOnlySet<string>;
+        grantedScopes.Should().NotBeNull();
+        grantedScopes!.Should().Contain("*");
     }
 
     private (MemberScopeMiddleware middleware, DefaultHttpContext context) Build(AuthContext authContext)


### PR DESCRIPTION
## Symptom

Once a user **logs in**, the realtime bridge loses its connection and falls back to polling. It works fine for **anonymous** viewers of a public tenant. Confirmed live: the browser's `/realtime/ticket` response is `{"token":null,"retry":false}` and the Socket.IO handshake gets `44{"message":"unauthorized"}`.

## Root cause

The realtime ticket endpoint mints a handshake ticket only after probing `GET /api/v1/entries` with the connection's own credentials. For an authenticated tenant **owner**, that probe returns **403** — so no ticket, and the bridge rejects the handshake.

The 403 comes from `MemberScopeMiddleware`. Its member **superuser** branch (effective permissions contain `*`) sets `GrantedScopes = "*"` but **never rebuilds the `PermissionTrie`**:

```csharp
if (effectivePermissions.Contains("*"))
{
    context.Items["GrantedScopes"] = (IReadOnlySet<string>)effectivePermissions;
    // PermissionTrie left as-is
}
else { /* rebuilds BOTH GrantedScopes and PermissionTrie */ }
```

Session tokens are minted from the subject's **global** role permissions (`GetSubjectPermissionsAsync` reads `SubjectRoles`), which are empty for a normal tenant owner — their access comes from tenant **membership**. So `AuthenticationMiddleware` builds an **empty** `PermissionTrie`, and the superuser branch doesn't fix it. The `HasPermissions` policy only checks `!trie.IsEmpty`, so every `HasPermissions`-gated endpoint (the legacy v1 Nightscout API) returns **403** for an authenticated owner on their own tenant. v4/dashboard endpoints use `GrantedScopes` (which *is* `"*"`), which is why the dashboard works but realtime doesn't.

Anonymous/public works because the public subject gets a real permission trie (and the InstanceKey path is superuser with the trie correctly set).

## Fix

Rebuild the `PermissionTrie` to `["*"]` in the member superuser branch, matching the `InstanceKey`/`PlatformAccess` branch right above it (which already sets both) and the non-superuser branch (which rebuilds both).

This is broader than realtime: it fixes **every** `HasPermissions`-gated (legacy v1) endpoint for authenticated tenant owners/admins.

## Test

`MemberScopeMiddlewareTests.TenantMemberWithWildcardRole_GetsSuperuserPermissionTrie` — an authenticated member whose `*` role must produce a non-empty wildcard trie even when the session token carries no permissions. **500/500 middleware+auth unit tests green.**
