### PR TITLE
fix(treatments): honor eventTime + dedup identifier-less treatments

### DIFF
--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -118,20 +118,69 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
     }
 
     /// <summary>
-    /// Establishes the dedup identity for a treatment. iOS uploaders (xDrip4iOS, Trio, Loop —
-    /// all LoopKit/NightscoutKit based) omit Nightscout's <c>_id</c> and instead send a stable
-    /// <c>syncIdentifier</c> for idempotency. Decomposition keys create-or-update on
-    /// <see cref="Treatment.Id"/> (persisted as <c>LegacyId</c>), so without this a re-uploaded
-    /// treatment has no <c>Id</c> to match against and is inserted again every sync, producing
-    /// duplicate rows. Adopting the <c>syncIdentifier</c> as the <c>Id</c> when none is present
-    /// makes re-uploads update in place and echoes a stable identifier back to the client.
+    /// Establishes the dedup identity for a treatment. Decomposition keys create-or-update on
+    /// <see cref="Treatment.Id"/> (persisted as <c>LegacyId</c>), so a treatment with no <c>Id</c>
+    /// has nothing to match against and is inserted again on every re-upload, producing duplicate
+    /// rows. Identity is resolved in precedence order:
+    /// <list type="number">
+    ///   <item><description>an explicit Nightscout <c>_id</c> (unchanged);</description></item>
+    ///   <item><description>the <c>syncIdentifier</c> sent by LoopKit/NightscoutKit uploaders
+    ///   (xDrip4iOS, Trio, Loop) that omit <c>_id</c>;</description></item>
+    ///   <item><description>a deterministic synthetic id derived from the event's defining fields
+    ///   for fully identifier-less treatments (e.g. xDrip4iOS BG checks).</description></item>
+    /// </list>
+    /// The synthetic id keys on the exact event time, so re-uploads of one logical event collapse
+    /// while genuinely distinct events (e.g. two boluses seconds apart) keep separate ids and are
+    /// never merged. Requires a resolved <see cref="Treatment.Mills"/> (see the Treatment timestamp
+    /// fallback); without one the treatment is left unidentified rather than risk a wrong key.
     /// </summary>
     private static void NormalizeIdentity(Treatment treatment)
     {
-        if (string.IsNullOrEmpty(treatment.Id) && !string.IsNullOrEmpty(treatment.SyncIdentifier))
+        if (!string.IsNullOrEmpty(treatment.Id))
+            return;
+
+        if (!string.IsNullOrEmpty(treatment.SyncIdentifier))
         {
             treatment.Id = treatment.SyncIdentifier;
+            return;
         }
+
+        if (treatment.Mills > 0 && !string.IsNullOrEmpty(treatment.EventType))
+        {
+            treatment.Id = ComputeSyntheticId(treatment);
+        }
+    }
+
+    /// <summary>
+    /// Computes a deterministic identifier for an identifier-less treatment by hashing its
+    /// defining fields. Every field that distinguishes one real event from another is included
+    /// (event type, exact time, source, and all dose/value fields), so only byte-identical
+    /// re-uploads of the same event collapse — distinct events never share an id.
+    /// </summary>
+    internal static string ComputeSyntheticId(Treatment t)
+    {
+        var canonical = string.Join(
+            "|",
+            t.EventType,
+            t.Mills.ToString(CultureInfo.InvariantCulture),
+            t.EnteredBy,
+            Fmt(t.Insulin),
+            Fmt(t.Carbs),
+            Fmt(t.Glucose),
+            t.GlucoseType,
+            Fmt(t.Duration),
+            Fmt(t.Absolute),
+            Fmt(t.Rate),
+            Fmt(t.Percent),
+            t.Notes);
+
+        var hash = System.Security.Cryptography.SHA256.HashData(
+            System.Text.Encoding.UTF8.GetBytes(canonical));
+        // "syn-" marker + 60 hex chars fits the 64-char legacy_id column.
+        return "syn-" + Convert.ToHexStringLower(hash)[..60];
+
+        static string Fmt(double? value) =>
+            value?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
     }
 
     /// <inheritdoc />

--- a/src/Core/Nocturne.Core.Models/Treatment.cs
+++ b/src/Core/Nocturne.Core.Models/Treatment.cs
@@ -156,29 +156,55 @@ public class Treatment : ProcessableDocumentBase
     [JsonPropertyName("mills")]
     public override long Mills
     {
-        get
-        {
-            if (_mills == 0 && !string.IsNullOrEmpty(_created_at))
-            {
-                if (
-                    DateTime.TryParse(
-                        _created_at,
-                        null,
-                        System.Globalization.DateTimeStyles.RoundtripKind,
-                        out var parsedDate
-                    )
-                )
-                {
-                    return (
-                        (DateTimeOffset)DateTime.SpecifyKind(parsedDate, DateTimeKind.Utc)
-                    ).ToUnixTimeMilliseconds();
-                }
-            }
-            return _mills;
-        }
+        get => ResolveMills();
         set => _mills = value;
     }
     private long _mills;
+
+    /// <summary>
+    /// Resolves the event time in Unix milliseconds from the available timestamp fields, in
+    /// precedence order: explicit <c>mills</c>, then <c>created_at</c>, then <c>eventTime</c>,
+    /// then <c>timestamp</c>, then <c>date</c>. Some clients (e.g. xDrip4iOS) send only
+    /// <c>eventTime</c> on certain treatments; without this fallback those records get stamped
+    /// with the ingestion time, which is both wrong and defeats identity/dedup.
+    /// </summary>
+    private long ResolveMills()
+    {
+        if (_mills > 0)
+            return _mills;
+
+        if (TryParseIsoMills(_created_at, out var mills))
+            return mills;
+        if (TryParseIsoMills(EventTime, out mills))
+            return mills;
+        if (TryParseIsoMills(Timestamp, out mills))
+            return mills;
+
+        if (Date is > 0)
+            return Date.Value;
+
+        return 0;
+    }
+
+    private static bool TryParseIsoMills(string? iso, out long mills)
+    {
+        mills = 0;
+        if (
+            !string.IsNullOrEmpty(iso)
+            && DateTime.TryParse(
+                iso,
+                null,
+                System.Globalization.DateTimeStyles.RoundtripKind,
+                out var parsed
+            )
+        )
+        {
+            mills = ((DateTimeOffset)DateTime.SpecifyKind(parsed, DateTimeKind.Utc))
+                .ToUnixTimeMilliseconds();
+            return true;
+        }
+        return false;
+    }
 
     /// <summary>
     /// Gets or sets the created at timestamp as ISO string
@@ -188,11 +214,15 @@ public class Treatment : ProcessableDocumentBase
     {
         get
         {
-            if (string.IsNullOrEmpty(_created_at) && _mills > 0)
+            if (string.IsNullOrEmpty(_created_at))
             {
-                return DateTimeOffset
-                    .FromUnixTimeMilliseconds(_mills)
-                    .ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+                var mills = ResolveMills();
+                if (mills > 0)
+                {
+                    return DateTimeOffset
+                        .FromUnixTimeMilliseconds(mills)
+                        .ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+                }
             }
             return _created_at;
         }

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
@@ -618,6 +618,87 @@ public class TreatmentDecomposerTests : IDisposable
     }
 
     [Fact]
+    public async Task DecomposeAsync_IdentifierlessTreatmentReuploaded_UpdatesInsteadOfDuplicating()
+    {
+        // Reproduces haribo's xDrip4iOS BG check: no _id, no syncIdentifier, only eventTime.
+        // Each sync re-sends the same logical event; without a synthetic id it duplicated.
+        Treatment MakeUpload() => new()
+        {
+            Id = null,
+            SyncIdentifier = null,
+            EventType = "BG Check",
+            EventTime = "2026-06-13T10:45:28.937Z",
+            Glucose = 250,
+            GlucoseType = "Finger",
+            Units = "mg/dl",
+            EnteredBy = "xDrip4iOS"
+        };
+
+        var firstResult = await _decomposer.DecomposeAsync(MakeUpload());
+        firstResult.CreatedRecords.Should().HaveCount(1);
+        firstResult.UpdatedRecords.Should().BeEmpty();
+
+        var bgCheck = firstResult.CreatedRecords[0].Should().BeOfType<V4Models.BGCheck>().Subject;
+        bgCheck.LegacyId.Should().StartWith("syn-");
+        // eventTime is honored, not the ingestion time.
+        bgCheck.Mills.Should().Be(DateTimeOffset.Parse("2026-06-13T10:45:28.937Z").ToUnixTimeMilliseconds());
+
+        // Re-upload (fresh deserialized object, same fields) must update, not duplicate.
+        var secondResult = await _decomposer.DecomposeAsync(MakeUpload());
+        secondResult.CreatedRecords.Should().BeEmpty();
+        secondResult.UpdatedRecords.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task DecomposeAsync_IdentifierlessTreatmentWithNoTime_StillCreatesWithoutSyntheticId()
+    {
+        // Safety guard for the synthetic-id precondition: with no _id, no syncIdentifier, and no
+        // resolvable time, we must NOT hash mills=0 into a bogus shared id — leave it unidentified
+        // and still create the record (no crash).
+        var treatment = new Treatment
+        {
+            Id = null,
+            SyncIdentifier = null,
+            EventType = "Note",
+            Notes = "no timestamp"
+            // no Mills / Created_at / EventTime / Timestamp / Date
+        };
+
+        var result = await _decomposer.DecomposeAsync(treatment);
+
+        result.CreatedRecords.Should().HaveCount(1);
+        result.CreatedRecords[0].Should().BeOfType<V4Models.Note>()
+            .Subject.LegacyId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DecomposeAsync_TwoDistinctIdentifierlessBoluses_BothPersist()
+    {
+        // Safety guard: dedup must NOT merge genuinely distinct doses. Two boluses a few seconds
+        // apart with no id are real and must both survive (IOB correctness).
+        var first = new Treatment
+        {
+            Id = null, EventType = "Correction Bolus",
+            EventTime = "2026-06-13T10:45:00.000Z", Insulin = 1.0, EnteredBy = "xDrip4iOS"
+        };
+        var second = new Treatment
+        {
+            Id = null, EventType = "Correction Bolus",
+            EventTime = "2026-06-13T10:45:05.000Z", Insulin = 1.0, EnteredBy = "xDrip4iOS"
+        };
+
+        var r1 = await _decomposer.DecomposeAsync(first);
+        var r2 = await _decomposer.DecomposeAsync(second);
+
+        r1.CreatedRecords.OfType<V4Models.Bolus>().Should().HaveCount(1);
+        r2.CreatedRecords.OfType<V4Models.Bolus>().Should().HaveCount(1);
+        r2.UpdatedRecords.Should().BeEmpty();
+
+        r1.CreatedRecords.OfType<V4Models.Bolus>().Single().LegacyId
+            .Should().NotBe(r2.CreatedRecords.OfType<V4Models.Bolus>().Single().LegacyId);
+    }
+
+    [Fact]
     public async Task DecomposeAsync_MealBolusTwice_UpdatesBothBolusAndCarbIntake()
     {
         // Arrange
@@ -715,9 +796,10 @@ public class TreatmentDecomposerTests : IDisposable
     }
 
     [Fact]
-    public async Task DecomposeAsync_NullId_StillCreatesRecord()
+    public async Task DecomposeAsync_NullId_StillCreatesRecordWithSyntheticId()
     {
-        // Arrange - treatment with no ID should still decompose (just can't deduplicate)
+        // A treatment with no _id/syncIdentifier still decomposes, and now receives a
+        // deterministic synthetic LegacyId so re-uploads can dedup against it.
         var treatment = new Treatment
         {
             Id = null,
@@ -732,7 +814,7 @@ public class TreatmentDecomposerTests : IDisposable
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
         var note = result.CreatedRecords[0].Should().BeOfType<V4Models.Note>().Subject;
-        note.LegacyId.Should().BeNull();
+        note.LegacyId.Should().StartWith("syn-");
         note.Text.Should().Be("Test note");
     }
 
@@ -1531,10 +1613,11 @@ public class TreatmentDecomposerTests : IDisposable
     }
 
     [Fact]
-    public async Task DecomposeAsync_NullIdTreatment_AlwaysCreatesNeverUpdates()
+    public async Task DecomposeAsync_IdenticalNullIdTreatments_DedupViaSyntheticId()
     {
-        // Arrange - two identical treatments with null IDs
-        var treatment = new Treatment
+        // Two byte-identical null-id treatments at the same time are genuine duplicates
+        // (e.g. an identifier-less re-upload) and now collapse via the synthetic LegacyId.
+        Treatment Make() => new()
         {
             Id = null,
             EventType = "Correction Bolus",
@@ -1542,14 +1625,13 @@ public class TreatmentDecomposerTests : IDisposable
             Insulin = 2.0
         };
 
-        var first = await _decomposer.DecomposeAsync(treatment);
-        var second = await _decomposer.DecomposeAsync(treatment);
+        var first = await _decomposer.DecomposeAsync(Make());
+        var second = await _decomposer.DecomposeAsync(Make());
 
-        // Assert
         first.CreatedRecords.Should().HaveCount(1);
-        second.CreatedRecords.Should().HaveCount(1);
         first.UpdatedRecords.Should().BeEmpty();
-        second.UpdatedRecords.Should().BeEmpty();
+        second.CreatedRecords.Should().BeEmpty();
+        second.UpdatedRecords.Should().HaveCount(1);
     }
 
     #endregion


### PR DESCRIPTION
## Problem

Some Nightscout uploaders send treatments with **no `_id` and no `syncIdentifier`**, carrying the event time in **`eventTime`** rather than `created_at`. Captured live from xDrip4iOS:
```json
[{"eventType":"BG Check","enteredBy":"xDrip4iOS","eventTime":"2026-06-13T10:45:28.937Z","glucose":250,"glucoseType":"Finger","units":"mg/dl"}]
```
Two bugs resulted:
1. nocturne ignored `eventTime` and stamped the ingestion time → wrong timestamp, and a *new* timestamp on every re-upload.
2. Decomposition dedups on `Treatment.Id` (→ `LegacyId`); with no id there's nothing to match, so each periodic re-upload INSERTed another row — unbounded duplicate finger BG checks.

## Fix

**(a) Honor `eventTime`** — `Treatment.Mills`/`Created_at` resolve via a fallback chain (`mills → created_at → eventTime → timestamp → date`). The `EventTime` property was previously read nowhere, so blast radius is just this bug path. Behavior is unchanged when `mills`/`created_at` are set.

**(b) Deterministic identity** — `NormalizeIdentity` resolves `_id → syncIdentifier → ComputeSyntheticId` (SHA-256 over `eventType` + exact `mills` + `enteredBy` + dose/value fields, `syn-` prefixed, fits the 64-char `legacy_id` column). Re-uploads of one logical event collapse via the existing `LegacyId` upsert; genuinely distinct events differ in `mills` → different id → **never merged**. A timeless treatment is left unidentified rather than hash `mills=0` into a shared key.

Deliberately **avoids** a fuzzy time-window content dedup — that could silently drop legitimately-distinct doses (e.g. a correction bolus seconds after a meal bolus). Applied at both `DecomposeAsync` and `DecomposeBatchAsync`; entries untouched; `_id`/`syncIdentifier` treatments unaffected. State-span upserts already key on `OriginalId`, so synthetic ids dedup those too.

## Tests
Added: identifier-less BG check re-upload dedups + honors `eventTime`; two distinct boluses seconds apart both persist (safety guard); identifier-less + timeless treatment still creates with null `LegacyId` (no bogus shared id). Updated 2 tests that asserted the old never-dedup behavior. Full suite green (Core.Models 232; TreatmentDecomposer 154).

Independently code-reviewed (verdict: approve).