### PR TITLE
feat(predictions): GET api/v4/predictions/profile-snapshot for on-device oref

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Analytics/PredictionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/PredictionController.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using OpenApi.Remote.Attributes;
@@ -28,15 +29,18 @@ namespace Nocturne.API.Controllers.V4.Analytics;
 public class PredictionController : ControllerBase
 {
     private readonly IPredictionService? _predictionService;
+    private readonly IProfileSnapshotService _profileSnapshotService;
     private readonly PredictionSource _source;
     private readonly ILogger<PredictionController> _logger;
 
     public PredictionController(
         ILogger<PredictionController> logger,
         IConfiguration configuration,
+        IProfileSnapshotService profileSnapshotService,
         IPredictionService? predictionService = null)
     {
         _predictionService = predictionService;
+        _profileSnapshotService = profileSnapshotService;
         _source = configuration.GetValue<PredictionSource>("Predictions:Source", PredictionSource.None);
         _logger = logger;
     }
@@ -97,6 +101,44 @@ public class PredictionController : ControllerBase
             Available = _predictionService != null && _source != PredictionSource.None,
             Source = _source.ToString(),
         });
+    }
+
+    /// <summary>
+    /// Get the pre-resolved therapy profile for the next 24 hours, flattened into contiguous
+    /// absolute-time segments, for an offline on-device <c>oref</c> prediction run.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="GetPredictions"/>, this action is intentionally available regardless of
+    /// <c>Predictions:Source</c>: the client runs oref on-device and needs its therapy profile
+    /// precisely when server-side prediction is off (the offline case). It depends only on the
+    /// unconditionally-registered profile resolvers, not on <see cref="IPredictionService"/>, so it
+    /// carries no <c>_predictionService</c>/<c>_source</c> guard.
+    ///
+    /// Clients must additionally apply the fixed oref constants <c>max_iob=10</c>, <c>max_basal=4</c>,
+    /// <c>max_daily_basal=2</c> (which <c>PredictionService.GetProfileAsync</c> hardcodes) to match a
+    /// server-side oref run; they are not part of this payload.
+    /// </remarks>
+    /// <param name="profileId">Optional profile name. The device omits it (resolves the active profile).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    [HttpGet("profile-snapshot")]
+    [RemoteQuery]
+    [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
+    [ProducesResponseType(typeof(ProfileSnapshotResponse), 200)]
+    [ProducesResponseType(typeof(PredictionErrorResponse), 500)]
+    public async Task<ActionResult<ProfileSnapshotResponse>> GetProfileSnapshot(
+        [FromQuery] string? profileId = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var result = await _profileSnapshotService.BuildAsync(profileId, cancellationToken);
+            return Ok(result);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error building profile snapshot for profile: {ProfileId}", profileId ?? "default");
+            return Problem(detail: "Failed to build profile snapshot", statusCode: 500, title: "Internal Server Error");
+        }
     }
 }
 
@@ -173,4 +215,62 @@ public class PredictionErrorResponse
 {
     /// <summary>Error message</summary>
     public string Error { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Pre-resolved therapy profile flattened into contiguous absolute-time segments covering
+/// <c>[now, now+24h)</c> for on-device oref prediction. Property names are pinned to snake_case
+/// with <see cref="JsonPropertyNameAttribute"/> so the wire contract is independent of any ambient
+/// serializer naming policy, and every field is emitted (including zeros) so the client's strict
+/// decoder never sees a missing key.
+/// </summary>
+/// <remarks>
+/// Clients must additionally apply the fixed oref constants <c>max_iob=10</c>, <c>max_basal=4</c>,
+/// <c>max_daily_basal=2</c> (see <c>PredictionService.GetProfileAsync</c>) to match a server-side run.
+/// </remarks>
+public sealed class ProfileSnapshotResponse
+{
+    /// <summary>When the snapshot was resolved (Unix ms); equals the window start.</summary>
+    [JsonPropertyName("fetched_at_mills")]
+    public long FetchedAtMills { get; set; }
+
+    /// <summary>Ascending, contiguous, gap/overlap-free segments covering [now, now+24h).</summary>
+    [JsonPropertyName("segments")]
+    public List<ProfileSnapshotSegment> Segments { get; set; } = new();
+}
+
+/// <summary>
+/// One flat segment of the resolved profile: all scalars are constant over <c>[start, end)</c>.
+/// </summary>
+public sealed class ProfileSnapshotSegment
+{
+    /// <summary>Segment start (Unix ms, inclusive).</summary>
+    [JsonPropertyName("start_mills")] public long StartMills { get; set; }
+
+    /// <summary>Segment end (Unix ms, exclusive).</summary>
+    [JsonPropertyName("end_mills")] public long EndMills { get; set; }
+
+    /// <summary>Duration of insulin action (hours).</summary>
+    [JsonPropertyName("dia")] public double Dia { get; set; }
+
+    /// <summary>Scheduled basal rate (U/hr).</summary>
+    [JsonPropertyName("basal")] public double Basal { get; set; }
+
+    /// <summary>Insulin sensitivity (mg/dL per U).</summary>
+    [JsonPropertyName("sens")] public double Sens { get; set; }
+
+    /// <summary>Carb ratio (g/U).</summary>
+    [JsonPropertyName("carb_ratio")] public double CarbRatio { get; set; }
+
+    /// <summary>Low BG target (mg/dL).</summary>
+    [JsonPropertyName("min_bg")] public double MinBg { get; set; }
+
+    /// <summary>High BG target (mg/dL).</summary>
+    [JsonPropertyName("max_bg")] public double MaxBg { get; set; }
+
+    /// <summary>Insulin activity peak (minutes).</summary>
+    [JsonPropertyName("peak")] public int Peak { get; set; }
+
+    /// <summary>Insulin activity curve model name (e.g. "rapid-acting").</summary>
+    [JsonPropertyName("curve")] public string Curve { get; set; } = "rapid-acting";
 }

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -474,6 +474,7 @@ public static class ServiceRegistrationExtensions
         services.AddScoped<ITargetRangeResolver, TargetRangeResolver>();
         services.AddScoped<ITherapySettingsResolver, TherapySettingsResolver>();
         services.AddScoped<ITherapyTimelineResolver, TherapyTimelineResolver>();
+        services.AddScoped<Services.Glucose.IProfileSnapshotService, Services.Glucose.ProfileSnapshotService>();
         services.AddScoped<ITempBasalResolver, TempBasalResolver>();
         services.AddScoped<IProfileProjectionService, ProfileProjectionService>();
         services.AddScoped<IDataEventSink<Profile>>(sp =>

--- a/src/API/Nocturne.API/Services/Glucose/ProfileSnapshotService.cs
+++ b/src/API/Nocturne.API/Services/Glucose/ProfileSnapshotService.cs
@@ -1,0 +1,199 @@
+using Nocturne.API.Controllers.V4.Analytics;
+using Nocturne.Core.Contracts.Profiles.Resolvers;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
+
+namespace Nocturne.API.Services.Glucose;
+
+/// <summary>
+/// Builds the pre-resolved therapy profile that the Prelude (Android) device runs its
+/// on-device <c>oref</c> prediction engine against: the next 24h of therapy flattened into
+/// contiguous, absolute-time segments where every emitted scalar is constant.
+/// </summary>
+/// <remarks>
+/// This mirrors <see cref="IPredictionService"/>'s per-instant oref profile
+/// (<c>PredictionService.GetProfileAsync</c>) but resolved across the whole window rather than
+/// at a single anchor. It reuses existing machinery only — <see cref="ITherapyTimelineResolver"/>
+/// for profile/CCP segmentation, the snapshot evaluators for schedule lookup, and
+/// <see cref="ITargetRangeResolver"/> for targets — and introduces no new resolution logic.
+/// </remarks>
+public interface IProfileSnapshotService
+{
+    /// <summary>
+    /// Builds the snapshot covering <c>[now, now + 24h)</c>.
+    /// </summary>
+    /// <param name="profileId">Optional explicit profile name. The device omits it; when null the
+    /// active profile is resolved (and honors profile switches inside the window).</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<ProfileSnapshotResponse> BuildAsync(string? profileId, CancellationToken ct = default);
+}
+
+/// <inheritdoc />
+public sealed class ProfileSnapshotService : IProfileSnapshotService
+{
+    private const long WindowMillis = 24L * 60 * 60 * 1000;
+    private const long StepMillis = 60_000;
+
+    private const double DefaultDia = 3.0;
+    private const double DefaultBasal = 1.0;
+    private const double DefaultSens = 50.0;
+    private const double DefaultCarbRatio = 10.0;
+    private const double DefaultMinBg = 100.0;
+    private const double DefaultMaxBg = 120.0;
+    private const int DefaultPeak = 75;
+    private const string DefaultCurve = "rapid-acting";
+
+    private readonly ITherapyTimelineResolver _timeline;
+    private readonly ITargetRangeResolver _targetRange;
+    private readonly ITherapySettingsResolver _therapySettings;
+    private readonly IPatientInsulinRepository _insulins;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<ProfileSnapshotService> _logger;
+
+    public ProfileSnapshotService(
+        ITherapyTimelineResolver timeline,
+        ITargetRangeResolver targetRange,
+        ITherapySettingsResolver therapySettings,
+        IPatientInsulinRepository insulins,
+        TimeProvider timeProvider,
+        ILogger<ProfileSnapshotService> logger)
+    {
+        _timeline = timeline;
+        _targetRange = targetRange;
+        _therapySettings = therapySettings;
+        _insulins = insulins;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    public async Task<ProfileSnapshotResponse> BuildAsync(string? profileId, CancellationToken ct = default)
+    {
+        var nowMills = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
+        var windowEnd = nowMills + WindowMillis;
+
+        var bolus = await _insulins.GetPrimaryBolusInsulinAsync(ct);
+        var peak = bolus?.Peak ?? DefaultPeak;
+        var curve = bolus?.Curve ?? DefaultCurve;
+
+        var response = new ProfileSnapshotResponse { FetchedAtMills = nowMills };
+
+        if (!await _therapySettings.HasDataAsync(ct))
+        {
+            response.Segments.Add(new ProfileSnapshotSegment
+            {
+                StartMills = nowMills,
+                EndMills = windowEnd,
+                Dia = bolus?.Dia ?? DefaultDia,
+                Basal = DefaultBasal,
+                Sens = DefaultSens,
+                CarbRatio = DefaultCarbRatio,
+                MinBg = DefaultMinBg,
+                MaxBg = DefaultMaxBg,
+                Peak = peak,
+                Curve = curve,
+            });
+            return response;
+        }
+
+        var timeline = await _timeline.BuildAsync(nowMills, windowEnd, profileId, ct);
+
+        foreach (var segment in timeline.Segments)
+        {
+            var snap = segment.Snapshot;
+            var targetCache = new Dictionary<int, (double Low, double High)>();
+
+            var t = segment.StartMills;
+            while (t < segment.EndMills)
+            {
+                var scalars = await ScalarsAtAsync(snap, t, profileId, targetCache, ct);
+
+                var tNext = segment.EndMills;
+                for (var c = t + StepMillis; c < segment.EndMills; c += StepMillis)
+                {
+                    var probe = await ScalarsAtAsync(snap, c, profileId, targetCache, ct);
+                    if (!probe.Equals(scalars))
+                    {
+                        tNext = c;
+                        break;
+                    }
+                }
+
+                response.Segments.Add(new ProfileSnapshotSegment
+                {
+                    StartMills = t,
+                    EndMills = tNext,
+                    Dia = snap.Dia,
+                    Basal = scalars.Basal,
+                    Sens = scalars.Sens,
+                    CarbRatio = scalars.CarbRatio,
+                    MinBg = scalars.MinBg,
+                    MaxBg = scalars.MaxBg,
+                    Peak = peak,
+                    Curve = curve,
+                });
+
+                t = tNext;
+            }
+        }
+
+        EnsureContiguous(response.Segments, nowMills, windowEnd);
+        return response;
+    }
+
+    private readonly record struct Scalars(double Sens, double CarbRatio, double Basal, double MinBg, double MaxBg);
+
+    private async Task<Scalars> ScalarsAtAsync(
+        TherapySnapshot snap,
+        long t,
+        string? profileId,
+        Dictionary<int, (double Low, double High)> targetCache,
+        CancellationToken ct)
+    {
+        var bucket = LocalSecondsOfDay(snap.Timezone, t + snap.CcpTimeshiftMs);
+        if (!targetCache.TryGetValue(bucket, out var target))
+        {
+            var low = await _targetRange.GetLowBGTargetAsync(t, profileId, ct);
+            var high = await _targetRange.GetHighBGTargetAsync(t, profileId, ct);
+            target = (low, high);
+            targetCache[bucket] = target;
+        }
+
+        return new Scalars(
+            snap.SensitivityAt(t),
+            snap.CarbRatioAt(t),
+            snap.BasalRateAt(t),
+            target.Low,
+            target.High);
+    }
+
+    private static int LocalSecondsOfDay(TimeZoneInfo? tz, long mills)
+    {
+        var dto = DateTimeOffset.FromUnixTimeMilliseconds(mills);
+        if (tz is not null)
+            dto = TimeZoneInfo.ConvertTime(dto, tz);
+        return (int)dto.TimeOfDay.TotalSeconds;
+    }
+
+    private static void EnsureContiguous(IReadOnlyList<ProfileSnapshotSegment> segments, long start, long end)
+    {
+        if (segments.Count == 0)
+            throw new InvalidOperationException("Profile snapshot produced no segments.");
+        if (segments[0].StartMills != start)
+            throw new InvalidOperationException(
+                $"Profile snapshot must start at {start}, but started at {segments[0].StartMills}.");
+        if (segments[^1].EndMills != end)
+            throw new InvalidOperationException(
+                $"Profile snapshot must end at {end}, but ended at {segments[^1].EndMills}.");
+
+        for (var i = 0; i < segments.Count; i++)
+        {
+            if (segments[i].EndMills <= segments[i].StartMills)
+                throw new InvalidOperationException(
+                    $"Profile snapshot segment {i} is non-positive width ({segments[i].StartMills}..{segments[i].EndMills}).");
+            if (i > 0 && segments[i].StartMills != segments[i - 1].EndMills)
+                throw new InvalidOperationException(
+                    $"Profile snapshot segments are not contiguous at index {i}: " +
+                    $"{segments[i - 1].EndMills} != {segments[i].StartMills}.");
+        }
+    }
+}

--- a/src/API/Nocturne.API/Services/Profiles/Resolvers/BasalRateResolver.cs
+++ b/src/API/Nocturne.API/Services/Profiles/Resolvers/BasalRateResolver.cs
@@ -15,6 +15,7 @@ internal sealed class BasalRateResolver : IBasalRateResolver
 {
     private readonly IBasalScheduleRepository _repo;
     private readonly ITherapySettingsRepository _therapyRepo;
+    private readonly IPatientRecordRepository _patientRecordRepo;
     private readonly IActiveProfileResolver _activeProfileResolver;
     private readonly ITenantAccessor _tenantAccessor;
     private readonly IMemoryCache _cache;
@@ -26,6 +27,7 @@ internal sealed class BasalRateResolver : IBasalRateResolver
     public BasalRateResolver(
         IBasalScheduleRepository repo,
         ITherapySettingsRepository therapyRepo,
+        IPatientRecordRepository patientRecordRepo,
         IActiveProfileResolver activeProfileResolver,
         ITenantAccessor tenantAccessor,
         IMemoryCache cache,
@@ -33,6 +35,7 @@ internal sealed class BasalRateResolver : IBasalRateResolver
     {
         _repo = repo;
         _therapyRepo = therapyRepo;
+        _patientRecordRepo = patientRecordRepo;
         _activeProfileResolver = activeProfileResolver;
         _tenantAccessor = tenantAccessor;
         _cache = cache;
@@ -55,7 +58,7 @@ internal sealed class BasalRateResolver : IBasalRateResolver
         var shiftedMills = timeMills + (adjustment?.TimeshiftMs ?? 0);
 
         var secondsFromMidnight = await ScheduleTimeHelper.GetSecondsFromMidnightAsync(
-            shiftedMills, profileName, timestamp, _therapyRepo, ct);
+            shiftedMills, profileName, timestamp, _therapyRepo, _patientRecordRepo, ct);
 
         var value = ScheduleResolution.FindValueAtTime(schedule.Entries, secondsFromMidnight)
             ?? DefaultBasalRate;

--- a/src/API/Nocturne.API/Services/Profiles/Resolvers/CarbRatioResolver.cs
+++ b/src/API/Nocturne.API/Services/Profiles/Resolvers/CarbRatioResolver.cs
@@ -14,6 +14,7 @@ internal sealed class CarbRatioResolver : ICarbRatioResolver
 {
     private readonly ICarbRatioScheduleRepository _repo;
     private readonly ITherapySettingsRepository _therapyRepo;
+    private readonly IPatientRecordRepository _patientRecordRepo;
     private readonly IActiveProfileResolver _activeProfileResolver;
     private readonly ITenantAccessor _tenantAccessor;
     private readonly IMemoryCache _cache;
@@ -25,6 +26,7 @@ internal sealed class CarbRatioResolver : ICarbRatioResolver
     public CarbRatioResolver(
         ICarbRatioScheduleRepository repo,
         ITherapySettingsRepository therapyRepo,
+        IPatientRecordRepository patientRecordRepo,
         IActiveProfileResolver activeProfileResolver,
         ITenantAccessor tenantAccessor,
         IMemoryCache cache,
@@ -32,6 +34,7 @@ internal sealed class CarbRatioResolver : ICarbRatioResolver
     {
         _repo = repo;
         _therapyRepo = therapyRepo;
+        _patientRecordRepo = patientRecordRepo;
         _activeProfileResolver = activeProfileResolver;
         _tenantAccessor = tenantAccessor;
         _cache = cache;
@@ -54,7 +57,7 @@ internal sealed class CarbRatioResolver : ICarbRatioResolver
         var shiftedMills = timeMills + (adjustment?.TimeshiftMs ?? 0);
 
         var secondsFromMidnight = await ScheduleTimeHelper.GetSecondsFromMidnightAsync(
-            shiftedMills, profileName, timestamp, _therapyRepo, ct);
+            shiftedMills, profileName, timestamp, _therapyRepo, _patientRecordRepo, ct);
 
         var value = ScheduleResolution.FindValueAtTime(schedule.Entries, secondsFromMidnight)
             ?? DefaultCarbRatio;

--- a/src/API/Nocturne.API/Services/Profiles/Resolvers/ScheduleTimeHelper.cs
+++ b/src/API/Nocturne.API/Services/Profiles/Resolvers/ScheduleTimeHelper.cs
@@ -4,25 +4,37 @@ using Nocturne.Core.Models;
 namespace Nocturne.API.Services.Profiles.Resolvers;
 
 /// <summary>
-/// Converts Unix milliseconds to local seconds-from-midnight using the profile's timezone
-/// from <see cref="ITherapySettingsRepository"/>. Shared across all schedule resolvers
-/// to avoid circular dependencies with <see cref="Core.Contracts.Profiles.Resolvers.ITherapySettingsResolver"/>.
+/// Converts Unix milliseconds to local seconds-from-midnight using the patient's timezone.
+/// Shared across all schedule resolvers; takes repositories directly (not
+/// <see cref="Core.Contracts.Profiles.Resolvers.ITherapySettingsResolver"/>) to avoid a
+/// circular dependency with that resolver. Timezone precedence matches
+/// <c>TherapySettingsResolver.GetTimezoneAsync</c>: canonical
+/// <see cref="Core.Models.V4.PatientRecord.Timezone"/> first, then the legacy per-profile
+/// <c>TherapySettings.Timezone</c>.
 /// </summary>
 internal static class ScheduleTimeHelper
 {
     /// <summary>
-    /// Converts Unix milliseconds to seconds-from-midnight in the profile's local timezone.
-    /// Falls back to UTC when no timezone is configured.
+    /// Converts Unix milliseconds to seconds-from-midnight in the patient's local timezone.
+    /// Prefers <see cref="IPatientRecordRepository"/>, falls back to the per-profile
+    /// <see cref="ITherapySettingsRepository"/> timezone, then UTC when neither is configured.
     /// </summary>
     public static async Task<int> GetSecondsFromMidnightAsync(
         long timeMills,
         string profileName,
         DateTime timestamp,
         ITherapySettingsRepository therapyRepo,
+        IPatientRecordRepository patientRecordRepo,
         CancellationToken ct)
     {
-        var therapy = await therapyRepo.GetActiveAtAsync(profileName, timestamp, ct);
-        var timezone = therapy?.Timezone;
+        var patient = await patientRecordRepo.GetAsync(ct);
+        var timezone = patient?.Timezone;
+
+        if (string.IsNullOrEmpty(timezone))
+        {
+            var therapy = await therapyRepo.GetActiveAtAsync(profileName, timestamp, ct);
+            timezone = therapy?.Timezone;
+        }
 
         var dto = DateTimeOffset.FromUnixTimeMilliseconds(timeMills);
 

--- a/src/API/Nocturne.API/Services/Profiles/Resolvers/SensitivityResolver.cs
+++ b/src/API/Nocturne.API/Services/Profiles/Resolvers/SensitivityResolver.cs
@@ -14,6 +14,7 @@ internal sealed class SensitivityResolver : ISensitivityResolver
 {
     private readonly ISensitivityScheduleRepository _repo;
     private readonly ITherapySettingsRepository _therapyRepo;
+    private readonly IPatientRecordRepository _patientRecordRepo;
     private readonly IActiveProfileResolver _activeProfileResolver;
     private readonly ITenantAccessor _tenantAccessor;
     private readonly IMemoryCache _cache;
@@ -25,6 +26,7 @@ internal sealed class SensitivityResolver : ISensitivityResolver
     public SensitivityResolver(
         ISensitivityScheduleRepository repo,
         ITherapySettingsRepository therapyRepo,
+        IPatientRecordRepository patientRecordRepo,
         IActiveProfileResolver activeProfileResolver,
         ITenantAccessor tenantAccessor,
         IMemoryCache cache,
@@ -32,6 +34,7 @@ internal sealed class SensitivityResolver : ISensitivityResolver
     {
         _repo = repo;
         _therapyRepo = therapyRepo;
+        _patientRecordRepo = patientRecordRepo;
         _activeProfileResolver = activeProfileResolver;
         _tenantAccessor = tenantAccessor;
         _cache = cache;
@@ -54,7 +57,7 @@ internal sealed class SensitivityResolver : ISensitivityResolver
         var shiftedMills = timeMills + (adjustment?.TimeshiftMs ?? 0);
 
         var secondsFromMidnight = await ScheduleTimeHelper.GetSecondsFromMidnightAsync(
-            shiftedMills, profileName, timestamp, _therapyRepo, ct);
+            shiftedMills, profileName, timestamp, _therapyRepo, _patientRecordRepo, ct);
 
         var value = ScheduleResolution.FindValueAtTime(schedule.Entries, secondsFromMidnight)
             ?? DefaultSensitivity;

--- a/src/API/Nocturne.API/Services/Profiles/Resolvers/TargetRangeResolver.cs
+++ b/src/API/Nocturne.API/Services/Profiles/Resolvers/TargetRangeResolver.cs
@@ -14,6 +14,7 @@ internal sealed class TargetRangeResolver : ITargetRangeResolver
 {
     private readonly ITargetRangeScheduleRepository _repo;
     private readonly ITherapySettingsRepository _therapyRepo;
+    private readonly IPatientRecordRepository _patientRecordRepo;
     private readonly IActiveProfileResolver _activeProfileResolver;
     private readonly ITenantAccessor _tenantAccessor;
     private readonly IMemoryCache _cache;
@@ -26,6 +27,7 @@ internal sealed class TargetRangeResolver : ITargetRangeResolver
     public TargetRangeResolver(
         ITargetRangeScheduleRepository repo,
         ITherapySettingsRepository therapyRepo,
+        IPatientRecordRepository patientRecordRepo,
         IActiveProfileResolver activeProfileResolver,
         ITenantAccessor tenantAccessor,
         IMemoryCache cache,
@@ -33,6 +35,7 @@ internal sealed class TargetRangeResolver : ITargetRangeResolver
     {
         _repo = repo;
         _therapyRepo = therapyRepo;
+        _patientRecordRepo = patientRecordRepo;
         _activeProfileResolver = activeProfileResolver;
         _tenantAccessor = tenantAccessor;
         _cache = cache;
@@ -68,7 +71,7 @@ internal sealed class TargetRangeResolver : ITargetRangeResolver
         var shiftedMills = timeMills + (adjustment?.TimeshiftMs ?? 0);
 
         var secondsFromMidnight = await ScheduleTimeHelper.GetSecondsFromMidnightAsync(
-            shiftedMills, profileName, timestamp, _therapyRepo, ct);
+            shiftedMills, profileName, timestamp, _therapyRepo, _patientRecordRepo, ct);
 
         var range = ScheduleResolution.FindRangeAtTime(schedule.Entries, secondsFromMidnight);
         return range ?? (DefaultLow, DefaultHigh);

--- a/tests/Unit/Nocturne.API.Tests/Services/Glucose/ProfileSnapshotServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Glucose/ProfileSnapshotServiceTests.cs
@@ -1,0 +1,223 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Nocturne.API.Controllers.V4.Analytics;
+using Nocturne.API.Services.Glucose;
+using Nocturne.Core.Contracts.Profiles.Resolvers;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.API.Tests.Services.Glucose;
+
+public class ProfileSnapshotServiceTests
+{
+    private const long Hour = 3_600_000L;
+    private const long Day = 24 * Hour;
+
+    private static readonly DateTimeOffset Midnight = new(2024, 1, 15, 0, 0, 0, TimeSpan.Zero);
+
+    private readonly Mock<ITherapyTimelineResolver> _timeline = new();
+    private readonly Mock<ITargetRangeResolver> _targetRange = new();
+    private readonly Mock<ITherapySettingsResolver> _therapySettings = new();
+    private readonly Mock<IPatientInsulinRepository> _insulins = new();
+    private readonly FakeTimeProvider _clock = new(Midnight);
+    private readonly ProfileSnapshotService _sut;
+
+    private readonly long _now = Midnight.ToUnixTimeMilliseconds();
+
+    public ProfileSnapshotServiceTests()
+    {
+        _therapySettings.Setup(r => r.HasDataAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _targetRange.Setup(r => r.GetLowBGTargetAsync(It.IsAny<long>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(100.0);
+        _targetRange.Setup(r => r.GetHighBGTargetAsync(It.IsAny<long>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(120.0);
+        _insulins.Setup(r => r.GetPrimaryBolusInsulinAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PatientInsulin { Peak = 60, Curve = "ultra-rapid", Dia = 5.0 });
+
+        _sut = new ProfileSnapshotService(
+            _timeline.Object,
+            _targetRange.Object,
+            _therapySettings.Object,
+            _insulins.Object,
+            _clock,
+            NullLogger<ProfileSnapshotService>.Instance);
+    }
+
+    private static ScheduleEntry Entry(int seconds, double value) => new() { TimeAsSeconds = seconds, Value = value };
+
+    private static TherapySnapshot Snapshot(
+        double dia = 5.0,
+        double? ccpPercentage = null,
+        long ccpTimeshiftMs = 0,
+        TimeZoneInfo? timezone = null,
+        IEnumerable<ScheduleEntry>? sens = null,
+        IEnumerable<ScheduleEntry>? carb = null,
+        IEnumerable<ScheduleEntry>? basal = null) =>
+        new(dia, 75, 30.0, timezone, ccpPercentage, ccpTimeshiftMs,
+            sens ?? new[] { Entry(0, 50.0) },
+            carb ?? new[] { Entry(0, 10.0) },
+            basal ?? new[] { Entry(0, 1.0) });
+
+    private void GivenTimeline(params TherapySegment[] segments) =>
+        _timeline.Setup(r => r.BuildAsync(_now, _now + Day, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TherapyTimeline(segments));
+
+    [Fact]
+    public async Task FlatProfile_EmitsSingleSegmentSpanningTheWindow()
+    {
+        GivenTimeline(new TherapySegment(_now, _now + Day, Snapshot()));
+
+        var result = await _sut.BuildAsync(null);
+
+        result.FetchedAtMills.Should().Be(_now);
+        result.Segments.Should().ContainSingle();
+        var seg = result.Segments[0];
+        seg.StartMills.Should().Be(_now);
+        seg.EndMills.Should().Be(_now + Day);
+        seg.Dia.Should().Be(5.0);
+        seg.Sens.Should().Be(50.0);
+        seg.CarbRatio.Should().Be(10.0);
+        seg.Basal.Should().Be(1.0);
+        seg.MinBg.Should().Be(100.0);
+        seg.MaxBg.Should().Be(120.0);
+        seg.Peak.Should().Be(60);
+        seg.Curve.Should().Be("ultra-rapid");
+    }
+
+    [Fact]
+    public async Task IntraDayBasalChange_CoalescesToDistinctStatesNotEveryMinute()
+    {
+        var basal = new[] { Entry(0, 0.8), Entry(6 * 3600, 1.0) };
+        GivenTimeline(new TherapySegment(_now, _now + Day, Snapshot(basal: basal)));
+
+        var result = await _sut.BuildAsync(null);
+
+        result.Segments.Should().HaveCount(2);
+        result.Segments[0].StartMills.Should().Be(_now);
+        result.Segments[0].EndMills.Should().Be(_now + 6 * Hour);
+        result.Segments[0].Basal.Should().Be(0.8);
+        result.Segments[1].StartMills.Should().Be(_now + 6 * Hour);
+        result.Segments[1].EndMills.Should().Be(_now + Day);
+        result.Segments[1].Basal.Should().Be(1.0);
+    }
+
+    [Fact]
+    public async Task SegmentsAreContiguousAndCoverTheFullWindow()
+    {
+        var basal = new[] { Entry(0, 0.8), Entry(6 * 3600, 1.0), Entry(18 * 3600, 0.6) };
+        var sens = new[] { Entry(0, 45.0), Entry(12 * 3600, 55.0) };
+        GivenTimeline(new TherapySegment(_now, _now + Day, Snapshot(sens: sens, basal: basal)));
+
+        var result = await _sut.BuildAsync(null);
+
+        result.Segments[0].StartMills.Should().Be(_now);
+        result.Segments[^1].EndMills.Should().Be(_now + Day);
+        for (var i = 1; i < result.Segments.Count; i++)
+            result.Segments[i].StartMills.Should().Be(result.Segments[i - 1].EndMills);
+    }
+
+    [Fact]
+    public async Task CcpActive_ScalesSensCarbInverseAndBasalForward_ButNotTargets()
+    {
+        GivenTimeline(new TherapySegment(_now, _now + Day, Snapshot(ccpPercentage: 200)));
+
+        var result = await _sut.BuildAsync(null);
+
+        var seg = result.Segments.Should().ContainSingle().Subject;
+        seg.Sens.Should().Be(25.0);
+        seg.CarbRatio.Should().Be(5.0);
+        seg.Basal.Should().Be(2.0);
+        seg.MinBg.Should().Be(100.0);
+        seg.MaxBg.Should().Be(120.0);
+    }
+
+    [Fact]
+    public async Task ProfileSwitchInWindow_ProducesGroupsWithDistinctTargetsPerSide()
+    {
+        var split = _now + 8 * Hour;
+        _timeline.Setup(r => r.BuildAsync(_now, _now + Day, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TherapyTimeline(new[]
+            {
+                new TherapySegment(_now, split, Snapshot()),
+                new TherapySegment(split, _now + Day, Snapshot()),
+            }));
+        _targetRange.Setup(r => r.GetLowBGTargetAsync(It.Is<long>(t => t >= split), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(110.0);
+
+        var result = await _sut.BuildAsync(null);
+
+        result.Segments.Should().HaveCount(2);
+        result.Segments[0].MinBg.Should().Be(100.0);
+        result.Segments[1].MinBg.Should().Be(110.0);
+        result.Segments[1].StartMills.Should().Be(split);
+    }
+
+    [Fact]
+    public async Task NoData_EmitsSingleDefaultSegmentMatchingPredictionServiceDefaults()
+    {
+        _therapySettings.Setup(r => r.HasDataAsync(It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        _insulins.Setup(r => r.GetPrimaryBolusInsulinAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PatientInsulin?)null);
+
+        var result = await _sut.BuildAsync(null);
+
+        var seg = result.Segments.Should().ContainSingle().Subject;
+        seg.StartMills.Should().Be(_now);
+        seg.EndMills.Should().Be(_now + Day);
+        seg.Dia.Should().Be(3.0);
+        seg.Basal.Should().Be(1.0);
+        seg.Sens.Should().Be(50.0);
+        seg.CarbRatio.Should().Be(10.0);
+        seg.MinBg.Should().Be(100.0);
+        seg.MaxBg.Should().Be(120.0);
+        seg.Peak.Should().Be(75);
+        seg.Curve.Should().Be("rapid-acting");
+        _timeline.Verify(r => r.BuildAsync(It.IsAny<long>(), It.IsAny<long>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task NoData_StillTakesDiaFromPrimaryBolusInsulinWhenPresent()
+    {
+        _therapySettings.Setup(r => r.HasDataAsync(It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        var result = await _sut.BuildAsync(null);
+
+        result.Segments.Should().ContainSingle().Which.Dia.Should().Be(5.0);
+    }
+
+    [Fact]
+    public async Task ResolverFault_PropagatesAndDoesNotEmitDefaults()
+    {
+        _timeline.Setup(r => r.BuildAsync(It.IsAny<long>(), It.IsAny<long>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        var act = () => _sut.BuildAsync(null);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void ResponseSerializesSnakeCaseAndEmitsZeroScalars()
+    {
+        var response = new ProfileSnapshotResponse
+        {
+            FetchedAtMills = _now,
+            Segments = { new ProfileSnapshotSegment { MinBg = 0.0, Curve = "rapid-acting" } },
+        };
+
+        var json = JsonSerializer.Serialize(response);
+
+        json.Should().Contain("\"fetched_at_mills\"");
+        json.Should().Contain("\"segments\"");
+        json.Should().Contain("\"start_mills\"");
+        json.Should().Contain("\"end_mills\"");
+        json.Should().Contain("\"carb_ratio\"");
+        json.Should().Contain("\"min_bg\":0");
+        json.Should().Contain("\"max_bg\":0");
+        json.Should().Contain("\"peak\":0");
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Profiles/Resolvers/BasalRateResolverTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Profiles/Resolvers/BasalRateResolverTests.cs
@@ -14,6 +14,7 @@ public class BasalRateResolverTests : IDisposable
 {
     private readonly Mock<IBasalScheduleRepository> _repo = new();
     private readonly Mock<ITherapySettingsRepository> _therapyRepo = new();
+    private readonly Mock<IPatientRecordRepository> _patientRecordRepo = new();
     private readonly Mock<IActiveProfileResolver> _activeProfileResolver = new();
     private readonly Mock<ITenantAccessor> _tenantAccessor = new();
     private readonly MemoryCache _cache = new(new MemoryCacheOptions());
@@ -31,6 +32,7 @@ public class BasalRateResolverTests : IDisposable
         _sut = new BasalRateResolver(
             _repo.Object,
             _therapyRepo.Object,
+            _patientRecordRepo.Object,
             _activeProfileResolver.Object,
             _tenantAccessor.Object,
             _cache,

--- a/tests/Unit/Nocturne.API.Tests/Services/Profiles/Resolvers/CarbRatioResolverTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Profiles/Resolvers/CarbRatioResolverTests.cs
@@ -14,6 +14,7 @@ public class CarbRatioResolverTests : IDisposable
 {
     private readonly Mock<ICarbRatioScheduleRepository> _repo = new();
     private readonly Mock<ITherapySettingsRepository> _therapyRepo = new();
+    private readonly Mock<IPatientRecordRepository> _patientRecordRepo = new();
     private readonly Mock<IActiveProfileResolver> _activeProfileResolver = new();
     private readonly Mock<ITenantAccessor> _tenantAccessor = new();
     private readonly MemoryCache _cache = new(new MemoryCacheOptions());
@@ -29,6 +30,7 @@ public class CarbRatioResolverTests : IDisposable
         _sut = new CarbRatioResolver(
             _repo.Object,
             _therapyRepo.Object,
+            _patientRecordRepo.Object,
             _activeProfileResolver.Object,
             _tenantAccessor.Object,
             _cache,

--- a/tests/Unit/Nocturne.API.Tests/Services/Profiles/Resolvers/SensitivityResolverTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Profiles/Resolvers/SensitivityResolverTests.cs
@@ -14,6 +14,7 @@ public class SensitivityResolverTests : IDisposable
 {
     private readonly Mock<ISensitivityScheduleRepository> _repo = new();
     private readonly Mock<ITherapySettingsRepository> _therapyRepo = new();
+    private readonly Mock<IPatientRecordRepository> _patientRecordRepo = new();
     private readonly Mock<IActiveProfileResolver> _activeProfileResolver = new();
     private readonly Mock<ITenantAccessor> _tenantAccessor = new();
     private readonly MemoryCache _cache = new(new MemoryCacheOptions());
@@ -29,6 +30,7 @@ public class SensitivityResolverTests : IDisposable
         _sut = new SensitivityResolver(
             _repo.Object,
             _therapyRepo.Object,
+            _patientRecordRepo.Object,
             _activeProfileResolver.Object,
             _tenantAccessor.Object,
             _cache,
@@ -110,5 +112,41 @@ public class SensitivityResolverTests : IDisposable
 
         result.Should().Be(100.0);
         _activeProfileResolver.Verify(r => r.GetActiveProfileNameAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // NoonMills (2024-01-15 12:00 UTC) maps to 07:00 in America/New_York (EST), selecting the
+    // pre-12:00 schedule value (40.0); UTC keeps it at noon (60.0). So the chosen timezone source
+    // is observable in the result.
+
+    [Fact]
+    public async Task UsesCanonicalPatientTimezone_OverLegacyTherapySettingsTimezone()
+    {
+        var schedule = MakeSchedule((0, 40.0), (12 * 3600, 60.0));
+        _repo.Setup(r => r.GetActiveAtAsync("Default", It.IsAny<DateTime>(), default))
+            .ReturnsAsync(schedule);
+        _therapyRepo.Setup(r => r.GetActiveAtAsync("Default", It.IsAny<DateTime>(), default))
+            .ReturnsAsync(new TherapySettings { Timezone = "UTC" });
+        _patientRecordRepo.Setup(r => r.GetAsync(default))
+            .ReturnsAsync(new PatientRecord { Timezone = "America/New_York" });
+
+        var result = await _sut.GetSensitivityAsync(NoonMills);
+
+        result.Should().Be(40.0);
+    }
+
+    [Fact]
+    public async Task FallsBackToTherapySettingsTimezone_WhenPatientRecordHasNone()
+    {
+        var schedule = MakeSchedule((0, 40.0), (12 * 3600, 60.0));
+        _repo.Setup(r => r.GetActiveAtAsync("Default", It.IsAny<DateTime>(), default))
+            .ReturnsAsync(schedule);
+        _therapyRepo.Setup(r => r.GetActiveAtAsync("Default", It.IsAny<DateTime>(), default))
+            .ReturnsAsync(new TherapySettings { Timezone = "America/New_York" });
+        _patientRecordRepo.Setup(r => r.GetAsync(default))
+            .ReturnsAsync(new PatientRecord { Timezone = null });
+
+        var result = await _sut.GetSensitivityAsync(NoonMills);
+
+        result.Should().Be(40.0);
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Profiles/Resolvers/TargetRangeResolverTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Profiles/Resolvers/TargetRangeResolverTests.cs
@@ -14,6 +14,7 @@ public class TargetRangeResolverTests : IDisposable
 {
     private readonly Mock<ITargetRangeScheduleRepository> _repo = new();
     private readonly Mock<ITherapySettingsRepository> _therapyRepo = new();
+    private readonly Mock<IPatientRecordRepository> _patientRecordRepo = new();
     private readonly Mock<IActiveProfileResolver> _activeProfileResolver = new();
     private readonly Mock<ITenantAccessor> _tenantAccessor = new();
     private readonly MemoryCache _cache = new(new MemoryCacheOptions());
@@ -29,6 +30,7 @@ public class TargetRangeResolverTests : IDisposable
         _sut = new TargetRangeResolver(
             _repo.Object,
             _therapyRepo.Object,
+            _patientRecordRepo.Object,
             _activeProfileResolver.Object,
             _tenantAccessor.Object,
             _cache,


### PR DESCRIPTION
## What

Adds `GET api/v4/predictions/profile-snapshot`, which serves the Prelude (Android) on-device `oref` prediction engine a pre-resolved therapy profile for the next 24h, flattened into contiguous absolute-time segments (each carrying constant `dia`/`basal`/`sens`/`carb_ratio`/`min_bg`/`max_bg`/`peak`/`curve`). It generalizes the single-anchor oref profile in `PredictionService.GetProfileAsync` to the whole window, reusing existing machinery only (`ITherapyTimelineResolver`, the snapshot evaluators, `ITargetRangeResolver`, `IPatientInsulinRepository`).

Two commits, sequenced:

### 1. `fix(profiles)` — canonical patient timezone in schedule resolution
`ScheduleTimeHelper` read the legacy per-profile `TherapySettings.Timezone` when converting an instant to local seconds-from-midnight, while the `TherapySnapshot` path (chart-data, and this new endpoint) uses the canonical `PatientRecord.Timezone`. The two diverged whenever those sources disagreed, so the standalone sensitivity/carb-ratio/basal/target resolvers — and `GetProfileAsync`, which uses them — could resolve a different scheduled value than the snapshot for the same instant.

Fix: `GetSecondsFromMidnightAsync` now consults `IPatientRecordRepository` first, then falls back to `TherapySettings.Timezone`, mirroring `GetTimezoneAsync`. It takes the repository (not `ITherapySettingsResolver`), so the helper's documented circular-dependency constraint still holds.

### 2. `feat(predictions)` — the endpoint
- `IProfileSnapshotService`/`ProfileSnapshotService`: walks the `TherapyTimeline` and coalesces a 1-minute scan into flat sub-segments; per-segment target lookups memoized by local-seconds-from-midnight; sens/carb/basal are in-memory snapshot reads.
- No-profile-data → single 24h default segment matching `GetProfileAsync`'s defaults. **Any resolver/timeline fault → 5xx, never a default segment** (the device persists this snapshot; defaults would corrupt on-device predictions).
- Registered **unconditionally** (not gated on `Predictions:Source`) — the offline client needs its profile precisely when server-side prediction is off. `no-store`. DTO pins snake_case via `[JsonPropertyName]`.

## Design notes
The behavioral decisions (timezone authority, fault asymmetry, memoization scope, no caching, contiguity invariant) are recorded in the design-review section of `docs/server-profile-snapshot-endpoint.md` on the Prelude side.

## Tests
Full `Nocturne.API.Tests` suite green (3447). Adds 9 service tests (coalescing, contiguity, CCP scaling, profile switch, no-data, fault propagation, JSON snake-case/emit-zeros) + canonical-tz precedence/fallback tests on `SensitivityResolver`.

## Follow-up (separate, Prelude side)
The Android client currently reaches this path via a raw bridge (`NocturneRawApi.getProfileSnapshotRaw`) because the pinned SDK spec predates it. Once this merges and the client regenerates, swap to the generated `PredictionsApi` and drop the bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)