### PR TITLE
fix(web): don't bounce public share-host viewers to login on 401

### DIFF
--- a/src/Web/packages/app/src/lib/api/auth-interceptor.test.ts
+++ b/src/Web/packages/app/src/lib/api/auth-interceptor.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Force browser mode so redirectToLogin runs its real logic — the node stub
+// sets browser=false to skip DOM side-effects, which would short-circuit it.
+vi.mock("$app/environment", () => ({
+  browser: true,
+  building: false,
+  dev: false,
+  version: "test",
+}));
+
+import { authInterceptorState } from "./auth-interceptor";
+
+function stubLocation(hostname: string) {
+  const location = { hostname, pathname: "/", search: "", href: "" };
+  vi.stubGlobal("window", { location });
+  return location;
+}
+
+describe("authInterceptorState.redirectToLogin", () => {
+  beforeEach(() => {
+    authInterceptorState.reset();
+    vi.unstubAllGlobals();
+  });
+
+  it("does NOT redirect public share-host viewers to login on 401", () => {
+    // A share-link visitor is anonymous by design; a 401 on a category the tenant
+    // didn't share must not bounce them to a login they can't complete.
+    const location = stubLocation("k7m2q9x4r3wt.share.nocturne.run");
+    authInterceptorState.redirectToLogin();
+    expect(location.href).toBe("");
+  });
+
+  it("still redirects normal tenant-host visitors to login on 401", () => {
+    const location = stubLocation("rhys.nocturne.run");
+    authInterceptorState.redirectToLogin();
+    expect(location.href).toContain("/auth/login?returnUrl=");
+  });
+
+  it("does NOT redirect guest sessions (existing exemption preserved)", () => {
+    const location = stubLocation("rhys.nocturne.run");
+    authInterceptorState.setGuestSession(true);
+    authInterceptorState.redirectToLogin();
+    expect(location.href).toBe("");
+  });
+});

--- a/src/Web/packages/app/src/lib/api/auth-interceptor.ts
+++ b/src/Web/packages/app/src/lib/api/auth-interceptor.ts
@@ -5,6 +5,7 @@
  */
 
 import { browser } from "$app/environment";
+import { isShareHost } from "$lib/share-host";
 
 /**
  * Auth interceptor state
@@ -35,6 +36,13 @@ class AuthInterceptorState {
     }
 
     if (!browser) {
+      return;
+    }
+
+    // Public share-host viewers are anonymous by design: the tenant shares only some data
+    // categories, so a 401 on an unshared one is expected and must not bounce the viewer to
+    // login — they have no account to sign into. Mirrors the guest-session exemption above.
+    if (isShareHost(window.location.hostname)) {
       return;
     }
 

--- a/src/Web/packages/app/src/lib/server/request-host.ts
+++ b/src/Web/packages/app/src/lib/server/request-host.ts
@@ -50,11 +50,6 @@ export function getEffectiveHost(
   return host;
 }
 
-/**
- * True when the host is a public share link of the form {token}.share.{baseDomain}.
- * The bare {slug}.{baseDomain} host and the literal share.{baseDomain} label are not share hosts.
- * Mirrors the API's TenantResolutionMiddleware, which gates anonymous read on this host shape.
- */
-export function isShareHost(host: string | null | undefined): boolean {
-  return host != null && /^[^.]+\.share\./i.test(host);
-}
+// Re-exported from the shared (non-server) module so the client 401 interceptor and these server
+// hooks share one definition of the share-host shape. See $lib/share-host.
+export { isShareHost } from "$lib/share-host";

--- a/src/Web/packages/app/src/lib/share-host.ts
+++ b/src/Web/packages/app/src/lib/share-host.ts
@@ -1,0 +1,11 @@
+/**
+ * True when the host is a public share link of the form {token}.share.{baseDomain}.
+ * The bare {slug}.{baseDomain} host and the literal share.{baseDomain} label are not share hosts.
+ * Mirrors the API's TenantResolutionMiddleware, which gates anonymous read on this host shape.
+ *
+ * Pure host-string predicate with no server-only dependencies, so it is safe to import on the
+ * client (e.g. the 401 auth-interceptor) as well as in server hooks.
+ */
+export function isShareHost(host: string | null | undefined): boolean {
+  return host != null && /^[^.]+\.share\./i.test(host);
+}

--- a/src/Web/remote-codegen.config.ts
+++ b/src/Web/remote-codegen.config.ts
@@ -9,6 +9,23 @@ export default {
   },
   nswagClientPath: './generated/nocturne-api-client',
   errorHandling: {
+    // The default redirects queries to /auth/login on 401. For a public share
+    // host ({token}.share.{baseDomain}) the viewer is anonymous by design and has
+    // no account to sign into — and the dashboard fetches categories the tenant
+    // may not have shared, each 401ing — so the default bounces them to login
+    // ("flash of dashboard, then redirect"). On a share host, surface 401 as a
+    // normal error instead so unshared categories just fail their widget rather
+    // than navigating away. Host detection mirrors $lib/share-host's isShareHost
+    // (inlined — generated code can't import it). Commands/forms already throw
+    // error(401) and never redirected.
+    on401: (kind: string) =>
+      kind === 'query'
+        ? `const { request, url } = getRequestEvent();\n` +
+          `    const shareHost = request.headers.get('x-forwarded-host') ?? request.headers.get('host') ?? '';\n` +
+          `    if (/^[^.]+\\.share\\./i.test(shareHost)) throw error(401, 'Unauthorized');\n` +
+          '    throw redirect(302, `/auth/login?returnUrl=${encodeURIComponent(url.pathname + url.search)}`)'
+        : `throw error(401, 'Unauthorized')`,
+
     // Forward the server's actual error message for 403 so the FE can show
     // a meaningful reason (e.g. "Insufficient permissions for …") instead of
     // a bare "Forbidden".


### PR DESCRIPTION
The public share link ({token}.share.{domain}) loads its read-only dashboard fine (SSR 200, assets, socket.io, glucose + shared categories), but then the **client 401 auth-interceptor** redirects anonymous viewers to `/auth/login` the moment the dashboard fetches a category the tenant did **not** share publicly.

### Evidence (prod gateway logs)
On a share host, with the dashboard shell already loaded:
```
GET /api/v4/current-therapy-state      -> 401
GET /api/v4/nutrition/carbs?...        -> 401
GET /api/v4/insulin/boluses?...        -> 401
GET /api/v4/notifications              -> 401
GET /api/v4/profile/summary            -> 401
GET /api/v4/observations/{notes,bg-checks,device-events} -> 401
GET /api/v4/device-status/aps?...      -> 401
... then ...
GET /auth/login?returnUrl=%2F          -> 200
```
`anonymousReadAccess` is true and glucose/trackers return 200 — only the non-shared categories 401, and `auth-interceptor.ts` turns the first 401 into `window.location.href = /auth/login?...`.

### Fix
Exempt public share hosts from the 401->login redirect, mirroring the existing guest-session exemption. A share-link viewer is anonymous by design and has no account to sign into; categories the tenant did not share simply render empty. `isShareHost` is extracted into a shared (non-server) module so the client interceptor and the server hooks use one definition. Adds interceptor tests (share host: no redirect; normal tenant: redirects; guest: still exempt).