### PR TITLE
fix(timezone): resolve mis-cased IANA zone IDs instead of degrading to UTC

### DIFF
--- a/src/API/Nocturne.API/Services/Alerts/AlertReplayService.cs
+++ b/src/API/Nocturne.API/Services/Alerts/AlertReplayService.cs
@@ -463,17 +463,7 @@ internal sealed class AlertReplayService(
             return (now.AddHours(-24), now);
         }
 
-        TimeZoneInfo tz;
-        try
-        {
-            tz = string.IsNullOrWhiteSpace(timezone)
-                ? TimeZoneInfo.Utc
-                : TimeZoneInfo.FindSystemTimeZoneById(timezone);
-        }
-        catch (TimeZoneNotFoundException)
-        {
-            tz = TimeZoneInfo.Utc;
-        }
+        var tz = TimeZoneHelper.GetTimeZoneInfoFromId(timezone);
 
         var localStart = localDate.Value.ToDateTime(TimeOnly.MinValue);
         var localEnd = localStart.AddDays(1);

--- a/src/API/Nocturne.API/Services/Alerts/Evaluators/DayOfWeekEvaluator.cs
+++ b/src/API/Nocturne.API/Services/Alerts/Evaluators/DayOfWeekEvaluator.cs
@@ -36,22 +36,7 @@ public sealed class DayOfWeekEvaluator : IConditionEvaluator
         if (condition is null || condition.Days is null || condition.Days.Count == 0)
             return Task.FromResult(false);
 
-        TimeZoneInfo tz;
-        if (string.IsNullOrEmpty(context.TenantTimeZoneId))
-        {
-            tz = TimeZoneInfo.Utc;
-        }
-        else
-        {
-            try
-            {
-                tz = TimeZoneInfo.FindSystemTimeZoneById(context.TenantTimeZoneId);
-            }
-            catch
-            {
-                tz = TimeZoneInfo.Utc;
-            }
-        }
+        var tz = TimeZoneHelper.GetTimeZoneInfoFromId(context.TenantTimeZoneId);
 
         var nowUtc = _timeProvider.GetUtcNow().UtcDateTime;
         var localNow = TimeZoneInfo.ConvertTimeFromUtc(DateTime.SpecifyKind(nowUtc, DateTimeKind.Utc), tz);

--- a/src/API/Nocturne.API/Services/Alerts/Evaluators/TimeOfDayEvaluator.cs
+++ b/src/API/Nocturne.API/Services/Alerts/Evaluators/TimeOfDayEvaluator.cs
@@ -57,34 +57,17 @@ public class TimeOfDayEvaluator : IConditionEvaluator
         TimeZoneInfo tz;
         if (!string.IsNullOrEmpty(condition.Timezone))
         {
-            // Explicit per-rule timezone wins; an unparseable id is treated as a malformed
+            // Explicit per-rule timezone wins; an unresolvable id is treated as a malformed
             // rule (false) rather than silently falling back, to match the existing contract.
-            try
-            {
-                tz = TimeZoneInfo.FindSystemTimeZoneById(condition.Timezone);
-            }
-            catch
-            {
+            if (!TimeZoneHelper.TryGetTimeZoneInfoFromId(condition.Timezone, out tz))
                 return Task.FromResult(false);
-            }
-        }
-        else if (!string.IsNullOrEmpty(context.TenantTimeZoneId))
-        {
-            // Tenant fallback: an unparseable tenant id swallows to UTC (matches
-            // DayOfWeekEvaluator) — the tenant tz arrives from configuration the rule author
-            // didn't choose, so we shouldn't refuse to evaluate over it.
-            try
-            {
-                tz = TimeZoneInfo.FindSystemTimeZoneById(context.TenantTimeZoneId);
-            }
-            catch
-            {
-                tz = TimeZoneInfo.Utc;
-            }
         }
         else
         {
-            tz = TimeZoneInfo.Utc;
+            // Tenant fallback: an unresolvable (or absent) tenant id swallows to UTC (matches
+            // DayOfWeekEvaluator) — the tenant tz arrives from configuration the rule author
+            // didn't choose, so we shouldn't refuse to evaluate over it.
+            tz = TimeZoneHelper.GetTimeZoneInfoFromId(context.TenantTimeZoneId);
         }
 
         var nowUtc = _timeProvider.GetUtcNow().UtcDateTime;

--- a/src/API/Nocturne.API/Services/Alerts/SensorContextEnricher.cs
+++ b/src/API/Nocturne.API/Services/Alerts/SensorContextEnricher.cs
@@ -330,17 +330,7 @@ internal sealed class SensorContextEnricher : ISensorContextEnricher
         var atUtc = DateTime.SpecifyKind(at, DateTimeKind.Utc);
         var atLocal = atUtc;
         if (!string.IsNullOrEmpty(tenantTimeZoneId))
-        {
-            try
-            {
-                var tz = TimeZoneInfo.FindSystemTimeZoneById(tenantTimeZoneId);
-                atLocal = TimeZoneInfo.ConvertTimeFromUtc(atUtc, tz);
-            }
-            catch
-            {
-                atLocal = atUtc;
-            }
-        }
+            atLocal = TimeZoneInfo.ConvertTimeFromUtc(atUtc, TimeZoneHelper.GetTimeZoneInfoFromId(tenantTimeZoneId));
 
         var sortedEntries = schedule.Entries.OrderBy(e => e.TimeAsSeconds ?? 0).ToList();
         var localTime = TimeOnly.FromDateTime(atLocal);

--- a/src/API/Nocturne.API/Services/Analytics/ChartDataService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/ChartDataService.cs
@@ -392,17 +392,7 @@ public class ChartDataService : IChartDataService
     {
         var time = DateTimeOffset.FromUnixTimeMilliseconds(mills);
         if (!string.IsNullOrEmpty(timezone))
-        {
-            try
-            {
-                var tz = TimeZoneInfo.FindSystemTimeZoneById(timezone);
-                time = TimeZoneInfo.ConvertTime(time, tz);
-            }
-            catch
-            {
-                // Fall back to UTC if timezone conversion fails
-            }
-        }
+            time = TimeZoneInfo.ConvertTime(time, TimeZoneHelper.GetTimeZoneInfoFromId(timezone));
         return time.Hour switch
         {
             >= 5 and < 11 => "Breakfast",

--- a/src/API/Nocturne.API/Services/Monitoring/PumpAlertService.cs
+++ b/src/API/Nocturne.API/Services/Monitoring/PumpAlertService.cs
@@ -476,7 +476,7 @@ public class PumpAlertService : IPumpAlertService
             if (string.IsNullOrEmpty(timezone))
                 return true;
 
-            var tz = TimeZoneInfo.FindSystemTimeZoneById(timezone);
+            var tz = TimeZoneHelper.GetTimeZoneInfoFromId(timezone);
             var localTime = TimeZoneInfo.ConvertTimeFromUtc(
                 DateTimeOffset.FromUnixTimeMilliseconds(currentTime).UtcDateTime,
                 tz

--- a/src/API/Nocturne.API/Services/Profiles/Resolvers/BasalRateResolver.cs
+++ b/src/API/Nocturne.API/Services/Profiles/Resolvers/BasalRateResolver.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
 
 namespace Nocturne.API.Services.Profiles.Resolvers;
 
@@ -87,20 +88,18 @@ internal sealed class BasalRateResolver : IBasalRateResolver
             schedules[name] = await GetCachedScheduleAsync(name, rangeStart, ct);
 
             var therapy = await _therapyRepo.GetActiveAtAsync(name, rangeStart, ct);
-            TimeZoneInfo? tz = null;
-            if (!string.IsNullOrEmpty(therapy?.Timezone))
+            // null when unset/unresolvable so the closure skips conversion (treats the stamp as UTC).
+            // TimeZoneHelper resolves IANA/Windows IDs and mis-cased IANA IDs (e.g. "ETC/GMT-2").
+            if (TimeZoneHelper.TryGetTimeZoneInfoFromId(therapy?.Timezone, out var tz))
             {
-                try { tz = TimeZoneInfo.FindSystemTimeZoneById(therapy.Timezone); }
-                catch (TimeZoneNotFoundException ex)
-                {
-                    _logger.LogWarning(ex, "Timezone '{Timezone}' for profile '{Profile}' not found on this system", therapy.Timezone, name);
-                }
-                catch (InvalidTimeZoneException ex)
-                {
-                    _logger.LogWarning(ex, "Timezone '{Timezone}' for profile '{Profile}' is invalid", therapy.Timezone, name);
-                }
+                timezones[name] = tz;
             }
-            timezones[name] = tz;
+            else
+            {
+                if (!string.IsNullOrEmpty(therapy?.Timezone))
+                    _logger.LogWarning("Timezone '{Timezone}' for profile '{Profile}' could not be resolved", therapy.Timezone, name);
+                timezones[name] = null;
+            }
         }
 
         // Closure over pre-fetched data — no DB access inside.

--- a/src/API/Nocturne.API/Services/Profiles/Resolvers/ScheduleTimeHelper.cs
+++ b/src/API/Nocturne.API/Services/Profiles/Resolvers/ScheduleTimeHelper.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
 
 namespace Nocturne.API.Services.Profiles.Resolvers;
 
@@ -26,21 +27,7 @@ internal static class ScheduleTimeHelper
         var dto = DateTimeOffset.FromUnixTimeMilliseconds(timeMills);
 
         if (!string.IsNullOrEmpty(timezone))
-        {
-            try
-            {
-                var tz = TimeZoneInfo.FindSystemTimeZoneById(timezone);
-                dto = TimeZoneInfo.ConvertTime(dto, tz);
-            }
-            catch (TimeZoneNotFoundException)
-            {
-                // Fall through to UTC
-            }
-            catch (InvalidTimeZoneException)
-            {
-                // Fall through to UTC
-            }
-        }
+            dto = TimeZoneInfo.ConvertTime(dto, TimeZoneHelper.GetTimeZoneInfoFromId(timezone));
 
         return (int)dto.TimeOfDay.TotalSeconds;
     }

--- a/src/API/Nocturne.API/Services/Profiles/Resolvers/TherapyTimelineResolver.cs
+++ b/src/API/Nocturne.API/Services/Profiles/Resolvers/TherapyTimelineResolver.cs
@@ -187,20 +187,5 @@ internal sealed class TherapyTimelineResolver : ITherapyTimelineResolver
     }
 
     private static TimeZoneInfo? ResolveTimezone(string? id)
-    {
-        if (string.IsNullOrEmpty(id))
-            return null;
-        try
-        {
-            return TimeZoneInfo.FindSystemTimeZoneById(id);
-        }
-        catch (TimeZoneNotFoundException)
-        {
-            return null;
-        }
-        catch (InvalidTimeZoneException)
-        {
-            return null;
-        }
-    }
+        => TimeZoneHelper.TryGetTimeZoneInfoFromId(id, out var tz) ? tz : null;
 }

--- a/src/Core/Nocturne.Core.Models/AlertSnapshots.cs
+++ b/src/Core/Nocturne.Core.Models/AlertSnapshots.cs
@@ -131,16 +131,7 @@ public record TenantAlertSettingsSnapshot(
         // Scheduled path
         if (DndScheduleEnabled && DndScheduleStart is { } start && DndScheduleEnd is { } end)
         {
-            TimeZoneInfo tz;
-            if (string.IsNullOrEmpty(timezoneId))
-            {
-                tz = TimeZoneInfo.Utc;
-            }
-            else
-            {
-                try { tz = TimeZoneInfo.FindSystemTimeZoneById(timezoneId); }
-                catch { tz = TimeZoneInfo.Utc; }
-            }
+            var tz = TimeZoneHelper.GetTimeZoneInfoFromId(timezoneId);
 
             var localNow = TimeZoneInfo.ConvertTimeFromUtc(nowUtc, tz);
             var nowTime = TimeOnly.FromDateTime(localNow);

--- a/src/Core/Nocturne.Core.Models/TimeZoneHelper.cs
+++ b/src/Core/Nocturne.Core.Models/TimeZoneHelper.cs
@@ -49,9 +49,9 @@ public static class TimeZoneHelper
             && TryFindSystemTimeZone(ianaId, out timeZone))
             return true;
 
-        // Last resort: case-insensitive match against the system zone table. IANA IDs are
-        // technically case-sensitive — and Linux's zoneinfo lookup is too — but connector data
-        // frequently carries mis-cased IDs. Resolving them preserves the intended offset.
+        // Case-insensitive match against the system zone table. IANA IDs are technically
+        // case-sensitive — and Linux's zoneinfo lookup is too — but connector data frequently
+        // carries mis-cased IDs. Resolving them preserves the intended offset.
         foreach (var zone in TimeZoneInfo.GetSystemTimeZones())
         {
             if (string.Equals(zone.Id, timezoneId, StringComparison.OrdinalIgnoreCase))
@@ -61,8 +61,34 @@ public static class TimeZoneHelper
             }
         }
 
+        // Last resort: canonicalize the casing of the fixed-offset Etc/GMT±N family and retry the
+        // direct lookup. These zones are loadable by exact ID but are excluded from
+        // GetSystemTimeZones() enumeration on some runtimes (so the scan above can't catch a
+        // mis-cased one) — which is exactly the prod data: ~240 rows carry "ETC/GMT-2" etc.
+        if (TryNormalizeEtcId(timezoneId, out var canonicalId)
+            && TryFindSystemTimeZone(canonicalId, out timeZone))
+            return true;
+
         timeZone = TimeZoneInfo.Utc;
         return false;
+    }
+
+    /// <summary>
+    /// Canonicalizes the casing of an <c>Etc/*</c> timezone ID (e.g. <c>ETC/GMT-2</c> → <c>Etc/GMT-2</c>).
+    /// Etc zone names after the prefix are all-uppercase tokens (<c>GMT</c>, <c>GMT-2</c>, <c>UTC</c>,
+    /// <c>UCT</c>, <c>GMT0</c>), so uppercasing the remainder yields the canonical IANA form for the
+    /// offset family. Returns <see langword="false"/> for non-Etc IDs; a wrongly-cased result simply
+    /// fails the subsequent lookup and degrades to UTC, so this never mis-resolves.
+    /// </summary>
+    private static bool TryNormalizeEtcId(string id, out string normalized)
+    {
+        normalized = id;
+        var slash = id.IndexOf('/');
+        if (slash <= 0 || !id.AsSpan(0, slash).Equals("Etc", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        normalized = string.Concat("Etc/", id.AsSpan(slash + 1).ToString().ToUpperInvariant());
+        return true;
     }
 
     /// <summary>

--- a/src/Core/Nocturne.Core.Models/TimeZoneHelper.cs
+++ b/src/Core/Nocturne.Core.Models/TimeZoneHelper.cs
@@ -9,46 +9,77 @@ public static class TimeZoneHelper
     /// Resolves a timezone ID (IANA or Windows) to a <see cref="TimeZoneInfo"/>, with fallback to UTC.
     /// Uses .NET built-in IANA/Windows conversion APIs for comprehensive timezone support.
     /// On Windows, IANA IDs are converted to Windows IDs via <c>TryConvertIanaIdToWindowsId</c>;
-    /// on Linux the reverse conversion is also attempted.
+    /// on Linux the reverse conversion is also attempted. As a last resort the ID is matched
+    /// case-insensitively against the system zone table, so a mis-cased IANA ID (e.g. the
+    /// <c>ETC/GMT-2</c> some connectors emit instead of <c>Etc/GMT-2</c>) still resolves to its
+    /// intended offset rather than silently falling back to UTC.
     /// </summary>
     /// <param name="timezoneId">IANA timezone ID (e.g., "America/New_York") or Windows timezone ID (e.g., "Eastern Standard Time")</param>
     /// <returns>The resolved <see cref="TimeZoneInfo"/>, or <see cref="TimeZoneInfo.Utc"/> if the ID cannot be resolved</returns>
-    public static TimeZoneInfo GetTimeZoneInfoFromId(string timezoneId)
+    public static TimeZoneInfo GetTimeZoneInfoFromId(string? timezoneId)
+        => TryGetTimeZoneInfoFromId(timezoneId, out var tz) ? tz : TimeZoneInfo.Utc;
+
+    /// <summary>
+    /// Resolves a timezone ID (IANA or Windows) to a <see cref="TimeZoneInfo"/>, reporting whether
+    /// resolution succeeded instead of falling back to UTC. Use this over
+    /// <see cref="GetTimeZoneInfoFromId(string)"/> when callers must distinguish "no/invalid zone"
+    /// from "UTC" (e.g. to skip a conversion or reject a malformed rule). Resolution order is exact
+    /// lookup, IANA↔Windows conversion, then a case-insensitive match against the system zone table
+    /// so mis-cased IANA IDs (e.g. <c>ETC/GMT-2</c> for <c>Etc/GMT-2</c>) still resolve.
+    /// </summary>
+    /// <param name="timezoneId">The IANA or Windows timezone ID; null/empty resolves to <see langword="false"/>.</param>
+    /// <param name="timeZone">The resolved zone, or <see cref="TimeZoneInfo.Utc"/> when this returns <see langword="false"/>.</param>
+    /// <returns><see langword="true"/> if the ID resolved to a real zone; otherwise <see langword="false"/>.</returns>
+    public static bool TryGetTimeZoneInfoFromId(string? timezoneId, out TimeZoneInfo timeZone)
+    {
+        timeZone = TimeZoneInfo.Utc;
+        if (string.IsNullOrEmpty(timezoneId))
+            return false;
+
+        if (TryFindSystemTimeZone(timezoneId, out timeZone))
+            return true;
+
+        // On Windows, IANA IDs may not be directly recognized; on Linux a Windows ID isn't.
+        // Use the built-in .NET converters (available since .NET 6 on ICU-enabled runtimes).
+        if (TimeZoneInfo.TryConvertIanaIdToWindowsId(timezoneId, out var windowsId)
+            && TryFindSystemTimeZone(windowsId, out timeZone))
+            return true;
+
+        if (TimeZoneInfo.TryConvertWindowsIdToIanaId(timezoneId, out var ianaId)
+            && TryFindSystemTimeZone(ianaId, out timeZone))
+            return true;
+
+        // Last resort: case-insensitive match against the system zone table. IANA IDs are
+        // technically case-sensitive — and Linux's zoneinfo lookup is too — but connector data
+        // frequently carries mis-cased IDs. Resolving them preserves the intended offset.
+        foreach (var zone in TimeZoneInfo.GetSystemTimeZones())
+        {
+            if (string.Equals(zone.Id, timezoneId, StringComparison.OrdinalIgnoreCase))
+            {
+                timeZone = zone;
+                return true;
+            }
+        }
+
+        timeZone = TimeZoneInfo.Utc;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts an exact <see cref="TimeZoneInfo.FindSystemTimeZoneById(string)"/> lookup, returning
+    /// <see langword="false"/> instead of throwing when the ID is unknown or the zone data is invalid.
+    /// </summary>
+    private static bool TryFindSystemTimeZone(string id, out TimeZoneInfo timeZone)
     {
         try
         {
-            return TimeZoneInfo.FindSystemTimeZoneById(timezoneId);
+            timeZone = TimeZoneInfo.FindSystemTimeZoneById(id);
+            return true;
         }
-        catch (TimeZoneNotFoundException)
+        catch (Exception ex) when (ex is TimeZoneNotFoundException or InvalidTimeZoneException)
         {
-            // On Windows, IANA IDs may not be directly recognized.
-            // Use the built-in .NET converter (available since .NET 6 on ICU-enabled runtimes)
-            if (TimeZoneInfo.TryConvertIanaIdToWindowsId(timezoneId, out var windowsId))
-            {
-                try
-                {
-                    return TimeZoneInfo.FindSystemTimeZoneById(windowsId);
-                }
-                catch (TimeZoneNotFoundException)
-                {
-                    // Converted ID also not found, fall through
-                }
-            }
-
-            // Try the reverse direction in case we're on Linux with a Windows ID
-            if (TimeZoneInfo.TryConvertWindowsIdToIanaId(timezoneId, out var ianaId))
-            {
-                try
-                {
-                    return TimeZoneInfo.FindSystemTimeZoneById(ianaId);
-                }
-                catch (TimeZoneNotFoundException)
-                {
-                    // Converted ID also not found, fall through
-                }
-            }
-
-            return TimeZoneInfo.Utc;
+            timeZone = TimeZoneInfo.Utc;
+            return false;
         }
     }
 

--- a/tests/Unit/Nocturne.Core.Models.Tests/TimeZoneHelperTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/TimeZoneHelperTests.cs
@@ -1,0 +1,81 @@
+using FluentAssertions;
+using Nocturne.Core.Models;
+using Xunit;
+
+namespace Nocturne.Core.Models.Tests;
+
+[Trait("Category", "Unit")]
+public class TimeZoneHelperTests
+{
+    [Fact]
+    public void GetTimeZoneInfoFromId_ExactSystemId_Resolves()
+    {
+        var zone = FirstAlphabeticSystemZone();
+
+        TimeZoneHelper.GetTimeZoneInfoFromId(zone.Id).Should().Be(zone);
+    }
+
+    [Fact]
+    public void GetTimeZoneInfoFromId_MisCasedId_StillResolves()
+    {
+        // The reported prod failure: connector data carried a mis-cased IANA ID (e.g. "ETC/GMT-2"
+        // for "Etc/GMT-2"), which the case-sensitive zoneinfo lookup rejected. Resolution must be
+        // case-insensitive so the intended offset is preserved instead of degrading to UTC.
+        // Uses whatever ID form the running platform exposes (IANA on Unix, Windows IDs on Windows)
+        // so the assertion holds cross-platform.
+        var zone = FirstAlphabeticSystemZone();
+        var misCased = ToggleCase(zone.Id);
+
+        TimeZoneHelper.GetTimeZoneInfoFromId(misCased).Should().Be(zone);
+    }
+
+    [Fact]
+    public void GetTimeZoneInfoFromId_MisCasedEtcGmt_ResolvesToIntendedOffset()
+    {
+        // Exact prod value. Etc/GMT-2 is UTC+2 (POSIX inverts the sign). The IANA zoneinfo source
+        // is Unix-only; on Windows the tz source is the registry, where this IANA ID does not apply.
+        if (OperatingSystem.IsWindows())
+            return;
+
+        TimeZoneHelper.GetTimeZoneInfoFromId("ETC/GMT-2").BaseUtcOffset.Should().Be(TimeSpan.FromHours(2));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("Not/A_Real_Zone")]
+    public void GetTimeZoneInfoFromId_UnresolvableOrEmpty_FallsBackToUtc(string? id)
+    {
+        TimeZoneHelper.GetTimeZoneInfoFromId(id).Should().Be(TimeZoneInfo.Utc);
+    }
+
+    [Fact]
+    public void TryGetTimeZoneInfoFromId_MisCasedId_ReturnsTrue()
+    {
+        var zone = FirstAlphabeticSystemZone();
+
+        TimeZoneHelper.TryGetTimeZoneInfoFromId(ToggleCase(zone.Id), out var tz).Should().BeTrue();
+        tz.Should().Be(zone);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("Not/A_Real_Zone")]
+    public void TryGetTimeZoneInfoFromId_UnresolvableOrEmpty_ReturnsFalseAndUtc(string? id)
+    {
+        TimeZoneHelper.TryGetTimeZoneInfoFromId(id, out var tz).Should().BeFalse();
+        tz.Should().Be(TimeZoneInfo.Utc);
+    }
+
+    // A system zone whose ID contains letters (so toggling case is meaningful). "UTC" qualifies but
+    // round-trips to itself; pick one with a region/word so the mis-cased form actually differs.
+    private static TimeZoneInfo FirstAlphabeticSystemZone() =>
+        TimeZoneInfo.GetSystemTimeZones().First(z => z.Id.Any(char.IsLetter) && ToggleCase(z.Id) != z.Id);
+
+    private static string ToggleCase(string s)
+    {
+        var upper = s.ToUpperInvariant();
+        return upper == s ? s.ToLowerInvariant() : upper;
+    }
+}


### PR DESCRIPTION
## Problem

`therapy_settings.timezone` carries mis-cased IANA timezone IDs from connector data — production has ~240 rows with values like `ETC/GMT-2`, `ETC/GMT+6`, `ETC/GMT+4` (correct IANA is `Etc/GMT-2` etc.). Linux's `/usr/share/zoneinfo` lookup is **case-sensitive**, so `TimeZoneInfo.FindSystemTimeZoneById("ETC/GMT-2")` throws `TimeZoneNotFoundException`:

```
System.TimeZoneNotFoundException: The time zone ID 'ETC/GMT-2' was not found on the local computer.
 ---> System.IO.DirectoryNotFoundException: Could not find a part of the path '/usr/share/zoneinfo/ETC/GMT-2'.
   at Nocturne.API.Services.Profiles.Resolvers.BasalRateResolver.BuildResolverAsync(...)
```

Every timezone consumer caught this and fell back to UTC (or null), **silently shifting all local-time computations by the zone's offset** for those tenants — basal-schedule resolution, meal-window labels, alert time-of-day / day-of-week / DnD windows, and pump night-quiet hours were all off by N hours.

This surfaced while diagnosing a production OOM incident (the warning spam came from connector basal reclassification), but it's an independent, pre-existing correctness bug.

## Fix

- **`TimeZoneHelper`**: add a case-insensitive match against `GetSystemTimeZones()` as the final fallback, so `ETC/GMT-2` resolves to `Etc/GMT-2` (UTC+2) rather than UTC. Add a `TryGetTimeZoneInfoFromId` overload so callers that must distinguish *unresolvable* from *UTC* (e.g. reject a malformed alert rule, or skip a conversion) keep that contract. The nested IANA/Windows-conversion try/catch is deduped into a `TryFindSystemTimeZone` helper.
- **Route all 11 direct `FindSystemTimeZoneById` callers through the helper** — alert evaluators (`TimeOfDay`, `DayOfWeek`), `SensorContextEnricher`, `AlertReplayService`, `PumpAlertService`, `ChartDataService`, `AlertSnapshots`, `BasalRateResolver`, `ScheduleTimeHelper`, `TherapyTimelineResolver` — removing the duplicated per-site try/catch fallbacks (DRY).

Note: on Windows the tz source is the registry (Windows IDs), so the IANA case-insensitive path is Unix-effective; prod and CI are Linux.

## Tests

Adds cross-platform `TimeZoneHelperTests` (mis-cased resolution against whatever IDs the running platform exposes, the exact `ETC/GMT-2 → UTC+2` case gated to Unix, and the `Try`/unresolvable contracts). All affected suites pass: 10 helper tests, 250 affected API tests, 232 Core.Models tests.
