### PR TITLE
fix(api): resolve sole tenant for /api/v4/status on the apex (single-tenant mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,13 @@ curl -fsS -X PUT "https://alice.$BASE_DOMAIN/api/v4/connectors/config/Dexcom/sec
 
 When the human is ready, they open the site and register the first passkey through the normal wizard — recovery codes and all — exactly as on a brand-new instance. Their pre-configured connectors and data are already there. (A bare `X-Instance-Key` without the `X-Instance-Service` marker is ignored, so an instance key accidentally forwarded onto a browser request can't bypass setup.)
 
+### Troubleshooting
+
+**Redirected to `/setup` even though a tenant is already configured.** Two usual causes:
+
+- **`BASE_DOMAIN` is unset.** The API resolves tenants as `{slug}.{BASE_DOMAIN}`, and the WebSocket bridge requires it. If it's empty, host→tenant resolution fails and the dashboard bounces to `/setup` (and the bridge logs `BASE_DOMAIN is required`). Set it in `.env` to the domain you serve Nocturne on, for **both** the API and web containers, then recreate them.
+- **Single-tenant install served at the base domain.** If your one tenant lives at the apex (`https://<BASE_DOMAIN>/`, no subdomain), update to the latest image — older builds reported `setup_required` for `/api/v4/status` on the apex and bounced configured single-tenant installs to `/setup`.
+
 ### Generating locally
 
 If you have the .NET 10 SDK and Aspire CLI installed, you can generate the production bundle from source:

--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -98,6 +98,25 @@ public class TenantResolutionMiddleware
             TenantlessAllowedPaths.Any(p => path.Equals(p, StringComparison.OrdinalIgnoreCase)) ||
             TenantlessAllowedPrefixes.Any(p => path.StartsWith(p, StringComparison.OrdinalIgnoreCase));
 
+        // On the apex (no subdomain), GET /api/v4/status is tenant-scoped yet listed as
+        // tenantless-allowed (so a fresh apex doesn't 404). On a single-tenant install,
+        // resolve the sole tenant so status reflects it instead of reporting
+        // "setup_required" — which would bounce a fully configured single-tenant install
+        // to /setup. Falls through to the normal tenantless passthrough when zero or
+        // multiple tenants exist, so multi-tenant apex behavior is unchanged.
+        if (slug == null && path.Equals("/api/v4/status", StringComparison.OrdinalIgnoreCase))
+        {
+            var soleStatusTenant = await GetSoleTenantAsync(context.RequestServices);
+            if (soleStatusTenant != null)
+            {
+                tenantAccessor.SetTenant(soleStatusTenant);
+                context.Items["TenantContext"] = soleStatusTenant;
+                PinTenantOnScopedDbContext(context, soleStatusTenant.TenantId);
+                await _next(context);
+                return;
+            }
+        }
+
         // Tenantless-allowed paths on the apex (no slug) operate across tenants.
         if (slug == null && isTenantlessAllowedPath)
         {

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantResolutionMiddlewareApexTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantResolutionMiddlewareApexTests.cs
@@ -1,0 +1,153 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Nocturne.API.Multitenancy;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Xunit;
+
+namespace Nocturne.API.Tests.Multitenancy;
+
+/// <summary>
+/// Apex (no-subdomain) resolution in <see cref="TenantResolutionMiddleware"/>. Single-tenant
+/// installs are served at the base domain itself, so the apex must resolve the sole tenant for
+/// tenant-scoped paths — including otherwise-tenantless ones like <c>GET /api/v4/status</c>.
+/// Leaving status tenantless on the apex made it report "setup_required", which bounced a fully
+/// configured single-tenant install to /setup. Multi-tenant and zero-tenant behaviour is
+/// unchanged, and infrastructure/liveness paths stay tenant-agnostic.
+/// </summary>
+public sealed class TenantResolutionMiddlewareApexTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly ServiceProvider _root;
+    private const string BaseDomain = "nocturne.theconen.de";
+
+    public TenantResolutionMiddlewareApexTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var services = new ServiceCollection();
+        services.AddDbContextFactory<NocturneDbContext>(o => o
+            .UseSqlite(_connection)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning)));
+        services.AddScoped(sp => sp.GetRequiredService<IDbContextFactory<NocturneDbContext>>().CreateDbContext());
+        services.AddScoped<ITenantAccessor, HttpContextTenantAccessor>();
+        services.AddMemoryCache();
+        _root = services.BuildServiceProvider();
+
+        using var seed = _root.GetRequiredService<IDbContextFactory<NocturneDbContext>>().CreateDbContext();
+        seed.Database.EnsureCreated();
+        seed.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        _root.Dispose();
+        _connection.Dispose();
+    }
+
+    private TenantResolutionMiddleware Build(RequestDelegate next) => new(
+        next,
+        NullLogger<TenantResolutionMiddleware>.Instance,
+        Options.Create(new BaseDomainOptions { BaseDomain = BaseDomain }),
+        _root.GetRequiredService<IMemoryCache>());
+
+    private Guid SeedTenant(string slug)
+    {
+        var id = Guid.CreateVersion7();
+        using var seed = _root.GetRequiredService<IDbContextFactory<NocturneDbContext>>().CreateDbContext();
+        seed.Tenants.Add(new TenantEntity { Id = id, Slug = slug, DisplayName = slug, IsActive = true });
+        seed.SaveChanges();
+        return id;
+    }
+
+    // Host == BaseDomain → apex, no subdomain.
+    private DefaultHttpContext ApexRequest(IServiceScope scope, string path)
+    {
+        var ctx = new DefaultHttpContext { RequestServices = scope.ServiceProvider };
+        ctx.Request.Headers["X-Forwarded-Host"] = BaseDomain;
+        ctx.Request.Path = path;
+        ctx.Response.Body = new MemoryStream();
+        return ctx;
+    }
+
+    [Fact]
+    public async Task Apex_status_resolves_the_sole_tenant_in_single_tenant_mode()
+    {
+        var tenantId = SeedTenant("theconen");
+        using var scope = _root.CreateScope();
+
+        var nextCalled = false;
+        var mw = Build(_ => { nextCalled = true; return Task.CompletedTask; });
+        var ctx = ApexRequest(scope, "/api/v4/status");
+
+        await mw.InvokeAsync(ctx);
+
+        // /api/v4/status is tenantless-allowed, but on the apex the sole tenant is resolved
+        // so StatusService reports that tenant instead of "setup_required".
+        nextCalled.Should().BeTrue();
+        var accessor = scope.ServiceProvider.GetRequiredService<ITenantAccessor>();
+        accessor.IsResolved.Should().BeTrue();
+        accessor.TenantId.Should().Be(tenantId);
+    }
+
+    [Fact]
+    public async Task Apex_health_probe_passes_through_without_resolving_a_tenant()
+    {
+        SeedTenant("theconen");
+        using var scope = _root.CreateScope();
+
+        var nextCalled = false;
+        var mw = Build(_ => { nextCalled = true; return Task.CompletedTask; });
+        var ctx = ApexRequest(scope, "/health");
+
+        await mw.InvokeAsync(ctx);
+
+        // Liveness/readiness probes must never depend on tenant state — no resolution, no DB touch.
+        nextCalled.Should().BeTrue();
+        scope.ServiceProvider.GetRequiredService<ITenantAccessor>().IsResolved.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Apex_status_with_multiple_tenants_stays_tenantless()
+    {
+        SeedTenant("alpha");
+        SeedTenant("beta");
+        using var scope = _root.CreateScope();
+
+        var nextCalled = false;
+        var mw = Build(_ => { nextCalled = true; return Task.CompletedTask; });
+        var ctx = ApexRequest(scope, "/api/v4/status");
+
+        await mw.InvokeAsync(ctx);
+
+        // With more than one tenant there is no sole tenant; status stays tenantless and passes
+        // through, so the apex status response is unchanged for multi-tenant deployments.
+        nextCalled.Should().BeTrue();
+        scope.ServiceProvider.GetRequiredService<ITenantAccessor>().IsResolved.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Apex_non_tenantless_path_with_no_tenants_returns_503_setup_required()
+    {
+        using var scope = _root.CreateScope();
+
+        var nextCalled = false;
+        var mw = Build(_ => { nextCalled = true; return Task.CompletedTask; });
+        var ctx = ApexRequest(scope, "/api/v4/entries");
+
+        await mw.InvokeAsync(ctx);
+
+        // Fresh install (zero tenants), non-tenantless path: 503 so the frontend goes to /setup.
+        nextCalled.Should().BeFalse();
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+    }
+}


### PR DESCRIPTION
## Summary

A single-tenant install served at its **base domain** (the apex, no subdomain) was redirected to `/setup` and couldn't reach the dashboard — even when fully configured with an owner and connectors.

## Root cause

On the apex, `GET /api/v4/status` is in `TenantlessAllowedPaths`, so it takes the tenantless early-return **before** the single-tenant auto-resolve and `StatusService` reports `status: "setup_required"` (no tenant resolved). The dashboard layout treats that as authoritative:

```ts
// (authenticated)/+layout.server.ts
if (status?.status === "setup_required") throw redirect(303, "/setup");
```

Every *other* endpoint auto-resolves the sole tenant on the apex (single-tenant mode); `/api/v4/status` was the one that didn't, so it looped configured single-tenant installs back to setup.

## Fix

Resolve the sole tenant for `/api/v4/status` on the apex so it reflects that tenant instead of `setup_required`. Scoped deliberately to `/api/v4/status` only — other tenantless paths (platform/admin/oidc/setup/health) still pass through untouched. **Multi-tenant and zero-tenant apex behavior is unchanged**: with no sole tenant, status stays tenantless and passes through exactly as before.

## Tests

Adds `TenantResolutionMiddlewareApexTests` (single-tenant resolves; multi-tenant stays tenantless; health stays tenant-agnostic; zero-tenant non-tenantless still 503s). Full multitenancy suite green (60 passed), including the existing apex-passthrough isolation tests.

## Notes

Reported by a self-hoster running single-tenant at their base domain. Also adds a short README troubleshooting note covering this and the related "`BASE_DOMAIN` unset" failure (which produces the same `/setup` symptom).