### PR TITLE
fix(connectors): source-scope the treatment resume watermark

### DIFF
--- a/src/API/Nocturne.API/Services/ConnectorPublishing/TreatmentPublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/TreatmentPublisher.cs
@@ -27,6 +27,8 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
     private readonly IBolusCalculationRepository _bolusCalculationRepository;
     private readonly ITempBasalRepository _tempBasalRepository;
     private readonly IBasalInjectionRepository _basalInjectionRepository;
+    private readonly INoteRepository _noteRepository;
+    private readonly IDeviceEventRepository _deviceEventRepository;
     private readonly IPatientInsulinRepository _patientInsulinRepository;
     private readonly IBasalRateResolver _basalRateResolver;
     private readonly ITherapySettingsResolver _therapySettingsResolver;
@@ -42,6 +44,8 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
         IBolusCalculationRepository bolusCalculationRepository,
         ITempBasalRepository tempBasalRepository,
         IBasalInjectionRepository basalInjectionRepository,
+        INoteRepository noteRepository,
+        IDeviceEventRepository deviceEventRepository,
         IPatientInsulinRepository patientInsulinRepository,
         IBasalRateResolver basalRateResolver,
         ITherapySettingsResolver therapySettingsResolver,
@@ -56,6 +60,8 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
         _bolusCalculationRepository = bolusCalculationRepository ?? throw new ArgumentNullException(nameof(bolusCalculationRepository));
         _tempBasalRepository = tempBasalRepository ?? throw new ArgumentNullException(nameof(tempBasalRepository));
         _basalInjectionRepository = basalInjectionRepository ?? throw new ArgumentNullException(nameof(basalInjectionRepository));
+        _noteRepository = noteRepository ?? throw new ArgumentNullException(nameof(noteRepository));
+        _deviceEventRepository = deviceEventRepository ?? throw new ArgumentNullException(nameof(deviceEventRepository));
         _patientInsulinRepository = patientInsulinRepository ?? throw new ArgumentNullException(nameof(patientInsulinRepository));
         _basalRateResolver = basalRateResolver ?? throw new ArgumentNullException(nameof(basalRateResolver));
         _therapySettingsResolver = therapySettingsResolver ?? throw new ArgumentNullException(nameof(therapySettingsResolver));
@@ -338,24 +344,24 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
         string source,
         CancellationToken cancellationToken = default)
     {
-        // TODO: Filter by source to support multi-connector catch-up. Currently returns global latest.
-        var latest = (await _treatmentService.GetTreatmentsAsync(
-                count: 1,
-                skip: 0,
-                cancellationToken: cancellationToken))
-            .FirstOrDefault();
+        // The v1 "treatments" collection spans every decomposed treatment type, so the resume
+        // watermark is the latest stored record of any of them for THIS source. Source-scoping is
+        // required for multi-connector catch-up: a tenant-global latest mis-classifies a newly
+        // enabled connector's first sync as incremental and skips its backfill.
+        var candidates = new[]
+        {
+            await _bolusRepository.GetLatestTimestampAsync(source, cancellationToken),
+            await _carbIntakeRepository.GetLatestTimestampAsync(source, cancellationToken),
+            await _bgCheckRepository.GetLatestTimestampAsync(source, cancellationToken),
+            await _bolusCalculationRepository.GetLatestTimestampAsync(source, cancellationToken),
+            await _tempBasalRepository.GetLatestTimestampAsync(source, cancellationToken),
+            await _basalInjectionRepository.GetLatestTimestampAsync(source, cancellationToken),
+            await _noteRepository.GetLatestTimestampAsync(source, cancellationToken),
+            await _deviceEventRepository.GetLatestTimestampAsync(source, cancellationToken),
+        };
 
-        if (latest == null)
-            return null;
-
-        if (!string.IsNullOrEmpty(latest.CreatedAt)
-            && DateTime.TryParse(latest.CreatedAt, out var createdAt))
-            return createdAt;
-
-        if (latest.Mills > 0)
-            return DateTimeOffset.FromUnixTimeMilliseconds(latest.Mills).UtcDateTime;
-
-        return null;
+        var present = candidates.Where(t => t.HasValue).Select(t => t!.Value).ToList();
+        return present.Count > 0 ? present.Max() : null;
     }
 
     // ── Patient Insulin resolution helpers ──────────────────────────────

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBGCheckRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBGCheckRepository.cs
@@ -83,6 +83,14 @@ public interface IBGCheckRepository : IV4Repository<BGCheck>
     /// <param name="ct">Cancellation token.</param>
     new Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
 
+    /// <summary>
+    /// Retrieve the timestamp of the most recently stored <see cref="BGCheck"/>, optionally scoped to a data source.
+    /// </summary>
+    /// <remarks>Used by connectors to resume per-source sync without re-fetching already-stored data.</remarks>
+    /// <param name="source">Optional data source filter. Pass <c>null</c> to search across all sources.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default);
+
     /// <summary>Retrieve all <see cref="BGCheck"/> records sharing the same correlation identifier.</summary>
     /// <param name="correlationId">Correlation ID linking related records.</param>
     /// <param name="ct">Cancellation token.</param>

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBasalInjectionRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBasalInjectionRepository.cs
@@ -35,4 +35,12 @@ public interface IBasalInjectionRepository : IV4Repository<BasalInjection>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The created records (excludes duplicates).</returns>
     Task<IEnumerable<BasalInjection>> BulkCreateAsync(IEnumerable<BasalInjection> records, CancellationToken ct = default);
+
+    /// <summary>
+    /// Retrieve the timestamp of the most recently stored <see cref="BasalInjection"/>, optionally scoped to a data source.
+    /// </summary>
+    /// <remarks>Used by connectors to resume per-source sync without re-fetching already-stored data.</remarks>
+    /// <param name="source">Optional data source filter. Pass <c>null</c> to search across all sources.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBolusCalculationRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBolusCalculationRepository.cs
@@ -78,6 +78,14 @@ public interface IBolusCalculationRepository : IV4Repository<BolusCalculation>
     /// <param name="ct">Cancellation token.</param>
     new Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
 
+    /// <summary>
+    /// Retrieve the timestamp of the most recently stored <see cref="BolusCalculation"/>, optionally scoped to a data source.
+    /// </summary>
+    /// <remarks>Used by connectors to resume per-source sync without re-fetching already-stored data.</remarks>
+    /// <param name="source">Optional data source filter. Pass <c>null</c> to search across all sources.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default);
+
     /// <summary>Retrieve all <see cref="BolusCalculation"/> records sharing the same correlation identifier.</summary>
     /// <param name="correlationId">Correlation ID linking related records (e.g., bolus + wizard).</param>
     /// <param name="ct">Cancellation token.</param>

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBolusRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBolusRepository.cs
@@ -96,6 +96,14 @@ public interface IBolusRepository : IV4Repository<Bolus>
     /// <param name="ct">Cancellation token.</param>
     new Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
 
+    /// <summary>
+    /// Retrieve the timestamp of the most recently stored <see cref="Bolus"/>, optionally scoped to a data source.
+    /// </summary>
+    /// <remarks>Used by connectors to resume per-source sync without re-fetching already-stored data.</remarks>
+    /// <param name="source">Optional data source filter. Pass <c>null</c> to search across all sources.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default);
+
     /// <summary>Retrieve all <see cref="Bolus"/> records sharing the same correlation identifier.</summary>
     /// <param name="correlationId">Correlation ID linking a bolus to its wizard calculation or meal.</param>
     /// <param name="ct">Cancellation token.</param>

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ICarbIntakeRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ICarbIntakeRepository.cs
@@ -93,6 +93,14 @@ public interface ICarbIntakeRepository : IV4Repository<CarbIntake>
     /// <param name="ct">Cancellation token.</param>
     new Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
 
+    /// <summary>
+    /// Retrieve the timestamp of the most recently stored <see cref="CarbIntake"/>, optionally scoped to a data source.
+    /// </summary>
+    /// <remarks>Used by connectors to resume per-source sync without re-fetching already-stored data.</remarks>
+    /// <param name="source">Optional data source filter. Pass <c>null</c> to search across all sources.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default);
+
     /// <summary>Retrieve all <see cref="CarbIntake"/> records sharing the same correlation identifier.</summary>
     /// <param name="correlationId">Correlation ID linking a carb entry to its associated bolus or meal.</param>
     /// <param name="ct">Cancellation token.</param>

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IDeviceEventRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IDeviceEventRepository.cs
@@ -93,6 +93,14 @@ public interface IDeviceEventRepository : IV4Repository<DeviceEvent>
     /// <param name="ct">Cancellation token.</param>
     new Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
 
+    /// <summary>
+    /// Retrieve the timestamp of the most recently stored <see cref="DeviceEvent"/>, optionally scoped to a data source.
+    /// </summary>
+    /// <remarks>Used by connectors to resume per-source sync without re-fetching already-stored data.</remarks>
+    /// <param name="source">Optional data source filter. Pass <c>null</c> to search across all sources.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default);
+
     /// <summary>Retrieve all <see cref="DeviceEvent"/> records sharing the same correlation identifier.</summary>
     /// <param name="correlationId">Correlation ID linking related records.</param>
     /// <param name="ct">Cancellation token.</param>

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/INoteRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/INoteRepository.cs
@@ -91,6 +91,14 @@ public interface INoteRepository : IV4Repository<Note>
     /// <param name="ct">Cancellation token.</param>
     new Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
 
+    /// <summary>
+    /// Retrieve the timestamp of the most recently stored <see cref="Note"/>, optionally scoped to a data source.
+    /// </summary>
+    /// <remarks>Used by connectors to resume per-source sync without re-fetching already-stored data.</remarks>
+    /// <param name="source">Optional data source filter. Pass <c>null</c> to search across all sources.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default);
+
     /// <summary>Retrieve all <see cref="Note"/> records sharing the same correlation identifier.</summary>
     /// <param name="correlationId">Correlation ID linking related records.</param>
     /// <param name="ct">Cancellation token.</param>

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ITempBasalRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ITempBasalRepository.cs
@@ -77,6 +77,14 @@ public interface ITempBasalRepository
     /// <param name="ct">Cancellation token.</param>
     Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
 
+    /// <summary>
+    /// Retrieve the start timestamp of the most recently stored <see cref="TempBasal"/>, optionally scoped to a data source.
+    /// </summary>
+    /// <remarks>Used by connectors to resume per-source sync without re-fetching already-stored data.</remarks>
+    /// <param name="source">Optional data source filter. Pass <c>null</c> to search across all sources.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default);
+
     /// <summary>Insert multiple <see cref="TempBasal"/> records in a single batch operation.</summary>
     /// <param name="records">Records to insert.</param>
     /// <param name="ct">Cancellation token.</param>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
@@ -209,6 +209,19 @@ public class BGCheckRepository : IBGCheckRepository
     }
 
     /// <summary>
+    /// Returns the timestamp of the most recently stored record, optionally scoped to a data source.
+    /// Used by connectors to resume per-source sync without re-fetching already-stored data.
+    /// </summary>
+    public async Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var query = ctx.BGChecks.AsNoTracking().AsQueryable();
+        if (source != null)
+            query = query.Where(e => e.DataSource == source);
+        return await query.MaxAsync(e => (DateTime?)e.Timestamp, ct);
+    }
+
+    /// <summary>
     /// Counts blood glucose check records within a timestamp range.
     /// </summary>
     /// <param name="from">Optional start timestamp filter.</param>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
@@ -204,6 +204,18 @@ public class BasalInjectionRepository : IBasalInjectionRepository
     }
 
     /// <summary>
+    /// Returns the timestamp of the most recently stored basal injection, optionally scoped to a data source.
+    /// Used by connectors to resume per-source sync without re-fetching already-stored data.
+    /// </summary>
+    public async Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default)
+    {
+        var query = _context.BasalInjections.AsNoTracking().AsQueryable();
+        if (source != null)
+            query = query.Where(e => e.DataSource == source);
+        return await query.MaxAsync(e => (DateTime?)e.Timestamp, ct);
+    }
+
+    /// <summary>
     /// Counts basal injection records within a timestamp range.
     /// </summary>
     /// <param name="from">Optional start timestamp filter.</param>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
@@ -224,6 +224,19 @@ public class BolusCalculationRepository : IBolusCalculationRepository
     }
 
     /// <summary>
+    /// Returns the timestamp of the most recently stored record, optionally scoped to a data source.
+    /// Used by connectors to resume per-source sync without re-fetching already-stored data.
+    /// </summary>
+    public async Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var query = ctx.BolusCalculations.AsNoTracking().AsQueryable();
+        if (source != null)
+            query = query.Where(e => e.DataSource == source);
+        return await query.MaxAsync(e => (DateTime?)e.Timestamp, ct);
+    }
+
+    /// <summary>
     /// Counts bolus calculation records within a timestamp range.
     /// </summary>
     /// <param name="from">Optional start timestamp filter.</param>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
@@ -258,6 +258,19 @@ public class BolusRepository : IBolusRepository
     }
 
     /// <summary>
+    /// Returns the timestamp of the most recently stored record, optionally scoped to a data source.
+    /// Used by connectors to resume per-source sync without re-fetching already-stored data.
+    /// </summary>
+    public async Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var query = ctx.Boluses.AsNoTracking().AsQueryable();
+        if (source != null)
+            query = query.Where(e => e.DataSource == source);
+        return await query.MaxAsync(e => (DateTime?)e.Timestamp, ct);
+    }
+
+    /// <summary>
     /// Counts bolus records within a timestamp range.
     /// </summary>
     /// <param name="from">Optional start timestamp filter.</param>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
@@ -265,6 +265,19 @@ public class CarbIntakeRepository : ICarbIntakeRepository
     }
 
     /// <summary>
+    /// Returns the timestamp of the most recently stored record, optionally scoped to a data source.
+    /// Used by connectors to resume per-source sync without re-fetching already-stored data.
+    /// </summary>
+    public async Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var query = ctx.CarbIntakes.AsNoTracking().AsQueryable();
+        if (source != null)
+            query = query.Where(e => e.DataSource == source);
+        return await query.MaxAsync(e => (DateTime?)e.Timestamp, ct);
+    }
+
+    /// <summary>
     /// Counts carbohydrate intake records within a timestamp range.
     /// </summary>
     /// <param name="from">Optional start timestamp filter.</param>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
@@ -224,6 +224,19 @@ public class DeviceEventRepository : IDeviceEventRepository
     }
 
     /// <summary>
+    /// Returns the timestamp of the most recently stored record, optionally scoped to a data source.
+    /// Used by connectors to resume per-source sync without re-fetching already-stored data.
+    /// </summary>
+    public async Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var query = ctx.DeviceEvents.AsNoTracking().AsQueryable();
+        if (source != null)
+            query = query.Where(e => e.DataSource == source);
+        return await query.MaxAsync(e => (DateTime?)e.Timestamp, ct);
+    }
+
+    /// <summary>
     /// Counts device event records within a timestamp range.
     /// </summary>
     /// <param name="from">Optional start timestamp filter.</param>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
@@ -209,6 +209,19 @@ public class NoteRepository : INoteRepository
     }
 
     /// <summary>
+    /// Returns the timestamp of the most recently stored record, optionally scoped to a data source.
+    /// Used by connectors to resume per-source sync without re-fetching already-stored data.
+    /// </summary>
+    public async Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var query = ctx.Notes.AsNoTracking().AsQueryable();
+        if (source != null)
+            query = query.Where(e => e.DataSource == source);
+        return await query.MaxAsync(e => (DateTime?)e.Timestamp, ct);
+    }
+
+    /// <summary>
     /// Counts note records within a timestamp range.
     /// </summary>
     /// <param name="from">Optional start timestamp filter.</param>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
@@ -225,6 +225,19 @@ public class TempBasalRepository : ITempBasalRepository
     }
 
     /// <summary>
+    /// Returns the start timestamp of the most recently stored temp basal, optionally scoped to a data source.
+    /// Used by connectors to resume per-source sync without re-fetching already-stored data.
+    /// </summary>
+    public async Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var query = ctx.TempBasals.AsNoTracking().AsQueryable();
+        if (source != null)
+            query = query.Where(e => e.DataSource == source);
+        return await query.MaxAsync(e => (DateTime?)e.StartTimestamp, ct);
+    }
+
+    /// <summary>
     /// Counts temporary basal records within a timestamp range.
     /// </summary>
     /// <param name="from">Optional start timestamp filter.</param>

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/TreatmentPublisherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/TreatmentPublisherTests.cs
@@ -27,6 +27,8 @@ public class TreatmentPublisherTests
     private readonly Mock<IBolusCalculationRepository> _mockBolusCalculationRepository;
     private readonly Mock<ITempBasalRepository> _mockTempBasalRepository;
     private readonly Mock<IBasalInjectionRepository> _mockBasalInjectionRepository;
+    private readonly Mock<INoteRepository> _mockNoteRepository;
+    private readonly Mock<IDeviceEventRepository> _mockDeviceEventRepository;
     private readonly Mock<IPatientInsulinRepository> _mockPatientInsulinRepository;
     private readonly Mock<IBasalRateResolver> _mockBasalRateResolver;
     private readonly Mock<ITherapySettingsResolver> _mockTherapySettingsResolver;
@@ -50,6 +52,8 @@ public class TreatmentPublisherTests
         _mockBolusCalculationRepository = new Mock<IBolusCalculationRepository>();
         _mockTempBasalRepository = new Mock<ITempBasalRepository>();
         _mockBasalInjectionRepository = new Mock<IBasalInjectionRepository>();
+        _mockNoteRepository = new Mock<INoteRepository>();
+        _mockDeviceEventRepository = new Mock<IDeviceEventRepository>();
         _mockPatientInsulinRepository = new Mock<IPatientInsulinRepository>();
         _mockBasalRateResolver = new Mock<IBasalRateResolver>();
         _mockTherapySettingsResolver = new Mock<ITherapySettingsResolver>();
@@ -81,6 +85,8 @@ public class TreatmentPublisherTests
             _mockBolusCalculationRepository.Object,
             _mockTempBasalRepository.Object,
             _mockBasalInjectionRepository.Object,
+            _mockNoteRepository.Object,
+            _mockDeviceEventRepository.Object,
             _mockPatientInsulinRepository.Object,
             _mockBasalRateResolver.Object,
             _mockTherapySettingsResolver.Object,
@@ -144,43 +150,51 @@ public class TreatmentPublisherTests
     }
 
     [Fact]
-    public async Task GetLatestTreatmentTimestampAsync_ReturnsCreatedAt_WhenAvailable()
+    public async Task GetLatestTreatmentTimestampAsync_ReturnsMaxAcrossAllTreatmentTypes()
     {
-        var createdAt = "2026-01-15T12:00:00Z";
-        _mockTreatmentService
-            .Setup(s => s.GetTreatmentsAsync(1, 0, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<Treatment> { new() { CreatedAt = createdAt } });
+        var older = new DateTime(2026, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        var newest = new DateTime(2026, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        _mockBolusRepository
+            .Setup(r => r.GetLatestTimestampAsync("connector-a", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(older);
+        _mockCarbIntakeRepository
+            .Setup(r => r.GetLatestTimestampAsync("connector-a", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(newest);
+        // The remaining treatment repos return null (no data of that type) by default.
 
-        var result = await _publisher.GetLatestTreatmentTimestampAsync("test-source");
+        var result = await _publisher.GetLatestTreatmentTimestampAsync("connector-a");
 
-        result.Should().Be(DateTime.Parse(createdAt));
+        result.Should().Be(newest);
     }
 
     [Fact]
-    public async Task GetLatestTreatmentTimestampAsync_ReturnsTimestamp_WhenOnlyMillsSet()
+    public async Task GetLatestTreatmentTimestampAsync_IsSourceScoped_AcrossEveryTreatmentType()
     {
-        // Treatment.CreatedAt auto-generates an ISO string from Mills,
-        // so the CreatedAt parsing path is taken even when only Mills is set.
-        var fixedTime = new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero);
-        var mills = fixedTime.ToUnixTimeMilliseconds();
-        _mockTreatmentService
-            .Setup(s => s.GetTreatmentsAsync(1, 0, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<Treatment> { new() { Mills = mills } });
+        // Regression: the resume watermark must be scoped to the requesting source. A tenant-global
+        // latest (the previous behaviour) mis-classifies a newly enabled connector's first sync as
+        // incremental and silently skips its backfill. Every decomposed treatment type must be
+        // queried for THIS source, and the legacy global treatment-store query must no longer run.
+        await _publisher.GetLatestTreatmentTimestampAsync("connector-a");
 
-        var result = await _publisher.GetLatestTreatmentTimestampAsync("test-source");
-
-        result.Should().NotBeNull();
-        result!.Value.Date.Should().Be(new DateTime(2026, 1, 15));
+        _mockBolusRepository.Verify(r => r.GetLatestTimestampAsync("connector-a", It.IsAny<CancellationToken>()), Times.Once);
+        _mockCarbIntakeRepository.Verify(r => r.GetLatestTimestampAsync("connector-a", It.IsAny<CancellationToken>()), Times.Once);
+        _mockBGCheckRepository.Verify(r => r.GetLatestTimestampAsync("connector-a", It.IsAny<CancellationToken>()), Times.Once);
+        _mockBolusCalculationRepository.Verify(r => r.GetLatestTimestampAsync("connector-a", It.IsAny<CancellationToken>()), Times.Once);
+        _mockTempBasalRepository.Verify(r => r.GetLatestTimestampAsync("connector-a", It.IsAny<CancellationToken>()), Times.Once);
+        _mockBasalInjectionRepository.Verify(r => r.GetLatestTimestampAsync("connector-a", It.IsAny<CancellationToken>()), Times.Once);
+        _mockNoteRepository.Verify(r => r.GetLatestTimestampAsync("connector-a", It.IsAny<CancellationToken>()), Times.Once);
+        _mockDeviceEventRepository.Verify(r => r.GetLatestTimestampAsync("connector-a", It.IsAny<CancellationToken>()), Times.Once);
+        _mockTreatmentService.Verify(
+            s => s.GetTreatmentsAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]
-    public async Task GetLatestTreatmentTimestampAsync_ReturnsNull_WhenNoTreatments()
+    public async Task GetLatestTreatmentTimestampAsync_ReturnsNull_WhenNoTreatmentsForSource()
     {
-        _mockTreatmentService
-            .Setup(s => s.GetTreatmentsAsync(1, 0, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<Treatment>());
-
-        var result = await _publisher.GetLatestTreatmentTimestampAsync("test-source");
+        // No stored treatment of any type for this source — the connector should treat it as a
+        // first sync (backfill), not resume from a (nonexistent) watermark.
+        var result = await _publisher.GetLatestTreatmentTimestampAsync("connector-a");
 
         result.Should().BeNull();
     }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/BolusRepositoryTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/BolusRepositoryTests.cs
@@ -124,6 +124,32 @@ public class BolusRepositoryTests : IDisposable
     }
 
     [Fact]
+    public async Task GetLatestTimestampAsync_IsScopedToSource()
+    {
+        // Regression: the per-source watermark must ignore other sources. connector-a's latest is
+        // older than connector-b's; a tenant-global latest would resume connector-a from b's clock
+        // and silently skip connector-a's backfill.
+        var aOld = new DateTime(2026, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        var aLatest = new DateTime(2026, 1, 12, 0, 0, 0, DateTimeKind.Utc);
+        var bNewer = new DateTime(2026, 1, 20, 0, 0, 0, DateTimeKind.Utc);
+
+        await _repo.CreateAsync(new Bolus { Timestamp = aOld, Insulin = 1.0, DataSource = "connector-a" });
+        await _repo.CreateAsync(new Bolus { Timestamp = aLatest, Insulin = 2.0, DataSource = "connector-a" });
+        await _repo.CreateAsync(new Bolus { Timestamp = bNewer, Insulin = 3.0, DataSource = "connector-b" });
+
+        (await _repo.GetLatestTimestampAsync("connector-a")).Should().Be(aLatest);
+        (await _repo.GetLatestTimestampAsync()).Should().Be(bNewer, "a null source returns the tenant-wide latest");
+    }
+
+    [Fact]
+    public async Task GetLatestTimestampAsync_ReturnsNull_WhenNoRecordsForSource()
+    {
+        await _repo.CreateAsync(new Bolus { Timestamp = DateTime.UtcNow, Insulin = 1.0, DataSource = "connector-b" });
+
+        (await _repo.GetLatestTimestampAsync("connector-a")).Should().BeNull();
+    }
+
+    [Fact]
     public async Task CreateAsync_WithoutDataSource_DoesNotDedupe()
     {
         // SyncIdentifier alone is not enough — needs DataSource scoping.


### PR DESCRIPTION
## Problem

`TreatmentPublisher.GetLatestTreatmentTimestampAsync(source)` — the resume watermark connectors use to decide where to continue a treatment sync — returned the tenant-**global** latest treatment (via the v1 treatment store) and ignored `source`.

Consequence: a connector that has run for months and then has treatment sync newly enabled sees a recent treatment from *another* source, computes its since-window as ~now, and **silently skips backfilling its own history**. This is a latent data-completeness bug today, independent of any new feature — it bites any tenant running more than one treatment source (e.g. a direct uploader plus a connector, or two pump connectors). Glucose is already source-scoped; treatments were not.

## Fix

- Add `Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default)` to the **eight** decomposed treatment-family V4 repositories — Bolus, CarbIntake, BGCheck, BolusCalculation, Note, DeviceEvent, TempBasal, BasalInjection — mirroring the existing `ISensorGlucoseRepository.GetLatestTimestampAsync` pattern (`AsNoTracking`, optional `DataSource == source` filter, `MAX` over the timestamp; TempBasal maxes `StartTimestamp`).
- Rewrite `TreatmentPublisher.GetLatestTreatmentTimestampAsync` to take the **source-filtered max across all eight** (injecting the `Note`/`DeviceEvent` repos it previously lacked). This preserves the original cross-type watermark semantics (the v1 "treatments" collection spans all these decomposed types) while scoping it per source, and drops the old global treatment-store query.

### Safety

The watermark can only move **older-or-equal** to the true per-source latest (a soft-deleted newest row drops `MAX` to an older value), never newer. Older is safe — the connector re-fetches and dedup collapses the overlap. It can never skip data.

## Tests

- `TreatmentPublisherTests`: source is passed to every treatment repo, the max is returned, and the legacy global treatment-store query is asserted **never** called. (constructor updated for the 2 new repos; 3 obsolete tests that mocked the removed path replaced.)
- `BolusRepositoryTests`: real-SQLite source-isolation test — source A's older watermark is returned for source A even when source B has newer rows; null source still returns the tenant-wide latest.

All affected unit tests green (19 publisher + 8 repo); full build clean.

## Follow-up (separate PR)

Device-status (`GetLatestDeviceStatusTimestampAsync`) has the **same** global-latest bug and is also multi-source (CareLink/Nightscout/Tandem/NocturneRemote all sync it), but its watermark tables — `aps_snapshots`, `pump_snapshots`, `uploader_snapshots` — carry no `data_source` column and the decomposer doesn't stamp one. Fixing it needs a schema migration plus threading the source through the device-status decompose path, so it's handled separately.
