### PR TITLE
fix(calendar): correct timezone handling for daily profiles

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
@@ -938,9 +938,15 @@ public class StatisticsController : ControllerBase
     {
         try
         {
-            // Normalise to UTC day boundaries.
-            var startDt = DateTime.SpecifyKind(startDate.Date, DateTimeKind.Utc);
-            var endDt = DateTime.SpecifyKind(endDate.Date, DateTimeKind.Utc).AddDays(1).AddTicks(-1);
+            var tzId = await _therapySettingsResolver.GetTimezoneAsync(ct: cancellationToken);
+            var tz = !string.IsNullOrEmpty(tzId)
+                ? TimeZoneHelper.GetTimeZoneInfoFromId(tzId)
+                : TimeZoneInfo.Utc;
+
+            var startLocalDate = DateTime.SpecifyKind(startDate.Date, DateTimeKind.Unspecified);
+            var endLocalDate = DateTime.SpecifyKind(endDate.Date, DateTimeKind.Unspecified);
+            var startDt = TimeZoneInfo.ConvertTimeToUtc(startLocalDate, tz);
+            var endDt = TimeZoneInfo.ConvertTimeToUtc(endLocalDate.AddDays(1).AddTicks(-1), tz);
 
             var glucoseTask   = _sensorGlucoseRepository.GetAsync(startDt, endDt, null, null, 100_000, descending: false, ct: cancellationToken);
             var bolusTask     = _bolusRepository.GetAsync(startDt, endDt, null, null, 10_000, descending: false, kind: BolusKind.Manual, ct: cancellationToken);
@@ -958,11 +964,6 @@ public class StatisticsController : ControllerBase
 
             // Daily basal totals come from the existing service path so the calendar's "totalBasal"
             // matches what /daily-basal-bolus-ratios would return for the same window.
-            var tzId = await _therapySettingsResolver.GetTimezoneAsync(ct: cancellationToken);
-            var tz = !string.IsNullOrEmpty(tzId)
-                ? TimeZoneHelper.GetTimeZoneInfoFromId(tzId)
-                : TimeZoneInfo.Utc;
-
             var dailyBasalBolus = _statisticsService.CalculateDailyBasalBolusRatios(
                 manualBoluses, algorithmBoluses, tempBasals, tz);
             var dailyBasalMap = new Dictionary<string, double>(StringComparer.Ordinal);
@@ -979,7 +980,7 @@ public class StatisticsController : ControllerBase
                 "July", "August", "September", "October", "November", "December"
             ];
 
-            for (var day = startDt.Date; day <= endDt.Date; day = day.AddDays(1))
+            for (var day = startLocalDate.Date; day <= endLocalDate.Date; day = day.AddDays(1))
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -995,8 +996,10 @@ public class StatisticsController : ControllerBase
                     monthsMap[monthKey] = monthBucket;
                 }
 
-                var dayStartUtc = DateTime.SpecifyKind(day, DateTimeKind.Utc);
-                var dayEndUtc = dayStartUtc.AddDays(1).AddTicks(-1);
+                var dayStartLocal = DateTime.SpecifyKind(day, DateTimeKind.Unspecified);
+                var dayEndLocal = dayStartLocal.AddDays(1).AddTicks(-1);
+                var dayStartUtc = TimeZoneInfo.ConvertTimeToUtc(dayStartLocal, tz);
+                var dayEndUtc = TimeZoneInfo.ConvertTimeToUtc(dayEndLocal, tz);
                 var dayStartMs = new DateTimeOffset(dayStartUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
                 var dayEndMs = new DateTimeOffset(dayEndUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
 

--- a/src/Web/packages/app/src/lib/components/calendar/CalendarDayCell.svelte
+++ b/src/Web/packages/app/src/lib/components/calendar/CalendarDayCell.svelte
@@ -10,6 +10,7 @@
   import type { TrackerInstanceDto, TrackerDefinitionDto } from "$api";
   import { formatGlucoseValue } from "$lib/utils/formatting";
   import type { GlucoseUnits } from "$lib/utils/formatting";
+  import { formatCalendarDate, getCalendarDayNumber } from "$lib/components/calendar/calendar-date";
 
   let {
     day,
@@ -85,7 +86,7 @@
     <span
       class="absolute top-1 left-2 text-xs text-muted-foreground font-medium z-10"
     >
-      {new Date(day.date).getDate()}
+      {getCalendarDayNumber(day.date)}
     </span>
 
     <!-- Tracker icons in top-right corner -->
@@ -151,6 +152,7 @@
             <div {...props} class="absolute inset-0">
               <DayGlucoseProfile
                 entries={day.entries}
+                dayStartMills={day.timestamp}
                 onclick={() => handleDayClick(day)}
               />
             </div>
@@ -163,7 +165,7 @@
       >
         <div class="space-y-1.5">
           <div class="font-medium text-sm">
-            {new Date(day.date).toLocaleDateString(undefined, {
+            {formatCalendarDate(day.date, undefined, {
               weekday: "long",
               month: "short",
               day: "numeric",
@@ -255,7 +257,7 @@
   {:else if day && "date" in day}
     <!-- Day exists in data but has no readings -->
     <span class="absolute top-1 left-2 text-xs text-muted-foreground">
-      {new Date(day.date).getDate()}
+      {getCalendarDayNumber(day.date)}
     </span>
     <!-- Tracker icons for days with no readings -->
     {#if dayTrackerEvents.length > 0}

--- a/src/Web/packages/app/src/lib/components/calendar/DayGlucoseProfile.svelte
+++ b/src/Web/packages/app/src/lib/components/calendar/DayGlucoseProfile.svelte
@@ -1,19 +1,21 @@
 <script lang="ts">
   /**
-   * Clickable calendar-day cell that fills the cell with a mini CGM curve
-   * via {@link GlucoseSparkline}. Falls back to a "No data" label when
-   * `entries` is empty.
+   * Clickable calendar-day cell that fills the cell with a mini CGM curve via
+   * {@link GlucoseSparkline}. Falls back to a "No data" label when `entries` is
+   * empty.
    */
   import GlucoseSparkline from "./GlucoseSparkline.svelte";
 
   interface Props {
     /** Glucose entries for the day: { mills, mgdl } */
     entries: Array<{ mills: number; mgdl: number }>;
+    /** Unix milliseconds for the start of the calendar day */
+    dayStartMills?: number;
     /** Click handler */
     onclick?: () => void;
   }
 
-  let { entries, onclick }: Props = $props();
+  let { entries, dayStartMills, onclick }: Props = $props();
 </script>
 
 <button
@@ -22,7 +24,7 @@
   {onclick}
 >
   {#if entries.length > 0}
-    <GlucoseSparkline {entries} />
+    <GlucoseSparkline {entries} {dayStartMills} />
   {:else}
     <svg width="100%" height="100%" class="rounded-lg overflow-hidden">
       <text

--- a/src/Web/packages/app/src/lib/components/calendar/GlucoseSparkline.svelte
+++ b/src/Web/packages/app/src/lib/components/calendar/GlucoseSparkline.svelte
@@ -2,11 +2,11 @@
   /**
    * Tiny glucose curve for embedding in calendar day cells. Uses the shared
    * GlucoseTrack component with threshold-coloured line and deviation-fill
-   * area, so the curve picks up the same visual contract as the dashboard
-   * chart (red below low, in-range with no fill, red above high).
+   * area, so the curve picks up the same visual contract as the dashboard chart
+   * (red below low, in-range with no fill, red above high).
    *
-   * Pure visual — no button, no click handling — so callers can wrap it
-   * in whatever interactive element they need without nested-button HTML.
+   * Pure visual — no button, no click handling — so callers can wrap it in
+   * whatever interactive element they need without nested-button HTML.
    */
   import { Chart, Svg } from "layerchart";
   import { scaleTime } from "d3-scale";
@@ -29,21 +29,30 @@
   interface Props {
     /** Glucose entries for the day: { mills, mgdl } */
     entries: Array<{ mills: number; mgdl: number }>;
+    /** Unix milliseconds for the start of the calendar day */
+    dayStartMills?: number;
   }
 
-  let { entries }: Props = $props();
+  let { entries, dayStartMills }: Props = $props();
 
   const glucoseData = $derived(
     entries
       .filter((e) => e.mgdl > 0)
       .map((e) => ({ time: new Date(e.mills), sgv: e.mgdl, color: "" }))
-      .sort((a, b) => a.time.getTime() - b.time.getTime()),
+      .sort((a, b) => a.time.getTime() - b.time.getTime())
   );
 
-  // Snap the x-domain to the local-day boundaries of the first entry so
-  // the curve fills the cell horizontally even when the day starts/ends
-  // with no readings.
+  // Snap the x-domain to the calendar day, not the first/last reading.
+  // Sparse days should show gaps instead of stretching partial data.
   const xDomain = $derived.by(() => {
+    const start = dayStartMills;
+    if (start !== undefined) {
+      return [new Date(start), new Date(start + 24 * 60 * 60 * 1000 - 1)] as [
+        Date,
+        Date,
+      ];
+    }
+
     if (entries.length === 0) return undefined;
     const ref = new Date(entries[0].mills);
     const y = ref.getFullYear();
@@ -75,8 +84,8 @@
       0,
       0,
       { basal: false, iob: false, cob: false },
-      { pumpMode: false, override: false, profile: false, activity: false },
-    ),
+      { pumpMode: false, override: false, profile: false, activity: false }
+    )
   );
 
   setGlucoseChartContext({
@@ -91,28 +100,28 @@
 
 {#if entries.length > 0 && xDomain}
   <div class="h-full w-full">
-  <Chart
-    data={glucoseData}
-    x={(d) => d.time}
-    y={(d) => d.sgv}
-    xScale={scaleTime()}
-    {xDomain}
-    yDomain={[0, THRESHOLDS.glucoseYMax]}
-    padding={{ top: 1, bottom: 1, left: 1, right: 1 }}
-  >
-    {#snippet children({ context })}
-      {(chartHeight = context.height, "")}
-      <Svg>
-        {#if chartHeight > 0}
-          <GlucoseTrack
-            lineColorMode="threshold"
-            areaMode="deviation"
-            showAxis={false}
-            showPoints={false}
-          />
-        {/if}
-      </Svg>
-    {/snippet}
-  </Chart>
+    <Chart
+      data={glucoseData}
+      x={(d) => d.time}
+      y={(d) => d.sgv}
+      xScale={scaleTime()}
+      {xDomain}
+      yDomain={[0, THRESHOLDS.glucoseYMax]}
+      padding={{ top: 1, bottom: 1, left: 1, right: 1 }}
+    >
+      {#snippet children({ context })}
+        {((chartHeight = context.height), "")}
+        <Svg>
+          {#if chartHeight > 0}
+            <GlucoseTrack
+              lineColorMode="threshold"
+              areaMode="deviation"
+              showAxis={false}
+              showPoints={false}
+            />
+          {/if}
+        </Svg>
+      {/snippet}
+    </Chart>
   </div>
 {/if}

--- a/src/Web/packages/app/src/lib/components/calendar/calendar-date.test.ts
+++ b/src/Web/packages/app/src/lib/components/calendar/calendar-date.test.ts
@@ -1,0 +1,29 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { formatCalendarDate, getCalendarDayNumber } from "./calendar-date";
+
+describe("calendar date helpers", () => {
+  const originalTimezone = process.env.TZ;
+
+  beforeAll(() => {
+    process.env.TZ = "America/New_York";
+  });
+
+  afterAll(() => {
+    if (originalTimezone === undefined) {
+      delete process.env.TZ;
+    } else {
+      process.env.TZ = originalTimezone;
+    }
+  });
+
+  it("reads the day number from the date string without UTC shifting", () => {
+    expect(getCalendarDayNumber("2026-06-01")).toBe(1);
+    expect(getCalendarDayNumber("2026-06-14")).toBe(14);
+  });
+
+  it("formats the weekday from the local calendar date", () => {
+    expect(formatCalendarDate("2026-06-14", "en-US", { weekday: "long" })).toBe(
+      "Sunday"
+    );
+  });
+});

--- a/src/Web/packages/app/src/lib/components/calendar/calendar-date.ts
+++ b/src/Web/packages/app/src/lib/components/calendar/calendar-date.ts
@@ -1,0 +1,17 @@
+export function parseCalendarDate(date: string): Date {
+  const [year, month, day] = date.split("-").map(Number);
+
+  return new Date(year, month - 1, day);
+}
+
+export function getCalendarDayNumber(date: string): number {
+  return parseCalendarDate(date).getDate();
+}
+
+export function formatCalendarDate(
+  date: string,
+  locales: Intl.LocalesArgument,
+  options: Intl.DateTimeFormatOptions
+): string {
+  return parseCalendarDate(date).toLocaleDateString(locales, options);
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsControllerTests.cs
@@ -22,6 +22,8 @@ public class StatisticsControllerTests
     private readonly Mock<ISensorGlucoseRepository> _glucoseRepoMock = new();
     private readonly Mock<IBolusRepository> _bolusRepoMock = new();
     private readonly Mock<ICarbIntakeRepository> _carbIntakeRepoMock = new();
+    private readonly Mock<ITempBasalRepository> _tempBasalRepoMock = new();
+    private readonly Mock<ITherapySettingsResolver> _therapySettingsResolverMock = new();
 
     private StatisticsController CreateController()
     {
@@ -31,11 +33,11 @@ public class StatisticsControllerTests
             Mock.Of<IProfileProjectionService>(),
             Mock.Of<IBasalRateResolver>(),
             Mock.Of<IBasalSegmentService>(),
-            Mock.Of<ITherapySettingsResolver>(),
+            _therapySettingsResolverMock.Object,
             _glucoseRepoMock.Object,
             _bolusRepoMock.Object,
             _carbIntakeRepoMock.Object,
-            Mock.Of<ITempBasalRepository>(),
+            _tempBasalRepoMock.Object,
             Mock.Of<ITenantAccessor>(),
             Mock.Of<IAidMetricsService>(),
             Mock.Of<IPatientDeviceRepository>(),
@@ -80,6 +82,22 @@ public class StatisticsControllerTests
                 It.IsAny<bool>(), It.IsAny<DateTime?>(), It.IsAny<Guid?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<CarbIntake>());
+
+        _tempBasalRepoMock
+            .Setup(r => r.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TempBasal>());
+
+        _statsServiceMock
+            .Setup(s => s.CalculateDailyBasalBolusRatios(
+                It.IsAny<IEnumerable<Bolus>>(),
+                It.IsAny<IEnumerable<Bolus>>(),
+                It.IsAny<IEnumerable<TempBasal>>(),
+                It.IsAny<TimeZoneInfo?>()))
+            .Returns(new DailyBasalBolusRatioResponse());
     }
 
     [Fact]
@@ -162,5 +180,67 @@ public class StatisticsControllerTests
             It.IsAny<IEnumerable<CarbIntake>>(),
             DiabetesPopulation.Type1Adult,
             It.IsAny<ExtendedAnalysisConfig?>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetPunchCardData_UsesTherapyTimezoneForCalendarDayBuckets()
+    {
+        var reading = new SensorGlucose
+        {
+            Timestamp = new DateTime(2026, 6, 1, 22, 30, 0, DateTimeKind.Utc),
+            Mgdl = 100,
+        };
+        DateTime? capturedFrom = null;
+        DateTime? capturedTo = null;
+
+        _therapySettingsResolverMock
+            .Setup(r => r.GetTimezoneAsync(null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("Europe/Stockholm");
+
+        _glucoseRepoMock
+            .Setup(r => r.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(),
+                It.IsAny<bool>(), It.IsAny<DateTime?>(), It.IsAny<Guid?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<DateTime?, DateTime?, string?, string?, int, int, bool, bool, DateTime?, Guid?, CancellationToken>(
+                (from, to, _, _, _, _, _, _, _, _, _) =>
+                {
+                    capturedFrom = from;
+                    capturedTo = to;
+                })
+            .ReturnsAsync(new[] { reading });
+        SetupEmptyTreatments();
+        _statsServiceMock
+            .Setup(s => s.CalculateTimeInRange(
+                It.IsAny<IEnumerable<SensorGlucose>>(),
+                It.IsAny<GlycemicThresholds?>()))
+            .Returns(new TimeInRangeMetrics
+            {
+                Percentages = new TimeInRangePercentages { Target = 100 },
+                Durations = new TimeInRangeDurations { Target = 5 },
+                RangeStats = new TimeInRangeDetailedStats
+                {
+                    Target = new PeriodMetrics { PeriodName = "In Range", Mean = 100 },
+                },
+            });
+
+        var controller = CreateController();
+
+        var result = await controller.GetPunchCardData(
+            new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 6, 2, 0, 0, 0, DateTimeKind.Utc));
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var payload = ok.Value.Should().BeOfType<PunchCardResponse>().Subject;
+        var month = payload.Months.Should().ContainSingle().Subject;
+        var juneFirst = month.Days.Should().ContainSingle(d => d.Date == "2026-06-01").Subject;
+        var juneSecond = month.Days.Should().ContainSingle(d => d.Date == "2026-06-02").Subject;
+
+        juneFirst.Entries.Should().BeEmpty();
+        juneSecond.Entries.Should().ContainSingle(e => e.Mills == reading.Mills);
+        capturedFrom.Should().Be(new DateTime(2026, 5, 31, 22, 0, 0, DateTimeKind.Utc));
+        capturedTo.Should().Be(new DateTime(2026, 6, 2, 21, 59, 59, 999, DateTimeKind.Utc).AddTicks(9999));
     }
 }


### PR DESCRIPTION
## Summary

Fixes calendar rendering for users outside UTC, especially users in UTC minus 4 timezones.

The calendar was treating local calendar days as UTC days. This caused two visible issues:

1. Date labels could shift back one day, for example June 1 showing as May 31.
2. Daily glucose profile charts could show only part of the day or appear shifted inside the wrong day cell.

## What changed

1. Calendar API queries now use the user therapy timezone when converting local day boundaries to UTC.
2. Daily calendar buckets are created from local calendar days instead of UTC days.
3. Calendar date labels are parsed as local calendar dates in the frontend, instead of using JavaScript UTC parsing for `YYYY-MM-DD`.
4. Daily glucose sparklines now use the calendar day start timestamp so partial day data stays positioned correctly.
5. Added regression tests for the timezone sensitive date parsing and backend calendar bucketing.

## Testing

Validated locally by reproducing the issue with Chrome DevTools Sensors set to `America/New_York`.

Ran:

```bash
pnpm exec vitest --config vitest.config.ts run src/lib/components/calendar/calendar-date.test.ts
dotnet test tests/Unit/Nocturne.API.Tests/Nocturne.API.Tests.csproj --filter "FullyQualifiedName~StatisticsControllerTests"