### PR TITLE
fix(auth): gate /api/v1/experiments/test on scopes so scoped uploader tokens pass

### DIFF
--- a/src/API/Nocturne.API/Controllers/V1/ExperimentsController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/ExperimentsController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
+using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.API.Controllers.V1;
 
@@ -12,7 +13,7 @@ namespace Nocturne.API.Controllers.V1;
 /// treats only a 200 as success (401 means "bad secret"). Without this endpoint Nocturne
 /// returns 404, so Loop reports a network error and aborts setup even though entries and
 /// devicestatus uploads succeed. Mirrors reference Nightscout, which gates the endpoint on
-/// read permission and returns <c>{ status: "ok" }</c>.
+/// read access and returns <c>{ status: "ok" }</c>.
 /// </remarks>
 [ApiController]
 [Tags("V1")]
@@ -23,11 +24,18 @@ public class ExperimentsController : ControllerBase
     /// Confirms the request carries valid, authorized credentials.
     /// </summary>
     /// <returns>200 with <c>{ status: "ok" }</c> when authorized; 401 otherwise.</returns>
+    /// <remarks>
+    /// Gated on read access to any core Nightscout data type (matched via scopes, like the
+    /// rest of v1). Using <see cref="RequireScopeAttribute"/> rather than a broad
+    /// <c>RequireRead</c> permission means scoped uploader tokens (e.g. a Loop key with
+    /// <c>glucose.readwrite</c>) pass, instead of only full-access/legacy <c>*</c> secrets.
+    /// </remarks>
     [HttpGet("experiments/test")]
-    [RequireRead]
+    [RequireScope(OAuthScopes.GlucoseRead, OAuthScopes.TreatmentsRead, OAuthScopes.DevicesRead)]
     [NightscoutEndpoint("/api/v1/experiments/test")]
     [ProducesResponseType(200)]
     [ProducesResponseType(401)]
+    [ProducesResponseType(403)]
     public IActionResult Test()
     {
         return Ok(new { status = "ok" });

--- a/tests/Unit/Nocturne.API.Tests/Controllers/ExperimentsControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/ExperimentsControllerTests.cs
@@ -1,7 +1,12 @@
 using System.Net;
 using System.Security.Cryptography;
 using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Nocturne.API.Tests.Infrastructure;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
 using Xunit;
 
 namespace Nocturne.API.Tests.Controllers;
@@ -27,6 +32,47 @@ public class ExperimentsControllerTests : IClassFixture<AuthenticationTestFactor
         client.DefaultRequestHeaders.Add(
             "api-secret",
             ComputeSha1Hash(AuthenticationTestFactory.ApiSecret));
+
+        var response = await client.GetAsync("/api/v1/experiments/test", CancellationToken.None);
+        var content = await response.Content.ReadAsStringAsync(CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("ok", content);
+    }
+
+    [Fact]
+    public async Task ExperimentsTest_GranularUploaderToken_Returns200Ok()
+    {
+        // A minted uploader token (e.g. a Loop key from the setup wizard) carries granular
+        // scopes like glucose.readwrite — not the legacy full-access "*". The connection probe
+        // must accept it; gating on a broad RequireRead permission used to 403 these tokens.
+        const string uploaderToken = "noc_granular-uploader-test-token";
+        using (var ctx = _factory.Services
+                   .GetRequiredService<IDbContextFactory<NocturneDbContext>>()
+                   .CreateDbContext())
+        {
+            ctx.OAuthGrants.Add(new OAuthGrantEntity
+            {
+                Id = Guid.NewGuid(),
+                TenantId = TestDatabaseSeeder.TenantId,
+                SubjectId = TestDatabaseSeeder.TestSubjectId,
+                GrantType = OAuthGrantTypes.Direct,
+                LegacySecretHash = TestDatabaseSeeder.Sha1Hex(uploaderToken),
+                IsMigrated = false,
+                Scopes =
+                [
+                    OAuthScopes.GlucoseReadWrite,
+                    OAuthScopes.TreatmentsReadWrite,
+                    OAuthScopes.DevicesReadWrite,
+                ],
+                Label = "Loop",
+                CreatedAt = DateTime.UtcNow,
+            });
+            ctx.SaveChanges();
+        }
+
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("api-secret", ComputeSha1Hash(uploaderToken));
 
         var response = await client.GetAsync("/api/v1/experiments/test", CancellationToken.None);
         var content = await response.Content.ReadAsStringAsync(CancellationToken.None);


### PR DESCRIPTION
## Problem

Follow-up to #401. With #401 deployed, a Loop user's token now **authenticates** (no more 401), but Loop's "add Nightscout service" check still failed — `GET /api/v1/experiments/test` returned **403**, so Loop aborts setup before uploading anything.

Root cause: `experiments/test` was the *only* endpoint using `[RequireRead]`, which requires a **broad** permission-trie entry (`*`, `api:*`, `api:*:read`, or `readable`). Granular OAuth scopes translate to **granular** permissions (`glucose.readwrite` → `api:entries:read`/`create`/`update`), and `PermissionTrie.Check` only expands wildcards in the *grant*, not the *query* — so `api:entries:read` never satisfies `api:*:read`. A correctly-scoped uploader token (a Loop key minted with `health.readwrite`) therefore got 403 on the probe, even though the actual upload endpoints — `CreateEntries`, `CreateDeviceStatus`, `CreateTreatments` — already use scope-based `[RequireScope(...ReadWrite)]` and accept it. Only legacy full-access `*` secrets passed the probe.

Confirmed on prod from gateway logs: same token → `GET /api/v4/glucose/sensor` 200 (scope-based) but `GET /api/v1/experiments/test` 403 (permission-trie).

## Fix

Switch the probe from `[RequireRead]` to `[RequireScope(GlucoseRead, TreatmentsRead, DevicesRead)]` (any core read scope), consistent with how the rest of v1 authorizes. `readwrite`/`*` satisfy a `read` requirement via `SatisfiesScope`, so Loop/AAPS/Trio/xDrip tokens pass; an unauthenticated request still gets 401 (Loop's "bad secret" signal).

`[RequireRead]` was used **only** on this endpoint; `[RequireWrite]` is used nowhere — so this is a one-endpoint fix, not a systemic change.

## Tests

- New: a granular (non-`*`) uploader grant gets **200** from `experiments/test` (would 403 before this change).
- Existing `experiments/test` (valid secret → 200, no auth → 401) and the `WriteEndpointScopeEnforcement` guard still pass.