### PR TITLE
fix(auth): default OidcProviderConfig.Scopes to empty

### DIFF
--- a/src/Core/Nocturne.Core.Models/Configuration/OidcProviderConfig.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/OidcProviderConfig.cs
@@ -41,8 +41,14 @@ public class OidcProviderConfig
     /// <summary>OAuth2 client secret. Should be supplied via secrets manager, not checked into source.</summary>
     public string? ClientSecret { get; set; }
 
-    /// <summary>OIDC scopes to request during authorization.</summary>
-    public List<string> Scopes { get; set; } = ["openid", "profile", "email"];
+    /// <summary>
+    /// Scopes to request during authorization. Left empty by default: .NET configuration binding
+    /// appends config-supplied scopes to whatever the list already contains, so a non-empty default
+    /// would pollute every provider's scopes (e.g. an OAuth2 provider would get <c>openid</c> forced
+    /// on). The provider service backfills protocol defaults from an empty list — OIDC providers get
+    /// <c>openid profile email</c>, OAuth2 providers use exactly the scopes they configure.
+    /// </summary>
+    public List<string> Scopes { get; set; } = [];
 
     /// <summary>Default <see cref="Nocturne.Core.Models.Authorization.Role"/> names to assign to new users from this provider.</summary>
     public List<string> DefaultRoles { get; set; } = ["readable"];

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcProviderServiceOAuth2Tests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcProviderServiceOAuth2Tests.cs
@@ -96,4 +96,25 @@ public class OidcProviderServiceOAuth2Tests
         provider.ProviderType.Should().Be(OidcProviderType.Oidc);
         provider.Scopes.Should().Contain("openid");
     }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetEnabledProviders_Oidc_WithDefaultEmptyScopes_BackfillsOidcDefaults()
+    {
+        // OidcProviderConfig.Scopes defaults to empty so config binding does not pollute scopes;
+        // an OIDC provider that configures none must still get the standard openid/profile/email.
+        var oidc = new OidcProviderConfig
+        {
+            Name = "Keycloak",
+            ProviderType = OidcProviderType.Oidc,
+            IssuerUrl = "https://id.example.com",
+            ClientId = "kc-client",
+            Scopes = [],
+        };
+        var service = BuildService(oidc);
+
+        var provider = (await service.GetEnabledProvidersAsync()).Single();
+
+        provider.Scopes.Should().Equal("openid", "profile", "email");
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to the generic OAuth2 provider support (#424). .NET configuration binding **appends** config-supplied list items to a property's existing contents rather than replacing them, so `OidcProviderConfig.Scopes` defaulting to `["openid","profile","email"]` polluted every config-managed provider's scopes. A GitHub (OAuth2) provider configured with `read:user user:email` ended up requesting `openid profile email read:user user:email` in its authorization URL.

This defaults `Scopes` to empty and relies on the existing `OidcProviderService.NormalizeScopes` backfill:
- **OIDC** providers with no configured scopes → `openid profile email` (unchanged behavior)
- **OAuth2** providers → exactly the scopes they configure (no `openid` pollution)

## Tests

Adds a unit test asserting an OIDC provider with empty/default scopes still backfills `openid profile email`. Full OIDC suite (66 tests) green.