### PR TITLE
fix(alerts): pin tenant on pooled DbContext to stop cross-tenant leaks

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Audit/AuditController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Audit/AuditController.cs
@@ -216,6 +216,9 @@ public class AuditController : ControllerBase
         var tenantId = _tenantAccessor.TenantId;
 
         await using var db = await _contextFactory.CreateDbContextAsync(ct);
+        // Pin the tenant on the pooled context so the global query filter and the RLS
+        // session variable both scope to this tenant — pooling does not reset TenantId.
+        db.TenantId = tenantId;
 
         var entity = await db.TenantAuditConfig
             .FirstOrDefaultAsync(c => c.TenantId == tenantId, ct);

--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertCustomSoundsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertCustomSoundsController.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Services;
 
 namespace Nocturne.API.Controllers.V4.Monitoring;
 
@@ -17,16 +18,16 @@ namespace Nocturne.API.Controllers.V4.Monitoring;
 [Route("api/v4/alert-sounds")]
 public class AlertCustomSoundsController : ControllerBase
 {
-    private readonly IDbContextFactory<NocturneDbContext> _contextFactory;
+    private readonly ITenantDbContextFactory _contextFactory;
     private readonly ILogger<AlertCustomSoundsController> _logger;
 
     /// <summary>
     /// Initializes a new instance of <see cref="AlertCustomSoundsController"/>.
     /// </summary>
-    /// <param name="contextFactory">Factory for creating <see cref="NocturneDbContext"/> instances.</param>
+    /// <param name="contextFactory">Tenant-scoped factory for creating <see cref="NocturneDbContext"/> instances.</param>
     /// <param name="logger">Logger instance.</param>
     public AlertCustomSoundsController(
-        IDbContextFactory<NocturneDbContext> contextFactory,
+        ITenantDbContextFactory contextFactory,
         ILogger<AlertCustomSoundsController> logger)
     {
         _contextFactory = contextFactory;
@@ -53,7 +54,7 @@ public class AlertCustomSoundsController : ControllerBase
         using var ms = new MemoryStream();
         await file.CopyToAsync(ms, ct);
 
-        await using var db = await _contextFactory.CreateDbContextAsync(ct);
+        await using var db = await _contextFactory.CreateAsync(ct);
 
         var entity = new AlertCustomSoundEntity
         {
@@ -89,7 +90,7 @@ public class AlertCustomSoundsController : ControllerBase
     [ProducesResponseType(typeof(List<AlertCustomSoundResponse>), StatusCodes.Status200OK)]
     public async Task<ActionResult<List<AlertCustomSoundResponse>>> GetSounds(CancellationToken ct)
     {
-        await using var db = await _contextFactory.CreateDbContextAsync(ct);
+        await using var db = await _contextFactory.CreateAsync(ct);
 
         var sounds = await db.AlertCustomSounds
             .AsNoTracking()
@@ -115,7 +116,7 @@ public class AlertCustomSoundsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> StreamSound(Guid id, CancellationToken ct)
     {
-        await using var db = await _contextFactory.CreateDbContextAsync(ct);
+        await using var db = await _contextFactory.CreateAsync(ct);
 
         var entity = await db.AlertCustomSounds
             .AsNoTracking()
@@ -137,7 +138,7 @@ public class AlertCustomSoundsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> DeleteSound(Guid id, CancellationToken ct)
     {
-        await using var db = await _contextFactory.CreateDbContextAsync(ct);
+        await using var db = await _contextFactory.CreateAsync(ct);
 
         var entity = await db.AlertCustomSounds
             .FirstOrDefaultAsync(s => s.Id == id, ct);

--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertInvitesController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertInvitesController.cs
@@ -6,6 +6,7 @@ using OpenApi.Remote.Attributes;
 using Nocturne.API.Extensions;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Services;
 
 namespace Nocturne.API.Controllers.V4.Monitoring;
 
@@ -18,16 +19,16 @@ namespace Nocturne.API.Controllers.V4.Monitoring;
 [Route("api/v4/alert-invites")]
 public class AlertInvitesController : ControllerBase
 {
-    private readonly IDbContextFactory<NocturneDbContext> _contextFactory;
+    private readonly ITenantDbContextFactory _contextFactory;
     private readonly ILogger<AlertInvitesController> _logger;
 
     /// <summary>
     /// Initializes a new instance of <see cref="AlertInvitesController"/>.
     /// </summary>
-    /// <param name="contextFactory">Factory for creating <see cref="NocturneDbContext"/> instances.</param>
+    /// <param name="contextFactory">Tenant-scoped factory for creating <see cref="NocturneDbContext"/> instances.</param>
     /// <param name="logger">Logger instance.</param>
     public AlertInvitesController(
-        IDbContextFactory<NocturneDbContext> contextFactory,
+        ITenantDbContextFactory contextFactory,
         ILogger<AlertInvitesController> logger)
     {
         _contextFactory = contextFactory;
@@ -45,7 +46,7 @@ public class AlertInvitesController : ControllerBase
     public async Task<ActionResult<AlertInviteResponse>> CreateInvite(
         [FromBody] CreateAlertInviteRequest request, CancellationToken ct)
     {
-        await using var db = await _contextFactory.CreateDbContextAsync(ct);
+        await using var db = await _contextFactory.CreateAsync(ct);
 
         // Verify the rule channel exists within this tenant
         var stepExists = await db.AlertRuleChannels
@@ -103,7 +104,7 @@ public class AlertInvitesController : ControllerBase
     [ProducesResponseType(StatusCodes.Status410Gone)]
     public async Task<ActionResult<AlertInviteResponse>> ValidateInvite(string token, CancellationToken ct)
     {
-        await using var db = await _contextFactory.CreateDbContextAsync(ct);
+        await using var db = await _contextFactory.CreateAsync(ct);
 
         var invite = await db.AlertInvites
             .AsNoTracking()
@@ -141,7 +142,7 @@ public class AlertInvitesController : ControllerBase
     [ProducesResponseType(StatusCodes.Status410Gone)]
     public async Task<ActionResult> RedeemInvite(string token, CancellationToken ct)
     {
-        await using var db = await _contextFactory.CreateDbContextAsync(ct);
+        await using var db = await _contextFactory.CreateAsync(ct);
 
         var invite = await db.AlertInvites
             .FirstOrDefaultAsync(i => i.Token == token, ct);
@@ -177,7 +178,7 @@ public class AlertInvitesController : ControllerBase
     [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<ActionResult> RevokeInvite(Guid id, CancellationToken ct)
     {
-        await using var db = await _contextFactory.CreateDbContextAsync(ct);
+        await using var db = await _contextFactory.CreateAsync(ct);
 
         var invite = await db.AlertInvites
             .FirstOrDefaultAsync(i => i.Id == id, ct);

--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertRulesController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertRulesController.cs
@@ -9,6 +9,7 @@ using Nocturne.Core.Models;
 using Nocturne.Core.Models.Alerts;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Services;
 
 namespace Nocturne.API.Controllers.V4.Monitoring;
 
@@ -34,7 +35,7 @@ namespace Nocturne.API.Controllers.V4.Monitoring;
 [Route("api/v4/alert-rules")]
 public class AlertRulesController : ControllerBase
 {
-    private readonly IDbContextFactory<NocturneDbContext> _contextFactory;
+    private readonly ITenantDbContextFactory _contextFactory;
     private readonly IAlertReferenceService _referenceService;
     private readonly IAlertDeliveryService _deliveryService;
     private readonly ILogger<AlertRulesController> _logger;
@@ -43,7 +44,7 @@ public class AlertRulesController : ControllerBase
     /// Initializes a new instance of <see cref="AlertRulesController"/>.
     /// </summary>
     public AlertRulesController(
-        IDbContextFactory<NocturneDbContext> contextFactory,
+        ITenantDbContextFactory contextFactory,
         IAlertReferenceService referenceService,
         IAlertDeliveryService deliveryService,
         ILogger<AlertRulesController> logger)
@@ -62,7 +63,7 @@ public class AlertRulesController : ControllerBase
     [ProducesResponseType(typeof(List<AlertRuleResponse>), StatusCodes.Status200OK)]
     public async Task<ActionResult<List<AlertRuleResponse>>> GetRules(CancellationToken ct)
     {
-        await using var db = await _contextFactory.CreateDbContextAsync(ct);
+        await using var db = await _contextFactory.CreateAsync(ct);
 
         var rules = await db.AlertRules
             .AsNoTracking()
@@ -82,7 +83,7 @@ public class AlertRulesController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<AlertRuleResponse>> GetRule(Guid id, CancellationToken ct)
     {
-        await using var db = await _contextFactory.CreateDbContextAsync(ct);
+        await using var db = await _contextFactory.CreateAsync(ct);
 
         var rule = await db.AlertRules
             .AsNoTracking()
@@ -110,7 +111,7 @@ public class AlertRulesController : ControllerBase
 
         // No cycle detection on create: the new id is server-generated, so the proposed tree
         // cannot reference an id it doesn't yet know. Cycles can only be introduced via PUT.
-        await using var db = await _contextFactory.CreateDbContextAsync(ct);
+        await using var db = await _contextFactory.CreateAsync(ct);
 
         var tenantId = db.TenantId;
 
@@ -173,7 +174,7 @@ public class AlertRulesController : ControllerBase
         if (RejectPumpModeOnGenericStateSpan(request.ConditionType, request.ConditionParams) is { } badRequest)
             return badRequest;
 
-        await using var db = await _contextFactory.CreateDbContextAsync(ct);
+        await using var db = await _contextFactory.CreateAsync(ct);
 
         var rule = await db.AlertRules
             .Include(r => r.Channels)
@@ -247,7 +248,7 @@ public class AlertRulesController : ControllerBase
     [ProducesResponseType(typeof(ReferencingRulesResponse), StatusCodes.Status409Conflict)]
     public async Task<ActionResult> DeleteRule(Guid id, CancellationToken ct)
     {
-        await using var db = await _contextFactory.CreateDbContextAsync(ct);
+        await using var db = await _contextFactory.CreateAsync(ct);
 
         var rule = await db.AlertRules.FirstOrDefaultAsync(r => r.Id == id, ct);
         if (rule is null)
@@ -277,7 +278,7 @@ public class AlertRulesController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<AlertRuleResponse>> ToggleRule(Guid id, CancellationToken ct)
     {
-        await using var db = await _contextFactory.CreateDbContextAsync(ct);
+        await using var db = await _contextFactory.CreateAsync(ct);
 
         var rule = await db.AlertRules
             .Include(r => r.Channels)
@@ -304,7 +305,7 @@ public class AlertRulesController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> TestFire(Guid id, CancellationToken ct)
     {
-        await using var db = await _contextFactory.CreateDbContextAsync(ct);
+        await using var db = await _contextFactory.CreateAsync(ct);
 
         var rule = await db.AlertRules
             .AsNoTracking()
@@ -334,7 +335,7 @@ public class AlertRulesController : ControllerBase
     public async Task<IActionResult> TestFireDryRun(
         [FromBody] TestFireDryRunRequest request, CancellationToken ct)
     {
-        await using var db = await _contextFactory.CreateDbContextAsync(ct);
+        await using var db = await _contextFactory.CreateAsync(ct);
         var tenantId = db.TenantId;
 
         // Synthesise channel snapshots with provisional ids — none of them point to a

--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertsController.cs
@@ -7,6 +7,7 @@ using Nocturne.Core.Contracts.Alerts;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Alerts;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Services;
 
 namespace Nocturne.API.Controllers.V4.Monitoring;
 
@@ -21,7 +22,7 @@ namespace Nocturne.API.Controllers.V4.Monitoring;
 [Route("api/v4/alerts")]
 public class AlertsController : ControllerBase
 {
-    private readonly IDbContextFactory<NocturneDbContext> _contextFactory;
+    private readonly ITenantDbContextFactory _contextFactory;
     private readonly IAlertAcknowledgementService _acknowledgementService;
     private readonly IAlertDeliveryService _deliveryService;
     private readonly ITenantAccessor _tenantAccessor;
@@ -30,13 +31,13 @@ public class AlertsController : ControllerBase
     /// <summary>
     /// Initializes a new instance of <see cref="AlertsController"/>.
     /// </summary>
-    /// <param name="contextFactory">Factory for creating <see cref="NocturneDbContext"/> instances.</param>
+    /// <param name="contextFactory">Tenant-scoped factory for creating <see cref="NocturneDbContext"/> instances.</param>
     /// <param name="acknowledgementService">Service for acknowledging alert excursions.</param>
     /// <param name="deliveryService">Service for marking alert delivery outcomes.</param>
     /// <param name="tenantAccessor">Accessor for the current request tenant context.</param>
     /// <param name="logger">Logger instance.</param>
     public AlertsController(
-        IDbContextFactory<NocturneDbContext> contextFactory,
+        ITenantDbContextFactory contextFactory,
         IAlertAcknowledgementService acknowledgementService,
         IAlertDeliveryService deliveryService,
         ITenantAccessor tenantAccessor,
@@ -57,7 +58,7 @@ public class AlertsController : ControllerBase
     [ProducesResponseType(typeof(List<ActiveExcursionResponse>), StatusCodes.Status200OK)]
     public async Task<ActionResult<List<ActiveExcursionResponse>>> GetActiveAlerts(CancellationToken ct)
     {
-        await using var db = await _contextFactory.CreateDbContextAsync(ct);
+        await using var db = await _contextFactory.CreateAsync(ct);
 
         var excursions = await db.AlertExcursions
             .AsNoTracking()
@@ -110,7 +111,7 @@ public class AlertsController : ControllerBase
         if (pageSize < 1) pageSize = 1;
         if (pageSize > 100) pageSize = 100;
 
-        await using var db = await _contextFactory.CreateDbContextAsync(ct);
+        await using var db = await _contextFactory.CreateAsync(ct);
 
         var query = db.AlertExcursions
             .AsNoTracking()
@@ -198,7 +199,7 @@ public class AlertsController : ControllerBase
     public async Task<ActionResult> SnoozeInstance(
         Guid instanceId, [FromBody] SnoozeRequest request, CancellationToken ct)
     {
-        await using var db = await _contextFactory.CreateDbContextAsync(ct);
+        await using var db = await _contextFactory.CreateAsync(ct);
 
         var instance = await db.AlertInstances
             .Include(i => i.AlertExcursion)
@@ -262,7 +263,7 @@ public class AlertsController : ControllerBase
     public async Task<ActionResult<List<PendingDeliveryResponse>>> GetPendingDeliveries(
         [FromQuery] ChannelType[] channelType, CancellationToken ct)
     {
-        await using var db = await _contextFactory.CreateDbContextAsync(ct);
+        await using var db = await _contextFactory.CreateAsync(ct);
 
         var query = db.AlertDeliveries
             .AsNoTracking()

--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/TenantAlertSettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/TenantAlertSettingsController.cs
@@ -2,9 +2,9 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
-using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Services;
 
 namespace Nocturne.API.Controllers.V4.Monitoring;
 
@@ -26,15 +26,11 @@ namespace Nocturne.API.Controllers.V4.Monitoring;
 [Tags("Monitoring")]
 public class TenantAlertSettingsController : ControllerBase
 {
-    private readonly IDbContextFactory<NocturneDbContext> _contextFactory;
-    private readonly ITenantAccessor _tenantAccessor;
+    private readonly ITenantDbContextFactory _contextFactory;
 
-    public TenantAlertSettingsController(
-        IDbContextFactory<NocturneDbContext> contextFactory,
-        ITenantAccessor tenantAccessor)
+    public TenantAlertSettingsController(ITenantDbContextFactory contextFactory)
     {
         _contextFactory = contextFactory;
-        _tenantAccessor = tenantAccessor;
     }
 
     /// <summary>
@@ -45,8 +41,7 @@ public class TenantAlertSettingsController : ControllerBase
     [ProducesResponseType(typeof(TenantAlertSettingsResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult<TenantAlertSettingsResponse>> Get(CancellationToken ct)
     {
-        await using var db = await _contextFactory.CreateDbContextAsync(ct);
-        db.TenantId = _tenantAccessor.TenantId;
+        await using var db = await _contextFactory.CreateAsync(ct);
 
         var entity = await db.TenantAlertSettings.FirstOrDefaultAsync(ct);
         if (entity is null)
@@ -69,8 +64,7 @@ public class TenantAlertSettingsController : ControllerBase
     public async Task<ActionResult<TenantAlertSettingsResponse>> Update(
         [FromBody] UpdateTenantAlertSettingsRequest request, CancellationToken ct)
     {
-        await using var db = await _contextFactory.CreateDbContextAsync(ct);
-        db.TenantId = _tenantAccessor.TenantId;
+        await using var db = await _contextFactory.CreateAsync(ct);
 
         var entity = await db.TenantAlertSettings.FirstOrDefaultAsync(ct);
         var isNew = entity is null;

--- a/src/API/Nocturne.API/Services/Alerts/AlertOrchestrator.cs
+++ b/src/API/Nocturne.API/Services/Alerts/AlertOrchestrator.cs
@@ -199,7 +199,7 @@ internal sealed class AlertOrchestrator(
 
         // Look up the rule's flat channel list; an empty list is allowed (the user explicitly
         // chose "no delivery channels" — alert still tracked, just not pushed anywhere).
-        var channels = await repository.GetChannelsForRuleAsync(rule.Id, ct);
+        var channels = await repository.GetChannelsForRuleAsync(tenantId, rule.Id, ct);
 
         // Active excursion count + tenant subject for payload.
         var activeExcursionCount = await repository.CountActiveExcursionsAsync(tenantId, ct);

--- a/src/API/Nocturne.API/Services/Alerts/AlertSweepService.cs
+++ b/src/API/Nocturne.API/Services/Alerts/AlertSweepService.cs
@@ -277,6 +277,7 @@ public class AlertSweepService : BackgroundService
                 if (extend)
                 {
                     await repository.UpdateInstanceAsync(new UpdateAlertInstanceRequest(
+                        tenantId,
                         instance.InstanceId,
                         SnoozedUntil: now.AddMinutes(cfg.ExtendMinutes),
                         SnoozeCount: instance.SnoozeCount + 1), ct);
@@ -288,6 +289,7 @@ public class AlertSweepService : BackgroundService
                 else
                 {
                     await repository.UpdateInstanceAsync(new UpdateAlertInstanceRequest(
+                        tenantId,
                         instance.InstanceId,
                         SnoozedUntil: DateTime.MinValue), ct);
 

--- a/src/API/Nocturne.API/Services/Alerts/ExcursionResolutionHandler.cs
+++ b/src/API/Nocturne.API/Services/Alerts/ExcursionResolutionHandler.cs
@@ -39,15 +39,15 @@ internal sealed class ExcursionResolutionHandler(
         var excursionId = transition.ExcursionId.Value;
         var now = timeProvider.GetUtcNow().UtcDateTime;
 
-        var instances = await repository.GetInstancesForExcursionAsync(excursionId, ct);
+        var instances = await repository.GetInstancesForExcursionAsync(tenantId, excursionId, ct);
         var instanceIds = instances.Select(i => i.Id).ToList();
 
         var reason = transition.CloseReason?.ToWireString();
-        await repository.ResolveInstancesForExcursionAsync(excursionId, now, reason, ct);
+        await repository.ResolveInstancesForExcursionAsync(tenantId, excursionId, now, reason, ct);
 
         if (instanceIds.Count > 0)
         {
-            await repository.ExpirePendingDeliveriesAsync(instanceIds, ct);
+            await repository.ExpirePendingDeliveriesAsync(tenantId, instanceIds, ct);
         }
 
         try
@@ -65,7 +65,7 @@ internal sealed class ExcursionResolutionHandler(
             logger.LogWarning(ex, "Failed to broadcast alert_resolved for excursion {ExcursionId}", excursionId);
         }
 
-        await ArchiveInAppNotificationsAsync(excursionId, ct);
+        await ArchiveInAppNotificationsAsync(tenantId, excursionId, ct);
 
         logger.LogInformation(
             "Excursion {ExcursionId} resolved (reason={Reason}), {Count} instances closed",
@@ -77,12 +77,12 @@ internal sealed class ExcursionResolutionHandler(
     /// excursion, so the bell/toast row clears once the alert is no longer firing.
     /// Iterates the unique InApp recipient userIds — one notification can exist per user.
     /// </summary>
-    private async Task ArchiveInAppNotificationsAsync(Guid excursionId, CancellationToken ct)
+    private async Task ArchiveInAppNotificationsAsync(Guid tenantId, Guid excursionId, CancellationToken ct)
     {
         IReadOnlyList<string> destinations;
         try
         {
-            destinations = await repository.GetInAppDestinationsForExcursionAsync(excursionId, ct);
+            destinations = await repository.GetInAppDestinationsForExcursionAsync(tenantId, excursionId, ct);
         }
         catch (Exception ex)
         {

--- a/src/API/Nocturne.API/Services/Platform/StatusService.cs
+++ b/src/API/Nocturne.API/Services/Platform/StatusService.cs
@@ -770,6 +770,11 @@ public class StatusService : IStatusService
     private async Task<DateTime?> LastModifiedAsync(Func<NocturneDbContext, Task<DateTime?>> query)
     {
         await using var ctx = await _dbContextFactory.CreateDbContextAsync();
+        // Pooled contexts do not reset TenantId, so a context leased from the factory carries
+        // the previous lessee's tenant. Pin the resolved tenant before querying so the
+        // tenant-scoped collections (entries/treatments/profile/devicestatus/food/settings) and
+        // RLS scope to this tenant rather than leaking another tenant's last-modified timestamps.
+        ctx.TenantId = _tenantAccessor.Context?.TenantId ?? Guid.Empty;
         return await query(ctx);
     }
 

--- a/src/Core/Nocturne.Core.Contracts/Alerts/IAlertRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/Alerts/IAlertRepository.cs
@@ -22,7 +22,10 @@ public interface IAlertRepository
     /// Returns the flat per-rule channel list. Channels are dispatched in parallel when the
     /// rule fires; <see cref="AlertRuleChannelSnapshot.SortOrder"/> is cosmetic only.
     /// </summary>
-    Task<IReadOnlyList<AlertRuleChannelSnapshot>> GetChannelsForRuleAsync(Guid ruleId, CancellationToken ct);
+    /// <param name="tenantId">The tenant that owns the rule, used to scope the query.</param>
+    /// <param name="ruleId">The alert rule identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<IReadOnlyList<AlertRuleChannelSnapshot>> GetChannelsForRuleAsync(Guid tenantId, Guid ruleId, CancellationToken ct);
 
     /// <summary>
     /// Creates a new <see cref="AlertInstanceSnapshot"/> for a triggered alert.
@@ -32,15 +35,17 @@ public interface IAlertRepository
     /// <summary>
     /// Returns all alert instances associated with a specific excursion.
     /// </summary>
+    /// <param name="tenantId">The tenant that owns the excursion, used to scope the query.</param>
     /// <param name="excursionId">The <see cref="AlertExcursion"/> identifier.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A read-only list of alert instances for the excursion.</returns>
-    Task<IReadOnlyList<AlertInstanceSnapshot>> GetInstancesForExcursionAsync(Guid excursionId, CancellationToken ct);
+    Task<IReadOnlyList<AlertInstanceSnapshot>> GetInstancesForExcursionAsync(Guid tenantId, Guid excursionId, CancellationToken ct);
 
     /// <summary>
     /// Resolves all active alert instances for the specified excursion, marking them
     /// with the given resolution timestamp and reason.
     /// </summary>
+    /// <param name="tenantId">The tenant that owns the excursion, used to scope the update.</param>
     /// <param name="excursionId">The <see cref="AlertExcursion"/> identifier.</param>
     /// <param name="resolvedAt">The timestamp when the excursion was resolved.</param>
     /// <param name="resolutionReason">
@@ -49,7 +54,7 @@ public interface IAlertRepository
     /// fall-back — every production call site has a reason.
     /// </param>
     /// <param name="ct">Cancellation token.</param>
-    Task ResolveInstancesForExcursionAsync(Guid excursionId, DateTime resolvedAt, string? resolutionReason, CancellationToken ct);
+    Task ResolveInstancesForExcursionAsync(Guid tenantId, Guid excursionId, DateTime resolvedAt, string? resolutionReason, CancellationToken ct);
 
     /// <summary>
     /// Returns every open excursion whose owning rule has auto-resolve enabled
@@ -65,7 +70,10 @@ public interface IAlertRepository
     /// <c>ExcursionResolutionHandler</c> to auto-archive in-app notifications when the
     /// excursion closes.
     /// </summary>
-    Task<IReadOnlyList<string>> GetInAppDestinationsForExcursionAsync(Guid excursionId, CancellationToken ct);
+    /// <param name="tenantId">The tenant that owns the excursion, used to scope the query.</param>
+    /// <param name="excursionId">The <see cref="AlertExcursion"/> identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<IReadOnlyList<string>> GetInAppDestinationsForExcursionAsync(Guid tenantId, Guid excursionId, CancellationToken ct);
 
     /// <summary>
     /// Updates an existing alert instance (e.g., advancing its escalation step or snooze state).
@@ -79,10 +87,11 @@ public interface IAlertRepository
     /// Expires all pending (unsent) deliveries for the specified alert instances,
     /// typically called when instances are resolved or acknowledged.
     /// </summary>
+    /// <param name="tenantId">The tenant that owns the instances, used to scope the update.</param>
     /// <param name="instanceIds">The alert instance identifiers whose pending deliveries should be expired.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A task that completes when the deliveries have been expired.</returns>
-    Task ExpirePendingDeliveriesAsync(IReadOnlyList<Guid> instanceIds, CancellationToken ct);
+    Task ExpirePendingDeliveriesAsync(Guid tenantId, IReadOnlyList<Guid> instanceIds, CancellationToken ct);
 
     /// <summary>
     /// Counts the number of active (unresolved) excursions for a tenant.

--- a/src/Core/Nocturne.Core.Models/AlertSnapshots.cs
+++ b/src/Core/Nocturne.Core.Models/AlertSnapshots.cs
@@ -41,7 +41,7 @@ public record CreateAlertInstanceRequest(Guid TenantId, Guid ExcursionId,
 /// <summary>
 /// Request to update an existing alert instance (snooze, status change).
 /// </summary>
-public record UpdateAlertInstanceRequest(Guid Id, string? Status = null,
+public record UpdateAlertInstanceRequest(Guid TenantId, Guid Id, string? Status = null,
     DateTime? SnoozedUntil = null, int? SnoozeCount = null);
 
 /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/AlertRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/AlertRepository.cs
@@ -10,6 +10,16 @@ namespace Nocturne.Infrastructure.Data.Repositories;
 /// Repository for alert orchestration queries and mutations.
 /// Methods are virtual to allow mocking with CallBase in tests.
 /// </summary>
+/// <remarks>
+/// Every method leases a context from the pooled factory and pins <c>context.TenantId</c>
+/// before touching any <c>ITenantScoped</c> table. Pooling does not reset that property, and
+/// both the EF global query filter and PostgreSQL Row-Level Security derive the active tenant
+/// from it — leaving it unset would scope reads/writes to whatever tenant the previous lessee
+/// left on the context (or fail closed under RLS when it lands as <see cref="Guid.Empty"/>).
+/// Cross-tenant sweeps cannot be expressed as a single query because the RLS policy
+/// (<c>tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid</c>) admits
+/// no "see all" value for the non-bypass app role, so they iterate active tenants explicitly.
+/// </remarks>
 public class AlertRepository : IAlertRepository
 {
     private readonly IDbContextFactory<NocturneDbContext> _contextFactory;
@@ -33,6 +43,7 @@ public class AlertRepository : IAlertRepository
         Guid tenantId, CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
+        context.TenantId = tenantId;
 
         return await context.AlertRules
             .AsNoTracking()
@@ -47,9 +58,10 @@ public class AlertRepository : IAlertRepository
 
     /// <inheritdoc/>
     public virtual async Task<IReadOnlyList<AlertRuleChannelSnapshot>> GetChannelsForRuleAsync(
-        Guid ruleId, CancellationToken ct)
+        Guid tenantId, Guid ruleId, CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
+        context.TenantId = tenantId;
 
         return await context.AlertRuleChannels
             .AsNoTracking()
@@ -66,6 +78,7 @@ public class AlertRepository : IAlertRepository
         CreateAlertInstanceRequest request, CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
+        context.TenantId = request.TenantId;
 
         var entity = new AlertInstanceEntity
         {
@@ -87,9 +100,10 @@ public class AlertRepository : IAlertRepository
 
     /// <inheritdoc/>
     public virtual async Task<IReadOnlyList<AlertInstanceSnapshot>> GetInstancesForExcursionAsync(
-        Guid excursionId, CancellationToken ct)
+        Guid tenantId, Guid excursionId, CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
+        context.TenantId = tenantId;
 
         return await context.AlertInstances
             .AsNoTracking()
@@ -103,9 +117,10 @@ public class AlertRepository : IAlertRepository
 
     /// <inheritdoc/>
     public virtual async Task ResolveInstancesForExcursionAsync(
-        Guid excursionId, DateTime resolvedAt, string? resolutionReason, CancellationToken ct)
+        Guid tenantId, Guid excursionId, DateTime resolvedAt, string? resolutionReason, CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
+        context.TenantId = tenantId;
 
         await context.AlertInstances
             .Where(i => i.AlertExcursionId == excursionId
@@ -125,6 +140,7 @@ public class AlertRepository : IAlertRepository
         UpdateAlertInstanceRequest request, CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
+        context.TenantId = request.TenantId;
 
         var entity = await context.AlertInstances
             .FirstOrDefaultAsync(i => i.Id == request.Id, ct);
@@ -147,14 +163,16 @@ public class AlertRepository : IAlertRepository
     /// <summary>
     /// Marks pending deliveries as expired for a set of alert instances.
     /// </summary>
+    /// <param name="tenantId">The unique identifier of the tenant.</param>
     /// <param name="instanceIds">The unique identifiers of the alert instances.</param>
     /// <param name="ct">The cancellation token.</param>
     public virtual async Task ExpirePendingDeliveriesAsync(
-        IReadOnlyList<Guid> instanceIds, CancellationToken ct)
+        Guid tenantId, IReadOnlyList<Guid> instanceIds, CancellationToken ct)
     {
         if (instanceIds.Count == 0) return;
 
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
+        context.TenantId = tenantId;
 
         await context.AlertDeliveries
             .Where(d => instanceIds.Contains(d.AlertInstanceId)
@@ -173,6 +191,7 @@ public class AlertRepository : IAlertRepository
         Guid tenantId, CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
+        context.TenantId = tenantId;
 
         return await context.AlertExcursions
             .AsNoTracking()
@@ -188,32 +207,39 @@ public class AlertRepository : IAlertRepository
     public virtual async Task<IReadOnlyList<HysteresisExcursionSnapshot>> GetExcursionsInHysteresisAsync(
         CancellationToken ct)
     {
-        await using var context = await _contextFactory.CreateDbContextAsync(ct);
-
         // Cross-tenant scan — sweep evaluates every tenant in a single tick, then sets
-        // tenant context per-excursion before invoking the tracker.
-        return await context.AlertExcursions
-            .AsNoTracking()
-            .IgnoreQueryFilters()
-            .Where(e => e.HysteresisStartedAt != null && e.EndedAt == null)
-            .Select(e => new HysteresisExcursionSnapshot(
-                e.Id, e.TenantId, e.AlertRuleId, e.HysteresisStartedAt))
-            .ToListAsync(ct);
+        // tenant context per-excursion before invoking the tracker. RLS scopes each query to
+        // one tenant, so iterate active tenants rather than relying on IgnoreQueryFilters
+        // (which bypasses the EF filter but not the fail-closed RLS policy).
+        var results = new List<HysteresisExcursionSnapshot>();
+        foreach (var tenantId in await GetActiveTenantIdsAsync(ct))
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync(ct);
+            context.TenantId = tenantId;
+
+            var rows = await context.AlertExcursions
+                .AsNoTracking()
+                .Where(e => e.HysteresisStartedAt != null && e.EndedAt == null)
+                .Select(e => new HysteresisExcursionSnapshot(
+                    e.Id, e.TenantId, e.AlertRuleId, e.HysteresisStartedAt))
+                .ToListAsync(ct);
+            results.AddRange(rows);
+        }
+
+        return results;
     }
 
     /// <inheritdoc/>
     public virtual async Task<IReadOnlyList<string>> GetInAppDestinationsForExcursionAsync(
-        Guid excursionId, CancellationToken ct)
+        Guid tenantId, Guid excursionId, CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
+        context.TenantId = tenantId;
 
-        // Cross-tenant safe: the excursionId is unique and the InApp destination is just the
-        // userId. IgnoreQueryFilters mirrors the pattern in GetAutoResolveExcursionsAsync.
         return await context.AlertDeliveries
             .AsNoTracking()
-            .IgnoreQueryFilters()
             .Where(d => d.ChannelType == ChannelType.InApp)
-            .Join(context.AlertInstances.AsNoTracking().IgnoreQueryFilters(),
+            .Join(context.AlertInstances.AsNoTracking(),
                 d => d.AlertInstanceId, i => i.Id, (d, i) => new { d, i })
             .Where(x => x.i.AlertExcursionId == excursionId
                         && !string.IsNullOrEmpty(x.d.Destination))
@@ -226,27 +252,34 @@ public class AlertRepository : IAlertRepository
     public virtual async Task<IReadOnlyList<AutoResolveExcursionSnapshot>> GetAutoResolveExcursionsAsync(
         CancellationToken ct)
     {
-        await using var context = await _contextFactory.CreateDbContextAsync(ct);
+        // Cross-tenant scan: the sweep evaluates every tenant's auto-resolvable excursions in a
+        // single tick. RLS scopes each query to one tenant, so iterate active tenants.
+        var results = new List<AutoResolveExcursionSnapshot>();
+        foreach (var tenantId in await GetActiveTenantIdsAsync(ct))
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync(ct);
+            context.TenantId = tenantId;
 
-        // Cross-tenant scan: bypass the global tenant filter since the sweep evaluates
-        // every tenant's auto-resolvable excursions in a single tick.
-        return await context.AlertExcursions
-            .AsNoTracking()
-            .IgnoreQueryFilters()
-            .Where(e => e.EndedAt == null)
-            .Join(context.AlertRules.AsNoTracking().IgnoreQueryFilters(),
-                e => e.AlertRuleId, r => r.Id, (e, r) => new { e, r })
-            .Where(x => x.r.IsEnabled
-                        && x.r.AutoResolveEnabled
-                        && x.r.AutoResolveParams != null)
-            .Select(x => new AutoResolveExcursionSnapshot(
-                x.e.Id,
-                x.e.TenantId,
-                new AlertRuleSnapshot(
-                    x.r.Id, x.r.TenantId, x.r.Name, x.r.ConditionType,
-                    x.r.ConditionParams, x.r.Severity, x.r.ClientConfiguration, x.r.SortOrder,
-                    x.r.AutoResolveEnabled, x.r.AutoResolveParams, x.r.AllowThroughDnd)))
-            .ToListAsync(ct);
+            var rows = await context.AlertExcursions
+                .AsNoTracking()
+                .Where(e => e.EndedAt == null)
+                .Join(context.AlertRules.AsNoTracking(),
+                    e => e.AlertRuleId, r => r.Id, (e, r) => new { e, r })
+                .Where(x => x.r.IsEnabled
+                            && x.r.AutoResolveEnabled
+                            && x.r.AutoResolveParams != null)
+                .Select(x => new AutoResolveExcursionSnapshot(
+                    x.e.Id,
+                    x.e.TenantId,
+                    new AlertRuleSnapshot(
+                        x.r.Id, x.r.TenantId, x.r.Name, x.r.ConditionType,
+                        x.r.ConditionParams, x.r.Severity, x.r.ClientConfiguration, x.r.SortOrder,
+                        x.r.AutoResolveEnabled, x.r.AutoResolveParams, x.r.AllowThroughDnd)))
+                .ToListAsync(ct);
+            results.AddRange(rows);
+        }
+
+        return results;
     }
 
     /// <summary>
@@ -259,6 +292,10 @@ public class AlertRepository : IAlertRepository
         Guid tenantId, CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
+        // patient_records is RLS-protected; stamp the tenant context before any scoped read so
+        // the interceptor sets app.current_tenant_id. tenants is not tenant-scoped, so it is
+        // readable regardless, but pinning up front keeps the whole method consistent.
+        context.TenantId = tenantId;
 
         var tenant = await context.Tenants
             .AsNoTracking()
@@ -268,11 +305,6 @@ public class AlertRepository : IAlertRepository
 
         if (tenant is null) return null;
 
-        // patient_records is RLS-protected; the factory-built context lands with TenantId
-        // unset (this method takes tenantId as a parameter — it can be called for any
-        // tenant from background services). Stamp the tenant context before the read so
-        // the interceptor sets app.current_tenant_id and the row is visible.
-        context.TenantId = tenantId;
         var preferredName = await context.PatientRecords
             .AsNoTracking()
             .Select(p => p.PreferredName)
@@ -288,11 +320,8 @@ public class AlertRepository : IAlertRepository
         Guid tenantId, Guid instanceId, string reason, CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
+        context.TenantId = tenantId;
 
-        // Tenant filter is defence-in-depth: RLS already scopes the query, but the
-        // factory-built context can land with TenantId=Guid.Empty in some paths
-        // (see project_alert_repo_tenant_filter_bug in MEMORY) and the explicit
-        // predicate keeps this method honest if that ever happens here.
         var instance = await context.AlertInstances
             .FirstOrDefaultAsync(i => i.Id == instanceId && i.TenantId == tenantId, ct);
         if (instance is null) return;
@@ -313,9 +342,8 @@ public class AlertRepository : IAlertRepository
         Guid tenantId, CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
+        context.TenantId = tenantId;
 
-        // RLS scopes the query to the active tenant; the explicit predicate is defence-in-depth
-        // for tests / paths that bypass the tenant accessor middleware.
         var row = await context.TenantAlertSettings
             .AsNoTracking()
             .Where(s => s.TenantId == tenantId)
@@ -339,13 +367,22 @@ public class AlertRepository : IAlertRepository
     public virtual async Task<IReadOnlyList<SignalLossRuleSnapshot>> GetEnabledSignalLossRulesAsync(
         CancellationToken ct)
     {
-        await using var context = await _contextFactory.CreateDbContextAsync(ct);
+        // Cross-tenant scan: iterate active tenants so RLS scopes each query correctly.
+        var results = new List<SignalLossRuleSnapshot>();
+        foreach (var tenantId in await GetActiveTenantIdsAsync(ct))
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync(ct);
+            context.TenantId = tenantId;
 
-        return await context.AlertRules
-            .AsNoTracking()
-            .Where(r => r.IsEnabled && r.ConditionType == AlertConditionType.SignalLoss)
-            .Select(r => new SignalLossRuleSnapshot(r.Id, r.TenantId, r.ConditionParams))
-            .ToListAsync(ct);
+            var rows = await context.AlertRules
+                .AsNoTracking()
+                .Where(r => r.IsEnabled && r.ConditionType == AlertConditionType.SignalLoss)
+                .Select(r => new SignalLossRuleSnapshot(r.Id, r.TenantId, r.ConditionParams))
+                .ToListAsync(ct);
+            results.AddRange(rows);
+        }
+
+        return results;
     }
 
     /// <summary>
@@ -358,6 +395,7 @@ public class AlertRepository : IAlertRepository
         Guid tenantId, CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
+        context.TenantId = tenantId;
 
         return await context.SensorGlucose
             .AsNoTracking()
@@ -376,25 +414,34 @@ public class AlertRepository : IAlertRepository
     public virtual async Task<IReadOnlyList<SnoozedInstanceSnapshot>> GetExpiredSnoozedInstancesAsync(
         DateTime asOf, CancellationToken ct)
     {
-        await using var context = await _contextFactory.CreateDbContextAsync(ct);
+        // Cross-tenant scan: iterate active tenants so RLS scopes each query correctly.
+        var results = new List<SnoozedInstanceSnapshot>();
+        foreach (var tenantId in await GetActiveTenantIdsAsync(ct))
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync(ct);
+            context.TenantId = tenantId;
 
-        return await context.AlertInstances
-            .AsNoTracking()
-            .Where(i => i.SnoozedUntil != null
-                        && i.SnoozedUntil <= asOf
-                        && i.Status != "resolved")
-            .Join(context.AlertExcursions,
-                i => i.AlertExcursionId,
-                e => e.Id,
-                (i, e) => new { Instance = i, Excursion = e })
-            .Join(context.AlertRules,
-                x => x.Excursion.AlertRuleId,
-                r => r.Id,
-                (x, r) => new SnoozedInstanceSnapshot(
-                    x.Instance.Id, x.Instance.TenantId, x.Instance.AlertExcursionId,
-                    x.Instance.Status, x.Instance.SnoozeCount,
-                    r.Id, r.ConditionType, r.ConditionParams, r.ClientConfiguration))
-            .ToListAsync(ct);
+            var rows = await context.AlertInstances
+                .AsNoTracking()
+                .Where(i => i.SnoozedUntil != null
+                            && i.SnoozedUntil <= asOf
+                            && i.Status != "resolved")
+                .Join(context.AlertExcursions,
+                    i => i.AlertExcursionId,
+                    e => e.Id,
+                    (i, e) => new { Instance = i, Excursion = e })
+                .Join(context.AlertRules,
+                    x => x.Excursion.AlertRuleId,
+                    r => r.Id,
+                    (x, r) => new SnoozedInstanceSnapshot(
+                        x.Instance.Id, x.Instance.TenantId, x.Instance.AlertExcursionId,
+                        x.Instance.Status, x.Instance.SnoozeCount,
+                        r.Id, r.ConditionType, r.ConditionParams, r.ClientConfiguration))
+                .ToListAsync(ct);
+            results.AddRange(rows);
+        }
+
+        return results;
     }
 
     /// <summary>
@@ -408,6 +455,7 @@ public class AlertRepository : IAlertRepository
         Guid tenantId, CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
+        context.TenantId = tenantId;
 
         var rows = await context.AlertExcursions
             .AsNoTracking()
@@ -437,5 +485,20 @@ public class AlertRepository : IAlertRepository
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
         await context.SaveChangesAsync(ct);
+    }
+
+    /// <summary>
+    /// Lists the ids of every active tenant. Reads the <c>tenants</c> table, which is not
+    /// tenant-scoped (no RLS policy), so it is queryable without a pinned tenant context and
+    /// drives the per-tenant iteration of the cross-tenant sweeps.
+    /// </summary>
+    private async Task<IReadOnlyList<Guid>> GetActiveTenantIdsAsync(CancellationToken ct)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(ct);
+        return await context.Tenants
+            .AsNoTracking()
+            .Where(t => t.IsActive)
+            .Select(t => t.Id)
+            .ToListAsync(ct);
     }
 }

--- a/tests/Integration/Nocturne.API.Tests/Monitoring/AlertRepositorySweepIntegrationTests.cs
+++ b/tests/Integration/Nocturne.API.Tests/Monitoring/AlertRepositorySweepIntegrationTests.cs
@@ -1,0 +1,107 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Nocturne.API.Tests.Integration.Infrastructure;
+using Nocturne.Core.Models.Alerts;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Interceptors;
+using Nocturne.Infrastructure.Data.Repositories;
+using Npgsql;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Nocturne.API.Tests.Integration.Monitoring;
+
+/// <summary>
+/// Exercises <see cref="AlertRepository"/> against the real PostgreSQL instance under Row-Level
+/// Security (the runtime <c>nocturne_app</c> role is <c>NOBYPASSRLS</c>). This is the half the
+/// InMemory unit tests cannot cover: the cross-tenant sweep methods must iterate active tenants
+/// — a single query cannot see across tenants because the fail-closed RLS policy
+/// (<c>tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid</c>) admits
+/// no "see all" value — and the per-tenant methods must pin the tenant so RLS returns its rows.
+///
+/// The repository is constructed over a context factory wired with the same
+/// <see cref="TenantConnectionInterceptor"/> the app uses, so <c>context.TenantId</c> drives the
+/// <c>app.current_tenant_id</c> session variable exactly as in production.
+/// </summary>
+[Trait("Category", "Integration")]
+public class AlertRepositorySweepIntegrationTests : AspireIntegrationTestBase
+{
+    public AlertRepositorySweepIntegrationTests(
+        AspireIntegrationTestFixture fixture,
+        ITestOutputHelper output)
+        : base(fixture, output) { }
+
+    [Fact]
+    public async Task SweepAndPerTenantReads_AreCorrectlyTenantScoped_UnderRls()
+    {
+        var connStr = await GetPostgresConnectionStringAsync()
+                      ?? throw new InvalidOperationException("No PostgreSQL connection string.");
+
+        // Two fresh tenants (unique slugs so re-runs against a persisted container don't collide).
+        await using var conn = new NpgsqlConnection(connStr);
+        await conn.OpenAsync();
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        var tenantA = await AuthTestHelpers.SeedTenantAsync(conn, $"sweep-a-{suffix}", "Sweep A");
+        var tenantB = await AuthTestHelpers.SeedTenantAsync(conn, $"sweep-b-{suffix}", "Sweep B");
+
+        // A context factory wired exactly like the app: Npgsql + the tenant RLS interceptor.
+        await using var dataSource = new NpgsqlDataSourceBuilder(connStr).Build();
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseNpgsql(dataSource)
+            .AddInterceptors(new TenantConnectionInterceptor())
+            .Options;
+        var factory = new InterceptingContextFactory(options);
+
+        // Seed rules through EF so the enum/jsonb mapping matches the live schema. The interceptor
+        // sets the RLS GUC from context.TenantId, satisfying the WITH CHECK policy on insert.
+        await SeedRuleAsync(factory, tenantA, "Signal loss A", AlertConditionType.SignalLoss);
+        await SeedRuleAsync(factory, tenantA, "High A", AlertConditionType.Threshold);
+        await SeedRuleAsync(factory, tenantB, "Signal loss B", AlertConditionType.SignalLoss);
+
+        var repo = new AlertRepository(factory);
+
+        // Cross-tenant sweep: must surface signal-loss rules for BOTH tenants.
+        var signalLoss = await repo.GetEnabledSignalLossRulesAsync(CancellationToken.None);
+        var signalLossTenants = signalLoss.Select(r => r.TenantId).ToHashSet();
+        signalLossTenants.Should().Contain(tenantA);
+        signalLossTenants.Should().Contain(tenantB);
+
+        // Per-tenant read: tenant A sees only its own rules, never tenant B's.
+        var rulesA = await repo.GetEnabledRulesAsync(tenantA, CancellationToken.None);
+        rulesA.Select(r => r.Name).Should().BeEquivalentTo(["Signal loss A", "High A"]);
+        rulesA.Should().OnlyContain(r => r.TenantId == tenantA);
+
+        var rulesB = await repo.GetEnabledRulesAsync(tenantB, CancellationToken.None);
+        rulesB.Select(r => r.Name).Should().BeEquivalentTo(["Signal loss B"]);
+        rulesB.Should().OnlyContain(r => r.TenantId == tenantB);
+    }
+
+    private static async Task SeedRuleAsync(
+        InterceptingContextFactory factory, Guid tenantId, string name, AlertConditionType type)
+    {
+        await using var ctx = factory.CreateDbContext();
+        ctx.TenantId = tenantId; // pins the RLS GUC so the insert's WITH CHECK passes
+        ctx.AlertRules.Add(new AlertRuleEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = tenantId,
+            Name = name,
+            ConditionType = type,
+            ConditionParams = type == AlertConditionType.SignalLoss ? "{\"timeoutMinutes\":20}" : "{}",
+            ClientConfiguration = "{}",
+            Severity = AlertRuleSeverity.Warning,
+            IsEnabled = true,
+            SortOrder = 0,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        await ctx.SaveChangesAsync();
+    }
+
+    private sealed class InterceptingContextFactory(DbContextOptions<NocturneDbContext> options)
+        : IDbContextFactory<NocturneDbContext>
+    {
+        public NocturneDbContext CreateDbContext() => new(options);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/AlertDeliveryEndpointTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/AlertDeliveryEndpointTests.cs
@@ -10,6 +10,7 @@ using Nocturne.API.Services.Platform;
 using Nocturne.Core.Contracts.Alerts;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Services;
 using Xunit;
 
 namespace Nocturne.API.Tests.Controllers.V4;
@@ -17,7 +18,7 @@ namespace Nocturne.API.Tests.Controllers.V4;
 [Trait("Category", "Unit")]
 public class AlertDeliveryEndpointTests
 {
-    private readonly Mock<IDbContextFactory<NocturneDbContext>> _contextFactoryMock = new();
+    private readonly Mock<ITenantDbContextFactory> _contextFactoryMock = new();
     private readonly Mock<IAlertAcknowledgementService> _acknowledgementServiceMock = new();
     private readonly Mock<IAlertDeliveryService> _deliveryServiceMock = new();
     private readonly Mock<ITenantAccessor> _tenantAccessorMock = new();

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Monitoring/AlertRulesControllerTenantScopingTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Monitoring/AlertRulesControllerTenantScopingTests.cs
@@ -1,0 +1,131 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Nocturne.API.Controllers.V4.Monitoring;
+using Nocturne.API.Services.Alerts;
+using Nocturne.Core.Contracts.Alerts;
+using Nocturne.Core.Models.Alerts;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4.Monitoring;
+
+/// <summary>
+/// Regression tests for tenant scoping on <see cref="AlertRulesController"/>.
+///
+/// The controller leases its <see cref="NocturneDbContext"/> from a pooled factory.
+/// Pooling does not reset the custom <c>TenantId</c> property, so a context leased
+/// without re-pinning the tenant carries whatever the previous lessee left on it. Both
+/// the EF global query filter and PostgreSQL RLS derive from that <c>TenantId</c>, so a
+/// stale value made <c>/alerts</c> intermittently surface another tenant's rules — most
+/// visibly the demo tenant's seeded "High"/"Low" rules. Going through
+/// <see cref="Infrastructure.Data.Services.ITenantDbContextFactory"/> stamps the resolved
+/// tenant onto every leased context, which these tests lock in.
+/// </summary>
+[Trait("Category", "Unit")]
+public class AlertRulesControllerTenantScopingTests
+{
+    private static readonly Guid TenantA = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid TenantB = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    [Fact]
+    public async Task GetRules_ReturnsOnlyCurrentTenantRules_NotAnotherTenantsDemoDefaults()
+    {
+        // Arrange: a shared store where tenant B holds the demo "High"/"Low" rules and
+        // tenant A holds its own custom rule.
+        var options = NewStore();
+        await SeedAsync(options,
+            (TenantA, "Overnight Low"),
+            (TenantB, "High"),
+            (TenantB, "Low"));
+
+        var controller = CreateControllerScopedTo(TenantA, options);
+
+        // Act
+        var result = await controller.GetRules(CancellationToken.None);
+
+        // Assert: only tenant A's rule — never tenant B's seeded defaults.
+        var rules = OkValue(result);
+        rules.Should().ContainSingle().Which.Name.Should().Be("Overnight Low");
+        rules.Select(r => r.Name).Should().NotContain(["High", "Low"]);
+    }
+
+    [Fact]
+    public async Task GetRule_ById_DoesNotReturnAnotherTenantsRule()
+    {
+        // Arrange: a rule that belongs to tenant B.
+        var options = NewStore();
+        var tenantBRuleId = Guid.NewGuid();
+        await SeedAsync(options, (TenantB, "High", tenantBRuleId));
+
+        var controller = CreateControllerScopedTo(TenantA, options);
+
+        // Act: tenant A asks for tenant B's rule by id.
+        var result = await controller.GetRule(tenantBRuleId, CancellationToken.None);
+
+        // Assert: it is invisible to tenant A, not leaked.
+        result.Result.Should().BeOfType<NotFoundResult>();
+    }
+
+    private static DbContextOptions<NocturneDbContext> NewStore() =>
+        new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+    private static async Task SeedAsync(
+        DbContextOptions<NocturneDbContext> options,
+        params (Guid TenantId, string Name, Guid Id)[] rules)
+    {
+        // Inserts are not subject to the tenant query filter, so a single context can seed
+        // rows for multiple tenants.
+        await using var seed = new NocturneDbContext(options);
+        foreach (var (tenantId, name, id) in rules)
+            seed.AlertRules.Add(NewRule(tenantId, name, id));
+        await seed.SaveChangesAsync();
+    }
+
+    private static Task SeedAsync(
+        DbContextOptions<NocturneDbContext> options,
+        params (Guid TenantId, string Name)[] rules) =>
+        SeedAsync(options, rules.Select(r => (r.TenantId, r.Name, Guid.NewGuid())).ToArray());
+
+    private static AlertRulesController CreateControllerScopedTo(
+        Guid tenantId, DbContextOptions<NocturneDbContext> options)
+    {
+        // TestTenantDbContextFactory mirrors the production ITenantDbContextFactory: every
+        // leased context is stamped with this tenant, regardless of pool state.
+        var seedContext = new NocturneDbContext(options) { TenantId = tenantId };
+        var factory = new TestTenantDbContextFactory(seedContext);
+
+        return new AlertRulesController(
+            factory,
+            Mock.Of<IAlertReferenceService>(),
+            Mock.Of<IAlertDeliveryService>(),
+            Mock.Of<ILogger<AlertRulesController>>());
+    }
+
+    private static List<AlertRuleResponse> OkValue(ActionResult<List<AlertRuleResponse>> result)
+    {
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        return ok.Value.Should().BeAssignableTo<List<AlertRuleResponse>>().Subject;
+    }
+
+    private static AlertRuleEntity NewRule(Guid tenantId, string name, Guid id) => new()
+    {
+        Id = id,
+        TenantId = tenantId,
+        Name = name,
+        ConditionType = AlertConditionType.Threshold,
+        ConditionParams = "{}",
+        ClientConfiguration = "{}",
+        Severity = AlertRuleSeverity.Warning,
+        IsEnabled = true,
+        SortOrder = 0,
+        CreatedAt = DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow,
+    };
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/ExcursionResolutionHandlerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/ExcursionResolutionHandlerTests.cs
@@ -26,7 +26,7 @@ public class ExcursionResolutionHandlerTests
 
     public ExcursionResolutionHandlerTests()
     {
-        _repository.Setup(r => r.GetInAppDestinationsForExcursionAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+        _repository.Setup(r => r.GetInAppDestinationsForExcursionAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<string>());
 
         _sut = new ExcursionResolutionHandler(
@@ -43,7 +43,7 @@ public class ExcursionResolutionHandlerTests
         var instanceId = Guid.NewGuid();
         var instance = new AlertInstanceSnapshot(instanceId, _tenantId, _excursionId,
             "escalating", DateTime.UtcNow, SnoozedUntil: null, SnoozeCount: 0);
-        _repository.Setup(r => r.GetInstancesForExcursionAsync(_excursionId, It.IsAny<CancellationToken>()))
+        _repository.Setup(r => r.GetInstancesForExcursionAsync(_tenantId, _excursionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[] { instance });
 
         var transition = new ExcursionTransition(
@@ -52,8 +52,9 @@ public class ExcursionResolutionHandlerTests
         await _sut.HandleClosedAsync(transition, _tenantId, CancellationToken.None);
 
         _repository.Verify(r => r.ResolveInstancesForExcursionAsync(
-            _excursionId, It.IsAny<DateTime>(), "auto", It.IsAny<CancellationToken>()), Times.Once);
+            _tenantId, _excursionId, It.IsAny<DateTime>(), "auto", It.IsAny<CancellationToken>()), Times.Once);
         _repository.Verify(r => r.ExpirePendingDeliveriesAsync(
+            _tenantId,
             It.Is<IReadOnlyList<Guid>>(ids => ids.Contains(instanceId)),
             It.IsAny<CancellationToken>()), Times.Once);
         _broadcast.Verify(b => b.BroadcastAlertEventAsync("alert_resolved", It.IsAny<object>()), Times.Once);
@@ -62,7 +63,7 @@ public class ExcursionResolutionHandlerTests
     [Fact]
     public async Task HandleClosed_HysteresisReason_MapsToHysteresisWireString()
     {
-        _repository.Setup(r => r.GetInstancesForExcursionAsync(_excursionId, It.IsAny<CancellationToken>()))
+        _repository.Setup(r => r.GetInstancesForExcursionAsync(_tenantId, _excursionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<AlertInstanceSnapshot>());
 
         var transition = new ExcursionTransition(
@@ -71,13 +72,13 @@ public class ExcursionResolutionHandlerTests
         await _sut.HandleClosedAsync(transition, _tenantId, CancellationToken.None);
 
         _repository.Verify(r => r.ResolveInstancesForExcursionAsync(
-            _excursionId, It.IsAny<DateTime>(), "hysteresis", It.IsAny<CancellationToken>()), Times.Once);
+            _tenantId, _excursionId, It.IsAny<DateTime>(), "hysteresis", It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task HandleClosed_NullCloseReason_PassesNullThrough()
     {
-        _repository.Setup(r => r.GetInstancesForExcursionAsync(_excursionId, It.IsAny<CancellationToken>()))
+        _repository.Setup(r => r.GetInstancesForExcursionAsync(_tenantId, _excursionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<AlertInstanceSnapshot>());
 
         var transition = new ExcursionTransition(ExcursionTransitionType.ExcursionClosed, _excursionId);
@@ -85,13 +86,13 @@ public class ExcursionResolutionHandlerTests
         await _sut.HandleClosedAsync(transition, _tenantId, CancellationToken.None);
 
         _repository.Verify(r => r.ResolveInstancesForExcursionAsync(
-            _excursionId, It.IsAny<DateTime>(), (string?)null, It.IsAny<CancellationToken>()), Times.Once);
+            _tenantId, _excursionId, It.IsAny<DateTime>(), (string?)null, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task HandleClosed_NoInstances_SkipsExpireDeliveries()
     {
-        _repository.Setup(r => r.GetInstancesForExcursionAsync(_excursionId, It.IsAny<CancellationToken>()))
+        _repository.Setup(r => r.GetInstancesForExcursionAsync(_tenantId, _excursionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<AlertInstanceSnapshot>());
 
         var transition = new ExcursionTransition(
@@ -100,7 +101,7 @@ public class ExcursionResolutionHandlerTests
         await _sut.HandleClosedAsync(transition, _tenantId, CancellationToken.None);
 
         _repository.Verify(r => r.ExpirePendingDeliveriesAsync(
-            It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()), Times.Never);
+            _tenantId, It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -117,9 +118,9 @@ public class ExcursionResolutionHandlerTests
     [Fact]
     public async Task HandleClosed_AutoArchivesInAppNotificationsForEachRecipient()
     {
-        _repository.Setup(r => r.GetInstancesForExcursionAsync(_excursionId, It.IsAny<CancellationToken>()))
+        _repository.Setup(r => r.GetInstancesForExcursionAsync(_tenantId, _excursionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<AlertInstanceSnapshot>());
-        _repository.Setup(r => r.GetInAppDestinationsForExcursionAsync(_excursionId, It.IsAny<CancellationToken>()))
+        _repository.Setup(r => r.GetInAppDestinationsForExcursionAsync(_tenantId, _excursionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[] { "user-a", "user-b" });
 
         var transition = new ExcursionTransition(
@@ -144,7 +145,7 @@ public class ExcursionResolutionHandlerTests
     [Fact]
     public async Task HandleClosed_NoInAppRecipients_SkipsArchive()
     {
-        _repository.Setup(r => r.GetInstancesForExcursionAsync(_excursionId, It.IsAny<CancellationToken>()))
+        _repository.Setup(r => r.GetInstancesForExcursionAsync(_tenantId, _excursionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<AlertInstanceSnapshot>());
 
         var transition = new ExcursionTransition(
@@ -158,7 +159,7 @@ public class ExcursionResolutionHandlerTests
     [Fact]
     public async Task HandleClosed_BroadcastFailure_DoesNotPropagate()
     {
-        _repository.Setup(r => r.GetInstancesForExcursionAsync(_excursionId, It.IsAny<CancellationToken>()))
+        _repository.Setup(r => r.GetInstancesForExcursionAsync(_tenantId, _excursionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<AlertInstanceSnapshot>());
         _broadcast.Setup(b => b.BroadcastAlertEventAsync(It.IsAny<string>(), It.IsAny<object>()))
             .ThrowsAsync(new InvalidOperationException("hub down"));
@@ -170,6 +171,6 @@ public class ExcursionResolutionHandlerTests
 
         await act.Should().NotThrowAsync();
         _repository.Verify(r => r.ResolveInstancesForExcursionAsync(
-            _excursionId, It.IsAny<DateTime>(), "auto", It.IsAny<CancellationToken>()), Times.Once);
+            _tenantId, _excursionId, It.IsAny<DateTime>(), "auto", It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/AlertRepositoryTenantScopingTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/AlertRepositoryTenantScopingTests.cs
@@ -1,0 +1,124 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.InMemory.Storage.Internal;
+using Nocturne.Core.Models.Alerts;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Repositories;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories;
+
+/// <summary>
+/// Tenant-scoping regression tests for <see cref="AlertRepository"/>. The repository leases
+/// contexts from the pooled factory, which does not reset <c>TenantId</c>. These tests assert
+/// (a) per-tenant methods pin the requested tenant even when the pooled context arrives tagged
+/// with a different tenant, and (b) the cross-tenant sweeps iterate every active tenant rather
+/// than relying on a single (RLS-blocked) query.
+///
+/// EF InMemory honours the dynamic <c>e.TenantId == context.TenantId</c> global filter, so it
+/// validates the tenant pinning. InMemory has no Row-Level Security; the RLS half of the fix
+/// follows the same <c>context.TenantId</c> pattern already proven by
+/// <c>GetTenantAlertContextAsync</c> in production and is covered by Postgres integration tests.
+/// </summary>
+public class AlertRepositoryTenantScopingTests
+{
+    private static readonly Guid TenantA = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid TenantB = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    [Fact]
+    public async Task GetEnabledRulesAsync_ScopesToRequestedTenant_EvenWhenPooledContextIsStale()
+    {
+        var options = NewStore();
+        await SeedAsync(options, ctx =>
+        {
+            ctx.Tenants.AddRange(NewTenant(TenantA), NewTenant(TenantB));
+            ctx.AlertRules.AddRange(
+                NewRule(TenantA, "Overnight Low"),
+                NewRule(TenantB, "High"),
+                NewRule(TenantB, "Low"));
+        });
+
+        // The factory hands back contexts already tagged with tenant B — the production hazard
+        // where a pooled context carries the previous lessee's tenant.
+        var repo = new AlertRepository(new InMemoryContextFactory(options, staleTenantId: TenantB));
+
+        var rules = await repo.GetEnabledRulesAsync(TenantA, CancellationToken.None);
+
+        rules.Select(r => r.Name).Should().BeEquivalentTo(["Overnight Low"]);
+    }
+
+    [Fact]
+    public async Task GetEnabledSignalLossRulesAsync_ReturnsRulesAcrossEveryActiveTenant()
+    {
+        var options = NewStore();
+        await SeedAsync(options, ctx =>
+        {
+            ctx.Tenants.AddRange(NewTenant(TenantA), NewTenant(TenantB));
+            ctx.AlertRules.AddRange(
+                NewRule(TenantA, "Signal loss A", AlertConditionType.SignalLoss),
+                NewRule(TenantB, "Signal loss B", AlertConditionType.SignalLoss),
+                NewRule(TenantA, "Unrelated threshold")); // must not appear
+        });
+
+        // Starts from an unset (Guid.Empty) context — the cross-tenant sweep must enumerate
+        // tenants itself rather than depending on whatever tenant the pool last left behind.
+        var repo = new AlertRepository(new InMemoryContextFactory(options, staleTenantId: Guid.Empty));
+
+        var rules = await repo.GetEnabledSignalLossRulesAsync(CancellationToken.None);
+
+        rules.Select(r => r.TenantId).Should().BeEquivalentTo([TenantA, TenantB]);
+    }
+
+    private static DbContextOptions<NocturneDbContext> NewStore() =>
+        new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseInMemoryDatabase($"alert_repo_tests_{Guid.NewGuid()}")
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+    private static async Task SeedAsync(DbContextOptions<NocturneDbContext> options, Action<NocturneDbContext> seed)
+    {
+        await using var ctx = new NocturneDbContext(options);
+        seed(ctx);
+        await ctx.SaveChangesAsync();
+    }
+
+    private static TenantEntity NewTenant(Guid id) => new()
+    {
+        Id = id,
+        Slug = id.ToString("N")[..8],
+        DisplayName = id.ToString("N")[..8],
+        IsActive = true,
+    };
+
+    private static AlertRuleEntity NewRule(
+        Guid tenantId, string name, AlertConditionType type = AlertConditionType.Threshold) => new()
+    {
+        Id = Guid.NewGuid(),
+        TenantId = tenantId,
+        Name = name,
+        ConditionType = type,
+        ConditionParams = "{}",
+        ClientConfiguration = "{}",
+        Severity = AlertRuleSeverity.Warning,
+        IsEnabled = true,
+        SortOrder = 0,
+        CreatedAt = DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow,
+    };
+
+    /// <summary>
+    /// An <see cref="IDbContextFactory{TContext}"/> over a shared InMemory store whose leased
+    /// contexts arrive pre-tagged with <paramref name="staleTenantId"/>, mimicking a pooled
+    /// context that was not reset. The repository must overwrite <c>TenantId</c> itself.
+    /// </summary>
+    private sealed class InMemoryContextFactory(
+        DbContextOptions<NocturneDbContext> options, Guid staleTenantId)
+        : IDbContextFactory<NocturneDbContext>
+    {
+        public NocturneDbContext CreateDbContext() => new(options) { TenantId = staleTenantId };
+
+        public Task<NocturneDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(CreateDbContext());
+    }
+}


### PR DESCRIPTION
## Problem

`NocturneDbContext` is pooled (`AddPooledDbContextFactory`) and its `TenantId` property is **not reset** between leases. Both isolation layers — the EF global query filter and PostgreSQL RLS — derive the active tenant from `context.TenantId`. Any code that leases a context from the raw `IDbContextFactory<NocturneDbContext>` without setting `TenantId` runs under whatever tenant the *previous* lessee left behind.

### Cross-tenant leaks (no explicit tenant predicate → returns the stale tenant's rows)
- The `/alerts` Monitoring controllers (`AlertRules`, `Alerts`, `AlertCustomSounds`, `AlertInvites`, `TenantAlertSettings`) intermittently served **another tenant's** alert rules — most visibly the demo tenant's seeded "High"/"Low" rules. Channel destinations (emails/webhooks/phone numbers) made this a PII exposure.
- `StatusService.LastModifiedAsync` read 12 tenant-scoped collections under the stale tenant.
- `AuditController.UpdateAuditConfig` wrote audit config under the stale tenant.

### Alerts runtime engine (`AlertRepository`)
Per-tenant methods *failed closed* under RLS (flaky alerts), and the cross-tenant sweeps used `.IgnoreQueryFilters()` — which bypasses the EF filter but **not** the fail-closed RLS policy (`tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid`). A single query can never see across tenants for the non-bypass `nocturne_app` role, so the `AlertSweepService` lifecycle (hysteresis close, auto-resolve, signal-loss, snooze) was intermittently broken in multi-tenant deployments.

## Fix
- **Monitoring controllers + AuditController** — pin the tenant (`ITenantDbContextFactory` / `db.TenantId`) before querying.
- **StatusService** — pin the resolved tenant on each leased context.
- **AlertRepository** — pin `context.TenantId` in every per-tenant method; thread `tenantId` into the by-id methods (`IAlertRepository` signature change + `UpdateAlertInstanceRequest.TenantId`); rewrite the four cross-tenant sweeps to enumerate active tenants and query per-tenant.

## Tests
- `AlertRulesControllerTenantScopingTests` and `AlertRepositoryTenantScopingTests` (InMemory): per-tenant pinning under a stale pooled context + cross-tenant sweep enumeration.
- `AlertRepositorySweepIntegrationTests` (Postgres + real RLS): the sweep surfaces every tenant's rules and per-tenant reads stay scoped. Validates the RLS half InMemory can't.
- Existing alert unit tests updated for the new signatures; all 480 pass locally.