### PR TITLE
feat(health): idempotent sync-dedup for StepCount/HeartRate/BodyWeight uploads

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Health/HeartRateController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/HeartRateController.cs
@@ -131,6 +131,7 @@ public class HeartRateController : ControllerBase
                 Device = request.Device,
                 EnteredBy = request.App,
                 DataSource = request.DataSource,
+                SyncIdentifier = request.SyncIdentifier,
             }).ToList();
 
             var result = await _heartRateService.CreateHeartRatesAsync(heartRateList, cancellationToken);
@@ -168,6 +169,7 @@ public class HeartRateController : ControllerBase
                 Device = request.Device,
                 EnteredBy = request.App,
                 DataSource = request.DataSource,
+                SyncIdentifier = request.SyncIdentifier,
             };
 
             var updated = await _heartRateService.UpdateHeartRateAsync(id, heartRate, cancellationToken);

--- a/src/API/Nocturne.API/Controllers/V4/Health/StepCountController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/StepCountController.cs
@@ -131,6 +131,7 @@ public class StepCountController : ControllerBase
                 Device = request.Device,
                 EnteredBy = request.App,
                 DataSource = request.DataSource,
+                SyncIdentifier = request.SyncIdentifier,
             }).ToList();
 
             var result = await _stepCountService.CreateStepCountsAsync(stepCountList, cancellationToken);
@@ -168,6 +169,7 @@ public class StepCountController : ControllerBase
                 Device = request.Device,
                 EnteredBy = request.App,
                 DataSource = request.DataSource,
+                SyncIdentifier = request.SyncIdentifier,
             };
 
             var updated = await _stepCountService.UpdateStepCountAsync(id, stepCount, cancellationToken);

--- a/src/API/Nocturne.API/Models/Requests/V4/UpsertHeartRateRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/UpsertHeartRateRequest.cs
@@ -37,7 +37,13 @@ public class UpsertHeartRateRequest
     public string? App { get; set; }
 
     /// <summary>
-    /// Upstream data source identifier.
+    /// Upstream data source identifier; paired with <see cref="SyncIdentifier"/> for dedup.
     /// </summary>
     public string? DataSource { get; set; }
+
+    /// <summary>
+    /// Stable per-source identifier. When paired with <see cref="DataSource"/>, re-uploading the
+    /// same measurement updates the existing record in place rather than creating a duplicate.
+    /// </summary>
+    public string? SyncIdentifier { get; set; }
 }

--- a/src/API/Nocturne.API/Models/Requests/V4/UpsertStepCountRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/UpsertStepCountRequest.cs
@@ -37,7 +37,13 @@ public class UpsertStepCountRequest
     public string? App { get; set; }
 
     /// <summary>
-    /// Upstream data source identifier.
+    /// Upstream data source identifier; paired with <see cref="SyncIdentifier"/> for dedup.
     /// </summary>
     public string? DataSource { get; set; }
+
+    /// <summary>
+    /// Stable per-source identifier. When paired with <see cref="DataSource"/>, re-uploading the
+    /// same measurement updates the existing record in place rather than creating a duplicate.
+    /// </summary>
+    public string? SyncIdentifier { get; set; }
 }

--- a/src/API/Nocturne.API/Services/Legacy/SimpleEntityService.cs
+++ b/src/API/Nocturne.API/Services/Legacy/SimpleEntityService.cs
@@ -4,6 +4,7 @@ using Nocturne.Core.Contracts.Legacy;
 using Nocturne.Core.Contracts.Health;
 using Nocturne.Core.Models;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.API.Services.Realtime;
 
 namespace Nocturne.API.Services.Legacy;
@@ -183,10 +184,78 @@ public abstract class SimpleEntityService<TDomain, TEntity>
 
             var processed = DocumentProcessingService.ProcessDocuments(itemList).ToList();
             var entities = processed.Select(ToEntity).ToList();
-            await EntitySet.AddRangeAsync(entities, cancellationToken);
+
+            // Intra-batch dedup on the sync key (keep the last occurrence) so a
+            // batch that repeats a (DataSource, SyncIdentifier) doesn't try to
+            // insert two rows that collide on the partial unique index.
+            entities = entities
+                .Select((entity, index) => (entity, index))
+                .GroupBy(item => item.entity is ISyncDedupable dedup
+                        && !string.IsNullOrEmpty(dedup.DataSource)
+                        && !string.IsNullOrEmpty(dedup.SyncIdentifier)
+                    ? $"sync|{dedup.DataSource}|{dedup.SyncIdentifier}"
+                    : $"idx|{item.index}")
+                .Select(group => group.Last().entity)
+                .ToList();
+
+            // Sync-identifier upsert: an entity whose (DataSource, SyncIdentifier)
+            // matches an existing non-deleted row (the global query filter scopes
+            // the lookup to this tenant) updates it in place; the rest are inserted.
+            // This makes repeated uploads of the same measurement idempotent.
+            //
+            // The existing rows for the whole batch are pre-loaded in ONE query
+            // keyed on the sync identifiers present (the
+            // (tenant_id, data_source, sync_identifier) index keeps it cheap) —
+            // one round trip instead of one per record, which matters for the
+            // historical backfill on a first permission grant.
+            var syncIdentifiers = entities
+                .Select(e => (e as ISyncDedupable)?.SyncIdentifier)
+                .Where(id => !string.IsNullOrEmpty(id))
+                .Distinct()
+                .ToList();
+
+            var existingByKey = new Dictionary<string, TEntity>(StringComparer.Ordinal);
+            if (syncIdentifiers.Count > 0)
+            {
+                var candidates = await EntitySet
+                    .Where(e => syncIdentifiers.Contains(
+                        EF.Property<string>(e, nameof(ISyncDedupable.SyncIdentifier))))
+                    .ToListAsync(cancellationToken);
+                foreach (var candidate in candidates)
+                {
+                    if (candidate is ISyncDedupable d
+                        && !string.IsNullOrEmpty(d.DataSource)
+                        && !string.IsNullOrEmpty(d.SyncIdentifier))
+                    {
+                        existingByKey[$"{d.DataSource}|{d.SyncIdentifier}"] = candidate;
+                    }
+                }
+            }
+
+            var resultEntities = new List<TEntity>(entities.Count);
+            var toInsert = new List<TEntity>();
+            foreach (var entity in entities)
+            {
+                if (entity is ISyncDedupable dedup
+                    && !string.IsNullOrEmpty(dedup.DataSource)
+                    && !string.IsNullOrEmpty(dedup.SyncIdentifier)
+                    && existingByKey.TryGetValue($"{dedup.DataSource}|{dedup.SyncIdentifier}", out var existing))
+                {
+                    UpdateEntity(existing, ToDomainModel(entity));
+                    resultEntities.Add(existing);
+                }
+                else
+                {
+                    toInsert.Add(entity);
+                    resultEntities.Add(entity);
+                }
+            }
+
+            if (toInsert.Count > 0)
+                await EntitySet.AddRangeAsync(toInsert, cancellationToken);
             await DbContext.SaveChangesAsync(cancellationToken);
 
-            var result = entities.Select(ToDomainModel).ToList();
+            var result = resultEntities.Select(ToDomainModel).ToList();
 
             await SignalRBroadcastService.BroadcastStorageCreateAsync(
                 CollectionName,
@@ -290,7 +359,10 @@ public abstract class SimpleEntityService<TDomain, TEntity>
                 return false;
             }
 
-            EntitySet.Remove(entity);
+            if (entity is ISoftDeletable softDeletable)
+                softDeletable.DeletedAt = DateTime.UtcNow;
+            else
+                EntitySet.Remove(entity);
             await DbContext.SaveChangesAsync(cancellationToken);
 
             await SignalRBroadcastService.BroadcastStorageDeleteAsync(

--- a/src/API/Nocturne.API/Services/V4/ActivityDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/ActivityDecomposer.cs
@@ -220,6 +220,12 @@ public class ActivityDecomposer : IActivityDecomposer, IDecomposer<Activity>
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// Deliberately HARD-deletes (unlike the soft-delete in
+    /// <c>SimpleEntityService.DeleteOneAsync</c>): this is the v1 activity
+    /// re-migration path, where the legacy row is being replaced wholesale, so a
+    /// soft-delete tombstone would only block re-creation by the same legacy id.
+    /// </remarks>
     public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
         var deleted = 0;

--- a/src/Core/Nocturne.Core.Models/BodyWeight.cs
+++ b/src/Core/Nocturne.Core.Models/BodyWeight.cs
@@ -54,4 +54,12 @@ public class BodyWeight : ProcessableDocumentBase
     [JsonPropertyName("data_source")]
     [NocturneOnly]
     public string? DataSource { get; set; }
+
+    /// <summary>
+    /// Stable per-source identifier for synchronization. When paired with <see cref="DataSource"/>,
+    /// re-uploading the same measurement updates the existing record in place rather than duplicating it.
+    /// </summary>
+    [JsonPropertyName("syncIdentifier")]
+    [NocturneOnly]
+    public string? SyncIdentifier { get; set; }
 }

--- a/src/Core/Nocturne.Core.Models/HeartRate.cs
+++ b/src/Core/Nocturne.Core.Models/HeartRate.cs
@@ -81,4 +81,12 @@ public class HeartRate : ProcessableDocumentBase
     [JsonPropertyName("data_source")]
     [NocturneOnly]
     public string? DataSource { get; set; }
+
+    /// <summary>
+    /// Stable per-source identifier for synchronization. When paired with <see cref="DataSource"/>,
+    /// re-uploading the same measurement updates the existing record in place rather than duplicating it.
+    /// </summary>
+    [JsonPropertyName("syncIdentifier")]
+    [NocturneOnly]
+    public string? SyncIdentifier { get; set; }
 }

--- a/src/Core/Nocturne.Core.Models/StepCount.cs
+++ b/src/Core/Nocturne.Core.Models/StepCount.cs
@@ -81,4 +81,12 @@ public class StepCount : ProcessableDocumentBase
     [JsonPropertyName("data_source")]
     [NocturneOnly]
     public string? DataSource { get; set; }
+
+    /// <summary>
+    /// Stable per-source identifier for synchronization. When paired with <see cref="DataSource"/>,
+    /// re-uploading the same measurement updates the existing record in place rather than duplicating it.
+    /// </summary>
+    [JsonPropertyName("syncIdentifier")]
+    [NocturneOnly]
+    public string? SyncIdentifier { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/BodyWeightEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/BodyWeightEntity.cs
@@ -7,7 +7,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Body composition measurement recorded by a scale or manual entry.
 /// </summary>
 [Table("body_weights")]
-public class BodyWeightEntity : ITenantScoped
+public class BodyWeightEntity : ITenantScoped, ISoftDeletable, ISyncDedupable
 {
     /// <summary>Owning tenant for RLS isolation.</summary>
     [Column("tenant_id")]
@@ -57,6 +57,19 @@ public class BodyWeightEntity : ITenantScoped
     [Column("utc_offset")]
     public int? UtcOffset { get; set; }
 
+    /// <summary>Origin data source identifier; first half of the sync-dedup key.</summary>
+    [Column("data_source")]
+    [MaxLength(256)]
+    public string? DataSource { get; set; }
+
+    /// <summary>
+    /// Stable per-source identifier; second half of the sync-dedup key. A create
+    /// matching an existing (DataSource, SyncIdentifier) row updates it in place.
+    /// </summary>
+    [Column("sync_identifier")]
+    [MaxLength(256)]
+    public string? SyncIdentifier { get; set; }
+
     /// <summary>Server-side row creation timestamp.</summary>
     [Column("sys_created_at")]
     public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
@@ -64,4 +77,10 @@ public class BodyWeightEntity : ITenantScoped
     /// <summary>Server-side row last-update timestamp.</summary>
     [Column("sys_updated_at")]
     public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is hidden by the global query filter.
+    /// </summary>
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/HeartRateEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/HeartRateEntity.cs
@@ -8,7 +8,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Maps to Nocturne.Core.Models.HeartRate
 /// </summary>
 [Table("heart_rates")]
-public class HeartRateEntity : ITenantScoped
+public class HeartRateEntity : ITenantScoped, ISoftDeletable, ISyncDedupable
 {
     /// <summary>
     /// Identifier of the tenant this heart rate record belongs to
@@ -71,6 +71,21 @@ public class HeartRateEntity : ITenantScoped
     public int? UtcOffset { get; set; }
 
     /// <summary>
+    /// Origin data source identifier; first half of the sync-dedup key.
+    /// </summary>
+    [Column("data_source")]
+    [MaxLength(256)]
+    public string? DataSource { get; set; }
+
+    /// <summary>
+    /// Stable per-source identifier; second half of the sync-dedup key. A create
+    /// matching an existing (DataSource, SyncIdentifier) row updates it in place.
+    /// </summary>
+    [Column("sync_identifier")]
+    [MaxLength(256)]
+    public string? SyncIdentifier { get; set; }
+
+    /// <summary>
     /// System tracking: when record was inserted
     /// </summary>
     [Column("sys_created_at")]
@@ -81,4 +96,10 @@ public class HeartRateEntity : ITenantScoped
     /// </summary>
     [Column("sys_updated_at")]
     public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is hidden by the global query filter.
+    /// </summary>
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ISyncDedupable.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ISyncDedupable.cs
@@ -1,0 +1,23 @@
+namespace Nocturne.Infrastructure.Data.Entities;
+
+/// <summary>
+/// Marks an entity whose creates should be deduplicated by an upstream sync key.
+/// When both <see cref="DataSource"/> and <see cref="SyncIdentifier"/> are present,
+/// a create that matches an existing (non-deleted) row for the same tenant updates
+/// that row in place rather than inserting a duplicate — making repeated uploads of
+/// the same measurement idempotent.
+/// </summary>
+/// <remarks>
+/// Backed by a partial unique index on <c>(tenant_id, data_source, sync_identifier)</c>
+/// filtered to <c>sync_identifier IS NOT NULL AND deleted_at IS NULL</c>, mirroring the
+/// V4 treatment entities. <c>SimpleEntityService</c> performs the upsert for any entity
+/// implementing this interface.
+/// </remarks>
+public interface ISyncDedupable
+{
+    /// <summary>Origin data source identifier (the first half of the dedup key).</summary>
+    string? DataSource { get; set; }
+
+    /// <summary>Stable per-source identifier for the measurement (the second half of the dedup key).</summary>
+    string? SyncIdentifier { get; set; }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/StepCountEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/StepCountEntity.cs
@@ -8,7 +8,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Maps to Nocturne.Core.Models.StepCount
 /// </summary>
 [Table("step_counts")]
-public class StepCountEntity : ITenantScoped
+public class StepCountEntity : ITenantScoped, ISoftDeletable, ISyncDedupable
 {
     /// <summary>
     /// Identifier of the tenant this step count record belongs to
@@ -71,6 +71,21 @@ public class StepCountEntity : ITenantScoped
     public int? UtcOffset { get; set; }
 
     /// <summary>
+    /// Origin data source identifier; first half of the sync-dedup key.
+    /// </summary>
+    [Column("data_source")]
+    [MaxLength(256)]
+    public string? DataSource { get; set; }
+
+    /// <summary>
+    /// Stable per-source identifier; second half of the sync-dedup key. A create
+    /// matching an existing (DataSource, SyncIdentifier) row updates it in place.
+    /// </summary>
+    [Column("sync_identifier")]
+    [MaxLength(256)]
+    public string? SyncIdentifier { get; set; }
+
+    /// <summary>
     /// System tracking: when record was inserted
     /// </summary>
     [Column("sys_created_at")]
@@ -81,4 +96,10 @@ public class StepCountEntity : ITenantScoped
     /// </summary>
     [Column("sys_updated_at")]
     public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is hidden by the global query filter.
+    /// </summary>
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/BodyWeightMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/BodyWeightMapper.cs
@@ -28,6 +28,8 @@ public static class BodyWeightMapper
             EnteredBy = bodyWeight.EnteredBy,
             CreatedAt = bodyWeight.CreatedAt,
             UtcOffset = bodyWeight.UtcOffset,
+            DataSource = bodyWeight.DataSource,
+            SyncIdentifier = bodyWeight.SyncIdentifier,
         };
     }
 
@@ -47,6 +49,8 @@ public static class BodyWeightMapper
             EnteredBy = entity.EnteredBy,
             CreatedAt = entity.CreatedAt,
             UtcOffset = entity.UtcOffset,
+            DataSource = entity.DataSource,
+            SyncIdentifier = entity.SyncIdentifier,
         };
     }
 
@@ -63,6 +67,8 @@ public static class BodyWeightMapper
         entity.EnteredBy = bodyWeight.EnteredBy;
         entity.CreatedAt = bodyWeight.CreatedAt;
         entity.UtcOffset = bodyWeight.UtcOffset;
+        entity.DataSource = bodyWeight.DataSource;
+        entity.SyncIdentifier = bodyWeight.SyncIdentifier;
         entity.SysUpdatedAt = DateTime.UtcNow;
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/HeartRateMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/HeartRateMapper.cs
@@ -26,6 +26,8 @@ public static class HeartRateMapper
             Device = heartRate.Device,
             EnteredBy = heartRate.EnteredBy,
             UtcOffset = heartRate.UtcOffset,
+            DataSource = heartRate.DataSource,
+            SyncIdentifier = heartRate.SyncIdentifier,
         };
     }
 
@@ -43,6 +45,8 @@ public static class HeartRateMapper
             Device = entity.Device,
             EnteredBy = entity.EnteredBy,
             UtcOffset = entity.UtcOffset,
+            DataSource = entity.DataSource,
+            SyncIdentifier = entity.SyncIdentifier,
         };
     }
 
@@ -57,6 +61,8 @@ public static class HeartRateMapper
         entity.Device = heartRate.Device;
         entity.EnteredBy = heartRate.EnteredBy;
         entity.UtcOffset = heartRate.UtcOffset;
+        entity.DataSource = heartRate.DataSource;
+        entity.SyncIdentifier = heartRate.SyncIdentifier;
         entity.SysUpdatedAt = DateTime.UtcNow;
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/StepCountMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/StepCountMapper.cs
@@ -26,6 +26,8 @@ public static class StepCountMapper
             Device = stepCount.Device,
             EnteredBy = stepCount.EnteredBy,
             UtcOffset = stepCount.UtcOffset,
+            DataSource = stepCount.DataSource,
+            SyncIdentifier = stepCount.SyncIdentifier,
         };
     }
 
@@ -43,6 +45,8 @@ public static class StepCountMapper
             Device = entity.Device,
             EnteredBy = entity.EnteredBy,
             UtcOffset = entity.UtcOffset,
+            DataSource = entity.DataSource,
+            SyncIdentifier = entity.SyncIdentifier,
         };
     }
 
@@ -57,6 +61,8 @@ public static class StepCountMapper
         entity.Device = stepCount.Device;
         entity.EnteredBy = stepCount.EnteredBy;
         entity.UtcOffset = stepCount.UtcOffset;
+        entity.DataSource = stepCount.DataSource;
+        entity.SyncIdentifier = stepCount.SyncIdentifier;
         entity.SysUpdatedAt = DateTime.UtcNow;
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260616124951_AddHealthMetricsSyncDedup.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260616124951_AddHealthMetricsSyncDedup.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260616124951_AddHealthMetricsSyncDedup")]
+    partial class AddHealthMetricsSyncDedup
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260616124951_AddHealthMetricsSyncDedup.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260616124951_AddHealthMetricsSyncDedup.cs
@@ -1,0 +1,235 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddHealthMetricsSyncDedup : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_step_counts_tenant_id",
+                table: "step_counts");
+
+            migrationBuilder.DropIndex(
+                name: "IX_heart_rates_tenant_id",
+                table: "heart_rates");
+
+            migrationBuilder.DropIndex(
+                name: "IX_body_weights_tenant_id",
+                table: "body_weights");
+
+            migrationBuilder.AddColumn<string>(
+                name: "data_source",
+                table: "step_counts",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "step_counts",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "step_counts",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "sync_identifier",
+                table: "step_counts",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "data_source",
+                table: "heart_rates",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "heart_rates",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "heart_rates",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "sync_identifier",
+                table: "heart_rates",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "data_source",
+                table: "body_weights",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "body_weights",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "deleted_by_user",
+                table: "body_weights",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "sync_identifier",
+                table: "body_weights",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_step_counts_tenant_source_sync_id",
+                table: "step_counts",
+                columns: new[] { "tenant_id", "data_source", "sync_identifier" },
+                unique: true,
+                filter: "sync_identifier IS NOT NULL AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_step_counts_tenant_timestamp",
+                table: "step_counts",
+                columns: new[] { "tenant_id", "timestamp" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_heart_rates_tenant_source_sync_id",
+                table: "heart_rates",
+                columns: new[] { "tenant_id", "data_source", "sync_identifier" },
+                unique: true,
+                filter: "sync_identifier IS NOT NULL AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_heart_rates_tenant_timestamp",
+                table: "heart_rates",
+                columns: new[] { "tenant_id", "timestamp" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_body_weights_tenant_mills",
+                table: "body_weights",
+                columns: new[] { "tenant_id", "mills" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_body_weights_tenant_source_sync_id",
+                table: "body_weights",
+                columns: new[] { "tenant_id", "data_source", "sync_identifier" },
+                unique: true,
+                filter: "sync_identifier IS NOT NULL AND deleted_at IS NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_step_counts_tenant_source_sync_id",
+                table: "step_counts");
+
+            migrationBuilder.DropIndex(
+                name: "ix_step_counts_tenant_timestamp",
+                table: "step_counts");
+
+            migrationBuilder.DropIndex(
+                name: "ix_heart_rates_tenant_source_sync_id",
+                table: "heart_rates");
+
+            migrationBuilder.DropIndex(
+                name: "ix_heart_rates_tenant_timestamp",
+                table: "heart_rates");
+
+            migrationBuilder.DropIndex(
+                name: "ix_body_weights_tenant_mills",
+                table: "body_weights");
+
+            migrationBuilder.DropIndex(
+                name: "ix_body_weights_tenant_source_sync_id",
+                table: "body_weights");
+
+            migrationBuilder.DropColumn(
+                name: "data_source",
+                table: "step_counts");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "step_counts");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "step_counts");
+
+            migrationBuilder.DropColumn(
+                name: "sync_identifier",
+                table: "step_counts");
+
+            migrationBuilder.DropColumn(
+                name: "data_source",
+                table: "heart_rates");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "heart_rates");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "heart_rates");
+
+            migrationBuilder.DropColumn(
+                name: "sync_identifier",
+                table: "heart_rates");
+
+            migrationBuilder.DropColumn(
+                name: "data_source",
+                table: "body_weights");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "body_weights");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user",
+                table: "body_weights");
+
+            migrationBuilder.DropColumn(
+                name: "sync_identifier",
+                table: "body_weights");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_step_counts_tenant_id",
+                table: "step_counts",
+                column: "tenant_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_heart_rates_tenant_id",
+                table: "heart_rates",
+                column: "tenant_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_body_weights_tenant_id",
+                table: "body_weights",
+                column: "tenant_id");
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -718,6 +718,22 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             .HasIndex(s => s.SysCreatedAt)
             .HasDatabaseName("ix_step_counts_sys_created_at");
 
+        // Non-filtered tenant+time index — covers the tenant FK (the filtered
+        // unique index below cannot) and serves tenant-scoped range reads.
+        modelBuilder
+            .Entity<StepCountEntity>()
+            .HasIndex(s => new { s.TenantId, s.Timestamp })
+            .HasDatabaseName("ix_step_counts_tenant_timestamp");
+
+        // StepCount gains a SyncIdentifier upsert key (mirrors boluses) so repeated
+        // uploads of the same bucket update in place instead of duplicating.
+        modelBuilder
+            .Entity<StepCountEntity>()
+            .HasIndex(s => new { s.TenantId, s.DataSource, s.SyncIdentifier })
+            .HasDatabaseName("ix_step_counts_tenant_source_sync_id")
+            .IsUnique()
+            .HasFilter("sync_identifier IS NOT NULL AND deleted_at IS NULL");
+
         // HeartRate indexes - optimized for time-range graph queries
         modelBuilder
             .Entity<HeartRateEntity>()
@@ -730,6 +746,19 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             .HasIndex(h => h.SysCreatedAt)
             .HasDatabaseName("ix_heart_rates_sys_created_at");
 
+        modelBuilder
+            .Entity<HeartRateEntity>()
+            .HasIndex(h => new { h.TenantId, h.Timestamp })
+            .HasDatabaseName("ix_heart_rates_tenant_timestamp");
+
+        // HeartRate gains a SyncIdentifier upsert key (mirrors boluses).
+        modelBuilder
+            .Entity<HeartRateEntity>()
+            .HasIndex(h => new { h.TenantId, h.DataSource, h.SyncIdentifier })
+            .HasDatabaseName("ix_heart_rates_tenant_source_sync_id")
+            .IsUnique()
+            .HasFilter("sync_identifier IS NOT NULL AND deleted_at IS NULL");
+
         // BodyWeight indexes - optimized for time-range graph queries
         modelBuilder
             .Entity<BodyWeightEntity>()
@@ -741,6 +770,19 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             .Entity<BodyWeightEntity>()
             .HasIndex(b => b.SysCreatedAt)
             .HasDatabaseName("ix_body_weights_sys_created_at");
+
+        modelBuilder
+            .Entity<BodyWeightEntity>()
+            .HasIndex(b => new { b.TenantId, b.Mills })
+            .HasDatabaseName("ix_body_weights_tenant_mills");
+
+        // BodyWeight gains a SyncIdentifier upsert key (mirrors boluses).
+        modelBuilder
+            .Entity<BodyWeightEntity>()
+            .HasIndex(b => new { b.TenantId, b.DataSource, b.SyncIdentifier })
+            .HasDatabaseName("ix_body_weights_tenant_source_sync_id")
+            .IsUnique()
+            .HasFilter("sync_identifier IS NOT NULL AND deleted_at IS NULL");
 
         // Discrepancy analysis indexes - optimized for dashboard queries
         modelBuilder

--- a/tests/Unit/Nocturne.API.Tests/Services/Health/BodyWeightServiceDedupTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Health/BodyWeightServiceDedupTests.cs
@@ -1,0 +1,72 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Health;
+using Nocturne.API.Services.Realtime;
+using Nocturne.Core.Contracts.Legacy;
+using Nocturne.Core.Models;
+using Nocturne.Infrastructure.Data;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Health;
+
+/// <summary>
+/// BodyWeight dedup — distinct from StepCount/HeartRate because BodyWeight is mills-based
+/// (not Timestamp) and its <c>syncIdentifier</c> flows through the model POST + the
+/// <c>[NocturneOnly]</c> attribute rather than an Upsert request DTO.
+/// </summary>
+public class BodyWeightServiceDedupTests
+{
+    private static (BodyWeightService service, NocturneDbContext context) CreateService()
+    {
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        var context = new NocturneDbContext(options) { TenantId = Guid.Parse("33333333-3333-3333-3333-333333333333") };
+
+        var processing = new Mock<IDocumentProcessingService>();
+        processing
+            .Setup(p => p.ProcessDocuments(It.IsAny<IEnumerable<BodyWeight>>()))
+            .Returns((IEnumerable<BodyWeight> docs) => docs);
+
+        var service = new BodyWeightService(
+            context,
+            processing.Object,
+            Mock.Of<ISignalRBroadcastService>(),
+            NullLogger<BodyWeightService>.Instance);
+
+        return (service, context);
+    }
+
+    private static BodyWeight Reading(string syncId, decimal weightKg) => new()
+    {
+        Mills = 1_700_000_000_000,
+        WeightKg = weightKg,
+        DataSource = "prelude",
+        SyncIdentifier = syncId,
+    };
+
+    [Fact]
+    public async Task Repeated_upload_of_same_sync_id_updates_in_place()
+    {
+        var (service, context) = CreateService();
+
+        await service.CreateBodyWeightsAsync([Reading("prelude-weight-abc", 80.5m)]);
+        await service.CreateBodyWeightsAsync([Reading("prelude-weight-abc", 81.2m)]);
+
+        var rows = await context.BodyWeights.AsNoTracking().ToListAsync();
+        rows.Should().ContainSingle();
+        rows[0].WeightKg.Should().Be(81.2m);
+    }
+
+    [Fact]
+    public async Task Distinct_sync_ids_insert_separate_rows()
+    {
+        var (service, context) = CreateService();
+
+        await service.CreateBodyWeightsAsync([Reading("w1", 80m), Reading("w2", 81m)]);
+
+        (await context.BodyWeights.AsNoTracking().ToListAsync()).Should().HaveCount(2);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Health/HeartRateServiceDedupTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Health/HeartRateServiceDedupTests.cs
@@ -1,0 +1,72 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Health;
+using Nocturne.API.Services.Realtime;
+using Nocturne.Core.Contracts.Legacy;
+using Nocturne.Core.Models;
+using Nocturne.Infrastructure.Data;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Health;
+
+/// <summary>
+/// HeartRate counterpart of <see cref="StepCountServiceDedupTests"/> — the sync-identifier
+/// upsert lives in the shared base, but this locks in that HeartRate's own service wiring
+/// participates in it.
+/// </summary>
+public class HeartRateServiceDedupTests
+{
+    private static (HeartRateService service, NocturneDbContext context) CreateService()
+    {
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        var context = new NocturneDbContext(options) { TenantId = Guid.Parse("22222222-2222-2222-2222-222222222222") };
+
+        var processing = new Mock<IDocumentProcessingService>();
+        processing
+            .Setup(p => p.ProcessDocuments(It.IsAny<IEnumerable<HeartRate>>()))
+            .Returns((IEnumerable<HeartRate> docs) => docs);
+
+        var service = new HeartRateService(
+            context,
+            processing.Object,
+            Mock.Of<ISignalRBroadcastService>(),
+            NullLogger<HeartRateService>.Instance);
+
+        return (service, context);
+    }
+
+    private static HeartRate Bucket(string syncId, int bpm) => new()
+    {
+        Timestamp = new DateTime(2026, 6, 16, 12, 0, 0, DateTimeKind.Utc),
+        Bpm = bpm,
+        DataSource = "prelude",
+        SyncIdentifier = syncId,
+    };
+
+    [Fact]
+    public async Task Repeated_upload_of_same_sync_id_updates_in_place()
+    {
+        var (service, context) = CreateService();
+
+        await service.CreateHeartRatesAsync([Bucket("prelude-hr-5m-1000", 60)]);
+        await service.CreateHeartRatesAsync([Bucket("prelude-hr-5m-1000", 72)]);
+
+        var rows = await context.HeartRates.AsNoTracking().ToListAsync();
+        rows.Should().ContainSingle();
+        rows[0].Bpm.Should().Be(72);
+    }
+
+    [Fact]
+    public async Task Distinct_sync_ids_insert_separate_rows()
+    {
+        var (service, context) = CreateService();
+
+        await service.CreateHeartRatesAsync([Bucket("a", 60), Bucket("b", 80)]);
+
+        (await context.HeartRates.AsNoTracking().ToListAsync()).Should().HaveCount(2);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Health/StepCountServiceDedupTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Health/StepCountServiceDedupTests.cs
@@ -1,0 +1,98 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Health;
+using Nocturne.API.Services.Realtime;
+using Nocturne.Core.Contracts.Legacy;
+using Nocturne.Core.Models;
+using Nocturne.Infrastructure.Data;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Health;
+
+/// <summary>
+/// Verifies the sync-identifier upsert that <see cref="StepCountService"/> inherits from
+/// <c>SimpleEntityService</c>: a create whose (DataSource, SyncIdentifier) matches an existing
+/// row updates it in place, making repeated uploads of the same bucket idempotent.
+/// </summary>
+public class StepCountServiceDedupTests
+{
+    private static (StepCountService service, NocturneDbContext context) CreateService()
+    {
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        var context = new NocturneDbContext(options) { TenantId = Guid.Parse("11111111-1111-1111-1111-111111111111") };
+
+        var processing = new Mock<IDocumentProcessingService>();
+        processing
+            .Setup(p => p.ProcessDocuments(It.IsAny<IEnumerable<StepCount>>()))
+            .Returns((IEnumerable<StepCount> docs) => docs);
+
+        var service = new StepCountService(
+            context,
+            processing.Object,
+            Mock.Of<ISignalRBroadcastService>(),
+            NullLogger<StepCountService>.Instance);
+
+        return (service, context);
+    }
+
+    private static StepCount Bucket(string syncId, int metric, string dataSource = "prelude") => new()
+    {
+        Timestamp = new DateTime(2026, 6, 16, 12, 0, 0, DateTimeKind.Utc),
+        Metric = metric,
+        Source = 0,
+        DataSource = dataSource,
+        SyncIdentifier = syncId,
+    };
+
+    [Fact]
+    public async Task Repeated_upload_of_same_sync_id_updates_in_place()
+    {
+        var (service, context) = CreateService();
+
+        await service.CreateStepCountsAsync([Bucket("prelude-steps-5m-1000", 100)]);
+        await service.CreateStepCountsAsync([Bucket("prelude-steps-5m-1000", 175)]);
+
+        var rows = await context.StepCounts.AsNoTracking().ToListAsync();
+        rows.Should().ContainSingle("the same (DataSource, SyncIdentifier) must upsert, not duplicate");
+        rows[0].Metric.Should().Be(175, "the re-upload carries the corrected value");
+    }
+
+    [Fact]
+    public async Task Distinct_sync_ids_insert_separate_rows()
+    {
+        var (service, context) = CreateService();
+
+        await service.CreateStepCountsAsync([Bucket("a", 100), Bucket("b", 200)]);
+
+        var rows = await context.StepCounts.AsNoTracking().ToListAsync();
+        rows.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task Duplicate_sync_id_within_one_batch_collapses_to_last()
+    {
+        var (service, context) = CreateService();
+
+        await service.CreateStepCountsAsync([Bucket("dup", 100), Bucket("dup", 250)]);
+
+        var rows = await context.StepCounts.AsNoTracking().ToListAsync();
+        rows.Should().ContainSingle("an intra-batch duplicate must not collide on the unique key");
+        rows[0].Metric.Should().Be(250);
+    }
+
+    [Fact]
+    public async Task Records_without_sync_identifier_always_insert()
+    {
+        var (service, context) = CreateService();
+
+        await service.CreateStepCountsAsync([Bucket(syncId: null!, metric: 100, dataSource: null!)]);
+        await service.CreateStepCountsAsync([Bucket(syncId: null!, metric: 100, dataSource: null!)]);
+
+        var rows = await context.StepCounts.AsNoTracking().ToListAsync();
+        rows.Should().HaveCount(2, "without a sync key, the blind-insert behaviour is preserved");
+    }
+}


### PR DESCRIPTION
## Why
Wearable metrics (steps, heart rate, body weight) are uploaded by at-least-once clients (e.g. the Prelude Android app reading Android Health Connect), so repeated POSTs must not create duplicate rows. Today these three entities sit on the legacy `ProcessableDocumentBase` / `SimpleEntityService` **blind-insert** path — every re-send duplicates.

A full V4/`IV4Record` migration was deliberately **rejected**: StepCount/HeartRate are entangled with the v1 `/activity` compatibility subsystem (`ActivityDecomposer` dedups on the string `Id`; `ActivityService`/actogram/ChartData consume the old services), so the by-the-book swap would mean rewriting clinical-compat code unrelated to the feature.

## What
A lean sync-dedup that keeps the existing models/services and touches nothing in the v1 activity / actogram / chart paths:

- New `ISyncDedupable` (`DataSource` + `SyncIdentifier`) on the three entities, now also `ISoftDeletable`; new `data_source` / `sync_identifier` / `deleted_at` columns.
- `SimpleEntityService.CreateManyAsync` upserts by `(DataSource, SyncIdentifier)` — a **single batched pre-load** of existing rows + intra-batch dedup, update-in-place or insert. `DeleteOneAsync` soft-deletes.
- `syncIdentifier` added to the models, mappers, `Upsert{StepCount,HeartRate}Request` DTOs and controllers (BodyWeight flows via its model POST).
- Filtered unique index `(tenant_id, data_source, sync_identifier) WHERE sync_identifier IS NOT NULL AND deleted_at IS NULL`, plus a non-filtered `(tenant_id, timestamp|mills)` covering index per table (mirrors `ix_boluses_tenant_timestamp` — replaces the auto FK index EF would otherwise drop). Migration `AddHealthMetricsSyncDedup`.

The existing array POST endpoints serve as the bulk routes; the change to the v1 activity / actogram / chart consumers is purely additive (new model property + the auto-applied soft-delete query filter).

## Tests
- New dedup unit tests for all three services (`StepCount`/`HeartRate`/`BodyWeight` ServiceDedupTests): in-place upsert, distinct-insert, intra-batch collapse, no-key blind-insert.
- Existing infra/core/API suites stay green (incl. the share-RLS coverage guard — `step_counts`/`heart_rates` already classified shareable, `body_weights` already in `KnownHiddenTables`).

## Notes
- Uploader clients need the `stepcount.readwrite` + `heartrate.readwrite` scopes (BodyWeight POST has no scope gate today).
- An internal reviewer pass found no Critical/High issues; the N+1 (batched), HR/BodyWeight test gap (added), and the ActivityDecomposer hard-delete asymmetry (commented) were addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)