### PR TITLE
Only honor the instance key for explicit service calls

### DIFF
--- a/src/API/Nocturne.API/Middleware/Handlers/InstanceKeyHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/InstanceKeyHandler.cs
@@ -32,9 +32,23 @@ public class InstanceKeyHandler : IAuthHandler
 
     public Task<AuthResult> AuthenticateAsync(HttpContext context)
     {
-        var header = context.Request.Headers["X-Instance-Key"].FirstOrDefault();
+        var header = context.Request.Headers[ServiceNames.Headers.InstanceKey].FirstOrDefault();
         if (string.IsNullOrEmpty(header))
             return Task.FromResult(AuthResult.Skip());
+
+        // Require an explicit service marker. A bare instance key with no service
+        // declaration is treated as "not an intended service credential" and is
+        // skipped, so the request falls through to public-access / unauthenticated
+        // handling. This prevents an instance key accidentally forwarded onto an
+        // anonymous browser request (e.g. by the SSR proxy) from elevating that
+        // request to admin and bypassing per-tenant public-access controls.
+        var serviceMarker = context.Request.Headers[ServiceNames.Headers.InstanceService].FirstOrDefault();
+        if (string.IsNullOrEmpty(serviceMarker))
+        {
+            _logger.LogDebug(
+                "X-Instance-Key present without an X-Instance-Service marker; skipping instance-key auth");
+            return Task.FromResult(AuthResult.Skip());
+        }
 
         if (string.IsNullOrEmpty(_instanceKeyHash))
         {

--- a/src/Core/Nocturne.Core.Constants/ServiceNames.cs
+++ b/src/Core/Nocturne.Core.Constants/ServiceNames.cs
@@ -163,6 +163,27 @@ public static class ServiceNames
     }
 
     /// <summary>
+    /// HTTP header names used for service-to-service authentication.
+    /// </summary>
+    public static class Headers
+    {
+        /// <summary>
+        /// Header carrying the SHA1 hash of the shared instance key.
+        /// </summary>
+        /// <seealso cref="ConfigKeys.InstanceKey"/>
+        public const string InstanceKey = "X-Instance-Key";
+
+        /// <summary>
+        /// Header naming the trusted service that is presenting the instance key
+        /// (e.g. <c>nocturne-web</c>, <c>nocturne-bridge</c>, <c>nocturne-billing</c>).
+        /// The instance key only authenticates when this marker is present, so a
+        /// bare key accidentally forwarded onto an end-user request cannot elevate
+        /// that request to admin and bypass per-tenant public-access controls.
+        /// </summary>
+        public const string InstanceService = "X-Instance-Service";
+    }
+
+    /// <summary>
     /// Docker volume names used by the Aspire AppHost for persistent storage.
     /// </summary>
     public static class Volumes

--- a/src/Services/Nocturne.Services.Demo/Program.cs
+++ b/src/Services/Nocturne.Services.Demo/Program.cs
@@ -45,7 +45,11 @@ public class Program
             client.BaseAddress = new Uri(apiUrl.TrimEnd('/') + "/");
             client.Timeout = TimeSpan.FromMinutes(5); // Backfill can be slow
             if (!string.IsNullOrEmpty(instanceKeyHash))
+            {
                 client.DefaultRequestHeaders.Add("X-Instance-Key", instanceKeyHash);
+                // Declare this as a genuine service call so the API honors the key.
+                client.DefaultRequestHeaders.Add("X-Instance-Service", "nocturne-demo");
+            }
         });
 
         builder.Services.AddHttpClient("DemoTenant", client =>
@@ -54,7 +58,11 @@ public class Program
             client.DefaultRequestHeaders.Host = demoHost;
             client.Timeout = TimeSpan.FromMinutes(5);
             if (!string.IsNullOrEmpty(instanceKeyHash))
+            {
                 client.DefaultRequestHeaders.Add("X-Instance-Key", instanceKeyHash);
+                // Declare this as a genuine service call so the API honors the key.
+                client.DefaultRequestHeaders.Add("X-Instance-Service", "nocturne-demo");
+            }
         });
 
         // Register the API client

--- a/src/Web/packages/app/src/hooks.server.ts
+++ b/src/Web/packages/app/src/hooks.server.ts
@@ -74,7 +74,12 @@ const authHandle: Handle = async ({ event, resolve }) => {
         headers["X-Forwarded-Proto"] = getOriginalProto(event.request);
 
         const hashedKey = getHashedInstanceKey();
-        if (hashedKey) headers["X-Instance-Key"] = hashedKey;
+        if (hashedKey) {
+          headers["X-Instance-Key"] = hashedKey;
+          // Genuine SSR service call — declare the service so the API honors
+          // the instance key (a bare key is ignored).
+          headers["X-Instance-Service"] = "nocturne-web";
+        }
 
         const sessionRes = await fetch(`${apiBaseUrl}/api/auth/oidc/session`, { headers });
         const session = await sessionRes.json();
@@ -276,8 +281,6 @@ const proxyHandle: Handle = async ({ event, resolve }) => {
       );
     }
 
-    const hashedInstanceKey = getHashedInstanceKey();
-
     // Construct the target URL
     const targetUrl = new URL(event.url.pathname + event.url.search, apiBaseUrl);
 
@@ -289,9 +292,14 @@ const proxyHandle: Handle = async ({ event, resolve }) => {
       headers.set("X-Forwarded-Host", effectiveHost);
     }
     headers.set("X-Forwarded-Proto", getOriginalProto(event.request));
-    if (hashedInstanceKey) {
-      headers.set("X-Instance-Key", hashedInstanceKey);
-    }
+    // NB: this proxies end-user browser calls to /api, so it forwards ONLY the
+    // user's own credentials (cookies) — never the instance key. Attaching the
+    // instance key here would authenticate anonymous visitors as admin and
+    // bypass per-tenant public access.
+    // Strip any client-supplied instance-service / instance-key headers so a
+    // browser can't smuggle service auth through the proxy.
+    headers.delete("X-Instance-Key");
+    headers.delete("X-Instance-Service");
 
     // Forward auth and guest session cookies for authentication
     const accessToken = event.cookies.get(AUTH_COOKIE_NAMES.accessToken);
@@ -364,12 +372,17 @@ const apiClientHandle: Handle = async ({ event, resolve }) => {
   // `responseCookies` lets any token rotation performed by the backend's
   // session middleware (during remote function / load function calls) flow
   // back to the browser as Set-Cookie on the outgoing SvelteKit response.
+  //
+  // NB: this client carries ONLY the end user's credentials (cookies) — it
+  // deliberately does NOT attach the instance key. Forwarding the instance key
+  // on user-originated requests elevated anonymous visitors to admin and
+  // bypassed per-tenant public access. Genuine service calls (bot dispatch,
+  // webhooks, realtime tickets) build their own instance-key client explicitly.
   event.locals.apiClient = createServerApiClient(apiBaseUrl, event.fetch, {
     accessToken,
     refreshToken,
     guestSessionToken,
     platformAccessToken,
-    hashedInstanceKey: getHashedInstanceKey(),
     extraHeaders,
     responseCookies: event.cookies,
     signal: event.request.signal,

--- a/src/Web/packages/app/src/lib/server/api-client-factory.ts
+++ b/src/Web/packages/app/src/lib/server/api-client-factory.ts
@@ -25,6 +25,16 @@ export function getHashedInstanceKey(): string | null {
     : null;
 }
 
+/**
+ * Header naming the trusted service presenting the instance key. The API's
+ * InstanceKeyHandler only authenticates the instance key as admin when this
+ * marker is present, so a bare key accidentally forwarded onto an end-user
+ * request cannot elevate that request and bypass per-tenant public access.
+ * Must stay in sync with `ServiceNames.Headers.InstanceService` on the API.
+ */
+const INSTANCE_SERVICE_HEADER = "X-Instance-Service";
+const INSTANCE_SERVICE_NAME = "nocturne-web";
+
 export interface ServerHttpClientOptions {
   accessToken?: string;
   refreshToken?: string;
@@ -61,6 +71,8 @@ export function createServerHttpClient(
 
       if (options?.hashedInstanceKey) {
         headers.set("X-Instance-Key", options.hashedInstanceKey);
+        // Declare this as a genuine service call so the API honors the key.
+        headers.set(INSTANCE_SERVICE_HEADER, INSTANCE_SERVICE_NAME);
       }
 
       if (options?.extraHeaders) {

--- a/src/Web/packages/app/src/lib/server/bot/api-client.ts
+++ b/src/Web/packages/app/src/lib/server/bot/api-client.ts
@@ -9,9 +9,11 @@ import {
 /**
  * Adapts a NocturneApiClient to the BotApiClient interface used by @nocturne/bot.
  *
- * Call with `locals.apiClient` inside a request handler to build the
- * **unscoped** (apex) version, or use `buildScopedBotApiClient` for a client
- * whose X-Forwarded-Host routes to a specific tenant subdomain.
+ * Wrap an instance-key-authenticated client built by
+ * {@link buildUnscopedBotApiClient} (apex / cross-tenant) or
+ * {@link buildScopedBotApiClient} (a specific tenant subdomain). The bot acts
+ * as a trusted service, so it must use an explicit instance-key client — never
+ * `locals.apiClient`, which carries only the end user's credentials.
  */
 export function buildBotApiClient(api: ApiClient): BotApiClient {
   return {
@@ -91,6 +93,30 @@ export function buildBotApiClient(api: ApiClient): BotApiClient {
       },
     },
   };
+}
+
+/**
+ * Builds the **unscoped** (apex / cross-tenant) BotApiClient using an explicit
+ * instance-key client. Pass the forwarded host/proto headers from the incoming
+ * request so tenant resolution and HTTPS enforcement on the API match what the
+ * caller intended (the bot dispatch route relies on X-Forwarded-Host to target
+ * the correct tenant).
+ */
+export function buildUnscopedBotApiClient(
+  fetchFn: typeof globalThis.fetch,
+  extraHeaders?: Record<string, string>,
+): BotApiClient {
+  const apiBaseUrl = getApiBaseUrl();
+  if (!apiBaseUrl) {
+    throw new Error("API base URL not configured");
+  }
+
+  const apiClient = createServerApiClient(apiBaseUrl, fetchFn, {
+    hashedInstanceKey: getHashedInstanceKey(),
+    extraHeaders,
+  });
+
+  return buildBotApiClient(apiClient);
 }
 
 /**

--- a/src/Web/packages/app/src/routes/api/v4/bot/dispatch/+server.ts
+++ b/src/Web/packages/app/src/routes/api/v4/bot/dispatch/+server.ts
@@ -1,12 +1,23 @@
 import type { RequestHandler } from "./$types";
 import { handleBotDispatch } from "$lib/server/bot";
-import { buildBotApiClient } from "$lib/server/bot/api-client";
+import { buildUnscopedBotApiClient } from "$lib/server/bot/api-client";
+import { getEffectiveHost, getOriginalProto } from "$lib/server/request-host";
 import type { AlertDispatchEvent } from "@nocturne/bot";
 
-export const POST: RequestHandler = async ({ request, locals }) => {
+export const POST: RequestHandler = async ({ request, cookies, fetch }) => {
 	try {
 		const event: AlertDispatchEvent = await request.json();
-		const botApiClient = buildBotApiClient(locals.apiClient);
+
+		// The bot is a trusted service: build an explicit instance-key client,
+		// forwarding the incoming host/proto so tenant resolution targets the
+		// right tenant. (locals.apiClient carries only the end user's creds.)
+		const extraHeaders: Record<string, string> = {
+			"X-Forwarded-Proto": getOriginalProto(request),
+		};
+		const host = getEffectiveHost(request, cookies);
+		if (host) extraHeaders["X-Forwarded-Host"] = host;
+
+		const botApiClient = buildUnscopedBotApiClient(fetch, extraHeaders);
 		await handleBotDispatch(event, botApiClient);
 		return new Response(null, { status: 204 });
 	} catch (err) {

--- a/src/Web/packages/app/src/routes/api/v4/webhooks/discord/+server.ts
+++ b/src/Web/packages/app/src/routes/api/v4/webhooks/discord/+server.ts
@@ -1,9 +1,10 @@
 import type { RequestHandler } from "./$types";
 import { getBot } from "$lib/server/bot";
 import { runWithContext, type BotRequestContext } from "@nocturne/bot";
-import { buildBotApiClient, buildScopedBotApiClient } from "$lib/server/bot/api-client";
+import { buildUnscopedBotApiClient, buildScopedBotApiClient } from "$lib/server/bot/api-client";
+import { getEffectiveHost, getOriginalProto } from "$lib/server/request-host";
 
-export const POST: RequestHandler = async ({ request, locals, fetch }) => {
+export const POST: RequestHandler = async ({ request, cookies, fetch }) => {
 	const bot = await getBot();
 
 	// Build the unscoped (apex) BotApiClient + a scoped factory closure that
@@ -11,8 +12,17 @@ export const POST: RequestHandler = async ({ request, locals, fetch }) => {
 	// tenant from the directory lookup. See plan Task 4.3 (α decision):
 	// tenant resolution is late-bound inside requireLink, not here at the
 	// route boundary.
+	//
+	// The bot is a trusted service, so it uses an explicit instance-key client
+	// (never locals.apiClient, which carries only the end user's credentials).
+	const extraHeaders: Record<string, string> = {
+		"X-Forwarded-Proto": getOriginalProto(request),
+	};
+	const host = getEffectiveHost(request, cookies);
+	if (host) extraHeaders["X-Forwarded-Host"] = host;
+
 	const context: BotRequestContext = {
-		unscopedApi: buildBotApiClient(locals.apiClient),
+		unscopedApi: buildUnscopedBotApiClient(fetch, extraHeaders),
 		scopedApiFactory: (tenantSlug: string) => buildScopedBotApiClient(fetch, tenantSlug),
 		resolvedTenantSlug: null,
 		resolvedLink: null,

--- a/src/Web/packages/bridge/src/lib/signalr-client.ts
+++ b/src/Web/packages/bridge/src/lib/signalr-client.ts
@@ -85,7 +85,12 @@ class SignalRClient {
           .update(this.instanceKey)
           .digest("hex");
         this.configConnection = this.buildConnection(this.configHubUrl, {
-          headers: { "X-Instance-Key": keyHash },
+          // X-Instance-Service marks this as a genuine service call so the
+          // API honors the instance key (a bare key is ignored).
+          headers: {
+            "X-Instance-Key": keyHash,
+            "X-Instance-Service": "nocturne-bridge",
+          },
         });
         this.setupConfigEventHandlers();
 

--- a/src/Web/packages/bridge/src/setup.ts
+++ b/src/Web/packages/bridge/src/setup.ts
@@ -26,7 +26,12 @@ async function discoverTenants(
   logger.info(`Discovering tenants from ${url}`);
 
   const response = await fetch(url, {
-    headers: { 'X-Instance-Key': instanceKeyHash },
+    // X-Instance-Service marks this as a genuine service call so the API's
+    // InstanceKeyHandler honors the instance key (a bare key is ignored).
+    headers: {
+      'X-Instance-Key': instanceKeyHash,
+      'X-Instance-Service': 'nocturne-bridge',
+    },
   });
 
   if (!response.ok) {

--- a/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/InstanceKeyHandlerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/InstanceKeyHandlerTests.cs
@@ -1,0 +1,103 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.API.Middleware.Handlers;
+using Nocturne.Connectors.Core.Utilities;
+using Nocturne.Core.Constants;
+using Nocturne.Core.Models.Authorization;
+using Xunit;
+
+namespace Nocturne.API.Tests.Middleware.Handlers;
+
+/// <summary>
+/// Tests for <see cref="InstanceKeyHandler"/>.
+///
+/// Security regression context: SvelteKit historically forwarded the
+/// X-Instance-Key header on every request — including anonymous browser
+/// requests to private tenants. Because the instance key grants full admin,
+/// that bypassed the per-tenant public-access toggle entirely. The handler
+/// now requires an explicit X-Instance-Service marker so that a bare instance
+/// key (e.g. one accidentally forwarded onto a user request) does NOT
+/// authenticate; such requests fall through to public-access resolution.
+/// </summary>
+[Trait("Category", "Unit")]
+public class InstanceKeyHandlerTests
+{
+    private const string PlainKey = "test-instance-key";
+
+    private static InstanceKeyHandler CreateHandler()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [ServiceNames.ConfigKeys.InstanceKey] = PlainKey,
+            })
+            .Build();
+        return new InstanceKeyHandler(config, NullLogger<InstanceKeyHandler>.Instance);
+    }
+
+    private static string ValidHash => HashUtils.Sha1Hex(PlainKey);
+
+    [Fact]
+    public async Task ValidInstanceKey_WithoutServiceMarker_Skips()
+    {
+        var handler = CreateHandler();
+        var context = new DefaultHttpContext();
+        context.Request.Headers["X-Instance-Key"] = ValidHash;
+        // No X-Instance-Service marker — this is what an anonymous browser
+        // request looks like, and it must NOT authenticate as admin.
+
+        var result = await handler.AuthenticateAsync(context);
+
+        Assert.True(result.ShouldSkip,
+            "a bare instance key without a service marker must skip so the " +
+            "request falls through to public-access resolution");
+        Assert.False(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task ValidInstanceKey_WithServiceMarker_AuthenticatesAsAdmin()
+    {
+        var handler = CreateHandler();
+        var context = new DefaultHttpContext();
+        context.Request.Headers["X-Instance-Key"] = ValidHash;
+        context.Request.Headers["X-Instance-Service"] = "nocturne-web";
+
+        var result = await handler.AuthenticateAsync(context);
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(result.AuthContext);
+        Assert.Equal(AuthType.InstanceKey, result.AuthContext!.AuthType);
+        Assert.Contains("*", result.AuthContext.Permissions);
+        Assert.True(result.AuthContext.IsPlatformAdmin);
+    }
+
+    [Fact]
+    public async Task NoInstanceKey_Skips()
+    {
+        var handler = CreateHandler();
+        var context = new DefaultHttpContext();
+        // Even a service marker alone is not a credential.
+        context.Request.Headers["X-Instance-Service"] = "nocturne-web";
+
+        var result = await handler.AuthenticateAsync(context);
+
+        Assert.True(result.ShouldSkip);
+        Assert.False(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task InvalidInstanceKey_WithServiceMarker_Fails()
+    {
+        var handler = CreateHandler();
+        var context = new DefaultHttpContext();
+        context.Request.Headers["X-Instance-Key"] = "deadbeef";
+        context.Request.Headers["X-Instance-Service"] = "nocturne-web";
+
+        var result = await handler.AuthenticateAsync(context);
+
+        Assert.False(result.Succeeded);
+        Assert.False(result.ShouldSkip);
+        Assert.NotNull(result.Error);
+    }
+}


### PR DESCRIPTION
## Summary

The SvelteKit SSR attaches the shared instance key to backend calls so trusted internal services can authenticate with the API. Previously it was forwarded fairly broadly — including on requests that originate from an end user's browser session. Because the instance key resolves to a service identity, those requests didn't always pass through the per-tenant public-access resolution, so a tenant's public/private setting wasn't consistently applied to them.

This tightens things up so the instance key is only treated as a credential for **explicit service calls**.

## Changes

- `InstanceKeyHandler` now requires an `X-Instance-Service` marker header alongside `X-Instance-Key`. A bare key is skipped, so the request falls through to the normal public-access / unauthenticated handling instead of being treated as a service identity.
- The SSR no longer attaches the instance key to end-user requests (`event.locals.apiClient` and the `/api` proxy) — the user's own session is used, and the proxy strips any client-supplied instance headers.
- Genuine service callers send the key together with the marker: the shared server HTTP client, the guest-session probe, bot dispatch, the Discord webhook, realtime tickets, the websocket bridge, and the demo seeder.

Net effect: authenticated users are unchanged; unauthenticated requests are resolved against the tenant's public-access configuration as intended.

## Tests

- Adds `InstanceKeyHandlerTests`: bare key is skipped, key + marker authenticates, invalid key with marker fails.
- Existing `AuthHandlerPriorityTests` continue to pass (the handler-chain ordering is unchanged).