### PR TITLE
fix(treatments): dedup on syncIdentifier when _id is absent

### DIFF
--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -117,9 +117,28 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         _logger = logger;
     }
 
+    /// <summary>
+    /// Establishes the dedup identity for a treatment. iOS uploaders (xDrip4iOS, Trio, Loop —
+    /// all LoopKit/NightscoutKit based) omit Nightscout's <c>_id</c> and instead send a stable
+    /// <c>syncIdentifier</c> for idempotency. Decomposition keys create-or-update on
+    /// <see cref="Treatment.Id"/> (persisted as <c>LegacyId</c>), so without this a re-uploaded
+    /// treatment has no <c>Id</c> to match against and is inserted again every sync, producing
+    /// duplicate rows. Adopting the <c>syncIdentifier</c> as the <c>Id</c> when none is present
+    /// makes re-uploads update in place and echoes a stable identifier back to the client.
+    /// </summary>
+    private static void NormalizeIdentity(Treatment treatment)
+    {
+        if (string.IsNullOrEmpty(treatment.Id) && !string.IsNullOrEmpty(treatment.SyncIdentifier))
+        {
+            treatment.Id = treatment.SyncIdentifier;
+        }
+    }
+
     /// <inheritdoc />
     public async Task<V4Models.DecompositionResult> DecomposeAsync(Treatment treatment, CancellationToken ct = default)
     {
+        NormalizeIdentity(treatment);
+
         var batch = new DecompositionBatchEntity
         {
             TenantId = _dbContext.TenantId,
@@ -1165,6 +1184,8 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
 
         foreach (var treatment in treatments)
         {
+            NormalizeIdentity(treatment);
+
             var eventType = treatment.EventType?.Trim();
             var hasInsulin = treatment.Insulin is > 0;
             var hasCarbs = treatment.Carbs is > 0;

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
@@ -556,6 +556,68 @@ public class TreatmentDecomposerTests : IDisposable
     }
 
     [Fact]
+    public async Task DecomposeAsync_NoIdButSyncIdentifier_AdoptsSyncIdentifierAsLegacyId()
+    {
+        // iOS uploaders (xDrip4iOS, Trio, Loop) omit _id and send only a syncIdentifier.
+        var treatment = new Treatment
+        {
+            Id = null,
+            SyncIdentifier = "xdrip-bg-sync-1",
+            EventType = "BG Check",
+            Mills = 1700000000000,
+            Glucose = 250,
+            GlucoseType = "Finger",
+            Units = "mg/dl"
+        };
+
+        var result = await _decomposer.DecomposeAsync(treatment);
+
+        result.CreatedRecords.Should().HaveCount(1);
+        var bgCheck = result.CreatedRecords[0].Should().BeOfType<V4Models.BGCheck>().Subject;
+        bgCheck.LegacyId.Should().Be("xdrip-bg-sync-1");
+    }
+
+    [Fact]
+    public async Task DecomposeAsync_ReuploadedTreatmentWithSameSyncIdentifier_UpdatesInsteadOfDuplicating()
+    {
+        // Reproduces haribo's duplicate finger-BG flood: an iOS uploader re-sends the same
+        // treatment every sync with no _id but a stable syncIdentifier. Each upload arrives
+        // as a freshly deserialized object (Id null), so dedup must key on the syncIdentifier.
+        var firstUpload = new Treatment
+        {
+            Id = null,
+            SyncIdentifier = "xdrip-bg-sync-dup",
+            EventType = "BG Check",
+            Mills = 1700000000000,
+            Glucose = 250,
+            GlucoseType = "Finger",
+            Units = "mg/dl"
+        };
+        var secondUpload = new Treatment
+        {
+            Id = null,
+            SyncIdentifier = "xdrip-bg-sync-dup",
+            EventType = "BG Check",
+            Mills = 1700000000000,
+            Glucose = 250,
+            GlucoseType = "Finger",
+            Units = "mg/dl"
+        };
+
+        var firstResult = await _decomposer.DecomposeAsync(firstUpload);
+        firstResult.CreatedRecords.Should().HaveCount(1);
+        firstResult.UpdatedRecords.Should().BeEmpty();
+
+        var secondResult = await _decomposer.DecomposeAsync(secondUpload);
+
+        // No duplicate row — the re-upload updates the existing BGCheck.
+        secondResult.CreatedRecords.Should().BeEmpty();
+        secondResult.UpdatedRecords.Should().HaveCount(1);
+        secondResult.UpdatedRecords[0].Should().BeOfType<V4Models.BGCheck>()
+            .Subject.LegacyId.Should().Be("xdrip-bg-sync-dup");
+    }
+
+    [Fact]
     public async Task DecomposeAsync_MealBolusTwice_UpdatesBothBolusAndCarbIntake()
     {
         // Arrange


### PR DESCRIPTION
## Problem

iOS uploaders (xDrip4iOS, Trio, Loop — all LoopKit/NightscoutKit based) don't send Nightscout's `_id`. They send a stable `syncIdentifier` for idempotency:

```json
{"eventType":"BG Check","glucose":250,"glucoseType":"Finger","syncIdentifier":"64182d43-…"}
```

`Treatment` deserializes `syncIdentifier` but decomposition keys create-or-update on `Treatment.Id` (= `_id`, persisted as `LegacyId`). With no `_id`, `GetByLegacyIdAsync(null)` never matches, so every periodic re-upload INSERTs a new row — unbounded duplicate treatments (observed live: a tenant's treatment table filling with repeated finger BG checks and sensor-start events; `bg_checks.sync_identifier` left NULL).

## Fix

Adopt `syncIdentifier` as the treatment `Id` when none is present, at the decomposer chokepoint (`NormalizeIdentity`, applied in both `DecomposeAsync` and `DecomposeBatchAsync` — so V1/V3/connector ingestion are all covered). Re-uploads now update in place, `LegacyId` is populated, and a stable identifier is echoed back to the client.

Scoped to treatments; entries are unaffected (already protected by the device+type+value+time-window dedup in the entries path).

## Tests

Added: a no-`_id`-with-`syncIdentifier` treatment adopts it as `LegacyId`; a re-uploaded treatment (fresh object, same `syncIdentifier`) updates in place instead of duplicating. Full TreatmentDecomposer suite (151 tests) passes.