### PR TITLE
fix(connectors): establish MyLife session during sync; surface auth failures

### DIFF
--- a/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeAuthTokenProvider.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeAuthTokenProvider.cs
@@ -27,17 +27,29 @@ public class MyLifeAuthTokenProvider(
     protected override async Task<(string? Token, DateTime ExpiresAt, IReadOnlyDictionary<string, string>? Metadata)> AcquireTokenAsync(
         MyLifeConnectorConfiguration config, CancellationToken cancellationToken)
     {
+        // Each step below fails by returning a null token (the base class records the connector as
+        // unhealthy). Log which step failed so the cause is diagnosable — without this every failure
+        // surfaces only as the generic "MyLife authentication failed" downstream. Messages are
+        // intentionally free of credentials/PII.
         var location = await _soapClient.GetUserLocationAsync(
             config.Username,
             cancellationToken
         );
-        if (location == null) return (null, DateTime.MinValue, null);
+        if (location == null)
+        {
+            _logger.LogWarning("MyLife auth failed at user-location lookup (GetUser20 returned no result)");
+            return (null, DateTime.MinValue, null);
+        }
 
         var serviceUrl = config.ServiceUrl;
         if (string.IsNullOrWhiteSpace(serviceUrl))
             serviceUrl = location.Country20?.ServiceUrl ?? location.Country20?.RestServiceUrl ?? string.Empty;
 
-        if (string.IsNullOrWhiteSpace(serviceUrl)) return (null, DateTime.MinValue, null);
+        if (string.IsNullOrWhiteSpace(serviceUrl))
+        {
+            _logger.LogWarning("MyLife auth failed: no service URL resolved from user location");
+            return (null, DateTime.MinValue, null);
+        }
 
         var login = await _soapClient.LoginAsync(
             serviceUrl,
@@ -47,19 +59,41 @@ public class MyLifeAuthTokenProvider(
             config.Password,
             cancellationToken
         );
-        if (login == null) return (null, DateTime.MinValue, null);
+        if (login == null)
+        {
+            _logger.LogWarning(
+                "MyLife auth failed at login: no response (appVersion {AppVersion}, appPlatform {AppPlatform})",
+                config.AppVersion, config.AppPlatform);
+            return (null, DateTime.MinValue, null);
+        }
 
-        if (string.IsNullOrWhiteSpace(login.AuthToken)) return (null, DateTime.MinValue, null);
+        if (string.IsNullOrWhiteSpace(login.AuthToken))
+        {
+            _logger.LogWarning(
+                "MyLife auth failed: login returned no auth token (check credentials; appVersion {AppVersion})",
+                config.AppVersion);
+            return (null, DateTime.MinValue, null);
+        }
 
         var patients = await _soapClient.SyncPatientListAsync(
             serviceUrl,
             login.AuthToken,
             cancellationToken
         );
-        if (patients.Count == 0) return (null, DateTime.MinValue, null);
+        if (patients.Count == 0)
+        {
+            _logger.LogWarning("MyLife auth failed: patient list was empty");
+            return (null, DateTime.MinValue, null);
+        }
 
         var patient = ResolvePatient(patients, config.PatientId);
-        if (patient == null) return (null, DateTime.MinValue, null);
+        if (patient == null)
+        {
+            _logger.LogWarning(
+                "MyLife auth failed: configured patient not found among {Count} patient(s)",
+                patients.Count);
+            return (null, DateTime.MinValue, null);
+        }
 
         var restServiceUrl = location.Country20?.RestServiceUrl ?? string.Empty;
 

--- a/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
@@ -122,16 +122,25 @@ public class MyLifeConnectorService(
 
         try
         {
-            // Validate session
+            // Establish the MyLife session up front. AcquireTokenAsync (reached via the token
+            // provider) performs the SOAP login and populates the session cache as a side effect;
+            // the token is cached so subsequent cycles reuse it. Without this call the session cache
+            // is never populated and every sync fails with "session not established".
+            var token = await tokenProvider.GetValidTokenAsync(config, cancellationToken);
+
             var session = sessionCache.Get(tenantAccessor.TenantId);
-            if (session == null
+            if (string.IsNullOrEmpty(token)
+                || session == null
                 || string.IsNullOrWhiteSpace(session.ServiceUrl)
                 || string.IsNullOrWhiteSpace(session.AuthToken)
                 || string.IsNullOrWhiteSpace(session.PatientId))
             {
                 result.Success = false;
-                result.Errors.Add("MyLife session not established");
+                result.Errors.Add("MyLife authentication failed; see connector logs for the failing step");
                 result.EndTime = DateTimeOffset.UtcNow;
+                _logger.LogWarning(
+                    "[{ConnectorSource}] Sync failed: MyLife authentication unsuccessful",
+                    ConnectorSource);
                 return result;
             }
 

--- a/tests/Unit/Nocturne.Connectors.MyLife.Tests/Services/MyLifeConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.MyLife.Tests/Services/MyLifeConnectorServiceTests.cs
@@ -1,0 +1,154 @@
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.MyLife.Configurations;
+using Nocturne.Connectors.MyLife.Mappers;
+using Nocturne.Connectors.MyLife.Services;
+using Nocturne.Core.Contracts.Multitenancy;
+using Xunit;
+
+namespace Nocturne.Connectors.MyLife.Tests.Services;
+
+/// <summary>
+/// Regression tests for <see cref="MyLifeConnectorService"/> authentication wiring. The connector
+/// must establish its SOAP session by invoking the token provider during sync. A refactor previously
+/// left that call out — <c>AuthenticateAsync</c> became a no-op and <c>PerformSyncInternalAsync</c>
+/// only validated the session — so the session cache was never populated and every sync failed with
+/// "session not established" regardless of credentials.
+/// </summary>
+public class MyLifeConnectorServiceTests
+{
+    private const string ServiceUrl = "https://svc.example";
+
+    [Fact]
+    public async Task SyncDataAsync_EstablishesSession_WithValidCredentials()
+    {
+        var tenantId = Guid.NewGuid();
+        using var http = new HttpClient(new SoapStubHandler(loginSucceeds: true));
+        var (service, sessionCache) = BuildService(http, tenantId);
+
+        var config = new MyLifeConnectorConfiguration
+        {
+            Username = "user@example.com",
+            Password = "secret",
+            PatientId = "patient-1"
+        };
+        var request = new SyncRequest { DataTypes = [SyncDataType.Glucose] };
+
+        var result = await service.SyncDataAsync(request, config, CancellationToken.None);
+
+        result.Success.Should().BeTrue("a valid login must establish the session and let the sync run");
+        var session = sessionCache.Get(tenantId);
+        session.Should().NotBeNull("the connector must populate the session cache via the token provider");
+        session!.AuthToken.Should().Be("tok-123");
+        session.ServiceUrl.Should().Be(ServiceUrl);
+        session.PatientId.Should().Be("patient-1");
+    }
+
+    [Fact]
+    public async Task SyncDataAsync_ReportsAuthFailure_WhenLoginFails()
+    {
+        var tenantId = Guid.NewGuid();
+        using var http = new HttpClient(new SoapStubHandler(loginSucceeds: false));
+        var (service, sessionCache) = BuildService(http, tenantId);
+
+        var config = new MyLifeConnectorConfiguration
+        {
+            Username = "user@example.com",
+            Password = "wrong",
+            PatientId = "patient-1"
+        };
+        var request = new SyncRequest { DataTypes = [SyncDataType.Glucose] };
+
+        var result = await service.SyncDataAsync(request, config, CancellationToken.None);
+
+        result.Success.Should().BeFalse("a failed login must surface as an unhealthy sync");
+        result.Errors.Should().Contain(e => e.Contains("auth", StringComparison.OrdinalIgnoreCase));
+        sessionCache.Get(tenantId).Should().BeNull("no session must be cached when login fails");
+    }
+
+    private static (MyLifeConnectorService Service, IMyLifeSessionCache SessionCache) BuildService(
+        HttpClient http, Guid tenantId)
+    {
+        var resolver = new ConnectorServerResolver<MyLifeConnectorConfiguration>(null, null, null);
+
+        var tenantAccessor = new Mock<ITenantAccessor>();
+        tenantAccessor.Setup(t => t.IsResolved).Returns(true);
+        tenantAccessor.Setup(t => t.TenantId).Returns(tenantId);
+
+        var soapClient = new MyLifeSoapClient(http, NullLogger<MyLifeSoapClient>.Instance);
+        var sessionCache = new MyLifeSessionCache();
+        var tokenProvider = new MyLifeAuthTokenProvider(
+            http,
+            new ConnectorTokenCache(),
+            resolver,
+            tenantAccessor.Object,
+            soapClient,
+            sessionCache,
+            NullLogger<MyLifeAuthTokenProvider>.Instance);
+        var syncService = new MyLifeSyncService(soapClient, NullLogger<MyLifeSyncService>.Instance);
+
+        var service = new MyLifeConnectorService(
+            http,
+            resolver,
+            NullLogger<MyLifeConnectorService>.Instance,
+            tokenProvider,
+            new MyLifeEventProcessor(),
+            sessionCache,
+            tenantAccessor.Object,
+            syncService,
+            publisher: null);
+
+        return (service, sessionCache);
+    }
+
+    /// <summary>
+    /// Stubs the MyLife SOAP endpoints, routing by SOAPAction. Returns a valid location, login, and
+    /// single-patient list; events and pump-settings return no result element so the sync completes
+    /// with no data (and never reaches the archive-decryption path).
+    /// </summary>
+    private sealed class SoapStubHandler(bool loginSucceeds) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var action = request.Headers.TryGetValues("SOAPAction", out var values)
+                ? values.FirstOrDefault() ?? string.Empty
+                : string.Empty;
+
+            var (status, body) = Respond(action);
+            return Task.FromResult(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "text/xml")
+            });
+        }
+
+        private (HttpStatusCode Status, string Body) Respond(string action)
+        {
+            if (action.Contains("GetUser20"))
+                return (HttpStatusCode.OK, Envelope("GetUser20Result",
+                    $"{{\"Country20\":{{\"ServiceUrl\":\"{ServiceUrl}\",\"RestServiceUrl\":\"https://rest.example\"}}}}"));
+
+            if (action.Contains("SyncPatientList"))
+                return (HttpStatusCode.OK, Envelope("SyncPatientListResult",
+                    "[{\"OnlinePatientId\":\"patient-1\",\"EmailNewPatient\":\"user@example.com\"}]"));
+
+            if (action.Contains("Login"))
+                return loginSucceeds
+                    ? (HttpStatusCode.OK, Envelope("LoginResult", "{\"UserId\":\"user-1\",\"AuthToken\":\"tok-123\"}"))
+                    : (HttpStatusCode.Unauthorized, string.Empty);
+
+            // SyncEvents / SyncPumpSettings: no result element → treated as "no data".
+            return (HttpStatusCode.OK,
+                "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"><s:Body/></s:Envelope>");
+        }
+
+        private static string Envelope(string element, string innerJson) =>
+            "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"><s:Body>"
+            + $"<{element}>{innerJson}</{element}></s:Body></s:Envelope>";
+    }
+}


### PR DESCRIPTION
## Problem

The MyLife connector **never logs in**, so every sync fails with `MyLife session not established` regardless of credentials — affecting all MyLife tenants.

- `MyLifeConnectorService.AuthenticateAsync()` is a no-op (returns `true`); its comment says auth happens in `PerformSyncInternalAsync` "where config is available"…
- …but `PerformSyncInternalAsync` only **validated** the session cache and bailed; it never **established** it.
- The code that performs the SOAP login and populates the session cache (`MyLifeAuthTokenProvider.AcquireTokenAsync`, reached via the base `GetValidTokenAsync`) was therefore never called. Every other connector (Tidepool, Glooko, Dexcom, Eversense, Twiist, Libre, CareLink) calls `GetValidTokenAsync` in its sync path — MyLife was the lone exception.

Confirmed in production: logs show `Starting background data sync` → `MyLife session not established` with **no** `Successfully/Failed to acquire token` and **no** SOAP log line — i.e. login is never attempted.

Compounding this, `AcquireTokenAsync` had **six** `return (null, …)` paths (location lookup, service URL, login, missing token, empty patient list, patient match), all unlogged — so even once the wiring is fixed, a genuine failure (bad credentials, app-version rejection, etc.) would still only surface as the generic message.

## Fix

1. **`MyLifeConnectorService`** — establish the session up front via `tokenProvider.GetValidTokenAsync(config, ct)` before syncing (mirrors the Tidepool pattern). If no token/session results, fail the sync with a clear auth error instead of the opaque "session not established".
2. **`MyLifeAuthTokenProvider`** — log which of the six auth steps failed. Messages are free of credentials/PII (no username/email/password).

## Tests

`MyLifeConnectorServiceTests` (stubbed SOAP endpoints, routed by SOAPAction):
- **success path** — a valid login establishes the session and the sync succeeds. This is the regression catcher: with the old code it fails because the session is never established.
- **failure path** — a failed login surfaces as an unhealthy sync (`Success == false`, auth error) and caches no session.

Full `Nocturne.Connectors.MyLife.Tests` suite passes (31/31).