### PR TITLE
perf(chart): make dashboard IOB/COB tick loop async/DB-free

### DIFF
--- a/src/API/Nocturne.API/Services/ChartData/Stages/IobCobComputeStage.cs
+++ b/src/API/Nocturne.API/Services/ChartData/Stages/IobCobComputeStage.cs
@@ -174,6 +174,10 @@ internal sealed class IobCobComputeStage(
         {
             ct.ThrowIfCancellationRequested();
 
+            // One in-memory therapy snapshot per tick drives every profile lookup below
+            // (DIA, sensitivity, scheduled basal rate, carb ratio) with zero DB round trips.
+            var snapshot = timeline.SnapshotAt(t);
+
             // Admit newly-elapsed entries (Mills/StartMills <= t)
             while (insulinHi < sortedBoluses.Count && sortedBoluses[insulinHi].Mills <= t)
                 insulinHi++;
@@ -198,7 +202,7 @@ internal sealed class IobCobComputeStage(
 
             var insulinCount = insulinHi - insulinLo;
             var iobResult = insulinCount > 0
-                ? iobCalculator.FromBoluses(sortedBoluses.GetRange(insulinLo, insulinCount), t)
+                ? iobCalculator.FromBoluses(sortedBoluses.GetRange(insulinLo, insulinCount), snapshot, t)
                 : new IobResult { Iob = 0 };
 
             var basalIob = 0.0;
@@ -207,6 +211,7 @@ internal sealed class IobCobComputeStage(
             {
                 var basalResult = iobCalculator.FromTempBasals(
                     sortedTempBasals.GetRange(basalLo, basalCount),
+                    snapshot,
                     t
                 );
                 basalIob = basalResult.BasalIob ?? 0;
@@ -225,6 +230,7 @@ internal sealed class IobCobComputeStage(
                     sortedTempBasals is not null && basalCount > 0
                         ? sortedTempBasals.GetRange(basalLo, basalCount)
                         : null,
+                    snapshot,
                     t
                 )
                 : new CobResult { Cob = 0 };

--- a/src/API/Nocturne.API/Services/Treatments/CobCalculator.cs
+++ b/src/API/Nocturne.API/Services/Treatments/CobCalculator.cs
@@ -112,6 +112,67 @@ public class CobCalculator(
     {
         var currentTime = time ?? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
+        // Insulin activity for the dynamic carb-delay calc comes from the full IOB total
+        // (boluses + temp basals + device snapshots) at the requested time.
+        double ActivityAt(long t) =>
+            iobCalculator
+                .CalculateTotalAsync(boluses ?? [], tempBasals, t, ct: default)
+                .GetAwaiter()
+                .GetResult()
+                ?.Activity ?? double.NaN;
+
+        return FromCarbIntakesCore(
+            carbIntakes,
+            currentTime,
+            GetCarbAbsorptionRateOrDefault,
+            GetSensitivityOrDefault,
+            GetCarbRatioOrDefault,
+            ActivityAt
+        );
+    }
+
+    /// <inheritdoc />
+    public CobResult FromCarbIntakes(
+        List<CarbIntake> carbIntakes,
+        List<Bolus>? boluses,
+        List<TempBasal>? tempBasals,
+        TherapySnapshot snapshot,
+        long time
+    )
+    {
+        // All resolutions come from the in-memory snapshot — no DB round trips in the tick loop.
+        // Profile-absent defaults match the legacy GetXOrDefault helpers.
+        double CarbAbsorptionAt(long _) =>
+            snapshot.CarbsPerHour > 0 ? snapshot.CarbsPerHour : DEFAULT_CARB_ABSORPTION_RATE;
+        double SensitivityAt(long t) =>
+            snapshot.SensitivityAt(t) is var s && s > 0 ? s : DEFAULT_SENSITIVITY;
+        double CarbRatioAt(long t) =>
+            snapshot.CarbRatioAt(t) is var c && c > 0 ? c : DEFAULT_CARB_RATIO;
+
+        // Temp basals carry zero insulin activity, so bolus-derived activity is the full activity
+        // signal — computed in-memory from the snapshot rather than via the async IOB total.
+        double ActivityAt(long t) =>
+            iobCalculator.FromBoluses(boluses ?? [], snapshot, t).Activity ?? double.NaN;
+
+        return FromCarbIntakesCore(
+            carbIntakes,
+            time,
+            CarbAbsorptionAt,
+            SensitivityAt,
+            CarbRatioAt,
+            ActivityAt
+        );
+    }
+
+    private CobResult FromCarbIntakesCore(
+        List<CarbIntake> carbIntakes,
+        long currentTime,
+        Func<long, double> carbAbsorptionAt,
+        Func<long, double> sensitivityAt,
+        Func<long, double> carbRatioAt,
+        Func<long, double> activityAt
+    )
+    {
         var totalCOB = 0.0;
         CarbIntake? lastCarbs = null;
         var isDecaying = 0.0;
@@ -121,7 +182,7 @@ public class CobCalculator(
 
         foreach (var carbIntake in sortedIntakes)
         {
-            var carbAbsorptionRateFromProfile = GetCarbAbsorptionRateOrDefault(carbIntake.Mills);
+            var carbAbsorptionRateFromProfile = carbAbsorptionAt(carbIntake.Mills);
 
             if (carbIntake.Carbs > 0 && carbIntake.Mills < currentTime)
             {
@@ -135,28 +196,13 @@ public class CobCalculator(
 
                 if (decaysinHr > -10)
                 {
-                    var actStartResult = iobCalculator
-                        .CalculateTotalAsync(
-                            boluses ?? [],
-                            tempBasals,
-                            lastDecayedBy,
-                            ct: default
-                        ).GetAwaiter().GetResult();
-                    var actStart = actStartResult?.Activity ?? double.NaN;
-
-                    var actEndResult = iobCalculator
-                        .CalculateTotalAsync(
-                            boluses ?? [],
-                            tempBasals,
-                            cCalc.DecayedBy.ToUnixTimeMilliseconds(),
-                            ct: default
-                        ).GetAwaiter().GetResult();
-                    var actEnd = actEndResult?.Activity ?? double.NaN;
+                    var actStart = activityAt(lastDecayedBy);
+                    var actEnd = activityAt(cCalc.DecayedBy.ToUnixTimeMilliseconds());
 
                     var avgActivity = (actStart + actEnd) / 2.0;
 
-                    var sensFromProfile = GetSensitivityOrDefault(carbIntake.Mills);
-                    var carbRatioFromProfile = GetCarbRatioOrDefault(carbIntake.Mills);
+                    var sensFromProfile = sensitivityAt(carbIntake.Mills);
+                    var carbRatioFromProfile = carbRatioAt(carbIntake.Mills);
 
                     var delayedCarbs =
                         carbRatioFromProfile * ((avgActivity * LIVER_SENS_RATIO) / sensFromProfile);
@@ -192,9 +238,9 @@ public class CobCalculator(
             }
         }
 
-        var sens = GetSensitivityOrDefault(currentTime);
-        var carbRatio = GetCarbRatioOrDefault(currentTime);
-        var carbAbsorptionRate = GetCarbAbsorptionRateOrDefault(currentTime);
+        var sens = sensitivityAt(currentTime);
+        var carbRatio = carbRatioAt(currentTime);
+        var carbAbsorptionRate = carbAbsorptionAt(currentTime);
 
         var rawCarbImpact = (((isDecaying * sens) / carbRatio) * carbAbsorptionRate) / 60.0;
 

--- a/src/API/Nocturne.API/Services/Treatments/IobCalculator.cs
+++ b/src/API/Nocturne.API/Services/Treatments/IobCalculator.cs
@@ -108,6 +108,27 @@ public class IobCalculator(
             ?? PEAK_MINUTES;
         var sens = sensitivity.GetSensitivityAsync(currentTime, null).GetAwaiter().GetResult();
 
+        return CalcBolusCore(bolus, dia, peak, sens, currentTime);
+    }
+
+    /// <inheritdoc />
+    public IobContribution CalcBolus(Bolus bolus, TherapySnapshot snapshot, long time)
+    {
+        if (bolus.Insulin <= 0)
+        {
+            return new IobContribution { IobContrib = 0, ActivityContrib = 0 };
+        }
+
+        // Same precedence as the async path: per-bolus insulin context wins, else the snapshot.
+        var dia = bolus.InsulinContext?.Dia ?? snapshot.Dia;
+        var peak = bolus.InsulinContext?.Peak ?? snapshot.PeakMinutes;
+        var sens = snapshot.SensitivityAt(time);
+
+        return CalcBolusCore(bolus, dia, peak, sens, time);
+    }
+
+    private static IobContribution CalcBolusCore(Bolus bolus, double dia, double peak, double sens, long currentTime)
+    {
         // Exact legacy algorithm constants
         var scaleFactor = SCALE_FACTOR_BASE / dia;
 
@@ -155,7 +176,18 @@ public class IobCalculator(
     public IobResult FromBoluses(List<Bolus> boluses, long? time = null)
     {
         var currentTime = time ?? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        return FromBolusesCore(boluses, currentTime, bolus => CalcBolus(bolus, currentTime));
+    }
 
+    /// <inheritdoc />
+    public IobResult FromBoluses(List<Bolus> boluses, TherapySnapshot snapshot, long time)
+    {
+        return FromBolusesCore(boluses, time, bolus => CalcBolus(bolus, snapshot, time));
+    }
+
+    private static IobResult FromBolusesCore(
+        List<Bolus> boluses, long currentTime, Func<Bolus, IobContribution> calc)
+    {
         if (boluses?.Any() != true)
         {
             return new IobResult
@@ -172,7 +204,7 @@ public class IobCalculator(
 
         foreach (var bolus in boluses.Where(b => b.Mills <= currentTime && b.Insulin > 0))
         {
-            var contribution = CalcBolus(bolus, currentTime);
+            var contribution = calc(bolus);
 
             totalIob += contribution.IobContrib;
             totalActivity += contribution.ActivityContrib;
@@ -208,8 +240,28 @@ public class IobCalculator(
         var scheduledBasalRate = tempBasal.ScheduledRate
             ?? basalRate.GetBasalRateAsync(tempBasal.StartMills, null).GetAwaiter().GetResult();
 
+        return CalcTempBasalCore(tempBasal, dia, scheduledBasalRate, currentTime);
+    }
+
+    /// <inheritdoc />
+    public IobContribution CalcTempBasal(TempBasal tempBasal, TherapySnapshot snapshot, long time)
+    {
+        if (!tempBasal.EndMills.HasValue)
+        {
+            return new IobContribution { IobContrib = 0, ActivityContrib = 0 };
+        }
+
+        var dia = tempBasal.InsulinContext?.Dia ?? snapshot.Dia;
+        var scheduledBasalRate = tempBasal.ScheduledRate ?? snapshot.BasalRateAt(tempBasal.StartMills);
+
+        return CalcTempBasalCore(tempBasal, dia, scheduledBasalRate, time);
+    }
+
+    private static IobContribution CalcTempBasalCore(
+        TempBasal tempBasal, double dia, double scheduledBasalRate, long currentTime)
+    {
         var treatmentStart = tempBasal.StartMills;
-        var treatmentEnd = tempBasal.EndMills.Value;
+        var treatmentEnd = tempBasal.EndMills!.Value;
 
         if (currentTime <= treatmentStart)
         {
@@ -249,7 +301,18 @@ public class IobCalculator(
     public IobResult FromTempBasals(List<TempBasal> tempBasals, long? time = null)
     {
         var currentTime = time ?? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        return FromTempBasalsCore(tempBasals, currentTime, tb => CalcTempBasal(tb, currentTime));
+    }
 
+    /// <inheritdoc />
+    public IobResult FromTempBasals(List<TempBasal> tempBasals, TherapySnapshot snapshot, long time)
+    {
+        return FromTempBasalsCore(tempBasals, time, tb => CalcTempBasal(tb, snapshot, time));
+    }
+
+    private static IobResult FromTempBasalsCore(
+        List<TempBasal> tempBasals, long currentTime, Func<TempBasal, IobContribution> calc)
+    {
         if (tempBasals?.Any() != true)
         {
             return new IobResult
@@ -265,7 +328,7 @@ public class IobCalculator(
 
         foreach (var tempBasal in tempBasals.Where(tb => tb.StartMills <= currentTime))
         {
-            var contribution = CalcTempBasal(tempBasal, currentTime);
+            var contribution = calc(tempBasal);
             totalBasalIob += contribution.IobContrib;
             totalActivity += contribution.ActivityContrib;
         }

--- a/src/Core/Nocturne.Core.Contracts/Treatments/ICobCalculator.cs
+++ b/src/Core/Nocturne.Core.Contracts/Treatments/ICobCalculator.cs
@@ -18,5 +18,19 @@ public interface ICobCalculator
         List<TempBasal>? tempBasals = null,
         long? time = null);
 
+    /// <summary>
+    /// Async-free overload for the chart COB tick loop. Resolves carb absorption, sensitivity and
+    /// carb ratio from the in-memory <paramref name="snapshot"/>, and derives insulin activity for
+    /// the dynamic carb-delay calculation directly from boluses (the only treatments that carry
+    /// activity) via the snapshot-based IOB path — so no profile resolver or device-snapshot DB
+    /// query is issued per carb per tick. See IobCobComputeStage.
+    /// </summary>
+    CobResult FromCarbIntakes(
+        List<CarbIntake> carbIntakes,
+        List<Bolus>? boluses,
+        List<TempBasal>? tempBasals,
+        TherapySnapshot snapshot,
+        long time);
+
     CarbCobContribution CalcCarbIntake(CarbIntake carbIntake, long time);
 }

--- a/src/Core/Nocturne.Core.Contracts/Treatments/IIobCalculator.cs
+++ b/src/Core/Nocturne.Core.Contracts/Treatments/IIobCalculator.cs
@@ -15,4 +15,22 @@ public interface IIobCalculator
     IobResult FromTempBasals(List<TempBasal> tempBasals, long? time = null);
     IobContribution CalcBolus(Bolus bolus, long? time = null);
     IobContribution CalcTempBasal(TempBasal tempBasal, long? time = null);
+
+    // --- Async-free overloads for the chart IOB/COB tick loop ---
+    // These resolve DIA, peak, sensitivity and the scheduled basal rate from a pre-built,
+    // in-memory <see cref="TherapySnapshot"/> instead of awaiting profile resolvers per call.
+    // The chart computes one snapshot per tick (TherapyTimeline.SnapshotAt) and evaluates
+    // hundreds of treatments against it without any DB round trip — see IobCobComputeStage.
+
+    /// <inheritdoc cref="CalcBolus(Bolus, long?)"/>
+    IobContribution CalcBolus(Bolus bolus, TherapySnapshot snapshot, long time);
+
+    /// <inheritdoc cref="CalcTempBasal(TempBasal, long?)"/>
+    IobContribution CalcTempBasal(TempBasal tempBasal, TherapySnapshot snapshot, long time);
+
+    /// <inheritdoc cref="FromBoluses(List{Bolus}, long?)"/>
+    IobResult FromBoluses(List<Bolus> boluses, TherapySnapshot snapshot, long time);
+
+    /// <inheritdoc cref="FromTempBasals(List{TempBasal}, long?)"/>
+    IobResult FromTempBasals(List<TempBasal> tempBasals, TherapySnapshot snapshot, long time);
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/ChartData/Stages/IobCobComputeStageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ChartData/Stages/IobCobComputeStageTests.cs
@@ -4,9 +4,11 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.API.Services.ChartData;
 using Nocturne.API.Services.ChartData.Stages;
+using Nocturne.API.Services.Treatments;
 using Nocturne.Core.Contracts.Analytics;
 using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Contracts.Treatments;
+using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
 using Nocturne.Tests.Shared.Mocks;
@@ -103,15 +105,15 @@ public class IobCobComputeStageTests
         };
 
         _mockIobCalculator
-            .Setup(s => s.FromBoluses(It.IsAny<List<Bolus>>(), It.IsAny<long?>()))
+            .Setup(s => s.FromBoluses(It.IsAny<List<Bolus>>(), It.IsAny<TherapySnapshot>(), It.IsAny<long>()))
             .Returns(new IobResult { Iob = 2.0 });
 
         _mockIobCalculator
-            .Setup(s => s.FromTempBasals(It.IsAny<List<TempBasal>>(), It.IsAny<long?>()))
+            .Setup(s => s.FromTempBasals(It.IsAny<List<TempBasal>>(), It.IsAny<TherapySnapshot>(), It.IsAny<long>()))
             .Returns(new IobResult { BasalIob = 0.5 });
 
         _mockCobCalculator
-            .Setup(s => s.FromCarbIntakes(It.IsAny<List<CarbIntake>>(), It.IsAny<List<Bolus>?>(), It.IsAny<List<TempBasal>?>(), It.IsAny<long?>()))
+            .Setup(s => s.FromCarbIntakes(It.IsAny<List<CarbIntake>>(), It.IsAny<List<Bolus>?>(), It.IsAny<List<TempBasal>?>(), It.IsAny<TherapySnapshot>(), It.IsAny<long>()))
             .Returns(new CobResult { Cob = 20.0 });
 
         var context = new ChartDataContext
@@ -166,11 +168,11 @@ public class IobCobComputeStageTests
 
         // Assert — IOB/COB calculators should never be called with no data
         _mockIobCalculator.Verify(
-            s => s.FromBoluses(It.IsAny<List<Bolus>>(), It.IsAny<long?>()),
+            s => s.FromBoluses(It.IsAny<List<Bolus>>(), It.IsAny<TherapySnapshot>(), It.IsAny<long>()),
             Times.Never
         );
         _mockCobCalculator.Verify(
-            s => s.FromCarbIntakes(It.IsAny<List<CarbIntake>>(), It.IsAny<List<Bolus>?>(), It.IsAny<List<TempBasal>?>(), It.IsAny<long?>()),
+            s => s.FromCarbIntakes(It.IsAny<List<CarbIntake>>(), It.IsAny<List<Bolus>?>(), It.IsAny<List<TempBasal>?>(), It.IsAny<TherapySnapshot>(), It.IsAny<long>()),
             Times.Never
         );
 
@@ -187,5 +189,108 @@ public class IobCobComputeStageTests
         result.CobSeries.Should().ContainSingle();
         result.IobSeries[0].Value.Should().Be(0);
         result.CobSeries[0].Value.Should().Be(0);
+    }
+
+    /// <summary>
+    /// Scaling regression for the dashboard-chart hang. With the <em>real</em> IOB and COB
+    /// calculators wired into the stage and a wide window full of treatments shaped like erik's
+    /// tenant (temp basals with null ScheduledRate and null InsulinContext, plus boluses and
+    /// carbs), evaluating every tick must issue <b>zero</b> profile-resolver or device-snapshot
+    /// DB calls — every lookup is served from the per-tick in-memory TherapySnapshot.
+    /// Before the fix this path made an unbounded number of sync-over-async DB calls
+    /// (O(ticks × treatments)), which pinned a thread for minutes.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_WideWindowWithNullProfileFields_IssuesNoPerTickDbCalls()
+    {
+        // 24h window at 5-min resolution → ~288 ticks; treatments every ~15 min with the
+        // "connector-populated" shape: null ScheduledRate / null InsulinContext.
+        var startTime = TestMills;
+        var endTime = TestMills + 24L * 60 * 60 * 1000;
+        const int intervalMinutes = 5;
+
+        var tempBasals = new List<TempBasal>();
+        var boluses = new List<Bolus>();
+        var carbs = new List<CarbIntake>();
+        for (long t = startTime - 8L * 60 * 60 * 1000; t < endTime; t += 15 * 60 * 1000)
+        {
+            tempBasals.Add(new TempBasal
+            {
+                StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(t).UtcDateTime,
+                EndTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(t + 15 * 60 * 1000).UtcDateTime,
+                Rate = 1.5,
+                ScheduledRate = null,
+                Origin = TempBasalOrigin.Algorithm,
+            });
+            boluses.Add(new Bolus
+            {
+                Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(t).UtcDateTime,
+                Insulin = 0.8,
+                InsulinContext = null,
+            });
+        }
+        for (long t = startTime; t < endTime; t += 3L * 60 * 60 * 1000)
+        {
+            carbs.Add(new CarbIntake
+            {
+                Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(t).UtcDateTime,
+                Carbs = 40,
+            });
+        }
+
+        // Counting resolvers — every one of these must stay at zero invocations.
+        var therapySettings = new Mock<ITherapySettingsResolver>(MockBehavior.Strict);
+        var sensitivity = new Mock<ISensitivityResolver>(MockBehavior.Strict);
+        var basalRate = new Mock<IBasalRateResolver>(MockBehavior.Strict);
+        var carbRatio = new Mock<ICarbRatioResolver>(MockBehavior.Strict);
+        var apsRepo = new Mock<IApsSnapshotRepository>(MockBehavior.Strict);
+        var pumpRepo = new Mock<IPumpSnapshotRepository>(MockBehavior.Strict);
+
+        var realIob = new IobCalculator(
+            therapySettings.Object, sensitivity.Object, basalRate.Object, apsRepo.Object, pumpRepo.Object);
+        var realCob = new CobCalculator(
+            NullLogger<CobCalculator>.Instance, realIob, sensitivity.Object, carbRatio.Object,
+            therapySettings.Object, apsRepo.Object);
+
+        // A snapshot with real schedules so the calculators produce non-trivial output.
+        var snapshot = new TherapySnapshot(
+            dia: 3.0, peakMinutes: 75, carbsPerHour: 30.0, timezone: null, ccpPercentage: null, ccpTimeshiftMs: 0,
+            sensitivityEntries: new[] { new ScheduleEntry { TimeAsSeconds = 0, Value = 50.0 } },
+            carbRatioEntries: new[] { new ScheduleEntry { TimeAsSeconds = 0, Value = 10.0 } },
+            basalEntries: new[] { new ScheduleEntry { TimeAsSeconds = 0, Value = 0.8 } });
+        var timelineResolver = new Mock<ITherapyTimelineResolver>();
+        timelineResolver
+            .Setup(r => r.BuildAsync(It.IsAny<long>(), It.IsAny<long>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((long from, long to, string? _, CancellationToken _) =>
+                new TherapyTimeline(new[] { new TherapySegment(from, to, snapshot) }));
+        var basalSeriesBuilder = new Mock<IBasalSeriesBuilder>();
+        basalSeriesBuilder
+            .Setup(b => b.BuildAsync(It.IsAny<List<TempBasal>>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<double>(), It.IsAny<TherapyTimeline>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<BasalPoint>());
+
+        var stage = new IobCobComputeStage(
+            realIob, realCob, basalSeriesBuilder.Object, timelineResolver.Object,
+            _cache, MockTenantAccessor.Create().Object, NullLogger<IobCobComputeStage>.Instance);
+
+        var context = new ChartDataContext
+        {
+            StartTime = startTime,
+            EndTime = endTime,
+            IntervalMinutes = intervalMinutes,
+            BufferStartTime = startTime - 8L * 60 * 60 * 1000,
+            DefaultBasalRate = 1.0,
+            BolusList = boluses,
+            CarbIntakeList = carbs,
+            TempBasalList = tempBasals,
+        };
+
+        // MockBehavior.Strict means any unconfigured async resolver / repo call throws — so the
+        // run completing at all proves the tick loop never touched them. The result is non-trivial.
+        var result = await stage.ExecuteAsync(context, CancellationToken.None);
+
+        result.IobSeries.Should().NotBeEmpty();
+        result.CobSeries.Should().NotBeEmpty();
+        result.IobSeries.Should().Contain(p => p.Value > 0, "boluses + temp basals should yield IOB");
+        result.CobSeries.Should().Contain(p => p.Value > 0, "carbs should yield COB");
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Treatments/CobCalculatorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Treatments/CobCalculatorTests.cs
@@ -90,6 +90,60 @@ public class CobCalculatorTests
         );
     }
 
+    #region TherapySnapshot overload (async-free chart hot path)
+
+    // Snapshot whose in-memory lookups equal the mocked resolvers (sens 50, carb ratio 18,
+    // carb absorption 30, DIA 3, basal 1.0). With no device snapshots present, the snapshot
+    // overload must reproduce the async path's COB exactly.
+    private static TherapySnapshot MatchingSnapshot() => new(
+        dia: DefaultDIA,
+        peakMinutes: 75,
+        carbsPerHour: DefaultCarbAbsorptionRate,
+        timezone: null,
+        ccpPercentage: null,
+        ccpTimeshiftMs: 0,
+        sensitivityEntries: new[] { new ScheduleEntry { TimeAsSeconds = 0, Value = DefaultSensitivity } },
+        carbRatioEntries: new[] { new ScheduleEntry { TimeAsSeconds = 0, Value = DefaultCarbRatio } },
+        basalEntries: new[] { new ScheduleEntry { TimeAsSeconds = 0, Value = DefaultBasalRate } });
+
+    [Fact]
+    public void FromCarbIntakes_SnapshotOverload_MatchesAsyncPath_WhenNoDeviceSnapshots()
+    {
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var carbs = new List<CarbIntake>
+        {
+            new() { Carbs = 50, Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(now - 45 * 60 * 1000).UtcDateTime },
+            new() { Carbs = 20, Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(now - 100 * 60 * 1000).UtcDateTime },
+        };
+        var boluses = new List<Bolus>
+        {
+            new() { Insulin = 3.0, Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(now - 60 * 60 * 1000).UtcDateTime },
+            new() { Insulin = 1.5, Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(now - 20 * 60 * 1000).UtcDateTime },
+        };
+        var tempBasals = new List<TempBasal>
+        {
+            new()
+            {
+                StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(now - 50 * 60 * 1000).UtcDateTime,
+                EndTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(now - 20 * 60 * 1000).UtcDateTime,
+                Rate = 1.8,
+                ScheduledRate = null,
+                Origin = TempBasalOrigin.Algorithm,
+            },
+        };
+
+        var viaAsync = _calculator.FromCarbIntakes(carbs, boluses, tempBasals, now);
+        var viaSnapshot = _calculator.FromCarbIntakes(carbs, boluses, tempBasals, MatchingSnapshot(), now);
+
+        Assert.Equal(viaAsync.Cob, viaSnapshot.Cob, 6);
+        Assert.Equal(viaAsync.DecayedBy, viaSnapshot.DecayedBy);
+        Assert.Equal(viaAsync.IsDecaying, viaSnapshot.IsDecaying);
+        Assert.Equal(viaAsync.RawCarbImpact.GetValueOrDefault(), viaSnapshot.RawCarbImpact.GetValueOrDefault(), 6);
+        Assert.True(viaSnapshot.Cob > 0, "sanity: the scenario should produce non-zero COB");
+    }
+
+    #endregion
+
     #region CalculateTotalAsync Tests
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/Treatments/IobCalculatorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Treatments/IobCalculatorTests.cs
@@ -19,6 +19,7 @@ public class IobCalculatorTests
     private readonly IobCalculator _calculator;
     private readonly Mock<IApsSnapshotRepository> _apsSnapshotRepo;
     private readonly Mock<IPumpSnapshotRepository> _pumpSnapshotRepo;
+    private readonly Mock<IBasalRateResolver> _basalRateResolver;
 
     private const double DefaultDIA = 3.0;
     private const double DefaultSensitivity = 95.0;
@@ -36,8 +37,8 @@ public class IobCalculatorTests
             .Setup(s => s.GetSensitivityAsync(It.IsAny<long>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(DefaultSensitivity);
 
-        var basalRateResolver = new Mock<IBasalRateResolver>();
-        basalRateResolver
+        _basalRateResolver = new Mock<IBasalRateResolver>();
+        _basalRateResolver
             .Setup(b => b.GetBasalRateAsync(It.IsAny<long>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(DefaultBasalRate);
 
@@ -55,7 +56,7 @@ public class IobCalculatorTests
         _calculator = new IobCalculator(
             therapySettings.Object,
             sensitivityResolver.Object,
-            basalRateResolver.Object,
+            _basalRateResolver.Object,
             _apsSnapshotRepo.Object,
             _pumpSnapshotRepo.Object
         );
@@ -195,6 +196,85 @@ public class IobCalculatorTests
         var result = _calculator.CalcTempBasal(tempBasal, now);
 
         Assert.True(result.IobContrib > 0, "TempBasal with rate > scheduled should have non-zero IOB");
+    }
+
+    #endregion
+
+    #region TherapySnapshot overloads (async-free chart hot path)
+
+    // A snapshot whose in-memory lookups return the same values as the mocked async resolvers
+    // (DIA 3.0, sensitivity 95.0, basal rate 1.0), so the snapshot overloads must produce
+    // numerically identical results to the legacy async-resolver path.
+    private static TherapySnapshot MatchingSnapshot() => new(
+        dia: DefaultDIA,
+        peakMinutes: 75,
+        carbsPerHour: 30.0,
+        timezone: null,
+        ccpPercentage: null,
+        ccpTimeshiftMs: 0,
+        sensitivityEntries: new[] { new ScheduleEntry { TimeAsSeconds = 0, Value = DefaultSensitivity } },
+        carbRatioEntries: null,
+        basalEntries: new[] { new ScheduleEntry { TimeAsSeconds = 0, Value = DefaultBasalRate } });
+
+    [Fact]
+    public void CalcBolus_SnapshotOverload_MatchesAsyncResolverPath()
+    {
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var bolus = new Bolus
+        {
+            Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(now - 40 * 60 * 1000).UtcDateTime,
+            Insulin = 2.5,
+        };
+
+        var viaAsync = _calculator.CalcBolus(bolus, now);
+        var viaSnapshot = _calculator.CalcBolus(bolus, MatchingSnapshot(), now);
+
+        Assert.Equal(viaAsync.IobContrib, viaSnapshot.IobContrib, 9);
+        Assert.Equal(viaAsync.ActivityContrib, viaSnapshot.ActivityContrib, 9);
+
+        // And it must not touch the async resolvers.
+        _basalRateResolver.Verify(b => b.GetBasalRateAsync(It.IsAny<long>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public void FromTempBasals_SnapshotOverload_MatchesAsyncPath()
+    {
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        // Null ScheduledRate forces resolution — the erik case. Snapshot must supply it in-memory.
+        var tempBasal = new TempBasal
+        {
+            StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(now - 60 * 60 * 1000).UtcDateTime,
+            EndTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(now - 30 * 60 * 1000).UtcDateTime,
+            Rate = 2.0,
+            ScheduledRate = null,
+            Origin = TempBasalOrigin.Algorithm,
+        };
+
+        // viaAsync resolves the scheduled rate via the (mocked) async resolver; viaSnapshot reads
+        // it from the in-memory snapshot. Both supply 1.0 here, so results must be identical.
+        var viaAsync = _calculator.FromTempBasals([tempBasal], now);
+        var viaSnapshot = _calculator.FromTempBasals([tempBasal], MatchingSnapshot(), now);
+
+        Assert.Equal(viaAsync.BasalIob, viaSnapshot.BasalIob);
+        Assert.NotNull(viaSnapshot.BasalIob);
+        Assert.True(viaSnapshot.BasalIob!.Value > 0);
+    }
+
+    [Fact]
+    public void FromBoluses_SnapshotOverload_MatchesAsyncPath()
+    {
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var boluses = new List<Bolus>
+        {
+            new() { Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(now - 20 * 60 * 1000).UtcDateTime, Insulin = 1.5 },
+            new() { Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(now - 90 * 60 * 1000).UtcDateTime, Insulin = 3.0 },
+        };
+
+        var viaAsync = _calculator.FromBoluses(boluses, now);
+        var viaSnapshot = _calculator.FromBoluses(boluses, MatchingSnapshot(), now);
+
+        Assert.Equal(viaAsync.Iob, viaSnapshot.Iob, 9);
+        Assert.Equal(viaAsync.Activity!.Value, viaSnapshot.Activity!.Value, 9);
     }
 
     #endregion


### PR DESCRIPTION
## Problem

The dashboard chart computes IOB/COB at every interval tick across the window. Per tick it resolved DIA, sensitivity and the scheduled basal rate **per bolus / per temp basal** via sync-over-async profile-resolver calls, and the COB stage additionally re-ran the full IOB total (`CalculateTotalAsync`, including device-snapshot DB lookups) **twice per active carb**. That's `O(ticks × treatments)` DB-backed resolutions per chart load.

For tenants whose temp basals all carry a **null `ScheduledRate`** (e.g. connectors that never populate it), the basal-rate fallback fired for every active temp basal on every tick — fanning out to tens of thousands of blocking DB calls and making the chart take **minutes** to load (SSR timed out with HTTP 499). A real tenant with ~1,100 such temp basals hit this; an equivalent tenant with populated `ScheduledRate` loaded the identical request in ~175 ms.

## Fix

Thread the already-built in-memory `TherapyTimeline` through the calculators. New `TherapySnapshot` overloads of `IIobCalculator.CalcBolus`/`FromBoluses`/`CalcTempBasal`/`FromTempBasals` and `ICobCalculator.FromCarbIntakes` resolve DIA, peak, sensitivity, scheduled basal rate and carb ratio from `TherapyTimeline.SnapshotAt(t)` with **zero DB access**. The decay math is shared with the async paths via private cores, so the numbers are unchanged.

COB now derives insulin activity directly from boluses via the snapshot IOB path instead of `CalculateTotalAsync`. Temp basals contribute no activity, so this is equivalent when no device-IOB snapshot is present; it also fixes a latent artifact where a present device-IOB snapshot nulled out the activity used for the dynamic carb-absorption delay.

This is the pattern `TherapyTimeline`/`TherapySnapshot` were designed for ("per-tick chart-data computations resolve via in-memory lookup instead of awaiting nested async calls").

## Tests

- **Characterization** — snapshot overloads produce numerically identical IOB/COB to the async-resolver path (`IobCalculatorTests`, `CobCalculatorTests`).
- **Scaling regression** — with `MockBehavior.Strict` resolvers, a ~288-tick window full of null-`ScheduledRate` temp basals + boluses + carbs completes with **zero** per-tick resolver/device-snapshot DB calls (`IobCobComputeStageTests`).

A latency-injecting micro-benchmark (DB round trip ≈ 1 ms) over a 90-min window measured ~2,480 → ~45 DB calls (~55× fewer) and a ~56× wall-clock speedup.