### PR TITLE
fix(connectors): twiist basal — Suspended only for real pump suspensions

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Twiist/Mappers/TwiistTempBasalMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Twiist/Mappers/TwiistTempBasalMapper.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using Microsoft.Extensions.Logging;
+using Nocturne.Connectors.Twiist.Models;
 using Nocturne.Connectors.Twiist.Utilities;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Models.V4;
@@ -7,10 +8,10 @@ using Nocturne.Core.Models.V4;
 namespace Nocturne.Connectors.Twiist.Mappers;
 
 /// <summary>
-/// Maps the Twiist insulin-delivery blob to V4 TempBasal records.
-/// Each blob record is a delivery interval carrying the deviation from the scheduled basal rate;
-/// the absolute rate is the scheduled rate plus that delta. Twiist is a closed-loop system, so
-/// records originate from the loop algorithm (or a suspension when the rate is zero).
+/// Maps Twiist basal data to V4 TempBasal records from two sources: the insulin-delivery blob
+/// (the loop-enacted rate each interval) and the Suspend/Resume events in the insulin history
+/// (actual pump suspensions). A zero blob rate is a loop low-temp, not a suspension — only Suspend
+/// events map to <see cref="TempBasalOrigin.Suspended"/>.
 /// </summary>
 public class TwiistTempBasalMapper(ILogger logger)
 {
@@ -18,7 +19,8 @@ public class TwiistTempBasalMapper(ILogger logger)
 
     /// <summary>
     /// Maps insulin-delivery records to TempBasal records using the scheduled basal rate to convert
-    /// each interval's delta into an absolute rate.
+    /// each interval's delta into an absolute rate. All are <see cref="TempBasalOrigin.Algorithm"/>
+    /// — a zero rate here is an algorithm low-temp, not a pump suspension.
     /// </summary>
     public IEnumerable<TempBasal> MapTempBasals(string? insulinDeliveryBlob, double scheduledRate)
     {
@@ -30,27 +32,73 @@ public class TwiistTempBasalMapper(ILogger logger)
 
         return records
             .Where(r => r.End > r.Start)
-            .Select(r =>
+            .Select(r => new TempBasal
             {
-                var rate = Math.Max(0, scheduledRate + r.DeltaUhr);
-                return new TempBasal
-                {
-                    Id = Guid.CreateVersion7(),
-                    StartTimestamp = r.Start,
-                    EndTimestamp = r.End,
-                    Rate = rate,
-                    ScheduledRate = scheduledRate,
-                    Origin = rate < 0.0005 ? TempBasalOrigin.Suspended : TempBasalOrigin.Algorithm,
-                    Device = DataSources.TwiistConnector,
-                    DataSource = DataSources.TwiistConnector,
-                    LegacyId = $"twiist_tempbasal_{r.Start.Ticks}",
-                    CreatedAt = now,
-                    ModifiedAt = now
-                };
+                Id = Guid.CreateVersion7(),
+                StartTimestamp = r.Start,
+                EndTimestamp = r.End,
+                Rate = Math.Max(0, scheduledRate + r.DeltaUhr),
+                ScheduledRate = scheduledRate,
+                Origin = TempBasalOrigin.Algorithm,
+                Device = DataSources.TwiistConnector,
+                DataSource = DataSources.TwiistConnector,
+                LegacyId = $"twiist_tempbasal_{r.Start.Ticks}",
+                CreatedAt = now,
+                ModifiedAt = now
             })
             .OrderBy(t => t.StartTimestamp)
             .ToList();
     }
+
+    /// <summary>
+    /// Maps Suspend/Resume dose events to zero-rate <see cref="TempBasalOrigin.Suspended"/> spans:
+    /// each Suspend opens a span that the next Resume closes. A Suspend with no following Resume is
+    /// still active, so its span is left open (null end).
+    /// </summary>
+    public IEnumerable<TempBasal> MapSuspensions(List<TwiistInsulinDose>? doses)
+    {
+        if (doses == null || doses.Count == 0)
+            return [];
+
+        var now = DateTime.UtcNow;
+        var spans = new List<TempBasal>();
+        DateTime? suspendStart = null;
+
+        foreach (var dose in doses
+                     .Where(d => d.StartDate != null && (IsType(d, "Suspend") || IsType(d, "Resume")))
+                     .OrderBy(d => d.StartDate!.Value))
+        {
+            if (IsType(dose, "Suspend"))
+                suspendStart ??= dose.StartDate!.Value.ToUniversalTime();
+            else if (suspendStart != null)
+            {
+                spans.Add(BuildSuspension(suspendStart.Value, dose.StartDate!.Value.ToUniversalTime(), now));
+                suspendStart = null;
+            }
+        }
+
+        if (suspendStart != null)
+            spans.Add(BuildSuspension(suspendStart.Value, null, now));
+
+        return spans;
+    }
+
+    private static bool IsType(TwiistInsulinDose dose, string type) =>
+        string.Equals(dose.DoseType, type, StringComparison.OrdinalIgnoreCase);
+
+    private static TempBasal BuildSuspension(DateTime start, DateTime? end, DateTime now) => new()
+    {
+        Id = Guid.CreateVersion7(),
+        StartTimestamp = start,
+        EndTimestamp = end,
+        Rate = 0,
+        Origin = TempBasalOrigin.Suspended,
+        Device = DataSources.TwiistConnector,
+        DataSource = DataSources.TwiistConnector,
+        LegacyId = $"twiist_suspend_{start.Ticks}",
+        CreatedAt = now,
+        ModifiedAt = now
+    };
 
     /// <summary>
     /// Parses the scheduled basal rate from the package details. The follower API returns it as a

--- a/src/Connectors/Nocturne.Connectors.Twiist/Services/TwiistConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Twiist/Services/TwiistConnectorService.cs
@@ -228,7 +228,9 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
         TwiistConnectorConfiguration config, CancellationToken cancellationToken)
     {
         var scheduledRate = _tempBasalMapper.ParseScheduledRate(status.Details?.BasalRateUnitsPerHour);
-        var tempBasals = _tempBasalMapper.MapTempBasals(status.InsulinDelivery?.Data, scheduledRate).ToList();
+        var tempBasals = _tempBasalMapper.MapTempBasals(status.InsulinDelivery?.Data, scheduledRate)
+            .Concat(_tempBasalMapper.MapSuspensions(status.InsulinHistory))
+            .ToList();
         if (tempBasals.Count == 0) return;
 
         var success = await PublishTempBasalDataAsync(tempBasals, config, cancellationToken);

--- a/tests/Unit/Nocturne.Connectors.Twiist.Tests/Mappers/TwiistTempBasalMapperTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Twiist.Tests/Mappers/TwiistTempBasalMapperTests.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Nocturne.Connectors.Twiist.Configurations;
 using Nocturne.Connectors.Twiist.Mappers;
+using Nocturne.Connectors.Twiist.Models;
 using Nocturne.Core.Models.V4;
 using Xunit;
 
@@ -14,9 +15,10 @@ public class TwiistTempBasalMapperTests
     private readonly TwiistTempBasalMapper _mapper = new(NullLogger.Instance);
 
     [Fact]
-    public void MapTempBasals_ConvertsDeltasToAbsoluteRates_AndTagsOrigin()
+    public void MapTempBasals_ConvertsDeltasToAbsoluteRates_AlwaysAlgorithmOrigin()
     {
-        // Two 5-minute intervals: +0.97 above scheduled, and a full suspension (-0.40 == -scheduled).
+        // Two 5-minute intervals: +0.97 above scheduled, and a zero-rate low-temp (-0.40 == -scheduled).
+        // Both are loop-enacted rates — a zero rate here is a low-temp, NOT a pump suspension.
         var start1 = new DateTime(2026, 6, 16, 22, 42, 0, DateTimeKind.Utc);
         var start2 = start1.AddMinutes(5);
         var blob = BuildBlob(
@@ -34,7 +36,45 @@ public class TwiistTempBasalMapperTests
         result[0].EndTimestamp.Should().Be(start1.AddMinutes(5));
 
         result[1].Rate.Should().BeApproximately(0.0, 0.001);
-        result[1].Origin.Should().Be(TempBasalOrigin.Suspended);
+        result[1].Origin.Should().Be(TempBasalOrigin.Algorithm);
+    }
+
+    [Fact]
+    public void MapSuspensions_PairsSuspendWithNextResume_AsSuspendedSpans()
+    {
+        var suspend1 = new DateTime(2026, 6, 16, 16, 21, 0, DateTimeKind.Utc);
+        var resume1 = new DateTime(2026, 6, 16, 18, 17, 0, DateTimeKind.Utc);
+        var suspend2 = new DateTime(2026, 6, 16, 23, 44, 0, DateTimeKind.Utc); // no matching resume -> open
+
+        var doses = new List<TwiistInsulinDose>
+        {
+            new() { DoseType = "Bolus", StartDate = suspend1.AddMinutes(1), Value = 1.0m },
+            new() { DoseType = "Suspend", StartDate = suspend1 },
+            new() { DoseType = "Resume", StartDate = resume1 },
+            new() { DoseType = "Suspend", StartDate = suspend2 }
+        };
+
+        var result = _mapper.MapSuspensions(doses).ToList();
+
+        result.Should().HaveCount(2);
+        result.Should().OnlyContain(t => t.Origin == TempBasalOrigin.Suspended && t.Rate == 0);
+
+        result[0].StartTimestamp.Should().Be(suspend1);
+        result[0].EndTimestamp.Should().Be(resume1);
+        result[1].StartTimestamp.Should().Be(suspend2);
+        result[1].EndTimestamp.Should().BeNull(); // still suspended
+    }
+
+    [Fact]
+    public void MapSuspensions_NoSuspendEvents_ReturnsEmpty()
+    {
+        var doses = new List<TwiistInsulinDose>
+        {
+            new() { DoseType = "Bolus", StartDate = DateTime.UtcNow, Value = 1.0m }
+        };
+
+        _mapper.MapSuspensions(doses).Should().BeEmpty();
+        _mapper.MapSuspensions(null).Should().BeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

#418 tagged any zero-rate insulin-delivery interval as `Origin = Suspended`. But a zero rate in the blob is the loop **enacting a 0 U/hr low-temp**, not a pump suspension — so closed-loop low-temps (common, benign) showed up as "Suspended", which over-reads as a problem in the UI. `Suspended` is a real pump state; `0 U/hr` is just a rate.

## Fix

- **Blob-derived rates → `Origin = Algorithm`** for all, including zero (loop low-temps).
- **Actual pump suspensions** come from the `Suspend`/`Resume` dose events in `insulinHistory`: each `Suspend` opens a zero-rate `Origin = Suspended` span that the next `Resume` closes; an unmatched trailing `Suspend` is left open-ended (null end = still suspended).

`SyncTempBasalsAsync` now publishes both the blob rates and the suspension spans.

## Tests

- Blob zero-rate now asserts `Algorithm` (was `Suspended`).
- New: `Suspend`/`Resume` pairing produces `Suspended` spans, including an open-ended trailing suspension; no suspend events → empty.

16 Twiist tests pass.

## Follow-up (ops)

The previously-deployed #418 wrote some zero-rate rows as `Suspended` for the test tenant; those will be cleaned up post-deploy so they re-sync with correct origins.