### PR TITLE
fix(glooko): re-authenticate when a changed glookoCode triggers 403 data_cant_view

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -184,6 +184,17 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             throw new HttpRequestException("422 UnprocessableEntity - Rate limited");
         }
 
+        // 403 on a patient-scoped endpoint (e.g. {"code":"data_cant_view"}) means the cached
+        // glookoCode is no longer authorized — typically it changed after an account/data-source
+        // re-link. Surface a distinct type so the sync re-authenticates and re-resolves the code
+        // instead of hammering the stale one until the 24h session cache expires.
+        if (response.StatusCode == HttpStatusCode.Forbidden)
+        {
+            var body = await GlookoHttpHelper.ReadResponseAsync(response);
+            _logger.LogWarning("Forbidden (403) fetching from {Url}: {Body}", absoluteUrl, body);
+            throw new GlookoDataForbiddenException($"Glooko returned 403 Forbidden for {absoluteUrl}: {body}");
+        }
+
         _logger.LogWarning("Failed to fetch from {Url}: {StatusCode}", absoluteUrl, response.StatusCode);
         throw new HttpRequestException($"HTTP {(int)response.StatusCode} {response.StatusCode}");
     }
@@ -203,6 +214,12 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                 if (result.HasValue) return result;
 
                 _logger.LogWarning("Attempt {AttemptNumber} failed for {Url}", attempt + 1, url);
+            }
+            catch (GlookoDataForbiddenException)
+            {
+                // The patient code is part of the URL; retrying it unchanged will 403 again.
+                // Bubble up immediately so the caller can re-authenticate and rebuild URLs.
+                throw;
             }
             catch (HttpRequestException ex) when (ex.Message.Contains("422"))
             {
@@ -321,70 +338,51 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                 "[{ConnectorSource}] Syncing {From:yyyy-MM-dd} to {To:yyyy-MM-dd} in {ChunkCount} chunk(s)",
                 ConnectorSource, from, to, chunks.Count);
 
-            for (var i = 0; i < chunks.Count; i++)
-            {
-                var (chunkFrom, chunkTo) = chunks[i];
-
-                await ReportMessageAsync(progressReporter, SyncMessageType.FetchingData,
-                    new()
-                    {
-                        ["from"] = chunkFrom.ToString("MMM dd"),
-                        ["to"] = chunkTo.ToString("MMM dd"),
-                        ["chunk"] = $"{i + 1}/{chunks.Count}",
-                    },
-                    cancellationToken);
-
-                var chunkSuccess = _syncConfig!.UseV3Api
-                    ? await FetchAndMapViaV3Async(chunkFrom, chunkTo, activeTypes, result, config, cancellationToken)
-                    : await FetchAndMapViaV2Async(chunkFrom, chunkTo, activeTypes, result, config, cancellationToken);
-
-                if (!chunkSuccess)
-                {
-                    _logger.LogWarning(
-                        "[{ConnectorSource}] Chunk {Chunk}/{Total} ({From:yyyy-MM-dd} to {To:yyyy-MM-dd}) failed, stopping sync",
-                        ConnectorSource, i + 1, chunks.Count, chunkFrom, chunkTo);
-                    result.Success = false;
-                    result.Message = "Sync failed during data fetch";
-                    result.Errors.Add($"Chunk {i + 1}/{chunks.Count} failed ({chunkFrom:yyyy-MM-dd} to {chunkTo:yyyy-MM-dd})");
-                    break;
-                }
-
-                _logger.LogInformation(
-                    "[{ConnectorSource}] Completed chunk {Chunk}/{Total} ({From:yyyy-MM-dd} to {To:yyyy-MM-dd})",
-                    ConnectorSource, i + 1, chunks.Count, chunkFrom, chunkTo);
-            }
-
-            // Profiles (V3 device settings — used in both modes, no V2 equivalent)
-            await ReportMessageAsync(progressReporter, SyncMessageType.ProcessingDataType,
-                new() { ["dataType"] = SyncDataType.Profiles.ToString() }, cancellationToken);
-
-            if (activeTypes.Contains(SyncDataType.Profiles))
+            // Run the sync; if Glooko rejects the patient code (403 data_cant_view) the cached
+            // glookoCode has gone stale (e.g. the account was re-linked), so re-authenticate once
+            // to resolve the current code and retry from scratch. A second 403 propagates to the
+            // outer handler and fails the sync rather than looping.
+            for (var attempt = 0; ; attempt++)
             {
                 try
                 {
-                    var deviceSettings = await FetchV3DeviceSettingsAsync();
-                    if (deviceSettings != null)
-                    {
-                        var profiles = _profileMapper.TransformDeviceSettingsToProfiles(deviceSettings);
-                        if (profiles.Any() && await PublishProfileDataAsync(profiles, config, cancellationToken))
-                        {
-                            result.ItemsSynced[SyncDataType.Profiles] = profiles.Count;
-                            _logger.LogInformation("[{ConnectorSource}] Published {Count} profiles from device settings",
-                                ConnectorSource, profiles.Count);
-                        }
-
-                        var profileStateSpans = _profileMapper.TransformDeviceSettingsToStateSpans(deviceSettings);
-                        if (profileStateSpans.Count > 0)
-                        {
-                            await PublishStateSpanDataAsync(profileStateSpans, config, cancellationToken);
-                            _logger.LogInformation("[{ConnectorSource}] Published {Count} profile state spans from device settings",
-                                ConnectorSource, profileStateSpans.Count);
-                        }
-                    }
+                    await RunSyncPassAsync(chunks, activeTypes, result, config, cancellationToken, progressReporter);
+                    break;
                 }
-                catch (Exception profileEx)
+                catch (GlookoDataForbiddenException ex) when (attempt == 0)
                 {
-                    _logger.LogWarning(profileEx, "[{ConnectorSource}] Failed to fetch/publish profile data", ConnectorSource);
+                    _logger.LogWarning(ex,
+                        "[{ConnectorSource}] Glooko returned 403 (data_cant_view) for patient code {Code}; the account's "
+                        + "glookoCode likely changed. Invalidating cached session and re-authenticating.",
+                        ConnectorSource, _userData?.GlookoCode);
+
+                    _tokenProvider.InvalidateToken();
+                    _sessionCookie = null;
+                    _userData = null;
+                    _meterUnits = null;
+                    _timezone = null;
+
+                    if (!await AuthenticateWithConfigAsync(config))
+                    {
+                        result.Success = false;
+                        result.Message = "Re-authentication failed after Glooko denied data access";
+                        result.Errors.Add("Re-authentication failed after Glooko returned 403 (data_cant_view)");
+                        break;
+                    }
+
+                    await ConfigureTimezoneTimelineAsync(config, cancellationToken);
+
+                    // Drop partial results from the aborted pass; the retry re-syncs from scratch
+                    // with the refreshed patient code.
+                    result.ItemsSynced.Clear();
+                    result.LastEntryTimes.Clear();
+                    result.Errors.Clear();
+                    result.Success = true;
+                    result.Message = "Sync completed successfully";
+
+                    _logger.LogInformation(
+                        "[{ConnectorSource}] Re-authenticated after 403; retrying sync with patient code {Code}",
+                        ConnectorSource, _userData?.GlookoCode);
                 }
             }
 
@@ -404,6 +402,88 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             await ReportMessageAsync(progressReporter, SyncMessageType.SyncFailed, null, cancellationToken);
             result.EndTime = DateTime.UtcNow;
             return result;
+        }
+    }
+
+    /// <summary>
+    ///     Runs one full sync pass: every date chunk followed by the profile/device-settings fetch.
+    ///     Throws <see cref="GlookoDataForbiddenException"/> when Glooko rejects the patient code, so
+    ///     the caller can re-authenticate and retry with a refreshed code.
+    /// </summary>
+    private async Task RunSyncPassAsync(
+        List<(DateTime From, DateTime To)> chunks,
+        HashSet<SyncDataType> activeTypes,
+        SyncResult result,
+        GlookoConnectorConfiguration config,
+        CancellationToken cancellationToken,
+        ISyncProgressReporter? progressReporter)
+    {
+        for (var i = 0; i < chunks.Count; i++)
+        {
+            var (chunkFrom, chunkTo) = chunks[i];
+
+            await ReportMessageAsync(progressReporter, SyncMessageType.FetchingData,
+                new()
+                {
+                    ["from"] = chunkFrom.ToString("MMM dd"),
+                    ["to"] = chunkTo.ToString("MMM dd"),
+                    ["chunk"] = $"{i + 1}/{chunks.Count}",
+                },
+                cancellationToken);
+
+            var chunkSuccess = _syncConfig!.UseV3Api
+                ? await FetchAndMapViaV3Async(chunkFrom, chunkTo, activeTypes, result, config, cancellationToken)
+                : await FetchAndMapViaV2Async(chunkFrom, chunkTo, activeTypes, result, config, cancellationToken);
+
+            if (!chunkSuccess)
+            {
+                _logger.LogWarning(
+                    "[{ConnectorSource}] Chunk {Chunk}/{Total} ({From:yyyy-MM-dd} to {To:yyyy-MM-dd}) failed, stopping sync",
+                    ConnectorSource, i + 1, chunks.Count, chunkFrom, chunkTo);
+                result.Success = false;
+                result.Message = "Sync failed during data fetch";
+                result.Errors.Add($"Chunk {i + 1}/{chunks.Count} failed ({chunkFrom:yyyy-MM-dd} to {chunkTo:yyyy-MM-dd})");
+                return;
+            }
+
+            _logger.LogInformation(
+                "[{ConnectorSource}] Completed chunk {Chunk}/{Total} ({From:yyyy-MM-dd} to {To:yyyy-MM-dd})",
+                ConnectorSource, i + 1, chunks.Count, chunkFrom, chunkTo);
+        }
+
+        // Profiles (V3 device settings — used in both modes, no V2 equivalent)
+        await ReportMessageAsync(progressReporter, SyncMessageType.ProcessingDataType,
+            new() { ["dataType"] = SyncDataType.Profiles.ToString() }, cancellationToken);
+
+        if (activeTypes.Contains(SyncDataType.Profiles))
+        {
+            try
+            {
+                var deviceSettings = await FetchV3DeviceSettingsAsync();
+                if (deviceSettings != null)
+                {
+                    var profiles = _profileMapper!.TransformDeviceSettingsToProfiles(deviceSettings);
+                    if (profiles.Any() && await PublishProfileDataAsync(profiles, config, cancellationToken))
+                    {
+                        result.ItemsSynced[SyncDataType.Profiles] = profiles.Count;
+                        _logger.LogInformation("[{ConnectorSource}] Published {Count} profiles from device settings",
+                            ConnectorSource, profiles.Count);
+                    }
+
+                    var profileStateSpans = _profileMapper.TransformDeviceSettingsToStateSpans(deviceSettings);
+                    if (profileStateSpans.Count > 0)
+                    {
+                        await PublishStateSpanDataAsync(profileStateSpans, config, cancellationToken);
+                        _logger.LogInformation("[{ConnectorSource}] Published {Count} profile state spans from device settings",
+                            ConnectorSource, profileStateSpans.Count);
+                    }
+                }
+            }
+            catch (GlookoDataForbiddenException) { throw; }
+            catch (Exception profileEx)
+            {
+                _logger.LogWarning(profileEx, "[{ConnectorSource}] Failed to fetch/publish profile data", ConnectorSource);
+            }
         }
     }
 
@@ -782,6 +862,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
 
             return batchData;
         }
+        catch (GlookoDataForbiddenException) { throw; }
         catch (InvalidOperationException) { throw; }
         catch (HttpRequestException) { throw; }
         catch (Exception ex)
@@ -944,6 +1025,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
 
             return graphData;
         }
+        catch (GlookoDataForbiddenException) { throw; }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error fetching Glooko v3 graph data");
@@ -977,6 +1059,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
 
             return settings;
         }
+        catch (GlookoDataForbiddenException) { throw; }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error fetching Glooko v3 device settings");

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoDataForbiddenException.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoDataForbiddenException.cs
@@ -1,0 +1,12 @@
+namespace Nocturne.Connectors.Glooko.Services;
+
+/// <summary>
+/// Thrown when Glooko returns 403 Forbidden (e.g. <c>data_cant_view</c>) on a patient-scoped
+/// data endpoint. The patient code (<c>glookoCode</c>) is baked into the request URL and can change
+/// when the account or its data source is re-linked, so retrying the same URL is futile — the sync
+/// must invalidate the cached session and re-authenticate to resolve the current code.
+/// </summary>
+public sealed class GlookoDataForbiddenException : Exception
+{
+    public GlookoDataForbiddenException(string message) : base(message) { }
+}

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceReauthTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceReauthTests.cs
@@ -1,0 +1,194 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.Glooko.Configurations;
+using Nocturne.Connectors.Glooko.Services;
+using Nocturne.Core.Constants;
+using Xunit;
+
+namespace Nocturne.Connectors.Glooko.Tests.Services;
+
+/// <summary>
+/// Covers the recovery path when Glooko's <c>glookoCode</c> changes underneath a cached session:
+/// patient-scoped endpoints start returning 403 <c>data_cant_view</c>, and the connector must
+/// re-authenticate once to resolve the new code rather than failing or looping.
+/// </summary>
+public class GlookoConnectorServiceReauthTests
+{
+    private const string OldCode = "eu-west-1-indigo-killdeer-4650";
+    private const string NewCode = "eu-west-1-blue-duke-4165";
+
+    [Fact]
+    public async Task SyncDataAsync_WhenPatientCodeChanges_ReauthenticatesAndRecovers()
+    {
+        // First auth resolves the stale code (403s); the re-auth resolves the new one (200s).
+        var tokenProvider = new SwitchingGlookoTokenProvider([OldCode, NewCode]);
+        var handler = new PatientCodeAwareHandler(forbiddenCode: OldCode);
+        var service = BuildService(handler, tokenProvider);
+
+        var request = new SyncRequest
+        {
+            DataTypes = [SyncDataType.Glucose],
+            From = DateTime.UtcNow.AddDays(-3), // single chunk keeps the test focused
+        };
+
+        var result = await service.SyncDataAsync(request, BuildConfig(), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        tokenProvider.AcquireCount.Should().Be(2, "the stale code should trigger exactly one re-auth");
+        handler.GraphRequestedCodes.Should().Contain(NewCode, "the retry must query with the refreshed code");
+    }
+
+    [Fact]
+    public async Task SyncDataAsync_WhenForbiddenPersistsAfterReauth_FailsWithoutLooping()
+    {
+        // Re-auth keeps resolving the same forbidden code — must give up after one retry, not loop.
+        var tokenProvider = new SwitchingGlookoTokenProvider([OldCode]); // exhausted queue keeps returning OldCode
+        var handler = new PatientCodeAwareHandler(forbiddenCode: OldCode);
+        var service = BuildService(handler, tokenProvider);
+
+        var request = new SyncRequest
+        {
+            DataTypes = [SyncDataType.Glucose],
+            From = DateTime.UtcNow.AddDays(-3),
+        };
+
+        var result = await service.SyncDataAsync(request, BuildConfig(), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        tokenProvider.AcquireCount.Should().Be(2, "it should re-auth exactly once before giving up");
+    }
+
+    // ── Test infrastructure ─────────────────────────────────────────────
+
+    private static GlookoConnectorConfiguration BuildConfig() => new()
+    {
+        ConnectSource = ConnectSource.Glooko,
+        Email = "user@example.com",
+        Password = "secret",
+        Server = GlookoConstants.RegionEU,
+        UseV3Api = true,
+    };
+
+    private static GlookoConnectorService BuildService(
+        PatientCodeAwareHandler handler, SwitchingGlookoTokenProvider tokenProvider) =>
+        new(
+            new HttpClient(handler),
+            new ConnectorServerResolver<GlookoConnectorConfiguration>(null, null, null),
+            NullLogger<GlookoConnectorService>.Instance,
+            Mock.Of<IRetryDelayStrategy>(),
+            Mock.Of<IRateLimitingStrategy>(),
+            tokenProvider);
+
+    /// <summary>
+    /// Token provider that returns a session cookie plus a <c>UserData</c> metadata blob whose
+    /// glookoCode advances with each acquisition, simulating a code change after re-link.
+    /// </summary>
+    private sealed class SwitchingGlookoTokenProvider : GlookoAuthTokenProvider
+    {
+        private readonly Queue<string> _codes;
+        private string _lastCode = string.Empty;
+
+        public int AcquireCount { get; private set; }
+
+        public SwitchingGlookoTokenProvider(IEnumerable<string> codes)
+            : base(
+                new HttpClient(),
+                new ConnectorTokenCache(),
+                new ConnectorServerResolver<GlookoConnectorConfiguration>(null, null, null),
+                new FakeTenantAccessor(),
+                NullLogger<GlookoAuthTokenProvider>.Instance)
+        {
+            _codes = new Queue<string>(codes);
+        }
+
+        protected override Task<(string? Token, DateTime ExpiresAt, IReadOnlyDictionary<string, string>? Metadata)> AcquireTokenAsync(
+            GlookoConnectorConfiguration config, CancellationToken cancellationToken)
+        {
+            AcquireCount++;
+            _lastCode = _codes.Count > 0 ? _codes.Dequeue() : _lastCode;
+
+            var userData = JsonSerializer.Serialize(
+                new GlookoUserData { User = new GlookoUserLogin { GlookoCode = _lastCode } });
+            var metadata = new Dictionary<string, string>
+            {
+                ["SessionCookie"] = "_logbook-web_session=sess",
+                ["UserData"] = userData,
+            };
+
+            return Task.FromResult<(string?, DateTime, IReadOnlyDictionary<string, string>?)>(
+                ("_logbook-web_session=sess", DateTime.UtcNow.AddHours(1), metadata));
+        }
+
+        private sealed class FakeTenantAccessor : Nocturne.Core.Contracts.Multitenancy.ITenantAccessor
+        {
+            public bool IsResolved => true;
+            public Guid TenantId => Guid.Empty;
+            public Nocturne.Core.Contracts.Multitenancy.TenantContext? Context => null;
+            public void SetTenant(Nocturne.Core.Contracts.Multitenancy.TenantContext context) { }
+        }
+    }
+
+    /// <summary>
+    /// Returns 403 <c>data_cant_view</c> for graph/device requests carrying the forbidden patient
+    /// code, and 200 otherwise. Records which codes the graph endpoint was queried with.
+    /// </summary>
+    private sealed class PatientCodeAwareHandler(string forbiddenCode) : HttpMessageHandler
+    {
+        public List<string> GraphRequestedCodes { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri?.PathAndQuery ?? string.Empty;
+
+            if (path.Contains("/api/v3/session/users", StringComparison.OrdinalIgnoreCase))
+                return Json("{\"currentUser\":{\"meterUnits\":\"mgdl\",\"timezone\":\"Australia/Sydney\"}}");
+
+            if (path.Contains("/api/v3/users/summary/histories", StringComparison.OrdinalIgnoreCase))
+                return Json("{\"histories\":[]}");
+
+            if (path.Contains("/api/v3/graph/data", StringComparison.OrdinalIgnoreCase))
+            {
+                var code = ExtractPatient(path);
+                GraphRequestedCodes.Add(code);
+                return code == forbiddenCode ? Forbidden() : Json("{\"series\":{}}");
+            }
+
+            if (path.Contains("/api/v3/devices_and_settings", StringComparison.OrdinalIgnoreCase))
+                return ExtractPatient(path) == forbiddenCode ? Forbidden() : Json("{}");
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+
+        private static string ExtractPatient(string pathAndQuery)
+        {
+            const string key = "patient=";
+            var start = pathAndQuery.IndexOf(key, StringComparison.OrdinalIgnoreCase);
+            if (start < 0) return string.Empty;
+            start += key.Length;
+            var end = pathAndQuery.IndexOf('&', start);
+            return end < 0 ? pathAndQuery[start..] : pathAndQuery[start..end];
+        }
+
+        private static Task<HttpResponseMessage> Json(string body) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            });
+
+        private static Task<HttpResponseMessage> Forbidden() =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.Forbidden)
+            {
+                Content = new StringContent(
+                    "{\"status\":403,\"code\":\"data_cant_view\",\"message\":\"user is not authorized to view data\"}",
+                    Encoding.UTF8, "application/json"),
+            });
+    }
+}


### PR DESCRIPTION
## Problem

Glooko's per-account `glookoCode` can **change** when the account or its data source is re-linked. That code is baked into patient-scoped v3 (`graph/data`, `devices_and_settings`) and v2 batch request URLs, and the resolved session (including the code) is cached **in-memory for 24h**. So once the code changes, the connector keeps querying the **stale** code and Glooko returns `403 {"code":"data_cant_view","message":"user is not authorized to view data"}` on every 5-min cycle until the cache expires — boluses, carbs and basals silently stop importing while a separate CGM feed keeps flowing.

A dead session returns **401** (handled by re-auth on expiry); this is **403** at the authorization layer, which the connector previously treated as a generic chunk failure and retried with the same stale code.

## Fix

- Detect a `403` on a Glooko data endpoint and surface it as `GlookoDataForbiddenException` (and skip the futile same-URL retries — the code is part of the URL).
- On the **first** occurrence during a sync, invalidate the cached session and **re-authenticate once** (re-resolving the current `glookoCode`), then retry the sync pass from scratch.
- A **second** 403 fails the sync rather than looping.

## Verification

Diagnosed live: prod was stuck on `eu-west-1-indigo-killdeer-4650` (403) while a fresh login resolved `eu-west-1-blue-duke-4165` and returned data on **both** the v3 and SSV2 endpoints.

Added `GlookoConnectorServiceReauthTests`:
- changed code → re-auth once → recovers (queries the new code, succeeds)
- persistent 403 → re-auth once → fails without looping

All 54 Glooko unit tests pass.

## Note

The SSV2 endpoints (`feat/glooko-ssv2-granular-sync`) send no `patient=` param and are structurally immune to this bug; that's the longer-term direction. This fix protects the v3/v2 patient-scoped paths that are the current default for every Glooko tenant.