### PR TITLE
fix(auth): accept noc_ direct grant tokens via ?token= query param

### DIFF
--- a/src/API/Nocturne.API/Middleware/Handlers/DirectGrantTokenHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/DirectGrantTokenHandler.cs
@@ -11,10 +11,17 @@ namespace Nocturne.API.Middleware.Handlers;
 /// <summary>
 /// Authentication handler for opaque direct grant tokens.
 /// Validates tokens by SHA-256 hashing and looking up the grant in the database.
+/// Accepts the token via the <c>Authorization: Bearer</c> header or the Nightscout-style
+/// <c>?token=</c> query parameter (how xDrip4iOS and other Nightscout uploaders send it).
 /// Skips JWT-formatted tokens (starting with "eyJ") to let other handlers process them.
 /// </summary>
 public class DirectGrantTokenHandler : IAuthHandler
 {
+    /// <summary>
+    /// Prefix identifying opaque direct grant tokens (see <see cref="Controllers.Authentication.DirectGrantController"/>).
+    /// </summary>
+    private const string TokenPrefix = "noc_";
+
     /// <summary>
     /// Handler priority (150 - after session cookies, before OIDC/legacy JWT)
     /// </summary>
@@ -42,13 +49,7 @@ public class DirectGrantTokenHandler : IAuthHandler
     /// <inheritdoc />
     public async Task<AuthResult> AuthenticateAsync(HttpContext context)
     {
-        var authHeader = context.Request.Headers.Authorization.FirstOrDefault();
-        if (string.IsNullOrEmpty(authHeader) || !authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
-        {
-            return AuthResult.Skip();
-        }
-
-        var token = authHeader["Bearer ".Length..].Trim();
+        var token = ExtractToken(context);
         if (string.IsNullOrEmpty(token))
         {
             return AuthResult.Skip();
@@ -83,7 +84,7 @@ public class DirectGrantTokenHandler : IAuthHandler
 
         if (grant == null)
         {
-            _logger.LogDebug("No matching direct grant found for bearer token");
+            _logger.LogDebug("No matching direct grant found for token");
             return AuthResult.Skip();
         }
 
@@ -104,6 +105,42 @@ public class DirectGrantTokenHandler : IAuthHandler
             TokenId = grant.Id,
             LimitTo24Hours = false, // Direct grants defer to MemberScopeMiddleware for 24-hour limits
         });
+    }
+
+    /// <summary>
+    /// Extracts a direct grant token from the request. Accepts the <c>Authorization: Bearer</c>
+    /// header (any opaque value) or the Nightscout-style <c>?token=</c> query parameter — how
+    /// xDrip4iOS and other Nightscout uploaders send their credential.
+    /// </summary>
+    /// <remarks>
+    /// On the query-parameter path the <c>noc_</c> prefix is normalized in: uploaders routinely
+    /// drop the human-facing marker and send only the secret suffix, so both <c>noc_&lt;secret&gt;</c>
+    /// and a bare <c>&lt;secret&gt;</c> resolve to the same grant. A value that isn't one of our
+    /// tokens simply won't match a grant and falls through (Skip) to <see cref="AccessTokenHandler"/>,
+    /// which owns the legacy <c>name-hash</c> <c>?token=</c> format.
+    /// </remarks>
+    private static string? ExtractToken(HttpContext context)
+    {
+        var authHeader = context.Request.Headers.Authorization.FirstOrDefault();
+        if (!string.IsNullOrEmpty(authHeader)
+            && authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        {
+            var bearer = authHeader["Bearer ".Length..].Trim();
+            if (!string.IsNullOrEmpty(bearer))
+            {
+                return bearer;
+            }
+        }
+
+        var queryToken = context.Request.Query["token"].FirstOrDefault();
+        if (!string.IsNullOrEmpty(queryToken))
+        {
+            return queryToken.StartsWith(TokenPrefix, StringComparison.Ordinal)
+                ? queryToken
+                : TokenPrefix + queryToken;
+        }
+
+        return null;
     }
 
     private async Task UpdateLastUsedAsync(Guid grantId, Guid tenantId, string? ipAddress, string? userAgent)

--- a/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/DirectGrantTokenHandlerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/DirectGrantTokenHandlerTests.cs
@@ -136,6 +136,87 @@ public class DirectGrantTokenHandlerTests : IDisposable
     }
 
     [Fact]
+    public async Task AuthenticateAsync_TokenQueryParam_ReturnsSuccess()
+    {
+        // Nightscout uploaders (xDrip4iOS etc.) send the token as ?token=noc_...
+        var token = "noc_querytoken12345";
+        var tokenHash = DirectGrantTokenHandler.ComputeSha256Hex(token);
+
+        await using (var ctx = new NocturneDbContext(_dbOptions) { TenantId = _testTenantId })
+        {
+            ctx.OAuthGrants.Add(new OAuthGrantEntity
+            {
+                Id = Guid.CreateVersion7(),
+                SubjectId = _subjectId,
+                GrantType = OAuthGrantTypes.Direct,
+                TokenHash = tokenHash,
+                Scopes = ["glucose.readwrite"],
+                CreatedAt = DateTime.UtcNow,
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        var context = CreateHttpContext();
+        context.Request.QueryString = new QueryString($"?token={token}");
+
+        var result = await _handler.AuthenticateAsync(context);
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(result.AuthContext);
+        Assert.Equal(AuthType.DirectGrant, result.AuthContext!.AuthType);
+        Assert.Equal(_subjectId, result.AuthContext.SubjectId);
+        Assert.Contains("glucose.readwrite", result.AuthContext.Scopes);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_TokenQueryParamWithoutPrefix_ReturnsSuccess()
+    {
+        // xDrip4iOS drops the human-facing "noc_" marker and sends only the secret suffix.
+        // The bare suffix must still resolve to the grant stored under the full noc_ token.
+        var token = "noc_baretoken1234567";
+        var bareSuffix = token["noc_".Length..];
+        var tokenHash = DirectGrantTokenHandler.ComputeSha256Hex(token);
+
+        await using (var ctx = new NocturneDbContext(_dbOptions) { TenantId = _testTenantId })
+        {
+            ctx.OAuthGrants.Add(new OAuthGrantEntity
+            {
+                Id = Guid.CreateVersion7(),
+                SubjectId = _subjectId,
+                GrantType = OAuthGrantTypes.Direct,
+                TokenHash = tokenHash,
+                Scopes = ["glucose.readwrite"],
+                CreatedAt = DateTime.UtcNow,
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        var context = CreateHttpContext();
+        context.Request.QueryString = new QueryString($"?token={bareSuffix}");
+
+        var result = await _handler.AuthenticateAsync(context);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(AuthType.DirectGrant, result.AuthContext!.AuthType);
+        Assert.Equal(_subjectId, result.AuthContext.SubjectId);
+        Assert.Contains("glucose.readwrite", result.AuthContext.Scopes);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_LegacyTokenQueryParam_ReturnsSkip()
+    {
+        // A legacy name-hash access token in ?token= matches no direct grant, so this handler
+        // must Skip (not Fail) and let it fall through to AccessTokenHandler.
+        var context = CreateHttpContext();
+        context.Request.QueryString = new QueryString("?token=rhys-a1b2c3d4e5f6g7h8");
+
+        var result = await _handler.AuthenticateAsync(context);
+
+        Assert.True(result.ShouldSkip);
+        Assert.False(result.Succeeded);
+    }
+
+    [Fact]
     public async Task AuthenticateAsync_InvalidOpaqueToken_ReturnsSkip()
     {
         var context = CreateHttpContext();


### PR DESCRIPTION
## Problem

Nightscout uploaders (xDrip4iOS et al.) authenticate by appending the credential as a `?token=<token>` query parameter. A `noc_` **direct grant** token sent that way was recognized by **no auth handler**:

- `DirectGrantTokenHandler` only read `Authorization: Bearer`
- `ApiKeyHandler` reads the `api-secret` header / `?secret=`
- `AccessTokenHandler` reads `?token=` but only accepts the legacy `name-hash` format (rejects `noc_` tokens)

So the request fell through every handler → unauthenticated → **401** on every `POST /api/v1/entries` (and treatments/devicestatus). Confirmed in production gateway logs against a live tenant.

## Fix

`DirectGrantTokenHandler` now also reads the token from the `?token=` query parameter, and **normalizes the `noc_` prefix**: uploaders were observed dropping the human-facing marker and sending only the secret suffix, so both `noc_<secret>` and a bare `<secret>` resolve to the same grant.

A token that isn't one of ours matches no grant and returns **Skip** (not Failure), so the legacy `name-hash` `?token=` flow still falls through to `AccessTokenHandler` unchanged. Tenant scoping and the membership check downstream are unaffected.

## Tests

Added unit coverage for the prefixed `?token=noc_…`, the prefix-stripped `?token=<suffix>`, and the legacy `name-hash` fall-through. Full `DirectGrantTokenHandler` suite (11 tests) passes.