### PR TITLE
fix(web): remote query .run() in detached contexts (year-overview + alerts polling) + lint guard

### DIFF
--- a/src/Web/packages/app/src/routes/(authenticated)/reports/year-overview/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/year-overview/+page.svelte
@@ -258,7 +258,7 @@
     if (metadataLoading) return;
     metadataLoading = true;
     try {
-      const result = await getAvailableYears();
+      const result = await getAvailableYears().run();
       availableYears = result.years ?? [];
       availableDataSources = result.availableDataSources ?? [];
       metadataLoaded = true;
@@ -278,7 +278,7 @@
       if (selectedDataSources.length > 0) {
         params.dataSources = selectedDataSources;
       }
-      const result = await getDailySummary(params);
+      const result = await getDailySummary(params).run();
       const days = result.days ?? [];
       yearData = new Map([...yearData, [year, days]]);
       loadGriTimeline(year);
@@ -298,7 +298,7 @@
         year,
         dataSources:
           selectedDataSources.length > 0 ? selectedDataSources : undefined,
-      });
+      }).run();
       const periods = result.periods ?? [];
       griTimelineData = new Map([...griTimelineData, [year, periods]]);
     } catch (err) {
@@ -433,11 +433,15 @@
   // Lifecycle
   // =========================================================================
 
-  onMount(async () => {
-    await loadMetadata();
-    if (sortedYears.length > 0) {
-      loadYearData(sortedYears[0]);
-    }
+  onMount(() => {
+    // `.run()` rejects when called during the render/effect flush, so defer the
+    // bootstrap to a microtask — onMount's synchronous body still counts as render.
+    queueMicrotask(async () => {
+      await loadMetadata();
+      if (sortedYears.length > 0) {
+        loadYearData(sortedYears[0]);
+      }
+    });
   });
 
   $effect(() => {


### PR DESCRIPTION
## Problem

Remote `query()` functions awaited **imperatively outside a reactive context** throw `This query was not created in a reactive context ... Use .run()`. The throw is swallowed by surrounding `try/catch`, so the symptom is silent missing/stale data.

Two live instances:

1. **Year Overview** (`reports/year-overview`) — empty heatmap. The year picker populates but `getDailySummary`/`getGriTimeline` (called after an `await` boundary and from an `IntersectionObserver`) silently fail. Backend returns correct data. Regressed by #331, which removed #240's `.run()` to fix the opposite *"`.run()` can only be called outside render"* error — a ping-pong.
2. **Alerts polling** (`AlertBanner`, `FiringToast`) — `getActiveAlerts()` is polled from `setInterval` (a detached callback). The initial `onMount` load works, but every poll tick silently fails, so the banner/toast **never refresh**.

## Fix

Restore `.run()` on the affected queries **and** defer the first `onMount` invocation via `queueMicrotask`, so `.run()` never fires during the render/effect flush (`setInterval`/observer/event-handler calls are already outside render). This is the pattern already proven in `HaloDial.svelte`. `command()` mutations (`acknowledge`, `snoozeInstance`, `toggleRule`) are correctly awaited bare and left unchanged.

## Lint guard

Adds `nocturne/no-imperative-remote-query` (warn) — flags a remote `query()` awaited or `.then()`-chained imperatively without `.run()`/`.current`/`.refresh()`. Query vs command is resolved by scanning the remote modules, so mutations aren't flagged. **Editor/local guard only** — this repo's CI doesn't run eslint. Verified locally: it flags the remaining offenders (`getMyTenants` in AppSidebar, `getEntryByTreatmentId` in glucose-chart, etc.) and is clean on the files fixed here.

## Verification

- API confirmed returning data for an affected tenant (years `[2025,2026]`, 156 populated days for 2026, monthly GRI).
- Lint rule run locally (`pnpm eslint`): fires on the unfixed sites, clean on the fixed ones, no crash.
- Not yet runtime-verified in a running app; relying on the HaloDial precedent + local lint.

## Follow-ups (not in this PR)

Other bare-`await`-a-query sites remain (flagged by the new rule) — they need per-call-context review before fixing, since converting reactive-context calls to `.run()` would reintroduce the render error.