### PR TITLE
fix(web): send unconfigured instances to setup instead of login

### DIFF
--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.server.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.server.ts
@@ -44,6 +44,13 @@ export const load: LayoutServerLoad = async ({ locals, cookies, url }) => {
   }
   const anonymousReadAccess = status?.anonymousReadAccess ?? false;
 
+  // A fresh instance with no resolved tenant reports "setup_required" — send it to setup rather
+  // than bouncing an anonymous visitor to login. (checkOnboarding fails open on a missing cookie
+  // or an unreachable auth-status call, so this is the authoritative no-tenant signal.)
+  if (status?.status === "setup_required") {
+    throw redirect(303, "/setup");
+  }
+
   // Redirect anonymous visitors to login when this tenant does not grant anonymous read access
   // (a private tenant). Public tenants keep serving their read-only dashboard, so the shell is
   // never rendered for a visitor who would otherwise see a burst of 401s and a client bounce.


### PR DESCRIPTION
Follow-up to #364. When no tenant is resolved, `/api/v4/status` returns `status=setup_required`; the dashboard layout now routes that to `/setup` before the anonymous login redirect can fire. `checkOnboarding` fails open (missing cookie or unreachable auth-status call), so the layout needs this authoritative no-tenant signal to avoid bouncing a fresh instance to the login page.