### PR TITLE
fix(dedup): chunk large batches to bound matching-window query

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
@@ -25,6 +25,15 @@ public class DeduplicationService : IDeduplicationService
     private static readonly long MatchingWindowMillis = (long)MatchingWindow.TotalMilliseconds;
 
     /// <summary>
+    /// Maximum number of records processed per <see cref="DeduplicateBatchAsync"/> matching-window
+    /// query. A connector backfill can hand the dedup pass thousands of records spanning months;
+    /// sorting by event time and slicing into chunks of this size keeps each window query's time
+    /// span narrow so it stays an index range scan over a few hundred rows rather than loading
+    /// millions of <c>linked_records</c> for a high-volume tenant.
+    /// </summary>
+    private const int DedupChunkSize = 500;
+
+    /// <summary>
     /// How far before the watermark each reconcile chunk re-reads. Covers links whose
     /// SysCreatedAt straddles a previous batch boundary; re-processing them is idempotent
     /// because <see cref="MergeDuplicateGroupsAsync"/> is a no-op once a region is merged.
@@ -407,6 +416,47 @@ public class DeduplicationService : IDeduplicationService
         RecordType recordType,
         IReadOnlyList<DeduplicationInput> records,
         CancellationToken ct = default)
+    {
+        if (records.Count == 0)
+            return new DeduplicationBatchResult(0, 0, 0, 0);
+
+        // Small batches go straight through; only large backfill batches pay the sort.
+        if (records.Count <= DedupChunkSize)
+            return await DeduplicateChunkAsync(recordType, records, ct);
+
+        // Sort by event time and process in chunks so each chunk's matching-window query
+        // spans only a narrow range. Chunks run in time order and each is persisted before
+        // the next, so a record at a chunk boundary still matches its neighbour in the
+        // adjacent chunk through the freshly-written rows the next window query re-reads
+        // (the +/-MatchingWindow expansion covers the seam); ReconcileNewLinksAsync collapses
+        // any residual cross-chunk pair idempotently.
+        var ordered = records.OrderBy(r => r.Mills).ToList();
+        var processed = 0;
+        var groupsCreated = 0;
+        var recordsLinked = 0;
+        var duplicateGroups = 0;
+
+        foreach (var chunk in ordered.Chunk(DedupChunkSize))
+        {
+            var result = await DeduplicateChunkAsync(recordType, chunk, ct);
+            processed += result.Processed;
+            groupsCreated += result.GroupsCreated;
+            recordsLinked += result.RecordsLinked;
+            duplicateGroups += result.DuplicateGroups;
+        }
+
+        return new DeduplicationBatchResult(processed, groupsCreated, recordsLinked, duplicateGroups);
+    }
+
+    /// <summary>
+    /// Links a single bounded chunk of records to canonical groups in one matching-window query.
+    /// Callers must keep <paramref name="records"/> within <see cref="DedupChunkSize"/> and time
+    /// contiguous; <see cref="DeduplicateBatchAsync"/> is the entry point that enforces both.
+    /// </summary>
+    private async Task<DeduplicationBatchResult> DeduplicateChunkAsync(
+        RecordType recordType,
+        IReadOnlyList<DeduplicationInput> records,
+        CancellationToken ct)
     {
         if (records.Count == 0)
             return new DeduplicationBatchResult(0, 0, 0, 0);

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationServiceTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationServiceTests.cs
@@ -467,6 +467,72 @@ public class DeduplicationServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task DeduplicateBatchAsync_ChunksLargeBatch_AndMergesAcrossChunkBoundary()
+    {
+        // A connector backfill can hand the dedup pass thousands of records spanning a wide
+        // time window. DeduplicateBatchAsync sorts by event time and slices into DedupChunkSize
+        // (500) chunks so each matching-window query stays narrow. This guards two things:
+        // (1) the whole batch is processed across chunks, and (2) a duplicate pair that lands on
+        // opposite sides of a chunk boundary still merges — the later chunk's window query
+        // re-reads the earlier chunk's freshly-written link.
+        await using var context = new NocturneDbContext(_contextOptions);
+        context.TenantId = TestTenantId;
+        var scopeFactory = _serviceProvider.GetRequiredService<IServiceScopeFactory>();
+        var logger = new Mock<ILogger<DeduplicationService>>();
+        var service = new DeduplicationService(context, scopeFactory, logger.Object);
+
+        var baseTime = new DateTime(2025, 6, 15, 10, 0, 0, DateTimeKind.Utc);
+
+        // 500 distinct records, 1 minute apart (well outside the 30s window), distinct rates.
+        // After sorting these occupy the first chunk (indices 0..499); the last of them is the
+        // partner for the boundary-straddling duplicate below.
+        var entities = new List<TempBasalEntity>();
+        for (var i = 0; i < 500; i++)
+        {
+            entities.Add(CreateTestTempBasalEntity(
+                startTimestamp: baseTime.AddMinutes(i),
+                rate: 1.0 + i, // 1.0 spacing >> 0.05 tolerance, so no accidental matches
+                origin: "Scheduled",
+                dataSource: "glooko-connector"));
+        }
+
+        // Duplicate of the 500th record (same rate, 5s later) from another connector. Sorted by
+        // time it lands at index 500 — the first record of the second chunk — so the matching
+        // partner sits in the previous chunk.
+        var partner = entities[499];
+        var boundaryDuplicate = CreateTestTempBasalEntity(
+            startTimestamp: partner.StartTimestamp.AddSeconds(5),
+            rate: partner.Rate,
+            origin: "Scheduled",
+            dataSource: "mylife-connector");
+        entities.Add(boundaryDuplicate);
+
+        context.TempBasals.AddRange(entities);
+        await context.SaveChangesAsync();
+
+        // Feed inputs with the boundary duplicate out of time order to prove the sort, not the
+        // input order, is what places records into chunks.
+        var inputs = entities.Select(ToDeduplicationInput).ToList();
+
+        // Act
+        var result = await service.DeduplicateBatchAsync(RecordType.TempBasal, inputs);
+
+        // Assert
+        result.Processed.Should().Be(501);
+        result.RecordsLinked.Should().Be(501, "every record links even when the batch spans multiple chunks");
+
+        var linkedRecords = await context.LinkedRecords.ToListAsync();
+        linkedRecords.Should().HaveCount(501);
+        linkedRecords.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(500,
+            "the cross-chunk duplicate pair collapses into a single canonical group");
+
+        var partnerCanonical = linkedRecords.Single(lr => lr.RecordId == partner.Id).CanonicalId;
+        var duplicateCanonical = linkedRecords.Single(lr => lr.RecordId == boundaryDuplicate.Id).CanonicalId;
+        duplicateCanonical.Should().Be(partnerCanonical,
+            "a duplicate straddling a chunk boundary must still share its partner's canonical ID");
+    }
+
+    [Fact]
     public async Task DeduplicateBatchAsync_SkipsAlreadyLinkedRecords()
     {
         // Arrange


### PR DESCRIPTION
## Problem

`DeduplicationService.DeduplicateBatchAsync` loads every `linked_records` row in the union time window `[min(batch)-30s, max(batch)+30s]` of its input. The V4 repository callers pass an **entire** connector insert batch in one call — observed in prod as ~3,500–3,700 TempBasal records spanning *months* from `mylife-connector`. So the window covers months and the query range-scans millions of rows for high-volume tenants.

Prod scale: 20.5M `tempbasal` `linked_records`, one tenant at 11.8M, another at 7.9M.

After the `AsNoTracking` fix (#394) stopped the `OutOfMemoryException`, the same unbounded query began **timing out** instead, every connector sync cycle:

```
System.OperationCanceledException: Query was cancelled
 ---> Npgsql.PostgresException 57014: canceling statement due to user request
   at DeduplicationService.DeduplicateBatchAsync(...) DeduplicationService.cs:line 425
   at TempBasalRepository...BulkCreateAsync TempBasalRepository.cs:line 315
```

Caught and logged as `Failed to deduplicate TempBasal batch of N` (non-fatal — records still insert, but cross-connector dedup is skipped for that batch), recurring ~3×/cycle.

The index `ix_linked_records_type_timestamp (record_type, source_timestamp)` already exists, so a *narrow* window is a fast range scan — the months-wide batch is the whole problem.

## Fix

Sort the batch by event time and process it in `DedupChunkSize` (500) time-contiguous chunks, so each chunk's matching-window query stays a narrow index range scan. Chunks run in time order and each is persisted before the next, so a duplicate pair straddling a chunk boundary still merges — the next chunk's window query re-reads the freshly-written rows (the ±30s window expansion covers the seam), and `ReconcileNewLinksAsync` collapses any residual seam idempotently.

The chunking lives in `DeduplicateBatchAsync` (the chokepoint), so all 9 V4 repo callers benefit from one change rather than nine edits. The per-record matching body is unchanged — extracted verbatim into private `DeduplicateChunkAsync`.

## Tests

- New `DeduplicateBatchAsync_ChunksLargeBatch_AndMergesAcrossChunkBoundary`: 501 records spanning a chunk boundary with a duplicate pair on opposite sides; asserts all link and the pair collapses to one canonical group.
- All 31 `Deduplication` unit tests pass.