### PR TITLE
fix(connectors): import full Nightscout history on initial backfill

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -222,7 +222,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     ///     Calculate the optimal "since" timestamp for fetching glucose entries
     ///     Uses catch-up logic to fetch from the most recent entry, or falls back to default lookback
     /// </summary>
-    protected async Task<DateTime> CalculateSinceTimestampAsync(
+    protected async Task<DateTime?> CalculateSinceTimestampAsync(
         TConfig config,
         DateTime? defaultSince = null
     )
@@ -240,7 +240,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     ///     Calculate the optimal "since" timestamp for fetching treatments
     ///     Uses catch-up logic to fetch from the most recent treatment, or falls back to default lookback
     /// </summary>
-    protected async Task<DateTime> CalculateTreatmentSinceTimestampAsync(
+    protected async Task<DateTime?> CalculateTreatmentSinceTimestampAsync(
         TConfig config,
         DateTime? defaultSince = null
     )
@@ -303,24 +303,45 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
     /// <summary>
     ///     Helper method to calculate the since timestamp from a latest timestamp.
-    ///     Falls back to a 6-month initial window when no prior data exists.
+    ///     When no prior data exists, falls back to <see cref="InitialSyncFloor"/> — which may be
+    ///     <c>null</c> (no lower bound) for connectors that import the source's full history.
     /// </summary>
-    private DateTime CalculateSinceFromTimestamp(DateTime? latestTimestamp, string dataType)
+    private DateTime? CalculateSinceFromTimestamp(DateTime? latestTimestamp, string dataType)
     {
         var catchUpSince = TryCalculateCatchUpSince(latestTimestamp, dataType);
         if (catchUpSince.HasValue)
             return catchUpSince.Value;
 
-        // Fallback to 6 months for initial sync if no existing data found
-        var fallbackSince = DateTime.UtcNow.AddMonths(-6);
-        _logger?.LogInformation(
-            "No existing {DataType} found for {ConnectorSource}, performing initial sync from {Since:yyyy-MM-dd HH:mm:ss} UTC",
-            dataType,
-            ConnectorSource,
-            fallbackSince
-        );
+        // No prior data: this is the initial sync. Most connectors bound the first backfill to
+        // InitialSyncFloor; a null floor means "no lower bound" — import the source's full history.
+        var fallbackSince = InitialSyncFloor;
+        if (fallbackSince.HasValue)
+            _logger?.LogInformation(
+                "No existing {DataType} found for {ConnectorSource}, performing initial sync from {Since:yyyy-MM-dd HH:mm:ss} UTC",
+                dataType,
+                ConnectorSource,
+                fallbackSince.Value
+            );
+        else
+            _logger?.LogInformation(
+                "No existing {DataType} found for {ConnectorSource}, performing initial sync over the source's full history",
+                dataType,
+                ConnectorSource
+            );
         return fallbackSince;
     }
+
+    /// <summary>
+    ///     Lower bound applied to an initial sync when no prior data exists for a data type.
+    ///     Connectors whose source is a full data export (e.g. Nightscout) override this to return
+    ///     <c>null</c> so the first backfill imports the entire history; the default bounds the
+    ///     initial window to <see cref="DefaultInitialSyncFloor"/> so a first sync against a
+    ///     long-running source is not unbounded.
+    /// </summary>
+    protected virtual DateTime? InitialSyncFloor => DefaultInitialSyncFloor();
+
+    /// <summary>The default initial backfill window: six months before now.</summary>
+    protected static DateTime DefaultInitialSyncFloor() => DateTime.UtcNow.AddMonths(-6);
 
     /// <summary>
     ///     Core synchronization logic that processes data types sequentially.

--- a/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
@@ -158,9 +158,10 @@ public class MyLifeConnectorService(
             var needRecords = treatmentSubTypes.Any(t => activeTypes.Contains(t));
             var needStateSpans = activeTypes.Contains(SyncDataType.StateSpans);
 
-            // Calculate since timestamps
-            var glucoseSince = await CalculateSinceTimestampAsync(config, request.From);
-            var treatmentSince = await CalculateTreatmentSinceTimestampAsync(config, request.From);
+            // Calculate since timestamps. MyLife streams the source month by month, so it needs a
+            // concrete lower bound; fall back to the default initial window when no cursor exists.
+            var glucoseSince = await CalculateSinceTimestampAsync(config, request.From) ?? DefaultInitialSyncFloor();
+            var treatmentSince = await CalculateTreatmentSinceTimestampAsync(config, request.From) ?? DefaultInitialSyncFloor();
             var overallSince = glucoseSince < treatmentSince ? glucoseSince : treatmentSince;
             var until = request.To ?? DateTime.UtcNow;
 

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
@@ -43,6 +43,11 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
     protected override string ConnectorSource => DataSources.NightscoutConnector;
     public override string ServiceName => "Nightscout";
 
+    // A Nightscout instance is a full data export, so the initial sync (no prior data) imports the
+    // source's entire history rather than the default bounded window — capping the first backfill
+    // would silently drop older records. Catch-up syncs still resume from each type's own cursor.
+    protected override DateTime? InitialSyncFloor => null;
+
     public override List<SyncDataType> SupportedDataTypes =>
     [
         SyncDataType.Glucose,

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutPerTypeCursorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutPerTypeCursorTests.cs
@@ -99,9 +99,11 @@ public class NightscoutPerTypeCursorTests
         handler.RequestUrls.Single(u => u.Contains("devicestatus.json"));
 
     [Fact]
-    public async Task Treatments_OpenEndedSync_UseOwnCursor_NotGlucoseCursor()
+    public async Task Treatments_OpenEndedSync_NoPriorTreatments_ImportsFullHistory_NotGlucoseCursor()
     {
-        // Glucose is fully caught up (latest entry ~now), but no treatments exist yet.
+        // Glucose is fully caught up (latest entry ~now), but no treatments exist yet. With no
+        // prior treatments the initial backfill must import the source's full history (no lower
+        // bound) and must NOT inherit the recent glucose cursor.
         var now = DateTime.UtcNow;
         var handler = new SequentialMockHandler();
         handler.Enqueue(JsonResponse(Array.Empty<Entry>()));      // auth check
@@ -121,10 +123,29 @@ public class NightscoutPerTypeCursorTests
         var result = await service.SyncDataAsync(request, config, CancellationToken.None);
 
         result.Success.Should().BeTrue();
-        var gte = ExtractGte(TreatmentsUrl(handler));
-        gte.Should().BeBefore(now.AddMonths(-3),
-            "with no treatments yet, treatments must backfill from their own initial window (~6 months), " +
-            "not from the recent glucose cursor");
+        Uri.UnescapeDataString(TreatmentsUrl(handler)).Should().NotContain("$gte",
+            "with no treatments yet, the initial backfill imports the full history (no lower bound), " +
+            "not the recent glucose cursor");
+    }
+
+    [Fact]
+    public async Task Glucose_InitialSync_NoPriorData_ImportsFullHistory_NoLowerBound()
+    {
+        // No glucose entries exist yet → the initial background sync imports the source's full
+        // history (no lower bound), not a capped window.
+        var handler = new SequentialMockHandler();
+
+        var config = Config();
+        var service = CreateService(handler, config, latestEntry: null);
+
+        // Background entry point (no explicit since): the framework derives From/To.
+        var result = await service.SyncDataAsync(config, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        var entriesPage = handler.RequestUrls.Single(u =>
+            u.Contains("entries.json") && u.Contains($"count={MaxCount}"));
+        Uri.UnescapeDataString(entriesPage).Should().NotContain("$gte",
+            "with no prior glucose data the initial sync imports the full history (no lower bound)");
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

When a Nightscout instance is added as an ongoing **connector**, the first background sync (no prior data) fell back to a hardcoded `DateTime.UtcNow.AddMonths(-6)` in `BaseConnectorService.CalculateSinceFromTimestamp`, so only the last 6 months were backfilled — older records were silently dropped. (The connector's `MaxHistoricalDays = 365` was metadata only and never enforced on the auto backfill.)

The API migration wizard (`MigrationJobService`) already imports the full history; this brings the connector's initial backfill in line with that.

## Change

- Add an overridable `InitialSyncFloor` to `BaseConnectorService`. Default is the existing 6-month window (`DefaultInitialSyncFloor()`), so **every other connector is unchanged**. A `null` floor means "no lower bound".
- The since-calculation (`CalculateSinceTimestampAsync` / `CalculateTreatmentSinceTimestampAsync` / `CalculateSinceFromTimestamp`) now returns `DateTime?`. A `null` floor flows through to `request.From`, so the fetch URL omits the `find[date][$gte]` / `find[created_at][$gte]` filter and paginates the source's full history — exactly how the migration wizard achieves "everything".
- `NightscoutConnectorService` overrides `InitialSyncFloor => null` (a Nightscout instance is a full data export).
- `MyLifeConnectorService` (the only other caller) coalesces to `DefaultInitialSyncFloor()` since it streams the source month-by-month and needs a concrete lower bound.

Glucose and treatments each backfill their full history independently via their own per-type cursors. Device status / activity keep tracking the glucose cursor on warm syncs (the deliberate high-volume guard) and only go full-history on a genuinely cold first sync.

## Tests

`NightscoutPerTypeCursorTests`:
- Updated the no-prior-treatments case to assert the request carries **no** lower bound (full history), not a 6-month window.
- Added `Glucose_InitialSync_NoPriorData_ImportsFullHistory_NoLowerBound`.

Verified green locally: Nightscout/connector API tests (68), Connectors.Core (37), MyLife (31), Dexcom/Tidepool/Glooko/Eversense — no regressions.