### PR TITLE
chore: authorization defaults and dashboard redirect

### DIFF
--- a/src/API/Nocturne.API/Authorization/AuthorizationConfiguration.cs
+++ b/src/API/Nocturne.API/Authorization/AuthorizationConfiguration.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Nocturne.API.Authorization;
+
+/// <summary>
+/// Central authorization wiring: the <see cref="PolicyNames.HasPermissions"/> policy, the
+/// default-deny fallback policy, and the controller discovery filter that drops dev-only
+/// controllers outside development.
+/// </summary>
+public static class AuthorizationConfiguration
+{
+    /// <summary>
+    /// Registers the <see cref="PolicyNames.HasPermissions"/> policy and applies it as the
+    /// <see cref="AuthorizationOptions.FallbackPolicy"/>, so every endpoint without an explicit
+    /// authorization attribute requires a non-empty <see cref="Nocturne.Core.Models.PermissionTrie"/>.
+    /// </summary>
+    /// <remarks>
+    /// The fallback admits the anonymous public subject on public tenants (its trie carries the
+    /// tenant's public permissions) and rejects anonymous callers on private tenants (empty trie).
+    /// Endpoints opt out with <c>[AllowAnonymous]</c>; privileged endpoints tighten access with
+    /// <c>[RequireAdmin]</c> or another <c>[Require*]</c> attribute, all of which require an
+    /// authenticated caller and therefore do not admit the public subject.
+    /// </remarks>
+    public static IServiceCollection AddNocturneAuthorization(this IServiceCollection services)
+    {
+        services.AddTransient<IAuthorizationHandler, HasPermissionsHandler>();
+
+        var hasPermissionsPolicy = new AuthorizationPolicyBuilder()
+            .AddRequirements(new HasPermissionsRequirement())
+            .Build();
+
+        services.AddAuthorization(options =>
+        {
+            options.AddPolicy(PolicyNames.HasPermissions, hasPermissionsPolicy);
+            options.FallbackPolicy = hasPermissionsPolicy;
+        });
+
+        return services;
+    }
+
+    /// <summary>
+    /// Configures controller discovery so controllers in the <c>.DevOnly</c> namespace are not
+    /// registered outside the development environment.
+    /// </summary>
+    /// <remarks>
+    /// Replaces the default <see cref="ControllerFeatureProvider"/> rather than appending a second
+    /// provider: feature providers only add to <see cref="ControllerFeature.Controllers"/>, so an
+    /// appended filter cannot remove controllers the default provider has already discovered.
+    /// </remarks>
+    public static void ConfigureControllerDiscovery(ApplicationPartManager manager, bool isDevelopment)
+    {
+        if (isDevelopment)
+        {
+            return;
+        }
+
+        var defaultProvider = manager.FeatureProviders
+            .FirstOrDefault(p => p.GetType() == typeof(ControllerFeatureProvider));
+        if (defaultProvider is not null)
+        {
+            manager.FeatureProviders.Remove(defaultProvider);
+        }
+
+        manager.FeatureProviders.Add(new DevOnlyExcludingControllerFeatureProvider());
+    }
+}
+
+/// <summary>
+/// Controller feature provider that excludes controllers in the <c>.DevOnly</c> namespace.
+/// </summary>
+public sealed class DevOnlyExcludingControllerFeatureProvider : ControllerFeatureProvider
+{
+    /// <inheritdoc />
+    protected override bool IsController(TypeInfo typeInfo)
+    {
+        if (typeInfo.Namespace?.Contains(".DevOnly", StringComparison.Ordinal) == true)
+        {
+            return false;
+        }
+
+        return base.IsController(typeInfo);
+    }
+}

--- a/src/API/Nocturne.API/Controllers/MetadataController.cs
+++ b/src/API/Nocturne.API/Controllers/MetadataController.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using OpenApi.Remote.Attributes;
@@ -32,6 +33,7 @@ namespace Nocturne.API.Controllers;
 [Route("api/[controller]")]
 [Tags("Metadata")]
 [AllowDuringSetup]
+[AllowAnonymous]
 public class MetadataController : ControllerBase
 {
     /// <summary>

--- a/src/API/Nocturne.API/Controllers/V1/AuthenticationController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/AuthenticationController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
 using Nocturne.API.Extensions;
@@ -12,6 +13,7 @@ namespace Nocturne.API.Controllers.V1;
 [ApiController]
 [Tags("V1")]
 [Route("api/v1")]
+[AllowAnonymous]
 public class AuthenticationController : ControllerBase
 {
     private readonly ILogger<AuthenticationController> _logger;

--- a/src/API/Nocturne.API/Controllers/V1/StatusController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/StatusController.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
 using Nocturne.Core.Contracts.Platform;
@@ -17,6 +18,7 @@ namespace Nocturne.API.Controllers.V1;
 [ApiController]
 [Tags("V1")]
 [Route("api/v1/[controller]")]
+[AllowAnonymous]
 public class StatusController : ControllerBase
 {
     private readonly IStatusService _statusService;

--- a/src/API/Nocturne.API/Controllers/V1/VersionsController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/VersionsController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
 using Nocturne.Core.Contracts.Platform;
@@ -13,6 +14,7 @@ namespace Nocturne.API.Controllers.V1;
 [ApiController]
 [Tags("V1")]
 [Route("api/[controller]")]
+[AllowAnonymous]
 public class VersionsController : ControllerBase
 {
     private readonly IVersionService _versionService;

--- a/src/API/Nocturne.API/Controllers/V3/LastModifiedController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/LastModifiedController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
 using Nocturne.Core.Contracts.Platform;
@@ -14,6 +15,7 @@ namespace Nocturne.API.Controllers.V3;
 [ApiController]
 [Tags("V3")]
 [Route("api/v3/[controller]")]
+[AllowAnonymous]
 public class LastModifiedController : ControllerBase
 {
     private readonly IStatusService _statusService;

--- a/src/API/Nocturne.API/Controllers/V3/StatusController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/StatusController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
 using Nocturne.Core.Contracts.Platform;
@@ -15,6 +16,7 @@ namespace Nocturne.API.Controllers.V3;
 [ApiController]
 [Tags("V3")]
 [Route("api/v3/[controller]")]
+[AllowAnonymous]
 public class StatusController : ControllerBase
 {
     private readonly IStatusService _statusService;

--- a/src/API/Nocturne.API/Controllers/V3/VersionController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/VersionController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
 using Nocturne.Core.Contracts.Platform;
@@ -14,6 +15,7 @@ namespace Nocturne.API.Controllers.V3;
 [ApiController]
 [Tags("V3 Version")]
 [Route("api/v3/[controller]")]
+[AllowAnonymous]
 public class VersionController : ControllerBase
 {
     private readonly IVersionService _versionService;

--- a/src/API/Nocturne.API/Controllers/V4/Identity/MemberInviteController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/MemberInviteController.cs
@@ -22,6 +22,7 @@ namespace Nocturne.API.Controllers.V4.Identity;
 [Tags("Identity")]
 [Route("api/v4/member-invites")]
 [Produces("application/json")]
+[Authorize]
 public class MemberInviteController : ControllerBase
 {
     private readonly IMemberInviteService _memberInviteService;

--- a/src/API/Nocturne.API/Controllers/V4/Platform/CompatibilityController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/CompatibilityController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using Nocturne.API.Attributes;
 using Nocturne.API.Configuration;
 using Nocturne.API.Services.Compatibility;
 using Nocturne.Connectors.Nightscout.Configurations;
@@ -65,6 +66,7 @@ public class CompatibilityController : ControllerBase
     /// Get overall compatibility metrics
     /// </summary>
     [HttpGet("metrics")]
+    [RequireAdmin]
     [ProducesResponseType(typeof(CompatibilityMetrics), StatusCodes.Status200OK)]
     public async Task<ActionResult<CompatibilityMetrics>> GetMetrics(
         [FromQuery] DateTimeOffset? fromDate = null,
@@ -92,6 +94,7 @@ public class CompatibilityController : ControllerBase
     /// Get per-endpoint compatibility metrics
     /// </summary>
     [HttpGet("endpoints")]
+    [RequireAdmin]
     [ProducesResponseType(typeof(IEnumerable<EndpointMetrics>), StatusCodes.Status200OK)]
     public async Task<ActionResult<IEnumerable<EndpointMetrics>>> GetEndpointMetrics(
         [FromQuery] DateTimeOffset? fromDate = null,
@@ -119,6 +122,7 @@ public class CompatibilityController : ControllerBase
     /// Get list of analyses with filtering and pagination
     /// </summary>
     [HttpGet("analyses")]
+    [RequireAdmin]
     [ProducesResponseType(typeof(AnalysesListResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult<AnalysesListResponse>> GetAnalyses(
         [FromQuery] string? requestPath = null,
@@ -181,6 +185,7 @@ public class CompatibilityController : ControllerBase
     /// Get detailed analysis by ID
     /// </summary>
     [HttpGet("analyses/{id}")]
+    [RequireAdmin]
     [ProducesResponseType(typeof(AnalysisDetailDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<AnalysisDetailDto>> GetAnalysisDetail(
@@ -263,6 +268,7 @@ public class CompatibilityController : ControllerBase
     /// Test API compatibility by comparing responses from Nightscout and Nocturne
     /// </summary>
     [HttpPost("test")]
+    [RequireAdmin]
     [ProducesResponseType(typeof(ManualTestResult), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<ManualTestResult>> TestApiComparison(

--- a/src/API/Nocturne.API/Controllers/V4/Platform/ServicesController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/ServicesController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
 using Nocturne.API.Models;
 using Nocturne.API.Multitenancy;
 using Nocturne.API.Services.Connectors;
@@ -282,6 +283,7 @@ public class ServicesController : ControllerBase
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Result of the delete operation</returns>
     [HttpDelete("data-sources/demo")]
+    [RequireAdmin]
     [RemoteCommand(Invalidates = ["GetServicesOverview", "GetActiveDataSources", "GetStatus"])]
     [ProducesResponseType(typeof(DataSourceDeleteResult), 200)]
     [ProducesResponseType(500)]
@@ -315,6 +317,7 @@ public class ServicesController : ControllerBase
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Result of the delete operation</returns>
     [HttpDelete("data-sources/{id}")]
+    [RequireAdmin]
     [RemoteCommand(Invalidates = ["GetServicesOverview", "GetActiveDataSources", "GetStatus"])]
     [ProducesResponseType(typeof(DataSourceDeleteResult), 200)]
     [ProducesResponseType(404)]
@@ -387,6 +390,7 @@ public class ServicesController : ControllerBase
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Result of the delete operation</returns>
     [HttpDelete("connectors/{id}/data")]
+    [RequireAdmin]
     [RemoteCommand(Invalidates = ["GetServicesOverview", "GetActiveDataSources", "GetStatus", "GetConnectorDataSummary"])]
     [ProducesResponseType(typeof(DataSourceDeleteResult), 200)]
     [ProducesResponseType(404)]
@@ -428,6 +432,7 @@ public class ServicesController : ControllerBase
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Sync result with success status and details</returns>
     [HttpPost("connectors/{id}/sync")]
+    [RequireAdmin]
     [RemoteCommand]
     [ProducesResponseType(typeof(Nocturne.Connectors.Core.Models.SyncResult), 200)]
     [ProducesResponseType(400)]
@@ -470,6 +475,7 @@ public class ServicesController : ControllerBase
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Sync result with success status and details.</returns>
     [HttpPost("connectors/{id}/reset-cursor")]
+    [RequireAdmin]
     [RemoteCommand]
     [ProducesResponseType(typeof(Nocturne.Connectors.Core.Models.SyncResult), 200)]
     [ProducesResponseType(400)]

--- a/src/API/Nocturne.API/Controllers/V4/Platform/StatusController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/StatusController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.Core.Contracts.Platform;
 using Nocturne.Core.Models;
@@ -15,6 +16,7 @@ namespace Nocturne.API.Controllers.V4.Platform;
 [Tags("Platform")]
 [Route("api/v4/[controller]")]
 [Produces("application/json")]
+[AllowAnonymous]
 public class StatusController : ControllerBase
 {
     private readonly IStatusService _statusService;

--- a/src/API/Nocturne.API/Controllers/V4/TenantAdmin/DeduplicationController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/TenantAdmin/DeduplicationController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
 using Nocturne.API.Authorization;
 using Nocturne.Core.Models;
 
@@ -15,6 +16,7 @@ namespace Nocturne.API.Controllers.V4.TenantAdmin;
 [Route("api/v4/admin/deduplication")]
 [Produces("application/json")]
 [AllowDuringSetup]
+[RequireAdmin]
 public class DeduplicationController : ControllerBase
 {
     private readonly IDeduplicationService _deduplicationService;

--- a/src/API/Nocturne.API/Controllers/V4/TenantAdmin/DiscrepancyController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/TenantAdmin/DiscrepancyController.cs
@@ -1,4 +1,10 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Nocturne.API.Attributes;
+using Nocturne.API.Configuration;
 using Nocturne.API.Services.Compatibility;
 using Nocturne.Core.Models;
 using Nocturne.Infrastructure.Data.Abstractions;
@@ -43,6 +49,7 @@ public class DiscrepancyController : ControllerBase
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Compatibility metrics including success rate and response times</returns>
     [HttpGet("metrics")]
+    [RequireAdmin]
     public async Task<ActionResult<CompatibilityMetrics>> GetCompatibilityMetrics(
         [FromQuery] DateTimeOffset? fromDate = null,
         [FromQuery] DateTimeOffset? toDate = null,
@@ -80,6 +87,7 @@ public class DiscrepancyController : ControllerBase
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>List of endpoint-specific compatibility metrics</returns>
     [HttpGet("endpoints")]
+    [RequireAdmin]
     public async Task<ActionResult<IEnumerable<EndpointMetrics>>> GetEndpointMetrics(
         [FromQuery] DateTimeOffset? fromDate = null,
         [FromQuery] DateTimeOffset? toDate = null,
@@ -121,6 +129,7 @@ public class DiscrepancyController : ControllerBase
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>List of detailed discrepancy analyses</returns>
     [HttpGet("analyses")]
+    [RequireAdmin]
     public async Task<ActionResult<IEnumerable<DiscrepancyAnalysisDto>>> GetDiscrepancyAnalyses(
         [FromQuery] string? requestPath = null,
         [FromQuery] int? overallMatch = null,
@@ -218,6 +227,7 @@ public class DiscrepancyController : ControllerBase
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Detailed discrepancy analysis</returns>
     [HttpGet("analyses/{id:guid}")]
+    [RequireAdmin]
     public async Task<ActionResult<DiscrepancyAnalysisDto>> GetDiscrepancyAnalysis(
         Guid id,
         CancellationToken cancellationToken = default
@@ -291,6 +301,7 @@ public class DiscrepancyController : ControllerBase
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Current compatibility status</returns>
     [HttpGet("status")]
+    [RequireAdmin]
     public async Task<ActionResult<CompatibilityStatus>> GetCompatibilityStatus(
         CancellationToken cancellationToken = default
     )
@@ -355,17 +366,28 @@ public class DiscrepancyController : ControllerBase
     /// Receive forwarded discrepancies from remote Nocturne instances
     /// </summary>
     /// <param name="request">The forwarded discrepancy data</param>
+    /// <param name="proxyOptions">Compatibility proxy options supplying the shared forwarding key.</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Acknowledgement of receipt</returns>
     [HttpPost("ingest")]
+    [AllowAnonymous]
     [ProducesResponseType(typeof(object), 200)]
     [ProducesResponseType(typeof(object), 400)]
     [ProducesResponseType(typeof(object), 401)]
     public async Task<ActionResult> IngestDiscrepancy(
         [FromBody] ForwardedDiscrepancyDto request,
+        [FromServices] IOptions<CompatibilityProxyConfiguration> proxyOptions,
         CancellationToken cancellationToken = default
     )
     {
+        // Inter-instance ingestion is machine-to-machine: the sending instance attaches the shared
+        // forwarding API key as a bearer token. Validate it here rather than via the user-oriented
+        // policies; ingestion stays closed when no key is configured.
+        if (!HasValidForwardingKey(proxyOptions.Value.DiscrepancyForwarding.ApiKey))
+        {
+            return Unauthorized();
+        }
+
         try
         {
             if (request == null || request.Analysis == null)
@@ -442,5 +464,29 @@ public class DiscrepancyController : ControllerBase
             );
             return Problem(detail: "Error processing forwarded discrepancy", statusCode: 500, title: "Internal Server Error");
         }
+    }
+
+    /// <summary>
+    /// Returns whether the request carries a bearer token matching the configured forwarding
+    /// API key. Returns <see langword="false"/> when no key is configured.
+    /// </summary>
+    private bool HasValidForwardingKey(string expectedKey)
+    {
+        if (string.IsNullOrEmpty(expectedKey))
+        {
+            return false;
+        }
+
+        var header = Request.Headers.Authorization.ToString();
+        const string scheme = "Bearer ";
+        if (!header.StartsWith(scheme, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var provided = header[scheme.Length..].Trim();
+        return CryptographicOperations.FixedTimeEquals(
+            Encoding.UTF8.GetBytes(provided),
+            Encoding.UTF8.GetBytes(expectedKey));
     }
 }

--- a/src/API/Nocturne.API/Controllers/V4/TenantAdmin/MigrationController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/TenantAdmin/MigrationController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
 using Nocturne.API.Services.Migration;
 using Nocturne.Core.Contracts.Connectors;
 using Nocturne.Core.Contracts.Multitenancy;
@@ -14,6 +15,7 @@ namespace Nocturne.API.Controllers.V4.TenantAdmin;
 [ApiController]
 [Tags("TenantAdmin")]
 [Route("api/v4/migration")]
+[RequireAdmin]
 public class MigrationController : ControllerBase
 {
     private readonly IMigrationJobService _migrationService;

--- a/src/API/Nocturne.API/Controllers/V4/TenantAdmin/NightscoutTransitionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/TenantAdmin/NightscoutTransitionController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using Nocturne.API.Attributes;
 using Nocturne.API.Configuration;
 using Nocturne.API.Services.Compatibility;
 using Nocturne.Connectors.Nightscout.Configurations;
@@ -19,6 +20,7 @@ namespace Nocturne.API.Controllers.V4.TenantAdmin;
 [Tags("TenantAdmin")]
 [Route("api/v4/nightscout-transition")]
 [Produces("application/json")]
+[RequireAdmin]
 public class NightscoutTransitionController : ControllerBase
 {
     private readonly NightscoutConnectorConfiguration? _nightscoutConfig;

--- a/src/API/Nocturne.API/Controllers/V4/TenantAdmin/ProcessingController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/TenantAdmin/ProcessingController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
 using Nocturne.Core.Models;
 
 namespace Nocturne.API.Controllers.V4.TenantAdmin;
@@ -10,6 +11,7 @@ namespace Nocturne.API.Controllers.V4.TenantAdmin;
 [ApiController]
 [Tags("TenantAdmin")]
 [Route("api/v4/processing")]
+[RequireAdmin]
 public class ProcessingController : ControllerBase
 {
     private readonly IProcessingStatusService _processingStatusService;

--- a/src/API/Nocturne.API/Hubs/AlarmHub.cs
+++ b/src/API/Nocturne.API/Hubs/AlarmHub.cs
@@ -10,6 +10,9 @@ namespace Nocturne.API.Hubs;
 /// <summary>
 /// SignalR hub for alarm notifications, replacing socket.io alarm namespace
 /// </summary>
+// Connections authenticate in-band after negotiate and are reachable only via the internal
+// realtime bridge, so the HTTP fallback authorization policy must not gate the handshake.
+[Microsoft.AspNetCore.Authorization.AllowAnonymous]
 public class AlarmHub : TenantAwareHub
 {
     private readonly ILogger<AlarmHub> _logger;

--- a/src/API/Nocturne.API/Hubs/AlertHub.cs
+++ b/src/API/Nocturne.API/Hubs/AlertHub.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using Nocturne.Core.Contracts.Alerts;
 
@@ -8,6 +9,9 @@ namespace Nocturne.API.Hubs;
 /// (dispatch, resolved, acknowledged) and can acknowledge all active excursions.
 /// Mounted at /hubs/alerts — the legacy AlarmHub remains at /hubs/alarms for compat.
 /// </summary>
+// Connections authenticate in-band after negotiate and are reachable only via the internal
+// realtime bridge, so the HTTP fallback authorization policy must not gate the handshake.
+[AllowAnonymous]
 public class AlertHub : TenantAwareHub
 {
     /// <summary>

--- a/src/API/Nocturne.API/Hubs/DataHub.cs
+++ b/src/API/Nocturne.API/Hubs/DataHub.cs
@@ -14,6 +14,9 @@ namespace Nocturne.API.Hubs;
 /// <summary>
 /// SignalR hub for real-time data updates, replacing socket.io main data connection
 /// </summary>
+// Connections authenticate in-band after negotiate and are reachable only via the internal
+// realtime bridge, so the HTTP fallback authorization policy must not gate the handshake.
+[AllowAnonymous]
 public class DataHub : TenantAwareHub
 {
     private readonly ILogger<DataHub> _logger;

--- a/src/API/Nocturne.API/Hubs/HomeAssistantHub.cs
+++ b/src/API/Nocturne.API/Hubs/HomeAssistantHub.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using Nocturne.Core.Contracts.Alerts;
@@ -15,6 +16,9 @@ namespace Nocturne.API.Hubs;
 /// when the channel is configured to allow it.
 /// Mounted at /hubs/home-assistant.
 /// </summary>
+// Connections authenticate in-band after negotiate and are reachable only via the internal
+// realtime bridge, so the HTTP fallback authorization policy must not gate the handshake.
+[AllowAnonymous]
 public class HomeAssistantHub : TenantAwareHub
 {
     /// <summary>

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -161,12 +161,8 @@ builder.Services.AddControllers(options =>
     options.Filters.AddService<ReadAccessAuditFilter>();
 })
 .ConfigureApplicationPartManager(manager =>
-{
-    if (!builder.Environment.IsDevelopment())
-    {
-        manager.FeatureProviders.Add(new RemoveDevOnlyControllersFeatureProvider());
-    }
-});
+    AuthorizationConfiguration.ConfigureControllerDiscovery(
+        manager, builder.Environment.IsDevelopment()));
 builder.Services.AddFluentValidationAutoValidation();
 builder.Services.AddValidatorsFromAssemblyContaining<Program>();
 builder.Services.AddProblemDetails();
@@ -282,12 +278,7 @@ builder
         };
     });
 
-builder.Services.AddTransient<IAuthorizationHandler, HasPermissionsHandler>();
-builder.Services.AddAuthorization(options =>
-{
-    options.AddPolicy(PolicyNames.HasPermissions, policy =>
-        policy.Requirements.Add(new HasPermissionsRequirement()));
-});
+builder.Services.AddNocturneAuthorization();
 
 // Configure CORS for frontend with credentials support
 // Note: AllowAnyOrigin() cannot be combined with AllowCredentials() per CORS spec
@@ -487,7 +478,7 @@ app.MapGet(
             }
         );
     }
-);
+).AllowAnonymous();
 
 app.MapDefaultEndpoints();
 
@@ -563,22 +554,6 @@ static bool IsRunningInNSwagContext()
     }
 
     return false;
-}
-
-/// <summary>
-/// Removes controllers in the .DevOnly namespace from non-development environments.
-/// Defined here to avoid creating a Nocturne.API.Infrastructure namespace that
-/// collides with relative namespace resolution in other files.
-/// </summary>
-file class RemoveDevOnlyControllersFeatureProvider
-    : Microsoft.AspNetCore.Mvc.Controllers.ControllerFeatureProvider
-{
-    protected override bool IsController(System.Reflection.TypeInfo typeInfo)
-    {
-        if (typeInfo.Namespace?.Contains(".DevOnly", StringComparison.Ordinal) == true)
-            return false;
-        return base.IsController(typeInfo);
-    }
 }
 
 // Make Program accessible for testing

--- a/src/API/Nocturne.API/Services/Platform/StatusService.cs
+++ b/src/API/Nocturne.API/Services/Platform/StatusService.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Nocturne.API.Extensions;
+using Nocturne.API.Services.Auth;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Platform;
 using Nocturne.Core.Contracts.Multitenancy;
@@ -33,6 +34,7 @@ public class StatusService : IStatusService
     private readonly IDbContextFactory<NocturneDbContext> _dbContextFactory;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly ITenantAccessor _tenantAccessor;
+    private readonly PublicAccessCacheService _publicAccessCacheService;
     private readonly ILogger<StatusService> _logger;
 
     private string TenantCacheId => _tenantAccessor.Context?.TenantId.ToString()
@@ -46,6 +48,7 @@ public class StatusService : IStatusService
         IDbContextFactory<NocturneDbContext> dbContextFactory,
         IHttpContextAccessor httpContextAccessor,
         ITenantAccessor tenantAccessor,
+        PublicAccessCacheService publicAccessCacheService,
         ILogger<StatusService> logger
     )
     {
@@ -56,6 +59,7 @@ public class StatusService : IStatusService
         _dbContextFactory = dbContextFactory;
         _httpContextAccessor = httpContextAccessor;
         _tenantAccessor = tenantAccessor;
+        _publicAccessCacheService = publicAccessCacheService;
         _logger = logger;
     }
 
@@ -163,6 +167,26 @@ public class StatusService : IStatusService
             }
         }
 
+        // Resolve whether this tenant grants anonymous read access (its public subject carries a
+        // read permission). Tenant-level and caller-independent, so safe to include in the cached
+        // per-tenant response; the web app uses it to gate anonymous dashboard access.
+        var anonymousReadAccess = false;
+        var publicTenantId = _tenantAccessor.Context?.TenantId;
+        if (publicTenantId.HasValue)
+        {
+            try
+            {
+                var publicAccess = await _publicAccessCacheService.GetPublicAccessAsync(publicTenantId.Value);
+                anonymousReadAccess = publicAccess is not null && GrantsReadAccess(publicAccess.EffectivePermissions);
+            }
+            catch (Exception ex)
+            {
+                // Resolving public access must not break the status endpoint. Fail safe: report no
+                // anonymous access so the web app requires sign-in rather than over-exposing.
+                _logger.LogWarning(ex, "Failed to resolve anonymous read access for tenant {TenantId}", publicTenantId.Value);
+            }
+        }
+
         var response = new StatusResponse
         {
             Status = "ok",
@@ -179,6 +203,7 @@ public class StatusService : IStatusService
             RuntimeState = _demoModeService.IsEnabled ? "demo" : "loaded",
             IsDemo = isDemo,
             NextResetAt = nextResetAt,
+            AnonymousReadAccess = anonymousReadAccess,
         };
 
         _logger.LogDebug(
@@ -190,6 +215,19 @@ public class StatusService : IStatusService
 
         return response;
     }
+
+    // Permissions that grant read access to dashboard data. Mirrors the web app's
+    // GLUCOSE_READ_PERMISSIONS so the per-tenant anonymousReadAccess flag matches the client's
+    // view of whether an anonymous visitor can see the dashboard (public tenants grant the Public
+    // subject granular scopes such as glucose.readwrite, not just the coarse readable/api:*:read).
+    private static readonly string[] ReadPermissions =
+        ["*", "api:*", "api:*:read", "readable", "glucose.read", "glucose.readwrite", "health.read", "health.readwrite"];
+
+    /// <summary>
+    /// Returns whether a permission set grants read access to dashboard data.
+    /// </summary>
+    private static bool GrantsReadAccess(IEnumerable<string> permissions)
+        => permissions.Any(p => ReadPermissions.Contains(p));
 
     /// <summary>
     /// Get the application version string

--- a/src/Aspire/Nocturne.Aspire.ServiceDefaults/Extensions.cs
+++ b/src/Aspire/Nocturne.Aspire.ServiceDefaults/Extensions.cs
@@ -141,17 +141,18 @@ public static class Extensions
         // Note: For production deployments exposed to the internet, consider
         // adding authentication or restricting access via network policies
 
-        // All health checks must pass for app to be considered ready to accept traffic after starting
+        // All health checks must pass for app to be considered ready to accept traffic after starting.
+        // AllowAnonymous so the probes stay reachable under a default authorization policy.
         app.MapHealthChecks("/health", new HealthCheckOptions
         {
             ResponseWriter = WriteResponse
-        });
+        }).AllowAnonymous();
 
         // Only health checks tagged with the "live" tag must pass for app to be considered alive
         app.MapHealthChecks(
             "/alive",
             new HealthCheckOptions { Predicate = r => r.Tags.Contains("live") }
-        );
+        ).AllowAnonymous();
 
         return app;
     }

--- a/src/Core/Nocturne.Core.Models/StatusResponse.cs
+++ b/src/Core/Nocturne.Core.Models/StatusResponse.cs
@@ -121,4 +121,13 @@ public class StatusResponse
     [JsonPropertyName("nextResetAt")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public DateTime? NextResetAt { get; set; }
+
+    /// <summary>
+    /// Whether this tenant grants read access to anonymous (unauthenticated) callers —
+    /// i.e. the tenant's public subject carries a read permission. The web app uses this
+    /// per-tenant signal to decide whether an anonymous visitor may view the dashboard or
+    /// should be redirected to sign in.
+    /// </summary>
+    [JsonPropertyName("anonymousReadAccess")]
+    public bool AnonymousReadAccess { get; set; }
 }

--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.server.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.server.ts
@@ -34,31 +34,36 @@ export const load: LayoutServerLoad = async ({ locals, cookies, url }) => {
     }
   }
 
+  // Fetch tenant status once — it drives both the anonymous-access gate and the demo banner.
+  // Default to no anonymous access on failure (fail safe: require sign-in rather than over-expose).
+  let status: Awaited<ReturnType<typeof locals.apiClient.status.getStatus>> | null = null;
+  try {
+    status = await locals.apiClient.status.getStatus();
+  } catch {
+    // Swallow — handled below by the conservative defaults.
+  }
+  const anonymousReadAccess = status?.anonymousReadAccess ?? false;
+
+  // Redirect anonymous visitors to login when this tenant does not grant anonymous read access
+  // (a private tenant). Public tenants keep serving their read-only dashboard, so the shell is
+  // never rendered for a visitor who would otherwise see a burst of 401s and a client bounce.
   if (!locals.isAuthenticated || !locals.user) {
-    if (locals.requireAuthentication) {
+    if (!anonymousReadAccess) {
       const returnUrl = encodeURIComponent(url.pathname + url.search);
       throw redirect(303, `/auth/login?returnUrl=${returnUrl}`);
     }
   }
 
   // Enable realtime glucose data for:
-  // - Public sites (requireAuthentication: false) — authDefaultRoles grants readable
-  // - Authenticated users with glucose read permissions
+  // - Authenticated users with a glucose read permission
+  // - Anonymous visitors on a tenant that grants public read access
   // The API enforces authorization on each endpoint as defense in depth.
-  const canViewRealtimeData =
-    !locals.requireAuthentication ||
-    hasGlucoseReadPermission(locals.effectivePermissions ?? []);
+  const canViewRealtimeData = locals.isAuthenticated
+    ? hasGlucoseReadPermission(locals.effectivePermissions ?? [])
+    : anonymousReadAccess;
 
-  // Fetch demo status for the banner (non-blocking — default to non-demo on failure)
-  let isDemo = false;
-  let nextResetAt: string | null = null;
-  try {
-    const status = await locals.apiClient.status.getStatus();
-    isDemo = status.isDemo ?? false;
-    nextResetAt = status.nextResetAt ? status.nextResetAt.toISOString() : null;
-  } catch {
-    // Swallow — demo banner is non-critical
-  }
+  const isDemo = status?.isDemo ?? false;
+  const nextResetAt = status?.nextResetAt ? status.nextResetAt.toISOString() : null;
 
   return {
     user: locals.user ?? null,

--- a/tests/Unit/Nocturne.API.Tests/Authorization/AuthorizationConfigurationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/AuthorizationConfigurationTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Nocturne.API.Attributes;
+using Nocturne.API.Authorization;
+using Xunit;
+
+namespace Nocturne.API.Tests.Authorization;
+
+/// <summary>
+/// Guards the default-deny authorization wiring: the fallback policy must stay in place, the
+/// tenant-admin controllers must keep their explicit gate (the fallback is too weak for them),
+/// the genuinely-public controllers must stay anonymous, and the dev-only controllers must be
+/// dropped outside development.
+/// </summary>
+public class AuthorizationConfigurationTests
+{
+    private static System.Reflection.Assembly ApiAssembly => typeof(AuthorizationConfiguration).Assembly;
+
+    [Fact]
+    public void AddNocturneAuthorization_SetsFallbackPolicy_RequiringPermissionTrie()
+    {
+        var services = new ServiceCollection();
+        services.AddNocturneAuthorization();
+        using var provider = services.BuildServiceProvider();
+
+        var options = provider.GetRequiredService<IOptions<AuthorizationOptions>>().Value;
+
+        options.FallbackPolicy.Should().NotBeNull(
+            "every endpoint without an explicit authorization attribute must be gated by default");
+        options.FallbackPolicy!.Requirements.Should().ContainSingle()
+            .Which.Should().BeOfType<HasPermissionsRequirement>();
+
+        var hasPermissions = options.GetPolicy(PolicyNames.HasPermissions);
+        hasPermissions.Should().NotBeNull();
+        hasPermissions!.Requirements.Should().ContainItemsAssignableTo<HasPermissionsRequirement>();
+    }
+
+    [Theory]
+    [InlineData("Nocturne.API.Controllers.V4.TenantAdmin.MigrationController")]
+    [InlineData("Nocturne.API.Controllers.V4.TenantAdmin.ProcessingController")]
+    [InlineData("Nocturne.API.Controllers.V4.TenantAdmin.NightscoutTransitionController")]
+    [InlineData("Nocturne.API.Controllers.V4.TenantAdmin.DeduplicationController")]
+    public void TenantAdminController_RequiresAdmin(string typeName)
+    {
+        var type = ApiAssembly.GetType(typeName);
+        type.Should().NotBeNull($"{typeName} should exist");
+
+        type!.GetCustomAttributes(inherit: true).OfType<RequireAdminAttribute>()
+            .Should().NotBeEmpty(
+                $"{typeName} exposes tenant-admin operations that the HasPermissions fallback cannot gate");
+    }
+
+    [Theory]
+    [InlineData("Nocturne.API.Controllers.V4.Platform.StatusController")]
+    [InlineData("Nocturne.API.Controllers.V1.StatusController")]
+    [InlineData("Nocturne.API.Controllers.V3.StatusController")]
+    [InlineData("Nocturne.API.Controllers.MetadataController")]
+    [InlineData("Nocturne.API.Controllers.V1.VersionsController")]
+    [InlineData("Nocturne.API.Controllers.V3.VersionController")]
+    [InlineData("Nocturne.API.Controllers.V3.LastModifiedController")]
+    [InlineData("Nocturne.API.Controllers.V1.AuthenticationController")]
+    public void PublicController_AllowsAnonymous(string typeName)
+    {
+        var type = ApiAssembly.GetType(typeName);
+        type.Should().NotBeNull($"{typeName} should exist");
+
+        type!.GetCustomAttributes(inherit: true).OfType<AllowAnonymousAttribute>()
+            .Should().NotBeEmpty(
+                $"{typeName} must stay reachable for unauthenticated callers under the fallback policy");
+    }
+
+    [Fact]
+    public void DiscrepancyIngest_IsAnonymous_WhileReadsRequireAdmin()
+    {
+        var type = ApiAssembly.GetType("Nocturne.API.Controllers.V4.TenantAdmin.DiscrepancyController");
+        type.Should().NotBeNull();
+
+        // Inter-instance ingestion validates a shared bearer key itself, so it opts out of the
+        // user-oriented policies.
+        var ingest = type!.GetMethod("IngestDiscrepancy");
+        ingest.Should().NotBeNull();
+        ingest!.GetCustomAttributes(inherit: true).OfType<AllowAnonymousAttribute>()
+            .Should().NotBeEmpty();
+
+        // The dashboard reads remain admin-only.
+        var metrics = type.GetMethod("GetCompatibilityMetrics");
+        metrics.Should().NotBeNull();
+        metrics!.GetCustomAttributes(inherit: true).OfType<RequireAdminAttribute>()
+            .Should().NotBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("Nocturne.API.Hubs.DataHub")]
+    [InlineData("Nocturne.API.Hubs.AlarmHub")]
+    [InlineData("Nocturne.API.Hubs.AlertHub")]
+    [InlineData("Nocturne.API.Hubs.HomeAssistantHub")]
+    public void RealtimeHub_AllowsAnonymous(string typeName)
+    {
+        var type = ApiAssembly.GetType(typeName);
+        type.Should().NotBeNull($"{typeName} should exist");
+
+        // These hubs authenticate in-band via the internal realtime bridge; the HTTP fallback
+        // policy must not gate their connection handshake or the bridge cannot connect.
+        type!.GetCustomAttributes(inherit: true).OfType<AllowAnonymousAttribute>()
+            .Should().NotBeEmpty(
+                $"{typeName} authenticates in-band and must stay exempt from the fallback policy");
+    }
+
+    [Theory]
+    [InlineData(false, false)] // outside development: dev-only controllers are excluded
+    [InlineData(true, true)]   // in development: dev-only controllers remain registered
+    public void ConfigureControllerDiscovery_TogglesDevOnlyControllers(bool isDevelopment, bool expectedPresent)
+    {
+        var manager = new ApplicationPartManager();
+        manager.ApplicationParts.Add(new AssemblyPart(ApiAssembly));
+        // Mimic the default provider that AddControllers registers.
+        manager.FeatureProviders.Add(new ControllerFeatureProvider());
+
+        AuthorizationConfiguration.ConfigureControllerDiscovery(manager, isDevelopment);
+
+        var feature = new ControllerFeature();
+        manager.PopulateFeature(feature);
+
+        var devOnlyPresent = feature.Controllers.Any(
+            c => c.Namespace?.Contains(".DevOnly", StringComparison.Ordinal) == true);
+        devOnlyPresent.Should().Be(expectedPresent);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/GoldenFiles/V1/StatusGoldenTests.GetStatusJson_AlwaysReturnsJson.verified.txt
+++ b/tests/Unit/Nocturne.API.Tests/GoldenFiles/V1/StatusGoldenTests.GetStatusJson_AlwaysReturnsJson.verified.txt
@@ -160,6 +160,7 @@
     boluscalcEnabled: false,
     authorized: null,
     runtimeState: loaded,
-    head: {Scrubbed}
+    head: {Scrubbed},
+    anonymousReadAccess: false
   }
 }

--- a/tests/Unit/Nocturne.API.Tests/GoldenFiles/V1/StatusGoldenTests.GetStatus_WithJsonAccept_ReturnsJsonStatus.verified.txt
+++ b/tests/Unit/Nocturne.API.Tests/GoldenFiles/V1/StatusGoldenTests.GetStatus_WithJsonAccept_ReturnsJsonStatus.verified.txt
@@ -160,6 +160,7 @@
     boluscalcEnabled: false,
     authorized: null,
     runtimeState: loaded,
-    head: {Scrubbed}
+    head: {Scrubbed},
+    anonymousReadAccess: false
   }
 }

--- a/tests/Unit/Nocturne.API.Tests/Infrastructure/TestPublicAccessCache.cs
+++ b/tests/Unit/Nocturne.API.Tests/Infrastructure/TestPublicAccessCache.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Auth;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Tests.Shared.Infrastructure;
+
+namespace Nocturne.API.Tests.Infrastructure;
+
+/// <summary>
+/// Builds a real <see cref="PublicAccessCacheService"/> for tests, backed by an empty in-memory
+/// database. It resolves no Public subject, so callers see anonymous read access reported as
+/// disabled — the correct default for tests that don't set up public access.
+/// </summary>
+internal static class TestPublicAccessCache
+{
+    public static PublicAccessCacheService Create()
+    {
+        var factory = new Mock<IDbContextFactory<NocturneDbContext>>();
+        factory
+            .Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => TestDbContextFactory.CreateInMemoryContext($"public_access_{Guid.NewGuid()}"));
+
+        return new PublicAccessCacheService(
+            new MemoryCache(new MemoryCacheOptions()),
+            factory.Object,
+            NullLogger<PublicAccessCacheService>.Instance);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/CacheIntegrationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/CacheIntegrationTests.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Nocturne.API.Tests.Infrastructure;
 using Microsoft.Extensions.Options;
 using Moq;
 using Nocturne.API.Services.Platform;
@@ -247,6 +248,7 @@ public class CacheIntegrationTests
             mockDbContextFactory.Object,
             httpContextAccessor,
             _mockTenantAccessor.Object,
+            TestPublicAccessCache.Create(),
             _mockStatusLogger.Object
         );
 
@@ -327,6 +329,7 @@ public class CacheIntegrationTests
             mockDbContextFactory.Object,
             httpContextAccessor,
             _mockTenantAccessor.Object,
+            TestPublicAccessCache.Create(),
             _mockStatusLogger.Object
         );
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Platform/StatusServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Platform/StatusServiceTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Nocturne.API.Services.Platform;
+using Nocturne.API.Tests.Infrastructure;
 using Nocturne.Core.Contracts.Platform;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Authorization;
@@ -853,6 +854,7 @@ public class StatusServiceTests
             mockDbContextFactory.Object,
             _httpContextAccessor,
             _mockTenantAccessor.Object,
+            TestPublicAccessCache.Create(),
             _mockLogger.Object
         );
     }


### PR DESCRIPTION
Routine hardening of the API's authorization defaults, plus a dashboard redirect fix.

**API**
- Add a fallback authorization policy so endpoints require a resolved permission set unless explicitly marked anonymous — matching the existing v1 read behaviour (public tenants stay readable; private tenants require a credential). Health probes, docs, and the public status/version/metadata/verifyauth endpoints are marked anonymous.
- Require admin on the tenant-admin controllers (migration, processing, nightscout-transition, deduplication, discrepancy reads) and the destructive service/compatibility actions; validate the configured forwarding key on the discrepancy `ingest` endpoint.
- Correct the dev-only controller exclusion so it actually applies outside Development.
- Surface a per-tenant anonymous-read flag on the status response.

**Web**
- Decide the dashboard login redirect from the tenant's anonymous-read flag on the status response rather than the instance-wide `requireAuthentication` setting, and gate realtime data the same way.

Adds unit tests for the fallback policy, the admin annotations, and the dev-only exclusion.