### PR TITLE
fix(audit): stop the mutation_audit_log firehose from system/connector writes

### DIFF
--- a/src/API/Nocturne.API/Services/Audit/AuditContext.cs
+++ b/src/API/Nocturne.API/Services/Audit/AuditContext.cs
@@ -16,4 +16,5 @@ public class AuditContext : IAuditContext
     public Guid? TokenId { get; set; }
     public string? CorrelationId { get; set; }
     public string? Endpoint { get; set; }
+    public bool IsSystem { get; set; }
 }

--- a/src/API/Nocturne.API/Services/Audit/SystemAuditScope.cs
+++ b/src/API/Nocturne.API/Services/Audit/SystemAuditScope.cs
@@ -19,6 +19,7 @@ public sealed class SystemAuditScope : IDisposable
     private readonly string? _authType;
     private readonly Guid? _tokenId;
     private readonly string? _ipAddress;
+    private readonly bool _isSystem;
 
     private SystemAuditScope(AuditContext target)
     {
@@ -28,12 +29,14 @@ public sealed class SystemAuditScope : IDisposable
         _authType = target.AuthType;
         _tokenId = target.TokenId;
         _ipAddress = target.IpAddress;
+        _isSystem = target.IsSystem;
 
         target.SubjectId = null;
         target.SubjectName = null;
         target.AuthType = null;
         target.TokenId = null;
         target.IpAddress = null;
+        target.IsSystem = true;
     }
 
     /// <summary>
@@ -54,6 +57,7 @@ public sealed class SystemAuditScope : IDisposable
         _target.AuthType = _authType;
         _target.TokenId = _tokenId;
         _target.IpAddress = _ipAddress;
+        _target.IsSystem = _isSystem;
     }
 
     private sealed class NoOpScope : IDisposable

--- a/src/Core/Nocturne.Core.Contracts/Audit/IAuditContext.cs
+++ b/src/Core/Nocturne.Core.Contracts/Audit/IAuditContext.cs
@@ -13,4 +13,12 @@ public interface IAuditContext
     Guid? TokenId { get; }
     string? CorrelationId { get; }
     string? Endpoint { get; }
+
+    /// <summary>
+    /// True for system/connector/background mutations (no human actor). These are high-volume
+    /// automated data ingestion whose provenance is already captured on the records themselves
+    /// (e.g. <c>data_source</c>), so they are NOT written to the mutation audit log. Defaults to
+    /// false (user-attributed actions), so every existing implementer stays auditable.
+    /// </summary>
+    bool IsSystem => false;
 }

--- a/src/Core/Nocturne.Core.Contracts/Audit/SystemAuditContext.cs
+++ b/src/Core/Nocturne.Core.Contracts/Audit/SystemAuditContext.cs
@@ -14,6 +14,7 @@ public sealed class SystemAuditContext : IAuditContext
     public Guid? TokenId => null;
     public string? CorrelationId { get; init; }
     public string? Endpoint { get; init; }
+    public bool IsSystem => true;
 
     /// <summary>
     /// Creates a system audit context for a background service endpoint.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Interceptors/MutationAuditInterceptor.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Interceptors/MutationAuditInterceptor.cs
@@ -79,6 +79,14 @@ public class MutationAuditInterceptor : SaveChangesInterceptor
                     entry.Property("DeletedByUser").CurrentValue = false;
             }
 
+            // System/connector/background mutations have no human actor. They are high-volume
+            // automated data ingestion (CGM readings, temp basals, etc.) whose provenance is
+            // already captured on the records themselves (data_source), so they are not recorded
+            // here — auditing them grew this table to 36GB / ~1.8M rows-per-day in production.
+            // The soft-delete/dedup maintenance above still runs for these mutations.
+            if (auditContext?.IsSystem == true)
+                continue;
+
             var audit = new MutationAuditLogEntity
             {
                 Id = Guid.CreateVersion7(),

--- a/tests/Unit/Nocturne.API.Tests/Services/Audit/SystemAuditScopeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Audit/SystemAuditScopeTests.cs
@@ -24,6 +24,7 @@ public class SystemAuditScopeTests
             ambient.AuthType.Should().BeNull();
             ambient.TokenId.Should().BeNull();
             ambient.IpAddress.Should().BeNull();
+            ambient.IsSystem.Should().BeTrue();
             ambient.CorrelationId.Should().Be("trace-123");
             ambient.Endpoint.Should().Be("POST /api/sync");
         }
@@ -44,6 +45,7 @@ public class SystemAuditScopeTests
 
         ambient.SubjectId.Should().Be(originalSubject);
         ambient.AuthType.Should().Be("Bearer");
+        ambient.IsSystem.Should().BeFalse();
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Interceptors/MutationAuditInterceptorTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Interceptors/MutationAuditInterceptorTests.cs
@@ -593,8 +593,11 @@ public class MutationAuditInterceptorTests : IDisposable
     }
 
     [Fact]
-    public async Task Create_WithDbContextAuditContext_PopulatesActorFields()
+    public async Task Create_UnderSystemAuditContext_ProducesNoAuditRecord()
     {
+        // System/connector/background mutations carry IsSystem=true and are NOT audited —
+        // their provenance lives on the records themselves. Regression guard for the
+        // mutation_audit_log firehose (~1.8M actorless rows/day) that filled prod disk.
         using var context = CreateContext();
         context.AuditContext = SystemAuditContext.ForService("service:demo-generator");
 
@@ -610,13 +613,34 @@ public class MutationAuditInterceptorTests : IDisposable
 
         await InvokeSavingChanges(context);
 
-        var log = context.ChangeTracker.Entries<MutationAuditLogEntity>()
-            .Select(e => e.Entity).Single();
-        log.AuthType.Should().Be("system");
-        log.Endpoint.Should().Be("service:demo-generator");
-        log.CorrelationId.Should().NotBeNullOrEmpty();
-        log.SubjectId.Should().BeNull();
-        log.IpAddress.Should().BeNull();
+        context.ChangeTracker.Entries<MutationAuditLogEntity>().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SoftDelete_UnderSystemAuditContext_MaintainsDeletedByUser_ButProducesNoAuditRecord()
+    {
+        // The dedup/soft-delete maintenance must still run for system mutations even though
+        // no audit row is written, so connector resync semantics are unchanged.
+        using var context = CreateContext();
+        var entity = new TestAuditableEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = _tenantId,
+            Name = "SystemDeleteMe",
+            DeletedAt = null
+        };
+        context.TestAuditables.Add(entity);
+        await context.SaveChangesAsync();
+
+        using var context2 = CreateContext();
+        context2.AuditContext = SystemAuditContext.ForService("connector:dexcom");
+        var tracked = await context2.TestAuditables.FindAsync(entity.Id);
+        tracked!.DeletedAt = DateTime.UtcNow;
+
+        await InvokeSavingChanges(context2);
+
+        context2.Entry(tracked).Property("DeletedByUser").CurrentValue.Should().NotBeNull();
+        context2.ChangeTracker.Entries<MutationAuditLogEntity>().Should().BeEmpty();
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

`mutation_audit_log` recorded every `IAuditable` change — including the high-volume automated data ingestion from the connector publishers (`GlucosePublisher`, `TreatmentPublisher`, `DevicePublisher`) and V4 decomposers. These run under `SystemAuditScope` / `SystemAuditContext` and have **no human actor**, so they added **~1.8M actorless rows/day** and grew the table to **36GB** in production, filling the disk (98.7% of rows had `subject_id IS NULL`).

## Fix

An audit log records *who changed what*. Actorless system/connector ingestion has no "who", and its provenance is already on the records themselves (`data_source`). So:

- Add an explicit `IsSystem` flag to `IAuditContext` (default `false` via a default-interface-method, so every existing implementer stays auditable).
- Set it under `SystemAuditScope` (restored on dispose) and `SystemAuditContext`.
- `MutationAuditInterceptor` skips writing the audit row when `IsSystem` is true.

**User-attributed mutations are unchanged** — including a user manually editing one of these records (it carries a subject → still audited). The soft-delete/dedup `DeletedByUser` maintenance still runs for system mutations, so connector resync semantics are unchanged.

## Tests

- Rewrote the system-context interceptor test to assert no audit row; added a soft-delete-under-system test proving `DeletedByUser` is still maintained with no audit row; added `IsSystem` set/restore assertions to `SystemAuditScopeTests`.
- Full unit suites pass: `Nocturne.Infrastructure.Data.Tests` 389/389, `Nocturne.API.Tests` 3393/3393.

Pairs with a prod cleanup that pruned the 36GB of accumulated actorless rows (kept user-attributed history).