### PR TITLE
fix(connectors): bind twiist patient id (PwdId -> PatientId)

### DIFF
--- a/nocturne.sln
+++ b/nocturne.sln
@@ -160,6 +160,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nocturne.Connectors.Dexcom.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nocturne.Aspire.ServiceDefaults.Tests", "tests\Unit\Nocturne.Aspire.ServiceDefaults.Tests\Nocturne.Aspire.ServiceDefaults.Tests.csproj", "{64AD1A7B-51A0-4800-9E66-12AE59089F4D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nocturne.Connectors.Twiist.Tests", "tests\Unit\Nocturne.Connectors.Twiist.Tests\Nocturne.Connectors.Twiist.Tests.csproj", "{1D50A73A-914F-487E-BC7C-7A58619A51D4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -806,6 +808,18 @@ Global
 		{64AD1A7B-51A0-4800-9E66-12AE59089F4D}.Release|x64.Build.0 = Release|Any CPU
 		{64AD1A7B-51A0-4800-9E66-12AE59089F4D}.Release|x86.ActiveCfg = Release|Any CPU
 		{64AD1A7B-51A0-4800-9E66-12AE59089F4D}.Release|x86.Build.0 = Release|Any CPU
+		{1D50A73A-914F-487E-BC7C-7A58619A51D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D50A73A-914F-487E-BC7C-7A58619A51D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1D50A73A-914F-487E-BC7C-7A58619A51D4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1D50A73A-914F-487E-BC7C-7A58619A51D4}.Debug|x64.Build.0 = Debug|Any CPU
+		{1D50A73A-914F-487E-BC7C-7A58619A51D4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1D50A73A-914F-487E-BC7C-7A58619A51D4}.Debug|x86.Build.0 = Debug|Any CPU
+		{1D50A73A-914F-487E-BC7C-7A58619A51D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1D50A73A-914F-487E-BC7C-7A58619A51D4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1D50A73A-914F-487E-BC7C-7A58619A51D4}.Release|x64.ActiveCfg = Release|Any CPU
+		{1D50A73A-914F-487E-BC7C-7A58619A51D4}.Release|x64.Build.0 = Release|Any CPU
+		{1D50A73A-914F-487E-BC7C-7A58619A51D4}.Release|x86.ActiveCfg = Release|Any CPU
+		{1D50A73A-914F-487E-BC7C-7A58619A51D4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -875,5 +889,6 @@ Global
 		{7F711727-8E92-41B0-98BB-5E9B6CA91FD5} = {F25A9213-C080-46DC-93A8-09D96E2C55A1}
 		{0563E4E3-D81A-454D-8C27-B53867751EC5} = {F25A9213-C080-46DC-93A8-09D96E2C55A1}
 		{64AD1A7B-51A0-4800-9E66-12AE59089F4D} = {F25A9213-C080-46DC-93A8-09D96E2C55A1}
+		{1D50A73A-914F-487E-BC7C-7A58619A51D4} = {F25A9213-C080-46DC-93A8-09D96E2C55A1}
 	EndGlobalSection
 EndGlobal

--- a/src/Connectors/Nocturne.Connectors.Twiist/Configurations/TwiistConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.Twiist/Configurations/TwiistConnectorConfiguration.cs
@@ -41,8 +41,12 @@ public class TwiistConnectorConfiguration : BaseConnectorConfiguration
     public string Password { get; init; } = string.Empty;
 
     /// <summary>
-    /// The PWD (person with diabetes) UUID to follow. Found via the overviews endpoint.
+    /// The PWD (person with diabetes) UUID v4 to follow, used as the path segment in
+    /// /pwd/{id}/package. Found via the follower overviews endpoint (the pwdId field).
+    /// Named to match its <see cref="ConnectorPropertyKey.PatientId"/> config key: the binder
+    /// resolves JSON keys from the camel-cased property name, so the name must match the key
+    /// or the persisted value never binds.
     /// </summary>
     [ConnectorProperty(ConnectorPropertyKey.PatientId, Required = true)]
-    public string PwdId { get; init; } = string.Empty;
+    public string PatientId { get; init; } = string.Empty;
 }

--- a/src/Connectors/Nocturne.Connectors.Twiist/Services/TwiistConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Twiist/Services/TwiistConnectorService.cs
@@ -71,7 +71,7 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
             if (package?.Status == null)
             {
                 _logger.LogWarning("[{Source}] Twiist returned empty package for PWD {PwdId}",
-                    ConnectorSource, config.PwdId);
+                    ConnectorSource, config.PatientId);
                 result.EndTime = DateTimeOffset.UtcNow;
                 return result;
             }
@@ -216,7 +216,7 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
         await _rateLimitingStrategy.ApplyDelayAsync(0);
 
         var result = await ExecuteWithRetryAsync(
-            async () => await FetchPackageCoreAsync(accessToken, config.PwdId, cancellationToken),
+            async () => await FetchPackageCoreAsync(accessToken, config.PatientId, cancellationToken),
             _retryDelayStrategy,
             async () =>
             {

--- a/tests/Unit/Nocturne.Connectors.Twiist.Tests/Configurations/TwiistConnectorConfigurationBindingTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Twiist.Tests/Configurations/TwiistConnectorConfigurationBindingTests.cs
@@ -1,0 +1,64 @@
+using System.Reflection;
+using System.Text.Json;
+using FluentAssertions;
+using Nocturne.Connectors.Core.Extensions;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.Twiist.Configurations;
+using Xunit;
+
+namespace Nocturne.Connectors.Twiist.Tests.Configurations;
+
+public class TwiistConnectorConfigurationBindingTests
+{
+    [Fact]
+    public void ApplyJsonToConfig_BindsPatientId_FromPersistedConfigKey()
+    {
+        // Shape persisted by the UI: the patient id lives under the "patientId" key
+        // (the camel-cased ConnectorPropertyKey.PatientId). The binder resolves JSON keys
+        // from the camel-cased property name, so the property must be named PatientId for the
+        // value to bind. Before the rename it was PwdId -> looked for "pwdId" -> never matched,
+        // so the connector synced with an empty id and hit /pwd//package (404).
+        const string pwdUuid = "7c4a6533-b8db-4cc4-823e-6ac9c99e07e5";
+        using var doc = JsonDocument.Parse(
+            $$"""
+            {
+                "enabled": true,
+                "username": "follower@example.com",
+                "patientId": "{{pwdUuid}}",
+                "syncGlucose": true
+            }
+            """);
+
+        var config = new TwiistConnectorConfiguration();
+        ConnectorConfigurationBinder.ApplyJsonToConfig(doc, config);
+
+        config.PatientId.Should().Be(pwdUuid);
+        config.Username.Should().Be("follower@example.com");
+    }
+
+    [Fact]
+    public void ConnectorProperties_HaveNameMatchingConfigKey()
+    {
+        // The binder keys off the camel-cased property NAME while values are persisted under the
+        // camel-cased ConnectorProperty KEY. If they diverge for any property, that value silently
+        // never binds. Guard the whole config so a future rename can't reintroduce the bug.
+        var mismatches = new List<string>();
+
+        foreach (var property in typeof(TwiistConnectorConfiguration)
+                     .GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            var attr = property.GetCustomAttribute<ConnectorPropertyAttribute>();
+            if (attr is null)
+                continue;
+
+            var nameKey = Camel(property.Name);
+            var configKey = Camel(attr.GetKeyName());
+            if (nameKey != configKey)
+                mismatches.Add($"{property.Name} binds '{nameKey}' but persists '{configKey}'");
+        }
+
+        mismatches.Should().BeEmpty();
+    }
+
+    private static string Camel(string s) => char.ToLowerInvariant(s[0]) + s[1..];
+}

--- a/tests/Unit/Nocturne.Connectors.Twiist.Tests/Nocturne.Connectors.Twiist.Tests.csproj
+++ b/tests/Unit/Nocturne.Connectors.Twiist.Tests/Nocturne.Connectors.Twiist.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="Moq"/>
+        <PackageReference Include="FluentAssertions"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="../../../src/Connectors/Nocturne.Connectors.Twiist/Nocturne.Connectors.Twiist.csproj"/>
+    </ItemGroup>
+</Project>


### PR DESCRIPTION
## Problem

The Twiist connector never receives its configured patient id, so it syncs with an empty id and requests `https://follower-service.mytwiistportal.com/pwd//package` — which returns 404 while the sync still reports `Success=True` (the empty-package branch). Result: a connector that looks connected/healthy but ingests nothing.

### Root cause

`ConnectorConfigurationBinder.ApplyJsonToConfig` resolves each JSON key from the **camel-cased C# property name**:

```csharp
var camelName = char.ToLowerInvariant(property.Name[0]) + property.Name[1..];
if (!root.TryGetProperty(camelName, out var element)) continue;
```

But values are **persisted under the camel-cased `ConnectorProperty` key**. The twiist property was named `PwdId` (→ looks for `pwdId`) while decorated with `[ConnectorProperty(ConnectorPropertyKey.PatientId)]`, so the UI saved the value under `patientId`. `pwdId != patientId` → the value silently never binds.

twiist is the only connector whose property name diverged from its config key, so it's the only one affected.

## Fix

Rename the property `PwdId` → `PatientId` so the camel-cased name matches the persisted key, restoring the property-name-equals-config-key convention every other connector already relies on. (`TwiistPackage.PwdId`, the API *response* model, is unrelated and unchanged.)

## Tests

New `Nocturne.Connectors.Twiist.Tests` project:
- **Binding regression** — applies the real persisted shape (`{"patientId": "<uuid>", ...}`) and asserts it reaches `config.PatientId`.
- **Convention guard** — asserts every `[ConnectorProperty]` property's camel-cased name equals its camel-cased key, so a future rename can't reintroduce this class of bug.

Both pass.

## Note

This restores binding; the user must still configure the actual PWD **UUID v4** (from the follower `/pwd/overviews` response, `pwdId` field) — Twiist rejects a non-UUID id with HTTP 400. A follow-up could auto-discover it via `/pwd/overviews` so the id doesn't have to be entered by hand.