### PR TITLE
fix(reports/settings): year-overview crash, insulin-delivery breakdown, patient form, support API URL

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Platform/ServicesController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/ServicesController.cs
@@ -1,8 +1,11 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using OpenApi.Remote.Attributes;
 using Nocturne.API.Models;
+using Nocturne.API.Multitenancy;
 using Nocturne.API.Services.Connectors;
 using Nocturne.Core.Contracts.Connectors;
+using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Services;
 
 namespace Nocturne.API.Controllers.V4.Platform;
@@ -25,6 +28,8 @@ public class ServicesController : ControllerBase
     private readonly IConnectorSyncService _connectorSyncService;
     private readonly ILogger<ServicesController> _logger;
     private readonly IConfiguration _configuration;
+    private readonly ITenantAccessor _tenantAccessor;
+    private readonly BaseDomainOptions _baseDomain;
 
     /// <summary>
     /// Initializes a new instance of <see cref="ServicesController"/>.
@@ -34,12 +39,16 @@ public class ServicesController : ControllerBase
     /// <param name="connectorSyncService">Service for triggering on-demand connector syncs.</param>
     /// <param name="logger">Logger instance.</param>
     /// <param name="configuration">Application configuration for base URL resolution.</param>
+    /// <param name="tenantAccessor">Resolved tenant context, used to build the tenant's subdomain base URL.</param>
+    /// <param name="baseDomain">Platform base-domain options used to construct the tenant subdomain.</param>
     public ServicesController(
         IDataSourceService dataSourceService,
         IConnectorHealthService connectorHealthService,
         IConnectorSyncService connectorSyncService,
         ILogger<ServicesController> logger,
-        IConfiguration configuration
+        IConfiguration configuration,
+        ITenantAccessor tenantAccessor,
+        IOptions<BaseDomainOptions> baseDomain
     )
     {
         _dataSourceService = dataSourceService;
@@ -47,6 +56,8 @@ public class ServicesController : ControllerBase
         _connectorSyncService = connectorSyncService;
         _logger = logger;
         _configuration = configuration;
+        _tenantAccessor = tenantAccessor;
+        _baseDomain = baseDomain.Value;
     }
 
     /// <summary>
@@ -592,14 +603,24 @@ public class ServicesController : ControllerBase
 
     private string GetBaseUrl()
     {
-        // Try to get configured base URL first
+        // Prefer the tenant's own subdomain ({slug}.{base-domain}). This is the URL
+        // external uploaders (xDrip+, Loop, AAPS) must target, and it differs per
+        // tenant — unlike the configured BaseUrl (apex) or the internal request host
+        // seen when the web app calls this endpoint server-side.
+        var slug = _tenantAccessor.Context?.Slug;
+        var baseDomain = _baseDomain.BaseDomain;
+        if (!string.IsNullOrEmpty(slug) && !string.IsNullOrEmpty(baseDomain))
+        {
+            return $"https://{slug}.{baseDomain.TrimEnd('/')}";
+        }
+
+        // Self-host / single-instance fallback: configured base URL, then request host.
         var configuredUrl = _configuration["BaseUrl"];
         if (!string.IsNullOrEmpty(configuredUrl))
         {
             return configuredUrl.TrimEnd('/');
         }
 
-        // Fall back to request URL
         var request = HttpContext.Request;
         return $"{request.Scheme}://{request.Host}";
     }

--- a/src/Web/packages/app/src/lib/components/patient/PatientClinicalForm.svelte
+++ b/src/Web/packages/app/src/lib/components/patient/PatientClinicalForm.svelte
@@ -13,10 +13,10 @@
   let { onstate }: Props = $props();
 
   let formEl = $state<HTMLFormElement | null>(null);
-  const state = new ClinicalState(() => formEl);
+  const clinical = new ClinicalState(() => formEl);
 
   $effect(() => {
-    onstate?.(state);
+    onstate?.(clinical);
   });
 </script>
 
@@ -24,29 +24,29 @@
   id="clinical-form"
   class="@container"
   bind:this={formEl}
-  {...state.guard.enhance()}
+  {...clinical.guard.enhance()}
 >
   <!-- Hidden fields for read-only record data -->
-  {#if state.record?.id}
-    <input type="hidden" name="id" value={state.record.id} />
+  {#if clinical.record?.id}
+    <input type="hidden" name="id" value={clinical.record.id} />
   {/if}
-  {#if state.record?.avatarUrl}
-    <input type="hidden" name="avatarUrl" value={state.record.avatarUrl} />
+  {#if clinical.record?.avatarUrl}
+    <input type="hidden" name="avatarUrl" value={clinical.record.avatarUrl} />
   {/if}
-  {#if state.record?.createdAt}
-    <input type="hidden" name="createdAt" value={state.record.createdAt instanceof Date ? state.record.createdAt.toISOString() : state.record.createdAt} />
+  {#if clinical.record?.createdAt}
+    <input type="hidden" name="createdAt" value={clinical.record.createdAt instanceof Date ? clinical.record.createdAt.toISOString() : clinical.record.createdAt} />
   {/if}
-  {#if state.record?.modifiedAt}
-    <input type="hidden" name="modifiedAt" value={state.record.modifiedAt instanceof Date ? state.record.modifiedAt.toISOString() : state.record.modifiedAt} />
+  {#if clinical.record?.modifiedAt}
+    <input type="hidden" name="modifiedAt" value={clinical.record.modifiedAt instanceof Date ? clinical.record.modifiedAt.toISOString() : clinical.record.modifiedAt} />
   {/if}
 
   <div class="grid gap-4 @sm:grid-cols-2">
     <div class="space-y-2">
       <Label for="diabetes-type">Diabetes Type</Label>
-      <Select.Root type="single" name="diabetesType" bind:value={state.diabetesType}>
-        <Select.Trigger id="diabetes-type" aria-invalid={state.guard.issuesFor("diabetesType").length > 0}>
-          {state.diabetesType
-            ? (diabetesTypeLabels[state.diabetesType as DiabetesType] ?? state.diabetesType)
+      <Select.Root type="single" name="diabetesType" bind:value={clinical.diabetesType}>
+        <Select.Trigger id="diabetes-type" aria-invalid={clinical.guard.issuesFor("diabetesType").length > 0}>
+          {clinical.diabetesType
+            ? (diabetesTypeLabels[clinical.diabetesType as DiabetesType] ?? clinical.diabetesType)
             : "Select type"}
         </Select.Trigger>
         <Select.Content>
@@ -55,18 +55,18 @@
           {/each}
         </Select.Content>
       </Select.Root>
-      {#each state.guard.issuesFor("diabetesType") as issue}
+      {#each clinical.guard.issuesFor("diabetesType") as issue}
         <p class="text-sm text-destructive">{issue.message}</p>
       {/each}
     </div>
 
-    {#if state.diabetesType === DiabetesType.Other}
+    {#if clinical.diabetesType === DiabetesType.Other}
       <div class="space-y-2">
         <Label for="diabetes-type-other">Specify Type</Label>
         <Input
           id="diabetes-type-other"
           name="diabetesTypeOther"
-          bind:value={state.diabetesTypeOther}
+          bind:value={clinical.diabetesTypeOther}
           placeholder="e.g. Type 3c"
         />
       </div>
@@ -78,7 +78,7 @@
         id="diagnosis-date"
         name="diagnosisDate"
         type="date"
-        bind:value={state.diagnosisDate}
+        bind:value={clinical.diagnosisDate}
       />
     </div>
 
@@ -88,7 +88,7 @@
         id="date-of-birth"
         name="dateOfBirth"
         type="date"
-        bind:value={state.dateOfBirth}
+        bind:value={clinical.dateOfBirth}
       />
     </div>
 
@@ -97,7 +97,7 @@
       <Input
         id="preferred-name"
         name="preferredName"
-        bind:value={state.preferredName}
+        bind:value={clinical.preferredName}
         placeholder="How you'd like to be addressed"
       />
     </div>
@@ -107,7 +107,7 @@
       <Input
         id="pronouns"
         name="pronouns"
-        bind:value={state.pronouns}
+        bind:value={clinical.pronouns}
         placeholder="e.g. she/her, he/him, they/them"
       />
     </div>
@@ -117,10 +117,10 @@
       <Input
         id="timezone"
         name="timezone"
-        bind:value={state.timezone}
+        bind:value={clinical.timezone}
         placeholder="e.g. Australia/Sydney"
       />
-      {#if state.timezoneAutoDetected}
+      {#if clinical.timezoneAutoDetected}
         <p class="text-xs text-muted-foreground">
           Auto-detected from your browser. Save to confirm — alerts with time-of-day rules use this to interpret window hours in your local time.
         </p>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/insulin-delivery/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/insulin-delivery/+page.svelte
@@ -62,7 +62,16 @@
           return d;
         })();
     startDate.setHours(0, 0, 0, 0);
-    return { startDate, endDate };
+    // Send ISO strings, not Date objects. A Date can't be serialised as a
+    // remote-query argument ("Unknown date type"), so passing Dates left this
+    // query erroring — empty on first load, hard error when the filter dates
+    // change. The server schema is z.coerce.date(), which parses the ISO
+    // strings back to dates; the cast satisfies the generated Date arg type.
+    // Same pattern as ReplayPanel's replay() call.
+    return {
+      startDate: startDate.toISOString() as unknown as Date,
+      endDate: endDate.toISOString() as unknown as Date,
+    };
   });
   const dailyRatiosResource = $derived(getDailyBasalBolusRatios(dailyRatiosDates));
 

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/year-overview/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/year-overview/+page.svelte
@@ -258,7 +258,7 @@
     if (metadataLoading) return;
     metadataLoading = true;
     try {
-      const result = await getAvailableYears().run();
+      const result = await getAvailableYears();
       availableYears = result.years ?? [];
       availableDataSources = result.availableDataSources ?? [];
       metadataLoaded = true;
@@ -278,7 +278,7 @@
       if (selectedDataSources.length > 0) {
         params.dataSources = selectedDataSources;
       }
-      const result = await getDailySummary(params).run();
+      const result = await getDailySummary(params);
       const days = result.days ?? [];
       yearData = new Map([...yearData, [year, days]]);
       loadGriTimeline(year);
@@ -298,7 +298,7 @@
         year,
         dataSources:
           selectedDataSources.length > 0 ? selectedDataSources : undefined,
-      }).run();
+      });
       const periods = result.periods ?? [];
       griTimelineData = new Map([...griTimelineData, [year, periods]]);
     } catch (err) {

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Platform/ServicesControllerResetCursorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Platform/ServicesControllerResetCursorTests.cs
@@ -2,11 +2,14 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using Nocturne.API.Controllers.V4.Platform;
+using Nocturne.API.Multitenancy;
 using Nocturne.API.Services.Connectors;
 using Nocturne.Connectors.Core.Models;
 using Nocturne.Core.Contracts.Connectors;
+using Nocturne.Core.Contracts.Multitenancy;
 using Xunit;
 
 namespace Nocturne.API.Tests.Controllers.V4.Platform;
@@ -25,7 +28,9 @@ public class ServicesControllerResetCursorTests
             Mock.Of<IConnectorHealthService>(),
             syncService,
             Mock.Of<ILogger<ServicesController>>(),
-            Mock.Of<IConfiguration>());
+            Mock.Of<IConfiguration>(),
+            Mock.Of<ITenantAccessor>(),
+            Options.Create(new BaseDomainOptions()));
 
     [Fact]
     public async Task ResetConnectorCursor_SetsUpperBound_ToForceExplicitRangeRePull()


### PR DESCRIPTION
Four independent, self-contained fixes.

### 1. Year overview — `.run()` rejects during render
`getAvailableYears()/getDailySummary()/getGriTimeline()` were invoked with `.run()` inside `onMount`/`$effect`, whose synchronous phase Svelte 5 treats as render. `.run()` rejects there ("On the client, .run() can only be called outside render… await the query directly"). Switched all three to awaiting the query directly.

### 2. Insulin delivery — Daily Basal/Bolus Breakdown empty + "Unknown date type"
The card passed raw `Date` objects as remote-query arguments, which aren't serialisable — so the query errored (silently empty on load, hard error when the filter dates changed). Now sends ISO strings; the server schema is `z.coerce.date()`, which parses them back. Same pattern `ReplayPanel` already uses.

### 3. Patient record — `Cannot access 'state' before initialization`
`PatientClinicalForm` named its state-class instance `const state`, which collides with Svelte 5 runes compilation (its siblings use `insulinList`/`deviceList` and work). Renamed to `clinical`.

### 4. Support — API endpoint should be the tenant subdomain
`GetBaseUrl()` returned the configured apex `BaseUrl` (or the internal request host on SSR calls). Now builds `https://{slug}.{base-domain}` from `ITenantAccessor` + `BaseDomainOptions`, falling back to the old behaviour for self-host. Also corrects the uploader setup URLs and the xDrip deep-link.

Verified: `Nocturne.API` builds clean; frontend changes are type-safe (the date cast mirrors existing ReplayPanel code).