### PR TITLE
fix(connectors): normalize connector-name casing in token cache

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorTokenCache.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorTokenCache.cs
@@ -15,25 +15,31 @@ public class ConnectorTokenCache : IConnectorTokenCache
 
     public Task<ConnectorSession?> GetAsync(string connectorName, Guid tenantId)
     {
-        if (_sessions.TryGetValue((connectorName, tenantId), out var session) && session.ExpiresAt > DateTime.UtcNow)
+        if (_sessions.TryGetValue(Key(connectorName, tenantId), out var session) && session.ExpiresAt > DateTime.UtcNow)
             return Task.FromResult<ConnectorSession?>(session);
         return Task.FromResult<ConnectorSession?>(null);
     }
 
     public Task SetAsync(string connectorName, Guid tenantId, ConnectorSession session)
     {
-        _sessions[(connectorName, tenantId)] = session;
+        _sessions[Key(connectorName, tenantId)] = session;
         return Task.CompletedTask;
     }
 
     public Task<SemaphoreSlim> GetLockAsync(string connectorName, Guid tenantId)
     {
-        var semaphore = _locks.GetOrAdd((connectorName, tenantId), _ => new SemaphoreSlim(1, 1));
+        var semaphore = _locks.GetOrAdd(Key(connectorName, tenantId), _ => new SemaphoreSlim(1, 1));
         return Task.FromResult(semaphore);
     }
 
     public void Invalidate(string connectorName, Guid tenantId)
     {
-        _sessions.TryRemove((connectorName, tenantId), out _);
+        _sessions.TryRemove(Key(connectorName, tenantId), out _);
     }
+
+    // Token providers key sessions by their PascalCase ConnectorName constant (e.g. "Eversense"),
+    // while invalidation on config save passes the lowercase route name (e.g. "eversense").
+    // Normalize so a credential change reliably clears the cached token regardless of casing.
+    private static (string, Guid) Key(string connectorName, Guid tenantId) =>
+        (connectorName.ToLowerInvariant(), tenantId);
 }

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/ConnectorTokenCacheTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/ConnectorTokenCacheTests.cs
@@ -89,6 +89,43 @@ public class ConnectorTokenCacheTests
     }
 
     [Fact]
+    public async Task Invalidate_RemovesEntry_WhenCasingDiffersFromStore()
+    {
+        // Token providers store under their PascalCase ConnectorName constant ("Eversense");
+        // config-save invalidation passes the lowercase route name ("eversense"). The cache
+        // must treat them as the same key, otherwise stale credentials survive a config change.
+        var tenantId = Guid.NewGuid();
+        await _cache.SetAsync("Eversense", tenantId, new ConnectorSession("token-123", DateTime.UtcNow.AddHours(1)));
+
+        _cache.Invalidate("eversense", tenantId);
+        var result = await _cache.GetAsync("Eversense", tenantId);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetAsync_IsCaseInsensitive_ForConnectorName()
+    {
+        var tenantId = Guid.NewGuid();
+        await _cache.SetAsync("Eversense", tenantId, new ConnectorSession("token-123", DateTime.UtcNow.AddHours(1)));
+
+        var result = await _cache.GetAsync("eversense", tenantId);
+
+        result!.Token.Should().Be("token-123");
+    }
+
+    [Fact]
+    public async Task GetLockAsync_ReturnsSameSemaphore_ForConnectorNameCasingVariants()
+    {
+        var tenantId = Guid.NewGuid();
+
+        var lock1 = await _cache.GetLockAsync("Eversense", tenantId);
+        var lock2 = await _cache.GetLockAsync("eversense", tenantId);
+
+        ReferenceEquals(lock1, lock2).Should().BeTrue();
+    }
+
+    [Fact]
     public async Task GetLockAsync_ReturnsSameSemaphore_ForSameTenant()
     {
         var tenantId = Guid.NewGuid();


### PR DESCRIPTION
## Problem

Connector credential changes don't take effect until the token expires naturally (up to ~24h for Eversense) or the API restarts.

The in-memory `ConnectorTokenCache` keys sessions by `(ConnectorName, TenantId)` using ordinal string comparison. The two sides of the cache use different casing for the connector name:

- **Store**: token providers cache under their PascalCase `ConnectorName` constant (e.g. `EversenseAuthTokenProvider.ConnectorName => "Eversense"`).
- **Invalidate**: `ConnectorConfigurationService.SaveConfigurationAsync` invalidates using the raw connector name from the route, which is **lowercase** (e.g. `/api/v4/services/connectors/eversense/...` → `"eversense"`).

`"eversense" != "Eversense"`, so the invalidation never removes the stored entry. The connector keeps authenticating with the **old** credentials.

This was hit in production: a tenant updated their Eversense follower account, but syncs kept using the previous account (which followed no patients → 0 readings) until the API was restarted.

## Fix

Normalize the connector name to lower-invariant at every cache key operation (get / set / lock / invalidate) via a single `Key` helper, so a config change reliably clears the cached token regardless of casing. Single chokepoint, applies to all connectors.

## Tests

Added regression coverage to `ConnectorTokenCacheTests`:
- `Invalidate_RemovesEntry_WhenCasingDiffersFromStore` (store `"Eversense"`, invalidate `"eversense"`, assert cleared)
- `GetAsync_IsCaseInsensitive_ForConnectorName`
- `GetLockAsync_ReturnsSameSemaphore_ForConnectorNameCasingVariants`

All 12 tests in the project pass.