### PR TITLE
fix(oauth): real app identifiers in known-client directory; fix Tray auth

### DIFF
--- a/src/Core/Nocturne.Core.Models/Authorization/KnownOAuthClients.cs
+++ b/src/Core/Nocturne.Core.Models/Authorization/KnownOAuthClients.cs
@@ -16,11 +16,13 @@ public static class KnownOAuthClients
     {
         new()
         {
-            SoftwareId = "org.trio.diabetes",
+            // iOS bundle id is org.nightscout.$(DEVELOPMENT_TEAM).trio; the team segment
+            // varies per build, so the stable software_id is the team-independent base.
+            SoftwareId = "org.nightscout.trio",
             DisplayName = "Trio",
-            Homepage = "https://github.com/nightscout/Trio",
+            Homepage = "https://triodocs.org",
             LogoUri = "/logos/trio.svg",
-            RedirectUris = ["trio://oauth/callback"],
+            RedirectUris = ["org.nightscout.trio://oauth/callback"],
             TypicalScopes =
             [
                 OAuthScopes.GlucoseReadWrite,
@@ -31,11 +33,12 @@ public static class KnownOAuthClients
         },
         new()
         {
-            SoftwareId = "org.nightscoutfoundation.xdrip",
+            // Real Android applicationId (Play Store / APK identity).
+            SoftwareId = "com.eveningoutpost.dexdrip",
             DisplayName = "xDrip+",
             Homepage = "https://github.com/NightscoutFoundation/xDrip",
             LogoUri = "/logos/xdrip.svg",
-            RedirectUris = ["org.nightscoutfoundation.xdrip://oauth/callback"],
+            RedirectUris = ["com.eveningoutpost.dexdrip://oauth/callback"],
             TypicalScopes =
             [
                 OAuthScopes.GlucoseReadWrite,
@@ -61,11 +64,13 @@ public static class KnownOAuthClients
         },
         new()
         {
-            SoftwareId = "org.androidaps.aaps",
+            // Real Android applicationId. (app.aaps is only the new internal source
+            // namespace; the installed package id remains info.nightscout.androidaps.)
+            SoftwareId = "info.nightscout.androidaps",
             DisplayName = "AAPS",
-            Homepage = "https://androidaps.readthedocs.io",
+            Homepage = "https://wiki.aaps.app",
             LogoUri = "/logos/aaps.svg",
-            RedirectUris = ["org.androidaps.aaps://oauth/callback"],
+            RedirectUris = ["info.nightscout.androidaps://oauth/callback"],
             TypicalScopes =
             [
                 OAuthScopes.GlucoseReadWrite,
@@ -76,8 +81,11 @@ public static class KnownOAuthClients
         },
         new()
         {
-            SoftwareId = "github.nightscout.nightscout",
-            DisplayName = "Nightscout",
+            // The classic self-hosted Nightscout server (cgm-remote-monitor) acting as a
+            // read-only follower of a Nocturne tenant. "Nightscout" is the server, not a
+            // distinct client app, so the id is rooted on the cgm-remote-monitor repo.
+            SoftwareId = "org.nightscout.cgm-remote-monitor",
+            DisplayName = "Nightscout (server)",
             Homepage = "https://nightscout.github.io/",
             LogoUri = "/logos/nightscout.svg",
             RedirectUris = [],
@@ -91,7 +99,8 @@ public static class KnownOAuthClients
         },
         new()
         {
-            SoftwareId = "io.sugarmate",
+            // Real Android applicationId (Sugarmate is now a Tandem Diabetes Care app).
+            SoftwareId = "com.tandemdiabetes.sugarmate",
             DisplayName = "Sugarmate",
             Homepage = "https://sugarmate.io/",
             LogoUri = "/logos/sugarmate.svg",
@@ -100,9 +109,10 @@ public static class KnownOAuthClients
         },
         new()
         {
-            SoftwareId = "com.nickenilsson.nightwatch",
+            // The maintained "Nightwatch" Android app (Markus Kallander); real package id.
+            SoftwareId = "se.cornixit.nightwatch",
             DisplayName = "Nightwatch",
-            Homepage = "https://github.com/nickenilsson/nightwatch",
+            Homepage = "https://play.google.com/store/apps/details?id=se.cornixit.nightwatch",
             LogoUri = "/logos/nightwatch.svg",
             RedirectUris = [],
             TypicalScopes = [OAuthScopes.GlucoseRead, OAuthScopes.TreatmentsRead],
@@ -156,7 +166,9 @@ public static class KnownOAuthClients
             DisplayName = "Nocturne Tray",
             Homepage = "https://github.com/nightscout/nocturne",
             LogoUri = "/logos/nocturne.svg",
-            RedirectUris = [],
+            // Auth-code + PKCE via a loopback listener (RFC 8252). The port varies per
+            // login; loopback redirect matching is port-agnostic at authorize time.
+            RedirectUris = ["http://127.0.0.1/callback"],
             TypicalScopes =
             [
                 OAuthScopes.GlucoseRead,

--- a/src/Desktop/Nocturne.Desktop.Tray/Services/OidcAuthService.cs
+++ b/src/Desktop/Nocturne.Desktop.Tray/Services/OidcAuthService.cs
@@ -14,7 +14,15 @@ namespace Nocturne.Desktop.Tray.Services;
 /// </summary>
 public sealed class OidcAuthService : IDisposable
 {
-    private const string ClientId = "nocturne-tray";
+    // Reverse-DNS software_id matching the bundled known-client directory entry. The
+    // server issues an opaque, per-tenant client_id for it via Dynamic Client
+    // Registration — client_ids are not stable across instances, so they can't be
+    // hardcoded.
+    private const string SoftwareId = "com.nocturne.tray";
+    private const string ClientName = "Nocturne Tray";
+    // Loopback redirect (RFC 8252) registered without a port. The actual login uses a
+    // random port; loopback redirect matching is port-agnostic at authorize time.
+    private const string RegistrationRedirectUri = "http://127.0.0.1/callback";
     private const string Scopes = "glucose.read treatments.read devices.read therapy.read";
 
     private readonly SettingsService _settingsService;
@@ -25,6 +33,7 @@ public sealed class OidcAuthService : IDisposable
     // PKCE + loopback state (live between StartLogin and callback)
     private string? _codeVerifier;
     private string? _redirectUri;
+    private string? _clientId;
     private HttpListener? _loopbackListener;
 
     /// <summary>
@@ -52,14 +61,22 @@ public sealed class OidcAuthService : IDisposable
 
     /// <summary>
     /// Starts the OAuth 2.0 Authorization Code + PKCE flow.
-    /// Opens the system browser to the OAuth authorize endpoint and starts
-    /// a loopback HTTP listener to receive the authorization code callback.
+    /// Registers the client (Dynamic Client Registration) to obtain a client_id, opens
+    /// the system browser to the OAuth authorize endpoint, and starts a loopback HTTP
+    /// listener to receive the authorization code callback.
     /// </summary>
-    public void StartLogin()
+    /// <returns><see langword="true"/> if the browser flow was launched.</returns>
+    public async Task<bool> StartLoginAsync()
     {
         var serverUrl = _settingsService.Settings.ServerUrl?.TrimEnd('/');
         if (string.IsNullOrEmpty(serverUrl))
-            return;
+            return false;
+
+        // Obtain an opaque client_id for this server. client_ids are per-tenant random
+        // values, so they can't be hardcoded — register by stable software_id instead.
+        _clientId = await RegisterClientAsync(serverUrl);
+        if (_clientId is null)
+            return false;
 
         // Generate PKCE pair
         _codeVerifier = GenerateCodeVerifier();
@@ -68,13 +85,13 @@ public sealed class OidcAuthService : IDisposable
         // Start loopback listener on a random port
         _redirectUri = StartLoopbackListener();
         if (_redirectUri is null)
-            return;
+            return false;
 
         // Build OAuth authorize URL
         var authorizeUrl =
             $"{serverUrl}/api/oauth/authorize"
             + $"?response_type=code"
-            + $"&client_id={Uri.EscapeDataString(ClientId)}"
+            + $"&client_id={Uri.EscapeDataString(_clientId)}"
             + $"&redirect_uri={Uri.EscapeDataString(_redirectUri)}"
             + $"&scope={Uri.EscapeDataString(Scopes)}"
             + $"&code_challenge={Uri.EscapeDataString(codeChallenge)}"
@@ -87,6 +104,41 @@ public sealed class OidcAuthService : IDisposable
                 UseShellExecute = true,
             }
         );
+        return true;
+    }
+
+    /// <summary>
+    /// Obtains an opaque <c>client_id</c> via RFC 7591 Dynamic Client Registration.
+    /// Registration is idempotent per tenant on <see cref="SoftwareId"/>, so reconnects
+    /// reuse the same client. Returns <see langword="null"/> on failure.
+    /// </summary>
+    private async Task<string?> RegisterClientAsync(string serverUrl)
+    {
+        try
+        {
+            var request = new ClientRegistrationRequest
+            {
+                SoftwareId = SoftwareId,
+                ClientName = ClientName,
+                RedirectUris = [RegistrationRedirectUri],
+                Scope = Scopes,
+            };
+
+            var response = await _httpClient.PostAsJsonAsync(
+                $"{serverUrl}/api/oauth/register",
+                request
+            );
+            if (!response.IsSuccessStatusCode)
+                return null;
+
+            var registration =
+                await response.Content.ReadFromJsonAsync<ClientRegistrationResponse>();
+            return string.IsNullOrEmpty(registration?.ClientId) ? null : registration.ClientId;
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     /// <summary>
@@ -121,7 +173,7 @@ public sealed class OidcAuthService : IDisposable
     public async Task<bool> RefreshTokensAsync()
     {
         var creds = await _credentialStore.GetCredentialsAsync();
-        if (creds is null || string.IsNullOrEmpty(creds.RefreshToken))
+        if (creds is null || string.IsNullOrEmpty(creds.RefreshToken) || string.IsNullOrEmpty(creds.ClientId))
             return false;
 
         try
@@ -132,7 +184,7 @@ public sealed class OidcAuthService : IDisposable
                 {
                     ["grant_type"] = "refresh_token",
                     ["refresh_token"] = creds.RefreshToken,
-                    ["client_id"] = ClientId,
+                    ["client_id"] = creds.ClientId,
                 }
             );
 
@@ -308,7 +360,7 @@ public sealed class OidcAuthService : IDisposable
     private async Task ExchangeCodeForTokensAsync(string code)
     {
         var serverUrl = _settingsService.Settings.ServerUrl?.TrimEnd('/');
-        if (string.IsNullOrEmpty(serverUrl) || _codeVerifier is null || _redirectUri is null)
+        if (string.IsNullOrEmpty(serverUrl) || _codeVerifier is null || _redirectUri is null || _clientId is null)
         {
             IsAuthenticated = false;
             AuthStateChanged?.Invoke();
@@ -323,7 +375,7 @@ public sealed class OidcAuthService : IDisposable
                     ["grant_type"] = "authorization_code",
                     ["code"] = code,
                     ["redirect_uri"] = _redirectUri,
-                    ["client_id"] = ClientId,
+                    ["client_id"] = _clientId,
                     ["code_verifier"] = _codeVerifier,
                 }
             );
@@ -350,6 +402,7 @@ public sealed class OidcAuthService : IDisposable
             var credentials = new NocturneCredentials
             {
                 ApiUrl = serverUrl,
+                ClientId = _clientId,
                 AccessToken = tokenResponse.AccessToken,
                 RefreshToken = tokenResponse.RefreshToken ?? "",
                 ExpiresAt = DateTimeOffset.UtcNow.AddSeconds(tokenResponse.ExpiresIn),
@@ -370,6 +423,7 @@ public sealed class OidcAuthService : IDisposable
         {
             _codeVerifier = null;
             _redirectUri = null;
+            _clientId = null;
         }
     }
 
@@ -429,7 +483,28 @@ public sealed class OidcAuthService : IDisposable
         _httpClient.Dispose();
     }
 
-    // ── Response model ──────────────────────────────────────────────────
+    // ── Request/response models ─────────────────────────────────────────
+
+    private sealed record ClientRegistrationRequest
+    {
+        [JsonPropertyName("software_id")]
+        public string SoftwareId { get; init; } = "";
+
+        [JsonPropertyName("client_name")]
+        public string? ClientName { get; init; }
+
+        [JsonPropertyName("redirect_uris")]
+        public List<string> RedirectUris { get; init; } = [];
+
+        [JsonPropertyName("scope")]
+        public string? Scope { get; init; }
+    }
+
+    private sealed record ClientRegistrationResponse
+    {
+        [JsonPropertyName("client_id")]
+        public string ClientId { get; init; } = "";
+    }
 
     private sealed record OAuthTokenResponse
     {

--- a/src/Desktop/Nocturne.Desktop.Tray/Views/SettingsWindow.xaml.cs
+++ b/src/Desktop/Nocturne.Desktop.Tray/Views/SettingsWindow.xaml.cs
@@ -183,8 +183,14 @@ public sealed partial class SettingsWindow : Window
                 return;
             }
 
-            _authService.StartLogin();
-            AuthStatusText.Text = "Waiting for browser sign-in...";
+            if (await _authService.StartLoginAsync())
+            {
+                AuthStatusText.Text = "Waiting for browser sign-in...";
+            }
+            else
+            {
+                AuthStatusText.Text = "Could not start sign-in. Check the server URL and try again.";
+            }
         }
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/OAuthClientEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/OAuthClientEntity.cs
@@ -35,7 +35,7 @@ public class OAuthClientEntity : ITenantScoped, IEntityTimestamped
 
     /// <summary>
     /// RFC 7591 software_id — reverse-DNS identifier that is stable across installs of the
-    /// same product (e.g., "org.trio.diabetes"). Used to match self-registering clients
+    /// same product (e.g., "org.nightscout.trio"). Used to match self-registering clients
     /// against the bundled known app directory for idempotent DCR.
     /// </summary>
     [MaxLength(255)]

--- a/tests/Unit/Nocturne.API.Tests/Authorization/KnownOAuthClientsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/KnownOAuthClientsTests.cs
@@ -7,13 +7,14 @@ namespace Nocturne.API.Tests.Authorization;
 public class KnownOAuthClientsTests
 {
     [Theory]
-    [InlineData("org.trio.diabetes", "Trio")]
-    [InlineData("org.nightscoutfoundation.xdrip", "xDrip+")]
-    [InlineData("org.androidaps.aaps", "AAPS")]
+    [InlineData("org.nightscout.trio", "Trio")]
+    [InlineData("com.eveningoutpost.dexdrip", "xDrip+")]
+    [InlineData("info.nightscout.androidaps", "AAPS")]
     [InlineData("org.loopkit.loop", "Loop")]
-    [InlineData("github.nightscout.nightscout", "Nightscout")]
-    [InlineData("io.sugarmate", "Sugarmate")]
-    [InlineData("com.nickenilsson.nightwatch", "Nightwatch")]
+    [InlineData("org.nightscout.cgm-remote-monitor", "Nightscout (server)")]
+    [InlineData("com.tandemdiabetes.sugarmate", "Sugarmate")]
+    [InlineData("se.cornixit.nightwatch", "Nightwatch")]
+    [InlineData("com.nocturne.tray", "Nocturne Tray")]
     [InlineData("dev.nocturne.prelude", "Prelude")]
     public void MatchBySoftwareId_ReturnsEntry_ForKnownSoftwareId(string softwareId, string expectedDisplayName)
     {
@@ -36,7 +37,7 @@ public class KnownOAuthClientsTests
     public void MatchBySoftwareId_IsCaseSensitive()
     {
         // software_id is case-sensitive per RFC 7591
-        KnownOAuthClients.MatchBySoftwareId("ORG.TRIO.DIABETES").Should().BeNull();
+        KnownOAuthClients.MatchBySoftwareId("ORG.NIGHTSCOUT.TRIO").Should().BeNull();
     }
 
     [Fact]


### PR DESCRIPTION
## What

The bundled known-OAuth-client directory (`KnownOAuthClients`) used invented or incorrect `software_id`s that no app actually sends, so a registering app would never be matched as a known/verified client. Replaced with each app's real, stable identifier:

| App | Was | Now | Basis |
|-----|-----|-----|-------|
| Trio | `org.trio.diabetes` | `org.nightscout.trio` | iOS bundle base `org.nightscout.$(TEAM).trio` (team-independent) |
| xDrip+ | `org.nightscoutfoundation.xdrip` | `com.eveningoutpost.dexdrip` | real Android `applicationId` |
| AAPS | `org.androidaps.aaps` | `info.nightscout.androidaps` | real `applicationId` (not `app.aaps`, the internal namespace) |
| Sugarmate | `io.sugarmate` | `com.tandemdiabetes.sugarmate` | real Android package |
| Nightscout | `github.nightscout.nightscout` (404) | `org.nightscout.cgm-remote-monitor` | the server as a read-only follower; display "Nightscout (server)" |
| Nightwatch | `com.nickenilsson.nightwatch` (404 repo) | `se.cornixit.nightwatch` | the maintained app's real package |
| Loop | `org.loopkit.loop` | *(unchanged)* | no authoritative fixed base; current is a fine convention |

Custom-scheme redirect URIs are aligned to each `software_id` (RFC 8252).

## Tray fix

The Tray hardcoded `client_id = "nocturne-tray"` and never registered — same class of bug the widget had (client_ids are per-tenant random GUIDs). It now performs Dynamic Client Registration with `software_id = com.nocturne.tray` (auth-code + PKCE, loopback redirect), and carries the issued `client_id` through token exchange and refresh. Its directory entry gains a loopback redirect (`http://127.0.0.1/callback`) so the seeded client can use the authorization-code flow (port-agnostic loopback matching at authorize time).

## Important caveat

Trio, xDrip+, Loop, AAPS, Sugarmate, and Nightwatch authenticate to Nightscout via the **legacy API-secret** today and do **not** perform OAuth Dynamic Client Registration. Confirmed by source review of each app. These directory entries therefore only take effect once each app adopts OAuth using the listed `software_id`. This PR makes the directory *correct and ready*; it does not (and cannot) make those third-party apps register on its own. The entries we control — widget (already working), Tray (this PR), Follower — do work.

Pre-seeded tenants that already have `com.nocturne.tray` with an empty redirect list would need a re-seed to pick up the loopback redirect; the Tray is pre-release so there should be none in practice.

## Tests

`KnownOAuthClientsTests` updated to the new ids/display names (incl. case-sensitivity). All KnownOAuthClients + OAuth register + redirect-validator tests pass (35). Tray builds clean.