### PR TITLE
fix(web): widen alert replay dialog and make it container-responsive

### DIFF
--- a/src/Web/packages/app/src/lib/components/alerts/ReplayPanel.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/ReplayPanel.svelte
@@ -499,7 +499,9 @@
   {/each}
 {/snippet}
 
-<div class="@container flex h-full min-h-0 flex-col gap-4">
+<div
+  class="@container flex h-full min-h-0 flex-col gap-4 overflow-y-auto @2xl:overflow-y-hidden"
+>
   <div class="flex flex-wrap items-center gap-2">
     <Popover.Root bind:open={datePickerOpen}>
       <Popover.Trigger>
@@ -593,7 +595,7 @@
 
     {#if xDomain}
       <div
-        class="grid flex-1 min-h-0 gap-4 @3xl:grid-cols-[minmax(0,1fr)_320px] @3xl:items-stretch"
+        class="grid gap-4 @2xl:min-h-0 @2xl:flex-1 @2xl:grid-cols-[minmax(0,1fr)_280px] @2xl:items-stretch @4xl:grid-cols-[minmax(0,1fr)_320px]"
       >
         <!-- Chart + playback + events list (left on wide containers, full width on narrow) -->
         <div class="flex min-w-0 min-h-0 flex-col gap-4">
@@ -644,19 +646,19 @@
 
           {#if isEmpty}
             <div
-              class="flex-1 min-h-0 rounded-md border bg-muted/30 px-4 py-6 text-center text-sm text-muted-foreground"
+              class="@2xl:flex-1 @2xl:min-h-0 rounded-md border bg-muted/30 px-4 py-6 text-center text-sm text-muted-foreground"
             >
               No events would have fired in this window.
             </div>
           {:else if firedMarkers.length === 0}
             <div
-              class="flex-1 min-h-0 rounded-md border border-dashed py-6 text-center text-xs text-muted-foreground"
+              class="@2xl:flex-1 @2xl:min-h-0 rounded-md border border-dashed py-6 text-center text-xs text-muted-foreground"
             >
               No events yet — playhead at start of window.
             </div>
           {:else}
             <div
-              class="flex-1 min-h-0 overflow-y-auto rounded-md border divide-y"
+              class="max-h-72 overflow-y-auto rounded-md border divide-y @2xl:max-h-none @2xl:flex-1 @2xl:min-h-0"
             >
               {#each firedMarkers as m, i (`${m.ev.ruleId ?? "x"}:${m.tMs}:${m.ev.kind ?? ""}:${i}`)}
                 {@const dimmed = currentTimeMs != null && m.tMs > currentTimeMs}
@@ -706,7 +708,7 @@
 
         <!-- Rule sidebar (right on wide containers, stacked under on narrow) -->
         {#if currentTimeMs != null}
-          <div class="min-h-0 overflow-y-auto">
+          <div class="@2xl:min-h-0 @2xl:overflow-y-auto">
             <RuleSidebar
               rules={allRules}
               {editingRuleId}

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/[id]/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/[id]/+page.svelte
@@ -631,7 +631,7 @@
 
 <Dialog.Root bind:open={replayOpen}>
   <Dialog.Content
-    class="flex h-[90vh] max-h-[90vh] w-[calc(100vw-1rem)] max-w-6xl flex-col gap-0 overflow-hidden p-0 sm:w-[95vw]"
+    class="flex h-[90vh] max-h-[90vh] w-[calc(100vw-1rem)] max-w-6xl flex-col gap-0 overflow-hidden p-0 sm:w-[95vw] sm:max-w-7xl"
   >
     <Dialog.Header class="border-b px-4 py-3">
       <Dialog.Title class="flex items-center gap-2">


### PR DESCRIPTION
## Problem

The alerts **Replay** dialog overflows and is cramped: the chart, playback strip, events list and rule sidebar are squeezed into one narrow column that overlaps.

## Root cause

`Dialog.Content` (shared shadcn base) bakes in `sm:max-w-lg` (512px). The Replay dialog overrode only the **unprefixed** `max-w-6xl`; `twMerge` keeps the `sm:` variant, so on any `sm`+ viewport the dialog was hard-capped at **512px**. The panel's `@container` query for the two-column layout (`@3xl` = 768px) could therefore never fire.

## Fix

- **Dialog**: add `sm:max-w-7xl` so it actually widens on desktop (now beats the base `sm:` variant).
- **ReplayPanel**: lower the two-column threshold to `@2xl` with a responsive sidebar (`280px` -> `320px` at `@4xl`), and make the **narrow single-column** case scroll the whole panel rather than nesting two fixed-height scroll panes (which caused the overlap). The events list gets a `max-h-72` cap when single-column so it can't run away.

Net: chart-left / rules-right split with room on desktop; clean vertically-scrolling stack on narrow widths. Presentational only (Tailwind classes), no logic changes.