### PR TITLE
fix(migrations): give migration DDL a 1h command timeout to prevent crash loops

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs
@@ -58,7 +58,15 @@ public static class DatabaseInitializationExtensions
                 cancellationToken);
 
             var optionsBuilder = new DbContextOptionsBuilder<NocturneDbContext>();
-            optionsBuilder.UseNpgsql(dataSource);
+            // A migration can include long-running DDL — e.g. building an index on a
+            // multi-million-row table — that exceeds Npgsql's default 30s command timeout.
+            // A timed-out migration command surfaces as a transient failure and crashes
+            // startup; under `restart: unless-stopped` the next boot re-runs the migration
+            // from scratch, so the build is killed and restarted forever — an unbreakable
+            // crash loop. Give migration DDL ample time to complete.
+            optionsBuilder.UseNpgsql(
+                dataSource,
+                npgsql => npgsql.CommandTimeout((int)TimeSpan.FromHours(1).TotalSeconds));
             optionsBuilder.AddInterceptors(interceptor);
 
             using var context = new NocturneDbContext(optionsBuilder.Options);


### PR DESCRIPTION
## Problem

The EF migrator context (`DatabaseInitializationExtensions.RunMigrationsAsync`) runs with Npgsql's **default 30s command timeout**. A migration that executes long-running DDL on a large table — e.g. `CREATE INDEX` on a multi-million-row table — exceeds that timeout. The timeout surfaces as a transient failure that crashes startup, and because deployments run with `restart: unless-stopped`, the next boot re-runs the migration **from scratch**, killing the in-progress build and starting it over. The migration can never complete: an unbreakable crash loop.

### Observed in production

Migration `20260518234626_AddMutationAuditLogLatestDeleteIndex` builds a 4-column index on `mutation_audit_log`, which on a real deployment was **~40M rows / 20GB**. The build takes ~60s — well past the 30s default — so the API crash-looped ~1000 times and the index never landed. (Remediated out-of-band by building the index manually and recording the migration; this PR prevents recurrence for any future slow-DDL migration.)

## Fix

Raise the **migrator** context's command timeout to 1 hour so large schema DDL has room to complete:

```csharp
optionsBuilder.UseNpgsql(
    dataSource,
    npgsql => npgsql.CommandTimeout((int)TimeSpan.FromHours(1).TotalSeconds));
```

Only the migration runner is affected — runtime DbContext pools keep their normal command timeout. The RLS-reconciler context isn't touched because it only resolves the EF model offline; its actual statements run per-table via a raw connection and are individually fast.