### PR TITLE
fix(alerts): use .run() for polled active-alerts query + remote-query lint guard

### DIFF
--- a/src/Web/packages/app/eslint.config.js
+++ b/src/Web/packages/app/eslint.config.js
@@ -6,6 +6,8 @@ import svelte from 'eslint-plugin-svelte';
 import globals from 'globals';
 import ts from 'typescript-eslint';
 
+import noImperativeRemoteQuery from "./tools/eslint/no-imperative-remote-query.js";
+
 export default ts.config(
   js.configs.recommended,
   ...ts.configs.recommended,
@@ -41,6 +43,20 @@ export default ts.config(
           assertionStyle: "never"
         }
       ]
+    }
+  },
+  {
+    // Guard against the year-overview/alerts-polling regression class: a remote
+    // query() awaited or `.then()`-chained imperatively (outside a reactive
+    // context) throws "not created in a reactive context ... Use .run()".
+    files: ["**/*.svelte", "**/*.svelte.ts"],
+    plugins: {
+      nocturne: {
+        rules: { "no-imperative-remote-query": noImperativeRemoteQuery }
+      }
+    },
+    rules: {
+      "nocturne/no-imperative-remote-query": "warn"
     }
   }
 );

--- a/src/Web/packages/app/src/lib/components/alerts/AlertBanner.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/AlertBanner.svelte
@@ -35,7 +35,7 @@
 
   async function fetchAlerts() {
     try {
-      const result = await getActiveAlerts();
+      const result = await getActiveAlerts().run();
       if (Array.isArray(result)) {
         alerts = result;
       }
@@ -60,8 +60,10 @@
     dismissedIds = new Set([...dismissedIds, id]);
   }
 
-  onMount(async () => {
-    await fetchAlerts();
+  onMount(() => {
+    // Defer the first fetch out of render so the query's `.run()` is valid;
+    // setInterval ticks already run outside render.
+    queueMicrotask(fetchAlerts);
     pollInterval = setInterval(fetchAlerts, 30000);
   });
 

--- a/src/Web/packages/app/src/lib/components/alerts/FiringToast.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/FiringToast.svelte
@@ -35,7 +35,7 @@
 
   async function poll(): Promise<void> {
     try {
-      const result = await getActiveAlerts();
+      const result = await getActiveAlerts().run();
       const list = Array.isArray(result) ? result : [];
       alerts = list;
       const fresh: ActiveExcursionResponse[] = [];
@@ -47,7 +47,9 @@
       }
       if (fresh.length > 0) queue = [...fresh, ...queue];
       // Remove toasts that were acknowledged elsewhere (other tab, banner, etc.)
-      const ackedIds = new Set(list.filter((a) => a.acknowledgedAt).map((a) => a.id));
+      const ackedIds = new Set(
+        list.filter((a) => a.acknowledgedAt).map((a) => a.id)
+      );
       if (ackedIds.size > 0) queue = queue.filter((a) => !ackedIds.has(a.id));
     } catch {
       // Silent: polling shouldn't surface transient errors.
@@ -55,7 +57,9 @@
   }
 
   onMount(() => {
-    poll();
+    // Defer the first poll out of render so the query's `.run()` is valid;
+    // setInterval ticks already run outside render.
+    queueMicrotask(poll);
     pollTimer = setInterval(poll, POLL_MS);
   });
 
@@ -118,7 +122,10 @@
       >
         <div class="flex items-start gap-2">
           <span
-            class="mt-0.5 grid h-7 w-7 shrink-0 place-items-center rounded-full {severity('critical', 'chip')}"
+            class="mt-0.5 grid h-7 w-7 shrink-0 place-items-center rounded-full {severity(
+              'critical',
+              'chip'
+            )}"
           >
             <Bell class="h-4 w-4" />
           </span>

--- a/src/Web/packages/app/tools/eslint/no-imperative-remote-query.js
+++ b/src/Web/packages/app/tools/eslint/no-imperative-remote-query.js
@@ -1,0 +1,122 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Custom ESLint rule: remote `query()` functions called imperatively must use
+ * `.run()` (or `.current` / `.refresh()`).
+ *
+ * SvelteKit remote `query()` functions can be awaited directly only when
+ * created in a reactive context (component init, `$effect`, `$derived`,
+ * `{#await}`). When created in a detached continuation — after an `await`,
+ * inside `setInterval` / `setTimeout` / observer callbacks, or via `.then()` —
+ * awaiting them throws "not created in a reactive context ... Use .run()". This
+ * rule flags those imperative call sites. Mutations use `command()`, which is
+ * correctly awaited directly, so only `query()` exports are matched.
+ *
+ * The set of query names is discovered by scanning the generated + hand-written
+ * remote modules under `src/lib/api`. Any failure to scan yields an empty set,
+ * which silently disables the rule rather than crashing the lint run.
+ */
+
+const ruleDir = path.dirname(fileURLToPath(import.meta.url));
+const SAFE_MEMBERS = new Set(["run", "current", "refresh"]);
+
+function loadQueryNames() {
+  const names = new Set();
+  const root = path.resolve(ruleDir, "..", "..", "src", "lib", "api");
+  const stack = [root];
+  try {
+    while (stack.length > 0) {
+      const dir = stack.pop();
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          stack.push(full);
+        } else if (entry.name.endsWith(".remote.ts")) {
+          // eslint-disable-next-line security/detect-non-literal-fs-filename
+          const src = fs.readFileSync(full, "utf8");
+          const re = /export\s+const\s+(\w+)\s*=\s*query\(/g;
+          let match;
+          while ((match = re.exec(src)) !== null) {
+            names.add(match[1]);
+          }
+        }
+      }
+    }
+  } catch {
+    // Scan failed (path moved, permissions, etc.) — disable the rule rather
+    // than break linting.
+    return new Set();
+  }
+  return names;
+}
+
+const QUERY_NAMES = loadQueryNames();
+
+/** @type {import("eslint").Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Remote query() functions called imperatively must use .run() (awaiting them outside a reactive context throws).",
+    },
+    schema: [],
+    messages: {
+      useRun:
+        "Remote query '{{name}}' is called imperatively — use {{name}}(...).run() (or .current / .refresh()). Awaiting it directly throws outside a reactive context; defer .run() out of render via queueMicrotask if needed (see HaloDial.svelte).",
+    },
+  },
+  create(context) {
+    // Only flag identifiers imported from a remote module in this file.
+    const remoteQueryImports = new Set();
+    return {
+      ImportDeclaration(node) {
+        const source = String(node.source.value ?? "");
+        if (!source.includes("remote")) return;
+        for (const spec of node.specifiers) {
+          if (
+            spec.type === "ImportSpecifier" &&
+            QUERY_NAMES.has(spec.local.name)
+          ) {
+            remoteQueryImports.add(spec.local.name);
+          }
+        }
+      },
+      CallExpression(node) {
+        if (node.callee.type !== "Identifier") return;
+        const name = node.callee.name;
+        if (!remoteQueryImports.has(name)) return;
+
+        const parent = node.parent;
+        // `getX(...).run()` / `.current` / `.refresh()` — the correct imperative form.
+        if (
+          parent &&
+          parent.type === "MemberExpression" &&
+          parent.object === node &&
+          parent.property.type === "Identifier" &&
+          SAFE_MEMBERS.has(parent.property.name)
+        ) {
+          return;
+        }
+
+        const isAwaited = parent && parent.type === "AwaitExpression";
+        const isThenChain =
+          parent &&
+          parent.type === "MemberExpression" &&
+          parent.object === node &&
+          parent.property.type === "Identifier" &&
+          (parent.property.name === "then" || parent.property.name === "catch");
+
+        if (isAwaited || isThenChain) {
+          context.report({ node, messageId: "useRun", data: { name } });
+        }
+      },
+    };
+  },
+};
+
+export default rule;


### PR DESCRIPTION
Follow-up to #334 (which shipped the year-overview `.run()` fix). Same regression class: a remote `query()` awaited imperatively **outside a reactive context** throws `This query was not created in a reactive context ... Use .run()`, and the throw is swallowed by a surrounding silent `catch`.

## Alerts polling (silent prod bug)

`AlertBanner.svelte` and `FiringToast.svelte` poll `getActiveAlerts()` from `setInterval` — a detached callback. The initial `onMount` load works, but **every poll tick silently fails**, so the banner/toast never refresh after first paint. Fix: `.run()` on the query + defer the first `onMount` poll via `queueMicrotask` (the `setInterval` ticks already run outside render). `command()` mutations (`acknowledge`, `snoozeInstance`, `toggleRule`) are correctly awaited bare and untouched.

## Lint guard

Adds `nocturne/no-imperative-remote-query` (warn) — flags a remote `query()` awaited or `.then()`-chained imperatively without `.run()`/`.current`/`.refresh()`. Query vs command is resolved by scanning the remote modules, so mutations aren't flagged. **Editor/local guard only** — this repo's CI doesn't run eslint. Verified locally (`pnpm eslint`): fires on the remaining offenders (`getMyTenants` in AppSidebar, `getEntryByTreatmentId` in glucose-chart, …), clean on the files fixed here, distinguishes queries from commands.

## Follow-ups (not here)

Other bare-`await`-a-query sites remain (flagged by the new rule); they need per-call-context review before fixing, since converting reactive-context calls to `.run()` would reintroduce the render error.