### PR TITLE
fix(connectors): add Twiist background sync service

### DIFF
--- a/src/API/Nocturne.API/Services/BackgroundServices/TwiistConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/TwiistConnectorBackgroundService.cs
@@ -1,0 +1,30 @@
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Twiist.Configurations;
+using Nocturne.Connectors.Twiist.Services;
+
+namespace Nocturne.API.Services.BackgroundServices;
+
+/// <summary>
+/// Background service that periodically syncs data from the Twiist Insight follower API via
+/// <see cref="TwiistConnectorService"/>.
+/// </summary>
+/// <seealso cref="ConnectorBackgroundService{TConfig}"/>
+public class TwiistConnectorBackgroundService : ConnectorBackgroundService<TwiistConnectorConfiguration>
+{
+    /// <param name="serviceProvider">Service provider used to create a DI scope per sync cycle.</param>
+    /// <param name="logger">Logger instance for this background service.</param>
+    public TwiistConnectorBackgroundService(
+        IServiceProvider serviceProvider,
+        ILogger<TwiistConnectorBackgroundService> logger
+    )
+        : base(serviceProvider, logger) { }
+
+    protected override string ConnectorName => "Twiist";
+
+    protected override async Task<SyncResult> PerformSyncAsync(IServiceProvider scopeProvider, TwiistConnectorConfiguration config, CancellationToken cancellationToken, ISyncProgressReporter? progressReporter = null)
+    {
+        var connectorService = scopeProvider.GetRequiredService<TwiistConnectorService>();
+        return await connectorService.SyncDataAsync(config, cancellationToken, since: null, progressReporter);
+    }
+}


### PR DESCRIPTION
## Problem

Twiist never synced automatically. Every other connector has a `ConnectorBackgroundService<TConfig>` in the API assembly — that's what auto-registers and runs the periodic per-tenant sync. Twiist (added in #162) was missing one, so it only synced when a user clicked **Sync now**; `last_sync_attempt` stayed null and no data ever flowed on its own.

## Fix

Add `TwiistConnectorBackgroundService`, mirroring the existing connector background services (e.g. `EversenseConnectorBackgroundService`), so Twiist polls on its configured interval like every other connector. It's auto-discovered by the assembly-scanning registration in `AddConnectors`.

## Follow-up idea

A guard test asserting every `[ConnectorRegistration]` config has a matching background service would prevent this whole class of omission — noted for a follow-up.