### PR TITLE
fix(setup): dark-theme onboarding, gate setup-redirect, harden web server

### DIFF
--- a/src/Web/packages/app/src/hooks.server.ts
+++ b/src/Web/packages/app/src/hooks.server.ts
@@ -195,8 +195,14 @@ const siteSecurityHandle: Handle = async ({ event, resolve }) => {
       const probeHost = getEffectiveHost(event.request, event.cookies);
       const probeHeaders: Record<string, string> = { "X-Forwarded-Proto": getOriginalProto(event.request) };
       if (probeHost) probeHeaders["X-Forwarded-Host"] = probeHost;
+      // Deliberately NO instance key here: a valid instance-key request bypasses the
+      // API's setup/recovery gate (TenantSetupMiddleware), so a privileged probe always
+      // sees 200 and can never detect setup_required/recovery_mode — leaving the
+      // authenticated page load to run and 503 instead of redirecting to /setup. Probing
+      // as an unprivileged visitor makes this gate observe the same 503 a real user gets.
+      // The status endpoint is [AllowAnonymous] and still returns requireAuthentication
+      // once setup is complete, so the auth-enforcement check below is unaffected.
       const apiClient = createServerApiClient(apiBaseUrl, fetch, {
-        hashedInstanceKey: getHashedInstanceKey(),
         extraHeaders: probeHeaders,
       });
 

--- a/src/Web/packages/app/src/instrumentation.server.ts
+++ b/src/Web/packages/app/src/instrumentation.server.ts
@@ -1,3 +1,22 @@
+// Keep the long-lived SvelteKit server process alive across a single request's
+// stray promise rejection. Node treats unhandled rejections as fatal by default,
+// so a benign mid-flight failure — e.g. a backend fetch aborted because the client
+// navigated away, or an API error thrown from a load/remote function that races the
+// teardown — would otherwise crash the whole web server and drop every other
+// in-flight session. Attaching any 'unhandledRejection' listener overrides that
+// fatal default; we still surface non-benign rejections to the logs.
+// Guarded against HMR re-registration in dev.
+if (!(globalThis as { __nocturneRejectionGuard?: boolean }).__nocturneRejectionGuard) {
+	(globalThis as { __nocturneRejectionGuard?: boolean }).__nocturneRejectionGuard = true;
+	process.on('unhandledRejection', (reason) => {
+		const name = (reason as { name?: string } | null)?.name;
+		// Aborted requests / timed-out probes are expected when clients disconnect —
+		// nothing actionable, so don't spam the logs.
+		if (name === 'AbortError' || name === 'TimeoutError') return;
+		console.error('Unhandled promise rejection (server kept alive):', reason);
+	});
+}
+
 // Skip all OpenTelemetry instrumentation in dev mode — the import-in-the-middle
 // ESM hook and getNodeAutoInstrumentations() add 60+ seconds to Vite startup by
 // intercepting every module load and eagerly patching ~30 Node.js packages.

--- a/src/Web/packages/app/src/routes/(unauthenticated)/setup/+page@.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/setup/+page@.svelte
@@ -278,8 +278,11 @@
   <title>Get Started - Nocturne</title>
 </svelte:head>
 
+<!-- The onboarding surface is always dark by design. Force a `dark` theme context so
+     shadcn children (inputs, recovery-code chips, buttons) render with dark tokens even
+     when the user's system theme — applied by ModeWatcher on <html> — is light. -->
 <div
-  class="relative min-h-screen grid grid-rows-[auto_1fr_auto] text-white"
+  class="dark relative min-h-screen grid grid-rows-[auto_1fr_auto] text-white"
   style="{styleVars}; background: var(--onb-navy);"
 >
   <!-- Background gradient -->

--- a/src/Web/packages/app/src/routes/(unauthenticated)/setup/steps/AccountCreation.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/setup/steps/AccountCreation.svelte
@@ -226,27 +226,33 @@
 
         <!-- Shared form fields -->
         <div class="space-y-2">
-          <Label for="display-name">Display name</Label>
+          <Label for="display-name" class="text-white/70">Display name</Label>
           <Input
             id="display-name"
             type="text"
             placeholder="Your name"
             bind:value={displayName}
             disabled={isRedirecting || isRegistering}
+            class="bg-white/5 border-white/10 text-white placeholder:text-white/25"
           />
-          <p class="text-xs text-muted-foreground">
+          <p class="text-xs text-white/30">
             This is how you will appear to others.
           </p>
         </div>
 
         <div class="space-y-2">
-          <Label for="pk-username">Username</Label>
+          <Label for="pk-username" class="text-white/70">Username</Label>
           <Input
             id="pk-username"
             type="text"
             placeholder="your-username"
             bind:value={username}
             disabled={isRedirecting || isRegistering}
+            class="bg-white/5 border-white/10 text-white placeholder:text-white/25 {usernameError
+              ? 'border-red-500/50'
+              : usernameValid
+                ? 'border-green-500/50'
+                : ''}"
           />
           {#if validatingUsername}
             <p class="text-xs text-white/40">Checking availability...</p>
@@ -258,7 +264,7 @@
               Available
             </p>
           {:else}
-            <p class="text-xs text-muted-foreground">
+            <p class="text-xs text-white/30">
               3-32 characters: letters, numbers, dots, underscores, and hyphens.
             </p>
           {/if}


### PR DESCRIPTION
## Summary

Three fixes around the first-run setup/onboarding flow, all surfaced while testing a fresh install on a light-mode system.

### 1. Onboarding inputs/recovery codes rendered as white boxes
The setup wizard is a bespoke **always-dark** surface, but its shadcn children (inputs, recovery-code chips, buttons) follow the system theme via `ModeWatcher` on `<html>`. On a light-mode system they fell back to light theme tokens (`--background: white`), producing white input boxes and a light recovery-codes panel. Dark-mode users never saw this.

- Force a `dark` theme context on the onboarding root in `setup/+page@.svelte`, so every shadcn child renders with dark tokens regardless of the user's system theme. This fixes the shared `RecoveryCodes` component **without modifying it** (it correctly uses theme tokens for its other, themed usages).
- Align `AccountCreation` inputs/labels with the dark styling `TenantIdentity` (step 1) already uses, so both setup steps look identical.

### 2. Authenticated dashboard load ran during `setup_required`
`siteSecurityHandle` probes setup/recovery state via `status.getStatus()`, but built that probe client **with the instance key** — which bypasses the API setup gate (`TenantSetupMiddleware`). The probe therefore always got a privileged `200`, never detected `setup_required`/`recovery_mode`, and let the request fall through to the authenticated page load, which then `503`'d (the "Error loading … chart data" log spam + empty-dashboard flash before redirect).

- Drop the instance key from the **probe only**, so it observes the same `503` an unprivileged visitor gets and redirects to `/setup` (or `/auth/recovery`) before the load runs. The status endpoint is `[AllowAnonymous]` and `settings.requireAuthentication` is always populated from config, so auth-enforcement is unaffected. The instance key is still used where genuinely needed (guest-session validation, the per-request user client).

### 3. A single stray rejection crash-looped the web server
In the `setup_required` state, client navigations abort in-flight SSR fetches; an `ApiException`/SvelteKit error thrown from a load/remote-function that raced teardown became an unhandled rejection. Node treats those as fatal, so one torn-down request killed the whole web process (and Aspire restarted it — a crash loop).

- Add a process-level `unhandledRejection` guard in `instrumentation.server.ts` (SvelteKit's `init` file, loaded once in dev and prod). Attaching the listener overrides Node's fatal default; benign `AbortError`/`TimeoutError` are ignored, everything else is still logged.

## Testing
- Relies on CI (unit + `Analyze (javascript-typescript)`) for type/build verification.
- Not yet manually exercised end-to-end against a running stack; reasoning for each fix is in the commit body and section descriptions above.