### PR TITLE
fix(devicestatus): prevent latched pump-suspended state from duplicate uploads

### DIFF
--- a/src/API/Nocturne.API/Services/V4/DeviceStatusDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/DeviceStatusDecomposer.cs
@@ -244,6 +244,29 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
 
         if (!priorSuspended && nowSuspended)
         {
+            // Guard against duplicate open spans. An uploader can emit two device statuses for the
+            // same suspend event sharing the SAME ingest Timestamp but different pump clocks (e.g.
+            // Trio uploads paired snapshots). Because GetLatestBeforeAsync uses a strict `<` on
+            // Timestamp, the second such snapshot cannot see its sibling as prior and reads
+            // prior=not-suspended — a spurious false→true transition. Opening a second span here
+            // leaves an orphan the single resume can't fully close, latching the pump "suspended"
+            // indefinitely. If a Suspended span is already open, this observation is already
+            // covered; do nothing.
+            var existingOpen = await _stateSpanService.GetStateSpansAsync(
+                category: StateSpanCategory.PumpMode,
+                state: PumpModeState.Suspended.ToString(),
+                active: true,
+                count: 1,
+                cancellationToken: ct);
+
+            if (existingOpen.Any())
+            {
+                _logger.LogDebug(
+                    "Skipped opening duplicate PumpMode/Suspended StateSpan for snapshot {SnapshotId}; a suspension is already active",
+                    newSnapshot.Id);
+                return;
+            }
+
             var span = new StateSpan
             {
                 Category = StateSpanCategory.PumpMode,
@@ -262,15 +285,17 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
         }
         else // priorSuspended && !nowSuspended
         {
-            var openSpans = await _stateSpanService.GetStateSpansAsync(
+            // Close ALL active Suspended spans, not just one: leftover duplicates (created before
+            // the open-guard above, or by concurrent decomposition) must all be closed on resume,
+            // otherwise an orphan keeps the pump latched "suspended".
+            var openSpans = (await _stateSpanService.GetStateSpansAsync(
                 category: StateSpanCategory.PumpMode,
                 state: PumpModeState.Suspended.ToString(),
                 active: true,
-                count: 1,
-                cancellationToken: ct);
+                count: int.MaxValue,
+                cancellationToken: ct)).ToList();
 
-            var openSpan = openSpans.FirstOrDefault();
-            if (openSpan is null)
+            if (openSpans.Count == 0)
             {
                 // No open span exists — the suspended=true state predates the StateSpan feature
                 // or the opening snapshot was never decomposed. Create a retroactive closed span
@@ -302,12 +327,15 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
                 return;
             }
 
-            openSpan.EndTimestamp = transitionAt;
-            var closed = await _stateSpanService.UpsertStateSpanAsync(openSpan, ct);
-            result.UpdatedRecords.Add(closed);
-            _logger.LogDebug(
-                "Closed PumpMode/Suspended StateSpan {SpanId} at {EndTimestamp}",
-                openSpan.Id, transitionAt);
+            foreach (var openSpan in openSpans)
+            {
+                openSpan.EndTimestamp = transitionAt;
+                var closed = await _stateSpanService.UpsertStateSpanAsync(openSpan, ct);
+                result.UpdatedRecords.Add(closed);
+                _logger.LogDebug(
+                    "Closed PumpMode/Suspended StateSpan {SpanId} at {EndTimestamp}",
+                    openSpan.Id, transitionAt);
+            }
         }
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerPumpSuspensionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerPumpSuspensionTests.cs
@@ -325,4 +325,91 @@ public class DeviceStatusDecomposerPumpSuspensionTests : IDisposable
             It.IsAny<CancellationToken>()),
             Times.Exactly(2));
     }
+
+    [Fact]
+    public async Task FalseToTrue_WhenSuspendedSpanAlreadyOpen_DoesNotOpenDuplicate()
+    {
+        // Regression (Erik / Trio): the uploader emits two suspended=true device statuses for the
+        // same suspend event sharing the SAME ingest Timestamp but different pump clocks. Because
+        // GetLatestBeforeAsync uses a strict `<` on Timestamp, the second snapshot can't see its
+        // sibling as prior and reads prior=not-suspended — a false→true transition that would open
+        // a SECOND Suspended span. The lone resume then closes only one span, leaving the other
+        // open-ended forever, so the dashboard reports the pump "suspended the whole time".
+        // Invariant: at most one open Suspended span. A false→true transition while one is already
+        // open must be a no-op.
+        var prior = new V4Models.PumpSnapshot { Suspended = false, Timestamp = new DateTime(2024, 1, 1, 11, 0, 0, DateTimeKind.Utc) };
+        _pumpRepoMock.Setup(r => r.GetLatestBeforeAsync(It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(prior);
+
+        var alreadyOpen = new StateSpan
+        {
+            Id = "open-1",
+            Category = StateSpanCategory.PumpMode,
+            State = PumpModeState.Suspended.ToString(),
+            StartTimestamp = new DateTime(2024, 1, 1, 11, 30, 0, DateTimeKind.Utc),
+            EndTimestamp = null,
+        };
+        _stateSpanServiceMock
+            .Setup(s => s.GetStateSpansAsync(
+                StateSpanCategory.PumpMode, PumpModeState.Suspended.ToString(),
+                null, null, null, true,
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { alreadyOpen });
+
+        var ds = MakeDeviceStatus("legacy-dup", 1704110400000, suspended: true);
+
+        await _decomposer.DecomposeAsync(ds);
+
+        // A suspension is already active; no new span should be opened.
+        _stateSpanServiceMock.Verify(
+            s => s.UpsertStateSpanAsync(It.IsAny<StateSpan>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task TrueToFalse_ClosesAllOpenSuspendedSpans()
+    {
+        // Defense-in-depth: if duplicate open Suspended spans already exist (e.g. records created
+        // before the open-guard fix), a resume must close ALL of them — not just one — so the pump
+        // doesn't stay latched "suspended" on a leftover open span.
+        var prior = new V4Models.PumpSnapshot { Suspended = true, Timestamp = new DateTime(2024, 1, 1, 11, 0, 0, DateTimeKind.Utc) };
+        _pumpRepoMock.Setup(r => r.GetLatestBeforeAsync(It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(prior);
+
+        var open1 = new StateSpan
+        {
+            Id = "open-1",
+            Category = StateSpanCategory.PumpMode,
+            State = PumpModeState.Suspended.ToString(),
+            StartTimestamp = prior.Timestamp,
+            EndTimestamp = null,
+        };
+        var open2 = new StateSpan
+        {
+            Id = "open-2",
+            Category = StateSpanCategory.PumpMode,
+            State = PumpModeState.Suspended.ToString(),
+            StartTimestamp = prior.Timestamp.AddSeconds(2),
+            EndTimestamp = null,
+        };
+        _stateSpanServiceMock
+            .Setup(s => s.GetStateSpansAsync(
+                StateSpanCategory.PumpMode, PumpModeState.Suspended.ToString(),
+                null, null, null, true,
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { open1, open2 });
+
+        var ds = MakeDeviceStatus("legacy-close-all", 1704110400000, suspended: false);
+
+        await _decomposer.DecomposeAsync(ds);
+
+        _stateSpanServiceMock.Verify(s => s.UpsertStateSpanAsync(
+            It.Is<StateSpan>(span => span.Id == "open-1" && span.EndTimestamp != null),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+        _stateSpanServiceMock.Verify(s => s.UpsertStateSpanAsync(
+            It.Is<StateSpan>(span => span.Id == "open-2" && span.EndTimestamp != null),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
 }


### PR DESCRIPTION
## Problem

A tenant's pump showed as **suspended continuously** for over a day, when it had actually been suspended for only ~5 minutes.

Some uploaders (observed with **Trio**) emit **two** `suspended=true` device statuses for a single suspend event that share the **same ingest `Timestamp`** but differ only in pump `clock`:

| snapshot | suspended | timestamp (Mills) | clock |
|---|---|---|---|
| A | t | 20:17:29.217 | 20:17:33 |
| B | t | 20:17:29.217 | 20:17:31 |

`DecomposePumpSuspensionAsync` resolves the prior snapshot via `GetLatestBeforeAsync`, which uses a strict `Timestamp <` comparison. The second suspended snapshot therefore can't see its sibling (identical `Timestamp`) and reads `prior = not-suspended` — a spurious `false→true` transition that opens a **second** `PumpMode/Suspended` `StateSpan`.

The single resume (`true→false`) only closed **one** open span (`count: 1`), leaving the other **open-ended**. `SensorContextEnricher` projects any active Suspended span as `ActivePumpSuspension`, so the pump reads as suspended indefinitely even though it resumed minutes later.

## Fix

Enforce the invariant **"at most one open Suspended span"**:

- **Open path** — skip opening a new span when a Suspended span is already active (prevents the duplicate).
- **Close path** — on resume, close **all** active Suspended spans rather than just one, so any pre-existing/concurrent duplicates self-heal.

## Tests

Two regression tests reproduce the exact scenario (both failed before the fix, pass after):
- `FalseToTrue_WhenSuspendedSpanAlreadyOpen_DoesNotOpenDuplicate`
- `TrueToFalse_ClosesAllOpenSuspendedSpans`

All existing pump-suspension / decomposer / enricher tests remain green.