### PR TITLE
fix(share): reset pooled DbContext carriers at a single factory chokepoint

### DIFF
--- a/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
@@ -292,21 +292,14 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
         var dbContext = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
         dbContext.AuditContext = SystemAuditContext.ForService($"connector:{ConnectorName}");
 
-        // Pin the RLS tenant on the scoped DbContext. NocturneDbContext is leased from a pool
-        // (AddPooledDbContextFactory) and its TenantId is NOT reset between leases, so a context
-        // can arrive carrying a previous lessee's tenant. On HTTP requests the auth handlers set
-        // dbContext.TenantId explicitly; background syncs have no such handler, so we must set it
-        // here. Setting ITenantAccessor alone does not retro-fit the already-leased context — the
-        // TenantConnectionInterceptor reads NocturneDbContext.TenantId to configure RLS on connection
-        // open. Without this, tenant-scoped reads (connector config + secrets) run under a stale or
-        // empty tenant and silently return nothing, so every connector authenticates with empty
-        // credentials and no data syncs.
+        // Pin the RLS tenant on the scoped DbContext. NocturneDbContext is pooled and the
+        // CarrierResettingDbContextFactory leases it with TenantId reset to Guid.Empty; the scoped
+        // registration re-pins from ITenantAccessor, and background syncs set it explicitly here
+        // because the flow depends on it — the TenantConnectionInterceptor reads
+        // NocturneDbContext.TenantId to configure RLS on connection open, and without a real tenant
+        // the tenant-scoped reads (connector config + secrets) silently return nothing, so every
+        // connector authenticates with empty credentials and no data syncs.
         dbContext.TenantId = tenantId;
-        // A pooled context that last served a public share keeps IsShareContext=true (pooling
-        // does not reset custom properties); clear the share carrier so the connector's reads
-        // are not denied by the per-category share RLS policy.
-        dbContext.IsShareContext = false;
-        dbContext.VisibleCategories = null;
 
         // Load per-tenant config via the loader
         var loader = scope.ServiceProvider.GetRequiredService<IConnectorConfigurationLoader<TConfig>>();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
@@ -100,6 +101,11 @@ public static class ServiceCollectionExtensions
             poolSize: 128
         );
 
+        // Reset the four pooled-context carriers to fail-closed defaults on every lease
+        // (pooling does not reset custom properties), so the raw IDbContextFactory callers
+        // cannot inherit a prior lessee's tenant or share state. See CarrierResettingDbContextFactory.
+        DecorateWithCarrierReset(services);
+
         // Register scoped NocturneDbContext that sets TenantId from ITenantAccessor.
         // All existing constructor injections of NocturneDbContext continue to work.
         // The context is returned to the pool when the scope ends.
@@ -112,13 +118,11 @@ public static class ServiceCollectionExtensions
             {
                 context.TenantId = tenantAccessor.TenantId;
             }
-            // Set the share carrier unconditionally so a pooled context never inherits a
-            // prior lessee's state. The directly-injected scoped context carries only the
-            // marker and always leaves the CSV null — a share that reads PHI on this path is
-            // denied (fail-closed); share PHI reads should go through ITenantDbContextFactory,
-            // which carries the CSV.
+            // Mark the scoped context as a share when the request is one. Carrier defaults (CSV
+            // null) are already set by CarrierResettingDbContextFactory; this path never resolves
+            // the CSV, so a share reading PHI here is denied (fail-closed) — share PHI reads go
+            // through ITenantDbContextFactory, which carries the CSV.
             context.IsShareContext = sp.GetService<ICategoryReadContext>()?.IsShare == true;
-            context.VisibleCategories = null;
             return context;
         });
 
@@ -144,6 +148,33 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IAvatarStore, DatabaseAvatarStore>();
 
         return services;
+    }
+
+    // Replaces the registered pooled IDbContextFactory<NocturneDbContext> with a decorator that
+    // resets the carrier properties on every lease. Applied immediately after
+    // AddPooledDbContextFactory so the descriptor it wraps is the pooling factory.
+    private static void DecorateWithCarrierReset(IServiceCollection services)
+    {
+        var descriptor = services.LastOrDefault(
+            d => d.ServiceType == typeof(IDbContextFactory<NocturneDbContext>))
+            ?? throw new InvalidOperationException(
+                "AddPooledDbContextFactory<NocturneDbContext> must be registered before decorating it.");
+
+        services.Remove(descriptor);
+        services.Add(new ServiceDescriptor(
+            typeof(IDbContextFactory<NocturneDbContext>),
+            sp => new CarrierResettingDbContextFactory(ResolveInner(descriptor, sp)),
+            descriptor.Lifetime));
+    }
+
+    private static IDbContextFactory<NocturneDbContext> ResolveInner(
+        ServiceDescriptor descriptor, IServiceProvider sp)
+    {
+        var inner =
+            descriptor.ImplementationInstance
+            ?? descriptor.ImplementationFactory?.Invoke(sp)
+            ?? ActivatorUtilities.CreateInstance(sp, descriptor.ImplementationType!);
+        return (IDbContextFactory<NocturneDbContext>)inner;
     }
 
     /// <summary>
@@ -240,6 +271,11 @@ public static class ServiceCollectionExtensions
             poolSize: 128
         );
 
+        // Reset the four pooled-context carriers to fail-closed defaults on every lease
+        // (pooling does not reset custom properties), so the raw IDbContextFactory callers
+        // cannot inherit a prior lessee's tenant or share state. See CarrierResettingDbContextFactory.
+        DecorateWithCarrierReset(services);
+
         // Register scoped DbContext, repositories, and shared services.
         AddDataServices(services);
 
@@ -265,13 +301,11 @@ public static class ServiceCollectionExtensions
             {
                 context.TenantId = tenantAccessor.TenantId;
             }
-            // Set the share carrier unconditionally so a pooled context never inherits a
-            // prior lessee's state. The directly-injected scoped context carries only the
-            // marker and always leaves the CSV null — a share that reads PHI on this path is
-            // denied (fail-closed); share PHI reads should go through ITenantDbContextFactory,
-            // which carries the CSV.
+            // Mark the scoped context as a share when the request is one. Carrier defaults (CSV
+            // null) are already set by CarrierResettingDbContextFactory; this path never resolves
+            // the CSV, so a share reading PHI here is denied (fail-closed) — share PHI reads go
+            // through ITenantDbContextFactory, which carries the CSV.
             context.IsShareContext = sp.GetService<ICategoryReadContext>()?.IsShare == true;
-            context.VisibleCategories = null;
             return context;
         });
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/CarrierResettingDbContextFactory.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/CarrierResettingDbContextFactory.cs
@@ -1,0 +1,46 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Nocturne.Infrastructure.Data.Services;
+
+/// <summary>
+/// Decorates the pooled <see cref="IDbContextFactory{TContext}"/> so every lease of a
+/// <see cref="NocturneDbContext"/> starts from fail-closed carrier defaults.
+///
+/// <para>
+/// <see cref="NocturneDbContext"/> is pooled (<c>AddPooledDbContextFactory</c>), and pooling
+/// does not reset custom properties between leases. A context returned to the pool therefore
+/// keeps the previous lessee's <see cref="NocturneDbContext.TenantId"/>,
+/// <see cref="NocturneDbContext.AuditContext"/>, <see cref="NocturneDbContext.IsShareContext"/>
+/// and <see cref="NocturneDbContext.VisibleCategories"/>. The <c>ITenantDbContextFactory</c> and
+/// scoped-context registration already stamp those on acquisition; the callers that take the raw
+/// factory and call <see cref="IDbContextFactory{TContext}.CreateDbContext"/> directly do not, so
+/// a context that last served a public share could carry <c>IsShareContext = true</c> into a later
+/// lease — and the per-category share RLS policy denies that lease's reads of any tenant-scoped
+/// table (a silent, fail-closed lockout), while a stale non-empty <see cref="NocturneDbContext.TenantId"/>
+/// could expose another tenant's rows.
+/// </para>
+///
+/// <para>
+/// This single chokepoint sits in front of every acquisition path (both
+/// <c>ITenantDbContextFactory</c> and the scoped registration resolve the same factory), so the
+/// raw callers are made safe without each having to reset the carrier. Callers that need real
+/// values pin them after acquisition; the reset only establishes the safe defaults.
+/// </para>
+/// </summary>
+internal sealed class CarrierResettingDbContextFactory(IDbContextFactory<NocturneDbContext> inner)
+    : IDbContextFactory<NocturneDbContext>
+{
+    public NocturneDbContext CreateDbContext() => Reset(inner.CreateDbContext());
+
+    public async ValueTask<NocturneDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+        Reset(await inner.CreateDbContextAsync(cancellationToken));
+
+    private static NocturneDbContext Reset(NocturneDbContext context)
+    {
+        context.TenantId = Guid.Empty;
+        context.AuditContext = null;
+        context.IsShareContext = false;
+        context.VisibleCategories = null;
+        return context;
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/TenantDbContextFactory.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/TenantDbContextFactory.cs
@@ -30,10 +30,10 @@ internal sealed class TenantDbContextFactory(
         if (tenantAccessor?.IsResolved == true)
             ctx.TenantId = tenantAccessor.TenantId;
 
-        // Set the share carrier unconditionally so a pooled context never inherits a prior
-        // lessee's share flag or CSV (pooling does not reset custom properties). The CSV is
-        // resolved post-auth, so it is carried only here, on the factory path; a share whose
-        // CSV is null is denied all categorized data by the RLS policy (fail-closed).
+        // Carry the real share flag and category CSV for this request; the CSV is resolved
+        // post-auth and is carried only on this factory path. Carrier defaults are already set by
+        // CarrierResettingDbContextFactory; a share whose CSV is null is denied all categorized
+        // data by the RLS policy (fail-closed).
         var isShare = categoryReadContext?.IsShare == true;
         ctx.IsShareContext = isShare;
         ctx.VisibleCategories = isShare ? categoryReadContext!.VisibleCategoriesCsv : null;

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/RlsCarrierResetIntegrationTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/RlsCarrierResetIntegrationTests.cs
@@ -1,0 +1,122 @@
+using Microsoft.Extensions.DependencyInjection;
+using Nocturne.Infrastructure.Data.Extensions;
+using Npgsql;
+
+namespace Nocturne.Infrastructure.Data.Tests.Rls;
+
+/// <summary>
+/// End-to-end proof that the carrier-reset chokepoint prevents the share-RLS background lockout:
+/// a pooled <see cref="NocturneDbContext"/> that last served a public share is reused by a normal
+/// read, and because <c>CarrierResettingDbContextFactory</c> resets <c>IsShareContext</c> on the
+/// lease, the <c>TenantConnectionInterceptor</c> writes <c>app.is_share='false'</c> and the reused
+/// connection is NOT denied a non-categorized (share-hidden) tenant-scoped table. Runs against the
+/// real pooled factory, interceptor and PostgreSQL RLS policy, not the C# carrier in isolation.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("RLS completeness")]
+public class RlsCarrierResetIntegrationTests
+{
+    // A non-categorized (share-hidden) tenant-scoped table: under a stale is_share='true' it is
+    // denied outright, which is the lockout this fix prevents.
+    private const string HiddenTable = "body_weights";
+
+    private readonly RlsCompletenessFixture _fx;
+
+    public RlsCarrierResetIntegrationTests(RlsCompletenessFixture fx) => _fx = fx;
+
+    [Fact]
+    public async Task ReusedPooledContext_AfterAShare_DoesNotLockOutANormalRead()
+    {
+        var tenant = Guid.NewGuid();
+        await SeedAsync(tenant);
+
+        // The real production registration: pooled factory + carrier-reset decorator + interceptor.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHttpContextAccessor();
+        services.AddPostgreSqlInfrastructure(_fx.AppConnectionString);
+        await using var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
+
+        // Lease 1 — a public share granted a category that does not unlock the hidden table. Its
+        // own scope returns the context to the pool (still carrying IsShareContext=true) before
+        // lease 2 acquires, even if the share assertion throws.
+        NocturneDbContext pooledContext;
+        await using (var shareContext = await factory.CreateDbContextAsync())
+        {
+            pooledContext = shareContext;
+            shareContext.TenantId = tenant;
+            shareContext.IsShareContext = true;
+            shareContext.VisibleCategories = "stepcount.read";
+            await shareContext.Database.OpenConnectionAsync();
+            (await CountAsync(shareContext, HiddenTable, tenant)).Should().Be(0,
+                "a public share must not see a hidden (non-categorized) table");
+        }
+
+        // Lease 2 — a normal read that reuses the same pooled object. The decorator must have
+        // cleared the share marker; without it the stale is_share='true' would deny the owner
+        // their own data.
+        await using var ownerContext = await factory.CreateDbContextAsync();
+        ownerContext.Should().BeSameAs(pooledContext,
+            "this single-threaded acquire-after-dispose must reuse the same pooled object, so the "
+            + "test exercises carrier reset on a reused context rather than a fresh one");
+        ownerContext.IsShareContext.Should().BeFalse(
+            "the chokepoint must clear a prior share's marker before the pooled context is reused");
+        ownerContext.TenantId = tenant;
+        await ownerContext.Database.OpenConnectionAsync();
+        (await CountAsync(ownerContext, HiddenTable, tenant)).Should().Be(1,
+            "a reused pooled context must not carry a stale share lockout into a normal read");
+    }
+
+    // Counts via the EF-managed connection so the count runs on the same session the
+    // TenantConnectionInterceptor configured when EF opened the connection.
+    private static async Task<long> CountAsync(NocturneDbContext context, string table, Guid tenant)
+    {
+        var connection = context.Database.GetDbConnection();
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = $"SELECT COUNT(*) FROM {table} WHERE tenant_id = @tid";
+        AddParam(cmd, "@tid", tenant);
+        return Convert.ToInt64(await cmd.ExecuteScalarAsync());
+    }
+
+    private async Task SeedAsync(Guid tenant)
+    {
+        await using var conn = await _fx.OpenMigratorConnectionAsync();
+
+        await using (var insertTenant = conn.CreateCommand())
+        {
+            insertTenant.CommandText = """
+                INSERT INTO tenants (id, slug, display_name, is_active, sys_created_at, sys_updated_at)
+                VALUES (@id, @slug, 'carrier-reset-test', true, now(), now())
+                """;
+            AddParam(insertTenant, "@id", tenant);
+            AddParam(insertTenant, "@slug", $"carrier-{tenant:N}");
+            await insertTenant.ExecuteNonQueryAsync();
+        }
+
+        // Row inserts run under the tenant so the multitenant RLS policy admits them.
+        await using (var setTenant = conn.CreateCommand())
+        {
+            setTenant.CommandText = "SELECT set_config('app.current_tenant_id', @tid, false)";
+            AddParam(setTenant, "@tid", tenant.ToString());
+            await setTenant.ExecuteScalarAsync();
+        }
+
+        await using (var insertRow = conn.CreateCommand())
+        {
+            insertRow.CommandText =
+                $"INSERT INTO {HiddenTable} (id, tenant_id, mills, weight_kg, sys_created_at, sys_updated_at) " +
+                "VALUES (gen_random_uuid(), @tid, 0, 0, now(), now())";
+            AddParam(insertRow, "@tid", tenant);
+            await insertRow.ExecuteNonQueryAsync();
+        }
+    }
+
+    private static void AddParam(System.Data.Common.DbCommand cmd, string name, object value)
+    {
+        var p = cmd.CreateParameter();
+        p.ParameterName = name;
+        p.Value = value;
+        cmd.Parameters.Add(p);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Nocturne.Infrastructure.Data.Extensions;
+using Nocturne.Infrastructure.Data.Services;
+
+namespace Nocturne.Infrastructure.Data.Tests.Extensions;
+
+[Trait("Category", "Unit")]
+public class ServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddPostgreSqlInfrastructure_RegistersCarrierResettingFactory_AsTheDbContextFactory()
+    {
+        // The chokepoint is only effective if it is the registered IDbContextFactory: a raw-factory
+        // caller resolves this interface, so if a refactor silently dropped the decoration, every
+        // raw lease would again inherit a pooled context's stale tenant/share carrier. Guards that.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(Mock.Of<IHttpContextAccessor>());
+        services.AddPostgreSqlInfrastructure("Host=localhost;Database=nocturne_test;Username=nocturne_app;Password=x");
+
+        using var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
+
+        factory.Should().BeOfType<CarrierResettingDbContextFactory>(
+            "every IDbContextFactory<NocturneDbContext> resolution must funnel through the carrier-reset chokepoint");
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/CarrierResettingDbContextFactoryTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/CarrierResettingDbContextFactoryTests.cs
@@ -1,0 +1,58 @@
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Infrastructure.Data.Services;
+
+namespace Nocturne.Infrastructure.Data.Tests.Services;
+
+[Trait("Category", "Unit")]
+public class CarrierResettingDbContextFactoryTests
+{
+    // A pooled context that last served a public share for another tenant: every carrier is
+    // dirty, which is exactly what pooling leaves behind because it does not reset custom
+    // properties between leases.
+    private static NocturneDbContext StalePooledContext() =>
+        new(new DbContextOptionsBuilder<NocturneDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options)
+        {
+            TenantId = Guid.NewGuid(),
+            AuditContext = Mock.Of<IAuditContext>(),
+            IsShareContext = true,
+            VisibleCategories = "glucose.read,treatments.read",
+        };
+
+    private static void ShouldBeFailClosed(NocturneDbContext context)
+    {
+        context.TenantId.Should().Be(Guid.Empty, "a fresh lease must not inherit a prior tenant");
+        context.AuditContext.Should().BeNull("a fresh lease must not inherit a prior audit context");
+        context.IsShareContext.Should().BeFalse("a fresh lease must not inherit a prior share marker");
+        context.VisibleCategories.Should().BeNull("a fresh lease must not inherit a prior share's category CSV");
+    }
+
+    [Fact]
+    public void CreateDbContext_ResetsEveryCarrier_OnAStalePooledContext()
+    {
+        var pooled = StalePooledContext();
+        var inner = new Mock<IDbContextFactory<NocturneDbContext>>();
+        inner.Setup(f => f.CreateDbContext()).Returns(pooled);
+
+        var factory = new CarrierResettingDbContextFactory(inner.Object);
+        using var leased = factory.CreateDbContext();
+
+        leased.Should().BeSameAs(pooled, "the decorator mutates the leased context in place, it does not replace it");
+        ShouldBeFailClosed(leased);
+    }
+
+    [Fact]
+    public async Task CreateDbContextAsync_ResetsEveryCarrier_OnAStalePooledContext()
+    {
+        var pooled = StalePooledContext();
+        var inner = new Mock<IDbContextFactory<NocturneDbContext>>();
+        inner.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>())).ReturnsAsync(pooled);
+
+        var factory = new CarrierResettingDbContextFactory(inner.Object);
+        await using var leased = await factory.CreateDbContextAsync();
+
+        leased.Should().BeSameAs(pooled);
+        ShouldBeFailClosed(leased);
+    }
+}


### PR DESCRIPTION
## Problem

`NocturneDbContext` is pooled (`AddPooledDbContextFactory`), and pooling does **not** reset custom properties between leases. A context returned to the pool keeps the previous lessee's `TenantId`, `AuditContext`, `IsShareContext`, and `VisibleCategories`.

`ITenantDbContextFactory` and the scoped-context registration restamp these on acquisition, but callers that take the **raw** `IDbContextFactory<NocturneDbContext>` and call `CreateDbContext()` directly do not. So a context that last served a public share could carry `IsShareContext = true` into a later (e.g. background) lease — and the per-category share RLS policy (from #377) denies that lease's reads of any tenant-scoped table: a silent, fail-closed **lockout** (e.g. a connector sync seeing zero glucose). A stale non-empty `TenantId` is the worse latent case.

This is the "finding 3" follow-up flagged in #377 — robustness/availability, **not** a leak (the share security property is already fully closed there).

## Fix

Decorate the pooled factory (both registrations) with `CarrierResettingDbContextFactory`, a single chokepoint in front of every acquisition path (`ITenantDbContextFactory` and the scoped registration both resolve the same factory). It resets all four carrier properties to fail-closed defaults on every lease; callers that need real values pin them after acquisition. The now-redundant per-site resets are removed.

This also closes the pre-existing `TenantId`/`AuditContext` pooled-staleness class in the same place.

## Tests

- **Unit** — the decorator resets all four properties; both pooled registrations are decorated.
- **Integration (real Postgres)** — a pooled connection that served a share does not lock out a later non-share lease.
- Full suite green: Infrastructure 369, Integration 18, API 3323.