### PR TITLE
feat(glooko): convert fake-UTC timestamps via a tenant timezone timeline

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/TimezoneTimelineController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/TimezoneTimelineController.cs
@@ -1,0 +1,121 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Services.Connectors;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Core.Contracts.Timezones;
+using Nocturne.Core.Models.Timezones;
+using OpenApi.Remote.Attributes;
+
+namespace Nocturne.API.Controllers.V4;
+
+/// <summary>
+/// Manages the tenant's timezone timeline — the ordered record of which IANA zone the person was in
+/// over time. Connectors that store local-wall-clock-stamped-as-UTC data (e.g. Glooko) use it to
+/// convert timestamps to true UTC, honouring daylight saving and travel/relocation.
+/// </summary>
+/// <seealso cref="ITimezoneTimelineService"/>
+[ApiController]
+[Route("api/v4/timezone-timeline")]
+[Tags("Timezone Timeline")]
+[Authorize]
+public class TimezoneTimelineController : ControllerBase
+{
+    private const string GlookoConnectorId = "glooko";
+
+    private readonly ITimezoneTimelineService _timeline;
+    private readonly IConnectorSyncService _syncService;
+    private readonly ILogger<TimezoneTimelineController> _logger;
+
+    public TimezoneTimelineController(
+        ITimezoneTimelineService timeline,
+        IConnectorSyncService syncService,
+        ILogger<TimezoneTimelineController> logger)
+    {
+        _timeline = timeline;
+        _syncService = syncService;
+        _logger = logger;
+    }
+
+    /// <summary>Get the tenant's timezone timeline, ordered by effective date.</summary>
+    [HttpGet]
+    [RemoteQuery]
+    public async Task<ActionResult<IReadOnlyList<TimezoneTimelineEntry>>> GetTimeline(CancellationToken cancellationToken)
+    {
+        var entries = await _timeline.GetTimelineAsync(cancellationToken);
+        return Ok(entries);
+    }
+
+    /// <summary>
+    /// Create or update a timeline entry. <c>EffectiveFrom</c> is a local wall-clock date/time (the
+    /// moment, in local terms, that the zone took effect). A trip is two entries (out + return); a
+    /// move is a single entry; the origin entry covers all earlier history.
+    /// </summary>
+    [HttpPut]
+    [RemoteCommand(Invalidates = ["GetTimeline"])]
+    public async Task<ActionResult<TimezoneTimelineEntry>> Upsert(
+        [FromBody] UpsertTimezoneEntryRequest request,
+        CancellationToken cancellationToken)
+    {
+        var saved = await _timeline.UpsertAsync(
+            new TimezoneTimelineEntry
+            {
+                Id = request.Id ?? Guid.Empty,
+                EffectiveFrom = request.EffectiveFrom,
+                Timezone = request.Timezone,
+            },
+            cancellationToken);
+
+        return Ok(saved);
+    }
+
+    /// <summary>Delete a timeline entry.</summary>
+    [HttpDelete("{id:guid}")]
+    [RemoteCommand(Invalidates = ["GetTimeline"])]
+    public async Task<ActionResult> Delete(Guid id, CancellationToken cancellationToken)
+    {
+        var deleted = await _timeline.DeleteAsync(id, cancellationToken);
+        return deleted ? NoContent() : NotFound();
+    }
+
+    /// <summary>
+    /// Re-correct already-imported data after a timeline change by re-pulling the affected window from
+    /// Glooko. Records re-flow the normal publish path and upsert in place on their stable
+    /// SyncIdentifier, so timestamps move without duplicating. Intended to be called after the user
+    /// confirms the affected window. Runs synchronously; the window is bounded.
+    /// </summary>
+    /// <param name="request">Optional lower bound (UTC). When null, the connector's default window is used.</param>
+    [HttpPost("recorrect")]
+    [RemoteCommand]
+    public async Task<ActionResult<RecorrectResult>> Recorrect(
+        [FromBody] RecorrectRequest request,
+        CancellationToken cancellationToken)
+    {
+        var syncRequest = new SyncRequest
+        {
+            From = request.From,
+            To = DateTime.UtcNow,
+            DataTypes = [],
+        };
+
+        _logger.LogInformation(
+            "Timezone re-correction requested: re-syncing Glooko from {From} to now", request.From?.ToString("o") ?? "default");
+
+        var result = await _syncService.TriggerSyncAsync(GlookoConnectorId, syncRequest, cancellationToken);
+        return Ok(new RecorrectResult(result.Success, result.Message));
+    }
+}
+
+/// <summary>Request to create or update a timezone timeline entry.</summary>
+/// <param name="Id">Existing entry id to update, or null to create.</param>
+/// <param name="EffectiveFrom">Local wall-clock instant from which the zone takes effect.</param>
+/// <param name="Timezone">IANA timezone id (e.g. "Australia/Sydney").</param>
+public record UpsertTimezoneEntryRequest(Guid? Id, DateTime EffectiveFrom, string Timezone);
+
+/// <summary>Request to re-correct imported data after a timeline change.</summary>
+/// <param name="From">Optional UTC lower bound for the re-pull window.</param>
+public record RecorrectRequest(DateTime? From);
+
+/// <summary>Outcome of a re-correction re-sync.</summary>
+/// <param name="Success">Whether the re-sync succeeded.</param>
+/// <param name="Message">Human-readable status message.</param>
+public record RecorrectResult(bool Success, string Message);

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -13,6 +13,7 @@ using Nocturne.API.Services.Analytics;
 using Nocturne.API.Services.Auth;
 using Nocturne.API.Services.BackgroundServices;
 using Nocturne.API.Services.CoachMarks;
+using Nocturne.API.Services.Timezones;
 using Nocturne.API.Services.ChartData;
 using Nocturne.API.Services.ChartData.Stages;
 using Nocturne.API.Services.ConnectorPublishing;
@@ -40,6 +41,7 @@ using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Nightscout.Services.WriteBack;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.CoachMarks;
+using Nocturne.Core.Contracts.Timezones;
 using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Contracts.Alerts;
 using Nocturne.Core.Contracts.Analytics;
@@ -525,6 +527,9 @@ public static class ServiceRegistrationExtensions
 
         // Coach marks
         services.AddScoped<ICoachMarkService, CoachMarkService>();
+
+        // Timezone timeline (fake-UTC connector conversion + travel/relocation)
+        services.AddScoped<ITimezoneTimelineService, TimezoneTimelineService>();
 
         // UI and display
         services.AddScoped<IUISettingsService, UISettingsService>();

--- a/src/API/Nocturne.API/Services/Timezones/TimezoneTimelineService.cs
+++ b/src/API/Nocturne.API/Services/Timezones/TimezoneTimelineService.cs
@@ -1,0 +1,132 @@
+using Microsoft.EntityFrameworkCore;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Contracts.Timezones;
+using Nocturne.Core.Models.Timezones;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Mappers;
+
+namespace Nocturne.API.Services.Timezones;
+
+/// <summary>
+/// Persists and reads the current tenant's timezone timeline. Works in both HTTP request scopes and
+/// background connector-sync scopes: it pins <see cref="NocturneDbContext.TenantId"/> from the ambient
+/// <see cref="ITenantAccessor"/> on each call, so RLS (and the WITH CHECK on writes) scope correctly
+/// without an HTTP context.
+/// </summary>
+/// <seealso cref="ITimezoneTimelineService"/>
+public class TimezoneTimelineService : ITimezoneTimelineService
+{
+    private readonly NocturneDbContext _db;
+    private readonly ITenantAccessor _tenantAccessor;
+    private readonly ILogger<TimezoneTimelineService> _logger;
+
+    public TimezoneTimelineService(
+        NocturneDbContext db,
+        ITenantAccessor tenantAccessor,
+        ILogger<TimezoneTimelineService> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _tenantAccessor = tenantAccessor ?? throw new ArgumentNullException(nameof(tenantAccessor));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    private Guid TenantId
+    {
+        get
+        {
+            var tenantId = _tenantAccessor.Context?.TenantId
+                ?? throw new InvalidOperationException("No tenant context for timezone timeline access.");
+            // Pin the context so RLS (USING + WITH CHECK) scopes to this tenant in any scope.
+            _db.TenantId = tenantId;
+            return tenantId;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<TimezoneTimelineEntry>> GetTimelineAsync(CancellationToken cancellationToken = default)
+    {
+        _ = TenantId;
+        var entities = await _db.TimezoneTimeline
+            .OrderBy(e => e.EffectiveFrom)
+            .ToListAsync(cancellationToken);
+
+        return entities.Select(TimezoneTimelineMapper.ToDomainModel).ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task<TimezoneTimeline> GetResolverAsync(double? fallbackOffsetHours, CancellationToken cancellationToken = default)
+    {
+        var entries = await GetTimelineAsync(cancellationToken);
+        return new TimezoneTimeline(entries, fallbackOffsetHours);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> EnsureOriginAsync(string ianaTimezone, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(ianaTimezone))
+            return false;
+
+        var tenantId = TenantId;
+
+        if (await _db.TimezoneTimeline.AnyAsync(cancellationToken))
+            return false;
+
+        var origin = new TimezoneTimelineEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = tenantId,
+            // Cover all history before any later move/trip entry.
+            EffectiveFrom = DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Unspecified),
+            Timezone = ianaTimezone,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+
+        _db.TimezoneTimeline.Add(origin);
+        await _db.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Seeded timezone timeline origin {Timezone} for tenant {TenantId}", ianaTimezone, tenantId);
+        return true;
+    }
+
+    /// <inheritdoc />
+    public async Task<TimezoneTimelineEntry> UpsertAsync(TimezoneTimelineEntry entry, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        var tenantId = TenantId;
+
+        TimezoneTimelineEntity? entity = null;
+        if (entry.Id != Guid.Empty)
+            entity = await _db.TimezoneTimeline.FirstOrDefaultAsync(e => e.Id == entry.Id, cancellationToken);
+
+        if (entity is null)
+        {
+            entity = TimezoneTimelineMapper.ToEntity(entry, tenantId);
+            _db.TimezoneTimeline.Add(entity);
+        }
+        else
+        {
+            entity.EffectiveFrom = DateTime.SpecifyKind(entry.EffectiveFrom, DateTimeKind.Unspecified);
+            entity.Timezone = entry.Timezone;
+            entity.UpdatedAt = DateTime.UtcNow;
+        }
+
+        await _db.SaveChangesAsync(cancellationToken);
+        return TimezoneTimelineMapper.ToDomainModel(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        _ = TenantId;
+        var entity = await _db.TimezoneTimeline.FirstOrDefaultAsync(e => e.Id == id, cancellationToken);
+        if (entity is null)
+            return false;
+
+        _db.TimezoneTimeline.Remove(entity);
+        await _db.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+}

--- a/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoSensorGlucoseMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoSensorGlucoseMapper.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Nocturne.Connectors.Glooko.Configurations;
 using Nocturne.Connectors.Glooko.Models;
@@ -61,6 +62,9 @@ public class GlookoSensorGlucoseMapper
                 Id = Guid.CreateVersion7(),
                 Timestamp = timestamp,
                 LegacyId = $"glooko_v3_{reading.X}",
+                // Keyed on the raw fake-UTC unix (stable across timezone re-correction), so re-imports
+                // update the row in place rather than duplicating it.
+                SyncIdentifier = $"glooko_v3_{reading.X}",
                 Device = _connectorSource,
                 DataSource = _connectorSource,
                 Mgdl = mgdl,
@@ -154,17 +158,16 @@ public class GlookoSensorGlucoseMapper
         if (string.IsNullOrWhiteSpace(timestamp))
             return null;
 
-        if (!DateTime.TryParse(timestamp, out var parsedDate))
+        // RoundtripKind keeps Glooko's fake-UTC wall-clock intact (a trailing Z is the local clock, not
+        // a real offset), so the time mapper can convert it via the timezone timeline (or the static
+        // offset fallback) just like the treatment paths.
+        if (!DateTime.TryParse(timestamp, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsedDate))
         {
             _logger.LogWarning("Failed to parse Glooko timestamp: '{Timestamp}'", timestamp);
             return null;
         }
 
-        var date = parsedDate.ToUniversalTime();
-        if (_config.TimezoneOffset != 0)
-            date = date.AddHours(-_config.TimezoneOffset);
-
-        return date;
+        return _timeMapper.GetCorrectedGlookoTime(parsedDate);
     }
 
     private SensorGlucose? ParseSensorGlucose(GlookoCgmReading reading)
@@ -183,12 +186,19 @@ public class GlookoSensorGlucoseMapper
                 ? $"glooko_cgm_{reading.Guid}"
                 : $"glooko_{date.Value.Ticks}";
 
+            // Stable across timezone re-correction: prefer Glooko's guid, else the RAW fake-UTC string
+            // (not the corrected ticks, which move when the timeline changes) — so re-imports upsert.
+            var syncId = !string.IsNullOrEmpty(reading.Guid)
+                ? $"glooko_cgm_{reading.Guid}"
+                : $"glooko_cgm_raw_{reading.Timestamp}";
+
             var now = DateTime.UtcNow;
             return new SensorGlucose
             {
                 Id = Guid.CreateVersion7(),
                 Timestamp = date.Value,
                 LegacyId = legacyId,
+                SyncIdentifier = syncId,
                 Device = _connectorSource,
                 DataSource = _connectorSource,
                 Mgdl = mgdl,

--- a/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoTimeMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoTimeMapper.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Nocturne.Connectors.Glooko.Configurations;
+using Nocturne.Core.Models.Timezones;
 
 namespace Nocturne.Connectors.Glooko.Mappers;
 
@@ -8,6 +9,7 @@ public class GlookoTimeMapper
 {
     private readonly GlookoConnectorConfiguration _config;
     private readonly ILogger _logger;
+    private TimezoneTimeline? _timeline;
 
     public GlookoTimeMapper(GlookoConnectorConfiguration config, ILogger logger)
     {
@@ -15,17 +17,21 @@ public class GlookoTimeMapper
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
+    /// <summary>
+    ///     Supplies the tenant's timezone timeline for this sync. When set, fake-UTC timestamps are
+    ///     converted per the zone in effect at each instant (honouring DST and travel/relocation).
+    ///     When unset, the legacy single <see cref="GlookoConnectorConfiguration.TimezoneOffset"/> applies.
+    /// </summary>
+    public void UseTimeline(TimezoneTimeline timeline) => _timeline = timeline;
+
     public DateTime GetCorrectedGlookoTime(DateTime rawDate)
     {
-        var offsetHours = _config.TimezoneOffset;
-        var corrected = rawDate.AddHours(-offsetHours);
-        _logger.LogDebug(
-            "GetCorrectedGlookoTime: Raw={Raw}, ConfigOffset={ConfigOffset}, Result={Result}",
-            rawDate,
-            _config.TimezoneOffset,
-            corrected
-        );
-        return corrected;
+        // Glooko stores fake UTC (local wall-clock stamped as UTC). The timeline interprets that
+        // wall-clock in the zone in effect at the time; without one, fall back to the static offset.
+        if (_timeline is { } timeline)
+            return timeline.ToUtc(rawDate);
+
+        return DateTime.SpecifyKind(rawDate.AddHours(-_config.TimezoneOffset), DateTimeKind.Utc);
     }
 
     /// <summary>

--- a/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoV4TreatmentMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoV4TreatmentMapper.cs
@@ -54,11 +54,14 @@ public class GlookoV4TreatmentMapper(string connectorSource, GlookoTimeMapper ti
 
                         if (hasInsulin)
                         {
+                            var bolusLegacyId = GenerateLegacyId("bolus", bolusDate, $"insulin:{bolus.InsulinDelivered}_carbs:{bolus.CarbsInput}");
                             boluses.Add(new Bolus
                             {
                                 Id = Guid.CreateVersion7(),
                                 Timestamp = correctedDate,
-                                LegacyId = GenerateLegacyId("bolus", bolusDate, $"insulin:{bolus.InsulinDelivered}_carbs:{bolus.CarbsInput}"),
+                                LegacyId = bolusLegacyId,
+                                // Stable (raw-timestamp-derived) key so re-correction upserts in place.
+                                SyncIdentifier = bolusLegacyId,
                                 Device = _connectorSource,
                                 DataSource = _connectorSource,
                                 Insulin = bolus.InsulinDelivered,
@@ -72,11 +75,13 @@ public class GlookoV4TreatmentMapper(string connectorSource, GlookoTimeMapper ti
 
                         if (hasCarbs)
                         {
+                            var carbLegacyId = GenerateLegacyId("carbs", bolusDate, $"insulin:{bolus.InsulinDelivered}_carbs:{bolus.CarbsInput}");
                             carbs.Add(new CarbIntake
                             {
                                 Id = Guid.CreateVersion7(),
                                 Timestamp = correctedDate,
-                                LegacyId = GenerateLegacyId("carbs", bolusDate, $"insulin:{bolus.InsulinDelivered}_carbs:{bolus.CarbsInput}"),
+                                LegacyId = carbLegacyId,
+                                SyncIdentifier = carbLegacyId,
                                 Device = _connectorSource,
                                 DataSource = _connectorSource,
                                 Carbs = bolus.CarbsInput,
@@ -340,11 +345,15 @@ public class GlookoV4TreatmentMapper(string connectorSource, GlookoTimeMapper ti
 
                 if (hasInsulin)
                 {
+                    var v3BolusLegacyId = GenerateLegacyId("v3_bolus", rawTimestamp, $"carbs:{carbsInput}_insulin:{insulin}");
                     boluses.Add(new Bolus
                     {
                         Id = Guid.CreateVersion7(),
                         Timestamp = correctedTimestamp,
-                        LegacyId = GenerateLegacyId("v3_bolus", rawTimestamp, $"carbs:{carbsInput}_insulin:{insulin}"),
+                        LegacyId = v3BolusLegacyId,
+                        // rawTimestamp is the raw fake-UTC (stable); key the upsert on it so re-correction
+                        // moves the row instead of duplicating it.
+                        SyncIdentifier = v3BolusLegacyId,
                         Device = _connectorSource,
                         DataSource = _connectorSource,
                         Insulin = insulin,
@@ -358,11 +367,13 @@ public class GlookoV4TreatmentMapper(string connectorSource, GlookoTimeMapper ti
 
                 if (hasCarbs)
                 {
+                    var v3CarbLegacyId = GenerateLegacyId("v3_carbs", rawTimestamp, $"carbs:{carbsInput}_insulin:{insulin}");
                     carbs.Add(new CarbIntake
                     {
                         Id = Guid.CreateVersion7(),
                         Timestamp = correctedTimestamp,
-                        LegacyId = GenerateLegacyId("v3_carbs", rawTimestamp, $"carbs:{carbsInput}_insulin:{insulin}"),
+                        LegacyId = v3CarbLegacyId,
+                        SyncIdentifier = v3CarbLegacyId,
                         Device = _connectorSource,
                         DataSource = _connectorSource,
                         Carbs = carbsInput,

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -10,8 +10,10 @@ using Nocturne.Connectors.Glooko.Mappers;
 using Nocturne.Connectors.Glooko.Models;
 using Nocturne.Connectors.Glooko.Utilities;
 using Nocturne.Core.Constants;
+using Nocturne.Core.Contracts.Timezones;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Timezones;
 using Nocturne.Core.Models.V4;
 
 namespace Nocturne.Connectors.Glooko.Services;
@@ -27,6 +29,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     private readonly IRateLimitingStrategy _rateLimitingStrategy;
     private readonly IRetryDelayStrategy _retryDelayStrategy;
     private readonly GlookoAuthTokenProvider _tokenProvider;
+    private readonly ITimezoneTimelineService? _timezoneTimelineService;
     private readonly ILogger<GlookoConnectorService> _glookoLogger;
 
     public GlookoConnectorService(
@@ -37,7 +40,8 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         IRateLimitingStrategy rateLimitingStrategy,
         GlookoAuthTokenProvider tokenProvider,
         IConnectorPublisher? publisher = null,
-        IMealMatchingService? mealMatchingService = null
+        IMealMatchingService? mealMatchingService = null,
+        ITimezoneTimelineService? timezoneTimelineService = null
     )
         : base(httpClient, serverResolver, logger, publisher)
     {
@@ -46,6 +50,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         _retryDelayStrategy = retryDelayStrategy ?? throw new ArgumentNullException(nameof(retryDelayStrategy));
         _rateLimitingStrategy = rateLimitingStrategy ?? throw new ArgumentNullException(nameof(rateLimitingStrategy));
         _tokenProvider = tokenProvider ?? throw new ArgumentNullException(nameof(tokenProvider));
+        _timezoneTimelineService = timezoneTimelineService;
         _glookoLogger = logger;
     }
 
@@ -294,10 +299,19 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes);
             var activeTypes = request.DataTypes.Where(t => enabledTypes.Contains(t)).ToHashSet();
 
+            // Resolve the tenant's timezone timeline before mapping any records. The account's home
+            // zone (from the V3 profile) seeds the timeline's origin on first sync; thereafter the
+            // user's travel/relocation entries drive per-record conversion. Falls back to the legacy
+            // static offset when the timeline is empty (e.g. V2-only accounts, or profile tz unknown).
+            await ConfigureTimezoneTimelineAsync(config, cancellationToken);
+
+            // The request window is real-UTC; Glooko queries expect fake-UTC (local wall-clock). Pad by
+            // a day each side so a non-zero offset between the two never clips edge data (dedup absorbs
+            // the overlap).
             var from = request.From.HasValue
-                ? _timeMapper.ToGlookoTime(request.From.Value)
-                : _timeMapper.ToGlookoTime(DateTime.UtcNow.AddMonths(-6));
-            var to = _timeMapper.ToGlookoTime(DateTime.UtcNow);
+                ? _timeMapper.ToGlookoTime(request.From.Value).AddDays(-1)
+                : _timeMapper.ToGlookoTime(DateTime.UtcNow.AddMonths(-6)).AddDays(-1);
+            var to = _timeMapper.ToGlookoTime(DateTime.UtcNow).AddDays(1);
 
             var chunks = DateChunker.Chunk(from, to, TimeSpan.FromDays(14)).ToList();
 
@@ -793,9 +807,10 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     }
 
     private string? _meterUnits;
+    private string? _timezone;
 
     /// <summary>
-    ///     Fetches user profile from v3 API to get meter units setting.
+    ///     Fetches user profile from v3 API to get meter units and the account's home timezone.
     /// </summary>
     public async Task<GlookoV3UsersResponse?> FetchV3UserProfileAsync()
     {
@@ -810,8 +825,9 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             if (profile?.CurrentUser != null)
             {
                 _meterUnits = profile.CurrentUser.MeterUnits;
-                _logger.LogInformation("[{ConnectorSource}] User profile loaded. MeterUnits: {Units}",
-                    ConnectorSource, _meterUnits);
+                _timezone = profile.CurrentUser.Timezone;
+                _logger.LogInformation("[{ConnectorSource}] User profile loaded. MeterUnits: {Units}, Timezone: {Timezone}",
+                    ConnectorSource, _meterUnits, _timezone ?? "(none)");
             }
 
             return profile;
@@ -820,6 +836,39 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         {
             _logger.LogError(ex, "Error fetching Glooko v3 user profile");
             return null;
+        }
+    }
+
+    /// <summary>
+    ///     Builds and installs the tenant's timezone timeline on the shared time mapper for this sync.
+    ///     For V3 accounts it fetches the profile (capturing the home zone and meter units in one call)
+    ///     and seeds the timeline origin from that zone on first sync. When no timezone service is wired
+    ///     or the timeline is empty, conversion falls back to the legacy static offset.
+    /// </summary>
+    private async Task ConfigureTimezoneTimelineAsync(GlookoConnectorConfiguration config, CancellationToken cancellationToken)
+    {
+        if (_timezoneTimelineService is null || _timeMapper is null)
+            return;
+
+        try
+        {
+            if (config.UseV3Api && string.IsNullOrEmpty(_meterUnits))
+                await FetchV3UserProfileAsync();
+
+            if (!string.IsNullOrWhiteSpace(_timezone))
+                await _timezoneTimelineService.EnsureOriginAsync(_timezone, cancellationToken);
+
+            var resolver = await _timezoneTimelineService.GetResolverAsync(config.TimezoneOffset, cancellationToken);
+            _timeMapper.UseTimeline(resolver);
+
+            _logger.LogInformation(
+                "[{ConnectorSource}] Timezone timeline configured (entries present: {HasEntries}, home zone: {Zone})",
+                ConnectorSource, resolver.HasEntries, _timezone ?? "(none)");
+        }
+        catch (Exception ex)
+        {
+            // Never fail a sync over timeline setup — fall back to the static offset.
+            _logger.LogWarning(ex, "[{ConnectorSource}] Failed to configure timezone timeline; using static offset", ConnectorSource);
         }
     }
 

--- a/src/Core/Nocturne.Core.Contracts/Timezones/ITimezoneTimelineService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Timezones/ITimezoneTimelineService.cs
@@ -1,0 +1,43 @@
+using Nocturne.Core.Models.Timezones;
+
+namespace Nocturne.Core.Contracts.Timezones;
+
+/// <summary>
+/// Manages the current tenant's timezone timeline — the ordered record of which IANA zone the person
+/// was in over time. Connectors that store data as local-wall-clock-stamped-as-UTC ("fake UTC", e.g.
+/// Glooko) read this timeline to convert timestamps to true UTC at ingest, honouring daylight saving
+/// and travel/relocation.
+/// </summary>
+/// <remarks>
+/// The timeline is tenant-scoped (a person fact), not subject- or connector-scoped, and is enforced by
+/// RLS on the underlying table. Reads work without an HTTP context, so background connector syncs can
+/// use it.
+/// </remarks>
+/// <seealso cref="TimezoneTimeline"/>
+public interface ITimezoneTimelineService
+{
+    /// <summary>Returns the current tenant's timeline entries, ordered by <c>EffectiveFrom</c> ascending.</summary>
+    Task<IReadOnlyList<TimezoneTimelineEntry>> GetTimelineAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Loads the tenant's timeline as a ready-to-use resolver.
+    /// </summary>
+    /// <param name="fallbackOffsetHours">
+    /// Legacy fixed offset (hours east of UTC) applied when the timeline is empty or a timestamp predates
+    /// the earliest entry — preserves a connector's pre-timeline behaviour so un-seeded tenants don't regress.
+    /// </param>
+    Task<TimezoneTimeline> GetResolverAsync(double? fallbackOffsetHours, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Seeds the origin entry (covering all history) from the given IANA zone when the tenant has no
+    /// timeline yet. Idempotent: does nothing if any entry already exists or the zone is blank.
+    /// </summary>
+    /// <returns>True if an origin entry was created.</returns>
+    Task<bool> EnsureOriginAsync(string ianaTimezone, CancellationToken cancellationToken = default);
+
+    /// <summary>Creates or updates a timeline entry for the current tenant.</summary>
+    Task<TimezoneTimelineEntry> UpsertAsync(TimezoneTimelineEntry entry, CancellationToken cancellationToken = default);
+
+    /// <summary>Deletes a timeline entry by id. Returns false if no such entry exists for the tenant.</summary>
+    Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default);
+}

--- a/src/Core/Nocturne.Core.Models/Timezones/TimezoneTimeline.cs
+++ b/src/Core/Nocturne.Core.Models/Timezones/TimezoneTimeline.cs
@@ -1,0 +1,116 @@
+namespace Nocturne.Core.Models.Timezones;
+
+/// <summary>
+/// Resolves a connector's "fake UTC" timestamps — local wall-clock stamped as if UTC — to true UTC,
+/// using an ordered timezone timeline. For each timestamp it picks the timeline entry in effect at
+/// that local instant and converts via <see cref="TimeZoneInfo"/>, so daylight saving is applied per
+/// the zone's historical rules for that date and travel/relocation is honoured by successive entries.
+/// </summary>
+/// <remarks>
+/// Matching is done in <b>local wall-clock</b> space (the same space the fake-UTC value and the
+/// entries' <see cref="TimezoneTimelineEntry.EffectiveFrom"/> live in), so there is no chicken-and-egg
+/// between "need the zone to get UTC" and "need the instant to pick the zone".
+///
+/// When the timeline is empty, or a timestamp predates the earliest entry, the resolver falls back to
+/// an optional legacy fixed offset (the connector's historical behaviour); with no offset it treats
+/// the value as already-UTC. This keeps existing tenants from regressing before an origin entry is seeded.
+/// </remarks>
+/// <seealso cref="TimezoneTimelineEntry"/>
+/// <seealso cref="Nocturne.Core.Models.TimeZoneHelper"/>
+public sealed class TimezoneTimeline
+{
+    // Entries sorted by EffectiveFrom descending, so the first whose EffectiveFrom <= the
+    // queried wall-clock is the one in effect.
+    private readonly IReadOnlyList<TimezoneTimelineEntry> _entriesDesc;
+    private readonly double? _fallbackOffsetHours;
+
+    /// <summary>
+    /// Creates a timeline resolver.
+    /// </summary>
+    /// <param name="entries">The timeline entries (any order).</param>
+    /// <param name="fallbackOffsetHours">
+    /// Legacy fixed offset (hours east of UTC) applied when no entry covers a timestamp. When null and
+    /// no entry applies, the timestamp is treated as already-UTC.
+    /// </param>
+    public TimezoneTimeline(IEnumerable<TimezoneTimelineEntry> entries, double? fallbackOffsetHours = null)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+
+        _entriesDesc = entries
+            .Where(e => !string.IsNullOrWhiteSpace(e.Timezone))
+            .OrderByDescending(e => e.EffectiveFrom)
+            .ToList();
+        _fallbackOffsetHours = fallbackOffsetHours;
+    }
+
+    /// <summary>Whether the timeline has at least one usable entry.</summary>
+    public bool HasEntries => _entriesDesc.Count > 0;
+
+    /// <summary>
+    /// Converts a fake-UTC timestamp (local wall-clock stamped as UTC) to true UTC.
+    /// </summary>
+    /// <param name="fakeUtc">
+    /// The connector timestamp. Only its wall-clock components are used (the kind is ignored), since the
+    /// value is the local clock reading dressed up as UTC.
+    /// </param>
+    /// <returns>The true UTC instant (<see cref="DateTimeKind.Utc"/>).</returns>
+    public DateTime ToUtc(DateTime fakeUtc)
+    {
+        var wall = DateTime.SpecifyKind(fakeUtc, DateTimeKind.Unspecified);
+
+        var entry = ResolveEntry(wall);
+        if (entry is null)
+        {
+            if (_fallbackOffsetHours is { } offset)
+                return DateTime.SpecifyKind(wall.AddHours(-offset), DateTimeKind.Utc);
+
+            return DateTime.SpecifyKind(wall, DateTimeKind.Utc);
+        }
+
+        var tz = TimeZoneHelper.GetTimeZoneInfoFromId(entry.Timezone);
+        return LocalToUtc(wall, tz);
+    }
+
+    /// <summary>
+    /// Returns the IANA/Windows timezone id in effect at the given local wall-clock instant, or null
+    /// when no entry covers it (timeline empty or instant predates the earliest entry).
+    /// </summary>
+    public string? ZoneAt(DateTime fakeUtc) =>
+        ResolveEntry(DateTime.SpecifyKind(fakeUtc, DateTimeKind.Unspecified))?.Timezone;
+
+    private TimezoneTimelineEntry? ResolveEntry(DateTime wallUnspecified)
+    {
+        // Entries are descending by EffectiveFrom, so the first one at or before the instant wins.
+        foreach (var entry in _entriesDesc)
+        {
+            if (DateTime.SpecifyKind(entry.EffectiveFrom, DateTimeKind.Unspecified) <= wallUnspecified)
+                return entry;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Converts an unspecified local wall-clock to UTC in the given zone, defensively handling the two
+    /// daylight-saving edge hours so a reading is never dropped:
+    /// <list type="bullet">
+    /// <item>Spring-forward gap (a local time that never existed): nudge forward past the gap.</item>
+    /// <item>Fall-back overlap (a local time that occurred twice): take the standard-time interpretation
+    /// (<see cref="TimeZoneInfo.ConvertTimeToUtc(DateTime, TimeZoneInfo)"/>'s default).</item>
+    /// </list>
+    /// </summary>
+    private static DateTime LocalToUtc(DateTime wall, TimeZoneInfo tz)
+    {
+        if (tz.IsInvalidTime(wall))
+        {
+            // The clock sprang forward over this local time; advance to the first instant that exists.
+            var nudged = wall;
+            for (var i = 0; i < 4 && tz.IsInvalidTime(nudged); i++)
+                nudged = nudged.AddHours(1);
+
+            wall = nudged;
+        }
+
+        return TimeZoneInfo.ConvertTimeToUtc(wall, tz);
+    }
+}

--- a/src/Core/Nocturne.Core.Models/Timezones/TimezoneTimelineEntry.cs
+++ b/src/Core/Nocturne.Core.Models/Timezones/TimezoneTimelineEntry.cs
@@ -1,0 +1,36 @@
+namespace Nocturne.Core.Models.Timezones;
+
+/// <summary>
+/// One segment of a tenant's timezone timeline: from <see cref="EffectiveFrom"/> onward (until the
+/// next entry), the person was in <see cref="Timezone"/>. Used to convert connector data that is
+/// stored as local wall-clock-stamped-as-UTC ("fake UTC" — e.g. Glooko) back to true UTC, honouring
+/// both daylight saving (via the zone's historical rules) and travel/relocation (via successive
+/// entries).
+/// </summary>
+/// <remarks>
+/// <see cref="EffectiveFrom"/> is a <b>local wall-clock</b> instant (<see cref="DateTimeKind.Unspecified"/>),
+/// not UTC: a person thinks "I moved on the 1st" in local terms, and fake-UTC data is itself local
+/// wall-clock, so matching happens in local space and avoids the chicken-and-egg of needing the zone
+/// to compute the UTC needed to pick the zone.
+/// </remarks>
+/// <seealso cref="TimezoneTimeline"/>
+public class TimezoneTimelineEntry
+{
+    /// <summary>Primary key (UUID v7).</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Local wall-clock instant from which this zone takes effect (<see cref="DateTimeKind.Unspecified"/>).
+    /// The origin entry uses <see cref="DateTime.MinValue"/> to cover all earlier history.
+    /// </summary>
+    public DateTime EffectiveFrom { get; set; }
+
+    /// <summary>IANA timezone id (e.g. <c>"Australia/Sydney"</c>). Windows ids are also accepted.</summary>
+    public string Timezone { get; set; } = string.Empty;
+
+    /// <summary>When this entry was created.</summary>
+    public DateTime? CreatedAt { get; set; }
+
+    /// <summary>When this entry was last updated.</summary>
+    public DateTime? UpdatedAt { get; set; }
+}

--- a/src/Core/Nocturne.Core.Models/V4/SensorGlucose.cs
+++ b/src/Core/Nocturne.Core.Models/V4/SensorGlucose.cs
@@ -73,6 +73,13 @@ public class SensorGlucose : IV4Record
     public string? LegacyId { get; set; }
 
     /// <summary>
+    /// Stable per-source identifier. Records matched on (DataSource, SyncIdentifier) are updated in
+    /// place on re-import (unlike the insert-only <see cref="LegacyId"/>), so a re-corrected timestamp
+    /// moves the existing row instead of duplicating it.
+    /// </summary>
+    public string? SyncIdentifier { get; set; }
+
+    /// <summary>
     /// When this record was created
     /// </summary>
     public DateTime CreatedAt { get; set; }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TimezoneTimelineEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TimezoneTimelineEntity.cs
@@ -1,0 +1,45 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Nocturne.Infrastructure.Data.Entities;
+
+/// <summary>
+/// PostgreSQL entity for a tenant's timezone timeline. Maps to the timezone_timeline table and to
+/// <see cref="Nocturne.Core.Models.Timezones.TimezoneTimelineEntry"/>. Each row says "from
+/// <see cref="EffectiveFrom"/> onward, the person was in <see cref="Timezone"/>", used to convert
+/// fake-UTC connector data (e.g. Glooko) to true UTC.
+/// </summary>
+[Table("timezone_timeline")]
+public class TimezoneTimelineEntity : ITenantScoped
+{
+    /// <summary>The unique identifier of the tenant this entry belongs to.</summary>
+    [Column("tenant_id")]
+    public Guid TenantId { get; set; }
+
+    /// <summary>Primary key — UUID Version 7.</summary>
+    [Key]
+    [Column("id")]
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Local wall-clock instant from which this zone takes effect. Stored without a time zone because
+    /// it is a wall-clock value (DateTimeKind.Unspecified), not a UTC instant; the origin entry uses
+    /// the minimum value to cover all earlier history.
+    /// </summary>
+    [Column("effective_from", TypeName = "timestamp without time zone")]
+    public DateTime EffectiveFrom { get; set; }
+
+    /// <summary>IANA timezone id (e.g. "Australia/Sydney").</summary>
+    [Column("timezone")]
+    [MaxLength(64)]
+    [Required]
+    public string Timezone { get; set; } = string.Empty;
+
+    /// <summary>When this entry was created (UTC).</summary>
+    [Column("created_at")]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>When this entry was last updated (UTC).</summary>
+    [Column("updated_at")]
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensorGlucoseEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensorGlucoseEntity.cs
@@ -77,6 +77,15 @@ public class SensorGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable
     public string? LegacyId { get; set; }
 
     /// <summary>
+    /// Stable per-source identifier for synchronization. Unlike <see cref="LegacyId"/> (insert-only),
+    /// a record matched by (DataSource, SyncIdentifier) is updated in place on re-import — required so
+    /// timezone re-correction can move a reading's timestamp without duplicating it.
+    /// </summary>
+    [Column("sync_identifier")]
+    [MaxLength(256)]
+    public string? SyncIdentifier { get; set; }
+
+    /// <summary>
     /// System tracking: when record was inserted
     /// </summary>
     [AuditIgnored]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/TimezoneTimelineMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/TimezoneTimelineMapper.cs
@@ -1,0 +1,35 @@
+using Nocturne.Core.Models.Timezones;
+using Nocturne.Infrastructure.Data.Entities;
+
+namespace Nocturne.Infrastructure.Data.Mappers;
+
+/// <summary>
+/// Maps between <see cref="TimezoneTimelineEntry"/> domain models and <see cref="TimezoneTimelineEntity"/>
+/// database entities.
+/// </summary>
+public static class TimezoneTimelineMapper
+{
+    /// <summary>Convert a database entity to a domain model.</summary>
+    public static TimezoneTimelineEntry ToDomainModel(TimezoneTimelineEntity entity) =>
+        new()
+        {
+            Id = entity.Id,
+            // The column is stored without a time zone; surface it as an explicit wall-clock value.
+            EffectiveFrom = DateTime.SpecifyKind(entity.EffectiveFrom, DateTimeKind.Unspecified),
+            Timezone = entity.Timezone,
+            CreatedAt = entity.CreatedAt,
+            UpdatedAt = entity.UpdatedAt,
+        };
+
+    /// <summary>Convert a domain model to a database entity.</summary>
+    public static TimezoneTimelineEntity ToEntity(TimezoneTimelineEntry model, Guid tenantId) =>
+        new()
+        {
+            Id = model.Id == Guid.Empty ? Guid.CreateVersion7() : model.Id,
+            TenantId = tenantId,
+            EffectiveFrom = DateTime.SpecifyKind(model.EffectiveFrom, DateTimeKind.Unspecified),
+            Timezone = model.Timezone,
+            CreatedAt = model.CreatedAt ?? DateTime.UtcNow,
+            UpdatedAt = model.UpdatedAt ?? DateTime.UtcNow,
+        };
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/SensorGlucoseMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/SensorGlucoseMapper.cs
@@ -27,6 +27,7 @@ public static class SensorGlucoseMapper
             CorrelationId = model.CorrelationId,
             PatientDeviceId = model.PatientDeviceId,
             LegacyId = model.LegacyId,
+            SyncIdentifier = model.SyncIdentifier,
             SysCreatedAt = DateTime.UtcNow,
             SysUpdatedAt = DateTime.UtcNow,
             Mgdl = model.Mgdl,
@@ -63,6 +64,7 @@ public static class SensorGlucoseMapper
             CorrelationId = entity.CorrelationId,
             PatientDeviceId = entity.PatientDeviceId,
             LegacyId = entity.LegacyId,
+            SyncIdentifier = entity.SyncIdentifier,
             CreatedAt = entity.SysCreatedAt,
             ModifiedAt = entity.SysUpdatedAt,
             Mgdl = entity.Mgdl,
@@ -96,6 +98,7 @@ public static class SensorGlucoseMapper
         entity.CorrelationId = model.CorrelationId;
         entity.PatientDeviceId = model.PatientDeviceId;
         entity.LegacyId = model.LegacyId;
+        entity.SyncIdentifier = model.SyncIdentifier;
         entity.SysUpdatedAt = DateTime.UtcNow;
         entity.Mgdl = model.Mgdl;
         entity.Direction = model.Direction?.ToString();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260609093227_AddTimezoneTimelineAndSensorGlucoseSyncId.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260609093227_AddTimezoneTimelineAndSensorGlucoseSyncId.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260609093227_AddTimezoneTimelineAndSensorGlucoseSyncId")]
+    partial class AddTimezoneTimelineAndSensorGlucoseSyncId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260609093227_AddTimezoneTimelineAndSensorGlucoseSyncId.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260609093227_AddTimezoneTimelineAndSensorGlucoseSyncId.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTimezoneTimelineAndSensorGlucoseSyncId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "sync_identifier",
+                table: "sensor_glucose",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "timezone_timeline",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    tenant_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    effective_from = table.Column<DateTime>(type: "timestamp without time zone", nullable: false),
+                    timezone = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_timezone_timeline", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_timezone_timeline_tenants_tenant_id",
+                        column: x => x.tenant_id,
+                        principalTable: "tenants",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_sensor_glucose_tenant_source_sync_id",
+                table: "sensor_glucose",
+                columns: new[] { "tenant_id", "data_source", "sync_identifier" },
+                unique: true,
+                filter: "sync_identifier IS NOT NULL AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_timezone_timeline_tenant_effective_from",
+                table: "timezone_timeline",
+                columns: new[] { "tenant_id", "effective_from" },
+                unique: true);
+
+            // Tenant isolation RLS for the new table (sensor_glucose already has it).
+            migrationBuilder.Sql("ALTER TABLE timezone_timeline ENABLE ROW LEVEL SECURITY;");
+            migrationBuilder.Sql("ALTER TABLE timezone_timeline FORCE ROW LEVEL SECURITY;");
+            migrationBuilder.Sql(
+                """
+                CREATE POLICY tenant_isolation ON timezone_timeline
+                    USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid)
+                    WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid);
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP POLICY IF EXISTS tenant_isolation ON timezone_timeline;");
+            migrationBuilder.Sql("ALTER TABLE timezone_timeline NO FORCE ROW LEVEL SECURITY;");
+            migrationBuilder.Sql("ALTER TABLE timezone_timeline DISABLE ROW LEVEL SECURITY;");
+
+            migrationBuilder.DropTable(
+                name: "timezone_timeline");
+
+            migrationBuilder.DropIndex(
+                name: "ix_sensor_glucose_tenant_source_sync_id",
+                table: "sensor_glucose");
+
+            migrationBuilder.DropColumn(
+                name: "sync_identifier",
+                table: "sensor_glucose");
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -308,6 +308,12 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
     public DbSet<MeterGlucoseEntity> MeterGlucose { get; set; }
 
     /// <summary>
+    /// Gets or sets the timezone timeline table — the tenant's ordered record of which IANA zone the
+    /// person was in over time, used to convert fake-UTC connector data (e.g. Glooko) to true UTC.
+    /// </summary>
+    public DbSet<TimezoneTimelineEntity> TimezoneTimeline { get; set; }
+
+    /// <summary>
     /// Gets or sets the Calibrations table for CGM sensor calibration records (v4 granular model)
     /// </summary>
     public DbSet<CalibrationEntity> Calibrations { get; set; }
@@ -1422,6 +1428,21 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             .HasDatabaseName("ix_boluses_tenant_source_sync_id")
             .IsUnique()
             .HasFilter("sync_identifier IS NOT NULL AND deleted_at IS NULL");
+
+        // SensorGlucose gains a SyncIdentifier upsert key (mirrors boluses/carbs) so timezone
+        // re-correction can move a reading's timestamp in place instead of duplicating it.
+        modelBuilder.Entity<SensorGlucoseEntity>()
+            .HasIndex(e => new { e.TenantId, e.DataSource, e.SyncIdentifier })
+            .HasDatabaseName("ix_sensor_glucose_tenant_source_sync_id")
+            .IsUnique()
+            .HasFilter("sync_identifier IS NOT NULL AND deleted_at IS NULL");
+
+        // TimezoneTimeline: one zone-change boundary per tenant per instant (the ordered list is
+        // inherently non-overlapping, so a duplicate effective_from is an authoring error).
+        modelBuilder.Entity<TimezoneTimelineEntity>()
+            .HasIndex(e => new { e.TenantId, e.EffectiveFrom })
+            .HasDatabaseName("ix_timezone_timeline_tenant_effective_from")
+            .IsUnique();
 
         // BasalInjections indexes
         modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -5,6 +5,7 @@ using Nocturne.Core.Contracts.Infrastructure;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
@@ -322,6 +323,60 @@ public class SensorGlucoseRepository : ISensorGlucoseRepository
                 return [];
             }
 
+            // Intra-batch SyncIdentifier dedup: keep last occurrence per (DataSource, SyncIdentifier).
+            // Records without both keys keep a unique grouping key so they're not collapsed.
+            entities = entities
+                .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
+                    ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
+                    : $"id|{e.Id}")
+                .Select(g => g.Last())
+                .ToList();
+
+            // DB-level SyncIdentifier upsert: rows matched by (DataSource, SyncIdentifier) are updated
+            // in place — so timezone re-correction moves a reading's timestamp instead of duplicating
+            // it. Everything else falls through to the LegacyId/insert path below. Mirrors BolusRepository.
+            var updatedEntities = new List<SensorGlucoseEntity>();
+            var syncKeyed = entities
+                .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
+                .ToList();
+
+            if (syncKeyed.Count > 0)
+            {
+                var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
+                var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
+
+                var existingRows = await ctx.SensorGlucose.IgnoreQueryFilters()
+                    .Where(e => e.TenantId == ctx.TenantId)
+                    .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
+                    .ToListAsync(ct);
+
+                var existingByKey = existingRows
+                    .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
+                    .ToDictionary(g => g.Key, g => g.First());
+
+                var toInsert = new List<SensorGlucoseEntity>();
+                foreach (var entity in entities)
+                {
+                    var hasKey = !string.IsNullOrEmpty(entity.DataSource)
+                        && !string.IsNullOrEmpty(entity.SyncIdentifier);
+                    if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
+                    {
+                        var domain = SensorGlucoseMapper.ToDomainModel(entity);
+                        SensorGlucoseMapper.UpdateEntity(existing, domain);
+                        updatedEntities.Add(existing);
+                    }
+                    else
+                    {
+                        toInsert.Add(entity);
+                    }
+                }
+
+                if (updatedEntities.Count > 0)
+                    await ctx.SaveChangesAsync(ct);
+
+                entities = toInsert;
+            }
+
             // Batch-level dedup: keep first occurrence per LegacyId
             entities = entities
                 .GroupBy(e => e.LegacyId ?? e.Id.ToString())
@@ -355,7 +410,7 @@ public class SensorGlucoseRepository : ISensorGlucoseRepository
                     .ToList();
             }
 
-            if (entities.Count == 0)
+            if (entities.Count == 0 && updatedEntities.Count == 0)
             {
                 await tx.CommitAsync(ct);
                 return [];
@@ -371,10 +426,12 @@ public class SensorGlucoseRepository : ISensorGlucoseRepository
 
             await tx.CommitAsync(ct);
 
-            // Insert-time deduplication: link saved records to canonical groups
+            // Insert-time deduplication: link saved records to canonical groups. Include the in-place
+            // updates (re-corrected timestamps) so their canonical grouping is re-driven on the new mills.
+            var saved = entities.Concat(updatedEntities).ToList();
             try
             {
-                var dedupInputs = entities.Select(e => new DeduplicationInput(
+                var dedupInputs = saved.Select(e => new DeduplicationInput(
                     RecordId: e.Id,
                     Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
                     DataSource: e.DataSource ?? "unknown",
@@ -385,10 +442,10 @@ public class SensorGlucoseRepository : ISensorGlucoseRepository
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "SensorGlucose", entities.Count);
+                _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "SensorGlucose", saved.Count);
             }
 
-            return entities.Select(SensorGlucoseMapper.ToDomainModel);
+            return saved.Select(SensorGlucoseMapper.ToDomainModel);
         });
     }
 

--- a/src/Web/packages/app/src/lib/components/layout/AppSidebar.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/AppSidebar.svelte
@@ -28,6 +28,7 @@
     BellOff,
     HeartHandshake,
     Plug,
+    Globe,
     Calendar,
     CheckCircle,
     Terminal,
@@ -302,6 +303,7 @@
           icon: Timer,
         },
         { title: "Connectors & Apps", href: "/settings/connectors", icon: Plug },
+        { title: "Timezone History", href: "/settings/timezone", icon: Globe },
         { title: "Sharing & Privacy", href: "/settings/members", icon: Users },
         ...(canViewAudit
           ? [{ title: "Audit Log", href: "/settings/audit", icon: ScrollText }]

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/+page.svelte
@@ -11,6 +11,7 @@
     ShieldCheck,
     Timer,
     Plug,
+    Globe,
     Users,
     ScrollText,
     HeartHandshake,
@@ -82,6 +83,12 @@
         description: "Connect data sources and authorized devices.",
         href: "/settings/connectors",
         icon: Plug,
+      },
+      {
+        title: "Timezone History",
+        description: "Where you've lived and travelled, for correct timestamps.",
+        href: "/settings/timezone",
+        icon: Globe,
       },
       {
         title: "Sharing & Privacy",

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/timezone/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/timezone/+page.svelte
@@ -1,0 +1,225 @@
+<script lang="ts">
+  import * as Card from "$lib/components/ui/card";
+  import { Button } from "$lib/components/ui/button";
+  import { Input } from "$lib/components/ui/input";
+  import { Label } from "$lib/components/ui/label";
+  import * as AlertDialog from "$lib/components/ui/alert-dialog";
+  import { Globe, Plus, Trash2, Loader2, RefreshCw } from "lucide-svelte";
+  import * as tz from "$api/generated/timezoneTimelines.generated.remote";
+  import type { TimezoneTimelineEntry } from "$api";
+
+  const timelineQuery = tz.getTimeline();
+  const entries = $derived<TimezoneTimelineEntry[]>(timelineQuery.current ?? []);
+
+  // All IANA zones for the picker, with the browser's current zone as the default.
+  const browserZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const zones: string[] =
+    "supportedValuesOf" in Intl ? (Intl as typeof Intl & { supportedValuesOf(k: string): string[] }).supportedValuesOf("timeZone") : [browserZone];
+
+  let newZone = $state(browserZone);
+  let newDate = $state(""); // datetime-local "YYYY-MM-DDTHH:mm"
+  let saving = $state(false);
+  let errorMessage = $state<string | null>(null);
+
+  let pendingDelete = $state<TimezoneTimelineEntry | null>(null);
+  let recorrectOpen = $state(false);
+  let recorrecting = $state(false);
+  let recorrectMessage = $state<string | null>(null);
+
+  // Treat the datetime-local value as a literal wall-clock (never new Date(), which would shift it by
+  // the browser offset). The backend stores it as wall-clock regardless of the trailing Z.
+  function toWallClockIso(local: string): string {
+    const withSeconds = /T\d\d:\d\d$/.test(local) ? `${local}:00` : local;
+    return `${withSeconds}Z`;
+  }
+
+  function isOrigin(e: TimezoneTimelineEntry): boolean {
+    const raw = String(e.effectiveFrom ?? "");
+    return raw.startsWith("0001-01-01");
+  }
+
+  function formatEffective(e: TimezoneTimelineEntry): string {
+    if (isOrigin(e)) return "From the beginning";
+    const raw = String(e.effectiveFrom ?? "").replace("Z", "");
+    return raw.replace("T", " ").slice(0, 16);
+  }
+
+  async function addEntry() {
+    if (!newZone || !newDate) return;
+    saving = true;
+    errorMessage = null;
+    try {
+      await tz.upsert({ effectiveFrom: toWallClockIso(newDate), timezone: newZone });
+      newDate = "";
+    } catch (e) {
+      errorMessage = (e as { message?: string })?.message ?? "Failed to add entry";
+    } finally {
+      saving = false;
+    }
+  }
+
+  async function confirmDelete() {
+    const entry = pendingDelete;
+    pendingDelete = null;
+    if (!entry?.id) return;
+    try {
+      await tz.remove(entry.id);
+    } catch (e) {
+      errorMessage = (e as { message?: string })?.message ?? "Failed to delete entry";
+    }
+  }
+
+  async function runRecorrect() {
+    recorrecting = true;
+    recorrectMessage = null;
+    try {
+      const result = await tz.recorrect({});
+      recorrectMessage = result.message ?? (result.success ? "Re-import started." : "Re-import failed.");
+    } catch (e) {
+      recorrectMessage = (e as { message?: string })?.message ?? "Re-import failed.";
+    } finally {
+      recorrecting = false;
+    }
+  }
+</script>
+
+<div class="mx-auto max-w-2xl space-y-6 p-4">
+  <div class="space-y-1">
+    <h1 class="text-xl font-semibold">Timezone history</h1>
+    <p class="text-muted-foreground text-sm">
+      Some sources (like Glooko) record times in local clock time. Tell Nocturne where you were over time
+      so those readings land at the right moment. Add an entry when you move or travel; daylight saving is
+      handled automatically.
+    </p>
+  </div>
+
+  <Card.Root>
+    <Card.Header>
+      <Card.Title>Where you've been</Card.Title>
+    </Card.Header>
+    <Card.Content class="space-y-4">
+      {#if entries.length === 0}
+        <p class="text-muted-foreground text-sm">
+          No entries yet. Your home timezone is filled in automatically on the next sync.
+        </p>
+      {:else}
+        <ul class="divide-border divide-y">
+          {#each entries as entry (entry.id)}
+            <li class="flex items-center justify-between gap-3 py-2">
+              <div class="flex items-center gap-2">
+                <Globe class="text-muted-foreground size-4 shrink-0" />
+                <div>
+                  <div class="text-sm font-medium">{entry.timezone}</div>
+                  <div class="text-muted-foreground text-xs">{formatEffective(entry)}</div>
+                </div>
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label="Delete entry"
+                onclick={() => (pendingDelete = entry)}
+              >
+                <Trash2 class="size-4" />
+              </Button>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </Card.Content>
+  </Card.Root>
+
+  <Card.Root>
+    <Card.Header>
+      <Card.Title>Add a location change</Card.Title>
+    </Card.Header>
+    <Card.Content class="space-y-4">
+      <div class="grid gap-3 sm:grid-cols-2">
+        <div class="space-y-1.5">
+          <Label for="tz-zone">Location (timezone)</Label>
+          <select
+            id="tz-zone"
+            bind:value={newZone}
+            class="border-input bg-background ring-offset-background focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:outline-none"
+          >
+            {#each zones as zone (zone)}
+              <option value={zone}>{zone}</option>
+            {/each}
+          </select>
+        </div>
+        <div class="space-y-1.5">
+          <Label for="tz-date">Arrived (local date & time)</Label>
+          <Input id="tz-date" type="datetime-local" bind:value={newDate} />
+        </div>
+      </div>
+
+      {#if errorMessage}
+        <p class="text-destructive text-sm">{errorMessage}</p>
+      {/if}
+
+      <Button onclick={addEntry} disabled={saving || !newDate || !newZone}>
+        {#if saving}
+          <Loader2 class="size-4 animate-spin" />
+        {:else}
+          <Plus class="size-4" />
+        {/if}
+        Add entry
+      </Button>
+    </Card.Content>
+  </Card.Root>
+
+  <Card.Root>
+    <Card.Header>
+      <Card.Title>Fix already-imported data</Card.Title>
+    </Card.Header>
+    <Card.Content class="space-y-3">
+      <p class="text-muted-foreground text-sm">
+        Changing your timezone history only affects new data automatically. Re-import recent Glooko data to
+        correct readings that were already saved.
+      </p>
+      {#if recorrectMessage}
+        <p class="text-sm">{recorrectMessage}</p>
+      {/if}
+      <Button variant="outline" onclick={() => (recorrectOpen = true)} disabled={recorrecting}>
+        {#if recorrecting}
+          <Loader2 class="size-4 animate-spin" />
+        {:else}
+          <RefreshCw class="size-4" />
+        {/if}
+        Re-import recent data
+      </Button>
+    </Card.Content>
+  </Card.Root>
+</div>
+
+<AlertDialog.Root open={pendingDelete !== null} onOpenChange={(o) => { if (!o) pendingDelete = null; }}>
+  <AlertDialog.Content>
+    <AlertDialog.Header>
+      <AlertDialog.Title>Delete this entry?</AlertDialog.Title>
+      <AlertDialog.Description>
+        {#if pendingDelete}
+          Remove {pendingDelete.timezone} ({formatEffective(pendingDelete)}) from your timezone history.
+        {/if}
+      </AlertDialog.Description>
+    </AlertDialog.Header>
+    <AlertDialog.Footer>
+      <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+      <AlertDialog.Action onclick={confirmDelete}>Delete</AlertDialog.Action>
+    </AlertDialog.Footer>
+  </AlertDialog.Content>
+</AlertDialog.Root>
+
+<AlertDialog.Root bind:open={recorrectOpen}>
+  <AlertDialog.Content>
+    <AlertDialog.Header>
+      <AlertDialog.Title>Re-import recent data?</AlertDialog.Title>
+      <AlertDialog.Description>
+        This re-pulls your recent Glooko data and re-corrects timestamps using your timezone history.
+        Existing readings are updated in place, not duplicated.
+      </AlertDialog.Description>
+    </AlertDialog.Header>
+    <AlertDialog.Footer>
+      <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+      <AlertDialog.Action onclick={runRecorrect}>Re-import</AlertDialog.Action>
+    </AlertDialog.Footer>
+  </AlertDialog.Content>
+</AlertDialog.Root>

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Mappers/GlookoSensorGlucoseTimelineTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Mappers/GlookoSensorGlucoseTimelineTests.cs
@@ -1,0 +1,110 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Connectors.Glooko.Configurations;
+using Nocturne.Connectors.Glooko.Mappers;
+using Nocturne.Connectors.Glooko.Models;
+using Nocturne.Core.Models.Timezones;
+using Xunit;
+
+namespace Nocturne.Connectors.Glooko.Tests.Mappers;
+
+/// <summary>
+/// Verifies the Glooko sensor-glucose mapper converts fake-UTC timestamps via the timezone timeline
+/// (DST-aware) and stamps a stable SyncIdentifier so re-correction upserts in place.
+/// </summary>
+public class GlookoSensorGlucoseTimelineTests
+{
+    private const string ConnectorSource = "glooko_test";
+
+    private static long Unix(DateTime fakeUtcWallClock) =>
+        new DateTimeOffset(DateTime.SpecifyKind(fakeUtcWallClock, DateTimeKind.Utc)).ToUnixTimeSeconds();
+
+    private static GlookoSensorGlucoseMapper MapperWithTimeline(TimezoneTimeline? timeline, double offset = 0)
+    {
+        var config = new GlookoConnectorConfiguration { TimezoneOffset = offset };
+        var timeMapper = new GlookoTimeMapper(config, NullLogger.Instance);
+        if (timeline is not null)
+            timeMapper.UseTimeline(timeline);
+        return new GlookoSensorGlucoseMapper(config, ConnectorSource, timeMapper, NullLogger.Instance);
+    }
+
+    private static GlookoV3GraphResponse CgmResponse(long x, double y) =>
+        new()
+        {
+            Series = new GlookoV3Series
+            {
+                CgmNormal = [new GlookoV3GlucoseDataPoint { X = x, Y = y, Value = (long)(y * 100), Calculated = false }],
+            },
+        };
+
+    [Fact]
+    public void V3Cgm_WithSydneyTimeline_ConvertsUsingDstOffsetForTheDate()
+    {
+        var timeline = new TimezoneTimeline(
+        [
+            new TimezoneTimelineEntry { Timezone = "Australia/Sydney", EffectiveFrom = DateTime.MinValue },
+        ]);
+        var mapper = MapperWithTimeline(timeline);
+
+        // Fake-UTC midnight on 2026-01-10 = local midnight Sydney (AEDT +11) -> 2026-01-09 13:00Z.
+        var x = Unix(new DateTime(2026, 1, 10, 0, 0, 0));
+        var result = mapper.TransformV3ToSensorGlucose(CgmResponse(x, 120), meterUnits: null).Single();
+
+        result.Timestamp.Should().Be(new DateTime(2026, 1, 9, 13, 0, 0, DateTimeKind.Utc));
+        result.Timestamp.Kind.Should().Be(DateTimeKind.Utc);
+        result.SyncIdentifier.Should().Be($"glooko_v3_{x}");
+    }
+
+    [Fact]
+    public void V3Cgm_NoTimeline_FallsBackToStaticOffset()
+    {
+        var mapper = MapperWithTimeline(timeline: null, offset: 0);
+
+        var x = Unix(new DateTime(2026, 1, 10, 0, 0, 0));
+        var result = mapper.TransformV3ToSensorGlucose(CgmResponse(x, 120), meterUnits: null).Single();
+
+        // Offset 0, no timeline: the fake-UTC value is taken as-is.
+        result.Timestamp.Should().Be(new DateTime(2026, 1, 10, 0, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void V2Cgm_WithTimeline_ConvertsAndUsesStableGuidSyncIdentifier()
+    {
+        var timeline = new TimezoneTimeline(
+        [
+            new TimezoneTimelineEntry { Timezone = "America/Toronto", EffectiveFrom = DateTime.MinValue },
+        ]);
+        var mapper = MapperWithTimeline(timeline);
+
+        var batch = new GlookoBatchData
+        {
+            Readings =
+            [
+                new GlookoCgmReading { Timestamp = "2026-03-09T07:00:00.000Z", Value = 12000, Guid = "abc-123" },
+            ],
+        };
+
+        var result = mapper.TransformBatchDataToSensorGlucose(batch).Single();
+
+        // 07:00 local Toronto on Mar 9 (EDT -4) -> 11:00Z.
+        result.Timestamp.Should().Be(new DateTime(2026, 3, 9, 11, 0, 0, DateTimeKind.Utc));
+        result.SyncIdentifier.Should().Be("glooko_cgm_abc-123");
+    }
+
+    [Fact]
+    public void V2Cgm_NoGuid_UsesRawTimestampSyncIdentifier_StableAcrossCorrection()
+    {
+        var mapper = MapperWithTimeline(
+            new TimezoneTimeline([new TimezoneTimelineEntry { Timezone = "America/Toronto", EffectiveFrom = DateTime.MinValue }]));
+
+        var batch = new GlookoBatchData
+        {
+            Readings = [new GlookoCgmReading { Timestamp = "2026-03-09T07:00:00.000Z", Value = 12000 }],
+        };
+
+        var result = mapper.TransformBatchDataToSensorGlucose(batch).Single();
+
+        // Keyed on the RAW fake-UTC string, not the corrected timestamp.
+        result.SyncIdentifier.Should().Be("glooko_cgm_raw_2026-03-09T07:00:00.000Z");
+    }
+}

--- a/tests/Unit/Nocturne.Core.Models.Tests/Timezones/TimezoneTimelineTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/Timezones/TimezoneTimelineTests.cs
@@ -1,0 +1,149 @@
+using FluentAssertions;
+using Nocturne.Core.Models.Timezones;
+using Xunit;
+
+namespace Nocturne.Core.Models.Tests.Timezones;
+
+[Trait("Category", "Unit")]
+public class TimezoneTimelineTests
+{
+    private static TimezoneTimelineEntry Entry(string zone, DateTime effectiveFromLocal) =>
+        new() { Id = Guid.NewGuid(), Timezone = zone, EffectiveFrom = DateTime.SpecifyKind(effectiveFromLocal, DateTimeKind.Unspecified) };
+
+    private static TimezoneTimelineEntry Origin(string zone) => Entry(zone, DateTime.MinValue);
+
+    private static DateTime FakeUtc(int y, int mo, int d, int h, int mi = 0) =>
+        new(y, mo, d, h, mi, 0, DateTimeKind.Utc);
+
+    private static DateTime Utc(int y, int mo, int d, int h, int mi = 0) =>
+        new(y, mo, d, h, mi, 0, DateTimeKind.Utc);
+
+    // ── Daylight saving handled per-date (the core fix) ──────────────────────
+
+    [Fact]
+    public void Sydney_SameWallClock_ConvertsWithDstOffsetForTheDate()
+    {
+        var timeline = new TimezoneTimeline([Origin("Australia/Sydney")]);
+
+        // Jan = AEDT (UTC+11); Jun = AEST (UTC+10). One static offset cannot do both.
+        timeline.ToUtc(FakeUtc(2026, 1, 10, 0, 0)).Should().Be(Utc(2026, 1, 9, 13, 0));
+        timeline.ToUtc(FakeUtc(2026, 6, 6, 0, 0)).Should().Be(Utc(2026, 6, 5, 14, 0));
+    }
+
+    [Fact]
+    public void Toronto_AcrossSpringForward_UsesEstThenEdt()
+    {
+        var timeline = new TimezoneTimeline([Origin("America/Toronto")]);
+
+        // The user's original report: 7am Mar 5 (EST -5) and 7am Mar 9 (EDT -4).
+        timeline.ToUtc(FakeUtc(2026, 3, 5, 7, 0)).Should().Be(Utc(2026, 3, 5, 12, 0));
+        timeline.ToUtc(FakeUtc(2026, 3, 9, 7, 0)).Should().Be(Utc(2026, 3, 9, 11, 0));
+    }
+
+    [Fact]
+    public void ResultIsAlwaysUtcKind()
+    {
+        var timeline = new TimezoneTimeline([Origin("America/Toronto")]);
+        timeline.ToUtc(FakeUtc(2026, 3, 9, 7, 0)).Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    // ── Travel (the Spain trip) ──────────────────────────────────────────────
+
+    [Fact]
+    public void SpainTrip_ReadingsInTripWindowUseTravelZone_OutsideUseHome()
+    {
+        // Home Sydney; trip to Madrid Mar 7-15 (CET UTC+1 in March); back to Sydney on return.
+        var timeline = new TimezoneTimeline(
+        [
+            Origin("Australia/Sydney"),
+            Entry("Europe/Madrid", new DateTime(2026, 3, 7)),
+            Entry("Australia/Sydney", new DateTime(2026, 3, 15)),
+        ]);
+
+        // Mid-trip reading: 08:00 Madrid CET -> 07:00Z
+        timeline.ToUtc(FakeUtc(2026, 3, 10, 8, 0)).Should().Be(Utc(2026, 3, 10, 7, 0));
+        // Before the trip: 08:00 Sydney AEDT (+11) -> previous day 21:00Z
+        timeline.ToUtc(FakeUtc(2026, 3, 5, 8, 0)).Should().Be(Utc(2026, 3, 4, 21, 0));
+        // After return: 08:00 Sydney AEDT (+11) -> previous day 21:00Z
+        timeline.ToUtc(FakeUtc(2026, 3, 20, 8, 0)).Should().Be(Utc(2026, 3, 19, 21, 0));
+    }
+
+    [Fact]
+    public void Move_OpenEndedRelocation_AppliesFromTheMoveDateForward()
+    {
+        var timeline = new TimezoneTimeline(
+        [
+            Origin("Australia/Sydney"),
+            Entry("America/Toronto", new DateTime(2026, 6, 1)),
+        ]);
+
+        // Before the move: Sydney AEST (+10)
+        timeline.ToUtc(FakeUtc(2026, 5, 20, 12, 0)).Should().Be(Utc(2026, 5, 20, 2, 0));
+        // After the move: Toronto EDT (-4)
+        timeline.ToUtc(FakeUtc(2026, 6, 10, 12, 0)).Should().Be(Utc(2026, 6, 10, 16, 0));
+    }
+
+    [Fact]
+    public void ZoneAt_PicksTheCoveringEntry()
+    {
+        var timeline = new TimezoneTimeline(
+        [
+            Origin("Australia/Sydney"),
+            Entry("Europe/Madrid", new DateTime(2026, 3, 7)),
+            Entry("Australia/Sydney", new DateTime(2026, 3, 15)),
+        ]);
+
+        timeline.ZoneAt(FakeUtc(2026, 3, 10, 8)).Should().Be("Europe/Madrid");
+        timeline.ZoneAt(FakeUtc(2026, 3, 5, 8)).Should().Be("Australia/Sydney");
+    }
+
+    // ── DST edge hours never throw and never drop a reading ──────────────────
+
+    [Fact]
+    public void SpringForwardGap_NonExistentLocalTime_IsNudgedPastTheGap()
+    {
+        var timeline = new TimezoneTimeline([Origin("America/Toronto")]);
+
+        // 02:30 on 2026-03-08 never existed (clocks jumped 02:00 -> 03:00). Nudge to 03:30 EDT (-4) = 07:30Z.
+        var act = () => timeline.ToUtc(FakeUtc(2026, 3, 8, 2, 30));
+        act.Should().NotThrow();
+        timeline.ToUtc(FakeUtc(2026, 3, 8, 2, 30)).Should().Be(Utc(2026, 3, 8, 7, 30));
+    }
+
+    [Fact]
+    public void FallBackAmbiguousHour_TakesStandardTimeInterpretation()
+    {
+        var timeline = new TimezoneTimeline([Origin("America/Toronto")]);
+
+        // 01:30 on 2026-11-01 occurs twice; standard-time (EST -5) interpretation = 06:30Z.
+        var result = timeline.ToUtc(FakeUtc(2026, 11, 1, 1, 30));
+        result.Kind.Should().Be(DateTimeKind.Utc);
+        result.Should().Be(Utc(2026, 11, 1, 6, 30));
+    }
+
+    // ── Empty-timeline fallback (no regression for un-seeded tenants) ────────
+
+    [Fact]
+    public void EmptyTimeline_WithLegacyOffset_AppliesTheOffset()
+    {
+        var timeline = new TimezoneTimeline([], fallbackOffsetHours: -5);
+
+        // Legacy behaviour: corrected = wall - offset = 07:00 - (-5) = 12:00Z.
+        timeline.ToUtc(FakeUtc(2026, 3, 5, 7, 0)).Should().Be(Utc(2026, 3, 5, 12, 0));
+    }
+
+    [Fact]
+    public void EmptyTimeline_NoOffset_TreatsValueAsUtc()
+    {
+        var timeline = new TimezoneTimeline([]);
+        timeline.ToUtc(FakeUtc(2026, 3, 5, 7, 0)).Should().Be(Utc(2026, 3, 5, 7, 0));
+    }
+
+    [Fact]
+    public void TimestampBeforeEarliestEntry_FallsBackNotThrows()
+    {
+        // Earliest entry starts 2026-06-01; a reading before it has no covering entry.
+        var timeline = new TimezoneTimeline([Entry("America/Toronto", new DateTime(2026, 6, 1))], fallbackOffsetHours: 0);
+        timeline.ToUtc(FakeUtc(2026, 1, 1, 7, 0)).Should().Be(Utc(2026, 1, 1, 7, 0));
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Authorization/ShareDataCategoriesGuardTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Authorization/ShareDataCategoriesGuardTests.cs
@@ -32,8 +32,9 @@ public class ShareDataCategoriesGuardTests
         "oauth_grants", "oauth_refresh_tokens", "patient_devices", "patient_insulins", "patient_records",
         "read_access_log", "sensitivity_schedules", "settings", "state_spans", "system_events",
         "target_range_schedules", "tenant_alert_settings",
-        "tenant_data_retention_config", "therapy_settings", "tracker_definitions", "tracker_instances",
-        "tracker_notification_thresholds", "tracker_presets", "treatment_foods", "user_food_favorites",
+        "tenant_data_retention_config", "therapy_settings", "timezone_timeline", "tracker_definitions",
+        "tracker_instances", "tracker_notification_thresholds", "tracker_presets", "treatment_foods",
+        "user_food_favorites",
     };
 
     private static IReadOnlyList<Type> TenantScopedEntities() =>


### PR DESCRIPTION
## Problem

Glooko stores every timestamp as **local wall-clock stamped as UTC** ("fake UTC") and provides **no usable per-record offset** — `pumpTimestampUtcOffset` is always `+00:00` (verified live across 8k+ records spanning a DST boundary). The connector applied one static `TimezoneOffset` to everything, so timestamps were wrong across **DST transitions** and **travel**.

Confirmed the data is **device-local, not home-normalized**: comparing a Spain trip (Madrid UTC+1) against home weeks (Sydney) showed an identical meal/glucose rhythm in wall-clock terms — i.e. travel readings carry the travel zone's local clock.

## Approach

A tenant-scoped **timezone timeline** (ordered IANA-zone segments). Each fake-UTC timestamp is converted in the zone in effect at that local instant, so historical DST rules apply automatically and travel/relocation is honoured. The origin zone is seeded from the Glooko account profile on first sync; trips/moves are user-entered. Matching happens in local-wall-clock space, avoiding the chicken-and-egg of needing the zone to compute the UTC needed to pick the zone.

Correction stays at ingest (mills-first). Re-correcting already-imported data is idempotent: `SensorGlucose` gains a `SyncIdentifier` (mirroring boluses/carbs) and the Glooko mappers stamp **stable, raw-fake-UTC/guid** SyncIdentifiers, so a re-corrected timestamp **updates the row in place** instead of duplicating.

## Changes

- **Core** — `TimezoneTimeline` resolver + `TimezoneTimelineEntry` (DST gap/ambiguous handling; empty-timeline fallback to the legacy static offset so un-seeded tenants don't regress)
- **Schema** — `timezone_timeline` table with `tenant_isolation` RLS; `sensor_glucose.sync_identifier` column + partial unique index; classified hidden-from-shares
- **Glooko** — `GlookoTimeMapper.UseTimeline()`; mappers convert via the timeline and set stable SyncIdentifiers on CGM (v2+v3) and boluses/carbs (v2+v3); `ParseV2Timestamp` now routes through the time mapper; connector captures `currentUser.timezone`, seeds the origin, installs the resolver, pads the fetch window
- **API** — `ITimezoneTimelineService` + `TimezoneTimelineController` (GET/PUT/DELETE + `POST recorrect` → windowed re-sync)
- **Web** — a "Timezone History" settings page: add (IANA picker + time) / delete entries, and a confirmed re-import

## Behaviour / rollout

- **Phase 1 (DST)** works headless — origin auto-seeds from the profile; new and re-synced data convert correctly. No regression for tenants whose zone can't be determined (static-offset fallback).
- **Phase 2 (travel/relocation)** — user adds timeline entries; a confirmed re-import re-corrects already-stored data without duplicating.

## Tests

- Resolver: Sydney AEDT/AEST, Toronto Mar 5 (EST) / Mar 9 (EDT), the Spain trip, a move, spring-forward/fall-back edge hours, fallback (11)
- Glooko mapper applies the timeline + stable SyncIdentifier (4)
- Share-RLS coverage guard updated for the new table
- 366 Infrastructure.Data unit tests still green (glucose repository change)

Generated API client is intentionally not committed — the `commit-generated-api-client` workflow regenerates it on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)