### PR TITLE
fix(auth): make noc_ tokens work with SHA-1 pre-hashing uploaders (Loop, AAPS, Trio)

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/DirectGrantController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/DirectGrantController.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
 using Nocturne.API.Extensions;
 using Nocturne.API.Middleware.Handlers;
+using Nocturne.Connectors.Core.Utilities;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
@@ -107,6 +108,10 @@ public class DirectGrantController : ControllerBase
             Scopes = normalizedScopes,
             Label = request.Label,
             TokenHash = tokenHash,
+            // Also store the SHA-1 of the token so uploaders that use the legacy Nightscout
+            // api-secret protocol (Loop, AAPS, Trio, iAPS) — which pre-hash the value with SHA-1
+            // before sending — authenticate with this same token via ApiKeyHandler's legacy path.
+            LegacySecretHash = HashUtils.Sha1Hex(plaintextToken),
             CreatedAt = DateTime.UtcNow,
         };
 
@@ -169,7 +174,7 @@ public class DirectGrantController : ControllerBase
                 Scopes = g.Scopes,
                 CreatedAt = g.CreatedAt,
                 LastUsedAt = g.LastUsedAt,
-                IsLegacy = g.LegacySecretHash != null,
+                IsLegacy = g.IsMigrated,
             })
             .ToListAsync();
 

--- a/src/API/Nocturne.API/Middleware/Handlers/ApiKeyHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/ApiKeyHandler.cs
@@ -106,8 +106,10 @@ public class ApiKeyHandler : IAuthHandler
         var userAgent = context.Request.Headers.UserAgent.FirstOrDefault();
         _ = UpdateLastUsedAsync(grant.Id, tenantCtx.TenantId, ipAddress, userAgent);
 
-        // 7. If this is a legacy grant's first use, nudge rotation
-        if (grant.LegacySecretHash != null && grant.LastUsedAt == null)
+        // 7. If this is a migrated full-access secret's first use, nudge rotation to scoped keys.
+        //    Minted noc_ tokens also carry a LegacySecretHash (for pre-hashing clients), so the
+        //    nudge keys off IsMigrated rather than the hash's presence.
+        if (grant.IsMigrated && grant.LastUsedAt == null)
         {
             var scopeFactory = context.RequestServices?.GetService<IServiceScopeFactory>();
             if (scopeFactory != null)

--- a/src/API/Nocturne.API/Services/Connectors/ConnectorConfigurationService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/ConnectorConfigurationService.cs
@@ -292,6 +292,7 @@ public class ConnectorConfigurationService : IConnectorConfigurationService
             Label = "Nightscout (migrated)",
             TokenHash = null,
             LegacySecretHash = sha1Hash,
+            IsMigrated = true,
             CreatedAt = DateTime.UtcNow,
         };
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/OAuthGrantEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/OAuthGrantEntity.cs
@@ -141,13 +141,27 @@ public class OAuthGrantEntity : ITenantScoped, IAuditable
     public string? TokenHash { get; set; }
 
     /// <summary>
-    /// SHA-1 hex hash of a legacy Nightscout API secret.
-    /// Only populated for migration-seeded grants to enable zero-friction backward compatibility.
+    /// SHA-1 hex hash of the grant's credential, in the form a Nightscout client sends it.
+    /// The legacy Nightscout <c>api-secret</c> protocol pre-hashes the secret with SHA-1 before
+    /// transmitting it, so uploaders that use that protocol (Loop, AAPS, Trio, iAPS, xDrip) send
+    /// <c>SHA-1(secret)</c> and we must match against this column.
+    /// Populated both for migration-seeded grants (the hash of the original Nightscout secret) and
+    /// for minted <c>noc_</c> tokens (the hash of the plaintext token), so a single credential
+    /// authenticates whether the client sends it verbatim (matched via <see cref="TokenHash"/>) or
+    /// pre-hashed (matched here).
     /// </summary>
     [Column("legacy_secret_hash")]
     [MaxLength(128)]
     [AuditRedacted]
     public string? LegacySecretHash { get; set; }
+
+    /// <summary>
+    /// True when this grant was seeded from a pre-existing, full-access Nightscout master API secret
+    /// (via migration or the Nightscout connector) rather than minted as a scoped <c>noc_</c> token.
+    /// Drives the rotation nudge and the "Legacy" badge in the UI; not part of authentication.
+    /// </summary>
+    [Column("is_migrated")]
+    public bool IsMigrated { get; set; }
 
     /// <summary>
     /// Whether this grant has been revoked

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260612202627_AddIsMigratedToOAuthGrants.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260612202627_AddIsMigratedToOAuthGrants.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260612202627_AddIsMigratedToOAuthGrants")]
+    partial class AddIsMigratedToOAuthGrants
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260612202627_AddIsMigratedToOAuthGrants.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260612202627_AddIsMigratedToOAuthGrants.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsMigratedToOAuthGrants : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "is_migrated",
+                table: "oauth_grants",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            // Backfill: every grant carrying a SHA-1 secret hash at this point was seeded from a
+            // pre-existing Nightscout master secret (migration or Nightscout connector). Minted
+            // noc_ tokens only start populating legacy_secret_hash from this release onward, so the
+            // condition cleanly distinguishes existing legacy grants. oauth_grants is RLS-protected
+            // with FORCE ROW LEVEL SECURITY, so a data UPDATE must run with the tenant context set
+            // per row's tenant; loop tenants and set app.current_tenant_id each iteration.
+            migrationBuilder.Sql("""
+                DO $$
+                DECLARE
+                    r RECORD;
+                BEGIN
+                    FOR r IN SELECT id FROM tenants LOOP
+                        PERFORM set_config('app.current_tenant_id', r.id::text, true);
+
+                        UPDATE oauth_grants
+                        SET is_migrated = true
+                        WHERE tenant_id = r.id
+                          AND legacy_secret_hash IS NOT NULL;
+                    END LOOP;
+                END $$;
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "is_migrated",
+                table: "oauth_grants");
+        }
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Infrastructure/TestDatabaseSeeder.cs
+++ b/tests/Unit/Nocturne.API.Tests/Infrastructure/TestDatabaseSeeder.cs
@@ -120,6 +120,7 @@ public static class TestDatabaseSeeder
                 SubjectId = TestSubjectId,
                 GrantType = OAuthGrantTypes.Direct,
                 LegacySecretHash = apiSecretHash,
+                IsMigrated = true,
                 Scopes = [OAuthScopes.FullAccess],
                 Label = "Legacy API Secret",
                 CreatedAt = DateTime.UtcNow,

--- a/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/ApiKeyHandlerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/ApiKeyHandlerTests.cs
@@ -139,6 +139,56 @@ public class ApiKeyHandlerTests : IDisposable
     }
 
     [Fact]
+    public async Task AuthenticateAsync_MintedTokenSentPreHashed_AuthenticatesAndDoesNotNudge()
+    {
+        // A minted noc_ token carries both a SHA-256 TokenHash (verbatim clients) and a SHA-1
+        // LegacySecretHash (clients that pre-hash, e.g. Loop/AAPS/Trio). When such a client sends
+        // SHA-1(token) in the api-secret header, it must authenticate via the legacy lookup path —
+        // and must NOT trigger the migrated-secret rotation nudge.
+        var token = "noc_minteduploaderkey";
+        var tokenHash = DirectGrantTokenHandler.ComputeSha256Hex(token);
+        var sha1Hash = HashUtils.Sha1Hex(token);
+
+        await using (var ctx = new NocturneDbContext(_dbOptions) { TenantId = _testTenantId })
+        {
+            ctx.OAuthGrants.Add(new OAuthGrantEntity
+            {
+                Id = Guid.CreateVersion7(),
+                SubjectId = _subjectId,
+                TenantId = _testTenantId,
+                GrantType = OAuthGrantTypes.Direct,
+                TokenHash = tokenHash,
+                LegacySecretHash = sha1Hash,
+                IsMigrated = false,
+                Scopes = ["health.readwrite"],
+                CreatedAt = DateTime.UtcNow,
+                LastUsedAt = null,
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        var mockNotificationService = new Mock<IInAppNotificationService>();
+        var context = CreateHttpContextWithServices(mockNotificationService.Object);
+        context.Request.Headers["api-secret"] = sha1Hash;
+
+        var result = await _handler.AuthenticateAsync(context);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(_subjectId, result.AuthContext!.SubjectId);
+        Assert.Contains("health.readwrite", result.AuthContext.Scopes);
+
+        await Task.Delay(200);
+
+        mockNotificationService.Verify(s => s.CreateNotificationAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<NotificationCategory?>(), It.IsAny<NotificationUrgency?>(),
+            It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(),
+            It.IsAny<string?>(), It.IsAny<List<NotificationActionDto>?>(),
+            It.IsAny<ResolutionConditions?>(), It.IsAny<Dictionary<string, object>?>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
     public async Task AuthenticateAsync_RevokedGrant_ReturnsFailure()
     {
         var token = "noc_revokedkey123";
@@ -298,6 +348,7 @@ public class ApiKeyHandlerTests : IDisposable
                 TenantId = _testTenantId,
                 GrantType = OAuthGrantTypes.Direct,
                 LegacySecretHash = sha1Hash,
+                IsMigrated = true,
                 Scopes = ["*"],
                 CreatedAt = DateTime.UtcNow,
                 LastUsedAt = null,
@@ -357,6 +408,7 @@ public class ApiKeyHandlerTests : IDisposable
                 TenantId = _testTenantId,
                 GrantType = OAuthGrantTypes.Direct,
                 LegacySecretHash = sha1Hash,
+                IsMigrated = true,
                 Scopes = ["*"],
                 CreatedAt = DateTime.UtcNow,
                 LastUsedAt = DateTime.UtcNow.AddDays(-1),


### PR DESCRIPTION
## Problem

A user configuring **Loop** to upload to their Nocturne instance gets `401 Unauthorized` when pasting their `noc_` API key into Loop's Nightscout "API Secret" field.

Root cause: uploaders that use the legacy Nightscout `api-secret` protocol (Loop, AAPS, Trio, iAPS) **SHA-1 hash** whatever you type into the API Secret field before sending it. So pasting a `noc_` token sends `SHA1("noc_…")` in the `api-secret` header. But we only stored the **SHA-256** `TokenHash`, so `ApiKeyHandler`'s legacy branch (which looks up `LegacySecretHash`) finds nothing → 401. The `?token=` fix in #400 only helped clients that send the token verbatim in the URL (xDrip).

This affected every non-OAuth uploader, not just Loop.

## Fix

Mint direct grants with **both** hashes:
- `TokenHash = SHA256(token)` — verbatim clients (xDrip header / `?token=`)
- `LegacySecretHash = SHA1(token)` — pre-hashing clients (Loop/AAPS/Trio/iAPS)

The same token now authenticates whichever way the uploader sends it. `LegacySecretHash` already meant "the SHA-1 hash a pre-hashing Nightscout client sends" (see the Nightscout connector in `ConnectorConfigurationService`); we just start populating it for minted tokens too.

### `IsMigrated` flag

`LegacySecretHash != null` had doubled as "this grant is a migrated full-access Nightscout master secret" — driving the rotation nudge (`ApiKeyHandler`) and the "Legacy" badge (`DirectGrantController.List`). Now that every token carries a `LegacySecretHash`, that signal moves to a dedicated `is_migrated` column. The migration backfills `is_migrated = true` for existing grants that carry a `legacy_secret_hash` (tenant-looped, since `oauth_grants` has FORCE RLS).

## Note

Already-issued tokens can't be backfilled (no plaintext is stored), so users on Loop/AAPS/Trio regenerate their key once after this ships.

## Tests

- New: a minted `noc_` token sent **pre-hashed** (`SHA1(token)`) authenticates and does **not** fire the rotation nudge.
- Updated the existing nudge tests to set `IsMigrated = true` (they assert the migrated-secret behaviour).
- All 49 auth/grant/connector tests pass.