### PR TITLE
fix(connectors): reconcile temp basal resync instead of delete-then-reinsert

### DIFF
--- a/src/API/Nocturne.API/Services/ConnectorPublishing/TreatmentPublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/TreatmentPublisher.cs
@@ -186,16 +186,23 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
 
             var minTimestamp = recordList.Min(r => r.StartTimestamp);
             var maxTimestamp = recordList.Max(r => r.StartTimestamp);
+            var incomingLegacyIds = recordList
+                .Select(r => r.LegacyId)
+                .Where(id => !string.IsNullOrEmpty(id))
+                .Select(id => id!)
+                .ToHashSet();
 
-            // Connector resync: the delete-then-reinsert is a system sweep, so its audit rows
-            // must carry AuthType IS NULL. The delete the dedup discriminator reads — not just the
-            // insert — has to be inside the scope; otherwise a resync invoked under an actor
-            // context (e.g. a manual sync) would write a user-attributed delete row and
-            // permanently block re-importing those temp basals.
+            // Connector resync reconciles the window idempotently rather than deleting it wholesale
+            // and re-inserting: soft-delete only the rows this source no longer reports, leaving
+            // still-reported rows active so BulkCreateAsync (which skips already-active legacy ids)
+            // makes an unchanged resync a no-op. The reconcile delete runs under SystemAuditScope so
+            // its audit rows carry AuthType IS NULL — the dedup discriminator reads the delete, so a
+            // resync invoked under an actor context (e.g. a manual sync) must not write a
+            // user-attributed delete that would permanently block a later re-import of those temps.
             using (SystemAuditScope.Push(_auditContext))
             {
-                await _tempBasalRepository.DeleteBySourceAndDateRangeAsync(
-                    source, minTimestamp, maxTimestamp, cancellationToken);
+                await _tempBasalRepository.SoftDeleteAbsentBySourceAndDateRangeAsync(
+                    source, minTimestamp, maxTimestamp, incomingLegacyIds, cancellationToken);
 
                 var reclassifiedCount = await ReclassifyScheduledAlgorithmicBasalsAsync(
                     recordList, cancellationToken);

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ITempBasalRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ITempBasalRepository.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// <remarks>
 /// <see cref="TempBasal"/> records are also used as the underlying store for the legacy V1/V3
 /// temp basal treatment projection. Unlike most V4 repositories, this interface does not extend
-/// <see cref="IV4Repository{T}"/> directly because it needs a source-and-date-range delete operation
+/// <see cref="IV4Repository{T}"/> directly because it needs a source-window reconcile operation
 /// used during connector re-sync.
 /// </remarks>
 /// <seealso cref="TempBasal"/>
@@ -87,21 +87,29 @@ public interface ITempBasalRepository
     );
 
     /// <summary>
-    /// Delete all <see cref="TempBasal"/> records for a given source within a date range.
+    /// Idempotently reconciles a source's temp basals within a date range: soft-deletes only the
+    /// rows this source no longer reports (their legacy id is absent from
+    /// <paramref name="keepLegacyIds"/>), leaving still-reported rows untouched.
     /// </summary>
     /// <remarks>
-    /// Used by connector re-sync operations to clear and replace a window of temp basal data
-    /// from a specific data source without affecting records from other sources.
+    /// Used by connector re-sync. Pair with <see cref="BulkCreateAsync"/> — which skips legacy ids
+    /// that are already active — so re-importing an unchanged window is a no-op rather than a
+    /// delete-the-whole-window-then-reinsert sweep. The old sweep re-created every record as a new
+    /// row each cycle (system-scope deletes don't block re-insertion), accumulating millions of
+    /// soft-deleted tombstones for high-volume connectors.
     /// </remarks>
     /// <param name="source">Data source identifier (e.g., connector name).</param>
-    /// <param name="from">Inclusive start of the range to delete.</param>
-    /// <param name="to">Exclusive end of the range to delete.</param>
+    /// <param name="from">Inclusive start of the reconcile range.</param>
+    /// <param name="to">Inclusive end of the reconcile range.</param>
+    /// <param name="keepLegacyIds">Legacy ids still reported by the source in this window; rows with
+    /// these ids are kept, all other active rows of this source in range are soft-deleted.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>Number of records deleted.</returns>
-    Task<int> DeleteBySourceAndDateRangeAsync(
+    /// <returns>Number of records soft-deleted.</returns>
+    Task<int> SoftDeleteAbsentBySourceAndDateRangeAsync(
         string source,
         DateTime from,
         DateTime to,
+        IReadOnlySet<string> keepLegacyIds,
         CancellationToken ct = default
     );
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
@@ -323,24 +323,23 @@ public class TempBasalRepository : ITempBasalRepository
         });
     }
 
-    /// <summary>
-    /// Deletes temporary basal records by data source and date range.
-    /// </summary>
-    /// <param name="source">The data source filter.</param>
-    /// <param name="from">The start timestamp filter.</param>
-    /// <param name="to">The end timestamp filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteBySourceAndDateRangeAsync(
+    /// <inheritdoc />
+    public async Task<int> SoftDeleteAbsentBySourceAndDateRangeAsync(
         string source,
         DateTime from,
         DateTime to,
+        IReadOnlySet<string> keepLegacyIds,
         CancellationToken ct = default
     )
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
+        // The global query filter already restricts to active (DeletedAt == null) rows for this
+        // tenant. Soft-delete only the window's rows whose legacy id the source no longer reports;
+        // a row with no legacy id can't be matched against the incoming set, so treat it as absent.
         return await ctx.AuditedSoftDeleteAsync(
-            ctx.TempBasals.Where(e => e.DataSource == source && e.StartTimestamp >= from && e.StartTimestamp <= to),
+            ctx.TempBasals.Where(e => e.DataSource == source
+                && e.StartTimestamp >= from && e.StartTimestamp <= to
+                && (e.LegacyId == null || !keepLegacyIds.Contains(e.LegacyId))),
             _auditContext, ct);
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/TreatmentPublisherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/TreatmentPublisherTests.cs
@@ -332,10 +332,10 @@ public class TreatmentPublisherTests
     }
 
     [Fact]
-    public async Task PublishTempBasalsAsync_RunsSweepDeleteUnderSystemAttribution()
+    public async Task PublishTempBasalsAsync_RunsReconcileDeleteUnderSystemAttribution()
     {
-        // The delete-then-reinsert sweep must write delete audit rows with AuthType IS NULL so the
-        // dedup discriminator treats them as system-initiated and lets future resyncs through. The
+        // The reconcile delete must write delete audit rows with AuthType IS NULL so the dedup
+        // discriminator treats them as system-initiated and lets future resyncs through. The
         // delete — not just the insert — is what the discriminator reads, so it has to run inside
         // the SystemAuditScope; trace fields must survive so the rows stay tied to the request.
         var auditContext = new AuditContext
@@ -350,8 +350,9 @@ public class TreatmentPublisherTests
         string? authTypeDuringDelete = "unset";
         string? correlationDuringDelete = null;
         _mockTempBasalRepository
-            .Setup(r => r.DeleteBySourceAndDateRangeAsync(
-                It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.SoftDeleteAbsentBySourceAndDateRangeAsync(
+                It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<IReadOnlySet<string>>(), It.IsAny<CancellationToken>()))
             .Callback(() =>
             {
                 authTypeDuringDelete = auditContext.AuthType;
@@ -374,13 +375,46 @@ public class TreatmentPublisherTests
         var result = await publisher.PublishTempBasalsAsync(records, "glooko-connector");
 
         result.Should().BeTrue();
-        authTypeDuringDelete.Should().BeNull("the sweep delete must be system-attributed");
+        authTypeDuringDelete.Should().BeNull("the reconcile delete must be system-attributed");
         correlationDuringDelete.Should().Be("trace-1", "trace fields must survive the scope");
         auditContext.AuthType.Should().Be("bearer", "actor fields must be restored after the scope");
         _mockTempBasalRepository.Verify(
-            r => r.DeleteBySourceAndDateRangeAsync(
-                "glooko-connector", It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            r => r.SoftDeleteAbsentBySourceAndDateRangeAsync(
+                "glooko-connector", It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<IReadOnlySet<string>>(), It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task PublishTempBasalsAsync_ReconcilesByIncomingLegacyIds_SoAResyncDoesNotChurn()
+    {
+        // The reconcile must pass the batch's legacy ids as the keep-set so still-reported rows are
+        // left active (and thus skipped by BulkCreateAsync's legacy-id dedup) instead of being
+        // deleted and re-created. This is what stops the per-cycle tombstone accumulation.
+        IReadOnlySet<string>? keepLegacyIds = null;
+        _mockTempBasalRepository
+            .Setup(r => r.SoftDeleteAbsentBySourceAndDateRangeAsync(
+                It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<IReadOnlySet<string>>(), It.IsAny<CancellationToken>()))
+            .Callback((string _, DateTime _, DateTime _, IReadOnlySet<string> keep, CancellationToken _) =>
+                keepLegacyIds = keep)
+            .ReturnsAsync(0);
+
+        var ts = new DateTime(2026, 5, 14, 12, 0, 0, DateTimeKind.Utc);
+        var records = new List<TempBasal>
+        {
+            new() { Id = Guid.NewGuid(), LegacyId = "glooko_tempbasal_1", StartTimestamp = ts, Rate = 0.5, Origin = TempBasalOrigin.Algorithm, DataSource = "glooko-connector" },
+            new() { Id = Guid.NewGuid(), LegacyId = "glooko_tempbasal_2", StartTimestamp = ts.AddMinutes(5), Rate = 0.6, Origin = TempBasalOrigin.Algorithm, DataSource = "glooko-connector" },
+            new() { Id = Guid.NewGuid(), LegacyId = null, StartTimestamp = ts.AddMinutes(10), Rate = 0.7, Origin = TempBasalOrigin.Algorithm, DataSource = "glooko-connector" },
+        };
+
+        var result = await _publisher.PublishTempBasalsAsync(records, "glooko-connector");
+
+        result.Should().BeTrue();
+        keepLegacyIds.Should().BeEquivalentTo(new[] { "glooko_tempbasal_1", "glooko_tempbasal_2" },
+            "only non-null incoming legacy ids form the keep-set");
+        _mockTempBasalRepository.Verify(
+            r => r.BulkCreateAsync(records, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

`TreatmentPublisher.PublishTempBasalsAsync` soft-deleted the **entire** source window (`DeleteBySourceAndDateRangeAsync(source, min, max)`) and then re-inserted, all under `SystemAuditScope`.

Because system-scope soft-deletes intentionally do **not** block re-insertion — `GetBlockingLegacyIdsAsync` only blocks legacy ids that are *active* or *user-deleted* ("system-sweep deletes stay re-creatable on resync") — every sync first soft-deleted all the active rows in the window, leaving nothing to block, then re-inserted the whole window as **brand-new rows with fresh ids**.

For high-volume connectors that re-import a months-wide window every cycle (mylife, glooko), this accumulates without bound. Observed in prod on one tenant:

| source | total temp_basals | distinct legacy_id | soft-deleted (system) | new in 30 min |
|---|---|---|---|---|
| mylife | 17.1M | 48k (~353 copies each) | 17.08M (99.75%) | 136k |
| glooko | 7.0M | 101k (~70 each) | 7.01M | 37k |

24.18M rows for one tenant, ~8M/day, table 9 GB. This also fed unbounded `linked_records` growth (20.5M) and the dedup matching-window query timeout (`Npgsql 57014`).

## Fix

Replace the blanket delete-then-reinsert with an **idempotent reconcile**:

- Soft-delete only the rows the source **no longer reports** (legacy id absent from the incoming batch) — genuine removals.
- Leave still-reported rows active. `BulkCreateAsync` already skips already-active legacy ids, so re-importing an unchanged window now **deletes nothing and inserts nothing** — zero churn.
- The reconcile delete stays under `SystemAuditScope`, so a removed-then-readded record isn't permanently blocked by a user-attributed delete.

`ITempBasalRepository.DeleteBySourceAndDateRangeAsync` → `SoftDeleteAbsentBySourceAndDateRangeAsync(source, from, to, keepLegacyIds, ct)` (the resync publisher was its only caller).

### Note on value updates
Both connectors derive a stable legacy id per event (mylife's event key includes the value; glooko's is timestamp-based), so a changed value yields a new legacy id (handled as remove+add). Same-legacy-id in-place value updates are therefore not propagated — acceptable for these sources and far outweighed by stopping the accumulation. Reclassification (Scheduled→Algorithm) is deterministic and applied on first import, so it remains stable across resyncs.

## Tests

- Retargeted the system-attribution test to the new method.
- New `PublishTempBasalsAsync_ReconcilesByIncomingLegacyIds_SoAResyncDoesNotChurn` — asserts the incoming legacy ids form the keep-set (nulls excluded) and `BulkCreateAsync` is still called.
- All 19 `TreatmentPublisher` tests pass.

## Follow-up (not in this PR)
A one-off cleanup of the ~24M accumulated soft-deleted tempbasal tombstones (and corresponding `linked_records`) for affected mylife/glooko tenants. Paired with #396 (dedup matching-window chunking).