### PR TITLE
docs(scalar): Nightscout legacy API gets its own Data Model section

### DIFF
--- a/docs/diagrams/diagrams.yaml
+++ b/docs/diagrams/diagrams.yaml
@@ -101,10 +101,12 @@ diagrams:
   - source: treatment-decomposition.mmd
     title: V1 Treatment Decomposition
     description: How the polymorphic v1 treatment blob is decomposed into focused v4 domain models based on eventType routing.
+    tags: [ns-model-treatments]
 
   - source: profile-decomposition.mmd
     title: V1 Profile Decomposition
     description: How the monolithic Nightscout v1 profile is decomposed into granular v4 domain models, and why each separation exists.
+    tags: [ns-model-profile]
 
   - source: device-insulin-relationships.mmd
     title: Device & Insulin Relationships
@@ -119,7 +121,7 @@ diagrams:
   - source: devicestatus-decomposition.mmd
     title: V1 DeviceStatus Decomposition
     description: How the legacy DeviceStatus blob (with nested openaps/loop/pump/uploader status objects) is decomposed into ApsSnapshot, PumpSnapshot, and UploaderSnapshot rows sharing a CorrelationId, and why each is separate.
-    tags: [Devices]
+    tags: [Devices, ns-model-devicestatus]
 
   - source: meal-event-view.mmd
     title: Meal Event View
@@ -129,7 +131,7 @@ diagrams:
   - source: glucose-source-taxonomy.mmd
     title: Glucose Source Taxonomy
     description: Why SensorGlucose, MeterGlucose, BGCheck, and Calibration are four separate tables. Different source-of-truth units, fidelity, provenance, retention, and device linkage.
-    tags: [Glucose]
+    tags: [Glucose, ns-model-entries]
 
   - source: er-diagram.mmd
     title: Full Entity Model

--- a/src/API/Nocturne.API/Configuration/DiagramDescriptionDocumentTransformer.cs
+++ b/src/API/Nocturne.API/Configuration/DiagramDescriptionDocumentTransformer.cs
@@ -6,18 +6,27 @@ using YamlDotNet.Serialization.NamingConventions;
 namespace Nocturne.API.Configuration;
 
 /// <summary>
-/// Builds the OpenAPI info.description from the diagram manifest, inlining
-/// each diagram's mermaid source as a fenced code block. A lazy-loading
-/// renderer registered via Scalar's <c>AddHeadContent</c> upgrades the
-/// blocks into rendered diagrams when they scroll into view.
+/// Builds the OpenAPI info.description (the Scalar "Introduction" page). For the
+/// Nocturne document this inlines the whole architecture manifest, each diagram's
+/// mermaid source rendered as a fenced code block. The Nightscout document instead
+/// gets a short intro that points readers at the per-collection Data Model pages, so
+/// its introduction is not a single giant architecture dump. A lazy-loading renderer
+/// registered via Scalar's <c>AddHeadContent</c> upgrades the blocks into rendered
+/// diagrams when they scroll into view.
 /// </summary>
 public sealed class DiagramDescriptionDocumentTransformer : IOpenApiDocumentTransformer
 {
-    private readonly string _description;
+    private const string NightscoutIntro = """
+        The legacy Nightscout REST API (v1–v3), preserved for **1:1 compatibility** with the original JavaScript implementation.
+
+        Every legacy write decomposes into Nocturne's granular v4 domain models, and every read projects back from v4 into the legacy shape — there are no standalone legacy tables. See the **Data Model** section for how each legacy collection (entries, treatments, devicestatus, profiles) maps to v4.
+        """;
+
+    private readonly string _nocturneDescription;
 
     public DiagramDescriptionDocumentTransformer(IWebHostEnvironment env)
     {
-        _description = BuildDescription(env);
+        _nocturneDescription = BuildDescription(env);
     }
 
     public Task TransformAsync(
@@ -25,7 +34,9 @@ public sealed class DiagramDescriptionDocumentTransformer : IOpenApiDocumentTran
         OpenApiDocumentTransformerContext context,
         CancellationToken cancellationToken)
     {
-        document.Info.Description = _description;
+        document.Info.Description = context.DocumentName == "nightscout"
+            ? NightscoutIntro
+            : _nocturneDescription;
         return Task.CompletedTask;
     }
 

--- a/src/API/Nocturne.API/Configuration/ScalarExtensionsDocumentTransformer.cs
+++ b/src/API/Nocturne.API/Configuration/ScalarExtensionsDocumentTransformer.cs
@@ -24,6 +24,8 @@ public sealed class ScalarExtensionsDocumentTransformer : IOpenApiDocumentTransf
     private static readonly Dictionary<string, string[]> NightscoutTagGroups = new()
     {
         ["Nightscout Legacy API"] = ["V1", "V2", "V3"],
+        ["Data Model"] =
+            ["ns-model-entries", "ns-model-treatments", "ns-model-devicestatus", "ns-model-profile"],
     };
 
     public Task TransformAsync(

--- a/src/API/Nocturne.API/Configuration/TagDescriptionDocumentTransformer.cs
+++ b/src/API/Nocturne.API/Configuration/TagDescriptionDocumentTransformer.cs
@@ -27,13 +27,25 @@ public sealed class TagDescriptionDocumentTransformer : IOpenApiDocumentTransfor
         ["V1"] = "Nightscout V1",
         ["V2"] = "Nightscout V2",
         ["V3"] = "Nightscout V3",
+        ["ns-model-entries"] = "Entries",
+        ["ns-model-treatments"] = "Treatments",
+        ["ns-model-devicestatus"] = "Device Status",
+        ["ns-model-profile"] = "Profile",
     };
 
     /// <summary>
-    /// Conceptual guide tags that have no operations of their own but still render as
-    /// a standalone sidebar page from their description. Added to the Nocturne document only.
+    /// Conceptual guide tags that have no operations of their own but still render as a
+    /// standalone sidebar page from their description (and any diagrams mapped to them),
+    /// keyed by the OpenAPI document they belong to. The Nocturne document carries the
+    /// <c>Syncing</c> guide; the Nightscout document carries the legacy-to-v4 model-mapping
+    /// pages, one per legacy collection.
     /// </summary>
-    private static readonly string[] StandaloneDocTags = ["Syncing"];
+    private static readonly Dictionary<string, string[]> StandaloneDocTagsByDocument = new()
+    {
+        ["nocturne"] = ["Syncing"],
+        ["nightscout"] =
+            ["ns-model-entries", "ns-model-treatments", "ns-model-devicestatus", "ns-model-profile"],
+    };
 
     private static readonly Dictionary<string, string> Descriptions = new()
     {
@@ -313,6 +325,40 @@ public sealed class TagDescriptionDocumentTransformer : IOpenApiDocumentTransfor
 
             > **Note:** V3 uses `identifier` (a string field) as the primary key for records, not the MongoDB `_id`. When migrating from V1, ensure your client uses the correct identifier field.
             """,
+
+        // ── Nightscout document → V4 model mapping (Data Model section) ──────
+
+        ["ns-model-entries"] = """
+            How legacy **entries** map to Nocturne's v4 glucose model.
+
+            A Nightscout entry is a single polymorphic document discriminated by `type` (`sgv`, `mbg`, `cal`). Nocturne does not store entries as one table — on write each entry is routed by type into a dedicated v4 glucose table, and reads project those tables back into the legacy entry shape.
+
+            | Legacy entry `type` | Nocturne v4 model |
+            | --- | --- |
+            | `sgv` (sensor glucose) | **SensorGlucose** |
+            | `mbg` (meter blood glucose) | **MeterGlucose** / **BGCheck** |
+            | `cal` (calibration) | **Calibration** |
+
+            Splitting by source preserves each reading's true units, fidelity, provenance, and device linkage rather than flattening everything into one numeric blob.
+            """,
+
+        ["ns-model-treatments"] = """
+            How legacy **treatments** map to Nocturne's v4 treatment model.
+
+            A Nightscout treatment is a single polymorphic blob whose `eventType` determines which fields are meaningful. On write, Nocturne routes each treatment by `eventType` into focused v4 domain models (boluses, carb intakes, temp basals, BG checks, notes, site/sensor changes, …); sibling rows that originated from one treatment stay linked by a shared `CorrelationId`. Reads recombine those rows back into the legacy treatment shape.
+            """,
+
+        ["ns-model-devicestatus"] = """
+            How legacy **devicestatus** maps to Nocturne's v4 device model.
+
+            A Nightscout devicestatus document bundles several independent status objects (`openaps`/`loop`, `pump`, `uploader`) into one blob. Nocturne decomposes it into separate v4 snapshots — **ApsSnapshot**, **PumpSnapshot**, and **UploaderSnapshot** — sharing a `CorrelationId` so the original document can be reassembled on read. Keeping them separate lets each evolve and be queried on its own.
+            """,
+
+        ["ns-model-profile"] = """
+            How legacy **profiles** map to Nocturne's v4 therapy model.
+
+            A Nightscout profile is a monolithic document holding therapy settings plus four time-of-day schedules. Nocturne decomposes it into granular v4 models — **Therapy Settings** and separate **Basal**, **Carb Ratio**, **Sensitivity**, and **Target Range** schedules — so each can be versioned and validated independently. Reads project them back into the single legacy profile shape.
+            """,
     };
 
     public Task TransformAsync(
@@ -338,10 +384,10 @@ public sealed class TagDescriptionDocumentTransformer : IOpenApiDocumentTransfor
         }
 
         // Standalone conceptual guide pages have no operations but still render as
-        // their own sidebar entry. Only surface them in the Nocturne document.
-        if (context.DocumentName == "nocturne")
+        // their own sidebar entry. Surface only the ones belonging to this document.
+        if (StandaloneDocTagsByDocument.TryGetValue(context.DocumentName, out var standaloneTags))
         {
-            foreach (var docTag in StandaloneDocTags)
+            foreach (var docTag in standaloneTags)
                 usedTags.Add(docTag);
         }
 


### PR DESCRIPTION
## What

In the `nightscout` Scalar document, the legacy-to-v4 model-mapping content had no home of its own — `DiagramDescriptionDocumentTransformer` dumped the **entire** diagram manifest (all v4 architecture diagrams *plus* the legacy decomposition diagrams) into `info.description`, producing one giant Introduction page "at the start." The `V1 Treatment/Profile/DeviceStatus Decomposition` diagrams were untagged, so they rendered *only* in that dump.

## Change

Add a per-document **"Data Model"** sidebar section to the `nightscout` doc, with one page per legacy collection showing how it decomposes into Nocturne's v4 models:

```
Data Model
  Entries        -> SensorGlucose / MeterGlucose / Calibration
  Treatments     -> Boluses / CarbIntakes / TempBasals / BGChecks / Notes ...
  Device Status  -> ApsSnapshot / PumpSnapshot / UploaderSnapshot
  Profile        -> TherapySettings + Basal/CarbRatio/Sensitivity/Target schedules
```

Each page carries a mapping narrative and its decomposition diagram (the diagrams are now tagged so they land on the right page). The `nightscout` Introduction is trimmed to a short intro that points at the section instead of the full architecture dump.

- Scoped entirely to the `nightscout` document via `StandaloneDocTagsByDocument` and `NightscoutTagGroups`; the `nocturne` document is unchanged.
- Docs/config only — no application code paths touched. `Nocturne.API` builds with 0 errors.

## Files
- `docs/diagrams/diagrams.yaml` — tag the four decomposition diagrams to per-collection tags
- `Configuration/TagDescriptionDocumentTransformer.cs` — display names, per-document standalone tags, mapping descriptions
- `Configuration/ScalarExtensionsDocumentTransformer.cs` — add the "Data Model" tag group
- `Configuration/DiagramDescriptionDocumentTransformer.cs` — document-aware Introduction