### PR TITLE
fix(alerts): fall back to BaseUrl for chat-bot dispatch when WEB_URL unset

### DIFF
--- a/src/API/Nocturne.API/Services/Alerts/Providers/ChatBotProvider.cs
+++ b/src/API/Nocturne.API/Services/Alerts/Providers/ChatBotProvider.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Json;
+using Nocturne.Core.Constants;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Alerts;
 
@@ -9,8 +10,11 @@ namespace Nocturne.API.Services.Alerts.Providers;
 /// to the Nocturne bot service over HTTP.
 /// </summary>
 /// <remarks>
-/// The bot endpoint is derived from the <c>WEB_URL</c> configuration value.
-/// Delivery is skipped with a warning when that value is not set.
+/// The bot endpoint is derived from <c>WEB_URL</c> when set (the internal web
+/// endpoint wired by the AppHost), otherwise from the deployment's public base
+/// URL (<see cref="ServiceNames.ConfigKeys.BaseUrl"/>) — which reaches the same
+/// SvelteKit dispatch route through the gateway. Delivery is skipped with a
+/// warning when neither is configured.
 /// </remarks>
 internal sealed class ChatBotProvider(
     IHttpClientFactory httpClientFactory,
@@ -45,7 +49,12 @@ internal sealed class ChatBotProvider(
         var webUrl = configuration["WEB_URL"];
         if (string.IsNullOrEmpty(webUrl))
         {
-            logger.LogWarning("WEB_URL not configured, cannot dispatch to chat bot");
+            webUrl = configuration[ServiceNames.ConfigKeys.BaseUrl];
+        }
+
+        if (string.IsNullOrEmpty(webUrl))
+        {
+            logger.LogWarning("Neither WEB_URL nor BaseUrl configured, cannot dispatch to chat bot");
             return;
         }
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/Providers/ChatBotProviderTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/Providers/ChatBotProviderTests.cs
@@ -33,7 +33,8 @@ public class ChatBotProviderTests
 
     private static ChatBotProvider CreateProvider(
         MockHttpMessageHandler handler,
-        string? webUrl = "https://web.example.com")
+        string? webUrl = "https://web.example.com",
+        string? baseUrl = null)
     {
         var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
 
@@ -44,6 +45,7 @@ public class ChatBotProviderTests
 
         var configMock = new Mock<IConfiguration>();
         configMock.Setup(c => c["WEB_URL"]).Returns(webUrl);
+        configMock.Setup(c => c["BaseUrl"]).Returns(baseUrl);
 
         var logger = NullLoggerFactory.Instance.CreateLogger<ChatBotProvider>();
 
@@ -91,11 +93,28 @@ public class ChatBotProviderTests
     }
 
     [Fact]
-    public async Task SendAsync_LogsWarning_WhenWebUrlNotConfigured()
+    public async Task SendAsync_FallsBackToBaseUrl_WhenWebUrlNotConfigured()
+    {
+        // Arrange -- no WEB_URL (the nocturne-cloud deployment shape), only the
+        // public base URL, which routes /api/v4/bot/dispatch to web via the gateway.
+        var handler = new MockHttpMessageHandler(HttpStatusCode.OK);
+        var provider = CreateProvider(handler, webUrl: "", baseUrl: "https://nocturne.run");
+
+        // Act
+        await provider.SendAsync(Guid.NewGuid(), ChannelType.DiscordDm, "u1", CreateTestPayload(), CancellationToken.None);
+
+        // Assert
+        handler.CapturedRequest.Should().NotBeNull();
+        handler.CapturedRequest!.RequestUri!.ToString()
+            .Should().Be("https://nocturne.run/api/v4/bot/dispatch");
+    }
+
+    [Fact]
+    public async Task SendAsync_LogsWarning_WhenNeitherUrlConfigured()
     {
         // Arrange
         var handler = new MockHttpMessageHandler(HttpStatusCode.OK);
-        var provider = CreateProvider(handler, webUrl: "");
+        var provider = CreateProvider(handler, webUrl: "", baseUrl: "");
 
         // Act -- should return early without throwing
         await provider.SendAsync(Guid.NewGuid(), ChannelType.DiscordDm, "u1", CreateTestPayload(), CancellationToken.None);


### PR DESCRIPTION
## Problem

`ChatBotProvider` located the bot dispatch endpoint solely from the `WEB_URL`
configuration value and skipped delivery (logging a warning) when it was unset.
Deployments that front `nocturne-web` with a gateway that routes `/api` to web —
so the dispatch route is reachable at the deployment's public base URL — set
`BaseUrl` (for OIDC redirects, invite links, etc.) but not `WEB_URL`. On those
deployments **every Discord/Slack/Telegram alert silently sat `pending` and
expired**, with no error recorded on the delivery row.

Observed in a downstream deployment: an enabled "Approaching low" rule fired
correctly (alert_instances created, no suppression), but the `discord_*`
deliveries never left `pending` (retry_count 0, empty last_error) while the API
log repeated `WEB_URL not configured, cannot dispatch to chat bot`.

## Fix

Prefer `WEB_URL` (the internal web endpoint the AppHost wires) and fall back to
`BaseUrl` — the same public-URL config key already used elsewhere for
external-facing URLs. Behaviour is unchanged where `WEB_URL` is set; only the
previously-failing no-`WEB_URL` case now delivers (via the gateway).

## Tests

- New `SendAsync_FallsBackToBaseUrl_WhenWebUrlNotConfigured`.
- Renamed the missing-config test to `SendAsync_LogsWarning_WhenNeitherUrlConfigured`.
- All ChatBotProvider tests pass.
