### PR TITLE
feat(dedup): carry soft-delete attribution on the row, drop the audit-log scan

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/AuditedBulkDeleteExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/AuditedBulkDeleteExtensions.cs
@@ -173,9 +173,14 @@ public static class AuditedBulkDeleteExtensions
             context.Set<MutationAuditLogEntity>().AddRange(auditEntries);
             await context.SaveChangesAsync(ct);
 
-            // Execute bulk soft delete
+            // Execute bulk soft delete, carrying the dedup attribution flag in the same
+            // update: a user-initiated delete blocks resync re-creation, a system sweep
+            // (no auth context) leaves the row re-creatable.
+            var isUserDelete = auditContext?.AuthType != null;
             var deletedCount = await query.ExecuteUpdateAsync(
-                s => s.SetProperty(e => e.DeletedAt, now), ct);
+                s => s
+                    .SetProperty(e => e.DeletedAt, now)
+                    .SetProperty(e => EF.Property<bool>(e, "DeletedByUser"), isUserDelete), ct);
 
             await transaction.CommitAsync(ct);
             return deletedCount;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/SoftDeleteDedupExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/SoftDeleteDedupExtensions.cs
@@ -1,13 +1,13 @@
 using Microsoft.EntityFrameworkCore;
 using Nocturne.Infrastructure.Data.Entities;
-using Nocturne.Infrastructure.Data.Entities.V4;
 
 namespace Nocturne.Infrastructure.Data.Extensions;
 
 /// <summary>
-/// Audit-aware soft-delete dedup helper for V4 bulk-create paths. The two-step
-/// query shape avoids EF Core's LATERAL/OUTER APPLY translation lottery and gives
-/// predictable SQL even on large legacy_id batches.
+/// Soft-delete dedup helper for V4 bulk-create paths. Blocking is decided from the
+/// <c>deleted_by_user</c> flag carried on each soft-deletable row (maintained by the
+/// audit interceptor and the bulk-delete helpers), so it is a single index seek with
+/// no audit-log scan or per-entity group-by.
 /// </summary>
 public static class SoftDeleteDedupExtensions
 {
@@ -15,20 +15,16 @@ public static class SoftDeleteDedupExtensions
     /// Returns the subset of <paramref name="legacyIds"/> that must be skipped on
     /// bulk insert. A legacy_id is blocking if either:
     ///   - an active row exists with that legacy_id, or
-    ///   - a soft-deleted row exists whose latest <c>delete</c> audit row has a
-    ///     non-null <see cref="MutationAuditLogEntity.AuthType"/> (i.e. an HTTP
-    ///     request populated the audit context, marking the delete as
-    ///     user/guest-initiated).
-    /// Soft-deleted rows whose latest <c>delete</c> audit row has
-    /// <c>AuthType IS NULL</c> — or rows with no audit row at all (pre-audit
-    /// legacy data) — do NOT block. Resync produces a fresh row with a new
-    /// <c>Id</c>; the prior soft-deleted row is left in place for audit continuity.
+    ///   - a soft-deleted row exists whose latest delete was user-initiated
+    ///     (its <c>deleted_by_user</c> flag is set).
+    /// Soft-deleted rows deleted by a system sweep (<c>deleted_by_user = false</c>),
+    /// and rows with no row at all (already hard-deleted / never existed), do NOT
+    /// block. Resync produces a fresh row with a new <c>Id</c>; the prior soft-deleted
+    /// row is left in place for audit continuity.
     ///
     /// Depends on connector-pipeline sweep deletes being wrapped in
-    /// <c>SystemAuditScope</c> at the call site so their audit rows carry
-    /// <c>AuthType IS NULL</c>. Depends on the audit-config retention validator
-    /// keeping <c>MutationAuditRetentionDays &gt;= SoftDeleteRetentionDays</c>
-    /// so user-delete audit rows outlive their soft-deleted entities.
+    /// <c>SystemAuditScope</c> at the call site so their delete carries no auth
+    /// context (<c>deleted_by_user = false</c>).
     /// </summary>
     public static async Task<HashSet<string>> GetBlockingLegacyIdsAsync<TEntity>(
         this NocturneDbContext ctx,
@@ -39,39 +35,25 @@ public static class SoftDeleteDedupExtensions
         if (legacyIds.Count == 0)
             return new HashSet<string>();
 
-        // Step 1: existing rows by legacy_id (ignore soft-delete filter)
         var existing = await ctx.Set<TEntity>().IgnoreQueryFilters().AsNoTracking()
             .Where(e => e.TenantId == ctx.TenantId
                      && e.LegacyId != null
                      && legacyIds.Contains(e.LegacyId))
-            .Select(e => new { e.Id, e.LegacyId, e.DeletedAt })
+            .Select(e => new
+            {
+                e.LegacyId,
+                e.DeletedAt,
+                DeletedByUser = EF.Property<bool>(e, "DeletedByUser")
+            })
             .ToListAsync(ct);
 
-        if (existing.Count == 0)
-            return new HashSet<string>();
-
         var blocking = new HashSet<string>();
-        var softDeletedById = new Dictionary<Guid, string>();
-
         foreach (var row in existing)
         {
-            if (row.DeletedAt == null)
+            // Active rows always block; a soft-deleted row blocks only when its latest
+            // delete was user-initiated (system-sweep deletes stay re-creatable on resync).
+            if (row.DeletedAt == null || row.DeletedByUser)
                 blocking.Add(row.LegacyId!);
-            else
-                softDeletedById[row.Id] = row.LegacyId!;
-        }
-
-        if (softDeletedById.Count == 0)
-            return blocking;
-
-        var entityType = typeof(TEntity).Name.Replace("Entity", "");
-        var userDeletedIds = await GetUserDeletedEntityIdsAsync(
-            ctx, entityType, softDeletedById.Keys.ToHashSet(), ct);
-
-        foreach (var userId in userDeletedIds)
-        {
-            if (softDeletedById.TryGetValue(userId, out var legacyId))
-                blocking.Add(legacyId);
         }
 
         return blocking;
@@ -81,8 +63,8 @@ public static class SoftDeleteDedupExtensions
     /// Sibling of <see cref="GetBlockingLegacyIdsAsync{TEntity}"/> for entities keyed
     /// by <c>CorrelationId</c> (Guid) instead of <c>LegacyId</c> (string). Currently
     /// used by <c>DeviceStatusExtrasEntity</c> only. Same discrimination semantics
-    /// otherwise — active rows always block, soft-deleted rows block iff the latest
-    /// delete audit row has <c>AuthType IS NOT NULL</c>.
+    /// otherwise — active rows always block, soft-deleted rows block iff their latest
+    /// delete was user-initiated (<c>deleted_by_user</c> is set).
     /// </summary>
     public static async Task<HashSet<Guid>> GetBlockingCorrelationIdsAsync(
         this NocturneDbContext ctx,
@@ -95,64 +77,21 @@ public static class SoftDeleteDedupExtensions
         var existing = await ctx.DeviceStatusExtras.IgnoreQueryFilters().AsNoTracking()
             .Where(e => e.TenantId == ctx.TenantId
                      && correlationIds.Contains(e.CorrelationId))
-            .Select(e => new { e.Id, e.CorrelationId, e.DeletedAt })
+            .Select(e => new
+            {
+                e.CorrelationId,
+                e.DeletedAt,
+                DeletedByUser = EF.Property<bool>(e, "DeletedByUser")
+            })
             .ToListAsync(ct);
 
-        if (existing.Count == 0)
-            return new HashSet<Guid>();
-
         var blocking = new HashSet<Guid>();
-        var softDeletedById = new Dictionary<Guid, Guid>();
-
         foreach (var row in existing)
         {
-            if (row.DeletedAt == null)
+            if (row.DeletedAt == null || row.DeletedByUser)
                 blocking.Add(row.CorrelationId);
-            else
-                softDeletedById[row.Id] = row.CorrelationId;
-        }
-
-        if (softDeletedById.Count == 0)
-            return blocking;
-
-        var userDeletedIds = await GetUserDeletedEntityIdsAsync(
-            ctx, "DeviceStatusExtras", softDeletedById.Keys.ToHashSet(), ct);
-
-        foreach (var userId in userDeletedIds)
-        {
-            if (softDeletedById.TryGetValue(userId, out var corrId))
-                blocking.Add(corrId);
         }
 
         return blocking;
-    }
-
-    // Latest "delete" audit row per soft-deleted entity, filtered to user-attributed.
-    // Materialize-first then group in memory — the EF in-memory provider can't
-    // translate GroupBy + OrderByDescending + First().AuthType, and on real
-    // Postgres this set is bounded by the dedup batch size, so the round-trip
-    // cost is dominated by the index seek added in Task 2.
-    private static async Task<HashSet<Guid>> GetUserDeletedEntityIdsAsync(
-        NocturneDbContext ctx,
-        string entityType,
-        HashSet<Guid> softDeletedIds,
-        CancellationToken ct)
-    {
-        if (softDeletedIds.Count == 0)
-            return new HashSet<Guid>();
-
-        var raw = await ctx.MutationAuditLog
-            .Where(a => a.EntityType == entityType
-                     && softDeletedIds.Contains(a.EntityId)
-                     && a.Action == "delete")
-            .Select(a => new { a.EntityId, a.AuthType, a.CreatedAt })
-            .ToListAsync(ct);
-
-        return raw
-            .GroupBy(a => a.EntityId)
-            .Select(g => g.OrderByDescending(a => a.CreatedAt).First())
-            .Where(d => d.AuthType != null)
-            .Select(d => d.EntityId)
-            .ToHashSet();
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Interceptors/MutationAuditInterceptor.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Interceptors/MutationAuditInterceptor.cs
@@ -67,6 +67,18 @@ public class MutationAuditInterceptor : SaveChangesInterceptor
             if (action == "update" && changesJson is null)
                 continue;
 
+            // Maintain the dedup flag carried by soft-deletable rows: a user-initiated
+            // soft-delete blocks connector resync from re-creating the row; a system
+            // sweep or a restore does not. Only meaningful for soft-delete transitions
+            // (Modified state) — a hard delete (Deleted state) removes the row entirely.
+            if (entry.State == EntityState.Modified && entry.Entity is ISoftDeletable)
+            {
+                if (action == "delete")
+                    entry.Property("DeletedByUser").CurrentValue = auditContext?.AuthType != null;
+                else if (action == "restore")
+                    entry.Property("DeletedByUser").CurrentValue = false;
+            }
+
             var audit = new MutationAuditLogEntity
             {
                 Id = Guid.CreateVersion7(),

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260610032449_AddDeletedByUserToSoftDeletables.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260610032449_AddDeletedByUserToSoftDeletables.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260610032449_AddDeletedByUserToSoftDeletables")]
+    partial class AddDeletedByUserToSoftDeletables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260610032449_AddDeletedByUserToSoftDeletables.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260610032449_AddDeletedByUserToSoftDeletables.cs
@@ -1,0 +1,340 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDeletedByUserToSoftDeletables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "uploader_snapshots",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "therapy_settings",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "temp_basals",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "target_range_schedules",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "sensor_glucose",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "sensitivity_schedules",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "pump_snapshots",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "patient_records",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "patient_insulins",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "patient_devices",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "notes",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "meter_glucose",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "devices",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "device_status_extras",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "device_events",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "decomposition_batches",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "carb_ratio_schedules",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "carb_intakes",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "calibrations",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "boluses",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "bolus_calculations",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "bg_checks",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "basal_schedules",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "basal_injections",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "aps_snapshots",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            // Backfill the dedup flag for existing soft-deleted rows so prior user
+            // deletions keep blocking connector resync (parity with the previous
+            // audit-row discriminator). Driven from the audit log — only entities with a
+            // user-attributed delete are touched, so tables of purely system-swept rows
+            // (e.g. temp_basals) cost a single empty index probe. Looped per tenant
+            // because both the entity tables and mutation_audit_log are RLS-scoped.
+            migrationBuilder.Sql("""
+                DO $$
+                DECLARE
+                    t uuid;
+                    m record;
+                BEGIN
+                    FOR t IN SELECT id FROM tenants LOOP
+                        PERFORM set_config('app.current_tenant_id', t::text, true);
+                        FOR m IN SELECT * FROM (VALUES
+                            ('ApsSnapshot','aps_snapshots'),
+                            ('BGCheck','bg_checks'),
+                            ('BasalSchedule','basal_schedules'),
+                            ('BolusCalculation','bolus_calculations'),
+                            ('Bolus','boluses'),
+                            ('Calibration','calibrations'),
+                            ('CarbIntake','carb_intakes'),
+                            ('CarbRatioSchedule','carb_ratio_schedules'),
+                            ('DeviceEvent','device_events'),
+                            ('DeviceStatusExtras','device_status_extras'),
+                            ('MeterGlucose','meter_glucose'),
+                            ('Note','notes'),
+                            ('PumpSnapshot','pump_snapshots'),
+                            ('SensitivitySchedule','sensitivity_schedules'),
+                            ('SensorGlucose','sensor_glucose'),
+                            ('TargetRangeSchedule','target_range_schedules'),
+                            ('TempBasal','temp_basals'),
+                            ('TherapySettings','therapy_settings'),
+                            ('UploaderSnapshot','uploader_snapshots')
+                        ) AS v(etype, tbl) LOOP
+                            EXECUTE format(
+                                'UPDATE %I x SET deleted_by_user = true
+                                 WHERE x.deleted_at IS NOT NULL AND x.id IN (
+                                   SELECT DISTINCT a.entity_id FROM mutation_audit_log a
+                                   WHERE a.entity_type = %L AND a.action = ''delete''
+                                     AND a.auth_type IS NOT NULL)',
+                                m.tbl, m.etype);
+                        END LOOP;
+                    END LOOP;
+                END $$;
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "uploader_snapshots");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "therapy_settings");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "temp_basals");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "target_range_schedules");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "sensor_glucose");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "sensitivity_schedules");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "pump_snapshots");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "patient_records");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "patient_insulins");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "patient_devices");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "notes");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "meter_glucose");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "devices");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "device_status_extras");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "device_events");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "decomposition_batches");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "carb_ratio_schedules");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "carb_intakes");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "calibrations");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "boluses");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "bolus_calculations");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "bg_checks");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "basal_schedules");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "basal_injections");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "aps_snapshots");
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260610073933_DropMutationAuditLogEntityLookupIndex.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260610073933_DropMutationAuditLogEntityLookupIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260610073933_DropMutationAuditLogEntityLookupIndex")]
+    partial class DropMutationAuditLogEntityLookupIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260610073933_DropMutationAuditLogEntityLookupIndex.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260610073933_DropMutationAuditLogEntityLookupIndex.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class DropMutationAuditLogEntityLookupIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_mutation_audit_log_entity_lookup",
+                table: "mutation_audit_log");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "ix_mutation_audit_log_entity_lookup",
+                table: "mutation_audit_log",
+                columns: new[] { "entity_type", "entity_id", "action", "created_at" });
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -3424,6 +3424,15 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
                 var nullValue = Expression.Constant(null, typeof(DateTime?));
                 var isNotDeleted = Expression.Equal(deletedAtProperty, nullValue);
                 body = Expression.AndAlso(body, isNotDeleted);
+
+                // Records whether the latest soft-delete was user-initiated. The soft-delete
+                // dedup discriminator (SoftDeleteDedupExtensions) blocks connector resync from
+                // re-creating a user-deleted row, while a system-sweep delete stays re-creatable.
+                // A shadow property so it lands on every soft-deletable table without a per-entity edit.
+                modelBuilder.Entity(entityType.ClrType)
+                    .Property<bool>("DeletedByUser")
+                    .HasColumnName("deleted_by_user")
+                    .HasDefaultValue(false);
             }
 
             modelBuilder.Entity(entityType.ClrType).HasQueryFilter(Expression.Lambda(body, parameter));

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -2576,9 +2576,6 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
 
             entity.HasIndex(e => new { e.TenantId, e.CreatedAt })
                 .HasDatabaseName("ix_mutation_audit_log_created");
-
-            entity.HasIndex(e => new { e.EntityType, e.EntityId, e.Action, e.CreatedAt })
-                .HasDatabaseName("ix_mutation_audit_log_entity_lookup");
         });
 
         // Configure Read Access Log entity defaults and indexes

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Extensions/SoftDeleteDedupExtensionsTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Extensions/SoftDeleteDedupExtensionsTests.cs
@@ -1,5 +1,4 @@
 using FluentAssertions;
-using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Tests.Shared.Infrastructure;
@@ -21,7 +20,10 @@ public class SoftDeleteDedupExtensionsTests : IDisposable
 
     public void Dispose() { _ctx.Dispose(); GC.SuppressFinalize(this); }
 
-    private TempBasalEntity SeedTempBasal(string legacyId, bool softDeleted)
+    // Blocking is decided from the deleted_by_user flag carried on the row (the audit
+    // interceptor / bulk-delete helpers set it at delete time). deletedByUser only
+    // applies to soft-deleted rows.
+    private TempBasalEntity SeedTempBasal(string legacyId, bool softDeleted, bool deletedByUser = false)
     {
         var entity = new TempBasalEntity
         {
@@ -33,23 +35,9 @@ public class SoftDeleteDedupExtensionsTests : IDisposable
             DeletedAt = softDeleted ? DateTime.UtcNow.AddHours(-1) : null,
         };
         _ctx.TempBasals.Add(entity);
+        _ctx.Entry(entity).Property("DeletedByUser").CurrentValue = deletedByUser;
         _ctx.SaveChanges();
         return entity;
-    }
-
-    private void SeedDeleteAudit(Guid entityId, string? authType, DateTime? createdAt = null)
-    {
-        _ctx.MutationAuditLog.Add(new MutationAuditLogEntity
-        {
-            Id = Guid.CreateVersion7(),
-            TenantId = TenantA,
-            EntityType = "TempBasal",
-            EntityId = entityId,
-            Action = "delete",
-            AuthType = authType,
-            CreatedAt = createdAt ?? DateTime.UtcNow,
-        });
-        _ctx.SaveChanges();
     }
 
     [Fact]
@@ -61,56 +49,17 @@ public class SoftDeleteDedupExtensionsTests : IDisposable
     }
 
     [Fact]
-    public async Task SoftDeleted_NoAuditRow_DoesNotBlock()
+    public async Task SoftDeleted_SystemDelete_DoesNotBlock()
     {
-        SeedTempBasal("legacy-1", softDeleted: true);
+        SeedTempBasal("legacy-1", softDeleted: true, deletedByUser: false);
         var blocked = await _ctx.GetBlockingLegacyIdsAsync<TempBasalEntity>(new HashSet<string> { "legacy-1" });
         blocked.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task SoftDeleted_SystemDelete_NullAuthType_DoesNotBlock()
+    public async Task SoftDeleted_UserDelete_Blocks()
     {
-        var entity = SeedTempBasal("legacy-1", softDeleted: true);
-        SeedDeleteAudit(entity.Id, authType: null);
-        var blocked = await _ctx.GetBlockingLegacyIdsAsync<TempBasalEntity>(new HashSet<string> { "legacy-1" });
-        blocked.Should().BeEmpty();
-    }
-
-    [Fact]
-    public async Task SoftDeleted_UserDelete_Bearer_Blocks()
-    {
-        var entity = SeedTempBasal("legacy-1", softDeleted: true);
-        SeedDeleteAudit(entity.Id, authType: "OAuthAccessToken");
-        var blocked = await _ctx.GetBlockingLegacyIdsAsync<TempBasalEntity>(new HashSet<string> { "legacy-1" });
-        blocked.Should().Contain("legacy-1");
-    }
-
-    [Fact]
-    public async Task SoftDeleted_GuestDelete_Blocks()
-    {
-        var entity = SeedTempBasal("legacy-1", softDeleted: true);
-        SeedDeleteAudit(entity.Id, authType: "Guest");
-        var blocked = await _ctx.GetBlockingLegacyIdsAsync<TempBasalEntity>(new HashSet<string> { "legacy-1" });
-        blocked.Should().Contain("legacy-1");
-    }
-
-    [Fact]
-    public async Task SoftDeleted_UserThenSystemLatestWins_DoesNotBlock()
-    {
-        var entity = SeedTempBasal("legacy-1", softDeleted: true);
-        SeedDeleteAudit(entity.Id, authType: "Bearer", createdAt: DateTime.UtcNow.AddDays(-2));
-        SeedDeleteAudit(entity.Id, authType: null,     createdAt: DateTime.UtcNow.AddDays(-1));
-        var blocked = await _ctx.GetBlockingLegacyIdsAsync<TempBasalEntity>(new HashSet<string> { "legacy-1" });
-        blocked.Should().BeEmpty();
-    }
-
-    [Fact]
-    public async Task SoftDeleted_SystemThenUserLatestWins_Blocks()
-    {
-        var entity = SeedTempBasal("legacy-1", softDeleted: true);
-        SeedDeleteAudit(entity.Id, authType: null,     createdAt: DateTime.UtcNow.AddDays(-2));
-        SeedDeleteAudit(entity.Id, authType: "Bearer", createdAt: DateTime.UtcNow.AddDays(-1));
+        SeedTempBasal("legacy-1", softDeleted: true, deletedByUser: true);
         var blocked = await _ctx.GetBlockingLegacyIdsAsync<TempBasalEntity>(new HashSet<string> { "legacy-1" });
         blocked.Should().Contain("legacy-1");
     }
@@ -123,13 +72,18 @@ public class SoftDeleteDedupExtensionsTests : IDisposable
     }
 
     [Fact]
+    public async Task UnknownLegacyId_DoesNotBlock()
+    {
+        var blocked = await _ctx.GetBlockingLegacyIdsAsync<TempBasalEntity>(new HashSet<string> { "legacy-unknown" });
+        blocked.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task MixedBatch_OnlyBlocksBlockingOnes()
     {
         SeedTempBasal("legacy-active", softDeleted: false);
-        var sysSoft = SeedTempBasal("legacy-system", softDeleted: true);
-        SeedDeleteAudit(sysSoft.Id, authType: null);
-        var userSoft = SeedTempBasal("legacy-user", softDeleted: true);
-        SeedDeleteAudit(userSoft.Id, authType: "Bearer");
+        SeedTempBasal("legacy-system", softDeleted: true, deletedByUser: false);
+        SeedTempBasal("legacy-user", softDeleted: true, deletedByUser: true);
 
         var blocked = await _ctx.GetBlockingLegacyIdsAsync<TempBasalEntity>(
             new HashSet<string> { "legacy-active", "legacy-system", "legacy-user", "legacy-unknown" });
@@ -137,7 +91,7 @@ public class SoftDeleteDedupExtensionsTests : IDisposable
         blocked.Should().BeEquivalentTo(new[] { "legacy-active", "legacy-user" });
     }
 
-    private DeviceStatusExtrasEntity SeedDeviceStatusExtras(Guid correlationId, bool softDeleted)
+    private DeviceStatusExtrasEntity SeedDeviceStatusExtras(Guid correlationId, bool softDeleted, bool deletedByUser = false)
     {
         var entity = new DeviceStatusExtrasEntity
         {
@@ -149,23 +103,9 @@ public class SoftDeleteDedupExtensionsTests : IDisposable
             DeletedAt = softDeleted ? DateTime.UtcNow.AddHours(-1) : null,
         };
         _ctx.DeviceStatusExtras.Add(entity);
+        _ctx.Entry(entity).Property("DeletedByUser").CurrentValue = deletedByUser;
         _ctx.SaveChanges();
         return entity;
-    }
-
-    private void SeedDeviceStatusExtrasDeleteAudit(Guid entityId, string? authType, DateTime? createdAt = null)
-    {
-        _ctx.MutationAuditLog.Add(new MutationAuditLogEntity
-        {
-            Id = Guid.CreateVersion7(),
-            TenantId = TenantA,
-            EntityType = "DeviceStatusExtras",
-            EntityId = entityId,
-            Action = "delete",
-            AuthType = authType,
-            CreatedAt = createdAt ?? DateTime.UtcNow,
-        });
-        _ctx.SaveChanges();
     }
 
     [Fact]
@@ -183,8 +123,7 @@ public class SoftDeleteDedupExtensionsTests : IDisposable
     public async Task CorrelationId_SystemSoftDeleted_DoesNotBlock()
     {
         var corrId = Guid.NewGuid();
-        var entity = SeedDeviceStatusExtras(corrId, softDeleted: true);
-        SeedDeviceStatusExtrasDeleteAudit(entity.Id, authType: null);
+        SeedDeviceStatusExtras(corrId, softDeleted: true, deletedByUser: false);
 
         var blocked = await _ctx.GetBlockingCorrelationIdsAsync(new HashSet<Guid> { corrId });
 
@@ -195,8 +134,7 @@ public class SoftDeleteDedupExtensionsTests : IDisposable
     public async Task CorrelationId_UserSoftDeleted_Blocks()
     {
         var corrId = Guid.NewGuid();
-        var entity = SeedDeviceStatusExtras(corrId, softDeleted: true);
-        SeedDeviceStatusExtrasDeleteAudit(entity.Id, authType: "Bearer");
+        SeedDeviceStatusExtras(corrId, softDeleted: true, deletedByUser: true);
 
         var blocked = await _ctx.GetBlockingCorrelationIdsAsync(new HashSet<Guid> { corrId });
 

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Interceptors/MutationAuditInterceptorTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Interceptors/MutationAuditInterceptorTests.cs
@@ -352,6 +352,81 @@ public class MutationAuditInterceptorTests : IDisposable
     }
 
     [Fact]
+    public async Task SoftDelete_UserAttributed_SetsDeletedByUserTrue()
+    {
+        using var context = CreateContext();
+        var entity = new TestAuditableEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = _tenantId,
+            Name = "UserDeleteMe",
+            DeletedAt = null
+        };
+        context.TestAuditables.Add(entity);
+        await context.SaveChangesAsync();
+
+        using var context2 = CreateContext();
+        var auditContext = new Mock<IAuditContext>();
+        auditContext.Setup(x => x.AuthType).Returns("Bearer");
+        context2.AuditContext = auditContext.Object;
+
+        var tracked = await context2.TestAuditables.FindAsync(entity.Id);
+        tracked!.DeletedAt = DateTime.UtcNow;
+
+        await InvokeSavingChanges(context2);
+
+        ((bool)context2.Entry(tracked).Property("DeletedByUser").CurrentValue!).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SoftDelete_SystemNoAuth_LeavesDeletedByUserFalse()
+    {
+        using var context = CreateContext();
+        var entity = new TestAuditableEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = _tenantId,
+            Name = "SystemDeleteMe",
+            DeletedAt = null
+        };
+        context.TestAuditables.Add(entity);
+        await context.SaveChangesAsync();
+
+        // No AuditContext and null HttpContext -> AuthType null -> system-attributed delete.
+        using var context2 = CreateContext();
+        var tracked = await context2.TestAuditables.FindAsync(entity.Id);
+        tracked!.DeletedAt = DateTime.UtcNow;
+
+        await InvokeSavingChanges(context2);
+
+        ((bool)context2.Entry(tracked).Property("DeletedByUser").CurrentValue!).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Restore_ResetsDeletedByUserToFalse()
+    {
+        using var context = CreateContext();
+        var entity = new TestAuditableEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = _tenantId,
+            Name = "RestoreMe",
+            DeletedAt = DateTime.UtcNow
+        };
+        context.TestAuditables.Add(entity);
+        context.Entry(entity).Property("DeletedByUser").CurrentValue = true;
+        await context.SaveChangesAsync();
+
+        using var context2 = CreateContext();
+        var tracked = await context2.TestAuditables.IgnoreQueryFilters().FirstAsync(e => e.Id == entity.Id);
+        tracked.DeletedAt = null;
+
+        await InvokeSavingChanges(context2);
+
+        ((bool)context2.Entry(tracked).Property("DeletedByUser").CurrentValue!).Should().BeFalse();
+    }
+
+    [Fact]
     public async Task AuditIgnored_PropertiesOmittedFromUpdateDiffs()
     {
         using var context = CreateContext();

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/TempBasalRepositoryBulkCreateTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/TempBasalRepositoryBulkCreateTests.cs
@@ -50,25 +50,13 @@ public class TempBasalRepositoryBulkCreateTests : IDisposable
             LegacyId = legacyId,
         };
 
-    private void SoftDelete(Guid id)
+    // deletedByUser mirrors the flag the audit interceptor / bulk-delete helpers set at
+    // delete time: a user-initiated delete blocks resync re-creation, a system sweep does not.
+    private void SoftDelete(Guid id, bool deletedByUser = false)
     {
         var entity = _context.TempBasals.IgnoreQueryFilters().Single(e => e.Id == id);
         entity.DeletedAt = DateTime.UtcNow;
-        _context.SaveChanges();
-    }
-
-    private void SeedDeleteAudit(Guid entityId, string? authType)
-    {
-        _context.MutationAuditLog.Add(new MutationAuditLogEntity
-        {
-            Id = Guid.CreateVersion7(),
-            TenantId = TenantA,
-            EntityType = "TempBasal",
-            EntityId = entityId,
-            Action = "delete",
-            AuthType = authType,
-            CreatedAt = DateTime.UtcNow,
-        });
+        _context.Entry(entity).Property("DeletedByUser").CurrentValue = deletedByUser;
         _context.SaveChanges();
     }
 
@@ -87,8 +75,7 @@ public class TempBasalRepositoryBulkCreateTests : IDisposable
     public async Task BulkCreateAsync_SystemSoftDeleted_ReImports()
     {
         var existing = await _repository.CreateAsync(CreateRecord("legacy-1"));
-        SoftDelete(existing.Id);
-        SeedDeleteAudit(existing.Id, authType: null);
+        SoftDelete(existing.Id, deletedByUser: false);
 
         var result = (await _repository.BulkCreateAsync([CreateRecord("legacy-1")])).ToList();
 
@@ -101,8 +88,7 @@ public class TempBasalRepositoryBulkCreateTests : IDisposable
     public async Task BulkCreateAsync_UserSoftDeleted_DoesNotReImport()
     {
         var existing = await _repository.CreateAsync(CreateRecord("legacy-1"));
-        SoftDelete(existing.Id);
-        SeedDeleteAudit(existing.Id, authType: "OAuthAccessToken");
+        SoftDelete(existing.Id, deletedByUser: true);
 
         var result = (await _repository.BulkCreateAsync([CreateRecord("legacy-1")])).ToList();
 


### PR DESCRIPTION
## Problem

The V4 connector soft-delete dedup (`SoftDeleteDedupExtensions`) decided whether a soft-deleted row blocks resync re-creation by **scanning `mutation_audit_log`** for the entity's latest `delete` row and checking its `auth_type`. That:

- coupled dedup correctness to the (unbounded, ballooning) audit log, and
- required a dedicated 4-column index on `mutation_audit_log` (`ix_mutation_audit_log_entity_lookup`) — the index whose **non-concurrent build on a 40M-row table crash-looped production**.

## Insight

The discriminator is only ever consulted for entities that step 1 already found as **currently-present and soft-deleted**. A hard-deleted/purged entity has no row and is never checked. So the only bit dedup needs — *was the latest soft-delete user-initiated* — can live **on the row itself** instead of in a separate scan/table.

Validated against production: every soft-deleted entity has exactly one `delete` row, **zero attribution flips, zero `created_at` ties** — so "latest-delete attribution" is exactly the on-row flag.

## Change

A `deleted_by_user` flag carried on every soft-deletable row:

- **Schema**: shadow property added to every `ISoftDeletable` table via the existing central tenant-filter loop (`NocturneDbContext.ConfigureTenantFilters`) — no per-entity class edits — default `false`.
- **Writers**: `MutationAuditInterceptor` sets it on a soft-delete (user vs system, from the audit context's `AuthType`) and clears it on restore; `AuditedSoftDeleteAsync` sets it in the same `ExecuteUpdate`.
- **Reader**: `SoftDeleteDedupExtensions` reads the flag directly — the second audit-log query and the in-memory `GroupBy`/`OrderByDescending` latest-wins logic are **deleted**. Blocking is now a single index seek on the rows already loaded in step 1.

This is **parity-exact** with the prior discriminator (`AuthType != null` ⇒ `deleted_by_user = true`), and decouples the dedup floor from the audit log so the audit log can be demoted/retained independently.

## Migration

`AddDeletedByUserToSoftDeletables` adds the column and **backfills** `deleted_by_user = true` for existing soft-deleted rows whose latest delete was user-attributed, looped per tenant for RLS. The backfill is audit-log-driven (only entities with a user delete are touched), so tables of purely system-swept rows cost a single empty index probe.

> Note: on very large deployments the backfill probes `mutation_audit_log`, so it benefits from the migrator command-timeout raise in #382.

## Tests

386 `Nocturne.Infrastructure.Data.Tests` unit tests green. Reader tests now drive blocking via the flag; added interceptor tests for user→true / system→false / restore→false.