### PR TITLE
feat(connectors): follower UX — surface empty-follow as unhealthy + auto-discover twiist patient

### DIFF
--- a/src/API/Nocturne.API/Services/Connectors/ConnectorConfigurationService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/ConnectorConfigurationService.cs
@@ -621,6 +621,11 @@ public class ConnectorConfigurationService : IConnectorConfigurationService
                     ["x-secret"] = true
                 };
 
+                if (connectorPropAttr.Hidden)
+                {
+                    secretSchema["x-hidden"] = true;
+                }
+
                 if (!string.IsNullOrEmpty(envPrefix))
                 {
                     secretSchema["x-envVar"] = connectorPropAttr.GetFullEnvVarName(envPrefix);
@@ -809,6 +814,11 @@ public class ConnectorConfigurationService : IConnectorConfigurationService
         if (!string.IsNullOrEmpty(connectorAttr.Format))
         {
             schema["format"] = connectorAttr.Format;
+        }
+
+        if (connectorAttr.Hidden)
+        {
+            schema["x-hidden"] = true;
         }
 
         return schema;

--- a/src/Connectors/Nocturne.Connectors.Core/Extensions/ConnectorPropertyAttribute.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Extensions/ConnectorPropertyAttribute.cs
@@ -56,6 +56,13 @@ public class ConnectorPropertyAttribute : Attribute
     public bool Secret { get; set; }
 
     /// <summary>
+    ///     Whether this property is hidden from the configuration UI. Hidden properties are still
+    ///     bound from config and usable as an advanced override, but are not rendered as a form
+    ///     field — used for values the connector derives automatically (e.g. an auto-discovered id).
+    /// </summary>
+    public bool Hidden { get; set; }
+
+    /// <summary>
     ///     Default value if not specified in configuration.
     /// </summary>
     public string? DefaultValue { get; set; }

--- a/src/Connectors/Nocturne.Connectors.Eversense/Services/EversenseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Eversense/Services/EversenseConnectorService.cs
@@ -93,10 +93,45 @@ public class EversenseConnectorService : BaseConnectorService<EversenseConnector
 
         try
         {
-            var patient = await FetchSelectedPatientAsync(config, cancellationToken);
+            var patients = await FetchPatientListAsync(config, cancellationToken);
+
+            if (patients == null)
+            {
+                // Token acquisition or the API call failed (already tracked). Surface as unhealthy
+                // so the failure is visible rather than looking like a successful empty sync.
+                result.Success = false;
+                result.Errors.Add(
+                    "Could not reach Eversense. Check the Eversense account email and password, then sync again.");
+                result.EndTime = DateTimeOffset.UtcNow;
+                return result;
+            }
+
+            if (patients.Count == 0)
+            {
+                result.Success = false;
+                result.Errors.Add(
+                    "Connected to Eversense, but this account is not following anyone in Eversense NOW. " +
+                    "In the Eversense NOW app, have the sensor wearer invite this account as a follower and " +
+                    "accept the invite, then sync again.");
+                result.EndTime = DateTimeOffset.UtcNow;
+                return result;
+            }
+
+            _logger.LogInformation(
+                "[{ConnectorSource}] Retrieved {Count} patient(s) from Eversense",
+                ConnectorSource,
+                patients.Count);
+
+            var patient = SelectPatient(patients, config.PatientUsername);
 
             if (patient == null)
             {
+                // Multiple followed patients and none matched the configured username.
+                result.Success = false;
+                result.Errors.Add(
+                    "This Eversense account follows multiple people (" +
+                    string.Join(", ", patients.Select(p => p.UserName)) +
+                    "). Set the patient username to the one you want to sync, then sync again.");
                 result.EndTime = DateTimeOffset.UtcNow;
                 return result;
             }
@@ -149,39 +184,6 @@ public class EversenseConnectorService : BaseConnectorService<EversenseConnector
 
         result.EndTime = DateTimeOffset.UtcNow;
         return result;
-    }
-
-    /// <summary>
-    ///     Fetches the patient list from the Eversense data API and selects the configured patient.
-    /// </summary>
-    private async Task<EversensePatientDatum?> FetchSelectedPatientAsync(
-        EversenseConnectorConfiguration config,
-        CancellationToken cancellationToken)
-    {
-        var patients = await FetchPatientListAsync(config, cancellationToken);
-        if (patients == null || patients.Count == 0)
-        {
-            _logger.LogWarning("[{ConnectorSource}] No patients returned from Eversense API", ConnectorSource);
-            return null;
-        }
-
-        _logger.LogInformation(
-            "[{ConnectorSource}] Retrieved {Count} patient(s) from Eversense",
-            ConnectorSource,
-            patients.Count);
-
-        var selected = SelectPatient(patients, config.PatientUsername);
-
-        if (selected == null && patients.Count > 1)
-        {
-            _logger.LogWarning(
-                "[{ConnectorSource}] Multiple patients found but no PatientUsername configured or no match. " +
-                "Available patients: {Patients}",
-                ConnectorSource,
-                string.Join(", ", patients.Select(p => p.UserName)));
-        }
-
-        return selected;
     }
 
     /// <summary>

--- a/src/Connectors/Nocturne.Connectors.Twiist/Configurations/TwiistConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.Twiist/Configurations/TwiistConnectorConfiguration.cs
@@ -42,11 +42,13 @@ public class TwiistConnectorConfiguration : BaseConnectorConfiguration
 
     /// <summary>
     /// The PWD (person with diabetes) UUID v4 to follow, used as the path segment in
-    /// /pwd/{id}/package. Found via the follower overviews endpoint (the pwdId field).
+    /// /pwd/{id}/package. Auto-discovered from the follower overviews endpoint when left blank
+    /// (the common single-follow case), so it is hidden from the UI and optional. A value can
+    /// still be set as an advanced override when an account follows more than one person.
     /// Named to match its <see cref="ConnectorPropertyKey.PatientId"/> config key: the binder
     /// resolves JSON keys from the camel-cased property name, so the name must match the key
     /// or the persisted value never binds.
     /// </summary>
-    [ConnectorProperty(ConnectorPropertyKey.PatientId, Required = true)]
+    [ConnectorProperty(ConnectorPropertyKey.PatientId, Hidden = true)]
     public string PatientId { get; init; } = string.Empty;
 }

--- a/src/Connectors/Nocturne.Connectors.Twiist/Configurations/TwiistConstants.cs
+++ b/src/Connectors/Nocturne.Connectors.Twiist/Configurations/TwiistConstants.cs
@@ -12,6 +12,12 @@ public static class TwiistConstants
     public const string FollowerServiceBaseUrl = "https://follower-service.mytwiistportal.com";
 
     /// <summary>
+    /// Endpoint listing the PWDs (people with diabetes) this follower account can see,
+    /// each with its pwdId. Used to auto-discover the patient id.
+    /// </summary>
+    public const string OverviewsPath = "/pwd/overviews";
+
+    /// <summary>
     /// User-Agent string mimicking the Twiist Insight iOS app.
     /// </summary>
     public const string UserAgent = "twiist insiight/1.0.2 CFNetwork/1568.100.1.2.3 Darwin/24.0.0";

--- a/src/Connectors/Nocturne.Connectors.Twiist/Models/TwiistOverview.cs
+++ b/src/Connectors/Nocturne.Connectors.Twiist/Models/TwiistOverview.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace Nocturne.Connectors.Twiist.Models;
+
+/// <summary>
+/// An entry from the Twiist follower overviews endpoint (/pwd/overviews): one PWD (person with
+/// diabetes) the authenticated follower account can see, with the id used by /pwd/{id}/package.
+/// </summary>
+public class TwiistOverview
+{
+    [JsonPropertyName("pwdId")]
+    public string? PwdId { get; set; }
+
+    [JsonPropertyName("pwdNickname")]
+    public string? PwdNickname { get; set; }
+}

--- a/src/Connectors/Nocturne.Connectors.Twiist/Services/TwiistConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Twiist/Services/TwiistConnectorService.cs
@@ -67,11 +67,24 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
 
         try
         {
-            var package = await FetchPackageAsync(config, cancellationToken);
+            var (pwdId, resolveError) = await ResolvePatientIdAsync(config, cancellationToken);
+            if (pwdId == null)
+            {
+                result.Success = false;
+                result.Errors.Add(resolveError!);
+                result.EndTime = DateTimeOffset.UtcNow;
+                return result;
+            }
+
+            var package = await FetchPackageAsync(pwdId, config, cancellationToken);
             if (package?.Status == null)
             {
                 _logger.LogWarning("[{Source}] Twiist returned empty package for PWD {PwdId}",
-                    ConnectorSource, config.PatientId);
+                    ConnectorSource, pwdId);
+                result.Success = false;
+                result.Errors.Add(
+                    "Connected to Twiist, but no data was returned for the followed patient. " +
+                    "If this persists, confirm the Twiist app is set up and sharing data.");
                 result.EndTime = DateTimeOffset.UtcNow;
                 return result;
             }
@@ -202,8 +215,99 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
         }
     }
 
-    private async Task<TwiistPackage?> FetchPackageAsync(
+    /// <summary>
+    /// Resolves the PWD id to follow. Uses the configured id when present (advanced override),
+    /// otherwise auto-discovers it from the follower overviews endpoint. Returns an instructive
+    /// error message (for the connector health state) when no single patient can be determined.
+    /// </summary>
+    private async Task<(string? PwdId, string? Error)> ResolvePatientIdAsync(
         TwiistConnectorConfiguration config, CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(config.PatientId))
+            return (config.PatientId, null);
+
+        var overviews = await FetchOverviewsAsync(config, cancellationToken);
+
+        if (overviews == null)
+            return (null, "Could not reach Twiist. Check the Twiist account email and password, then sync again.");
+
+        if (overviews.Count == 0)
+            return (null,
+                "Connected to Twiist, but this account is not following anyone. In the Twiist app, " +
+                "share data with this account (or sign in with the account the data is shared with), then sync again.");
+
+        var withId = overviews.Where(o => !string.IsNullOrWhiteSpace(o.PwdId)).ToList();
+
+        if (withId.Count == 1)
+        {
+            _logger.LogInformation("[{Source}] Auto-discovered Twiist patient from overviews", ConnectorSource);
+            return (withId[0].PwdId, null);
+        }
+
+        if (withId.Count == 0)
+            return (null,
+                "Connected to Twiist, but no shared patient id was returned. Confirm data sharing is active in the Twiist app, then sync again.");
+
+        // More than one followed patient: we can't pick automatically.
+        var names = string.Join(", ", withId.Select(o => o.PwdNickname ?? o.PwdId));
+        return (null,
+            $"This Twiist account follows multiple people ({names}). Following more than one person isn't supported yet.");
+    }
+
+    private async Task<List<TwiistOverview>?> FetchOverviewsAsync(
+        TwiistConnectorConfiguration config, CancellationToken cancellationToken)
+    {
+        var accessToken = await _tokenProvider.GetValidTokenAsync(config, cancellationToken);
+        if (string.IsNullOrEmpty(accessToken))
+        {
+            _logger.LogWarning("[{Source}] Failed to get valid token for overviews fetch", ConnectorSource);
+            TrackFailedRequest("Failed to get valid token");
+            return null;
+        }
+
+        await _rateLimitingStrategy.ApplyDelayAsync(0);
+
+        return await ExecuteWithRetryAsync(
+            async () => await FetchOverviewsCoreAsync(accessToken, cancellationToken),
+            _retryDelayStrategy,
+            async () =>
+            {
+                _tokenProvider.InvalidateToken();
+                var newToken = await _tokenProvider.GetValidTokenAsync(config, cancellationToken);
+                if (string.IsNullOrEmpty(newToken)) return false;
+                accessToken = newToken;
+                return true;
+            },
+            maxRetries: config.MaxRetryAttempts,
+            operationName: "FetchTwiistOverviews");
+    }
+
+    private async Task<List<TwiistOverview>?> FetchOverviewsCoreAsync(
+        string accessToken, CancellationToken cancellationToken)
+    {
+        var url = $"{TwiistConstants.FollowerServiceBaseUrl}{TwiistConstants.OverviewsPath}";
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("*/*"));
+        request.Headers.Add("User-Agent", TwiistConstants.UserAgent);
+
+        var response = await _httpClient.SendAsync(request, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorContent = await response.Content.ReadAsStringAsync(cancellationToken);
+            throw new HttpRequestException(
+                $"HTTP {(int)response.StatusCode} {response.StatusCode}: {errorContent}",
+                null,
+                response.StatusCode);
+        }
+
+        return await DeserializeResponseAsync<List<TwiistOverview>>(response) ?? [];
+    }
+
+    private async Task<TwiistPackage?> FetchPackageAsync(
+        string pwdId, TwiistConnectorConfiguration config, CancellationToken cancellationToken)
     {
         var accessToken = await _tokenProvider.GetValidTokenAsync(config, cancellationToken);
         if (string.IsNullOrEmpty(accessToken))
@@ -216,7 +320,7 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
         await _rateLimitingStrategy.ApplyDelayAsync(0);
 
         var result = await ExecuteWithRetryAsync(
-            async () => await FetchPackageCoreAsync(accessToken, config.PatientId, cancellationToken),
+            async () => await FetchPackageCoreAsync(accessToken, pwdId, cancellationToken),
             _retryDelayStrategy,
             async () =>
             {

--- a/src/Web/packages/app/src/lib/components/settings/ConnectorConfigForm.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/ConnectorConfigForm.svelte
@@ -125,6 +125,9 @@
       // Skip secret fields - they're handled separately
       if (secretFieldSet.has(propName)) continue;
 
+      // Skip hidden fields - connector derives these automatically
+      if (propSchema["x-hidden"] === true) continue;
+
       // Skip 'enabled' field - it's controlled by the "Enable Connector" toggle
       if (propName.toLowerCase() === "enabled") continue;
 
@@ -166,7 +169,7 @@
         name,
         schema: schema.properties[name],
       }))
-      .filter((s) => s.schema);
+      .filter((s) => s.schema && s.schema["x-hidden"] !== true);
   });
 
   // Get non-secret fields in the Credentials category
@@ -174,8 +177,10 @@
     const secretFieldSet = new Set(schema.secrets ?? []);
     return Object.entries(schema.properties)
       .filter(
-        ([name]) =>
-          getPropertyMeta(name).category === "Credentials" && !secretFieldSet.has(name)
+        ([name, propSchema]) =>
+          getPropertyMeta(name).category === "Credentials" &&
+          !secretFieldSet.has(name) &&
+          propSchema["x-hidden"] !== true
       )
       .map(([name, schema]) => ({ name, schema }));
   });

--- a/src/Web/packages/app/src/lib/utils/connector-json-schema.ts
+++ b/src/Web/packages/app/src/lib/utils/connector-json-schema.ts
@@ -14,6 +14,10 @@ export interface JsonSchemaProperty {
   "x-envVar"?: string;
   /** Category for UI grouping (x-category extension) */
   "x-category"?: string;
+  /** Whether this property is hidden from the UI (x-hidden extension) */
+  "x-hidden"?: boolean;
+  /** Whether this property holds a secret (x-secret extension) */
+  "x-secret"?: boolean;
 }
 
 export interface JsonSchema {

--- a/tests/Unit/Nocturne.Connectors.Eversense.Tests/Services/EversenseConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Eversense.Tests/Services/EversenseConnectorServiceTests.cs
@@ -215,7 +215,7 @@ public class EversenseConnectorServiceTests
     }
 
     [Fact]
-    public async Task SyncDataAsync_EmptyPatientList_SkipsPublish()
+    public async Task SyncDataAsync_EmptyPatientList_ReportsUnhealthyWithGuidance()
     {
         // Arrange
         var publisherMock = new Mock<IConnectorPublisher>();
@@ -234,8 +234,11 @@ public class EversenseConnectorServiceTests
         // Act
         var result = await fixture.Service.SyncDataAsync(request, fixture.Config, CancellationToken.None);
 
-        // Assert
-        result.Success.Should().BeTrue();
+        // Assert — empty follow list is a setup problem, surfaced as unhealthy with instructions
+        // rather than a silent successful empty sync.
+        result.Success.Should().BeFalse();
+        result.Errors.Should().ContainSingle()
+            .Which.Should().Contain("not following anyone");
 
         publisherMock.Verify(p => p.Glucose.PublishSensorGlucoseAsync(
             It.IsAny<IEnumerable<SensorGlucose>>(),
@@ -244,7 +247,7 @@ public class EversenseConnectorServiceTests
     }
 
     [Fact]
-    public async Task SyncDataAsync_MultiplePatientsWithoutConfiguredUsername_SkipsPublishAndLogs()
+    public async Task SyncDataAsync_MultiplePatientsWithoutConfiguredUsername_ReportsUnhealthyWithNames()
     {
         // Arrange
         var patients = new List<EversensePatientDatum>
@@ -272,8 +275,6 @@ public class EversenseConnectorServiceTests
         var publisherMock = new Mock<IConnectorPublisher>();
         publisherMock.Setup(p => p.IsAvailable).Returns(true);
 
-        var loggerMock = new Mock<ILogger<EversenseConnectorService>>();
-
         var fixture = new ServiceFixture(
             tokenToReturn: "valid-token",
             httpResponses: new Dictionary<string, HttpResponseMessage>
@@ -281,7 +282,6 @@ public class EversenseConnectorServiceTests
                 [EversenseConstants.Endpoints.GetFollowingPatientList] = CreateJsonResponse(patients)
             },
             publisher: publisherMock.Object,
-            serviceLogger: loggerMock.Object,
             patientUsername: null); // No patient username configured
 
         var request = new SyncRequest { DataTypes = [SyncDataType.Glucose] };
@@ -289,23 +289,16 @@ public class EversenseConnectorServiceTests
         // Act
         var result = await fixture.Service.SyncDataAsync(request, fixture.Config, CancellationToken.None);
 
-        // Assert
-        result.Success.Should().BeTrue();
+        // Assert — ambiguous selection is surfaced as unhealthy, naming the available patients
+        // so the user knows which username to configure.
+        result.Success.Should().BeFalse();
+        result.Errors.Should().ContainSingle()
+            .Which.Should().Contain("alice@example.com").And.Contain("bob@example.com");
 
         publisherMock.Verify(p => p.Glucose.PublishSensorGlucoseAsync(
             It.IsAny<IEnumerable<SensorGlucose>>(),
             It.IsAny<string>(),
             It.IsAny<CancellationToken>()), Times.Never);
-
-        // Verify a warning was logged about multiple patients
-        loggerMock.Verify(
-            x => x.Log(
-                LogLevel.Warning,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Multiple patients")),
-                It.IsAny<Exception?>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 
     #endregion

--- a/tests/Unit/Nocturne.Connectors.Twiist.Tests/Services/TwiistConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Twiist.Tests/Services/TwiistConnectorServiceTests.cs
@@ -1,0 +1,188 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.Twiist.Configurations;
+using Nocturne.Connectors.Twiist.Models;
+using Nocturne.Connectors.Twiist.Services;
+using Nocturne.Core.Contracts.Multitenancy;
+using Xunit;
+
+namespace Nocturne.Connectors.Twiist.Tests.Services;
+
+public class TwiistConnectorServiceTests
+{
+    private const string PwdId = "7c4a6533-b8db-4cc4-823e-6ac9c99e07e5";
+
+    [Fact]
+    public async Task SyncDataAsync_AutoDiscoversSinglePatient_FetchesThatPackage()
+    {
+        var overviews = new List<TwiistOverview> { new() { PwdId = PwdId, PwdNickname = "Pat" } };
+        var fixture = new ServiceFixture(responses: new()
+        {
+            [TwiistConstants.OverviewsPath] = Json(overviews),
+            ["/package"] = Json(new TwiistPackage { PwdId = PwdId, Status = new TwiistStatus() })
+        });
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] }, fixture.Config, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        // The package was fetched for the auto-discovered id, not an empty path.
+        fixture.RequestedPaths.Should().Contain(p => p.Contains($"/pwd/{PwdId}/package"));
+    }
+
+    [Fact]
+    public async Task SyncDataAsync_NoFollowedPatients_ReportsUnhealthyWithGuidance()
+    {
+        var fixture = new ServiceFixture(responses: new()
+        {
+            [TwiistConstants.OverviewsPath] = Json(new List<TwiistOverview>())
+        });
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] }, fixture.Config, CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Errors.Should().ContainSingle().Which.Should().Contain("not following anyone");
+    }
+
+    [Fact]
+    public async Task SyncDataAsync_MultipleFollowedPatients_ReportsUnhealthyWithNames()
+    {
+        var overviews = new List<TwiistOverview>
+        {
+            new() { PwdId = PwdId, PwdNickname = "Pat" },
+            new() { PwdId = "11111111-2222-3333-4444-555555555555", PwdNickname = "Sam" }
+        };
+        var fixture = new ServiceFixture(responses: new()
+        {
+            [TwiistConstants.OverviewsPath] = Json(overviews)
+        });
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] }, fixture.Config, CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Errors.Should().ContainSingle()
+            .Which.Should().Contain("Pat").And.Contain("Sam");
+    }
+
+    [Fact]
+    public async Task SyncDataAsync_ConfiguredPatientId_SkipsOverviewDiscovery()
+    {
+        var fixture = new ServiceFixture(
+            responses: new()
+            {
+                ["/package"] = Json(new TwiistPackage { PwdId = PwdId, Status = new TwiistStatus() })
+            },
+            patientId: PwdId);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] }, fixture.Config, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        fixture.RequestedPaths.Should().NotContain(p => p.Contains(TwiistConstants.OverviewsPath));
+        fixture.RequestedPaths.Should().Contain(p => p.Contains($"/pwd/{PwdId}/package"));
+    }
+
+    [Fact]
+    public async Task SyncDataAsync_PackageNotFound_ReportsUnhealthy()
+    {
+        var overviews = new List<TwiistOverview> { new() { PwdId = PwdId, PwdNickname = "Pat" } };
+        var fixture = new ServiceFixture(responses: new()
+        {
+            [TwiistConstants.OverviewsPath] = Json(overviews),
+            ["/package"] = new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent("{\"message\":\"Validation failed (uuid v 4 is expected)\"}")
+            }
+        });
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] }, fixture.Config, CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Errors.Should().ContainSingle().Which.Should().Contain("no data");
+    }
+
+    private static HttpResponseMessage Json<T>(T content) => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, "application/json")
+    };
+
+    private sealed class FakeTwiistAuthTokenProvider(string? token) : TwiistAuthTokenProvider(
+        new HttpClient(),
+        new ConnectorTokenCache(),
+        new ConnectorServerResolver<TwiistConnectorConfiguration>(null, null, null),
+        new FakeTenantAccessor(),
+        NullLogger<TwiistAuthTokenProvider>.Instance,
+        Mock.Of<IRetryDelayStrategy>())
+    {
+        protected override Task<(string? Token, DateTime ExpiresAt, IReadOnlyDictionary<string, string>? Metadata)> AcquireTokenAsync(
+            TwiistConnectorConfiguration config, CancellationToken cancellationToken) =>
+            Task.FromResult<(string?, DateTime, IReadOnlyDictionary<string, string>?)>(
+                token is null ? (null, DateTime.MinValue, null) : (token, DateTime.UtcNow.AddHours(1), null));
+
+        private sealed class FakeTenantAccessor : ITenantAccessor
+        {
+            public bool IsResolved => true;
+            public Guid TenantId => Guid.Empty;
+            public TenantContext? Context => null;
+            public void SetTenant(TenantContext context) { }
+        }
+    }
+
+    private sealed class CapturingHandler(Dictionary<string, HttpResponseMessage> responses, List<string> requested)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri?.PathAndQuery ?? string.Empty;
+            requested.Add(path);
+            foreach (var (key, response) in responses)
+                if (path.Contains(key, StringComparison.OrdinalIgnoreCase))
+                    return Task.FromResult(response);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+    }
+
+    private sealed class ServiceFixture
+    {
+        public TwiistConnectorService Service { get; }
+        public TwiistConnectorConfiguration Config { get; }
+        public List<string> RequestedPaths { get; } = [];
+
+        public ServiceFixture(
+            Dictionary<string, HttpResponseMessage> responses,
+            string? token = "valid-token",
+            string patientId = "")
+        {
+            Config = new TwiistConnectorConfiguration
+            {
+                Username = "follower@example.com",
+                Password = "pw",
+                PatientId = patientId
+            };
+
+            var httpClient = new HttpClient(new CapturingHandler(responses, RequestedPaths));
+            var publisher = new Mock<IConnectorPublisher>();
+            publisher.Setup(p => p.IsAvailable).Returns(true);
+
+            Service = new TwiistConnectorService(
+                httpClient,
+                new ConnectorServerResolver<TwiistConnectorConfiguration>(null, null, null),
+                NullLogger<TwiistConnectorService>.Instance,
+                Mock.Of<IRetryDelayStrategy>(),
+                Mock.Of<IRateLimitingStrategy>(),
+                new FakeTwiistAuthTokenProvider(token),
+                publisher.Object);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Follower-style connectors (Eversense, Twiist) authenticate fine but return no data when the account follows nobody — yet they reported a **healthy, 0-item sync**, which is indistinguishable from "connected and working" in the UI. Twiist additionally required the user to hand-enter the followed person's raw **PWD UUID v4**, with no way to discover it in-product.

## Changes

### Surface empty-follow as unhealthy (both connectors)
A sync that can't determine a patient now sets `Success=false` with an instructive message (which becomes `last_error_message` and shows in the UI), instead of a silent successful empty sync.

- **Eversense**: empty following-patient list → message explaining how to invite/accept a follower in Eversense NOW; multiple followed patients with no match → message naming them and asking which username to set; auth/fetch failure → surfaced rather than treated as "no patients".
- **Twiist**: empty/unreachable/multiple → instructive messages; an empty data package is no longer reported as success.

### Twiist patient auto-discovery + hidden field
- Auto-discover the PWD id from the follower **overviews** endpoint (`/pwd/overviews`, `pwdId` field) when none is configured — the common single-follow case. The user no longer needs the UUID.
- `PatientId` is now **optional** and **hidden** from the UI, kept as an advanced override for accounts that follow more than one person.

### Generic hidden-property support
- New `Hidden` flag on `ConnectorPropertyAttribute`, emitted as `x-hidden` in the generated config schema (alongside `x-secret`).
- The connector config form (`ConnectorConfigForm.svelte`) skips `x-hidden` properties in all three field groups. Hidden properties still bind from config.

## Tests
- New `TwiistConnectorServiceTests`: auto-discovers single patient and fetches that package; empty / multiple / not-found report unhealthy; a configured id skips discovery.
- Updated `EversenseConnectorServiceTests`: empty list and ambiguous-multiple now assert the unhealthy paths and messages.
- Existing Core + binding/convention guard tests still pass (Core 42, Eversense 24, Twiist 7).

Frontend type-check is clean for the edited files (remaining svelte-check errors are pre-existing stale generated-client noise, regenerated by CI).