### PR TITLE
fix: current glucose status text type error

### DIFF
--- a/src/Web/packages/app/src/lib/components/dashboard/CurrentBGDisplay.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/CurrentBGDisplay.svelte
@@ -19,6 +19,7 @@
   import {
     formatGlucoseValue,
     formatGlucoseDelta,
+    minutesAgo,
   } from "$lib/utils/formatting";
   import { Clock } from "lucide-svelte";
 
@@ -86,11 +87,18 @@
     rawCurrentBG === 0 && realtimeStore.entries.length === 0
   );
 
-  // Time since last reading
-  const timeSince = $derived(realtimeStore.timeSinceReading);
+  function formatTimeSinceLastReading(): string {
+    return minutesAgo(lastUpdated, currentTime.getTime());
+  }
 
   // Status text - show "Connection Error" when disconnected
-  const statusText = $derived(isDisconnected ? "Connection Error" : timeSince);
+  const statusText = $derived.by(() =>
+    isDisconnected ? "Connection Error" : formatTimeSinceLastReading()
+  );
+
+  const statusTooltip = $derived.by(
+    () => `Last reading: ${formatTimeSinceLastReading()}`
+  );
 
   // Format current time in local timezone
   const formattedLocalTime = $derived(
@@ -212,7 +220,7 @@
           {isStale}
           {isDisconnected}
           {statusText}
-          statusTooltip="Last reading: {timeSince}"
+          {statusTooltip}
           size="lg"
         />
         <div class="text-center">

--- a/src/Web/packages/app/src/lib/components/dashboard/CurrentBGDisplay.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/CurrentBGDisplay.svelte.test.ts
@@ -1,0 +1,36 @@
+import { render } from "vitest-browser-svelte";
+import { describe, expect, it, vi } from "vitest";
+
+const now = Date.UTC(2026, 5, 14, 9, 30, 0);
+
+vi.mock("$lib/stores/realtime-store.svelte", () => ({
+  getRealtimeStore: () => ({
+    currentBG: 123,
+    currentEntry: { mills: now, sgv: 123 },
+    bgDelta: 4,
+    lastUpdated: now,
+    now,
+    isConnected: true,
+    entries: [{ mills: now, sgv: 123 }],
+    direction: "Flat",
+    demoMode: false,
+    pillsData: { cob: null, basal: null, iob: null, loop: null },
+    trackerInstances: [],
+    trackerDefinitions: [],
+    timeSinceReading: Symbol("derived sentinel"),
+  }),
+}));
+
+vi.mock("$lib/stores/settings-store.svelte", () => ({
+  getSettingsStore: () => ({
+    features: { trackerPills: { enabled: false } },
+  }),
+}));
+
+import CurrentBGDisplay from "./CurrentBGDisplay.svelte";
+
+describe("CurrentBGDisplay", () => {
+  it("renders status text without reading a Symbol timeSinceReading value", () => {
+    expect(() => render(CurrentBGDisplay, { showPills: false })).not.toThrow();
+  });
+});

--- a/src/Web/packages/app/src/lib/utils/formatting.test.ts
+++ b/src/Web/packages/app/src/lib/utils/formatting.test.ts
@@ -35,6 +35,7 @@ const {
 	formatDateDetailed,
 	formatDateForInput,
 	formatDateTimeCompact,
+	minutesAgo,
 	formatInsulinDisplay,
 	formatCarbDisplay,
 	formatPercentageDisplay,
@@ -133,6 +134,26 @@ describe("Glucose conversion", () => {
 });
 
 describe("Date formatting", () => {
+	describe("minutesAgo", () => {
+		it("formats elapsed minutes with Intl relative time formatting", () => {
+			const expected = new Intl.RelativeTimeFormat("en", {
+				numeric: "always",
+				style: "short",
+			}).format(-5, "minute");
+
+			expect(minutesAgo(1_000, 301_000)).toBe(expected);
+		});
+
+		it("does not return negative elapsed minutes", () => {
+			const expected = new Intl.RelativeTimeFormat("en", {
+				numeric: "always",
+				style: "short",
+			}).format(-0, "minute");
+
+			expect(minutesAgo(301_000, 1_000)).toBe(expected);
+		});
+	});
+
 	describe("formatDateTime", () => {
 		it("returns — for undefined", () => {
 			expect(formatDateTime(undefined)).toBe("—");

--- a/src/Web/packages/app/src/lib/utils/formatting.ts
+++ b/src/Web/packages/app/src/lib/utils/formatting.ts
@@ -222,6 +222,15 @@ export function time(date: Date | number, compact?: boolean): string {
   return d.toLocaleTimeString(locale(), options);
 }
 
+/** Format elapsed time as minutes ago using the user's language preference. */
+export function minutesAgo(from: number, to: number = Date.now()): string {
+  const minutes = Math.max(0, Math.floor((to - from) / 60000));
+  return new Intl.RelativeTimeFormat(locale(), {
+    numeric: "always",
+    style: "short",
+  }).format(-minutes, "minute");
+}
+
 // =============================================================================
 // Date Formatting
 // =============================================================================


### PR DESCRIPTION
Hello, while setting up nocturne locally I found this type error in `CurrentBGDisplay`. Im using Dexcom share, and a Dexcom G7 sensor (t1d myself) 

<img width="2388" height="781" alt="CleanShot 2026-06-14 at 11 41 15" src="https://github.com/user-attachments/assets/c04638d7-1010-488c-a483-6a584029f400" />


## Summary

Fixes the current glucose status text so Svelte receives a concrete string instead of a derived runtime sentinel value.

Adds a shared `minutesAgo()` formatter that uses `Intl.RelativeTimeFormat` with the current preferred language instead of hardcoded English minute text.

Adds a component regression test that renders `CurrentBGDisplay` with a Symbol-valued `timeSinceReading` store field, proving the component no longer reads that value into rendered status text.

## Root cause

`CurrentBGDisplay` wrapped `realtimeStore.timeSinceReading` in another derived value and then passed that value into `GlucoseValueIndicator`. In some runtime paths this produced a Symbol value, which Svelte could not render as text.

## Validation

Passed: `pnpm --dir src/Web/packages/app exec vitest run src/lib/utils/formatting.test.ts`

Checked: `pnpm --dir src/Web/packages/app exec svelte-check-native --tsconfig ./tsconfig.json 2>&1 | rg "CurrentBGDisplay|formatting"` returned no matching diagnostics.

Could not run locally: `pnpm --dir src/Web/packages/app exec vitest --config vitest.browser.config.ts run src/lib/components/dashboard/CurrentBGDisplay.svelte.test.ts` because local Playwright Chromium is not installed.