### PR TITLE
fix(connectors): honor configured MaxRetryAttempts in data-fetch retries

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -1181,7 +1181,11 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     /// <param name="operation">The async operation to execute</param>
     /// <param name="retryStrategy">Strategy for calculating retry delays</param>
     /// <param name="reAuthenticateOnUnauthorized">Optional callback to re-authenticate on 401 responses</param>
-    /// <param name="maxRetries">Maximum number of retry attempts (default: 3)</param>
+    /// <param name="maxRetries">
+    ///     Maximum number of attempts (default: 3). Clamped to a floor of 1 so a connector's
+    ///     configured MaxRetryAttempts of 0 still makes a single attempt instead of skipping
+    ///     the operation entirely.
+    /// </param>
     /// <param name="operationName">Name of the operation for logging</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The result of the operation, or default(T) on failure</returns>
@@ -1194,6 +1198,10 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
         CancellationToken cancellationToken = default
     )
     {
+        // Connectors pass their configured MaxRetryAttempts, which allows 0; the loop needs at
+        // least one attempt for the operation to run.
+        maxRetries = Math.Max(1, maxRetries);
+
         var opName = operationName ?? "operation";
         HttpRequestException? lastException = null;
 

--- a/src/Connectors/Nocturne.Connectors.Dexcom/Services/DexcomConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Dexcom/Services/DexcomConnectorService.cs
@@ -154,6 +154,7 @@ public class DexcomConnectorService : BaseConnectorService<DexcomConnectorConfig
                 sessionId = newToken;
                 return true;
             },
+            maxRetries: config.MaxRetryAttempts,
             operationName: "FetchDexcomData"
         );
 

--- a/src/Connectors/Nocturne.Connectors.Eversense/Services/EversenseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Eversense/Services/EversenseConnectorService.cs
@@ -229,6 +229,7 @@ public class EversenseConnectorService : BaseConnectorService<EversenseConnector
                 token = newToken;
                 return true;
             },
+            maxRetries: config.MaxRetryAttempts,
             operationName: "FetchEversensePatientList"
         );
 

--- a/src/Connectors/Nocturne.Connectors.FreeStyle/Services/LibreLinkUpConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.FreeStyle/Services/LibreLinkUpConnectorService.cs
@@ -156,6 +156,7 @@ public class LibreConnectorService(
                 _selectedConnection = null;
                 return await AuthenticateWithConfigAsync(config);
             },
+            maxRetries: config.MaxRetryAttempts,
             operationName: "FetchSensorGlucoseData"
         );
 

--- a/src/Connectors/Nocturne.Connectors.MyFitnessPal/Services/MyFitnessPalConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyFitnessPal/Services/MyFitnessPalConnectorService.cs
@@ -234,6 +234,7 @@ public class MyFitnessPalConnectorService : BaseConnectorService<MyFitnessPalCon
         return await ExecuteWithRetryAsync(
             async () => await FetchDiaryCoreAsync(from, to, cancellationToken),
             _retryDelayStrategy,
+            maxRetries: _config.MaxRetryAttempts,
             operationName: "FetchMyFitnessPalDiary",
             cancellationToken: cancellationToken
         );

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
@@ -680,6 +680,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         return await ExecuteWithRetryAsync(
             async () => await FetchDataCoreAsync<T>(url),
             _retryDelayStrategy,
+            maxRetries: _currentConfig.MaxRetryAttempts,
             operationName: operationName);
     }
 

--- a/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolConnectorService.cs
@@ -229,6 +229,7 @@ public class TidepoolConnectorService : BaseConnectorService<TidepoolConnectorCo
                 userId = refreshedSession?.Metadata?.GetValueOrDefault("UserId");
                 return !string.IsNullOrEmpty(userId);
             },
+            maxRetries: config.MaxRetryAttempts,
             operationName: $"FetchTidepoolData({dataType})"
         );
     }

--- a/src/Connectors/Nocturne.Connectors.Twiist/Services/TwiistConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Twiist/Services/TwiistConnectorService.cs
@@ -226,6 +226,7 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
                 accessToken = newToken;
                 return true;
             },
+            maxRetries: config.MaxRetryAttempts,
             operationName: "FetchTwiistPackage");
 
         return result;

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutConnectorRetryTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutConnectorRetryTests.cs
@@ -1,0 +1,113 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.Nightscout.Configurations;
+using Nocturne.Connectors.Nightscout.Services;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Connectors;
+
+/// <summary>
+/// Verifies the connector honours the configured MaxRetryAttempts when a fetch hits a
+/// retryable error, rather than always using the framework default.
+/// </summary>
+public class NightscoutConnectorRetryTests
+{
+    private static NightscoutConnectorService CreateService(
+        HttpMessageHandler handler,
+        int? maxRetryAttempts = null)
+    {
+        var config = new NightscoutConnectorConfiguration
+        {
+            Url = "https://nightscout.example.com",
+            ApiSecret = "test-secret",
+        };
+        if (maxRetryAttempts.HasValue)
+            config.MaxRetryAttempts = maxRetryAttempts.Value;
+
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri(config.Url),
+        };
+
+        return new NightscoutConnectorService(
+            httpClient,
+            new ConnectorServerResolver<NightscoutConnectorConfiguration>(null, null, null),
+            Mock.Of<ILogger<NightscoutConnectorService>>(),
+            Mock.Of<IRetryDelayStrategy>(),
+            Mock.Of<IRateLimitingStrategy>(),
+            new ConnectorRegistration<NightscoutConnectorConfiguration>(config, "Nightscout"));
+    }
+
+    [Fact]
+    public async Task FetchGlucoseData_RetryableError_RetriesUpToConfiguredMaxRetryAttempts()
+    {
+        // Arrange: a connector configured to attempt 5 times, hitting a retryable 503 every time
+        var handler = new CountingStatusHandler(HttpStatusCode.ServiceUnavailable);
+        var service = CreateService(handler, maxRetryAttempts: 5);
+
+        // Act: the fetch exhausts every attempt then surfaces the last error
+        var act = async () => await service.FetchGlucoseDataAsync();
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>();
+        handler.CallCount.Should().Be(5, "MaxRetryAttempts should drive the number of attempts");
+    }
+
+    [Fact]
+    public async Task FetchGlucoseData_DefaultConfig_AttemptsThreeTimes()
+    {
+        // Arrange: default config (MaxRetryAttempts defaults to 3) — locks in prior behaviour
+        var handler = new CountingStatusHandler(HttpStatusCode.ServiceUnavailable);
+        var service = CreateService(handler);
+
+        // Act
+        var act = async () => await service.FetchGlucoseDataAsync();
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>();
+        handler.CallCount.Should().Be(3, "the default of 3 attempts must be unchanged");
+    }
+
+    [Fact]
+    public async Task FetchGlucoseData_ZeroMaxRetryAttempts_AttemptsExactlyOnce()
+    {
+        // Arrange: MaxRetryAttempts = 0 must still try once (clamped to a floor of 1),
+        // not skip the fetch entirely
+        var handler = new CountingStatusHandler(HttpStatusCode.ServiceUnavailable);
+        var service = CreateService(handler, maxRetryAttempts: 0);
+
+        // Act
+        var act = async () => await service.FetchGlucoseDataAsync();
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>();
+        handler.CallCount.Should().Be(1, "0 retries means a single attempt, not zero");
+    }
+
+    /// <summary>
+    /// Handler that returns a fixed status code for every request and counts the calls.
+    /// </summary>
+    private sealed class CountingStatusHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+
+        public CountingStatusHandler(HttpStatusCode status) => _status = status;
+
+        public int CallCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            CallCount++;
+            return Task.FromResult(new HttpResponseMessage(_status)
+            {
+                Content = new StringContent("service unavailable"),
+            });
+        }
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/BaseConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/BaseConnectorServiceTests.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Nocturne.Connectors.Core.Interfaces;
@@ -27,6 +29,13 @@ public class BaseConnectorServiceTests
         public override Task<bool> AuthenticateAsync() => Task.FromResult(true);
         public override Task<IEnumerable<Nocturne.Core.Models.Entry>> FetchGlucoseDataAsync(DateTime? since = null)
             => Task.FromResult(Enumerable.Empty<Nocturne.Core.Models.Entry>());
+
+        // Exposes the protected retry helper so its attempt-count behaviour can be tested directly.
+        public Task<string?> InvokeExecuteWithRetryAsync(
+            Func<Task<string?>> operation,
+            IRetryDelayStrategy retryDelayStrategy,
+            int maxRetries)
+            => ExecuteWithRetryAsync(operation, retryDelayStrategy, maxRetries: maxRetries);
     }
 
     public class TestConfig : BaseConnectorConfiguration
@@ -71,5 +80,48 @@ public class BaseConnectorServiceTests
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() =>
             new TestConnectorService(httpClient, null!));
+    }
+
+    [Fact]
+    public async Task ExecuteWithRetryAsync_RetryableError_AttemptsUpToMaxRetries()
+    {
+        // Arrange: a connector configured to attempt 5 times, hitting a retryable 503 every time
+        var service = new TestConnectorService(new HttpClient(), Mock.Of<ILogger<TestConnectorService>>());
+        var attempts = 0;
+        Func<Task<string?>> alwaysFails = () =>
+        {
+            attempts++;
+            throw new HttpRequestException("unavailable", null, HttpStatusCode.ServiceUnavailable);
+        };
+
+        // Act: the helper exhausts every attempt then surfaces the last error
+        var act = async () =>
+            await service.InvokeExecuteWithRetryAsync(alwaysFails, Mock.Of<IRetryDelayStrategy>(), maxRetries: 5);
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>();
+        attempts.Should().Be(5, "maxRetries should drive the number of attempts");
+    }
+
+    [Fact]
+    public async Task ExecuteWithRetryAsync_ZeroMaxRetries_AttemptsExactlyOnce()
+    {
+        // Arrange: MaxRetryAttempts of 0 must still try once (clamped to a floor of 1),
+        // not skip the operation entirely
+        var service = new TestConnectorService(new HttpClient(), Mock.Of<ILogger<TestConnectorService>>());
+        var attempts = 0;
+        Func<Task<string?>> alwaysFails = () =>
+        {
+            attempts++;
+            throw new HttpRequestException("unavailable", null, HttpStatusCode.ServiceUnavailable);
+        };
+
+        // Act
+        var act = async () =>
+            await service.InvokeExecuteWithRetryAsync(alwaysFails, Mock.Of<IRetryDelayStrategy>(), maxRetries: 0);
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>();
+        attempts.Should().Be(1, "0 is clamped to a single attempt");
     }
 }


### PR DESCRIPTION
## Problem

The **Max Retry Attempts** connector setting (`MaxRetryAttempts` on `BaseConnectorConfiguration`, surfaced in the UI for every connector) was never read at runtime. Each connector's data-fetch retry loop went through `BaseConnectorService.ExecuteWithRetryAsync`, whose `maxRetries` parameter defaulted to `3` and was never overridden — so the field did nothing.

## Change

- Centralize the floor-of-1 clamp inside `ExecuteWithRetryAsync` (`maxRetries = Math.Max(1, maxRetries)`), so callers pass the raw config value and a configured `0` still makes a single attempt rather than skipping the fetch entirely. The default of `3` is unchanged.
- Pass `config.MaxRetryAttempts` from every connector that has a data-fetch retry loop:
  - Nightscout, Dexcom, Eversense, LibreLinkUp, Twiist, Tidepool, MyFitnessPal.

## Deliberately out of scope

- **Auth-token providers** keep their existing per-connector counts (e.g. CareLink uses `2`, intentionally fewer because its credential login is heavy). This PR only touches the data-fetch path.
- **Gluroo, Glooko, MyLife** have no connector-level retry loop at all (they rely on the Polly HTTP resilience handler), so `MaxRetryAttempts` remains inert for them. Wiring them would mean adding a retry loop they don't currently have — a separate change.
- The startup-time Polly resilience handler (`HttpClientExtensions`) keeps its fixed retry count; it's configured once at DI registration and can't see per-tenant config.

## Tests

- `BaseConnectorServiceTests`: `ExecuteWithRetryAsync` honors the configured attempt count, and clamps `0` to a single attempt.
- `NightscoutConnectorRetryTests`: end-to-end — a retryable `503` is attempted exactly `MaxRetryAttempts` times (5), the default config still attempts 3, and `0` attempts once.

Core.Tests: 39 passed · Nightscout (API.Tests): 51 passed.
