### PR TITLE
fix(portal): emit heading ids so in-page anchors prerender

### DIFF
--- a/src/Web/packages/portal/package.json
+++ b/src/Web/packages/portal/package.json
@@ -23,6 +23,7 @@
 		"formsnap": "^2.0.1",
 		"mdsvex": "^0.12.3",
 		"mode-watcher": "^1.1.0",
+		"rehype-slug": "^6.0.0",
 		"svelte": "^5.45.4",
 		"svelte-check-native": "^0.2.0",
 		"svelte-sonner": "^1.0.7",

--- a/src/Web/packages/portal/svelte.config.js
+++ b/src/Web/packages/portal/svelte.config.js
@@ -1,11 +1,15 @@
 import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 import { mdsvex } from 'mdsvex';
+import rehypeSlug from 'rehype-slug';
 import { remarkVars } from '@nocturne/cms/remark/vars';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-  preprocess: [vitePreprocess(), mdsvex({ extensions: ['.svx'], remarkPlugins: [remarkVars] })],
+  preprocess: [
+    vitePreprocess(),
+    mdsvex({ extensions: ['.svx'], remarkPlugins: [remarkVars], rehypePlugins: [rehypeSlug] }),
+  ],
   extensions: ['.svelte', '.svx'],
   kit: {
     adapter: adapter({

--- a/src/Web/pnpm-lock.yaml
+++ b/src/Web/pnpm-lock.yaml
@@ -656,6 +656,9 @@ importers:
       mode-watcher:
         specifier: ^1.1.0
         version: 1.1.0(svelte@5.45.2)
+      rehype-slug:
+        specifier: ^6.0.0
+        version: 6.0.0
       svelte:
         specifier: ^5.37.0
         version: 5.45.2
@@ -4459,6 +4462,9 @@ packages:
     resolution: {integrity: sha512-eFmhDi2xQ+2reMRY2AbJ2oa10uFOl1oyGbAKdCZiNOk94NJHi7aN0OBELSC9v35ZAPQdr+uRBi93/Gu4SlBdrA==}
     engines: {node: '>=18'}
 
+  github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -4515,11 +4521,17 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
+  hast-util-heading-rank@3.0.0:
+    resolution: {integrity: sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==}
+
   hast-util-sanitize@5.0.2:
     resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
 
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-to-string@3.0.1:
+    resolution: {integrity: sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==}
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
@@ -5630,6 +5642,9 @@ packages:
   regexp-tree@0.1.27:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
     hasBin: true
+
+  rehype-slug@6.0.0:
+    resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -10898,6 +10913,8 @@ snapshots:
       readable-stream: 4.7.0
       safe-buffer: 5.2.1
 
+  github-slugger@2.0.0: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -10955,6 +10972,10 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-heading-rank@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hast-util-sanitize@5.0.2:
     dependencies:
       '@types/hast': 3.0.4
@@ -10974,6 +10995,10 @@ snapshots:
       space-separated-tokens: 2.0.2
       stringify-entities: 4.0.4
       zwitch: 2.0.4
+
+  hast-util-to-string@3.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
 
   hast-util-whitespace@3.0.0:
     dependencies:
@@ -12255,6 +12280,14 @@ snapshots:
   readdirp@5.0.0: {}
 
   regexp-tree@0.1.27: {}
+
+  rehype-slug@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      github-slugger: 2.0.0
+      hast-util-heading-rank: 3.0.0
+      hast-util-to-string: 3.0.1
+      unist-util-visit: 5.1.0
 
   remark-gfm@4.0.1:
     dependencies:


### PR DESCRIPTION
@
## Problem

The **Deploy Portal to GitHub Pages** workflow [failed on main](https://github.com/nightscout/nocturne/actions/runs/28146538927) (after #424 merged). The build compiled fine but SvelteKit prerender threw:

> `pages contain links to /docs/windows-widget#connect-to-your-nocturne-server, but no element with id="connect-to-your-nocturne-server" exists`

The portal mdsvex pipeline only ran `remarkVars`, so doc headings rendered with **no `id` attributes**. The `windows-widget` guide links to its own `#connect-to-your-nocturne-server` section, but with no heading ids the anchor target never existed, so prerender (`handleMissingId` defaults to `fail`) errored and the deploy failed.

## Fix

Add `rehype-slug` to the mdsvex `rehypePlugins` so every heading gets a slug `id`. This resolves the dangling anchor and makes all doc sections deep-linkable, preventing the next anchor link from hitting the same wall.

## Verification

`pnpm --filter @nocturne/portal build` now exits 0 (`Wrote site to "build"`), and the rendered page carries `<h2 id="connect-to-your-nocturne-server">`.
@