### PR TITLE
feat(alerts): per-excursion acknowledge endpoint for v4 alerts API

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertsController.cs
@@ -189,6 +189,43 @@ public class AlertsController : ControllerBase
     }
 
     /// <summary>
+    /// Acknowledge a single alert excursion, halting escalation delivery for its
+    /// active instances. Acknowledging an excursion that is already acknowledged
+    /// or already closed is a no-op. Returns 404 when the excursion does not
+    /// exist for the current tenant.
+    /// </summary>
+    /// <seealso cref="IAlertAcknowledgementService.AcknowledgeExcursionAsync"/>
+    [HttpPost("excursions/{excursionId:guid}/acknowledge")]
+    [RemoteCommand(Invalidates = ["GetActiveAlerts"])]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> AcknowledgeExcursion(
+        Guid excursionId, [FromBody] AcknowledgeRequest request, CancellationToken ct)
+    {
+        var tenantId = _tenantAccessor.TenantId;
+
+        // The acknowledgement service silently no-ops on an unknown excursion, so
+        // resolve existence here (tenant-scoped context — another tenant's
+        // excursion is invisible and yields 404).
+        await using var db = await _contextFactory.CreateAsync(ct);
+        var exists = await db.AlertExcursions
+            .AsNoTracking()
+            .AnyAsync(e => e.Id == excursionId, ct);
+
+        if (!exists)
+            return NotFound();
+
+        await _acknowledgementService.AcknowledgeExcursionAsync(
+            tenantId,
+            excursionId,
+            request.AcknowledgedBy ?? "unknown",
+            broadcast: true,
+            ct);
+
+        return NoContent();
+    }
+
+    /// <summary>
     /// Snooze an alert instance for the specified duration.
     /// </summary>
     [HttpPost("instances/{instanceId:guid}/snooze")]

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/AlertAcknowledgeEndpointTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/AlertAcknowledgeEndpointTests.cs
@@ -1,0 +1,181 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Nocturne.API.Controllers.V4.Monitoring;
+using Nocturne.Core.Contracts.Alerts;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Services;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4;
+
+[Trait("Category", "Unit")]
+public class AlertAcknowledgeEndpointTests
+{
+    private readonly DbContextOptions<NocturneDbContext> _options;
+    private readonly Mock<ITenantDbContextFactory> _contextFactoryMock = new();
+    private readonly Mock<IAlertAcknowledgementService> _acknowledgementServiceMock = new();
+    private readonly Mock<IAlertDeliveryService> _deliveryServiceMock = new();
+    private readonly Mock<ITenantAccessor> _tenantAccessorMock = new();
+    private readonly Mock<ILogger<AlertsController>> _loggerMock = new();
+
+    private readonly Guid _tenantId = Guid.NewGuid();
+
+    public AlertAcknowledgeEndpointTests()
+    {
+        _options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseInMemoryDatabase($"alerts_ack_endpoint_tests_{Guid.NewGuid()}")
+            .Options;
+        using (var db = new NocturneDbContext(_options))
+        {
+            db.Database.EnsureCreated();
+        }
+
+        _tenantAccessorMock.Setup(t => t.IsResolved).Returns(true);
+        _tenantAccessorMock.Setup(t => t.TenantId).Returns(_tenantId);
+
+        // The controller disposes the context (await using), so hand out a fresh
+        // tenant-scoped context per call against the shared in-memory store.
+        _contextFactoryMock
+            .Setup(f => f.CreateAsync(It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                var ctx = new NocturneDbContext(_options) { TenantId = _tenantId };
+                return ValueTask.FromResult(ctx);
+            });
+    }
+
+    private AlertsController CreateController()
+    {
+        var controller = new AlertsController(
+            _contextFactoryMock.Object,
+            _acknowledgementServiceMock.Object,
+            _deliveryServiceMock.Object,
+            _tenantAccessorMock.Object,
+            _loggerMock.Object);
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        return controller;
+    }
+
+    private async Task<Guid> SeedExcursionAsync(Guid? tenantId = null)
+    {
+        var t = tenantId ?? _tenantId;
+        await using var db = new NocturneDbContext(_options);
+        db.TenantId = t;
+        var excursion = new AlertExcursionEntity
+        {
+            Id = Guid.NewGuid(),
+            TenantId = t,
+            AlertRuleId = Guid.NewGuid(),
+            StartedAt = DateTime.UtcNow.AddMinutes(-5),
+        };
+        db.AlertExcursions.Add(excursion);
+        await db.SaveChangesAsync();
+        return excursion.Id;
+    }
+
+    // ---- AcknowledgeExcursion ----
+
+    [Fact]
+    public async Task AcknowledgeExcursion_ExistingExcursion_CallsServiceAndReturnsNoContent()
+    {
+        // Arrange
+        var excursionId = await SeedExcursionAsync();
+        var controller = CreateController();
+        var request = new AcknowledgeRequest { AcknowledgedBy = "user:bob" };
+
+        // Act
+        var result = await controller.AcknowledgeExcursion(excursionId, request, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<NoContentResult>();
+        _acknowledgementServiceMock.Verify(
+            s => s.AcknowledgeExcursionAsync(_tenantId, excursionId, "user:bob", true, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task AcknowledgeExcursion_NoAcknowledgedBy_DefaultsToUnknown()
+    {
+        // Arrange
+        var excursionId = await SeedExcursionAsync();
+        var controller = CreateController();
+        var request = new AcknowledgeRequest();
+
+        // Act
+        var result = await controller.AcknowledgeExcursion(excursionId, request, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<NoContentResult>();
+        _acknowledgementServiceMock.Verify(
+            s => s.AcknowledgeExcursionAsync(_tenantId, excursionId, "unknown", true, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task AcknowledgeExcursion_UnknownExcursion_ReturnsNotFound()
+    {
+        // Arrange
+        var controller = CreateController();
+        var request = new AcknowledgeRequest { AcknowledgedBy = "user:bob" };
+
+        // Act
+        var result = await controller.AcknowledgeExcursion(Guid.NewGuid(), request, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<NotFoundResult>();
+        _acknowledgementServiceMock.Verify(
+            s => s.AcknowledgeExcursionAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task AcknowledgeExcursion_OtherTenantsExcursion_ReturnsNotFound()
+    {
+        // Arrange — excursion exists but belongs to a different tenant; the
+        // tenant-scoped context's query filter must hide it (404, not leak).
+        var excursionId = await SeedExcursionAsync(tenantId: Guid.NewGuid());
+        var controller = CreateController();
+        var request = new AcknowledgeRequest { AcknowledgedBy = "user:bob" };
+
+        // Act
+        var result = await controller.AcknowledgeExcursion(excursionId, request, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<NotFoundResult>();
+        _acknowledgementServiceMock.Verify(
+            s => s.AcknowledgeExcursionAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ---- Acknowledge (all) ----
+
+    [Fact]
+    public async Task Acknowledge_CallsServiceForTenant_AndReturnsNoContent()
+    {
+        // Arrange
+        var controller = CreateController();
+        var request = new AcknowledgeRequest { AcknowledgedBy = "user:bob" };
+
+        // Act
+        var result = await controller.Acknowledge(request, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<NoContentResult>();
+        _acknowledgementServiceMock.Verify(
+            s => s.AcknowledgeAllAsync(_tenantId, "user:bob", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `POST /api/v4/alerts/excursions/{excursionId}/acknowledge` to `AlertsController` so the Prelude mobile app can acknowledge a single alert excursion (previously only acknowledge-all existed).
- Reuses the existing `AcknowledgeRequest` body (`{ acknowledged_by?: string }`, defaulting to `unknown`) and calls the already-existing `IAlertAcknowledgementService.AcknowledgeExcursionAsync` with broadcast enabled, so the `alert_acknowledged` SignalR event fires for connected clients.
- Returns `404` when the excursion does not exist or belongs to another tenant. The acknowledgement service silently no-ops on unknown excursions, so the controller resolves existence on a tenant-scoped context first (mirrors the `SnoozeInstance` per-instance pattern).
- Matches sibling endpoints: `[RemoteCommand(Invalidates = [GetActiveAlerts])]`, `ProducesResponseType` attributes, controller-level `[Authorize]` (no per-endpoint scope, same as the existing acknowledge-all endpoint).
- TS client intentionally not regenerated (CI handles that on merge).

## Tests
- New `AlertAcknowledgeEndpointTests` (controller): success path, default `acknowledged_by`, unknown excursion 404, cross-tenant 404 (query-filter isolation), plus acknowledge-all coverage which previously had no controller test.
- Service-level `AcknowledgeExcursionAsync` behaviour was already covered by `AlertAcknowledgementServiceTests`.
- `dotnet test tests/Unit/Nocturne.API.Tests --filter FullyQualifiedName~Services.Alerts|FullyQualifiedName~AlertAcknowledgeEndpointTests|FullyQualifiedName~AlertDeliveryEndpointTests`: 466 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)