### PR TITLE
fix(connectors): skip enabled connectors missing required configuration

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Core/Models/BaseConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Models/BaseConnectorConfiguration.cs
@@ -140,56 +140,89 @@ public abstract class BaseConnectorConfiguration : IConnectorConfiguration
     }
 
     /// <summary>
+    ///     Whether every required property — those marked [Required] or
+    ///     [ConnectorProperty(Required = true)] — has a value. Required secrets are merged into the
+    ///     configuration before this is evaluated, so a connector that is enabled but missing its
+    ///     credentials (e.g. enabled via the UI toggle, or saved before secrets were entered, or a
+    ///     required secret later removed) reports false here and must not sync — otherwise it polls
+    ///     every cycle with empty credentials and fails authentication forever.
+    /// </summary>
+    public bool HasRequiredConfiguration()
+    {
+        foreach (var (property, _, _) in GetRequiredProperties())
+        {
+            if (IsRequiredValueMissing(property, property.GetValue(this)))
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
     ///     Validates all properties marked with [Required] attribute or
     ///     [ConnectorProperty(Required = true)].
     ///     Throws ArgumentException if any required string property is null or empty.
     /// </summary>
     private void ValidateRequiredProperties()
     {
-        var properties = GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
-
-        foreach (var property in properties)
+        foreach (var (property, displayName, connectorProp) in GetRequiredProperties())
         {
-            var isRequired = false;
-            string? displayName = null;
-
-            // Check for [Required] attribute
-            if (property.GetCustomAttribute<RequiredAttribute>() != null)
-            {
-                isRequired = true;
-                displayName = property.Name;
-            }
-
-            // Check for [ConnectorProperty(Required = true)]
-            var connectorProp = property.GetCustomAttribute<ConnectorPropertyAttribute>();
-            if (connectorProp is { Required: true })
-            {
-                isRequired = true;
-                displayName = connectorProp.GetKeyName();
-            }
-
-            if (!isRequired)
+            var value = property.GetValue(this);
+            if (!IsRequiredValueMissing(property, value))
                 continue;
 
-            var value = property.GetValue(this);
-
-            // For string properties, check for null or whitespace
             if (property.PropertyType == typeof(string))
             {
-                if (!string.IsNullOrWhiteSpace(value as string)) continue;
                 var envVarHint = connectorProp != null && EnvPrefix != null
                     ? $" (set via {connectorProp.GetFullEnvVarName(EnvPrefix)} or configuration)"
                     : "";
                 throw new ArgumentException(
                     $"{ConnectorName}: {displayName} is required{envVarHint}");
             }
-            // For nullable value types, check for null
-            else if (Nullable.GetUnderlyingType(property.PropertyType) != null && value == null)
-            {
-                throw new ArgumentException(
-                    $"{ConnectorName}: {displayName} is required");
-            }
+
+            throw new ArgumentException(
+                $"{ConnectorName}: {displayName} is required");
         }
+    }
+
+    /// <summary>
+    ///     Enumerates the properties required via [Required] or [ConnectorProperty(Required = true)],
+    ///     with their display name and connector-property attribute (if any). Shared by
+    ///     <see cref="HasRequiredConfiguration"/> and <see cref="ValidateRequiredProperties"/> so
+    ///     both agree on what "required" means.
+    /// </summary>
+    private IEnumerable<(PropertyInfo Property, string DisplayName, ConnectorPropertyAttribute? ConnectorProp)>
+        GetRequiredProperties()
+    {
+        foreach (var property in GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            string? displayName = null;
+
+            if (property.GetCustomAttribute<RequiredAttribute>() != null)
+                displayName = property.Name;
+
+            var connectorProp = property.GetCustomAttribute<ConnectorPropertyAttribute>();
+            if (connectorProp is { Required: true })
+                displayName = connectorProp.GetKeyName();
+
+            if (displayName != null)
+                yield return (property, displayName, connectorProp);
+        }
+    }
+
+    /// <summary>
+    ///     Whether a required property's value counts as missing: null/whitespace for strings,
+    ///     null for nullable value types. Non-nullable value types always carry a value.
+    /// </summary>
+    private static bool IsRequiredValueMissing(PropertyInfo property, object? value)
+    {
+        if (property.PropertyType == typeof(string))
+            return string.IsNullOrWhiteSpace(value as string);
+
+        if (Nullable.GetUnderlyingType(property.PropertyType) != null)
+            return value == null;
+
+        return false;
     }
 
     /// <summary>

--- a/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorConfigurationLoader.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorConfigurationLoader.cs
@@ -61,6 +61,20 @@ public class ConnectorConfigurationLoader<TConfig>(
                 registration.ConnectorName);
         }
 
+        // A connector can have a config row that is enabled yet missing its required credentials —
+        // enabled via the UI toggle, saved before secrets were entered, or a required secret later
+        // removed. Required secrets have been merged above, so if the connector is still missing
+        // required configuration, syncing it would authenticate with empty credentials and fail
+        // every cycle. Treat incomplete configuration as not configured and skip it, exactly like a
+        // tenant that never configured the connector at all.
+        if (config.Enabled && !config.HasRequiredConfiguration())
+        {
+            logger.LogDebug(
+                "{ConnectorName} is enabled but missing required configuration; skipping sync",
+                registration.ConnectorName);
+            config.Enabled = false;
+        }
+
         return config;
     }
 

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/ConnectorConfigurationLoaderTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/ConnectorConfigurationLoaderTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using Nocturne.Connectors.Core.Extensions;
 using Nocturne.Connectors.Core.Models;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Core.Contracts.Connectors;
@@ -69,11 +70,75 @@ public class ConnectorConfigurationLoaderTests
         config.Username.Should().Be("user@example.com", "the stored configuration must be applied");
     }
 
+    [Fact]
+    public async Task LoadForTenantAsync_DisablesConnector_WhenRequiredSecretMissing()
+    {
+        // The connector has an enabled config row (e.g. enabled via the UI toggle, or its
+        // non-secret config saved) but its required secret was never provided.
+        var configService = new Mock<IConnectorConfigurationService>();
+        configService
+            .Setup(s => s.GetConfigurationAsync(ConnectorName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConnectorConfigurationResponse
+            {
+                ConnectorName = ConnectorName,
+                Configuration = JsonDocument.Parse("{\"enabled\": true, \"url\": \"https://ns.example.com\"}")
+            });
+        configService
+            .Setup(s => s.GetSecretsAsync(ConnectorName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, string>());
+
+        var config = await CreateRequiredSecretLoader(configService).LoadForTenantAsync(CancellationToken.None);
+
+        config.Enabled.Should().BeFalse(
+            "a connector enabled without its required credentials must not sync — it would fail authentication every cycle");
+    }
+
+    [Fact]
+    public async Task LoadForTenantAsync_KeepsConnectorEnabled_WhenRequiredSecretProvided()
+    {
+        var configService = new Mock<IConnectorConfigurationService>();
+        configService
+            .Setup(s => s.GetConfigurationAsync(ConnectorName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConnectorConfigurationResponse
+            {
+                ConnectorName = ConnectorName,
+                Configuration = JsonDocument.Parse("{\"enabled\": true, \"url\": \"https://ns.example.com\"}")
+            });
+        configService
+            .Setup(s => s.GetSecretsAsync(ConnectorName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, string> { ["apiSecret"] = "s3cr3t" });
+
+        var config = await CreateRequiredSecretLoader(configService).LoadForTenantAsync(CancellationToken.None);
+
+        config.Enabled.Should().BeTrue("a connector with its required credentials present must sync");
+        config.ApiSecret.Should().Be("s3cr3t", "the required secret must be applied from the secret store");
+    }
+
+    private static ConnectorConfigurationLoader<RequiredSecretTestConfig> CreateRequiredSecretLoader(
+        Mock<IConnectorConfigurationService> configService)
+    {
+        var registration = new ConnectorRegistration<RequiredSecretTestConfig>(new RequiredSecretTestConfig(), ConnectorName);
+        return new ConnectorConfigurationLoader<RequiredSecretTestConfig>(
+            registration,
+            configService.Object,
+            NullLogger<ConnectorConfigurationLoader<RequiredSecretTestConfig>>.Instance);
+    }
+
     private sealed class LoaderTestConfig : BaseConnectorConfiguration
     {
         public LoaderTestConfig() => ConnectSource = ConnectSource.Dexcom;
 
         public string Username { get; set; } = string.Empty;
+
+        protected override void ValidateSourceSpecificConfiguration() { }
+    }
+
+    private sealed class RequiredSecretTestConfig : BaseConnectorConfiguration
+    {
+        public RequiredSecretTestConfig() => ConnectSource = ConnectSource.Nightscout;
+
+        [ConnectorProperty(ConnectorPropertyKey.ApiSecret, Required = true, Secret = true)]
+        public string ApiSecret { get; set; } = string.Empty;
 
         protected override void ValidateSourceSpecificConfiguration() { }
     }


### PR DESCRIPTION
## Problem

Connectors that are **enabled but not fully configured** are polled on every sync cycle and fail authentication forever.

A connector's `enabled` flag is independent of whether its required credentials exist. Two paths create an enabled-but-incomplete row:

- the enable toggle (`PATCH /api/v4/connectors/config/{name}/active` → `SetActiveAsync`) flips `enabled=true` before any credentials are entered;
- `SaveConfiguration` deliberately **skips secret fields** during required-field validation, so a config like `{ "url": "...", "enabled": true }` saves with no `apiSecret`.

The per-tenant sync gate in `ConnectorBackgroundService` only checked `config.Enabled`, so these rows sync every cycle and fail auth.

`#309` closed the *"tenant never configured the connector"* hole (no config row → `Enabled = false`). It did **not** cover the *"row exists, enabled, but required fields missing"* hole.

Observed in production, e.g. Nightscout connectors that have a `url` saved but no `apiSecret` → `Authentication failed` every ~5 minutes.

## Fix

Extend the same loader that `#309` touched. After the config JSON **and** secrets are merged, if the connector is enabled but its required configuration is incomplete, treat it as not configured and skip it.

- `BaseConnectorConfiguration.HasRequiredConfiguration()` — new public check that reports whether all properties marked `[Required]` / `[ConnectorProperty(Required = true)]` (including required secrets) are populated. The required-property enumeration is now shared with `ValidateRequiredProperties()`, so both agree on what "required" means (no duplicated reflection).
- `ConnectorConfigurationLoader.LoadForTenantAsync` — after merging secrets, set `Enabled = false` when enabled but `!HasRequiredConfiguration()`.

### Behaviour
- **Skips:** enabled connectors missing a required field/secret (toggle-only, partial save, or a removed secret).
- **Unchanged:** connectors with all required fields present keep syncing — including ones with *wrong* credentials, which correctly continue to retry and surface as unhealthy.

## Tests

Added regression tests to `ConnectorConfigurationLoaderTests` (enabled + url but no `apiSecret` → disabled; required secret present → stays enabled). Full `Nocturne.Connectors.Core.Tests` suite passes (37/37).