### PR TITLE
feat(connectors): sync Twiist basal (temp basals from insulin-delivery blob)

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Twiist/Configurations/TwiistConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.Twiist/Configurations/TwiistConnectorConfiguration.cs
@@ -19,7 +19,7 @@ namespace Nocturne.Connectors.Twiist.Configurations;
     "Twiist Insight",
     SupportsHistoricalSync = false,
     SupportsManualSync = true,
-    SupportedDataTypes = [SyncDataType.Glucose, SyncDataType.Boluses, SyncDataType.CarbIntake]
+    SupportedDataTypes = [SyncDataType.Glucose, SyncDataType.Boluses, SyncDataType.CarbIntake, SyncDataType.TempBasals]
 )]
 public class TwiistConnectorConfiguration : BaseConnectorConfiguration
 {

--- a/src/Connectors/Nocturne.Connectors.Twiist/Mappers/TwiistTempBasalMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Twiist/Mappers/TwiistTempBasalMapper.cs
@@ -1,0 +1,71 @@
+using System.Globalization;
+using Microsoft.Extensions.Logging;
+using Nocturne.Connectors.Twiist.Utilities;
+using Nocturne.Core.Constants;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.Connectors.Twiist.Mappers;
+
+/// <summary>
+/// Maps the Twiist insulin-delivery blob to V4 TempBasal records.
+/// Each blob record is a delivery interval carrying the deviation from the scheduled basal rate;
+/// the absolute rate is the scheduled rate plus that delta. Twiist is a closed-loop system, so
+/// records originate from the loop algorithm (or a suspension when the rate is zero).
+/// </summary>
+public class TwiistTempBasalMapper(ILogger logger)
+{
+    private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    /// <summary>
+    /// Maps insulin-delivery records to TempBasal records using the scheduled basal rate to convert
+    /// each interval's delta into an absolute rate.
+    /// </summary>
+    public IEnumerable<TempBasal> MapTempBasals(string? insulinDeliveryBlob, double scheduledRate)
+    {
+        var records = TwiistBlobDecoder.ParseInsulinDeliveryRecords(insulinDeliveryBlob);
+        if (records.Count == 0)
+            return [];
+
+        var now = DateTime.UtcNow;
+
+        return records
+            .Where(r => r.End > r.Start)
+            .Select(r =>
+            {
+                var rate = Math.Max(0, scheduledRate + r.DeltaUhr);
+                return new TempBasal
+                {
+                    Id = Guid.CreateVersion7(),
+                    StartTimestamp = r.Start,
+                    EndTimestamp = r.End,
+                    Rate = rate,
+                    ScheduledRate = scheduledRate,
+                    Origin = rate < 0.0005 ? TempBasalOrigin.Suspended : TempBasalOrigin.Algorithm,
+                    Device = DataSources.TwiistConnector,
+                    DataSource = DataSources.TwiistConnector,
+                    LegacyId = $"twiist_tempbasal_{r.Start.Ticks}",
+                    CreatedAt = now,
+                    ModifiedAt = now
+                };
+            })
+            .OrderBy(t => t.StartTimestamp)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Parses the scheduled basal rate from the package details. The follower API returns it as a
+    /// stringified number; returns 0 when absent or unparseable (deltas then map to absolute rate
+    /// directly, clamped at zero).
+    /// </summary>
+    public double ParseScheduledRate(string? basalRateUnitsPerHour)
+    {
+        if (string.IsNullOrWhiteSpace(basalRateUnitsPerHour))
+            return 0;
+
+        if (double.TryParse(basalRateUnitsPerHour, NumberStyles.Float, CultureInfo.InvariantCulture, out var rate))
+            return rate;
+
+        _logger.LogWarning("[twiist] Could not parse scheduled basal rate '{Value}'", basalRateUnitsPerHour);
+        return 0;
+    }
+}

--- a/src/Connectors/Nocturne.Connectors.Twiist/Models/TwiistPackage.cs
+++ b/src/Connectors/Nocturne.Connectors.Twiist/Models/TwiistPackage.cs
@@ -105,6 +105,13 @@ public class TwiistDetails
 
     [JsonPropertyName("scheduledBasalRate")]
     public decimal? ScheduledBasalRate { get; set; }
+
+    /// <summary>
+    /// Current scheduled basal rate in U/hr. The follower API returns this as a stringified
+    /// number under "basalRate_UnitsPerHour"; insulin-delivery blob records are deltas from it.
+    /// </summary>
+    [JsonPropertyName("basalRate_UnitsPerHour")]
+    public string? BasalRateUnitsPerHour { get; set; }
 }
 
 public class TwiistLoopAlgorithm

--- a/src/Connectors/Nocturne.Connectors.Twiist/Services/TwiistConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Twiist/Services/TwiistConnectorService.cs
@@ -21,6 +21,7 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
     private readonly TwiistGlucoseMapper _glucoseMapper;
     private readonly TwiistInsulinMapper _insulinMapper;
     private readonly TwiistMealMapper _mealMapper;
+    private readonly TwiistTempBasalMapper _tempBasalMapper;
     private readonly IRateLimitingStrategy _rateLimitingStrategy;
     private readonly IRetryDelayStrategy _retryDelayStrategy;
     private readonly TwiistAuthTokenProvider _tokenProvider;
@@ -41,13 +42,14 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
         _glucoseMapper = new TwiistGlucoseMapper(logger);
         _insulinMapper = new TwiistInsulinMapper(logger);
         _mealMapper = new TwiistMealMapper(logger);
+        _tempBasalMapper = new TwiistTempBasalMapper(logger);
     }
 
     protected override string ConnectorSource => DataSources.TwiistConnector;
     public override string ServiceName => "Twiist Insight";
 
     public override List<SyncDataType> SupportedDataTypes =>
-        [SyncDataType.Glucose, SyncDataType.Boluses, SyncDataType.CarbIntake];
+        [SyncDataType.Glucose, SyncDataType.Boluses, SyncDataType.CarbIntake, SyncDataType.TempBasals];
 
     public override Task<bool> AuthenticateAsync()
     {
@@ -105,6 +107,12 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
             if (enabledTypes.Contains(SyncDataType.CarbIntake))
             {
                 await SyncCarbIntakeAsync(package.Status, result, config, cancellationToken);
+            }
+
+            // Temp basals from the insulin-delivery blob (closed-loop enacted rates)
+            if (enabledTypes.Contains(SyncDataType.TempBasals))
+            {
+                await SyncTempBasalsAsync(package.Status, result, config, cancellationToken);
             }
         }
         catch (OperationCanceledException)
@@ -212,6 +220,30 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
         {
             _logger.LogInformation("[{Source}] Synced {Count} meal records from Twiist",
                 ConnectorSource, carbs.Count);
+        }
+    }
+
+    private async Task SyncTempBasalsAsync(
+        TwiistStatus status, SyncResult result,
+        TwiistConnectorConfiguration config, CancellationToken cancellationToken)
+    {
+        var scheduledRate = _tempBasalMapper.ParseScheduledRate(status.Details?.BasalRateUnitsPerHour);
+        var tempBasals = _tempBasalMapper.MapTempBasals(status.InsulinDelivery?.Data, scheduledRate).ToList();
+        if (tempBasals.Count == 0) return;
+
+        var success = await PublishTempBasalDataAsync(tempBasals, config, cancellationToken);
+        result.ItemsSynced[SyncDataType.TempBasals] = tempBasals.Count;
+        result.LastEntryTimes[SyncDataType.TempBasals] = tempBasals.Max(t => t.StartTimestamp);
+
+        if (!success)
+        {
+            result.Success = false;
+            result.Errors.Add("TempBasal publish failed");
+        }
+        else
+        {
+            _logger.LogInformation("[{Source}] Synced {Count} temp basal records from Twiist",
+                ConnectorSource, tempBasals.Count);
         }
     }
 

--- a/tests/Unit/Nocturne.Connectors.Twiist.Tests/Mappers/TwiistTempBasalMapperTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Twiist.Tests/Mappers/TwiistTempBasalMapperTests.cs
@@ -1,0 +1,81 @@
+using System.Buffers.Binary;
+using System.IO.Compression;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Connectors.Twiist.Configurations;
+using Nocturne.Connectors.Twiist.Mappers;
+using Nocturne.Core.Models.V4;
+using Xunit;
+
+namespace Nocturne.Connectors.Twiist.Tests.Mappers;
+
+public class TwiistTempBasalMapperTests
+{
+    private readonly TwiistTempBasalMapper _mapper = new(NullLogger.Instance);
+
+    [Fact]
+    public void MapTempBasals_ConvertsDeltasToAbsoluteRates_AndTagsOrigin()
+    {
+        // Two 5-minute intervals: +0.97 above scheduled, and a full suspension (-0.40 == -scheduled).
+        var start1 = new DateTime(2026, 6, 16, 22, 42, 0, DateTimeKind.Utc);
+        var start2 = start1.AddMinutes(5);
+        var blob = BuildBlob(
+            (start1, start1.AddMinutes(5), 0.97),
+            (start2, start2.AddMinutes(5), -0.40));
+
+        var result = _mapper.MapTempBasals(blob, scheduledRate: 0.40).ToList();
+
+        result.Should().HaveCount(2);
+
+        result[0].Rate.Should().BeApproximately(1.37, 0.001);
+        result[0].ScheduledRate.Should().Be(0.40);
+        result[0].Origin.Should().Be(TempBasalOrigin.Algorithm);
+        result[0].StartTimestamp.Should().Be(start1);
+        result[0].EndTimestamp.Should().Be(start1.AddMinutes(5));
+
+        result[1].Rate.Should().BeApproximately(0.0, 0.001);
+        result[1].Origin.Should().Be(TempBasalOrigin.Suspended);
+    }
+
+    [Fact]
+    public void MapTempBasals_EmptyBlob_ReturnsEmpty()
+    {
+        _mapper.MapTempBasals(null, 0.4).Should().BeEmpty();
+        _mapper.MapTempBasals("", 0.4).Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("0.4", 0.4)]
+    [InlineData("1.25", 1.25)]
+    [InlineData(null, 0.0)]
+    [InlineData("", 0.0)]
+    [InlineData("not-a-number", 0.0)]
+    public void ParseScheduledRate_HandlesStringifiedNumbersAndJunk(string? input, double expected)
+    {
+        _mapper.ParseScheduledRate(input).Should().BeApproximately(expected, 0.0001);
+    }
+
+    /// <summary>
+    /// Builds a Twiist insulin-delivery blob the way the API encodes it: raw-deflate over fixed
+    /// 10-byte little-endian records (u32 start, u32 end seconds-since-2008, i16 delta*100), base64.
+    /// </summary>
+    private static string BuildBlob(params (DateTime Start, DateTime End, double Delta)[] records)
+    {
+        var raw = new byte[records.Length * 10];
+        for (var i = 0; i < records.Length; i++)
+        {
+            var span = raw.AsSpan(i * 10);
+            BinaryPrimitives.WriteUInt32LittleEndian(span,
+                (uint)(records[i].Start - TwiistConstants.BlobEpoch).TotalSeconds);
+            BinaryPrimitives.WriteUInt32LittleEndian(span[4..],
+                (uint)(records[i].End - TwiistConstants.BlobEpoch).TotalSeconds);
+            BinaryPrimitives.WriteInt16LittleEndian(span[8..],
+                (short)Math.Round(records[i].Delta * 100));
+        }
+
+        using var output = new MemoryStream();
+        using (var deflate = new DeflateStream(output, CompressionMode.Compress, leaveOpen: true))
+            deflate.Write(raw, 0, raw.Length);
+        return Convert.ToBase64String(output.ToArray());
+    }
+}


### PR DESCRIPTION
## Problem

Twiist captured glucose, boluses and carbs but **not basal** — `temp_basals` stayed empty for every Twiist tenant. The basal data was actually available all along: `TwiistBlobDecoder.ParseInsulinDeliveryRecords` already decodes the `insulinDelivery` blob into `(start, end, delta-from-scheduled U/hr)` records, but that decoder was dead code, never wired into the sync.

## Fix

- **`TwiistTempBasalMapper`**: each insulin-delivery interval becomes a `TempBasal` with the **absolute rate** = scheduled + delta (clamped at 0), `ScheduledRate` recorded, and `Origin = Algorithm` (closed-loop) or `Suspended` when the rate is zero.
- The scheduled rate comes from `details.basalRate_UnitsPerHour` (the API returns it as a stringified number; added the correctly-keyed model property + tolerant parsing).
- Wired `SyncTempBasalsAsync` into the sync and added `TempBasals` to the connector's supported data types (service + registration), gated by the existing `SyncTempBasals` toggle.

## Verification

Decoded against live data: 56 contiguous 5-minute intervals, deltas −0.40…+0.97 over a 0.4 U/hr schedule → 0.00…1.37 U/hr absolute (max basal 2.0) — all sane, including a `delta=-0.40 → 0.00 U/hr` suspension.

## Tests

`TwiistTempBasalMapperTests`: delta→absolute conversion, origin tagging (Algorithm vs Suspended), empty blob, and scheduled-rate parsing (stringified numbers + junk). Existing Twiist tests still pass (14 total).