### PR TITLE
refactor(v4): extract V4RepositoryBase + normalize cross-type deltas

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IV4TimeSeriesEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IV4TimeSeriesEntity.cs
@@ -1,0 +1,15 @@
+namespace Nocturne.Infrastructure.Data.Entities;
+
+/// <summary>
+/// A V4 record entity that carries the canonical time-series columns the shared
+/// <see cref="Repositories.V4.V4RepositoryBase{TModel,TEntity}"/> filters, orders, and watermarks
+/// on. Extends <see cref="IV4Entity"/> (Id, LegacyId, TenantId, DeletedAt) with the domain
+/// timestamp, data source, and device. Span-shaped types (e.g. TempBasal, which keys on
+/// StartTimestamp) deliberately do NOT implement this and stay off the shared base.
+/// </summary>
+public interface IV4TimeSeriesEntity : IV4Entity
+{
+    DateTime Timestamp { get; set; }
+    string? DataSource { get; set; }
+    string? Device { get; set; }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IV4TimeSeriesEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IV4TimeSeriesEntity.cs
@@ -6,6 +6,12 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// on. Extends <see cref="IV4Entity"/> (Id, LegacyId, TenantId, DeletedAt) with the domain
 /// timestamp, data source, and device. Span-shaped types (e.g. TempBasal, which keys on
 /// StartTimestamp) deliberately do NOT implement this and stay off the shared base.
+///
+/// Implementers MUST map these three members as ordinary EF columns (plain auto-properties with a
+/// <c>[Column]</c> mapping) — not explicit-interface implementations, backing-field-only, or
+/// <c>[NotMapped]</c> — so the base's generic <c>ctx.Set&lt;TEntity&gt;()</c> queries translate the
+/// interface-member access to SQL (the same way it already does for ITenantScoped.TenantId and
+/// ISoftDeletable.DeletedAt).
 /// </summary>
 public interface IV4TimeSeriesEntity : IV4Entity
 {

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BGCheckEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BGCheckEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.BGCheck
 /// </summary>
 [Table("bg_checks")]
-public class BGCheckEntity : ITenantScoped, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class BGCheckEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BGCheckEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BGCheckEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.BGCheck
 /// </summary>
 [Table("bg_checks")]
-public class BGCheckEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISystemTimestamped
+public class BGCheckEntity : ITenantScoped, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalInjectionEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalInjectionEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.BasalInjection.
 /// </summary>
 [Table("basal_injections")]
-public class BasalInjectionEntity : ITenantScoped, IAuditable, ISoftDeletable, ISystemTimestamped
+public class BasalInjectionEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalScheduleEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.BasalSchedule
 /// </summary>
 [Table("basal_schedules")]
-public class BasalScheduleEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity, ISystemTimestamped
+public class BasalScheduleEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusCalculationEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusCalculationEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.BolusCalculation
 /// </summary>
 [Table("bolus_calculations")]
-public class BolusCalculationEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity, ISystemTimestamped
+public class BolusCalculationEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.Bolus
 /// </summary>
 [Table("boluses")]
-public class BolusEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity, ISystemTimestamped
+public class BolusEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CalibrationEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CalibrationEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.Calibration
 /// </summary>
 [Table("calibrations")]
-public class CalibrationEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISystemTimestamped
+public class CalibrationEntity : ITenantScoped, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CalibrationEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CalibrationEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.Calibration
 /// </summary>
 [Table("calibrations")]
-public class CalibrationEntity : ITenantScoped, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class CalibrationEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbIntakeEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbIntakeEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.CarbIntake
 /// </summary>
 [Table("carb_intakes")]
-public class CarbIntakeEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity, ISystemTimestamped
+public class CarbIntakeEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbRatioScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbRatioScheduleEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.CarbRatioSchedule
 /// </summary>
 [Table("carb_ratio_schedules")]
-public class CarbRatioScheduleEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISystemTimestamped
+public class CarbRatioScheduleEntity : ITenantScoped, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbRatioScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbRatioScheduleEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.CarbRatioSchedule
 /// </summary>
 [Table("carb_ratio_schedules")]
-public class CarbRatioScheduleEntity : ITenantScoped, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class CarbRatioScheduleEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceEventEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceEventEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.DeviceEvent
 /// </summary>
 [Table("device_events")]
-public class DeviceEventEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity, ISystemTimestamped
+public class DeviceEventEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/MeterGlucoseEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/MeterGlucoseEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.MeterGlucose
 /// </summary>
 [Table("meter_glucose")]
-public class MeterGlucoseEntity : ITenantScoped, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class MeterGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/MeterGlucoseEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/MeterGlucoseEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.MeterGlucose
 /// </summary>
 [Table("meter_glucose")]
-public class MeterGlucoseEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISystemTimestamped
+public class MeterGlucoseEntity : ITenantScoped, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/NoteEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/NoteEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.Note
 /// </summary>
 [Table("notes")]
-public class NoteEntity : ITenantScoped, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class NoteEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/NoteEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/NoteEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.Note
 /// </summary>
 [Table("notes")]
-public class NoteEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISystemTimestamped
+public class NoteEntity : ITenantScoped, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensitivityScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensitivityScheduleEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.SensitivitySchedule
 /// </summary>
 [Table("sensitivity_schedules")]
-public class SensitivityScheduleEntity : ITenantScoped, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class SensitivityScheduleEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensitivityScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensitivityScheduleEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.SensitivitySchedule
 /// </summary>
 [Table("sensitivity_schedules")]
-public class SensitivityScheduleEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISystemTimestamped
+public class SensitivityScheduleEntity : ITenantScoped, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensorGlucoseEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensorGlucoseEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.SensorGlucose
 /// </summary>
 [Table("sensor_glucose")]
-public class SensorGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity, ISystemTimestamped
+public class SensorGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TargetRangeScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TargetRangeScheduleEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.TargetRangeSchedule
 /// </summary>
 [Table("target_range_schedules")]
-public class TargetRangeScheduleEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISystemTimestamped
+public class TargetRangeScheduleEntity : ITenantScoped, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TargetRangeScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TargetRangeScheduleEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.TargetRangeSchedule
 /// </summary>
 [Table("target_range_schedules")]
-public class TargetRangeScheduleEntity : ITenantScoped, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class TargetRangeScheduleEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TherapySettingsEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TherapySettingsEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.TherapySettings
 /// </summary>
 [Table("therapy_settings")]
-public class TherapySettingsEntity : ITenantScoped, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class TherapySettingsEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TherapySettingsEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TherapySettingsEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.TherapySettings
 /// </summary>
 [Table("therapy_settings")]
-public class TherapySettingsEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISystemTimestamped
+public class TherapySettingsEntity : ITenantScoped, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
@@ -155,7 +155,7 @@ public class BGCheckRepository : V4RepositoryBase<BGCheck, BGCheckEntity>, IBGCh
 
             await _deduplicationService.DeduplicateBatchAsync(RecordType.BGCheck, dedupInputs, ct);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "BGCheck", inserted.Count);
         }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Infrastructure;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
@@ -16,7 +17,7 @@ namespace Nocturne.Infrastructure.Data.Repositories.V4;
 /// participant, so it inherits the shared CRUD/soft-delete surface from
 /// <see cref="V4RepositoryBase{TModel,TEntity}"/> and keeps only the dedup-specific behaviour as
 /// overrides (extended <c>GetAsync</c> with the non-primary LinkedRecords filter, dedup
-/// <c>BulkCreateAsync</c>). Soft-deletes use the plain (non-audited) path, matching the base.
+/// <c>BulkCreateAsync</c>). Soft-deletes inherit the base's audited path.
 /// </summary>
 public class BGCheckRepository : V4RepositoryBase<BGCheck, BGCheckEntity>, IBGCheckRepository
 {
@@ -28,12 +29,14 @@ public class BGCheckRepository : V4RepositoryBase<BGCheck, BGCheckEntity>, IBGCh
     /// </summary>
     /// <param name="contextFactory">The tenant database context factory.</param>
     /// <param name="deduplicationService">The deduplication service.</param>
+    /// <param name="auditContext">The audit context for tracking mutations (used by the base soft-delete path).</param>
     /// <param name="logger">The logger instance.</param>
     public BGCheckRepository(
         ITenantDbContextFactory contextFactory,
         IDeduplicationService deduplicationService,
+        IAuditContext auditContext,
         ILogger<BGCheckRepository> logger)
-        : base(contextFactory)
+        : base(contextFactory, auditContext)
     {
         _deduplicationService = deduplicationService;
         _logger = logger;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
@@ -52,6 +52,13 @@ public class BGCheckRepository : V4RepositoryBase<BGCheck, BGCheckEntity>, IBGCh
     protected override void ApplyUpdate(BGCheckEntity target, BGCheck source) => BGCheckMapper.UpdateEntity(target, source);
 
     /// <summary>
+    /// Excludes non-primary cross-connector duplicates so <see cref="V4RepositoryBase{TModel,TEntity}.CountAsync"/>
+    /// matches the rows <c>GetAsync</c> returns. Mirrors the inline filter in the extended <c>GetAsync</c>.
+    /// </summary>
+    protected override IQueryable<BGCheckEntity> ApplyReadVisibility(IQueryable<BGCheckEntity> query, NocturneDbContext ctx) =>
+        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == "bgcheck" && !lr.IsPrimary && lr.RecordId == b.Id));
+
+    /// <summary>
     /// Routes the base 7-arg form through the extended BG-check query (non-primary LinkedRecords
     /// exclusion + ordering), preserving the pre-base default-interface bridge behaviour.
     /// </summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
@@ -12,12 +12,14 @@ using Nocturne.Infrastructure.Data.Services;
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
-/// Repository for managing blood glucose check records in the database.
-/// Includes support for cross-connector deduplication.
+/// Repository for managing blood glucose check records in the database. A DeduplicationService
+/// participant, so it inherits the shared CRUD/soft-delete surface from
+/// <see cref="V4RepositoryBase{TModel,TEntity}"/> and keeps only the dedup-specific behaviour as
+/// overrides (extended <c>GetAsync</c> with the non-primary LinkedRecords filter, dedup
+/// <c>BulkCreateAsync</c>). Soft-deletes use the plain (non-audited) path, matching the base.
 /// </summary>
-public class BGCheckRepository : IBGCheckRepository
+public class BGCheckRepository : V4RepositoryBase<BGCheck, BGCheckEntity>, IBGCheckRepository
 {
-    private readonly ITenantDbContextFactory _contextFactory;
     private readonly IDeduplicationService _deduplicationService;
     private readonly ILogger<BGCheckRepository> _logger;
 
@@ -31,11 +33,30 @@ public class BGCheckRepository : IBGCheckRepository
         ITenantDbContextFactory contextFactory,
         IDeduplicationService deduplicationService,
         ILogger<BGCheckRepository> logger)
+        : base(contextFactory)
     {
-        _contextFactory = contextFactory;
         _deduplicationService = deduplicationService;
         _logger = logger;
     }
+
+    /// <inheritdoc />
+    protected override BGCheckEntity ToEntity(BGCheck model) => BGCheckMapper.ToEntity(model);
+
+    /// <inheritdoc />
+    protected override BGCheck ToDomain(BGCheckEntity entity) => BGCheckMapper.ToDomainModel(entity);
+
+    /// <inheritdoc />
+    protected override void ApplyUpdate(BGCheckEntity target, BGCheck source) => BGCheckMapper.UpdateEntity(target, source);
+
+    /// <summary>
+    /// Routes the base 7-arg form through the extended BG-check query (non-primary LinkedRecords
+    /// exclusion + ordering), preserving the pre-base default-interface bridge behaviour.
+    /// </summary>
+    public override Task<IEnumerable<BGCheck>> GetAsync(
+        DateTime? from, DateTime? to, string? device, string? source,
+        int limit = 100, int offset = 0, bool descending = true,
+        CancellationToken ct = default)
+        => GetAsync(from, to, device, source, limit, offset, descending, nativeOnly: false, ct);
 
     /// <summary>
     /// Gets blood glucose check records based on filter criteria.
@@ -63,7 +84,7 @@ public class BGCheckRepository : IBGCheckRepository
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var query = ctx.BGChecks.AsNoTracking().AsQueryable();
         if (from.HasValue)
             query = query.Where(e => e.Timestamp >= from.Value);
@@ -86,160 +107,6 @@ public class BGCheckRepository : IBGCheckRepository
     }
 
     /// <summary>
-    /// Gets a blood glucose check record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The blood glucose check, or null if not found.</returns>
-    public async Task<BGCheck?> GetByIdAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.BGChecks.FindAsync([id], ct);
-        return entity is null ? null : BGCheckMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Gets a blood glucose check record by its legacy (MongoDB) identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The blood glucose check, or null if not found.</returns>
-    public async Task<BGCheck?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.BGChecks.FirstOrDefaultAsync(e => e.LegacyId == legacyId, ct);
-        return entity is null ? null : BGCheckMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Creates a new blood glucose check record.
-    /// </summary>
-    /// <param name="model">The blood glucose check to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The created blood glucose check.</returns>
-    public async Task<BGCheck> CreateAsync(BGCheck model, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = BGCheckMapper.ToEntity(model);
-        ctx.BGChecks.Add(entity);
-        await ctx.SaveChangesAsync(ct);
-        return BGCheckMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Updates an existing blood glucose check record.
-    /// </summary>
-    /// <param name="id">The unique identifier of the record to update.</param>
-    /// <param name="model">The updated record data.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The updated blood glucose check.</returns>
-    public async Task<BGCheck> UpdateAsync(Guid id, BGCheck model, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity =
-            await ctx.BGChecks.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"BGCheck {id} not found");
-        BGCheckMapper.UpdateEntity(entity, model);
-        await ctx.SaveChangesAsync(ct);
-        return BGCheckMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Deletes a blood glucose check record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity =
-            await ctx.BGChecks.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"BGCheck {id} not found");
-        entity.DeletedAt = DateTime.UtcNow;
-        await ctx.SaveChangesAsync(ct);
-    }
-
-    /// <inheritdoc />
-    public async Task<BGCheck> RestoreAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.BGChecks.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
-            .FirstOrDefaultAsync(ct)
-            ?? throw new KeyNotFoundException($"Soft-deleted BGCheck {id} not found");
-        entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return BGCheckMapper.ToDomainModel(entity);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<BGCheck>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var idSet = ids.ToHashSet();
-        var entities = await ctx.BGChecks.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
-            .ToListAsync(ct);
-        foreach (var entity in entities)
-            entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return entities.Select(BGCheckMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<BGCheck>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entities = await ctx.BGChecks.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .OrderByDescending(e => e.DeletedAt)
-            .Skip(offset).Take(limit)
-            .AsNoTracking()
-            .ToListAsync(ct);
-        return entities.Select(BGCheckMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.BGChecks.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .CountAsync(ct);
-    }
-
-    /// <summary>
-    /// Returns the timestamp of the most recently stored record, optionally scoped to a data source.
-    /// Used by connectors to resume per-source sync without re-fetching already-stored data.
-    /// </summary>
-    public async Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.BGChecks.AsNoTracking().AsQueryable();
-        if (source != null)
-            query = query.Where(e => e.DataSource == source);
-        return await query.MaxAsync(e => (DateTime?)e.Timestamp, ct);
-    }
-
-    /// <summary>
-    /// Counts blood glucose check records within a timestamp range.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The count of matching records.</returns>
-    public async Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.BGChecks.AsNoTracking().AsQueryable();
-        if (from.HasValue)
-            query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue)
-            query = query.Where(e => e.Timestamp <= to.Value);
-        return await query.CountAsync(ct);
-    }
-
-    /// <summary>
     /// Gets blood glucose check records by correlation identifier.
     /// </summary>
     /// <param name="correlationId">The correlation identifier.</param>
@@ -250,7 +117,7 @@ public class BGCheckRepository : IBGCheckRepository
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entities = await ctx
             .BGChecks.AsNoTracking()
             .Where(e => e.CorrelationId == correlationId)
@@ -259,30 +126,17 @@ public class BGCheckRepository : IBGCheckRepository
     }
 
     /// <summary>
-    /// Deletes a blood glucose check record by its legacy identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.BGChecks.Where(e => e.LegacyId == legacyId)
-            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
-    }
-
-    /// <summary>
     /// Performs a bulk creation of blood glucose check records, handling deduplication.
     /// </summary>
     /// <param name="records">The collection of records to create.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>A collection of created records.</returns>
-    public async Task<IEnumerable<BGCheck>> BulkCreateAsync(
+    public override async Task<IEnumerable<BGCheck>> BulkCreateAsync(
         IEnumerable<BGCheck> records,
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var strategy = ctx.Database.CreateExecutionStrategy();
         return await strategy.ExecuteAsync(async () =>
         {

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
@@ -136,83 +136,28 @@ public class BGCheckRepository : V4RepositoryBase<BGCheck, BGCheckEntity>, IBGCh
     }
 
     /// <summary>
-    /// Performs a bulk creation of blood glucose check records, handling deduplication.
+    /// Insert-time deduplication: link saved records to canonical groups (runs after commit).
     /// </summary>
-    /// <param name="records">The collection of records to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>A collection of created records.</returns>
-    public override async Task<IEnumerable<BGCheck>> BulkCreateAsync(
-        IEnumerable<BGCheck> records,
-        CancellationToken ct = default
-    )
+    protected override async Task PostCommitDedupAsync(
+        NocturneDbContext ctx, IReadOnlyList<BGCheckEntity> inserted, CancellationToken ct)
     {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        var strategy = ctx.Database.CreateExecutionStrategy();
-        return await strategy.ExecuteAsync(async () =>
+        if (inserted.Count == 0)
+            return;
+
+        try
         {
-            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-            var entities = records.Select(BGCheckMapper.ToEntity).ToList();
-            if (entities.Count == 0)
-            {
-                await tx.CommitAsync(ct);
-                return [];
-            }
+            var dedupInputs = inserted.Select(e => new DeduplicationInput(
+                RecordId: e.Id,
+                Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
+                DataSource: e.DataSource ?? "unknown",
+                Criteria: new MatchCriteria { GlucoseValue = e.Glucose, GlucoseTolerance = 1.0 }
+            )).ToList();
 
-            // Batch-level dedup: keep first occurrence per LegacyId
-            entities = entities
-                .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-                .Select(g => g.First())
-                .ToList();
-
-            // DB-level dedup: filter out records whose LegacyId already exists
-            var legacyIds = entities
-                .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-                .Select(e => e.LegacyId!)
-                .ToHashSet();
-
-            if (legacyIds.Count > 0)
-            {
-                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<BGCheckEntity>(legacyIds, ct);
-
-                entities = entities
-                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
-                    .ToList();
-            }
-
-            if (entities.Count == 0)
-            {
-                await tx.CommitAsync(ct);
-                return [];
-            }
-
-            const int batchSize = 500;
-            foreach (var batch in entities.Chunk(batchSize))
-            {
-                ctx.BGChecks.AddRange(batch);
-                await ctx.SaveChangesAsync(ct);
-                ctx.ChangeTracker.Clear();
-            }
-
-            await tx.CommitAsync(ct);
-
-            // Insert-time deduplication: link saved records to canonical groups
-            try
-            {
-                var dedupInputs = entities.Select(e => new DeduplicationInput(
-                    RecordId: e.Id,
-                    Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    DataSource: e.DataSource ?? "unknown",
-                    Criteria: new MatchCriteria { GlucoseValue = e.Glucose, GlucoseTolerance = 1.0 }
-                )).ToList();
-
-                await _deduplicationService.DeduplicateBatchAsync(RecordType.BGCheck, dedupInputs, ct);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "BGCheck", entities.Count);
-            }
-
-            return entities.Select(BGCheckMapper.ToDomainModel);
-        });
+            await _deduplicationService.DeduplicateBatchAsync(RecordType.BGCheck, dedupInputs, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "BGCheck", inserted.Count);
+        }
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
@@ -3,6 +3,8 @@ using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
@@ -233,53 +235,122 @@ public class BasalInjectionRepository : IBasalInjectionRepository
     }
 
     /// <summary>
-    /// Bulk-create basal injection records with LegacyId-based deduplication.
-    /// Records whose LegacyId already exists for the tenant are skipped.
+    /// Bulk-create basal injection records. Atomic (the whole insert runs in one transaction via the
+    /// connection's execution strategy) and audit-aware: rows whose latest delete was user-initiated
+    /// stay blocked from resync re-creation. Deduplicates by (DataSource, SyncIdentifier) upsert and by
+    /// LegacyId. Mirrors the established <see cref="BolusRepository"/> bulk path, minus
+    /// DeduplicationService participation (BasalInjection is LegacyId-only / SyncId-keyed, never
+    /// cross-connector dedup-linked).
     /// </summary>
     public async Task<IEnumerable<BasalInjection>> BulkCreateAsync(IEnumerable<BasalInjection> records, CancellationToken ct = default)
     {
-        var entities = records.Select(BasalInjectionMapper.ToEntity).ToList();
-        if (entities.Count == 0)
-            return [];
-
-        // Intra-batch dedup: keep first occurrence per LegacyId
-        entities = entities
-            .GroupBy(e => !string.IsNullOrEmpty(e.LegacyId) ? e.LegacyId : e.Id.ToString())
-            .Select(g => g.First())
-            .ToList();
-
-        // DB-level dedup: filter out records whose LegacyId already exists
-        var legacyIds = entities
-            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-            .Select(e => e.LegacyId!)
-            .ToHashSet();
-
-        if (legacyIds.Count > 0)
+        var strategy = _context.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
         {
-            var existingLegacyIds = await _context.BasalInjections.IgnoreQueryFilters().AsNoTracking()
-                .Where(e => e.TenantId == _context.TenantId)
-                .Where(e => legacyIds.Contains(e.LegacyId!))
-                .Select(e => e.LegacyId)
-                .ToListAsync(ct);
+            await using var tx = await _context.Database.BeginTransactionAsync(ct);
+            var entities = records.Select(BasalInjectionMapper.ToEntity).ToList();
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
 
-            var existingSet = existingLegacyIds.ToHashSet();
+            // Intra-batch SyncIdentifier dedup: keep last occurrence per (DataSource, SyncIdentifier).
+            // Records without both keys keep a unique grouping key so they're not collapsed.
             entities = entities
-                .Where(e => string.IsNullOrEmpty(e.LegacyId) || !existingSet.Contains(e.LegacyId))
+                .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
+                    ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
+                    : $"id|{e.Id}")
+                .Select(g => g.Last())
                 .ToList();
-        }
 
-        if (entities.Count == 0)
-            return [];
+            // DB-level SyncIdentifier upsert: rows matched by (DataSource, SyncIdentifier) are updated
+            // in place rather than inserted — so a connector replay updates the existing row instead of
+            // hitting the partial unique index. Everything else falls through to the LegacyId/insert
+            // path below. Mirrors BolusRepository.
+            var updatedEntities = new List<BasalInjectionEntity>();
+            var syncKeyed = entities
+                .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
+                .ToList();
 
-        const int batchSize = 500;
-        foreach (var batch in entities.Chunk(batchSize))
-        {
-            _context.BasalInjections.AddRange(batch);
-            await _context.SaveChangesAsync(ct);
-            _context.ChangeTracker.Clear();
-        }
+            if (syncKeyed.Count > 0)
+            {
+                var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
+                var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
 
-        return entities.Select(BasalInjectionMapper.ToDomainModel);
+                var existingRows = await _context.BasalInjections.IgnoreQueryFilters()
+                    .Where(e => e.TenantId == _context.TenantId)
+                    .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
+                    .ToListAsync(ct);
+
+                var existingByKey = existingRows
+                    .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
+                    .ToDictionary(g => g.Key, g => g.First());
+
+                var toInsert = new List<BasalInjectionEntity>();
+                foreach (var entity in entities)
+                {
+                    var hasKey = !string.IsNullOrEmpty(entity.DataSource)
+                        && !string.IsNullOrEmpty(entity.SyncIdentifier);
+                    if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
+                    {
+                        // Update in place — mirror the single-record CreateAsync path via the mapper.
+                        var domain = BasalInjectionMapper.ToDomainModel(entity);
+                        BasalInjectionMapper.UpdateEntity(existing, domain);
+                        updatedEntities.Add(existing);
+                    }
+                    else
+                    {
+                        toInsert.Add(entity);
+                    }
+                }
+
+                if (updatedEntities.Count > 0)
+                {
+                    // Persist updates before the insert-chunking loop clears the tracker.
+                    await _context.SaveChangesAsync(ct);
+                }
+
+                entities = toInsert;
+            }
+
+            // Batch-level dedup: keep first occurrence per LegacyId
+            entities = entities
+                .GroupBy(e => e.LegacyId ?? e.Id.ToString())
+                .Select(g => g.First())
+                .ToList();
+
+            // DB-level dedup: filter out records whose LegacyId is blocking (active row, or a
+            // soft-deleted row whose latest delete was user-initiated). System-sweep deletes stay
+            // re-creatable. Replaces the inline existence check, which ignored the user-delete flag.
+            var legacyIds = entities
+                .Where(e => !string.IsNullOrEmpty(e.LegacyId))
+                .Select(e => e.LegacyId!)
+                .ToHashSet();
+
+            if (legacyIds.Count > 0)
+            {
+                var blockedLegacyIds = await _context.GetBlockingLegacyIdsAsync<BasalInjectionEntity>(legacyIds, ct);
+
+                entities = entities
+                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
+                    .ToList();
+            }
+
+            if (entities.Count > 0)
+            {
+                const int batchSize = 500;
+                foreach (var batch in entities.Chunk(batchSize))
+                {
+                    _context.BasalInjections.AddRange(batch);
+                    await _context.SaveChangesAsync(ct);
+                    _context.ChangeTracker.Clear();
+                }
+            }
+
+            await tx.CommitAsync(ct);
+            return updatedEntities.Concat(entities).Select(BasalInjectionMapper.ToDomainModel);
+        });
     }
 
     public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, CancellationToken ct = default)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalScheduleRepository.cs
@@ -18,8 +18,6 @@ namespace Nocturne.Infrastructure.Data.Repositories.V4;
 /// </summary>
 public class BasalScheduleRepository : V4RepositoryBase<BasalSchedule, BasalScheduleEntity>, IBasalScheduleRepository
 {
-    private readonly IAuditContext _auditContext;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="BasalScheduleRepository"/> class.
     /// </summary>
@@ -28,9 +26,8 @@ public class BasalScheduleRepository : V4RepositoryBase<BasalSchedule, BasalSche
     /// <param name="logger">The logger instance.</param>
     // logger is unused for this LegacyId-only type but retained for DI + direct test construction.
     public BasalScheduleRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext, ILogger<BasalScheduleRepository> logger)
-        : base(contextFactory)
+        : base(contextFactory, auditContext)
     {
-        _auditContext = auditContext;
     }
 
     /// <inheritdoc />
@@ -84,20 +81,6 @@ public class BasalScheduleRepository : V4RepositoryBase<BasalSchedule, BasalSche
     }
 
     /// <summary>
-    /// Deletes a basal schedule record by its legacy identifier, routing through the audited
-    /// soft-delete helper.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The number of deleted records.</returns>
-    public override async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        return await ctx.AuditedSoftDeleteAsync(
-            ctx.BasalSchedules.Where(e => e.LegacyId == legacyId), _auditContext, ct);
-    }
-
-    /// <summary>
     /// Deletes basal schedule records by legacy identifier prefix.
     /// </summary>
     /// <param name="prefix">The legacy identifier prefix.</param>
@@ -108,7 +91,7 @@ public class BasalScheduleRepository : V4RepositoryBase<BasalSchedule, BasalSche
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
             ctx.BasalSchedules.Where(e => e.LegacyId != null && e.LegacyId.StartsWith(prefix)),
-            _auditContext, ct);
+            AuditContext, ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalScheduleRepository.cs
@@ -11,13 +11,14 @@ using Nocturne.Infrastructure.Data.Services;
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
-/// Repository for managing basal schedules in the database.
+/// Repository for managing basal schedules in the database. A LegacyId-only type (no SyncId-upsert,
+/// no DeduplicationService participation), so it uses the shared
+/// <see cref="V4RepositoryBase{TModel,TEntity}"/> behaviour unchanged except its legacy-id deletes,
+/// which route through the audited soft-delete helper, plus the basal-schedule-specific queries below.
 /// </summary>
-public class BasalScheduleRepository : IBasalScheduleRepository
+public class BasalScheduleRepository : V4RepositoryBase<BasalSchedule, BasalScheduleEntity>, IBasalScheduleRepository
 {
-    private readonly ITenantDbContextFactory _contextFactory;
     private readonly IAuditContext _auditContext;
-    private readonly ILogger<BasalScheduleRepository> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BasalScheduleRepository"/> class.
@@ -25,76 +26,22 @@ public class BasalScheduleRepository : IBasalScheduleRepository
     /// <param name="contextFactory">The tenant database context factory.</param>
     /// <param name="auditContext">The audit context for tracking mutations.</param>
     /// <param name="logger">The logger instance.</param>
+    // logger is unused for this LegacyId-only type but retained for DI + direct test construction.
     public BasalScheduleRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext, ILogger<BasalScheduleRepository> logger)
+        : base(contextFactory)
     {
-        _contextFactory = contextFactory;
         _auditContext = auditContext;
-        _logger = logger;
     }
 
-    /// <summary>
-    /// Gets basal schedules based on filter criteria.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="device">Optional device filter.</param>
-    /// <param name="source">Optional data source filter.</param>
-    /// <param name="limit">The maximum number of records to return.</param>
-    /// <param name="offset">The number of records to skip.</param>
-    /// <param name="descending">Whether to sort by timestamp in descending order.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>A collection of basal schedules.</returns>
-    public async Task<IEnumerable<BasalSchedule>> GetAsync(
-        DateTime? from,
-        DateTime? to,
-        string? device,
-        string? source,
-        int limit = 100,
-        int offset = 0,
-        bool descending = true,
-        CancellationToken ct = default
-    )
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.BasalSchedules.AsNoTracking().AsQueryable();
-        if (from.HasValue)
-            query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue)
-            query = query.Where(e => e.Timestamp <= to.Value);
-        if (device != null)
-            query = query.Where(e => e.Device == device);
-        if (source != null)
-            query = query.Where(e => e.DataSource == source);
-        query = descending ? query.OrderByDescending(e => e.Timestamp) : query.OrderBy(e => e.Timestamp);
-        var entities = await query.Skip(offset).Take(limit).ToListAsync(ct);
-        return entities.Select(BasalScheduleMapper.ToDomainModel);
-    }
+    /// <inheritdoc />
+    protected override BasalScheduleEntity ToEntity(BasalSchedule model) => BasalScheduleMapper.ToEntity(model);
 
-    /// <summary>
-    /// Gets a basal schedule by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The basal schedule, or null if not found.</returns>
-    public async Task<BasalSchedule?> GetByIdAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.BasalSchedules.FindAsync([id], ct);
-        return entity is null ? null : BasalScheduleMapper.ToDomainModel(entity);
-    }
+    /// <inheritdoc />
+    protected override BasalSchedule ToDomain(BasalScheduleEntity entity) => BasalScheduleMapper.ToDomainModel(entity);
 
-    /// <summary>
-    /// Gets a basal schedule by its legacy (MongoDB) identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The basal schedule, or null if not found.</returns>
-    public async Task<BasalSchedule?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.BasalSchedules.FirstOrDefaultAsync(e => e.LegacyId == legacyId, ct);
-        return entity is null ? null : BasalScheduleMapper.ToDomainModel(entity);
-    }
+    /// <inheritdoc />
+    protected override void ApplyUpdate(BasalScheduleEntity target, BasalSchedule source) =>
+        BasalScheduleMapper.UpdateEntity(target, source);
 
     /// <summary>
     /// Gets basal schedules by profile name.
@@ -107,7 +54,7 @@ public class BasalScheduleRepository : IBasalScheduleRepository
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entities = await ctx
             .BasalSchedules.AsNoTracking()
             .Where(e => e.ProfileName == profileName)
@@ -126,7 +73,7 @@ public class BasalScheduleRepository : IBasalScheduleRepository
     public async Task<BasalSchedule?> GetActiveAtAsync(
         string profileName, DateTime timestamp, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entity = await ctx.BasalSchedules
             .AsNoTracking()
             .Where(e => e.ProfileName == profileName && e.Timestamp <= timestamp)
@@ -137,111 +84,15 @@ public class BasalScheduleRepository : IBasalScheduleRepository
     }
 
     /// <summary>
-    /// Creates a new basal schedule record.
-    /// </summary>
-    /// <param name="model">The basal schedule to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The created basal schedule.</returns>
-    public async Task<BasalSchedule> CreateAsync(BasalSchedule model, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = BasalScheduleMapper.ToEntity(model);
-        ctx.BasalSchedules.Add(entity);
-        await ctx.SaveChangesAsync(ct);
-        return BasalScheduleMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Updates an existing basal schedule record.
-    /// </summary>
-    /// <param name="id">The unique identifier of the schedule to update.</param>
-    /// <param name="model">The updated schedule data.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The updated basal schedule.</returns>
-    public async Task<BasalSchedule> UpdateAsync(Guid id, BasalSchedule model, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity =
-            await ctx.BasalSchedules.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"BasalSchedule {id} not found");
-        BasalScheduleMapper.UpdateEntity(entity, model);
-        await ctx.SaveChangesAsync(ct);
-        return BasalScheduleMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Deletes a basal schedule record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity =
-            await ctx.BasalSchedules.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"BasalSchedule {id} not found");
-        entity.DeletedAt = DateTime.UtcNow;
-        await ctx.SaveChangesAsync(ct);
-    }
-
-    /// <inheritdoc />
-    public async Task<BasalSchedule> RestoreAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.BasalSchedules.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
-            .FirstOrDefaultAsync(ct)
-            ?? throw new KeyNotFoundException($"Soft-deleted BasalSchedule {id} not found");
-        entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return BasalScheduleMapper.ToDomainModel(entity);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<BasalSchedule>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var idSet = ids.ToHashSet();
-        var entities = await ctx.BasalSchedules.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
-            .ToListAsync(ct);
-        foreach (var entity in entities)
-            entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return entities.Select(BasalScheduleMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<BasalSchedule>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entities = await ctx.BasalSchedules.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .OrderByDescending(e => e.DeletedAt)
-            .Skip(offset).Take(limit)
-            .AsNoTracking()
-            .ToListAsync(ct);
-        return entities.Select(BasalScheduleMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.BasalSchedules.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .CountAsync(ct);
-    }
-
-    /// <summary>
-    /// Deletes a basal schedule record by its legacy identifier.
+    /// Deletes a basal schedule record by its legacy identifier, routing through the audited
+    /// soft-delete helper.
     /// </summary>
     /// <param name="legacyId">The legacy identifier.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
+    public override async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
             ctx.BasalSchedules.Where(e => e.LegacyId == legacyId), _auditContext, ct);
     }
@@ -254,28 +105,10 @@ public class BasalScheduleRepository : IBasalScheduleRepository
     /// <returns>The number of deleted records.</returns>
     public async Task<int> DeleteByLegacyIdPrefixAsync(string prefix, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
             ctx.BasalSchedules.Where(e => e.LegacyId != null && e.LegacyId.StartsWith(prefix)),
             _auditContext, ct);
-    }
-
-    /// <summary>
-    /// Counts basal schedule records within a timestamp range.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The count of matching records.</returns>
-    public async Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.BasalSchedules.AsNoTracking().AsQueryable();
-        if (from.HasValue)
-            query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue)
-            query = query.Where(e => e.Timestamp <= to.Value);
-        return await query.CountAsync(ct);
     }
 
     /// <summary>
@@ -289,72 +122,11 @@ public class BasalScheduleRepository : IBasalScheduleRepository
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entities = await ctx
             .BasalSchedules.AsNoTracking()
             .Where(e => e.CorrelationId == correlationId)
             .ToListAsync(ct);
         return entities.Select(BasalScheduleMapper.ToDomainModel);
-    }
-
-    /// <summary>
-    /// Performs a bulk creation of basal schedule records, handling deduplication.
-    /// </summary>
-    /// <param name="records">The collection of records to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>A collection of created schedules.</returns>
-    public async Task<IEnumerable<BasalSchedule>> BulkCreateAsync(
-        IEnumerable<BasalSchedule> records,
-        CancellationToken ct = default
-    )
-    {
-        var entities = records.Select(BasalScheduleMapper.ToEntity).ToList();
-        if (entities.Count == 0)
-            return [];
-
-        // Batch-level dedup: keep first occurrence per LegacyId
-        entities = entities
-            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-            .Select(g => g.First())
-            .ToList();
-
-        // DB-level dedup: filter out records whose LegacyId already exists
-        var legacyIds = entities
-            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-            .Select(e => e.LegacyId!)
-            .ToHashSet();
-
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var strategy = ctx.Database.CreateExecutionStrategy();
-        return await strategy.ExecuteAsync(async () =>
-        {
-            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-            if (legacyIds.Count > 0)
-            {
-                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<BasalScheduleEntity>(legacyIds, ct);
-
-                entities = entities
-                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
-                    .ToList();
-            }
-
-            if (entities.Count == 0)
-            {
-                await tx.CommitAsync(ct);
-                return [];
-            }
-
-            const int batchSize = 500;
-            foreach (var batch in entities.Chunk(batchSize))
-            {
-                ctx.BasalSchedules.AddRange(batch);
-                await ctx.SaveChangesAsync(ct);
-                ctx.ChangeTracker.Clear();
-            }
-
-            await tx.CommitAsync(ct);
-            return entities.Select(BasalScheduleMapper.ToDomainModel);
-        });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
@@ -13,12 +13,14 @@ using Nocturne.Infrastructure.Data.Services;
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
-/// Repository for managing bolus calculation records in the database.
-/// Includes support for cross-connector deduplication.
+/// Repository for managing bolus calculation records in the database. A DeduplicationService
+/// participant, so it inherits the shared CRUD/soft-delete surface from
+/// <see cref="V4RepositoryBase{TModel,TEntity}"/> and keeps only the dedup-specific behaviour as
+/// overrides (the <c>GetAsync</c> with the non-primary LinkedRecords filter, dedup
+/// <c>BulkCreateAsync</c>, audited soft-deletes).
 /// </summary>
-public class BolusCalculationRepository : IBolusCalculationRepository
+public class BolusCalculationRepository : V4RepositoryBase<BolusCalculation, BolusCalculationEntity>, IBolusCalculationRepository
 {
-    private readonly ITenantDbContextFactory _contextFactory;
     private readonly IDeduplicationService _deduplicationService;
     private readonly IAuditContext _auditContext;
     private readonly ILogger<BolusCalculationRepository> _logger;
@@ -36,16 +38,26 @@ public class BolusCalculationRepository : IBolusCalculationRepository
         IAuditContext auditContext,
         ILogger<BolusCalculationRepository> logger
     )
+        : base(contextFactory)
     {
-        _contextFactory = contextFactory;
         _deduplicationService = deduplicationService;
         _auditContext = auditContext;
         _logger = logger;
     }
 
+    /// <inheritdoc />
+    protected override BolusCalculationEntity ToEntity(BolusCalculation model) => BolusCalculationMapper.ToEntity(model);
+
+    /// <inheritdoc />
+    protected override BolusCalculation ToDomain(BolusCalculationEntity entity) => BolusCalculationMapper.ToDomainModel(entity);
+
+    /// <inheritdoc />
+    protected override void ApplyUpdate(BolusCalculationEntity target, BolusCalculation source) => BolusCalculationMapper.UpdateEntity(target, source);
+
     /// <summary>
     /// Gets bolus calculation records based on filter criteria.
     /// Deduplicates records using the <see cref="IDeduplicationService"/>.
+    /// Overrides the base 7-arg form to add the non-primary LinkedRecords exclusion.
     /// </summary>
     /// <param name="from">Optional start timestamp filter.</param>
     /// <param name="to">Optional end timestamp filter.</param>
@@ -56,7 +68,7 @@ public class BolusCalculationRepository : IBolusCalculationRepository
     /// <param name="descending">Whether to sort by timestamp in descending order.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>A collection of bolus calculations.</returns>
-    public async Task<IEnumerable<BolusCalculation>> GetAsync(
+    public override async Task<IEnumerable<BolusCalculation>> GetAsync(
         DateTime? from,
         DateTime? to,
         string? device,
@@ -67,7 +79,7 @@ public class BolusCalculationRepository : IBolusCalculationRepository
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var query = ctx.BolusCalculations.AsNoTracking().AsQueryable();
         if (from.HasValue)
             query = query.Where(e => e.Timestamp >= from.Value);
@@ -88,173 +100,6 @@ public class BolusCalculationRepository : IBolusCalculationRepository
     }
 
     /// <summary>
-    /// Gets a bolus calculation record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The bolus calculation, or null if not found.</returns>
-    public async Task<BolusCalculation?> GetByIdAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.BolusCalculations.FindAsync([id], ct);
-        return entity is null ? null : BolusCalculationMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Gets a bolus calculation record by its legacy (MongoDB) identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The bolus calculation, or null if not found.</returns>
-    public async Task<BolusCalculation?> GetByLegacyIdAsync(
-        string legacyId,
-        CancellationToken ct = default
-    )
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.BolusCalculations.FirstOrDefaultAsync(
-            e => e.LegacyId == legacyId,
-            ct
-        );
-        return entity is null ? null : BolusCalculationMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Creates a new bolus calculation record.
-    /// </summary>
-    /// <param name="model">The bolus calculation to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The created bolus calculation.</returns>
-    public async Task<BolusCalculation> CreateAsync(
-        BolusCalculation model,
-        CancellationToken ct = default
-    )
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = BolusCalculationMapper.ToEntity(model);
-        ctx.BolusCalculations.Add(entity);
-        await ctx.SaveChangesAsync(ct);
-        return BolusCalculationMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Updates an existing bolus calculation record.
-    /// </summary>
-    /// <param name="id">The unique identifier of the record to update.</param>
-    /// <param name="model">The updated record data.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The updated bolus calculation.</returns>
-    public async Task<BolusCalculation> UpdateAsync(
-        Guid id,
-        BolusCalculation model,
-        CancellationToken ct = default
-    )
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity =
-            await ctx.BolusCalculations.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"BolusCalculation {id} not found");
-        BolusCalculationMapper.UpdateEntity(entity, model);
-        await ctx.SaveChangesAsync(ct);
-        return BolusCalculationMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Deletes a bolus calculation record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity =
-            await ctx.BolusCalculations.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"BolusCalculation {id} not found");
-        entity.DeletedAt = DateTime.UtcNow;
-        await ctx.SaveChangesAsync(ct);
-    }
-
-    /// <inheritdoc />
-    public async Task<BolusCalculation> RestoreAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.BolusCalculations.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
-            .FirstOrDefaultAsync(ct)
-            ?? throw new KeyNotFoundException($"Soft-deleted BolusCalculation {id} not found");
-        entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return BolusCalculationMapper.ToDomainModel(entity);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<BolusCalculation>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var idSet = ids.ToHashSet();
-        var entities = await ctx.BolusCalculations.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
-            .ToListAsync(ct);
-        foreach (var entity in entities)
-            entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return entities.Select(BolusCalculationMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<BolusCalculation>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entities = await ctx.BolusCalculations.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .OrderByDescending(e => e.DeletedAt)
-            .Skip(offset).Take(limit)
-            .AsNoTracking()
-            .ToListAsync(ct);
-        return entities.Select(BolusCalculationMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.BolusCalculations.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .CountAsync(ct);
-    }
-
-    /// <summary>
-    /// Returns the timestamp of the most recently stored record, optionally scoped to a data source.
-    /// Used by connectors to resume per-source sync without re-fetching already-stored data.
-    /// </summary>
-    public async Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.BolusCalculations.AsNoTracking().AsQueryable();
-        if (source != null)
-            query = query.Where(e => e.DataSource == source);
-        return await query.MaxAsync(e => (DateTime?)e.Timestamp, ct);
-    }
-
-    /// <summary>
-    /// Counts bolus calculation records within a timestamp range.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The count of matching records.</returns>
-    public async Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.BolusCalculations.AsNoTracking().AsQueryable();
-        if (from.HasValue)
-            query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue)
-            query = query.Where(e => e.Timestamp <= to.Value);
-        return await query.CountAsync(ct);
-    }
-
-    /// <summary>
     /// Gets bolus calculation records by correlation identifier.
     /// </summary>
     /// <param name="correlationId">The correlation identifier.</param>
@@ -265,7 +110,7 @@ public class BolusCalculationRepository : IBolusCalculationRepository
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entities = await ctx
             .BolusCalculations.AsNoTracking()
             .Where(e => e.CorrelationId == correlationId)
@@ -279,9 +124,9 @@ public class BolusCalculationRepository : IBolusCalculationRepository
     /// <param name="legacyId">The legacy identifier.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
+    public override async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
             ctx.BolusCalculations.Where(e => e.LegacyId == legacyId), _auditContext, ct);
     }
@@ -292,12 +137,12 @@ public class BolusCalculationRepository : IBolusCalculationRepository
     /// <param name="records">The collection of records to create.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>A collection of created records.</returns>
-    public async Task<IEnumerable<BolusCalculation>> BulkCreateAsync(
+    public override async Task<IEnumerable<BolusCalculation>> BulkCreateAsync(
         IEnumerable<BolusCalculation> records,
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var strategy = ctx.Database.CreateExecutionStrategy();
         return await strategy.ExecuteAsync(async () =>
         {

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
@@ -124,83 +124,28 @@ public class BolusCalculationRepository : V4RepositoryBase<BolusCalculation, Bol
     }
 
     /// <summary>
-    /// Performs a bulk creation of bolus calculation records, handling deduplication.
+    /// Insert-time deduplication: link saved records to canonical groups (runs after commit).
     /// </summary>
-    /// <param name="records">The collection of records to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>A collection of created records.</returns>
-    public override async Task<IEnumerable<BolusCalculation>> BulkCreateAsync(
-        IEnumerable<BolusCalculation> records,
-        CancellationToken ct = default
-    )
+    protected override async Task PostCommitDedupAsync(
+        NocturneDbContext ctx, IReadOnlyList<BolusCalculationEntity> inserted, CancellationToken ct)
     {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        var strategy = ctx.Database.CreateExecutionStrategy();
-        return await strategy.ExecuteAsync(async () =>
+        if (inserted.Count == 0)
+            return;
+
+        try
         {
-            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-            var entities = records.Select(BolusCalculationMapper.ToEntity).ToList();
-            if (entities.Count == 0)
-            {
-                await tx.CommitAsync(ct);
-                return [];
-            }
+            var dedupInputs = inserted.Select(e => new DeduplicationInput(
+                RecordId: e.Id,
+                Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
+                DataSource: e.DataSource ?? "unknown",
+                Criteria: new MatchCriteria { Carbs = e.CarbInput ?? 0, CarbsTolerance = 1.0 }
+            )).ToList();
 
-            // Batch-level dedup: keep first occurrence per LegacyId
-            entities = entities
-                .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-                .Select(g => g.First())
-                .ToList();
-
-            // DB-level dedup: filter out records whose LegacyId already exists
-            var legacyIds = entities
-                .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-                .Select(e => e.LegacyId!)
-                .ToHashSet();
-
-            if (legacyIds.Count > 0)
-            {
-                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<BolusCalculationEntity>(legacyIds, ct);
-
-                entities = entities
-                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
-                    .ToList();
-            }
-
-            if (entities.Count == 0)
-            {
-                await tx.CommitAsync(ct);
-                return [];
-            }
-
-            const int batchSize = 500;
-            foreach (var batch in entities.Chunk(batchSize))
-            {
-                ctx.BolusCalculations.AddRange(batch);
-                await ctx.SaveChangesAsync(ct);
-                ctx.ChangeTracker.Clear();
-            }
-
-            await tx.CommitAsync(ct);
-
-            // Insert-time deduplication: link saved records to canonical groups
-            try
-            {
-                var dedupInputs = entities.Select(e => new DeduplicationInput(
-                    RecordId: e.Id,
-                    Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    DataSource: e.DataSource ?? "unknown",
-                    Criteria: new MatchCriteria { Carbs = e.CarbInput ?? 0, CarbsTolerance = 1.0 }
-                )).ToList();
-
-                await _deduplicationService.DeduplicateBatchAsync(RecordType.BolusCalculation, dedupInputs, ct);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "BolusCalculation", entities.Count);
-            }
-
-            return entities.Select(BolusCalculationMapper.ToDomainModel);
-        });
+            await _deduplicationService.DeduplicateBatchAsync(RecordType.BolusCalculation, dedupInputs, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "BolusCalculation", inserted.Count);
+        }
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
@@ -53,6 +53,13 @@ public class BolusCalculationRepository : V4RepositoryBase<BolusCalculation, Bol
     protected override void ApplyUpdate(BolusCalculationEntity target, BolusCalculation source) => BolusCalculationMapper.UpdateEntity(target, source);
 
     /// <summary>
+    /// Excludes non-primary cross-connector duplicates so <see cref="V4RepositoryBase{TModel,TEntity}.CountAsync"/>
+    /// matches the rows <c>GetAsync</c> returns. Mirrors the inline filter in the extended <c>GetAsync</c>.
+    /// </summary>
+    protected override IQueryable<BolusCalculationEntity> ApplyReadVisibility(IQueryable<BolusCalculationEntity> query, NocturneDbContext ctx) =>
+        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == "boluscalculation" && !lr.IsPrimary && lr.RecordId == b.Id));
+
+    /// <summary>
     /// Gets bolus calculation records based on filter criteria.
     /// Deduplicates records using the <see cref="IDeduplicationService"/>.
     /// Overrides the base 7-arg form to add the non-primary LinkedRecords exclusion.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
@@ -143,7 +143,7 @@ public class BolusCalculationRepository : V4RepositoryBase<BolusCalculation, Bol
 
             await _deduplicationService.DeduplicateBatchAsync(RecordType.BolusCalculation, dedupInputs, ct);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "BolusCalculation", inserted.Count);
         }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
@@ -22,7 +22,6 @@ namespace Nocturne.Infrastructure.Data.Repositories.V4;
 public class BolusCalculationRepository : V4RepositoryBase<BolusCalculation, BolusCalculationEntity>, IBolusCalculationRepository
 {
     private readonly IDeduplicationService _deduplicationService;
-    private readonly IAuditContext _auditContext;
     private readonly ILogger<BolusCalculationRepository> _logger;
 
     /// <summary>
@@ -38,10 +37,9 @@ public class BolusCalculationRepository : V4RepositoryBase<BolusCalculation, Bol
         IAuditContext auditContext,
         ILogger<BolusCalculationRepository> logger
     )
-        : base(contextFactory)
+        : base(contextFactory, auditContext)
     {
         _deduplicationService = deduplicationService;
-        _auditContext = auditContext;
         _logger = logger;
     }
 
@@ -116,19 +114,6 @@ public class BolusCalculationRepository : V4RepositoryBase<BolusCalculation, Bol
             .Where(e => e.CorrelationId == correlationId)
             .ToListAsync(ct);
         return entities.Select(BolusCalculationMapper.ToDomainModel);
-    }
-
-    /// <summary>
-    /// Deletes a bolus calculation record by its legacy identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The number of deleted records.</returns>
-    public override async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        return await ctx.AuditedSoftDeleteAsync(
-            ctx.BolusCalculations.Where(e => e.LegacyId == legacyId), _auditContext, ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
@@ -22,7 +22,6 @@ namespace Nocturne.Infrastructure.Data.Repositories.V4;
 public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepository
 {
     private readonly IDeduplicationService _deduplicationService;
-    private readonly IAuditContext _auditContext;
     private readonly ILogger<BolusRepository> _logger;
 
     /// <summary>
@@ -37,10 +36,9 @@ public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepos
         IDeduplicationService deduplicationService,
         IAuditContext auditContext,
         ILogger<BolusRepository> logger)
-        : base(contextFactory)
+        : base(contextFactory, auditContext)
     {
         _deduplicationService = deduplicationService;
-        _auditContext = auditContext;
         _logger = logger;
     }
 
@@ -172,19 +170,6 @@ public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepos
     }
 
     /// <summary>
-    /// Deletes a bolus record by its legacy identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The number of deleted records.</returns>
-    public override async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        return await ctx.AuditedSoftDeleteAsync(
-            ctx.Boluses.Where(e => e.LegacyId == legacyId), _auditContext, ct);
-    }
-
-    /// <summary>
     /// Deletes bolus records matching the given data source and sync identifier.
     /// </summary>
     /// <param name="dataSource">The external data source name.</param>
@@ -196,7 +181,7 @@ public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepos
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
             ctx.Boluses.Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier),
-            _auditContext, ct);
+            AuditContext, ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
@@ -303,7 +303,7 @@ public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepos
 
             await _deduplicationService.DeduplicateBatchAsync(RecordType.Bolus, dedupInputs, ct);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "Bolus", inserted.Count);
         }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
@@ -13,12 +13,14 @@ using Nocturne.Infrastructure.Data.Services;
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
-/// Repository for managing bolus records in the database.
-/// Includes support for cross-connector deduplication.
+/// Repository for managing bolus records. A SyncId-upsert + DeduplicationService participant, so it
+/// inherits the shared CRUD/soft-delete surface from <see cref="V4RepositoryBase{TModel,TEntity}"/>
+/// and keeps only the dedup-specific behaviour as overrides (extended <c>GetAsync</c> with the
+/// non-primary LinkedRecords filter + keyset cursor, SyncId-upsert <c>CreateAsync</c>/
+/// <c>BulkCreateAsync</c>, and audited soft-deletes).
 /// </summary>
-public class BolusRepository : IBolusRepository
+public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepository
 {
-    private readonly ITenantDbContextFactory _contextFactory;
     private readonly IDeduplicationService _deduplicationService;
     private readonly IAuditContext _auditContext;
     private readonly ILogger<BolusRepository> _logger;
@@ -35,12 +37,32 @@ public class BolusRepository : IBolusRepository
         IDeduplicationService deduplicationService,
         IAuditContext auditContext,
         ILogger<BolusRepository> logger)
+        : base(contextFactory)
     {
-        _contextFactory = contextFactory;
         _deduplicationService = deduplicationService;
         _auditContext = auditContext;
         _logger = logger;
     }
+
+    /// <inheritdoc />
+    protected override BolusEntity ToEntity(Bolus model) => BolusMapper.ToEntity(model);
+
+    /// <inheritdoc />
+    protected override Bolus ToDomain(BolusEntity entity) => BolusMapper.ToDomainModel(entity);
+
+    /// <inheritdoc />
+    protected override void ApplyUpdate(BolusEntity target, Bolus source) => BolusMapper.UpdateEntity(target, source);
+
+    /// <summary>
+    /// Routes the base 7-arg form through the extended bolus query (non-primary LinkedRecords
+    /// exclusion + ordering), preserving the pre-base default-interface bridge behaviour.
+    /// </summary>
+    public override Task<IEnumerable<Bolus>> GetAsync(
+        DateTime? from, DateTime? to, string? device, string? source,
+        int limit = 100, int offset = 0, bool descending = true,
+        CancellationToken ct = default)
+        => GetAsync(from, to, device, source, limit, offset, descending,
+            nativeOnly: false, kind: null, afterTimestamp: null, afterId: null, ct);
 
     /// <summary>
     /// Gets bolus records based on filter criteria.
@@ -74,7 +96,7 @@ public class BolusRepository : IBolusRepository
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var query = ctx.Boluses.AsNoTracking().AsQueryable();
         if (from.HasValue)
             query = query.Where(e => e.Timestamp >= from.Value);
@@ -118,32 +140,6 @@ public class BolusRepository : IBolusRepository
     }
 
     /// <summary>
-    /// Gets a bolus record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The bolus record, or null if not found.</returns>
-    public async Task<Bolus?> GetByIdAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.Boluses.FindAsync([id], ct);
-        return entity is null ? null : BolusMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Gets a bolus record by its legacy (MongoDB) identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The bolus record, or null if not found.</returns>
-    public async Task<Bolus?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.Boluses.FirstOrDefaultAsync(e => e.LegacyId == legacyId, ct);
-        return entity is null ? null : BolusMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
     /// Creates a new bolus record. When <c>DataSource</c> and <c>SyncIdentifier</c>
     /// match an existing row for this tenant, the record is updated in place rather
     /// than inserted — making the operation idempotent for connector replays.
@@ -152,9 +148,9 @@ public class BolusRepository : IBolusRepository
     /// <param name="model">The bolus to create.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The created or updated bolus record.</returns>
-    public async Task<Bolus> CreateAsync(Bolus model, CancellationToken ct = default)
+    public override async Task<Bolus> CreateAsync(Bolus model, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         if (!string.IsNullOrEmpty(model.DataSource) && !string.IsNullOrEmpty(model.SyncIdentifier))
         {
             var existing = await ctx.Boluses
@@ -176,146 +172,14 @@ public class BolusRepository : IBolusRepository
     }
 
     /// <summary>
-    /// Updates an existing bolus record.
-    /// </summary>
-    /// <param name="id">The unique identifier of the record to update.</param>
-    /// <param name="model">The updated record data.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The updated bolus record.</returns>
-    public async Task<Bolus> UpdateAsync(Guid id, Bolus model, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity =
-            await ctx.Boluses.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"Bolus {id} not found");
-        BolusMapper.UpdateEntity(entity, model);
-        await ctx.SaveChangesAsync(ct);
-        return BolusMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Deletes a bolus record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity =
-            await ctx.Boluses.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"Bolus {id} not found");
-        entity.DeletedAt = DateTime.UtcNow;
-        await ctx.SaveChangesAsync(ct);
-    }
-
-    /// <inheritdoc />
-    public async Task<Bolus> RestoreAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.Boluses.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
-            .FirstOrDefaultAsync(ct)
-            ?? throw new KeyNotFoundException($"Soft-deleted Bolus {id} not found");
-        entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return BolusMapper.ToDomainModel(entity);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<Bolus>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var idSet = ids.ToHashSet();
-        var entities = await ctx.Boluses.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
-            .ToListAsync(ct);
-        foreach (var entity in entities)
-            entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return entities.Select(BolusMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<Bolus>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entities = await ctx.Boluses.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .OrderByDescending(e => e.DeletedAt)
-            .Skip(offset).Take(limit)
-            .AsNoTracking()
-            .ToListAsync(ct);
-        return entities.Select(BolusMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.Boluses.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .CountAsync(ct);
-    }
-
-    /// <summary>
-    /// Returns the timestamp of the most recently stored record, optionally scoped to a data source.
-    /// Used by connectors to resume per-source sync without re-fetching already-stored data.
-    /// </summary>
-    public async Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.Boluses.AsNoTracking().AsQueryable();
-        if (source != null)
-            query = query.Where(e => e.DataSource == source);
-        return await query.MaxAsync(e => (DateTime?)e.Timestamp, ct);
-    }
-
-    /// <summary>
-    /// Counts bolus records within a timestamp range.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The count of matching records.</returns>
-    public async Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.Boluses.AsNoTracking().AsQueryable();
-        if (from.HasValue)
-            query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue)
-            query = query.Where(e => e.Timestamp <= to.Value);
-        return await query.CountAsync(ct);
-    }
-
-    /// <summary>
-    /// Gets bolus records by correlation identifier.
-    /// </summary>
-    /// <param name="correlationId">The correlation identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>A collection of bolus records.</returns>
-    public async Task<IEnumerable<Bolus>> GetByCorrelationIdAsync(
-        Guid correlationId,
-        CancellationToken ct = default
-    )
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entities = await ctx
-            .Boluses.AsNoTracking()
-            .Where(e => e.CorrelationId == correlationId)
-            .ToListAsync(ct);
-        return entities.Select(BolusMapper.ToDomainModel);
-    }
-
-    /// <summary>
     /// Deletes a bolus record by its legacy identifier.
     /// </summary>
     /// <param name="legacyId">The legacy identifier.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
+    public override async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
             ctx.Boluses.Where(e => e.LegacyId == legacyId), _auditContext, ct);
     }
@@ -329,10 +193,29 @@ public class BolusRepository : IBolusRepository
     /// <returns>The number of deleted records.</returns>
     public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
             ctx.Boluses.Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier),
             _auditContext, ct);
+    }
+
+    /// <summary>
+    /// Gets bolus records by correlation identifier.
+    /// </summary>
+    /// <param name="correlationId">The correlation identifier.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A collection of bolus records.</returns>
+    public async Task<IEnumerable<Bolus>> GetByCorrelationIdAsync(
+        Guid correlationId,
+        CancellationToken ct = default
+    )
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var entities = await ctx
+            .Boluses.AsNoTracking()
+            .Where(e => e.CorrelationId == correlationId)
+            .ToListAsync(ct);
+        return entities.Select(BolusMapper.ToDomainModel);
     }
 
     /// <summary>
@@ -341,12 +224,12 @@ public class BolusRepository : IBolusRepository
     /// <param name="records">The collection of records to create.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>A collection of created records.</returns>
-    public async Task<IEnumerable<Bolus>> BulkCreateAsync(
+    public override async Task<IEnumerable<Bolus>> BulkCreateAsync(
         IEnumerable<Bolus> records,
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var strategy = ctx.Database.CreateExecutionStrategy();
         return await strategy.ExecuteAsync(async () =>
         {

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
@@ -317,10 +317,17 @@ public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepos
                     await ctx.SaveChangesAsync(ct);
                     ctx.ChangeTracker.Clear();
                 }
+            }
 
-                // Insert-time deduplication: link saved records to canonical groups.
-                // Only runs on newly inserted entities — updated-in-place rows were
-                // already linked when first inserted.
+            await tx.CommitAsync(ct);
+
+            // Insert-time deduplication runs AFTER commit: the ingested rows are durably
+            // persisted first, and dedup linking is best-effort (a failure is logged and
+            // healed by the reconcile service, not allowed to roll back the insert).
+            // Only runs on newly inserted entities — updated-in-place rows were already
+            // linked when first inserted.
+            if (entities.Count > 0)
+            {
                 try
                 {
                     var dedupInputs = entities.Select(e => new DeduplicationInput(
@@ -338,7 +345,6 @@ public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepos
                 }
             }
 
-            await tx.CommitAsync(ct);
             return updatedEntities.Concat(entities).Select(BolusMapper.ToDomainModel);
         });
     }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
@@ -52,6 +52,13 @@ public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepos
     protected override void ApplyUpdate(BolusEntity target, Bolus source) => BolusMapper.UpdateEntity(target, source);
 
     /// <summary>
+    /// Excludes non-primary cross-connector duplicates so <see cref="CountAsync"/> matches the rows
+    /// <c>GetAsync</c> returns. Mirrors the inline filter in the extended <c>GetAsync</c>.
+    /// </summary>
+    protected override IQueryable<BolusEntity> ApplyReadVisibility(IQueryable<BolusEntity> query, NocturneDbContext ctx) =>
+        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == "bolus" && !lr.IsPrimary && lr.RecordId == b.Id));
+
+    /// <summary>
     /// Routes the base 7-arg form through the extended bolus query (non-primary LinkedRecords
     /// exclusion + ordering), preserving the pre-base default-interface bridge behaviour.
     /// </summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
@@ -211,148 +211,101 @@ public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepos
     }
 
     /// <summary>
-    /// Performs a bulk creation of bolus records, handling deduplication.
+    /// SyncId-upsert split: intra-batch keep-last per (DataSource, SyncIdentifier), then match existing
+    /// rows in the DB by that key and update them in place. Persists the updates inside the transaction
+    /// before returning so the base's insert loop (which clears the tracker) doesn't lose them.
     /// </summary>
-    /// <param name="records">The collection of records to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>A collection of created records.</returns>
-    public override async Task<IEnumerable<Bolus>> BulkCreateAsync(
-        IEnumerable<Bolus> records,
-        CancellationToken ct = default
-    )
+    protected override async Task<(List<BolusEntity> Updated, List<BolusEntity> ToInsert)> SplitUpsertsAsync(
+        NocturneDbContext ctx, List<BolusEntity> entities, CancellationToken ct)
     {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        var strategy = ctx.Database.CreateExecutionStrategy();
-        return await strategy.ExecuteAsync(async () =>
+        // Intra-batch SyncIdentifier dedup: keep last occurrence per
+        // (DataSource, SyncIdentifier). Records without both keys keep a
+        // unique grouping key so they're not collapsed.
+        entities = entities
+            .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
+                ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
+                : $"id|{e.Id}")
+            .Select(g => g.Last())
+            .ToList();
+
+        // DB-level SyncIdentifier upsert: match any existing rows keyed by
+        // (DataSource, SyncIdentifier) and update them in place. Everything
+        // else falls through to the insert path below.
+        var syncKeyed = entities
+            .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
+            .ToList();
+
+        var updatedEntities = new List<BolusEntity>();
+        if (syncKeyed.Count == 0)
+            return (updatedEntities, entities);
+
+        var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
+        var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
+
+        // Over-fetches by a Cartesian amount; the partial unique index
+        // on (tenant_id, data_source, sync_identifier) keeps this cheap.
+        var existingRows = await ctx.Boluses.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId)
+            .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
+            .ToListAsync(ct);
+
+        var existingByKey = existingRows
+            .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
+            .ToDictionary(g => g.Key, g => g.First());
+
+        var toInsert = new List<BolusEntity>();
+        foreach (var entity in entities)
         {
-            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-            var entities = records.Select(BolusMapper.ToEntity).ToList();
-            if (entities.Count == 0)
+            var hasKey = !string.IsNullOrEmpty(entity.DataSource)
+                && !string.IsNullOrEmpty(entity.SyncIdentifier);
+            if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
             {
-                await tx.CommitAsync(ct);
-                return [];
+                // Update in place — mirror the single-record CreateAsync path via the mapper.
+                var domain = BolusMapper.ToDomainModel(entity);
+                BolusMapper.UpdateEntity(existing, domain);
+                updatedEntities.Add(existing);
             }
-
-            // Intra-batch SyncIdentifier dedup: keep last occurrence per
-            // (DataSource, SyncIdentifier). Records without both keys keep a
-            // unique grouping key so they're not collapsed.
-            entities = entities
-                .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
-                    ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
-                    : $"id|{e.Id}")
-                .Select(g => g.Last())
-                .ToList();
-
-            // DB-level SyncIdentifier upsert: match any existing rows keyed by
-            // (DataSource, SyncIdentifier) and update them in place. Everything
-            // else falls through to the insert path below.
-            var syncKeyed = entities
-                .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
-                .ToList();
-
-            var updatedEntities = new List<BolusEntity>();
-            if (syncKeyed.Count > 0)
+            else
             {
-                var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
-                var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
-
-                // Over-fetches by a Cartesian amount; the partial unique index
-                // on (tenant_id, data_source, sync_identifier) keeps this cheap.
-                var existingRows = await ctx.Boluses.IgnoreQueryFilters()
-                    .Where(e => e.TenantId == ctx.TenantId)
-                    .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
-                    .ToListAsync(ct);
-
-                var existingByKey = existingRows
-                    .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
-                    .ToDictionary(g => g.Key, g => g.First());
-
-                var toInsert = new List<BolusEntity>();
-                foreach (var entity in entities)
-                {
-                    var hasKey = !string.IsNullOrEmpty(entity.DataSource)
-                        && !string.IsNullOrEmpty(entity.SyncIdentifier);
-                    if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
-                    {
-                        // Update in place — mirror the single-record CreateAsync path via the mapper.
-                        var domain = BolusMapper.ToDomainModel(entity);
-                        BolusMapper.UpdateEntity(existing, domain);
-                        updatedEntities.Add(existing);
-                    }
-                    else
-                    {
-                        toInsert.Add(entity);
-                    }
-                }
-
-                if (updatedEntities.Count > 0)
-                {
-                    // Persist updates before the insert-chunking loop clears the tracker.
-                    await ctx.SaveChangesAsync(ct);
-                }
-
-                entities = toInsert;
+                toInsert.Add(entity);
             }
+        }
 
-            // Batch-level dedup: keep first occurrence per LegacyId
-            entities = entities
-                .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-                .Select(g => g.First())
-                .ToList();
+        if (updatedEntities.Count > 0)
+        {
+            // Persist updates before the insert-chunking loop clears the tracker.
+            await ctx.SaveChangesAsync(ct);
+        }
 
-            // DB-level dedup: filter out records whose LegacyId already exists
-            var legacyIds = entities
-                .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-                .Select(e => e.LegacyId!)
-                .ToHashSet();
+        return (updatedEntities, toInsert);
+    }
 
-            if (legacyIds.Count > 0)
-            {
-                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<BolusEntity>(legacyIds, ct);
+    /// <summary>
+    /// Insert-time deduplication runs AFTER commit: the ingested rows are durably persisted first, and
+    /// dedup linking is best-effort (a failure is logged and healed by the reconcile service, not allowed
+    /// to roll back the insert). Only runs on newly inserted entities — updated-in-place rows were already
+    /// linked when first inserted.
+    /// </summary>
+    protected override async Task PostCommitDedupAsync(
+        NocturneDbContext ctx, IReadOnlyList<BolusEntity> inserted, CancellationToken ct)
+    {
+        if (inserted.Count == 0)
+            return;
 
-                entities = entities
-                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
-                    .ToList();
-            }
+        try
+        {
+            var dedupInputs = inserted.Select(e => new DeduplicationInput(
+                RecordId: e.Id,
+                Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
+                DataSource: e.DataSource ?? "unknown",
+                Criteria: new MatchCriteria { Insulin = e.Insulin, InsulinTolerance = 0.05 }
+            )).ToList();
 
-            if (entities.Count > 0)
-            {
-                const int batchSize = 500;
-                foreach (var batch in entities.Chunk(batchSize))
-                {
-                    ctx.Boluses.AddRange(batch);
-                    await ctx.SaveChangesAsync(ct);
-                    ctx.ChangeTracker.Clear();
-                }
-            }
-
-            await tx.CommitAsync(ct);
-
-            // Insert-time deduplication runs AFTER commit: the ingested rows are durably
-            // persisted first, and dedup linking is best-effort (a failure is logged and
-            // healed by the reconcile service, not allowed to roll back the insert).
-            // Only runs on newly inserted entities — updated-in-place rows were already
-            // linked when first inserted.
-            if (entities.Count > 0)
-            {
-                try
-                {
-                    var dedupInputs = entities.Select(e => new DeduplicationInput(
-                        RecordId: e.Id,
-                        Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                        DataSource: e.DataSource ?? "unknown",
-                        Criteria: new MatchCriteria { Insulin = e.Insulin, InsulinTolerance = 0.05 }
-                    )).ToList();
-
-                    await _deduplicationService.DeduplicateBatchAsync(RecordType.Bolus, dedupInputs, ct);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "Bolus", entities.Count);
-                }
-            }
-
-            return updatedEntities.Concat(entities).Select(BolusMapper.ToDomainModel);
-        });
+            await _deduplicationService.DeduplicateBatchAsync(RecordType.Bolus, dedupInputs, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "Bolus", inserted.Count);
+        }
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CalibrationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CalibrationRepository.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
@@ -19,11 +20,11 @@ public class CalibrationRepository : V4RepositoryBase<Calibration, CalibrationEn
     /// Initializes a new instance of the <see cref="CalibrationRepository"/> class.
     /// </summary>
     /// <param name="contextFactory">The tenant database context factory.</param>
+    /// <param name="auditContext">The audit context for tracking mutations (used by the base soft-delete path).</param>
     /// <param name="logger">The logger instance.</param>
-    // logger is unused for this LegacyId-only type but retained for DI + direct test construction;
-    // it moves to the base ctor when the DeduplicationService participants (which log) are migrated.
-    public CalibrationRepository(ITenantDbContextFactory contextFactory, ILogger<CalibrationRepository> logger)
-        : base(contextFactory)
+    // logger is unused for this LegacyId-only type but retained for DI + direct test construction.
+    public CalibrationRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext, ILogger<CalibrationRepository> logger)
+        : base(contextFactory, auditContext)
     {
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CalibrationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CalibrationRepository.cs
@@ -3,195 +3,37 @@ using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
-using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
-/// Repository for managing calibration records in the database.
+/// Repository for managing calibration records. A LegacyId-only type (no SyncId-upsert, no
+/// DeduplicationService participation), so it uses the shared <see cref="V4RepositoryBase{TModel,TEntity}"/>
+/// behaviour unchanged plus the calibration-specific queries below.
 /// </summary>
-public class CalibrationRepository : ICalibrationRepository
+public class CalibrationRepository : V4RepositoryBase<Calibration, CalibrationEntity>, ICalibrationRepository
 {
-    private readonly ITenantDbContextFactory _contextFactory;
-    private readonly ILogger<CalibrationRepository> _logger;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="CalibrationRepository"/> class.
     /// </summary>
     /// <param name="contextFactory">The tenant database context factory.</param>
     /// <param name="logger">The logger instance.</param>
     public CalibrationRepository(ITenantDbContextFactory contextFactory, ILogger<CalibrationRepository> logger)
+        : base(contextFactory)
     {
-        _contextFactory = contextFactory;
-        _logger = logger;
-    }
-
-    /// <summary>
-    /// Gets calibration records based on filter criteria.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="device">Optional device filter.</param>
-    /// <param name="source">Optional data source filter.</param>
-    /// <param name="limit">The maximum number of records to return.</param>
-    /// <param name="offset">The number of records to skip.</param>
-    /// <param name="descending">Whether to sort by timestamp in descending order.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>A collection of calibrations.</returns>
-    public async Task<IEnumerable<Calibration>> GetAsync(
-        DateTime? from, DateTime? to, string? device, string? source,
-        int limit = 100, int offset = 0, bool descending = true,
-        CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.Calibrations.AsNoTracking().AsQueryable();
-        if (from.HasValue) query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue) query = query.Where(e => e.Timestamp <= to.Value);
-        if (device != null) query = query.Where(e => e.Device == device);
-        if (source != null) query = query.Where(e => e.DataSource == source);
-        query = descending ? query.OrderByDescending(e => e.Timestamp) : query.OrderBy(e => e.Timestamp);
-        var entities = await query.Skip(offset).Take(limit).ToListAsync(ct);
-        return entities.Select(CalibrationMapper.ToDomainModel);
-    }
-
-    /// <summary>
-    /// Gets a calibration record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The calibration record, or null if not found.</returns>
-    public async Task<Calibration?> GetByIdAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.Calibrations.FindAsync([id], ct);
-        return entity is null ? null : CalibrationMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Gets a calibration record by its legacy identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The calibration record, or null if not found.</returns>
-    public async Task<Calibration?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.Calibrations.FirstOrDefaultAsync(e => e.LegacyId == legacyId, ct);
-        return entity is null ? null : CalibrationMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Creates a new calibration record.
-    /// </summary>
-    /// <param name="model">The calibration to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The created calibration record.</returns>
-    public async Task<Calibration> CreateAsync(Calibration model, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = CalibrationMapper.ToEntity(model);
-        ctx.Calibrations.Add(entity);
-        await ctx.SaveChangesAsync(ct);
-        return CalibrationMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Updates an existing calibration record.
-    /// </summary>
-    /// <param name="id">The unique identifier of the record to update.</param>
-    /// <param name="model">The updated record data.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The updated calibration record.</returns>
-    public async Task<Calibration> UpdateAsync(Guid id, Calibration model, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.Calibrations.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"Calibration {id} not found");
-        CalibrationMapper.UpdateEntity(entity, model);
-        await ctx.SaveChangesAsync(ct);
-        return CalibrationMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Deletes a calibration record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.Calibrations.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"Calibration {id} not found");
-        entity.DeletedAt = DateTime.UtcNow;
-        await ctx.SaveChangesAsync(ct);
     }
 
     /// <inheritdoc />
-    public async Task<Calibration> RestoreAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.Calibrations.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
-            .FirstOrDefaultAsync(ct)
-            ?? throw new KeyNotFoundException($"Soft-deleted Calibration {id} not found");
-        entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return CalibrationMapper.ToDomainModel(entity);
-    }
+    protected override CalibrationEntity ToEntity(Calibration model) => CalibrationMapper.ToEntity(model);
 
     /// <inheritdoc />
-    public async Task<IEnumerable<Calibration>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var idSet = ids.ToHashSet();
-        var entities = await ctx.Calibrations.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
-            .ToListAsync(ct);
-        foreach (var entity in entities)
-            entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return entities.Select(CalibrationMapper.ToDomainModel);
-    }
+    protected override Calibration ToDomain(CalibrationEntity entity) => CalibrationMapper.ToDomainModel(entity);
 
     /// <inheritdoc />
-    public async Task<IEnumerable<Calibration>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entities = await ctx.Calibrations.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .OrderByDescending(e => e.DeletedAt)
-            .Skip(offset).Take(limit)
-            .AsNoTracking()
-            .ToListAsync(ct);
-        return entities.Select(CalibrationMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.Calibrations.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .CountAsync(ct);
-    }
-
-    /// <summary>
-    /// Counts calibration records within a timestamp range.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The count of matching records.</returns>
-    public async Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.Calibrations.AsNoTracking().AsQueryable();
-        if (from.HasValue) query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue) query = query.Where(e => e.Timestamp <= to.Value);
-        return await query.CountAsync(ct);
-    }
+    protected override void ApplyUpdate(CalibrationEntity target, Calibration source) =>
+        CalibrationMapper.UpdateEntity(target, source);
 
     /// <summary>
     /// Gets calibration records by correlation identifier.
@@ -201,56 +43,12 @@ public class CalibrationRepository : ICalibrationRepository
     /// <returns>A collection of calibrations.</returns>
     public async Task<IEnumerable<Calibration>> GetByCorrelationIdAsync(Guid correlationId, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entities = await ctx.Calibrations
             .AsNoTracking()
             .Where(e => e.CorrelationId == correlationId)
             .ToListAsync(ct);
         return entities.Select(CalibrationMapper.ToDomainModel);
-    }
-
-    /// <summary>
-    /// Deletes a calibration record by its legacy identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.Calibrations
-            .Where(e => e.LegacyId == legacyId)
-            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
-    }
-
-    /// <summary>
-    /// Gets the timestamp of the latest calibration record.
-    /// </summary>
-    /// <param name="source">Optional data source filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The latest timestamp, or null if no records found.</returns>
-    public async Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.Calibrations.AsNoTracking().AsQueryable();
-        if (source != null)
-            query = query.Where(e => e.DataSource == source);
-        return await query.MaxAsync(e => (DateTime?)e.Timestamp, ct);
-    }
-
-    /// <summary>
-    /// Gets the timestamp of the oldest calibration record.
-    /// </summary>
-    /// <param name="source">Optional data source filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The oldest timestamp, or null if no records found.</returns>
-    public async Task<DateTime?> GetOldestTimestampAsync(string? source = null, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.Calibrations.AsNoTracking().AsQueryable();
-        if (source != null)
-            query = query.Where(e => e.DataSource == source);
-        return await query.MinAsync(e => (DateTime?)e.Timestamp, ct);
     }
 
     /// <summary>
@@ -261,7 +59,7 @@ public class CalibrationRepository : ICalibrationRepository
     /// <returns>Number of records deleted.</returns>
     public async Task<int> DeleteBySourceAsync(string source, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.Calibrations
             .Where(e => e.DataSource == source)
             .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
@@ -276,7 +74,7 @@ public class CalibrationRepository : ICalibrationRepository
     /// <returns>Number of records deleted.</returns>
     public async Task<int> DeleteByTimeRangeAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var query = ctx.Calibrations.AsQueryable();
 
         if (from.HasValue)
@@ -285,60 +83,5 @@ public class CalibrationRepository : ICalibrationRepository
             query = query.Where(e => e.Timestamp < to.Value);
 
         return await query.ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<Calibration>> BulkCreateAsync(
-        IEnumerable<Calibration> records,
-        CancellationToken ct = default)
-    {
-        var entities = records.Select(CalibrationMapper.ToEntity).ToList();
-        if (entities.Count == 0)
-            return [];
-
-        // Batch-level dedup: keep first occurrence per LegacyId
-        entities = entities
-            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-            .Select(g => g.First())
-            .ToList();
-
-        // DB-level dedup: filter out records whose LegacyId already exists
-        var legacyIds = entities
-            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-            .Select(e => e.LegacyId!)
-            .ToHashSet();
-
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var strategy = ctx.Database.CreateExecutionStrategy();
-        return await strategy.ExecuteAsync(async () =>
-        {
-            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-            if (legacyIds.Count > 0)
-            {
-                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<CalibrationEntity>(legacyIds, ct);
-
-                entities = entities
-                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
-                    .ToList();
-            }
-
-            if (entities.Count == 0)
-            {
-                await tx.CommitAsync(ct);
-                return [];
-            }
-
-            const int batchSize = 500;
-            foreach (var batch in entities.Chunk(batchSize))
-            {
-                ctx.Calibrations.AddRange(batch);
-                await ctx.SaveChangesAsync(ct);
-                ctx.ChangeTracker.Clear();
-            }
-
-            await tx.CommitAsync(ct);
-            return entities.Select(CalibrationMapper.ToDomainModel);
-        });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CalibrationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CalibrationRepository.cs
@@ -20,6 +20,8 @@ public class CalibrationRepository : V4RepositoryBase<Calibration, CalibrationEn
     /// </summary>
     /// <param name="contextFactory">The tenant database context factory.</param>
     /// <param name="logger">The logger instance.</param>
+    // logger is unused for this LegacyId-only type but retained for DI + direct test construction;
+    // it moves to the base ctor when the DeduplicationService participants (which log) are migrated.
     public CalibrationRepository(ITenantDbContextFactory contextFactory, ILogger<CalibrationRepository> logger)
         : base(contextFactory)
     {

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
@@ -340,10 +340,17 @@ public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntit
                     await ctx.SaveChangesAsync(ct);
                     ctx.ChangeTracker.Clear();
                 }
+            }
 
-                // Insert-time deduplication: link saved records to canonical groups.
-                // Only runs on newly inserted entities — updated-in-place rows were
-                // already linked when first inserted.
+            await tx.CommitAsync(ct);
+
+            // Insert-time deduplication runs AFTER commit: the ingested rows are durably
+            // persisted first, and dedup linking is best-effort (a failure is logged and
+            // healed by the reconcile service, not allowed to roll back the insert).
+            // Only runs on newly inserted entities — updated-in-place rows were already
+            // linked when first inserted.
+            if (entities.Count > 0)
+            {
                 try
                 {
                     var dedupInputs = entities.Select(e => new DeduplicationInput(
@@ -361,7 +368,6 @@ public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntit
                 }
             }
 
-            await tx.CommitAsync(ct);
             return updatedEntities.Concat(entities).Select(CarbIntakeMapper.ToDomainModel);
         });
     }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
@@ -210,148 +210,101 @@ public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntit
     }
 
     /// <summary>
-    /// Performs a bulk creation of carbohydrate intake records, handling deduplication.
+    /// SyncId-upsert split: intra-batch keep-last per (DataSource, SyncIdentifier), then match existing
+    /// rows in the DB by that key and update them in place. Persists the updates inside the transaction
+    /// before returning so the base's insert loop (which clears the tracker) doesn't lose them.
     /// </summary>
-    /// <param name="records">The collection of records to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>A collection of created records.</returns>
-    public override async Task<IEnumerable<CarbIntake>> BulkCreateAsync(
-        IEnumerable<CarbIntake> records,
-        CancellationToken ct = default
-    )
+    protected override async Task<(List<CarbIntakeEntity> Updated, List<CarbIntakeEntity> ToInsert)> SplitUpsertsAsync(
+        NocturneDbContext ctx, List<CarbIntakeEntity> entities, CancellationToken ct)
     {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        var strategy = ctx.Database.CreateExecutionStrategy();
-        return await strategy.ExecuteAsync(async () =>
+        // Intra-batch SyncIdentifier dedup: keep last occurrence per
+        // (DataSource, SyncIdentifier). Records without both keys keep a
+        // unique grouping key so they're not collapsed.
+        entities = entities
+            .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
+                ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
+                : $"id|{e.Id}")
+            .Select(g => g.Last())
+            .ToList();
+
+        // DB-level SyncIdentifier upsert: match any existing rows keyed by
+        // (DataSource, SyncIdentifier) and update them in place. Everything
+        // else falls through to the insert path below.
+        var syncKeyed = entities
+            .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
+            .ToList();
+
+        var updatedEntities = new List<CarbIntakeEntity>();
+        if (syncKeyed.Count == 0)
+            return (updatedEntities, entities);
+
+        var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
+        var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
+
+        // Over-fetches by a Cartesian amount; the partial unique index
+        // on (tenant_id, data_source, sync_identifier) keeps this cheap.
+        var existingRows = await ctx.CarbIntakes.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId)
+            .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
+            .ToListAsync(ct);
+
+        var existingByKey = existingRows
+            .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
+            .ToDictionary(g => g.Key, g => g.First());
+
+        var toInsert = new List<CarbIntakeEntity>();
+        foreach (var entity in entities)
         {
-            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-            var entities = records.Select(CarbIntakeMapper.ToEntity).ToList();
-            if (entities.Count == 0)
+            var hasKey = !string.IsNullOrEmpty(entity.DataSource)
+                && !string.IsNullOrEmpty(entity.SyncIdentifier);
+            if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
             {
-                await tx.CommitAsync(ct);
-                return [];
+                // Update in place — mirror the single-record CreateAsync path via the mapper.
+                var domain = CarbIntakeMapper.ToDomainModel(entity);
+                CarbIntakeMapper.UpdateEntity(existing, domain);
+                updatedEntities.Add(existing);
             }
-
-            // Intra-batch SyncIdentifier dedup: keep last occurrence per
-            // (DataSource, SyncIdentifier). Records without both keys keep a
-            // unique grouping key so they're not collapsed.
-            entities = entities
-                .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
-                    ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
-                    : $"id|{e.Id}")
-                .Select(g => g.Last())
-                .ToList();
-
-            // DB-level SyncIdentifier upsert: match any existing rows keyed by
-            // (DataSource, SyncIdentifier) and update them in place. Everything
-            // else falls through to the insert path below.
-            var syncKeyed = entities
-                .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
-                .ToList();
-
-            var updatedEntities = new List<CarbIntakeEntity>();
-            if (syncKeyed.Count > 0)
+            else
             {
-                var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
-                var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
-
-                // Over-fetches by a Cartesian amount; the partial unique index
-                // on (tenant_id, data_source, sync_identifier) keeps this cheap.
-                var existingRows = await ctx.CarbIntakes.IgnoreQueryFilters()
-                    .Where(e => e.TenantId == ctx.TenantId)
-                    .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
-                    .ToListAsync(ct);
-
-                var existingByKey = existingRows
-                    .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
-                    .ToDictionary(g => g.Key, g => g.First());
-
-                var toInsert = new List<CarbIntakeEntity>();
-                foreach (var entity in entities)
-                {
-                    var hasKey = !string.IsNullOrEmpty(entity.DataSource)
-                        && !string.IsNullOrEmpty(entity.SyncIdentifier);
-                    if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
-                    {
-                        // Update in place — mirror the single-record CreateAsync path via the mapper.
-                        var domain = CarbIntakeMapper.ToDomainModel(entity);
-                        CarbIntakeMapper.UpdateEntity(existing, domain);
-                        updatedEntities.Add(existing);
-                    }
-                    else
-                    {
-                        toInsert.Add(entity);
-                    }
-                }
-
-                if (updatedEntities.Count > 0)
-                {
-                    // Persist updates before the insert-chunking loop clears the tracker.
-                    await ctx.SaveChangesAsync(ct);
-                }
-
-                entities = toInsert;
+                toInsert.Add(entity);
             }
+        }
 
-            // Batch-level dedup: keep first occurrence per LegacyId
-            entities = entities
-                .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-                .Select(g => g.First())
-                .ToList();
+        if (updatedEntities.Count > 0)
+        {
+            // Persist updates before the insert-chunking loop clears the tracker.
+            await ctx.SaveChangesAsync(ct);
+        }
 
-            // DB-level dedup: filter out records whose LegacyId already exists
-            var legacyIds = entities
-                .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-                .Select(e => e.LegacyId!)
-                .ToHashSet();
+        return (updatedEntities, toInsert);
+    }
 
-            if (legacyIds.Count > 0)
-            {
-                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<CarbIntakeEntity>(legacyIds, ct);
+    /// <summary>
+    /// Insert-time deduplication runs AFTER commit: the ingested rows are durably persisted first, and
+    /// dedup linking is best-effort (a failure is logged and healed by the reconcile service, not allowed
+    /// to roll back the insert). Only runs on newly inserted entities — updated-in-place rows were already
+    /// linked when first inserted.
+    /// </summary>
+    protected override async Task PostCommitDedupAsync(
+        NocturneDbContext ctx, IReadOnlyList<CarbIntakeEntity> inserted, CancellationToken ct)
+    {
+        if (inserted.Count == 0)
+            return;
 
-                entities = entities
-                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
-                    .ToList();
-            }
+        try
+        {
+            var dedupInputs = inserted.Select(e => new DeduplicationInput(
+                RecordId: e.Id,
+                Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
+                DataSource: e.DataSource ?? "unknown",
+                Criteria: new MatchCriteria { Carbs = e.Carbs, CarbsTolerance = 1.0 }
+            )).ToList();
 
-            if (entities.Count > 0)
-            {
-                const int batchSize = 500;
-                foreach (var batch in entities.Chunk(batchSize))
-                {
-                    ctx.CarbIntakes.AddRange(batch);
-                    await ctx.SaveChangesAsync(ct);
-                    ctx.ChangeTracker.Clear();
-                }
-            }
-
-            await tx.CommitAsync(ct);
-
-            // Insert-time deduplication runs AFTER commit: the ingested rows are durably
-            // persisted first, and dedup linking is best-effort (a failure is logged and
-            // healed by the reconcile service, not allowed to roll back the insert).
-            // Only runs on newly inserted entities — updated-in-place rows were already
-            // linked when first inserted.
-            if (entities.Count > 0)
-            {
-                try
-                {
-                    var dedupInputs = entities.Select(e => new DeduplicationInput(
-                        RecordId: e.Id,
-                        Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                        DataSource: e.DataSource ?? "unknown",
-                        Criteria: new MatchCriteria { Carbs = e.Carbs, CarbsTolerance = 1.0 }
-                    )).ToList();
-
-                    await _deduplicationService.DeduplicateBatchAsync(RecordType.CarbIntake, dedupInputs, ct);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "CarbIntake", entities.Count);
-                }
-            }
-
-            return updatedEntities.Concat(entities).Select(CarbIntakeMapper.ToDomainModel);
-        });
+            await _deduplicationService.DeduplicateBatchAsync(RecordType.CarbIntake, dedupInputs, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "CarbIntake", inserted.Count);
+        }
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
@@ -13,12 +13,15 @@ using Nocturne.Infrastructure.Data.Services;
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
-/// Repository for managing carbohydrate intake records in the database.
-/// Includes support for cross-connector deduplication.
+/// Repository for managing carbohydrate intake records in the database. A SyncId-upsert +
+/// DeduplicationService participant, so it inherits the shared CRUD/soft-delete surface from
+/// <see cref="V4RepositoryBase{TModel,TEntity}"/> and keeps only the dedup-specific behaviour as
+/// overrides (extended <c>GetAsync</c> with the non-primary LinkedRecords filter + keyset cursor,
+/// SyncId-upsert <c>CreateAsync</c>/<c>BulkCreateAsync</c>, the non-primary-excluding <c>CountAsync</c>,
+/// and audited soft-deletes).
 /// </summary>
-public class CarbIntakeRepository : ICarbIntakeRepository
+public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntity>, ICarbIntakeRepository
 {
-    private readonly ITenantDbContextFactory _contextFactory;
     private readonly IDeduplicationService _deduplicationService;
     private readonly IAuditContext _auditContext;
     private readonly ILogger<CarbIntakeRepository> _logger;
@@ -35,12 +38,32 @@ public class CarbIntakeRepository : ICarbIntakeRepository
         IDeduplicationService deduplicationService,
         IAuditContext auditContext,
         ILogger<CarbIntakeRepository> logger)
+        : base(contextFactory)
     {
-        _contextFactory = contextFactory;
         _deduplicationService = deduplicationService;
         _auditContext = auditContext;
         _logger = logger;
     }
+
+    /// <inheritdoc />
+    protected override CarbIntakeEntity ToEntity(CarbIntake model) => CarbIntakeMapper.ToEntity(model);
+
+    /// <inheritdoc />
+    protected override CarbIntake ToDomain(CarbIntakeEntity entity) => CarbIntakeMapper.ToDomainModel(entity);
+
+    /// <inheritdoc />
+    protected override void ApplyUpdate(CarbIntakeEntity target, CarbIntake source) => CarbIntakeMapper.UpdateEntity(target, source);
+
+    /// <summary>
+    /// Routes the base 7-arg form through the extended carb-intake query (non-primary LinkedRecords
+    /// exclusion + ordering), preserving the pre-base default-interface bridge behaviour.
+    /// </summary>
+    public override Task<IEnumerable<CarbIntake>> GetAsync(
+        DateTime? from, DateTime? to, string? device, string? source,
+        int limit = 100, int offset = 0, bool descending = true,
+        CancellationToken ct = default)
+        => GetAsync(from, to, device, source, limit, offset, descending,
+            nativeOnly: false, afterTimestamp: null, afterId: null, ct);
 
     /// <summary>
     /// Gets carbohydrate intake records based on filter criteria.
@@ -72,7 +95,7 @@ public class CarbIntakeRepository : ICarbIntakeRepository
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var query = ctx.CarbIntakes.AsNoTracking().AsQueryable();
         if (from.HasValue)
             query = query.Where(e => e.Timestamp >= from.Value);
@@ -114,38 +137,6 @@ public class CarbIntakeRepository : ICarbIntakeRepository
     }
 
     /// <summary>
-    /// Gets a carbohydrate intake record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The carbohydrate intake, or null if not found.</returns>
-    public async Task<CarbIntake?> GetByIdAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.CarbIntakes.FindAsync([id], ct);
-        return entity is null ? null : CarbIntakeMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Gets a carbohydrate intake record by its legacy (MongoDB) identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The carbohydrate intake, or null if not found.</returns>
-    public async Task<CarbIntake?> GetByLegacyIdAsync(
-        string legacyId,
-        CancellationToken ct = default
-    )
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.CarbIntakes.FirstOrDefaultAsync(
-            e => e.LegacyId == legacyId,
-            ct
-        );
-        return entity is null ? null : CarbIntakeMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
     /// Creates a new carbohydrate intake record. When <c>DataSource</c> and
     /// <c>SyncIdentifier</c> match an existing row for this tenant, the record is
     /// updated in place rather than inserted — making the operation idempotent
@@ -155,9 +146,9 @@ public class CarbIntakeRepository : ICarbIntakeRepository
     /// <param name="model">The carbohydrate intake to create.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The created or updated carbohydrate intake.</returns>
-    public async Task<CarbIntake> CreateAsync(CarbIntake model, CancellationToken ct = default)
+    public override async Task<CarbIntake> CreateAsync(CarbIntake model, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         if (!string.IsNullOrEmpty(model.DataSource) && !string.IsNullOrEmpty(model.SyncIdentifier))
         {
             var existing = await ctx.CarbIntakes
@@ -179,114 +170,15 @@ public class CarbIntakeRepository : ICarbIntakeRepository
     }
 
     /// <summary>
-    /// Updates an existing carbohydrate intake record.
-    /// </summary>
-    /// <param name="id">The unique identifier of the record to update.</param>
-    /// <param name="model">The updated record data.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The updated carbohydrate intake.</returns>
-    public async Task<CarbIntake> UpdateAsync(
-        Guid id,
-        CarbIntake model,
-        CancellationToken ct = default
-    )
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity =
-            await ctx.CarbIntakes.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"CarbIntake {id} not found");
-        CarbIntakeMapper.UpdateEntity(entity, model);
-        await ctx.SaveChangesAsync(ct);
-        return CarbIntakeMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Deletes a carbohydrate intake record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity =
-            await ctx.CarbIntakes.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"CarbIntake {id} not found");
-        entity.DeletedAt = DateTime.UtcNow;
-        await ctx.SaveChangesAsync(ct);
-    }
-
-    /// <inheritdoc />
-    public async Task<CarbIntake> RestoreAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.CarbIntakes.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
-            .FirstOrDefaultAsync(ct)
-            ?? throw new KeyNotFoundException($"Soft-deleted CarbIntake {id} not found");
-        entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return CarbIntakeMapper.ToDomainModel(entity);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<CarbIntake>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var idSet = ids.ToHashSet();
-        var entities = await ctx.CarbIntakes.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
-            .ToListAsync(ct);
-        foreach (var entity in entities)
-            entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return entities.Select(CarbIntakeMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<CarbIntake>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entities = await ctx.CarbIntakes.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .OrderByDescending(e => e.DeletedAt)
-            .Skip(offset).Take(limit)
-            .AsNoTracking()
-            .ToListAsync(ct);
-        return entities.Select(CarbIntakeMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.CarbIntakes.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .CountAsync(ct);
-    }
-
-    /// <summary>
-    /// Returns the timestamp of the most recently stored record, optionally scoped to a data source.
-    /// Used by connectors to resume per-source sync without re-fetching already-stored data.
-    /// </summary>
-    public async Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.CarbIntakes.AsNoTracking().AsQueryable();
-        if (source != null)
-            query = query.Where(e => e.DataSource == source);
-        return await query.MaxAsync(e => (DateTime?)e.Timestamp, ct);
-    }
-
-    /// <summary>
     /// Counts carbohydrate intake records within a timestamp range.
     /// </summary>
     /// <param name="from">Optional start timestamp filter.</param>
     /// <param name="to">Optional end timestamp filter.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The count of matching records.</returns>
-    public async Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
+    public override async Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var query = ctx.CarbIntakes.AsNoTracking().AsQueryable();
         if (from.HasValue)
             query = query.Where(e => e.Timestamp >= from.Value);
@@ -313,7 +205,7 @@ public class CarbIntakeRepository : ICarbIntakeRepository
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entities = await ctx
             .CarbIntakes.AsNoTracking()
             .Where(e => e.CorrelationId == correlationId)
@@ -327,9 +219,9 @@ public class CarbIntakeRepository : ICarbIntakeRepository
     /// <param name="legacyId">The legacy identifier.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
+    public override async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
             ctx.CarbIntakes.Where(e => e.LegacyId == legacyId), _auditContext, ct);
     }
@@ -343,7 +235,7 @@ public class CarbIntakeRepository : ICarbIntakeRepository
     /// <returns>The number of deleted records.</returns>
     public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
             ctx.CarbIntakes.Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier),
             _auditContext, ct);
@@ -355,12 +247,12 @@ public class CarbIntakeRepository : ICarbIntakeRepository
     /// <param name="records">The collection of records to create.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>A collection of created records.</returns>
-    public async Task<IEnumerable<CarbIntake>> BulkCreateAsync(
+    public override async Task<IEnumerable<CarbIntake>> BulkCreateAsync(
         IEnumerable<CarbIntake> records,
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var strategy = ctx.Database.CreateExecutionStrategy();
         return await strategy.ExecuteAsync(async () =>
         {

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
@@ -53,6 +53,14 @@ public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntit
     protected override void ApplyUpdate(CarbIntakeEntity target, CarbIntake source) => CarbIntakeMapper.UpdateEntity(target, source);
 
     /// <summary>
+    /// Excludes non-primary cross-connector duplicates so <see cref="V4RepositoryBase{TModel,TEntity}.CountAsync"/>
+    /// matches the rows <c>GetAsync</c> returns (otherwise pagination totals are inflated by duplicate
+    /// meals imported from multiple connectors). Mirrors the inline filter in the extended <c>GetAsync</c>.
+    /// </summary>
+    protected override IQueryable<CarbIntakeEntity> ApplyReadVisibility(IQueryable<CarbIntakeEntity> query, NocturneDbContext ctx) =>
+        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == "carbintake" && !lr.IsPrimary && lr.RecordId == b.Id));
+
+    /// <summary>
     /// Routes the base 7-arg form through the extended carb-intake query (non-primary LinkedRecords
     /// exclusion + ordering), preserving the pre-base default-interface bridge behaviour.
     /// </summary>
@@ -165,31 +173,6 @@ public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntit
         ctx.CarbIntakes.Add(entity);
         await ctx.SaveChangesAsync(ct);
         return CarbIntakeMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Counts carbohydrate intake records within a timestamp range.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The count of matching records.</returns>
-    public override async Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
-    {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        var query = ctx.CarbIntakes.AsNoTracking().AsQueryable();
-        if (from.HasValue)
-            query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue)
-            query = query.Where(e => e.Timestamp <= to.Value);
-
-        // Exclude non-primary duplicates from cross-connector deduplication so the
-        // count matches the rows GetAsync returns (otherwise pagination totals are
-        // inflated by duplicate meals imported from multiple connectors).
-        query = query.Where(b => !ctx.LinkedRecords
-            .Any(lr => lr.RecordType == "carbintake" && !lr.IsPrimary && lr.RecordId == b.Id));
-
-        return await query.CountAsync(ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
@@ -23,7 +23,6 @@ namespace Nocturne.Infrastructure.Data.Repositories.V4;
 public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntity>, ICarbIntakeRepository
 {
     private readonly IDeduplicationService _deduplicationService;
-    private readonly IAuditContext _auditContext;
     private readonly ILogger<CarbIntakeRepository> _logger;
 
     /// <summary>
@@ -38,10 +37,9 @@ public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntit
         IDeduplicationService deduplicationService,
         IAuditContext auditContext,
         ILogger<CarbIntakeRepository> logger)
-        : base(contextFactory)
+        : base(contextFactory, auditContext)
     {
         _deduplicationService = deduplicationService;
-        _auditContext = auditContext;
         _logger = logger;
     }
 
@@ -214,19 +212,6 @@ public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntit
     }
 
     /// <summary>
-    /// Deletes a carbohydrate intake record by its legacy identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The number of deleted records.</returns>
-    public override async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        return await ctx.AuditedSoftDeleteAsync(
-            ctx.CarbIntakes.Where(e => e.LegacyId == legacyId), _auditContext, ct);
-    }
-
-    /// <summary>
     /// Deletes carbohydrate intake records matching the given data source and sync identifier.
     /// </summary>
     /// <param name="dataSource">The external data source name.</param>
@@ -238,7 +223,7 @@ public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntit
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
             ctx.CarbIntakes.Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier),
-            _auditContext, ct);
+            AuditContext, ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
@@ -302,7 +302,7 @@ public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntit
 
             await _deduplicationService.DeduplicateBatchAsync(RecordType.CarbIntake, dedupInputs, ct);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "CarbIntake", inserted.Count);
         }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbRatioScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbRatioScheduleRepository.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
@@ -20,10 +21,11 @@ public class CarbRatioScheduleRepository : V4RepositoryBase<CarbRatioSchedule, C
     /// Initializes a new instance of the <see cref="CarbRatioScheduleRepository"/> class.
     /// </summary>
     /// <param name="contextFactory">The tenant database context factory.</param>
+    /// <param name="auditContext">The audit context for tracking mutations (used by the base soft-delete path).</param>
     /// <param name="logger">The logger instance.</param>
     // logger is unused for this LegacyId-only type but retained for DI + direct test construction.
-    public CarbRatioScheduleRepository(ITenantDbContextFactory contextFactory, ILogger<CarbRatioScheduleRepository> logger)
-        : base(contextFactory)
+    public CarbRatioScheduleRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext, ILogger<CarbRatioScheduleRepository> logger)
+        : base(contextFactory, auditContext)
     {
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbRatioScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbRatioScheduleRepository.cs
@@ -3,94 +3,39 @@ using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
-using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
-/// Repository for managing carbohydrate ratio schedules in the database.
+/// Repository for managing carbohydrate ratio schedules in the database. A LegacyId-only type (no
+/// SyncId-upsert, no DeduplicationService participation), so it uses the shared
+/// <see cref="V4RepositoryBase{TModel,TEntity}"/> behaviour unchanged plus the carb-ratio-specific
+/// queries below.
 /// </summary>
-public class CarbRatioScheduleRepository : ICarbRatioScheduleRepository
+public class CarbRatioScheduleRepository : V4RepositoryBase<CarbRatioSchedule, CarbRatioScheduleEntity>, ICarbRatioScheduleRepository
 {
-    private readonly ITenantDbContextFactory _contextFactory;
-    private readonly ILogger<CarbRatioScheduleRepository> _logger;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="CarbRatioScheduleRepository"/> class.
     /// </summary>
     /// <param name="contextFactory">The tenant database context factory.</param>
     /// <param name="logger">The logger instance.</param>
+    // logger is unused for this LegacyId-only type but retained for DI + direct test construction.
     public CarbRatioScheduleRepository(ITenantDbContextFactory contextFactory, ILogger<CarbRatioScheduleRepository> logger)
+        : base(contextFactory)
     {
-        _contextFactory = contextFactory;
-        _logger = logger;
     }
 
-    /// <summary>
-    /// Gets carbohydrate ratio schedules based on filter criteria.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="device">Optional device filter.</param>
-    /// <param name="source">Optional data source filter.</param>
-    /// <param name="limit">The maximum number of records to return.</param>
-    /// <param name="offset">The number of records to skip.</param>
-    /// <param name="descending">Whether to sort by timestamp in descending order.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>A collection of carbohydrate ratio schedules.</returns>
-    public async Task<IEnumerable<CarbRatioSchedule>> GetAsync(
-        DateTime? from,
-        DateTime? to,
-        string? device,
-        string? source,
-        int limit = 100,
-        int offset = 0,
-        bool descending = true,
-        CancellationToken ct = default
-    )
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.CarbRatioSchedules.AsNoTracking().AsQueryable();
-        if (from.HasValue)
-            query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue)
-            query = query.Where(e => e.Timestamp <= to.Value);
-        if (device != null)
-            query = query.Where(e => e.Device == device);
-        if (source != null)
-            query = query.Where(e => e.DataSource == source);
-        query = descending ? query.OrderByDescending(e => e.Timestamp) : query.OrderBy(e => e.Timestamp);
-        var entities = await query.Skip(offset).Take(limit).ToListAsync(ct);
-        return entities.Select(CarbRatioScheduleMapper.ToDomainModel);
-    }
+    /// <inheritdoc />
+    protected override CarbRatioScheduleEntity ToEntity(CarbRatioSchedule model) => CarbRatioScheduleMapper.ToEntity(model);
 
-    /// <summary>
-    /// Gets a carbohydrate ratio schedule by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The carbohydrate ratio schedule, or null if not found.</returns>
-    public async Task<CarbRatioSchedule?> GetByIdAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.CarbRatioSchedules.FindAsync([id], ct);
-        return entity is null ? null : CarbRatioScheduleMapper.ToDomainModel(entity);
-    }
+    /// <inheritdoc />
+    protected override CarbRatioSchedule ToDomain(CarbRatioScheduleEntity entity) => CarbRatioScheduleMapper.ToDomainModel(entity);
 
-    /// <summary>
-    /// Gets a carbohydrate ratio schedule by its legacy (MongoDB) identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The carbohydrate ratio schedule, or null if not found.</returns>
-    public async Task<CarbRatioSchedule?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.CarbRatioSchedules.FirstOrDefaultAsync(e => e.LegacyId == legacyId, ct);
-        return entity is null ? null : CarbRatioScheduleMapper.ToDomainModel(entity);
-    }
+    /// <inheritdoc />
+    protected override void ApplyUpdate(CarbRatioScheduleEntity target, CarbRatioSchedule source) =>
+        CarbRatioScheduleMapper.UpdateEntity(target, source);
 
     /// <summary>
     /// Gets carbohydrate ratio schedules by profile name.
@@ -103,7 +48,7 @@ public class CarbRatioScheduleRepository : ICarbRatioScheduleRepository
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entities = await ctx
             .CarbRatioSchedules.AsNoTracking()
             .Where(e => e.ProfileName == profileName)
@@ -122,7 +67,7 @@ public class CarbRatioScheduleRepository : ICarbRatioScheduleRepository
     public async Task<CarbRatioSchedule?> GetActiveAtAsync(
         string profileName, DateTime timestamp, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entity = await ctx.CarbRatioSchedules
             .AsNoTracking()
             .Where(e => e.ProfileName == profileName && e.Timestamp <= timestamp)
@@ -133,116 +78,6 @@ public class CarbRatioScheduleRepository : ICarbRatioScheduleRepository
     }
 
     /// <summary>
-    /// Creates a new carbohydrate ratio schedule record.
-    /// </summary>
-    /// <param name="model">The carbohydrate ratio schedule to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The created carbohydrate ratio schedule.</returns>
-    public async Task<CarbRatioSchedule> CreateAsync(CarbRatioSchedule model, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = CarbRatioScheduleMapper.ToEntity(model);
-        ctx.CarbRatioSchedules.Add(entity);
-        await ctx.SaveChangesAsync(ct);
-        return CarbRatioScheduleMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Updates an existing carbohydrate ratio schedule record.
-    /// </summary>
-    /// <param name="id">The unique identifier of the schedule to update.</param>
-    /// <param name="model">The updated schedule data.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The updated carbohydrate ratio schedule.</returns>
-    public async Task<CarbRatioSchedule> UpdateAsync(Guid id, CarbRatioSchedule model, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity =
-            await ctx.CarbRatioSchedules.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"CarbRatioSchedule {id} not found");
-        CarbRatioScheduleMapper.UpdateEntity(entity, model);
-        await ctx.SaveChangesAsync(ct);
-        return CarbRatioScheduleMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Deletes a carbohydrate ratio schedule record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity =
-            await ctx.CarbRatioSchedules.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"CarbRatioSchedule {id} not found");
-        entity.DeletedAt = DateTime.UtcNow;
-        await ctx.SaveChangesAsync(ct);
-    }
-
-    /// <inheritdoc />
-    public async Task<CarbRatioSchedule> RestoreAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.CarbRatioSchedules.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
-            .FirstOrDefaultAsync(ct)
-            ?? throw new KeyNotFoundException($"Soft-deleted CarbRatioSchedule {id} not found");
-        entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return CarbRatioScheduleMapper.ToDomainModel(entity);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<CarbRatioSchedule>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var idSet = ids.ToHashSet();
-        var entities = await ctx.CarbRatioSchedules.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
-            .ToListAsync(ct);
-        foreach (var entity in entities)
-            entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return entities.Select(CarbRatioScheduleMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<CarbRatioSchedule>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entities = await ctx.CarbRatioSchedules.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .OrderByDescending(e => e.DeletedAt)
-            .Skip(offset).Take(limit)
-            .AsNoTracking()
-            .ToListAsync(ct);
-        return entities.Select(CarbRatioScheduleMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.CarbRatioSchedules.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .CountAsync(ct);
-    }
-
-    /// <summary>
-    /// Deletes a carbohydrate ratio schedule record by its legacy identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.CarbRatioSchedules.Where(e => e.LegacyId == legacyId)
-            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
-    }
-
-    /// <summary>
     /// Deletes carbohydrate ratio schedule records by legacy identifier prefix.
     /// </summary>
     /// <param name="prefix">The legacy identifier prefix.</param>
@@ -250,28 +85,10 @@ public class CarbRatioScheduleRepository : ICarbRatioScheduleRepository
     /// <returns>The number of deleted records.</returns>
     public async Task<int> DeleteByLegacyIdPrefixAsync(string prefix, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx
             .CarbRatioSchedules.Where(e => e.LegacyId != null && e.LegacyId.StartsWith(prefix))
             .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
-    }
-
-    /// <summary>
-    /// Counts carbohydrate ratio schedule records within a timestamp range.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The count of matching records.</returns>
-    public async Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.CarbRatioSchedules.AsNoTracking().AsQueryable();
-        if (from.HasValue)
-            query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue)
-            query = query.Where(e => e.Timestamp <= to.Value);
-        return await query.CountAsync(ct);
     }
 
     /// <summary>
@@ -285,72 +102,11 @@ public class CarbRatioScheduleRepository : ICarbRatioScheduleRepository
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entities = await ctx
             .CarbRatioSchedules.AsNoTracking()
             .Where(e => e.CorrelationId == correlationId)
             .ToListAsync(ct);
         return entities.Select(CarbRatioScheduleMapper.ToDomainModel);
-    }
-
-    /// <summary>
-    /// Performs a bulk creation of carbohydrate ratio schedule records, handling deduplication.
-    /// </summary>
-    /// <param name="records">The collection of records to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>A collection of created schedules.</returns>
-    public async Task<IEnumerable<CarbRatioSchedule>> BulkCreateAsync(
-        IEnumerable<CarbRatioSchedule> records,
-        CancellationToken ct = default
-    )
-    {
-        var entities = records.Select(CarbRatioScheduleMapper.ToEntity).ToList();
-        if (entities.Count == 0)
-            return [];
-
-        // Batch-level dedup: keep first occurrence per LegacyId
-        entities = entities
-            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-            .Select(g => g.First())
-            .ToList();
-
-        // DB-level dedup: filter out records whose LegacyId already exists
-        var legacyIds = entities
-            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-            .Select(e => e.LegacyId!)
-            .ToHashSet();
-
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var strategy = ctx.Database.CreateExecutionStrategy();
-        return await strategy.ExecuteAsync(async () =>
-        {
-            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-            if (legacyIds.Count > 0)
-            {
-                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<CarbRatioScheduleEntity>(legacyIds, ct);
-
-                entities = entities
-                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
-                    .ToList();
-            }
-
-            if (entities.Count == 0)
-            {
-                await tx.CommitAsync(ct);
-                return [];
-            }
-
-            const int batchSize = 500;
-            foreach (var batch in entities.Chunk(batchSize))
-            {
-                ctx.CarbRatioSchedules.AddRange(batch);
-                await ctx.SaveChangesAsync(ct);
-                ctx.ChangeTracker.Clear();
-            }
-
-            await tx.CommitAsync(ct);
-            return entities.Select(CarbRatioScheduleMapper.ToDomainModel);
-        });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
@@ -22,7 +22,6 @@ namespace Nocturne.Infrastructure.Data.Repositories.V4;
 public class DeviceEventRepository : V4RepositoryBase<DeviceEvent, DeviceEventEntity>, IDeviceEventRepository
 {
     private readonly IDeduplicationService _deduplicationService;
-    private readonly IAuditContext _auditContext;
     private readonly ILogger<DeviceEventRepository> _logger;
 
     /// <summary>
@@ -37,10 +36,9 @@ public class DeviceEventRepository : V4RepositoryBase<DeviceEvent, DeviceEventEn
         IDeduplicationService deduplicationService,
         IAuditContext auditContext,
         ILogger<DeviceEventRepository> logger)
-        : base(contextFactory)
+        : base(contextFactory, auditContext)
     {
         _deduplicationService = deduplicationService;
-        _auditContext = auditContext;
         _logger = logger;
     }
 
@@ -131,19 +129,6 @@ public class DeviceEventRepository : V4RepositoryBase<DeviceEvent, DeviceEventEn
     }
 
     /// <summary>
-    /// Deletes a device event record by its legacy identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The number of deleted records.</returns>
-    public override async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        return await ctx.AuditedSoftDeleteAsync(
-            ctx.DeviceEvents.Where(e => e.LegacyId == legacyId), _auditContext, ct);
-    }
-
-    /// <summary>
     /// Deletes device event records matching the given data source and sync identifier.
     /// </summary>
     /// <param name="dataSource">The external data source name.</param>
@@ -155,7 +140,7 @@ public class DeviceEventRepository : V4RepositoryBase<DeviceEvent, DeviceEventEn
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
             ctx.DeviceEvents.Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier),
-            _auditContext, ct);
+            AuditContext, ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
@@ -151,84 +151,29 @@ public class DeviceEventRepository : V4RepositoryBase<DeviceEvent, DeviceEventEn
     }
 
     /// <summary>
-    /// Performs a bulk creation of device event records, handling deduplication.
+    /// Insert-time deduplication: link saved records to canonical groups (runs after commit).
     /// </summary>
-    /// <param name="records">The collection of records to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>A collection of created records.</returns>
-    public override async Task<IEnumerable<DeviceEvent>> BulkCreateAsync(
-        IEnumerable<DeviceEvent> records,
-        CancellationToken ct = default
-    )
+    protected override async Task PostCommitDedupAsync(
+        NocturneDbContext ctx, IReadOnlyList<DeviceEventEntity> inserted, CancellationToken ct)
     {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        var strategy = ctx.Database.CreateExecutionStrategy();
-        return await strategy.ExecuteAsync(async () =>
+        if (inserted.Count == 0)
+            return;
+
+        try
         {
-            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-            var entities = records.Select(DeviceEventMapper.ToEntity).ToList();
-            if (entities.Count == 0)
-            {
-                await tx.CommitAsync(ct);
-                return [];
-            }
+            var dedupInputs = inserted.Select(e => new DeduplicationInput(
+                RecordId: e.Id,
+                Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
+                DataSource: e.DataSource ?? "unknown",
+                Criteria: new MatchCriteria { EventType = e.EventType }
+            )).ToList();
 
-            // Batch-level dedup: keep first occurrence per LegacyId
-            entities = entities
-                .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-                .Select(g => g.First())
-                .ToList();
-
-            // DB-level dedup: filter out records whose LegacyId already exists
-            var legacyIds = entities
-                .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-                .Select(e => e.LegacyId!)
-                .ToHashSet();
-
-            if (legacyIds.Count > 0)
-            {
-                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<DeviceEventEntity>(legacyIds, ct);
-
-                entities = entities
-                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
-                    .ToList();
-            }
-
-            if (entities.Count == 0)
-            {
-                await tx.CommitAsync(ct);
-                return [];
-            }
-
-            const int batchSize = 500;
-            foreach (var batch in entities.Chunk(batchSize))
-            {
-                ctx.DeviceEvents.AddRange(batch);
-                await ctx.SaveChangesAsync(ct);
-                ctx.ChangeTracker.Clear();
-            }
-
-            await tx.CommitAsync(ct);
-
-            // Insert-time deduplication: link saved records to canonical groups
-            try
-            {
-                var dedupInputs = entities.Select(e => new DeduplicationInput(
-                    RecordId: e.Id,
-                    Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    DataSource: e.DataSource ?? "unknown",
-                    Criteria: new MatchCriteria { EventType = e.EventType }
-                )).ToList();
-
-                await _deduplicationService.DeduplicateBatchAsync(RecordType.DeviceEvent, dedupInputs, ct);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "DeviceEvent", entities.Count);
-            }
-
-            return entities.Select(DeviceEventMapper.ToDomainModel);
-        });
+            await _deduplicationService.DeduplicateBatchAsync(RecordType.DeviceEvent, dedupInputs, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "DeviceEvent", inserted.Count);
+        }
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
@@ -13,12 +13,14 @@ using Nocturne.Infrastructure.Data.Services;
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
-/// Repository for managing device event records in the database.
-/// Includes support for cross-connector deduplication.
+/// Repository for managing device event records in the database. A DeduplicationService participant,
+/// so it inherits the shared CRUD/soft-delete surface from
+/// <see cref="V4RepositoryBase{TModel,TEntity}"/> and keeps only the dedup-specific behaviour as
+/// overrides (extended <c>GetAsync</c> with the non-primary LinkedRecords filter, dedup
+/// <c>BulkCreateAsync</c>, audited soft-deletes) plus the event-type query helpers.
 /// </summary>
-public class DeviceEventRepository : IDeviceEventRepository
+public class DeviceEventRepository : V4RepositoryBase<DeviceEvent, DeviceEventEntity>, IDeviceEventRepository
 {
-    private readonly ITenantDbContextFactory _contextFactory;
     private readonly IDeduplicationService _deduplicationService;
     private readonly IAuditContext _auditContext;
     private readonly ILogger<DeviceEventRepository> _logger;
@@ -35,12 +37,31 @@ public class DeviceEventRepository : IDeviceEventRepository
         IDeduplicationService deduplicationService,
         IAuditContext auditContext,
         ILogger<DeviceEventRepository> logger)
+        : base(contextFactory)
     {
-        _contextFactory = contextFactory;
         _deduplicationService = deduplicationService;
         _auditContext = auditContext;
         _logger = logger;
     }
+
+    /// <inheritdoc />
+    protected override DeviceEventEntity ToEntity(DeviceEvent model) => DeviceEventMapper.ToEntity(model);
+
+    /// <inheritdoc />
+    protected override DeviceEvent ToDomain(DeviceEventEntity entity) => DeviceEventMapper.ToDomainModel(entity);
+
+    /// <inheritdoc />
+    protected override void ApplyUpdate(DeviceEventEntity target, DeviceEvent source) => DeviceEventMapper.UpdateEntity(target, source);
+
+    /// <summary>
+    /// Routes the base 7-arg form through the extended device-event query (non-primary LinkedRecords
+    /// exclusion + ordering), preserving the pre-base default-interface bridge behaviour.
+    /// </summary>
+    public override Task<IEnumerable<DeviceEvent>> GetAsync(
+        DateTime? from, DateTime? to, string? device, string? source,
+        int limit = 100, int offset = 0, bool descending = true,
+        CancellationToken ct = default)
+        => GetAsync(from, to, device, source, limit, offset, descending, nativeOnly: false, ct);
 
     /// <summary>
     /// Gets device event records based on filter criteria.
@@ -68,7 +89,7 @@ public class DeviceEventRepository : IDeviceEventRepository
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var query = ctx.DeviceEvents.AsNoTracking().AsQueryable();
         if (from.HasValue)
             query = query.Where(e => e.Timestamp >= from.Value);
@@ -91,170 +112,6 @@ public class DeviceEventRepository : IDeviceEventRepository
     }
 
     /// <summary>
-    /// Gets a device event record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The device event, or null if not found.</returns>
-    public async Task<DeviceEvent?> GetByIdAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.DeviceEvents.FindAsync([id], ct);
-        return entity is null ? null : DeviceEventMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Gets a device event record by its legacy (MongoDB) identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The device event, or null if not found.</returns>
-    public async Task<DeviceEvent?> GetByLegacyIdAsync(
-        string legacyId,
-        CancellationToken ct = default
-    )
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.DeviceEvents.FirstOrDefaultAsync(
-            e => e.LegacyId == legacyId,
-            ct
-        );
-        return entity is null ? null : DeviceEventMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Creates a new device event record.
-    /// </summary>
-    /// <param name="model">The device event to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The created device event.</returns>
-    public async Task<DeviceEvent> CreateAsync(DeviceEvent model, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = DeviceEventMapper.ToEntity(model);
-        ctx.DeviceEvents.Add(entity);
-        await ctx.SaveChangesAsync(ct);
-        return DeviceEventMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Updates an existing device event record.
-    /// </summary>
-    /// <param name="id">The unique identifier of the record to update.</param>
-    /// <param name="model">The updated record data.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The updated device event.</returns>
-    public async Task<DeviceEvent> UpdateAsync(
-        Guid id,
-        DeviceEvent model,
-        CancellationToken ct = default
-    )
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity =
-            await ctx.DeviceEvents.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"DeviceEvent {id} not found");
-        DeviceEventMapper.UpdateEntity(entity, model);
-        await ctx.SaveChangesAsync(ct);
-        return DeviceEventMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Deletes a device event record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity =
-            await ctx.DeviceEvents.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"DeviceEvent {id} not found");
-        entity.DeletedAt = DateTime.UtcNow;
-        await ctx.SaveChangesAsync(ct);
-    }
-
-    /// <inheritdoc />
-    public async Task<DeviceEvent> RestoreAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.DeviceEvents.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
-            .FirstOrDefaultAsync(ct)
-            ?? throw new KeyNotFoundException($"Soft-deleted DeviceEvent {id} not found");
-        entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return DeviceEventMapper.ToDomainModel(entity);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<DeviceEvent>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var idSet = ids.ToHashSet();
-        var entities = await ctx.DeviceEvents.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
-            .ToListAsync(ct);
-        foreach (var entity in entities)
-            entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return entities.Select(DeviceEventMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<DeviceEvent>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entities = await ctx.DeviceEvents.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .OrderByDescending(e => e.DeletedAt)
-            .Skip(offset).Take(limit)
-            .AsNoTracking()
-            .ToListAsync(ct);
-        return entities.Select(DeviceEventMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.DeviceEvents.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .CountAsync(ct);
-    }
-
-    /// <summary>
-    /// Returns the timestamp of the most recently stored record, optionally scoped to a data source.
-    /// Used by connectors to resume per-source sync without re-fetching already-stored data.
-    /// </summary>
-    public async Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.DeviceEvents.AsNoTracking().AsQueryable();
-        if (source != null)
-            query = query.Where(e => e.DataSource == source);
-        return await query.MaxAsync(e => (DateTime?)e.Timestamp, ct);
-    }
-
-    /// <summary>
-    /// Counts device event records within a timestamp range.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The count of matching records.</returns>
-    public async Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.DeviceEvents.AsNoTracking().AsQueryable();
-        if (from.HasValue)
-            query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue)
-            query = query.Where(e => e.Timestamp <= to.Value);
-        return await query.CountAsync(ct);
-    }
-
-    /// <summary>
     /// Gets device event records by correlation identifier.
     /// </summary>
     /// <param name="correlationId">The correlation identifier.</param>
@@ -265,7 +122,7 @@ public class DeviceEventRepository : IDeviceEventRepository
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entities = await ctx
             .DeviceEvents.AsNoTracking()
             .Where(e => e.CorrelationId == correlationId)
@@ -279,9 +136,9 @@ public class DeviceEventRepository : IDeviceEventRepository
     /// <param name="legacyId">The legacy identifier.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
+    public override async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
             ctx.DeviceEvents.Where(e => e.LegacyId == legacyId), _auditContext, ct);
     }
@@ -295,7 +152,7 @@ public class DeviceEventRepository : IDeviceEventRepository
     /// <returns>The number of deleted records.</returns>
     public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
             ctx.DeviceEvents.Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier),
             _auditContext, ct);
@@ -307,12 +164,12 @@ public class DeviceEventRepository : IDeviceEventRepository
     /// <param name="records">The collection of records to create.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>A collection of created records.</returns>
-    public async Task<IEnumerable<DeviceEvent>> BulkCreateAsync(
+    public override async Task<IEnumerable<DeviceEvent>> BulkCreateAsync(
         IEnumerable<DeviceEvent> records,
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var strategy = ctx.Database.CreateExecutionStrategy();
         return await strategy.ExecuteAsync(async () =>
         {
@@ -391,7 +248,7 @@ public class DeviceEventRepository : IDeviceEventRepository
     /// <returns>The latest device event, or null if none found.</returns>
     public async Task<DeviceEvent?> GetLatestByEventTypeAsync(DeviceEventType eventType, DateTime? asOf, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var eventTypeString = eventType.ToString();
         var query = ctx.DeviceEvents
             .AsNoTracking()
@@ -414,7 +271,7 @@ public class DeviceEventRepository : IDeviceEventRepository
     /// <returns>The latest device event, or null if none found.</returns>
     public async Task<DeviceEvent?> GetLatestByEventTypesAsync(DeviceEventType[] eventTypes, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var eventTypeStrings = eventTypes.Select(t => t.ToString()).ToList();
         var entity = await ctx.DeviceEvents
             .AsNoTracking()

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
@@ -52,6 +52,13 @@ public class DeviceEventRepository : V4RepositoryBase<DeviceEvent, DeviceEventEn
     protected override void ApplyUpdate(DeviceEventEntity target, DeviceEvent source) => DeviceEventMapper.UpdateEntity(target, source);
 
     /// <summary>
+    /// Excludes non-primary cross-connector duplicates so <see cref="V4RepositoryBase{TModel,TEntity}.CountAsync"/>
+    /// matches the rows <c>GetAsync</c> returns. Mirrors the inline filter in the extended <c>GetAsync</c>.
+    /// </summary>
+    protected override IQueryable<DeviceEventEntity> ApplyReadVisibility(IQueryable<DeviceEventEntity> query, NocturneDbContext ctx) =>
+        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == "deviceevent" && !lr.IsPrimary && lr.RecordId == b.Id));
+
+    /// <summary>
     /// Routes the base 7-arg form through the extended device-event query (non-primary LinkedRecords
     /// exclusion + ordering), preserving the pre-base default-interface bridge behaviour.
     /// </summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
@@ -170,7 +170,7 @@ public class DeviceEventRepository : V4RepositoryBase<DeviceEvent, DeviceEventEn
 
             await _deduplicationService.DeduplicateBatchAsync(RecordType.DeviceEvent, dedupInputs, ct);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "DeviceEvent", inserted.Count);
         }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/MeterGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/MeterGlucoseRepository.cs
@@ -3,195 +3,40 @@ using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
-using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
-/// Repository for managing meter glucose (fingerstick) records in the database.
+/// Repository for managing meter glucose (fingerstick) records in the database. A LegacyId-only type
+/// (no SyncId-upsert, no DeduplicationService participation), so it uses the shared
+/// <see cref="V4RepositoryBase{TModel,TEntity}"/> behaviour unchanged plus the meter-glucose-specific
+/// queries below.
 /// </summary>
-public class MeterGlucoseRepository : IMeterGlucoseRepository
+public class MeterGlucoseRepository : V4RepositoryBase<MeterGlucose, MeterGlucoseEntity>, IMeterGlucoseRepository
 {
-    private readonly ITenantDbContextFactory _contextFactory;
-    private readonly ILogger<MeterGlucoseRepository> _logger;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="MeterGlucoseRepository"/> class.
     /// </summary>
     /// <param name="contextFactory">The tenant database context factory.</param>
     /// <param name="logger">The logger instance.</param>
+    // logger is unused for this LegacyId-only type but retained for DI + direct test construction;
+    // it moves to the base ctor when the DeduplicationService participants (which log) are migrated.
     public MeterGlucoseRepository(ITenantDbContextFactory contextFactory, ILogger<MeterGlucoseRepository> logger)
+        : base(contextFactory)
     {
-        _contextFactory = contextFactory;
-        _logger = logger;
-    }
-
-    /// <summary>
-    /// Gets meter glucose records based on filter criteria.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="device">Optional device filter.</param>
-    /// <param name="source">Optional data source filter.</param>
-    /// <param name="limit">The maximum number of records to return.</param>
-    /// <param name="offset">The number of records to skip.</param>
-    /// <param name="descending">Whether to sort by timestamp in descending order.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>A collection of meter glucose records.</returns>
-    public async Task<IEnumerable<MeterGlucose>> GetAsync(
-        DateTime? from, DateTime? to, string? device, string? source,
-        int limit = 100, int offset = 0, bool descending = true,
-        CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.MeterGlucose.AsNoTracking().AsQueryable();
-        if (from.HasValue) query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue) query = query.Where(e => e.Timestamp <= to.Value);
-        if (device != null) query = query.Where(e => e.Device == device);
-        if (source != null) query = query.Where(e => e.DataSource == source);
-        query = descending ? query.OrderByDescending(e => e.Timestamp) : query.OrderBy(e => e.Timestamp);
-        var entities = await query.Skip(offset).Take(limit).ToListAsync(ct);
-        return entities.Select(MeterGlucoseMapper.ToDomainModel);
-    }
-
-    /// <summary>
-    /// Gets a meter glucose record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The meter glucose record, or null if not found.</returns>
-    public async Task<MeterGlucose?> GetByIdAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.MeterGlucose.FindAsync([id], ct);
-        return entity is null ? null : MeterGlucoseMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Gets a meter glucose record by its legacy identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The meter glucose record, or null if not found.</returns>
-    public async Task<MeterGlucose?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.MeterGlucose.FirstOrDefaultAsync(e => e.LegacyId == legacyId, ct);
-        return entity is null ? null : MeterGlucoseMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Creates a new meter glucose record.
-    /// </summary>
-    /// <param name="model">The meter glucose to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The created meter glucose record.</returns>
-    public async Task<MeterGlucose> CreateAsync(MeterGlucose model, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = MeterGlucoseMapper.ToEntity(model);
-        ctx.MeterGlucose.Add(entity);
-        await ctx.SaveChangesAsync(ct);
-        return MeterGlucoseMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Updates an existing meter glucose record.
-    /// </summary>
-    /// <param name="id">The unique identifier of the record to update.</param>
-    /// <param name="model">The updated record data.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The updated meter glucose record.</returns>
-    public async Task<MeterGlucose> UpdateAsync(Guid id, MeterGlucose model, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.MeterGlucose.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"MeterGlucose {id} not found");
-        MeterGlucoseMapper.UpdateEntity(entity, model);
-        await ctx.SaveChangesAsync(ct);
-        return MeterGlucoseMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Deletes a meter glucose record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.MeterGlucose.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"MeterGlucose {id} not found");
-        entity.DeletedAt = DateTime.UtcNow;
-        await ctx.SaveChangesAsync(ct);
     }
 
     /// <inheritdoc />
-    public async Task<MeterGlucose> RestoreAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.MeterGlucose.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
-            .FirstOrDefaultAsync(ct)
-            ?? throw new KeyNotFoundException($"Soft-deleted MeterGlucose {id} not found");
-        entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return MeterGlucoseMapper.ToDomainModel(entity);
-    }
+    protected override MeterGlucoseEntity ToEntity(MeterGlucose model) => MeterGlucoseMapper.ToEntity(model);
 
     /// <inheritdoc />
-    public async Task<IEnumerable<MeterGlucose>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var idSet = ids.ToHashSet();
-        var entities = await ctx.MeterGlucose.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
-            .ToListAsync(ct);
-        foreach (var entity in entities)
-            entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return entities.Select(MeterGlucoseMapper.ToDomainModel);
-    }
+    protected override MeterGlucose ToDomain(MeterGlucoseEntity entity) => MeterGlucoseMapper.ToDomainModel(entity);
 
     /// <inheritdoc />
-    public async Task<IEnumerable<MeterGlucose>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entities = await ctx.MeterGlucose.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .OrderByDescending(e => e.DeletedAt)
-            .Skip(offset).Take(limit)
-            .AsNoTracking()
-            .ToListAsync(ct);
-        return entities.Select(MeterGlucoseMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.MeterGlucose.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .CountAsync(ct);
-    }
-
-    /// <summary>
-    /// Counts meter glucose records within a timestamp range.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The count of matching records.</returns>
-    public async Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.MeterGlucose.AsNoTracking().AsQueryable();
-        if (from.HasValue) query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue) query = query.Where(e => e.Timestamp <= to.Value);
-        return await query.CountAsync(ct);
-    }
+    protected override void ApplyUpdate(MeterGlucoseEntity target, MeterGlucose source) =>
+        MeterGlucoseMapper.UpdateEntity(target, source);
 
     /// <summary>
     /// Gets meter glucose records by correlation identifier.
@@ -201,56 +46,12 @@ public class MeterGlucoseRepository : IMeterGlucoseRepository
     /// <returns>A collection of meter glucose records.</returns>
     public async Task<IEnumerable<MeterGlucose>> GetByCorrelationIdAsync(Guid correlationId, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entities = await ctx.MeterGlucose
             .AsNoTracking()
             .Where(e => e.CorrelationId == correlationId)
             .ToListAsync(ct);
         return entities.Select(MeterGlucoseMapper.ToDomainModel);
-    }
-
-    /// <summary>
-    /// Deletes a meter glucose record by its legacy identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.MeterGlucose
-            .Where(e => e.LegacyId == legacyId)
-            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
-    }
-
-    /// <summary>
-    /// Gets the timestamp of the latest meter glucose record.
-    /// </summary>
-    /// <param name="source">Optional data source filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The latest timestamp, or null if no records found.</returns>
-    public async Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.MeterGlucose.AsNoTracking().AsQueryable();
-        if (source != null)
-            query = query.Where(e => e.DataSource == source);
-        return await query.MaxAsync(e => (DateTime?)e.Timestamp, ct);
-    }
-
-    /// <summary>
-    /// Gets the timestamp of the oldest meter glucose record.
-    /// </summary>
-    /// <param name="source">Optional data source filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The oldest timestamp, or null if no records found.</returns>
-    public async Task<DateTime?> GetOldestTimestampAsync(string? source = null, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.MeterGlucose.AsNoTracking().AsQueryable();
-        if (source != null)
-            query = query.Where(e => e.DataSource == source);
-        return await query.MinAsync(e => (DateTime?)e.Timestamp, ct);
     }
 
     /// <summary>
@@ -261,7 +62,7 @@ public class MeterGlucoseRepository : IMeterGlucoseRepository
     /// <returns>Number of records deleted.</returns>
     public async Task<int> DeleteBySourceAsync(string source, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.MeterGlucose
             .Where(e => e.DataSource == source)
             .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
@@ -276,7 +77,7 @@ public class MeterGlucoseRepository : IMeterGlucoseRepository
     /// <returns>Number of records deleted.</returns>
     public async Task<int> DeleteByTimeRangeAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var query = ctx.MeterGlucose.AsQueryable();
 
         if (from.HasValue)
@@ -285,60 +86,5 @@ public class MeterGlucoseRepository : IMeterGlucoseRepository
             query = query.Where(e => e.Timestamp < to.Value);
 
         return await query.ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<MeterGlucose>> BulkCreateAsync(
-        IEnumerable<MeterGlucose> records,
-        CancellationToken ct = default)
-    {
-        var entities = records.Select(MeterGlucoseMapper.ToEntity).ToList();
-        if (entities.Count == 0)
-            return [];
-
-        // Batch-level dedup: keep first occurrence per LegacyId
-        entities = entities
-            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-            .Select(g => g.First())
-            .ToList();
-
-        // DB-level dedup: filter out records whose LegacyId already exists
-        var legacyIds = entities
-            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-            .Select(e => e.LegacyId!)
-            .ToHashSet();
-
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var strategy = ctx.Database.CreateExecutionStrategy();
-        return await strategy.ExecuteAsync(async () =>
-        {
-            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-            if (legacyIds.Count > 0)
-            {
-                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<MeterGlucoseEntity>(legacyIds, ct);
-
-                entities = entities
-                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
-                    .ToList();
-            }
-
-            if (entities.Count == 0)
-            {
-                await tx.CommitAsync(ct);
-                return [];
-            }
-
-            const int batchSize = 500;
-            foreach (var batch in entities.Chunk(batchSize))
-            {
-                ctx.MeterGlucose.AddRange(batch);
-                await ctx.SaveChangesAsync(ct);
-                ctx.ChangeTracker.Clear();
-            }
-
-            await tx.CommitAsync(ct);
-            return entities.Select(MeterGlucoseMapper.ToDomainModel);
-        });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/MeterGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/MeterGlucoseRepository.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
@@ -20,11 +21,11 @@ public class MeterGlucoseRepository : V4RepositoryBase<MeterGlucose, MeterGlucos
     /// Initializes a new instance of the <see cref="MeterGlucoseRepository"/> class.
     /// </summary>
     /// <param name="contextFactory">The tenant database context factory.</param>
+    /// <param name="auditContext">The audit context for tracking mutations (used by the base soft-delete path).</param>
     /// <param name="logger">The logger instance.</param>
-    // logger is unused for this LegacyId-only type but retained for DI + direct test construction;
-    // it moves to the base ctor when the DeduplicationService participants (which log) are migrated.
-    public MeterGlucoseRepository(ITenantDbContextFactory contextFactory, ILogger<MeterGlucoseRepository> logger)
-        : base(contextFactory)
+    // logger is unused for this LegacyId-only type but retained for DI + direct test construction.
+    public MeterGlucoseRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext, ILogger<MeterGlucoseRepository> logger)
+        : base(contextFactory, auditContext)
     {
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
@@ -12,12 +12,14 @@ using Nocturne.Infrastructure.Data.Services;
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
-/// Repository for managing note records in the database.
-/// Includes support for cross-connector deduplication.
+/// Repository for managing note records in the database. A DeduplicationService participant, so it
+/// inherits the shared CRUD/soft-delete surface from <see cref="V4RepositoryBase{TModel,TEntity}"/>
+/// and keeps only the dedup-specific behaviour as overrides (extended <c>GetAsync</c> with the
+/// non-primary LinkedRecords filter, dedup <c>BulkCreateAsync</c>). Soft-deletes use the plain
+/// (non-audited) path, matching the base.
 /// </summary>
-public class NoteRepository : INoteRepository
+public class NoteRepository : V4RepositoryBase<Note, NoteEntity>, INoteRepository
 {
-    private readonly ITenantDbContextFactory _contextFactory;
     private readonly IDeduplicationService _deduplicationService;
     private readonly ILogger<NoteRepository> _logger;
 
@@ -31,11 +33,30 @@ public class NoteRepository : INoteRepository
         ITenantDbContextFactory contextFactory,
         IDeduplicationService deduplicationService,
         ILogger<NoteRepository> logger)
+        : base(contextFactory)
     {
-        _contextFactory = contextFactory;
         _deduplicationService = deduplicationService;
         _logger = logger;
     }
+
+    /// <inheritdoc />
+    protected override NoteEntity ToEntity(Note model) => NoteMapper.ToEntity(model);
+
+    /// <inheritdoc />
+    protected override Note ToDomain(NoteEntity entity) => NoteMapper.ToDomainModel(entity);
+
+    /// <inheritdoc />
+    protected override void ApplyUpdate(NoteEntity target, Note source) => NoteMapper.UpdateEntity(target, source);
+
+    /// <summary>
+    /// Routes the base 7-arg form through the extended note query (non-primary LinkedRecords
+    /// exclusion + ordering), preserving the pre-base default-interface bridge behaviour.
+    /// </summary>
+    public override Task<IEnumerable<Note>> GetAsync(
+        DateTime? from, DateTime? to, string? device, string? source,
+        int limit = 100, int offset = 0, bool descending = true,
+        CancellationToken ct = default)
+        => GetAsync(from, to, device, source, limit, offset, descending, nativeOnly: false, ct);
 
     /// <summary>
     /// Gets note records based on filter criteria.
@@ -63,7 +84,7 @@ public class NoteRepository : INoteRepository
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var query = ctx.Notes.AsNoTracking().AsQueryable();
         if (from.HasValue)
             query = query.Where(e => e.Timestamp >= from.Value);
@@ -86,160 +107,6 @@ public class NoteRepository : INoteRepository
     }
 
     /// <summary>
-    /// Gets a note record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The note record, or null if not found.</returns>
-    public async Task<Note?> GetByIdAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.Notes.FindAsync([id], ct);
-        return entity is null ? null : NoteMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Gets a note record by its legacy identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The note record, or null if not found.</returns>
-    public async Task<Note?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.Notes.FirstOrDefaultAsync(e => e.LegacyId == legacyId, ct);
-        return entity is null ? null : NoteMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Creates a new note record.
-    /// </summary>
-    /// <param name="model">The note to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The created note record.</returns>
-    public async Task<Note> CreateAsync(Note model, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = NoteMapper.ToEntity(model);
-        ctx.Notes.Add(entity);
-        await ctx.SaveChangesAsync(ct);
-        return NoteMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Updates an existing note record.
-    /// </summary>
-    /// <param name="id">The unique identifier of the record to update.</param>
-    /// <param name="model">The updated record data.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The updated note record.</returns>
-    public async Task<Note> UpdateAsync(Guid id, Note model, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity =
-            await ctx.Notes.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"Note {id} not found");
-        NoteMapper.UpdateEntity(entity, model);
-        await ctx.SaveChangesAsync(ct);
-        return NoteMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Deletes a note record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity =
-            await ctx.Notes.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"Note {id} not found");
-        entity.DeletedAt = DateTime.UtcNow;
-        await ctx.SaveChangesAsync(ct);
-    }
-
-    /// <inheritdoc />
-    public async Task<Note> RestoreAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.Notes.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
-            .FirstOrDefaultAsync(ct)
-            ?? throw new KeyNotFoundException($"Soft-deleted Note {id} not found");
-        entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return NoteMapper.ToDomainModel(entity);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<Note>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var idSet = ids.ToHashSet();
-        var entities = await ctx.Notes.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
-            .ToListAsync(ct);
-        foreach (var entity in entities)
-            entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return entities.Select(NoteMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<Note>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entities = await ctx.Notes.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .OrderByDescending(e => e.DeletedAt)
-            .Skip(offset).Take(limit)
-            .AsNoTracking()
-            .ToListAsync(ct);
-        return entities.Select(NoteMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.Notes.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .CountAsync(ct);
-    }
-
-    /// <summary>
-    /// Returns the timestamp of the most recently stored record, optionally scoped to a data source.
-    /// Used by connectors to resume per-source sync without re-fetching already-stored data.
-    /// </summary>
-    public async Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.Notes.AsNoTracking().AsQueryable();
-        if (source != null)
-            query = query.Where(e => e.DataSource == source);
-        return await query.MaxAsync(e => (DateTime?)e.Timestamp, ct);
-    }
-
-    /// <summary>
-    /// Counts note records within a timestamp range.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The count of matching records.</returns>
-    public async Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.Notes.AsNoTracking().AsQueryable();
-        if (from.HasValue)
-            query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue)
-            query = query.Where(e => e.Timestamp <= to.Value);
-        return await query.CountAsync(ct);
-    }
-
-    /// <summary>
     /// Gets note records by correlation identifier.
     /// </summary>
     /// <param name="correlationId">The correlation identifier.</param>
@@ -250,25 +117,12 @@ public class NoteRepository : INoteRepository
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entities = await ctx
             .Notes.AsNoTracking()
             .Where(e => e.CorrelationId == correlationId)
             .ToListAsync(ct);
         return entities.Select(NoteMapper.ToDomainModel);
-    }
-
-    /// <summary>
-    /// Deletes a note record by its legacy identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.Notes.Where(e => e.LegacyId == legacyId)
-            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 
     /// <summary>
@@ -280,7 +134,7 @@ public class NoteRepository : INoteRepository
     /// <returns>The number of deleted records.</returns>
     public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.Notes.Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier)
             .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
@@ -291,12 +145,12 @@ public class NoteRepository : INoteRepository
     /// <param name="records">The collection of records to create.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>A collection of created notes.</returns>
-    public async Task<IEnumerable<Note>> BulkCreateAsync(
+    public override async Task<IEnumerable<Note>> BulkCreateAsync(
         IEnumerable<Note> records,
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var strategy = ctx.Database.CreateExecutionStrategy();
         return await strategy.ExecuteAsync(async () =>
         {

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
@@ -169,7 +169,7 @@ public class NoteRepository : V4RepositoryBase<Note, NoteEntity>, INoteRepositor
 
             await _deduplicationService.DeduplicateBatchAsync(RecordType.Note, dedupInputs, ct);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "Note", inserted.Count);
         }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
@@ -52,6 +52,13 @@ public class NoteRepository : V4RepositoryBase<Note, NoteEntity>, INoteRepositor
     protected override void ApplyUpdate(NoteEntity target, Note source) => NoteMapper.UpdateEntity(target, source);
 
     /// <summary>
+    /// Excludes non-primary cross-connector duplicates so <see cref="V4RepositoryBase{TModel,TEntity}.CountAsync"/>
+    /// matches the rows <c>GetAsync</c> returns. Mirrors the inline filter in the extended <c>GetAsync</c>.
+    /// </summary>
+    protected override IQueryable<NoteEntity> ApplyReadVisibility(IQueryable<NoteEntity> query, NocturneDbContext ctx) =>
+        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == "note" && !lr.IsPrimary && lr.RecordId == b.Id));
+
+    /// <summary>
     /// Routes the base 7-arg form through the extended note query (non-primary LinkedRecords
     /// exclusion + ordering), preserving the pre-base default-interface bridge behaviour.
     /// </summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Infrastructure;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
@@ -15,8 +16,8 @@ namespace Nocturne.Infrastructure.Data.Repositories.V4;
 /// Repository for managing note records in the database. A DeduplicationService participant, so it
 /// inherits the shared CRUD/soft-delete surface from <see cref="V4RepositoryBase{TModel,TEntity}"/>
 /// and keeps only the dedup-specific behaviour as overrides (extended <c>GetAsync</c> with the
-/// non-primary LinkedRecords filter, dedup <c>BulkCreateAsync</c>). Soft-deletes use the plain
-/// (non-audited) path, matching the base.
+/// non-primary LinkedRecords filter, dedup <c>BulkCreateAsync</c>). Soft-deletes inherit the base's
+/// audited path.
 /// </summary>
 public class NoteRepository : V4RepositoryBase<Note, NoteEntity>, INoteRepository
 {
@@ -28,12 +29,14 @@ public class NoteRepository : V4RepositoryBase<Note, NoteEntity>, INoteRepositor
     /// </summary>
     /// <param name="contextFactory">The tenant database context factory.</param>
     /// <param name="deduplicationService">The deduplication service.</param>
+    /// <param name="auditContext">The audit context for tracking mutations (used by the base soft-delete path).</param>
     /// <param name="logger">The logger instance.</param>
     public NoteRepository(
         ITenantDbContextFactory contextFactory,
         IDeduplicationService deduplicationService,
+        IAuditContext auditContext,
         ILogger<NoteRepository> logger)
-        : base(contextFactory)
+        : base(contextFactory, auditContext)
     {
         _deduplicationService = deduplicationService;
         _logger = logger;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
@@ -150,83 +150,28 @@ public class NoteRepository : V4RepositoryBase<Note, NoteEntity>, INoteRepositor
     }
 
     /// <summary>
-    /// Performs a bulk creation of note records, handling deduplication.
+    /// Insert-time deduplication: link saved records to canonical groups (runs after commit).
     /// </summary>
-    /// <param name="records">The collection of records to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>A collection of created notes.</returns>
-    public override async Task<IEnumerable<Note>> BulkCreateAsync(
-        IEnumerable<Note> records,
-        CancellationToken ct = default
-    )
+    protected override async Task PostCommitDedupAsync(
+        NocturneDbContext ctx, IReadOnlyList<NoteEntity> inserted, CancellationToken ct)
     {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        var strategy = ctx.Database.CreateExecutionStrategy();
-        return await strategy.ExecuteAsync(async () =>
+        if (inserted.Count == 0)
+            return;
+
+        try
         {
-            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-            var entities = records.Select(NoteMapper.ToEntity).ToList();
-            if (entities.Count == 0)
-            {
-                await tx.CommitAsync(ct);
-                return [];
-            }
+            var dedupInputs = inserted.Select(e => new DeduplicationInput(
+                RecordId: e.Id,
+                Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
+                DataSource: e.DataSource ?? "unknown",
+                Criteria: new MatchCriteria()
+            )).ToList();
 
-            // Batch-level dedup: keep first occurrence per LegacyId
-            entities = entities
-                .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-                .Select(g => g.First())
-                .ToList();
-
-            // DB-level dedup: filter out records whose LegacyId already exists
-            var legacyIds = entities
-                .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-                .Select(e => e.LegacyId!)
-                .ToHashSet();
-
-            if (legacyIds.Count > 0)
-            {
-                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<NoteEntity>(legacyIds, ct);
-
-                entities = entities
-                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
-                    .ToList();
-            }
-
-            if (entities.Count == 0)
-            {
-                await tx.CommitAsync(ct);
-                return [];
-            }
-
-            const int batchSize = 500;
-            foreach (var batch in entities.Chunk(batchSize))
-            {
-                ctx.Notes.AddRange(batch);
-                await ctx.SaveChangesAsync(ct);
-                ctx.ChangeTracker.Clear();
-            }
-
-            await tx.CommitAsync(ct);
-
-            // Insert-time deduplication: link saved records to canonical groups
-            try
-            {
-                var dedupInputs = entities.Select(e => new DeduplicationInput(
-                    RecordId: e.Id,
-                    Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    DataSource: e.DataSource ?? "unknown",
-                    Criteria: new MatchCriteria()
-                )).ToList();
-
-                await _deduplicationService.DeduplicateBatchAsync(RecordType.Note, dedupInputs, ct);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "Note", entities.Count);
-            }
-
-            return entities.Select(NoteMapper.ToDomainModel);
-        });
+            await _deduplicationService.DeduplicateBatchAsync(RecordType.Note, dedupInputs, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "Note", inserted.Count);
+        }
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensitivityScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensitivityScheduleRepository.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
@@ -20,10 +21,11 @@ public class SensitivityScheduleRepository : V4RepositoryBase<SensitivitySchedul
     /// Initializes a new instance of the <see cref="SensitivityScheduleRepository"/> class.
     /// </summary>
     /// <param name="contextFactory">The tenant database context factory.</param>
+    /// <param name="auditContext">The audit context for tracking mutations (used by the base soft-delete path).</param>
     /// <param name="logger">The logger instance.</param>
     // logger is unused for this LegacyId-only type but retained for DI + direct test construction.
-    public SensitivityScheduleRepository(ITenantDbContextFactory contextFactory, ILogger<SensitivityScheduleRepository> logger)
-        : base(contextFactory)
+    public SensitivityScheduleRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext, ILogger<SensitivityScheduleRepository> logger)
+        : base(contextFactory, auditContext)
     {
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensitivityScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensitivityScheduleRepository.cs
@@ -3,94 +3,39 @@ using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
-using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
-/// Repository for managing insulin sensitivity schedules (ISF) in the database.
+/// Repository for managing insulin sensitivity schedules (ISF) in the database. A LegacyId-only type
+/// (no SyncId-upsert, no DeduplicationService participation), so it uses the shared
+/// <see cref="V4RepositoryBase{TModel,TEntity}"/> behaviour unchanged plus the sensitivity-specific
+/// queries below.
 /// </summary>
-public class SensitivityScheduleRepository : ISensitivityScheduleRepository
+public class SensitivityScheduleRepository : V4RepositoryBase<SensitivitySchedule, SensitivityScheduleEntity>, ISensitivityScheduleRepository
 {
-    private readonly ITenantDbContextFactory _contextFactory;
-    private readonly ILogger<SensitivityScheduleRepository> _logger;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="SensitivityScheduleRepository"/> class.
     /// </summary>
     /// <param name="contextFactory">The tenant database context factory.</param>
     /// <param name="logger">The logger instance.</param>
+    // logger is unused for this LegacyId-only type but retained for DI + direct test construction.
     public SensitivityScheduleRepository(ITenantDbContextFactory contextFactory, ILogger<SensitivityScheduleRepository> logger)
+        : base(contextFactory)
     {
-        _contextFactory = contextFactory;
-        _logger = logger;
     }
 
-    /// <summary>
-    /// Gets insulin sensitivity schedules based on filter criteria.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="device">Optional device filter.</param>
-    /// <param name="source">Optional data source filter.</param>
-    /// <param name="limit">The maximum number of records to return.</param>
-    /// <param name="offset">The number of records to skip.</param>
-    /// <param name="descending">Whether to sort by timestamp in descending order.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>A collection of insulin sensitivity schedules.</returns>
-    public async Task<IEnumerable<SensitivitySchedule>> GetAsync(
-        DateTime? from,
-        DateTime? to,
-        string? device,
-        string? source,
-        int limit = 100,
-        int offset = 0,
-        bool descending = true,
-        CancellationToken ct = default
-    )
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.SensitivitySchedules.AsNoTracking().AsQueryable();
-        if (from.HasValue)
-            query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue)
-            query = query.Where(e => e.Timestamp <= to.Value);
-        if (device != null)
-            query = query.Where(e => e.Device == device);
-        if (source != null)
-            query = query.Where(e => e.DataSource == source);
-        query = descending ? query.OrderByDescending(e => e.Timestamp) : query.OrderBy(e => e.Timestamp);
-        var entities = await query.Skip(offset).Take(limit).ToListAsync(ct);
-        return entities.Select(SensitivityScheduleMapper.ToDomainModel);
-    }
+    /// <inheritdoc />
+    protected override SensitivityScheduleEntity ToEntity(SensitivitySchedule model) => SensitivityScheduleMapper.ToEntity(model);
 
-    /// <summary>
-    /// Gets an insulin sensitivity schedule record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The insulin sensitivity schedule, or null if not found.</returns>
-    public async Task<SensitivitySchedule?> GetByIdAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.SensitivitySchedules.FindAsync([id], ct);
-        return entity is null ? null : SensitivityScheduleMapper.ToDomainModel(entity);
-    }
+    /// <inheritdoc />
+    protected override SensitivitySchedule ToDomain(SensitivityScheduleEntity entity) => SensitivityScheduleMapper.ToDomainModel(entity);
 
-    /// <summary>
-    /// Gets an insulin sensitivity schedule record by its legacy identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The insulin sensitivity schedule, or null if not found.</returns>
-    public async Task<SensitivitySchedule?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.SensitivitySchedules.FirstOrDefaultAsync(e => e.LegacyId == legacyId, ct);
-        return entity is null ? null : SensitivityScheduleMapper.ToDomainModel(entity);
-    }
+    /// <inheritdoc />
+    protected override void ApplyUpdate(SensitivityScheduleEntity target, SensitivitySchedule source) =>
+        SensitivityScheduleMapper.UpdateEntity(target, source);
 
     /// <summary>
     /// Gets insulin sensitivity schedule records by profile name.
@@ -103,7 +48,7 @@ public class SensitivityScheduleRepository : ISensitivityScheduleRepository
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entities = await ctx
             .SensitivitySchedules.AsNoTracking()
             .Where(e => e.ProfileName == profileName)
@@ -122,7 +67,7 @@ public class SensitivityScheduleRepository : ISensitivityScheduleRepository
     public async Task<SensitivitySchedule?> GetActiveAtAsync(
         string profileName, DateTime timestamp, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entity = await ctx.SensitivitySchedules
             .AsNoTracking()
             .Where(e => e.ProfileName == profileName && e.Timestamp <= timestamp)
@@ -133,120 +78,6 @@ public class SensitivityScheduleRepository : ISensitivityScheduleRepository
     }
 
     /// <summary>
-    /// Creates a new insulin sensitivity schedule record.
-    /// </summary>
-    /// <param name="model">The insulin sensitivity schedule to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The created record.</returns>
-    public async Task<SensitivitySchedule> CreateAsync(SensitivitySchedule model, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = SensitivityScheduleMapper.ToEntity(model);
-        ctx.SensitivitySchedules.Add(entity);
-        await ctx.SaveChangesAsync(ct);
-        return SensitivityScheduleMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Updates an existing insulin sensitivity schedule record.
-    /// </summary>
-    /// <param name="id">The unique identifier of the record to update.</param>
-    /// <param name="model">The updated record data.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The updated record.</returns>
-    public async Task<SensitivitySchedule> UpdateAsync(
-        Guid id,
-        SensitivitySchedule model,
-        CancellationToken ct = default
-    )
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity =
-            await ctx.SensitivitySchedules.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"SensitivitySchedule {id} not found");
-        SensitivityScheduleMapper.UpdateEntity(entity, model);
-        await ctx.SaveChangesAsync(ct);
-        return SensitivityScheduleMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Deletes an insulin sensitivity schedule record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity =
-            await ctx.SensitivitySchedules.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"SensitivitySchedule {id} not found");
-        entity.DeletedAt = DateTime.UtcNow;
-        await ctx.SaveChangesAsync(ct);
-    }
-
-    /// <inheritdoc />
-    public async Task<SensitivitySchedule> RestoreAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.SensitivitySchedules.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
-            .FirstOrDefaultAsync(ct)
-            ?? throw new KeyNotFoundException($"Soft-deleted SensitivitySchedule {id} not found");
-        entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return SensitivityScheduleMapper.ToDomainModel(entity);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<SensitivitySchedule>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var idSet = ids.ToHashSet();
-        var entities = await ctx.SensitivitySchedules.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
-            .ToListAsync(ct);
-        foreach (var entity in entities)
-            entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return entities.Select(SensitivityScheduleMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<SensitivitySchedule>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entities = await ctx.SensitivitySchedules.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .OrderByDescending(e => e.DeletedAt)
-            .Skip(offset).Take(limit)
-            .AsNoTracking()
-            .ToListAsync(ct);
-        return entities.Select(SensitivityScheduleMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.SensitivitySchedules.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .CountAsync(ct);
-    }
-
-    /// <summary>
-    /// Deletes an insulin sensitivity schedule record by its legacy identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.SensitivitySchedules.Where(e => e.LegacyId == legacyId)
-            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
-    }
-
-    /// <summary>
     /// Deletes insulin sensitivity schedule records by legacy identifier prefix.
     /// </summary>
     /// <param name="prefix">The legacy identifier prefix.</param>
@@ -254,28 +85,10 @@ public class SensitivityScheduleRepository : ISensitivityScheduleRepository
     /// <returns>The number of deleted records.</returns>
     public async Task<int> DeleteByLegacyIdPrefixAsync(string prefix, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx
             .SensitivitySchedules.Where(e => e.LegacyId != null && e.LegacyId.StartsWith(prefix))
             .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
-    }
-
-    /// <summary>
-    /// Counts insulin sensitivity schedule records within a timestamp range.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The count of matching records.</returns>
-    public async Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.SensitivitySchedules.AsNoTracking().AsQueryable();
-        if (from.HasValue)
-            query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue)
-            query = query.Where(e => e.Timestamp <= to.Value);
-        return await query.CountAsync(ct);
     }
 
     /// <summary>
@@ -289,72 +102,11 @@ public class SensitivityScheduleRepository : ISensitivityScheduleRepository
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entities = await ctx
             .SensitivitySchedules.AsNoTracking()
             .Where(e => e.CorrelationId == correlationId)
             .ToListAsync(ct);
         return entities.Select(SensitivityScheduleMapper.ToDomainModel);
-    }
-
-    /// <summary>
-    /// Performs a bulk creation of insulin sensitivity schedule records, handling deduplication.
-    /// </summary>
-    /// <param name="records">The collection of records to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>A collection of created schedules.</returns>
-    public async Task<IEnumerable<SensitivitySchedule>> BulkCreateAsync(
-        IEnumerable<SensitivitySchedule> records,
-        CancellationToken ct = default
-    )
-    {
-        var entities = records.Select(SensitivityScheduleMapper.ToEntity).ToList();
-        if (entities.Count == 0)
-            return [];
-
-        // Batch-level dedup: keep first occurrence per LegacyId
-        entities = entities
-            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-            .Select(g => g.First())
-            .ToList();
-
-        // DB-level dedup: filter out records whose LegacyId already exists
-        var legacyIds = entities
-            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-            .Select(e => e.LegacyId!)
-            .ToHashSet();
-
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var strategy = ctx.Database.CreateExecutionStrategy();
-        return await strategy.ExecuteAsync(async () =>
-        {
-            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-            if (legacyIds.Count > 0)
-            {
-                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<SensitivityScheduleEntity>(legacyIds, ct);
-
-                entities = entities
-                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
-                    .ToList();
-            }
-
-            if (entities.Count == 0)
-            {
-                await tx.CommitAsync(ct);
-                return [];
-            }
-
-            const int batchSize = 500;
-            foreach (var batch in entities.Chunk(batchSize))
-            {
-                ctx.SensitivitySchedules.AddRange(batch);
-                await ctx.SaveChangesAsync(ct);
-                ctx.ChangeTracker.Clear();
-            }
-
-            await tx.CommitAsync(ct);
-            return entities.Select(SensitivityScheduleMapper.ToDomainModel);
-        });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -135,6 +135,38 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
     }
 
     /// <summary>
+    /// Creates a new sensor glucose record. When <c>DataSource</c> and <c>SyncIdentifier</c>
+    /// match an existing row for this tenant, the record is updated in place rather than
+    /// inserted — making the operation idempotent for connector replays. Tenant scoping is
+    /// implicit via the DbContext's RLS-equivalent query filter. Mirrors BolusRepository.
+    /// </summary>
+    /// <param name="model">The sensor glucose record to create.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The created or updated sensor glucose record.</returns>
+    public override async Task<SensorGlucose> CreateAsync(SensorGlucose model, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        if (!string.IsNullOrEmpty(model.DataSource) && !string.IsNullOrEmpty(model.SyncIdentifier))
+        {
+            var existing = await ctx.SensorGlucose
+                .FirstOrDefaultAsync(
+                    e => e.DataSource == model.DataSource && e.SyncIdentifier == model.SyncIdentifier,
+                    ct);
+            if (existing != null)
+            {
+                SensorGlucoseMapper.UpdateEntity(existing, model);
+                await ctx.SaveChangesAsync(ct);
+                return SensorGlucoseMapper.ToDomainModel(existing);
+            }
+        }
+
+        var entity = SensorGlucoseMapper.ToEntity(model);
+        ctx.SensorGlucose.Add(entity);
+        await ctx.SaveChangesAsync(ct);
+        return SensorGlucoseMapper.ToDomainModel(entity);
+    }
+
+    /// <summary>
     /// Gets sensor glucose records by correlation identifier.
     /// </summary>
     /// <param name="correlationId">The correlation identifier.</param>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -13,12 +13,14 @@ using Nocturne.Infrastructure.Data.Services;
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
-/// Repository for managing sensor glucose (CGM) records in the database.
-/// Includes support for cross-connector deduplication.
+/// Repository for managing sensor glucose (CGM) records in the database. A SyncId-upsert (bulk) +
+/// DeduplicationService participant, so it inherits the shared CRUD/soft-delete surface from
+/// <see cref="V4RepositoryBase{TModel,TEntity}"/> and keeps only the dedup-specific behaviour as
+/// overrides (extended <c>GetAsync</c> with the non-primary LinkedRecords filter + keyset cursor,
+/// SyncId-upsert <c>BulkCreateAsync</c>, audited soft-deletes, and source/time-range deletes).
 /// </summary>
-public class SensorGlucoseRepository : ISensorGlucoseRepository
+public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlucoseEntity>, ISensorGlucoseRepository
 {
-    private readonly ITenantDbContextFactory _contextFactory;
     private readonly IDeduplicationService _deduplicationService;
     private readonly IAuditContext _auditContext;
     private readonly ILogger<SensorGlucoseRepository> _logger;
@@ -36,12 +38,32 @@ public class SensorGlucoseRepository : ISensorGlucoseRepository
         IAuditContext auditContext,
         ILogger<SensorGlucoseRepository> logger
     )
+        : base(contextFactory)
     {
-        _contextFactory = contextFactory;
         _deduplicationService = deduplicationService;
         _auditContext = auditContext;
         _logger = logger;
     }
+
+    /// <inheritdoc />
+    protected override SensorGlucoseEntity ToEntity(SensorGlucose model) => SensorGlucoseMapper.ToEntity(model);
+
+    /// <inheritdoc />
+    protected override SensorGlucose ToDomain(SensorGlucoseEntity entity) => SensorGlucoseMapper.ToDomainModel(entity);
+
+    /// <inheritdoc />
+    protected override void ApplyUpdate(SensorGlucoseEntity target, SensorGlucose source) => SensorGlucoseMapper.UpdateEntity(target, source);
+
+    /// <summary>
+    /// Routes the base 7-arg form through the extended sensor-glucose query (non-primary LinkedRecords
+    /// exclusion + ordering), preserving the pre-base default-interface bridge behaviour.
+    /// </summary>
+    public override Task<IEnumerable<SensorGlucose>> GetAsync(
+        DateTime? from, DateTime? to, string? device, string? source,
+        int limit = 100, int offset = 0, bool descending = true,
+        CancellationToken ct = default)
+        => GetAsync(from, to, device, source, limit, offset, descending,
+            nativeOnly: false, afterTimestamp: null, afterId: null, ct);
 
     /// <summary>
     /// Gets sensor glucose records based on filter criteria.
@@ -73,7 +95,7 @@ public class SensorGlucoseRepository : ISensorGlucoseRepository
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var query = ctx.SensorGlucose.AsNoTracking().AsQueryable();
         if (from.HasValue)
             query = query.Where(e => e.Timestamp >= from.Value);
@@ -115,160 +137,6 @@ public class SensorGlucoseRepository : ISensorGlucoseRepository
     }
 
     /// <summary>
-    /// Gets a sensor glucose record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The sensor glucose record, or null if not found.</returns>
-    public async Task<SensorGlucose?> GetByIdAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.SensorGlucose.FindAsync([id], ct);
-        return entity is null ? null : SensorGlucoseMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Gets a sensor glucose record by its legacy identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The sensor glucose record, or null if not found.</returns>
-    public async Task<SensorGlucose?> GetByLegacyIdAsync(
-        string legacyId,
-        CancellationToken ct = default
-    )
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.SensorGlucose.FirstOrDefaultAsync(
-            e => e.LegacyId == legacyId,
-            ct
-        );
-        return entity is null ? null : SensorGlucoseMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Creates a new sensor glucose record.
-    /// </summary>
-    /// <param name="model">The sensor glucose record to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The created sensor glucose record.</returns>
-    public async Task<SensorGlucose> CreateAsync(
-        SensorGlucose model,
-        CancellationToken ct = default
-    )
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = SensorGlucoseMapper.ToEntity(model);
-        ctx.SensorGlucose.Add(entity);
-        await ctx.SaveChangesAsync(ct);
-        return SensorGlucoseMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Updates an existing sensor glucose record.
-    /// </summary>
-    /// <param name="id">The unique identifier of the record to update.</param>
-    /// <param name="model">The updated record data.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The updated sensor glucose record.</returns>
-    public async Task<SensorGlucose> UpdateAsync(
-        Guid id,
-        SensorGlucose model,
-        CancellationToken ct = default
-    )
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity =
-            await ctx.SensorGlucose.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"SensorGlucose {id} not found");
-        SensorGlucoseMapper.UpdateEntity(entity, model);
-        await ctx.SaveChangesAsync(ct);
-        return SensorGlucoseMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Deletes a sensor glucose record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity =
-            await ctx.SensorGlucose.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"SensorGlucose {id} not found");
-        entity.DeletedAt = DateTime.UtcNow;
-        await ctx.SaveChangesAsync(ct);
-    }
-
-    /// <inheritdoc />
-    public async Task<SensorGlucose> RestoreAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.SensorGlucose.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
-            .FirstOrDefaultAsync(ct)
-            ?? throw new KeyNotFoundException($"Soft-deleted SensorGlucose {id} not found");
-        entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return SensorGlucoseMapper.ToDomainModel(entity);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<SensorGlucose>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var idSet = ids.ToHashSet();
-        var entities = await ctx.SensorGlucose.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
-            .ToListAsync(ct);
-        foreach (var entity in entities)
-            entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return entities.Select(SensorGlucoseMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<SensorGlucose>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entities = await ctx.SensorGlucose.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .OrderByDescending(e => e.DeletedAt)
-            .Skip(offset).Take(limit)
-            .AsNoTracking()
-            .ToListAsync(ct);
-        return entities.Select(SensorGlucoseMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.SensorGlucose.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .CountAsync(ct);
-    }
-
-    /// <summary>
-    /// Counts sensor glucose records within a timestamp range.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The count of matching records.</returns>
-    public async Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.SensorGlucose.AsNoTracking().AsQueryable();
-        if (from.HasValue)
-            query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue)
-            query = query.Where(e => e.Timestamp <= to.Value);
-        return await query.CountAsync(ct);
-    }
-
-    /// <summary>
     /// Gets sensor glucose records by correlation identifier.
     /// </summary>
     /// <param name="correlationId">The correlation identifier.</param>
@@ -279,7 +147,7 @@ public class SensorGlucoseRepository : ISensorGlucoseRepository
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entities = await ctx
             .SensorGlucose.AsNoTracking()
             .Where(e => e.CorrelationId == correlationId)
@@ -293,9 +161,9 @@ public class SensorGlucoseRepository : ISensorGlucoseRepository
     /// <param name="legacyId">The legacy identifier.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
+    public override async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
             ctx.SensorGlucose.Where(e => e.LegacyId == legacyId), _auditContext, ct);
     }
@@ -306,12 +174,12 @@ public class SensorGlucoseRepository : ISensorGlucoseRepository
     /// <param name="records">The collection of records to create.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>A collection of created records.</returns>
-    public async Task<IEnumerable<SensorGlucose>> BulkCreateAsync(
+    public override async Task<IEnumerable<SensorGlucose>> BulkCreateAsync(
         IEnumerable<SensorGlucose> records,
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var strategy = ctx.Database.CreateExecutionStrategy();
         return await strategy.ExecuteAsync(async () =>
         {
@@ -438,24 +306,6 @@ public class SensorGlucoseRepository : ISensorGlucoseRepository
     }
 
     /// <summary>
-    /// Gets the timestamp of the latest sensor glucose record.
-    /// </summary>
-    /// <param name="source">Optional data source filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The latest timestamp, or null if no records found.</returns>
-    public async Task<DateTime?> GetLatestTimestampAsync(
-        string? source = null,
-        CancellationToken ct = default
-    )
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.SensorGlucose.AsNoTracking().AsQueryable();
-        if (source != null)
-            query = query.Where(e => e.DataSource == source);
-        return await query.MaxAsync(e => (DateTime?)e.Timestamp, ct);
-    }
-
-    /// <summary>
     /// Gets the timestamp of the oldest sensor glucose record.
     /// </summary>
     /// <param name="source">Optional data source filter.</param>
@@ -466,7 +316,7 @@ public class SensorGlucoseRepository : ISensorGlucoseRepository
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var query = ctx.SensorGlucose.AsNoTracking().AsQueryable();
         if (source != null)
             query = query.Where(e => e.DataSource == source);
@@ -481,7 +331,7 @@ public class SensorGlucoseRepository : ISensorGlucoseRepository
     /// <returns>Number of matching records.</returns>
     public async Task<int> CountBySourceAsync(string source, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.SensorGlucose
             .AsNoTracking()
             .Where(e => e.DataSource == source)
@@ -496,7 +346,7 @@ public class SensorGlucoseRepository : ISensorGlucoseRepository
     /// <returns>Number of records deleted.</returns>
     public async Task<int> DeleteBySourceAsync(string source, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
             ctx.SensorGlucose.Where(e => e.DataSource == source), _auditContext, ct);
     }
@@ -510,7 +360,7 @@ public class SensorGlucoseRepository : ISensorGlucoseRepository
     /// <returns>Number of records deleted.</returns>
     public async Task<int> DeleteByTimeRangeAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var query = ctx.SensorGlucose.AsQueryable();
 
         if (from.HasValue)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -53,6 +53,13 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
     protected override void ApplyUpdate(SensorGlucoseEntity target, SensorGlucose source) => SensorGlucoseMapper.UpdateEntity(target, source);
 
     /// <summary>
+    /// Excludes non-primary cross-connector duplicates so <see cref="V4RepositoryBase{TModel,TEntity}.CountAsync"/>
+    /// matches the rows <c>GetAsync</c> returns. Mirrors the inline filter in the extended <c>GetAsync</c>.
+    /// </summary>
+    protected override IQueryable<SensorGlucoseEntity> ApplyReadVisibility(IQueryable<SensorGlucoseEntity> query, NocturneDbContext ctx) =>
+        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == "sensorglucose" && !lr.IsPrimary && lr.RecordId == b.Id));
+
+    /// <summary>
     /// Routes the base 7-arg form through the extended sensor-glucose query (non-primary LinkedRecords
     /// exclusion + ordering), preserving the pre-base default-interface bridge behaviour.
     /// </summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -22,7 +22,6 @@ namespace Nocturne.Infrastructure.Data.Repositories.V4;
 public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlucoseEntity>, ISensorGlucoseRepository
 {
     private readonly IDeduplicationService _deduplicationService;
-    private readonly IAuditContext _auditContext;
     private readonly ILogger<SensorGlucoseRepository> _logger;
 
     /// <summary>
@@ -38,10 +37,9 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
         IAuditContext auditContext,
         ILogger<SensorGlucoseRepository> logger
     )
-        : base(contextFactory)
+        : base(contextFactory, auditContext)
     {
         _deduplicationService = deduplicationService;
-        _auditContext = auditContext;
         _logger = logger;
     }
 
@@ -153,19 +151,6 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
             .Where(e => e.CorrelationId == correlationId)
             .ToListAsync(ct);
         return entities.Select(SensorGlucoseMapper.ToDomainModel);
-    }
-
-    /// <summary>
-    /// Deletes a sensor glucose record by its legacy identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The number of deleted records.</returns>
-    public override async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        return await ctx.AuditedSoftDeleteAsync(
-            ctx.SensorGlucose.Where(e => e.LegacyId == legacyId), _auditContext, ct);
     }
 
     /// <summary>
@@ -330,7 +315,7 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
-            ctx.SensorGlucose.Where(e => e.DataSource == source), _auditContext, ct);
+            ctx.SensorGlucose.Where(e => e.DataSource == source), AuditContext, ct);
     }
 
     /// <summary>
@@ -350,6 +335,6 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
         if (to.HasValue)
             query = query.Where(e => e.Timestamp < to.Value);
 
-        return await ctx.AuditedSoftDeleteAsync(query, _auditContext, ct);
+        return await ctx.AuditedSoftDeleteAsync(query, AuditContext, ct);
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -264,6 +264,8 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
     protected override async Task PostCommitDedupAsync(
         NocturneDbContext ctx, IReadOnlyList<SensorGlucoseEntity> inserted, CancellationToken ct)
     {
+        if (inserted.Count == 0) return;
+
         try
         {
             var dedupInputs = inserted.Select(e => new DeduplicationInput(

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -306,24 +306,6 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
     }
 
     /// <summary>
-    /// Gets the timestamp of the oldest sensor glucose record.
-    /// </summary>
-    /// <param name="source">Optional data source filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The oldest timestamp, or null if no records found.</returns>
-    public async Task<DateTime?> GetOldestTimestampAsync(
-        string? source = null,
-        CancellationToken ct = default
-    )
-    {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        var query = ctx.SensorGlucose.AsNoTracking().AsQueryable();
-        if (source != null)
-            query = query.Where(e => e.DataSource == source);
-        return await query.MinAsync(e => (DateTime?)e.Timestamp, ct);
-    }
-
-    /// <summary>
     /// Counts sensor glucose records for the given data source.
     /// </summary>
     /// <param name="source">Data source identifier.</param>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -306,12 +306,14 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
 
             await tx.CommitAsync(ct);
 
-            // Insert-time deduplication: link saved records to canonical groups. Include the in-place
-            // updates (re-corrected timestamps) so their canonical grouping is re-driven on the new mills.
+            // Insert-time deduplication: link newly inserted records to canonical groups. Feeds
+            // inserts-only (matching Bolus/CarbIntake). Since dedup runs after commit (D4), upserted
+            // rows are reached as committed canonicals via their committed value, so re-feeding them is
+            // redundant — already-linked rows skip self-relinking and add no match candidates.
             var saved = entities.Concat(updatedEntities).ToList();
             try
             {
-                var dedupInputs = saved.Select(e => new DeduplicationInput(
+                var dedupInputs = entities.Select(e => new DeduplicationInput(
                     RecordId: e.Id,
                     Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
                     DataSource: e.DataSource ?? "unknown",

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -193,142 +193,92 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
     }
 
     /// <summary>
-    /// Performs a bulk creation of sensor glucose records, handling deduplication.
+    /// SyncId-upsert split: intra-batch keep-last per (DataSource, SyncIdentifier), then match existing
+    /// rows in the DB by that key and update them in place — so timezone re-correction moves a reading's
+    /// timestamp instead of duplicating it. Persists the updates inside the transaction before returning
+    /// so the base's insert loop (which clears the tracker) doesn't lose them. Mirrors BolusRepository.
     /// </summary>
-    /// <param name="records">The collection of records to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>A collection of created records.</returns>
-    public override async Task<IEnumerable<SensorGlucose>> BulkCreateAsync(
-        IEnumerable<SensorGlucose> records,
-        CancellationToken ct = default
-    )
+    protected override async Task<(List<SensorGlucoseEntity> Updated, List<SensorGlucoseEntity> ToInsert)> SplitUpsertsAsync(
+        NocturneDbContext ctx, List<SensorGlucoseEntity> entities, CancellationToken ct)
     {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        var strategy = ctx.Database.CreateExecutionStrategy();
-        return await strategy.ExecuteAsync(async () =>
+        // Intra-batch SyncIdentifier dedup: keep last occurrence per (DataSource, SyncIdentifier).
+        // Records without both keys keep a unique grouping key so they're not collapsed.
+        entities = entities
+            .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
+                ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
+                : $"id|{e.Id}")
+            .Select(g => g.Last())
+            .ToList();
+
+        // DB-level SyncIdentifier upsert: rows matched by (DataSource, SyncIdentifier) are updated
+        // in place. Everything else falls through to the LegacyId/insert path below.
+        var updatedEntities = new List<SensorGlucoseEntity>();
+        var syncKeyed = entities
+            .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
+            .ToList();
+
+        if (syncKeyed.Count == 0)
+            return (updatedEntities, entities);
+
+        var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
+        var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
+
+        var existingRows = await ctx.SensorGlucose.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId)
+            .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
+            .ToListAsync(ct);
+
+        var existingByKey = existingRows
+            .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
+            .ToDictionary(g => g.Key, g => g.First());
+
+        var toInsert = new List<SensorGlucoseEntity>();
+        foreach (var entity in entities)
         {
-            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-            var entities = records.Select(SensorGlucoseMapper.ToEntity).ToList();
-            if (entities.Count == 0)
+            var hasKey = !string.IsNullOrEmpty(entity.DataSource)
+                && !string.IsNullOrEmpty(entity.SyncIdentifier);
+            if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
             {
-                await tx.CommitAsync(ct);
-                return [];
+                var domain = SensorGlucoseMapper.ToDomainModel(entity);
+                SensorGlucoseMapper.UpdateEntity(existing, domain);
+                updatedEntities.Add(existing);
             }
-
-            // Intra-batch SyncIdentifier dedup: keep last occurrence per (DataSource, SyncIdentifier).
-            // Records without both keys keep a unique grouping key so they're not collapsed.
-            entities = entities
-                .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
-                    ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
-                    : $"id|{e.Id}")
-                .Select(g => g.Last())
-                .ToList();
-
-            // DB-level SyncIdentifier upsert: rows matched by (DataSource, SyncIdentifier) are updated
-            // in place — so timezone re-correction moves a reading's timestamp instead of duplicating
-            // it. Everything else falls through to the LegacyId/insert path below. Mirrors BolusRepository.
-            var updatedEntities = new List<SensorGlucoseEntity>();
-            var syncKeyed = entities
-                .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
-                .ToList();
-
-            if (syncKeyed.Count > 0)
+            else
             {
-                var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
-                var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
-
-                var existingRows = await ctx.SensorGlucose.IgnoreQueryFilters()
-                    .Where(e => e.TenantId == ctx.TenantId)
-                    .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
-                    .ToListAsync(ct);
-
-                var existingByKey = existingRows
-                    .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
-                    .ToDictionary(g => g.Key, g => g.First());
-
-                var toInsert = new List<SensorGlucoseEntity>();
-                foreach (var entity in entities)
-                {
-                    var hasKey = !string.IsNullOrEmpty(entity.DataSource)
-                        && !string.IsNullOrEmpty(entity.SyncIdentifier);
-                    if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
-                    {
-                        var domain = SensorGlucoseMapper.ToDomainModel(entity);
-                        SensorGlucoseMapper.UpdateEntity(existing, domain);
-                        updatedEntities.Add(existing);
-                    }
-                    else
-                    {
-                        toInsert.Add(entity);
-                    }
-                }
-
-                if (updatedEntities.Count > 0)
-                    await ctx.SaveChangesAsync(ct);
-
-                entities = toInsert;
+                toInsert.Add(entity);
             }
+        }
 
-            // Batch-level dedup: keep first occurrence per LegacyId
-            entities = entities
-                .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-                .Select(g => g.First())
-                .ToList();
+        if (updatedEntities.Count > 0)
+            await ctx.SaveChangesAsync(ct);
 
-            // DB-level dedup: filter out records whose LegacyId already exists
-            var legacyIds = entities
-                .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-                .Select(e => e.LegacyId!)
-                .ToHashSet();
+        return (updatedEntities, toInsert);
+    }
 
-            if (legacyIds.Count > 0)
-            {
-                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<SensorGlucoseEntity>(legacyIds, ct);
+    /// <summary>
+    /// Insert-time deduplication: link newly inserted records to canonical groups. Feeds inserts-only
+    /// (matching Bolus/CarbIntake). Since dedup runs after commit (D4), upserted rows are reached as
+    /// committed canonicals via their committed value, so re-feeding them is redundant — already-linked
+    /// rows skip self-relinking and add no match candidates.
+    /// </summary>
+    protected override async Task PostCommitDedupAsync(
+        NocturneDbContext ctx, IReadOnlyList<SensorGlucoseEntity> inserted, CancellationToken ct)
+    {
+        try
+        {
+            var dedupInputs = inserted.Select(e => new DeduplicationInput(
+                RecordId: e.Id,
+                Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
+                DataSource: e.DataSource ?? "unknown",
+                Criteria: new MatchCriteria { GlucoseValue = e.Mgdl, GlucoseTolerance = 1.0 }
+            )).ToList();
 
-                entities = entities
-                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
-                    .ToList();
-            }
-
-            if (entities.Count == 0 && updatedEntities.Count == 0)
-            {
-                await tx.CommitAsync(ct);
-                return [];
-            }
-
-            const int batchSize = 500;
-            foreach (var batch in entities.Chunk(batchSize))
-            {
-                ctx.SensorGlucose.AddRange(batch);
-                await ctx.SaveChangesAsync(ct);
-                ctx.ChangeTracker.Clear();
-            }
-
-            await tx.CommitAsync(ct);
-
-            // Insert-time deduplication: link newly inserted records to canonical groups. Feeds
-            // inserts-only (matching Bolus/CarbIntake). Since dedup runs after commit (D4), upserted
-            // rows are reached as committed canonicals via their committed value, so re-feeding them is
-            // redundant — already-linked rows skip self-relinking and add no match candidates.
-            var saved = entities.Concat(updatedEntities).ToList();
-            try
-            {
-                var dedupInputs = entities.Select(e => new DeduplicationInput(
-                    RecordId: e.Id,
-                    Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    DataSource: e.DataSource ?? "unknown",
-                    Criteria: new MatchCriteria { GlucoseValue = e.Mgdl, GlucoseTolerance = 1.0 }
-                )).ToList();
-
-                await _deduplicationService.DeduplicateBatchAsync(RecordType.SensorGlucose, dedupInputs, ct);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "SensorGlucose", saved.Count);
-            }
-
-            return saved.Select(SensorGlucoseMapper.ToDomainModel);
-        });
+            await _deduplicationService.DeduplicateBatchAsync(RecordType.SensorGlucose, dedupInputs, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "SensorGlucose", inserted.Count);
+        }
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -277,7 +277,7 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
 
             await _deduplicationService.DeduplicateBatchAsync(RecordType.SensorGlucose, dedupInputs, ct);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "SensorGlucose", inserted.Count);
         }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TargetRangeScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TargetRangeScheduleRepository.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
@@ -20,10 +21,11 @@ public class TargetRangeScheduleRepository : V4RepositoryBase<TargetRangeSchedul
     /// Initializes a new instance of the <see cref="TargetRangeScheduleRepository"/> class.
     /// </summary>
     /// <param name="contextFactory">The tenant database context factory.</param>
+    /// <param name="auditContext">The audit context for tracking mutations (used by the base soft-delete path).</param>
     /// <param name="logger">The logger instance.</param>
     // logger is unused for this LegacyId-only type but retained for DI + direct test construction.
-    public TargetRangeScheduleRepository(ITenantDbContextFactory contextFactory, ILogger<TargetRangeScheduleRepository> logger)
-        : base(contextFactory)
+    public TargetRangeScheduleRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext, ILogger<TargetRangeScheduleRepository> logger)
+        : base(contextFactory, auditContext)
     {
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TargetRangeScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TargetRangeScheduleRepository.cs
@@ -3,94 +3,39 @@ using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
-using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
-/// Repository for managing target range schedules in the database.
+/// Repository for managing target range schedules in the database. A LegacyId-only type (no
+/// SyncId-upsert, no DeduplicationService participation), so it uses the shared
+/// <see cref="V4RepositoryBase{TModel,TEntity}"/> behaviour unchanged plus the target-range-specific
+/// queries below.
 /// </summary>
-public class TargetRangeScheduleRepository : ITargetRangeScheduleRepository
+public class TargetRangeScheduleRepository : V4RepositoryBase<TargetRangeSchedule, TargetRangeScheduleEntity>, ITargetRangeScheduleRepository
 {
-    private readonly ITenantDbContextFactory _contextFactory;
-    private readonly ILogger<TargetRangeScheduleRepository> _logger;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="TargetRangeScheduleRepository"/> class.
     /// </summary>
     /// <param name="contextFactory">The tenant database context factory.</param>
     /// <param name="logger">The logger instance.</param>
+    // logger is unused for this LegacyId-only type but retained for DI + direct test construction.
     public TargetRangeScheduleRepository(ITenantDbContextFactory contextFactory, ILogger<TargetRangeScheduleRepository> logger)
+        : base(contextFactory)
     {
-        _contextFactory = contextFactory;
-        _logger = logger;
     }
 
-    /// <summary>
-    /// Gets target range schedules based on filter criteria.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="device">Optional device filter.</param>
-    /// <param name="source">Optional data source filter.</param>
-    /// <param name="limit">The maximum number of records to return.</param>
-    /// <param name="offset">The number of records to skip.</param>
-    /// <param name="descending">Whether to sort by timestamp in descending order.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>A collection of target range schedules.</returns>
-    public async Task<IEnumerable<TargetRangeSchedule>> GetAsync(
-        DateTime? from,
-        DateTime? to,
-        string? device,
-        string? source,
-        int limit = 100,
-        int offset = 0,
-        bool descending = true,
-        CancellationToken ct = default
-    )
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.TargetRangeSchedules.AsNoTracking().AsQueryable();
-        if (from.HasValue)
-            query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue)
-            query = query.Where(e => e.Timestamp <= to.Value);
-        if (device != null)
-            query = query.Where(e => e.Device == device);
-        if (source != null)
-            query = query.Where(e => e.DataSource == source);
-        query = descending ? query.OrderByDescending(e => e.Timestamp) : query.OrderBy(e => e.Timestamp);
-        var entities = await query.Skip(offset).Take(limit).ToListAsync(ct);
-        return entities.Select(TargetRangeScheduleMapper.ToDomainModel);
-    }
+    /// <inheritdoc />
+    protected override TargetRangeScheduleEntity ToEntity(TargetRangeSchedule model) => TargetRangeScheduleMapper.ToEntity(model);
 
-    /// <summary>
-    /// Gets a target range schedule by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The target range schedule, or null if not found.</returns>
-    public async Task<TargetRangeSchedule?> GetByIdAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.TargetRangeSchedules.FindAsync([id], ct);
-        return entity is null ? null : TargetRangeScheduleMapper.ToDomainModel(entity);
-    }
+    /// <inheritdoc />
+    protected override TargetRangeSchedule ToDomain(TargetRangeScheduleEntity entity) => TargetRangeScheduleMapper.ToDomainModel(entity);
 
-    /// <summary>
-    /// Gets a target range schedule by its legacy (MongoDB) identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The target range schedule, or null if not found.</returns>
-    public async Task<TargetRangeSchedule?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.TargetRangeSchedules.FirstOrDefaultAsync(e => e.LegacyId == legacyId, ct);
-        return entity is null ? null : TargetRangeScheduleMapper.ToDomainModel(entity);
-    }
+    /// <inheritdoc />
+    protected override void ApplyUpdate(TargetRangeScheduleEntity target, TargetRangeSchedule source) =>
+        TargetRangeScheduleMapper.UpdateEntity(target, source);
 
     /// <summary>
     /// Gets target range schedules by profile name.
@@ -103,7 +48,7 @@ public class TargetRangeScheduleRepository : ITargetRangeScheduleRepository
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entities = await ctx
             .TargetRangeSchedules.AsNoTracking()
             .Where(e => e.ProfileName == profileName)
@@ -122,7 +67,7 @@ public class TargetRangeScheduleRepository : ITargetRangeScheduleRepository
     public async Task<TargetRangeSchedule?> GetActiveAtAsync(
         string profileName, DateTime timestamp, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entity = await ctx.TargetRangeSchedules
             .AsNoTracking()
             .Where(e => e.ProfileName == profileName && e.Timestamp <= timestamp)
@@ -133,120 +78,6 @@ public class TargetRangeScheduleRepository : ITargetRangeScheduleRepository
     }
 
     /// <summary>
-    /// Creates a new target range schedule.
-    /// </summary>
-    /// <param name="model">The target range schedule to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The created target range schedule.</returns>
-    public async Task<TargetRangeSchedule> CreateAsync(TargetRangeSchedule model, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = TargetRangeScheduleMapper.ToEntity(model);
-        ctx.TargetRangeSchedules.Add(entity);
-        await ctx.SaveChangesAsync(ct);
-        return TargetRangeScheduleMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Updates an existing target range schedule.
-    /// </summary>
-    /// <param name="id">The unique identifier of the schedule to update.</param>
-    /// <param name="model">The updated schedule data.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The updated target range schedule.</returns>
-    public async Task<TargetRangeSchedule> UpdateAsync(
-        Guid id,
-        TargetRangeSchedule model,
-        CancellationToken ct = default
-    )
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity =
-            await ctx.TargetRangeSchedules.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"TargetRangeSchedule {id} not found");
-        TargetRangeScheduleMapper.UpdateEntity(entity, model);
-        await ctx.SaveChangesAsync(ct);
-        return TargetRangeScheduleMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Deletes a target range schedule by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity =
-            await ctx.TargetRangeSchedules.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"TargetRangeSchedule {id} not found");
-        entity.DeletedAt = DateTime.UtcNow;
-        await ctx.SaveChangesAsync(ct);
-    }
-
-    /// <inheritdoc />
-    public async Task<TargetRangeSchedule> RestoreAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.TargetRangeSchedules.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
-            .FirstOrDefaultAsync(ct)
-            ?? throw new KeyNotFoundException($"Soft-deleted TargetRangeSchedule {id} not found");
-        entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return TargetRangeScheduleMapper.ToDomainModel(entity);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<TargetRangeSchedule>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var idSet = ids.ToHashSet();
-        var entities = await ctx.TargetRangeSchedules.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
-            .ToListAsync(ct);
-        foreach (var entity in entities)
-            entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return entities.Select(TargetRangeScheduleMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<TargetRangeSchedule>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entities = await ctx.TargetRangeSchedules.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .OrderByDescending(e => e.DeletedAt)
-            .Skip(offset).Take(limit)
-            .AsNoTracking()
-            .ToListAsync(ct);
-        return entities.Select(TargetRangeScheduleMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.TargetRangeSchedules.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .CountAsync(ct);
-    }
-
-    /// <summary>
-    /// Deletes target range schedules by legacy identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.TargetRangeSchedules.Where(e => e.LegacyId == legacyId)
-            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
-    }
-
-    /// <summary>
     /// Deletes target range schedules by legacy identifier prefix.
     /// </summary>
     /// <param name="prefix">The legacy identifier prefix.</param>
@@ -254,28 +85,10 @@ public class TargetRangeScheduleRepository : ITargetRangeScheduleRepository
     /// <returns>The number of deleted records.</returns>
     public async Task<int> DeleteByLegacyIdPrefixAsync(string prefix, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx
             .TargetRangeSchedules.Where(e => e.LegacyId != null && e.LegacyId.StartsWith(prefix))
             .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
-    }
-
-    /// <summary>
-    /// Counts target range schedules within a timestamp range.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The count of matching records.</returns>
-    public async Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.TargetRangeSchedules.AsNoTracking().AsQueryable();
-        if (from.HasValue)
-            query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue)
-            query = query.Where(e => e.Timestamp <= to.Value);
-        return await query.CountAsync(ct);
     }
 
     /// <summary>
@@ -289,72 +102,11 @@ public class TargetRangeScheduleRepository : ITargetRangeScheduleRepository
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entities = await ctx
             .TargetRangeSchedules.AsNoTracking()
             .Where(e => e.CorrelationId == correlationId)
             .ToListAsync(ct);
         return entities.Select(TargetRangeScheduleMapper.ToDomainModel);
-    }
-
-    /// <summary>
-    /// Perfroms a bulk creation of target range schedules, handling deduplication.
-    /// </summary>
-    /// <param name="records">The collection of records to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>A collection of created schedules.</returns>
-    public async Task<IEnumerable<TargetRangeSchedule>> BulkCreateAsync(
-        IEnumerable<TargetRangeSchedule> records,
-        CancellationToken ct = default
-    )
-    {
-        var entities = records.Select(TargetRangeScheduleMapper.ToEntity).ToList();
-        if (entities.Count == 0)
-            return [];
-
-        // Batch-level dedup: keep first occurrence per LegacyId
-        entities = entities
-            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-            .Select(g => g.First())
-            .ToList();
-
-        // DB-level dedup: filter out records whose LegacyId already exists
-        var legacyIds = entities
-            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-            .Select(e => e.LegacyId!)
-            .ToHashSet();
-
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var strategy = ctx.Database.CreateExecutionStrategy();
-        return await strategy.ExecuteAsync(async () =>
-        {
-            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-            if (legacyIds.Count > 0)
-            {
-                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<TargetRangeScheduleEntity>(legacyIds, ct);
-
-                entities = entities
-                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
-                    .ToList();
-            }
-
-            if (entities.Count == 0)
-            {
-                await tx.CommitAsync(ct);
-                return [];
-            }
-
-            const int batchSize = 500;
-            foreach (var batch in entities.Chunk(batchSize))
-            {
-                ctx.TargetRangeSchedules.AddRange(batch);
-                await ctx.SaveChangesAsync(ct);
-                ctx.ChangeTracker.Clear();
-            }
-
-            await tx.CommitAsync(ct);
-            return entities.Select(TargetRangeScheduleMapper.ToDomainModel);
-        });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
@@ -327,7 +327,7 @@ public class TempBasalRepository : ITempBasalRepository
 
                 await _deduplicationService.DeduplicateBatchAsync(RecordType.TempBasal, dedupInputs, ct);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "TempBasal", entities.Count);
             }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TherapySettingsRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TherapySettingsRepository.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
@@ -20,10 +21,11 @@ public class TherapySettingsRepository : V4RepositoryBase<TherapySettings, Thera
     /// Initializes a new instance of the <see cref="TherapySettingsRepository"/> class.
     /// </summary>
     /// <param name="contextFactory">The tenant database context factory.</param>
+    /// <param name="auditContext">The audit context for tracking mutations (used by the base soft-delete path).</param>
     /// <param name="logger">The logger instance.</param>
     // logger is unused for this LegacyId-only type but retained for DI + direct test construction.
-    public TherapySettingsRepository(ITenantDbContextFactory contextFactory, ILogger<TherapySettingsRepository> logger)
-        : base(contextFactory)
+    public TherapySettingsRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext, ILogger<TherapySettingsRepository> logger)
+        : base(contextFactory, auditContext)
     {
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TherapySettingsRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TherapySettingsRepository.cs
@@ -3,94 +3,39 @@ using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
-using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
-/// Repository for managing therapy settings in the database.
+/// Repository for managing therapy settings in the database. A LegacyId-only type (no SyncId-upsert,
+/// no DeduplicationService participation), so it uses the shared
+/// <see cref="V4RepositoryBase{TModel,TEntity}"/> behaviour unchanged plus the therapy-settings-specific
+/// queries below.
 /// </summary>
-public class TherapySettingsRepository : ITherapySettingsRepository
+public class TherapySettingsRepository : V4RepositoryBase<TherapySettings, TherapySettingsEntity>, ITherapySettingsRepository
 {
-    private readonly ITenantDbContextFactory _contextFactory;
-    private readonly ILogger<TherapySettingsRepository> _logger;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="TherapySettingsRepository"/> class.
     /// </summary>
     /// <param name="contextFactory">The tenant database context factory.</param>
     /// <param name="logger">The logger instance.</param>
+    // logger is unused for this LegacyId-only type but retained for DI + direct test construction.
     public TherapySettingsRepository(ITenantDbContextFactory contextFactory, ILogger<TherapySettingsRepository> logger)
+        : base(contextFactory)
     {
-        _contextFactory = contextFactory;
-        _logger = logger;
     }
 
-    /// <summary>
-    /// Gets therapy settings based on filter criteria.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="device">Optional device filter.</param>
-    /// <param name="source">Optional data source filter.</param>
-    /// <param name="limit">The maximum number of records to return.</param>
-    /// <param name="offset">The number of records to skip.</param>
-    /// <param name="descending">Whether to sort by timestamp in descending order.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>A collection of therapy settings.</returns>
-    public async Task<IEnumerable<TherapySettings>> GetAsync(
-        DateTime? from,
-        DateTime? to,
-        string? device,
-        string? source,
-        int limit = 100,
-        int offset = 0,
-        bool descending = true,
-        CancellationToken ct = default
-    )
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.TherapySettings.AsNoTracking().AsQueryable();
-        if (from.HasValue)
-            query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue)
-            query = query.Where(e => e.Timestamp <= to.Value);
-        if (device != null)
-            query = query.Where(e => e.Device == device);
-        if (source != null)
-            query = query.Where(e => e.DataSource == source);
-        query = descending ? query.OrderByDescending(e => e.Timestamp) : query.OrderBy(e => e.Timestamp);
-        var entities = await query.Skip(offset).Take(limit).ToListAsync(ct);
-        return entities.Select(TherapySettingsMapper.ToDomainModel);
-    }
+    /// <inheritdoc />
+    protected override TherapySettingsEntity ToEntity(TherapySettings model) => TherapySettingsMapper.ToEntity(model);
 
-    /// <summary>
-    /// Gets therapy settings by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The therapy settings, or null if not found.</returns>
-    public async Task<TherapySettings?> GetByIdAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.TherapySettings.FindAsync([id], ct);
-        return entity is null ? null : TherapySettingsMapper.ToDomainModel(entity);
-    }
+    /// <inheritdoc />
+    protected override TherapySettings ToDomain(TherapySettingsEntity entity) => TherapySettingsMapper.ToDomainModel(entity);
 
-    /// <summary>
-    /// Gets therapy settings by its legacy (MongoDB) identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The therapy settings, or null if not found.</returns>
-    public async Task<TherapySettings?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.TherapySettings.FirstOrDefaultAsync(e => e.LegacyId == legacyId, ct);
-        return entity is null ? null : TherapySettingsMapper.ToDomainModel(entity);
-    }
+    /// <inheritdoc />
+    protected override void ApplyUpdate(TherapySettingsEntity target, TherapySettings source) =>
+        TherapySettingsMapper.UpdateEntity(target, source);
 
     /// <summary>
     /// Gets therapy settings by profile name.
@@ -103,7 +48,7 @@ public class TherapySettingsRepository : ITherapySettingsRepository
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entities = await ctx
             .TherapySettings.AsNoTracking()
             .Where(e => e.ProfileName == profileName)
@@ -122,7 +67,7 @@ public class TherapySettingsRepository : ITherapySettingsRepository
     public async Task<TherapySettings?> GetActiveAtAsync(
         string profileName, DateTime timestamp, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entity = await ctx.TherapySettings
             .AsNoTracking()
             .Where(e => e.ProfileName == profileName && e.Timestamp <= timestamp)
@@ -133,116 +78,6 @@ public class TherapySettingsRepository : ITherapySettingsRepository
     }
 
     /// <summary>
-    /// Creates a new therapy settings record.
-    /// </summary>
-    /// <param name="model">The therapy settings to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The created therapy settings.</returns>
-    public async Task<TherapySettings> CreateAsync(TherapySettings model, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = TherapySettingsMapper.ToEntity(model);
-        ctx.TherapySettings.Add(entity);
-        await ctx.SaveChangesAsync(ct);
-        return TherapySettingsMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Updates an existing therapy settings record.
-    /// </summary>
-    /// <param name="id">The unique identifier of the settings to update.</param>
-    /// <param name="model">The updated settings data.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The updated therapy settings.</returns>
-    public async Task<TherapySettings> UpdateAsync(Guid id, TherapySettings model, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity =
-            await ctx.TherapySettings.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"TherapySettings {id} not found");
-        TherapySettingsMapper.UpdateEntity(entity, model);
-        await ctx.SaveChangesAsync(ct);
-        return TherapySettingsMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Deletes therapy settings by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity =
-            await ctx.TherapySettings.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"TherapySettings {id} not found");
-        entity.DeletedAt = DateTime.UtcNow;
-        await ctx.SaveChangesAsync(ct);
-    }
-
-    /// <inheritdoc />
-    public async Task<TherapySettings> RestoreAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.TherapySettings.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
-            .FirstOrDefaultAsync(ct)
-            ?? throw new KeyNotFoundException($"Soft-deleted TherapySettings {id} not found");
-        entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return TherapySettingsMapper.ToDomainModel(entity);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<TherapySettings>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var idSet = ids.ToHashSet();
-        var entities = await ctx.TherapySettings.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
-            .ToListAsync(ct);
-        foreach (var entity in entities)
-            entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return entities.Select(TherapySettingsMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<TherapySettings>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entities = await ctx.TherapySettings.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .OrderByDescending(e => e.DeletedAt)
-            .Skip(offset).Take(limit)
-            .AsNoTracking()
-            .ToListAsync(ct);
-        return entities.Select(TherapySettingsMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.TherapySettings.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .CountAsync(ct);
-    }
-
-    /// <summary>
-    /// Deletes therapy settings by legacy identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.TherapySettings.Where(e => e.LegacyId == legacyId)
-            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
-    }
-
-    /// <summary>
     /// Deletes therapy settings by legacy identifier prefix.
     /// </summary>
     /// <param name="prefix">The legacy identifier prefix.</param>
@@ -250,28 +85,10 @@ public class TherapySettingsRepository : ITherapySettingsRepository
     /// <returns>The number of deleted records.</returns>
     public async Task<int> DeleteByLegacyIdPrefixAsync(string prefix, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx
             .TherapySettings.Where(e => e.LegacyId != null && e.LegacyId.StartsWith(prefix))
             .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
-    }
-
-    /// <summary>
-    /// Counts therapy settings within a timestamp range.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The count of matching records.</returns>
-    public async Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.TherapySettings.AsNoTracking().AsQueryable();
-        if (from.HasValue)
-            query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue)
-            query = query.Where(e => e.Timestamp <= to.Value);
-        return await query.CountAsync(ct);
     }
 
     /// <summary>
@@ -285,72 +102,11 @@ public class TherapySettingsRepository : ITherapySettingsRepository
         CancellationToken ct = default
     )
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entities = await ctx
             .TherapySettings.AsNoTracking()
             .Where(e => e.CorrelationId == correlationId)
             .ToListAsync(ct);
         return entities.Select(TherapySettingsMapper.ToDomainModel);
-    }
-
-    /// <summary>
-    /// Performs a bulk creation of therapy settings records, handling deduplication.
-    /// </summary>
-    /// <param name="records">The collection of records to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>A collection of created settings.</returns>
-    public async Task<IEnumerable<TherapySettings>> BulkCreateAsync(
-        IEnumerable<TherapySettings> records,
-        CancellationToken ct = default
-    )
-    {
-        var entities = records.Select(TherapySettingsMapper.ToEntity).ToList();
-        if (entities.Count == 0)
-            return [];
-
-        // Batch-level dedup: keep first occurrence per LegacyId
-        entities = entities
-            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-            .Select(g => g.First())
-            .ToList();
-
-        // DB-level dedup: filter out records whose LegacyId already exists
-        var legacyIds = entities
-            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-            .Select(e => e.LegacyId!)
-            .ToHashSet();
-
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var strategy = ctx.Database.CreateExecutionStrategy();
-        return await strategy.ExecuteAsync(async () =>
-        {
-            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-            if (legacyIds.Count > 0)
-            {
-                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<TherapySettingsEntity>(legacyIds, ct);
-
-                entities = entities
-                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
-                    .ToList();
-            }
-
-            if (entities.Count == 0)
-            {
-                await tx.CommitAsync(ct);
-                return [];
-            }
-
-            const int batchSize = 500;
-            foreach (var batch in entities.Chunk(batchSize))
-            {
-                ctx.TherapySettings.AddRange(batch);
-                await ctx.SaveChangesAsync(ct);
-                ctx.ChangeTracker.Clear();
-            }
-
-            await tx.CommitAsync(ct);
-            return entities.Select(TherapySettingsMapper.ToDomainModel);
-        });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
@@ -223,51 +223,51 @@ public abstract class V4RepositoryBase<TModel, TEntity>
         return await query.MinAsync(e => (DateTime?)e.Timestamp, ct);
     }
 
+    /// <summary>SyncId-upsert types override: match existing rows by (DataSource, SyncIdentifier), update them in
+    /// place, and return (rows updated in place, rows still to insert). Default: nothing upserted.</summary>
+    protected virtual Task<(List<TEntity> Updated, List<TEntity> ToInsert)> SplitUpsertsAsync(
+        NocturneDbContext ctx, List<TEntity> entities, CancellationToken ct)
+        => Task.FromResult((new List<TEntity>(), entities));
+
+    /// <summary>DeduplicationService participants override: link the just-inserted rows into canonical groups
+    /// (runs AFTER commit). Default: no-op.</summary>
+    protected virtual Task PostCommitDedupAsync(
+        NocturneDbContext ctx, IReadOnlyList<TEntity> inserted, CancellationToken ct)
+        => Task.CompletedTask;
+
     /// <summary>
     /// Bulk-inserts records with batch-level and DB-level deduplication by LegacyId. The base
-    /// implements the LegacyId-only path; SyncId-upsert / DeduplicationService participants override.
+    /// implements the LegacyId-only path; SyncId-upsert / DeduplicationService participants override
+    /// the <see cref="SplitUpsertsAsync"/> / <see cref="PostCommitDedupAsync"/> hooks rather than the
+    /// whole method.
     /// </summary>
     public virtual async Task<IEnumerable<TModel>> BulkCreateAsync(
-        IEnumerable<TModel> records, CancellationToken ct = default)
+        IEnumerable<TModel> recordsParam, CancellationToken ct = default)
     {
-        var entities = records.Select(ToEntity).ToList();
-        if (entities.Count == 0)
-            return [];
-
-        // Batch-level dedup: keep first occurrence per LegacyId.
-        entities = entities
-            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-            .Select(g => g.First())
-            .ToList();
-
-        // DB-level dedup: filter out records whose LegacyId already exists.
-        var legacyIds = entities
-            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-            .Select(e => e.LegacyId!)
-            .ToHashSet();
-
+        var records = recordsParam.ToList();
+        if (records.Count == 0) return [];
         await using var ctx = await ContextFactory.CreateAsync(ct);
         var strategy = ctx.Database.CreateExecutionStrategy();
         return await strategy.ExecuteAsync(async () =>
         {
             await using var tx = await ctx.Database.BeginTransactionAsync(ct);
+            var entities = records.Select(ToEntity).ToList();
 
+            var (updated, toInsert) = await SplitUpsertsAsync(ctx, entities, ct);
+
+            // Batch-level LegacyId dedup
+            toInsert = toInsert.GroupBy(e => e.LegacyId ?? e.Id.ToString()).Select(g => g.First()).ToList();
+            var legacyIds = toInsert.Where(e => !string.IsNullOrEmpty(e.LegacyId)).Select(e => e.LegacyId!).ToHashSet();
             if (legacyIds.Count > 0)
             {
-                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<TEntity>(legacyIds, ct);
-                entities = entities
-                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
-                    .ToList();
+                var blocked = await ctx.GetBlockingLegacyIdsAsync<TEntity>(legacyIds, ct);
+                toInsert = toInsert.Where(e => string.IsNullOrEmpty(e.LegacyId) || !blocked.Contains(e.LegacyId)).ToList();
             }
 
-            if (entities.Count == 0)
-            {
-                await tx.CommitAsync(ct);
-                return [];
-            }
+            if (toInsert.Count == 0 && updated.Count == 0) { await tx.CommitAsync(ct); return Enumerable.Empty<TModel>(); }
 
             const int batchSize = 500;
-            foreach (var batch in entities.Chunk(batchSize))
+            foreach (var batch in toInsert.Chunk(batchSize))
             {
                 ctx.Set<TEntity>().AddRange(batch);
                 await ctx.SaveChangesAsync(ct);
@@ -275,7 +275,8 @@ public abstract class V4RepositoryBase<TModel, TEntity>
             }
 
             await tx.CommitAsync(ct);
-            return entities.Select(ToDomain);
+            await PostCommitDedupAsync(ctx, toInsert, ct);
+            return updated.Concat(toInsert).Select(ToDomain);
         });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
@@ -44,7 +44,12 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     protected abstract void ApplyUpdate(TEntity target, TModel source);
 
     /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.GetAsync" />
-    public async Task<IEnumerable<TModel>> GetAsync(
+    /// <remarks>
+    /// Virtual so dedup participants (which expose an extended overload with a non-primary
+    /// LinkedRecords filter + keyset cursor) can override this 7-arg form to route through their
+    /// filtered overload, preserving the pre-base default-interface bridge behaviour.
+    /// </remarks>
+    public virtual async Task<IEnumerable<TModel>> GetAsync(
         DateTime? from, DateTime? to, string? device, string? source,
         int limit = 100, int offset = 0, bool descending = true,
         CancellationToken ct = default)
@@ -77,7 +82,8 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     }
 
     /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.CreateAsync" />
-    public async Task<TModel> CreateAsync(TModel model, CancellationToken ct = default)
+    /// <remarks>Virtual: SyncId-upsert types (Bolus, CarbIntake) override to upsert in place.</remarks>
+    public virtual async Task<TModel> CreateAsync(TModel model, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         var entity = ToEntity(model);
@@ -167,7 +173,8 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     }
 
     /// <summary>Soft-deletes the record(s) with the given legacy id. Returns the number affected.</summary>
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
+    /// <remarks>Virtual: dedup participants override to route through the audited soft-delete helper.</remarks>
+    public virtual async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.Set<TEntity>()

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Extensions;
@@ -24,13 +25,24 @@ namespace Nocturne.Infrastructure.Data.Repositories.V4;
 /// <typeparam name="TEntity">The EF entity type backing <typeparamref name="TModel"/>.</typeparam>
 public abstract class V4RepositoryBase<TModel, TEntity>
     where TModel : class, IV4Record
-    where TEntity : class, IV4TimeSeriesEntity
+    where TEntity : class, IV4TimeSeriesEntity, IAuditable
 {
     /// <summary>Tenant-scoped context factory. Exposed so subclasses can implement type-specific queries.</summary>
     protected ITenantDbContextFactory ContextFactory { get; }
 
-    /// <summary>Initializes the base with the tenant-scoped context factory.</summary>
-    protected V4RepositoryBase(ITenantDbContextFactory contextFactory) => ContextFactory = contextFactory;
+    /// <summary>
+    /// Actor/request metadata for the audited soft-delete path. Exposed so subclasses' type-specific
+    /// audited deletes (e.g. DeleteBySyncIdentifierAsync, DeleteByLegacyIdPrefixAsync) share the same
+    /// attribution as the base DeleteByLegacyIdAsync.
+    /// </summary>
+    protected IAuditContext AuditContext { get; }
+
+    /// <summary>Initializes the base with the tenant-scoped context factory and audit context.</summary>
+    protected V4RepositoryBase(ITenantDbContextFactory contextFactory, IAuditContext auditContext)
+    {
+        ContextFactory = contextFactory;
+        AuditContext = auditContext;
+    }
 
     // ── Per-type static-mapper bridges (the only code the base needs from each repository) ──
 
@@ -173,13 +185,16 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     }
 
     /// <summary>Soft-deletes the record(s) with the given legacy id. Returns the number affected.</summary>
-    /// <remarks>Virtual: dedup participants override to route through the audited soft-delete helper.</remarks>
+    /// <remarks>
+    /// Routes through the audited soft-delete helper so every V4 type writes a mutation_audit_log row
+    /// and carries the user-delete dedup discriminator. Virtual so types with a type-specific delete
+    /// surface can still override.
+    /// </remarks>
     public virtual async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
-        return await ctx.Set<TEntity>()
-            .Where(e => e.LegacyId == legacyId)
-            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
+        return await ctx.AuditedSoftDeleteAsync(
+            ctx.Set<TEntity>().Where(e => e.LegacyId == legacyId), AuditContext, ct);
     }
 
     /// <summary>Latest stored record timestamp, optionally scoped to a data source (connector watermark).</summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
@@ -174,11 +174,19 @@ public abstract class V4RepositoryBase<TModel, TEntity>
             .CountAsync(ct);
     }
 
+    /// <summary>
+    /// Read-visibility hook applied by <see cref="CountAsync"/> (and reusable by future read paths) so
+    /// counts match the rows reads return. The base is identity; dedup participants override it to
+    /// exclude non-primary LinkedRecords for their RecordType — replacing the per-type CountAsync
+    /// overrides that each carried the same exclusion.
+    /// </summary>
+    protected virtual IQueryable<TEntity> ApplyReadVisibility(IQueryable<TEntity> query, NocturneDbContext ctx) => query;
+
     /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.CountAsync" />
     public virtual async Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
-        var query = ctx.Set<TEntity>().AsNoTracking().AsQueryable();
+        var query = ApplyReadVisibility(ctx.Set<TEntity>().AsNoTracking().AsQueryable(), ctx);
         if (from.HasValue) query = query.Where(e => e.Timestamp >= from.Value);
         if (to.HasValue) query = query.Where(e => e.Timestamp <= to.Value);
         return await query.CountAsync(ct);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
@@ -1,0 +1,251 @@
+using Microsoft.EntityFrameworkCore;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Extensions;
+using Nocturne.Infrastructure.Data.Services;
+
+namespace Nocturne.Infrastructure.Data.Repositories.V4;
+
+/// <summary>
+/// Shared CRUD, soft-delete, and LegacyId-deduplicated bulk-create implementation for the V4 record
+/// repositories. Concrete repositories supply three static-mapper bridges
+/// (<see cref="ToEntity"/>, <see cref="ToDomain"/>, <see cref="ApplyUpdate"/>) and keep only their
+/// type-specific query methods; everything that was previously copy-pasted across every repository
+/// lives here once.
+/// </summary>
+/// <remarks>
+/// Behaviour is intentionally identical to the pre-refactor per-type repositories (the golden suite
+/// holds it constant). Per-type strategy points that some types diverge on — SyncId-upsert,
+/// DeduplicationService participation, non-primary-excluding counts — are exposed as
+/// <see langword="virtual"/> members (<see cref="BulkCreateAsync"/>, <see cref="CountAsync"/>) for
+/// the dedup participants to override; the base implements the LegacyId-only path.
+/// </remarks>
+/// <typeparam name="TModel">The V4 domain record type.</typeparam>
+/// <typeparam name="TEntity">The EF entity type backing <typeparamref name="TModel"/>.</typeparam>
+public abstract class V4RepositoryBase<TModel, TEntity>
+    where TModel : class, IV4Record
+    where TEntity : class, IV4TimeSeriesEntity
+{
+    /// <summary>Tenant-scoped context factory. Exposed so subclasses can implement type-specific queries.</summary>
+    protected ITenantDbContextFactory ContextFactory { get; }
+
+    /// <summary>Initializes the base with the tenant-scoped context factory.</summary>
+    protected V4RepositoryBase(ITenantDbContextFactory contextFactory) => ContextFactory = contextFactory;
+
+    // ── Per-type static-mapper bridges (the only code the base needs from each repository) ──
+
+    /// <summary>Maps a domain model to its EF entity (delegates to the type's static mapper).</summary>
+    protected abstract TEntity ToEntity(TModel model);
+
+    /// <summary>Maps an EF entity to its domain model (delegates to the type's static mapper).</summary>
+    protected abstract TModel ToDomain(TEntity entity);
+
+    /// <summary>Applies a domain model's values onto an existing tracked entity (in-place update).</summary>
+    protected abstract void ApplyUpdate(TEntity target, TModel source);
+
+    /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.GetAsync" />
+    public async Task<IEnumerable<TModel>> GetAsync(
+        DateTime? from, DateTime? to, string? device, string? source,
+        int limit = 100, int offset = 0, bool descending = true,
+        CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var query = ctx.Set<TEntity>().AsNoTracking().AsQueryable();
+        if (from.HasValue) query = query.Where(e => e.Timestamp >= from.Value);
+        if (to.HasValue) query = query.Where(e => e.Timestamp <= to.Value);
+        if (device != null) query = query.Where(e => e.Device == device);
+        if (source != null) query = query.Where(e => e.DataSource == source);
+        query = descending ? query.OrderByDescending(e => e.Timestamp) : query.OrderBy(e => e.Timestamp);
+        var entities = await query.Skip(offset).Take(limit).ToListAsync(ct);
+        return entities.Select(ToDomain);
+    }
+
+    /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.GetByIdAsync" />
+    public async Task<TModel?> GetByIdAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var entity = await ctx.Set<TEntity>().FindAsync([id], ct);
+        return entity is null ? null : ToDomain(entity);
+    }
+
+    /// <summary>Returns a single record by its legacy (MongoDB ObjectId) identifier, or null.</summary>
+    public async Task<TModel?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var entity = await ctx.Set<TEntity>().FirstOrDefaultAsync(e => e.LegacyId == legacyId, ct);
+        return entity is null ? null : ToDomain(entity);
+    }
+
+    /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.CreateAsync" />
+    public async Task<TModel> CreateAsync(TModel model, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var entity = ToEntity(model);
+        ctx.Set<TEntity>().Add(entity);
+        await ctx.SaveChangesAsync(ct);
+        return ToDomain(entity);
+    }
+
+    /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.UpdateAsync" />
+    public async Task<TModel> UpdateAsync(Guid id, TModel model, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var entity = await ctx.Set<TEntity>().FindAsync([id], ct)
+            ?? throw new KeyNotFoundException($"{typeof(TModel).Name} {id} not found");
+        ApplyUpdate(entity, model);
+        await ctx.SaveChangesAsync(ct);
+        return ToDomain(entity);
+    }
+
+    /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.DeleteAsync" />
+    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var entity = await ctx.Set<TEntity>().FindAsync([id], ct)
+            ?? throw new KeyNotFoundException($"{typeof(TModel).Name} {id} not found");
+        entity.DeletedAt = DateTime.UtcNow;
+        await ctx.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.RestoreAsync" />
+    public async Task<TModel> RestoreAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var entity = await ctx.Set<TEntity>().IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Soft-deleted {typeof(TModel).Name} {id} not found");
+        entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return ToDomain(entity);
+    }
+
+    /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.BulkRestoreAsync" />
+    public async Task<IEnumerable<TModel>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var idSet = ids.ToHashSet();
+        var entities = await ctx.Set<TEntity>().IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
+            .ToListAsync(ct);
+        foreach (var entity in entities)
+            entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return entities.Select(ToDomain);
+    }
+
+    /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.GetDeletedAsync" />
+    public async Task<IEnumerable<TModel>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var entities = await ctx.Set<TEntity>().IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .OrderByDescending(e => e.DeletedAt)
+            .Skip(offset).Take(limit)
+            .AsNoTracking()
+            .ToListAsync(ct);
+        return entities.Select(ToDomain);
+    }
+
+    /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.CountDeletedAsync" />
+    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        return await ctx.Set<TEntity>().IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
+            .CountAsync(ct);
+    }
+
+    /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.CountAsync" />
+    public virtual async Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var query = ctx.Set<TEntity>().AsNoTracking().AsQueryable();
+        if (from.HasValue) query = query.Where(e => e.Timestamp >= from.Value);
+        if (to.HasValue) query = query.Where(e => e.Timestamp <= to.Value);
+        return await query.CountAsync(ct);
+    }
+
+    /// <summary>Soft-deletes the record(s) with the given legacy id. Returns the number affected.</summary>
+    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        return await ctx.Set<TEntity>()
+            .Where(e => e.LegacyId == legacyId)
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
+    }
+
+    /// <summary>Latest stored record timestamp, optionally scoped to a data source (connector watermark).</summary>
+    public async Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var query = ctx.Set<TEntity>().AsNoTracking().AsQueryable();
+        if (source != null) query = query.Where(e => e.DataSource == source);
+        return await query.MaxAsync(e => (DateTime?)e.Timestamp, ct);
+    }
+
+    /// <summary>Oldest stored record timestamp, optionally scoped to a data source.</summary>
+    public async Task<DateTime?> GetOldestTimestampAsync(string? source = null, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var query = ctx.Set<TEntity>().AsNoTracking().AsQueryable();
+        if (source != null) query = query.Where(e => e.DataSource == source);
+        return await query.MinAsync(e => (DateTime?)e.Timestamp, ct);
+    }
+
+    /// <summary>
+    /// Bulk-inserts records with batch-level and DB-level deduplication by LegacyId. The base
+    /// implements the LegacyId-only path; SyncId-upsert / DeduplicationService participants override.
+    /// </summary>
+    public virtual async Task<IEnumerable<TModel>> BulkCreateAsync(
+        IEnumerable<TModel> records, CancellationToken ct = default)
+    {
+        var entities = records.Select(ToEntity).ToList();
+        if (entities.Count == 0)
+            return [];
+
+        // Batch-level dedup: keep first occurrence per LegacyId.
+        entities = entities
+            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
+            .Select(g => g.First())
+            .ToList();
+
+        // DB-level dedup: filter out records whose LegacyId already exists.
+        var legacyIds = entities
+            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
+            .Select(e => e.LegacyId!)
+            .ToHashSet();
+
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var strategy = ctx.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
+        {
+            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
+
+            if (legacyIds.Count > 0)
+            {
+                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<TEntity>(legacyIds, ct);
+                entities = entities
+                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
+                    .ToList();
+            }
+
+            if (entities.Count == 0)
+            {
+                await tx.CommitAsync(ct);
+                return [];
+            }
+
+            const int batchSize = 500;
+            foreach (var batch in entities.Chunk(batchSize))
+            {
+                ctx.Set<TEntity>().AddRange(batch);
+                await ctx.SaveChangesAsync(ct);
+                ctx.ChangeTracker.Clear();
+            }
+
+            await tx.CommitAsync(ct);
+            return entities.Select(ToDomain);
+        });
+    }
+}

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/AuditDeltaGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/AuditDeltaGoldenTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.Extensions.DependencyInjection;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Entities;
+
+namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
+
+/// <summary>
+/// Goldens pinning the soft-delete-on-<c>DeleteByLegacyIdAsync</c> audit behaviour the
+/// V4RepositoryBase refactor NORMALIZES (delta D5). Today the base's <c>DeleteByLegacyIdAsync</c>
+/// is a plain <c>ExecuteUpdateAsync</c> that bypasses the change tracker, so it writes NO
+/// <see cref="MutationAuditLogEntity"/> row — only the six dedup participants that override it with
+/// the audited helper produce one. The two scenarios below pin both sides of that split so D5 lands
+/// as a deliberate, visible re-baseline:
+///   - a RAW type (BGCheck inherits the plain base) → NO audit row;
+///   - an AUDITED type (DeviceEvent overrides with the audited helper) → audit row present.
+/// The <see cref="V4GoldenFixture"/>'s <c>SystemAuditContext</c> short-circuits the
+/// <c>MutationAuditInterceptor</c> (IsSystem == true), so the only audit rows that can appear here
+/// come from the audited soft-delete helper, which writes them directly.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("V4 goldens")]
+public class AuditDeltaGoldenTests
+{
+    private readonly V4GoldenFixture _fx;
+
+    public AuditDeltaGoldenTests(V4GoldenFixture fx) => _fx = fx;
+
+    private static readonly DateTime T0 = new(2026, 5, 1, 9, 0, 0, DateTimeKind.Utc);
+
+    private Task<int> AuditRowCountAsync(Guid tenant, string entityType, Guid entityId) =>
+        _fx.QueryAsync(tenant, ctx => ctx.Set<MutationAuditLogEntity>().AsNoTracking()
+            .CountAsync(a => a.EntityType == entityType && a.EntityId == entityId && a.Action == "delete"));
+
+    [Fact]
+    public async Task D5_RawType_BGCheck_DeleteByLegacyId_DoesNotWriteAuditRow()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IBGCheckRepository>();
+
+        var created = await repo.CreateAsync(
+            new BGCheck { Timestamp = T0, Glucose = 95, DataSource = "manual", LegacyId = "bg-del" },
+            CancellationToken.None);
+
+        var deleted = await repo.DeleteByLegacyIdAsync("bg-del", CancellationToken.None);
+        deleted.Should().Be(1);
+
+        // Pre-D5 baseline: a RAW type inherits the plain base DeleteByLegacyIdAsync (ExecuteUpdate,
+        // change-tracker-bypassing), so NO mutation_audit_log row is written.
+        (await AuditRowCountAsync(tenant, "BGCheck", created.Id)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task D5_AuditedType_DeviceEvent_DeleteByLegacyId_WritesAuditRow()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IDeviceEventRepository>();
+
+        var created = await repo.CreateAsync(
+            new DeviceEvent { Timestamp = T0, EventType = DeviceEventType.SiteChange, DataSource = "aaps", LegacyId = "de-del" },
+            CancellationToken.None);
+
+        var deleted = await repo.DeleteByLegacyIdAsync("de-del", CancellationToken.None);
+        deleted.Should().Be(1);
+
+        // An AUDITED type wrote an audit row before D5 and still does after (unchanged).
+        (await AuditRowCountAsync(tenant, "DeviceEvent", created.Id)).Should().Be(1);
+    }
+}

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/AuditDeltaGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/AuditDeltaGoldenTests.cs
@@ -7,13 +7,12 @@ namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
 
 /// <summary>
 /// Goldens pinning the soft-delete-on-<c>DeleteByLegacyIdAsync</c> audit behaviour the
-/// V4RepositoryBase refactor NORMALIZES (delta D5). Today the base's <c>DeleteByLegacyIdAsync</c>
-/// is a plain <c>ExecuteUpdateAsync</c> that bypasses the change tracker, so it writes NO
-/// <see cref="MutationAuditLogEntity"/> row — only the six dedup participants that override it with
-/// the audited helper produce one. The two scenarios below pin both sides of that split so D5 lands
-/// as a deliberate, visible re-baseline:
-///   - a RAW type (BGCheck inherits the plain base) → NO audit row;
-///   - an AUDITED type (DeviceEvent overrides with the audited helper) → audit row present.
+/// V4RepositoryBase refactor NORMALIZED (delta D5). The base's <c>DeleteByLegacyIdAsync</c> now
+/// routes through the audited soft-delete helper, so EVERY V4 type writes a
+/// <see cref="MutationAuditLogEntity"/> row on a legacy-id delete — not just the dedup participants
+/// that used to override it. The two scenarios below pin both sides post-normalization:
+///   - a formerly-RAW type (BGCheck, which inherited the plain base) → audit row present (the D5 delta);
+///   - an already-AUDITED type (DeviceEvent) → audit row present (unchanged).
 /// The <see cref="V4GoldenFixture"/>'s <c>SystemAuditContext</c> short-circuits the
 /// <c>MutationAuditInterceptor</c> (IsSystem == true), so the only audit rows that can appear here
 /// come from the audited soft-delete helper, which writes them directly.
@@ -33,7 +32,7 @@ public class AuditDeltaGoldenTests
             .CountAsync(a => a.EntityType == entityType && a.EntityId == entityId && a.Action == "delete"));
 
     [Fact]
-    public async Task D5_RawType_BGCheck_DeleteByLegacyId_DoesNotWriteAuditRow()
+    public async Task D5_FormerlyRawType_BGCheck_DeleteByLegacyId_WritesAuditRow()
     {
         var tenant = Guid.NewGuid();
         using var scope = await _fx.BeginTenantScopeAsync(tenant);
@@ -46,9 +45,9 @@ public class AuditDeltaGoldenTests
         var deleted = await repo.DeleteByLegacyIdAsync("bg-del", CancellationToken.None);
         deleted.Should().Be(1);
 
-        // Pre-D5 baseline: a RAW type inherits the plain base DeleteByLegacyIdAsync (ExecuteUpdate,
-        // change-tracker-bypassing), so NO mutation_audit_log row is written.
-        (await AuditRowCountAsync(tenant, "BGCheck", created.Id)).Should().Be(0);
+        // D5 re-baseline (was 0): the base DeleteByLegacyIdAsync now routes through the audited
+        // soft-delete helper, so a formerly-raw type writes a mutation_audit_log row too.
+        (await AuditRowCountAsync(tenant, "BGCheck", created.Id)).Should().Be(1);
     }
 
     [Fact]

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/BolusGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/BolusGoldenTests.cs
@@ -1,0 +1,77 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
+
+/// <summary>
+/// Golden tests pinning the CURRENT dedup behaviour of <c>BolusRepository</c> (the hardest case:
+/// SyncId-upsert + DeduplicationService + value-tolerance MatchCriteria). Held identical across the
+/// V4RepositoryBase refactor; intentional deltas (D1–D7) are re-baselined explicitly.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("V4 goldens")]
+public class BolusGoldenTests
+{
+    private readonly V4GoldenFixture _fx;
+
+    public BolusGoldenTests(V4GoldenFixture fx) => _fx = fx;
+
+    [Fact]
+    public async Task BulkCreate_TwoSourcesWithinWindowAndTolerance_LinkIntoOneCanonicalGroup()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IBolusRepository>();
+
+        var t0 = new DateTime(2026, 3, 1, 12, 0, 0, DateTimeKind.Utc);
+        await repo.BulkCreateAsync(
+            new[]
+            {
+                new Bolus { Timestamp = t0, Insulin = 5.0, DataSource = "aaps", LegacyId = "a1" },
+                new Bolus { Timestamp = t0.AddSeconds(10), Insulin = 5.02, DataSource = "loop", LegacyId = "b1" },
+            },
+            CancellationToken.None);
+
+        // Dedup links rows into canonical groups; it never deletes — both rows persist physically.
+        var rowCount = await _fx.QueryAsync(tenant, ctx => ctx.Boluses.AsNoTracking().CountAsync());
+        rowCount.Should().Be(2);
+
+        // Within ±30s and within the 0.05 U insulin tolerance, so the DeduplicationService groups
+        // the two under a single canonical id with exactly one primary.
+        var links = await _fx.QueryAsync(tenant, ctx =>
+            ctx.LinkedRecords.AsNoTracking().Where(lr => lr.RecordType == "bolus").ToListAsync());
+
+        links.Should().HaveCount(2);
+        links.Select(l => l.CanonicalId).Distinct().Should()
+            .HaveCount(1, "both boluses link into one canonical group");
+        links.Count(l => l.IsPrimary).Should()
+            .Be(1, "exactly one primary survives per canonical group");
+    }
+
+    [Fact]
+    public async Task BulkCreate_SameSyncIdentifierTwice_UpsertsInPlace_NoDuplicateRow()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IBolusRepository>();
+
+        var t0 = new DateTime(2026, 3, 2, 8, 0, 0, DateTimeKind.Utc);
+        await repo.BulkCreateAsync(
+            new[] { new Bolus { Timestamp = t0, Insulin = 4.0, DataSource = "aaps", SyncIdentifier = "sync-1" } },
+            CancellationToken.None);
+
+        // Connector replay of the same (DataSource, SyncIdentifier) with a corrected dose upserts in
+        // place rather than inserting a second row.
+        await repo.BulkCreateAsync(
+            new[] { new Bolus { Timestamp = t0, Insulin = 4.6, DataSource = "aaps", SyncIdentifier = "sync-1" } },
+            CancellationToken.None);
+
+        var rows = await _fx.QueryAsync(tenant, ctx =>
+            ctx.Boluses.AsNoTracking().Where(b => b.DataSource == "aaps").ToListAsync());
+
+        rows.Should().HaveCount(1, "the SyncIdentifier match updates in place");
+        rows[0].Insulin.Should().Be(4.6, "the replayed dose overwrites the original");
+    }
+}

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/BolusGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/BolusGoldenTests.cs
@@ -74,4 +74,34 @@ public class BolusGoldenTests
         rows.Should().HaveCount(1, "the SyncIdentifier match updates in place");
         rows[0].Insulin.Should().Be(4.6, "the replayed dose overwrites the original");
     }
+
+    [Fact]
+    public async Task GetAsync_SevenArg_ViaGenericInterface_ExcludesNonPrimaryDuplicates()
+    {
+        // Pins the migration's highest-risk path: the base's plain 7-arg GetAsync is overridden to
+        // route through the bolus query's non-primary LinkedRecords filter, so a deduped non-primary
+        // row is excluded even when GetAsync is invoked via the generic IV4Repository<Bolus> (the old
+        // default-interface bridge). If the override regressed, this returns 2 instead of 1.
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IBolusRepository>();
+
+        var t0 = new DateTime(2026, 3, 3, 9, 0, 0, DateTimeKind.Utc);
+        await repo.BulkCreateAsync(
+            new[]
+            {
+                new Bolus { Timestamp = t0, Insulin = 5.0, DataSource = "aaps", LegacyId = "p-a" },
+                new Bolus { Timestamp = t0.AddSeconds(10), Insulin = 5.02, DataSource = "loop", LegacyId = "p-b" },
+            },
+            CancellationToken.None);
+
+        // Two physical rows, linked into one canonical group (one primary, one non-primary).
+        var physical = await _fx.QueryAsync(tenant, ctx => ctx.Boluses.AsNoTracking().CountAsync());
+        physical.Should().Be(2);
+
+        var v4 = (IV4Repository<Bolus>)repo;
+        var visible = await v4.GetAsync(null, null, null, null, 100, 0, true, CancellationToken.None);
+
+        visible.Should().HaveCount(1, "the 7-arg GetAsync excludes the non-primary deduped row");
+    }
 }

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupDeltaGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupDeltaGoldenTests.cs
@@ -21,7 +21,7 @@ namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
 /// moved Bolus's dedup to run post-commit, BOTH now collapse C with the upserted B into ONE canonical
 /// group (the DeduplicationService runs on a separate connection and sees B's upserted physical value
 /// only once committed):
-///   D2_SensorGlucose_UnionFeed_NewPlusUpsertedSibling_CollapseIntoOneGroup     → ONE canonical group.
+///   D2_SensorGlucose_PostCommitDedup_NewPlusUpsertedSibling_CollapseIntoOneGroup     → ONE canonical group.
 ///   D2_Bolus_PostCommitDedup_NewPlusUpsertedSibling_CollapseIntoOneGroup       → ONE canonical group.
 /// Both run the same scenario byte-for-byte: seed a SyncId-keyed row B in its own group, then a
 /// second BulkCreateAsync carrying a fresh insert C (no SyncId) at B's time+value AND a SyncId-upsert
@@ -207,7 +207,7 @@ public class DedupDeltaGoldenTests
     //   2. Batch = [ C: fresh insert at T0+10s with B's value; B: SyncId-upsert moved to T0+10s ].
 
     [Fact]
-    public async Task D2_SensorGlucose_UnionFeed_NewPlusUpsertedSibling_CollapseIntoOneGroup()
+    public async Task D2_SensorGlucose_PostCommitDedup_NewPlusUpsertedSibling_CollapseIntoOneGroup()
     {
         var tenant = Guid.NewGuid();
         using var scope = await _fx.BeginTenantScopeAsync(tenant);

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupDeltaGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupDeltaGoldenTests.cs
@@ -115,19 +115,21 @@ public class DedupDeltaGoldenTests
     // ── D3: SensorGlucose single CreateAsync does NOT upsert (bulk does); Bolus single DOES ───────
 
     [Fact]
-    public async Task D3_SensorGlucose_SingleCreate_DoesNotUpsertOnSyncId_ThrowsOnDuplicate()
+    public async Task D3_SensorGlucose_SingleCreate_UpsertsOnSyncId_LatestWins()
     {
         var tenant = Guid.NewGuid();
         using var scope = await _fx.BeginTenantScopeAsync(tenant);
         var repo = scope.ServiceProvider.GetRequiredService<ISensorGlucoseRepository>();
 
         await repo.CreateAsync(new SensorGlucose { Timestamp = T0, Mgdl = 100, DataSource = "dexcom", SyncIdentifier = "sg-s" }, CancellationToken.None);
-        var act = async () => await repo.CreateAsync(
-            new SensorGlucose { Timestamp = T0, Mgdl = 142, DataSource = "dexcom", SyncIdentifier = "sg-s" }, CancellationToken.None);
+        await repo.CreateAsync(new SensorGlucose { Timestamp = T0, Mgdl = 142, DataSource = "dexcom", SyncIdentifier = "sg-s" }, CancellationToken.None);
 
-        // SensorGlucose single CreateAsync does NOT upsert (only bulk does, D3), so the duplicate
-        // SyncId hits the unique index and throws.
-        await act.Should().ThrowAsync<DbUpdateException>("SensorGlucose single CreateAsync does not upsert on SyncId today (D3)");
+        // D3 re-baseline: SensorGlucose single CreateAsync now upserts on (DataSource, SyncIdentifier)
+        // in place (mirroring Bolus/CarbIntake), so the duplicate SyncId updates the existing row
+        // instead of hitting the unique index — one row, latest value wins.
+        var rows = await _fx.QueryAsync(tenant, ctx => ctx.SensorGlucose.AsNoTracking().ToListAsync());
+        rows.Should().HaveCount(1, "SensorGlucose single CreateAsync upserts on SyncId (D3)");
+        rows[0].Mgdl.Should().Be(142);
     }
 
     [Fact]

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupDeltaGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupDeltaGoldenTests.cs
@@ -269,4 +269,36 @@ public class DedupDeltaGoldenTests
         links.Select(l => l.CanonicalId).Distinct().Should()
             .HaveCount(1, "post-commit dedup sees B's upserted value, so C collapses with B into one group (D4)");
     }
+
+    [Fact]
+    public async Task D2_CarbIntake_PostCommitDedup_NewPlusUpsertedSibling_CollapseIntoOneGroup()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<ICarbIntakeRepository>();
+
+        // 1. Seed B (SyncId-keyed) — its own canonical group.
+        await repo.BulkCreateAsync(new[]
+        {
+            new CarbIntake { Timestamp = T0, Carbs = 30, DataSource = "aaps", SyncIdentifier = "c-B" },
+        }, CancellationToken.None);
+
+        // 2. C is a fresh insert at T0+10s; B is SyncId-upserted onto T0+10s with C's value — byte-for
+        //    byte the Bolus/SensorGlucose scenarios above. CarbIntake had the same D4 post-commit flip
+        //    but no dedicated golden; B's upserted value is committed and therefore visible to the dedup
+        //    engine's separate connection, so C value-matches B and they collapse into ONE group.
+        await repo.BulkCreateAsync(new[]
+        {
+            new CarbIntake { Timestamp = T0.AddSeconds(10), Carbs = 45, DataSource = "loop", LegacyId = "c-C" },
+            new CarbIntake { Timestamp = T0.AddSeconds(10), Carbs = 45, DataSource = "aaps", SyncIdentifier = "c-B" },
+        }, CancellationToken.None);
+
+        (await _fx.QueryAsync(tenant, ctx => ctx.CarbIntakes.AsNoTracking().CountAsync()))
+            .Should().Be(2, "B upserts in place; C inserts — two physical rows");
+
+        var links = await _fx.QueryAsync(tenant, ctx =>
+            ctx.LinkedRecords.AsNoTracking().Where(lr => lr.RecordType == "carbintake").ToListAsync());
+        links.Select(l => l.CanonicalId).Distinct().Should()
+            .HaveCount(1, "post-commit dedup sees B's upserted value, so C collapses with B into one group");
+    }
 }

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupDeltaGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupDeltaGoldenTests.cs
@@ -1,0 +1,168 @@
+using Microsoft.Extensions.DependencyInjection;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
+
+/// <summary>
+/// Goldens pinning the CURRENT behaviour of the single-vs-bulk SyncId-upsert inconsistencies the
+/// V4RepositoryBase refactor is expected to NORMALIZE (deltas D1, D3, D7). Capturing them now means
+/// each lands in PR-C as a deliberate, visible re-baseline of a named test — not a silent change.
+/// These assertions encode today's behaviour, INCLUDING the latent bugs.
+///
+/// Note: every V4 SyncId-upsert type carries a partial unique index on
+/// (tenant_id, data_source, sync_identifier). So a path that fails to upsert on a duplicate
+/// SyncIdentifier does not insert a second row — it throws a unique-violation. The asymmetry is:
+///   - BasalInjection: single CreateAsync upserts; BULK does not → bulk throws (D1).
+///   - SensorGlucose:  bulk upserts; single CreateAsync does not → single throws (D3).
+///   - Bolus:          both upsert (the consistent reference).
+/// D2 (SensorGlucose re-driving dedup on inserts∪updates vs Bolus inserts-only) is intentionally
+/// NOT pinned here yet — a faithful scenario needs to distinguish the two and the obvious
+/// "merge two separate groups" scenario does not (both keep two groups). Left as a known gap.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("V4 goldens")]
+public class DedupDeltaGoldenTests
+{
+    private readonly V4GoldenFixture _fx;
+
+    public DedupDeltaGoldenTests(V4GoldenFixture fx) => _fx = fx;
+
+    private static readonly DateTime T0 = new(2026, 6, 1, 9, 0, 0, DateTimeKind.Utc);
+
+    private static BasalInjection Bi(double units, string source, string? legacyId = null, string? syncId = null) =>
+        new()
+        {
+            Timestamp = T0,
+            Units = units,
+            DataSource = source,
+            LegacyId = legacyId,
+            SyncIdentifier = syncId,
+            InsulinContext = new TreatmentInsulinContext { InsulinName = "test" },
+        };
+
+    // ── D1: BasalInjection — single CreateAsync upserts on SyncId, but BULK does not ──────────────
+
+    [Fact]
+    public async Task D1_BasalInjection_Bulk_IsLegacyIdOnly_NoCanonicalLinks()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IBasalInjectionRepository>();
+
+        await repo.BulkCreateAsync(new[]
+        {
+            Bi(10, "aaps", legacyId: "bi-1"),
+            Bi(11, "loop", legacyId: "bi-2"),
+            Bi(10, "aaps", legacyId: "bi-1"),
+        }, CancellationToken.None);
+
+        (await _fx.QueryAsync(tenant, ctx => ctx.BasalInjections.AsNoTracking().CountAsync()))
+            .Should().Be(2, "intra-batch LegacyId dedup collapses the duplicate");
+        (await _fx.QueryAsync(tenant, ctx => ctx.LinkedRecords.AsNoTracking().CountAsync()))
+            .Should().Be(0, "BasalInjection is not a DeduplicationService participant");
+    }
+
+    [Fact]
+    public async Task D1_BasalInjection_Bulk_DoesNotUpsertOnSyncId_ThrowsOnDuplicate()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IBasalInjectionRepository>();
+
+        // Same (DataSource, SyncIdentifier), distinct LegacyIds so both pass LegacyId dedup. The bulk
+        // path does not upsert on SyncId (the D1 bug), so the second insert hits the unique index and
+        // throws — whereas the single CreateAsync path would have collapsed these (next test).
+        var act = async () => await repo.BulkCreateAsync(new[]
+        {
+            Bi(10, "aaps", legacyId: "bi-a", syncId: "bi-sync"),
+            Bi(14, "aaps", legacyId: "bi-b", syncId: "bi-sync"),
+        }, CancellationToken.None);
+
+        await act.Should().ThrowAsync<DbUpdateException>("bulk does not upsert on SyncId today (D1)");
+    }
+
+    [Fact]
+    public async Task D1_BasalInjection_SingleCreate_UpsertsOnSyncId()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IBasalInjectionRepository>();
+
+        await repo.CreateAsync(Bi(10, "aaps", syncId: "bi-sync"), CancellationToken.None);
+        await repo.CreateAsync(Bi(14, "aaps", syncId: "bi-sync"), CancellationToken.None);
+
+        var rows = await _fx.QueryAsync(tenant, ctx => ctx.BasalInjections.AsNoTracking().ToListAsync());
+        rows.Should().HaveCount(1, "single CreateAsync upserts on SyncIdentifier");
+        rows[0].Units.Should().Be(14);
+    }
+
+    // ── D3: SensorGlucose single CreateAsync does NOT upsert (bulk does); Bolus single DOES ───────
+
+    [Fact]
+    public async Task D3_SensorGlucose_SingleCreate_DoesNotUpsertOnSyncId_ThrowsOnDuplicate()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<ISensorGlucoseRepository>();
+
+        await repo.CreateAsync(new SensorGlucose { Timestamp = T0, Mgdl = 100, DataSource = "dexcom", SyncIdentifier = "sg-s" }, CancellationToken.None);
+        var act = async () => await repo.CreateAsync(
+            new SensorGlucose { Timestamp = T0, Mgdl = 142, DataSource = "dexcom", SyncIdentifier = "sg-s" }, CancellationToken.None);
+
+        // SensorGlucose single CreateAsync does NOT upsert (only bulk does, D3), so the duplicate
+        // SyncId hits the unique index and throws.
+        await act.Should().ThrowAsync<DbUpdateException>("SensorGlucose single CreateAsync does not upsert on SyncId today (D3)");
+    }
+
+    [Fact]
+    public async Task D3_Bolus_SingleCreate_UpsertsOnSyncId_OneRow()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IBolusRepository>();
+
+        await repo.CreateAsync(new Bolus { Timestamp = T0, Insulin = 4.0, DataSource = "aaps", SyncIdentifier = "b-s" }, CancellationToken.None);
+        await repo.CreateAsync(new Bolus { Timestamp = T0, Insulin = 4.6, DataSource = "aaps", SyncIdentifier = "b-s" }, CancellationToken.None);
+
+        var rows = await _fx.QueryAsync(tenant, ctx => ctx.Boluses.AsNoTracking().ToListAsync());
+        rows.Should().HaveCount(1, "Bolus single CreateAsync upserts on SyncId (the consistent reference)");
+        rows[0].Insulin.Should().Be(4.6);
+    }
+
+    // ── D7: only CarbIntake.CountAsync excludes non-primary links; Bolus/SensorGlucose over-count ──
+
+    [Fact]
+    public async Task D7_CarbIntake_CountExcludesNonPrimary_ButBolusAndSensorGlucoseOverCount()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+
+        var carb = scope.ServiceProvider.GetRequiredService<ICarbIntakeRepository>();
+        await carb.BulkCreateAsync(new[]
+        {
+            new CarbIntake { Timestamp = T0, Carbs = 30, DataSource = "aaps", LegacyId = "c-a" },
+            new CarbIntake { Timestamp = T0.AddSeconds(10), Carbs = 30.5, DataSource = "loop", LegacyId = "c-b" },
+        }, CancellationToken.None);
+
+        var bolus = scope.ServiceProvider.GetRequiredService<IBolusRepository>();
+        await bolus.BulkCreateAsync(new[]
+        {
+            new Bolus { Timestamp = T0, Insulin = 5.0, DataSource = "aaps", LegacyId = "b-a" },
+            new Bolus { Timestamp = T0.AddSeconds(10), Insulin = 5.02, DataSource = "loop", LegacyId = "b-b" },
+        }, CancellationToken.None);
+
+        var sg = scope.ServiceProvider.GetRequiredService<ISensorGlucoseRepository>();
+        await sg.BulkCreateAsync(new[]
+        {
+            new SensorGlucose { Timestamp = T0, Mgdl = 120, DataSource = "dexcom", LegacyId = "g-a" },
+            new SensorGlucose { Timestamp = T0.AddSeconds(10), Mgdl = 120.5, DataSource = "libre", LegacyId = "g-b" },
+        }, CancellationToken.None);
+
+        // Each pair links into one canonical group. Only CarbIntake.CountAsync excludes the
+        // non-primary today (D7); Bolus and SensorGlucose over-count relative to what GetAsync returns.
+        (await carb.CountAsync(null, null)).Should().Be(1, "CarbIntake.CountAsync excludes non-primary (D7)");
+        (await bolus.CountAsync(null, null)).Should().Be(2, "Bolus.CountAsync over-counts non-primary today (D7)");
+        (await sg.CountAsync(null, null)).Should().Be(2, "SensorGlucose.CountAsync over-counts non-primary today (D7)");
+    }
+}

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupDeltaGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupDeltaGoldenTests.cs
@@ -16,9 +16,26 @@ namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
 ///   - BasalInjection: single CreateAsync upserts; BULK does not → bulk throws (D1).
 ///   - SensorGlucose:  bulk upserts; single CreateAsync does not → single throws (D3).
 ///   - Bolus:          both upsert (the consistent reference).
-/// D2 (SensorGlucose re-driving dedup on inserts∪updates vs Bolus inserts-only) is intentionally
-/// NOT pinned here yet — a faithful scenario needs to distinguish the two and the obvious
-/// "merge two separate groups" scenario does not (both keep two groups). Left as a known gap.
+/// D2 (SensorGlucose re-driving dedup on inserts∪updates vs Bolus inserts-only) IS an observable
+/// behavioural delta — PR-C's normalization is a real re-baseline, not a dead-code cleanup. It is
+/// pinned by the paired goldens below:
+///   D2_SensorGlucose_UnionFeed_NewPlusUpsertedSibling_CollapseIntoOneGroup → ONE canonical group.
+///   D2_Bolus_InsertsOnlyFeed_NewPlusUpsertedSibling_StayTwoGroups          → TWO canonical groups.
+/// Both run the same scenario byte-for-byte: seed a SyncId-keyed row B in its own group, then a
+/// second BulkCreateAsync carrying a fresh insert C (no SyncId) at B's time+value AND a SyncId-upsert
+/// of B onto that same time+value. The only difference is the dedup feed:
+///   - SensorGlucose unions inserts+updates (SensorGlucoseRepository.cs:287 — `entities.Concat(
+///     updatedEntities)` → `dedupInputs` at :290-297), so the upserted B is in the dedup batch and
+///     C collapses with B into one group.
+///   - Bolus feeds inserts only (BolusRepository.cs:341 — `dedupInputs` from `entities`, the whole
+///     block gated by `if (entities.Count > 0)` at :326), so B is excluded from the batch and C
+///     never collapses with it — two groups persist.
+/// (The earlier "two far-apart rows, upsert one near the other" attempt failed to distinguish them
+/// because the upsert never refreshes B's `linked_records.SourceTimestamp`, so B's persisted row
+/// stays at its old position and a new sibling can match it identically with or without the union-
+/// feed. The distinguishing case is the NEW-insert-plus-upserted-sibling batch above, where whether
+/// the engine receives B's updated value as input is what flips the grouping — confirmed empirically
+/// against the live DeduplicationService + real Postgres.)
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("V4 goldens")]
@@ -164,5 +181,82 @@ public class DedupDeltaGoldenTests
         (await carb.CountAsync(null, null)).Should().Be(1, "CarbIntake.CountAsync excludes non-primary (D7)");
         (await bolus.CountAsync(null, null)).Should().Be(2, "Bolus.CountAsync over-counts non-primary today (D7)");
         (await sg.CountAsync(null, null)).Should().Be(2, "SensorGlucose.CountAsync over-counts non-primary today (D7)");
+    }
+
+    // ── D2: union-feed (SensorGlucose) vs inserts-only (Bolus) IS observable ───────────────────────
+    //
+    // The distinguishing case: a batch carrying a fresh insert C plus a SyncId-upsert of an existing
+    // row B onto C's time+value. SensorGlucose unions inserts+updates into the dedup batch, so the
+    // engine sees B's UPDATED value and collapses C with B (one group). Bolus feeds inserts only, so B
+    // is absent from the batch and C does not collapse with it (two groups). Confirmed empirically:
+    // with the engine instrumented, the SensorGlucose matcher saw B's updated value (matched=True) and
+    // the Bolus matcher did not (matched=False), for the same candidate B in the same ±30s window.
+    //
+    // Each scenario runs as two BulkCreateAsync calls under one tenant:
+    //   1. Seed B at T0 (its own canonical group), keyed by (DataSource, SyncIdentifier).
+    //   2. Batch = [ C: fresh insert at T0+10s with B's value; B: SyncId-upsert moved to T0+10s ].
+    // B's linked_records.SourceTimestamp stays at T0 (never refreshed), which is inside C's ±30s
+    // window — so the candidacy is identical; what flips the result is whether B's updated value
+    // reaches the dedup batch as input.
+
+    [Fact]
+    public async Task D2_SensorGlucose_UnionFeed_NewPlusUpsertedSibling_CollapseIntoOneGroup()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<ISensorGlucoseRepository>();
+
+        // 1. Seed B (SyncId-keyed) — its own canonical group.
+        await repo.BulkCreateAsync(new[]
+        {
+            new SensorGlucose { Timestamp = T0, Mgdl = 100, DataSource = "dexcom", SyncIdentifier = "sg-B" },
+        }, CancellationToken.None);
+
+        // 2. C is a fresh insert at T0+10s; B is SyncId-upserted onto T0+10s with C's value.
+        await repo.BulkCreateAsync(new[]
+        {
+            new SensorGlucose { Timestamp = T0.AddSeconds(10), Mgdl = 120, DataSource = "libre", LegacyId = "sg-C" },
+            new SensorGlucose { Timestamp = T0.AddSeconds(10), Mgdl = 120, DataSource = "dexcom", SyncIdentifier = "sg-B" },
+        }, CancellationToken.None);
+
+        (await _fx.QueryAsync(tenant, ctx => ctx.SensorGlucose.AsNoTracking().CountAsync()))
+            .Should().Be(2, "B upserts in place; C inserts — two physical rows");
+
+        var links = await _fx.QueryAsync(tenant, ctx =>
+            ctx.LinkedRecords.AsNoTracking().Where(lr => lr.RecordType == "sensorglucose").ToListAsync());
+        links.Select(l => l.CanonicalId).Distinct().Should()
+            .HaveCount(1, "C links to B via B's persisted linked_records row — one group");
+    }
+
+    [Fact]
+    public async Task D2_Bolus_InsertsOnlyFeed_NewPlusUpsertedSibling_StayTwoGroups()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IBolusRepository>();
+
+        // 1. Seed B (SyncId-keyed) — its own canonical group.
+        await repo.BulkCreateAsync(new[]
+        {
+            new Bolus { Timestamp = T0, Insulin = 4.0, DataSource = "aaps", SyncIdentifier = "b-B" },
+        }, CancellationToken.None);
+
+        // 2. C is a fresh insert at T0+10s; B is SyncId-upserted onto T0+10s with C's value — byte-for
+        //    byte the SensorGlucose scenario above. The ONLY difference is BolusRepository feeds dedup
+        //    inserts-only (excludes the upserted B), so C never sees B in the dedup batch and they stay
+        //    in SEPARATE canonical groups. This is the observable D2 delta.
+        await repo.BulkCreateAsync(new[]
+        {
+            new Bolus { Timestamp = T0.AddSeconds(10), Insulin = 5.0, DataSource = "loop", LegacyId = "b-C" },
+            new Bolus { Timestamp = T0.AddSeconds(10), Insulin = 5.0, DataSource = "aaps", SyncIdentifier = "b-B" },
+        }, CancellationToken.None);
+
+        (await _fx.QueryAsync(tenant, ctx => ctx.Boluses.AsNoTracking().CountAsync()))
+            .Should().Be(2, "B upserts in place; C inserts — two physical rows");
+
+        var links = await _fx.QueryAsync(tenant, ctx =>
+            ctx.LinkedRecords.AsNoTracking().Where(lr => lr.RecordType == "bolus").ToListAsync());
+        links.Select(l => l.CanonicalId).Distinct().Should()
+            .HaveCount(2, "inserts-only feed never hands B to the dedup batch, so C stays in its own group (D2)");
     }
 }

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupDeltaGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupDeltaGoldenTests.cs
@@ -150,7 +150,7 @@ public class DedupDeltaGoldenTests
     // ── D7: only CarbIntake.CountAsync excludes non-primary links; Bolus/SensorGlucose over-count ──
 
     [Fact]
-    public async Task D7_CarbIntake_CountExcludesNonPrimary_ButBolusAndSensorGlucoseOverCount()
+    public async Task D7_AllDedupParticipants_CountExcludesNonPrimary()
     {
         var tenant = Guid.NewGuid();
         using var scope = await _fx.BeginTenantScopeAsync(tenant);
@@ -176,11 +176,12 @@ public class DedupDeltaGoldenTests
             new SensorGlucose { Timestamp = T0.AddSeconds(10), Mgdl = 120.5, DataSource = "libre", LegacyId = "g-b" },
         }, CancellationToken.None);
 
-        // Each pair links into one canonical group. Only CarbIntake.CountAsync excludes the
-        // non-primary today (D7); Bolus and SensorGlucose over-count relative to what GetAsync returns.
+        // D7 re-baseline: each pair links into one canonical group, and ALL dedup participants now
+        // exclude the non-primary via the base CountAsync + ApplyReadVisibility hook (was: only
+        // CarbIntake excluded; Bolus and SensorGlucose over-counted at 2).
         (await carb.CountAsync(null, null)).Should().Be(1, "CarbIntake.CountAsync excludes non-primary (D7)");
-        (await bolus.CountAsync(null, null)).Should().Be(2, "Bolus.CountAsync over-counts non-primary today (D7)");
-        (await sg.CountAsync(null, null)).Should().Be(2, "SensorGlucose.CountAsync over-counts non-primary today (D7)");
+        (await bolus.CountAsync(null, null)).Should().Be(1, "Bolus.CountAsync now excludes non-primary (D7)");
+        (await sg.CountAsync(null, null)).Should().Be(1, "SensorGlucose.CountAsync now excludes non-primary (D7)");
     }
 
     // ── D2: new-insert-plus-upserted-sibling collapse ──────────────────────────────────────────────

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupDeltaGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupDeltaGoldenTests.cs
@@ -16,26 +16,20 @@ namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
 ///   - BasalInjection: single CreateAsync upserts; BULK does not → bulk throws (D1).
 ///   - SensorGlucose:  bulk upserts; single CreateAsync does not → single throws (D3).
 ///   - Bolus:          both upsert (the consistent reference).
-/// D2 (SensorGlucose re-driving dedup on inserts∪updates vs Bolus inserts-only) IS an observable
-/// behavioural delta — PR-C's normalization is a real re-baseline, not a dead-code cleanup. It is
-/// pinned by the paired goldens below:
-///   D2_SensorGlucose_UnionFeed_NewPlusUpsertedSibling_CollapseIntoOneGroup → ONE canonical group.
-///   D2_Bolus_InsertsOnlyFeed_NewPlusUpsertedSibling_StayTwoGroups          → TWO canonical groups.
+/// D2 pins the new-insert-plus-upserted-sibling collapse for SensorGlucose and Bolus. After delta D4
+/// moved Bolus's dedup to run post-commit, BOTH now collapse C with the upserted B into ONE canonical
+/// group (the DeduplicationService runs on a separate connection and sees B's upserted physical value
+/// only once committed):
+///   D2_SensorGlucose_UnionFeed_NewPlusUpsertedSibling_CollapseIntoOneGroup     → ONE canonical group.
+///   D2_Bolus_PostCommitDedup_NewPlusUpsertedSibling_CollapseIntoOneGroup       → ONE canonical group.
 /// Both run the same scenario byte-for-byte: seed a SyncId-keyed row B in its own group, then a
 /// second BulkCreateAsync carrying a fresh insert C (no SyncId) at B's time+value AND a SyncId-upsert
-/// of B onto that same time+value. The only difference is the dedup feed:
-///   - SensorGlucose unions inserts+updates (SensorGlucoseRepository.cs:287 — `entities.Concat(
-///     updatedEntities)` → `dedupInputs` at :290-297), so the upserted B is in the dedup batch and
-///     C collapses with B into one group.
-///   - Bolus feeds inserts only (BolusRepository.cs:341 — `dedupInputs` from `entities`, the whole
-///     block gated by `if (entities.Count > 0)` at :326), so B is excluded from the batch and C
-///     never collapses with it — two groups persist.
-/// (The earlier "two far-apart rows, upsert one near the other" attempt failed to distinguish them
-/// because the upsert never refreshes B's `linked_records.SourceTimestamp`, so B's persisted row
-/// stays at its old position and a new sibling can match it identically with or without the union-
-/// feed. The distinguishing case is the NEW-insert-plus-upserted-sibling batch above, where whether
-/// the engine receives B's updated value as input is what flips the grouping — confirmed empirically
-/// against the live DeduplicationService + real Postgres.)
+/// of B onto that same time+value. B's linked_records.SourceTimestamp stays at T0 (the upsert never
+/// refreshes it), inside C's ±30s window, so B is always a candidate; the collapse turns on the dedup
+/// engine value-matching against B's COMMITTED upserted row. (Pre-D4, Bolus ran dedup inside the open
+/// transaction, so its separate dedup connection saw B's OLD value and the two stayed in separate
+/// groups — that "inserts-only feed" framing conflated the dedup input list with this commit-
+/// visibility effect; the live driver is the latter.)
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("V4 goldens")]
@@ -183,21 +177,27 @@ public class DedupDeltaGoldenTests
         (await sg.CountAsync(null, null)).Should().Be(2, "SensorGlucose.CountAsync over-counts non-primary today (D7)");
     }
 
-    // ── D2: union-feed (SensorGlucose) vs inserts-only (Bolus) IS observable ───────────────────────
+    // ── D2: new-insert-plus-upserted-sibling collapse ──────────────────────────────────────────────
     //
-    // The distinguishing case: a batch carrying a fresh insert C plus a SyncId-upsert of an existing
-    // row B onto C's time+value. SensorGlucose unions inserts+updates into the dedup batch, so the
-    // engine sees B's UPDATED value and collapses C with B (one group). Bolus feeds inserts only, so B
-    // is absent from the batch and C does not collapse with it (two groups). Confirmed empirically:
-    // with the engine instrumented, the SensorGlucose matcher saw B's updated value (matched=True) and
-    // the Bolus matcher did not (matched=False), for the same candidate B in the same ±30s window.
+    // The scenario: a batch carrying a fresh insert C plus a SyncId-upsert of an existing row B onto
+    // C's time+value. B's linked_records.SourceTimestamp stays at T0 (the upsert never refreshes it),
+    // which is inside C's ±30s window — so B is always a candidate for C. Whether C collapses with B
+    // turns on whether the dedup engine, when value-matching, sees B's UPSERTED physical value.
+    //
+    // The DeduplicationService runs on its own scoped NocturneDbContext (a separate connection from
+    // the repository's BulkCreate transaction). So it sees B's upserted physical row only once that
+    // row is COMMITTED:
+    //   - SensorGlucose has always committed before running dedup → B's new value is visible →
+    //     C collapses with B into ONE group.
+    //   - Bolus, AFTER delta D4 moved dedup to run post-commit, now does the same → ONE group.
+    //     (Before D4, Bolus ran dedup inside the still-open transaction, so the separate dedup
+    //     connection saw B's OLD value, C did not value-match, and the two stayed in SEPARATE groups.
+    //     The earlier "inserts-only feed" framing of this delta conflated the dedup input list with
+    //     this commit-visibility effect; the live driver is the latter.)
     //
     // Each scenario runs as two BulkCreateAsync calls under one tenant:
     //   1. Seed B at T0 (its own canonical group), keyed by (DataSource, SyncIdentifier).
     //   2. Batch = [ C: fresh insert at T0+10s with B's value; B: SyncId-upsert moved to T0+10s ].
-    // B's linked_records.SourceTimestamp stays at T0 (never refreshed), which is inside C's ±30s
-    // window — so the candidacy is identical; what flips the result is whether B's updated value
-    // reaches the dedup batch as input.
 
     [Fact]
     public async Task D2_SensorGlucose_UnionFeed_NewPlusUpsertedSibling_CollapseIntoOneGroup()
@@ -229,7 +229,7 @@ public class DedupDeltaGoldenTests
     }
 
     [Fact]
-    public async Task D2_Bolus_InsertsOnlyFeed_NewPlusUpsertedSibling_StayTwoGroups()
+    public async Task D2_Bolus_PostCommitDedup_NewPlusUpsertedSibling_CollapseIntoOneGroup()
     {
         var tenant = Guid.NewGuid();
         using var scope = await _fx.BeginTenantScopeAsync(tenant);
@@ -242,9 +242,10 @@ public class DedupDeltaGoldenTests
         }, CancellationToken.None);
 
         // 2. C is a fresh insert at T0+10s; B is SyncId-upserted onto T0+10s with C's value — byte-for
-        //    byte the SensorGlucose scenario above. The ONLY difference is BolusRepository feeds dedup
-        //    inserts-only (excludes the upserted B), so C never sees B in the dedup batch and they stay
-        //    in SEPARATE canonical groups. This is the observable D2 delta.
+        //    byte the SensorGlucose scenario above. After D4 moved Bolus's dedup to run post-commit,
+        //    B's upserted value is committed and therefore visible to the dedup engine's separate
+        //    connection, so C value-matches B and they collapse into ONE canonical group — matching
+        //    SensorGlucose.
         await repo.BulkCreateAsync(new[]
         {
             new Bolus { Timestamp = T0.AddSeconds(10), Insulin = 5.0, DataSource = "loop", LegacyId = "b-C" },
@@ -256,7 +257,9 @@ public class DedupDeltaGoldenTests
 
         var links = await _fx.QueryAsync(tenant, ctx =>
             ctx.LinkedRecords.AsNoTracking().Where(lr => lr.RecordType == "bolus").ToListAsync());
+        // D4 re-baseline (was 2 groups): dedup now runs after commit, so C sees B's committed upserted
+        // value and links to it — one group.
         links.Select(l => l.CanonicalId).Distinct().Should()
-            .HaveCount(2, "inserts-only feed never hands B to the dedup batch, so C stays in its own group (D2)");
+            .HaveCount(1, "post-commit dedup sees B's upserted value, so C collapses with B into one group (D4)");
     }
 }

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupDeltaGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupDeltaGoldenTests.cs
@@ -13,7 +13,8 @@ namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
 /// Note: every V4 SyncId-upsert type carries a partial unique index on
 /// (tenant_id, data_source, sync_identifier). So a path that fails to upsert on a duplicate
 /// SyncIdentifier does not insert a second row — it throws a unique-violation. The asymmetry is:
-///   - BasalInjection: single CreateAsync upserts; BULK does not → bulk throws (D1).
+///   - BasalInjection: single CreateAsync upserts; BULK now upserts too after the D1 fix (was: bulk
+///     threw on a duplicate SyncIdentifier).
 ///   - SensorGlucose:  bulk upserts; single CreateAsync does not → single throws (D3).
 ///   - Bolus:          both upsert (the consistent reference).
 /// D2 pins the new-insert-plus-upserted-sibling collapse for SensorGlucose and Bolus. After delta D4
@@ -75,22 +76,25 @@ public class DedupDeltaGoldenTests
     }
 
     [Fact]
-    public async Task D1_BasalInjection_Bulk_DoesNotUpsertOnSyncId_ThrowsOnDuplicate()
+    public async Task D1_BasalInjection_Bulk_UpsertsOnSyncId_LatestWins()
     {
         var tenant = Guid.NewGuid();
         using var scope = await _fx.BeginTenantScopeAsync(tenant);
         var repo = scope.ServiceProvider.GetRequiredService<IBasalInjectionRepository>();
 
-        // Same (DataSource, SyncIdentifier), distinct LegacyIds so both pass LegacyId dedup. The bulk
-        // path does not upsert on SyncId (the D1 bug), so the second insert hits the unique index and
-        // throws — whereas the single CreateAsync path would have collapsed these (next test).
-        var act = async () => await repo.BulkCreateAsync(new[]
+        // Same (DataSource, SyncIdentifier), distinct LegacyIds so both pass LegacyId dedup. After the
+        // D1 fix the bulk path upserts on SyncId (intra-batch keep-last + DB-level upsert), so the two
+        // collapse to a single row with the latest value — matching the single CreateAsync path and
+        // never hitting the partial unique index. (Pre-D1 baseline: this threw a DbUpdateException.)
+        await repo.BulkCreateAsync(new[]
         {
             Bi(10, "aaps", legacyId: "bi-a", syncId: "bi-sync"),
             Bi(14, "aaps", legacyId: "bi-b", syncId: "bi-sync"),
         }, CancellationToken.None);
 
-        await act.Should().ThrowAsync<DbUpdateException>("bulk does not upsert on SyncId today (D1)");
+        var rows = await _fx.QueryAsync(tenant, ctx => ctx.BasalInjections.AsNoTracking().ToListAsync());
+        rows.Should().HaveCount(1, "bulk now upserts on SyncIdentifier (D1 fix)");
+        rows[0].Units.Should().Be(14, "intra-batch keep-last makes the latest value win");
     }
 
     [Fact]

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupParticipantGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupParticipantGoldenTests.cs
@@ -24,11 +24,16 @@ public class DedupParticipantGoldenTests
 
     // Two records within ±30s that match criteria must collapse to one canonical group (1 primary),
     // while both physical rows persist (dedup links, never deletes).
-    private async Task AssertOneCanonicalGroupAsync(Guid tenant, int physicalRows, Func<NocturneDbContext, Task<int>> countRows)
+    private async Task AssertOneCanonicalGroupAsync(
+        Guid tenant, int physicalRows, string recordType, Func<NocturneDbContext, Task<int>> countRows)
     {
         (await _fx.QueryAsync(tenant, countRows)).Should().Be(physicalRows, "dedup links rows, it never deletes them");
 
-        var links = await _fx.QueryAsync(tenant, ctx => ctx.LinkedRecords.AsNoTracking().ToListAsync());
+        var links = await _fx.QueryAsync(tenant, ctx =>
+            ctx.LinkedRecords.AsNoTracking().Where(lr => lr.RecordType == recordType).ToListAsync());
+        // The distinct-canonical + single-primary pair is the real grouping guard (a count alone would
+        // still be `physicalRows` if dedup split them into separate groups); the count only catches
+        // dedup not running at all.
         links.Should().HaveCount(physicalRows);
         links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(1, "matching records link into one canonical group");
         links.Count(l => l.IsPrimary).Should().Be(1, "exactly one primary per canonical group");
@@ -49,7 +54,7 @@ public class DedupParticipantGoldenTests
             },
             CancellationToken.None);
 
-        await AssertOneCanonicalGroupAsync(tenant, 2, ctx => ctx.SensorGlucose.AsNoTracking().CountAsync());
+        await AssertOneCanonicalGroupAsync(tenant, 2, "sensorglucose", ctx => ctx.SensorGlucose.AsNoTracking().CountAsync());
     }
 
     [Fact]
@@ -82,7 +87,7 @@ public class DedupParticipantGoldenTests
             },
             CancellationToken.None);
 
-        await AssertOneCanonicalGroupAsync(tenant, 2, ctx => ctx.CarbIntakes.AsNoTracking().CountAsync());
+        await AssertOneCanonicalGroupAsync(tenant, 2, "carbintake", ctx => ctx.CarbIntakes.AsNoTracking().CountAsync());
     }
 
     [Fact]
@@ -115,7 +120,7 @@ public class DedupParticipantGoldenTests
             },
             CancellationToken.None);
 
-        await AssertOneCanonicalGroupAsync(tenant, 2, ctx => ctx.BGChecks.AsNoTracking().CountAsync());
+        await AssertOneCanonicalGroupAsync(tenant, 2, "bgcheck", ctx => ctx.BGChecks.AsNoTracking().CountAsync());
     }
 
     [Fact]
@@ -133,7 +138,7 @@ public class DedupParticipantGoldenTests
             },
             CancellationToken.None);
 
-        await AssertOneCanonicalGroupAsync(tenant, 2, ctx => ctx.DeviceEvents.AsNoTracking().CountAsync());
+        await AssertOneCanonicalGroupAsync(tenant, 2, "deviceevent", ctx => ctx.DeviceEvents.AsNoTracking().CountAsync());
     }
 
     [Fact]
@@ -152,7 +157,7 @@ public class DedupParticipantGoldenTests
             },
             CancellationToken.None);
 
-        await AssertOneCanonicalGroupAsync(tenant, 2, ctx => ctx.Notes.AsNoTracking().CountAsync());
+        await AssertOneCanonicalGroupAsync(tenant, 2, "note", ctx => ctx.Notes.AsNoTracking().CountAsync());
     }
 
     [Fact]
@@ -170,7 +175,7 @@ public class DedupParticipantGoldenTests
             },
             CancellationToken.None);
 
-        await AssertOneCanonicalGroupAsync(tenant, 2, ctx => ctx.BolusCalculations.AsNoTracking().CountAsync());
+        await AssertOneCanonicalGroupAsync(tenant, 2, "boluscalculation", ctx => ctx.BolusCalculations.AsNoTracking().CountAsync());
     }
 
     [Fact]
@@ -189,6 +194,6 @@ public class DedupParticipantGoldenTests
             },
             CancellationToken.None);
 
-        await AssertOneCanonicalGroupAsync(tenant, 2, ctx => ctx.TempBasals.AsNoTracking().CountAsync());
+        await AssertOneCanonicalGroupAsync(tenant, 2, "tempbasal", ctx => ctx.TempBasals.AsNoTracking().CountAsync());
     }
 }

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupParticipantGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupParticipantGoldenTests.cs
@@ -1,0 +1,194 @@
+using Microsoft.Extensions.DependencyInjection;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
+
+/// <summary>
+/// Goldens pinning the CURRENT cross-connector dedup behaviour of the remaining
+/// DeduplicationService participants (Bolus is covered in <see cref="BolusGoldenTests"/>). Each type
+/// links two within-window records that match its per-type MatchCriteria into a single canonical
+/// group; the SyncId-upsert types also upsert in place on replay. Held identical across the
+/// V4RepositoryBase refactor; intentional deltas (D1–D7) are re-baselined explicitly.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("V4 goldens")]
+public class DedupParticipantGoldenTests
+{
+    private readonly V4GoldenFixture _fx;
+
+    public DedupParticipantGoldenTests(V4GoldenFixture fx) => _fx = fx;
+
+    private static readonly DateTime T0 = new(2026, 4, 1, 9, 0, 0, DateTimeKind.Utc);
+
+    // Two records within ±30s that match criteria must collapse to one canonical group (1 primary),
+    // while both physical rows persist (dedup links, never deletes).
+    private async Task AssertOneCanonicalGroupAsync(Guid tenant, int physicalRows, Func<NocturneDbContext, Task<int>> countRows)
+    {
+        (await _fx.QueryAsync(tenant, countRows)).Should().Be(physicalRows, "dedup links rows, it never deletes them");
+
+        var links = await _fx.QueryAsync(tenant, ctx => ctx.LinkedRecords.AsNoTracking().ToListAsync());
+        links.Should().HaveCount(physicalRows);
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(1, "matching records link into one canonical group");
+        links.Count(l => l.IsPrimary).Should().Be(1, "exactly one primary per canonical group");
+    }
+
+    [Fact]
+    public async Task SensorGlucose_WithinWindowAndTolerance_LinksIntoOneGroup()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<ISensorGlucoseRepository>();
+
+        await repo.BulkCreateAsync(
+            new[]
+            {
+                new SensorGlucose { Timestamp = T0, Mgdl = 120, DataSource = "dexcom", LegacyId = "g-a" },
+                new SensorGlucose { Timestamp = T0.AddSeconds(10), Mgdl = 120.5, DataSource = "libre", LegacyId = "g-b" },
+            },
+            CancellationToken.None);
+
+        await AssertOneCanonicalGroupAsync(tenant, 2, ctx => ctx.SensorGlucose.AsNoTracking().CountAsync());
+    }
+
+    [Fact]
+    public async Task SensorGlucose_SameSyncIdentifierTwice_UpsertsInPlace()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<ISensorGlucoseRepository>();
+
+        await repo.BulkCreateAsync(new[] { new SensorGlucose { Timestamp = T0, Mgdl = 100, DataSource = "dexcom", SyncIdentifier = "s-1" } }, CancellationToken.None);
+        await repo.BulkCreateAsync(new[] { new SensorGlucose { Timestamp = T0, Mgdl = 142, DataSource = "dexcom", SyncIdentifier = "s-1" } }, CancellationToken.None);
+
+        var rows = await _fx.QueryAsync(tenant, ctx => ctx.SensorGlucose.AsNoTracking().Where(g => g.DataSource == "dexcom").ToListAsync());
+        rows.Should().HaveCount(1);
+        rows[0].Mgdl.Should().Be(142);
+    }
+
+    [Fact]
+    public async Task CarbIntake_WithinWindowAndTolerance_LinksIntoOneGroup()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<ICarbIntakeRepository>();
+
+        await repo.BulkCreateAsync(
+            new[]
+            {
+                new CarbIntake { Timestamp = T0, Carbs = 30, DataSource = "aaps", LegacyId = "c-a" },
+                new CarbIntake { Timestamp = T0.AddSeconds(10), Carbs = 30.5, DataSource = "loop", LegacyId = "c-b" },
+            },
+            CancellationToken.None);
+
+        await AssertOneCanonicalGroupAsync(tenant, 2, ctx => ctx.CarbIntakes.AsNoTracking().CountAsync());
+    }
+
+    [Fact]
+    public async Task CarbIntake_SameSyncIdentifierTwice_UpsertsInPlace()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<ICarbIntakeRepository>();
+
+        await repo.BulkCreateAsync(new[] { new CarbIntake { Timestamp = T0, Carbs = 20, DataSource = "aaps", SyncIdentifier = "c-1" } }, CancellationToken.None);
+        await repo.BulkCreateAsync(new[] { new CarbIntake { Timestamp = T0, Carbs = 45, DataSource = "aaps", SyncIdentifier = "c-1" } }, CancellationToken.None);
+
+        var rows = await _fx.QueryAsync(tenant, ctx => ctx.CarbIntakes.AsNoTracking().Where(c => c.DataSource == "aaps").ToListAsync());
+        rows.Should().HaveCount(1);
+        rows[0].Carbs.Should().Be(45);
+    }
+
+    [Fact]
+    public async Task BGCheck_WithinWindowAndTolerance_LinksIntoOneGroup()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IBGCheckRepository>();
+
+        await repo.BulkCreateAsync(
+            new[]
+            {
+                new BGCheck { Timestamp = T0, Glucose = 95, DataSource = "manual", LegacyId = "b-a" },
+                new BGCheck { Timestamp = T0.AddSeconds(10), Glucose = 95.5, DataSource = "meter", LegacyId = "b-b" },
+            },
+            CancellationToken.None);
+
+        await AssertOneCanonicalGroupAsync(tenant, 2, ctx => ctx.BGChecks.AsNoTracking().CountAsync());
+    }
+
+    [Fact]
+    public async Task DeviceEvent_SameEventTypeWithinWindow_LinksIntoOneGroup()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IDeviceEventRepository>();
+
+        await repo.BulkCreateAsync(
+            new[]
+            {
+                new DeviceEvent { Timestamp = T0, EventType = DeviceEventType.SiteChange, DataSource = "aaps", LegacyId = "d-a" },
+                new DeviceEvent { Timestamp = T0.AddSeconds(10), EventType = DeviceEventType.SiteChange, DataSource = "loop", LegacyId = "d-b" },
+            },
+            CancellationToken.None);
+
+        await AssertOneCanonicalGroupAsync(tenant, 2, ctx => ctx.DeviceEvents.AsNoTracking().CountAsync());
+    }
+
+    [Fact]
+    public async Task Note_WithinWindow_LinksIntoOneGroup_OnTimeAlone()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<INoteRepository>();
+
+        // Note dedup uses an empty MatchCriteria — records match on the ±30s time window + source alone.
+        await repo.BulkCreateAsync(
+            new[]
+            {
+                new Note { Timestamp = T0, Text = "exercise", DataSource = "aaps", LegacyId = "n-a" },
+                new Note { Timestamp = T0.AddSeconds(10), Text = "walk", DataSource = "loop", LegacyId = "n-b" },
+            },
+            CancellationToken.None);
+
+        await AssertOneCanonicalGroupAsync(tenant, 2, ctx => ctx.Notes.AsNoTracking().CountAsync());
+    }
+
+    [Fact]
+    public async Task BolusCalculation_WithinWindowAndTolerance_LinksIntoOneGroup()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IBolusCalculationRepository>();
+
+        await repo.BulkCreateAsync(
+            new[]
+            {
+                new BolusCalculation { Timestamp = T0, CarbInput = 40, DataSource = "aaps", LegacyId = "bc-a" },
+                new BolusCalculation { Timestamp = T0.AddSeconds(10), CarbInput = 40.5, DataSource = "loop", LegacyId = "bc-b" },
+            },
+            CancellationToken.None);
+
+        await AssertOneCanonicalGroupAsync(tenant, 2, ctx => ctx.BolusCalculations.AsNoTracking().CountAsync());
+    }
+
+    [Fact]
+    public async Task TempBasal_WithinWindowAndRateTolerance_LinksIntoOneGroup()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<ITempBasalRepository>();
+
+        // TempBasal dedups on Rate (±0.05) at StartTimestamp.
+        await repo.BulkCreateAsync(
+            new[]
+            {
+                new TempBasal { StartTimestamp = T0, Rate = 0.80, Origin = TempBasalOrigin.Algorithm, DataSource = "aaps", LegacyId = "tb-a" },
+                new TempBasal { StartTimestamp = T0.AddSeconds(10), Rate = 0.82, Origin = TempBasalOrigin.Algorithm, DataSource = "loop", LegacyId = "tb-b" },
+            },
+            CancellationToken.None);
+
+        await AssertOneCanonicalGroupAsync(tenant, 2, ctx => ctx.TempBasals.AsNoTracking().CountAsync());
+    }
+}

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/GoldenTestDoubles.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/GoldenTestDoubles.cs
@@ -1,0 +1,33 @@
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Multitenancy;
+
+namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
+
+/// <summary>
+/// Settable <see cref="ITenantAccessor"/> for golden tests. The fixture sets the current tenant
+/// before a scenario resolves a scope; the scoped <see cref="NocturneDbContext"/> and
+/// <c>TenantDbContextFactory</c> both read it to stamp the RLS tenant carrier.
+/// </summary>
+internal sealed class TestTenantAccessor : ITenantAccessor
+{
+    public Guid TenantId => Context?.TenantId ?? Guid.Empty;
+    public bool IsResolved => Context is not null;
+    public TenantContext? Context { get; private set; }
+    public void SetTenant(TenantContext context) => Context = context;
+}
+
+/// <summary>
+/// System-attributed <see cref="IAuditContext"/> (no human actor), matching how connectors ingest —
+/// so audited soft-deletes in the dedup paths are treated as system-initiated, as in production.
+/// </summary>
+internal sealed class SystemAuditContext : IAuditContext
+{
+    public Guid? SubjectId => null;
+    public string? SubjectName => null;
+    public string? AuthType => null;
+    public string? IpAddress => null;
+    public Guid? TokenId => null;
+    public string? CorrelationId => null;
+    public string? Endpoint => null;
+    public bool IsSystem => true;
+}

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/LegacyIdOnlyGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/LegacyIdOnlyGoldenTests.cs
@@ -1,0 +1,182 @@
+using Microsoft.Extensions.DependencyInjection;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
+
+/// <summary>
+/// Goldens pinning the CURRENT behaviour of the LegacyId-only V4 repositories — the ones that do NOT
+/// participate in cross-connector canonical dedup. Each: intra-batch LegacyId dedup collapses a
+/// duplicate, and (the classification guard) NO canonical links are created. If the V4RepositoryBase
+/// refactor accidentally wires one of these onto the DeduplicationService axis, the zero-links
+/// assertion fails. Held identical across the refactor.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("V4 goldens")]
+public class LegacyIdOnlyGoldenTests
+{
+    private readonly V4GoldenFixture _fx;
+
+    public LegacyIdOnlyGoldenTests(V4GoldenFixture fx) => _fx = fx;
+
+    private static readonly DateTime T0 = new(2026, 5, 1, 9, 0, 0, DateTimeKind.Utc);
+
+    private async Task AssertLegacyIdDedupAndNoLinksAsync(Guid tenant, Func<NocturneDbContext, Task<int>> countRows)
+    {
+        // Two distinct LegacyIds + one intra-batch duplicate of the first → the duplicate collapses.
+        (await _fx.QueryAsync(tenant, countRows)).Should().Be(2, "intra-batch LegacyId dedup keeps one row per LegacyId");
+        // These types are not DeduplicationService participants — they never create canonical links.
+        (await _fx.QueryAsync(tenant, ctx => ctx.LinkedRecords.AsNoTracking().CountAsync()))
+            .Should().Be(0, "LegacyId-only repositories must not create canonical links");
+    }
+
+    [Fact]
+    public async Task MeterGlucose_LegacyIdDedup_NoCanonicalLinks()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IMeterGlucoseRepository>();
+        await repo.BulkCreateAsync(new[]
+        {
+            new MeterGlucose { Timestamp = T0, Mgdl = 100, DataSource = "aaps", LegacyId = "m-1" },
+            new MeterGlucose { Timestamp = T0.AddSeconds(5), Mgdl = 101, DataSource = "loop", LegacyId = "m-2" },
+            new MeterGlucose { Timestamp = T0, Mgdl = 100, DataSource = "aaps", LegacyId = "m-1" },
+        }, CancellationToken.None);
+        await AssertLegacyIdDedupAndNoLinksAsync(tenant, ctx => ctx.MeterGlucose.AsNoTracking().CountAsync());
+    }
+
+    [Fact]
+    public async Task Calibration_LegacyIdDedup_NoCanonicalLinks()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<ICalibrationRepository>();
+        await repo.BulkCreateAsync(new[]
+        {
+            new Calibration { Timestamp = T0, DataSource = "dexcom", LegacyId = "cal-1" },
+            new Calibration { Timestamp = T0.AddSeconds(5), DataSource = "dexcom", LegacyId = "cal-2" },
+            new Calibration { Timestamp = T0, DataSource = "dexcom", LegacyId = "cal-1" },
+        }, CancellationToken.None);
+        await AssertLegacyIdDedupAndNoLinksAsync(tenant, ctx => ctx.Calibrations.AsNoTracking().CountAsync());
+    }
+
+    [Fact]
+    public async Task ApsSnapshot_LegacyIdDedup_NoCanonicalLinks()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IApsSnapshotRepository>();
+        await repo.BulkCreateAsync(new[]
+        {
+            new ApsSnapshot { Timestamp = T0, DataSource = "loop", LegacyId = "aps-1" },
+            new ApsSnapshot { Timestamp = T0.AddSeconds(5), DataSource = "loop", LegacyId = "aps-2" },
+            new ApsSnapshot { Timestamp = T0, DataSource = "loop", LegacyId = "aps-1" },
+        }, CancellationToken.None);
+        await AssertLegacyIdDedupAndNoLinksAsync(tenant, ctx => ctx.ApsSnapshots.AsNoTracking().CountAsync());
+    }
+
+    [Fact]
+    public async Task PumpSnapshot_LegacyIdDedup_NoCanonicalLinks()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IPumpSnapshotRepository>();
+        await repo.BulkCreateAsync(new[]
+        {
+            new PumpSnapshot { Timestamp = T0, DataSource = "loop", LegacyId = "pump-1" },
+            new PumpSnapshot { Timestamp = T0.AddSeconds(5), DataSource = "loop", LegacyId = "pump-2" },
+            new PumpSnapshot { Timestamp = T0, DataSource = "loop", LegacyId = "pump-1" },
+        }, CancellationToken.None);
+        await AssertLegacyIdDedupAndNoLinksAsync(tenant, ctx => ctx.PumpSnapshots.AsNoTracking().CountAsync());
+    }
+
+    [Fact]
+    public async Task UploaderSnapshot_LegacyIdDedup_NoCanonicalLinks()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IUploaderSnapshotRepository>();
+        await repo.BulkCreateAsync(new[]
+        {
+            new UploaderSnapshot { Timestamp = T0, DataSource = "xdrip", LegacyId = "up-1" },
+            new UploaderSnapshot { Timestamp = T0.AddSeconds(5), DataSource = "xdrip", LegacyId = "up-2" },
+            new UploaderSnapshot { Timestamp = T0, DataSource = "xdrip", LegacyId = "up-1" },
+        }, CancellationToken.None);
+        await AssertLegacyIdDedupAndNoLinksAsync(tenant, ctx => ctx.UploaderSnapshots.AsNoTracking().CountAsync());
+    }
+
+    [Fact]
+    public async Task BasalSchedule_LegacyIdDedup_NoCanonicalLinks()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IBasalScheduleRepository>();
+        await repo.BulkCreateAsync(new[]
+        {
+            new BasalSchedule { Timestamp = T0, DataSource = "aaps", LegacyId = "bs-1" },
+            new BasalSchedule { Timestamp = T0.AddSeconds(5), DataSource = "aaps", LegacyId = "bs-2" },
+            new BasalSchedule { Timestamp = T0, DataSource = "aaps", LegacyId = "bs-1" },
+        }, CancellationToken.None);
+        await AssertLegacyIdDedupAndNoLinksAsync(tenant, ctx => ctx.BasalSchedules.AsNoTracking().CountAsync());
+    }
+
+    [Fact]
+    public async Task CarbRatioSchedule_LegacyIdDedup_NoCanonicalLinks()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<ICarbRatioScheduleRepository>();
+        await repo.BulkCreateAsync(new[]
+        {
+            new CarbRatioSchedule { Timestamp = T0, DataSource = "aaps", LegacyId = "cr-1" },
+            new CarbRatioSchedule { Timestamp = T0.AddSeconds(5), DataSource = "aaps", LegacyId = "cr-2" },
+            new CarbRatioSchedule { Timestamp = T0, DataSource = "aaps", LegacyId = "cr-1" },
+        }, CancellationToken.None);
+        await AssertLegacyIdDedupAndNoLinksAsync(tenant, ctx => ctx.CarbRatioSchedules.AsNoTracking().CountAsync());
+    }
+
+    [Fact]
+    public async Task SensitivitySchedule_LegacyIdDedup_NoCanonicalLinks()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<ISensitivityScheduleRepository>();
+        await repo.BulkCreateAsync(new[]
+        {
+            new SensitivitySchedule { Timestamp = T0, DataSource = "aaps", LegacyId = "ss-1" },
+            new SensitivitySchedule { Timestamp = T0.AddSeconds(5), DataSource = "aaps", LegacyId = "ss-2" },
+            new SensitivitySchedule { Timestamp = T0, DataSource = "aaps", LegacyId = "ss-1" },
+        }, CancellationToken.None);
+        await AssertLegacyIdDedupAndNoLinksAsync(tenant, ctx => ctx.SensitivitySchedules.AsNoTracking().CountAsync());
+    }
+
+    [Fact]
+    public async Task TargetRangeSchedule_LegacyIdDedup_NoCanonicalLinks()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<ITargetRangeScheduleRepository>();
+        await repo.BulkCreateAsync(new[]
+        {
+            new TargetRangeSchedule { Timestamp = T0, DataSource = "aaps", LegacyId = "tr-1" },
+            new TargetRangeSchedule { Timestamp = T0.AddSeconds(5), DataSource = "aaps", LegacyId = "tr-2" },
+            new TargetRangeSchedule { Timestamp = T0, DataSource = "aaps", LegacyId = "tr-1" },
+        }, CancellationToken.None);
+        await AssertLegacyIdDedupAndNoLinksAsync(tenant, ctx => ctx.TargetRangeSchedules.AsNoTracking().CountAsync());
+    }
+
+    [Fact]
+    public async Task TherapySettings_LegacyIdDedup_NoCanonicalLinks()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<ITherapySettingsRepository>();
+        await repo.BulkCreateAsync(new[]
+        {
+            new TherapySettings { Timestamp = T0, DataSource = "aaps", LegacyId = "th-1" },
+            new TherapySettings { Timestamp = T0.AddSeconds(5), DataSource = "aaps", LegacyId = "th-2" },
+            new TherapySettings { Timestamp = T0, DataSource = "aaps", LegacyId = "th-1" },
+        }, CancellationToken.None);
+        await AssertLegacyIdDedupAndNoLinksAsync(tenant, ctx => ctx.TherapySettings.AsNoTracking().CountAsync());
+    }
+}

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/V4GoldenFixture.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/V4GoldenFixture.cs
@@ -1,0 +1,192 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Extensions;
+using Nocturne.Infrastructure.Data.Interceptors;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Infrastructure.Data.Services;
+using Testcontainers.PostgreSql;
+
+namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
+
+/// <summary>
+/// Golden-test fixture for the V4 repository dedup behaviour. Spins up a real PostgreSQL container
+/// (same role bootstrap + migrations as <c>RlsCompletenessFixture</c>) and stands up the production
+/// data-layer DI container via <see cref="ServiceCollectionExtensions.AddPostgreSqlInfrastructure"/>
+/// pointed at the container — so goldens exercise the real repositories AND the real
+/// <c>DeduplicationService</c> against real Postgres, not mocks. These goldens capture current
+/// behaviour and are held identical across the V4RepositoryBase refactor.
+/// </summary>
+public class V4GoldenFixture : IAsyncLifetime
+{
+    private const string DbName = "nocturne_v4_goldens";
+    private const string BootstrapUser = "postgres";
+    private const string BootstrapPassword = "bootstrap-test-password";
+    private const string MigratorPassword = "v4-goldens-migrator-password";
+    private const string AppPassword = "v4-goldens-app-password";
+    private const string WebPassword = "v4-goldens-web-password";
+
+    private PostgreSqlContainer? _container;
+    private ServiceProvider? _provider;
+    private readonly TestTenantAccessor _accessor = new();
+
+    public string MigratorConnectionString { get; private set; } = string.Empty;
+
+    public async Task InitializeAsync()
+    {
+        var initScriptPath = ResolveInitScriptPath();
+
+        _container = new PostgreSqlBuilder()
+            .WithImage("postgres:17.6")
+            .WithDatabase(DbName)
+            .WithUsername(BootstrapUser)
+            .WithPassword(BootstrapPassword)
+            .WithEnvironment("NOCTURNE_MIGRATOR_PASSWORD", MigratorPassword)
+            .WithEnvironment("NOCTURNE_APP_PASSWORD", AppPassword)
+            .WithEnvironment("NOCTURNE_WEB_PASSWORD", WebPassword)
+            .WithBindMount(initScriptPath, "/docker-entrypoint-initdb.d/00-init.sh")
+            .Build();
+
+        await _container.StartAsync();
+
+        var host = _container.Hostname;
+        var port = _container.GetMappedPublicPort(5432);
+
+        MigratorConnectionString =
+            $"Host={host};Port={port};Database={DbName};Username=nocturne_migrator;Password={MigratorPassword}";
+        var appConnectionString =
+            $"Host={host};Port={port};Database={DbName};Username=nocturne_app;Password={AppPassword}";
+
+        await DatabaseInitializationExtensions.RunMigrationsAsync(
+            MigratorConnectionString,
+            NullLogger.Instance,
+            new TenantConnectionInterceptor());
+
+        await DatabaseInitializationExtensions.ReconcileShareRlsPoliciesAsync(
+            MigratorConnectionString,
+            NullLogger.Instance);
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["PostgreSql:ConnectionString"] = appConnectionString,
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        // MutationAuditInterceptor resolves IHttpContextAccessor (registered by the API in prod).
+        services.AddHttpContextAccessor();
+        services.AddSingleton<ITenantAccessor>(_accessor);
+        services.AddSingleton<IAuditContext, SystemAuditContext>();
+        services.AddPostgreSqlInfrastructure(config);
+        RegisterV4Repositories(services);
+        _provider = services.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// Registers the V4 record repositories under test. In production these are registered by the API
+    /// layer (<c>ServiceRegistrationExtensions</c>), which the data-layer test project does not
+    /// reference; the impls live in Infrastructure.Data, so we wire them directly here.
+    /// </summary>
+    private static void RegisterV4Repositories(IServiceCollection services)
+    {
+        services.AddScoped<ISensorGlucoseRepository, SensorGlucoseRepository>();
+        services.AddScoped<IMeterGlucoseRepository, MeterGlucoseRepository>();
+        services.AddScoped<ICalibrationRepository, CalibrationRepository>();
+        services.AddScoped<IBolusRepository, BolusRepository>();
+        services.AddScoped<IBasalInjectionRepository, BasalInjectionRepository>();
+        services.AddScoped<ITempBasalRepository, TempBasalRepository>();
+        services.AddScoped<ICarbIntakeRepository, CarbIntakeRepository>();
+        services.AddScoped<IBGCheckRepository, BGCheckRepository>();
+        services.AddScoped<INoteRepository, NoteRepository>();
+        services.AddScoped<IDeviceEventRepository, DeviceEventRepository>();
+        services.AddScoped<IBolusCalculationRepository, BolusCalculationRepository>();
+        services.AddScoped<IApsSnapshotRepository, ApsSnapshotRepository>();
+        services.AddScoped<IPumpSnapshotRepository, PumpSnapshotRepository>();
+        services.AddScoped<IUploaderSnapshotRepository, UploaderSnapshotRepository>();
+        services.AddScoped<ITherapySettingsRepository, TherapySettingsRepository>();
+        services.AddScoped<IBasalScheduleRepository, BasalScheduleRepository>();
+        services.AddScoped<ICarbRatioScheduleRepository, CarbRatioScheduleRepository>();
+        services.AddScoped<ISensitivityScheduleRepository, SensitivityScheduleRepository>();
+        services.AddScoped<ITargetRangeScheduleRepository, TargetRangeScheduleRepository>();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_provider is not null)
+        {
+            await _provider.DisposeAsync();
+        }
+
+        if (_container is not null)
+        {
+            await _container.StopAsync();
+            await _container.DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// Seeds a fresh tenant (migrator role — the tenants table is not RLS-scoped), pins it as the
+    /// current tenant, and returns a DI scope for resolving repositories under that tenant.
+    /// </summary>
+    public async Task<IServiceScope> BeginTenantScopeAsync(Guid tenantId)
+    {
+        await SeedTenantAsync(tenantId);
+        PinTenant(tenantId);
+        return _provider!.CreateScope();
+    }
+
+    /// <summary>
+    /// Runs a read against a tenant-scoped context (via the production <c>ITenantDbContextFactory</c>)
+    /// for snapshotting persisted state after a scenario.
+    /// </summary>
+    public async Task<T> QueryAsync<T>(Guid tenantId, Func<NocturneDbContext, Task<T>> query)
+    {
+        PinTenant(tenantId);
+        var factory = _provider!.GetRequiredService<ITenantDbContextFactory>();
+        await using var ctx = await factory.CreateAsync();
+        return await query(ctx);
+    }
+
+    private void PinTenant(Guid tenantId) =>
+        _accessor.SetTenant(new TenantContext(tenantId, $"t-{tenantId:N}", "Golden", IsActive: true));
+
+    private async Task SeedTenantAsync(Guid tenantId)
+    {
+        // Seed via a bare EF context on the migrator connection (no interceptors, no tenant carrier):
+        // TenantEntity is ISystemTimestamped, not ITenantScoped, so it is exempt from RLS.
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseNpgsql(MigratorConnectionString)
+            .Options;
+        await using var ctx = new NocturneDbContext(options);
+        ctx.Tenants.Add(new TenantEntity { Id = tenantId, Slug = $"t-{tenantId:N}", DisplayName = "Golden" });
+        await ctx.SaveChangesAsync();
+    }
+
+    private static string ResolveInitScriptPath()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Join(dir.FullName, "docs/postgres/container-init/00-init.sh")))
+        {
+            dir = dir.Parent;
+        }
+
+        if (dir is null)
+        {
+            throw new InvalidOperationException(
+                "Could not locate docs/postgres/container-init/00-init.sh by walking up from " + AppContext.BaseDirectory);
+        }
+
+        return Path.Join(dir.FullName, "docs/postgres/container-init/00-init.sh");
+    }
+}
+
+[CollectionDefinition("V4 goldens")]
+public class V4GoldenCollection : ICollectionFixture<V4GoldenFixture>
+{
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/EntryDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/EntryDecomposerTests.cs
@@ -25,8 +25,8 @@ public class EntryDecomposerTests : IDisposable
         var mockDedup = new Mock<IDeduplicationService>();
         var ctxFactory = new TestTenantDbContextFactory(_context);
         var sgRepo = new SensorGlucoseRepository(ctxFactory, mockDedup.Object, new Mock<IAuditContext>().Object, NullLogger<SensorGlucoseRepository>.Instance);
-        var mgRepo = new MeterGlucoseRepository(ctxFactory, NullLogger<MeterGlucoseRepository>.Instance);
-        var calRepo = new CalibrationRepository(ctxFactory, NullLogger<CalibrationRepository>.Instance);
+        var mgRepo = new MeterGlucoseRepository(ctxFactory, new Mock<IAuditContext>().Object, NullLogger<MeterGlucoseRepository>.Instance);
+        var calRepo = new CalibrationRepository(ctxFactory, new Mock<IAuditContext>().Object, NullLogger<CalibrationRepository>.Instance);
 
         var mockConfigProvider = new Mock<IGlucoseProcessingConfigProvider>();
         mockConfigProvider.Setup(x => x.GetSourceDefaultsAsync(It.IsAny<CancellationToken>()))

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerNotesTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerNotesTests.cs
@@ -33,8 +33,8 @@ public class TreatmentDecomposerNotesTests : IDisposable
         var ctxFactory = new TestTenantDbContextFactory(_context);
         var bolusRepo = new BolusRepository(ctxFactory, mockDedup.Object, mockAudit, NullLogger<BolusRepository>.Instance);
         var carbIntakeRepo = new CarbIntakeRepository(ctxFactory, mockDedup.Object, mockAudit, NullLogger<CarbIntakeRepository>.Instance);
-        var bgCheckRepo = new BGCheckRepository(ctxFactory, mockDedup.Object, NullLogger<BGCheckRepository>.Instance);
-        var noteRepo = new NoteRepository(ctxFactory, mockDedup.Object, NullLogger<NoteRepository>.Instance);
+        var bgCheckRepo = new BGCheckRepository(ctxFactory, mockDedup.Object, mockAudit, NullLogger<BGCheckRepository>.Instance);
+        var noteRepo = new NoteRepository(ctxFactory, mockDedup.Object, mockAudit, NullLogger<NoteRepository>.Instance);
         var deviceEventRepo = new DeviceEventRepository(ctxFactory, mockDedup.Object, mockAudit, NullLogger<DeviceEventRepository>.Instance);
         var bolusCalcRepo = new BolusCalculationRepository(ctxFactory, mockDedup.Object, mockAudit, NullLogger<BolusCalculationRepository>.Instance);
         var stateSpanServiceMock = new Mock<IStateSpanService>();

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
@@ -41,8 +41,8 @@ public class TreatmentDecomposerTests : IDisposable
         var ctxFactory = new TestTenantDbContextFactory(_context);
         var bolusRepo = new BolusRepository(ctxFactory, mockDedup.Object, mockAudit, NullLogger<BolusRepository>.Instance);
         var carbIntakeRepo = new CarbIntakeRepository(ctxFactory, mockDedup.Object, mockAudit, NullLogger<CarbIntakeRepository>.Instance);
-        var bgCheckRepo = new BGCheckRepository(ctxFactory, mockDedup.Object, NullLogger<BGCheckRepository>.Instance);
-        var noteRepo = new NoteRepository(ctxFactory, mockDedup.Object, NullLogger<NoteRepository>.Instance);
+        var bgCheckRepo = new BGCheckRepository(ctxFactory, mockDedup.Object, mockAudit, NullLogger<BGCheckRepository>.Instance);
+        var noteRepo = new NoteRepository(ctxFactory, mockDedup.Object, mockAudit, NullLogger<NoteRepository>.Instance);
         var deviceEventRepo = new DeviceEventRepository(ctxFactory, mockDedup.Object, mockAudit, NullLogger<DeviceEventRepository>.Instance);
         var bolusCalcRepo = new BolusCalculationRepository(ctxFactory, mockDedup.Object, mockAudit, NullLogger<BolusCalculationRepository>.Instance);
         _stateSpanServiceMock = new Mock<IStateSpanService>();

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/CalibrationRepositoryBulkCreateTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/CalibrationRepositoryBulkCreateTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
@@ -21,7 +22,7 @@ public class CalibrationRepositoryBulkCreateTests : IDisposable
         var dbName = $"calibration_bulk_tests_{Guid.NewGuid()}";
         _context = TestDbContextFactory.CreateInMemoryContext(dbName);
         _context.TenantId = TenantA;
-        _repository = new CalibrationRepository(new TestTenantDbContextFactory(_context), NullLogger<CalibrationRepository>.Instance);
+        _repository = new CalibrationRepository(new TestTenantDbContextFactory(_context), new SystemAuditContext(), NullLogger<CalibrationRepository>.Instance);
     }
 
     public void Dispose()

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/MeterGlucoseRepositoryBulkCreateTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/MeterGlucoseRepositoryBulkCreateTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
@@ -21,7 +22,7 @@ public class MeterGlucoseRepositoryBulkCreateTests : IDisposable
         var dbName = $"meter_glucose_bulk_tests_{Guid.NewGuid()}";
         _context = TestDbContextFactory.CreateInMemoryContext(dbName);
         _context.TenantId = TenantA;
-        _repository = new MeterGlucoseRepository(new TestTenantDbContextFactory(_context), NullLogger<MeterGlucoseRepository>.Instance);
+        _repository = new MeterGlucoseRepository(new TestTenantDbContextFactory(_context), new SystemAuditContext(), NullLogger<MeterGlucoseRepository>.Instance);
     }
 
     public void Dispose()


### PR DESCRIPTION
## What this is

Extracts a shared `V4RepositoryBase<TModel, TEntity>` for the V4 record repositories, eliminating the byte-identical copy-paste CRUD/soft-delete/bulk-create logic that was duplicated across ~17 repos, and normalizes a set of latent cross-type inconsistencies. **Net ~−2,760 lines** (and that's *with* ~1,000 lines of new golden tests — the production-code reduction is larger).

It is the foundation for upcoming native V4-shaped realtime broadcasting (separate PR): every V4 write path now converges on a single, consistent base, so a broadcast side-effect has one home.

## How to read it (36 commits, in three phases)

**1. Safety net first (goldens).** Per-type Testcontainers goldens against real Postgres + the real `DeduplicationService` (not mocks), pinning current dedup/bulk behaviour AND the cross-type "deltas" (the latent inconsistencies). Captured green against pre-refactor code as the baseline.

**2. Behaviour-PRESERVING extraction.** `V4RepositoryBase` + 14 repositories migrated onto it (7 dedup participants, 7 LegacyId-only). Goldens held identical the whole way — the migration changed structure, not behaviour. Each dedup participant is now thin: three static-mapper bridges + its extended `GetAsync` + small hook overrides.

**3. Deliberate delta normalizations (D1–D7), each a flagged commit re-baselining its named golden:**
- **D1** — BasalInjection bulk now upserts on SyncId (was throwing on the unique index).
- **D2** — SensorGlucose dedup feed → inserts-only (post-D4 commit-visibility makes the old union feed redundant).
- **D3** — SensorGlucose single `CreateAsync` now upserts on SyncId (was throwing), matching Bolus.
- **D4** — dedup runs *after* commit for Bolus/CarbIntake. **This fixed a real latent bug**: `DeduplicationService` runs on a *separate* context/connection, so the old inside-transaction dedup was matching against *stale committed state* (it couldn't see its own uncommitted writes). Moving it after commit makes it dedup against actual values.
- **D5** — all V4 soft-deletes are now audited in the base (BGCheck/Note previously bypassed the audit log via raw `ExecuteUpdate`). Knowingly accepted side effect: this also audits creates/updates of those types on user-authenticated paths (modest-volume manual/clinical records; the bulk-ingestion firehose stays `SystemAuditScope`-suppressed).
- **D6** — BasalInjection bulk is now atomic (execution-strategy + transaction) and audit-aware (`GetBlockingLegacyIdsAsync` honouring the user-delete discrimination).
- **D7** — `CountAsync` excludes non-primary deduped rows for all participants (was only CarbIntake), so counts match `GetAsync`.

**4. Capstone — `BulkCreateAsync` template extraction.** Now the shapes are uniform, the 7 participants' near-identical `BulkCreateAsync` collapse into one template on the base with two virtual hooks: `SplitUpsertsAsync` (SyncId upsert) and `PostCommitDedupAsync` (canonical dedup). Plus `ApplyReadVisibility` (the non-primary exclusion). Behaviour-preserving (goldens green).

## Not on the base (by design)
TempBasal (span-shaped), BasalInjection (standalone/direct-context — its bulk was fixed in-place by D6/D1), the 3 device-status snapshots (no `data_source` column — separate follow-up), and the reference/singleton types (Device, PatientDevice, PatientInsulin, PatientRecord, DeviceStatusExtras).

## Testing
- 33 per-type Testcontainers goldens (the `integration-db` CI job, real Postgres 17.6 — not the Aspire E2E suite).
- 402 Infrastructure.Data unit tests; 3,474 API unit tests. All green (one unrelated, pre-existing flaky memory benchmark excluded).
- No schema migrations. No public API contract changes.

## Reviewed
Each phase was reviewed by a separate pass: migrations confirmed behaviour-identical method-by-method; the deltas confirmed correct with the D5 side-effect and D4 bugfix called out explicitly; the hook extraction confirmed behaviour-equivalent across empty/all-blocked/upsert-only/retry edge cases.
