### PR TITLE
feat(oauth): register Prelude as a known client + web Quick Connect

### DIFF
--- a/src/Core/Nocturne.Core.Models/Authorization/KnownOAuthClients.cs
+++ b/src/Core/Nocturne.Core.Models/Authorization/KnownOAuthClients.cs
@@ -123,6 +123,20 @@ public static class KnownOAuthClients
         },
         new()
         {
+            SoftwareId = "dev.nocturne.prelude",
+            DisplayName = "Prelude",
+            Homepage = "https://github.com/nightscout/prelude",
+            LogoUri = "/logos/prelude.svg",
+            RedirectUris = ["dev.nocturne.prelude://oauth/callback"],
+            TypicalScopes =
+            [
+                OAuthScopes.GlucoseRead,
+                OAuthScopes.TreatmentsRead,
+                OAuthScopes.DevicesRead,
+            ],
+        },
+        new()
+        {
             SoftwareId = "com.nocturne.widget.windows",
             DisplayName = "Nocturne Windows Widget",
             Homepage = "https://github.com/nightscout/nocturne",

--- a/src/Web/packages/app/src/lib/components/PreludeQuickConnect.svelte
+++ b/src/Web/packages/app/src/lib/components/PreludeQuickConnect.svelte
@@ -1,0 +1,310 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { browser } from "$app/environment";
+  import QRCode from "qrcode";
+  import { Button } from "$lib/components/ui/button";
+  import { Input } from "$lib/components/ui/input";
+  import { Separator } from "$lib/components/ui/separator";
+  import {
+    Smartphone,
+    CheckCircle,
+    Loader2,
+    Check,
+    Shield,
+    AlertTriangle,
+    X,
+  } from "lucide-svelte";
+  import { buildPreludeDeepLink, buildConnectPageUrl } from "$lib/utils/prelude-links";
+  import { getDeviceInfo } from "$routes/(authenticated)/oauth/oauth.remote";
+  import { deviceApprove } from "$api/generated/oAuths.generated.remote";
+  import { getOAuthScopeDescription } from "$lib/constants/oauth-scopes";
+
+  interface Props {
+    /** Origin URL of the Nocturne instance (trailing slash tolerated). */
+    instanceUrl: string;
+  }
+
+  let { instanceUrl }: Props = $props();
+
+  let qrDataUrl = $state<string | null>(null);
+  let isAndroid = $state(false);
+
+  const connectPageUrl = $derived(buildConnectPageUrl(instanceUrl));
+  const deepLink = $derived(buildPreludeDeepLink(instanceUrl));
+
+  // ── Device authorization state ─────────────────────────────────
+  let deviceCodeInput = $state("");
+  let deviceLookupLoading = $state(false);
+  let deviceLookupError = $state<string | null>(null);
+  let deviceInfo = $state<{
+    userCode: string;
+    clientId: string;
+    displayName: string | null;
+    isKnown: boolean;
+    scopes: string[];
+  } | null>(null);
+  let deviceApproveLoading = $state(false);
+  let deviceApproved = $state(false);
+  let deviceDenied = $state(false);
+
+  const deviceAppName = $derived(
+    deviceInfo ? (deviceInfo.displayName ?? deviceInfo.clientId) : "",
+  );
+
+  onMount(async () => {
+    if (browser) {
+      isAndroid = /android/i.test(navigator.userAgent);
+    }
+    try {
+      qrDataUrl = await QRCode.toDataURL(connectPageUrl, {
+        width: 200,
+        margin: 2,
+        color: { dark: "#000000", light: "#ffffff" },
+      });
+    } catch (err) {
+      console.warn("[PreludeQuickConnect] QR code generation failed:", err);
+    }
+  });
+
+  async function lookupDeviceCode() {
+    const code = deviceCodeInput.trim();
+    if (!code) return;
+
+    deviceLookupLoading = true;
+    deviceLookupError = null;
+
+    try {
+      const info = await getDeviceInfo({ userCode: code }).run();
+      if (!info) {
+        deviceLookupError = "Invalid or expired device code.";
+        return;
+      }
+      deviceInfo = {
+        userCode: info.userCode ?? code,
+        clientId: info.clientId ?? "",
+        displayName: info.clientDisplayName ?? null,
+        isKnown: info.isKnownClient ?? false,
+        scopes: (info.scopes ?? []).filter(Boolean),
+      };
+    } catch {
+      deviceLookupError = "Invalid or expired device code. Please check and try again.";
+    } finally {
+      deviceLookupLoading = false;
+    }
+  }
+
+  async function handleApproveDevice() {
+    if (!deviceInfo) return;
+    deviceApproveLoading = true;
+    try {
+      await deviceApprove({ user_code: deviceInfo.userCode, approved: true });
+      deviceApproved = true;
+    } catch {
+      deviceLookupError = "Failed to approve. The code may have expired.";
+    } finally {
+      deviceApproveLoading = false;
+    }
+  }
+
+  async function handleDenyDevice() {
+    if (!deviceInfo) return;
+    deviceApproveLoading = true;
+    try {
+      await deviceApprove({ user_code: deviceInfo.userCode, approved: false });
+      deviceDenied = true;
+    } catch {
+      deviceLookupError = "Failed to deny the request.";
+    } finally {
+      deviceApproveLoading = false;
+    }
+  }
+
+  function handleDeviceCodeSubmit(e: SubmitEvent) {
+    e.preventDefault();
+    lookupDeviceCode();
+  }
+</script>
+
+<div class="space-y-4">
+  <div>
+    <p class="text-sm font-medium">Quick Connect</p>
+    <p class="text-muted-foreground text-sm">
+      Scan the QR with Prelude, then approve the code it shows you here.
+    </p>
+  </div>
+
+  {#if isAndroid}
+    <Button href={deepLink} class="w-full">
+      <Smartphone class="mr-2 h-4 w-4" />
+      Open in Prelude
+    </Button>
+    {#if qrDataUrl}
+      <details class="text-sm">
+        <summary class="text-muted-foreground cursor-pointer">
+          Or scan from another device
+        </summary>
+        <div class="flex justify-center pt-3">
+          <img
+            src={qrDataUrl}
+            alt="QR code to connect Prelude"
+            width="200"
+            height="200"
+            class="rounded"
+          />
+        </div>
+      </details>
+    {/if}
+  {:else if qrDataUrl}
+    <div class="flex justify-center">
+      <img
+        src={qrDataUrl}
+        alt="QR code to connect Prelude"
+        width="200"
+        height="200"
+        class="rounded"
+      />
+    </div>
+    <p class="text-muted-foreground text-center text-sm">
+      In Prelude, tap Settings → Account → Connect with QR and scan this code
+    </p>
+  {/if}
+
+  <Separator />
+
+  <!-- Device Authorization Code Section -->
+  <div class="space-y-3">
+    <div>
+      <p class="text-sm font-medium">Enter Authorization Code</p>
+      <p class="text-muted-foreground text-sm">
+        Prelude displays a short code after it scans. Enter it here to approve.
+      </p>
+    </div>
+
+    {#if deviceApproved}
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        class="flex items-center gap-2 rounded bg-green-50 p-3 text-sm text-green-900 dark:bg-green-950 dark:text-green-100"
+      >
+        <CheckCircle class="h-4 w-4" />
+        Device authorized successfully. Prelude is now connected.
+      </div>
+    {:else if deviceDenied}
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        class="bg-muted flex items-center gap-2 rounded p-3 text-sm"
+      >
+        <X class="h-4 w-4" />
+        Authorization denied. The device will not be granted access.
+      </div>
+    {:else if deviceInfo}
+      <!-- Consent / Approval -->
+      <div class="space-y-3 rounded-md border p-3">
+        <div class="flex items-center gap-2">
+          <Shield class="h-4 w-4 text-primary" />
+          <p class="text-sm font-medium">
+            <span class="text-foreground font-semibold">{deviceAppName}</span> wants access
+          </p>
+        </div>
+
+        {#if !deviceInfo.isKnown}
+          <div
+            class="flex items-start gap-3 rounded-md border border-yellow-200 bg-yellow-50 p-3 dark:border-yellow-900/50 dark:bg-yellow-900/20"
+          >
+            <AlertTriangle
+              class="mt-0.5 h-4 w-4 shrink-0 text-yellow-600 dark:text-yellow-400"
+            />
+            <p class="text-sm text-yellow-800 dark:text-yellow-200">
+              This application is not in the Nocturne known app directory. Only
+              approve if you trust this application.
+            </p>
+          </div>
+        {/if}
+
+        <div>
+          <p class="text-muted-foreground mb-2 text-xs font-medium">Requested permissions:</p>
+          <ul class="space-y-1">
+            {#each deviceInfo.scopes as scope (scope)}
+              <li class="flex items-start gap-2 text-sm">
+                <Check class="mt-0.5 h-3 w-3 shrink-0 text-primary" />
+                <span class="text-muted-foreground">
+                  {getOAuthScopeDescription(scope)}
+                </span>
+              </li>
+            {/each}
+          </ul>
+        </div>
+
+        {#if deviceLookupError}
+          <div
+            class="flex items-start gap-2 rounded-md border border-destructive/20 bg-destructive/5 p-2"
+          >
+            <AlertTriangle class="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+            <p class="text-sm text-destructive">{deviceLookupError}</p>
+          </div>
+        {/if}
+
+        <div class="flex gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            class="flex-1"
+            disabled={deviceApproveLoading}
+            onclick={handleDenyDevice}
+          >
+            {#if deviceApproveLoading}
+              <Loader2 class="mr-2 h-4 w-4 animate-spin" />
+            {/if}
+            Deny
+          </Button>
+          <Button
+            size="sm"
+            class="flex-1"
+            disabled={deviceApproveLoading}
+            onclick={handleApproveDevice}
+          >
+            {#if deviceApproveLoading}
+              <Loader2 class="mr-2 h-4 w-4 animate-spin" />
+            {/if}
+            Approve
+          </Button>
+        </div>
+      </div>
+    {:else}
+      <!-- Code Entry -->
+      {#if deviceLookupError}
+        <div
+          class="flex items-start gap-2 rounded-md border border-destructive/20 bg-destructive/5 p-2"
+        >
+          <AlertTriangle class="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+          <p class="text-sm text-destructive">{deviceLookupError}</p>
+        </div>
+      {/if}
+
+      <form onsubmit={handleDeviceCodeSubmit} class="flex items-center gap-2">
+        <Input
+          type="text"
+          placeholder="XXXX-YYYY"
+          maxlength={9}
+          autocomplete="off"
+          class="text-center uppercase tracking-widest"
+          bind:value={deviceCodeInput}
+          disabled={deviceLookupLoading}
+        />
+        <Button
+          type="submit"
+          size="sm"
+          disabled={deviceLookupLoading || !deviceCodeInput.trim()}
+        >
+          {#if deviceLookupLoading}
+            <Loader2 class="mr-2 h-4 w-4 animate-spin" />
+          {/if}
+          Continue
+        </Button>
+      </form>
+    {/if}
+  </div>
+</div>

--- a/src/Web/packages/app/src/lib/utils/prelude-links.ts
+++ b/src/Web/packages/app/src/lib/utils/prelude-links.ts
@@ -1,0 +1,28 @@
+/**
+ * Normalizes an instance URL by removing trailing slashes.
+ * Returns empty string if input is empty (for SSR safety).
+ */
+function normalize(instanceUrl: string): string {
+  return instanceUrl.replace(/\/+$/, "");
+}
+
+/**
+ * Builds the Prelude deep link that hands the Android app its Nocturne
+ * instance URL to begin OAuth device-grant pairing.
+ *
+ * @param instanceUrl — the Nocturne instance origin URL (with or without trailing slash)
+ */
+export function buildPreludeDeepLink(instanceUrl: string): string {
+  const normalized = normalize(instanceUrl);
+  return `prelude://connect?url=${encodeURIComponent(normalized)}`;
+}
+
+/**
+ * Builds the public connect page URL a phone QR scanner can open. Prelude's
+ * in-app scanner reads this URL directly and recovers the instance origin;
+ * a system camera opens it in the browser, where the trampoline page
+ * redirects to {@link buildPreludeDeepLink}.
+ */
+export function buildConnectPageUrl(instanceUrl: string): string {
+  return `${normalize(instanceUrl)}/connect/prelude`;
+}

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/+page.svelte
@@ -38,6 +38,7 @@
     ChevronRight,
     Loader2,
     KeyRound,
+    Smartphone,
   } from "lucide-svelte";
   import SettingsPageSkeleton from "$lib/components/settings/SettingsPageSkeleton.svelte";
   import DataSourceRow from "$lib/components/settings/DataSourceRow.svelte";
@@ -46,6 +47,7 @@
   import ApiTokens from "$lib/components/settings/ApiTokens.svelte";
   import DeduplicationDialog from "$lib/components/connectors/DeduplicationDialog.svelte";
   import AppLogo from "$lib/components/ui/AppLogo.svelte";
+  import PreludeQuickConnect from "$lib/components/PreludeQuickConnect.svelte";
   import UploaderSetupDialog from "$lib/components/connectors/UploaderSetupDialog.svelte";
   import ConnectorDetailsDialog from "$lib/components/connectors/ConnectorDetailsDialog.svelte";
   import ManualSyncDialog, { type BatchSyncResult } from "$lib/components/connectors/ManualSyncDialog.svelte";
@@ -445,6 +447,24 @@
             {/each}
           </div>
         {/if}
+      </CardContent>
+    </Card>
+
+    <!-- Connect Prelude (Android follower — OAuth device-grant QR pairing) -->
+    <Card>
+      <CardHeader>
+        <CardTitle class="flex items-center gap-2">
+          <Smartphone class="h-5 w-5" />
+          Connect Prelude
+        </CardTitle>
+        <CardDescription>
+          Pair the Prelude Android app by scanning a QR and approving a short code
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <PreludeQuickConnect
+          instanceUrl={typeof window !== "undefined" ? window.location.origin : ""}
+        />
       </CardContent>
     </Card>
 

--- a/src/Web/packages/app/src/routes/(fullscreen)/connect/prelude/+page.svelte
+++ b/src/Web/packages/app/src/routes/(fullscreen)/connect/prelude/+page.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { Button } from "$lib/components/ui/button";
+  import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+  } from "$lib/components/ui/card";
+  import { ExternalLink, Smartphone, Copy, Check } from "lucide-svelte";
+  import { buildPreludeDeepLink } from "$lib/utils/prelude-links";
+
+  let viewState: "redirecting" | "fallback" = $state("redirecting");
+  let copied = $state(false);
+  let copyTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  const instanceUrl = typeof window !== "undefined" ? window.location.origin : "";
+  const deepLink = buildPreludeDeepLink(instanceUrl);
+
+  onMount(() => {
+    window.location.href = deepLink;
+    const timeout = setTimeout(() => {
+      viewState = "fallback";
+    }, 2000);
+    return () => {
+      clearTimeout(timeout);
+      if (copyTimeout) clearTimeout(copyTimeout);
+    };
+  });
+
+  async function copyUrl() {
+    try {
+      await navigator.clipboard.writeText(instanceUrl);
+      copied = true;
+      if (copyTimeout) clearTimeout(copyTimeout);
+      copyTimeout = setTimeout(() => (copied = false), 2000);
+    } catch {
+      // Clipboard API unavailable; user can still long-press the code block.
+    }
+  }
+</script>
+
+<div class="flex min-h-screen items-center justify-center p-4">
+  {#if viewState === "redirecting"}
+    <Card class="w-full max-w-md text-center">
+      <CardHeader>
+        <CardTitle>Opening Prelude</CardTitle>
+        <CardDescription>Redirecting to Prelude to start the connection...</CardDescription>
+      </CardHeader>
+    </Card>
+  {:else}
+    <Card class="w-full max-w-md">
+      <CardHeader>
+        <CardTitle>Connect Prelude</CardTitle>
+        <CardDescription>
+          Prelude didn't open automatically. You can try these options:
+        </CardDescription>
+      </CardHeader>
+      <CardContent class="space-y-4">
+        <Button href={deepLink} class="w-full">
+          <Smartphone class="mr-2 h-4 w-4" />
+          Open in Prelude
+        </Button>
+
+        <div class="space-y-2">
+          <p class="text-sm font-medium">Manual setup</p>
+          <p class="text-muted-foreground text-sm">
+            In Prelude, open Settings &gt; Account &gt; Connect with QR (or use Manual setup),
+            and enter this URL:
+          </p>
+          <div class="flex items-center gap-2">
+            <code class="bg-muted flex-1 rounded px-3 py-2 text-sm break-all">
+              {instanceUrl}
+            </code>
+            <Button variant="ghost" size="icon" onclick={copyUrl}>
+              {#if copied}
+                <Check class="h-4 w-4" />
+              {:else}
+                <Copy class="h-4 w-4" />
+              {/if}
+            </Button>
+          </div>
+          <p class="text-muted-foreground text-sm">
+            Then approve the code Prelude shows you back on this site.
+          </p>
+        </div>
+
+        <div class="pt-2">
+          <p class="text-muted-foreground text-sm">Don't have Prelude installed?</p>
+          <Button
+            href="https://github.com/nightscout/prelude/releases"
+            target="_blank"
+            variant="link"
+            class="px-0"
+          >
+            <ExternalLink class="mr-1 h-3 w-3" />
+            Download Prelude
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  {/if}
+</div>

--- a/src/Web/packages/app/static/logos/prelude.svg
+++ b/src/Web/packages/app/static/logos/prelude.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" role="img" aria-label="Prelude">
+  <rect width="48" height="48" rx="11" fill="#0B1220"/>
+  <path d="M8 28c4 0 5-12 9-12s5 18 9 18 4-14 8-14h6"
+        fill="none" stroke="#4ADE80" stroke-width="3"
+        stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/tests/Unit/Nocturne.API.Tests/Authorization/KnownOAuthClientsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/KnownOAuthClientsTests.cs
@@ -14,6 +14,7 @@ public class KnownOAuthClientsTests
     [InlineData("github.nightscout.nightscout", "Nightscout")]
     [InlineData("io.sugarmate", "Sugarmate")]
     [InlineData("com.nickenilsson.nightwatch", "Nightwatch")]
+    [InlineData("dev.nocturne.prelude", "Prelude")]
     public void MatchBySoftwareId_ReturnsEntry_ForKnownSoftwareId(string softwareId, string expectedDisplayName)
     {
         var entry = KnownOAuthClients.MatchBySoftwareId(softwareId);


### PR DESCRIPTION
## Summary
Adds support for pairing the **Prelude** Android app via the existing OAuth 2.0 Device Authorization Grant (RFC 8628), mirroring the xDrip+ Quick Connect flow. No secret travels in the QR — the user scans, approves a short code on the authenticated web page, and Prelude receives a short-lived JWT + rotating refresh token.

## Changes
- **Known client**: register `dev.nocturne.prelude` (Prelude, read scopes `glucose.read treatments.read devices.read`) in `KnownOAuthClients` so the consent screen shows a trusted app + logo.
- **Web**: `PreludeQuickConnect.svelte` (QR + device-code approval), `prelude-links.ts` helpers, the `/connect/prelude` trampoline route, a "Connect Prelude" card on the connectors page, and a `prelude.svg` logo.

## Notes
- **No backend behaviour change** — the device-grant endpoints (`/api/oauth/device`, `/api/oauth/token`, `/api/oauth/device-approve`) are client-agnostic; Prelude self-registers via DCR before requesting a code, and the refresh_token grant is already supported.
- The client app side lives in the Prelude repo (camera QR scanner + device-grant client + refresh-on-401).

## Tests
- `KnownOAuthClientsTests` extended with the Prelude entry; full suite green (14/14). The generic `AllEntries_*` invariants also cover it (valid scopes, unique software_id, required fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)