### PR TITLE
fix(connectors): delete connector data consistently across all types + disable the connector

### DIFF
--- a/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
@@ -4,11 +4,13 @@ using Microsoft.Extensions.Logging;
 using Nocturne.Connectors.Core.Models;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Core.Constants;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Connectors;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Services;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Extensions;
 
 namespace Nocturne.API.Services.Connectors;
 
@@ -24,6 +26,8 @@ public class DataSourceService : IDataSourceService
     private readonly ISensorGlucoseRepository _sensorGlucose;
     private readonly IMeterGlucoseRepository _meterGlucose;
     private readonly ICalibrationRepository _calibrations;
+    private readonly IAuditContext _auditContext;
+    private readonly IConnectorConfigurationService _connectorConfiguration;
     private readonly ILogger<DataSourceService> _logger;
 
     public DataSourceService(
@@ -31,6 +35,8 @@ public class DataSourceService : IDataSourceService
         ISensorGlucoseRepository sensorGlucose,
         IMeterGlucoseRepository meterGlucose,
         ICalibrationRepository calibrations,
+        IAuditContext auditContext,
+        IConnectorConfigurationService connectorConfiguration,
         ILogger<DataSourceService> logger
     )
     {
@@ -38,6 +44,8 @@ public class DataSourceService : IDataSourceService
         _sensorGlucose = sensorGlucose;
         _meterGlucose = meterGlucose;
         _calibrations = calibrations;
+        _auditContext = auditContext;
+        _connectorConfiguration = connectorConfiguration;
         _logger = logger;
     }
 
@@ -856,51 +864,12 @@ public class DataSourceService : IDataSourceService
                 deviceId
             );
 
-            // Delete from V4 glucose tables
-            var sensorGlucoseDeleted = await _sensorGlucose.DeleteBySourceAsync(deviceId, cancellationToken);
-            var meterGlucoseDeleted = await _meterGlucose.DeleteBySourceAsync(deviceId, cancellationToken);
-            var calibrationsDeleted = await _calibrations.DeleteBySourceAsync(deviceId, cancellationToken);
+            // Disable the connector before purging so a scheduled or in-flight sync cannot
+            // re-import the data we are about to delete.
+            await _connectorConfiguration.SetActiveAsync(
+                connectorId, isActive: false, _auditContext.SubjectName, cancellationToken);
 
-            var bolusesDeleted = await _context
-                .Boluses.Where(b => b.DataSource == deviceId)
-                .ExecuteDeleteAsync(cancellationToken);
-            var carbIntakesDeleted = await _context
-                .CarbIntakes.Where(c => c.DataSource == deviceId)
-                .ExecuteDeleteAsync(cancellationToken);
-            var bgChecksDeleted = await _context
-                .BGChecks.Where(b => b.DataSource == deviceId)
-                .ExecuteDeleteAsync(cancellationToken);
-            var notesDeleted = await _context
-                .Notes.Where(n => n.DataSource == deviceId)
-                .ExecuteDeleteAsync(cancellationToken);
-            var deviceEventsDeleted = await _context
-                .DeviceEvents.Where(de => de.DataSource == deviceId)
-                .ExecuteDeleteAsync(cancellationToken);
-            var bolusCalcsDeleted = await _context
-                .BolusCalculations.Where(bc => bc.DataSource == deviceId)
-                .ExecuteDeleteAsync(cancellationToken);
-
-            var deviceStatusDeleted = await _context
-                .ApsSnapshots.Where(ds => ds.Device == deviceId)
-                .ExecuteDeleteAsync(cancellationToken);
-
-            var stateSpansDeleted = await _context
-                .StateSpans.Where(s => s.Source == deviceId)
-                .ExecuteDeleteAsync(cancellationToken);
-
-            // Build per-type deletion counts
-            var deletedCounts = new Dictionary<string, long>();
-            if (sensorGlucoseDeleted > 0) deletedCounts[nameof(SyncDataType.Glucose)] = sensorGlucoseDeleted;
-            if (meterGlucoseDeleted > 0) deletedCounts[nameof(SyncDataType.ManualBG)] = meterGlucoseDeleted;
-            if (calibrationsDeleted > 0) deletedCounts[nameof(SyncDataType.Calibrations)] = calibrationsDeleted;
-            if (bolusesDeleted > 0) deletedCounts[nameof(SyncDataType.Boluses)] = bolusesDeleted;
-            if (carbIntakesDeleted > 0) deletedCounts[nameof(SyncDataType.CarbIntake)] = carbIntakesDeleted;
-            if (bgChecksDeleted > 0) deletedCounts[nameof(SyncDataType.BGChecks)] = bgChecksDeleted;
-            if (bolusCalcsDeleted > 0) deletedCounts[nameof(SyncDataType.BolusCalculations)] = bolusCalcsDeleted;
-            if (notesDeleted > 0) deletedCounts[nameof(SyncDataType.Notes)] = notesDeleted;
-            if (deviceEventsDeleted > 0) deletedCounts[nameof(SyncDataType.DeviceEvents)] = deviceEventsDeleted;
-            if (deviceStatusDeleted > 0) deletedCounts[nameof(SyncDataType.DeviceStatus)] = deviceStatusDeleted;
-            if (stateSpansDeleted > 0) deletedCounts[nameof(SyncDataType.StateSpans)] = stateSpansDeleted;
+            var deletedCounts = await DeleteAllSourceDataAsync(deviceId, cancellationToken);
 
             _logger.LogInformation(
                 "Deleted data for connector {ConnectorId} (device {DeviceId}): {DeletedCounts}",
@@ -926,6 +895,71 @@ public class DataSourceService : IDataSourceService
                 Error = "Failed to delete connector data",
             };
         }
+    }
+
+    /// <summary>
+    /// Deletes every data type written by <paramref name="deviceId"/>, routing each entity through
+    /// the strongest audited path it supports so the deletes are attributed to the current request
+    /// and the soft-delete dedup keeps them from re-importing — the same way glucose already behaves.
+    /// Returns the per-type deleted counts (non-zero entries only).
+    /// </summary>
+    /// <remarks>
+    /// Capability matrix (entity interfaces decide the path):
+    /// <list type="bullet">
+    /// <item>Glucose and the auditable+soft-deletable treatments (Bolus, CarbIntake, BolusCalculation,
+    ///   DeviceEvent) take the audited soft-delete path. The audit row's non-null AuthType is what makes
+    ///   the soft-delete dedup block re-import (<see cref="SoftDeleteDedupExtensions"/>).</item>
+    /// <item>StateSpan is auditable but not soft-deletable, so it takes the audited hard-delete path.</item>
+    /// <item>BGChecks, Notes and device status are soft-deletable but not auditable, so they soft-delete
+    ///   without an audit row; with the connector disabled they do not re-import.</item>
+    /// </list>
+    /// </remarks>
+    private async Task<Dictionary<string, long>> DeleteAllSourceDataAsync(
+        string deviceId,
+        CancellationToken cancellationToken
+    )
+    {
+        // Glucose: audited soft-delete, user-attributed (via the V4 repositories).
+        var sensorGlucoseDeleted = await _sensorGlucose.DeleteBySourceAsync(deviceId, cancellationToken);
+        var meterGlucoseDeleted = await _meterGlucose.DeleteBySourceAsync(deviceId, cancellationToken);
+        var calibrationsDeleted = await _calibrations.DeleteBySourceAsync(deviceId, cancellationToken);
+
+        // Auditable + soft-deletable treatments: audited soft-delete, user-attributed.
+        var bolusesDeleted = await _context.AuditedSoftDeleteAsync(
+            _context.Boluses.Where(b => b.DataSource == deviceId), _auditContext, cancellationToken);
+        var carbIntakesDeleted = await _context.AuditedSoftDeleteAsync(
+            _context.CarbIntakes.Where(c => c.DataSource == deviceId), _auditContext, cancellationToken);
+        var bolusCalcsDeleted = await _context.AuditedSoftDeleteAsync(
+            _context.BolusCalculations.Where(bc => bc.DataSource == deviceId), _auditContext, cancellationToken);
+        var deviceEventsDeleted = await _context.AuditedSoftDeleteAsync(
+            _context.DeviceEvents.Where(de => de.DataSource == deviceId), _auditContext, cancellationToken);
+
+        // StateSpan is auditable but not soft-deletable: audited hard delete.
+        var stateSpansDeleted = await _context.AuditedExecuteDeleteAsync(
+            _context.StateSpans.Where(s => s.Source == deviceId), _auditContext, cancellationToken);
+
+        // Soft-deletable but not auditable: soft-delete without an audit row.
+        var bgChecksDeleted = await _context.SoftDeleteAsync(
+            _context.BGChecks.Where(b => b.DataSource == deviceId), cancellationToken);
+        var notesDeleted = await _context.SoftDeleteAsync(
+            _context.Notes.Where(n => n.DataSource == deviceId), cancellationToken);
+        var deviceStatusDeleted = await _context.SoftDeleteAsync(
+            _context.ApsSnapshots.Where(ds => ds.Device == deviceId), cancellationToken);
+
+        var deletedCounts = new Dictionary<string, long>();
+        if (sensorGlucoseDeleted > 0) deletedCounts[nameof(SyncDataType.Glucose)] = sensorGlucoseDeleted;
+        if (meterGlucoseDeleted > 0) deletedCounts[nameof(SyncDataType.ManualBG)] = meterGlucoseDeleted;
+        if (calibrationsDeleted > 0) deletedCounts[nameof(SyncDataType.Calibrations)] = calibrationsDeleted;
+        if (bolusesDeleted > 0) deletedCounts[nameof(SyncDataType.Boluses)] = bolusesDeleted;
+        if (carbIntakesDeleted > 0) deletedCounts[nameof(SyncDataType.CarbIntake)] = carbIntakesDeleted;
+        if (bgChecksDeleted > 0) deletedCounts[nameof(SyncDataType.BGChecks)] = bgChecksDeleted;
+        if (bolusCalcsDeleted > 0) deletedCounts[nameof(SyncDataType.BolusCalculations)] = bolusCalcsDeleted;
+        if (notesDeleted > 0) deletedCounts[nameof(SyncDataType.Notes)] = notesDeleted;
+        if (deviceEventsDeleted > 0) deletedCounts[nameof(SyncDataType.DeviceEvents)] = deviceEventsDeleted;
+        if (deviceStatusDeleted > 0) deletedCounts[nameof(SyncDataType.DeviceStatus)] = deviceStatusDeleted;
+        if (stateSpansDeleted > 0) deletedCounts[nameof(SyncDataType.StateSpans)] = stateSpansDeleted;
+
+        return deletedCounts;
     }
 
     private static string GenerateId(string deviceId)
@@ -986,53 +1020,9 @@ public class DataSourceService : IDataSourceService
             // The deviceId is the raw Device field value from sensor_glucose (e.g. "dexcom-connector",
             // "xDrip-DexcomG6 Samsung Galaxy S21"). For connectors this also matches DataSource.
             // For uploaders, Device is set by the client app and DataSource may differ.
-            // We match on both Device and DataSource to cover both cases.
             var deviceId = source.DeviceId;
 
-            // Delete V4 glucose tables by DataSource
-            var sensorGlucoseDeleted = await _sensorGlucose.DeleteBySourceAsync(deviceId, cancellationToken);
-            var meterGlucoseDeleted = await _meterGlucose.DeleteBySourceAsync(deviceId, cancellationToken);
-            var calibrationsDeleted = await _calibrations.DeleteBySourceAsync(deviceId, cancellationToken);
-            var bolusesDeleted = await _context
-                .Boluses.Where(b => b.DataSource == deviceId)
-                .ExecuteDeleteAsync(cancellationToken);
-            var carbIntakesDeleted = await _context
-                .CarbIntakes.Where(c => c.DataSource == deviceId)
-                .ExecuteDeleteAsync(cancellationToken);
-            var bgChecksDeleted = await _context
-                .BGChecks.Where(b => b.DataSource == deviceId)
-                .ExecuteDeleteAsync(cancellationToken);
-            var notesDeleted = await _context
-                .Notes.Where(n => n.DataSource == deviceId)
-                .ExecuteDeleteAsync(cancellationToken);
-            var deviceEventsDeleted = await _context
-                .DeviceEvents.Where(de => de.DataSource == deviceId)
-                .ExecuteDeleteAsync(cancellationToken);
-            var bolusCalcsDeleted = await _context
-                .BolusCalculations.Where(bc => bc.DataSource == deviceId)
-                .ExecuteDeleteAsync(cancellationToken);
-
-            // Delete device status by device
-            var deviceStatusDeleted = await _context
-                .ApsSnapshots.Where(ds => ds.Device == deviceId)
-                .ExecuteDeleteAsync(cancellationToken);
-
-            var stateSpansDeleted = await _context
-                .StateSpans.Where(s => s.Source == deviceId)
-                .ExecuteDeleteAsync(cancellationToken);
-
-            var deletedCounts = new Dictionary<string, long>();
-            if (sensorGlucoseDeleted > 0) deletedCounts[nameof(SyncDataType.Glucose)] = sensorGlucoseDeleted;
-            if (meterGlucoseDeleted > 0) deletedCounts[nameof(SyncDataType.ManualBG)] = meterGlucoseDeleted;
-            if (calibrationsDeleted > 0) deletedCounts[nameof(SyncDataType.Calibrations)] = calibrationsDeleted;
-            if (bolusesDeleted > 0) deletedCounts[nameof(SyncDataType.Boluses)] = bolusesDeleted;
-            if (carbIntakesDeleted > 0) deletedCounts[nameof(SyncDataType.CarbIntake)] = carbIntakesDeleted;
-            if (bgChecksDeleted > 0) deletedCounts[nameof(SyncDataType.BGChecks)] = bgChecksDeleted;
-            if (notesDeleted > 0) deletedCounts[nameof(SyncDataType.Notes)] = notesDeleted;
-            if (deviceEventsDeleted > 0) deletedCounts[nameof(SyncDataType.DeviceEvents)] = deviceEventsDeleted;
-            if (bolusCalcsDeleted > 0) deletedCounts[nameof(SyncDataType.BolusCalculations)] = bolusCalcsDeleted;
-            if (deviceStatusDeleted > 0) deletedCounts[nameof(SyncDataType.DeviceStatus)] = deviceStatusDeleted;
-            if (stateSpansDeleted > 0) deletedCounts[nameof(SyncDataType.StateSpans)] = stateSpansDeleted;
+            var deletedCounts = await DeleteAllSourceDataAsync(deviceId, cancellationToken);
 
             _logger.LogInformation(
                 "Deleted data for {DeviceId}: {DeletedCounts}",

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceDeleteConnectorDataTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceDeleteConnectorDataTests.cs
@@ -1,0 +1,227 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Audit;
+using Nocturne.API.Services.Connectors;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.Nightscout.Configurations;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Connectors;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Extensions;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Connectors;
+
+/// <summary>
+/// Covers the consistency fix for <see cref="DataSourceService.DeleteConnectorDataAsync"/>: every
+/// data type a connector wrote must be deleted through the strongest audited path it supports (so
+/// auditable types are user-attributed and the soft-delete dedup blocks re-import), and the connector
+/// must be disabled so a scheduled sync can't re-import. Previously treatments hard-deleted with no
+/// audit and silently re-imported on the next sync.
+/// </summary>
+[Trait("Category", "Unit")]
+public class DataSourceServiceDeleteConnectorDataTests : IDisposable
+{
+    private static readonly Guid TenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    private const string ConnectorId = "nightscout";
+    private const string AuthType = "OAuthAccessToken";
+
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<NocturneDbContext> _dbOptions;
+    private readonly string _deviceId;
+
+    private readonly Mock<ISensorGlucoseRepository> _sensorGlucose = new();
+    private readonly Mock<IMeterGlucoseRepository> _meterGlucose = new();
+    private readonly Mock<ICalibrationRepository> _calibrations = new();
+    private readonly Mock<IConnectorConfigurationService> _connectorConfig = new();
+
+    private readonly AuditContext _auditContext = new()
+    {
+        SubjectId = Guid.Parse("00000000-0000-0000-0000-0000000000aa"),
+        SubjectName = "admin@example.com",
+        AuthType = AuthType,
+    };
+
+    public DataSourceServiceDeleteConnectorDataTests()
+    {
+        // Force-load the Nightscout connector assembly so the static metadata registry can resolve
+        // the connector id to its data-source id ("nightscout-connector").
+        _ = typeof(NightscoutConnectorConfiguration);
+        _deviceId = ConnectorMetadataService.GetByConnectorId(ConnectorId)?.DataSourceId
+            ?? throw new InvalidOperationException("Nightscout connector metadata failed to load");
+
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _dbOptions = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+
+        using var db = NewContext();
+        db.Database.EnsureCreated();
+        db.Tenants.Add(new TenantEntity { Id = TenantId, Slug = "test" });
+        db.SaveChanges();
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    private NocturneDbContext NewContext() => new(_dbOptions) { TenantId = TenantId };
+
+    private DataSourceService CreateService(NocturneDbContext context) => new(
+        context,
+        _sensorGlucose.Object,
+        _meterGlucose.Object,
+        _calibrations.Object,
+        _auditContext,
+        _connectorConfig.Object,
+        NullLogger<DataSourceService>.Instance);
+
+    private void SeedOneOfEachType()
+    {
+        using var db = NewContext();
+
+        // Auditable + soft-deletable: audited soft-delete, user-attributed, blocks re-import.
+        db.Boluses.Add(new BolusEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            LegacyId = "bolus-1",
+            DataSource = _deviceId,
+            Timestamp = DateTime.UtcNow,
+            Insulin = 1.5,
+        });
+        db.CarbIntakes.Add(new CarbIntakeEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            LegacyId = "carb-1",
+            DataSource = _deviceId,
+            Timestamp = DateTime.UtcNow,
+            Carbs = 20,
+        });
+
+        // Auditable but not soft-deletable: audited hard delete.
+        db.StateSpans.Add(new StateSpanEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            Source = _deviceId,
+            Category = "PumpMode",
+            State = "Automatic",
+            StartTimestamp = DateTime.UtcNow,
+        });
+
+        // Soft-deletable but not auditable: soft-delete without an audit row.
+        db.BGChecks.Add(new BGCheckEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            LegacyId = "bgcheck-1",
+            DataSource = _deviceId,
+            Timestamp = DateTime.UtcNow,
+            Glucose = 100,
+        });
+        db.ApsSnapshots.Add(new ApsSnapshotEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            LegacyId = "aps-1",
+            Device = _deviceId,
+            Timestamp = DateTime.UtcNow,
+            AidAlgorithm = "Loop",
+        });
+
+        db.SaveChanges();
+    }
+
+    [Fact]
+    public async Task DeleteConnectorData_RoutesEachTypeThroughItsStrongestAuditedPath()
+    {
+        SeedOneOfEachType();
+
+        await using (var ctx = NewContext())
+        {
+            var result = await CreateService(ctx).DeleteConnectorDataAsync(ConnectorId);
+            result.Success.Should().BeTrue();
+            result.DeletedCounts.Should().Contain(new KeyValuePair<string, long>("Boluses", 1));
+            result.DeletedCounts.Should().Contain(new KeyValuePair<string, long>("StateSpans", 1));
+        }
+
+        await using var assertCtx = NewContext();
+
+        // Auditable treatments are soft-deleted (row retained, DeletedAt set) — not hard-deleted.
+        var bolus = await assertCtx.Boluses.IgnoreQueryFilters()
+            .SingleAsync(b => b.LegacyId == "bolus-1");
+        bolus.DeletedAt.Should().NotBeNull();
+
+        // ...and carry a user-attributed delete audit row.
+        (await assertCtx.MutationAuditLog.SingleAsync(a =>
+            a.EntityType == "Bolus" && a.EntityId == bolus.Id && a.Action == "delete"))
+            .AuthType.Should().Be(AuthType);
+
+        // StateSpan is hard-deleted but still leaves a user-attributed delete audit row.
+        (await assertCtx.StateSpans.IgnoreQueryFilters().AnyAsync(s => s.Source == _deviceId))
+            .Should().BeFalse();
+        (await assertCtx.MutationAuditLog.Where(a => a.EntityType == "StateSpan" && a.Action == "delete")
+            .ToListAsync())
+            .Should().ContainSingle().Which.AuthType.Should().Be(AuthType);
+
+        // Non-auditable types are soft-deleted with no audit row.
+        var bgCheck = await assertCtx.BGChecks.IgnoreQueryFilters()
+            .SingleAsync(b => b.LegacyId == "bgcheck-1");
+        bgCheck.DeletedAt.Should().NotBeNull();
+        (await assertCtx.ApsSnapshots.IgnoreQueryFilters().SingleAsync(a => a.LegacyId == "aps-1"))
+            .DeletedAt.Should().NotBeNull();
+        (await assertCtx.MutationAuditLog.AnyAsync(a => a.EntityType == "BGCheck"))
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DeleteConnectorData_BlocksReimportOfAuditableTreatments()
+    {
+        SeedOneOfEachType();
+
+        await using (var ctx = NewContext())
+            await CreateService(ctx).DeleteConnectorDataAsync(ConnectorId);
+
+        // The dedup that guards bulk-create now treats the user-deleted bolus as blocking, so the
+        // next sync cannot re-import it.
+        await using var assertCtx = NewContext();
+        var blocked = await assertCtx.GetBlockingLegacyIdsAsync<BolusEntity>(
+            new HashSet<string> { "bolus-1" });
+        blocked.Should().Contain("bolus-1");
+    }
+
+    [Fact]
+    public async Task DeleteConnectorData_DisablesTheConnector()
+    {
+        SeedOneOfEachType();
+
+        await using (var ctx = NewContext())
+            await CreateService(ctx).DeleteConnectorDataAsync(ConnectorId);
+
+        _connectorConfig.Verify(c => c.SetActiveAsync(
+            ConnectorId, false, It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteConnectorData_UnknownConnector_ReturnsFailureWithoutDisabling()
+    {
+        await using var ctx = NewContext();
+        var result = await CreateService(ctx).DeleteConnectorDataAsync("not-a-connector");
+
+        result.Success.Should().BeFalse();
+        _connectorConfig.Verify(c => c.SetActiveAsync(
+            It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}


### PR DESCRIPTION
## Problem

`DELETE /api/v4/services/connectors/{id}/data` deleted data **inconsistently across types**:

- **Glucose** → audited soft-delete (user-attributed → the soft-delete dedup blocks re-import).
- **Treatments / device data** (Boluses, CarbIntakes, BGChecks, Notes, DeviceEvents, BolusCalculations, ApsSnapshots, StateSpans) → raw `ExecuteDelete` → **hard delete, no audit, no soft-delete, no dedup block.**

And it left the connector **enabled**. So on the next scheduled sync, everything *except* glucose silently re-imported — a confusing half-and-half purge.

## Fix

- **Disable the connector first**, so a scheduled or in-flight sync can't re-import the data being purged.
- **Route every type through the strongest audited path it supports**, extracted into one `DeleteAllSourceDataAsync` helper (also reused by the by-source delete path, removing the duplicated block):
  - auditable + soft-deletable (glucose, Bolus, CarbIntake, BolusCalculation, DeviceEvent) → **audited soft-delete**; the user-attributed audit row is what makes the dedup block re-import.
  - auditable, not soft-deletable (StateSpan) → **audited hard delete**.
  - soft-deletable, not auditable (BGChecks, Notes, device status) → **soft-delete** with no audit row; with the connector disabled they do not re-import.

## Tests

New `DataSourceServiceDeleteConnectorDataTests` covers: per-type routing through the right path, the dedup-blocks-re-import guarantee, the connector being disabled, and the unknown-connector failure path.

## Notes

Independent of #383 — works whether the dedup reads the legacy audit-log scan or the new on-row `deleted_by_user` flag (both block a user-attributed soft-delete). No migration; pure code.