### PR TITLE
feat(api): headless first-tenant setup + migrate instance-key hash to SHA-256

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,35 @@ docker compose up -d
 
 The production compose includes [Watchtower](https://github.com/nicholas-fedor/watchtower) for automatic container updates (checks daily), and omits the Aspire dashboard and Scalar API explorer. Watchtower will automatically pull new images as they are published — no manual updates needed.
 
+### First-run setup
+
+A fresh install has no tenants, so the API answers every request with `503 {"error":"setup_required"}` until the first owner secures the instance. This is expected — it's the signal for the web UI to show the setup wizard.
+
+**In a browser (normal path).** Open your Nocturne site (the apex `https://<BASE_DOMAIN>/`). The setup wizard walks you through creating the first tenant and registering a passkey (or linking an OIDC provider). When it completes you're shown a set of recovery codes — save them. That's the whole setup.
+
+**Headless / automated setup (no browser).** Trusted automation can stand up a tenant — create it, configure connectors, change settings, push data — before any human registers a passkey, using the `INSTANCE_KEY` from your `.env`. The instance key is the highest-trust service credential (cross-tenant platform admin), so treat it like a root password. Requests authenticate with two headers: `X-Instance-Key` carrying the **SHA-256 hex of `INSTANCE_KEY`**, and an `X-Instance-Service` marker naming the caller.
+
+```bash
+# The X-Instance-Key header is the SHA-256 hex of your raw INSTANCE_KEY, not the key itself.
+KEY_HASH=$(printf %s "$INSTANCE_KEY" | sha256sum | cut -d' ' -f1)
+
+# 1. Create the first tenant. This endpoint is anonymous and tenantless — call it on the apex.
+curl -fsS -X POST "https://$BASE_DOMAIN/api/v4/setup/tenant" \
+  -H 'Content-Type: application/json' \
+  -d '{"slug":"alice","displayName":"Alice"}'
+
+# 2. Configure the tenant as trusted automation. Target the tenant's subdomain and
+#    present the instance key + service marker. Normal tenant traffic still gets 503
+#    until a human completes setup, but instance-key calls are allowed through.
+curl -fsS -X PUT "https://alice.$BASE_DOMAIN/api/v4/connectors/config/Dexcom/secrets" \
+  -H "X-Instance-Key: $KEY_HASH" \
+  -H 'X-Instance-Service: nocturne-setup-agent' \
+  -H 'Content-Type: application/json' \
+  -d '{ "username": "...", "password": "..." }'
+```
+
+When the human is ready, they open the site and register the first passkey through the normal wizard — recovery codes and all — exactly as on a brand-new instance. Their pre-configured connectors and data are already there. (A bare `X-Instance-Key` without the `X-Instance-Service` marker is ignored, so an instance key accidentally forwarded onto a browser request can't bypass setup.)
+
 ### Generating locally
 
 If you have the .NET 10 SDK and Aspire CLI installed, you can generate the production bundle from source:

--- a/src/API/Nocturne.API/Authorization/InstanceKeyValidator.cs
+++ b/src/API/Nocturne.API/Authorization/InstanceKeyValidator.cs
@@ -1,0 +1,81 @@
+using Nocturne.Connectors.Core.Utilities;
+using Nocturne.Core.Constants;
+
+namespace Nocturne.API.Authorization;
+
+/// <summary>
+/// Classification of a request's instance-key credential.
+/// </summary>
+public enum InstanceKeyRequestKind
+{
+    /// <summary>No instance-key credential is present — the header or the service marker is missing.</summary>
+    Absent,
+
+    /// <summary>A credential was presented but no instance key is configured on the server.</summary>
+    NotConfigured,
+
+    /// <summary>A credential was presented but does not match the configured instance key.</summary>
+    Invalid,
+
+    /// <summary>A valid instance-key service request from a trusted in-cluster caller.</summary>
+    Valid,
+}
+
+/// <summary>
+/// Validates the shared instance key used for service-to-service authentication.
+/// A valid request carries both the <see cref="ServiceNames.Headers.InstanceKey"/>
+/// header (SHA-256 hash of the key) and an <see cref="ServiceNames.Headers.InstanceService"/>
+/// marker.
+/// </summary>
+/// <remarks>
+/// Shared by <see cref="Middleware.Handlers.InstanceKeyHandler"/> (which authenticates the
+/// request) and <see cref="Middleware.TenantSetupMiddleware"/> (which lets such requests
+/// bypass the setup gate), so the validation rules — including the requirement of a service
+/// marker — live in exactly one place.
+/// </remarks>
+public interface IInstanceKeyValidator
+{
+    /// <summary>
+    /// Classifies the request's instance-key credential without mutating the request.
+    /// </summary>
+    InstanceKeyRequestKind Classify(HttpContext context);
+}
+
+/// <inheritdoc />
+public class InstanceKeyValidator : IInstanceKeyValidator
+{
+    private readonly string _instanceKeyHash;
+
+    public InstanceKeyValidator(IConfiguration configuration)
+    {
+        var instanceKey =
+            configuration[$"Parameters:{ServiceNames.Parameters.InstanceKey}"]
+            ?? configuration[ServiceNames.ConfigKeys.InstanceKey]
+            ?? "";
+        _instanceKeyHash = !string.IsNullOrEmpty(instanceKey) ? HashUtils.Sha256Hex(instanceKey) : "";
+    }
+
+    /// <inheritdoc />
+    public InstanceKeyRequestKind Classify(HttpContext context)
+    {
+        var header = context.Request.Headers[ServiceNames.Headers.InstanceKey].FirstOrDefault();
+        if (string.IsNullOrEmpty(header))
+            return InstanceKeyRequestKind.Absent;
+
+        // Require an explicit service marker. A bare instance key with no service
+        // declaration is treated as "not an intended service credential" so that an
+        // instance key accidentally forwarded onto an anonymous browser request
+        // (e.g. by the SSR proxy) does not elevate that request or slip past the
+        // setup gate.
+        var serviceMarker = context.Request.Headers[ServiceNames.Headers.InstanceService].FirstOrDefault();
+        if (string.IsNullOrEmpty(serviceMarker))
+            return InstanceKeyRequestKind.Absent;
+
+        if (string.IsNullOrEmpty(_instanceKeyHash))
+            return InstanceKeyRequestKind.NotConfigured;
+
+        return string.Equals(header, _instanceKeyHash, StringComparison.OrdinalIgnoreCase)
+            ? InstanceKeyRequestKind.Valid
+            : InstanceKeyRequestKind.Invalid;
+    }
+}

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -1,5 +1,6 @@
 using System.Threading.RateLimiting;
 using Fido2NetLib;
+using Nocturne.API.Authorization;
 using Nocturne.API.Configuration;
 using Nocturne.API.Services;
 using Nocturne.API.Middleware.Handlers;
@@ -229,6 +230,10 @@ public static class ServiceRegistrationExtensions
         services.AddScoped<ITenantMemberService, TenantMemberService>();
         services.AddScoped<ITenantRoleService, TenantRoleService>();
         services.AddScoped<ITenantService, TenantService>();
+
+        // Shared by InstanceKeyHandler (authentication) and TenantSetupMiddleware
+        // (setup-gate bypass) so instance-key validation rules live in one place.
+        services.AddSingleton<IInstanceKeyValidator, InstanceKeyValidator>();
 
         // Auth handlers (executed in priority order, lowest first)
         services.AddSingleton<IAuthHandler, PlatformAccessCookieHandler>(); // Priority 40

--- a/src/API/Nocturne.API/Hubs/DataHub.cs
+++ b/src/API/Nocturne.API/Hubs/DataHub.cs
@@ -78,8 +78,8 @@ public class DataHub : TenantAwareHub
                         ?? configuration?[ServiceNames.ConfigKeys.InstanceKey];
                     if (!string.IsNullOrEmpty(configuredSecret))
                     {
-                        // Calculate SHA1 hash of the configured secret
-                        var expectedHash = HashUtils.Sha1Hex(configuredSecret);
+                        // Calculate SHA-256 hash of the configured secret
+                        var expectedHash = HashUtils.Sha256Hex(configuredSecret);
 
                         // Compare with provided secret (should be the hashed value)
                         isAuthorized = authData.Secret.ToLowerInvariant() == expectedHash;

--- a/src/API/Nocturne.API/Middleware/Handlers/InstanceKeyHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/InstanceKeyHandler.cs
@@ -1,14 +1,14 @@
-using Nocturne.Connectors.Core.Utilities;
-using Nocturne.Core.Constants;
+using Nocturne.API.Authorization;
 using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.API.Middleware.Handlers;
 
 /// <summary>
 /// Authentication handler for instance key (infrastructure service authentication).
-/// Validates the SHA1 hash of the instance key sent in the X-Instance-Key header.
-/// Used by internal services (SSR, WebSocket bridge) to authenticate with the API.
-/// Grants full admin (*) permissions.
+/// Validates the SHA1 hash of the instance key sent in the X-Instance-Key header
+/// (with an X-Instance-Service marker) via <see cref="IInstanceKeyValidator"/>.
+/// Used by internal services (SSR, WebSocket bridge) and trusted automation to
+/// authenticate with the API. Grants full admin (*) permissions.
 /// </summary>
 public class InstanceKeyHandler : IAuthHandler
 {
@@ -16,68 +16,50 @@ public class InstanceKeyHandler : IAuthHandler
 
     public string Name => "InstanceKeyHandler";
 
-    private readonly string _instanceKeyHash;
+    private readonly IInstanceKeyValidator _validator;
     private readonly ILogger<InstanceKeyHandler> _logger;
 
-    public InstanceKeyHandler(IConfiguration configuration, ILogger<InstanceKeyHandler> logger)
+    public InstanceKeyHandler(IInstanceKeyValidator validator, ILogger<InstanceKeyHandler> logger)
     {
+        _validator = validator;
         _logger = logger;
-
-        var instanceKey =
-            configuration[$"Parameters:{ServiceNames.Parameters.InstanceKey}"]
-            ?? configuration[ServiceNames.ConfigKeys.InstanceKey]
-            ?? "";
-        _instanceKeyHash = !string.IsNullOrEmpty(instanceKey) ? HashUtils.Sha1Hex(instanceKey) : "";
     }
 
     public Task<AuthResult> AuthenticateAsync(HttpContext context)
     {
-        var header = context.Request.Headers[ServiceNames.Headers.InstanceKey].FirstOrDefault();
-        if (string.IsNullOrEmpty(header))
-            return Task.FromResult(AuthResult.Skip());
-
-        // Require an explicit service marker. A bare instance key with no service
-        // declaration is treated as "not an intended service credential" and is
-        // skipped, so the request falls through to public-access / unauthenticated
-        // handling. This prevents an instance key accidentally forwarded onto an
-        // anonymous browser request (e.g. by the SSR proxy) from elevating that
-        // request to admin and bypassing per-tenant public-access controls.
-        var serviceMarker = context.Request.Headers[ServiceNames.Headers.InstanceService].FirstOrDefault();
-        if (string.IsNullOrEmpty(serviceMarker))
+        switch (_validator.Classify(context))
         {
-            _logger.LogDebug(
-                "X-Instance-Key present without an X-Instance-Service marker; skipping instance-key auth");
-            return Task.FromResult(AuthResult.Skip());
+            case InstanceKeyRequestKind.Absent:
+                // No header, or a bare key with no service marker — fall through to
+                // public-access / unauthenticated handling.
+                return Task.FromResult(AuthResult.Skip());
+
+            case InstanceKeyRequestKind.NotConfigured:
+                _logger.LogWarning("X-Instance-Key header provided but no instance key configured");
+                return Task.FromResult(AuthResult.Failure("Instance key not configured"));
+
+            case InstanceKeyRequestKind.Invalid:
+                _logger.LogWarning("Invalid instance key provided");
+                return Task.FromResult(AuthResult.Failure("Invalid instance key"));
+
+            default:
+                _logger.LogDebug("Instance key authentication successful");
+                return Task.FromResult(AuthResult.Success(new AuthContext
+                {
+                    IsAuthenticated = true,
+                    AuthType = AuthType.InstanceKey,
+                    SubjectName = "instance-service",
+                    Permissions = ["*"],
+                    Roles = ["admin"],
+                    // The instance key is the highest-trust service credential in
+                    // the system (shared only with trusted in-cluster services). It
+                    // already skips tenant membership checks and grants permission
+                    // wildcard, so it must also carry platform_admin so that cross-
+                    // tenant admin endpoints (e.g. /api/v4/admin/tenants/provision)
+                    // are callable by provisioners. Without this, external admin
+                    // calls authenticated via X-Instance-Key get 403 Forbidden.
+                    IsPlatformAdmin = true,
+                }));
         }
-
-        if (string.IsNullOrEmpty(_instanceKeyHash))
-        {
-            _logger.LogWarning("X-Instance-Key header provided but no instance key configured");
-            return Task.FromResult(AuthResult.Failure("Instance key not configured"));
-        }
-
-        if (!string.Equals(header, _instanceKeyHash, StringComparison.OrdinalIgnoreCase))
-        {
-            _logger.LogWarning("Invalid instance key provided");
-            return Task.FromResult(AuthResult.Failure("Invalid instance key"));
-        }
-
-        _logger.LogDebug("Instance key authentication successful");
-        return Task.FromResult(AuthResult.Success(new AuthContext
-        {
-            IsAuthenticated = true,
-            AuthType = AuthType.InstanceKey,
-            SubjectName = "instance-service",
-            Permissions = ["*"],
-            Roles = ["admin"],
-            // The instance key is the highest-trust service credential in
-            // the system (shared only with trusted in-cluster services). It
-            // already skips tenant membership checks and grants permission
-            // wildcard, so it must also carry platform_admin so that cross-
-            // tenant admin endpoints (e.g. /api/v4/admin/tenants/provision)
-            // are callable by provisioners. Without this, external admin
-            // calls authenticated via X-Instance-Key get 403 Forbidden.
-            IsPlatformAdmin = true,
-        }));
     }
 }

--- a/src/API/Nocturne.API/Middleware/TenantSetupMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/TenantSetupMiddleware.cs
@@ -9,7 +9,9 @@ namespace Nocturne.API.Middleware;
 /// Middleware that returns 503 for freshly provisioned tenants (no passkey
 /// credentials) or tenants in recovery mode (orphaned subjects with no
 /// passkey and no OIDC binding). Allows passkey setup, admin, and metadata
-/// endpoints through so setup/recovery flows can complete.
+/// endpoints through so setup/recovery flows can complete. Trusted instance-key
+/// service requests also bypass the gate (see <see cref="IInstanceKeyValidator"/>)
+/// so automation can configure a tenant before a human owner registers a passkey.
 ///
 /// Runs after TenantResolutionMiddleware. When no tenant is resolved
 /// (e.g. tenantless cross-tenant paths, or zero-tenant setup), the
@@ -56,11 +58,13 @@ public class TenantSetupMiddleware
     /// <param name="context">The current HTTP context.</param>
     /// <param name="tenantAccessor">Accessor for the resolved tenant identity.</param>
     /// <param name="db">Database context for querying passkey credentials and orphaned subjects.</param>
+    /// <param name="instanceKeyValidator">Validator used to let trusted instance-key callers bypass the setup gate.</param>
     /// <returns>A task that completes when the middleware has finished processing.</returns>
     public async Task InvokeAsync(
         HttpContext context,
         ITenantAccessor tenantAccessor,
-        NocturneDbContext db)
+        NocturneDbContext db,
+        IInstanceKeyValidator instanceKeyValidator)
     {
         // Only check when a tenant has been resolved
         if (!tenantAccessor.IsResolved)
@@ -81,6 +85,21 @@ public class TenantSetupMiddleware
         // OIDC bootstrap login, admin provisioning, metadata).
         var endpoint = context.GetEndpoint();
         if (endpoint?.Metadata.GetMetadata<AllowDuringSetupAttribute>() is not null)
+        {
+            await _next(context);
+            return;
+        }
+
+        // A valid instance-key service request (trusted in-cluster automation — a
+        // provisioner or a headless setup agent) bypasses the setup/recovery gate.
+        // The instance key is the highest-trust service credential and already grants
+        // platform-admin once setup completes; letting it through here lets automation
+        // stand up a tenant (connectors, settings, seed data) before a human owner has
+        // registered a passkey. Untrusted tenant traffic still gets 503 until then.
+        // A bare key without the X-Instance-Service marker does NOT qualify (see
+        // IInstanceKeyValidator), so a key accidentally forwarded onto a browser
+        // request cannot slip past the gate.
+        if (instanceKeyValidator.Classify(context) == InstanceKeyRequestKind.Valid)
         {
             await _next(context);
             return;

--- a/src/API/Nocturne.API/Services/Auth/TotpHelper.cs
+++ b/src/API/Nocturne.API/Services/Auth/TotpHelper.cs
@@ -5,6 +5,10 @@ namespace Nocturne.API.Services.Auth;
 
 /// <summary>
 /// RFC 6238 TOTP computation helper. HMAC-SHA1, 6-digit codes, 30-second time step.
+/// HMAC-SHA1 is fixed by the ecosystem, not a choice: authenticator apps default to it
+/// (the provisioning URI omits the algorithm parameter, i.e. SHA-1), and many ignore a
+/// SHA-256 request outright. HMAC's security does not depend on SHA-1 collision
+/// resistance, so this is intentionally NOT migrated alongside the instance key.
 /// </summary>
 public static class TotpHelper
 {

--- a/src/API/Nocturne.API/Services/Connectors/ConnectorConfigurationService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/ConnectorConfigurationService.cs
@@ -264,6 +264,8 @@ public class ConnectorConfigurationService : IConnectorConfigurationService
             return;
         }
 
+        // SHA-1 is required here: the Nightscout `api-secret` protocol hashes the secret
+        // with SHA-1, so legacy clients (xDrip, etc.) send that hash and we must match it.
         var sha1Hash = HashUtils.Sha1Hex(apiSecret);
 
         var alreadyExists = await _context.OAuthGrants

--- a/src/Connectors/Nocturne.Connectors.Core/Utilities/HashUtils.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Utilities/HashUtils.cs
@@ -23,7 +23,9 @@ public static class HashUtils
 
     /// <summary>
     ///     Computes SHA1 hash and returns as lowercase hex string.
-    ///     Used for Nightscout API secret hashing and treatment ID generation.
+    ///     Used only for Nightscout API-secret hashing, which the Nightscout
+    ///     <c>api-secret</c> wire protocol mandates as SHA-1. Internal hashing we
+    ///     control uses SHA-256 (see <see cref="Sha256Hex"/>) — do not use SHA-1 for new code.
     /// </summary>
     /// <param name="input">The string to hash</param>
     /// <returns>Lowercase hex string of the SHA1 hash</returns>
@@ -32,21 +34,5 @@ public static class HashUtils
         using var sha1 = SHA1.Create();
         var hashBytes = sha1.ComputeHash(Encoding.UTF8.GetBytes(input));
         return Convert.ToHexString(hashBytes).ToLowerInvariant();
-    }
-
-    /// <summary>
-    ///     Generates a unique treatment/entry ID based on event type, timestamp, and additional data.
-    ///     Uses SHA1 to create a consistent, reproducible ID for deduplication.
-    /// </summary>
-    /// <param name="source">The connector source identifier (e.g., "glooko", "dexcom")</param>
-    /// <param name="eventType">The type of event (e.g., "Meal Bolus", "Correction Bolus")</param>
-    /// <param name="timestamp">The timestamp of the event</param>
-    /// <param name="additionalData">Optional additional data for uniqueness (e.g., "carbs:50_insulin:5")</param>
-    /// <returns>A unique hex ID for the treatment</returns>
-    public static string GenerateEventId(string source, string eventType, DateTime timestamp,
-        string? additionalData = null)
-    {
-        var dataToHash = $"{source}_{eventType}_{timestamp.Ticks}_{additionalData ?? ""}";
-        return Sha1Hex(dataToHash);
     }
 }

--- a/src/Services/Nocturne.Services.Demo/Program.cs
+++ b/src/Services/Nocturne.Services.Demo/Program.cs
@@ -37,7 +37,7 @@ public class Program
         var demoHost = builder.Configuration["DemoService:DemoHost"] ?? "demo.localhost";
         var instanceKey = builder.Configuration["DemoService:InstanceKey"] ?? "";
         var instanceKeyHash = !string.IsNullOrEmpty(instanceKey)
-            ? Nocturne.Connectors.Core.Utilities.HashUtils.Sha1Hex(instanceKey)
+            ? Nocturne.Connectors.Core.Utilities.HashUtils.Sha256Hex(instanceKey)
             : "";
 
         builder.Services.AddHttpClient("DemoAdmin", client =>

--- a/src/Web/packages/app/src/lib/server/api-client-factory.ts
+++ b/src/Web/packages/app/src/lib/server/api-client-factory.ts
@@ -21,7 +21,7 @@ export function getApiBaseUrl(): string | null {
 export function getHashedInstanceKey(): string | null {
   const instanceKey = env.INSTANCE_KEY;
   return instanceKey
-    ? createHash("sha1").update(instanceKey).digest("hex").toLowerCase()
+    ? createHash("sha256").update(instanceKey).digest("hex").toLowerCase()
     : null;
 }
 

--- a/src/Web/packages/bridge/src/lib/signalr-client.ts
+++ b/src/Web/packages/bridge/src/lib/signalr-client.ts
@@ -81,7 +81,7 @@ class SignalRClient {
       }
 
       if (this.configHubUrl) {
-        const keyHash = createHash("sha1")
+        const keyHash = createHash("sha256")
           .update(this.instanceKey)
           .digest("hex");
         this.configConnection = this.buildConnection(this.configHubUrl, {
@@ -290,7 +290,7 @@ class SignalRClient {
       );
     }
     try {
-      const secretHash = createHash("sha1")
+      const secretHash = createHash("sha256")
         .update(this.instanceKey)
         .digest("hex")
         .toLowerCase();
@@ -350,7 +350,7 @@ class SignalRClient {
     }
 
     try {
-      const secretHash = createHash("sha1")
+      const secretHash = createHash("sha256")
         .update(this.instanceKey)
         .digest("hex")
         .toLowerCase();

--- a/src/Web/packages/bridge/src/setup.ts
+++ b/src/Web/packages/bridge/src/setup.ts
@@ -126,7 +126,7 @@ export async function setupBridge(
   // from accepting browser connections.
   logger.info(`Bridge tenant discovery starting (baseDomain: ${baseDomain})`);
 
-  const instanceKeyHash = createHash('sha1')
+  const instanceKeyHash = createHash('sha256')
     .update(config.instanceKey)
     .digest('hex')
     .toLowerCase();

--- a/tests/Unit/Nocturne.API.Tests/Middleware/AuthHandlerPriorityTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/AuthHandlerPriorityTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
+using Nocturne.API.Authorization;
 using Nocturne.API.Middleware;
 using Nocturne.API.Middleware.Handlers;
 using Nocturne.API.Services.Auth;
@@ -35,7 +36,7 @@ public class AuthHandlerPriorityTests
     public void InstanceKeyHandler_ShouldRunAfter_SessionCookieHandler()
     {
         var instanceKeyHandler = new InstanceKeyHandler(
-            new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build(),
+            new InstanceKeyValidator(new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build()),
             NullLogger<InstanceKeyHandler>.Instance);
 
         var sessionCookieHandler = new SessionCookieHandler(
@@ -53,7 +54,7 @@ public class AuthHandlerPriorityTests
     public void InstanceKeyHandler_ShouldRunBefore_OidcTokenHandler()
     {
         var instanceKeyHandler = new InstanceKeyHandler(
-            new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build(),
+            new InstanceKeyValidator(new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build()),
             NullLogger<InstanceKeyHandler>.Instance);
 
         instanceKeyHandler.Priority.Should().BeLessThan(100,

--- a/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/InstanceKeyHandlerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/InstanceKeyHandlerTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.API.Authorization;
 using Nocturne.API.Middleware.Handlers;
 using Nocturne.Connectors.Core.Utilities;
 using Nocturne.Core.Constants;
@@ -33,10 +34,10 @@ public class InstanceKeyHandlerTests
                 [ServiceNames.ConfigKeys.InstanceKey] = PlainKey,
             })
             .Build();
-        return new InstanceKeyHandler(config, NullLogger<InstanceKeyHandler>.Instance);
+        return new InstanceKeyHandler(new InstanceKeyValidator(config), NullLogger<InstanceKeyHandler>.Instance);
     }
 
-    private static string ValidHash => HashUtils.Sha1Hex(PlainKey);
+    private static string ValidHash => HashUtils.Sha256Hex(PlainKey);
 
     [Fact]
     public async Task ValidInstanceKey_WithoutServiceMarker_Skips()

--- a/tests/Unit/Nocturne.API.Tests/Middleware/TenantSetupMiddlewareTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/TenantSetupMiddlewareTests.cs
@@ -5,10 +5,13 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.API.Authorization;
 using Nocturne.API.Middleware;
+using Nocturne.Connectors.Core.Utilities;
+using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
@@ -22,6 +25,11 @@ public class TenantSetupMiddlewareTests : IDisposable
     private readonly NocturneDbContext _dbContext;
     private readonly Mock<ITenantAccessor> _tenantAccessor;
     private readonly Guid _tenantId = Guid.CreateVersion7();
+
+    // Default validator with no instance key configured — Classify() always returns
+    // Absent, so it never bypasses. Used by every test that isn't exercising the bypass.
+    private readonly IInstanceKeyValidator _noInstanceKey =
+        new InstanceKeyValidator(new ConfigurationBuilder().Build());
 
     public TenantSetupMiddlewareTests()
     {
@@ -83,7 +91,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         ctx.Response.Body = new MemoryStream();
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
 
         // Assert
         ctx.Response.StatusCode.Should().Be(503);
@@ -125,7 +133,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         var (mw, ctx) = Build(onNext: () => nextCalled = true);
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
 
         // Assert
         nextCalled.Should().BeTrue();
@@ -141,7 +149,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         var (mw, ctx) = Build(onNext: () => nextCalled = true);
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
 
         // Assert
         nextCalled.Should().BeTrue();
@@ -197,7 +205,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         var (mw, ctx) = Build();
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
 
         // Assert
         ctx.Response.StatusCode.Should().Be(503);
@@ -267,7 +275,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         var (mw, ctx) = Build(onNext: () => nextCalled = true);
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
 
         // Assert
         nextCalled.Should().BeTrue();
@@ -308,7 +316,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         var (mw, ctx) = Build(onNext: () => nextCalled = true);
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
 
         // Assert
         nextCalled.Should().BeTrue();
@@ -329,7 +337,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         ctx.SetEndpoint(CreateEndpoint(new AllowDuringSetupAttribute()));
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
 
         // Assert
         nextCalled.Should().BeTrue();
@@ -344,7 +352,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         ctx.SetEndpoint(CreateEndpoint());
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
 
         // Assert
         ctx.Response.StatusCode.Should().Be(503);
@@ -359,7 +367,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         // (no SetEndpoint call)
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
 
         // Assert
         nextCalled.Should().BeTrue();
@@ -379,7 +387,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         ctx.Response.Body = new MemoryStream();
 
         // Act — tenant is resolved (simulating single-tenant auto-resolution)
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
 
         // Assert
         ctx.Response.StatusCode.Should().Be(503);
@@ -420,7 +428,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         var (mw, ctx) = Build(onNext: () => nextCalled = true);
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
 
         // Assert
         nextCalled.Should().BeTrue();
@@ -477,7 +485,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         var (mw, ctx) = Build(onNext: () => nextCalled = true);
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
 
         // Assert
         nextCalled.Should().BeTrue("OIDC identity alone should satisfy the setup check");
@@ -559,7 +567,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         var (mw, ctx) = Build(onNext: () => nextCalled = true);
 
         // Act — middleware checks tenant B
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
 
         // Assert
         nextCalled.Should().BeTrue(
@@ -625,7 +633,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         var (mw, ctx) = Build(onNext: () => nextCalled = true);
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
 
         // Assert — should pass through cleanly, no 503, no recovery mode
         nextCalled.Should().BeTrue();
@@ -658,12 +666,116 @@ public class TenantSetupMiddlewareTests : IDisposable
         var (mw, ctx) = Build();
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
 
         // Assert
         ctx.Response.StatusCode.Should().Be(503);
         ctx.Response.Body.Seek(0, SeekOrigin.Begin);
         var body = await new StreamReader(ctx.Response.Body).ReadToEndAsync();
         body.Should().Contain("setup_required");
+    }
+
+    private static IInstanceKeyValidator ValidatorFor(string instanceKey)
+        => new InstanceKeyValidator(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [ServiceNames.ConfigKeys.InstanceKey] = instanceKey,
+            })
+            .Build());
+
+    [Fact]
+    public async Task WhenValidInstanceKeyRequest_BypassesSetupGate_WithNoCredentials()
+    {
+        // Arrange — tenant has no owner credential (would normally 503), but the caller
+        // presents a valid instance-key service credential (header + service marker).
+        const string key = "bootstrap-key";
+        var nextCalled = false;
+        var (mw, ctx) = Build(onNext: () => nextCalled = true);
+        ctx.Request.Headers[ServiceNames.Headers.InstanceKey] = HashUtils.Sha256Hex(key);
+        ctx.Request.Headers[ServiceNames.Headers.InstanceService] = "nocturne-setup-agent";
+
+        // Act
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, ValidatorFor(key));
+
+        // Assert
+        nextCalled.Should().BeTrue("a trusted instance-key caller must reach config endpoints during setup");
+        ctx.Response.StatusCode.Should().NotBe(503);
+    }
+
+    [Fact]
+    public async Task WhenInstanceKeyRequest_DuringRecoveryMode_BypassesGate()
+    {
+        // Arrange — tenant is in recovery mode (a healthy member plus an orphaned subject),
+        // which normally 503s. A valid instance-key caller must still get through.
+        var healthySubjectId = Guid.CreateVersion7();
+        var orphanedSubjectId = Guid.CreateVersion7();
+        _dbContext.Subjects.Add(new SubjectEntity
+        {
+            Id = healthySubjectId, Name = "Healthy", IsActive = true, IsSystemSubject = false,
+        });
+        _dbContext.PasskeyCredentials.Add(new PasskeyCredentialEntity
+        {
+            Id = Guid.CreateVersion7(), SubjectId = healthySubjectId,
+            CredentialId = System.Text.Encoding.UTF8.GetBytes("cred-1"), PublicKey = [], SignCount = 0,
+        });
+        _dbContext.TenantMembers.Add(new TenantMemberEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = _tenantId, SubjectId = healthySubjectId,
+        });
+        _dbContext.Subjects.Add(new SubjectEntity
+        {
+            Id = orphanedSubjectId, Name = "Orphaned", IsActive = true, IsSystemSubject = false,
+        });
+        _dbContext.TenantMembers.Add(new TenantMemberEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = _tenantId, SubjectId = orphanedSubjectId,
+        });
+        await _dbContext.SaveChangesAsync();
+
+        const string key = "bootstrap-key";
+        var nextCalled = false;
+        var (mw, ctx) = Build(onNext: () => nextCalled = true);
+        ctx.Request.Headers[ServiceNames.Headers.InstanceKey] = HashUtils.Sha256Hex(key);
+        ctx.Request.Headers[ServiceNames.Headers.InstanceService] = "nocturne-setup-agent";
+
+        // Act
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, ValidatorFor(key));
+
+        // Assert
+        nextCalled.Should().BeTrue();
+        ctx.Response.StatusCode.Should().NotBe(503);
+    }
+
+    [Fact]
+    public async Task WhenInstanceKeyHeaderHasNoServiceMarker_StillBlocks()
+    {
+        // Arrange — a bare instance key without the X-Instance-Service marker must NOT
+        // bypass, mirroring InstanceKeyHandler: a key accidentally forwarded onto a
+        // browser request should not slip past the setup gate.
+        const string key = "bootstrap-key";
+        var (mw, ctx) = Build();
+        ctx.Request.Headers[ServiceNames.Headers.InstanceKey] = HashUtils.Sha256Hex(key);
+        // no X-Instance-Service marker
+
+        // Act
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, ValidatorFor(key));
+
+        // Assert
+        ctx.Response.StatusCode.Should().Be(503);
+    }
+
+    [Fact]
+    public async Task WhenInstanceKeyHashIsWrong_StillBlocks()
+    {
+        // Arrange — a service marker plus a non-matching key hash must not bypass.
+        var (mw, ctx) = Build();
+        ctx.Request.Headers[ServiceNames.Headers.InstanceKey] = HashUtils.Sha256Hex("not-the-key");
+        ctx.Request.Headers[ServiceNames.Headers.InstanceService] = "nocturne-setup-agent";
+
+        // Act
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, ValidatorFor("bootstrap-key"));
+
+        // Assert
+        ctx.Response.StatusCode.Should().Be(503);
     }
 }


### PR DESCRIPTION
## Summary

Two related changes to the instance-key path:

1. **Headless first-tenant setup.** Trusted instance-key requests (`X-Instance-Key` + `X-Instance-Service`) now bypass the `TenantSetupMiddleware` 503 (`setup_required`/`recovery_mode`) gate. This lets automation stand up a tenant end-to-end — create it, configure connectors, change settings, push data — **before** any human registers a passkey. The human then completes the normal setup wizard exactly as on a fresh instance (the bypass never creates an owner subject, so the wizard's `owner_already_exists` guard still passes). A bare key without the `X-Instance-Service` marker does **not** bypass, mirroring `InstanceKeyHandler`.

2. **Instance-key wire hash SHA-1 → SHA-256.** Hygiene: removes SHA-1 from the one place we control where it isn't externally forced.

## Implementation

- New shared `InstanceKeyValidator` (classifies a request's instance-key credential), used by **both** `InstanceKeyHandler` (auth) and `TenantSetupMiddleware` (gate bypass), so the validation rules — including the service-marker requirement — live in one place.
- SHA-256 applied to every receiver (`InstanceKeyValidator`, `DataHub`) and every sender (web SSR, bridge ×4, demo service). The nocturne-cloud **billing** sender flips in a paired PR on that repo.
- SHA-1 **kept** where an external protocol mandates it — the Nightscout `api-secret` hash and TOTP (`HMAC-SHA1`) — both now annotated as such. Removed the unused `GenerateEventId`.
- README documents the browser and headless setup flows.

## Deploy / coordination

**Hard cutover** — receivers and senders must flip together. The nocturne-cloud billing sender is a separate, coupled PR; deploy both together. For nocturne-cloud, pin `nocturne-api` until the billing image is built, then a single redeploy flips both within the restart window (only billing→api provisioning is exposed, and it's retryable). Self-hosters on the compose bundle get all instance-key images from the same `:latest`, so Watchtower pulls them as one set. No persisted state is keyed on the hash and `INSTANCE_KEY` itself is unchanged, so there is no permanent break and no secret rotation.

## Testing

`dotnet test` (unit): instance-key, setup-middleware (incl. new bypass tests), auth-handler-priority, legacy-grant, api-key suites — all green. Builds clean.