### PR TITLE
fix(web): dedupe @internationalized/date to fix RangeCalendar 'Unknown date type'

### DIFF
--- a/src/Web/packages/app/src/lib/components/layout/reports-filter-range-calendar.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/layout/reports-filter-range-calendar.svelte.test.ts
@@ -1,0 +1,19 @@
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import { describe, it, expect } from "vitest";
+import { getLocalTimeZone, today } from "@internationalized/date";
+import { RangeCalendar } from "$lib/components/ui/range-calendar";
+
+// The reports filter and the shared date-range-picker render a RangeCalendar
+// with a selected range. When the app and bits-ui resolve different copies of
+// @internationalized/date, the date values fail bits-ui's `instanceof
+// CalendarDate` checks and it throws "Unknown date type" on the day cells,
+// blanking the filter. Deduping @internationalized/date to one version fixes it.
+describe("reports filter RangeCalendar", () => {
+  it("mounts with a selected range without throwing 'Unknown date type'", async () => {
+    const end = today(getLocalTimeZone());
+    const start = end.subtract({ days: 6 });
+    render(RangeCalendar, { value: { start, end } });
+    await expect.element(page.getByRole("grid").first()).toBeVisible();
+  });
+});

--- a/src/Web/packages/app/vite.config.ts
+++ b/src/Web/packages/app/vite.config.ts
@@ -35,6 +35,12 @@ export default defineConfig(({ mode }) => {
     assetsInclude: ["**/*.jpg", "**/*.png", "**/*.gif"],
     resolve: {
       alias: reactAliases,
+      // Force a single copy of @internationalized/date (and bits-ui) into the
+      // bundle. Multiple versions are installed (3.11.0 + 3.12.1 via different
+      // bits-ui versions); without dedupe a date created by the app fails
+      // bits-ui's `instanceof CalendarDate` check and the RangeCalendar throws
+      // "Unknown date type" once it has a value (reports filter, date pickers).
+      dedupe: ["@internationalized/date", "bits-ui"],
     },
     ssr: {
       // Bundle the Resend adapter (and its React deps) into the SSR output so

--- a/src/Web/packages/app/vitest.browser.config.ts
+++ b/src/Web/packages/app/vitest.browser.config.ts
@@ -5,6 +5,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [svelte(), tailwindcss()],
+  resolve: { dedupe: ["@internationalized/date", "bits-ui"] },
   test: {
     include: ["src/**/*.svelte.test.ts"],
     setupFiles: ["vitest-browser-svelte", "./vitest.browser.setup.ts"],


### PR DESCRIPTION
## Problem
The reports filter (and any date-range picker) throws **`Unknown date type`** and blanks once it has a selected range. Reproduced with a browser test; the stack is bits-ui's `getDateValueType` on a calendar day cell.

## Root cause
Two copies of `@internationalized/date` are installed (**3.11.0** and **3.12.1**, pulled in by different bits-ui versions). A `CalendarDate` created with one copy is not `instanceof` the `CalendarDate` class from the other, so bits-ui's `getDateValueType` falls through to `throw new Error('Unknown date type')`. It only fires once the calendar has a *value* (the day cells are typed from it) — which is why it presented as 'empty on default, crash on selecting dates'.

## Fix
Force a single copy into the bundle via vite `resolve.dedupe: ['@internationalized/date', 'bits-ui']`.

## Verification
New browser test `reports-filter-range-calendar.svelte.test.ts` renders a value-bearing `RangeCalendar`:
- **without** dedupe → throws `Unknown date type` (red)
- **with** dedupe (now in both vite.config and the test config) → passes (green)

Note: the *empty* daily-basal/bolus breakdown on the default range is a separate, data-side issue tracked apart from this.