### PR TITLE
refactor: reduce top cyclomatic-complexity hotspots + fix entry utcOffset handling

### DIFF
--- a/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
@@ -544,91 +544,18 @@ public class EntriesController : ControllerBase
         );
         try
         {
-            List<Entry> entriesToCreate = new();
+            if (!TryParseEntries(entryData, out var entriesToCreate))
+            {
+                return BadRequest(
+                    new
+                    {
+                        status = 400,
+                        message = "Invalid entry data format",
+                        type = "client",
+                    }
+                );
+            }
 
-            // Handle different input types
-            if (entryData is JsonElement jsonElement)
-            {
-                // Handle JSON from HTTP requests
-                if (jsonElement.ValueKind == JsonValueKind.Array)
-                {
-                    foreach (var element in jsonElement.EnumerateArray())
-                    {
-                        var entry = JsonSerializer.Deserialize<Entry>(
-                            element.GetRawText(),
-                            new JsonSerializerOptions { PropertyNameCaseInsensitive = true }
-                        );
-                        if (entry != null)
-                            entriesToCreate.Add(entry);
-                    }
-                }
-                else
-                {
-                    var entry = JsonSerializer.Deserialize<Entry>(
-                        jsonElement.GetRawText(),
-                        new JsonSerializerOptions { PropertyNameCaseInsensitive = true }
-                    );
-                    if (entry != null)
-                        entriesToCreate.Add(entry);
-                }
-            }
-            else if (entryData is Entry singleEntry)
-            {
-                // Handle direct Entry object (for unit tests)
-                entriesToCreate.Add(singleEntry);
-            }
-            else if (entryData is Entry[] entryArray)
-            {
-                // Handle array of Entry objects (for unit tests)
-                entriesToCreate.AddRange(entryArray);
-            }
-            else if (entryData is IEnumerable<Entry> entryCollection)
-            {
-                // Handle IEnumerable<Entry> (for unit tests)
-                entriesToCreate.AddRange(entryCollection);
-            }
-            else
-            {
-                // Try to deserialize as JSON string if it's a raw object
-                try
-                {
-                    var jsonString = JsonSerializer.Serialize(entryData);
-                    var element = JsonSerializer.Deserialize<JsonElement>(jsonString);
-
-                    if (element.ValueKind == JsonValueKind.Array)
-                    {
-                        foreach (var arrayElement in element.EnumerateArray())
-                        {
-                            var entry = JsonSerializer.Deserialize<Entry>(
-                                arrayElement.GetRawText(),
-                                new JsonSerializerOptions { PropertyNameCaseInsensitive = true }
-                            );
-                            if (entry != null)
-                                entriesToCreate.Add(entry);
-                        }
-                    }
-                    else
-                    {
-                        var entry = JsonSerializer.Deserialize<Entry>(
-                            element.GetRawText(),
-                            new JsonSerializerOptions { PropertyNameCaseInsensitive = true }
-                        );
-                        if (entry != null)
-                            entriesToCreate.Add(entry);
-                    }
-                }
-                catch
-                {
-                    return BadRequest(
-                        new
-                        {
-                            status = 400,
-                            message = "Invalid entry data format",
-                            type = "client",
-                        }
-                    );
-                }
-            }
             if (entriesToCreate.Count == 0)
             {
                 return BadRequest(
@@ -639,39 +566,10 @@ public class EntriesController : ControllerBase
                         type = "client",
                     }
                 );
-            } // Validate entries have meaningful data
-            var validEntries = new List<Entry>();
-            foreach (var entry in entriesToCreate)
-            {
-                // Check if entry has meaningful glucose data or is a valid non-sgv type
-                bool hasMeaningfulData = false;
-
-                // Check for meaningful glucose values
-                if (entry.Sgv.HasValue && entry.Sgv.Value > 0)
-                    hasMeaningfulData = true;
-                if (entry.Mgdl > 0)
-                    hasMeaningfulData = true;
-
-                // Check for meaningful timestamp
-                if (entry.Mills > 0)
-                    hasMeaningfulData = true;
-                if (entry.Date.HasValue)
-                    hasMeaningfulData = true;
-                if (
-                    !string.IsNullOrEmpty(entry.DateString)
-                    && entry.DateString != "1970-01-01T00:00:00.000Z"
-                )
-                    hasMeaningfulData = true;
-
-                // Allow non-sgv types with just type specified (like calibrations)
-                if (!string.IsNullOrEmpty(entry.Type) && entry.Type != "sgv")
-                    hasMeaningfulData = true;
-
-                if (hasMeaningfulData)
-                {
-                    validEntries.Add(entry);
-                }
             }
+
+            // Validate entries have meaningful data
+            var validEntries = entriesToCreate.Where(HasMeaningfulData).ToList();
 
             if (validEntries.Count == 0)
             {
@@ -688,36 +586,7 @@ public class EntriesController : ControllerBase
             // Validate and prepare entries
             foreach (var entry in validEntries)
             {
-                // Generate ID if not provided
-                if (string.IsNullOrEmpty(entry.Id))
-                {
-                    entry.Id = Guid.CreateVersion7().ToString("N");
-                }
-
-                // Set mills from date if not provided
-                if (entry.Mills == 0 && entry.Date.HasValue)
-                {
-                    var dateValue = entry.Date.Value;
-                    var dateOffset =
-                        dateValue.Kind == DateTimeKind.Unspecified
-                            ? new DateTimeOffset(dateValue, TimeSpan.Zero)
-                            : new DateTimeOffset(dateValue);
-                    entry.Mills = dateOffset.ToUnixTimeMilliseconds();
-                }
-
-                // Set dateString if not provided
-                if (string.IsNullOrEmpty(entry.DateString) && entry.Mills > 0)
-                {
-                    entry.DateString = DateTimeOffset
-                        .FromUnixTimeMilliseconds(entry.Mills)
-                        .ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
-                }
-
-                // Default type to "sgv" if not specified
-                if (string.IsNullOrEmpty(entry.Type))
-                {
-                    entry.Type = "sgv";
-                }
+                NormalizeEntry(entry, treatUnspecifiedDateAsUtc: true);
             }
 
             // Process entries for sanitization and timestamp conversion
@@ -798,6 +667,146 @@ public class EntriesController : ControllerBase
                     error = ex.Message,
                 }
             );
+        }
+    }
+
+    /// <summary>
+    /// Parses the loosely-typed entries request body (JsonElement, a single Entry, an Entry[]/
+    /// IEnumerable&lt;Entry&gt; from tests, or a raw object) into a list of entries. Returns false
+    /// only when a raw object cannot be deserialized as entry JSON; a malformed JsonElement instead
+    /// throws and is handled by the caller's outer catch (matching the original inline behavior).
+    /// </summary>
+    private static bool TryParseEntries(object entryData, out List<Entry> entries)
+    {
+        entries = new List<Entry>();
+
+        if (entryData is JsonElement jsonElement)
+        {
+            AddEntriesFromJsonElement(jsonElement, entries);
+        }
+        else if (entryData is Entry singleEntry)
+        {
+            entries.Add(singleEntry);
+        }
+        else if (entryData is Entry[] entryArray)
+        {
+            entries.AddRange(entryArray);
+        }
+        else if (entryData is IEnumerable<Entry> entryCollection)
+        {
+            entries.AddRange(entryCollection);
+        }
+        else
+        {
+            // Try to deserialize as JSON if it's a raw object
+            try
+            {
+                var jsonString = JsonSerializer.Serialize(entryData);
+                var element = JsonSerializer.Deserialize<JsonElement>(jsonString);
+                AddEntriesFromJsonElement(element, entries);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Appends the entries contained in a JSON element (array of entries, or a single entry) to
+    /// <paramref name="entries"/>, skipping elements that deserialize to null.
+    /// </summary>
+    private static void AddEntriesFromJsonElement(JsonElement element, List<Entry> entries)
+    {
+        if (element.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in element.EnumerateArray())
+            {
+                var entry = DeserializeEntry(item);
+                if (entry != null)
+                    entries.Add(entry);
+            }
+        }
+        else
+        {
+            var entry = DeserializeEntry(element);
+            if (entry != null)
+                entries.Add(entry);
+        }
+    }
+
+    private static Entry? DeserializeEntry(JsonElement element) =>
+        JsonSerializer.Deserialize<Entry>(
+            element.GetRawText(),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+    /// <summary>
+    /// True when an entry carries meaningful glucose data, a usable timestamp, or a non-sgv type.
+    /// </summary>
+    private static bool HasMeaningfulData(Entry entry)
+    {
+        // Meaningful glucose values
+        if (entry.Sgv.HasValue && entry.Sgv.Value > 0)
+            return true;
+        if (entry.Mgdl > 0)
+            return true;
+
+        // Meaningful timestamp
+        if (entry.Mills > 0)
+            return true;
+        if (entry.Date.HasValue)
+            return true;
+        if (!string.IsNullOrEmpty(entry.DateString)
+            && entry.DateString != "1970-01-01T00:00:00.000Z")
+            return true;
+
+        // Non-sgv types with just a type specified (like calibrations)
+        if (!string.IsNullOrEmpty(entry.Type) && entry.Type != "sgv")
+            return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Fills in derived entry fields before persistence: a generated id, mills from date, a date
+    /// string from mills, and a default "sgv" type. <paramref name="treatUnspecifiedDateAsUtc"/>
+    /// controls how a <see cref="DateTimeKind.Unspecified"/> date is converted to mills — the sync
+    /// endpoint treats it as UTC, the async endpoint uses the runtime default offset (preserving each
+    /// endpoint's original behavior).
+    /// </summary>
+    private static void NormalizeEntry(Entry entry, bool treatUnspecifiedDateAsUtc)
+    {
+        // Generate ID if not provided
+        if (string.IsNullOrEmpty(entry.Id))
+        {
+            entry.Id = Guid.CreateVersion7().ToString("N");
+        }
+
+        // Set mills from date if not provided
+        if (entry.Mills == 0 && entry.Date.HasValue)
+        {
+            var dateValue = entry.Date.Value;
+            var dateOffset =
+                treatUnspecifiedDateAsUtc && dateValue.Kind == DateTimeKind.Unspecified
+                    ? new DateTimeOffset(dateValue, TimeSpan.Zero)
+                    : new DateTimeOffset(dateValue);
+            entry.Mills = dateOffset.ToUnixTimeMilliseconds();
+        }
+
+        // Set dateString if not provided
+        if (string.IsNullOrEmpty(entry.DateString) && entry.Mills > 0)
+        {
+            entry.DateString = DateTimeOffset
+                .FromUnixTimeMilliseconds(entry.Mills)
+                .ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+        }
+
+        // Default type to "sgv" if not specified
+        if (string.IsNullOrEmpty(entry.Type))
+        {
+            entry.Type = "sgv";
         }
     }
 
@@ -1089,91 +1098,17 @@ public class EntriesController : ControllerBase
 
         try
         {
-            List<Entry> entriesToCreate = new();
-
-            // Handle different input types (same logic as sync endpoint)
-            if (entryData is JsonElement jsonElement)
+            if (!TryParseEntries(entryData, out var entriesToCreate))
             {
-                // Handle JSON from HTTP requests
-                if (jsonElement.ValueKind == JsonValueKind.Array)
-                {
-                    foreach (var element in jsonElement.EnumerateArray())
+                return BadRequest(
+                    new
                     {
-                        var entry = JsonSerializer.Deserialize<Entry>(
-                            element.GetRawText(),
-                            new JsonSerializerOptions { PropertyNameCaseInsensitive = true }
-                        );
-                        if (entry != null)
-                            entriesToCreate.Add(entry);
+                        status = 400,
+                        message = "Invalid entry data format",
+                        type = "client",
+                        correlationId = correlationId,
                     }
-                }
-                else
-                {
-                    var entry = JsonSerializer.Deserialize<Entry>(
-                        jsonElement.GetRawText(),
-                        new JsonSerializerOptions { PropertyNameCaseInsensitive = true }
-                    );
-                    if (entry != null)
-                        entriesToCreate.Add(entry);
-                }
-            }
-            else if (entryData is Entry singleEntry)
-            {
-                // Handle direct Entry object
-                entriesToCreate.Add(singleEntry);
-            }
-            else if (entryData is Entry[] entryArray)
-            {
-                // Handle array of Entry objects
-                entriesToCreate.AddRange(entryArray);
-            }
-            else if (entryData is IEnumerable<Entry> entryCollection)
-            {
-                // Handle IEnumerable<Entry>
-                entriesToCreate.AddRange(entryCollection);
-            }
-            else
-            {
-                // Try to deserialize as JSON string if it's a raw object
-                try
-                {
-                    var jsonString = JsonSerializer.Serialize(entryData);
-                    var element = JsonSerializer.Deserialize<JsonElement>(jsonString);
-
-                    if (element.ValueKind == JsonValueKind.Array)
-                    {
-                        foreach (var arrayElement in element.EnumerateArray())
-                        {
-                            var entry = JsonSerializer.Deserialize<Entry>(
-                                arrayElement.GetRawText(),
-                                new JsonSerializerOptions { PropertyNameCaseInsensitive = true }
-                            );
-                            if (entry != null)
-                                entriesToCreate.Add(entry);
-                        }
-                    }
-                    else
-                    {
-                        var entry = JsonSerializer.Deserialize<Entry>(
-                            element.GetRawText(),
-                            new JsonSerializerOptions { PropertyNameCaseInsensitive = true }
-                        );
-                        if (entry != null)
-                            entriesToCreate.Add(entry);
-                    }
-                }
-                catch
-                {
-                    return BadRequest(
-                        new
-                        {
-                            status = 400,
-                            message = "Invalid entry data format",
-                            type = "client",
-                            correlationId = correlationId,
-                        }
-                    );
-                }
+                );
             }
 
             if (entriesToCreate.Count == 0)
@@ -1190,38 +1125,7 @@ public class EntriesController : ControllerBase
             }
 
             // Basic validation (same as sync endpoint)
-            var validEntries = new List<Entry>();
-            foreach (var entry in entriesToCreate)
-            {
-                // Check if entry has meaningful data or is a valid non-sgv type
-                bool hasMeaningfulData = false;
-
-                // Check for meaningful glucose values
-                if (entry.Sgv.HasValue && entry.Sgv.Value > 0)
-                    hasMeaningfulData = true;
-                if (entry.Mgdl > 0)
-                    hasMeaningfulData = true;
-
-                // Check for meaningful timestamp
-                if (entry.Mills > 0)
-                    hasMeaningfulData = true;
-                if (entry.Date.HasValue)
-                    hasMeaningfulData = true;
-                if (
-                    !string.IsNullOrEmpty(entry.DateString)
-                    && entry.DateString != "1970-01-01T00:00:00.000Z"
-                )
-                    hasMeaningfulData = true;
-
-                // Allow non-sgv types with just type specified (like calibrations)
-                if (!string.IsNullOrEmpty(entry.Type) && entry.Type != "sgv")
-                    hasMeaningfulData = true;
-
-                if (hasMeaningfulData)
-                {
-                    validEntries.Add(entry);
-                }
-            }
+            var validEntries = entriesToCreate.Where(HasMeaningfulData).ToList();
 
             if (validEntries.Count == 0)
             {
@@ -1243,34 +1147,11 @@ public class EntriesController : ControllerBase
                 cancellationToken
             );
 
-            // Prepare entries for processing (same validation as sync endpoint)
+            // Prepare entries for processing. The async endpoint historically converted
+            // Unspecified-kind dates using the runtime default offset (not UTC); preserved here.
             foreach (var entry in validEntries)
             {
-                // Generate ID if not provided
-                if (string.IsNullOrEmpty(entry.Id))
-                {
-                    entry.Id = Guid.CreateVersion7().ToString("N");
-                }
-
-                // Set mills from date if not provided
-                if (entry.Mills == 0 && entry.Date.HasValue)
-                {
-                    entry.Mills = ((DateTimeOffset)entry.Date.Value).ToUnixTimeMilliseconds();
-                }
-
-                // Set dateString if not provided
-                if (string.IsNullOrEmpty(entry.DateString) && entry.Mills > 0)
-                {
-                    entry.DateString = DateTimeOffset
-                        .FromUnixTimeMilliseconds(entry.Mills)
-                        .ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
-                }
-
-                // Default type to "sgv" if not specified
-                if (string.IsNullOrEmpty(entry.Type))
-                {
-                    entry.Type = "sgv";
-                }
+                NormalizeEntry(entry, treatUnspecifiedDateAsUtc: false);
             }
 
             // Process entries for sanitization and timestamp conversion

--- a/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
@@ -586,7 +586,7 @@ public class EntriesController : ControllerBase
             // Validate and prepare entries
             foreach (var entry in validEntries)
             {
-                NormalizeEntry(entry, treatUnspecifiedDateAsUtc: true);
+                NormalizeEntry(entry);
             }
 
             // Process entries for sanitization and timestamp conversion
@@ -771,13 +771,12 @@ public class EntriesController : ControllerBase
     }
 
     /// <summary>
-    /// Fills in derived entry fields before persistence: a generated id, mills from date, a date
-    /// string from mills, and a default "sgv" type. <paramref name="treatUnspecifiedDateAsUtc"/>
-    /// controls how a <see cref="DateTimeKind.Unspecified"/> date is converted to mills — the sync
-    /// endpoint treats it as UTC, the async endpoint uses the runtime default offset (preserving each
-    /// endpoint's original behavior).
+    /// Fills in derived entry fields before persistence: a generated id, a date string from mills,
+    /// and a default "sgv" type. Mills itself is not derived here — <see cref="Entry.Mills"/> is the
+    /// source of truth and already computes from the <c>date</c>/<c>dateString</c> fields as UTC, so
+    /// the controller must not re-derive it (re-deriving it inconsistently was a latent bug).
     /// </summary>
-    private static void NormalizeEntry(Entry entry, bool treatUnspecifiedDateAsUtc)
+    private static void NormalizeEntry(Entry entry)
     {
         // Generate ID if not provided
         if (string.IsNullOrEmpty(entry.Id))
@@ -785,18 +784,7 @@ public class EntriesController : ControllerBase
             entry.Id = Guid.CreateVersion7().ToString("N");
         }
 
-        // Set mills from date if not provided
-        if (entry.Mills == 0 && entry.Date.HasValue)
-        {
-            var dateValue = entry.Date.Value;
-            var dateOffset =
-                treatUnspecifiedDateAsUtc && dateValue.Kind == DateTimeKind.Unspecified
-                    ? new DateTimeOffset(dateValue, TimeSpan.Zero)
-                    : new DateTimeOffset(dateValue);
-            entry.Mills = dateOffset.ToUnixTimeMilliseconds();
-        }
-
-        // Set dateString if not provided
+        // Materialize dateString from mills if the client didn't send one
         if (string.IsNullOrEmpty(entry.DateString) && entry.Mills > 0)
         {
             entry.DateString = DateTimeOffset
@@ -1148,11 +1136,10 @@ public class EntriesController : ControllerBase
                 cancellationToken
             );
 
-            // Prepare entries for processing. The async endpoint historically converted
-            // Unspecified-kind dates using the runtime default offset (not UTC); preserved here.
+            // Prepare entries for processing
             foreach (var entry in validEntries)
             {
-                NormalizeEntry(entry, treatUnspecifiedDateAsUtc: false);
+                NormalizeEntry(entry);
             }
 
             // Process entries for sanitization and timestamp conversion

--- a/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
@@ -737,10 +737,11 @@ public class EntriesController : ControllerBase
         }
     }
 
+    private static readonly JsonSerializerOptions EntryDeserializerOptions =
+        new() { PropertyNameCaseInsensitive = true };
+
     private static Entry? DeserializeEntry(JsonElement element) =>
-        JsonSerializer.Deserialize<Entry>(
-            element.GetRawText(),
-            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        JsonSerializer.Deserialize<Entry>(element.GetRawText(), EntryDeserializerOptions);
 
     /// <summary>
     /// True when an entry carries meaningful glucose data, a usable timestamp, or a non-sgv type.

--- a/src/API/Nocturne.API/Services/Analytics/DataOverviewService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/DataOverviewService.cs
@@ -489,272 +489,250 @@ public class DataOverviewService : IDataOverviewService
             .LinkedRecords.Where(lr => lr.RecordType == "carbintake" && !lr.IsPrimary)
             .Select(lr => lr.RecordId);
 
-        // Helper to determine the local month (1-12) for a UTC timestamp
-        int TimestampToMonth(DateTime utcTimestamp)
-        {
-            var utcDto = new DateTimeOffset(utcTimestamp, TimeSpan.Zero);
-            var local = TimeZoneInfo.ConvertTime(utcDto, tz);
-            return local.Month;
-        }
-
-        // --- Query all glucose readings for the entire year (2 queries total) ---
+        // --- Collect glucose readings by month (CGM + meter) ---
         // Each source is queried independently so one failure doesn't prevent the others.
         var allGlucoseByMonth = new Dictionary<int, List<double>>();
 
         // SensorGlucose (CGM)
-        try
-        {
-            var sensorValues = await context
-                .SensorGlucose.Where(e =>
-                    e.Timestamp >= startUtc && e.Timestamp < endUtc && e.Mgdl > 0
-                )
+        await AccumulateMonthlyReadingsAsync(
+            context.SensorGlucose
+                .Where(e => e.Timestamp >= startUtc && e.Timestamp < endUtc && e.Mgdl > 0)
                 .Where(e => !hasFilter || dataSources!.Contains(e.DataSource!))
                 .Where(e => !npSensorGlucoseIds.Contains(e.Id))
-                .Select(e => new { e.Timestamp, e.Mgdl })
-                .ToListAsync(cancellationToken);
-
-            foreach (var v in sensorValues)
-            {
-                var m = TimestampToMonth(v.Timestamp);
-                if (!allGlucoseByMonth.TryGetValue(m, out var list))
-                {
-                    list = new List<double>();
-                    allGlucoseByMonth[m] = list;
-                }
-                list.Add(v.Mgdl);
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to collect SensorGlucose for GRI year {Year}", year);
-        }
+                .Select(e => new { e.Timestamp, e.Mgdl }),
+            r => r.Timestamp, r => r.Mgdl, allGlucoseByMonth, tz,
+            "Failed to collect SensorGlucose for GRI year {Year}", year, cancellationToken);
 
         // MeterGlucose (finger sticks)
-        try
-        {
-            var meterValues = await context
-                .MeterGlucose.Where(e =>
-                    e.Timestamp >= startUtc && e.Timestamp < endUtc && e.Mgdl > 0
-                )
+        await AccumulateMonthlyReadingsAsync(
+            context.MeterGlucose
+                .Where(e => e.Timestamp >= startUtc && e.Timestamp < endUtc && e.Mgdl > 0)
                 .Where(e => !hasFilter || dataSources!.Contains(e.DataSource!))
-                .Select(e => new { e.Timestamp, e.Mgdl })
-                .ToListAsync(cancellationToken);
+                .Select(e => new { e.Timestamp, e.Mgdl }),
+            r => r.Timestamp, r => r.Mgdl, allGlucoseByMonth, tz,
+            "Failed to collect MeterGlucose for GRI year {Year}", year, cancellationToken);
 
-            foreach (var v in meterValues)
-            {
-                var m = TimestampToMonth(v.Timestamp);
-                if (!allGlucoseByMonth.TryGetValue(m, out var list))
-                {
-                    list = new List<double>();
-                    allGlucoseByMonth[m] = list;
-                }
-                list.Add(v.Mgdl);
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to collect MeterGlucose for GRI year {Year}", year);
-        }
-
-        // --- Query all insulin data for the entire year (3 queries total) ---
-        // Manual boluses grouped by month
+        // --- Collect insulin totals by month (manual bolus, algorithm bolus, temp basal) ---
+        // Manual boluses
         var manualBolusByMonth = new Dictionary<int, double>();
-        try
-        {
-            var manualBoluses = await context
-                .Boluses.Where(e =>
-                    e.Timestamp >= startUtc && e.Timestamp < endUtc && e.Insulin > 0
-                )
+        await AccumulateMonthlyTotalsAsync(
+            context.Boluses
+                .Where(e => e.Timestamp >= startUtc && e.Timestamp < endUtc && e.Insulin > 0)
                 .Where(e => e.BolusKind != "Algorithm")
                 .Where(e => !hasFilter || dataSources!.Contains(e.DataSource!))
                 .Where(e => !nonPrimaryBolusIds.Contains(e.Id))
-                .Select(e => new { e.Timestamp, e.Insulin })
-                .ToListAsync(cancellationToken);
+                .Select(e => new { e.Timestamp, e.Insulin }),
+            r => r.Timestamp, r => r.Insulin, manualBolusByMonth, tz,
+            "Failed to collect manual bolus totals for GRI year {Year}", year, cancellationToken);
 
-            foreach (var b in manualBoluses)
-            {
-                var m = TimestampToMonth(b.Timestamp);
-                manualBolusByMonth.TryGetValue(m, out var existing);
-                manualBolusByMonth[m] = existing + b.Insulin;
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(
-                ex,
-                "Failed to collect manual bolus totals for GRI year {Year}",
-                year
-            );
-        }
-
-        // Algorithm boluses (APS SMBs -> basal) grouped by month
+        // Algorithm boluses (APS SMBs -> basal)
         var algorithmBolusByMonth = new Dictionary<int, double>();
-        try
-        {
-            var algorithmBoluses = await context
-                .Boluses.Where(e =>
-                    e.Timestamp >= startUtc && e.Timestamp < endUtc && e.Insulin > 0
-                )
+        await AccumulateMonthlyTotalsAsync(
+            context.Boluses
+                .Where(e => e.Timestamp >= startUtc && e.Timestamp < endUtc && e.Insulin > 0)
                 .Where(e => e.BolusKind == "Algorithm")
                 .Where(e => !hasFilter || dataSources!.Contains(e.DataSource!))
                 .Where(e => !nonPrimaryBolusIds.Contains(e.Id))
-                .Select(e => new { e.Timestamp, e.Insulin })
-                .ToListAsync(cancellationToken);
+                .Select(e => new { e.Timestamp, e.Insulin }),
+            r => r.Timestamp, r => r.Insulin, algorithmBolusByMonth, tz,
+            "Failed to collect algorithm bolus totals for GRI year {Year}", year, cancellationToken);
 
-            foreach (var b in algorithmBoluses)
-            {
-                var m = TimestampToMonth(b.Timestamp);
-                algorithmBolusByMonth.TryGetValue(m, out var existing);
-                algorithmBolusByMonth[m] = existing + b.Insulin;
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(
-                ex,
-                "Failed to collect algorithm bolus totals for GRI year {Year}",
-                year
-            );
-        }
-
-        // TempBasals (pump basal delivery) grouped by month
+        // TempBasals (pump basal delivery): insulin = rate * duration, defaulting to a 5-minute span.
         var tempBasalByMonth = new Dictionary<int, double>();
-        try
-        {
-            var tempBasalRecords = await context
-                .TempBasals.Where(e =>
-                    e.StartTimestamp >= startUtc && e.StartTimestamp < endUtc && e.Rate > 0
-                )
+        await AccumulateMonthlyTotalsAsync(
+            context.TempBasals
+                .Where(e => e.StartTimestamp >= startUtc && e.StartTimestamp < endUtc && e.Rate > 0)
                 .Where(e => !hasFilter || dataSources!.Contains(e.DataSource!))
                 .Where(e => !nonPrimaryTempBasalIds.Contains(e.Id))
-                .Select(e => new
-                {
-                    e.StartTimestamp,
-                    e.Rate,
-                    e.EndTimestamp,
-                })
-                .ToListAsync(cancellationToken);
+                .Select(e => new { e.StartTimestamp, e.Rate, e.EndTimestamp }),
+            r => r.StartTimestamp,
+            r => r.Rate * (r.EndTimestamp.HasValue
+                ? (r.EndTimestamp.Value - r.StartTimestamp).TotalHours
+                : 5.0 / 60.0),
+            tempBasalByMonth, tz,
+            "Failed to collect TempBasal totals for GRI year {Year}", year, cancellationToken);
 
-            const double defaultDurationMinutes = 5.0;
-
-            foreach (var r in tempBasalRecords)
-            {
-                var durationHours = r.EndTimestamp.HasValue
-                    ? (r.EndTimestamp.Value - r.StartTimestamp).TotalHours
-                    : defaultDurationMinutes / 60.0;
-                var insulin = r.Rate * durationHours;
-                if (insulin > 0)
-                {
-                    var m = TimestampToMonth(r.StartTimestamp);
-                    tempBasalByMonth.TryGetValue(m, out var existing);
-                    tempBasalByMonth[m] = existing + insulin;
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to collect TempBasal totals for GRI year {Year}", year);
-        }
-
-        // --- Query all carb data for the entire year (1 query) ---
+        // --- Collect carb totals by month ---
         var carbsByMonth = new Dictionary<int, double>();
-        try
-        {
-            var carbRecords = await context
-                .CarbIntakes.Where(e =>
-                    e.Timestamp >= startUtc && e.Timestamp < endUtc && e.Carbs > 0
-                )
+        await AccumulateMonthlyTotalsAsync(
+            context.CarbIntakes
+                .Where(e => e.Timestamp >= startUtc && e.Timestamp < endUtc && e.Carbs > 0)
                 .Where(e => !hasFilter || dataSources!.Contains(e.DataSource!))
                 .Where(e => !nonPrimaryCarbIds.Contains(e.Id))
-                .Select(e => new { e.Timestamp, e.Carbs })
-                .ToListAsync(cancellationToken);
-
-            foreach (var c in carbRecords)
-            {
-                var m = TimestampToMonth(c.Timestamp);
-                carbsByMonth.TryGetValue(m, out var existing);
-                carbsByMonth[m] = existing + c.Carbs;
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to collect carb totals for GRI year {Year}", year);
-        }
+                .Select(e => new { e.Timestamp, e.Carbs }),
+            r => r.Timestamp, r => r.Carbs, carbsByMonth, tz,
+            "Failed to collect carb totals for GRI year {Year}", year, cancellationToken);
 
         // --- Group by month and compute GRI, TDD, carbs per period ---
         for (var month = 1; month <= 12; month++)
         {
-            if (
-                !allGlucoseByMonth.TryGetValue(month, out var glucoseReadings)
-                || glucoseReadings.Count < minimumReadings
-            )
-                continue;
-
-            // Bucket readings into TIR zones
-            var totalCount = glucoseReadings.Count;
-            var veryLowCount = glucoseReadings.Count(v => v < 54);
-            var lowCount = glucoseReadings.Count(v => v >= 54 && v < 70);
-            var targetCount = glucoseReadings.Count(v => v >= 70 && v <= 180);
-            var highCount = glucoseReadings.Count(v => v > 180 && v <= 250);
-            var veryHighCount = glucoseReadings.Count(v => v > 250);
-
-            var percentages = new TimeInRangePercentages
-            {
-                VeryLow = (double)veryLowCount / totalCount * 100.0,
-                Low = (double)lowCount / totalCount * 100.0,
-                Target = (double)targetCount / totalCount * 100.0,
-                High = (double)highCount / totalCount * 100.0,
-                VeryHigh = (double)veryHighCount / totalCount * 100.0,
-            };
-
-            var timeInRange = new TimeInRangeMetrics { Percentages = percentages };
-
-            var gri = _statisticsService.CalculateGRI(timeInRange);
-            var averageGlucose = Math.Round(glucoseReadings.Average(), 1);
-
-            // Compute TDD for the month
-            var localMonthStart = new DateTime(year, month, 1, 0, 0, 0, DateTimeKind.Unspecified);
-            var localMonthEnd =
-                month == 12
-                    ? new DateTime(year + 1, 1, 1, 0, 0, 0, DateTimeKind.Unspecified)
-                    : new DateTime(year, month + 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
-            var daysInMonth = (localMonthEnd - localMonthStart).TotalDays;
-
-            double? totalDailyDose = null;
-            manualBolusByMonth.TryGetValue(month, out var totalBolusUnits);
-            algorithmBolusByMonth.TryGetValue(month, out var algorithmBasalUnits);
-            tempBasalByMonth.TryGetValue(month, out var tempBasalUnits);
-            var totalBasalUnits = algorithmBasalUnits + tempBasalUnits;
-
-            if (totalBolusUnits > 0 || totalBasalUnits > 0)
-            {
-                var totalInsulin = totalBolusUnits + totalBasalUnits;
-                totalDailyDose = Math.Round(totalInsulin / daysInMonth, 2);
-            }
-
-            // Average daily carbs for the month
-            double? averageDailyCarbs = null;
-            if (carbsByMonth.TryGetValue(month, out var carbSum) && carbSum > 0)
-                averageDailyCarbs = Math.Round(carbSum / daysInMonth, 1);
-
-            var periodStartStr = localMonthStart.ToString("yyyy-MM-dd");
-            var periodEndStr = localMonthEnd.AddDays(-1).ToString("yyyy-MM-dd");
-
-            periods.Add(
-                new GriTimelinePeriod
-                {
-                    PeriodStart = periodStartStr,
-                    PeriodEnd = periodEndStr,
-                    Gri = gri,
-                    AverageGlucoseMgdl = averageGlucose,
-                    TotalDailyDose = totalDailyDose,
-                    AverageDailyCarbs = averageDailyCarbs,
-                    ReadingCount = totalCount,
-                }
-            );
+            var period = BuildGriPeriod(
+                month, year, minimumReadings,
+                allGlucoseByMonth, manualBolusByMonth, algorithmBolusByMonth, tempBasalByMonth, carbsByMonth);
+            if (period != null)
+                periods.Add(period);
         }
 
         return new GriTimelineResponse { Year = year, Periods = periods.ToArray() };
+    }
+
+    /// <summary>
+    /// Local month (1-12) for a UTC timestamp, in the user's time zone.
+    /// </summary>
+    private static int TimestampToMonth(DateTime utcTimestamp, TimeZoneInfo tz)
+    {
+        var utcDto = new DateTimeOffset(utcTimestamp, TimeSpan.Zero);
+        var local = TimeZoneInfo.ConvertTime(utcDto, tz);
+        return local.Month;
+    }
+
+    /// <summary>
+    /// Materializes a timestamped/valued query and appends each reading to its month's bucket.
+    /// A query failure is logged and leaves the accumulator untouched (per-source isolation).
+    /// </summary>
+    private async Task AccumulateMonthlyReadingsAsync<T>(
+        IQueryable<T> query,
+        Func<T, DateTime> timestampSelector,
+        Func<T, double> valueSelector,
+        Dictionary<int, List<double>> readingsByMonth,
+        TimeZoneInfo tz,
+        string failureMessage,
+        int year,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var rows = await query.ToListAsync(cancellationToken);
+            foreach (var row in rows)
+            {
+                var month = TimestampToMonth(timestampSelector(row), tz);
+                if (!readingsByMonth.TryGetValue(month, out var list))
+                {
+                    list = new List<double>();
+                    readingsByMonth[month] = list;
+                }
+                list.Add(valueSelector(row));
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, failureMessage, year);
+        }
+    }
+
+    /// <summary>
+    /// Materializes a timestamped/valued query and sums positive values into per-month totals.
+    /// Non-positive values are ignored. A query failure is logged and leaves the accumulator untouched.
+    /// </summary>
+    private async Task AccumulateMonthlyTotalsAsync<T>(
+        IQueryable<T> query,
+        Func<T, DateTime> timestampSelector,
+        Func<T, double> valueSelector,
+        Dictionary<int, double> totalsByMonth,
+        TimeZoneInfo tz,
+        string failureMessage,
+        int year,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var rows = await query.ToListAsync(cancellationToken);
+            foreach (var row in rows)
+            {
+                var value = valueSelector(row);
+                if (value <= 0)
+                    continue;
+                var month = TimestampToMonth(timestampSelector(row), tz);
+                totalsByMonth.TryGetValue(month, out var existing);
+                totalsByMonth[month] = existing + value;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, failureMessage, year);
+        }
+    }
+
+    /// <summary>
+    /// Builds one month's GRI timeline period, or null when the month has fewer than
+    /// <paramref name="minimumReadings"/> glucose readings.
+    /// </summary>
+    private GriTimelinePeriod? BuildGriPeriod(
+        int month,
+        int year,
+        int minimumReadings,
+        Dictionary<int, List<double>> allGlucoseByMonth,
+        Dictionary<int, double> manualBolusByMonth,
+        Dictionary<int, double> algorithmBolusByMonth,
+        Dictionary<int, double> tempBasalByMonth,
+        Dictionary<int, double> carbsByMonth)
+    {
+        if (
+            !allGlucoseByMonth.TryGetValue(month, out var glucoseReadings)
+            || glucoseReadings.Count < minimumReadings
+        )
+            return null;
+
+        // Bucket readings into TIR zones
+        var totalCount = glucoseReadings.Count;
+        var veryLowCount = glucoseReadings.Count(v => v < 54);
+        var lowCount = glucoseReadings.Count(v => v >= 54 && v < 70);
+        var targetCount = glucoseReadings.Count(v => v >= 70 && v <= 180);
+        var highCount = glucoseReadings.Count(v => v > 180 && v <= 250);
+        var veryHighCount = glucoseReadings.Count(v => v > 250);
+
+        var percentages = new TimeInRangePercentages
+        {
+            VeryLow = (double)veryLowCount / totalCount * 100.0,
+            Low = (double)lowCount / totalCount * 100.0,
+            Target = (double)targetCount / totalCount * 100.0,
+            High = (double)highCount / totalCount * 100.0,
+            VeryHigh = (double)veryHighCount / totalCount * 100.0,
+        };
+
+        var timeInRange = new TimeInRangeMetrics { Percentages = percentages };
+
+        var gri = _statisticsService.CalculateGRI(timeInRange);
+        var averageGlucose = Math.Round(glucoseReadings.Average(), 1);
+
+        // Compute TDD for the month
+        var localMonthStart = new DateTime(year, month, 1, 0, 0, 0, DateTimeKind.Unspecified);
+        var localMonthEnd =
+            month == 12
+                ? new DateTime(year + 1, 1, 1, 0, 0, 0, DateTimeKind.Unspecified)
+                : new DateTime(year, month + 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
+        var daysInMonth = (localMonthEnd - localMonthStart).TotalDays;
+
+        double? totalDailyDose = null;
+        manualBolusByMonth.TryGetValue(month, out var totalBolusUnits);
+        algorithmBolusByMonth.TryGetValue(month, out var algorithmBasalUnits);
+        tempBasalByMonth.TryGetValue(month, out var tempBasalUnits);
+        var totalBasalUnits = algorithmBasalUnits + tempBasalUnits;
+
+        if (totalBolusUnits > 0 || totalBasalUnits > 0)
+        {
+            var totalInsulin = totalBolusUnits + totalBasalUnits;
+            totalDailyDose = Math.Round(totalInsulin / daysInMonth, 2);
+        }
+
+        // Average daily carbs for the month
+        double? averageDailyCarbs = null;
+        if (carbsByMonth.TryGetValue(month, out var carbSum) && carbSum > 0)
+            averageDailyCarbs = Math.Round(carbSum / daysInMonth, 1);
+
+        var periodStartStr = localMonthStart.ToString("yyyy-MM-dd");
+        var periodEndStr = localMonthEnd.AddDays(-1).ToString("yyyy-MM-dd");
+
+        return new GriTimelinePeriod
+        {
+            PeriodStart = periodStartStr,
+            PeriodEnd = periodEndStr,
+            Gri = gri,
+            AverageGlucoseMgdl = averageGlucose,
+            TotalDailyDose = totalDailyDose,
+            AverageDailyCarbs = averageDailyCarbs,
+            ReadingCount = totalCount,
+        };
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Services/Legacy/DocumentProcessingService.cs
+++ b/src/API/Nocturne.API/Services/Legacy/DocumentProcessingService.cs
@@ -181,7 +181,9 @@ public class DocumentProcessingService : IDocumentProcessingService
                 // Use existing Mills value to set CreatedAt
                 var dateFromMills = DateTimeOffset.FromUnixTimeMilliseconds(document.Mills);
                 document.CreatedAt = dateFromMills.ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
-                document.UtcOffset = 0; // Assume UTC if no timezone info
+                // The timestamp carried no zone; honor an offset the client sent directly
+                // (Nightscout entries may set utcOffset independently of date), else assume UTC.
+                document.UtcOffset ??= 0;
 
                 _logger.LogDebug(
                     "Used explicit Mills timestamp: {Mills} -> {CreatedAt}",
@@ -218,7 +220,8 @@ public class DocumentProcessingService : IDocumentProcessingService
                     var dateTimeOffset = new DateTimeOffset(utcDateTime, TimeSpan.Zero);
                     document.CreatedAt = dateTimeOffset.ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
                     document.Mills = dateTimeOffset.ToUnixTimeMilliseconds();
-                    document.UtcOffset = 0; // No offset for UTC
+                    // The timestamp string carried no zone; honor a client-supplied offset, else assume UTC.
+                    document.UtcOffset ??= 0;
                 }
                 else
                 {
@@ -236,7 +239,9 @@ public class DocumentProcessingService : IDocumentProcessingService
                 // Use existing Mills value to set CreatedAt
                 var dateFromMills = DateTimeOffset.FromUnixTimeMilliseconds(document.Mills);
                 document.CreatedAt = dateFromMills.ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
-                document.UtcOffset = 0; // Assume UTC if no timezone info
+                // mills fixes the instant (UTC); honor an independently-supplied utcOffset
+                // (e.g. AAPS/Loop send date + utcOffset with no created_at), else assume UTC.
+                document.UtcOffset ??= 0;
             }
             else
             {

--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -183,31 +183,46 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             value?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
     }
 
-    /// <inheritdoc />
-    public async Task<V4Models.DecompositionResult> DecomposeAsync(Treatment treatment, CancellationToken ct = default)
+    /// <summary>
+    /// The set of v4 records a treatment decomposes into, plus the state-span sub-kind flags
+    /// and the parsed device-event type. Computed once by <see cref="ClassifyTreatment"/> and
+    /// consumed by both the single and batch decomposition paths.
+    /// </summary>
+    private readonly record struct TreatmentClassification(
+        bool ProduceBolus,
+        bool ProduceCarbIntake,
+        bool ProduceBGCheck,
+        bool ProduceNote,
+        bool ProduceBolusCalc,
+        bool ProduceDeviceEvent,
+        bool DelegateToStateSpan,
+        bool IsProfileSwitch,
+        bool IsOverride,
+        bool IsTemporaryTarget,
+        bool IsAnnouncement,
+        DeviceEventType ParsedDeviceEventType)
     {
-        NormalizeIdentity(treatment);
+        /// <summary>
+        /// True when no record type was selected and nothing is delegated to a state span —
+        /// i.e. the treatment carries no recognized event type and no insulin/carb data.
+        /// </summary>
+        public bool ProducesNothing =>
+            !ProduceBolus && !ProduceCarbIntake && !ProduceBGCheck
+            && !ProduceNote && !ProduceBolusCalc && !ProduceDeviceEvent && !DelegateToStateSpan;
+    }
 
-        var batch = new DecompositionBatchEntity
-        {
-            TenantId = _dbContext.TenantId,
-            Source = "treatment_decomposer",
-            SourceRecordId = treatment.Id,
-            CreatedAt = DateTime.UtcNow,
-        };
-        _dbContext.DecompositionBatches.Add(batch);
-        await _dbContext.SaveChangesAsync(ct);
-
-        var result = new V4Models.DecompositionResult
-        {
-            CorrelationId = batch.Id
-        };
-
+    /// <summary>
+    /// Classifies which v4 records a legacy <see cref="Treatment"/> decomposes into, based on its
+    /// <see cref="Treatment.EventType"/> and the insulin/carb data present. This mapping is shared
+    /// by <see cref="DecomposeAsync"/> and <see cref="DecomposeBatchAsync"/> so it lives in exactly
+    /// one place.
+    /// </summary>
+    private TreatmentClassification ClassifyTreatment(Treatment treatment)
+    {
         var eventType = treatment.EventType?.Trim();
         var hasInsulin = treatment.Insulin is > 0;
         var hasCarbs = treatment.Carbs is > 0;
 
-        // Determine which records to produce based on EventType
         var produceBolus = false;
         var produceCarbIntake = false;
         var produceBGCheck = false;
@@ -323,18 +338,46 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             produceNote = true;
         }
 
-        // Handle StateSpan delegation
-        if (delegateToStateSpan)
+        return new TreatmentClassification(
+            produceBolus, produceCarbIntake, produceBGCheck, produceNote, produceBolusCalc,
+            produceDeviceEvent, delegateToStateSpan, isProfileSwitch, isOverride, isTemporaryTarget,
+            isAnnouncement, parsedDeviceEventType);
+    }
+
+    /// <inheritdoc />
+    public async Task<V4Models.DecompositionResult> DecomposeAsync(Treatment treatment, CancellationToken ct = default)
+    {
+        NormalizeIdentity(treatment);
+
+        var batch = new DecompositionBatchEntity
         {
-            if (isProfileSwitch)
+            TenantId = _dbContext.TenantId,
+            Source = "treatment_decomposer",
+            SourceRecordId = treatment.Id,
+            CreatedAt = DateTime.UtcNow,
+        };
+        _dbContext.DecompositionBatches.Add(batch);
+        await _dbContext.SaveChangesAsync(ct);
+
+        var result = new V4Models.DecompositionResult
+        {
+            CorrelationId = batch.Id
+        };
+
+        var c = ClassifyTreatment(treatment);
+
+        // Handle StateSpan delegation
+        if (c.DelegateToStateSpan)
+        {
+            if (c.IsProfileSwitch)
             {
                 await DecomposeProfileSwitchAsync(treatment, result, ct);
             }
-            else if (isOverride)
+            else if (c.IsOverride)
             {
                 await DecomposeOverrideAsync(treatment, result, ct);
             }
-            else if (isTemporaryTarget)
+            else if (c.IsTemporaryTarget)
             {
                 await DecomposeTemporaryTargetAsync(treatment, result, ct);
             }
@@ -345,38 +388,38 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         }
 
         // Produce v4 records
-        if (produceBolus)
+        if (c.ProduceBolus)
         {
             await DecomposeBolusAsync(treatment, result, ct);
         }
 
-        if (produceCarbIntake)
+        if (c.ProduceCarbIntake)
         {
             await DecomposeCarbIntakeAsync(treatment, result, ct);
         }
 
-        if (produceBGCheck)
+        if (c.ProduceBGCheck)
         {
             await DecomposeBGCheckAsync(treatment, result, ct);
         }
 
-        if (produceNote)
+        if (c.ProduceNote)
         {
-            await DecomposeNoteAsync(treatment, result, isAnnouncement, ct);
+            await DecomposeNoteAsync(treatment, result, c.IsAnnouncement, ct);
         }
 
-        if (produceBolusCalc)
+        if (c.ProduceBolusCalc)
         {
             await DecomposeBolusCalculationAsync(treatment, result, ct);
         }
 
-        if (produceDeviceEvent)
+        if (c.ProduceDeviceEvent)
         {
-            await DecomposeDeviceEventAsync(treatment, result, parsedDeviceEventType, ct);
+            await DecomposeDeviceEventAsync(treatment, result, c.ParsedDeviceEventType, ct);
 
-            if (parsedDeviceEventType is DeviceEventType.PumpSuspend or DeviceEventType.PumpResume)
+            if (c.ParsedDeviceEventType is DeviceEventType.PumpSuspend or DeviceEventType.PumpResume)
             {
-                await DecomposePumpSuspensionFromTreatmentAsync(treatment, parsedDeviceEventType, result, ct);
+                await DecomposePumpSuspensionFromTreatmentAsync(treatment, c.ParsedDeviceEventType, result, ct);
             }
         }
 
@@ -394,8 +437,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         }
 
         // If nothing was produced and there's no delegation, log a warning
-        if (!produceBolus && !produceCarbIntake && !produceBGCheck
-            && !produceNote && !produceBolusCalc && !produceDeviceEvent && !delegateToStateSpan)
+        if (c.ProducesNothing)
         {
             _logger.LogWarning(
                 "Unknown event type '{EventType}' for treatment {Id} with no insulin/carbs, skipping decomposition",
@@ -1235,124 +1277,13 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         {
             NormalizeIdentity(treatment);
 
-            var eventType = treatment.EventType?.Trim();
-            var hasInsulin = treatment.Insulin is > 0;
-            var hasCarbs = treatment.Carbs is > 0;
-
-            // Classification flags (same logic as DecomposeAsync)
-            var produceBolus = false;
-            var produceCarbIntake = false;
-            var produceBGCheck = false;
-            var produceNote = false;
-            var produceBolusCalc = false;
-            var produceDeviceEvent = false;
-            var delegateToStateSpan = false;
-            var isProfileSwitch = false;
-            var isOverride = false;
-            var isTemporaryTarget = false;
-            var isAnnouncement = false;
-            DeviceEventType parsedDeviceEventType = default;
-
-            if (IsTempBasal(eventType))
-            {
-                delegateToStateSpan = true;
-            }
-            else if (string.Equals(eventType, "Profile Switch", StringComparison.OrdinalIgnoreCase))
-            {
-                isProfileSwitch = true;
-                delegateToStateSpan = true;
-            }
-            else if (string.Equals(eventType, "Temporary Override", StringComparison.OrdinalIgnoreCase))
-            {
-                isOverride = true;
-                delegateToStateSpan = true;
-            }
-            else if (string.Equals(eventType, "Temporary Target", StringComparison.OrdinalIgnoreCase)
-                  || string.Equals(eventType, "Temporary Target Cancel", StringComparison.OrdinalIgnoreCase))
-            {
-                isTemporaryTarget = true;
-                delegateToStateSpan = true;
-            }
-            else if (eventType != null && TreatmentTypes.DeviceEventTypeMap.TryGetValue(eventType, out parsedDeviceEventType))
-            {
-                produceDeviceEvent = true;
-            }
-            else if (string.Equals(eventType, "Meal Bolus", StringComparison.OrdinalIgnoreCase)
-                  || string.Equals(eventType, "Snack Bolus", StringComparison.OrdinalIgnoreCase)
-                  || string.Equals(eventType, "Combo Bolus", StringComparison.OrdinalIgnoreCase))
-            {
-                produceBolus = true;
-                produceCarbIntake = true;
-            }
-            else if (string.Equals(eventType, "Correction Bolus", StringComparison.OrdinalIgnoreCase)
-                  || string.Equals(eventType, "SMB", StringComparison.OrdinalIgnoreCase)
-                  || string.Equals(eventType, "Automatic Bolus", StringComparison.OrdinalIgnoreCase))
-            {
-                produceBolus = true;
-            }
-            else if (string.Equals(eventType, "Bolus", StringComparison.OrdinalIgnoreCase)
-                  || string.Equals(eventType, "External Insulin", StringComparison.OrdinalIgnoreCase))
-            {
-                produceBolus = true;
-            }
-            else if (string.Equals(eventType, "Carb Correction", StringComparison.OrdinalIgnoreCase))
-            {
-                produceCarbIntake = true;
-            }
-            else if (string.Equals(eventType, "BG Check", StringComparison.OrdinalIgnoreCase))
-            {
-                produceBGCheck = true;
-            }
-            else if (string.Equals(eventType, "Announcement", StringComparison.OrdinalIgnoreCase))
-            {
-                produceNote = true;
-                isAnnouncement = true;
-            }
-            else if (string.Equals(eventType, "Note", StringComparison.OrdinalIgnoreCase)
-                  || string.Equals(eventType, "Exercise", StringComparison.OrdinalIgnoreCase))
-            {
-                produceNote = true;
-            }
-            else if (string.Equals(eventType, "Bolus Wizard", StringComparison.OrdinalIgnoreCase))
-            {
-                produceBolusCalc = true;
-                if (hasInsulin)
-                    produceBolus = true;
-            }
-
-            // Override rule: both insulin and carbs → always produce both
-            if (hasInsulin && hasCarbs)
-            {
-                produceBolus = true;
-                produceCarbIntake = true;
-            }
-
-            // Fallback: for unrecognized event types, produce records based on what data is present
-            if (!produceBolus && !produceCarbIntake && !produceBGCheck
-                && !produceNote && !produceBolusCalc && !produceDeviceEvent && !delegateToStateSpan)
-            {
-                if (hasInsulin)
-                    produceBolus = true;
-                if (hasCarbs)
-                    produceCarbIntake = true;
-
-                if (produceBolus || produceCarbIntake)
-                {
-                    _logger.LogInformation(
-                        "Unrecognized event type '{EventType}' for treatment {Id}, producing records based on data (insulin={HasInsulin}, carbs={HasCarbs})",
-                        treatment.EventType, treatment.Id, hasInsulin, hasCarbs);
-                }
-            }
-
-            // Note for any treatment with non-empty Notes (unless already producing a Note)
-            if (!produceNote && !string.IsNullOrWhiteSpace(treatment.Notes))
-                produceNote = true;
+            var c = ClassifyTreatment(treatment);
 
             // Collect state span treatments for individual upsert
-            if (delegateToStateSpan)
+            if (c.DelegateToStateSpan)
             {
                 // TempBasal treatments can also be bulk-inserted
-                if (!isProfileSwitch && !isOverride && !isTemporaryTarget)
+                if (!c.IsProfileSwitch && !c.IsOverride && !c.IsTemporaryTarget)
                 {
                     var tempBasal = MapToTempBasal(treatment, batch.Id);
                     tempBasal.DeviceId = await _deviceService.ResolveAsync(
@@ -1362,11 +1293,11 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
                 }
                 else
                 {
-                    stateSpanTreatments.Add((treatment, isProfileSwitch, isOverride, isTemporaryTarget));
+                    stateSpanTreatments.Add((treatment, c.IsProfileSwitch, c.IsOverride, c.IsTemporaryTarget));
                 }
             }
 
-            if (produceBolus)
+            if (c.ProduceBolus)
             {
                 var isAlgorithmBolus = (treatment.IsBasalInsulin == true && treatment.Insulin > 0)
                     || (string.Equals(treatment.EventType, "Correction Bolus", StringComparison.OrdinalIgnoreCase) && IsAapsUpload(treatment))
@@ -1387,39 +1318,38 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
                 bolusList.Add(model);
             }
 
-            if (produceCarbIntake)
+            if (c.ProduceCarbIntake)
                 carbList.Add(MapToCarbIntake(treatment, batch.Id));
 
-            if (produceBGCheck)
+            if (c.ProduceBGCheck)
                 bgCheckList.Add(MapToBGCheck(treatment, batch.Id));
 
-            if (produceNote)
-                noteList.Add(MapToNote(treatment, batch.Id, isAnnouncement));
+            if (c.ProduceNote)
+                noteList.Add(MapToNote(treatment, batch.Id, c.IsAnnouncement));
 
-            if (produceBolusCalc)
+            if (c.ProduceBolusCalc)
                 bolusCalcList.Add(MapToBolusCalculation(treatment, batch.Id));
 
-            if (produceDeviceEvent)
+            if (c.ProduceDeviceEvent)
             {
-                var model = MapToDeviceEvent(treatment, batch.Id, parsedDeviceEventType);
+                var model = MapToDeviceEvent(treatment, batch.Id, c.ParsedDeviceEventType);
                 model.DeviceId = await _deviceService.ResolveAsync(
                     V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
                 model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
                 deviceEventList.Add(model);
 
-                if (parsedDeviceEventType is DeviceEventType.PumpSuspend or DeviceEventType.PumpResume)
+                if (c.ParsedDeviceEventType is DeviceEventType.PumpSuspend or DeviceEventType.PumpResume)
                 {
-                    pumpSuspendResumeTreatments.Add((treatment, parsedDeviceEventType));
+                    pumpSuspendResumeTreatments.Add((treatment, c.ParsedDeviceEventType));
                 }
             }
 
             // Track for post-insert linking
-            if (produceBolus && produceBolusCalc && treatment.Id != null)
+            if (c.ProduceBolus && c.ProduceBolusCalc && treatment.Id != null)
                 bolusCalcLinkTreatmentIds.Add(treatment.Id);
 
             // Log unrecognized treatments
-            if (!produceBolus && !produceCarbIntake && !produceBGCheck
-                && !produceNote && !produceBolusCalc && !produceDeviceEvent && !delegateToStateSpan)
+            if (c.ProducesNothing)
             {
                 _logger.LogWarning(
                     "Unknown event type '{EventType}' for treatment {Id} with no insulin/carbs, skipping decomposition",

--- a/src/Connectors/Nocturne.Connectors.CareLink/Services/CareLinkConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.CareLink/Services/CareLinkConnectorService.cs
@@ -123,8 +123,43 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
             return result;
         }
 
-        // Determine role
-        CareLinkUserInfo? userInfo = null;
+        var userInfo = await FetchUserInfoAsync(config, cancellationToken);
+        var role = userInfo?.Role ?? string.Empty;
+        var isCarePartner = role.Equals(CareLinkConstants.CarePartnerRoles.CarePartner, StringComparison.OrdinalIgnoreCase)
+            || role.Equals(CareLinkConstants.CarePartnerRoles.CarePartnerOus, StringComparison.OrdinalIgnoreCase);
+
+        var data = await TryFetchDataAsync(config, userInfo, isCarePartner, result, cancellationToken);
+        if (data == null)
+        {
+            result.EndTime = DateTimeOffset.UtcNow;
+            return result;
+        }
+
+        // Seed the tenant timezone timeline from the pump's reported zone (idempotent; first sync only).
+        await ConfigureCareLinkTimezoneAsync(data, cancellationToken);
+
+        var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes);
+        var isStale = IsDataStale(data);
+
+        await PublishSensorGlucoseStepAsync(data, config, enabledTypes, isStale, result, cancellationToken);
+        await PublishDeviceStatusStepAsync(data, config, enabledTypes, result, cancellationToken);
+        await PublishAlarmStepAsync(data, config, result, cancellationToken);
+        await PublishTreatmentsStepAsync(data, config, enabledTypes, result, cancellationToken);
+
+        // Persist refresh token if it changed during sync
+        await PersistRefreshTokenIfChangedAsync(cancellationToken);
+
+        result.EndTime = DateTimeOffset.UtcNow;
+        return result;
+    }
+
+    /// <summary>
+    ///     Fetches the authenticated CareLink user for role determination. Returns null on any
+    ///     failure — the caller then treats the session as a (non-care-partner) patient.
+    /// </summary>
+    private async Task<CareLinkUserInfo?> FetchUserInfoAsync(
+        CareLinkConnectorConfiguration config, CancellationToken cancellationToken)
+    {
         try
         {
             var host = GetServerHost(config);
@@ -134,7 +169,7 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
                 cancellationToken);
 
             if (response.IsSuccessStatusCode)
-                userInfo = await DeserializeResponseAsync<CareLinkUserInfo>(response, cancellationToken);
+                return await DeserializeResponseAsync<CareLinkUserInfo>(response, cancellationToken);
         }
         catch (OperationCanceledException) { throw; }
         catch (HttpRequestException ex)
@@ -150,10 +185,21 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
             _logger.LogWarning(ex, "[{ConnectorSource}] Failed to fetch user info", ConnectorSource);
         }
 
-        var role = userInfo?.Role ?? string.Empty;
-        var isCarePartner = role.Equals(CareLinkConstants.CarePartnerRoles.CarePartner, StringComparison.OrdinalIgnoreCase)
-            || role.Equals(CareLinkConstants.CarePartnerRoles.CarePartnerOus, StringComparison.OrdinalIgnoreCase);
+        return null;
+    }
 
+    /// <summary>
+    ///     Fetches CareLink data for the resolved role. On a fetch error, records the failure on
+    ///     <paramref name="result"/> and returns null; also returns null (without failing the sync)
+    ///     when the service has no data to return.
+    /// </summary>
+    private async Task<CareLinkData?> TryFetchDataAsync(
+        CareLinkConnectorConfiguration config,
+        CareLinkUserInfo? userInfo,
+        bool isCarePartner,
+        SyncResult result,
+        CancellationToken cancellationToken)
+    {
         CareLinkData? data;
         try
         {
@@ -167,151 +213,184 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
             _logger.LogError(ex, "[{ConnectorSource}] Failed to fetch CareLink data", ConnectorSource);
             result.Success = false;
             result.Errors.Add($"Data fetch failed: {ex.Message}");
-            result.EndTime = DateTimeOffset.UtcNow;
-            return result;
+            return null;
         }
         catch (JsonException ex)
         {
             _logger.LogError(ex, "[{ConnectorSource}] Failed to fetch CareLink data", ConnectorSource);
             result.Success = false;
             result.Errors.Add($"Data fetch failed: {ex.Message}");
-            result.EndTime = DateTimeOffset.UtcNow;
-            return result;
+            return null;
         }
         catch (InvalidOperationException ex)
         {
             _logger.LogError(ex, "[{ConnectorSource}] Failed to fetch CareLink data", ConnectorSource);
             result.Success = false;
             result.Errors.Add($"Data fetch failed: {ex.Message}");
-            result.EndTime = DateTimeOffset.UtcNow;
-            return result;
+            return null;
         }
 
         if (data == null)
-        {
             _logger.LogWarning("[{ConnectorSource}] No data returned from CareLink", ConnectorSource);
-            result.EndTime = DateTimeOffset.UtcNow;
-            return result;
-        }
 
-        // Seed the tenant timezone timeline from the pump's reported zone (idempotent; first sync only).
-        await ConfigureCareLinkTimezoneAsync(data, cancellationToken);
+        return data;
+    }
 
-        var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes);
-        var isStale = IsDataStale(data);
+    /// <summary>
+    ///     Publishes sensor glucose, skipping when glucose is disabled or the data is stale.
+    /// </summary>
+    private async Task PublishSensorGlucoseStepAsync(
+        CareLinkData data,
+        CareLinkConnectorConfiguration config,
+        List<SyncDataType> enabledTypes,
+        bool isStale,
+        SyncResult result,
+        CancellationToken cancellationToken)
+    {
+        if (!enabledTypes.Contains(SyncDataType.Glucose))
+            return;
 
-        // Publish sensor glucose (skip if stale)
-        if (enabledTypes.Contains(SyncDataType.Glucose) && !isStale)
-        {
-            try
-            {
-                var sgRecords = _sgMapper.Map(data);
-                if (sgRecords.Count > 0)
-                {
-                    var success = await PublishSensorGlucoseDataAsync(sgRecords, config, cancellationToken);
-                    result.ItemsSynced[SyncDataType.Glucose] = sgRecords.Count;
-                    if (!success)
-                    {
-                        result.Success = false;
-                        result.Errors.Add("SensorGlucose publish failed");
-                    }
-                    else
-                    {
-                        _logger.LogInformation(
-                            "[{ConnectorSource}] Synced {Count} SensorGlucose records",
-                            ConnectorSource, sgRecords.Count);
-                    }
-                }
-            }
-            catch (OperationCanceledException) { throw; }
-            catch (HttpRequestException ex)
-            {
-                _logger.LogError(ex, "[{ConnectorSource}] Error publishing SensorGlucose", ConnectorSource);
-                result.Success = false;
-                result.Errors.Add($"SensorGlucose error: {ex.Message}");
-            }
-            catch (InvalidOperationException ex)
-            {
-                _logger.LogError(ex, "[{ConnectorSource}] Error publishing SensorGlucose", ConnectorSource);
-                result.Success = false;
-                result.Errors.Add($"SensorGlucose error: {ex.Message}");
-            }
-        }
-        else if (isStale && enabledTypes.Contains(SyncDataType.Glucose))
+        if (isStale)
         {
             _logger.LogDebug("[{ConnectorSource}] Skipping SGVs — data is stale (>{Threshold} min)",
                 ConnectorSource, CareLinkConstants.StaleDataThresholdMinutes);
+            return;
         }
 
-        // Publish DeviceStatus (always, even when stale)
-        if (enabledTypes.Contains(SyncDataType.DeviceStatus))
+        try
         {
-            try
+            var sgRecords = _sgMapper.Map(data);
+            if (sgRecords.Count > 0)
             {
-                var deviceStatus = CareLinkDeviceStatusMapper.Map(data);
-                var success = await PublishDeviceStatusAsync([deviceStatus], config, cancellationToken);
-                result.ItemsSynced[SyncDataType.DeviceStatus] = 1;
+                var success = await PublishSensorGlucoseDataAsync(sgRecords, config, cancellationToken);
+                result.ItemsSynced[SyncDataType.Glucose] = sgRecords.Count;
                 if (!success)
                 {
                     result.Success = false;
-                    result.Errors.Add("DeviceStatus publish failed");
+                    result.Errors.Add("SensorGlucose publish failed");
                 }
                 else
                 {
-                    _logger.LogInformation("[{ConnectorSource}] Synced DeviceStatus", ConnectorSource);
+                    _logger.LogInformation(
+                        "[{ConnectorSource}] Synced {Count} SensorGlucose records",
+                        ConnectorSource, sgRecords.Count);
                 }
             }
-            catch (OperationCanceledException) { throw; }
-            catch (HttpRequestException ex)
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "[{ConnectorSource}] Error publishing SensorGlucose", ConnectorSource);
+            result.Success = false;
+            result.Errors.Add($"SensorGlucose error: {ex.Message}");
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogError(ex, "[{ConnectorSource}] Error publishing SensorGlucose", ConnectorSource);
+            result.Success = false;
+            result.Errors.Add($"SensorGlucose error: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    ///     Publishes device status (always, even when data is stale).
+    /// </summary>
+    private async Task PublishDeviceStatusStepAsync(
+        CareLinkData data,
+        CareLinkConnectorConfiguration config,
+        List<SyncDataType> enabledTypes,
+        SyncResult result,
+        CancellationToken cancellationToken)
+    {
+        if (!enabledTypes.Contains(SyncDataType.DeviceStatus))
+            return;
+
+        try
+        {
+            var deviceStatus = CareLinkDeviceStatusMapper.Map(data);
+            var success = await PublishDeviceStatusAsync([deviceStatus], config, cancellationToken);
+            result.ItemsSynced[SyncDataType.DeviceStatus] = 1;
+            if (!success)
             {
-                _logger.LogError(ex, "[{ConnectorSource}] Error publishing DeviceStatus", ConnectorSource);
                 result.Success = false;
-                result.Errors.Add($"DeviceStatus error: {ex.Message}");
+                result.Errors.Add("DeviceStatus publish failed");
             }
-            catch (InvalidOperationException ex)
+            else
             {
-                _logger.LogError(ex, "[{ConnectorSource}] Error publishing DeviceStatus", ConnectorSource);
-                result.Success = false;
-                result.Errors.Add($"DeviceStatus error: {ex.Message}");
+                _logger.LogInformation("[{ConnectorSource}] Synced DeviceStatus", ConnectorSource);
             }
         }
-
-        // Publish alarm as SystemEvent (dedup by datetime+code)
-        if (data.LastAlarm != null)
+        catch (OperationCanceledException) { throw; }
+        catch (HttpRequestException ex)
         {
-            try
+            _logger.LogError(ex, "[{ConnectorSource}] Error publishing DeviceStatus", ConnectorSource);
+            result.Success = false;
+            result.Errors.Add($"DeviceStatus error: {ex.Message}");
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogError(ex, "[{ConnectorSource}] Error publishing DeviceStatus", ConnectorSource);
+            result.Success = false;
+            result.Errors.Add($"DeviceStatus error: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    ///     Publishes the latest alarm as a SystemEvent, deduped by datetime+code. Alarm failures
+    ///     are logged but never fail the sync.
+    /// </summary>
+    private async Task PublishAlarmStepAsync(
+        CareLinkData data,
+        CareLinkConnectorConfiguration config,
+        SyncResult result,
+        CancellationToken cancellationToken)
+    {
+        if (data.LastAlarm == null)
+            return;
+
+        try
+        {
+            var alarmKey = $"{data.LastAlarm.Datetime}_{data.LastAlarm.Code}";
+            if (alarmKey != _lastAlarmKey)
             {
-                var alarmKey = $"{data.LastAlarm.Datetime}_{data.LastAlarm.Code}";
-                if (alarmKey != _lastAlarmKey)
+                var pumpOffsetMs = Utilities.CareLinkTimestampParser.CalculatePumpOffsetMs(
+                    data.MedicalDeviceTime ?? "", data.CurrentServerTime);
+                var systemEvent = CareLinkSystemEventMapper.Map(data.LastAlarm, pumpOffsetMs, data.CurrentServerTime);
+                if (systemEvent != null)
                 {
-                    var pumpOffsetMs = Utilities.CareLinkTimestampParser.CalculatePumpOffsetMs(
-                        data.MedicalDeviceTime ?? "", data.CurrentServerTime);
-                    var systemEvent = CareLinkSystemEventMapper.Map(data.LastAlarm, pumpOffsetMs, data.CurrentServerTime);
-                    if (systemEvent != null)
+                    var success = await PublishSystemEventDataAsync([systemEvent], config, cancellationToken);
+                    if (success)
                     {
-                        var success = await PublishSystemEventDataAsync([systemEvent], config, cancellationToken);
-                        if (success)
-                        {
-                            _lastAlarmKey = alarmKey;
-                            _logger.LogInformation("[{ConnectorSource}] Published alarm event {Code}",
-                                ConnectorSource, data.LastAlarm.Code);
-                        }
+                        _lastAlarmKey = alarmKey;
+                        _logger.LogInformation("[{ConnectorSource}] Published alarm event {Code}",
+                            ConnectorSource, data.LastAlarm.Code);
                     }
                 }
             }
-            catch (OperationCanceledException) { throw; }
-            catch (HttpRequestException ex)
-            {
-                _logger.LogWarning(ex, "[{ConnectorSource}] Error publishing alarm event", ConnectorSource);
-            }
-            catch (InvalidOperationException ex)
-            {
-                _logger.LogWarning(ex, "[{ConnectorSource}] Error publishing alarm event", ConnectorSource);
-            }
         }
+        catch (OperationCanceledException) { throw; }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "[{ConnectorSource}] Error publishing alarm event", ConnectorSource);
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning(ex, "[{ConnectorSource}] Error publishing alarm event", ConnectorSource);
+        }
+    }
 
-        // Publish treatments (boluses, carbs, temp basals) + notification events from the periodic payload.
-        // These are historical markers with their own timestamps, so staleness does not apply.
+    /// <summary>
+    ///     Publishes treatments (boluses, carbs, temp basals) plus notification events from the
+    ///     periodic payload. These are historical markers with their own timestamps, so staleness
+    ///     does not apply.
+    /// </summary>
+    private async Task PublishTreatmentsStepAsync(
+        CareLinkData data,
+        CareLinkConnectorConfiguration config,
+        List<SyncDataType> enabledTypes,
+        SyncResult result,
+        CancellationToken cancellationToken)
+    {
         try
         {
             var pumpOffsetMs = Utilities.CareLinkTimestampParser.CalculatePumpOffsetMs(
@@ -364,12 +443,6 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
             result.Success = false;
             result.Errors.Add($"Treatment error: {ex.Message}");
         }
-
-        // Persist refresh token if it changed during sync
-        await PersistRefreshTokenIfChangedAsync(cancellationToken);
-
-        result.EndTime = DateTimeOffset.UtcNow;
-        return result;
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/AuthAuditLogEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/AuthAuditLogEntity.cs
@@ -8,7 +8,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Tracks all authentication-related events for security monitoring
 /// </summary>
 [Table("auth_audit_log")]
-public class AuthAuditLogEntity
+public class AuthAuditLogEntity : IEntityCreated
 {
     /// <summary>
     /// Primary key - UUID Version 7 for time-ordered, globally unique identification

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/BodyWeightEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/BodyWeightEntity.cs
@@ -7,7 +7,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Body composition measurement recorded by a scale or manual entry.
 /// </summary>
 [Table("body_weights")]
-public class BodyWeightEntity : ITenantScoped, ISoftDeletable, ISyncDedupable
+public class BodyWeightEntity : ITenantScoped, ISoftDeletable, ISyncDedupable, ISystemTimestamped
 {
     /// <summary>Owning tenant for RLS isolation.</summary>
     [Column("tenant_id")]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ClockFaceEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ClockFaceEntity.cs
@@ -8,7 +8,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Stores user-created clock face layouts with drag-and-drop configured elements
 /// </summary>
 [Table("clock_faces")]
-public class ClockFaceEntity : ITenantScoped
+public class ClockFaceEntity : ITenantScoped, ISystemTimestamped, IEntityCreated
 {
     /// <summary>
     /// Identifier of the tenant this clock face belongs to

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ConnectorConfigurationEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ConnectorConfigurationEntity.cs
@@ -9,7 +9,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Secret properties (passwords, API keys) are stored encrypted in SecretsJson.
 /// </summary>
 [Table("connector_configurations")]
-public class ConnectorConfigurationEntity : ITenantScoped
+public class ConnectorConfigurationEntity : ITenantScoped, ISystemTimestamped
 {
     /// <summary>
     /// Identifier of the tenant this connector configuration belongs to

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ConnectorFoodEntryEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ConnectorFoodEntryEntity.cs
@@ -8,7 +8,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// PostgreSQL entity for connector-imported food entries.
 /// </summary>
 [Table("connector_food_entries")]
-public class ConnectorFoodEntryEntity : ITenantScoped
+public class ConnectorFoodEntryEntity : ITenantScoped, ISystemTimestamped
 {
     /// <summary>
     /// Identifier of the tenant this food entry belongs to

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/FoodEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/FoodEntity.cs
@@ -9,7 +9,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Maps to Nocturne.Core.Models.Food
 /// </summary>
 [Table("foods")]
-public class FoodEntity : ITenantScoped
+public class FoodEntity : ITenantScoped, ISystemTimestamped
 {
     /// <summary>
     /// Identifier of the tenant this food belongs to

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/HeartRateEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/HeartRateEntity.cs
@@ -8,7 +8,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Maps to Nocturne.Core.Models.HeartRate
 /// </summary>
 [Table("heart_rates")]
-public class HeartRateEntity : ITenantScoped, ISoftDeletable, ISyncDedupable
+public class HeartRateEntity : ITenantScoped, ISoftDeletable, ISyncDedupable, ISystemTimestamped
 {
     /// <summary>
     /// Identifier of the tenant this heart rate record belongs to

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IEntityCreated.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IEntityCreated.cs
@@ -1,0 +1,14 @@
+namespace Nocturne.Infrastructure.Data.Entities;
+
+/// <summary>
+/// Marker for auth/identity entities carrying a created_at timestamp set on insert.
+/// Separate from <see cref="ISystemCreated"/> because these tables use the
+/// created_at / updated_at naming convention rather than sys_*.
+/// </summary>
+public interface IEntityCreated
+{
+    /// <summary>
+    /// When the record was created.
+    /// </summary>
+    DateTime CreatedAt { get; set; }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IEntityTimestamped.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IEntityTimestamped.cs
@@ -1,0 +1,14 @@
+namespace Nocturne.Infrastructure.Data.Entities;
+
+/// <summary>
+/// Marker for auth/identity entities carrying created_at / updated_at timestamps.
+/// NocturneDbContext stamps <see cref="IEntityCreated.CreatedAt"/> on insert and
+/// <see cref="UpdatedAt"/> on every save.
+/// </summary>
+public interface IEntityTimestamped : IEntityCreated
+{
+    /// <summary>
+    /// When the record was last updated.
+    /// </summary>
+    DateTime UpdatedAt { get; set; }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ISystemCreated.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ISystemCreated.cs
@@ -1,0 +1,13 @@
+namespace Nocturne.Infrastructure.Data.Entities;
+
+/// <summary>
+/// Marker for entities carrying a system-managed creation timestamp (sys_created_at).
+/// NocturneDbContext stamps <see cref="SysCreatedAt"/> on insert.
+/// </summary>
+public interface ISystemCreated
+{
+    /// <summary>
+    /// System tracking: when the record was inserted.
+    /// </summary>
+    DateTime SysCreatedAt { get; set; }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ISystemTimestamped.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ISystemTimestamped.cs
@@ -1,0 +1,15 @@
+namespace Nocturne.Infrastructure.Data.Entities;
+
+/// <summary>
+/// Marker for entities carrying system-managed creation and update timestamps
+/// (sys_created_at / sys_updated_at). NocturneDbContext stamps
+/// <see cref="ISystemCreated.SysCreatedAt"/> on insert and <see cref="SysUpdatedAt"/>
+/// on every save.
+/// </summary>
+public interface ISystemTimestamped : ISystemCreated
+{
+    /// <summary>
+    /// System tracking: when the record was last updated.
+    /// </summary>
+    DateTime SysUpdatedAt { get; set; }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/LinkedRecordEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/LinkedRecordEntity.cs
@@ -8,7 +8,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Links records from different sources that represent the same underlying event.
 /// </summary>
 [Table("linked_records")]
-public class LinkedRecordEntity : ITenantScoped
+public class LinkedRecordEntity : ITenantScoped, ISystemCreated
 {
     /// <summary>
     /// Identifier of the tenant this linked record belongs to

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/OAuthAuthorizationCodeEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/OAuthAuthorizationCodeEntity.cs
@@ -9,7 +9,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// only its SHA-256 hash is persisted for verification during token exchange.
 /// </summary>
 [Table("oauth_authorization_codes")]
-public class OAuthAuthorizationCodeEntity : ITenantScoped
+public class OAuthAuthorizationCodeEntity : ITenantScoped, IEntityCreated
 {
     /// <summary>
     /// Primary key - UUID Version 7

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/OAuthClientEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/OAuthClientEntity.cs
@@ -9,7 +9,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// this table records clients that have been authorized at least once.
 /// </summary>
 [Table("oauth_clients")]
-public class OAuthClientEntity : ITenantScoped
+public class OAuthClientEntity : ITenantScoped, IEntityTimestamped
 {
     /// <summary>
     /// Primary key - UUID Version 7

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/OAuthDeviceCodeEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/OAuthDeviceCodeEntity.cs
@@ -8,7 +8,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Used by headless clients (CLI tools, scripts, IoT devices, pump rigs).
 /// </summary>
 [Table("oauth_device_codes")]
-public class OAuthDeviceCodeEntity : ITenantScoped
+public class OAuthDeviceCodeEntity : ITenantScoped, IEntityCreated
 {
     /// <summary>
     /// Primary key - UUID Version 7

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/OAuthGrantEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/OAuthGrantEntity.cs
@@ -9,7 +9,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// User-to-user shares (followers/caregivers) use the same table with grant_type = follower.
 /// </summary>
 [Table("oauth_grants")]
-public class OAuthGrantEntity : ITenantScoped, IAuditable
+public class OAuthGrantEntity : ITenantScoped, IAuditable, IEntityCreated
 {
     /// <summary>
     /// Primary key - UUID Version 7

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/OidcProviderEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/OidcProviderEntity.cs
@@ -8,7 +8,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Stores configuration for external identity providers
 /// </summary>
 [Table("oidc_providers")]
-public class OidcProviderEntity
+public class OidcProviderEntity : IEntityTimestamped
 {
     /// <summary>
     /// Primary key - UUID Version 7 for time-ordered, globally unique identification

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/PlatformSettingsEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/PlatformSettingsEntity.cs
@@ -9,7 +9,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// tracks which fields have values so the UI can show configuration status without exposing secrets.
 /// </summary>
 [Table("platform_settings")]
-public class PlatformSettingsEntity
+public class PlatformSettingsEntity : ISystemTimestamped
 {
     /// <summary>Primary key.</summary>
     [Key]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/RefreshTokenEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/RefreshTokenEntity.cs
@@ -8,7 +8,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Stored in database for revocation support - access tokens are short-lived JWTs validated statelessly
 /// </summary>
 [Table("refresh_tokens")]
-public class RefreshTokenEntity
+public class RefreshTokenEntity : IEntityTimestamped
 {
     /// <summary>
     /// Primary key - UUID Version 7 for time-ordered, globally unique identification

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/RoleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/RoleEntity.cs
@@ -8,7 +8,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Defines sets of permissions that can be assigned to subjects
 /// </summary>
 [Table("roles")]
-public class RoleEntity
+public class RoleEntity : IEntityTimestamped
 {
     /// <summary>
     /// Primary key - UUID Version 7 for time-ordered, globally unique identification

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/SettingsEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/SettingsEntity.cs
@@ -8,7 +8,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Maps to Nocturne.Core.Models.Settings
 /// </summary>
 [Table("settings")]
-public class SettingsEntity : ITenantScoped, IAuditable
+public class SettingsEntity : ITenantScoped, IAuditable, ISystemTimestamped
 {
     /// <summary>
     /// Identifier of the tenant this setting belongs to

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/StepCountEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/StepCountEntity.cs
@@ -8,7 +8,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Maps to Nocturne.Core.Models.StepCount
 /// </summary>
 [Table("step_counts")]
-public class StepCountEntity : ITenantScoped, ISoftDeletable, ISyncDedupable
+public class StepCountEntity : ITenantScoped, ISoftDeletable, ISyncDedupable, ISystemTimestamped
 {
     /// <summary>
     /// Identifier of the tenant this step count record belongs to

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/SubjectEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/SubjectEntity.cs
@@ -8,7 +8,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Represents both human users and automated devices that can authenticate
 /// </summary>
 [Table("subjects")]
-public class SubjectEntity
+public class SubjectEntity : IEntityTimestamped
 {
     /// <summary>
     /// Primary key - UUID Version 7 for time-ordered, globally unique identification

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TenantAuditConfigEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TenantAuditConfigEntity.cs
@@ -11,7 +11,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// No RLS policy on this table.
 /// </summary>
 [Table("tenant_audit_config")]
-public class TenantAuditConfigEntity
+public class TenantAuditConfigEntity : ISystemTimestamped
 {
     /// <summary>Primary key (UUID v7).</summary>
     [Key]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TenantEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TenantEntity.cs
@@ -8,7 +8,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Each tenant has its own subdomain and isolated clinical data.
 /// </summary>
 [Table("tenants")]
-public class TenantEntity
+public class TenantEntity : ISystemTimestamped
 {
     /// <summary>
     /// Unique identifier for the tenant

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TenantMemberEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TenantMemberEntity.cs
@@ -7,7 +7,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Join entity linking subjects to tenants (many-to-many).
 /// </summary>
 [Table("tenant_members")]
-public class TenantMemberEntity
+public class TenantMemberEntity : ISystemTimestamped
 {
     /// <summary>
     /// Unique identifier for the tenant member link

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TenantMemberRoleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TenantMemberRoleEntity.cs
@@ -7,7 +7,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Join entity linking tenant members to roles (many-to-many).
 /// </summary>
 [Table("tenant_member_roles")]
-public class TenantMemberRoleEntity
+public class TenantMemberRoleEntity : ISystemCreated
 {
     /// <summary>
     /// Unique identifier for the member role link

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TenantRoleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TenantRoleEntity.cs
@@ -7,7 +7,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Represents a role within a tenant, defining a set of permissions for members.
 /// </summary>
 [Table("tenant_roles")]
-public class TenantRoleEntity
+public class TenantRoleEntity : ISystemTimestamped
 {
     /// <summary>
     /// Unique identifier for the tenant role

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TreatmentFoodEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TreatmentFoodEntity.cs
@@ -8,7 +8,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// PostgreSQL entity for food attribution entries linked to carb intake records.
 /// </summary>
 [Table("treatment_foods")]
-public class TreatmentFoodEntity : ITenantScoped
+public class TreatmentFoodEntity : ITenantScoped, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/UserFoodFavoriteEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/UserFoodFavoriteEntity.cs
@@ -7,7 +7,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// PostgreSQL entity for user food favorites.
 /// </summary>
 [Table("user_food_favorites")]
-public class UserFoodFavoriteEntity : ITenantScoped
+public class UserFoodFavoriteEntity : ITenantScoped, ISystemCreated
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/ApsSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/ApsSnapshotEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.ApsSnapshot
 /// </summary>
 [Table("aps_snapshots")]
-public class ApsSnapshotEntity : ITenantScoped, ISoftDeletable, IV4Entity
+public class ApsSnapshotEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BGCheckEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BGCheckEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.BGCheck
 /// </summary>
 [Table("bg_checks")]
-public class BGCheckEntity : ITenantScoped, ISoftDeletable, IV4Entity
+public class BGCheckEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalInjectionEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalInjectionEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.BasalInjection.
 /// </summary>
 [Table("basal_injections")]
-public class BasalInjectionEntity : ITenantScoped, IAuditable, ISoftDeletable
+public class BasalInjectionEntity : ITenantScoped, IAuditable, ISoftDeletable, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalScheduleEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.BasalSchedule
 /// </summary>
 [Table("basal_schedules")]
-public class BasalScheduleEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity
+public class BasalScheduleEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusCalculationEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusCalculationEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.BolusCalculation
 /// </summary>
 [Table("bolus_calculations")]
-public class BolusCalculationEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity
+public class BolusCalculationEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.Bolus
 /// </summary>
 [Table("boluses")]
-public class BolusEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity
+public class BolusEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CalibrationEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CalibrationEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.Calibration
 /// </summary>
 [Table("calibrations")]
-public class CalibrationEntity : ITenantScoped, ISoftDeletable, IV4Entity
+public class CalibrationEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbIntakeEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbIntakeEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.CarbIntake
 /// </summary>
 [Table("carb_intakes")]
-public class CarbIntakeEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity
+public class CarbIntakeEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbRatioScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbRatioScheduleEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.CarbRatioSchedule
 /// </summary>
 [Table("carb_ratio_schedules")]
-public class CarbRatioScheduleEntity : ITenantScoped, ISoftDeletable, IV4Entity
+public class CarbRatioScheduleEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceEventEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceEventEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.DeviceEvent
 /// </summary>
 [Table("device_events")]
-public class DeviceEventEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity
+public class DeviceEventEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceStatusExtrasEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceStatusExtrasEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.DeviceStatusExtras
 /// </summary>
 [Table("device_status_extras")]
-public class DeviceStatusExtrasEntity : ITenantScoped, IAuditable, ISoftDeletable
+public class DeviceStatusExtrasEntity : ITenantScoped, IAuditable, ISoftDeletable, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/MeterGlucoseEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/MeterGlucoseEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.MeterGlucose
 /// </summary>
 [Table("meter_glucose")]
-public class MeterGlucoseEntity : ITenantScoped, ISoftDeletable, IV4Entity
+public class MeterGlucoseEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/NoteEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/NoteEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.Note
 /// </summary>
 [Table("notes")]
-public class NoteEntity : ITenantScoped, ISoftDeletable, IV4Entity
+public class NoteEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PatientDeviceEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PatientDeviceEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.PatientDevice
 /// </summary>
 [Table("patient_devices")]
-public class PatientDeviceEntity : ITenantScoped, ISoftDeletable
+public class PatientDeviceEntity : ITenantScoped, ISoftDeletable, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PatientInsulinEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PatientInsulinEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.PatientInsulin
 /// </summary>
 [Table("patient_insulins")]
-public class PatientInsulinEntity : ITenantScoped, ISoftDeletable
+public class PatientInsulinEntity : ITenantScoped, ISoftDeletable, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PatientRecordEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PatientRecordEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.PatientRecord
 /// </summary>
 [Table("patient_records")]
-public class PatientRecordEntity : ITenantScoped, ISoftDeletable
+public class PatientRecordEntity : ITenantScoped, ISoftDeletable, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PumpSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PumpSnapshotEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.PumpSnapshot
 /// </summary>
 [Table("pump_snapshots")]
-public class PumpSnapshotEntity : ITenantScoped, ISoftDeletable, IV4Entity
+public class PumpSnapshotEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensitivityScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensitivityScheduleEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.SensitivitySchedule
 /// </summary>
 [Table("sensitivity_schedules")]
-public class SensitivityScheduleEntity : ITenantScoped, ISoftDeletable, IV4Entity
+public class SensitivityScheduleEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensorGlucoseEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensorGlucoseEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.SensorGlucose
 /// </summary>
 [Table("sensor_glucose")]
-public class SensorGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity
+public class SensorGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TargetRangeScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TargetRangeScheduleEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.TargetRangeSchedule
 /// </summary>
 [Table("target_range_schedules")]
-public class TargetRangeScheduleEntity : ITenantScoped, ISoftDeletable, IV4Entity
+public class TargetRangeScheduleEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TempBasalEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TempBasalEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.TempBasal
 /// </summary>
 [Table("temp_basals")]
-public class TempBasalEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity
+public class TempBasalEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TherapySettingsEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TherapySettingsEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.TherapySettings
 /// </summary>
 [Table("therapy_settings")]
-public class TherapySettingsEntity : ITenantScoped, ISoftDeletable, IV4Entity
+public class TherapySettingsEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/UploaderSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/UploaderSnapshotEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.UploaderSnapshot
 /// </summary>
 [Table("uploader_snapshots")]
-public class UploaderSnapshotEntity : ITenantScoped, ISoftDeletable, IV4Entity
+public class UploaderSnapshotEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -2,6 +2,7 @@ using System.Linq.Expressions;
 using System.Text.Json;
 using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Models;
 using Nocturne.Infrastructure.Data.Entities;
@@ -3075,7 +3076,7 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
     }
 
     /// <summary>
-    /// Update system tracking timestamps before saving
+    /// Update system tracking timestamps before saving, and enforce tenant ownership.
     /// </summary>
     private void UpdateTimestamps()
     {
@@ -3083,360 +3084,88 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
 
         foreach (var entry in ChangeTracker.Entries())
         {
-            // Enforce tenant ID on all new ITenantScoped entities
-            if (entry.State == EntityState.Added && entry.Entity is ITenantScoped tenantScoped)
+            var isAdded = entry.State == EntityState.Added;
+
+            EnforceTenantOwnership(entry, isAdded);
+
+            // System tracking columns (sys_created_at / sys_updated_at) on tenant data.
+            if (isAdded && entry.Entity is ISystemCreated systemCreated)
             {
-                if (tenantScoped.TenantId == Guid.Empty && TenantId != Guid.Empty)
-                {
-                    tenantScoped.TenantId = TenantId;
-                }
-                else if (tenantScoped.TenantId == Guid.Empty)
-                {
-                    throw new InvalidOperationException(
-                        $"Cannot save {entry.Entity.GetType().Name} without a TenantId. " +
-                        "Ensure tenant context is resolved before writing data.");
-                }
+                systemCreated.SysCreatedAt = utcNow;
+            }
+            if (entry.Entity is ISystemTimestamped systemTimestamped)
+            {
+                systemTimestamped.SysUpdatedAt = utcNow;
             }
 
-            // Prevent cross-tenant writes
-            if (entry.State == EntityState.Modified && entry.Entity is ITenantScoped modifiedTenant)
+            // Auth/identity tables use the created_at / updated_at convention instead.
+            if (isAdded && entry.Entity is IEntityCreated entityCreated)
             {
-                if (TenantId != Guid.Empty && modifiedTenant.TenantId != TenantId)
-                {
-                    throw new InvalidOperationException(
-                        $"Cannot modify {entry.Entity.GetType().Name} belonging to tenant " +
-                        $"{modifiedTenant.TenantId} from tenant context {TenantId}.");
-                }
+                entityCreated.CreatedAt = utcNow;
+            }
+            if (entry.Entity is IEntityTimestamped entityTimestamped)
+            {
+                entityTimestamped.UpdatedAt = utcNow;
             }
 
-            if (entry.Entity is FoodEntity foodEntity)
+            ApplyEntitySpecificTimestamps(entry.Entity, isAdded, utcNow);
+        }
+    }
+
+    /// <summary>
+    /// Enforces tenant ownership on a tracked entity: stamps the resolved tenant on new
+    /// rows and blocks cross-tenant modifications.
+    /// </summary>
+    private void EnforceTenantOwnership(EntityEntry entry, bool isAdded)
+    {
+        if (entry.Entity is not ITenantScoped tenantScoped)
+        {
+            return;
+        }
+
+        if (isAdded)
+        {
+            if (tenantScoped.TenantId == Guid.Empty && TenantId != Guid.Empty)
             {
-                if (entry.State == EntityState.Added)
-                {
-                    foodEntity.SysCreatedAt = utcNow;
-                }
-                foodEntity.SysUpdatedAt = utcNow;
+                tenantScoped.TenantId = TenantId;
             }
-            else if (entry.Entity is ConnectorFoodEntryEntity connectorFoodEntryEntity)
+            else if (tenantScoped.TenantId == Guid.Empty)
             {
-                if (entry.State == EntityState.Added)
-                {
-                    connectorFoodEntryEntity.SysCreatedAt = utcNow;
-                }
-                connectorFoodEntryEntity.SysUpdatedAt = utcNow;
+                throw new InvalidOperationException(
+                    $"Cannot save {entry.Entity.GetType().Name} without a TenantId. " +
+                    "Ensure tenant context is resolved before writing data.");
             }
-            else if (entry.Entity is TreatmentFoodEntity treatmentFoodEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    treatmentFoodEntity.SysCreatedAt = utcNow;
-                }
-                treatmentFoodEntity.SysUpdatedAt = utcNow;
-            }
-            else if (entry.Entity is UserFoodFavoriteEntity userFoodFavoriteEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    userFoodFavoriteEntity.SysCreatedAt = utcNow;
-                }
-            }
-            else if (entry.Entity is SettingsEntity settingsEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    settingsEntity.SysCreatedAt = utcNow;
-                }
-                settingsEntity.SysUpdatedAt = utcNow;
-            }
-            else if (entry.Entity is StepCountEntity stepCountEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    stepCountEntity.SysCreatedAt = utcNow;
-                }
-                stepCountEntity.SysUpdatedAt = utcNow;
-            }
-            else if (entry.Entity is HeartRateEntity heartRateEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    heartRateEntity.SysCreatedAt = utcNow;
-                }
-                heartRateEntity.SysUpdatedAt = utcNow;
-            }
-// Auth entities
-            else if (entry.Entity is RefreshTokenEntity refreshTokenEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    refreshTokenEntity.CreatedAt = utcNow;
-                }
-                refreshTokenEntity.UpdatedAt = utcNow;
-            }
-            else if (entry.Entity is SubjectEntity subjectEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    subjectEntity.CreatedAt = utcNow;
-                }
-                subjectEntity.UpdatedAt = utcNow;
-            }
-            else if (entry.Entity is RoleEntity roleEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    roleEntity.CreatedAt = utcNow;
-                }
-                roleEntity.UpdatedAt = utcNow;
-            }
-            else if (entry.Entity is OidcProviderEntity oidcProviderEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    oidcProviderEntity.CreatedAt = utcNow;
-                }
-                oidcProviderEntity.UpdatedAt = utcNow;
-            }
-            else if (entry.Entity is AuthAuditLogEntity authAuditLogEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    authAuditLogEntity.CreatedAt = utcNow;
-                }
-            }
-            else if (entry.Entity is LinkedRecordEntity linkedRecordEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    linkedRecordEntity.SysCreatedAt = utcNow;
-                }
-            }
-            else if (entry.Entity is ConnectorConfigurationEntity connectorConfigEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    connectorConfigEntity.SysCreatedAt = utcNow;
-                    connectorConfigEntity.LastModified = DateTimeOffset.UtcNow;
-                }
-                connectorConfigEntity.SysUpdatedAt = utcNow;
-            }
-            // OAuth entities
-            else if (entry.Entity is OAuthClientEntity oauthClientEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    oauthClientEntity.CreatedAt = utcNow;
-                }
-                oauthClientEntity.UpdatedAt = utcNow;
-            }
-            else if (entry.Entity is OAuthGrantEntity oauthGrantEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    oauthGrantEntity.CreatedAt = utcNow;
-                }
-            }
-            else if (entry.Entity is OAuthRefreshTokenEntity oauthRefreshTokenEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    oauthRefreshTokenEntity.IssuedAt = utcNow;
-                }
-            }
-            else if (entry.Entity is OAuthDeviceCodeEntity oauthDeviceCodeEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    oauthDeviceCodeEntity.CreatedAt = utcNow;
-                }
-            }
-            else if (entry.Entity is OAuthAuthorizationCodeEntity oauthAuthCodeEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    oauthAuthCodeEntity.CreatedAt = utcNow;
-                }
-            }
-            else if (entry.Entity is ClockFaceEntity clockFaceEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    clockFaceEntity.CreatedAt = utcNow;
-                    clockFaceEntity.SysCreatedAt = utcNow;
-                }
-                clockFaceEntity.UpdatedAt = utcNow;
-                clockFaceEntity.SysUpdatedAt = utcNow;
-            }
-            // V4 Granular Model entities
-            else if (entry.Entity is SensorGlucoseEntity sensorGlucoseEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    sensorGlucoseEntity.SysCreatedAt = utcNow;
-                }
-                sensorGlucoseEntity.SysUpdatedAt = utcNow;
-            }
-            else if (entry.Entity is MeterGlucoseEntity meterGlucoseEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    meterGlucoseEntity.SysCreatedAt = utcNow;
-                }
-                meterGlucoseEntity.SysUpdatedAt = utcNow;
-            }
-            else if (entry.Entity is CalibrationEntity calibrationEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    calibrationEntity.SysCreatedAt = utcNow;
-                }
-                calibrationEntity.SysUpdatedAt = utcNow;
-            }
-            else if (entry.Entity is BolusEntity bolusEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    bolusEntity.SysCreatedAt = utcNow;
-                }
-                bolusEntity.SysUpdatedAt = utcNow;
-            }
-            else if (entry.Entity is BasalInjectionEntity basalInjectionEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    basalInjectionEntity.SysCreatedAt = utcNow;
-                }
-                basalInjectionEntity.SysUpdatedAt = utcNow;
-            }
-            else if (entry.Entity is CarbIntakeEntity carbIntakeEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    carbIntakeEntity.SysCreatedAt = utcNow;
-                }
-                carbIntakeEntity.SysUpdatedAt = utcNow;
-            }
-            else if (entry.Entity is BGCheckEntity bgCheckEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    bgCheckEntity.SysCreatedAt = utcNow;
-                }
-                bgCheckEntity.SysUpdatedAt = utcNow;
-            }
-            else if (entry.Entity is NoteEntity noteEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    noteEntity.SysCreatedAt = utcNow;
-                }
-                noteEntity.SysUpdatedAt = utcNow;
-            }
-            else if (entry.Entity is DeviceEventEntity deviceEventEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    deviceEventEntity.SysCreatedAt = utcNow;
-                }
-                deviceEventEntity.SysUpdatedAt = utcNow;
-            }
-            else if (entry.Entity is BolusCalculationEntity bolusCalculationEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    bolusCalculationEntity.SysCreatedAt = utcNow;
-                }
-                bolusCalculationEntity.SysUpdatedAt = utcNow;
-            }
-            else if (entry.Entity is ApsSnapshotEntity apsSnapshotEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    apsSnapshotEntity.SysCreatedAt = utcNow;
-                }
-                apsSnapshotEntity.SysUpdatedAt = utcNow;
-            }
-            else if (entry.Entity is PumpSnapshotEntity pumpSnapshotEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    pumpSnapshotEntity.SysCreatedAt = utcNow;
-                }
-                pumpSnapshotEntity.SysUpdatedAt = utcNow;
-            }
-            else if (entry.Entity is UploaderSnapshotEntity uploaderSnapshotEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    uploaderSnapshotEntity.SysCreatedAt = utcNow;
-                }
-                uploaderSnapshotEntity.SysUpdatedAt = utcNow;
-            }
-            // V4 Profile Decomposition entities
-            else if (entry.Entity is TherapySettingsEntity therapySettingsEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    therapySettingsEntity.SysCreatedAt = utcNow;
-                }
-                therapySettingsEntity.SysUpdatedAt = utcNow;
-            }
-            else if (entry.Entity is BasalScheduleEntity basalScheduleEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    basalScheduleEntity.SysCreatedAt = utcNow;
-                }
-                basalScheduleEntity.SysUpdatedAt = utcNow;
-            }
-            else if (entry.Entity is CarbRatioScheduleEntity carbRatioScheduleEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    carbRatioScheduleEntity.SysCreatedAt = utcNow;
-                }
-                carbRatioScheduleEntity.SysUpdatedAt = utcNow;
-            }
-            else if (entry.Entity is SensitivityScheduleEntity sensitivityScheduleEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    sensitivityScheduleEntity.SysCreatedAt = utcNow;
-                }
-                sensitivityScheduleEntity.SysUpdatedAt = utcNow;
-            }
-            else if (entry.Entity is TargetRangeScheduleEntity targetRangeScheduleEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    targetRangeScheduleEntity.SysCreatedAt = utcNow;
-                }
-                targetRangeScheduleEntity.SysUpdatedAt = utcNow;
-            }
-            else if (entry.Entity is TenantEntity tenantEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    tenantEntity.SysCreatedAt = utcNow;
-                }
-                tenantEntity.SysUpdatedAt = utcNow;
-            }
-            else if (entry.Entity is TenantMemberEntity tenantMemberEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    tenantMemberEntity.SysCreatedAt = utcNow;
-                }
-                tenantMemberEntity.SysUpdatedAt = utcNow;
-            }
-            else if (entry.Entity is PlatformSettingsEntity platformSettingsEntity)
-            {
-                if (entry.State == EntityState.Added)
-                {
-                    platformSettingsEntity.SysCreatedAt = utcNow;
-                }
-                platformSettingsEntity.SysUpdatedAt = utcNow;
-            }
+        }
+        else if (entry.State == EntityState.Modified
+            && TenantId != Guid.Empty
+            && tenantScoped.TenantId != TenantId)
+        {
+            throw new InvalidOperationException(
+                $"Cannot modify {entry.Entity.GetType().Name} belonging to tenant " +
+                $"{tenantScoped.TenantId} from tenant context {TenantId}.");
+        }
+    }
+
+    /// <summary>
+    /// Applies timestamps for the few entities whose columns do not follow either the
+    /// sys_* or created_at/updated_at conventions covered by the marker interfaces.
+    /// </summary>
+    private static void ApplyEntitySpecificTimestamps(object entity, bool isAdded, DateTime utcNow)
+    {
+        switch (entity)
+        {
+            // Nullable updated_at, set on every save alongside its ISystemTimestamped stamps.
+            case ClockFaceEntity clockFace:
+                clockFace.UpdatedAt = utcNow;
+                break;
+            // Mirror of sys_created_at on a DateTimeOffset column, set on insert only.
+            case ConnectorConfigurationEntity connectorConfig when isAdded:
+                connectorConfig.LastModified = utcNow;
+                break;
+            // Creation timestamp stored as issued_at, set on insert only.
+            case OAuthRefreshTokenEntity oauthRefreshToken when isAdded:
+                oauthRefreshToken.IssuedAt = utcNow;
+                break;
         }
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
@@ -104,223 +104,130 @@ public class DeduplicationService : IDeduplicationService
             return Guid.CreateVersion7();
         }
 
-        // For state spans, check category and state
+        // Each typed branch scans the candidate canonical groups for a value-level match within
+        // the time window; the time-window membership alone is enough for notes.
         if (recordType == RecordType.StateSpan && criteria.Category.HasValue)
         {
-            var canonicalIds = potentialMatches.Select(m => m.CanonicalId).Distinct().ToList();
             var categoryStr = criteria.Category.Value.ToString();
-
-            foreach (var canonicalId in canonicalIds)
-            {
-                var recordIds = potentialMatches
-                    .Where(m => m.CanonicalId == canonicalId)
-                    .Select(m => m.RecordId)
-                    .ToList();
-
-                var stateSpans = await _context.StateSpans
-                    .Where(s => recordIds.Contains(s.Id))
-                    .ToListAsync(cancellationToken);
-
-                foreach (var stateSpan in stateSpans)
-                {
-                    if (!string.Equals(stateSpan.Category, categoryStr, StringComparison.OrdinalIgnoreCase))
-                        continue;
-
-                    if (!string.IsNullOrEmpty(criteria.State) &&
-                        !string.Equals(stateSpan.State, criteria.State, StringComparison.OrdinalIgnoreCase))
-                        continue;
-
-                    // Match found
-                    return canonicalId;
-                }
-            }
+            var match = await FindMatchingCanonicalIdAsync(
+                potentialMatches,
+                ids => _context.StateSpans.Where(s => ids.Contains(s.Id)),
+                s => string.Equals(s.Category, categoryStr, StringComparison.OrdinalIgnoreCase)
+                    && (string.IsNullOrEmpty(criteria.State)
+                        || string.Equals(s.State, criteria.State, StringComparison.OrdinalIgnoreCase)),
+                cancellationToken);
+            if (match.HasValue)
+                return match.Value;
         }
-        // For sensor glucose, check glucose value matching
         else if (recordType == RecordType.SensorGlucose && criteria.GlucoseValue.HasValue)
         {
-            var canonicalIds = potentialMatches.Select(m => m.CanonicalId).Distinct().ToList();
-
-            foreach (var canonicalId in canonicalIds)
-            {
-                var recordIds = potentialMatches
-                    .Where(m => m.CanonicalId == canonicalId)
-                    .Select(m => m.RecordId)
-                    .ToList();
-
-                var readings = await _context.SensorGlucose
-                    .Where(r => recordIds.Contains(r.Id))
-                    .ToListAsync(cancellationToken);
-
-                foreach (var reading in readings)
-                {
-                    if (Math.Abs(reading.Mgdl - criteria.GlucoseValue.Value) <= criteria.GlucoseTolerance)
-                    {
-                        return canonicalId;
-                    }
-                }
-            }
+            var match = await FindMatchingCanonicalIdAsync(
+                potentialMatches,
+                ids => _context.SensorGlucose.Where(r => ids.Contains(r.Id)),
+                r => Math.Abs(r.Mgdl - criteria.GlucoseValue.Value) <= criteria.GlucoseTolerance,
+                cancellationToken);
+            if (match.HasValue)
+                return match.Value;
         }
-        // For boluses, check insulin value matching
         else if (recordType == RecordType.Bolus && criteria.Insulin.HasValue)
         {
-            var canonicalIds = potentialMatches.Select(m => m.CanonicalId).Distinct().ToList();
-
-            foreach (var canonicalId in canonicalIds)
-            {
-                var recordIds = potentialMatches
-                    .Where(m => m.CanonicalId == canonicalId)
-                    .Select(m => m.RecordId)
-                    .ToList();
-
-                var boluses = await _context.Boluses
-                    .Where(b => recordIds.Contains(b.Id))
-                    .ToListAsync(cancellationToken);
-
-                foreach (var bolus in boluses)
-                {
-                    if (Math.Abs(bolus.Insulin - criteria.Insulin.Value) <= criteria.InsulinTolerance)
-                    {
-                        return canonicalId;
-                    }
-                }
-            }
+            var match = await FindMatchingCanonicalIdAsync(
+                potentialMatches,
+                ids => _context.Boluses.Where(b => ids.Contains(b.Id)),
+                b => Math.Abs(b.Insulin - criteria.Insulin.Value) <= criteria.InsulinTolerance,
+                cancellationToken);
+            if (match.HasValue)
+                return match.Value;
         }
-        // For carb intakes, check carbs value matching
         else if (recordType == RecordType.CarbIntake && criteria.Carbs.HasValue)
         {
-            var canonicalIds = potentialMatches.Select(m => m.CanonicalId).Distinct().ToList();
-
-            foreach (var canonicalId in canonicalIds)
-            {
-                var recordIds = potentialMatches
-                    .Where(m => m.CanonicalId == canonicalId)
-                    .Select(m => m.RecordId)
-                    .ToList();
-
-                var carbs = await _context.CarbIntakes
-                    .Where(c => recordIds.Contains(c.Id))
-                    .ToListAsync(cancellationToken);
-
-                foreach (var carb in carbs)
-                {
-                    if (Math.Abs(carb.Carbs - criteria.Carbs.Value) <= criteria.CarbsTolerance)
-                    {
-                        return canonicalId;
-                    }
-                }
-            }
+            var match = await FindMatchingCanonicalIdAsync(
+                potentialMatches,
+                ids => _context.CarbIntakes.Where(c => ids.Contains(c.Id)),
+                c => Math.Abs(c.Carbs - criteria.Carbs.Value) <= criteria.CarbsTolerance,
+                cancellationToken);
+            if (match.HasValue)
+                return match.Value;
         }
-        // For BG checks, check glucose value matching
         else if (recordType == RecordType.BGCheck && criteria.GlucoseValue.HasValue)
         {
-            var canonicalIds = potentialMatches.Select(m => m.CanonicalId).Distinct().ToList();
-
-            foreach (var canonicalId in canonicalIds)
-            {
-                var recordIds = potentialMatches
-                    .Where(m => m.CanonicalId == canonicalId)
-                    .Select(m => m.RecordId)
-                    .ToList();
-
-                var bgChecks = await _context.BGChecks
-                    .Where(bg => recordIds.Contains(bg.Id))
-                    .ToListAsync(cancellationToken);
-
-                foreach (var bg in bgChecks)
-                {
-                    if (Math.Abs(bg.Glucose - criteria.GlucoseValue.Value) <= criteria.GlucoseTolerance)
-                    {
-                        return canonicalId;
-                    }
-                }
-            }
+            var match = await FindMatchingCanonicalIdAsync(
+                potentialMatches,
+                ids => _context.BGChecks.Where(bg => ids.Contains(bg.Id)),
+                bg => Math.Abs(bg.Glucose - criteria.GlucoseValue.Value) <= criteria.GlucoseTolerance,
+                cancellationToken);
+            if (match.HasValue)
+                return match.Value;
         }
-        // For device events, check event type matching
         else if (recordType == RecordType.DeviceEvent && !string.IsNullOrEmpty(criteria.EventType))
         {
-            var canonicalIds = potentialMatches.Select(m => m.CanonicalId).Distinct().ToList();
-
-            foreach (var canonicalId in canonicalIds)
-            {
-                var recordIds = potentialMatches
-                    .Where(m => m.CanonicalId == canonicalId)
-                    .Select(m => m.RecordId)
-                    .ToList();
-
-                var events = await _context.DeviceEvents
-                    .Where(e => recordIds.Contains(e.Id))
-                    .ToListAsync(cancellationToken);
-
-                foreach (var e in events)
-                {
-                    if (string.Equals(e.EventType, criteria.EventType, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return canonicalId;
-                    }
-                }
-            }
+            var match = await FindMatchingCanonicalIdAsync(
+                potentialMatches,
+                ids => _context.DeviceEvents.Where(e => ids.Contains(e.Id)),
+                e => string.Equals(e.EventType, criteria.EventType, StringComparison.OrdinalIgnoreCase),
+                cancellationToken);
+            if (match.HasValue)
+                return match.Value;
         }
-        // For notes, time-window only matching
         else if (recordType == RecordType.Note)
         {
+            // Notes match on time window alone.
             if (potentialMatches.Count > 0)
             {
                 return potentialMatches.First().CanonicalId;
             }
         }
-        // For bolus calculations, check carb input matching
         else if (recordType == RecordType.BolusCalculation && criteria.Carbs.HasValue)
         {
-            var canonicalIds = potentialMatches.Select(m => m.CanonicalId).Distinct().ToList();
-
-            foreach (var canonicalId in canonicalIds)
-            {
-                var recordIds = potentialMatches
-                    .Where(m => m.CanonicalId == canonicalId)
-                    .Select(m => m.RecordId)
-                    .ToList();
-
-                var calcs = await _context.BolusCalculations
-                    .Where(bc => recordIds.Contains(bc.Id))
-                    .ToListAsync(cancellationToken);
-
-                foreach (var bc in calcs)
-                {
-                    if (Math.Abs((bc.CarbInput ?? 0) - criteria.Carbs.Value) <= criteria.CarbsTolerance)
-                    {
-                        return canonicalId;
-                    }
-                }
-            }
+            var match = await FindMatchingCanonicalIdAsync(
+                potentialMatches,
+                ids => _context.BolusCalculations.Where(bc => ids.Contains(bc.Id)),
+                bc => Math.Abs((bc.CarbInput ?? 0) - criteria.Carbs.Value) <= criteria.CarbsTolerance,
+                cancellationToken);
+            if (match.HasValue)
+                return match.Value;
         }
-        // For temp basals, check rate and origin matching
         else if (recordType == RecordType.TempBasal && criteria.Rate.HasValue)
         {
-            var canonicalIds = potentialMatches.Select(m => m.CanonicalId).Distinct().ToList();
-
-            foreach (var canonicalId in canonicalIds)
-            {
-                var recordIds = potentialMatches
-                    .Where(m => m.CanonicalId == canonicalId)
-                    .Select(m => m.RecordId)
-                    .ToList();
-
-                var tempBasals = await _context.TempBasals
-                    .Where(tb => recordIds.Contains(tb.Id))
-                    .ToListAsync(cancellationToken);
-
-                foreach (var tb in tempBasals)
-                {
-                    if (Math.Abs(tb.Rate - criteria.Rate.Value) <= criteria.RateTolerance)
-                    {
-                        return canonicalId;
-                    }
-                }
-            }
+            var match = await FindMatchingCanonicalIdAsync(
+                potentialMatches,
+                ids => _context.TempBasals.Where(tb => ids.Contains(tb.Id)),
+                tb => Math.Abs(tb.Rate - criteria.Rate.Value) <= criteria.RateTolerance,
+                cancellationToken);
+            if (match.HasValue)
+                return match.Value;
         }
 
         // No matching records found, create a new canonical ID
         return Guid.CreateVersion7();
+    }
+
+    /// <summary>
+    /// Scans the candidate canonical groups for one whose underlying records include a value-level
+    /// match. For each distinct canonical ID in <paramref name="potentialMatches"/>, loads that
+    /// group's records via <paramref name="query"/> and returns the canonical ID if any record
+    /// satisfies <paramref name="isMatch"/>. Returns null when no group matches. The per-record
+    /// predicate runs in memory after materialization, exactly as the original per-type loops did.
+    /// </summary>
+    private async Task<Guid?> FindMatchingCanonicalIdAsync<TEntity>(
+        List<LinkedRecordEntity> potentialMatches,
+        Func<List<Guid>, IQueryable<TEntity>> query,
+        Func<TEntity, bool> isMatch,
+        CancellationToken cancellationToken)
+    {
+        foreach (var canonicalId in potentialMatches.Select(m => m.CanonicalId).Distinct())
+        {
+            var recordIds = potentialMatches
+                .Where(m => m.CanonicalId == canonicalId)
+                .Select(m => m.RecordId)
+                .ToList();
+
+            var entities = await query(recordIds).ToListAsync(cancellationToken);
+            if (entities.Any(isMatch))
+                return canonicalId;
+        }
+
+        return null;
     }
 
     /// <inheritdoc />

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V1/EntriesControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V1/EntriesControllerTests.cs
@@ -359,4 +359,50 @@ public class EntriesControllerTests
         entry.DateString.Should().NotBeNullOrEmpty();
         entry.DateString.Should().Contain("2023-06-12");
     }
+
+    [Fact]
+    public async Task CreateEntriesAsync_DerivesSameUtcMillsAsSyncEndpoint()
+    {
+        // A date-bearing entry must resolve to the same UTC mills on both the sync and async
+        // endpoints — the conversion lives in Entry.Mills (UTC), not in the controller, so the two
+        // endpoints can never diverge by timezone again.
+        var entryWithDate = new Entry
+        {
+            Sgv = 120,
+            Date = DateTimeOffset.Parse("2023-06-12T10:30:00.000Z").DateTime,
+        };
+
+        List<Entry>? processedInput = null;
+        _mockDocumentProcessingService
+            .Setup(x => x.ProcessDocuments(It.IsAny<IEnumerable<Entry>>()))
+            .Callback<IEnumerable<Entry>>(entries => processedInput = entries.ToList())
+            .Returns<IEnumerable<Entry>>(entries => entries);
+
+        _mockEntryService
+            .Setup(x =>
+                x.CheckForDuplicateEntryAsync(
+                    It.IsAny<string?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<int?>(),
+                    It.IsAny<long>(),
+                    It.IsAny<int>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync((Entry?)null);
+
+        _mockEntryService
+            .Setup(x =>
+                x.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<CancellationToken>())
+            )
+            .ReturnsAsync(new[] { new Entry { Id = "created-id", Sgv = 120 } });
+
+        // Act
+        await _controller.CreateEntriesAsync(entryWithDate);
+
+        // Assert: identical UTC mills to the sync endpoint, regardless of server time zone.
+        processedInput.Should().NotBeNull();
+        processedInput.Should().HaveCount(1);
+        processedInput![0].Mills.Should().Be(1686565800000);
+    }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Legacy/DocumentProcessingServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Legacy/DocumentProcessingServiceTests.cs
@@ -198,6 +198,26 @@ public class DocumentProcessingServiceTests
     }
 
     [Fact]
+    public void ProcessTimestamp_HonorsClientSuppliedUtcOffset_WithZSuffixedCreatedAt()
+    {
+        // A Z-suffixed created_at carries no real offset, so a separately-supplied utcOffset
+        // must still win (this routes through the mills+default-created_at branch).
+        var entry = new Entry
+        {
+            Sgv = 120,
+            Mills = 1686565800000,
+            CreatedAt = "2023-06-12T10:30:00.000Z",
+            UtcOffset = -300,
+        };
+
+        // Act
+        _service.ProcessTimestamp(entry);
+
+        // Assert
+        Assert.Equal(-300, entry.UtcOffset);
+    }
+
+    [Fact]
     public void SanitizeHtml_WithMaliciousContent_RemovesDangerousElements()
     {
         // Arrange

--- a/tests/Unit/Nocturne.API.Tests/Services/Legacy/DocumentProcessingServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Legacy/DocumentProcessingServiceTests.cs
@@ -165,6 +165,39 @@ public class DocumentProcessingServiceTests
     }
 
     [Fact]
+    public void ProcessTimestamp_HonorsClientSuppliedUtcOffset_WhenTimestampHasNoZone()
+    {
+        // AAPS/Loop upload SGV entries as date (UTC mills) + utcOffset (minutes) with no created_at.
+        // The offset is the only local-time signal for direct NS-API uploaders, so it must survive.
+        var entry = new Entry
+        {
+            Sgv = 120,
+            Mills = 1686565800000, // 2023-06-12T10:30:00Z
+            UtcOffset = -300, // client's local offset (UTC-05:00)
+        };
+
+        // Act
+        _service.ProcessTimestamp(entry);
+
+        // Assert
+        Assert.Equal(-300, entry.UtcOffset); // preserved, not clobbered to 0
+        Assert.Equal(1686565800000, entry.Mills); // instant unchanged
+    }
+
+    [Fact]
+    public void ProcessTimestamp_DefaultsUtcOffsetToZero_WhenClientOmitsIt()
+    {
+        // A mills-only entry with no offset still defaults to 0 (assume UTC).
+        var entry = new Entry { Sgv = 120, Mills = 1686565800000 };
+
+        // Act
+        _service.ProcessTimestamp(entry);
+
+        // Assert
+        Assert.Equal(0, entry.UtcOffset);
+    }
+
+    [Fact]
     public void SanitizeHtml_WithMaliciousContent_RemovesDangerousElements()
     {
         // Arrange

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/UpdateTimestampsTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/UpdateTimestampsTests.cs
@@ -1,0 +1,209 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Nocturne.Infrastructure.Data.Entities;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests;
+
+/// <summary>
+/// Verifies the single enforcement point for system timestamps and tenant ownership:
+/// <c>NocturneDbContext.UpdateTimestamps</c>, driven by the timestamp marker interfaces
+/// (<see cref="ISystemTimestamped"/>, <see cref="ISystemCreated"/>,
+/// <see cref="IEntityTimestamped"/>, <see cref="IEntityCreated"/>) plus a small set of
+/// entity-specific columns. EF InMemory runs the SaveChanges override, so timestamp
+/// stamping is exercised end to end.
+/// </summary>
+public class UpdateTimestampsTests
+{
+    // A clearly-stale sentinel so a freshly-stamped utcNow value is unambiguously newer.
+    private static readonly DateTime Stale = new(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task SystemTimestamped_StampsBothOnInsert_AndBumpsUpdatedOnModify()
+    {
+        var options = NewStore();
+        var tenantId = Guid.NewGuid();
+        var id = Guid.CreateVersion7();
+        var before = DateTime.UtcNow;
+
+        await using (var ctx = new NocturneDbContext(options) { TenantId = tenantId })
+        {
+            ctx.Foods.Add(new FoodEntity { Id = id, SysCreatedAt = Stale, SysUpdatedAt = Stale });
+            await ctx.SaveChangesAsync();
+        }
+
+        DateTime createdAfterInsert;
+        await using (var ctx = new NocturneDbContext(options) { TenantId = tenantId })
+        {
+            var food = await ctx.Foods.SingleAsync();
+            food.SysCreatedAt.Should().BeOnOrAfter(before, "sys_created_at is stamped on insert");
+            food.SysUpdatedAt.Should().BeOnOrAfter(before, "sys_updated_at is stamped on insert");
+            createdAfterInsert = food.SysCreatedAt;
+
+            food.Name = "changed";
+            await Task.Delay(5);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (var ctx = new NocturneDbContext(options) { TenantId = tenantId })
+        {
+            var food = await ctx.Foods.SingleAsync();
+            food.SysCreatedAt.Should().Be(createdAfterInsert, "sys_created_at is preserved across updates");
+            food.SysUpdatedAt.Should().BeAfter(createdAfterInsert, "sys_updated_at is bumped on every save");
+        }
+    }
+
+    [Fact]
+    public async Task SystemCreated_StampsCreatedOnInsertOnly()
+    {
+        var options = NewStore();
+        var tenantId = Guid.NewGuid();
+        var before = DateTime.UtcNow;
+
+        await using (var ctx = new NocturneDbContext(options) { TenantId = tenantId })
+        {
+            ctx.UserFoodFavorites.Add(new UserFoodFavoriteEntity { Id = Guid.CreateVersion7(), SysCreatedAt = Stale });
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (var verify = new NocturneDbContext(options) { TenantId = tenantId })
+        {
+            var favorite = await verify.UserFoodFavorites.SingleAsync();
+            favorite.SysCreatedAt.Should().BeOnOrAfter(before, "create-only entities are stamped on insert");
+        }
+    }
+
+    [Fact]
+    public async Task EntityTimestamped_StampsCreatedAndUpdated()
+    {
+        var options = NewStore();
+        var before = DateTime.UtcNow;
+
+        await using (var ctx = new NocturneDbContext(options))
+        {
+            ctx.Subjects.Add(new SubjectEntity { Id = Guid.CreateVersion7(), CreatedAt = Stale, UpdatedAt = Stale });
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (var verify = new NocturneDbContext(options))
+        {
+            var subject = await verify.Subjects.SingleAsync();
+            subject.CreatedAt.Should().BeOnOrAfter(before, "created_at is stamped on insert");
+            subject.UpdatedAt.Should().BeOnOrAfter(before, "updated_at is stamped on insert");
+        }
+    }
+
+    [Fact]
+    public async Task ClockFace_StampsAllFourConventions()
+    {
+        var options = NewStore();
+        var tenantId = Guid.NewGuid();
+        var before = DateTime.UtcNow;
+
+        await using (var ctx = new NocturneDbContext(options) { TenantId = tenantId })
+        {
+            ctx.ClockFaces.Add(new ClockFaceEntity
+            {
+                Id = Guid.CreateVersion7(),
+                CreatedAt = Stale,
+                UpdatedAt = null,
+                SysCreatedAt = Stale,
+                SysUpdatedAt = Stale,
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (var verify = new NocturneDbContext(options) { TenantId = tenantId })
+        {
+            var clockFace = await verify.ClockFaces.SingleAsync();
+            clockFace.SysCreatedAt.Should().BeOnOrAfter(before);
+            clockFace.SysUpdatedAt.Should().BeOnOrAfter(before);
+            clockFace.CreatedAt.Should().BeOnOrAfter(before);
+            clockFace.UpdatedAt.Should().NotBeNull("the nullable updated_at is stamped on every save");
+            clockFace.UpdatedAt!.Value.Should().BeOnOrAfter(before);
+        }
+    }
+
+    [Fact]
+    public async Task ConnectorConfiguration_StampsLastModifiedOnInsert()
+    {
+        var options = NewStore();
+        var tenantId = Guid.NewGuid();
+        var before = DateTimeOffset.UtcNow;
+
+        await using (var ctx = new NocturneDbContext(options) { TenantId = tenantId })
+        {
+            ctx.ConnectorConfigurations.Add(new ConnectorConfigurationEntity
+            {
+                Id = Guid.CreateVersion7(),
+                LastModified = new DateTimeOffset(Stale),
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (var verify = new NocturneDbContext(options) { TenantId = tenantId })
+        {
+            var config = await verify.ConnectorConfigurations.SingleAsync();
+            config.LastModified.Should().BeOnOrAfter(before, "last_modified is stamped on insert");
+        }
+    }
+
+    [Fact]
+    public async Task OAuthRefreshToken_StampsIssuedAtOnInsert()
+    {
+        var options = NewStore();
+        var tenantId = Guid.NewGuid();
+        var before = DateTime.UtcNow;
+
+        await using (var ctx = new NocturneDbContext(options) { TenantId = tenantId })
+        {
+            ctx.OAuthRefreshTokens.Add(new OAuthRefreshTokenEntity { Id = Guid.CreateVersion7(), IssuedAt = Stale });
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (var verify = new NocturneDbContext(options) { TenantId = tenantId })
+        {
+            var token = await verify.OAuthRefreshTokens.SingleAsync();
+            token.IssuedAt.Should().BeOnOrAfter(before, "issued_at is stamped on insert");
+        }
+    }
+
+    [Fact]
+    public async Task TenantScoped_InheritsTenantFromContextOnInsert()
+    {
+        var options = NewStore();
+        var tenantId = Guid.NewGuid();
+
+        await using (var ctx = new NocturneDbContext(options) { TenantId = tenantId })
+        {
+            ctx.Foods.Add(new FoodEntity { Id = Guid.CreateVersion7() });
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (var verify = new NocturneDbContext(options) { TenantId = tenantId })
+        {
+            var food = await verify.Foods.SingleAsync();
+            food.TenantId.Should().Be(tenantId, "a new tenant-scoped row inherits the resolved tenant");
+        }
+    }
+
+    [Fact]
+    public async Task TenantScoped_WithoutResolvableTenant_Throws()
+    {
+        var options = NewStore();
+        await using var ctx = new NocturneDbContext(options); // TenantId left as Guid.Empty
+
+        ctx.Foods.Add(new FoodEntity { Id = Guid.CreateVersion7() });
+
+        var act = () => ctx.SaveChangesAsync();
+        await act.Should().ThrowAsync<InvalidOperationException>(
+            "saving a tenant-scoped entity without a resolvable tenant must fail closed");
+    }
+
+    private static DbContextOptions<NocturneDbContext> NewStore() =>
+        new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseInMemoryDatabase($"update_timestamps_{Guid.NewGuid()}")
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/UpdateTimestampsTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/UpdateTimestampsTests.cs
@@ -142,10 +142,23 @@ public class UpdateTimestampsTests
             await ctx.SaveChangesAsync();
         }
 
+        DateTimeOffset stampedOnInsert;
         await using (var verify = new NocturneDbContext(options) { TenantId = tenantId })
         {
             var config = await verify.ConnectorConfigurations.SingleAsync();
             config.LastModified.Should().BeOnOrAfter(before, "last_modified is stamped on insert");
+            stampedOnInsert = config.LastModified;
+
+            // last_modified is insert-only: a later save must not bump it.
+            await Task.Delay(5);
+            verify.Entry(config).State = EntityState.Modified;
+            await verify.SaveChangesAsync();
+        }
+
+        await using (var verify = new NocturneDbContext(options) { TenantId = tenantId })
+        {
+            var config = await verify.ConnectorConfigurations.SingleAsync();
+            config.LastModified.Should().Be(stampedOnInsert, "last_modified is not re-stamped on update");
         }
     }
 
@@ -162,10 +175,23 @@ public class UpdateTimestampsTests
             await ctx.SaveChangesAsync();
         }
 
+        DateTime stampedOnInsert;
         await using (var verify = new NocturneDbContext(options) { TenantId = tenantId })
         {
             var token = await verify.OAuthRefreshTokens.SingleAsync();
             token.IssuedAt.Should().BeOnOrAfter(before, "issued_at is stamped on insert");
+            stampedOnInsert = token.IssuedAt;
+
+            // issued_at is insert-only: a later save must not bump it.
+            await Task.Delay(5);
+            verify.Entry(token).State = EntityState.Modified;
+            await verify.SaveChangesAsync();
+        }
+
+        await using (var verify = new NocturneDbContext(options) { TenantId = tenantId })
+        {
+            var token = await verify.OAuthRefreshTokens.SingleAsync();
+            token.IssuedAt.Should().Be(stampedOnInsert, "issued_at is not re-stamped on update");
         }
     }
 
@@ -199,6 +225,30 @@ public class UpdateTimestampsTests
         var act = () => ctx.SaveChangesAsync();
         await act.Should().ThrowAsync<InvalidOperationException>(
             "saving a tenant-scoped entity without a resolvable tenant must fail closed");
+    }
+
+    [Fact]
+    public async Task TenantScoped_CrossTenantModify_Throws()
+    {
+        var options = NewStore();
+        var ownerTenant = Guid.NewGuid();
+        var otherTenant = Guid.NewGuid();
+        var id = Guid.CreateVersion7();
+
+        await using (var ctx = new NocturneDbContext(options) { TenantId = ownerTenant })
+        {
+            ctx.Foods.Add(new FoodEntity { Id = id });
+            await ctx.SaveChangesAsync();
+        }
+
+        await using var attacker = new NocturneDbContext(options) { TenantId = otherTenant };
+        // IgnoreQueryFilters reaches the other tenant's row; the modify guard must still reject it.
+        var food = await attacker.Foods.IgnoreQueryFilters().SingleAsync();
+        food.Name = "tampered";
+
+        var act = () => attacker.SaveChangesAsync();
+        await act.Should().ThrowAsync<InvalidOperationException>(
+            "modifying a row owned by another tenant must fail closed");
     }
 
     private static DbContextOptions<NocturneDbContext> NewStore() =>


### PR DESCRIPTION
@
Refactors the backend's highest cyclomatic-complexity methods (identified via static analysis) into smaller, DRY, single-responsibility pieces, plus two correctness fixes uncovered while tracing the entry ingestion path. Every change is behavior-preserving (or an explicit, tested fix), built clean, and independently reviewed.

## Complexity refactors
- **`NocturneDbContext.UpdateTimestamps`** (cc 93): replaced the 35-branch entity type-switch with timestamp marker interfaces (`ISystemCreated`/`ISystemTimestamped`, `IEntityCreated`/`IEntityTimestamped`) + a small entity-specific tail. Tenant enforcement extracted to `EnforceTenantOwnership`. The `sys_*` safety net now covers every system-timestamped entity uniformly.
- **`TreatmentDecomposer`** (cc 90 + 61): extracted the event-type classification block that was duplicated byte-for-byte across `DecomposeBatchAsync` and `DecomposeAsync` into one `ClassifyTreatment` helper.
- **`CareLinkConnectorService.PerformSyncInternalAsync`** (cc 53): extracted per-step publish methods (glucose, device status, alarm, treatments) from the flat sync loop.
- **`DataOverviewService.GetGriTimelineAsync`** (cc 51): extracted two generic monthly accumulators + a `BuildGriPeriod` helper from six repeated query/bucket blocks.
- **`DeduplicationService.GetOrCreateCanonicalIdAsync`** (cc 48): extracted the canonical-group matching loop (repeated across 8 record types) into a generic `FindMatchingCanonicalIdAsync<T>`.
- **`EntriesController.CreateEntries` / `CreateEntriesAsync`** (cc 41 each): shared the duplicated parse / validate / normalize logic via `TryParseEntries`, `HasMeaningfulData`, `NormalizeEntry`.

## Correctness fixes (entry ingestion)
- **Removed a dead, divergent date→mills conversion** in the create endpoints. `Entry.Date` is `[JsonIgnore]` and `Entry.Mills` already derives mills from `date`/`dateString` as UTC, so the guard was unreachable — but the two endpoints interpreted `Unspecified`-kind dates inconsistently (UTC vs local). `Entry.Mills` is now the single source of truth.
- **Honor a client-supplied `utcOffset`** instead of zeroing it. AAPS/Loop/xDrip send entries as UTC `date` + standalone `utcOffset` (minutes) with no `created_at` (per the NS v3 contract). `ProcessTimestamp` was discarding it (`UtcOffset = 0`), breaking local-day bucketing in analytics for non-UTC direct-upload tenants. The no-embedded-zone branches now default-only (`UtcOffset ??= 0`); offset-deriving branches are unchanged.

## Net
~445 fewer lines of production code (duplication removed) + new test coverage. All affected unit suites pass (API 3446, Infrastructure.Data 399, CareLink 68). Each commit was reviewed for behavior preservation; the dedup and timestamp paths (with prior incident history) got extra scrutiny.
@