### PR TITLE
docs(portal): add SDK usage page derived from sdk configs

### DIFF
--- a/src/Web/packages/portal/.gitignore
+++ b/src/Web/packages/portal/.gitignore
@@ -4,3 +4,5 @@ static/logos/
 static/fonts/
 # Release assets are copied from deploy/portainer at build/dev time
 src/lib/release/
+# SDK manifest is derived from sdk/<lang>/config.yaml at build/dev time
+src/lib/sdk/generated/

--- a/src/Web/packages/portal/package.json
+++ b/src/Web/packages/portal/package.json
@@ -4,10 +4,11 @@
 	"type": "module",
 	"description": "Nocturne Portal - Configuration wizard and documentation",
 	"scripts": {
-		"dev": "vite dev",
-		"build": "vite build",
+		"sdk:manifest": "node scripts/generate-sdk-manifest.mjs",
+		"dev": "node scripts/generate-sdk-manifest.mjs && vite dev",
+		"build": "node scripts/generate-sdk-manifest.mjs && vite build",
 		"preview": "vite preview",
-		"check": "svelte-kit sync && svelte-check-native --tsconfig ./tsconfig.json"
+		"check": "node scripts/generate-sdk-manifest.mjs && svelte-kit sync && svelte-check-native --tsconfig ./tsconfig.json"
 	},
 	"devDependencies": {
 		"@lucide/svelte": "^0.555.0",

--- a/src/Web/packages/portal/scripts/generate-sdk-manifest.mjs
+++ b/src/Web/packages/portal/scripts/generate-sdk-manifest.mjs
@@ -1,0 +1,86 @@
+// Derives the list of supported SDKs from the OpenAPI-generator configs under
+// sdk/<lang>/config.yaml — the same files the sdk-publish.yml workflow uses to
+// build and publish each SDK. The docs SDK page consumes the emitted manifest,
+// so the page's language list can never drift from what we actually publish.
+//
+// Output (gitignored, regenerated on every dev/build/check): a flat list of
+// { dir, generator, package }. Presentation (registry URLs, install commands)
+// lives alongside in sdks.ts, keyed by dir. Run via the dev/build/check scripts.
+
+import { readFileSync, readdirSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/** Walk up from the script dir until we find the repo's sdk/ directory. */
+function findSdkDir() {
+  let cur = here;
+  for (let i = 0; i < 8; i++) {
+    const candidate = join(cur, "sdk");
+    if (existsSync(join(candidate, "filter-v4-spec.js"))) return candidate;
+    const parent = dirname(cur);
+    if (parent === cur) break;
+    cur = parent;
+  }
+  return null;
+}
+
+/**
+ * Minimal reader for our flat, hand-maintained config.yaml files. We only need
+ * the top-level generatorName and a handful of additionalProperties keys, so a
+ * line-wise `key: value` scan is enough — no YAML dependency.
+ */
+function readConfig(text) {
+  const out = {};
+  for (const raw of text.split(/\r?\n/)) {
+    const m = raw.match(/^\s*([A-Za-z0-9_]+):\s*(.+?)\s*$/);
+    if (!m) continue;
+    const [, key, value] = m;
+    out[key] = value.replace(/^["']|["']$/g, "");
+  }
+  return out;
+}
+
+/** The canonical published identifier differs by generator. */
+function packageId(generator, c) {
+  switch (generator) {
+    case "typescript-fetch":
+      return c.npmName;
+    case "python":
+      return c.projectName; // pip/PyPI name (import name is packageName)
+    case "swift6":
+      return c.projectName; // SPM product name
+    case "java":
+    case "kotlin":
+      return c.groupId && c.artifactId ? `${c.groupId}:${c.artifactId}` : c.artifactId;
+    default:
+      return c.packageName ?? c.npmName ?? c.projectName ?? c.artifactId;
+  }
+}
+
+const sdkDir = findSdkDir();
+const entries = [];
+
+if (!sdkDir) {
+  console.warn("[sdk-manifest] sdk/ directory not found; writing empty manifest");
+} else {
+  for (const dir of readdirSync(sdkDir, { withFileTypes: true })) {
+    if (!dir.isDirectory()) continue;
+    const configPath = join(sdkDir, dir.name, "config.yaml");
+    if (!existsSync(configPath)) continue;
+    const c = readConfig(readFileSync(configPath, "utf8"));
+    if (!c.generatorName) continue;
+    entries.push({
+      dir: dir.name,
+      generator: c.generatorName,
+      package: packageId(c.generatorName, c) ?? dir.name,
+    });
+  }
+  entries.sort((a, b) => a.dir.localeCompare(b.dir));
+}
+
+const outDir = resolve(here, "../src/lib/sdk/generated");
+mkdirSync(outDir, { recursive: true });
+writeFileSync(join(outDir, "manifest.json"), JSON.stringify(entries, null, 2) + "\n");
+console.log(`[sdk-manifest] wrote ${entries.length} SDK(s) to src/lib/sdk/generated/manifest.json`);

--- a/src/Web/packages/portal/src/content/docs/connecting-apps/device-flow.svx
+++ b/src/Web/packages/portal/src/content/docs/connecting-apps/device-flow.svx
@@ -18,6 +18,12 @@ Nocturne uses the Device Authorization flow for apps that either can't easily op
 redirect-based browser flow or run on devices with limited input. The user authorizes
 on a separate device (phone, computer) by entering a short code.
 
+<Callout type="tip" title="Prefer an SDK for API calls?">
+  The code below uses raw HTTP requests to show the device flow end to end. Once you
+  have an access token, you don't have to hand-write API calls — official SDKs for
+  the V4 API are available in several languages. See <a href="/docs/sdks">SDKs</a>.
+</Callout>
+
 ## 1. Register your app
 
 Before your app can authenticate users, it needs a `client_id`. Nocturne supports

--- a/src/Web/packages/portal/src/content/docs/connecting-apps/index.svx
+++ b/src/Web/packages/portal/src/content/docs/connecting-apps/index.svx
@@ -17,6 +17,12 @@ Every client is a public client — there are no client secrets. PKCE replaces t
 which makes this flow safe for desktop apps and SPAs. For mobile apps or devices
 with limited input, see the [Device Authorization flow guide](/docs/connecting-apps/device-flow).
 
+<Callout type="tip" title="Prefer an SDK for API calls?">
+  The code below uses raw HTTP requests to show the OAuth flow end to end. Once you
+  have an access token, you don't have to hand-write API calls — official SDKs for
+  the V4 API are available in several languages. See <a href="/docs/sdks">SDKs</a>.
+</Callout>
+
 ## 1. Register your app
 
 Before your app can authenticate users, it needs a `client_id`. Nocturne supports

--- a/src/Web/packages/portal/src/content/docs/sdks.svx
+++ b/src/Web/packages/portal/src/content/docs/sdks.svx
@@ -1,0 +1,45 @@
+---
+title: SDKs
+---
+
+<script>
+  import Callout from '@nocturne/cms/components/Callout.svelte';
+  import SdkList from '$lib/components/docs/SdkList.svelte';
+</script>
+
+# SDKs
+
+Official Nocturne SDKs are generated from the **V4 API** OpenAPI specification and
+published to each language's standard package registry. They give you typed models
+and request methods for the V4 API surface, so you don't have to hand-write HTTP
+requests like the examples in the [Connecting your app](/docs/connecting-apps) guide.
+
+## Supported languages
+
+<SdkList />
+
+<Callout type="info" title="Versions track releases">
+  SDK versions follow Nocturne releases. Where the install line shows
+  <code>&lt;version&gt;</code>, use the latest version listed on the package's
+  registry page. The package links above always point to the current release.
+</Callout>
+
+## How SDKs fit with authentication
+
+The SDKs cover **API calls**, not the interactive authorization flow. You still obtain
+an access token using OAuth 2.0 as described in the
+[Connecting your app](/docs/connecting-apps) guide (Authorization Code + PKCE) or the
+[Mobile & device flow](/docs/connecting-apps/device-flow) guide. Once you have an
+access token, configure the SDK client to send it as a `Bearer` token and call the
+V4 API through the generated methods.
+
+Because each SDK is generated from the OpenAPI spec, the available methods and models
+mirror the V4 API exactly. For language-specific construction and method names, see the
+generated README on the package's registry page (linked above).
+
+<Callout type="tip" title="No SDK for your stack?">
+  Every SDK is generated from the same OpenAPI document. You can point any OpenAPI
+  generator at the V4 spec to produce a client in a language we don't publish yet,
+  or call the API directly over HTTP as shown in the
+  [Connecting your app](/docs/connecting-apps) guide.
+</Callout>

--- a/src/Web/packages/portal/src/lib/components/DocsSidebar.svelte
+++ b/src/Web/packages/portal/src/lib/components/DocsSidebar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { page } from "$app/state";
-    import { Rocket, Download, Settings, Shield, Share2, Bell, Bot, Code2, KeyRound, Activity, LayoutGrid, ChevronRight, ChevronDown } from "@lucide/svelte";
+    import { Rocket, Download, Settings, Shield, Share2, Bell, Bot, Code2, KeyRound, Activity, LayoutGrid, Package, ChevronRight, ChevronDown } from "@lucide/svelte";
 
     const navSections = [
         {
@@ -83,6 +83,13 @@
             items: [
                 { href: "/docs/connecting-apps", label: "App authorization (PKCE)" },
                 { href: "/docs/connecting-apps/device-flow", label: "Mobile & device flow" },
+            ],
+        },
+        {
+            title: "SDKs",
+            icon: Package,
+            items: [
+                { href: "/docs/sdks", label: "Official SDKs" },
             ],
         },
         {

--- a/src/Web/packages/portal/src/lib/components/docs/SdkList.svelte
+++ b/src/Web/packages/portal/src/lib/components/docs/SdkList.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+    // Renders the supported-SDK table. The rows come from SDKS, which is derived
+    // from sdk/<lang>/config.yaml at build time — adding or removing an SDK there
+    // updates this table with no edit here.
+    import { SDKS } from "$lib/sdk/sdks";
+</script>
+
+<table>
+    <thead>
+        <tr>
+            <th>Language</th>
+            <th>Package</th>
+            <th>Install</th>
+        </tr>
+    </thead>
+    <tbody>
+        {#each SDKS as sdk (sdk.dir)}
+            <tr>
+                <td>{sdk.name}</td>
+                <td>
+                    <a href={sdk.registryUrl} target="_blank" rel="noreferrer">
+                        <code>{sdk.package}</code>
+                    </a>
+                    <br />
+                    <span class="text-sm text-muted-foreground">{sdk.registry}</span>
+                </td>
+                <td><code>{sdk.install}</code></td>
+            </tr>
+        {/each}
+    </tbody>
+</table>

--- a/src/Web/packages/portal/src/lib/sdk/sdks.ts
+++ b/src/Web/packages/portal/src/lib/sdk/sdks.ts
@@ -1,0 +1,98 @@
+// The supported-SDK list is DERIVED from sdk/<lang>/config.yaml at build time
+// (see scripts/generate-sdk-manifest.mjs) so it can never drift from what we
+// actually publish. This module only adds the presentation details that aren't
+// in those configs — display name, registry, and install command — keyed by the
+// SDK directory name. A newly added SDK shows up automatically; if it has no
+// presentation entry yet it still lists with its package name and a sane default.
+
+import manifest from "./generated/manifest.json";
+
+export interface SdkManifestEntry {
+  /** SDK directory under sdk/ (also the stable presentation key). */
+  dir: string;
+  /** OpenAPI-generator name from config.yaml. */
+  generator: string;
+  /** Canonical published package identifier. */
+  package: string;
+}
+
+export interface Sdk extends SdkManifestEntry {
+  /** Human-readable language name. */
+  name: string;
+  /** Registry the package is published to. */
+  registry: string;
+  /** Link to the package on its registry. */
+  registryUrl: string;
+  /** Copy-pasteable install command / dependency line. */
+  install: string;
+}
+
+interface Presentation {
+  name: string;
+  registry: string;
+  registryUrl: (pkg: string) => string;
+  install: (pkg: string) => string;
+}
+
+// Maven coordinates (group:artifact) map to a central.sonatype.com path.
+const mavenUrl = (pkg: string) =>
+  `https://central.sonatype.com/artifact/${pkg.replace(":", "/")}`;
+const mavenGradle = (pkg: string) => `implementation("${pkg}:<version>")`;
+
+const PRESENTATION: Record<string, Presentation> = {
+  csharp: {
+    name: "C# / .NET",
+    registry: "NuGet",
+    registryUrl: (p) => `https://www.nuget.org/packages/${p}/`,
+    install: (p) => `dotnet add package ${p}`,
+  },
+  typescript: {
+    name: "TypeScript / JavaScript",
+    registry: "npm",
+    registryUrl: (p) => `https://www.npmjs.com/package/${p}`,
+    install: (p) => `npm install ${p}`,
+  },
+  python: {
+    name: "Python",
+    registry: "PyPI",
+    registryUrl: (p) => `https://pypi.org/project/${p}/`,
+    install: (p) => `pip install ${p}`,
+  },
+  rust: {
+    name: "Rust",
+    registry: "crates.io",
+    registryUrl: (p) => `https://crates.io/crates/${p}`,
+    install: (p) => `cargo add ${p}`,
+  },
+  java: {
+    name: "Java",
+    registry: "Maven Central",
+    registryUrl: mavenUrl,
+    install: mavenGradle,
+  },
+  kotlin: {
+    name: "Kotlin",
+    registry: "Maven Central",
+    registryUrl: mavenUrl,
+    install: mavenGradle,
+  },
+  swift: {
+    name: "Swift",
+    registry: "Swift Package Manager",
+    // Published to its own GitHub repo rather than a package index.
+    registryUrl: () => "https://github.com/nightscout/nocturne-swift",
+    install: () =>
+      `.package(url: "https://github.com/nightscout/nocturne-swift.git", from: "<version>")`,
+  },
+};
+
+export const SDKS: Sdk[] = (manifest as SdkManifestEntry[]).map((entry) => {
+  const p = PRESENTATION[entry.dir];
+  return {
+    ...entry,
+    name: p?.name ?? entry.dir,
+    registry: p?.registry ?? "—",
+    registryUrl: p ? p.registryUrl(entry.package) : "#",
+    install: p ? p.install(entry.package) : entry.package,
+  };
+});


### PR DESCRIPTION
## What

Adds a `/docs/sdks` page to the portal documenting the official Nocturne SDKs, and flags in the existing **Connecting Apps** guides that their raw-HTTP examples can be replaced by an SDK for API calls once a token is obtained.

## Why

The connecting-apps guides only showed hand-written HTTP requests, with no mention that we publish SDKs. This adds a discoverable SDK page and cross-links it from the OAuth guides.

## How it stays up to date

The supported-language list is **derived from `sdk/<lang>/config.yaml`** — the same configs `sdk-publish.yml` uses to build and publish — via a build-time manifest (`generate-sdk-manifest.mjs`, wired into `dev`/`build`/`check`, output gitignored). So the page can't drift from what we actually publish; a newly added SDK appears automatically. Presentation details not in those configs (registry URLs, install commands) are keyed by language with a fallback.

Per-SDK method signatures are intentionally **not** documented (those generated client surfaces aren't verified here) — the page shows accurate install commands + registry links and points to each package's generated README.

## Verification

- `pnpm run check` → 0 errors
- `pnpm run build` → `/docs/sdks.html` prerenders with the real derived package names (all 7 SDKs: C#, TypeScript, Python, Rust, Java, Kotlin, Swift)