### PR TITLE
fix(oauth): allow Dynamic Client Registration without redirect_uris

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/OAuthController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/OAuthController.cs
@@ -947,28 +947,25 @@ public class OAuthController : ControllerBase
             });
         }
 
-        // RFC 7591 Section 2.0.1: redirect_uris is REQUIRED for native apps
-        if (request.RedirectUris is null || request.RedirectUris.Count == 0)
+        // redirect_uris is only needed for the authorization-code flow. Device-flow
+        // (RFC 8628) and refresh-only clients register without any; a client with no
+        // registered redirect URI simply cannot use the authorization-code flow, which
+        // ValidateRedirectUriAsync already fails closed on. When present, every URI must
+        // pass RFC 8252 validation.
+        if (request.RedirectUris is { Count: > 0 })
         {
-            return BadRequest(new OAuthError
+            var invalidUris = request.RedirectUris
+                .Where(u => !redirectUriValidator.IsValidForRegistration(u))
+                .ToList();
+            if (invalidUris.Count > 0)
             {
-                Error = "invalid_redirect_uri",
-                ErrorDescription = "At least one redirect_uri is required.",
-            });
-        }
-
-        // Validate every redirect URI per RFC 8252
-        var invalidUris = request.RedirectUris
-            .Where(u => !redirectUriValidator.IsValidForRegistration(u))
-            .ToList();
-        if (invalidUris.Count > 0)
-        {
-            return BadRequest(new OAuthError
-            {
-                Error = "invalid_redirect_uri",
-                ErrorDescription =
-                    $"The following redirect_uris are not allowed: {string.Join(", ", invalidUris)}.",
-            });
+                return BadRequest(new OAuthError
+                {
+                    Error = "invalid_redirect_uri",
+                    ErrorDescription =
+                        $"The following redirect_uris are not allowed: {string.Join(", ", invalidUris)}.",
+                });
+            }
         }
 
         // Strict scope validation against the canonical registry

--- a/tests/Unit/Nocturne.API.Tests/Authorization/OAuthControllerRegisterTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/OAuthControllerRegisterTests.cs
@@ -1,0 +1,131 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Controllers.Authentication;
+using Nocturne.API.Models.OAuth;
+using Nocturne.API.Services.Auth;
+using Nocturne.Core.Contracts.Auth;
+using Xunit;
+
+namespace Nocturne.API.Tests.Authorization;
+
+/// <summary>
+/// Unit tests for the <see cref="OAuthController"/> Dynamic Client Registration endpoint,
+/// focused on the redirect_uris requirement. Device-flow clients (RFC 8628, e.g. the
+/// Windows widget) register without any redirect_uris, so registration must succeed when
+/// none are supplied.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Category", "OAuth")]
+public class OAuthControllerRegisterTests
+{
+    private readonly Mock<IOAuthClientService> _clientService = new();
+    private readonly RedirectUriValidator _redirectUriValidator = new();
+
+    private OAuthController CreateController()
+    {
+        return new OAuthController(
+            _clientService.Object,
+            Mock.Of<IOAuthGrantService>(),
+            Mock.Of<IOAuthTokenService>(),
+            Mock.Of<IOAuthDeviceCodeService>(),
+            Mock.Of<ISubjectService>(),
+            Mock.Of<IJwtService>(),
+            Mock.Of<IOAuthTokenRevocationCache>(),
+            NullLogger<OAuthController>.Instance
+        )
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            },
+        };
+    }
+
+    [Fact]
+    public async Task Register_WithNoRedirectUris_SucceedsForDeviceFlowClient()
+    {
+        _clientService
+            .Setup(s => s.RegisterClientAsync(
+                "com.nocturne.widget.windows",
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.Is<IReadOnlyList<string>>(u => u.Count == 0),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OAuthClientInfo
+            {
+                ClientId = "generated-client-id",
+                SoftwareId = "com.nocturne.widget.windows",
+                IsKnown = true,
+            });
+
+        var controller = CreateController();
+        var request = new ClientRegistrationRequest
+        {
+            SoftwareId = "com.nocturne.widget.windows",
+            ClientName = "Nocturne Windows Widget",
+            Scope = "glucose.read",
+            RedirectUris = [],
+        };
+
+        var result = await controller.Register(request, _redirectUriValidator, CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var body = ok.Value.Should().BeOfType<ClientRegistrationResponse>().Subject;
+        body.ClientId.Should().Be("generated-client-id");
+        _clientService.VerifyAll();
+    }
+
+    [Fact]
+    public async Task Register_WithInvalidRedirectUri_ReturnsBadRequest()
+    {
+        var controller = CreateController();
+        var request = new ClientRegistrationRequest
+        {
+            SoftwareId = "com.example.app",
+            Scope = "glucose.read",
+            // Non-loopback http is not a valid native redirect URI (RFC 8252).
+            RedirectUris = ["http://example.com/callback"],
+        };
+
+        var result = await controller.Register(request, _redirectUriValidator, CancellationToken.None);
+
+        var bad = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        bad.Value.Should().BeOfType<OAuthError>()
+            .Which.Error.Should().Be("invalid_redirect_uri");
+        _clientService.Verify(
+            s => s.RegisterClientAsync(
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Register_WithValidCustomSchemeRedirectUri_Succeeds()
+    {
+        _clientService
+            .Setup(s => s.RegisterClientAsync(
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.Is<IReadOnlyList<string>>(u => u.Count == 1),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OAuthClientInfo { ClientId = "generated-client-id" });
+
+        var controller = CreateController();
+        var request = new ClientRegistrationRequest
+        {
+            SoftwareId = "com.nocturne.widget.windows",
+            Scope = "glucose.read",
+            RedirectUris = ["com.nocturne.widget.windows://oauth/callback"],
+        };
+
+        var result = await controller.Register(request, _redirectUriValidator, CancellationToken.None);
+
+        result.Should().BeOfType<OkObjectResult>();
+    }
+}


### PR DESCRIPTION
## What

`/oauth/register` (RFC 7591 Dynamic Client Registration) required at least one `redirect_uri`. But redirect URIs are only used by the authorization-code flow — device-flow (RFC 8628) and refresh-only clients have none, so they were forced to send a placeholder redirect URI they never use.

This makes `redirect_uris` optional: each URI is still validated per RFC 8252 **when present**, but an empty/absent list is now accepted.

## Why it's safe

A client registered with no redirect URI still **cannot** use the authorization-code flow: `OAuthClientService.ValidateRedirectUriAsync` fails closed on an empty registered set. So this only unblocks device-flow / refresh-only registration; it does not weaken the auth-code path.

This unblocks device-flow known-directory apps that ship with no redirect URIs (Sugarmate, Nightscout, Nightwatch, Follower, Tray, Home Assistant, the Windows widget) from registering without a placeholder.

## Tests

New `OAuthControllerRegisterTests`: registration succeeds with no redirect_uris, still rejects an invalid redirect URI, and accepts a valid custom-scheme one.