### PR TITLE
fix(auth): replay rotation successor to concurrent requests, stop domain-wide cookie wipes

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/OidcController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/OidcController.cs
@@ -472,7 +472,8 @@ public class OidcController : ControllerBase
     /// <returns>A new <see cref="OidcTokenResponse"/> with rotated tokens.</returns>
     /// <remarks>
     /// The refresh token is read from the cookie or the <c>Refresh</c> Authorization header (for API clients).
-    /// On failure, all session cookies are cleared to force re-authentication.
+    /// On failure, returns 401 without touching cookies — session cookies are domain-wide, so a
+    /// deletion issued for a stale token would wipe a newer session the browser obtained concurrently.
     /// Logs <see cref="AuthAuditEventType.TokenRefreshed"/> on success.
     /// </remarks>
     /// <response code="200">Tokens refreshed successfully.</response>
@@ -501,8 +502,8 @@ public class OidcController : ControllerBase
 
         if (result == null)
         {
-            // Clear cookies if refresh failed
-            ClearSessionCookies();
+            // No cookie clearing on failure: a stale token (e.g. from a restored tab) must
+            // not wipe the domain-wide session cookies of a newer concurrent session.
             return Unauthorized(
                 new
                 {

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -176,6 +176,7 @@ public static class ServiceRegistrationExtensions
         services.AddScoped<IAuthAuditService, AuthAuditService>();
         services.AddScoped<IJwtService, JwtService>();
         services.AddScoped<IRefreshTokenService, RefreshTokenService>();
+        services.AddSingleton<IRotationSuccessorCache, RotationSuccessorCache>();
         services.AddScoped<IFirstPartyTokenRepository, EfFirstPartyTokenRepository>();
         services.AddScoped<ISubjectService, SubjectService>();
         services.AddScoped<ISessionService, SessionService>();

--- a/src/API/Nocturne.API/Middleware/Handlers/SessionCookieHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/SessionCookieHandler.cs
@@ -79,12 +79,16 @@ public class SessionCookieHandler : IAuthHandler
 
             // Credentials were recognised (cookie present) but invalid — stop the chain.
             // Returning Failure (not Skip) prevents dev-mode auto-auth from kicking in
-            // with the stale request cookies after we've already cleared the response cookies.
+            // with the stale request cookies.
+            // Deliberately do NOT clear cookies here: the session cookies are domain-wide,
+            // so a deletion issued for a stale token (e.g. a restored tab still carrying
+            // yesterday's expired cookie) would wipe a newer session the browser obtained
+            // concurrently. The bad cookie simply keeps failing until the next login
+            // overwrites it.
             _logger.LogDebug(
-                "Access token validation failed ({Error}) and refresh failed, clearing session cookies",
+                "Access token validation failed ({Error}) and refresh failed",
                 validationResult.ErrorCode
             );
-            ClearSessionCookies(context);
             return AuthResult.Failure("Session expired or revoked");
         }
 
@@ -98,13 +102,11 @@ public class SessionCookieHandler : IAuthHandler
                 return refreshResult;
             }
 
-            // Had refresh token but it failed - clear cookies.
-            // Return Failure so the chain stops here rather than falling through to
-            // dev-mode auto-auth (which would re-authenticate using the stale request cookies).
-            _logger.LogDebug(
-                "No access token and refresh token validation failed, clearing session cookies"
-            );
-            ClearSessionCookies(context);
+            // Had refresh token but it failed. Return Failure so the chain stops here
+            // rather than falling through to dev-mode auto-auth (which would
+            // re-authenticate using the stale request cookies). No cookie clearing —
+            // see above.
+            _logger.LogDebug("No access token and refresh token validation failed");
             return AuthResult.Failure("Session expired or revoked");
         }
         // No cookies at all - just skip to next handler without clearing anything
@@ -138,7 +140,6 @@ public class SessionCookieHandler : IAuthHandler
 
             if (newTokens == null)
             {
-                ClearSessionCookies(context);
                 return null;
             }
 
@@ -242,22 +243,6 @@ public class SessionCookieHandler : IAuthHandler
                 Expires = DateTimeOffset.UtcNow.Add(_options.Session.RefreshTokenLifetime),
             }
         );
-    }
-
-    /// <summary>
-    /// Clear session cookies
-    /// </summary>
-    private void ClearSessionCookies(HttpContext context)
-    {
-        var cookieOptions = new CookieOptions
-        {
-            Path = _options.Cookie.Path,
-            Domain = _options.Cookie.Domain,
-        };
-
-        context.Response.Cookies.Delete(_options.Cookie.AccessTokenName, cookieOptions);
-        context.Response.Cookies.Delete(_options.Cookie.RefreshTokenName, cookieOptions);
-        context.Response.Cookies.Delete("IsAuthenticated", cookieOptions);
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Services/Auth/RefreshTokenService.cs
+++ b/src/API/Nocturne.API/Services/Auth/RefreshTokenService.cs
@@ -27,6 +27,7 @@ public class RefreshTokenService : IRefreshTokenService
 {
     private readonly IFirstPartyTokenRepository _repository;
     private readonly IJwtService _jwtService;
+    private readonly IRotationSuccessorCache _successorCache;
     private readonly JwtOptions _options;
     private readonly ILogger<RefreshTokenService> _logger;
 
@@ -35,16 +36,19 @@ public class RefreshTokenService : IRefreshTokenService
     /// </summary>
     /// <param name="repository">Repository for refresh token persistence.</param>
     /// <param name="jwtService">Service for generating crypto-random tokens and computing token hashes.</param>
+    /// <param name="successorCache">Grace-period store replaying a rotation's successor to concurrent requests.</param>
     /// <param name="options">JWT configuration options including refresh token lifetime settings.</param>
     /// <param name="logger">The logger instance.</param>
     public RefreshTokenService(
         IFirstPartyTokenRepository repository,
         IJwtService jwtService,
+        IRotationSuccessorCache successorCache,
         IOptions<JwtOptions> options,
         ILogger<RefreshTokenService> logger)
     {
         _repository = repository;
         _jwtService = jwtService;
+        _successorCache = successorCache;
         _options = options.Value;
         _logger = logger;
     }
@@ -171,7 +175,17 @@ public class RefreshTokenService : IRefreshTokenService
         {
             // A concurrent request rotated this token between our read and our claim. Treat
             // it as a benign race: don't create a second successor (no fork) and don't revoke
-            // the family — the request that won carries the new cookie back to the client.
+            // the family. If the winner has already published its successor, hand that back so
+            // this request authenticates with the same pair the client is converging on.
+            var racedSuccessor = await _successorCache.GetAsync(tokenHash);
+            if (racedSuccessor != null)
+            {
+                _logger.LogDebug(
+                    "Lost refresh-token rotation race for subject {SubjectId} — replaying the winner's successor.",
+                    oldRecord.SubjectId);
+                return racedSuccessor;
+            }
+
             _logger.LogDebug(
                 "Lost refresh-token rotation race for subject {SubjectId} — a concurrent request rotated first.",
                 oldRecord.SubjectId);
@@ -179,6 +193,10 @@ public class RefreshTokenService : IRefreshTokenService
         }
 
         await _repository.CreateAsync(newRecord);
+
+        // Publish the successor for the grace window so concurrent requests still carrying
+        // the old cookie receive this same token instead of failing authentication.
+        await _successorCache.StoreAsync(tokenHash, newRefreshToken, RotationGracePeriod);
 
         _logger.LogDebug(
             "Rotated refresh token for subject {SubjectId}. Old: {OldTokenId}, New: {NewTokenId}",
@@ -190,7 +208,9 @@ public class RefreshTokenService : IRefreshTokenService
     /// <summary>
     /// Handles presentation of an already-revoked refresh token. Reuse of a rotated token
     /// within <see cref="RotationGracePeriod"/> is a concurrent-request race (the client had
-    /// not yet received the rotated cookie); beyond it, reuse signals the token leaked and the
+    /// not yet received the rotated cookie) — when the successor is still cached, it is
+    /// replayed so the request authenticates like the one that won the rotation. Beyond the
+    /// grace period, reuse signals the token leaked and the
     /// token family is revoked. Tokens revoked for any other reason are simply rejected.
     /// </summary>
     private async Task<string?> HandleReuseOfRevokedTokenAsync(RefreshTokenRecord oldRecord)
@@ -205,6 +225,16 @@ public class RefreshTokenService : IRefreshTokenService
         var timeSinceRevocation = DateTime.UtcNow - oldRecord.RevokedAt!.Value;
         if (timeSinceRevocation < RotationGracePeriod)
         {
+            var successor = await _successorCache.GetAsync(oldRecord.TokenHash);
+            if (successor != null)
+            {
+                _logger.LogDebug(
+                    "Refresh token reuse within grace period ({Elapsed:F1}s) for subject {SubjectId} — " +
+                    "concurrent request, replaying the rotation's successor.",
+                    timeSinceRevocation.TotalSeconds, oldRecord.SubjectId);
+                return successor;
+            }
+
             _logger.LogDebug(
                 "Refresh token reuse within grace period ({Elapsed:F1}s) for subject {SubjectId} — " +
                 "concurrent request, skipping family revocation.",

--- a/src/API/Nocturne.API/Services/Auth/RotationSuccessorCache.cs
+++ b/src/API/Nocturne.API/Services/Auth/RotationSuccessorCache.cs
@@ -1,0 +1,46 @@
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Infrastructure.Cache.Abstractions;
+
+namespace Nocturne.API.Services.Auth;
+
+/// <summary>
+/// Cache-backed store mapping a rotated refresh token's hash to its successor token.
+/// Entries expire after the rotation grace period, so a replayed token only resolves
+/// while the reuse is plausibly a concurrent-request race rather than theft. Keys are
+/// SHA-256 hashes of the predecessor token, so the cache key itself reveals nothing.
+/// </summary>
+/// <seealso cref="IRotationSuccessorCache"/>
+/// <seealso cref="RefreshTokenService"/>
+public class RotationSuccessorCache : IRotationSuccessorCache
+{
+    private readonly ICacheService _cache;
+
+    private const string KeyPrefix = "auth:rotation-successor:";
+
+    /// <summary>
+    /// Initialises a new <see cref="RotationSuccessorCache"/>.
+    /// </summary>
+    /// <param name="cache">Distributed or in-process cache used for successor entries.</param>
+    public RotationSuccessorCache(ICacheService cache)
+    {
+        _cache = cache;
+    }
+
+    /// <inheritdoc />
+    public async Task StoreAsync(string oldTokenHash, string successorToken, TimeSpan ttl, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(oldTokenHash) || ttl <= TimeSpan.Zero)
+            return;
+
+        await _cache.SetAsync($"{KeyPrefix}{oldTokenHash}", successorToken, ttl, ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> GetAsync(string oldTokenHash, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(oldTokenHash))
+            return null;
+
+        return await _cache.GetAsync<string>($"{KeyPrefix}{oldTokenHash}", ct);
+    }
+}

--- a/src/Core/Nocturne.Core.Contracts/Auth/IRotationSuccessorCache.cs
+++ b/src/Core/Nocturne.Core.Contracts/Auth/IRotationSuccessorCache.cs
@@ -1,0 +1,28 @@
+namespace Nocturne.Core.Contracts.Auth;
+
+/// <summary>
+/// Short-lived store mapping a just-rotated refresh token (by hash) to its successor token.
+/// An SSR web app fans out several parallel requests per navigation that all carry the same
+/// refresh-token cookie; whichever request rotates first wins, and the others present a
+/// token that is already revoked. Replaying the winner's successor to those losers keeps
+/// them authenticated instead of rendering the user signed out. Entries expire after the
+/// rotation grace period, preserving reuse detection for genuinely stale tokens.
+/// </summary>
+public interface IRotationSuccessorCache
+{
+    /// <summary>
+    /// Record the successor of a rotated token for the duration of the grace period.
+    /// </summary>
+    /// <param name="oldTokenHash">SHA-256 hash of the rotated (now revoked) token.</param>
+    /// <param name="successorToken">Plaintext successor refresh token.</param>
+    /// <param name="ttl">How long replay is allowed (the rotation grace period).</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task StoreAsync(string oldTokenHash, string successorToken, TimeSpan ttl, CancellationToken ct = default);
+
+    /// <summary>
+    /// Look up the successor of a rotated token. Returns null when absent or expired.
+    /// </summary>
+    /// <param name="oldTokenHash">SHA-256 hash of the rotated token being replayed.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<string?> GetAsync(string oldTokenHash, CancellationToken ct = default);
+}

--- a/tests/Integration/Nocturne.API.Tests/Auth/SessionCookieIntegrationTests.cs
+++ b/tests/Integration/Nocturne.API.Tests/Auth/SessionCookieIntegrationTests.cs
@@ -10,8 +10,8 @@ namespace Nocturne.API.Tests.Integration.Auth;
 /// <summary>
 /// Integration tests for session cookie authentication via the SessionCookieHandler.
 /// Validates that the handler authenticates from the .Nocturne.AccessToken cookie,
-/// clears cookies on invalid/expired tokens, and falls through to the next handler
-/// when no cookies are present.
+/// rejects invalid/expired tokens (without clearing the domain-wide session cookies),
+/// and falls through to the next handler when no cookies are present.
 /// </summary>
 [Trait("Category", "Integration")]
 public class SessionCookieIntegrationTests : AspireIntegrationTestBase
@@ -69,7 +69,7 @@ public class SessionCookieIntegrationTests : AspireIntegrationTestBase
     }
 
     [Fact]
-    public async Task SessionCookie_InvalidAccessToken_NoRefresh_ClearsAndSkips()
+    public async Task SessionCookie_InvalidAccessToken_NoRefresh_Rejects()
     {
         // Arrange - set an invalid JWT as the access token cookie
         var handler = new HttpClientHandler();

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/RefreshTokenServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/RefreshTokenServiceTests.cs
@@ -15,6 +15,7 @@ public class RefreshTokenServiceTests
 {
     private readonly Mock<IFirstPartyTokenRepository> _repository = new();
     private readonly Mock<IJwtService> _jwtService = new();
+    private readonly Mock<IRotationSuccessorCache> _successorCache = new();
     private readonly JwtOptions _options = new() { RefreshTokenLifetimeDays = 7 };
     private readonly Guid _subjectId = Guid.CreateVersion7();
 
@@ -22,6 +23,7 @@ public class RefreshTokenServiceTests
         new(
             _repository.Object,
             _jwtService.Object,
+            _successorCache.Object,
             Options.Create(_options),
             NullLogger<RefreshTokenService>.Instance);
 
@@ -171,6 +173,14 @@ public class RefreshTokenServiceTests
                 rec.TokenHash == "hash-new" &&
                 rec.SubjectId == _subjectId),
             default));
+
+        // The successor is published for the grace window so concurrent requests still
+        // carrying the old cookie can converge on the same token.
+        _successorCache.Verify(c => c.StoreAsync(
+            "hash-old",
+            "new-token",
+            It.IsAny<TimeSpan>(),
+            default));
     }
 
     [Fact]
@@ -310,6 +320,99 @@ public class RefreshTokenServiceTests
         // Family should NOT be revoked
         _repository.Verify(
             r => r.RevokeAllForSubjectAsync(It.IsAny<Guid>(), It.IsAny<string>(), default),
+            Times.Never);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task RotateRefreshTokenAsync_ReuseWithinGracePeriod_WithCachedSuccessor_ReturnsSuccessor()
+    {
+        // Arrange — token rotated seconds ago by a concurrent request; the winner's
+        // successor is still in the grace-period cache.
+        _jwtService.Setup(j => j.HashRefreshToken("raced")).Returns("hash-raced");
+
+        _repository.Setup(r => r.FindByHashAsync("hash-raced", default))
+            .ReturnsAsync(MakeRecord(
+                revokedAt: DateTime.UtcNow.AddSeconds(-2),
+                expiresAt: DateTime.UtcNow.AddHours(1),
+                replacedByTokenId: Guid.CreateVersion7()));
+
+        _successorCache.Setup(c => c.GetAsync("hash", default))
+            .ReturnsAsync("winners-token");
+
+        var service = CreateService();
+
+        // Act — the loser authenticates with the same token the winner received.
+        var result = await service.RotateRefreshTokenAsync("raced");
+
+        // Assert
+        result.Should().Be("winners-token");
+
+        // No fork, no revocation: the existing successor is replayed, not re-rotated.
+        _repository.Verify(r => r.CreateAsync(It.IsAny<RefreshTokenRecord>(), default), Times.Never);
+        _repository.Verify(
+            r => r.RevokeAllForSubjectAsync(It.IsAny<Guid>(), It.IsAny<string>(), default),
+            Times.Never);
+        _repository.Verify(
+            r => r.RevokeByOidcSessionAsync(It.IsAny<string>(), It.IsAny<string>(), default),
+            Times.Never);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task RotateRefreshTokenAsync_LostAtomicClaim_WithCachedSuccessor_ReturnsWinnersToken()
+    {
+        // Arrange — token reads as active but a concurrent request wins the atomic claim;
+        // by the time this caller checks, the winner has already published its successor.
+        var oldTokenId = Guid.CreateVersion7();
+        _jwtService.Setup(j => j.HashRefreshToken("old-token")).Returns("hash-old");
+        _jwtService.Setup(j => j.GenerateRefreshToken()).Returns("would-be-fork");
+        _jwtService.Setup(j => j.HashRefreshToken("would-be-fork")).Returns("hash-fork");
+
+        _repository.Setup(r => r.FindByHashAsync("hash-old", default))
+            .ReturnsAsync(MakeRecord(
+                id: oldTokenId,
+                revokedAt: null,
+                expiresAt: DateTime.UtcNow.AddHours(1)));
+
+        _repository.Setup(r => r.TryMarkRotatedAsync(oldTokenId, It.IsAny<Guid>(), default))
+            .ReturnsAsync(false);
+
+        _successorCache.Setup(c => c.GetAsync("hash-old", default))
+            .ReturnsAsync("winners-token");
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.RotateRefreshTokenAsync("old-token");
+
+        // Assert — converges on the winner's token instead of throwing.
+        result.Should().Be("winners-token");
+        _repository.Verify(r => r.CreateAsync(It.IsAny<RefreshTokenRecord>(), default), Times.Never);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task RotateRefreshTokenAsync_RevokedWithoutSuccessor_ReturnsNull_WithoutConsultingCache()
+    {
+        // Arrange — a token revoked by logout (no successor link) presented within what
+        // would be the grace window. Logout must not be resurrectable via the cache.
+        _jwtService.Setup(j => j.HashRefreshToken("logged-out")).Returns("hash-logged-out");
+
+        _repository.Setup(r => r.FindByHashAsync("hash-logged-out", default))
+            .ReturnsAsync(MakeRecord(
+                revokedAt: DateTime.UtcNow.AddSeconds(-2),
+                expiresAt: DateTime.UtcNow.AddHours(1)));
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.RotateRefreshTokenAsync("logged-out");
+
+        // Assert
+        result.Should().BeNull();
+        _successorCache.Verify(
+            c => c.GetAsync(It.IsAny<string>(), default),
             Times.Never);
     }
 


### PR DESCRIPTION
## Problem

Users with busy dashboards or multiple tabs keep getting signed out / stuck in login loops (reported by the as-nocturne tenant on nocturne.run; prod audit log shows 45 logins across 5 users on June 11 alone, including one passkey user who had to sign in 19 times in 2.5 hours).

Production forensics (refresh_tokens + auth_audit_log) showed two compounding causes:

### 1. Rotation race losers render the user signed out

At access-token expiry (15 min), an SSR page fans out several parallel requests that all carry the same refresh-token cookie. One request wins the atomic rotation (#326); the losers hit the grace-period path, which **skips authentication**. Server-side that's harmless, but the losers' *responses* say "unauthenticated" — so the page that lost the race renders the login screen. Every 15 minutes the user rolls the dice; heavy pages (many remote-function calls) and multi-tab users lose almost every time. The DB signature matches exactly: long chains of perfectly valid, never-revoked tokens abandoned mid-chain, with a fresh manual login seconds after a successful rotation (e.g. rotation at 21:20:10.7, manual passkey login at 21:20:13.0).

**Fix:** when a rotation is claimed, publish the successor token in a short-lived cache (`IRotationSuccessorCache`, TTL = the existing 60s grace period, keyed by the predecessor's SHA-256 hash). Grace-period reusers and lost-claim racers get the *same successor pair the winner got* and authenticate normally — the same reuse-leeway behavior Auth0/Okta implement for rotating refresh tokens. Cache miss (other instance / restart) falls back to today's skip-auth behavior. Tokens revoked by logout have no successor link and are never resurrectable; a successor revoked after caching fails downstream validation, so a logout immediately after rotation still wins.

### 2. Stale tokens wipe the domain-wide session cookies

Session cookies are domain-wide in the SaaS deployment (`Domain=.nocturne.run`, shared across tenant subdomains). Any request carrying a stale refresh token — typically a restored tab still holding yesterday's expired cookie — got a cookie-**clearing** response, deleting `.Nocturne.AccessToken` / `.Nocturne.RefreshToken` / `IsAuthenticated` for *every* tab and tenant, wiping the brand-new session the user just obtained. The audit log shows the resulting bursts: 5 fresh OIDC logins in 4 minutes while restored tabs settled.

**Fix:** failed validation/refresh now returns 401/`Failure` **without** deleting cookies (`SessionCookieHandler` + the explicit `/api/auth/oidc/refresh` endpoint). The bad cookie just keeps failing until the next login overwrites it. Logout still clears cookies.

## Testing

- New unit tests: winner publishes successor; grace-period reuse with cached successor returns it without forking or revoking; lost atomic claim converges on the winner's token; logout-revoked tokens never consult the cache.
- Full `Nocturne.API.Tests` unit suite: 3396 passed.

## Security notes

- The successor is cached plaintext for ≤60s, keyed by a hash; exposure window equals the existing grace period during which reuse is already deemed benign.
- Reuse detection outside the grace window (session-chain revocation, #327) is unchanged.