### PR TITLE
fix(connectors): stop TreatmentPublisher poisoning the shared DbContext; de-pool NocturneDbContext

### DIFF
--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -227,12 +227,11 @@ public class TenantResolutionMiddleware
 
     /// <summary>
     /// Pins the resolved tenant onto the request-scoped <see cref="NocturneDbContext"/>.
-    /// The scoped context is pool-leased (<c>AddPooledDbContextFactory</c>) and its
-    /// <c>TenantId</c> is a custom property that pooling does not reset, so without this a
-    /// request can inherit a previous lessee's tenant. The <c>TenantConnectionInterceptor</c>
+    /// The scoped context's <c>TenantId</c> defaults to <c>Guid.Empty</c>, so without this a
+    /// directly-injected context has no tenant set. The <c>TenantConnectionInterceptor</c>
     /// reads <c>TenantId</c> to scope Row-Level Security on connection open, so any
     /// directly-injected context (e.g. connector-configuration reads) would otherwise run under
-    /// a stale tenant — most visibly on unauthenticated flows (setup/onboarding) that have no
+    /// an empty tenant — most visibly on unauthenticated flows (setup/onboarding) that have no
     /// auth handler to set it.
     /// </summary>
     private static void PinTenantOnScopedDbContext(HttpContext context, Guid tenantId)
@@ -241,8 +240,8 @@ public class TenantResolutionMiddleware
         if (db is null)
             return;
         db.TenantId = tenantId;
-        // Set the share carrier unconditionally so a pooled context never inherits a prior
-        // lessee's share state. The scoped-direct context carries only the marker (known
+        // Set the share carrier unconditionally so a directly-injected context never carries
+        // unintended share state. The scoped-direct context carries only the marker (known
         // pre-auth) and leaves the CSV null, so a share reading PHI on this path is denied.
         db.IsShareContext = context.RequestServices.GetService<ICategoryReadContext>()?.IsShare == true;
         db.VisibleCategories = null;

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/TreatmentPublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/TreatmentPublisher.cs
@@ -6,8 +6,8 @@ using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
-using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Services;
 
 namespace Nocturne.API.Services.ConnectorPublishing;
 
@@ -19,7 +19,7 @@ namespace Nocturne.API.Services.ConnectorPublishing;
 /// <seealso cref="ITreatmentPublisher"/>
 internal sealed class TreatmentPublisher : ITreatmentPublisher
 {
-    private readonly NocturneDbContext _dbContext;
+    private readonly ITenantDbContextFactory _contextFactory;
     private readonly ITreatmentService _treatmentService;
     private readonly IBolusRepository _bolusRepository;
     private readonly ICarbIntakeRepository _carbIntakeRepository;
@@ -34,7 +34,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
     private readonly ILogger<TreatmentPublisher> _logger;
 
     public TreatmentPublisher(
-        NocturneDbContext dbContext,
+        ITenantDbContextFactory contextFactory,
         ITreatmentService treatmentService,
         IBolusRepository bolusRepository,
         ICarbIntakeRepository carbIntakeRepository,
@@ -48,7 +48,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
         IAuditContext auditContext,
         ILogger<TreatmentPublisher> logger)
     {
-        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
         _treatmentService = treatmentService ?? throw new ArgumentNullException(nameof(treatmentService));
         _bolusRepository = bolusRepository ?? throw new ArgumentNullException(nameof(bolusRepository));
         _carbIntakeRepository = carbIntakeRepository ?? throw new ArgumentNullException(nameof(carbIntakeRepository));
@@ -302,19 +302,20 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
             var batchList = batches.ToList();
             if (batchList.Count == 0) return true;
 
+            await using var ctx = await _contextFactory.CreateAsync(cancellationToken);
             foreach (var batch in batchList)
             {
-                _dbContext.DecompositionBatches.Add(new DecompositionBatchEntity
+                ctx.DecompositionBatches.Add(new DecompositionBatchEntity
                 {
                     Id = batch.Id,
-                    TenantId = _dbContext.TenantId,
+                    TenantId = ctx.TenantId,
                     Source = batch.Source,
                     SourceRecordId = batch.SourceRecordId,
                     CreatedAt = batch.CreatedAt,
                 });
             }
 
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            await ctx.SaveChangesAsync(cancellationToken);
             _logger.LogDebug("Published {Count} DecompositionBatch records for {Source}", batchList.Count, source);
             return true;
         }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/ServiceCollectionExtensions.cs
@@ -65,8 +65,10 @@ public static class ServiceCollectionExtensions
         var dataSource = dataSourceBuilder.Build();
         services.AddSingleton(dataSource);
 
-        // Use AddPooledDbContextFactory for multitenant context pooling
-        services.AddPooledDbContextFactory<NocturneDbContext>(
+        // Non-pooled: each acquisition is a fresh context, discarded after use. A faulted context
+        // is never returned to a pool and reused, so a fault cannot poison later callers. Database
+        // connections are pooled by the NpgsqlDataSource singleton.
+        services.AddDbContextFactory<NocturneDbContext>(
             (sp, options) =>
             {
                 options.UseNpgsql(
@@ -97,18 +99,17 @@ public static class ServiceCollectionExtensions
                 options.AddInterceptors(
                     sp.GetRequiredService<TenantConnectionInterceptor>(),
                     sp.GetRequiredService<MutationAuditInterceptor>());
-            },
-            poolSize: 128
+            }
         );
 
-        // Reset the four pooled-context carriers to fail-closed defaults on every lease
-        // (pooling does not reset custom properties), so the raw IDbContextFactory callers
-        // cannot inherit a prior lessee's tenant or share state. See CarrierResettingDbContextFactory.
+        // Normalize the four context carriers to fail-closed defaults on every acquisition, so raw
+        // IDbContextFactory callers start from a known-safe tenant/share state. See
+        // CarrierResettingDbContextFactory.
         DecorateWithCarrierReset(services);
 
         // Register scoped NocturneDbContext that sets TenantId from ITenantAccessor.
         // All existing constructor injections of NocturneDbContext continue to work.
-        // The context is returned to the pool when the scope ends.
+        // The context is disposed when the scope ends.
         services.AddScoped(sp =>
         {
             var factory = sp.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
@@ -150,15 +151,15 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
-    // Replaces the registered pooled IDbContextFactory<NocturneDbContext> with a decorator that
-    // resets the carrier properties on every lease. Applied immediately after
-    // AddPooledDbContextFactory so the descriptor it wraps is the pooling factory.
+    // Replaces the registered IDbContextFactory<NocturneDbContext> with a decorator that
+    // normalizes the carrier properties on every acquisition. Applied immediately after
+    // AddDbContextFactory so the descriptor it wraps is the registered factory.
     private static void DecorateWithCarrierReset(IServiceCollection services)
     {
         var descriptor = services.LastOrDefault(
             d => d.ServiceType == typeof(IDbContextFactory<NocturneDbContext>))
             ?? throw new InvalidOperationException(
-                "AddPooledDbContextFactory<NocturneDbContext> must be registered before decorating it.");
+                "AddDbContextFactory<NocturneDbContext> must be registered before decorating it.");
 
         services.Remove(descriptor);
         services.Add(new ServiceDescriptor(
@@ -235,8 +236,10 @@ public static class ServiceCollectionExtensions
         var dataSource = dataSourceBuilder.Build();
         services.AddSingleton(dataSource);
 
-        // Use AddPooledDbContextFactory for multitenant context pooling
-        services.AddPooledDbContextFactory<NocturneDbContext>(
+        // Non-pooled: each acquisition is a fresh context, discarded after use. A faulted context
+        // is never returned to a pool and reused, so a fault cannot poison later callers. Database
+        // connections are pooled by the NpgsqlDataSource singleton.
+        services.AddDbContextFactory<NocturneDbContext>(
             (sp, options) =>
             {
                 options.UseNpgsql(
@@ -267,13 +270,12 @@ public static class ServiceCollectionExtensions
                 options.AddInterceptors(
                     sp.GetRequiredService<TenantConnectionInterceptor>(),
                     sp.GetRequiredService<MutationAuditInterceptor>());
-            },
-            poolSize: 128
+            }
         );
 
-        // Reset the four pooled-context carriers to fail-closed defaults on every lease
-        // (pooling does not reset custom properties), so the raw IDbContextFactory callers
-        // cannot inherit a prior lessee's tenant or share state. See CarrierResettingDbContextFactory.
+        // Normalize the four context carriers to fail-closed defaults on every acquisition, so raw
+        // IDbContextFactory callers start from a known-safe tenant/share state. See
+        // CarrierResettingDbContextFactory.
         DecorateWithCarrierReset(services);
 
         // Register scoped DbContext, repositories, and shared services.
@@ -291,7 +293,7 @@ public static class ServiceCollectionExtensions
     {
         // Register scoped NocturneDbContext that sets TenantId from ITenantAccessor.
         // All existing constructor injections of NocturneDbContext continue to work.
-        // The context is returned to the pool when the scope ends.
+        // The context is disposed when the scope ends.
         services.AddScoped(sp =>
         {
             var factory = sp.GetRequiredService<IDbContextFactory<NocturneDbContext>>();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/CarrierResettingDbContextFactory.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/CarrierResettingDbContextFactory.cs
@@ -3,21 +3,18 @@ using Microsoft.EntityFrameworkCore;
 namespace Nocturne.Infrastructure.Data.Services;
 
 /// <summary>
-/// Decorates the pooled <see cref="IDbContextFactory{TContext}"/> so every lease of a
+/// Decorates the <see cref="IDbContextFactory{TContext}"/> so every acquisition of a
 /// <see cref="NocturneDbContext"/> starts from fail-closed carrier defaults.
 ///
 /// <para>
-/// <see cref="NocturneDbContext"/> is pooled (<c>AddPooledDbContextFactory</c>), and pooling
-/// does not reset custom properties between leases. A context returned to the pool therefore
-/// keeps the previous lessee's <see cref="NocturneDbContext.TenantId"/>,
+/// The context carries per-request state — <see cref="NocturneDbContext.TenantId"/>,
 /// <see cref="NocturneDbContext.AuditContext"/>, <see cref="NocturneDbContext.IsShareContext"/>
-/// and <see cref="NocturneDbContext.VisibleCategories"/>. The <c>ITenantDbContextFactory</c> and
-/// scoped-context registration already stamp those on acquisition; the callers that take the raw
-/// factory and call <see cref="IDbContextFactory{TContext}.CreateDbContext"/> directly do not, so
-/// a context that last served a public share could carry <c>IsShareContext = true</c> into a later
-/// lease — and the per-category share RLS policy denies that lease's reads of any tenant-scoped
-/// table (a silent, fail-closed lockout), while a stale non-empty <see cref="NocturneDbContext.TenantId"/>
-/// could expose another tenant's rows.
+/// and <see cref="NocturneDbContext.VisibleCategories"/> — that the RLS policy reads. The
+/// <c>ITenantDbContextFactory</c> and scoped-context registration stamp those on acquisition;
+/// callers that take the raw factory and call <see cref="IDbContextFactory{TContext}.CreateDbContext"/>
+/// directly do not. Normalizing to safe defaults here guarantees that, however a context is
+/// obtained, a missing stamp fails closed: a null category CSV denies categorized reads rather
+/// than exposing them, and an empty <see cref="NocturneDbContext.TenantId"/> matches no tenant's rows.
 /// </para>
 ///
 /// <para>

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
@@ -507,9 +507,9 @@ public class ConnectorBackgroundServiceTests
     [Fact]
     public async Task SyncForTenant_PinsScopedDbContextToSyncedTenant_ForRlsIsolation()
     {
-        // Regression test for the connector-wide outage: NocturneDbContext is leased from a pool
-        // (AddPooledDbContextFactory) and its TenantId is NOT reset between leases. The background
-        // sync must set dbContext.TenantId to the tenant being synced — otherwise the
+        // Regression test for the connector-wide outage: a NocturneDbContext's TenantId defaults
+        // to Guid.Empty. The background sync must set dbContext.TenantId to the tenant being
+        // synced — otherwise the
         // TenantConnectionInterceptor applies a stale/empty RLS tenant, tenant-scoped reads
         // (connector config + secrets) silently return nothing, and every connector authenticates
         // with empty credentials. Before the fix the scoped context stayed at Guid.Empty here.

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/TreatmentPublisherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/TreatmentPublisherTests.cs
@@ -12,6 +12,7 @@ using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Services;
 using Xunit;
 
 namespace Nocturne.API.Tests.Services.ConnectorPublishing;
@@ -29,7 +30,16 @@ public class TreatmentPublisherTests
     private readonly Mock<IPatientInsulinRepository> _mockPatientInsulinRepository;
     private readonly Mock<IBasalRateResolver> _mockBasalRateResolver;
     private readonly Mock<ITherapySettingsResolver> _mockTherapySettingsResolver;
+    private Mock<ITenantDbContextFactory> _mockContextFactory = null!;
     private readonly TreatmentPublisher _publisher;
+
+    private static readonly Guid TestTenantId = Guid.NewGuid();
+
+    private static NocturneDbContext NewDbContext() =>
+        new(new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options)
+        { TenantId = TestTenantId };
 
     public TreatmentPublisherTests()
     {
@@ -57,13 +67,13 @@ public class TreatmentPublisherTests
 
     private TreatmentPublisher CreatePublisher(IAuditContext auditContext)
     {
-        var dbOptions = new DbContextOptionsBuilder<NocturneDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        var dbContext = new NocturneDbContext(dbOptions);
+        _mockContextFactory = new Mock<ITenantDbContextFactory>();
+        _mockContextFactory
+            .Setup(f => f.CreateAsync(It.IsAny<CancellationToken>()))
+            .Returns(() => new ValueTask<NocturneDbContext>(NewDbContext()));
 
         return new TreatmentPublisher(
-            dbContext,
+            _mockContextFactory.Object,
             _mockTreatmentService.Object,
             _mockBolusRepository.Object,
             _mockCarbIntakeRepository.Object,
@@ -106,6 +116,31 @@ public class TreatmentPublisherTests
         var result = await _publisher.PublishTreatmentsAsync(new List<Treatment>(), "test-source");
 
         result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task PublishDecompositionBatchesAsync_ConcurrentCalls_AcquireIndependentContexts()
+    {
+        var calls = Enumerable.Range(0, 16).Select(i =>
+            _publisher.PublishDecompositionBatchesAsync(
+                new[]
+                {
+                    new DecompositionBatch
+                    {
+                        Id = Guid.NewGuid(),
+                        Source = "test-source",
+                        SourceRecordId = $"record-{i}",
+                        CreatedAt = DateTime.UtcNow,
+                    },
+                },
+                "test-source"));
+
+        var results = await Task.WhenAll(calls);
+
+        results.Should().OnlyContain(r => r);
+        _mockContextFactory.Verify(
+            f => f.CreateAsync(It.IsAny<CancellationToken>()),
+            Times.Exactly(16));
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

Production `nocturne-api` cascaded into an API-wide outage: thousands/hour of EF Core `"A second operation was started on this context instance before a previous operation completed"`, growing exponentially and spreading to every service that leases a `NocturneDbContext` (connector publishers, alert/notification sweeps, the `Statistics/periods` dashboard endpoint — surfacing as **400s on dashboard widgets**). Only a process restart cleared it.

## Root cause (confirmed from logs)

The earliest errors were all `TreatmentPublisher`, source `mylife-connector`, before spreading to victims.

- `TreatmentPublisher` was the **only** connector publisher injecting the request-scoped `NocturneDbContext` directly (for decomposition-batch writes); every sibling uses `ITenantDbContextFactory` per call.
- On the MyLife sync path a second operation overlapped its `SaveChangesAsync`, tripping EF's `ConcurrencyDetector`.
- Because the context is **pooled** (`AddPooledDbContextFactory`), the faulted instance returned to the pool and every subsequent lease re-threw — one connector's bug cascaded API-wide.

## Fix

1. **`PublishDecompositionBatchesAsync`** now uses `ITenantDbContextFactory` (own per-call context via `await using`), matching the other publishers — removes it from the shared-context race at the source.
2. **De-pool `NocturneDbContext`**: `AddPooledDbContextFactory(…, poolSize: 128)` → `AddDbContextFactory(…)` at both registration sites. A faulted context is now discarded rather than reused, so any future concurrent-use bug stays isolated instead of poisoning the pool. `NpgsqlDataSource` still pools the database connections.
3. **Regression test** that fires 16 concurrent `PublishDecompositionBatchesAsync` calls and asserts each acquires its own context with no `ConcurrencyDetector` throw.

## Tests

1,313 `Nocturne.API.Tests` + 350 `Nocturne.Infrastructure.Data.Tests` green.