### PR TITLE
fix(auth): close cross-tenant login holes and honor revoked memberships

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/OidcController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/OidcController.cs
@@ -199,17 +199,37 @@ public class OidcController : ControllerBase
         // Clear state cookie (single use)
         ClearStateCookie();
 
+        // The callback runs on the tenant subdomain (OidcCallbackRedirectMiddleware has already
+        // bounced apex callbacks to {slug}.{baseDomain}), so the resolved tenant is the one being
+        // logged into. Pass it through so a session is only issued to a member of that tenant.
+        var currentTenantId = (HttpContext.Items["TenantContext"] as TenantContext)?.TenantId;
+
         // Handle the callback
         var result = await _authService.HandleCallbackAsync(
             code,
             state,
             expectedState,
             GetClientIpAddress(),
-            Request.Headers.UserAgent
+            Request.Headers.UserAgent,
+            currentTenantId
         );
 
         if (!result.Success)
         {
+            // Authenticated identity that is not a member of this tenant: issue no session and
+            // send them to the tenant login page, which offers the request-membership option
+            // when the tenant allows access requests.
+            if (result.IsAccessDenied)
+            {
+                // CompleteLoginAsync has already logged the denial with the tenant id.
+                await _auditService.LogAsync(AuthAuditEventType.FailedAuth, result.SubjectId, success: false,
+                    ipAddress: GetClientIpAddress(), userAgent: Request.Headers.UserAgent,
+                    errorMessage: "not_a_member",
+                    detailsJson: JsonSerializer.Serialize(new { method = "oidc", reason = "not_a_member" }));
+
+                return RedirectToLogin();
+            }
+
             _logger.LogWarning(
                 "OIDC callback failed: {Error} - {Description}",
                 result.Error,
@@ -813,6 +833,13 @@ public class OidcController : ControllerBase
             $"/auth/error?error={Uri.EscapeDataString(error)}&description={Uri.EscapeDataString(description)}";
         return Redirect(returnUrl);
     }
+
+    /// <summary>
+    /// Redirect to the tenant login page. Used when an authenticated identity is denied because
+    /// it is not a member of the tenant; the login page surfaces the request-membership option
+    /// when the tenant allows access requests.
+    /// </summary>
+    private IActionResult RedirectToLogin() => Redirect("/auth/login");
 
     #endregion
 }

--- a/src/API/Nocturne.API/Controllers/Authentication/TotpController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/TotpController.cs
@@ -9,6 +9,7 @@ using Nocturne.API.Authorization;
 using Nocturne.API.Extensions;
 using Nocturne.API.Services.Auth;
 using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Configuration;
 using Nocturne.Infrastructure.Data.Entities;
 
@@ -37,6 +38,8 @@ public class TotpController : ControllerBase
     private readonly ISessionService _sessionService;
     private readonly ISubjectService _subjectService;
     private readonly IAuthAuditService _auditService;
+    private readonly ITenantAccessor _tenantAccessor;
+    private readonly ITenantMemberService _tenantMemberService;
     private readonly OidcOptions _oidcOptions;
     private readonly ILogger<TotpController> _logger;
 
@@ -48,6 +51,8 @@ public class TotpController : ControllerBase
         ISessionService sessionService,
         ISubjectService subjectService,
         IAuthAuditService auditService,
+        ITenantAccessor tenantAccessor,
+        ITenantMemberService tenantMemberService,
         IOptions<OidcOptions> oidcOptions,
         ILogger<TotpController> logger)
     {
@@ -55,6 +60,8 @@ public class TotpController : ControllerBase
         _sessionService = sessionService;
         _subjectService = subjectService;
         _auditService = auditService;
+        _tenantAccessor = tenantAccessor;
+        _tenantMemberService = tenantMemberService;
         _oidcOptions = oidcOptions.Value;
         _logger = logger;
     }
@@ -228,6 +235,18 @@ public class TotpController : ControllerBase
             await _auditService.LogAsync(AuthAuditEventType.FailedAuth, subjectId: null, success: false,
                 ipAddress: ip, userAgent: ua,
                 detailsJson: JsonSerializer.Serialize(new { method = "totp", username = request.Username }));
+            return Problem(detail: "Invalid username or code", statusCode: 400, title: "Bad Request");
+        }
+
+        // VerifyLoginAsync resolves the subject by username globally, so a member of another
+        // tenant with a valid TOTP credential could otherwise be issued a session here. Require
+        // membership of the tenant being logged into; respond as for an invalid code so the
+        // failure does not reveal that the account exists on a different tenant.
+        if (!await _tenantMemberService.IsMemberAsync(result.SubjectId, _tenantAccessor.TenantId))
+        {
+            await _auditService.LogAsync(AuthAuditEventType.FailedAuth, result.SubjectId, success: false,
+                ipAddress: ip, userAgent: ua,
+                detailsJson: JsonSerializer.Serialize(new { method = "totp", reason = "not_a_member" }));
             return Problem(detail: "Invalid username or code", statusCode: 400, title: "Bad Request");
         }
 

--- a/src/API/Nocturne.API/Controllers/V4/DevOnly/DevAdminController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/DevOnly/DevAdminController.cs
@@ -665,7 +665,7 @@ public class DevAdminController : ControllerBase
             var deviceStatusCount = await _db.ApsSnapshots.LongCountAsync(ct);
             var profileCount = await _db.TherapySettings.CountAsync(ct);
             var memberCount = await _db.TenantMembers
-                .Where(m => m.TenantId == tenant.Id && m.RevokedAt == null)
+                .Where(m => m.TenantId == tenant.Id)
                 .CountAsync(ct);
 
             var connectors = await _db.ConnectorConfigurations

--- a/src/API/Nocturne.API/Controllers/V4/Identity/MemberInviteController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/MemberInviteController.cs
@@ -148,7 +148,7 @@ public class MemberInviteController : ControllerBase
         var member = await _dbContext.TenantMembers
             .Include(m => m.MemberRoles)
             .Include(m => m.Subject)
-            .Where(m => m.Id == id && m.TenantId == tenantId && m.RevokedAt == null)
+            .Where(m => m.Id == id && m.TenantId == tenantId)
             .FirstOrDefaultAsync(ct);
 
         if (member == null)
@@ -212,7 +212,7 @@ public class MemberInviteController : ControllerBase
         var member = await _dbContext.TenantMembers
             .Include(m => m.MemberRoles)
             .Include(m => m.Subject)
-            .Where(m => m.Id == id && m.TenantId == tenantId && m.RevokedAt == null)
+            .Where(m => m.Id == id && m.TenantId == tenantId)
             .FirstOrDefaultAsync(ct);
 
         if (member == null)
@@ -246,7 +246,7 @@ public class MemberInviteController : ControllerBase
 
         var tenantId = _tenantAccessor.TenantId;
         var member = await _dbContext.TenantMembers
-            .Where(m => m.Id == id && m.TenantId == tenantId && m.RevokedAt == null)
+            .Where(m => m.Id == id && m.TenantId == tenantId)
             .FirstOrDefaultAsync(ct);
 
         if (member == null)
@@ -276,7 +276,7 @@ public class MemberInviteController : ControllerBase
         var tenantId = _tenantAccessor.TenantId;
         var member = await _dbContext.TenantMembers
             .Include(m => m.Subject)
-            .Where(m => m.Id == id && m.TenantId == tenantId && m.RevokedAt == null)
+            .Where(m => m.Id == id && m.TenantId == tenantId)
             .FirstOrDefaultAsync(ct);
 
         if (member == null)
@@ -315,8 +315,7 @@ public class MemberInviteController : ControllerBase
             .Include(m => m.Subject)
             .Where(m => m.TenantId == tenantId
                 && m.Subject!.IsSystemSubject
-                && m.Subject.Name == "Public"
-                && m.RevokedAt == null)
+                && m.Subject.Name == "Public")
             .FirstOrDefaultAsync(ct);
 
         if (member == null)

--- a/src/API/Nocturne.API/Controllers/V4/SetupController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/SetupController.cs
@@ -142,7 +142,7 @@ public partial class SetupController : ControllerBase
             tenant.Id.ToString());
 
         var exists = await context.TenantMembers.AsNoTracking()
-            .AnyAsync(m => m.TenantId == tenant.Id && m.Username == normalized && m.RevokedAt == null, ct);
+            .AnyAsync(m => m.TenantId == tenant.Id && m.Username == normalized, ct);
 
         if (exists)
             return Ok(new SlugValidationResult(false, "This username is already taken"));

--- a/src/API/Nocturne.API/Middleware/MemberScopeMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/MemberScopeMiddleware.cs
@@ -124,8 +124,7 @@ public class MemberScopeMiddleware
             .Include(tm => tm.MemberRoles)
                 .ThenInclude(mr => mr.TenantRole)
             .Where(tm => tm.SubjectId == authContext.SubjectId.Value
-                         && tm.TenantId == authContext.TenantId.Value
-                         && tm.RevokedAt == null)
+                         && tm.TenantId == authContext.TenantId.Value)
             .FirstOrDefaultAsync();
 
         if (membership == null)

--- a/src/API/Nocturne.API/Services/Auth/OidcAuthService.cs
+++ b/src/API/Nocturne.API/Services/Auth/OidcAuthService.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Serialization;
 using Microsoft.Extensions.Options;
 using Nocturne.API.Helpers;
 using Nocturne.Core.Constants;
+using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Configuration;
 using Nocturne.Core.Models.Authorization;
 
@@ -27,6 +28,7 @@ public class OidcAuthService : IOidcAuthService
     private readonly IJwtService _jwtService;
     private readonly IRefreshTokenService _refreshTokenService;
     private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ITenantMemberService _tenantMemberService;
     private readonly OidcOptions _options;
     private readonly IConfiguration _configuration;
     private readonly ILogger<OidcAuthService> _logger;
@@ -40,6 +42,7 @@ public class OidcAuthService : IOidcAuthService
     /// <param name="jwtService">Service for generating Nocturne access tokens (non-rotation refresh path only).</param>
     /// <param name="refreshTokenService">Service for validating refresh tokens (non-rotation refresh path only).</param>
     /// <param name="httpClientFactory">Factory for the <c>OidcProvider</c> named HTTP client.</param>
+    /// <param name="tenantMemberService">Service for verifying tenant membership before issuing a login session.</param>
     /// <param name="options">OIDC session and state configuration options.</param>
     /// <param name="configuration">Application configuration for reading the base URL.</param>
     /// <param name="logger">Logger instance.</param>
@@ -50,6 +53,7 @@ public class OidcAuthService : IOidcAuthService
         IJwtService jwtService,
         IRefreshTokenService refreshTokenService,
         IHttpClientFactory httpClientFactory,
+        ITenantMemberService tenantMemberService,
         IOptions<OidcOptions> options,
         IConfiguration configuration,
         ILogger<OidcAuthService> logger
@@ -61,6 +65,7 @@ public class OidcAuthService : IOidcAuthService
         _jwtService = jwtService;
         _refreshTokenService = refreshTokenService;
         _httpClientFactory = httpClientFactory;
+        _tenantMemberService = tenantMemberService;
         _options = options.Value;
         _configuration = configuration;
         _logger = logger;
@@ -249,7 +254,8 @@ public class OidcAuthService : IOidcAuthService
         string state,
         string expectedState,
         string? ipAddress = null,
-        string? userAgent = null
+        string? userAgent = null,
+        Guid? currentTenantId = null
     )
     {
         var parsed = await ValidateCallbackAndParseIdTokenAsync(code, state, expectedState);
@@ -258,10 +264,27 @@ public class OidcAuthService : IOidcAuthService
             return OidcCallbackResult.Failed(parsed.Error ?? "callback_failed", parsed.ErrorDescription);
         }
 
-        var stateData = parsed.StateData!;
-        var provider = parsed.Provider!;
-        var idTokenClaims = parsed.Claims!;
+        return await CompleteLoginAsync(
+            parsed.StateData!, parsed.Provider!, parsed.Claims!, currentTenantId, ipAddress, userAgent);
+    }
 
+    /// <summary>
+    /// Completes a login after the OIDC callback has been validated and the ID token parsed:
+    /// resolves the subject from the external identity, enforces tenant membership, and issues
+    /// a session. Because an OIDC identity resolves to a <em>global</em> subject, a valid external
+    /// identity must still be a member of <paramref name="currentTenantId"/> before a session is
+    /// issued — otherwise any external identity could mint a session on any tenant's subdomain.
+    /// Extracted from <see cref="HandleCallbackAsync"/> so the membership gate can be unit-tested
+    /// without exercising the OIDC code exchange.
+    /// </summary>
+    internal async Task<OidcCallbackResult> CompleteLoginAsync(
+        OidcStateData stateData,
+        OidcProvider provider,
+        OidcIdTokenClaims idTokenClaims,
+        Guid? currentTenantId,
+        string? ipAddress,
+        string? userAgent)
+    {
         // Find or create subject
         var subject = await _subjectService.FindOrCreateFromOidcAsync(
             provider.Id,
@@ -271,6 +294,20 @@ public class OidcAuthService : IOidcAuthService
             idTokenClaims.Name ?? idTokenClaims.PreferredUsername,
             provider.DefaultRoles
         );
+
+        // Cross-tenant guard: deny — without issuing a session — when the authenticated
+        // identity is not a member of the tenant being logged into. The per-request
+        // membership gate in AuthenticationMiddleware would block this subject's data
+        // access anyway, but only after a session (and a "logged in" UI) already existed.
+        if (currentTenantId is { } tenantId
+            && !await _tenantMemberService.IsMemberAsync(subject.Id, tenantId))
+        {
+            _logger.LogWarning(
+                "OIDC login denied: subject {SubjectId} is not a member of tenant {TenantId}",
+                subject.Id,
+                tenantId);
+            return OidcCallbackResult.NotAMember(subject.Id, stateData.ReturnUrl);
+        }
 
         // Update last login
         await _subjectService.UpdateLastLoginAsync(subject.Id);

--- a/src/API/Nocturne.API/Services/Auth/PasskeyService.cs
+++ b/src/API/Nocturne.API/Services/Auth/PasskeyService.cs
@@ -255,6 +255,7 @@ public class PasskeyService : IPasskeyService
             ?? throw new InvalidOperationException("Credential not found.");
 
         // Verify the credential's subject is a member of the current tenant
+        // (the global query filter on TenantMemberEntity already excludes revoked memberships).
         var isMember = await _dbContext.TenantMembers
             .AnyAsync(tm => tm.TenantId == tenantId && tm.SubjectId == storedCredential.SubjectId);
         if (!isMember)

--- a/src/API/Nocturne.API/Services/Auth/PublicAccessCacheService.cs
+++ b/src/API/Nocturne.API/Services/Auth/PublicAccessCacheService.cs
@@ -94,8 +94,7 @@ public sealed class PublicAccessCacheService
             .Include(tm => tm.Subject)
             .Where(tm => tm.TenantId == tenantId
                          && tm.Subject!.IsSystemSubject
-                         && tm.Subject.Name == "Public"
-                         && tm.RevokedAt == null)
+                         && tm.Subject.Name == "Public")
             .FirstOrDefaultAsync();
 
         if (membership == null)

--- a/src/API/Nocturne.API/Services/Identity/MemberInviteService.cs
+++ b/src/API/Nocturne.API/Services/Identity/MemberInviteService.cs
@@ -143,8 +143,7 @@ public class MemberInviteService : IMemberInviteService
         // Check if already an active member of this tenant
         var existingMember = await _dbContext.TenantMembers
             .Where(m => m.TenantId == entity.TenantId
-                        && m.SubjectId == acceptingSubjectId
-                        && m.RevokedAt == null)
+                        && m.SubjectId == acceptingSubjectId)
             .FirstOrDefaultAsync();
 
         if (existingMember != null)

--- a/src/API/Nocturne.API/Services/Identity/MembershipRequestService.cs
+++ b/src/API/Nocturne.API/Services/Identity/MembershipRequestService.cs
@@ -63,7 +63,7 @@ public class MembershipRequestService : IMembershipRequestService
 
         // Find all tenant members whose roles include "members.manage" or "*"
         var membersToNotify = await _dbContext.TenantMembers
-            .Where(m => m.TenantId == tenantId && m.RevokedAt == null)
+            .Where(m => m.TenantId == tenantId)
             .Where(m => m.MemberRoles.Any(mr =>
                 mr.TenantRole.Permissions.Any(p => p == "members.manage" || p == "*")))
             .Select(m => m.SubjectId)

--- a/src/Core/Nocturne.Core.Contracts/Auth/IOidcAuthService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Auth/IOidcAuthService.cs
@@ -34,13 +34,18 @@ public interface IOidcAuthService
     /// <param name="expectedState">Expected state value from cookie</param>
     /// <param name="ipAddress">Client IP address</param>
     /// <param name="userAgent">User agent string</param>
+    /// <param name="currentTenantId">
+    /// The tenant the login is being performed against (the resolved subdomain tenant).
+    /// When set, the resolved subject must be a member of this tenant or no session is issued.
+    /// </param>
     /// <returns>Authentication result with session tokens</returns>
     Task<OidcCallbackResult> HandleCallbackAsync(
         string code,
         string state,
         string expectedState,
         string? ipAddress = null,
-        string? userAgent = null
+        string? userAgent = null,
+        Guid? currentTenantId = null
     );
 
     /// <summary>
@@ -209,6 +214,19 @@ public class OidcCallbackResult
     public string? ReturnUrl { get; set; }
 
     /// <summary>
+    /// True when authentication succeeded but the subject is not a member of the tenant
+    /// being logged into. No session is issued; the caller should redirect to the tenant's
+    /// login page (where the request-membership option is offered when the tenant allows it).
+    /// </summary>
+    public bool IsAccessDenied { get; set; }
+
+    /// <summary>
+    /// Subject resolved from the OIDC identity, when known. Set for successful and
+    /// access-denied results so the caller can write an accurate audit entry.
+    /// </summary>
+    public Guid? SubjectId { get; set; }
+
+    /// <summary>
     /// Create a successful result
     /// </summary>
     public static OidcCallbackResult Succeeded(
@@ -222,6 +240,7 @@ public class OidcCallbackResult
             Tokens = tokens,
             UserInfo = userInfo,
             ReturnUrl = returnUrl,
+            SubjectId = tokens.SubjectId,
         };
 
     /// <summary>
@@ -233,6 +252,21 @@ public class OidcCallbackResult
             Success = false,
             Error = error,
             ErrorDescription = description,
+        };
+
+    /// <summary>
+    /// Create an access-denied result for an authenticated identity that is not a member
+    /// of the tenant being logged into. No session is issued.
+    /// </summary>
+    public static OidcCallbackResult NotAMember(Guid subjectId, string? returnUrl = null) =>
+        new()
+        {
+            Success = false,
+            IsAccessDenied = true,
+            SubjectId = subjectId,
+            Error = "not_a_member",
+            ErrorDescription = "You are not a member of this account.",
+            ReturnUrl = returnUrl,
         };
 }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -541,6 +541,13 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
         // Configure per-tenant global query filters
         ConfigureTenantFilters(modelBuilder);
 
+        // Tenant membership is "active" only while not revoked. Enforcing this once here
+        // keeps every membership query (auth gates, setup detection, admin listings) from
+        // having to repeat `RevokedAt == null`. The matching partial unique index
+        // (ix_tenant_members_tenant_subject, filtered on revoked_at IS NULL) lets a revoked
+        // membership coexist with a fresh active one, so re-adds remain valid.
+        modelBuilder.Entity<TenantMemberEntity>().HasQueryFilter(tm => tm.RevokedAt == null);
+
         // Configure cascade deletes from tenant to all tenant-scoped entities
         ConfigureTenantCascadeDeletes(modelBuilder);
 

--- a/tests/Integration/Nocturne.API.Tests/Auth/MultitenantIsolationIntegrationTests.cs
+++ b/tests/Integration/Nocturne.API.Tests/Auth/MultitenantIsolationIntegrationTests.cs
@@ -10,10 +10,14 @@ using Xunit.Abstractions;
 namespace Nocturne.API.Tests.Integration.Auth;
 
 /// <summary>
-/// Integration tests verifying that tenant data isolation is enforced end-to-end.
-/// Each test seeds data in one tenant and confirms it is invisible from another,
-/// covering entries, treatments, profiles, auth grants, OAuth clients, and tenant
-/// resolution edge cases (unknown subdomain, inactive tenant, apex domain).
+/// Integration tests verifying that tenant data isolation and cross-tenant
+/// authorization are enforced end-to-end. Each test seeds data in one tenant and
+/// confirms it is invisible from another, covering entries, treatments, profiles,
+/// auth grants, OAuth clients, and tenant resolution edge cases (unknown subdomain,
+/// inactive tenant, apex domain). The "subject membership authorization gate"
+/// section additionally verifies that a valid access token issued for one tenant
+/// cannot read or write against another tenant, and that a tenant member without
+/// the platform_admin role cannot reach the platform-admin API.
 /// </summary>
 [Trait("Category", "Integration")]
 public class MultitenantIsolationIntegrationTests : AspireIntegrationTestBase
@@ -420,5 +424,163 @@ public class MultitenantIsolationIntegrationTests : AspireIntegrationTestBase
             reactivateCmd.Parameters.AddWithValue("id", _tenantBId);
             await reactivateCmd.ExecuteNonQueryAsync();
         }
+    }
+
+    // ── Subject membership authorization gate ───────────────────────────────
+    // The tests above pair each tenant's api-secret admin client with its own
+    // subdomain. That proves query-filter/RLS data isolation, but the api-secret
+    // authenticates as an admin API key on the resolved tenant, which bypasses the
+    // membership check. The tests below send ONLY a subject's Bearer access token,
+    // so AuthenticationMiddleware.IsMemberAsync is the gate under test: a valid
+    // token for one tenant must not authenticate against another tenant.
+
+    [Fact]
+    public async Task SubjectA_Token_CannotRead_OnTenantB()
+    {
+        // Subject A holds a valid access token but is not a member of tenant B.
+        using var client = AuthTestHelpers.CreateTenantBearerClient(
+            Fixture, _slugB, _baseDomain, _accessTokenA);
+
+        var response = await client.GetAsync("/api/v1/entries/current");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            "a valid access token for tenant A must not authenticate against tenant B");
+    }
+
+    [Fact]
+    public async Task SubjectB_Token_CannotRead_OnTenantA()
+    {
+        // Symmetric check from the other direction.
+        using var client = AuthTestHelpers.CreateTenantBearerClient(
+            Fixture, _slugA, _baseDomain, _accessTokenB);
+
+        var response = await client.GetAsync("/api/v1/entries/current");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            "a valid access token for tenant B must not authenticate against tenant A");
+    }
+
+    [Fact]
+    public async Task SubjectA_Token_CanAccess_OwnTenant()
+    {
+        // Positive control: the same token, used against its OWN tenant, both
+        // authenticates and is authorized to write. This proves the 401s in the
+        // cross-tenant tests come from the membership gate, not an invalid token.
+        using var client = AuthTestHelpers.CreateTenantBearerClient(
+            Fixture, _slugA, _baseDomain, _accessTokenA);
+
+        var now = DateTimeOffset.UtcNow;
+        var entryPayload = new[]
+        {
+            new
+            {
+                type = "sgv",
+                sgv = 120,
+                date = now.ToUnixTimeMilliseconds(),
+                dateString = now.UtcDateTime.ToString("o")
+            }
+        };
+        var response = await client.PostAsJsonAsync("/api/v1/entries", entryPayload);
+
+        response.StatusCode.Should().BeOneOf(
+            new[] { HttpStatusCode.OK, HttpStatusCode.Created },
+            "a subject must be able to write to a tenant it belongs to using its own access token");
+    }
+
+    [Fact]
+    public async Task SubjectA_Token_CannotWrite_ToTenantB()
+    {
+        // Attempt to write into tenant B using tenant A's token.
+        using var attacker = AuthTestHelpers.CreateTenantBearerClient(
+            Fixture, _slugB, _baseDomain, _accessTokenA);
+
+        var now = DateTimeOffset.UtcNow;
+        var entryPayload = new[]
+        {
+            new
+            {
+                type = "sgv",
+                sgv = 321,
+                date = now.ToUnixTimeMilliseconds(),
+                dateString = now.UtcDateTime.ToString("o")
+            }
+        };
+        var writeResponse = await attacker.PostAsJsonAsync("/api/v1/entries", entryPayload);
+
+        // Assert - the write is rejected at the auth layer...
+        writeResponse.StatusCode.Should().BeOneOf(
+            new[] { HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden },
+            "a subject must not be able to write into a tenant it does not belong to");
+
+        // ...and nothing landed in tenant B.
+        using var clientB = AuthTestHelpers.CreateAuthenticatedTenantClient(
+            Fixture, _slugB, _baseDomain, _accessTokenB);
+        var getResponse = await clientB.GetAsync("/api/v1/entries?count=100");
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await getResponse.Content.ReadAsStringAsync();
+        var entries = JsonSerializer.Deserialize<JsonElement>(content);
+        var leaked = entries.EnumerateArray().Any(e =>
+            e.TryGetProperty("sgv", out var sgv) && sgv.GetInt32() == 321);
+        leaked.Should().BeFalse("a cross-tenant write must not create data in the target tenant");
+    }
+
+    [Fact]
+    public async Task TenantMember_WithoutPlatformAdmin_CannotUse_PlatformAdminApi()
+    {
+        // Subject A is a member (and admin) of tenant A, but is not a platform
+        // admin. The platform-admin tenant API requires the platform_admin role,
+        // so an ordinary tenant member must be forbidden even on their own tenant.
+        using var client = AuthTestHelpers.CreateTenantBearerClient(
+            Fixture, _slugA, _baseDomain, _accessTokenA);
+
+        var response = await client.GetAsync("/api/v4/admin/tenants");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "a tenant member without the platform_admin role must not access the platform-admin API");
+    }
+
+    [Fact]
+    public async Task RevokedMember_Token_IsDenied_OnOwnTenant()
+    {
+        // Sanity: subject A is a member of tenant A and can write before revocation.
+        var now = DateTimeOffset.UtcNow;
+        using (var before = AuthTestHelpers.CreateTenantBearerClient(Fixture, _slugA, _baseDomain, _accessTokenA))
+        {
+            var ok = await before.PostAsJsonAsync("/api/v1/entries", new[]
+            {
+                new { type = "sgv", sgv = 111, date = now.ToUnixTimeMilliseconds(), dateString = now.UtcDateTime.ToString("o") }
+            });
+            ok.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.Created);
+        }
+
+        // Revoke subject A's membership in tenant A. No app path soft-revokes today, so simulate it
+        // directly, the same way other tests toggle tenants.is_active.
+        var connStr = await GetPostgresConnectionStringAsync();
+        await using (var conn = new NpgsqlConnection(connStr))
+        {
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "UPDATE tenant_members SET revoked_at = now() WHERE subject_id = @s AND tenant_id = @t;";
+            cmd.Parameters.AddWithValue("s", _subjectAId);
+            cmd.Parameters.AddWithValue("t", _tenantAId);
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        // The same previously-valid token is now rejected for both read and write — the membership
+        // gate (via the RevokedAt query filter) no longer sees subject A as a member of tenant A.
+        using var client = AuthTestHelpers.CreateTenantBearerClient(Fixture, _slugA, _baseDomain, _accessTokenA);
+
+        var read = await client.GetAsync("/api/v1/entries/current");
+        read.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            "a revoked member must not authenticate, even with a previously-valid access token");
+
+        var write = await client.PostAsJsonAsync("/api/v1/entries", new[]
+        {
+            new { type = "sgv", sgv = 112, date = now.ToUnixTimeMilliseconds(), dateString = now.UtcDateTime.ToString("o") }
+        });
+        write.StatusCode.Should().BeOneOf(
+            new[] { HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden },
+            "a revoked member must not be able to write");
     }
 }

--- a/tests/Integration/Nocturne.API.Tests/Infrastructure/AuthTestHelpers.cs
+++ b/tests/Integration/Nocturne.API.Tests/Infrastructure/AuthTestHelpers.cs
@@ -476,6 +476,25 @@ public static class AuthTestHelpers
     }
 
     /// <summary>
+    /// Creates an HttpClient targeting a specific tenant by slug with ONLY a Bearer
+    /// access token (no api-secret). Use this to exercise the subject-membership
+    /// authorization gate in <c>AuthenticationMiddleware</c>: an api-secret header
+    /// authenticates as an admin API key on the resolved tenant and bypasses the
+    /// membership check, so it would mask cross-tenant authorization failures.
+    /// </summary>
+    public static HttpClient CreateTenantBearerClient(
+        AspireIntegrationTestFixture fixture,
+        string slug,
+        string baseDomain,
+        string accessToken)
+    {
+        var client = fixture.CreateHttpClient("nocturne-api", "api");
+        client.DefaultRequestHeaders.Host = $"{slug}.{baseDomain}";
+        client.DefaultRequestHeaders.Add("Authorization", $"Bearer {accessToken}");
+        return client;
+    }
+
+    /// <summary>
     /// Extracts the base domain (host:port) from an HttpClient's BaseAddress.
     /// </summary>
     public static string GetBaseDomain(HttpClient apiClient)

--- a/tests/Unit/Nocturne.API.Tests/Controllers/TotpControllerLoginGateTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/TotpControllerLoginGateTests.cs
@@ -1,0 +1,95 @@
+using System.Threading;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Nocturne.API.Controllers.Authentication;
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.Configuration;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers;
+
+/// <summary>
+/// Tests for the cross-tenant guard on TOTP login. <see cref="ITotpService.VerifyLoginAsync"/>
+/// resolves the subject by username globally, so the controller must verify the resolved
+/// subject is a member of the tenant being logged into before issuing a session.
+/// </summary>
+public class TotpControllerLoginGateTests
+{
+    private readonly Mock<ITotpService> _totpService = new();
+    private readonly Mock<ISessionService> _sessionService = new();
+    private readonly Mock<ISubjectService> _subjectService = new();
+    private readonly Mock<IAuthAuditService> _auditService = new();
+    private readonly Mock<ITenantAccessor> _tenantAccessor = new();
+    private readonly Mock<ITenantMemberService> _tenantMemberService = new();
+
+    private TotpController CreateController()
+        => new(
+            _totpService.Object,
+            _sessionService.Object,
+            _subjectService.Object,
+            _auditService.Object,
+            _tenantAccessor.Object,
+            _tenantMemberService.Object,
+            Options.Create(new OidcOptions()),
+            NullLogger<TotpController>.Instance)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Login_WhenSubjectIsNotMemberOfTenant_DeniesWithoutIssuingSession()
+    {
+        var subjectId = Guid.NewGuid();
+        var tenantId = Guid.NewGuid();
+        _totpService
+            .Setup(s => s.VerifyLoginAsync("rhys", "123456"))
+            .ReturnsAsync(new TotpLoginResult(subjectId, "rhys", "Rhys"));
+        _tenantAccessor.Setup(a => a.TenantId).Returns(tenantId);
+        _tenantMemberService
+            .Setup(t => t.IsMemberAsync(subjectId, tenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var controller = CreateController();
+        var result = await controller.Login(new TotpLoginRequest { Username = "rhys", Code = "123456" });
+
+        result.Result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(400, "a non-member must be rejected like an invalid code");
+
+        _sessionService.Verify(
+            s => s.IssueSessionAsync(It.IsAny<Guid>(), It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "a TOTP login from a non-member must not mint a session");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Login_WhenSubjectIsMemberOfTenant_IssuesSession()
+    {
+        var subjectId = Guid.NewGuid();
+        var tenantId = Guid.NewGuid();
+        _totpService
+            .Setup(s => s.VerifyLoginAsync("rhys", "123456"))
+            .ReturnsAsync(new TotpLoginResult(subjectId, "rhys", "Rhys"));
+        _tenantAccessor.Setup(a => a.TenantId).Returns(tenantId);
+        _tenantMemberService
+            .Setup(t => t.IsMemberAsync(subjectId, tenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _sessionService
+            .Setup(s => s.IssueSessionAsync(It.IsAny<Guid>(), It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SessionTokenPair("access-token", "refresh-token", 3600));
+
+        var controller = CreateController();
+        var result = await controller.Login(new TotpLoginRequest { Username = "rhys", Code = "123456" });
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        _sessionService.Verify(
+            s => s.IssueSessionAsync(subjectId, It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcAuthServiceLinkTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcAuthServiceLinkTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Options;
 using Moq;
 using Nocturne.API.Services.Auth;
 using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.Configuration;
 using Xunit;
@@ -23,6 +24,7 @@ public class OidcAuthServiceLinkTests
     private readonly Mock<IJwtService> _jwtService = new();
     private readonly Mock<IRefreshTokenService> _refreshTokenService = new();
     private readonly Mock<IHttpClientFactory> _httpFactory = new();
+    private readonly Mock<ITenantMemberService> _tenantMemberService = new();
     private readonly Mock<IConfiguration> _configuration = new();
     private readonly OidcAuthService _service;
 
@@ -36,6 +38,7 @@ public class OidcAuthServiceLinkTests
             _jwtService.Object,
             _refreshTokenService.Object,
             _httpFactory.Object,
+            _tenantMemberService.Object,
             options,
             _configuration.Object,
             NullLogger<OidcAuthService>.Instance);

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcAuthServiceLoginGateTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcAuthServiceLoginGateTests.cs
@@ -1,0 +1,167 @@
+using System.Threading;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Nocturne.API.Services.Auth;
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Core.Models.Configuration;
+using Xunit;
+using Subject = Nocturne.Core.Models.Authorization.Subject;
+
+namespace Nocturne.API.Tests.Services.Auth;
+
+/// <summary>
+/// Tests for the cross-tenant login guard in
+/// <see cref="OidcAuthService.CompleteLoginAsync"/>. An OIDC identity resolves to a global
+/// subject, so a valid external identity must still be a member of the tenant being logged
+/// into before a session is issued. Without this gate, any external identity could mint a
+/// session on any tenant's subdomain.
+/// </summary>
+public class OidcAuthServiceLoginGateTests
+{
+    private readonly Mock<ISubjectService> _subjectService = new();
+    private readonly Mock<IOidcProviderService> _providerService = new();
+    private readonly Mock<ISessionService> _sessionService = new();
+    private readonly Mock<IJwtService> _jwtService = new();
+    private readonly Mock<IRefreshTokenService> _refreshTokenService = new();
+    private readonly Mock<IHttpClientFactory> _httpFactory = new();
+    private readonly Mock<ITenantMemberService> _tenantMemberService = new();
+    private readonly Mock<IConfiguration> _configuration = new();
+    private readonly OidcAuthService _service;
+
+    public OidcAuthServiceLoginGateTests()
+    {
+        var options = Options.Create(new OidcOptions());
+        _service = new OidcAuthService(
+            _providerService.Object,
+            _subjectService.Object,
+            _sessionService.Object,
+            _jwtService.Object,
+            _refreshTokenService.Object,
+            _httpFactory.Object,
+            _tenantMemberService.Object,
+            options,
+            _configuration.Object,
+            NullLogger<OidcAuthService>.Instance);
+    }
+
+    private static OidcAuthService.OidcStateData LoginState(string tenantSlug = "erik", string returnUrl = "/")
+        => new()
+        {
+            Intent = "login",
+            ReturnUrl = returnUrl,
+            ProviderId = Guid.NewGuid(),
+            Nonce = "n",
+            TenantSlug = tenantSlug,
+            CreatedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
+        };
+
+    private static OidcProvider Provider()
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            Name = "Google",
+            IssuerUrl = "https://accounts.google.com",
+            ClientId = "nocturne",
+            IsEnabled = true,
+        };
+
+    private static OidcAuthService.OidcIdTokenClaims Claims()
+        => new() { Sub = "google-123", Email = "user@example.com" };
+
+    private Subject SetupResolvedSubject()
+    {
+        var subject = new Subject { Id = Guid.NewGuid(), Name = "Rhys", Email = "user@example.com" };
+        _subjectService
+            .Setup(s => s.FindOrCreateFromOidcAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<IEnumerable<string>?>()))
+            .ReturnsAsync(subject);
+        return subject;
+    }
+
+    private void SetupSessionIssuance()
+    {
+        _subjectService.Setup(s => s.UpdateLastLoginAsync(It.IsAny<Guid>())).Returns(Task.CompletedTask);
+        _subjectService.Setup(s => s.GetSubjectPermissionsAsync(It.IsAny<Guid>())).ReturnsAsync(new List<string>());
+        _subjectService.Setup(s => s.GetSubjectRolesAsync(It.IsAny<Guid>())).ReturnsAsync(new List<string>());
+        _sessionService
+            .Setup(s => s.IssueSessionAsync(It.IsAny<Guid>(), It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SessionTokenPair("access-token", "refresh-token", 3600));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CompleteLoginAsync_WhenSubjectIsNotMemberOfTenant_DeniesWithoutIssuingSession()
+    {
+        var subject = SetupResolvedSubject();
+        var tenantId = Guid.NewGuid();
+        _tenantMemberService
+            .Setup(t => t.IsMemberAsync(subject.Id, tenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await _service.CompleteLoginAsync(
+            LoginState(), Provider(), Claims(), tenantId, ipAddress: null, userAgent: null);
+
+        result.Success.Should().BeFalse();
+        result.IsAccessDenied.Should().BeTrue("a non-member must be denied a session");
+        result.SubjectId.Should().Be(subject.Id);
+        result.Tokens.Should().BeNull("no session may be issued for a non-member");
+
+        _sessionService.Verify(
+            s => s.IssueSessionAsync(It.IsAny<Guid>(), It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the cross-tenant login must not mint a session");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CompleteLoginAsync_WhenSubjectIsMemberOfTenant_IssuesSession()
+    {
+        var subject = SetupResolvedSubject();
+        var tenantId = Guid.NewGuid();
+        _tenantMemberService
+            .Setup(t => t.IsMemberAsync(subject.Id, tenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        SetupSessionIssuance();
+
+        var result = await _service.CompleteLoginAsync(
+            LoginState(), Provider(), Claims(), tenantId, ipAddress: null, userAgent: null);
+
+        result.Success.Should().BeTrue();
+        result.IsAccessDenied.Should().BeFalse();
+        result.Tokens.Should().NotBeNull();
+
+        _sessionService.Verify(
+            s => s.IssueSessionAsync(subject.Id, It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CompleteLoginAsync_WhenNoTenantResolved_IssuesSession()
+    {
+        // Single-tenant / unresolved-tenant deployments have no subdomain tenant to gate on.
+        var subject = SetupResolvedSubject();
+        SetupSessionIssuance();
+
+        var result = await _service.CompleteLoginAsync(
+            LoginState(tenantSlug: null!), Provider(), Claims(), currentTenantId: null, ipAddress: null, userAgent: null);
+
+        result.Success.Should().BeTrue();
+        result.IsAccessDenied.Should().BeFalse();
+
+        _tenantMemberService.Verify(
+            t => t.IsMemberAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "with no resolved tenant there is nothing to check membership against");
+        _sessionService.Verify(
+            s => s.IssueSessionAsync(subject.Id, It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/TenantMemberRevokedFilterTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/TenantMemberRevokedFilterTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Nocturne.Infrastructure.Data.Entities;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests;
+
+/// <summary>
+/// Verifies the single enforcement point for "active membership": the global query filter on
+/// <see cref="TenantMemberEntity"/> (<c>RevokedAt == null</c>). Every membership check across the
+/// auth gates relies on this filter rather than repeating the predicate, so a revoked membership
+/// must be invisible to ordinary queries and only reachable via <c>IgnoreQueryFilters()</c>.
+/// EF InMemory honours global query filters, matching the pattern used by the alert-scoping tests.
+/// </summary>
+public class TenantMemberRevokedFilterTests
+{
+    [Fact]
+    public async Task TenantMembers_AreExcludedWhenRevoked()
+    {
+        var options = NewStore();
+        var tenantId = Guid.NewGuid();
+        var activeSubject = Guid.NewGuid();
+        var revokedSubject = Guid.NewGuid();
+
+        await using (var seedCtx = new NocturneDbContext(options))
+        {
+            seedCtx.TenantMembers.AddRange(
+                NewMember(tenantId, activeSubject, revokedAt: null),
+                NewMember(tenantId, revokedSubject, revokedAt: DateTime.UtcNow));
+            await seedCtx.SaveChangesAsync();
+        }
+
+        await using var ctx = new NocturneDbContext(options);
+
+        var visible = await ctx.TenantMembers.Select(m => m.SubjectId).ToListAsync();
+        visible.Should().BeEquivalentTo(new[] { activeSubject },
+            "the global query filter must hide revoked memberships from every membership query");
+
+        var all = await ctx.TenantMembers.IgnoreQueryFilters().Select(m => m.SubjectId).ToListAsync();
+        all.Should().BeEquivalentTo(new[] { activeSubject, revokedSubject },
+            "IgnoreQueryFilters bypasses the filter, confirming the revoked row exists but is filtered");
+    }
+
+    private static DbContextOptions<NocturneDbContext> NewStore() =>
+        new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseInMemoryDatabase($"tenant_member_revoked_{Guid.NewGuid()}")
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+    private static TenantMemberEntity NewMember(Guid tenantId, Guid subjectId, DateTime? revokedAt) => new()
+    {
+        Id = Guid.CreateVersion7(),
+        TenantId = tenantId,
+        SubjectId = subjectId,
+        RevokedAt = revokedAt,
+    };
+}


### PR DESCRIPTION
## Why

OIDC and TOTP login each resolved a **global** subject from the credential and issued a session **without checking that the subject is a member of the tenant being logged into**. So a member of tenant A could complete a login on tenant B's subdomain and receive a session cookie — appearing "logged in" (with a brief UI flash) even though the per-request membership gate then blocked all data access. Passkey login already verified membership; OIDC and TOTP were the gaps.

Reported in production (a user's Google identity, a member of one tenant, could log in on another tenant's subdomain).

## What

- **OIDC** — gate session issuance on tenant membership in `OidcAuthService.CompleteLoginAsync` (extracted from `HandleCallbackAsync` so it's unit-testable). Non-members get **no session** and are redirected to the tenant login page, where the existing "Request membership" UI appears when the tenant allows access requests.
- **TOTP** — same membership gate in `TotpController.Login` before issuing a session; on failure it responds exactly like an invalid code, so it doesn't reveal that the account exists on another tenant.
- **Revoked memberships** — honored everywhere via a single EF **global query filter** on `TenantMemberEntity` (`RevokedAt == null`), matching the codebase's existing soft-delete filter pattern. This replaces ~15 duplicated `RevokedAt == null` predicates across the auth gates, setup detection, and admin queries (the partial unique index `ix_tenant_members_tenant_subject` already anticipated soft-revoke, so re-adds remain valid).

## Tests

- Unit: `OidcAuthServiceLoginGateTests`, `TotpControllerLoginGateTests` (non-member → no session, via `IssueSessionAsync` never called), `TenantMemberRevokedFilterTests` (filter hides revoked, `IgnoreQueryFilters` sees it).
- Integration (`MultitenantIsolationIntegrationTests`): cross-tenant API membership-gate tests (valid token for tenant A → 401 on tenant B) and a revoked-member test (revoke via SQL → previously-valid token → 401).
- Local: full unit suites green (3252 API + 343 data-layer). Integration tests run in CI (the local Aspire+Testcontainers fixture wouldn't complete on the dev box).
