### PR TITLE
feat(v4): broadcast native V4 record shapes over SignalR from the repository chokepoint

### DIFF
--- a/src/API/Nocturne.API/Controllers/V1/DeviceStatusController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/DeviceStatusController.cs
@@ -224,7 +224,7 @@ public class DeviceStatusController : ControllerBase
             var projectedResults = new List<DeviceStatus>();
             foreach (var ds in deviceStatusEntries)
             {
-                await _decomposer.DecomposeAsync(ds, cancellationToken);
+                await _decomposer.DecomposeAsync(ds, WriteOrigin.Live, cancellationToken);
 
                 // Project the V4 snapshots back to DeviceStatus shape for the response
                 var projected = ds;
@@ -306,7 +306,7 @@ public class DeviceStatusController : ControllerBase
             var deviceStatusToDelete = await _projection.GetByIdAsync(id, cancellationToken);
 
             // Delete V4 snapshot records by legacy ID
-            var deleted = await _decomposer.DeleteByLegacyIdAsync(id, cancellationToken);
+            var deleted = await _decomposer.DeleteByLegacyIdAsync(id, WriteOrigin.Live, cancellationToken);
 
             if (deleted > 0 || deviceStatusToDelete != null)
             {
@@ -398,7 +398,7 @@ public class DeviceStatusController : ControllerBase
             {
                 if (!string.IsNullOrEmpty(record.Id))
                 {
-                    var count = await _decomposer.DeleteByLegacyIdAsync(record.Id, cancellationToken);
+                    var count = await _decomposer.DeleteByLegacyIdAsync(record.Id, WriteOrigin.Live, cancellationToken);
                     if (count > 0)
                         deletedCount++;
                 }

--- a/src/API/Nocturne.API/Controllers/V3/DeviceStatusController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/DeviceStatusController.cs
@@ -274,7 +274,7 @@ public class DeviceStatusController : BaseV3Controller<DeviceStatus>
             var projectedResults = new List<DeviceStatus>();
             foreach (var ds in recordsList)
             {
-                await _decomposer.DecomposeAsync(ds, cancellationToken);
+                await _decomposer.DecomposeAsync(ds, WriteOrigin.Live, cancellationToken);
 
                 // Project the V4 snapshots back to DeviceStatus shape for the response
                 var projected = ds;
@@ -386,8 +386,8 @@ public class DeviceStatusController : BaseV3Controller<DeviceStatus>
             }
 
             // Delete old V4 records by legacy ID, then decompose the updated DeviceStatus
-            await _decomposer.DeleteByLegacyIdAsync(id, cancellationToken);
-            await _decomposer.DecomposeAsync(deviceStatus, cancellationToken);
+            await _decomposer.DeleteByLegacyIdAsync(id, WriteOrigin.Live, cancellationToken);
+            await _decomposer.DecomposeAsync(deviceStatus, WriteOrigin.Live, cancellationToken);
 
             // Project the V4 snapshots back to DeviceStatus shape for the response
             var updated = await _projection.GetByIdAsync(id, cancellationToken) ?? deviceStatus;
@@ -447,7 +447,7 @@ public class DeviceStatusController : BaseV3Controller<DeviceStatus>
             var deviceStatusToDelete = await _projection.GetByIdAsync(id, cancellationToken);
 
             // Delete V4 snapshot records by legacy ID
-            var deleted = await _decomposer.DeleteByLegacyIdAsync(id, cancellationToken);
+            var deleted = await _decomposer.DeleteByLegacyIdAsync(id, WriteOrigin.Live, cancellationToken);
 
             if (deleted == 0 && deviceStatusToDelete == null)
             {

--- a/src/API/Nocturne.API/Controllers/V4/Base/V4CrudControllerBase.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Base/V4CrudControllerBase.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Controllers.V4.Base;
 
@@ -66,7 +67,7 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
         if (model.Timestamp == default)
             return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
 
-        var created = await Repository.CreateAsync(model, ct);
+        var created = await Repository.CreateAsync(model, WriteOrigin.Live, ct);
         created = await OnAfterCreateAsync(created, ct);
         return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
     }
@@ -98,7 +99,7 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
 
         try
         {
-            var updated = await Repository.UpdateAsync(id, model, ct);
+            var updated = await Repository.UpdateAsync(id, model, WriteOrigin.Live, ct);
             return Ok(updated);
         }
         catch (KeyNotFoundException)
@@ -119,7 +120,7 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
     {
         try
         {
-            await Repository.DeleteAsync(id, ct);
+            await Repository.DeleteAsync(id, WriteOrigin.Live, ct);
             return NoContent();
         }
         catch (KeyNotFoundException)
@@ -156,7 +157,7 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
     {
         try
         {
-            var restored = await Repository.RestoreAsync(id, ct);
+            var restored = await Repository.RestoreAsync(id, WriteOrigin.Live, ct);
             await OnAfterRestoreAsync(restored, ct);
             return Ok(restored);
         }
@@ -176,7 +177,7 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
     public virtual async Task<ActionResult<IEnumerable<TModel>>> BulkRestore(
         [FromBody] Guid[] ids, CancellationToken ct = default)
     {
-        var restored = await Repository.BulkRestoreAsync(ids, ct);
+        var restored = await Repository.BulkRestoreAsync(ids, WriteOrigin.Live, ct);
         return Ok(restored);
     }
 

--- a/src/API/Nocturne.API/Controllers/V4/Devices/DeviceEventController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/DeviceEventController.cs
@@ -4,6 +4,7 @@ using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Controllers.V4.Devices;
 
@@ -77,7 +78,7 @@ public class DeviceEventController(IDeviceEventRepository repo)
         if (string.IsNullOrEmpty(dataSource) || string.IsNullOrEmpty(syncIdentifier))
             return BadRequest("dataSource and syncIdentifier are required");
 
-        var deleted = await ((IDeviceEventRepository)Repository).DeleteBySyncIdentifierAsync(dataSource, syncIdentifier, ct);
+        var deleted = await ((IDeviceEventRepository)Repository).DeleteBySyncIdentifierAsync(dataSource, syncIdentifier, WriteOrigin.Live, ct);
         return deleted > 0 ? NoContent() : NotFound();
     }
 }

--- a/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
@@ -9,6 +9,7 @@ using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Controllers.V4.Glucose;
 
@@ -53,7 +54,7 @@ public class SensorGlucoseController(
 
         await glucoseResolver.ResolveAsync(model, request.GlucoseProcessing, request.SmoothedMgdl, request.UnsmoothedMgdl, ct);
 
-        var created = await Repository.CreateAsync(model, ct);
+        var created = await Repository.CreateAsync(model, WriteOrigin.Live, ct);
         created = await OnAfterCreateAsync(created, ct);
         return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
     }
@@ -110,7 +111,7 @@ public class SensorGlucoseController(
 
         try
         {
-            var updated = await Repository.UpdateAsync(id, model, ct);
+            var updated = await Repository.UpdateAsync(id, model, WriteOrigin.Live, ct);
 
             // V4 writes bypass the legacy entry sink; emit the realtime "entries" update here.
             await glucoseEvents.OnUpdatedAsync(updated, ct);
@@ -144,7 +145,7 @@ public class SensorGlucoseController(
         for (var i = 0; i < models.Count; i++)
             await glucoseResolver.ResolveAsync(models[i], requests[i].GlucoseProcessing, requests[i].SmoothedMgdl, requests[i].UnsmoothedMgdl, ct);
 
-        var created = await Repository.BulkCreateAsync(models, ct);
+        var created = await Repository.BulkCreateAsync(models, WriteOrigin.Live, ct);
         var createdArray = created.ToArray();
 
         // Evaluate alerts for the most recent reading only (not every historical reading during backfill)

--- a/src/API/Nocturne.API/Controllers/V4/Health/PatientRecordController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/PatientRecordController.cs
@@ -4,6 +4,7 @@ using OpenApi.Remote.Attributes;
 using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Controllers.V4.Health;
 
@@ -68,7 +69,7 @@ public class PatientRecordController : ControllerBase
         [FromBody] PatientRecord model,
         CancellationToken cancellationToken = default)
     {
-        var updated = await _recordRepo.UpdateAsync(model, cancellationToken);
+        var updated = await _recordRepo.UpdateAsync(model, WriteOrigin.Live, cancellationToken);
         return Ok(updated);
     }
 
@@ -99,7 +100,7 @@ public class PatientRecordController : ControllerBase
         CancellationToken cancellationToken = default)
     {
         await ResolveDeviceIdAsync(model, cancellationToken);
-        var created = await _deviceRepo.CreateAsync(model, cancellationToken);
+        var created = await _deviceRepo.CreateAsync(model, WriteOrigin.Live, cancellationToken);
         return CreatedAtAction(nameof(GetDevices), created);
     }
 
@@ -115,7 +116,7 @@ public class PatientRecordController : ControllerBase
         CancellationToken cancellationToken = default)
     {
         await ResolveDeviceIdAsync(model, cancellationToken);
-        var updated = await _deviceRepo.UpdateAsync(id, model, cancellationToken);
+        var updated = await _deviceRepo.UpdateAsync(id, model, WriteOrigin.Live, cancellationToken);
         return Ok(updated);
     }
 
@@ -127,7 +128,7 @@ public class PatientRecordController : ControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<ActionResult> DeleteDevice(Guid id, CancellationToken cancellationToken = default)
     {
-        await _deviceRepo.DeleteAsync(id, cancellationToken);
+        await _deviceRepo.DeleteAsync(id, WriteOrigin.Live, cancellationToken);
         return NoContent();
     }
 
@@ -170,7 +171,7 @@ public class PatientRecordController : ControllerBase
         [FromBody] PatientInsulin model,
         CancellationToken cancellationToken = default)
     {
-        var created = await _insulinRepo.CreateAsync(model, cancellationToken);
+        var created = await _insulinRepo.CreateAsync(model, WriteOrigin.Live, cancellationToken);
         if (created.IsPrimary)
             await _insulinRepo.SetPrimaryAsync(created.Id, cancellationToken);
         return CreatedAtAction(nameof(GetInsulins), created);
@@ -187,7 +188,7 @@ public class PatientRecordController : ControllerBase
         [FromBody] PatientInsulin model,
         CancellationToken cancellationToken = default)
     {
-        var updated = await _insulinRepo.UpdateAsync(id, model, cancellationToken);
+        var updated = await _insulinRepo.UpdateAsync(id, model, WriteOrigin.Live, cancellationToken);
         if (updated.IsPrimary)
             await _insulinRepo.SetPrimaryAsync(updated.Id, cancellationToken);
         return Ok(updated);
@@ -201,7 +202,7 @@ public class PatientRecordController : ControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<ActionResult> DeleteInsulin(Guid id, CancellationToken cancellationToken = default)
     {
-        await _insulinRepo.DeleteAsync(id, cancellationToken);
+        await _insulinRepo.DeleteAsync(id, WriteOrigin.Live, cancellationToken);
         return NoContent();
     }
 

--- a/src/API/Nocturne.API/Controllers/V4/Profiles/ProfileController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Profiles/ProfileController.cs
@@ -5,6 +5,7 @@ using Nocturne.Core.Contracts.Profiles;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Controllers.V4.Profiles;
 
@@ -163,13 +164,13 @@ public class ProfileController : ControllerBase
         foreach (var ts in all.Where(ts => ts.IsDefault && ts.Id != target.Id))
         {
             ts.IsDefault = false;
-            await _therapyRepo.UpdateAsync(ts.Id, ts, ct);
+            await _therapyRepo.UpdateAsync(ts.Id, ts, WriteOrigin.Live, ct);
         }
 
         if (!target.IsDefault)
         {
             target.IsDefault = true;
-            await _therapyRepo.UpdateAsync(target.Id, target, ct);
+            await _therapyRepo.UpdateAsync(target.Id, target, WriteOrigin.Live, ct);
         }
 
         return NoContent();
@@ -299,7 +300,7 @@ public class ProfileController : ControllerBase
     {
         if (model.Timestamp == default)
             return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
-        var created = await _therapyRepo.CreateAsync(model, ct);
+        var created = await _therapyRepo.CreateAsync(model, WriteOrigin.Live, ct);
         return CreatedAtAction(nameof(GetTherapySettingsById), new { id = created.Id }, created);
     }
 
@@ -323,7 +324,7 @@ public class ProfileController : ControllerBase
             return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
         try
         {
-            var updated = await _therapyRepo.UpdateAsync(id, model, ct);
+            var updated = await _therapyRepo.UpdateAsync(id, model, WriteOrigin.Live, ct);
             return Ok(updated);
         }
         catch (KeyNotFoundException)
@@ -343,7 +344,7 @@ public class ProfileController : ControllerBase
     {
         try
         {
-            await _therapyRepo.DeleteAsync(id, ct);
+            await _therapyRepo.DeleteAsync(id, WriteOrigin.Live, ct);
             return NoContent();
         }
         catch (KeyNotFoundException)
@@ -401,7 +402,7 @@ public class ProfileController : ControllerBase
     {
         if (model.Timestamp == default)
             return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
-        var created = await _basalRepo.CreateAsync(model, ct);
+        var created = await _basalRepo.CreateAsync(model, WriteOrigin.Live, ct);
         return CreatedAtAction(nameof(GetBasalScheduleById), new { id = created.Id }, created);
     }
 
@@ -425,7 +426,7 @@ public class ProfileController : ControllerBase
             return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
         try
         {
-            var updated = await _basalRepo.UpdateAsync(id, model, ct);
+            var updated = await _basalRepo.UpdateAsync(id, model, WriteOrigin.Live, ct);
             return Ok(updated);
         }
         catch (KeyNotFoundException)
@@ -445,7 +446,7 @@ public class ProfileController : ControllerBase
     {
         try
         {
-            await _basalRepo.DeleteAsync(id, ct);
+            await _basalRepo.DeleteAsync(id, WriteOrigin.Live, ct);
             return NoContent();
         }
         catch (KeyNotFoundException)
@@ -503,7 +504,7 @@ public class ProfileController : ControllerBase
     {
         if (model.Timestamp == default)
             return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
-        var created = await _carbRatioRepo.CreateAsync(model, ct);
+        var created = await _carbRatioRepo.CreateAsync(model, WriteOrigin.Live, ct);
         return CreatedAtAction(nameof(GetCarbRatioScheduleById), new { id = created.Id }, created);
     }
 
@@ -531,7 +532,7 @@ public class ProfileController : ControllerBase
             return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
         try
         {
-            var updated = await _carbRatioRepo.UpdateAsync(id, model, ct);
+            var updated = await _carbRatioRepo.UpdateAsync(id, model, WriteOrigin.Live, ct);
             return Ok(updated);
         }
         catch (KeyNotFoundException)
@@ -551,7 +552,7 @@ public class ProfileController : ControllerBase
     {
         try
         {
-            await _carbRatioRepo.DeleteAsync(id, ct);
+            await _carbRatioRepo.DeleteAsync(id, WriteOrigin.Live, ct);
             return NoContent();
         }
         catch (KeyNotFoundException)
@@ -609,7 +610,7 @@ public class ProfileController : ControllerBase
     {
         if (model.Timestamp == default)
             return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
-        var created = await _sensitivityRepo.CreateAsync(model, ct);
+        var created = await _sensitivityRepo.CreateAsync(model, WriteOrigin.Live, ct);
         return CreatedAtAction(
             nameof(GetSensitivityScheduleById),
             new { id = created.Id },
@@ -641,7 +642,7 @@ public class ProfileController : ControllerBase
             return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
         try
         {
-            var updated = await _sensitivityRepo.UpdateAsync(id, model, ct);
+            var updated = await _sensitivityRepo.UpdateAsync(id, model, WriteOrigin.Live, ct);
             return Ok(updated);
         }
         catch (KeyNotFoundException)
@@ -664,7 +665,7 @@ public class ProfileController : ControllerBase
     {
         try
         {
-            await _sensitivityRepo.DeleteAsync(id, ct);
+            await _sensitivityRepo.DeleteAsync(id, WriteOrigin.Live, ct);
             return NoContent();
         }
         catch (KeyNotFoundException)
@@ -722,7 +723,7 @@ public class ProfileController : ControllerBase
     {
         if (model.Timestamp == default)
             return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
-        var created = await _targetRangeRepo.CreateAsync(model, ct);
+        var created = await _targetRangeRepo.CreateAsync(model, WriteOrigin.Live, ct);
         return CreatedAtAction(
             nameof(GetTargetRangeScheduleById),
             new { id = created.Id },
@@ -754,7 +755,7 @@ public class ProfileController : ControllerBase
             return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
         try
         {
-            var updated = await _targetRangeRepo.UpdateAsync(id, model, ct);
+            var updated = await _targetRangeRepo.UpdateAsync(id, model, WriteOrigin.Live, ct);
             return Ok(updated);
         }
         catch (KeyNotFoundException)
@@ -777,7 +778,7 @@ public class ProfileController : ControllerBase
     {
         try
         {
-            await _targetRangeRepo.DeleteAsync(id, ct);
+            await _targetRangeRepo.DeleteAsync(id, WriteOrigin.Live, ct);
             return NoContent();
         }
         catch (KeyNotFoundException)

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/BasalInjectionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/BasalInjectionController.cs
@@ -4,6 +4,7 @@ using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Controllers.V4.Treatments;
 
@@ -62,7 +63,7 @@ public class BasalInjectionController(
         var model = MapCreateToModel(request);
         model.InsulinContext = BuildContext(insulin!);
 
-        var created = await Repository.CreateAsync(model, ct);
+        var created = await Repository.CreateAsync(model, WriteOrigin.Live, ct);
         return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
     }
 
@@ -86,7 +87,7 @@ public class BasalInjectionController(
 
         try
         {
-            var updated = await Repository.UpdateAsync(id, model, ct);
+            var updated = await Repository.UpdateAsync(id, model, WriteOrigin.Live, ct);
             return Ok(updated);
         }
         catch (KeyNotFoundException)

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/BolusController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/BolusController.cs
@@ -4,6 +4,7 @@ using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Controllers.V4.Treatments;
 
@@ -53,7 +54,7 @@ public class BolusController(IBolusRepository repo, IPatientInsulinRepository in
 
         await EnrichInsulinContextAsync(model, request.PatientInsulinId, ct);
 
-        var created = await Repository.CreateAsync(model, ct);
+        var created = await Repository.CreateAsync(model, WriteOrigin.Live, ct);
         created = await OnAfterCreateAsync(created, ct);
         return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
     }
@@ -74,7 +75,7 @@ public class BolusController(IBolusRepository repo, IPatientInsulinRepository in
 
         try
         {
-            var updated = await Repository.UpdateAsync(id, model, ct);
+            var updated = await Repository.UpdateAsync(id, model, WriteOrigin.Live, ct);
             return Ok(updated);
         }
         catch (KeyNotFoundException)
@@ -156,7 +157,7 @@ public class BolusController(IBolusRepository repo, IPatientInsulinRepository in
         if (string.IsNullOrEmpty(dataSource) || string.IsNullOrEmpty(syncIdentifier))
             return BadRequest("dataSource and syncIdentifier are required");
 
-        var deleted = await ((IBolusRepository)Repository).DeleteBySyncIdentifierAsync(dataSource, syncIdentifier, ct);
+        var deleted = await ((IBolusRepository)Repository).DeleteBySyncIdentifierAsync(dataSource, syncIdentifier, WriteOrigin.Live, ct);
         return deleted > 0 ? NoContent() : NotFound();
     }
 

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/NoteController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/NoteController.cs
@@ -4,6 +4,7 @@ using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Controllers.V4.Treatments;
 
@@ -74,7 +75,7 @@ public class NoteController(INoteRepository repo)
         if (string.IsNullOrEmpty(dataSource) || string.IsNullOrEmpty(syncIdentifier))
             return BadRequest("dataSource and syncIdentifier are required");
 
-        var deleted = await ((INoteRepository)Repository).DeleteBySyncIdentifierAsync(dataSource, syncIdentifier, ct);
+        var deleted = await ((INoteRepository)Repository).DeleteBySyncIdentifierAsync(dataSource, syncIdentifier, WriteOrigin.Live, ct);
         return deleted > 0 ? NoContent() : NotFound();
     }
 }

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/NutritionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/NutritionController.cs
@@ -14,6 +14,7 @@ using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Mappers.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Controllers.V4.Treatments;
 
@@ -158,7 +159,7 @@ public class NutritionController : ControllerBase
             CorrelationId = correlationId,
         };
 
-        var created = await _carbIntakeRepo.CreateAsync(model, ct);
+        var created = await _carbIntakeRepo.CreateAsync(model, WriteOrigin.Live, ct);
         return CreatedAtAction(nameof(GetCarbIntakeById), new { id = created.Id }, created);
     }
 
@@ -199,7 +200,7 @@ public class NutritionController : ControllerBase
 
         try
         {
-            var updated = await _carbIntakeRepo.UpdateAsync(id, model, ct);
+            var updated = await _carbIntakeRepo.UpdateAsync(id, model, WriteOrigin.Live, ct);
             return Ok(updated);
         }
         catch (KeyNotFoundException)
@@ -219,7 +220,7 @@ public class NutritionController : ControllerBase
     {
         try
         {
-            await _carbIntakeRepo.DeleteAsync(id, ct);
+            await _carbIntakeRepo.DeleteAsync(id, WriteOrigin.Live, ct);
             return NoContent();
         }
         catch (KeyNotFoundException)
@@ -243,7 +244,7 @@ public class NutritionController : ControllerBase
         if (string.IsNullOrEmpty(dataSource) || string.IsNullOrEmpty(syncIdentifier))
             return BadRequest("dataSource and syncIdentifier are required");
 
-        var deleted = await _carbIntakeRepo.DeleteBySyncIdentifierAsync(dataSource, syncIdentifier, ct);
+        var deleted = await _carbIntakeRepo.DeleteBySyncIdentifierAsync(dataSource, syncIdentifier, WriteOrigin.Live, ct);
         return deleted > 0 ? NoContent() : NotFound();
     }
 
@@ -460,11 +461,11 @@ public class NutritionController : ControllerBase
         }
 
         var bolusBefore = await _context.Boluses.CountAsync(ct);
-        var createdBolus = await _bolusRepo.CreateAsync(bolusModel, ct);
+        var createdBolus = await _bolusRepo.CreateAsync(bolusModel, WriteOrigin.Live, ct);
         var bolusWasNew = (await _context.Boluses.CountAsync(ct)) > bolusBefore;
 
         var carbBefore = await _context.CarbIntakes.CountAsync(ct);
-        var createdCarb = await _carbIntakeRepo.CreateAsync(carbModel, ct);
+        var createdCarb = await _carbIntakeRepo.CreateAsync(carbModel, WriteOrigin.Live, ct);
         var carbWasNew = (await _context.CarbIntakes.CountAsync(ct)) > carbBefore;
 
         await tx.CommitAsync(ct);

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -661,6 +661,11 @@ public static class ServiceRegistrationExtensions
         services.AddScoped<ISignalRBroadcastService, SignalRBroadcastService>();
         services.AddScoped<ISyncProgressReporter, SignalRSyncProgressReporter>();
 
+        // Native V4 record broadcasting (companion + Prelude) over the glucose/care/device/therapy
+        // categories. Open generic so every V4 model type resolves; the repository chokepoint fires it
+        // for live writes only. Additive to the legacy v1 IDataEventSink<T> projections above.
+        services.AddScoped(typeof(IV4RecordBroadcaster<>), typeof(SignalRV4RecordBroadcaster<>));
+
         // Push notifications
         services.AddScoped<INotificationV2Service, NotificationV2Service>();
         services.AddScoped<INotificationV1Service, NotificationV1Service>();

--- a/src/API/Nocturne.API/Hubs/DataHub.cs
+++ b/src/API/Nocturne.API/Hubs/DataHub.cs
@@ -250,7 +250,7 @@ public class DataHub : TenantAwareHub
     {
         try
         {
-            var enabledCollections = new[] { "entries", "treatments", "devicestatus", "profiles" };
+            var enabledCollections = Services.Realtime.RealtimeCategories.All;
             var collections = request.Collections ?? enabledCollections;
             var subscribed = new List<string>();
 

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/DevicePublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/DevicePublisher.cs
@@ -38,13 +38,13 @@ internal sealed class DevicePublisher : IDevicePublisher
     public async Task<bool> PublishDeviceStatusAsync(
         IEnumerable<DeviceStatus> deviceStatuses,
         string source,
-        CancellationToken cancellationToken = default)
+        WriteOrigin origin, CancellationToken cancellationToken = default)
     {
         try
         {
             foreach (var ds in deviceStatuses)
             {
-                await _decomposer.DecomposeAsync(ds, cancellationToken);
+                await _decomposer.DecomposeAsync(ds, origin, cancellationToken);
             }
             return true;
         }
@@ -59,7 +59,7 @@ internal sealed class DevicePublisher : IDevicePublisher
     public async Task<bool> PublishDeviceEventsAsync(
         IEnumerable<DeviceEvent> records,
         string source,
-        CancellationToken cancellationToken = default)
+        WriteOrigin origin, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -67,7 +67,7 @@ internal sealed class DevicePublisher : IDevicePublisher
             if (recordList.Count == 0) return true;
 
             using (SystemAuditScope.Push(_auditContext))
-                await _deviceEventRepository.BulkCreateAsync(recordList, cancellationToken);
+                await _deviceEventRepository.BulkCreateAsync(recordList, origin, cancellationToken);
             _logger.LogDebug("Published {Count} DeviceEvent records for {Source}", recordList.Count, source);
             return true;
         }

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/GlucosePublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/GlucosePublisher.cs
@@ -11,6 +11,7 @@ using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Services.ConnectorPublishing;
 
@@ -57,7 +58,7 @@ internal sealed class GlucosePublisher : IGlucosePublisher
     public async Task<bool> PublishEntriesAsync(
         IEnumerable<Entry> entries,
         string source,
-        CancellationToken cancellationToken = default)
+        WriteOrigin origin, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -78,7 +79,7 @@ internal sealed class GlucosePublisher : IGlucosePublisher
     public async Task<bool> PublishSensorGlucoseAsync(
         IEnumerable<SensorGlucose> records,
         string source,
-        CancellationToken cancellationToken = default)
+        WriteOrigin origin, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -88,7 +89,7 @@ internal sealed class GlucosePublisher : IGlucosePublisher
             await StampPatientDeviceIdsAsync(recordList, source, cancellationToken);
             List<SensorGlucose> created;
             using (SystemAuditScope.Push(_auditContext))
-                created = (await _sensorGlucoseRepository.BulkCreateAsync(recordList, cancellationToken)).ToList();
+                created = (await _sensorGlucoseRepository.BulkCreateAsync(recordList, origin, cancellationToken)).ToList();
             await UpdateLastReadingAtAsync(cancellationToken);
             await EvaluateAlertsForSensorGlucoseAsync(recordList, cancellationToken);
 

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/MetadataPublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/MetadataPublisher.cs
@@ -8,6 +8,7 @@ using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
 using Nocturne.Core.Contracts.Repositories;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Services.ConnectorPublishing;
 
@@ -52,7 +53,7 @@ internal sealed class MetadataPublisher : IMetadataPublisher
     public async Task<bool> PublishProfilesAsync(
         IEnumerable<Profile> profiles,
         string source,
-        CancellationToken cancellationToken = default)
+        WriteOrigin origin, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -70,7 +71,7 @@ internal sealed class MetadataPublisher : IMetadataPublisher
     public async Task<bool> PublishFoodAsync(
         IEnumerable<Food> foods,
         string source,
-        CancellationToken cancellationToken = default)
+        WriteOrigin origin, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -88,7 +89,7 @@ internal sealed class MetadataPublisher : IMetadataPublisher
     public async Task<IReadOnlyList<ConnectorFoodEntry>?> PublishConnectorFoodEntriesAsync(
         IEnumerable<ConnectorFoodEntryImport> entries,
         string source,
-        CancellationToken cancellationToken = default)
+        WriteOrigin origin, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -108,7 +109,7 @@ internal sealed class MetadataPublisher : IMetadataPublisher
     public async Task<bool> PublishActivityAsync(
         IEnumerable<Activity> activities,
         string source,
-        CancellationToken cancellationToken = default)
+        WriteOrigin origin, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -126,7 +127,7 @@ internal sealed class MetadataPublisher : IMetadataPublisher
     public async Task<bool> PublishStateSpansAsync(
         IEnumerable<StateSpan> stateSpans,
         string source,
-        CancellationToken cancellationToken = default)
+        WriteOrigin origin, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -147,7 +148,7 @@ internal sealed class MetadataPublisher : IMetadataPublisher
     public async Task<bool> PublishSystemEventsAsync(
         IEnumerable<SystemEvent> systemEvents,
         string source,
-        CancellationToken cancellationToken = default)
+        WriteOrigin origin, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -165,14 +166,14 @@ internal sealed class MetadataPublisher : IMetadataPublisher
     public async Task<bool> PublishNotesAsync(
         IEnumerable<Note> records,
         string source,
-        CancellationToken cancellationToken = default)
+        WriteOrigin origin, CancellationToken cancellationToken = default)
     {
         try
         {
             var recordList = records.ToList();
             if (recordList.Count == 0) return true;
 
-            await _noteRepository.BulkCreateAsync(recordList, cancellationToken);
+            await _noteRepository.BulkCreateAsync(recordList, origin, cancellationToken);
             _logger.LogDebug("Published {Count} Note records for {Source}", recordList.Count, source);
             return true;
         }

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/TreatmentPublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/TreatmentPublisher.cs
@@ -8,6 +8,7 @@ using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Services.ConnectorPublishing;
 
@@ -72,7 +73,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
     public async Task<bool> PublishTreatmentsAsync(
         IEnumerable<Treatment> treatments,
         string source,
-        CancellationToken cancellationToken = default)
+        WriteOrigin origin, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -90,16 +91,16 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
     public async Task<bool> PublishBolusesAsync(
         IEnumerable<Bolus> records,
         string source,
-        CancellationToken cancellationToken = default)
+        WriteOrigin origin, CancellationToken cancellationToken = default)
     {
         try
         {
             var recordList = records.ToList();
             if (recordList.Count == 0) return true;
 
-            await ResolvePatientInsulinsForBolusesAsync(recordList, cancellationToken);
+            await ResolvePatientInsulinsForBolusesAsync(recordList, origin, cancellationToken);
             using (SystemAuditScope.Push(_auditContext))
-                await _bolusRepository.BulkCreateAsync(recordList, cancellationToken);
+                await _bolusRepository.BulkCreateAsync(recordList, origin, cancellationToken);
             _logger.LogDebug("Published {Count} Bolus records for {Source}", recordList.Count, source);
             return true;
         }
@@ -114,7 +115,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
     public async Task<bool> PublishCarbIntakesAsync(
         IEnumerable<CarbIntake> records,
         string source,
-        CancellationToken cancellationToken = default)
+        WriteOrigin origin, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -122,7 +123,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
             if (recordList.Count == 0) return true;
 
             using (SystemAuditScope.Push(_auditContext))
-                await _carbIntakeRepository.BulkCreateAsync(recordList, cancellationToken);
+                await _carbIntakeRepository.BulkCreateAsync(recordList, origin, cancellationToken);
             _logger.LogDebug("Published {Count} CarbIntake records for {Source}", recordList.Count, source);
             return true;
         }
@@ -137,7 +138,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
     public async Task<bool> PublishBGChecksAsync(
         IEnumerable<BGCheck> records,
         string source,
-        CancellationToken cancellationToken = default)
+        WriteOrigin origin, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -145,7 +146,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
             if (recordList.Count == 0) return true;
 
             using (SystemAuditScope.Push(_auditContext))
-                await _bgCheckRepository.BulkCreateAsync(recordList, cancellationToken);
+                await _bgCheckRepository.BulkCreateAsync(recordList, origin, cancellationToken);
             _logger.LogDebug("Published {Count} BGCheck records for {Source}", recordList.Count, source);
             return true;
         }
@@ -160,7 +161,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
     public async Task<bool> PublishBolusCalculationsAsync(
         IEnumerable<BolusCalculation> records,
         string source,
-        CancellationToken cancellationToken = default)
+        WriteOrigin origin, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -168,7 +169,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
             if (recordList.Count == 0) return true;
 
             using (SystemAuditScope.Push(_auditContext))
-                await _bolusCalculationRepository.BulkCreateAsync(recordList, cancellationToken);
+                await _bolusCalculationRepository.BulkCreateAsync(recordList, origin, cancellationToken);
             _logger.LogDebug("Published {Count} BolusCalculation records for {Source}", recordList.Count, source);
             return true;
         }
@@ -183,7 +184,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
     public async Task<bool> PublishTempBasalsAsync(
         IEnumerable<TempBasal> records,
         string source,
-        CancellationToken cancellationToken = default)
+        WriteOrigin origin, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -218,7 +219,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
                         + "(rate differs from programmed basal schedule) for {Source}",
                         reclassifiedCount, recordList.Count, source);
 
-                await _tempBasalRepository.BulkCreateAsync(recordList, cancellationToken);
+                await _tempBasalRepository.BulkCreateAsync(recordList, origin, cancellationToken);
             }
             _logger.LogDebug("Published {Count} TempBasal records for {Source}", recordList.Count, source);
             return true;
@@ -283,16 +284,16 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
     public async Task<bool> PublishBasalInjectionsAsync(
         IEnumerable<BasalInjection> records,
         string source,
-        CancellationToken cancellationToken = default)
+        WriteOrigin origin, CancellationToken cancellationToken = default)
     {
         try
         {
             var recordList = records.ToList();
             if (recordList.Count == 0) return true;
 
-            await ResolvePatientInsulinsForBasalInjectionsAsync(recordList, cancellationToken);
+            await ResolvePatientInsulinsForBasalInjectionsAsync(recordList, origin, cancellationToken);
             using (SystemAuditScope.Push(_auditContext))
-                await _basalInjectionRepository.BulkCreateAsync(recordList, cancellationToken);
+                await _basalInjectionRepository.BulkCreateAsync(recordList, origin, cancellationToken);
 
             _logger.LogDebug("Published {Count} BasalInjection records for {Source}", recordList.Count, source);
             return true;
@@ -308,7 +309,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
     public async Task<bool> PublishDecompositionBatchesAsync(
         IEnumerable<DecompositionBatch> batches,
         string source,
-        CancellationToken cancellationToken = default)
+        WriteOrigin origin, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -372,7 +373,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
     /// <see cref="PatientInsulin"/> record and updates the context in place.
     /// </summary>
     private async Task ResolvePatientInsulinsForBolusesAsync(
-        List<Bolus> records, CancellationToken ct)
+        List<Bolus> records, WriteOrigin origin, CancellationToken ct)
     {
         var needsResolution = records
             .Where(r => r.InsulinContext is { PatientInsulinId: var id } && id == Guid.Empty)
@@ -385,7 +386,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
         foreach (var bolus in needsResolution)
         {
             var resolved = await ResolveOrCreatePatientInsulinAsync(
-                bolus.InsulinContext!, InsulinRole.Bolus, cache, ct);
+                bolus.InsulinContext!, InsulinRole.Bolus, cache, origin, ct);
             bolus.InsulinContext = resolved;
         }
     }
@@ -396,7 +397,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
     /// <see cref="PatientInsulin"/> record and updates the context in place.
     /// </summary>
     private async Task ResolvePatientInsulinsForBasalInjectionsAsync(
-        List<BasalInjection> records, CancellationToken ct)
+        List<BasalInjection> records, WriteOrigin origin, CancellationToken ct)
     {
         var needsResolution = records
             .Where(r => r.InsulinContext.PatientInsulinId == Guid.Empty)
@@ -409,7 +410,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
         foreach (var injection in needsResolution)
         {
             var resolved = await ResolveOrCreatePatientInsulinAsync(
-                injection.InsulinContext, InsulinRole.Basal, cache, ct);
+                injection.InsulinContext, InsulinRole.Basal, cache, origin, ct);
             injection.InsulinContext = resolved;
         }
     }
@@ -433,6 +434,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
         TreatmentInsulinContext context,
         InsulinRole role,
         List<PatientInsulin> cache,
+        WriteOrigin origin,
         CancellationToken ct)
     {
         var name = context.InsulinName;
@@ -474,7 +476,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
 
         PatientInsulin created;
         using (SystemAuditScope.Push(_auditContext))
-            created = await _patientInsulinRepository.CreateAsync(newInsulin, ct);
+            created = await _patientInsulinRepository.CreateAsync(newInsulin, origin, ct);
         cache.Add(created);
 
         _logger.LogInformation(

--- a/src/API/Nocturne.API/Services/Devices/DeviceService.cs
+++ b/src/API/Nocturne.API/Services/Devices/DeviceService.cs
@@ -3,6 +3,7 @@ using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Services.Devices;
 
@@ -47,7 +48,7 @@ public class DeviceService : IDeviceService
             if (timestamp > existing.LastSeenTimestamp)
             {
                 existing.LastSeenTimestamp = timestamp;
-                await _repository.UpdateAsync(existing.Id, existing, ct);
+                await _repository.UpdateAsync(existing.Id, existing, WriteOrigin.Live, ct);
             }
             _cache[key] = existing.Id;
             return existing.Id;
@@ -62,7 +63,7 @@ public class DeviceService : IDeviceService
             FirstSeenTimestamp = timestamp,
             LastSeenTimestamp = timestamp
         };
-        var created = await _repository.CreateAsync(device, ct);
+        var created = await _repository.CreateAsync(device, WriteOrigin.Live, ct);
         _cache[key] = created.Id;
         return created.Id;
     }

--- a/src/API/Nocturne.API/Services/Effects/WriteSideEffectsService.cs
+++ b/src/API/Nocturne.API/Services/Effects/WriteSideEffectsService.cs
@@ -130,7 +130,7 @@ public class WriteSideEffectsService : IWriteSideEffects
 
         if (options.DecomposeToV4)
         {
-            await _pipeline.DecomposeAsync((IEnumerable<T>)records, cancellationToken);
+            await _pipeline.DecomposeAsync((IEnumerable<T>)records, WriteOrigin.Live, cancellationToken);
         }
     }
 
@@ -164,7 +164,7 @@ public class WriteSideEffectsService : IWriteSideEffects
 
         if (options.DecomposeToV4)
         {
-            await _pipeline.DecomposeAsync(record, cancellationToken);
+            await _pipeline.DecomposeAsync(record, WriteOrigin.Live, cancellationToken);
         }
     }
 
@@ -183,7 +183,7 @@ public class WriteSideEffectsService : IWriteSideEffects
 
         if (options.DecomposeToV4)
         {
-            await _pipeline.DeleteByLegacyIdAsync<T>(legacyId, cancellationToken);
+            await _pipeline.DeleteByLegacyIdAsync<T>(legacyId, WriteOrigin.Live, cancellationToken);
         }
     }
 

--- a/src/API/Nocturne.API/Services/Glucose/EntryService.cs
+++ b/src/API/Nocturne.API/Services/Glucose/EntryService.cs
@@ -183,7 +183,7 @@ public class EntryService : IEntryService
 
         foreach (var entry in validEntries)
         {
-            await _decomposer.DecomposeAsync(entry, cancellationToken);
+            await _decomposer.DecomposeAsync(entry, WriteOrigin.Live, cancellationToken);
         }
 
         await _events.OnCreatedAsync(validEntries, cancellationToken);
@@ -207,7 +207,7 @@ public class EntryService : IEntryService
 
         // Ensure the entry carries the correct ID for LegacyId-based upsert
         entry.Id = id;
-        await _decomposer.DecomposeAsync(entry, cancellationToken);
+        await _decomposer.DecomposeAsync(entry, WriteOrigin.Live, cancellationToken);
 
         await _events.OnUpdatedAsync(entry, cancellationToken);
 
@@ -224,7 +224,7 @@ public class EntryService : IEntryService
         CancellationToken cancellationToken = default)
     {
         var entryToDelete = await _store.GetByIdAsync(id, cancellationToken);
-        var deletedCount = await _decomposer.DeleteByLegacyIdAsync(id, cancellationToken);
+        var deletedCount = await _decomposer.DeleteByLegacyIdAsync(id, WriteOrigin.Live, cancellationToken);
 
         var deleted = deletedCount > 0;
         if (deleted)
@@ -241,7 +241,7 @@ public class EntryService : IEntryService
         string? find = null,
         CancellationToken cancellationToken = default)
     {
-        var deletedCount = await _decomposer.BulkDeleteAsync(find, cancellationToken);
+        var deletedCount = await _decomposer.BulkDeleteAsync(find, WriteOrigin.Live, cancellationToken);
 
         await _events.OnBulkDeletedAsync(deletedCount, cancellationToken);
 

--- a/src/API/Nocturne.API/Services/Health/ActivityService.cs
+++ b/src/API/Nocturne.API/Services/Health/ActivityService.cs
@@ -207,7 +207,7 @@ public class ActivityService : IActivityService
             {
                 try
                 {
-                    await _activityDecomposer.DecomposeAsync(sensorActivity, cancellationToken);
+                    await _activityDecomposer.DecomposeAsync(sensorActivity, WriteOrigin.Live, cancellationToken);
                     results.Add(sensorActivity);
                 }
                 catch (Exception ex)
@@ -307,7 +307,7 @@ public class ActivityService : IActivityService
             // Attempt to delete decomposed records (heart rate / step count)
             try
             {
-                await _activityDecomposer.DeleteByLegacyIdAsync(id, cancellationToken);
+                await _activityDecomposer.DeleteByLegacyIdAsync(id, WriteOrigin.Live, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -372,6 +372,7 @@ public class ActivityService : IActivityService
                 {
                     await _activityDecomposer.DeleteByLegacyIdAsync(
                         activity.Id,
+                        WriteOrigin.Live,
                         cancellationToken
                     );
                 }

--- a/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
+++ b/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
@@ -658,7 +658,7 @@ internal class MigrationJob
 
             try
             {
-                await decomposer.DecomposeBatchAsync(entries, ct);
+                await decomposer.DecomposeBatchAsync(entries, WriteOrigin.Backfill, ct);
                 totalMigrated += entries.Length;
             }
             catch (Exception ex)
@@ -729,7 +729,7 @@ internal class MigrationJob
 
             try
             {
-                await decomposer.DecomposeBatchAsync(treatments, ct);
+                await decomposer.DecomposeBatchAsync(treatments, WriteOrigin.Backfill, ct);
                 totalMigrated += treatments.Length;
             }
             catch (Exception ex)
@@ -802,7 +802,7 @@ internal class MigrationJob
 
             try
             {
-                await decomposer.DecomposeBatchAsync(statuses, ct);
+                await decomposer.DecomposeBatchAsync(statuses, WriteOrigin.Backfill, ct);
                 totalMigrated += statuses.Length;
             }
             catch (Exception ex)
@@ -875,7 +875,7 @@ internal class MigrationJob
                         profile.Id = Guid.CreateVersion7().ToString();
                     }
 
-                    await decomposer.DecomposeAsync(profile, ct);
+                    await decomposer.DecomposeAsync(profile, WriteOrigin.Backfill, ct);
                     totalMigrated++;
                     UpdateCollectionProgress(collectionName, profiles.Length, totalMigrated, totalFailed, false);
                     UpdateOverallProgress();
@@ -1038,7 +1038,7 @@ internal class MigrationJob
 
             try
             {
-                await decomposer.DecomposeBatchAsync(activities, ct);
+                await decomposer.DecomposeBatchAsync(activities, WriteOrigin.Backfill, ct);
                 totalMigrated += activities.Length;
             }
             catch (Exception ex)
@@ -1250,7 +1250,7 @@ internal class MigrationJob
 
         using var scope = CreateTenantScope();
         var decomposer = scope.ServiceProvider.GetRequiredService<Core.Contracts.V4.IDeviceStatusDecomposer>();
-        await decomposer.DecomposeAsync(status, ct);
+        await decomposer.DecomposeAsync(status, WriteOrigin.Backfill, ct);
     }
 
     private async Task TransformProfileAsync(
@@ -1295,7 +1295,7 @@ internal class MigrationJob
 
         using var scope = CreateTenantScope();
         var decomposer = scope.ServiceProvider.GetRequiredService<Nocturne.Core.Contracts.V4.IProfileDecomposer>();
-        await decomposer.DecomposeAsync(profile, ct);
+        await decomposer.DecomposeAsync(profile, WriteOrigin.Backfill, ct);
     }
 
     private async Task TransformFoodAsync(

--- a/src/API/Nocturne.API/Services/Profiles/ProfileWriteService.cs
+++ b/src/API/Nocturne.API/Services/Profiles/ProfileWriteService.cs
@@ -49,7 +49,7 @@ public class ProfileWriteService : IProfileWriteService
                 profile.Id = Guid.CreateVersion7().ToString();
             }
 
-            await _decomposer.DecomposeAsync(profile, cancellationToken);
+            await _decomposer.DecomposeAsync(profile, WriteOrigin.Live, cancellationToken);
         }
 
         await _sideEffects.OnCreatedAsync(
@@ -73,7 +73,7 @@ public class ProfileWriteService : IProfileWriteService
         // Ensure the profile has the correct ID for decomposition
         profile.Id = id;
 
-        await _decomposer.DecomposeAsync(profile, cancellationToken);
+        await _decomposer.DecomposeAsync(profile, WriteOrigin.Live, cancellationToken);
 
         await _sideEffects.OnUpdatedAsync(
             CollectionName,
@@ -92,7 +92,7 @@ public class ProfileWriteService : IProfileWriteService
         CancellationToken cancellationToken = default
     )
     {
-        var deleted = await _decomposer.DeleteByLegacyIdAsync(id, cancellationToken);
+        var deleted = await _decomposer.DeleteByLegacyIdAsync(id, WriteOrigin.Live, cancellationToken);
 
         if (deleted > 0)
         {

--- a/src/API/Nocturne.API/Services/Realtime/RealtimeCategories.cs
+++ b/src/API/Nocturne.API/Services/Realtime/RealtimeCategories.cs
@@ -1,0 +1,35 @@
+namespace Nocturne.API.Services.Realtime;
+
+/// <summary>
+/// The realtime broadcast category names — the SignalR group tokens clients subscribe to via
+/// <c>DataHub.Subscribe</c>. Single source of truth so the hub allowlist and the broadcasters agree.
+/// </summary>
+/// <remarks>
+/// The four <see cref="V4"/> categories carry native V4 record shapes (with a <c>recordType</c>
+/// discriminator) and are additive: the four legacy <see cref="V1"/> collections — which the Node
+/// socket.io bridge subscribes to — keep their own broadcasts untouched. <c>care</c> is the
+/// treatment-family category, named distinctly so it never collides with the v1 <c>treatments</c> group.
+/// </remarks>
+public static class RealtimeCategories
+{
+    // Legacy v1 collections (projected shapes; the socket.io bridge subscribes to these).
+    public const string Entries = "entries";
+    public const string Treatments = "treatments";
+    public const string DeviceStatus = "devicestatus";
+    public const string Profiles = "profiles";
+
+    // Native V4 categories (record shapes + recordType discriminator).
+    public const string Glucose = "glucose";
+    public const string Care = "care";
+    public const string Device = "device";
+    public const string Therapy = "therapy";
+
+    /// <summary>The legacy v1 collection names.</summary>
+    public static readonly string[] V1 = [Entries, Treatments, DeviceStatus, Profiles];
+
+    /// <summary>The native V4 category names.</summary>
+    public static readonly string[] V4 = [Glucose, Care, Device, Therapy];
+
+    /// <summary>Every subscribable category (v1 + V4) — the <c>DataHub.Subscribe</c> allowlist.</summary>
+    public static readonly string[] All = [.. V1, .. V4];
+}

--- a/src/API/Nocturne.API/Services/Realtime/SignalRV4RecordBroadcaster.cs
+++ b/src/API/Nocturne.API/Services/Realtime/SignalRV4RecordBroadcaster.cs
@@ -1,0 +1,42 @@
+using Nocturne.Core.Contracts.Events;
+
+namespace Nocturne.API.Services.Realtime;
+
+/// <summary>
+/// SignalR adapter for <see cref="IV4RecordBroadcaster{TModel}"/>: broadcasts native V4 record shapes to
+/// the V4 category group with a <c>recordType</c> discriminator. Registered as an open generic so every
+/// V4 model type resolves; types absent from <see cref="V4BroadcastMap"/> (the dormant <c>therapy</c>
+/// family) broadcast nothing.
+/// </summary>
+/// <typeparam name="TModel">The V4 domain model type being broadcast.</typeparam>
+public sealed class SignalRV4RecordBroadcaster<TModel>(ISignalRBroadcastService broadcast)
+    : IV4RecordBroadcaster<TModel>
+    where TModel : class
+{
+    public async Task BroadcastCreatedAsync(IReadOnlyList<TModel> items, CancellationToken ct = default)
+    {
+        if (items.Count == 0 || !V4BroadcastMap.TryGet(typeof(TModel), out var category, out var recordType))
+            return;
+
+        foreach (var item in items)
+            await broadcast.BroadcastStorageCreateAsync(category, new { recordType, doc = item });
+    }
+
+    public async Task BroadcastUpdatedAsync(IReadOnlyList<TModel> items, CancellationToken ct = default)
+    {
+        if (items.Count == 0 || !V4BroadcastMap.TryGet(typeof(TModel), out var category, out var recordType))
+            return;
+
+        foreach (var item in items)
+            await broadcast.BroadcastStorageUpdateAsync(category, new { recordType, doc = item });
+    }
+
+    public async Task BroadcastDeletedAsync(IReadOnlyList<Guid> ids, CancellationToken ct = default)
+    {
+        if (ids.Count == 0 || !V4BroadcastMap.TryGet(typeof(TModel), out var category, out var recordType))
+            return;
+
+        foreach (var id in ids)
+            await broadcast.BroadcastStorageDeleteAsync(category, new { recordType, id });
+    }
+}

--- a/src/API/Nocturne.API/Services/Realtime/V4BroadcastMap.cs
+++ b/src/API/Nocturne.API/Services/Realtime/V4BroadcastMap.cs
@@ -1,0 +1,48 @@
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.API.Services.Realtime;
+
+/// <summary>
+/// Maps each V4 domain model type to its broadcast category and <c>recordType</c> discriminator.
+/// </summary>
+/// <remarks>
+/// The treatment family (Bolus, CarbIntake, BG check, calculations, basal, notes, device events) rides
+/// the <c>care</c> category despite some names; the glucose family rides <c>glucose</c>; device snapshots
+/// ride <c>device</c>. The <c>therapy</c> category (schedules/therapy settings) is intentionally
+/// unmapped — defined and subscribable but dormant until wired — so those writes broadcast nothing.
+/// </remarks>
+internal static class V4BroadcastMap
+{
+    private static readonly Dictionary<Type, (string Category, string RecordType)> Map = new()
+    {
+        [typeof(SensorGlucose)] = (RealtimeCategories.Glucose, "sensorGlucose"),
+        [typeof(MeterGlucose)] = (RealtimeCategories.Glucose, "meterGlucose"),
+        [typeof(Calibration)] = (RealtimeCategories.Glucose, "calibration"),
+
+        [typeof(Bolus)] = (RealtimeCategories.Care, "bolus"),
+        [typeof(CarbIntake)] = (RealtimeCategories.Care, "carbIntake"),
+        [typeof(BGCheck)] = (RealtimeCategories.Care, "bgCheck"),
+        [typeof(BolusCalculation)] = (RealtimeCategories.Care, "bolusCalculation"),
+        [typeof(BasalInjection)] = (RealtimeCategories.Care, "basalInjection"),
+        [typeof(TempBasal)] = (RealtimeCategories.Care, "tempBasal"),
+        [typeof(Note)] = (RealtimeCategories.Care, "note"),
+        [typeof(DeviceEvent)] = (RealtimeCategories.Care, "deviceEvent"),
+
+        [typeof(ApsSnapshot)] = (RealtimeCategories.Device, "apsSnapshot"),
+        [typeof(PumpSnapshot)] = (RealtimeCategories.Device, "pumpSnapshot"),
+        [typeof(UploaderSnapshot)] = (RealtimeCategories.Device, "uploaderSnapshot"),
+    };
+
+    /// <summary>Look up the category + recordType for a V4 model type. False when the type is unmapped (dormant).</summary>
+    public static bool TryGet(Type modelType, out string category, out string recordType)
+    {
+        if (Map.TryGetValue(modelType, out var entry))
+        {
+            (category, recordType) = entry;
+            return true;
+        }
+
+        category = recordType = string.Empty;
+        return false;
+    }
+}

--- a/src/API/Nocturne.API/Services/Treatments/TreatmentReadService.cs
+++ b/src/API/Nocturne.API/Services/Treatments/TreatmentReadService.cs
@@ -114,7 +114,7 @@ public class TreatmentReadService : ITreatmentStore
         {
             try
             {
-                var result = await _decomposer.DecomposeAsync(treatment, ct);
+                var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live, ct);
                 var tempBasal = result.CreatedRecords
                     .OfType<Core.Models.V4.TempBasal>()
                     .FirstOrDefault();
@@ -141,7 +141,7 @@ public class TreatmentReadService : ITreatmentStore
         treatment.Id = id;
         try
         {
-            await _decomposer.DecomposeAsync(treatment, ct);
+            await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live, ct);
             return await GetByIdAsync(id, ct);
         }
         catch (Exception ex)
@@ -154,7 +154,7 @@ public class TreatmentReadService : ITreatmentStore
     /// <inheritdoc />
     public async Task<bool> DeleteAsync(string id, CancellationToken ct = default)
     {
-        var deleted = await _pipeline.DeleteByLegacyIdAsync<Treatment>(id, ct);
+        var deleted = await _pipeline.DeleteByLegacyIdAsync<Treatment>(id, WriteOrigin.Live, ct);
 
         // Also check TempBasal (not covered by the pipeline's LegacyId delete)
         var tempBasal = await _tempBasalRepo.GetByLegacyIdAsync(id, ct);
@@ -165,7 +165,7 @@ public class TreatmentReadService : ITreatmentStore
         {
             try
             {
-                await _tempBasalRepo.DeleteAsync(tempBasal.Id, ct);
+                await _tempBasalRepo.DeleteAsync(tempBasal.Id, WriteOrigin.Live, ct);
                 return true;
             }
             catch (Exception ex)

--- a/src/API/Nocturne.API/Services/Treatments/TreatmentService.cs
+++ b/src/API/Nocturne.API/Services/Treatments/TreatmentService.cs
@@ -191,7 +191,7 @@ public class TreatmentService : ITreatmentService
         ApplyJsonPatch(existing, patchData);
 
         // Re-decompose (idempotent upsert via LegacyId matching)
-        await _decomposer.DecomposeAsync(existing, cancellationToken);
+        await _decomposer.DecomposeAsync(existing, WriteOrigin.Live, cancellationToken);
 
         await _cache.InvalidateAsync(cancellationToken);
         await _events.OnUpdatedAsync(existing, cancellationToken);
@@ -250,7 +250,7 @@ public class TreatmentService : ITreatmentService
     public async Task<long> DeleteTreatmentsAsync(
         string? find = null, CancellationToken cancellationToken = default)
     {
-        var count = await _decomposer.BulkDeleteAsync(find, cancellationToken);
+        var count = await _decomposer.BulkDeleteAsync(find, WriteOrigin.Live, cancellationToken);
         if (count > 0)
             await _cache.InvalidateAsync(cancellationToken);
         return count;

--- a/src/API/Nocturne.API/Services/V4/ActivityDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/ActivityDecomposer.cs
@@ -74,7 +74,7 @@ public class ActivityDecomposer : IActivityDecomposer, IDecomposer<Activity>
     /// <inheritdoc/>
     public async Task<DecompositionResult> DecomposeAsync(
         Activity activity,
-        CancellationToken ct = default
+        WriteOrigin origin, CancellationToken ct = default
     )
     {
         var batch = new DecompositionBatchEntity
@@ -91,11 +91,11 @@ public class ActivityDecomposer : IActivityDecomposer, IDecomposer<Activity>
 
         if (IsHeartRate(activity))
         {
-            await DecomposeHeartRateAsync(activity, result, ct);
+            await DecomposeHeartRateAsync(activity, result, origin, ct);
         }
         else if (IsStepCount(activity))
         {
-            await DecomposeStepCountAsync(activity, result, ct);
+            await DecomposeStepCountAsync(activity, result, origin, ct);
         }
         else
         {
@@ -110,7 +110,7 @@ public class ActivityDecomposer : IActivityDecomposer, IDecomposer<Activity>
 
     /// <inheritdoc/>
     public async Task<DecompositionResult> DecomposeBatchAsync(
-        IReadOnlyList<Activity> activities, CancellationToken ct = default)
+        IReadOnlyList<Activity> activities, WriteOrigin origin, CancellationToken ct = default)
     {
         if (activities.Count == 0)
             return new DecompositionResult();
@@ -226,7 +226,7 @@ public class ActivityDecomposer : IActivityDecomposer, IDecomposer<Activity>
     /// re-migration path, where the legacy row is being replaced wholesale, so a
     /// soft-delete tombstone would only block re-creation by the same legacy id.
     /// </remarks>
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
+    public async Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default)
     {
         var deleted = 0;
 
@@ -326,7 +326,7 @@ public class ActivityDecomposer : IActivityDecomposer, IDecomposer<Activity>
     private async Task DecomposeHeartRateAsync(
         Activity activity,
         DecompositionResult result,
-        CancellationToken ct
+        WriteOrigin origin, CancellationToken ct
     )
     {
         var existing =
@@ -363,7 +363,7 @@ public class ActivityDecomposer : IActivityDecomposer, IDecomposer<Activity>
     private async Task DecomposeStepCountAsync(
         Activity activity,
         DecompositionResult result,
-        CancellationToken ct
+        WriteOrigin origin, CancellationToken ct
     )
     {
         var existing =

--- a/src/API/Nocturne.API/Services/V4/DecompositionPipeline.cs
+++ b/src/API/Nocturne.API/Services/V4/DecompositionPipeline.cs
@@ -36,7 +36,7 @@ public class DecompositionPipeline : IDecompositionPipeline
         _logger = logger;
     }
 
-    public async Task<BatchDecompositionResult> DecomposeAsync<T>(IEnumerable<T> records, CancellationToken ct = default) where T : class
+    public async Task<BatchDecompositionResult> DecomposeAsync<T>(IEnumerable<T> records, WriteOrigin origin, CancellationToken ct = default) where T : class
     {
         var result = new BatchDecompositionResult();
         var decomposer = ResolveDecomposer<T>();
@@ -45,7 +45,7 @@ public class DecompositionPipeline : IDecompositionPipeline
         {
             try
             {
-                var decomposed = await decomposer.DecomposeAsync(record, ct);
+                var decomposed = await decomposer.DecomposeAsync(record, origin, ct);
                 result.Succeeded++;
                 result.Results.Add(decomposed);
             }
@@ -59,14 +59,14 @@ public class DecompositionPipeline : IDecompositionPipeline
         return result;
     }
 
-    public async Task<BatchDecompositionResult> DecomposeAsync<T>(T record, CancellationToken ct = default) where T : class
+    public async Task<BatchDecompositionResult> DecomposeAsync<T>(T record, WriteOrigin origin, CancellationToken ct = default) where T : class
     {
         var result = new BatchDecompositionResult();
         var decomposer = ResolveDecomposer<T>();
 
         try
         {
-            var decomposed = await decomposer.DecomposeAsync(record, ct);
+            var decomposed = await decomposer.DecomposeAsync(record, origin, ct);
             result.Succeeded++;
             result.Results.Add(decomposed);
         }
@@ -79,13 +79,13 @@ public class DecompositionPipeline : IDecompositionPipeline
         return result;
     }
 
-    public async Task<int> DeleteByLegacyIdAsync<T>(string legacyId, CancellationToken ct = default) where T : class
+    public async Task<int> DeleteByLegacyIdAsync<T>(string legacyId, WriteOrigin origin, CancellationToken ct = default) where T : class
     {
         var decomposer = ResolveDecomposer<T>();
 
         try
         {
-            return await decomposer.DeleteByLegacyIdAsync(legacyId, ct);
+            return await decomposer.DeleteByLegacyIdAsync(legacyId, origin, ct);
         }
         catch (Exception ex)
         {

--- a/src/API/Nocturne.API/Services/V4/DeviceStatusDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/DeviceStatusDecomposer.cs
@@ -72,7 +72,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
     }
 
     /// <inheritdoc />
-    public async Task<V4Models.DecompositionResult> DecomposeAsync(DeviceStatus ds, CancellationToken ct = default)
+    public async Task<V4Models.DecompositionResult> DecomposeAsync(DeviceStatus ds, WriteOrigin origin, CancellationToken ct = default)
     {
         var batch = new DecompositionBatchEntity
         {
@@ -99,34 +99,34 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
 
         if (ds.Pump != null)
         {
-            pumpDeviceId = await DecomposePumpAsync(ds, legacyId, result, ct);
+            pumpDeviceId = await DecomposePumpAsync(ds, legacyId, result, origin, ct);
         }
 
         if (ds.Cgm != null)
         {
-            await RegisterCgmDeviceAsync(ds, ct);
+            await RegisterCgmDeviceAsync(ds, origin, ct);
         }
 
         if (ds.OpenAps != null)
         {
-            await DecomposeApsFromOpenApsAsync(ds, legacyId, result, pumpDeviceId, ct);
+            await DecomposeApsFromOpenApsAsync(ds, legacyId, result, pumpDeviceId, origin, ct);
         }
         else if (ds.Loop != null)
         {
-            await DecomposeApsFromLoopAsync(ds, legacyId, result, pumpDeviceId, ct);
+            await DecomposeApsFromLoopAsync(ds, legacyId, result, pumpDeviceId, origin, ct);
         }
 
         if (ds.Uploader != null || ds.UploaderBattery.HasValue)
         {
-            await DecomposeUploaderAsync(ds, legacyId, result, ct);
+            await DecomposeUploaderAsync(ds, legacyId, result, origin, ct);
         }
 
         if (ds.Override is { Active: true })
         {
-            await DecomposeOverrideAsync(ds, legacyId, result, ct);
+            await DecomposeOverrideAsync(ds, legacyId, result, origin, ct);
         }
 
-        await DecomposeExtrasAsync(ds, result, ct);
+        await DecomposeExtrasAsync(ds, result, origin, ct);
 
         return result;
     }
@@ -134,29 +134,29 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
     #region APS Decomposition
 
     private async Task DecomposeApsFromOpenApsAsync(
-        DeviceStatus ds, string? legacyId, V4Models.DecompositionResult result, Guid? pumpDeviceId, CancellationToken ct)
+        DeviceStatus ds, string? legacyId, V4Models.DecompositionResult result, Guid? pumpDeviceId, WriteOrigin origin, CancellationToken ct)
     {
         var model = MapToApsSnapshotFromOpenAps(ds, legacyId, result.CorrelationId);
 
         model.DeviceId = pumpDeviceId;
         model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(pumpDeviceId, ds.Mills, ct);
 
-        await UpsertApsSnapshotAsync(legacyId, model, result, ct);
+        await UpsertApsSnapshotAsync(legacyId, model, result, origin, ct);
     }
 
     private async Task DecomposeApsFromLoopAsync(
-        DeviceStatus ds, string? legacyId, V4Models.DecompositionResult result, Guid? pumpDeviceId, CancellationToken ct)
+        DeviceStatus ds, string? legacyId, V4Models.DecompositionResult result, Guid? pumpDeviceId, WriteOrigin origin, CancellationToken ct)
     {
         var model = MapToApsSnapshotFromLoop(ds, legacyId, result.CorrelationId);
 
         model.DeviceId = pumpDeviceId;
         model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(pumpDeviceId, ds.Mills, ct);
 
-        await UpsertApsSnapshotAsync(legacyId, model, result, ct);
+        await UpsertApsSnapshotAsync(legacyId, model, result, origin, ct);
     }
 
     private async Task UpsertApsSnapshotAsync(
-        string? legacyId, V4Models.ApsSnapshot model, V4Models.DecompositionResult result, CancellationToken ct)
+        string? legacyId, V4Models.ApsSnapshot model, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
     {
         var existing = legacyId != null
             ? await _apsRepo.GetByLegacyIdAsync(legacyId, ct)
@@ -165,13 +165,13 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
         if (existing != null)
         {
             model.Id = existing.Id;
-            var updated = await _apsRepo.UpdateAsync(existing.Id, model, ct);
+            var updated = await _apsRepo.UpdateAsync(existing.Id, model, origin, ct);
             result.UpdatedRecords.Add(updated);
             _logger.LogDebug("Updated existing ApsSnapshot {Id} from legacy device status {LegacyId}", existing.Id, legacyId);
         }
         else
         {
-            var created = await _apsRepo.CreateAsync(model, ct);
+            var created = await _apsRepo.CreateAsync(model, origin, ct);
             result.CreatedRecords.Add(created);
             _logger.LogDebug("Created ApsSnapshot from legacy device status {LegacyId}", legacyId);
         }
@@ -193,7 +193,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
             : ds.Pump?.Model;
 
     private async Task<Guid?> DecomposePumpAsync(
-        DeviceStatus ds, string? legacyId, V4Models.DecompositionResult result, CancellationToken ct)
+        DeviceStatus ds, string? legacyId, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
     {
         var model = MapToPumpSnapshot(ds, legacyId, result.CorrelationId);
 
@@ -212,19 +212,19 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
         if (existing != null)
         {
             model.Id = existing.Id;
-            persisted = await _pumpRepo.UpdateAsync(existing.Id, model, ct);
+            persisted = await _pumpRepo.UpdateAsync(existing.Id, model, origin, ct);
             result.UpdatedRecords.Add(persisted);
             _logger.LogDebug("Updated existing PumpSnapshot {Id} from legacy device status {LegacyId}", existing.Id, legacyId);
         }
         else
         {
-            persisted = await _pumpRepo.CreateAsync(model, ct);
+            persisted = await _pumpRepo.CreateAsync(model, origin, ct);
             result.CreatedRecords.Add(persisted);
             _logger.LogDebug("Created PumpSnapshot from legacy device status {LegacyId}", legacyId);
         }
 
-        await DecomposePumpSuspensionAsync(ds, persisted, result, ct);
-        await DecomposePumpModeAsync(ds, persisted, result, ct);
+        await DecomposePumpSuspensionAsync(ds, persisted, result, origin, ct);
+        await DecomposePumpModeAsync(ds, persisted, result, origin, ct);
 
         return model.DeviceId;
     }
@@ -252,7 +252,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
         DeviceStatus ds,
         V4Models.PumpSnapshot newSnapshot,
         V4Models.DecompositionResult result,
-        CancellationToken ct)
+        WriteOrigin origin, CancellationToken ct)
     {
         var prior = await _pumpRepo.GetLatestBeforeAsync(newSnapshot.Timestamp, ct);
         var priorSuspended = prior?.Suspended ?? false;
@@ -384,7 +384,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
         DeviceStatus ds,
         V4Models.PumpSnapshot newSnapshot,
         V4Models.DecompositionResult result,
-        CancellationToken ct)
+        WriteOrigin origin, CancellationToken ct)
     {
         var newMode = ParsePumpMode(newSnapshot.PumpMode);
         if (newMode is null)
@@ -473,7 +473,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
     /// sensor shows up as an in-use device. No-op unless the connector populated manufacturer +
     /// model/serial (<see cref="IDeviceService.ResolveAsync"/> returns null when either is missing).
     /// </summary>
-    private async Task RegisterCgmDeviceAsync(DeviceStatus ds, CancellationToken ct)
+    private async Task RegisterCgmDeviceAsync(DeviceStatus ds, WriteOrigin origin, CancellationToken ct)
     {
         await _deviceService.ResolveAsync(
             V4Models.DeviceCategory.CGM,
@@ -487,7 +487,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
     #region Uploader Decomposition
 
     private async Task DecomposeUploaderAsync(
-        DeviceStatus ds, string? legacyId, V4Models.DecompositionResult result, CancellationToken ct)
+        DeviceStatus ds, string? legacyId, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
     {
         var model = MapToUploaderSnapshot(ds, legacyId, result.CorrelationId);
 
@@ -504,13 +504,13 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
         if (existing != null)
         {
             model.Id = existing.Id;
-            var updated = await _uploaderRepo.UpdateAsync(existing.Id, model, ct);
+            var updated = await _uploaderRepo.UpdateAsync(existing.Id, model, origin, ct);
             result.UpdatedRecords.Add(updated);
             _logger.LogDebug("Updated existing UploaderSnapshot {Id} from legacy device status {LegacyId}", existing.Id, legacyId);
         }
         else
         {
-            var created = await _uploaderRepo.CreateAsync(model, ct);
+            var created = await _uploaderRepo.CreateAsync(model, origin, ct);
             result.CreatedRecords.Add(created);
             _logger.LogDebug("Created UploaderSnapshot from legacy device status {LegacyId}", legacyId);
         }
@@ -521,7 +521,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
     #region Override Decomposition
 
     private async Task DecomposeOverrideAsync(
-        DeviceStatus ds, string? legacyId, V4Models.DecompositionResult result, CancellationToken ct)
+        DeviceStatus ds, string? legacyId, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
     {
         var timestamp = ResolveTimestamp(ds);
         var stateSpan = new StateSpan
@@ -547,7 +547,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
     #region Extras Decomposition
 
     private async Task DecomposeExtrasAsync(
-        DeviceStatus ds, V4Models.DecompositionResult result, CancellationToken ct)
+        DeviceStatus ds, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
     {
         var extras = new Dictionary<string, object?>();
 
@@ -585,7 +585,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
             Extras = extras,
         };
 
-        var created = await _extrasRepo.CreateAsync(model, ct);
+        var created = await _extrasRepo.CreateAsync(model, origin, ct);
         result.CreatedRecords.Add(created);
         _logger.LogDebug("Created DeviceStatusExtras with {Count} keys for correlation {CorrelationId}",
             extras.Count, result.CorrelationId);
@@ -597,7 +597,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
 
     /// <inheritdoc />
     public async Task<V4Models.DecompositionResult> DecomposeBatchAsync(
-        IReadOnlyList<DeviceStatus> statuses, CancellationToken ct = default)
+        IReadOnlyList<DeviceStatus> statuses, WriteOrigin origin, CancellationToken ct = default)
     {
         if (statuses.Count == 0)
             return new V4Models.DecompositionResult();
@@ -650,7 +650,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
 
             if (ds.Cgm != null)
             {
-                await RegisterCgmDeviceAsync(ds, ct);
+                await RegisterCgmDeviceAsync(ds, origin, ct);
             }
 
             if (ds.OpenAps != null)
@@ -705,25 +705,25 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
         {
             if (apsList.Count > 0)
             {
-                var created = await _apsRepo.BulkCreateAsync(apsList, ct);
+                var created = await _apsRepo.BulkCreateAsync(apsList, origin, ct);
                 result.CreatedRecords.AddRange(created);
             }
 
             if (pumpList.Count > 0)
             {
-                var created = await _pumpRepo.BulkCreateAsync(pumpList, ct);
+                var created = await _pumpRepo.BulkCreateAsync(pumpList, origin, ct);
                 result.CreatedRecords.AddRange(created);
             }
 
             if (uploaderList.Count > 0)
             {
-                var created = await _uploaderRepo.BulkCreateAsync(uploaderList, ct);
+                var created = await _uploaderRepo.BulkCreateAsync(uploaderList, origin, ct);
                 result.CreatedRecords.AddRange(created);
             }
 
             if (extrasList.Count > 0)
             {
-                var created = await _extrasRepo.BulkCreateAsync(extrasList, ct);
+                var created = await _extrasRepo.BulkCreateAsync(extrasList, origin, ct);
                 result.CreatedRecords.AddRange(created);
             }
         }
@@ -751,8 +751,8 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
                 var ds = statuses.FirstOrDefault(s => s.Id == pumpSnapshot.LegacyId);
                 if (ds != null)
                 {
-                    await DecomposePumpSuspensionAsync(ds, pumpSnapshot, result, ct);
-                    await DecomposePumpModeAsync(ds, pumpSnapshot, result, ct);
+                    await DecomposePumpSuspensionAsync(ds, pumpSnapshot, result, origin, ct);
+                    await DecomposePumpModeAsync(ds, pumpSnapshot, result, origin, ct);
                 }
             }
         }
@@ -1028,7 +1028,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
     #endregion
 
     /// <inheritdoc />
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
+    public async Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default)
     {
         var deleted = 0;
 
@@ -1046,9 +1046,9 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
             correlationId = uploaderSnapshot?.CorrelationId;
         }
 
-        deleted += await _apsRepo.DeleteByLegacyIdAsync(legacyId, ct);
-        deleted += await _pumpRepo.DeleteByLegacyIdAsync(legacyId, ct);
-        deleted += await _uploaderRepo.DeleteByLegacyIdAsync(legacyId, ct);
+        deleted += await _apsRepo.DeleteByLegacyIdAsync(legacyId, origin, ct);
+        deleted += await _pumpRepo.DeleteByLegacyIdAsync(legacyId, origin, ct);
+        deleted += await _uploaderRepo.DeleteByLegacyIdAsync(legacyId, origin, ct);
 
         if (correlationId.HasValue)
             deleted += await _extrasRepo.DeleteByCorrelationIdAsync(correlationId.Value, ct);

--- a/src/API/Nocturne.API/Services/V4/EntryDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/EntryDecomposer.cs
@@ -56,7 +56,7 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
     }
 
     /// <inheritdoc />
-    public async Task<DecompositionResult> DecomposeAsync(Entry entry, CancellationToken ct = default)
+    public async Task<DecompositionResult> DecomposeAsync(Entry entry, WriteOrigin origin, CancellationToken ct = default)
     {
         var batch = new DecompositionBatchEntity
         {
@@ -78,13 +78,13 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
         switch (entryType)
         {
             case "sgv":
-                await DecomposeSgvAsync(entry, result, ct);
+                await DecomposeSgvAsync(entry, result, origin, ct);
                 break;
             case "mbg":
-                await DecomposeMbgAsync(entry, result, ct);
+                await DecomposeMbgAsync(entry, result, origin, ct);
                 break;
             case "cal":
-                await DecomposeCalAsync(entry, result, ct);
+                await DecomposeCalAsync(entry, result, origin, ct);
                 break;
             default:
                 _logger.LogWarning("Unknown entry type '{Type}' for entry {Id}, skipping decomposition", entry.Type, entry.Id);
@@ -94,7 +94,7 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
         return result;
     }
 
-    private async Task DecomposeSgvAsync(Entry entry, DecompositionResult result, CancellationToken ct)
+    private async Task DecomposeSgvAsync(Entry entry, DecompositionResult result, WriteOrigin origin, CancellationToken ct)
     {
         var existing = entry.Id != null
             ? await _sensorGlucoseRepository.GetByLegacyIdAsync(entry.Id, ct)
@@ -122,19 +122,19 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
         if (existing != null)
         {
             model.Id = existing.Id;
-            var updated = await _sensorGlucoseRepository.UpdateAsync(existing.Id, model, ct);
+            var updated = await _sensorGlucoseRepository.UpdateAsync(existing.Id, model, origin, ct);
             result.UpdatedRecords.Add(updated);
             _logger.LogDebug("Updated existing SensorGlucose {Id} from legacy entry {LegacyId}", existing.Id, entry.Id);
         }
         else
         {
-            var created = await _sensorGlucoseRepository.CreateAsync(model, ct);
+            var created = await _sensorGlucoseRepository.CreateAsync(model, origin, ct);
             result.CreatedRecords.Add(created);
             _logger.LogDebug("Created SensorGlucose from legacy entry {LegacyId}", entry.Id);
         }
     }
 
-    private async Task DecomposeMbgAsync(Entry entry, DecompositionResult result, CancellationToken ct)
+    private async Task DecomposeMbgAsync(Entry entry, DecompositionResult result, WriteOrigin origin, CancellationToken ct)
     {
         var existing = entry.Id != null
             ? await _meterGlucoseRepository.GetByLegacyIdAsync(entry.Id, ct)
@@ -145,19 +145,19 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
         if (existing != null)
         {
             model.Id = existing.Id;
-            var updated = await _meterGlucoseRepository.UpdateAsync(existing.Id, model, ct);
+            var updated = await _meterGlucoseRepository.UpdateAsync(existing.Id, model, origin, ct);
             result.UpdatedRecords.Add(updated);
             _logger.LogDebug("Updated existing MeterGlucose {Id} from legacy entry {LegacyId}", existing.Id, entry.Id);
         }
         else
         {
-            var created = await _meterGlucoseRepository.CreateAsync(model, ct);
+            var created = await _meterGlucoseRepository.CreateAsync(model, origin, ct);
             result.CreatedRecords.Add(created);
             _logger.LogDebug("Created MeterGlucose from legacy entry {LegacyId}", entry.Id);
         }
     }
 
-    private async Task DecomposeCalAsync(Entry entry, DecompositionResult result, CancellationToken ct)
+    private async Task DecomposeCalAsync(Entry entry, DecompositionResult result, WriteOrigin origin, CancellationToken ct)
     {
         var existing = entry.Id != null
             ? await _calibrationRepository.GetByLegacyIdAsync(entry.Id, ct)
@@ -168,13 +168,13 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
         if (existing != null)
         {
             model.Id = existing.Id;
-            var updated = await _calibrationRepository.UpdateAsync(existing.Id, model, ct);
+            var updated = await _calibrationRepository.UpdateAsync(existing.Id, model, origin, ct);
             result.UpdatedRecords.Add(updated);
             _logger.LogDebug("Updated existing Calibration {Id} from legacy entry {LegacyId}", existing.Id, entry.Id);
         }
         else
         {
-            var created = await _calibrationRepository.CreateAsync(model, ct);
+            var created = await _calibrationRepository.CreateAsync(model, origin, ct);
             result.CreatedRecords.Add(created);
             _logger.LogDebug("Created Calibration from legacy entry {LegacyId}", entry.Id);
         }
@@ -182,7 +182,7 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
 
     /// <inheritdoc />
     public async Task<DecompositionResult> DecomposeBatchAsync(
-        IReadOnlyList<Entry> entries, CancellationToken ct = default)
+        IReadOnlyList<Entry> entries, WriteOrigin origin, CancellationToken ct = default)
     {
         if (entries.Count == 0)
             return new DecompositionResult();
@@ -245,19 +245,19 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
         {
             if (sgvList.Count > 0)
             {
-                var created = await _sensorGlucoseRepository.BulkCreateAsync(sgvList, ct);
+                var created = await _sensorGlucoseRepository.BulkCreateAsync(sgvList, origin, ct);
                 result.CreatedRecords.AddRange(created);
             }
 
             if (mbgList.Count > 0)
             {
-                var created = await _meterGlucoseRepository.BulkCreateAsync(mbgList, ct);
+                var created = await _meterGlucoseRepository.BulkCreateAsync(mbgList, origin, ct);
                 result.CreatedRecords.AddRange(created);
             }
 
             if (calList.Count > 0)
             {
-                var created = await _calibrationRepository.BulkCreateAsync(calList, ct);
+                var created = await _calibrationRepository.BulkCreateAsync(calList, origin, ct);
                 result.CreatedRecords.AddRange(created);
             }
         }
@@ -266,7 +266,7 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
     }
 
     /// <inheritdoc />
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
+    public async Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default)
     {
         var strategy = _dbContext.Database.CreateExecutionStrategy();
 
@@ -296,7 +296,7 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
     }
 
     /// <inheritdoc />
-    public async Task<long> BulkDeleteAsync(string? find, CancellationToken ct = default)
+    public async Task<long> BulkDeleteAsync(string? find, WriteOrigin origin, CancellationToken ct = default)
     {
         var (fromMills, toMills) = Core.Models.Entries.EntryDomainLogic.ParseTimeRangeFromFind(find);
 

--- a/src/API/Nocturne.API/Services/V4/EntryDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/EntryDecomposer.cs
@@ -268,6 +268,7 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
     /// <inheritdoc />
     public async Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default)
     {
+        // origin is accepted for interface uniformity; the v4-native delete broadcast is deferred to the glucose-unification follow-up (deletes here bypass the repository chokepoint).
         var strategy = _dbContext.Database.CreateExecutionStrategy();
 
         return await strategy.ExecuteAsync(async () =>
@@ -298,6 +299,7 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
     /// <inheritdoc />
     public async Task<long> BulkDeleteAsync(string? find, WriteOrigin origin, CancellationToken ct = default)
     {
+        // origin is accepted for interface uniformity; the v4-native delete broadcast is deferred to the glucose-unification follow-up (deletes here bypass the repository chokepoint).
         var (fromMills, toMills) = Core.Models.Entries.EntryDomainLogic.ParseTimeRangeFromFind(find);
 
         // ParseTimeRangeFromFind extracts $gte/$lte from any field, not just

--- a/src/API/Nocturne.API/Services/V4/ProfileDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/ProfileDecomposer.cs
@@ -60,7 +60,7 @@ public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
     }
 
     /// <inheritdoc />
-    public async Task<V4Models.DecompositionResult> DecomposeAsync(Profile profile, CancellationToken ct = default)
+    public async Task<V4Models.DecompositionResult> DecomposeAsync(Profile profile, WriteOrigin origin, CancellationToken ct = default)
     {
         var batch = new DecompositionBatchEntity
         {
@@ -88,11 +88,11 @@ public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
             var legacyId = $"{profile.Id}:{storeName}";
             var isDefault = string.Equals(storeName, profile.DefaultProfile, StringComparison.OrdinalIgnoreCase);
 
-            await DecomposeTherapySettingsAsync(profile, profileData, storeName, legacyId, isDefault, result, ct);
-            await DecomposeBasalScheduleAsync(profile, profileData, storeName, legacyId, result, ct);
-            await DecomposeCarbRatioScheduleAsync(profile, profileData, storeName, legacyId, result, ct);
-            await DecomposeSensitivityScheduleAsync(profile, profileData, storeName, legacyId, result, ct);
-            await DecomposeTargetRangeScheduleAsync(profile, profileData, storeName, legacyId, result, ct);
+            await DecomposeTherapySettingsAsync(profile, profileData, storeName, legacyId, isDefault, result, origin, ct);
+            await DecomposeBasalScheduleAsync(profile, profileData, storeName, legacyId, result, origin, ct);
+            await DecomposeCarbRatioScheduleAsync(profile, profileData, storeName, legacyId, result, origin, ct);
+            await DecomposeSensitivityScheduleAsync(profile, profileData, storeName, legacyId, result, origin, ct);
+            await DecomposeTargetRangeScheduleAsync(profile, profileData, storeName, legacyId, result, origin, ct);
         }
 
         return result;
@@ -100,7 +100,7 @@ public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
 
     /// <inheritdoc />
     public async Task<V4Models.DecompositionResult> DecomposeBatchAsync(
-        IReadOnlyList<Profile> profiles, CancellationToken ct = default)
+        IReadOnlyList<Profile> profiles, WriteOrigin origin, CancellationToken ct = default)
     {
         if (profiles.Count == 0)
             return new V4Models.DecompositionResult();
@@ -148,31 +148,31 @@ public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
         {
             if (therapySettingsList.Count > 0)
             {
-                var created = await _therapySettingsRepo.BulkCreateAsync(therapySettingsList, ct);
+                var created = await _therapySettingsRepo.BulkCreateAsync(therapySettingsList, origin, ct);
                 result.CreatedRecords.AddRange(created);
             }
 
             if (basalScheduleList.Count > 0)
             {
-                var created = await _basalScheduleRepo.BulkCreateAsync(basalScheduleList, ct);
+                var created = await _basalScheduleRepo.BulkCreateAsync(basalScheduleList, origin, ct);
                 result.CreatedRecords.AddRange(created);
             }
 
             if (carbRatioScheduleList.Count > 0)
             {
-                var created = await _carbRatioScheduleRepo.BulkCreateAsync(carbRatioScheduleList, ct);
+                var created = await _carbRatioScheduleRepo.BulkCreateAsync(carbRatioScheduleList, origin, ct);
                 result.CreatedRecords.AddRange(created);
             }
 
             if (sensitivityScheduleList.Count > 0)
             {
-                var created = await _sensitivityScheduleRepo.BulkCreateAsync(sensitivityScheduleList, ct);
+                var created = await _sensitivityScheduleRepo.BulkCreateAsync(sensitivityScheduleList, origin, ct);
                 result.CreatedRecords.AddRange(created);
             }
 
             if (targetRangeScheduleList.Count > 0)
             {
-                var created = await _targetRangeScheduleRepo.BulkCreateAsync(targetRangeScheduleList, ct);
+                var created = await _targetRangeScheduleRepo.BulkCreateAsync(targetRangeScheduleList, origin, ct);
                 result.CreatedRecords.AddRange(created);
             }
         }
@@ -193,7 +193,7 @@ public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
         string legacyId,
         bool isDefault,
         V4Models.DecompositionResult result,
-        CancellationToken ct)
+        WriteOrigin origin, CancellationToken ct)
     {
         var existing = await _therapySettingsRepo.GetByLegacyIdAsync(legacyId, ct);
         var model = MapToTherapySettings(profile, profileData, storeName, legacyId, isDefault, result.CorrelationId);
@@ -201,13 +201,13 @@ public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
         if (existing != null)
         {
             model.Id = existing.Id;
-            var updated = await _therapySettingsRepo.UpdateAsync(existing.Id, model, ct);
+            var updated = await _therapySettingsRepo.UpdateAsync(existing.Id, model, origin, ct);
             result.UpdatedRecords.Add(updated);
             _logger.LogDebug("Updated existing TherapySettings {Id} from legacy profile {LegacyId}", existing.Id, legacyId);
         }
         else
         {
-            var created = await _therapySettingsRepo.CreateAsync(model, ct);
+            var created = await _therapySettingsRepo.CreateAsync(model, origin, ct);
             result.CreatedRecords.Add(created);
             _logger.LogDebug("Created TherapySettings from legacy profile {LegacyId}", legacyId);
         }
@@ -219,7 +219,7 @@ public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
         string storeName,
         string legacyId,
         V4Models.DecompositionResult result,
-        CancellationToken ct)
+        WriteOrigin origin, CancellationToken ct)
     {
         var existing = await _basalScheduleRepo.GetByLegacyIdAsync(legacyId, ct);
         var model = MapToBasalSchedule(profile, profileData, storeName, legacyId, result.CorrelationId);
@@ -227,13 +227,13 @@ public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
         if (existing != null)
         {
             model.Id = existing.Id;
-            var updated = await _basalScheduleRepo.UpdateAsync(existing.Id, model, ct);
+            var updated = await _basalScheduleRepo.UpdateAsync(existing.Id, model, origin, ct);
             result.UpdatedRecords.Add(updated);
             _logger.LogDebug("Updated existing BasalSchedule {Id} from legacy profile {LegacyId}", existing.Id, legacyId);
         }
         else
         {
-            var created = await _basalScheduleRepo.CreateAsync(model, ct);
+            var created = await _basalScheduleRepo.CreateAsync(model, origin, ct);
             result.CreatedRecords.Add(created);
             _logger.LogDebug("Created BasalSchedule from legacy profile {LegacyId}", legacyId);
         }
@@ -245,7 +245,7 @@ public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
         string storeName,
         string legacyId,
         V4Models.DecompositionResult result,
-        CancellationToken ct)
+        WriteOrigin origin, CancellationToken ct)
     {
         var existing = await _carbRatioScheduleRepo.GetByLegacyIdAsync(legacyId, ct);
         var model = MapToCarbRatioSchedule(profile, profileData, storeName, legacyId, result.CorrelationId);
@@ -253,13 +253,13 @@ public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
         if (existing != null)
         {
             model.Id = existing.Id;
-            var updated = await _carbRatioScheduleRepo.UpdateAsync(existing.Id, model, ct);
+            var updated = await _carbRatioScheduleRepo.UpdateAsync(existing.Id, model, origin, ct);
             result.UpdatedRecords.Add(updated);
             _logger.LogDebug("Updated existing CarbRatioSchedule {Id} from legacy profile {LegacyId}", existing.Id, legacyId);
         }
         else
         {
-            var created = await _carbRatioScheduleRepo.CreateAsync(model, ct);
+            var created = await _carbRatioScheduleRepo.CreateAsync(model, origin, ct);
             result.CreatedRecords.Add(created);
             _logger.LogDebug("Created CarbRatioSchedule from legacy profile {LegacyId}", legacyId);
         }
@@ -271,7 +271,7 @@ public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
         string storeName,
         string legacyId,
         V4Models.DecompositionResult result,
-        CancellationToken ct)
+        WriteOrigin origin, CancellationToken ct)
     {
         var existing = await _sensitivityScheduleRepo.GetByLegacyIdAsync(legacyId, ct);
         var model = MapToSensitivitySchedule(profile, profileData, storeName, legacyId, result.CorrelationId);
@@ -279,13 +279,13 @@ public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
         if (existing != null)
         {
             model.Id = existing.Id;
-            var updated = await _sensitivityScheduleRepo.UpdateAsync(existing.Id, model, ct);
+            var updated = await _sensitivityScheduleRepo.UpdateAsync(existing.Id, model, origin, ct);
             result.UpdatedRecords.Add(updated);
             _logger.LogDebug("Updated existing SensitivitySchedule {Id} from legacy profile {LegacyId}", existing.Id, legacyId);
         }
         else
         {
-            var created = await _sensitivityScheduleRepo.CreateAsync(model, ct);
+            var created = await _sensitivityScheduleRepo.CreateAsync(model, origin, ct);
             result.CreatedRecords.Add(created);
             _logger.LogDebug("Created SensitivitySchedule from legacy profile {LegacyId}", legacyId);
         }
@@ -297,7 +297,7 @@ public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
         string storeName,
         string legacyId,
         V4Models.DecompositionResult result,
-        CancellationToken ct)
+        WriteOrigin origin, CancellationToken ct)
     {
         var existing = await _targetRangeScheduleRepo.GetByLegacyIdAsync(legacyId, ct);
         var model = MapToTargetRangeSchedule(profile, profileData, storeName, legacyId, result.CorrelationId);
@@ -305,13 +305,13 @@ public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
         if (existing != null)
         {
             model.Id = existing.Id;
-            var updated = await _targetRangeScheduleRepo.UpdateAsync(existing.Id, model, ct);
+            var updated = await _targetRangeScheduleRepo.UpdateAsync(existing.Id, model, origin, ct);
             result.UpdatedRecords.Add(updated);
             _logger.LogDebug("Updated existing TargetRangeSchedule {Id} from legacy profile {LegacyId}", existing.Id, legacyId);
         }
         else
         {
-            var created = await _targetRangeScheduleRepo.CreateAsync(model, ct);
+            var created = await _targetRangeScheduleRepo.CreateAsync(model, origin, ct);
             result.CreatedRecords.Add(created);
             _logger.LogDebug("Created TargetRangeSchedule from legacy profile {LegacyId}", legacyId);
         }
@@ -480,16 +480,16 @@ public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
     #endregion
 
     /// <inheritdoc />
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
+    public async Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default)
     {
         var prefix = legacyId + ":";
         var deleted = 0;
 
-        deleted += await _therapySettingsRepo.DeleteByLegacyIdPrefixAsync(prefix, ct);
-        deleted += await _basalScheduleRepo.DeleteByLegacyIdPrefixAsync(prefix, ct);
-        deleted += await _carbRatioScheduleRepo.DeleteByLegacyIdPrefixAsync(prefix, ct);
-        deleted += await _sensitivityScheduleRepo.DeleteByLegacyIdPrefixAsync(prefix, ct);
-        deleted += await _targetRangeScheduleRepo.DeleteByLegacyIdPrefixAsync(prefix, ct);
+        deleted += await _therapySettingsRepo.DeleteByLegacyIdPrefixAsync(prefix, origin, ct);
+        deleted += await _basalScheduleRepo.DeleteByLegacyIdPrefixAsync(prefix, origin, ct);
+        deleted += await _carbRatioScheduleRepo.DeleteByLegacyIdPrefixAsync(prefix, origin, ct);
+        deleted += await _sensitivityScheduleRepo.DeleteByLegacyIdPrefixAsync(prefix, origin, ct);
+        deleted += await _targetRangeScheduleRepo.DeleteByLegacyIdPrefixAsync(prefix, origin, ct);
 
         if (deleted > 0)
             _logger.LogDebug("Deleted {Count} V4 records for legacy profile {LegacyId}", deleted, legacyId);

--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -1510,6 +1510,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
     /// <inheritdoc />
     public async Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default)
     {
+        // origin is accepted for interface uniformity; the v4-native delete broadcast is deferred to the glucose-unification follow-up (deletes here bypass the repository chokepoint).
         var strategy = _dbContext.Database.CreateExecutionStrategy();
 
         return await strategy.ExecuteAsync(async () =>
@@ -1552,6 +1553,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
     /// <inheritdoc />
     public async Task<long> BulkDeleteAsync(string? find, WriteOrigin origin, CancellationToken ct = default)
     {
+        // origin is accepted for interface uniformity; the v4-native delete broadcast is deferred to the glucose-unification follow-up (deletes here bypass the repository chokepoint).
         var (fromMills, toMills) = Core.Models.Entries.EntryDomainLogic.ParseTimeRangeFromFind(find);
 
         // Reject implausible timestamps that clearly aren't time bounds

--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -345,7 +345,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
     }
 
     /// <inheritdoc />
-    public async Task<V4Models.DecompositionResult> DecomposeAsync(Treatment treatment, CancellationToken ct = default)
+    public async Task<V4Models.DecompositionResult> DecomposeAsync(Treatment treatment, WriteOrigin origin, CancellationToken ct = default)
     {
         NormalizeIdentity(treatment);
 
@@ -371,55 +371,55 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         {
             if (c.IsProfileSwitch)
             {
-                await DecomposeProfileSwitchAsync(treatment, result, ct);
+                await DecomposeProfileSwitchAsync(treatment, result, origin, ct);
             }
             else if (c.IsOverride)
             {
-                await DecomposeOverrideAsync(treatment, result, ct);
+                await DecomposeOverrideAsync(treatment, result, origin, ct);
             }
             else if (c.IsTemporaryTarget)
             {
-                await DecomposeTemporaryTargetAsync(treatment, result, ct);
+                await DecomposeTemporaryTargetAsync(treatment, result, origin, ct);
             }
             else
             {
-                await DecomposeTempBasalAsync(treatment, result, ct);
+                await DecomposeTempBasalAsync(treatment, result, origin, ct);
             }
         }
 
         // Produce v4 records
         if (c.ProduceBolus)
         {
-            await DecomposeBolusAsync(treatment, result, ct);
+            await DecomposeBolusAsync(treatment, result, origin, ct);
         }
 
         if (c.ProduceCarbIntake)
         {
-            await DecomposeCarbIntakeAsync(treatment, result, ct);
+            await DecomposeCarbIntakeAsync(treatment, result, origin, ct);
         }
 
         if (c.ProduceBGCheck)
         {
-            await DecomposeBGCheckAsync(treatment, result, ct);
+            await DecomposeBGCheckAsync(treatment, result, origin, ct);
         }
 
         if (c.ProduceNote)
         {
-            await DecomposeNoteAsync(treatment, result, c.IsAnnouncement, ct);
+            await DecomposeNoteAsync(treatment, result, c.IsAnnouncement, origin, ct);
         }
 
         if (c.ProduceBolusCalc)
         {
-            await DecomposeBolusCalculationAsync(treatment, result, ct);
+            await DecomposeBolusCalculationAsync(treatment, result, origin, ct);
         }
 
         if (c.ProduceDeviceEvent)
         {
-            await DecomposeDeviceEventAsync(treatment, result, c.ParsedDeviceEventType, ct);
+            await DecomposeDeviceEventAsync(treatment, result, c.ParsedDeviceEventType, origin, ct);
 
             if (c.ParsedDeviceEventType is DeviceEventType.PumpSuspend or DeviceEventType.PumpResume)
             {
-                await DecomposePumpSuspensionFromTreatmentAsync(treatment, c.ParsedDeviceEventType, result, ct);
+                await DecomposePumpSuspensionFromTreatmentAsync(treatment, c.ParsedDeviceEventType, result, origin, ct);
             }
         }
 
@@ -433,7 +433,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         if (bolus != null && bolusCalc != null && bolus.BolusCalculationId != bolusCalc.Id)
         {
             bolus.BolusCalculationId = bolusCalc.Id;
-            await _bolusRepository.UpdateAsync(bolus.Id, bolus, ct);
+            await _bolusRepository.UpdateAsync(bolus.Id, bolus, origin, ct);
         }
 
         // If nothing was produced and there's no delegation, log a warning
@@ -449,7 +449,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
 
     #region Decomposition Methods
 
-    private async Task DecomposeBolusAsync(Treatment treatment, V4Models.DecompositionResult result, CancellationToken ct)
+    private async Task DecomposeBolusAsync(Treatment treatment, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
     {
         // Algorithm-delivered micro boluses:
         //   - isBasalInsulin flag (legacy AAPS convention)
@@ -463,7 +463,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
 
         if (isAlgorithmBolus)
         {
-            await DecomposeMicroBolusAsync(treatment, result, ct);
+            await DecomposeMicroBolusAsync(treatment, result, origin, ct);
             return;
         }
 
@@ -479,19 +479,19 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         if (existing != null)
         {
             model.Id = existing.Id;
-            var updated = await _bolusRepository.UpdateAsync(existing.Id, model, ct);
+            var updated = await _bolusRepository.UpdateAsync(existing.Id, model, origin, ct);
             result.UpdatedRecords.Add(updated);
             _logger.LogDebug("Updated existing Bolus {Id} from legacy treatment {LegacyId}", existing.Id, treatment.Id);
         }
         else
         {
-            var created = await _bolusRepository.CreateAsync(model, ct);
+            var created = await _bolusRepository.CreateAsync(model, origin, ct);
             result.CreatedRecords.Add(created);
             _logger.LogDebug("Created Bolus from legacy treatment {LegacyId}", treatment.Id);
         }
     }
 
-    private async Task DecomposeMicroBolusAsync(Treatment treatment, V4Models.DecompositionResult result, CancellationToken ct)
+    private async Task DecomposeMicroBolusAsync(Treatment treatment, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
     {
         var existing = treatment.Id != null
             ? await _bolusRepository.GetByLegacyIdAsync(treatment.Id, ct)
@@ -507,19 +507,19 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         if (existing != null)
         {
             model.Id = existing.Id;
-            var updated = await _bolusRepository.UpdateAsync(existing.Id, model, ct);
+            var updated = await _bolusRepository.UpdateAsync(existing.Id, model, origin, ct);
             result.UpdatedRecords.Add(updated);
             _logger.LogDebug("Updated existing algorithm Bolus {Id} from legacy treatment {LegacyId}", existing.Id, treatment.Id);
         }
         else
         {
-            var created = await _bolusRepository.CreateAsync(model, ct);
+            var created = await _bolusRepository.CreateAsync(model, origin, ct);
             result.CreatedRecords.Add(created);
             _logger.LogDebug("Created algorithm Bolus from legacy treatment {LegacyId}", treatment.Id);
         }
     }
 
-    private async Task DecomposeCarbIntakeAsync(Treatment treatment, V4Models.DecompositionResult result, CancellationToken ct)
+    private async Task DecomposeCarbIntakeAsync(Treatment treatment, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
     {
         var existing = treatment.Id != null
             ? await _carbIntakeRepository.GetByLegacyIdAsync(treatment.Id, ct)
@@ -531,14 +531,14 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         if (existing != null)
         {
             model.Id = existing.Id;
-            var updated = await _carbIntakeRepository.UpdateAsync(existing.Id, model, ct);
+            var updated = await _carbIntakeRepository.UpdateAsync(existing.Id, model, origin, ct);
             result.UpdatedRecords.Add(updated);
             carbIntakeId = existing.Id;
             _logger.LogDebug("Updated existing CarbIntake {Id} from legacy treatment {LegacyId}", existing.Id, treatment.Id);
         }
         else
         {
-            var created = await _carbIntakeRepository.CreateAsync(model, ct);
+            var created = await _carbIntakeRepository.CreateAsync(model, origin, ct);
             result.CreatedRecords.Add(created);
             carbIntakeId = created.Id;
             _logger.LogDebug("Created CarbIntake from legacy treatment {LegacyId}", treatment.Id);
@@ -558,7 +558,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         }
     }
 
-    private async Task DecomposeBGCheckAsync(Treatment treatment, V4Models.DecompositionResult result, CancellationToken ct)
+    private async Task DecomposeBGCheckAsync(Treatment treatment, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
     {
         var existing = treatment.Id != null
             ? await _bgCheckRepository.GetByLegacyIdAsync(treatment.Id, ct)
@@ -569,19 +569,19 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         if (existing != null)
         {
             model.Id = existing.Id;
-            var updated = await _bgCheckRepository.UpdateAsync(existing.Id, model, ct);
+            var updated = await _bgCheckRepository.UpdateAsync(existing.Id, model, origin, ct);
             result.UpdatedRecords.Add(updated);
             _logger.LogDebug("Updated existing BGCheck {Id} from legacy treatment {LegacyId}", existing.Id, treatment.Id);
         }
         else
         {
-            var created = await _bgCheckRepository.CreateAsync(model, ct);
+            var created = await _bgCheckRepository.CreateAsync(model, origin, ct);
             result.CreatedRecords.Add(created);
             _logger.LogDebug("Created BGCheck from legacy treatment {LegacyId}", treatment.Id);
         }
     }
 
-    private async Task DecomposeNoteAsync(Treatment treatment, V4Models.DecompositionResult result, bool isAnnouncement, CancellationToken ct)
+    private async Task DecomposeNoteAsync(Treatment treatment, V4Models.DecompositionResult result, bool isAnnouncement, WriteOrigin origin, CancellationToken ct)
     {
         var existing = treatment.Id != null
             ? await _noteRepository.GetByLegacyIdAsync(treatment.Id, ct)
@@ -592,19 +592,19 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         if (existing != null)
         {
             model.Id = existing.Id;
-            var updated = await _noteRepository.UpdateAsync(existing.Id, model, ct);
+            var updated = await _noteRepository.UpdateAsync(existing.Id, model, origin, ct);
             result.UpdatedRecords.Add(updated);
             _logger.LogDebug("Updated existing Note {Id} from legacy treatment {LegacyId}", existing.Id, treatment.Id);
         }
         else
         {
-            var created = await _noteRepository.CreateAsync(model, ct);
+            var created = await _noteRepository.CreateAsync(model, origin, ct);
             result.CreatedRecords.Add(created);
             _logger.LogDebug("Created Note from legacy treatment {LegacyId}", treatment.Id);
         }
     }
 
-    private async Task DecomposeDeviceEventAsync(Treatment treatment, V4Models.DecompositionResult result, DeviceEventType deviceEventType, CancellationToken ct)
+    private async Task DecomposeDeviceEventAsync(Treatment treatment, V4Models.DecompositionResult result, DeviceEventType deviceEventType, WriteOrigin origin, CancellationToken ct)
     {
         var existing = treatment.Id != null
             ? await _deviceEventRepository.GetByLegacyIdAsync(treatment.Id, ct)
@@ -618,13 +618,13 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         if (existing != null)
         {
             model.Id = existing.Id;
-            var updated = await _deviceEventRepository.UpdateAsync(existing.Id, model, ct);
+            var updated = await _deviceEventRepository.UpdateAsync(existing.Id, model, origin, ct);
             result.UpdatedRecords.Add(updated);
             _logger.LogDebug("Updated existing DeviceEvent {Id} from legacy treatment {LegacyId}", existing.Id, treatment.Id);
         }
         else
         {
-            var created = await _deviceEventRepository.CreateAsync(model, ct);
+            var created = await _deviceEventRepository.CreateAsync(model, origin, ct);
             result.CreatedRecords.Add(created);
             _logger.LogDebug("Created DeviceEvent from legacy treatment {LegacyId}", treatment.Id);
         }
@@ -639,7 +639,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         Treatment treatment,
         DeviceEventType deviceEventType,
         V4Models.DecompositionResult result,
-        CancellationToken ct)
+        WriteOrigin origin, CancellationToken ct)
     {
         var timestamp = DateTimeOffset.FromUnixTimeMilliseconds(treatment.Mills).UtcDateTime;
 
@@ -689,7 +689,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         }
     }
 
-    private async Task DecomposeBolusCalculationAsync(Treatment treatment, V4Models.DecompositionResult result, CancellationToken ct)
+    private async Task DecomposeBolusCalculationAsync(Treatment treatment, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
     {
         var existing = treatment.Id != null
             ? await _bolusCalculationRepository.GetByLegacyIdAsync(treatment.Id, ct)
@@ -700,19 +700,19 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         if (existing != null)
         {
             model.Id = existing.Id;
-            var updated = await _bolusCalculationRepository.UpdateAsync(existing.Id, model, ct);
+            var updated = await _bolusCalculationRepository.UpdateAsync(existing.Id, model, origin, ct);
             result.UpdatedRecords.Add(updated);
             _logger.LogDebug("Updated existing BolusCalculation {Id} from legacy treatment {LegacyId}", existing.Id, treatment.Id);
         }
         else
         {
-            var created = await _bolusCalculationRepository.CreateAsync(model, ct);
+            var created = await _bolusCalculationRepository.CreateAsync(model, origin, ct);
             result.CreatedRecords.Add(created);
             _logger.LogDebug("Created BolusCalculation from legacy treatment {LegacyId}", treatment.Id);
         }
     }
 
-    private async Task DecomposeTempBasalAsync(Treatment treatment, V4Models.DecompositionResult result, CancellationToken ct)
+    private async Task DecomposeTempBasalAsync(Treatment treatment, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
     {
         var existing = treatment.Id != null
             ? await _tempBasalRepository.GetByLegacyIdAsync(treatment.Id, ct)
@@ -745,19 +745,19 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         if (existing != null)
         {
             model.Id = existing.Id;
-            var updated = await _tempBasalRepository.UpdateAsync(existing.Id, model, ct);
+            var updated = await _tempBasalRepository.UpdateAsync(existing.Id, model, origin, ct);
             result.UpdatedRecords.Add(updated);
             _logger.LogDebug("Updated existing TempBasal {Id} from legacy treatment {LegacyId}", existing.Id, treatment.Id);
         }
         else
         {
-            var created = await _tempBasalRepository.CreateAsync(model, ct);
+            var created = await _tempBasalRepository.CreateAsync(model, origin, ct);
             result.CreatedRecords.Add(created);
             _logger.LogDebug("Created TempBasal from legacy treatment {LegacyId}", treatment.Id);
         }
     }
 
-    private async Task DecomposeProfileSwitchAsync(Treatment treatment, V4Models.DecompositionResult result, CancellationToken ct)
+    private async Task DecomposeProfileSwitchAsync(Treatment treatment, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
     {
         var stateSpan = new StateSpan
         {
@@ -794,7 +794,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
                         Store = { [syntheticStoreName] = profileData }
                     };
 
-                    var profileResult = await _profileDecomposer.DecomposeAsync(syntheticProfile, ct);
+                    var profileResult = await _profileDecomposer.DecomposeAsync(syntheticProfile, origin, ct);
                     result.CreatedRecords.AddRange(profileResult.CreatedRecords);
                     result.UpdatedRecords.AddRange(profileResult.UpdatedRecords);
 
@@ -813,7 +813,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         }
     }
 
-    private async Task DecomposeOverrideAsync(Treatment treatment, V4Models.DecompositionResult result, CancellationToken ct)
+    private async Task DecomposeOverrideAsync(Treatment treatment, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
     {
         var stateSpan = new StateSpan
         {
@@ -833,7 +833,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         _logger.LogDebug("Delegated Temporary Override treatment {LegacyId} to IStateSpanService", treatment.Id);
     }
 
-    private async Task DecomposeTemporaryTargetAsync(Treatment treatment, V4Models.DecompositionResult result, CancellationToken ct)
+    private async Task DecomposeTemporaryTargetAsync(Treatment treatment, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
     {
         var isCancelled = treatment.Duration is null or 0
             || string.Equals(treatment.EventType, "Temporary Target Cancel", StringComparison.OrdinalIgnoreCase);
@@ -1238,7 +1238,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
 
     /// <inheritdoc />
     public async Task<V4Models.DecompositionResult> DecomposeBatchAsync(
-        IReadOnlyList<Treatment> treatments, CancellationToken ct = default)
+        IReadOnlyList<Treatment> treatments, WriteOrigin origin, CancellationToken ct = default)
     {
         if (treatments.Count == 0)
             return new V4Models.DecompositionResult();
@@ -1362,7 +1362,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         foreach (var (treatment, isPs, _, _) in stateSpanTreatments.Where(t => t.IsProfileSwitch))
         {
             var spanResult = new V4Models.DecompositionResult { CorrelationId = batch.Id };
-            await DecomposeProfileSwitchAsync(treatment, spanResult, ct);
+            await DecomposeProfileSwitchAsync(treatment, spanResult, origin, ct);
             result.CreatedRecords.AddRange(spanResult.CreatedRecords);
             result.UpdatedRecords.AddRange(spanResult.UpdatedRecords);
 
@@ -1421,43 +1421,43 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         {
             if (bolusList.Count > 0)
             {
-                var created = await _bolusRepository.BulkCreateAsync(bolusList, ct);
+                var created = await _bolusRepository.BulkCreateAsync(bolusList, origin, ct);
                 result.CreatedRecords.AddRange(created);
             }
 
             if (carbList.Count > 0)
             {
-                var created = await _carbIntakeRepository.BulkCreateAsync(carbList, ct);
+                var created = await _carbIntakeRepository.BulkCreateAsync(carbList, origin, ct);
                 result.CreatedRecords.AddRange(created);
             }
 
             if (bgCheckList.Count > 0)
             {
-                var created = await _bgCheckRepository.BulkCreateAsync(bgCheckList, ct);
+                var created = await _bgCheckRepository.BulkCreateAsync(bgCheckList, origin, ct);
                 result.CreatedRecords.AddRange(created);
             }
 
             if (noteList.Count > 0)
             {
-                var created = await _noteRepository.BulkCreateAsync(noteList, ct);
+                var created = await _noteRepository.BulkCreateAsync(noteList, origin, ct);
                 result.CreatedRecords.AddRange(created);
             }
 
             if (bolusCalcList.Count > 0)
             {
-                var created = await _bolusCalculationRepository.BulkCreateAsync(bolusCalcList, ct);
+                var created = await _bolusCalculationRepository.BulkCreateAsync(bolusCalcList, origin, ct);
                 result.CreatedRecords.AddRange(created);
             }
 
             if (deviceEventList.Count > 0)
             {
-                var created = await _deviceEventRepository.BulkCreateAsync(deviceEventList, ct);
+                var created = await _deviceEventRepository.BulkCreateAsync(deviceEventList, origin, ct);
                 result.CreatedRecords.AddRange(created);
             }
 
             if (tempBasalList.Count > 0)
             {
-                var created = await _tempBasalRepository.BulkCreateAsync(tempBasalList, ct);
+                var created = await _tempBasalRepository.BulkCreateAsync(tempBasalList, origin, ct);
                 result.CreatedRecords.AddRange(created);
             }
         }
@@ -1465,7 +1465,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         // Post-insert pump suspend/resume pass: sequential, order-dependent
         foreach (var (treatment, eventType) in pumpSuspendResumeTreatments.OrderBy(t => t.Treatment.Mills))
         {
-            await DecomposePumpSuspensionFromTreatmentAsync(treatment, eventType, result, ct);
+            await DecomposePumpSuspensionFromTreatmentAsync(treatment, eventType, result, origin, ct);
         }
 
         // Upsert remaining state spans (Override, TemporaryTarget — ProfileSwitch already done in pre-pass)
@@ -1475,9 +1475,9 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             var spanResult = new V4Models.DecompositionResult { CorrelationId = batch.Id };
 
             if (isOv)
-                await DecomposeOverrideAsync(treatment, spanResult, ct);
+                await DecomposeOverrideAsync(treatment, spanResult, origin, ct);
             else if (isTt)
-                await DecomposeTemporaryTargetAsync(treatment, spanResult, ct);
+                await DecomposeTemporaryTargetAsync(treatment, spanResult, origin, ct);
 
             result.CreatedRecords.AddRange(spanResult.CreatedRecords);
             result.UpdatedRecords.AddRange(spanResult.UpdatedRecords);
@@ -1499,7 +1499,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
                     && bolus.BolusCalculationId != calc.Id)
                 {
                     bolus.BolusCalculationId = calc.Id;
-                    await _bolusRepository.UpdateAsync(bolus.Id, bolus, ct);
+                    await _bolusRepository.UpdateAsync(bolus.Id, bolus, origin, ct);
                 }
             }
         }
@@ -1508,7 +1508,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
     }
 
     /// <inheritdoc />
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
+    public async Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default)
     {
         var strategy = _dbContext.Database.CreateExecutionStrategy();
 
@@ -1550,7 +1550,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
     }
 
     /// <inheritdoc />
-    public async Task<long> BulkDeleteAsync(string? find, CancellationToken ct = default)
+    public async Task<long> BulkDeleteAsync(string? find, WriteOrigin origin, CancellationToken ct = default)
     {
         var (fromMills, toMills) = Core.Models.Entries.EntryDomainLogic.ParseTimeRangeFromFind(find);
 

--- a/src/Connectors/Nocturne.Connectors.Core/Interfaces/IDevicePublisher.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Interfaces/IDevicePublisher.cs
@@ -1,5 +1,6 @@
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Connectors.Core.Interfaces;
 
@@ -8,12 +9,12 @@ public interface IDevicePublisher
     Task<bool> PublishDeviceStatusAsync(
         IEnumerable<DeviceStatus> deviceStatuses,
         string source,
-        CancellationToken cancellationToken = default);
+        WriteOrigin origin, CancellationToken cancellationToken = default);
 
     Task<bool> PublishDeviceEventsAsync(
         IEnumerable<DeviceEvent> records,
         string source,
-        CancellationToken cancellationToken = default);
+        WriteOrigin origin, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns the timestamp of the most recent device-status record for the current tenant,

--- a/src/Connectors/Nocturne.Connectors.Core/Interfaces/IGlucosePublisher.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Interfaces/IGlucosePublisher.cs
@@ -1,5 +1,6 @@
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Connectors.Core.Interfaces;
 
@@ -8,12 +9,12 @@ public interface IGlucosePublisher
     Task<bool> PublishEntriesAsync(
         IEnumerable<Entry> entries,
         string source,
-        CancellationToken cancellationToken = default);
+        WriteOrigin origin, CancellationToken cancellationToken = default);
 
     Task<bool> PublishSensorGlucoseAsync(
         IEnumerable<SensorGlucose> records,
         string source,
-        CancellationToken cancellationToken = default);
+        WriteOrigin origin, CancellationToken cancellationToken = default);
 
     Task<DateTime?> GetLatestEntryTimestampAsync(
         string source,

--- a/src/Connectors/Nocturne.Connectors.Core/Interfaces/IMetadataPublisher.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Interfaces/IMetadataPublisher.cs
@@ -1,5 +1,6 @@
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Connectors.Core.Interfaces;
 
@@ -8,37 +9,37 @@ public interface IMetadataPublisher
     Task<bool> PublishProfilesAsync(
         IEnumerable<Profile> profiles,
         string source,
-        CancellationToken cancellationToken = default);
+        WriteOrigin origin, CancellationToken cancellationToken = default);
 
     Task<bool> PublishFoodAsync(
         IEnumerable<Food> foods,
         string source,
-        CancellationToken cancellationToken = default);
+        WriteOrigin origin, CancellationToken cancellationToken = default);
 
     Task<IReadOnlyList<ConnectorFoodEntry>?> PublishConnectorFoodEntriesAsync(
         IEnumerable<ConnectorFoodEntryImport> entries,
         string source,
-        CancellationToken cancellationToken = default);
+        WriteOrigin origin, CancellationToken cancellationToken = default);
 
     Task<bool> PublishActivityAsync(
         IEnumerable<Activity> activities,
         string source,
-        CancellationToken cancellationToken = default);
+        WriteOrigin origin, CancellationToken cancellationToken = default);
 
     Task<bool> PublishStateSpansAsync(
         IEnumerable<StateSpan> stateSpans,
         string source,
-        CancellationToken cancellationToken = default);
+        WriteOrigin origin, CancellationToken cancellationToken = default);
 
     Task<bool> PublishSystemEventsAsync(
         IEnumerable<SystemEvent> systemEvents,
         string source,
-        CancellationToken cancellationToken = default);
+        WriteOrigin origin, CancellationToken cancellationToken = default);
 
     Task<bool> PublishNotesAsync(
         IEnumerable<Note> records,
         string source,
-        CancellationToken cancellationToken = default);
+        WriteOrigin origin, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns the timestamp of the most recent activity record for the current tenant,

--- a/src/Connectors/Nocturne.Connectors.Core/Interfaces/ITreatmentPublisher.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Interfaces/ITreatmentPublisher.cs
@@ -1,5 +1,6 @@
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Connectors.Core.Interfaces;
 
@@ -8,42 +9,42 @@ public interface ITreatmentPublisher
     Task<bool> PublishTreatmentsAsync(
         IEnumerable<Treatment> treatments,
         string source,
-        CancellationToken cancellationToken = default);
+        WriteOrigin origin, CancellationToken cancellationToken = default);
 
     Task<bool> PublishBolusesAsync(
         IEnumerable<Bolus> records,
         string source,
-        CancellationToken cancellationToken = default);
+        WriteOrigin origin, CancellationToken cancellationToken = default);
 
     Task<bool> PublishCarbIntakesAsync(
         IEnumerable<CarbIntake> records,
         string source,
-        CancellationToken cancellationToken = default);
+        WriteOrigin origin, CancellationToken cancellationToken = default);
 
     Task<bool> PublishBGChecksAsync(
         IEnumerable<BGCheck> records,
         string source,
-        CancellationToken cancellationToken = default);
+        WriteOrigin origin, CancellationToken cancellationToken = default);
 
     Task<bool> PublishBolusCalculationsAsync(
         IEnumerable<BolusCalculation> records,
         string source,
-        CancellationToken cancellationToken = default);
+        WriteOrigin origin, CancellationToken cancellationToken = default);
 
     Task<bool> PublishTempBasalsAsync(
         IEnumerable<TempBasal> records,
         string source,
-        CancellationToken cancellationToken = default);
+        WriteOrigin origin, CancellationToken cancellationToken = default);
 
     Task<bool> PublishDecompositionBatchesAsync(
         IEnumerable<DecompositionBatch> batches,
         string source,
-        CancellationToken cancellationToken = default);
+        WriteOrigin origin, CancellationToken cancellationToken = default);
 
     Task<bool> PublishBasalInjectionsAsync(
         IEnumerable<BasalInjection> records,
         string source,
-        CancellationToken cancellationToken = default);
+        WriteOrigin origin, CancellationToken cancellationToken = default);
 
     Task<DateTime?> GetLatestTreatmentTimestampAsync(
         string source,

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -6,6 +6,7 @@ using Nocturne.Connectors.Core.Models;
 using Nocturne.Connectors.Core.Utilities;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Connectors.Core.Services;
 
@@ -539,7 +540,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             return false;
         }
 
-        return await _publisher.Glucose.PublishEntriesAsync(entries, ConnectorSource, cancellationToken);
+        return await _publisher.Glucose.PublishEntriesAsync(entries, ConnectorSource, WriteOrigin.Live, cancellationToken); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
     }
 
     /// <summary>
@@ -559,9 +560,9 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
         return await _publisher.Treatments.PublishTreatmentsAsync(
             treatments,
-            ConnectorSource,
+            ConnectorSource, WriteOrigin.Live,
             cancellationToken
-        );
+        ); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
     }
 
     /// <summary>
@@ -581,9 +582,9 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
         return await _publisher.Device.PublishDeviceStatusAsync(
             deviceStatuses,
-            ConnectorSource,
+            ConnectorSource, WriteOrigin.Live,
             cancellationToken
-        );
+        ); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
     }
 
     /// <summary>
@@ -601,7 +602,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             return false;
         }
 
-        return await _publisher.Metadata.PublishProfilesAsync(profiles, ConnectorSource, cancellationToken);
+        return await _publisher.Metadata.PublishProfilesAsync(profiles, ConnectorSource, WriteOrigin.Live, cancellationToken); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
     }
 
     /// <summary>
@@ -619,7 +620,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             return false;
         }
 
-        return await _publisher.Metadata.PublishFoodAsync(foods, ConnectorSource, cancellationToken);
+        return await _publisher.Metadata.PublishFoodAsync(foods, ConnectorSource, WriteOrigin.Live, cancellationToken); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
     }
 
     /// <summary>
@@ -639,9 +640,9 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
         return await _publisher.Metadata.PublishActivityAsync(
             activities,
-            ConnectorSource,
+            ConnectorSource, WriteOrigin.Live,
             cancellationToken
-        );
+        ); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
     }
 
     /// <summary>
@@ -661,9 +662,9 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
         return await _publisher.Metadata.PublishStateSpansAsync(
             stateSpans,
-            ConnectorSource,
+            ConnectorSource, WriteOrigin.Live,
             cancellationToken
-        );
+        ); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
     }
 
     /// <summary>
@@ -683,9 +684,9 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
         return await _publisher.Metadata.PublishSystemEventsAsync(
             systemEvents,
-            ConnectorSource,
+            ConnectorSource, WriteOrigin.Live,
             cancellationToken
-        );
+        ); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
     }
 
     /// <summary>
@@ -747,9 +748,9 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
         return await _publisher.Glucose.PublishSensorGlucoseAsync(
             records,
-            ConnectorSource,
+            ConnectorSource, WriteOrigin.Live,
             cancellationToken
-        );
+        ); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
     }
 
     /// <summary>
@@ -767,7 +768,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             return false;
         }
 
-        return await _publisher.Treatments.PublishBolusesAsync(records, ConnectorSource, cancellationToken);
+        return await _publisher.Treatments.PublishBolusesAsync(records, ConnectorSource, WriteOrigin.Live, cancellationToken); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
     }
 
     /// <summary>
@@ -785,7 +786,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             return false;
         }
 
-        return await _publisher.Treatments.PublishDecompositionBatchesAsync(batches, ConnectorSource, cancellationToken);
+        return await _publisher.Treatments.PublishDecompositionBatchesAsync(batches, ConnectorSource, WriteOrigin.Live, cancellationToken); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
     }
 
     /// <summary>
@@ -805,9 +806,9 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
         return await _publisher.Treatments.PublishCarbIntakesAsync(
             records,
-            ConnectorSource,
+            ConnectorSource, WriteOrigin.Live,
             cancellationToken
-        );
+        ); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
     }
 
     /// <summary>
@@ -825,7 +826,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             return false;
         }
 
-        return await _publisher.Treatments.PublishBGChecksAsync(records, ConnectorSource, cancellationToken);
+        return await _publisher.Treatments.PublishBGChecksAsync(records, ConnectorSource, WriteOrigin.Live, cancellationToken); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
     }
 
     /// <summary>
@@ -845,9 +846,9 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
         return await _publisher.Treatments.PublishBolusCalculationsAsync(
             records,
-            ConnectorSource,
+            ConnectorSource, WriteOrigin.Live,
             cancellationToken
-        );
+        ); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
     }
 
     /// <summary>
@@ -865,7 +866,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             return false;
         }
 
-        return await _publisher.Metadata.PublishNotesAsync(records, ConnectorSource, cancellationToken);
+        return await _publisher.Metadata.PublishNotesAsync(records, ConnectorSource, WriteOrigin.Live, cancellationToken); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
     }
 
     /// <summary>
@@ -885,9 +886,9 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
         return await _publisher.Device.PublishDeviceEventsAsync(
             records,
-            ConnectorSource,
+            ConnectorSource, WriteOrigin.Live,
             cancellationToken
-        );
+        ); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
     }
 
     /// <summary>
@@ -907,9 +908,9 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
         return await _publisher.Treatments.PublishTempBasalsAsync(
             records,
-            ConnectorSource,
+            ConnectorSource, WriteOrigin.Live,
             cancellationToken
-        );
+        ); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
     }
 
     /// <summary>
@@ -929,9 +930,9 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
         return await _publisher.Treatments.PublishBasalInjectionsAsync(
             records,
-            ConnectorSource,
+            ConnectorSource, WriteOrigin.Live,
             cancellationToken
-        );
+        ); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
     }
 
     #endregion

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -22,6 +22,13 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     protected readonly ILogger _logger;
     private readonly IConnectorPublisher? _publisher;
 
+    // Broadcast origin for this run's glucose / care (treatment-family) publishes, resolved once from the
+    // pre-run resume watermark and memoized so every batch and granular publish in the run agrees — a
+    // paginated or multi-call first sync can't flip to Live mid-backfill. The connector service is
+    // resolved fresh per sync run, so these are naturally per-run.
+    private WriteOrigin? _glucosePublishOrigin;
+    private WriteOrigin? _treatmentPublishOrigin;
+
     /// <summary>
     ///     Base constructor for connector services using IHttpClientFactory pattern
     /// </summary>
@@ -528,6 +535,42 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     /// <summary>
     ///     Submits glucose data directly to the API via HTTP
     /// </summary>
+    /// <summary>
+    ///     The broadcast origin for this run's glucose-family publishes: <see cref="WriteOrigin.Backfill"/>
+    ///     on the source's first-ever glucose sync (no prior data — suppress so a first sync of history
+    ///     doesn't flood clients), else <see cref="WriteOrigin.Live"/>. Memoized for the run.
+    /// </summary>
+    protected async Task<WriteOrigin> GlucosePublishOriginAsync()
+    {
+        _glucosePublishOrigin ??= await ResolvePublishOriginAsync(
+            () => _publisher!.Glucose.GetLatestEntryTimestampAsync(ConnectorSource));
+        return _glucosePublishOrigin.Value;
+    }
+
+    /// <summary>
+    ///     The broadcast origin for this run's care-family (treatment) publishes — Bolus, CarbIntake,
+    ///     BG check, calculations, basal, notes, device events. Backfill on the source's first-ever
+    ///     treatment sync, else Live. Memoized for the run.
+    /// </summary>
+    protected async Task<WriteOrigin> TreatmentPublishOriginAsync()
+    {
+        _treatmentPublishOrigin ??= await ResolvePublishOriginAsync(
+            () => _publisher!.Treatments.GetLatestTreatmentTimestampAsync(ConnectorSource));
+        return _treatmentPublishOrigin.Value;
+    }
+
+    /// <summary>
+    ///     Resolves a publish origin from a resume watermark: Backfill when no prior data exists (initial
+    ///     full-history sync), else Live. When the publisher is unavailable the publish will fail anyway,
+    ///     so the origin is irrelevant and defaults to Live.
+    /// </summary>
+    private async Task<WriteOrigin> ResolvePublishOriginAsync(Func<Task<DateTime?>> latestTimestamp)
+    {
+        if (_publisher is not { IsAvailable: true })
+            return WriteOrigin.Live;
+        return await latestTimestamp() is null ? WriteOrigin.Backfill : WriteOrigin.Live;
+    }
+
     protected virtual async Task<bool> PublishGlucoseDataAsync(
         IEnumerable<Entry> entries,
         TConfig config,
@@ -540,7 +583,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             return false;
         }
 
-        return await _publisher.Glucose.PublishEntriesAsync(entries, ConnectorSource, WriteOrigin.Live, cancellationToken); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
+        return await _publisher.Glucose.PublishEntriesAsync(entries, ConnectorSource, await GlucosePublishOriginAsync(), cancellationToken);
     }
 
     /// <summary>
@@ -560,9 +603,9 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
         return await _publisher.Treatments.PublishTreatmentsAsync(
             treatments,
-            ConnectorSource, WriteOrigin.Live,
+            ConnectorSource, await TreatmentPublishOriginAsync(),
             cancellationToken
-        ); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
+        );
     }
 
     /// <summary>
@@ -584,7 +627,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             deviceStatuses,
             ConnectorSource, WriteOrigin.Live,
             cancellationToken
-        ); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
+        ); // Dormant broadcast category (snapshots off-base / no V4 category yet) — origin irrelevant until wired.
     }
 
     /// <summary>
@@ -602,7 +645,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             return false;
         }
 
-        return await _publisher.Metadata.PublishProfilesAsync(profiles, ConnectorSource, WriteOrigin.Live, cancellationToken); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
+        return await _publisher.Metadata.PublishProfilesAsync(profiles, ConnectorSource, WriteOrigin.Live, cancellationToken); // Dormant broadcast category (snapshots off-base / no V4 category yet) — origin irrelevant until wired.
     }
 
     /// <summary>
@@ -620,7 +663,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             return false;
         }
 
-        return await _publisher.Metadata.PublishFoodAsync(foods, ConnectorSource, WriteOrigin.Live, cancellationToken); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
+        return await _publisher.Metadata.PublishFoodAsync(foods, ConnectorSource, WriteOrigin.Live, cancellationToken); // Dormant broadcast category (snapshots off-base / no V4 category yet) — origin irrelevant until wired.
     }
 
     /// <summary>
@@ -642,7 +685,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             activities,
             ConnectorSource, WriteOrigin.Live,
             cancellationToken
-        ); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
+        ); // Dormant broadcast category (snapshots off-base / no V4 category yet) — origin irrelevant until wired.
     }
 
     /// <summary>
@@ -664,7 +707,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             stateSpans,
             ConnectorSource, WriteOrigin.Live,
             cancellationToken
-        ); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
+        ); // Dormant broadcast category (snapshots off-base / no V4 category yet) — origin irrelevant until wired.
     }
 
     /// <summary>
@@ -686,7 +729,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             systemEvents,
             ConnectorSource, WriteOrigin.Live,
             cancellationToken
-        ); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
+        ); // Dormant broadcast category (snapshots off-base / no V4 category yet) — origin irrelevant until wired.
     }
 
     /// <summary>
@@ -748,9 +791,9 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
         return await _publisher.Glucose.PublishSensorGlucoseAsync(
             records,
-            ConnectorSource, WriteOrigin.Live,
+            ConnectorSource, await GlucosePublishOriginAsync(),
             cancellationToken
-        ); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
+        );
     }
 
     /// <summary>
@@ -768,7 +811,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             return false;
         }
 
-        return await _publisher.Treatments.PublishBolusesAsync(records, ConnectorSource, WriteOrigin.Live, cancellationToken); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
+        return await _publisher.Treatments.PublishBolusesAsync(records, ConnectorSource, await TreatmentPublishOriginAsync(), cancellationToken);
     }
 
     /// <summary>
@@ -786,7 +829,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             return false;
         }
 
-        return await _publisher.Treatments.PublishDecompositionBatchesAsync(batches, ConnectorSource, WriteOrigin.Live, cancellationToken); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
+        return await _publisher.Treatments.PublishDecompositionBatchesAsync(batches, ConnectorSource, await TreatmentPublishOriginAsync(), cancellationToken);
     }
 
     /// <summary>
@@ -806,9 +849,9 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
         return await _publisher.Treatments.PublishCarbIntakesAsync(
             records,
-            ConnectorSource, WriteOrigin.Live,
+            ConnectorSource, await TreatmentPublishOriginAsync(),
             cancellationToken
-        ); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
+        );
     }
 
     /// <summary>
@@ -826,7 +869,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             return false;
         }
 
-        return await _publisher.Treatments.PublishBGChecksAsync(records, ConnectorSource, WriteOrigin.Live, cancellationToken); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
+        return await _publisher.Treatments.PublishBGChecksAsync(records, ConnectorSource, await TreatmentPublishOriginAsync(), cancellationToken);
     }
 
     /// <summary>
@@ -846,9 +889,9 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
         return await _publisher.Treatments.PublishBolusCalculationsAsync(
             records,
-            ConnectorSource, WriteOrigin.Live,
+            ConnectorSource, await TreatmentPublishOriginAsync(),
             cancellationToken
-        ); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
+        );
     }
 
     /// <summary>
@@ -866,7 +909,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             return false;
         }
 
-        return await _publisher.Metadata.PublishNotesAsync(records, ConnectorSource, WriteOrigin.Live, cancellationToken); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
+        return await _publisher.Metadata.PublishNotesAsync(records, ConnectorSource, await TreatmentPublishOriginAsync(), cancellationToken);
     }
 
     /// <summary>
@@ -886,9 +929,9 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
         return await _publisher.Device.PublishDeviceEventsAsync(
             records,
-            ConnectorSource, WriteOrigin.Live,
+            ConnectorSource, await TreatmentPublishOriginAsync(),
             cancellationToken
-        ); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
+        );
     }
 
     /// <summary>
@@ -908,9 +951,9 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
         return await _publisher.Treatments.PublishTempBasalsAsync(
             records,
-            ConnectorSource, WriteOrigin.Live,
+            ConnectorSource, await TreatmentPublishOriginAsync(),
             cancellationToken
-        ); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
+        );
     }
 
     /// <summary>
@@ -930,9 +973,9 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
         return await _publisher.Treatments.PublishBasalInjectionsAsync(
             records,
-            ConnectorSource, WriteOrigin.Live,
+            ConnectorSource, await TreatmentPublishOriginAsync(),
             cancellationToken
-        ); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
+        );
     }
 
     #endregion

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -711,7 +711,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             return;
 
         var importedEntries = await _connectorPublisher.Metadata.PublishConnectorFoodEntriesAsync(
-            foodEntryImports, ConnectorSource, WriteOrigin.Live, cancellationToken); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
+            foodEntryImports, ConnectorSource, WriteOrigin.Live, cancellationToken); // Food is a dormant broadcast category — origin irrelevant until wired.
 
         if (importedEntries is not { Count: > 0 })
             return;

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -15,6 +15,7 @@ using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Timezones;
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Connectors.Glooko.Services;
 
@@ -710,7 +711,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             return;
 
         var importedEntries = await _connectorPublisher.Metadata.PublishConnectorFoodEntriesAsync(
-            foodEntryImports, ConnectorSource, cancellationToken);
+            foodEntryImports, ConnectorSource, WriteOrigin.Live, cancellationToken); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
 
         if (importedEntries is not { Count: > 0 })
             return;

--- a/src/Connectors/Nocturne.Connectors.MyFitnessPal/Services/MyFitnessPalConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyFitnessPal/Services/MyFitnessPalConnectorService.cs
@@ -112,7 +112,7 @@ public class MyFitnessPalConnectorService : BaseConnectorService<MyFitnessPalCon
                         foodEntryImports,
                         ConnectorSource, WriteOrigin.Live,
                         cancellationToken
-                    ); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
+                    ); // Food is a dormant broadcast category — origin irrelevant until wired.
                     if (imported == null)
                     {
                         result.Success = false;

--- a/src/Connectors/Nocturne.Connectors.MyFitnessPal/Services/MyFitnessPalConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyFitnessPal/Services/MyFitnessPalConnectorService.cs
@@ -10,6 +10,7 @@ using Nocturne.Connectors.MyFitnessPal.Configurations;
 using Nocturne.Connectors.MyFitnessPal.Models;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Models;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Connectors.MyFitnessPal.Services;
 
@@ -109,9 +110,9 @@ public class MyFitnessPalConnectorService : BaseConnectorService<MyFitnessPalCon
                 {
                     var imported = await _connectorPublisher.Metadata.PublishConnectorFoodEntriesAsync(
                         foodEntryImports,
-                        ConnectorSource,
+                        ConnectorSource, WriteOrigin.Live,
                         cancellationToken
-                    );
+                    ); // TODO(PR-D commit 3): source Backfill vs Live from initial-vs-catch-up
                     if (imported == null)
                     {
                         result.Success = false;

--- a/src/Core/Nocturne.Core.Contracts/Events/IV4RecordBroadcaster.cs
+++ b/src/Core/Nocturne.Core.Contracts/Events/IV4RecordBroadcaster.cs
@@ -1,0 +1,25 @@
+namespace Nocturne.Core.Contracts.Events;
+
+/// <summary>
+/// Driven port for broadcasting native V4 record shapes to modern realtime subscribers (the desktop
+/// companion + Prelude) over the four V4 categories (<c>glucose</c>/<c>care</c>/<c>device</c>/<c>therapy</c>).
+/// </summary>
+/// <typeparam name="TModel">The V4 domain model type whose writes are broadcast.</typeparam>
+/// <remarks>
+/// Fired from the V4 repository chokepoint, for live writes only — the chokepoint gates on
+/// <see cref="V4.WriteOrigin"/> and never calls this for backfill imports. All methods default to no-op
+/// so a type with no category mapping (e.g. the dormant <c>therapy</c> schedules) broadcasts nothing.
+/// The payload carries a <c>recordType</c> discriminator so per-category subscribers filter per-type
+/// client-side. Additive to the legacy v1 <c>IDataEventSink&lt;T&gt;</c> projections, which are untouched.
+/// </remarks>
+public interface IV4RecordBroadcaster<in TModel> where TModel : class
+{
+    /// <summary>Broadcast newly created records as <c>create</c> events on their category group.</summary>
+    Task BroadcastCreatedAsync(IReadOnlyList<TModel> items, CancellationToken ct = default) => Task.CompletedTask;
+
+    /// <summary>Broadcast materially-changed records as <c>update</c> events on their category group.</summary>
+    Task BroadcastUpdatedAsync(IReadOnlyList<TModel> items, CancellationToken ct = default) => Task.CompletedTask;
+
+    /// <summary>Broadcast deleted record ids as <c>delete</c> events on their category group.</summary>
+    Task BroadcastDeletedAsync(IReadOnlyList<Guid> ids, CancellationToken ct = default) => Task.CompletedTask;
+}

--- a/src/Core/Nocturne.Core.Contracts/V4/IActivityDecomposer.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/IActivityDecomposer.cs
@@ -20,7 +20,7 @@ public interface IActivityDecomposer
     /// Returns a result with created/updated records for heart rate or step count data.
     /// Returns an empty result for regular activities (caller should proceed with StateSpan storage).
     /// </summary>
-    Task<DecompositionResult> DecomposeAsync(Activity activity, CancellationToken ct = default);
+    Task<DecompositionResult> DecomposeAsync(Activity activity, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Decomposes a batch of legacy Activities into dedicated v4 models, using bulk insert.
@@ -33,13 +33,13 @@ public interface IActivityDecomposer
     /// A <see cref="DecompositionResult"/> containing all created V4 records across all activities.
     /// </returns>
     Task<DecompositionResult> DecomposeBatchAsync(
-        IReadOnlyList<Activity> activities, CancellationToken ct = default);
+        IReadOnlyList<Activity> activities, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Deletes all dedicated records that were decomposed from a legacy Activity with the given ID.
     /// </summary>
     /// <returns>Total number of records deleted across heart_rates and step_counts tables</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Determines whether an activity represents heart rate data (has "bpm" in AdditionalProperties).

--- a/src/Core/Nocturne.Core.Contracts/V4/IDecomposer.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/IDecomposer.cs
@@ -22,7 +22,7 @@ public interface IDecomposer<in T> where T : class
     /// <param name="record">The legacy record to decompose.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A <see cref="DecompositionResult"/> containing the created or updated v4 records.</returns>
-    Task<DecompositionResult> DecomposeAsync(T record, CancellationToken ct = default);
+    Task<DecompositionResult> DecomposeAsync(T record, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Deletes all v4 records that were previously decomposed from the legacy record
@@ -31,5 +31,5 @@ public interface IDecomposer<in T> where T : class
     /// <param name="legacyId">The legacy record identifier.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The total number of v4 records deleted across all target tables.</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/IDecompositionPipeline.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/IDecompositionPipeline.cs
@@ -20,7 +20,7 @@ public interface IDecompositionPipeline
     /// <param name="records">The legacy records to decompose.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A <see cref="BatchDecompositionResult"/> summarizing successes and failures.</returns>
-    Task<BatchDecompositionResult> DecomposeAsync<T>(IEnumerable<T> records, CancellationToken ct = default) where T : class;
+    Task<BatchDecompositionResult> DecomposeAsync<T>(IEnumerable<T> records, WriteOrigin origin, CancellationToken ct = default) where T : class;
 
     /// <summary>
     /// Decomposes a single legacy record into v4 models via the appropriate
@@ -30,7 +30,7 @@ public interface IDecompositionPipeline
     /// <param name="record">The legacy record to decompose.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A <see cref="BatchDecompositionResult"/> with a single entry.</returns>
-    Task<BatchDecompositionResult> DecomposeAsync<T>(T record, CancellationToken ct = default) where T : class;
+    Task<BatchDecompositionResult> DecomposeAsync<T>(T record, WriteOrigin origin, CancellationToken ct = default) where T : class;
 
     /// <summary>
     /// Deletes all v4 records that were decomposed from a legacy record of type
@@ -40,5 +40,5 @@ public interface IDecompositionPipeline
     /// <param name="legacyId">The legacy record identifier.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The total number of v4 records deleted.</returns>
-    Task<int> DeleteByLegacyIdAsync<T>(string legacyId, CancellationToken ct = default) where T : class;
+    Task<int> DeleteByLegacyIdAsync<T>(string legacyId, WriteOrigin origin, CancellationToken ct = default) where T : class;
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/IDeviceStatusDecomposer.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/IDeviceStatusDecomposer.cs
@@ -14,7 +14,7 @@ public interface IDeviceStatusDecomposer
     /// Extracts APS, pump, and uploader snapshots from a DeviceStatus record
     /// and persists them to v4 tables. Idempotent via LegacyId matching.
     /// </summary>
-    Task<DecompositionResult> DecomposeAsync(DeviceStatus deviceStatus, CancellationToken ct = default);
+    Task<DecompositionResult> DecomposeAsync(DeviceStatus deviceStatus, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Decomposes a batch of DeviceStatus records into typed v4 snapshot tables using bulk-insert
@@ -24,7 +24,7 @@ public interface IDeviceStatusDecomposer
     /// <param name="statuses">DeviceStatus records to decompose.</param>
     /// <param name="ct">Cancellation token.</param>
     Task<DecompositionResult> DecomposeBatchAsync(
-        IReadOnlyList<DeviceStatus> statuses, CancellationToken ct = default);
+        IReadOnlyList<DeviceStatus> statuses, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Deletes all v4 snapshot records that were decomposed from a legacy DeviceStatus with the given ID.
@@ -32,5 +32,5 @@ public interface IDeviceStatusDecomposer
     /// <param name="legacyId">The legacy DeviceStatus ID</param>
     /// <param name="ct">Cancellation token</param>
     /// <returns>Total number of v4 records deleted across all snapshot tables</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/IEntryDecomposer.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/IEntryDecomposer.cs
@@ -23,7 +23,7 @@ public interface IEntryDecomposer
     /// A <see cref="DecompositionResult"/> containing the created or updated v4 record.
     /// Returns an empty result if the entry type is unrecognized.
     /// </returns>
-    Task<DecompositionResult> DecomposeAsync(Entry entry, CancellationToken ct = default);
+    Task<DecompositionResult> DecomposeAsync(Entry entry, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Deletes all v4 records that were decomposed from a legacy Entry with the given ID.
@@ -31,7 +31,7 @@ public interface IEntryDecomposer
     /// <param name="legacyId">The legacy Entry ID</param>
     /// <param name="ct">Cancellation token</param>
     /// <returns>Total number of v4 records deleted across all tables</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Bulk-deletes V4 records matching the given MongoDB-style find query.
@@ -40,7 +40,7 @@ public interface IEntryDecomposer
     /// <param name="find">Optional MongoDB-style find query for time-range extraction.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Total number of records deleted across all V4 tables.</returns>
-    Task<long> BulkDeleteAsync(string? find, CancellationToken ct = default);
+    Task<long> BulkDeleteAsync(string? find, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Decomposes a batch of legacy entries into v4 records using bulk-insert,
@@ -54,5 +54,5 @@ public interface IEntryDecomposer
     /// contains all bulk-inserted v4 records. Entries with unrecognised types are skipped.
     /// </returns>
     Task<DecompositionResult> DecomposeBatchAsync(
-        IReadOnlyList<Entry> entries, CancellationToken ct = default);
+        IReadOnlyList<Entry> entries, WriteOrigin origin, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/IProfileDecomposer.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/IProfileDecomposer.cs
@@ -23,7 +23,7 @@ public interface IProfileDecomposer
     /// A <see cref="DecompositionResult"/> containing all created or updated V4 records.
     /// A single Profile with N named stores produces N sets of 5 records each.
     /// </returns>
-    Task<DecompositionResult> DecomposeAsync(Profile profile, CancellationToken ct = default);
+    Task<DecompositionResult> DecomposeAsync(Profile profile, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Decomposes a batch of legacy Profiles into V4 records, using bulk insert for each schedule type.
@@ -35,7 +35,7 @@ public interface IProfileDecomposer
     /// A <see cref="DecompositionResult"/> containing all created V4 records across all profiles.
     /// </returns>
     Task<DecompositionResult> DecomposeBatchAsync(
-        IReadOnlyList<Profile> profiles, CancellationToken ct = default);
+        IReadOnlyList<Profile> profiles, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Deletes all V4 records that were decomposed from a legacy Profile with the given ID.
@@ -44,5 +44,5 @@ public interface IProfileDecomposer
     /// <param name="legacyId">The legacy Profile._id</param>
     /// <param name="ct">Cancellation token</param>
     /// <returns>Total number of V4 records deleted across all tables</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/ITreatmentDecomposer.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/ITreatmentDecomposer.cs
@@ -25,7 +25,7 @@ public interface ITreatmentDecomposer
     /// A single Treatment may produce multiple records (e.g., Bolus + CarbIntake for a Meal Bolus).
     /// Returns an empty result if the event type is unrecognized and no insulin/carbs are present.
     /// </returns>
-    Task<DecompositionResult> DecomposeAsync(Treatment treatment, CancellationToken ct = default);
+    Task<DecompositionResult> DecomposeAsync(Treatment treatment, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Decomposes a batch of legacy Treatments into v4 records using bulk-insert operations,
@@ -37,7 +37,7 @@ public interface ITreatmentDecomposer
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A single <see cref="DecompositionResult"/> containing all created v4 records.</returns>
     Task<DecompositionResult> DecomposeBatchAsync(
-        IReadOnlyList<Treatment> treatments, CancellationToken ct = default);
+        IReadOnlyList<Treatment> treatments, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Deletes all v4 records that were decomposed from a legacy Treatment with the given ID.
@@ -45,7 +45,7 @@ public interface ITreatmentDecomposer
     /// <param name="legacyId">The legacy Treatment ID</param>
     /// <param name="ct">Cancellation token</param>
     /// <returns>Total number of v4 records deleted across all tables</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Bulk-deletes V4 treatment records matching the optional find filter (time range).
@@ -53,5 +53,5 @@ public interface ITreatmentDecomposer
     /// <param name="find">Optional Nightscout-compatible find query for time range filtering.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Total number of V4 records deleted across all treatment tables.</returns>
-    Task<long> BulkDeleteAsync(string? find, CancellationToken ct = default);
+    Task<long> BulkDeleteAsync(string? find, WriteOrigin origin, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IApsSnapshotRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IApsSnapshotRepository.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -43,18 +44,18 @@ public interface IApsSnapshotRepository : IV4Repository<ApsSnapshot>
     /// <summary>Persist a new <see cref="ApsSnapshot"/> and return the saved entity.</summary>
     /// <param name="model">Record to create.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<ApsSnapshot> CreateAsync(ApsSnapshot model, CancellationToken ct = default);
+    new Task<ApsSnapshot> CreateAsync(ApsSnapshot model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Replace an existing <see cref="ApsSnapshot"/> identified by <paramref name="id"/>.</summary>
     /// <param name="id">UUID v7 identifier of the record to update.</param>
     /// <param name="model">Updated record data.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<ApsSnapshot> UpdateAsync(Guid id, ApsSnapshot model, CancellationToken ct = default);
+    new Task<ApsSnapshot> UpdateAsync(Guid id, ApsSnapshot model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete an <see cref="ApsSnapshot"/> by its UUID v7.</summary>
     /// <param name="id">UUID v7 identifier of the record to delete.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, CancellationToken ct = default);
+    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Delete the <see cref="ApsSnapshot"/> with the given legacy MongoDB ObjectId.
@@ -62,7 +63,7 @@ public interface IApsSnapshotRepository : IV4Repository<ApsSnapshot>
     /// <param name="legacyId">Original MongoDB ObjectId string.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Retrieve <see cref="ApsSnapshot"/> records matching any of the given correlation IDs.</summary>
     /// <param name="correlationIds">Correlation IDs to match.</param>
@@ -114,5 +115,5 @@ public interface IApsSnapshotRepository : IV4Repository<ApsSnapshot>
     /// <returns>The records that were actually inserted (duplicates excluded).</returns>
     Task<IEnumerable<ApsSnapshot>> BulkCreateAsync(
         IEnumerable<ApsSnapshot> records,
-        CancellationToken ct = default);
+        WriteOrigin origin, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBGCheckRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBGCheckRepository.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -58,24 +59,24 @@ public interface IBGCheckRepository : IV4Repository<BGCheck>
     /// <summary>Persist a new <see cref="BGCheck"/> and return the saved entity.</summary>
     /// <param name="model">Record to create.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<BGCheck> CreateAsync(BGCheck model, CancellationToken ct = default);
+    new Task<BGCheck> CreateAsync(BGCheck model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Replace an existing <see cref="BGCheck"/> identified by <paramref name="id"/>.</summary>
     /// <param name="id">UUID v7 identifier of the record to update.</param>
     /// <param name="model">Updated record data.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<BGCheck> UpdateAsync(Guid id, BGCheck model, CancellationToken ct = default);
+    new Task<BGCheck> UpdateAsync(Guid id, BGCheck model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete a <see cref="BGCheck"/> by its UUID v7.</summary>
     /// <param name="id">UUID v7 identifier of the record to delete.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, CancellationToken ct = default);
+    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete the <see cref="BGCheck"/> with the given legacy MongoDB ObjectId.</summary>
     /// <param name="legacyId">Original MongoDB ObjectId string.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Count <see cref="BGCheck"/> records within an optional time range.</summary>
     /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
@@ -105,6 +106,6 @@ public interface IBGCheckRepository : IV4Repository<BGCheck>
     /// <returns>The inserted records with server-assigned fields populated.</returns>
     Task<IEnumerable<BGCheck>> BulkCreateAsync(
         IEnumerable<BGCheck> records,
-        CancellationToken ct = default
+        WriteOrigin origin, CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBasalInjectionRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBasalInjectionRepository.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -18,7 +19,7 @@ public interface IBasalInjectionRepository : IV4Repository<BasalInjection>
     /// <param name="syncIdentifier">The external sync identifier (e.g., UUID from the uploading system).</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted.</returns>
-    Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, CancellationToken ct = default);
+    Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Find a single <see cref="BasalInjection"/> matching the given data source and sync identifier.</summary>
     /// <param name="dataSource">The external data source name.</param>
@@ -34,7 +35,7 @@ public interface IBasalInjectionRepository : IV4Repository<BasalInjection>
     /// <param name="records">The records to create.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The created records (excludes duplicates).</returns>
-    Task<IEnumerable<BasalInjection>> BulkCreateAsync(IEnumerable<BasalInjection> records, CancellationToken ct = default);
+    Task<IEnumerable<BasalInjection>> BulkCreateAsync(IEnumerable<BasalInjection> records, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Retrieve the timestamp of the most recently stored <see cref="BasalInjection"/>, optionally scoped to a data source.

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBasalScheduleRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBasalScheduleRepository.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -61,24 +62,24 @@ public interface IBasalScheduleRepository : IV4Repository<BasalSchedule>
     /// <summary>Persist a new <see cref="BasalSchedule"/> and return the saved entity.</summary>
     /// <param name="model">Record to create.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<BasalSchedule> CreateAsync(BasalSchedule model, CancellationToken ct = default);
+    new Task<BasalSchedule> CreateAsync(BasalSchedule model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Replace an existing <see cref="BasalSchedule"/> identified by <paramref name="id"/>.</summary>
     /// <param name="id">UUID v7 identifier of the record to update.</param>
     /// <param name="model">Updated record data.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<BasalSchedule> UpdateAsync(Guid id, BasalSchedule model, CancellationToken ct = default);
+    new Task<BasalSchedule> UpdateAsync(Guid id, BasalSchedule model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete a <see cref="BasalSchedule"/> by its UUID v7.</summary>
     /// <param name="id">UUID v7 identifier of the record to delete.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, CancellationToken ct = default);
+    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete the <see cref="BasalSchedule"/> with the given legacy MongoDB ObjectId.</summary>
     /// <param name="legacyId">Original MongoDB ObjectId string.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Delete all <see cref="BasalSchedule"/> records whose legacy ObjectId starts with <paramref name="prefix"/>.
@@ -87,7 +88,7 @@ public interface IBasalScheduleRepository : IV4Repository<BasalSchedule>
     /// <param name="prefix">Legacy ObjectId prefix to match.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted.</returns>
-    Task<int> DeleteByLegacyIdPrefixAsync(string prefix, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Count <see cref="BasalSchedule"/> records within an optional time range.</summary>
     /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
@@ -109,6 +110,6 @@ public interface IBasalScheduleRepository : IV4Repository<BasalSchedule>
     /// <returns>The inserted records with server-assigned fields populated.</returns>
     Task<IEnumerable<BasalSchedule>> BulkCreateAsync(
         IEnumerable<BasalSchedule> records,
-        CancellationToken ct = default
+        WriteOrigin origin, CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBolusCalculationRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBolusCalculationRepository.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -49,7 +50,7 @@ public interface IBolusCalculationRepository : IV4Repository<BolusCalculation>
     /// <summary>Persist a new <see cref="BolusCalculation"/> and return the saved entity.</summary>
     /// <param name="model">Record to create.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<BolusCalculation> CreateAsync(BolusCalculation model, CancellationToken ct = default);
+    new Task<BolusCalculation> CreateAsync(BolusCalculation model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Replace an existing <see cref="BolusCalculation"/> identified by <paramref name="id"/>.</summary>
     /// <param name="id">UUID v7 identifier of the record to update.</param>
@@ -58,19 +59,19 @@ public interface IBolusCalculationRepository : IV4Repository<BolusCalculation>
     new Task<BolusCalculation> UpdateAsync(
         Guid id,
         BolusCalculation model,
-        CancellationToken ct = default
+        WriteOrigin origin, CancellationToken ct = default
     );
 
     /// <summary>Delete a <see cref="BolusCalculation"/> by its UUID v7.</summary>
     /// <param name="id">UUID v7 identifier of the record to delete.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, CancellationToken ct = default);
+    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete the <see cref="BolusCalculation"/> with the given legacy MongoDB ObjectId.</summary>
     /// <param name="legacyId">Original MongoDB ObjectId string.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Count <see cref="BolusCalculation"/> records within an optional time range.</summary>
     /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
@@ -100,6 +101,6 @@ public interface IBolusCalculationRepository : IV4Repository<BolusCalculation>
     /// <returns>The inserted records with server-assigned fields populated.</returns>
     Task<IEnumerable<BolusCalculation>> BulkCreateAsync(
         IEnumerable<BolusCalculation> records,
-        CancellationToken ct = default
+        WriteOrigin origin, CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBolusRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBolusRepository.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -64,31 +65,31 @@ public interface IBolusRepository : IV4Repository<Bolus>
     /// <summary>Persist a new <see cref="Bolus"/> and return the saved entity.</summary>
     /// <param name="model">Record to create.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<Bolus> CreateAsync(Bolus model, CancellationToken ct = default);
+    new Task<Bolus> CreateAsync(Bolus model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Replace an existing <see cref="Bolus"/> identified by <paramref name="id"/>.</summary>
     /// <param name="id">UUID v7 identifier of the record to update.</param>
     /// <param name="model">Updated record data.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<Bolus> UpdateAsync(Guid id, Bolus model, CancellationToken ct = default);
+    new Task<Bolus> UpdateAsync(Guid id, Bolus model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete a <see cref="Bolus"/> by its UUID v7.</summary>
     /// <param name="id">UUID v7 identifier of the record to delete.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, CancellationToken ct = default);
+    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete the <see cref="Bolus"/> with the given legacy MongoDB ObjectId.</summary>
     /// <param name="legacyId">Original MongoDB ObjectId string.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete <see cref="Bolus"/> records matching the given data source and sync identifier.</summary>
     /// <param name="dataSource">The external data source name.</param>
     /// <param name="syncIdentifier">The external sync identifier (e.g., UUID from the uploading system).</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted.</returns>
-    Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, CancellationToken ct = default);
+    Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Count <see cref="Bolus"/> records within an optional time range.</summary>
     /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
@@ -118,6 +119,6 @@ public interface IBolusRepository : IV4Repository<Bolus>
     /// <returns>The inserted records with server-assigned fields populated.</returns>
     Task<IEnumerable<Bolus>> BulkCreateAsync(
         IEnumerable<Bolus> records,
-        CancellationToken ct = default
+        WriteOrigin origin, CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ICalibrationRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ICalibrationRepository.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -40,24 +41,24 @@ public interface ICalibrationRepository : IV4Repository<Calibration>
     /// <summary>Persist a new <see cref="Calibration"/> and return the saved entity.</summary>
     /// <param name="model">Record to create.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<Calibration> CreateAsync(Calibration model, CancellationToken ct = default);
+    new Task<Calibration> CreateAsync(Calibration model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Replace an existing <see cref="Calibration"/> identified by <paramref name="id"/>.</summary>
     /// <param name="id">UUID v7 identifier of the record to update.</param>
     /// <param name="model">Updated record data.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<Calibration> UpdateAsync(Guid id, Calibration model, CancellationToken ct = default);
+    new Task<Calibration> UpdateAsync(Guid id, Calibration model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete a <see cref="Calibration"/> by its UUID v7.</summary>
     /// <param name="id">UUID v7 identifier of the record to delete.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, CancellationToken ct = default);
+    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete the <see cref="Calibration"/> with the given legacy MongoDB ObjectId.</summary>
     /// <param name="legacyId">Original MongoDB ObjectId string.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Count <see cref="Calibration"/> records within an optional time range.</summary>
     /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
@@ -111,5 +112,5 @@ public interface ICalibrationRepository : IV4Repository<Calibration>
     /// <returns>The records that were actually inserted (duplicates excluded).</returns>
     Task<IEnumerable<Calibration>> BulkCreateAsync(
         IEnumerable<Calibration> records,
-        CancellationToken ct = default);
+        WriteOrigin origin, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ICarbIntakeRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ICarbIntakeRepository.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -61,31 +62,31 @@ public interface ICarbIntakeRepository : IV4Repository<CarbIntake>
     /// <summary>Persist a new <see cref="CarbIntake"/> and return the saved entity.</summary>
     /// <param name="model">Record to create.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<CarbIntake> CreateAsync(CarbIntake model, CancellationToken ct = default);
+    new Task<CarbIntake> CreateAsync(CarbIntake model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Replace an existing <see cref="CarbIntake"/> identified by <paramref name="id"/>.</summary>
     /// <param name="id">UUID v7 identifier of the record to update.</param>
     /// <param name="model">Updated record data.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<CarbIntake> UpdateAsync(Guid id, CarbIntake model, CancellationToken ct = default);
+    new Task<CarbIntake> UpdateAsync(Guid id, CarbIntake model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete a <see cref="CarbIntake"/> by its UUID v7.</summary>
     /// <param name="id">UUID v7 identifier of the record to delete.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, CancellationToken ct = default);
+    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete the <see cref="CarbIntake"/> with the given legacy MongoDB ObjectId.</summary>
     /// <param name="legacyId">Original MongoDB ObjectId string.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete <see cref="CarbIntake"/> records matching the given data source and sync identifier.</summary>
     /// <param name="dataSource">The external data source name.</param>
     /// <param name="syncIdentifier">The external sync identifier (e.g., UUID from the uploading system).</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted.</returns>
-    Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, CancellationToken ct = default);
+    Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Count <see cref="CarbIntake"/> records within an optional time range.</summary>
     /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
@@ -115,6 +116,6 @@ public interface ICarbIntakeRepository : IV4Repository<CarbIntake>
     /// <returns>The inserted records with server-assigned fields populated.</returns>
     Task<IEnumerable<CarbIntake>> BulkCreateAsync(
         IEnumerable<CarbIntake> records,
-        CancellationToken ct = default
+        WriteOrigin origin, CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ICarbRatioScheduleRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ICarbRatioScheduleRepository.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -64,24 +65,24 @@ public interface ICarbRatioScheduleRepository : IV4Repository<CarbRatioSchedule>
     /// <summary>Persist a new <see cref="CarbRatioSchedule"/> and return the saved entity.</summary>
     /// <param name="model">Record to create.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<CarbRatioSchedule> CreateAsync(CarbRatioSchedule model, CancellationToken ct = default);
+    new Task<CarbRatioSchedule> CreateAsync(CarbRatioSchedule model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Replace an existing <see cref="CarbRatioSchedule"/> identified by <paramref name="id"/>.</summary>
     /// <param name="id">UUID v7 identifier of the record to update.</param>
     /// <param name="model">Updated record data.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<CarbRatioSchedule> UpdateAsync(Guid id, CarbRatioSchedule model, CancellationToken ct = default);
+    new Task<CarbRatioSchedule> UpdateAsync(Guid id, CarbRatioSchedule model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete a <see cref="CarbRatioSchedule"/> by its UUID v7.</summary>
     /// <param name="id">UUID v7 identifier of the record to delete.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, CancellationToken ct = default);
+    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete the <see cref="CarbRatioSchedule"/> with the given legacy MongoDB ObjectId.</summary>
     /// <param name="legacyId">Original MongoDB ObjectId string.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Delete all <see cref="CarbRatioSchedule"/> records whose legacy ObjectId starts with <paramref name="prefix"/>.
@@ -90,7 +91,7 @@ public interface ICarbRatioScheduleRepository : IV4Repository<CarbRatioSchedule>
     /// <param name="prefix">Legacy ObjectId prefix to match.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted.</returns>
-    Task<int> DeleteByLegacyIdPrefixAsync(string prefix, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Count <see cref="CarbRatioSchedule"/> records within an optional time range.</summary>
     /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
@@ -112,6 +113,6 @@ public interface ICarbRatioScheduleRepository : IV4Repository<CarbRatioSchedule>
     /// <returns>The inserted records with server-assigned fields populated.</returns>
     Task<IEnumerable<CarbRatioSchedule>> BulkCreateAsync(
         IEnumerable<CarbRatioSchedule> records,
-        CancellationToken ct = default
+        WriteOrigin origin, CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IDeviceEventRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IDeviceEventRepository.cs
@@ -1,5 +1,6 @@
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -61,31 +62,31 @@ public interface IDeviceEventRepository : IV4Repository<DeviceEvent>
     /// <summary>Persist a new <see cref="DeviceEvent"/> and return the saved entity.</summary>
     /// <param name="model">Record to create.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<DeviceEvent> CreateAsync(DeviceEvent model, CancellationToken ct = default);
+    new Task<DeviceEvent> CreateAsync(DeviceEvent model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Replace an existing <see cref="DeviceEvent"/> identified by <paramref name="id"/>.</summary>
     /// <param name="id">UUID v7 identifier of the record to update.</param>
     /// <param name="model">Updated record data.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<DeviceEvent> UpdateAsync(Guid id, DeviceEvent model, CancellationToken ct = default);
+    new Task<DeviceEvent> UpdateAsync(Guid id, DeviceEvent model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete a <see cref="DeviceEvent"/> by its UUID v7.</summary>
     /// <param name="id">UUID v7 identifier of the record to delete.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, CancellationToken ct = default);
+    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete the <see cref="DeviceEvent"/> with the given legacy MongoDB ObjectId.</summary>
     /// <param name="legacyId">Original MongoDB ObjectId string.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete <see cref="DeviceEvent"/> records matching the given data source and sync identifier.</summary>
     /// <param name="dataSource">The external data source name.</param>
     /// <param name="syncIdentifier">The external sync identifier (e.g., UUID from the uploading system).</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted.</returns>
-    Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, CancellationToken ct = default);
+    Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Count <see cref="DeviceEvent"/> records within an optional time range.</summary>
     /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
@@ -115,7 +116,7 @@ public interface IDeviceEventRepository : IV4Repository<DeviceEvent>
     /// <returns>The inserted records with server-assigned fields populated.</returns>
     Task<IEnumerable<DeviceEvent>> BulkCreateAsync(
         IEnumerable<DeviceEvent> records,
-        CancellationToken ct = default
+        WriteOrigin origin, CancellationToken ct = default
     );
 
     /// <summary>

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IDeviceRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IDeviceRepository.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -38,11 +39,11 @@ public interface IDeviceRepository
     /// <summary>Persist a new <see cref="Device"/> record and return the saved entity.</summary>
     /// <param name="model">Device record to create.</param>
     /// <param name="ct">Cancellation token.</param>
-    Task<Device> CreateAsync(Device model, CancellationToken ct = default);
+    Task<Device> CreateAsync(Device model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Replace an existing <see cref="Device"/> identified by <paramref name="id"/>.</summary>
     /// <param name="id">UUID v7 identifier of the record to update.</param>
     /// <param name="model">Updated device data.</param>
     /// <param name="ct">Cancellation token.</param>
-    Task<Device> UpdateAsync(Guid id, Device model, CancellationToken ct = default);
+    Task<Device> UpdateAsync(Guid id, Device model, WriteOrigin origin, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IDeviceStatusExtrasRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IDeviceStatusExtrasRepository.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -14,7 +15,7 @@ public interface IDeviceStatusExtrasRepository
     /// <summary>Persist a new <see cref="DeviceStatusExtras"/> and return the saved entity.</summary>
     /// <param name="model">Record to create.</param>
     /// <param name="ct">Cancellation token.</param>
-    Task<DeviceStatusExtras> CreateAsync(DeviceStatusExtras model, CancellationToken ct = default);
+    Task<DeviceStatusExtras> CreateAsync(DeviceStatusExtras model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Retrieve <see cref="DeviceStatusExtras"/> records matching any of the given correlation IDs.</summary>
     /// <param name="correlationIds">Correlation IDs to match.</param>
@@ -35,5 +36,5 @@ public interface IDeviceStatusExtrasRepository
     /// <returns>The records that were actually inserted (duplicates excluded).</returns>
     Task<IEnumerable<DeviceStatusExtras>> BulkCreateAsync(
         IEnumerable<DeviceStatusExtras> records,
-        CancellationToken ct = default);
+        WriteOrigin origin, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IMeterGlucoseRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IMeterGlucoseRepository.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -40,24 +41,24 @@ public interface IMeterGlucoseRepository : IV4Repository<MeterGlucose>
     /// <summary>Persist a new <see cref="MeterGlucose"/> record and return the saved entity.</summary>
     /// <param name="model">Record to create.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<MeterGlucose> CreateAsync(MeterGlucose model, CancellationToken ct = default);
+    new Task<MeterGlucose> CreateAsync(MeterGlucose model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Replace an existing <see cref="MeterGlucose"/> identified by <paramref name="id"/>.</summary>
     /// <param name="id">UUID v7 identifier of the record to update.</param>
     /// <param name="model">Updated record data.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<MeterGlucose> UpdateAsync(Guid id, MeterGlucose model, CancellationToken ct = default);
+    new Task<MeterGlucose> UpdateAsync(Guid id, MeterGlucose model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete a <see cref="MeterGlucose"/> record by its UUID v7.</summary>
     /// <param name="id">UUID v7 identifier of the record to delete.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, CancellationToken ct = default);
+    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete the <see cref="MeterGlucose"/> record with the given legacy MongoDB ObjectId.</summary>
     /// <param name="legacyId">Original MongoDB ObjectId string.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Count <see cref="MeterGlucose"/> records within an optional time range.</summary>
     /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
@@ -111,5 +112,5 @@ public interface IMeterGlucoseRepository : IV4Repository<MeterGlucose>
     /// <returns>The records that were actually inserted (duplicates excluded).</returns>
     Task<IEnumerable<MeterGlucose>> BulkCreateAsync(
         IEnumerable<MeterGlucose> records,
-        CancellationToken ct = default);
+        WriteOrigin origin, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/INoteRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/INoteRepository.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -59,31 +60,31 @@ public interface INoteRepository : IV4Repository<Note>
     /// <summary>Persist a new <see cref="Note"/> and return the saved entity.</summary>
     /// <param name="model">Record to create.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<Note> CreateAsync(Note model, CancellationToken ct = default);
+    new Task<Note> CreateAsync(Note model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Replace an existing <see cref="Note"/> identified by <paramref name="id"/>.</summary>
     /// <param name="id">UUID v7 identifier of the record to update.</param>
     /// <param name="model">Updated record data.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<Note> UpdateAsync(Guid id, Note model, CancellationToken ct = default);
+    new Task<Note> UpdateAsync(Guid id, Note model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete a <see cref="Note"/> by its UUID v7.</summary>
     /// <param name="id">UUID v7 identifier of the record to delete.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, CancellationToken ct = default);
+    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete the <see cref="Note"/> with the given legacy MongoDB ObjectId.</summary>
     /// <param name="legacyId">Original MongoDB ObjectId string.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete <see cref="Note"/> records matching the given data source and sync identifier.</summary>
     /// <param name="dataSource">The external data source name.</param>
     /// <param name="syncIdentifier">The external sync identifier (e.g., UUID from the uploading system).</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted.</returns>
-    Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, CancellationToken ct = default);
+    Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Count <see cref="Note"/> records within an optional time range.</summary>
     /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
@@ -113,6 +114,6 @@ public interface INoteRepository : IV4Repository<Note>
     /// <returns>The inserted records with server-assigned fields populated.</returns>
     Task<IEnumerable<Note>> BulkCreateAsync(
         IEnumerable<Note> records,
-        CancellationToken ct = default
+        WriteOrigin origin, CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IPatientDeviceRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IPatientDeviceRepository.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -26,11 +27,11 @@ public interface IPatientDeviceRepository
     Task<PatientDevice?> GetByIdAsync(Guid id, CancellationToken ct = default);
 
     /// <summary>Creates a new patient device record.</summary>
-    Task<PatientDevice> CreateAsync(PatientDevice model, CancellationToken ct = default);
+    Task<PatientDevice> CreateAsync(PatientDevice model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Updates an existing patient device record.</summary>
-    Task<PatientDevice> UpdateAsync(Guid id, PatientDevice model, CancellationToken ct = default);
+    Task<PatientDevice> UpdateAsync(Guid id, PatientDevice model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Deletes a patient device record by ID.</summary>
-    Task DeleteAsync(Guid id, CancellationToken ct = default);
+    Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IPatientInsulinRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IPatientInsulinRepository.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -20,13 +21,13 @@ public interface IPatientInsulinRepository
     Task<PatientInsulin?> GetByIdAsync(Guid id, CancellationToken ct = default);
 
     /// <summary>Creates a new patient insulin record.</summary>
-    Task<PatientInsulin> CreateAsync(PatientInsulin model, CancellationToken ct = default);
+    Task<PatientInsulin> CreateAsync(PatientInsulin model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Updates an existing patient insulin record.</summary>
-    Task<PatientInsulin> UpdateAsync(Guid id, PatientInsulin model, CancellationToken ct = default);
+    Task<PatientInsulin> UpdateAsync(Guid id, PatientInsulin model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Deletes a patient insulin record by ID.</summary>
-    Task DeleteAsync(Guid id, CancellationToken ct = default);
+    Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Returns the insulin designated as the primary bolus insulin, or null if none is set.</summary>
     Task<PatientInsulin?> GetPrimaryBolusInsulinAsync(CancellationToken ct = default);

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IPatientRecordRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IPatientRecordRepository.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -21,5 +22,5 @@ public interface IPatientRecordRepository
     Task<PatientRecord> GetOrCreateAsync(CancellationToken ct = default);
 
     /// <summary>Updates the patient record and returns the saved result.</summary>
-    Task<PatientRecord> UpdateAsync(PatientRecord model, CancellationToken ct = default);
+    Task<PatientRecord> UpdateAsync(PatientRecord model, WriteOrigin origin, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IPumpSnapshotRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IPumpSnapshotRepository.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -41,24 +42,24 @@ public interface IPumpSnapshotRepository : IV4Repository<PumpSnapshot>
     /// <summary>Persist a new <see cref="PumpSnapshot"/> and return the saved entity.</summary>
     /// <param name="model">Record to create.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<PumpSnapshot> CreateAsync(PumpSnapshot model, CancellationToken ct = default);
+    new Task<PumpSnapshot> CreateAsync(PumpSnapshot model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Replace an existing <see cref="PumpSnapshot"/> identified by <paramref name="id"/>.</summary>
     /// <param name="id">UUID v7 identifier of the record to update.</param>
     /// <param name="model">Updated record data.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<PumpSnapshot> UpdateAsync(Guid id, PumpSnapshot model, CancellationToken ct = default);
+    new Task<PumpSnapshot> UpdateAsync(Guid id, PumpSnapshot model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete a <see cref="PumpSnapshot"/> by its UUID v7.</summary>
     /// <param name="id">UUID v7 identifier of the record to delete.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, CancellationToken ct = default);
+    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete the <see cref="PumpSnapshot"/> with the given legacy MongoDB ObjectId.</summary>
     /// <param name="legacyId">Original MongoDB ObjectId string.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Retrieve <see cref="PumpSnapshot"/> records matching any of the given correlation IDs.</summary>
     /// <param name="correlationIds">Correlation IDs to match.</param>
@@ -105,5 +106,5 @@ public interface IPumpSnapshotRepository : IV4Repository<PumpSnapshot>
     /// <returns>The records that were actually inserted (duplicates excluded).</returns>
     Task<IEnumerable<PumpSnapshot>> BulkCreateAsync(
         IEnumerable<PumpSnapshot> records,
-        CancellationToken ct = default);
+        WriteOrigin origin, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ISensitivityScheduleRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ISensitivityScheduleRepository.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -65,24 +66,24 @@ public interface ISensitivityScheduleRepository : IV4Repository<SensitivitySched
     /// <summary>Persist a new <see cref="SensitivitySchedule"/> and return the saved entity.</summary>
     /// <param name="model">Record to create.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<SensitivitySchedule> CreateAsync(SensitivitySchedule model, CancellationToken ct = default);
+    new Task<SensitivitySchedule> CreateAsync(SensitivitySchedule model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Replace an existing <see cref="SensitivitySchedule"/> identified by <paramref name="id"/>.</summary>
     /// <param name="id">UUID v7 identifier of the record to update.</param>
     /// <param name="model">Updated record data.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<SensitivitySchedule> UpdateAsync(Guid id, SensitivitySchedule model, CancellationToken ct = default);
+    new Task<SensitivitySchedule> UpdateAsync(Guid id, SensitivitySchedule model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete a <see cref="SensitivitySchedule"/> by its UUID v7.</summary>
     /// <param name="id">UUID v7 identifier of the record to delete.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, CancellationToken ct = default);
+    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete the <see cref="SensitivitySchedule"/> with the given legacy MongoDB ObjectId.</summary>
     /// <param name="legacyId">Original MongoDB ObjectId string.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Delete all <see cref="SensitivitySchedule"/> records whose legacy ObjectId starts with <paramref name="prefix"/>.
@@ -91,7 +92,7 @@ public interface ISensitivityScheduleRepository : IV4Repository<SensitivitySched
     /// <param name="prefix">Legacy ObjectId prefix to match.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted.</returns>
-    Task<int> DeleteByLegacyIdPrefixAsync(string prefix, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Count <see cref="SensitivitySchedule"/> records within an optional time range.</summary>
     /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
@@ -113,6 +114,6 @@ public interface ISensitivityScheduleRepository : IV4Repository<SensitivitySched
     /// <returns>The inserted records with server-assigned fields populated.</returns>
     Task<IEnumerable<SensitivitySchedule>> BulkCreateAsync(
         IEnumerable<SensitivitySchedule> records,
-        CancellationToken ct = default
+        WriteOrigin origin, CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ISensorGlucoseRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ISensorGlucoseRepository.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -63,24 +64,24 @@ public interface ISensorGlucoseRepository : IV4Repository<SensorGlucose>
     /// <summary>Persist a new <see cref="SensorGlucose"/> record and return the saved entity.</summary>
     /// <param name="model">Record to create.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<SensorGlucose> CreateAsync(SensorGlucose model, CancellationToken ct = default);
+    new Task<SensorGlucose> CreateAsync(SensorGlucose model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Replace an existing <see cref="SensorGlucose"/> identified by <paramref name="id"/>.</summary>
     /// <param name="id">UUID v7 identifier of the record to update.</param>
     /// <param name="model">Updated record data.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<SensorGlucose> UpdateAsync(Guid id, SensorGlucose model, CancellationToken ct = default);
+    new Task<SensorGlucose> UpdateAsync(Guid id, SensorGlucose model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete a <see cref="SensorGlucose"/> record by its UUID v7.</summary>
     /// <param name="id">UUID v7 identifier of the record to delete.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, CancellationToken ct = default);
+    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete the <see cref="SensorGlucose"/> with the given legacy MongoDB ObjectId.</summary>
     /// <param name="legacyId">Original MongoDB ObjectId string.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Count <see cref="SensorGlucose"/> records within an optional time range.</summary>
     /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
@@ -102,7 +103,7 @@ public interface ISensorGlucoseRepository : IV4Repository<SensorGlucose>
     /// <returns>The inserted records with server-assigned fields populated.</returns>
     Task<IEnumerable<SensorGlucose>> BulkCreateAsync(
         IEnumerable<SensorGlucose> records,
-        CancellationToken ct = default
+        WriteOrigin origin, CancellationToken ct = default
     );
 
     /// <summary>

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ITargetRangeScheduleRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ITargetRangeScheduleRepository.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -64,24 +65,24 @@ public interface ITargetRangeScheduleRepository : IV4Repository<TargetRangeSched
     /// <summary>Persist a new <see cref="TargetRangeSchedule"/> and return the saved entity.</summary>
     /// <param name="model">Record to create.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<TargetRangeSchedule> CreateAsync(TargetRangeSchedule model, CancellationToken ct = default);
+    new Task<TargetRangeSchedule> CreateAsync(TargetRangeSchedule model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Replace an existing <see cref="TargetRangeSchedule"/> identified by <paramref name="id"/>.</summary>
     /// <param name="id">UUID v7 identifier of the record to update.</param>
     /// <param name="model">Updated record data.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<TargetRangeSchedule> UpdateAsync(Guid id, TargetRangeSchedule model, CancellationToken ct = default);
+    new Task<TargetRangeSchedule> UpdateAsync(Guid id, TargetRangeSchedule model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete a <see cref="TargetRangeSchedule"/> by its UUID v7.</summary>
     /// <param name="id">UUID v7 identifier of the record to delete.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, CancellationToken ct = default);
+    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete the <see cref="TargetRangeSchedule"/> with the given legacy MongoDB ObjectId.</summary>
     /// <param name="legacyId">Original MongoDB ObjectId string.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Delete all <see cref="TargetRangeSchedule"/> records whose legacy ObjectId starts with <paramref name="prefix"/>.
@@ -90,7 +91,7 @@ public interface ITargetRangeScheduleRepository : IV4Repository<TargetRangeSched
     /// <param name="prefix">Legacy ObjectId prefix to match.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted.</returns>
-    Task<int> DeleteByLegacyIdPrefixAsync(string prefix, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Count <see cref="TargetRangeSchedule"/> records within an optional time range.</summary>
     /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
@@ -112,6 +113,6 @@ public interface ITargetRangeScheduleRepository : IV4Repository<TargetRangeSched
     /// <returns>The inserted records with server-assigned fields populated.</returns>
     Task<IEnumerable<TargetRangeSchedule>> BulkCreateAsync(
         IEnumerable<TargetRangeSchedule> records,
-        CancellationToken ct = default
+        WriteOrigin origin, CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ITempBasalRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ITempBasalRepository.cs
@@ -1,5 +1,6 @@
 using Nocturne.Core.Models.V4;
 using Nocturne.Core.Contracts.Glucose;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -52,24 +53,24 @@ public interface ITempBasalRepository
     /// <summary>Persist a new <see cref="TempBasal"/> and return the saved entity.</summary>
     /// <param name="model">Record to create.</param>
     /// <param name="ct">Cancellation token.</param>
-    Task<TempBasal> CreateAsync(TempBasal model, CancellationToken ct = default);
+    Task<TempBasal> CreateAsync(TempBasal model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Replace an existing <see cref="TempBasal"/> identified by <paramref name="id"/>.</summary>
     /// <param name="id">UUID v7 identifier of the record to update.</param>
     /// <param name="model">Updated record data.</param>
     /// <param name="ct">Cancellation token.</param>
-    Task<TempBasal> UpdateAsync(Guid id, TempBasal model, CancellationToken ct = default);
+    Task<TempBasal> UpdateAsync(Guid id, TempBasal model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete a <see cref="TempBasal"/> by its UUID v7.</summary>
     /// <param name="id">UUID v7 identifier of the record to delete.</param>
     /// <param name="ct">Cancellation token.</param>
-    Task DeleteAsync(Guid id, CancellationToken ct = default);
+    Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete the <see cref="TempBasal"/> with the given legacy MongoDB ObjectId.</summary>
     /// <param name="legacyId">Original MongoDB ObjectId string.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Count <see cref="TempBasal"/> records within an optional time range.</summary>
     /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
@@ -91,7 +92,7 @@ public interface ITempBasalRepository
     /// <returns>The inserted records with server-assigned fields populated.</returns>
     Task<IEnumerable<TempBasal>> BulkCreateAsync(
         IEnumerable<TempBasal> records,
-        CancellationToken ct = default
+        WriteOrigin origin, CancellationToken ct = default
     );
 
     /// <summary>

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ITherapySettingsRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ITherapySettingsRepository.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -66,24 +67,24 @@ public interface ITherapySettingsRepository : IV4Repository<TherapySettings>
     /// <summary>Persist a new <see cref="TherapySettings"/> record and return the saved entity.</summary>
     /// <param name="model">Record to create.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<TherapySettings> CreateAsync(TherapySettings model, CancellationToken ct = default);
+    new Task<TherapySettings> CreateAsync(TherapySettings model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Replace an existing <see cref="TherapySettings"/> record identified by <paramref name="id"/>.</summary>
     /// <param name="id">UUID v7 identifier of the record to update.</param>
     /// <param name="model">Updated record data.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<TherapySettings> UpdateAsync(Guid id, TherapySettings model, CancellationToken ct = default);
+    new Task<TherapySettings> UpdateAsync(Guid id, TherapySettings model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete a <see cref="TherapySettings"/> record by its UUID v7.</summary>
     /// <param name="id">UUID v7 identifier of the record to delete.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, CancellationToken ct = default);
+    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete the <see cref="TherapySettings"/> record with the given legacy MongoDB ObjectId.</summary>
     /// <param name="legacyId">Original MongoDB ObjectId string.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Delete all <see cref="TherapySettings"/> records whose legacy ObjectId starts with <paramref name="prefix"/>.
@@ -92,7 +93,7 @@ public interface ITherapySettingsRepository : IV4Repository<TherapySettings>
     /// <param name="prefix">Legacy ObjectId prefix to match.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted.</returns>
-    Task<int> DeleteByLegacyIdPrefixAsync(string prefix, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Count <see cref="TherapySettings"/> records within an optional time range.</summary>
     /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
@@ -114,6 +115,6 @@ public interface ITherapySettingsRepository : IV4Repository<TherapySettings>
     /// <returns>The inserted records with server-assigned fields populated.</returns>
     Task<IEnumerable<TherapySettings>> BulkCreateAsync(
         IEnumerable<TherapySettings> records,
-        CancellationToken ct = default
+        WriteOrigin origin, CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IUploaderSnapshotRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IUploaderSnapshotRepository.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -41,24 +42,24 @@ public interface IUploaderSnapshotRepository : IV4Repository<UploaderSnapshot>
     /// <summary>Persist a new <see cref="UploaderSnapshot"/> and return the saved entity.</summary>
     /// <param name="model">Record to create.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<UploaderSnapshot> CreateAsync(UploaderSnapshot model, CancellationToken ct = default);
+    new Task<UploaderSnapshot> CreateAsync(UploaderSnapshot model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Replace an existing <see cref="UploaderSnapshot"/> identified by <paramref name="id"/>.</summary>
     /// <param name="id">UUID v7 identifier of the record to update.</param>
     /// <param name="model">Updated record data.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task<UploaderSnapshot> UpdateAsync(Guid id, UploaderSnapshot model, CancellationToken ct = default);
+    new Task<UploaderSnapshot> UpdateAsync(Guid id, UploaderSnapshot model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete an <see cref="UploaderSnapshot"/> by its UUID v7.</summary>
     /// <param name="id">UUID v7 identifier of the record to delete.</param>
     /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, CancellationToken ct = default);
+    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Delete the <see cref="UploaderSnapshot"/> with the given legacy MongoDB ObjectId.</summary>
     /// <param name="legacyId">Original MongoDB ObjectId string.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Retrieve <see cref="UploaderSnapshot"/> records matching any of the given correlation IDs.</summary>
     /// <param name="correlationIds">Correlation IDs to match.</param>
@@ -94,5 +95,5 @@ public interface IUploaderSnapshotRepository : IV4Repository<UploaderSnapshot>
     /// <returns>The records that were actually inserted (duplicates excluded).</returns>
     Task<IEnumerable<UploaderSnapshot>> BulkCreateAsync(
         IEnumerable<UploaderSnapshot> records,
-        CancellationToken ct = default);
+        WriteOrigin origin, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IV4Repository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IV4Repository.cs
@@ -1,6 +1,10 @@
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
+
+// All mutating methods carry a required WriteOrigin (no default): the repository chokepoint uses it to
+// decide whether the write is a live event to broadcast or a backfill import to keep silent.
 
 /// <summary>
 /// Generic CRUD repository contract for all V4 <see cref="IV4Record"/> entity types.
@@ -40,42 +44,47 @@ public interface IV4Repository<T> where T : class, IV4Record
     /// Persist a new record and return the saved entity with any server-assigned fields populated.
     /// </summary>
     /// <param name="model">Record to create.</param>
+    /// <param name="origin">Whether this is a live write (broadcast) or a backfill import (silent).</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The created record as persisted.</returns>
-    Task<T> CreateAsync(T model, CancellationToken ct = default);
+    Task<T> CreateAsync(T model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Replace an existing record identified by <paramref name="id"/> with the supplied data.
     /// </summary>
     /// <param name="id">UUID v7 identifier of the record to update.</param>
     /// <param name="model">Updated record data.</param>
+    /// <param name="origin">Whether this is a live write (broadcast) or a backfill import (silent).</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The updated record as persisted.</returns>
-    Task<T> UpdateAsync(Guid id, T model, CancellationToken ct = default);
+    Task<T> UpdateAsync(Guid id, T model, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Delete the record with the given identifier.
     /// </summary>
     /// <param name="id">UUID v7 identifier of the record to delete.</param>
+    /// <param name="origin">Whether this is a live write (broadcast) or a backfill import (silent).</param>
     /// <param name="ct">Cancellation token.</param>
-    Task DeleteAsync(Guid id, CancellationToken ct = default);
+    Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Restore a soft-deleted record by clearing its DeletedAt timestamp.
     /// </summary>
     /// <param name="id">UUID v7 identifier of the soft-deleted record.</param>
+    /// <param name="origin">Whether this is a live write (broadcast) or a backfill import (silent).</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The restored record.</returns>
     /// <exception cref="KeyNotFoundException">If no soft-deleted record with the given ID exists.</exception>
-    Task<T> RestoreAsync(Guid id, CancellationToken ct = default);
+    Task<T> RestoreAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Restore multiple soft-deleted records by clearing their DeletedAt timestamps.
     /// </summary>
     /// <param name="ids">UUID v7 identifiers of the soft-deleted records.</param>
+    /// <param name="origin">Whether this is a live write (broadcast) or a backfill import (silent).</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The restored records (only those that were actually soft-deleted).</returns>
-    Task<IEnumerable<T>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default);
+    Task<IEnumerable<T>> BulkRestoreAsync(IEnumerable<Guid> ids, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Retrieve soft-deleted records for the "trash" view, ordered by deletion date (newest first).

--- a/src/Core/Nocturne.Core.Contracts/V4/WriteOrigin.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/WriteOrigin.cs
@@ -1,0 +1,25 @@
+namespace Nocturne.Core.Contracts.V4;
+
+/// <summary>
+/// Classifies why a V4 write is happening, so the repository chokepoint can decide whether the write
+/// is a genuinely-new live event worth broadcasting or a bulk/historical import that must stay silent.
+/// </summary>
+/// <remarks>
+/// Required (no default) on every mutating repository method and on the decomposers. Ambient/AsyncLocal
+/// scoping was rejected: pooled DbContext carriers in this codebase have leaked prior-lessee state, so
+/// the origin is threaded explicitly as a parameter instead.
+/// </remarks>
+public enum WriteOrigin
+{
+    /// <summary>
+    /// A genuinely-new write from a live path — v1/v3 uploads, native V4 controller writes, or a
+    /// connector's incremental catch-up. The chokepoint broadcasts these.
+    /// </summary>
+    Live,
+
+    /// <summary>
+    /// A bulk/historical import — MongoDB migration or a connector's initial full-history sync. The
+    /// chokepoint suppresses broadcasts so clients aren't flooded with data that isn't new.
+    /// </summary>
+    Backfill,
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/AuditedBulkDeleteExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/AuditedBulkDeleteExtensions.cs
@@ -103,7 +103,20 @@ public static class AuditedBulkDeleteExtensions
     /// Executes a bulk soft delete with audit trail. Queries affected records,
     /// writes audit entries, then sets <c>DeletedAt</c> — all in one transaction.
     /// </summary>
+    /// <returns>The number of records soft-deleted.</returns>
     public static async Task<int> AuditedSoftDeleteAsync<T>(
+        this NocturneDbContext context,
+        IQueryable<T> query,
+        IAuditContext? auditContext,
+        CancellationToken ct = default) where T : class, IAuditable, ISoftDeletable
+        => (await context.AuditedSoftDeleteWithIdsAsync(query, auditContext, ct)).Count;
+
+    /// <summary>
+    /// As <see cref="AuditedSoftDeleteAsync{T}"/>, but returns the ids of the soft-deleted records so the
+    /// caller can broadcast per-record delete events. The records are already materialized for the audit
+    /// snapshot, so surfacing their ids costs no extra query.
+    /// </summary>
+    public static async Task<List<Guid>> AuditedSoftDeleteWithIdsAsync<T>(
         this NocturneDbContext context,
         IQueryable<T> query,
         IAuditContext? auditContext,
@@ -121,7 +134,7 @@ public static class AuditedBulkDeleteExtensions
             if (affectedRecords.Count == 0)
             {
                 await transaction.CommitAsync(ct);
-                return 0;
+                return [];
             }
 
             var now = DateTime.UtcNow;
@@ -177,13 +190,13 @@ public static class AuditedBulkDeleteExtensions
             // update: a user-initiated delete blocks resync re-creation, a system sweep
             // (no auth context) leaves the row re-creatable.
             var isUserDelete = auditContext?.AuthType != null;
-            var deletedCount = await query.ExecuteUpdateAsync(
+            await query.ExecuteUpdateAsync(
                 s => s
                     .SetProperty(e => e.DeletedAt, now)
                     .SetProperty(e => EF.Property<bool>(e, "DeletedByUser"), isUserDelete), ct);
 
             await transaction.CommitAsync(ct);
-            return deletedCount;
+            return auditEntries.Select(a => a.EntityId).ToList();
         });
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
@@ -6,6 +6,7 @@ using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
@@ -87,7 +88,7 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
     /// <param name="model">The APS snapshot to create.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The created APS snapshot.</returns>
-    public async Task<ApsSnapshot> CreateAsync(ApsSnapshot model, CancellationToken ct = default)
+    public async Task<ApsSnapshot> CreateAsync(ApsSnapshot model, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = ApsSnapshotMapper.ToEntity(model);
@@ -103,7 +104,7 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
     /// <param name="model">The updated snapshot data.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The updated APS snapshot.</returns>
-    public async Task<ApsSnapshot> UpdateAsync(Guid id, ApsSnapshot model, CancellationToken ct = default)
+    public async Task<ApsSnapshot> UpdateAsync(Guid id, ApsSnapshot model, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.ApsSnapshots.FindAsync([id], ct)
@@ -118,7 +119,7 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
     /// </summary>
     /// <param name="id">The unique identifier.</param>
     /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+    public async Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.ApsSnapshots.FindAsync([id], ct)
@@ -128,7 +129,7 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
     }
 
     /// <inheritdoc />
-    public async Task<ApsSnapshot> RestoreAsync(Guid id, CancellationToken ct = default)
+    public async Task<ApsSnapshot> RestoreAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.ApsSnapshots.IgnoreQueryFilters()
@@ -141,7 +142,7 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
     }
 
     /// <inheritdoc />
-    public async Task<IEnumerable<ApsSnapshot>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    public async Task<IEnumerable<ApsSnapshot>> BulkRestoreAsync(IEnumerable<Guid> ids, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var idSet = ids.ToHashSet();
@@ -241,7 +242,7 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
     /// <param name="legacyId">The legacy identifier.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
+    public async Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         return await ctx.ApsSnapshots
@@ -292,7 +293,7 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
     /// <inheritdoc />
     public async Task<IEnumerable<ApsSnapshot>> BulkCreateAsync(
         IEnumerable<ApsSnapshot> records,
-        CancellationToken ct = default)
+        WriteOrigin origin, CancellationToken ct = default)
     {
         var entities = records.Select(ApsSnapshotMapper.ToEntity).ToList();
         if (entities.Count == 0)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.Infrastructure;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
@@ -36,8 +37,9 @@ public class BGCheckRepository : V4RepositoryBase<BGCheck, BGCheckEntity>, IBGCh
         ITenantDbContextFactory contextFactory,
         IDeduplicationService deduplicationService,
         IAuditContext auditContext,
-        ILogger<BGCheckRepository> logger)
-        : base(contextFactory, auditContext)
+        ILogger<BGCheckRepository> logger,
+        IV4RecordBroadcaster<BGCheck>? broadcaster = null)
+        : base(contextFactory, auditContext, broadcaster)
     {
         _deduplicationService = deduplicationService;
         _logger = logger;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
@@ -9,6 +9,7 @@ using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
@@ -139,7 +140,7 @@ public class BGCheckRepository : V4RepositoryBase<BGCheck, BGCheckEntity>, IBGCh
     /// Insert-time deduplication: link saved records to canonical groups (runs after commit).
     /// </summary>
     protected override async Task PostCommitDedupAsync(
-        NocturneDbContext ctx, IReadOnlyList<BGCheckEntity> inserted, CancellationToken ct)
+        NocturneDbContext ctx, IReadOnlyList<BGCheckEntity> inserted, WriteOrigin origin, CancellationToken ct)
     {
         if (inserted.Count == 0)
             return;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
@@ -20,6 +21,7 @@ public class BasalInjectionRepository : IBasalInjectionRepository
     private readonly NocturneDbContext _context;
     private readonly IAuditContext _auditContext;
     private readonly ILogger<BasalInjectionRepository> _logger;
+    private readonly IV4RecordBroadcaster<BasalInjection>? _broadcaster;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BasalInjectionRepository"/> class.
@@ -27,15 +29,30 @@ public class BasalInjectionRepository : IBasalInjectionRepository
     /// <param name="context">The database context.</param>
     /// <param name="auditContext">The audit context for tracking mutations.</param>
     /// <param name="logger">The logger instance.</param>
+    /// <param name="broadcaster">Optional native V4 broadcaster; null disables broadcasting.</param>
     public BasalInjectionRepository(
         NocturneDbContext context,
         IAuditContext auditContext,
-        ILogger<BasalInjectionRepository> logger)
+        ILogger<BasalInjectionRepository> logger,
+        IV4RecordBroadcaster<BasalInjection>? broadcaster = null)
     {
         _context = context;
         _auditContext = auditContext;
         _logger = logger;
+        _broadcaster = broadcaster;
     }
+
+    /// <summary>
+    /// Fires the native V4 broadcast for a just-committed write — but only for <see cref="WriteOrigin.Live"/>
+    /// writes (backfill imports stay silent). Mirrors the gate in <c>V4RepositoryBase.RaiseBroadcastAsync</c>.
+    /// </summary>
+    private Task RaiseBroadcastAsync(
+        IReadOnlyList<BasalInjection> created,
+        IReadOnlyList<BasalInjection> updated,
+        IReadOnlyList<Guid> deletedIds,
+        WriteOrigin origin,
+        CancellationToken ct)
+        => V4RecordBroadcast.RaiseAsync(_broadcaster, created, updated, deletedIds, origin, ct);
 
     /// <summary>
     /// Gets basal injection records based on filter criteria.
@@ -117,14 +134,19 @@ public class BasalInjectionRepository : IBasalInjectionRepository
             {
                 BasalInjectionMapper.UpdateEntity(existing, model);
                 await _context.SaveChangesAsync(ct);
-                return BasalInjectionMapper.ToDomainModel(existing);
+                var upserted = BasalInjectionMapper.ToDomainModel(existing);
+                // An in-place upsert broadcasts as an update.
+                await RaiseBroadcastAsync([], [upserted], [], origin, ct);
+                return upserted;
             }
         }
 
         var entity = BasalInjectionMapper.ToEntity(model);
         _context.BasalInjections.Add(entity);
         await _context.SaveChangesAsync(ct);
-        return BasalInjectionMapper.ToDomainModel(entity);
+        var created = BasalInjectionMapper.ToDomainModel(entity);
+        await RaiseBroadcastAsync([created], [], [], origin, ct);
+        return created;
     }
 
     /// <summary>
@@ -141,7 +163,9 @@ public class BasalInjectionRepository : IBasalInjectionRepository
             ?? throw new KeyNotFoundException($"BasalInjection {id} not found");
         BasalInjectionMapper.UpdateEntity(entity, model);
         await _context.SaveChangesAsync(ct);
-        return BasalInjectionMapper.ToDomainModel(entity);
+        var updated = BasalInjectionMapper.ToDomainModel(entity);
+        await RaiseBroadcastAsync([], [updated], [], origin, ct);
+        return updated;
     }
 
     /// <summary>
@@ -159,6 +183,7 @@ public class BasalInjectionRepository : IBasalInjectionRepository
             ?? throw new KeyNotFoundException($"BasalInjection {id} not found");
         entity.DeletedAt = DateTime.UtcNow;
         await _context.SaveChangesAsync(ct);
+        await RaiseBroadcastAsync([], [], [id], origin, ct);
     }
 
     /// <inheritdoc />
@@ -170,7 +195,10 @@ public class BasalInjectionRepository : IBasalInjectionRepository
             ?? throw new KeyNotFoundException($"Soft-deleted BasalInjection {id} not found");
         entity.DeletedAt = null;
         await _context.SaveChangesAsync(ct);
-        return BasalInjectionMapper.ToDomainModel(entity);
+        // A restored record reappears in the dataset: broadcast it as a create so clients re-add it.
+        var restored = BasalInjectionMapper.ToDomainModel(entity);
+        await RaiseBroadcastAsync([restored], [], [], origin, ct);
+        return restored;
     }
 
     /// <inheritdoc />
@@ -183,7 +211,9 @@ public class BasalInjectionRepository : IBasalInjectionRepository
         foreach (var entity in entities)
             entity.DeletedAt = null;
         await _context.SaveChangesAsync(ct);
-        return entities.Select(BasalInjectionMapper.ToDomainModel);
+        var restored = entities.Select(BasalInjectionMapper.ToDomainModel).ToList();
+        await RaiseBroadcastAsync(restored, [], [], origin, ct);
+        return restored;
     }
 
     /// <inheritdoc />
@@ -350,7 +380,12 @@ public class BasalInjectionRepository : IBasalInjectionRepository
             }
 
             await tx.CommitAsync(ct);
-            return updatedEntities.Concat(entities).Select(BasalInjectionMapper.ToDomainModel);
+            // Inserts broadcast as create; in-place upserts broadcast as update (unconditionally —
+            // no material-change diffing on this off-base path).
+            var insertedModels = entities.Select(BasalInjectionMapper.ToDomainModel).ToList();
+            var updatedModels = updatedEntities.Select(BasalInjectionMapper.ToDomainModel).ToList();
+            await RaiseBroadcastAsync(insertedModels, updatedModels, [], origin, ct);
+            return updatedModels.Concat(insertedModels);
         });
     }
 
@@ -368,6 +403,7 @@ public class BasalInjectionRepository : IBasalInjectionRepository
             entity.DeletedAt = now;
 
         await _context.SaveChangesAsync(ct);
+        await RaiseBroadcastAsync([], [], entities.Select(e => e.Id).ToList(), origin, ct);
         return entities.Count;
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
@@ -6,6 +6,7 @@ using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
@@ -104,7 +105,7 @@ public class BasalInjectionRepository : IBasalInjectionRepository
     /// <param name="model">The basal injection to create.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The created or updated basal injection record.</returns>
-    public async Task<BasalInjection> CreateAsync(BasalInjection model, CancellationToken ct = default)
+    public async Task<BasalInjection> CreateAsync(BasalInjection model, WriteOrigin origin, CancellationToken ct = default)
     {
         if (!string.IsNullOrEmpty(model.DataSource) && !string.IsNullOrEmpty(model.SyncIdentifier))
         {
@@ -133,7 +134,7 @@ public class BasalInjectionRepository : IBasalInjectionRepository
     /// <param name="model">The updated record data.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The updated basal injection record.</returns>
-    public async Task<BasalInjection> UpdateAsync(Guid id, BasalInjection model, CancellationToken ct = default)
+    public async Task<BasalInjection> UpdateAsync(Guid id, BasalInjection model, WriteOrigin origin, CancellationToken ct = default)
     {
         var entity =
             await _context.BasalInjections.FirstOrDefaultAsync(e => e.Id == id, ct)
@@ -151,7 +152,7 @@ public class BasalInjectionRepository : IBasalInjectionRepository
     /// </summary>
     /// <param name="id">The unique identifier.</param>
     /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+    public async Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
     {
         var entity =
             await _context.BasalInjections.FirstOrDefaultAsync(e => e.Id == id, ct)
@@ -161,7 +162,7 @@ public class BasalInjectionRepository : IBasalInjectionRepository
     }
 
     /// <inheritdoc />
-    public async Task<BasalInjection> RestoreAsync(Guid id, CancellationToken ct = default)
+    public async Task<BasalInjection> RestoreAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
     {
         var entity = await _context.BasalInjections.IgnoreQueryFilters()
             .Where(e => e.TenantId == _context.TenantId && e.Id == id && e.DeletedAt != null)
@@ -173,7 +174,7 @@ public class BasalInjectionRepository : IBasalInjectionRepository
     }
 
     /// <inheritdoc />
-    public async Task<IEnumerable<BasalInjection>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    public async Task<IEnumerable<BasalInjection>> BulkRestoreAsync(IEnumerable<Guid> ids, WriteOrigin origin, CancellationToken ct = default)
     {
         var idSet = ids.ToHashSet();
         var entities = await _context.BasalInjections.IgnoreQueryFilters()
@@ -242,7 +243,7 @@ public class BasalInjectionRepository : IBasalInjectionRepository
     /// DeduplicationService participation (BasalInjection is LegacyId-only / SyncId-keyed, never
     /// cross-connector dedup-linked).
     /// </summary>
-    public async Task<IEnumerable<BasalInjection>> BulkCreateAsync(IEnumerable<BasalInjection> records, CancellationToken ct = default)
+    public async Task<IEnumerable<BasalInjection>> BulkCreateAsync(IEnumerable<BasalInjection> records, WriteOrigin origin, CancellationToken ct = default)
     {
         var strategy = _context.Database.CreateExecutionStrategy();
         return await strategy.ExecuteAsync(async () =>
@@ -353,7 +354,7 @@ public class BasalInjectionRepository : IBasalInjectionRepository
         });
     }
 
-    public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, CancellationToken ct = default)
+    public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, WriteOrigin origin, CancellationToken ct = default)
     {
         var entities = await _context.BasalInjections
             .Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalScheduleRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
@@ -26,8 +27,8 @@ public class BasalScheduleRepository : V4RepositoryBase<BasalSchedule, BasalSche
     /// <param name="auditContext">The audit context for tracking mutations.</param>
     /// <param name="logger">The logger instance.</param>
     // logger is unused for this LegacyId-only type but retained for DI + direct test construction.
-    public BasalScheduleRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext, ILogger<BasalScheduleRepository> logger)
-        : base(contextFactory, auditContext)
+    public BasalScheduleRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext, ILogger<BasalScheduleRepository> logger, IV4RecordBroadcaster<BasalSchedule>? broadcaster = null)
+        : base(contextFactory, auditContext, broadcaster)
     {
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalScheduleRepository.cs
@@ -7,6 +7,7 @@ using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
@@ -86,7 +87,7 @@ public class BasalScheduleRepository : V4RepositoryBase<BasalSchedule, BasalSche
     /// <param name="prefix">The legacy identifier prefix.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdPrefixAsync(string prefix, CancellationToken ct = default)
+    public async Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
@@ -9,6 +9,7 @@ using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
@@ -127,7 +128,7 @@ public class BolusCalculationRepository : V4RepositoryBase<BolusCalculation, Bol
     /// Insert-time deduplication: link saved records to canonical groups (runs after commit).
     /// </summary>
     protected override async Task PostCommitDedupAsync(
-        NocturneDbContext ctx, IReadOnlyList<BolusCalculationEntity> inserted, CancellationToken ct)
+        NocturneDbContext ctx, IReadOnlyList<BolusCalculationEntity> inserted, WriteOrigin origin, CancellationToken ct)
     {
         if (inserted.Count == 0)
             return;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.Infrastructure;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
@@ -36,9 +37,10 @@ public class BolusCalculationRepository : V4RepositoryBase<BolusCalculation, Bol
         ITenantDbContextFactory contextFactory,
         IDeduplicationService deduplicationService,
         IAuditContext auditContext,
-        ILogger<BolusCalculationRepository> logger
+        ILogger<BolusCalculationRepository> logger,
+        IV4RecordBroadcaster<BolusCalculation>? broadcaster = null
     )
-        : base(contextFactory, auditContext)
+        : base(contextFactory, auditContext, broadcaster)
     {
         _deduplicationService = deduplicationService;
         _logger = logger;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.Infrastructure;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
@@ -36,8 +37,9 @@ public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepos
         ITenantDbContextFactory contextFactory,
         IDeduplicationService deduplicationService,
         IAuditContext auditContext,
-        ILogger<BolusRepository> logger)
-        : base(contextFactory, auditContext)
+        ILogger<BolusRepository> logger,
+        IV4RecordBroadcaster<Bolus>? broadcaster = null)
+        : base(contextFactory, auditContext, broadcaster)
     {
         _deduplicationService = deduplicationService;
         _logger = logger;
@@ -167,14 +169,19 @@ public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepos
             {
                 BolusMapper.UpdateEntity(existing, model);
                 await ctx.SaveChangesAsync(ct);
-                return BolusMapper.ToDomainModel(existing);
+                var upserted = BolusMapper.ToDomainModel(existing);
+                // A single explicit upsert always broadcasts (no material-change gate on the single path).
+                await RaiseBroadcastAsync([], [upserted], [], origin, ct);
+                return upserted;
             }
         }
 
         var entity = BolusMapper.ToEntity(model);
         ctx.Boluses.Add(entity);
         await ctx.SaveChangesAsync(ct);
-        return BolusMapper.ToDomainModel(entity);
+        var created = BolusMapper.ToDomainModel(entity);
+        await RaiseBroadcastAsync([created], [], [], origin, ct);
+        return created;
     }
 
     /// <summary>
@@ -216,7 +223,7 @@ public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepos
     /// rows in the DB by that key and update them in place. Persists the updates inside the transaction
     /// before returning so the base's insert loop (which clears the tracker) doesn't lose them.
     /// </summary>
-    protected override async Task<(List<BolusEntity> Updated, List<BolusEntity> ToInsert)> SplitUpsertsAsync(
+    protected override async Task<UpsertSplit> SplitUpsertsAsync(
         NocturneDbContext ctx, List<BolusEntity> entities, CancellationToken ct)
     {
         // Intra-batch SyncIdentifier dedup: keep last occurrence per
@@ -237,8 +244,9 @@ public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepos
             .ToList();
 
         var updatedEntities = new List<BolusEntity>();
+        var materiallyChanged = new List<BolusEntity>();
         if (syncKeyed.Count == 0)
-            return (updatedEntities, entities);
+            return new UpsertSplit(updatedEntities, materiallyChanged, entities);
 
         var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
         var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
@@ -265,6 +273,9 @@ public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepos
                 var domain = BolusMapper.ToDomainModel(entity);
                 BolusMapper.UpdateEntity(existing, domain);
                 updatedEntities.Add(existing);
+                // Capture material changes now, before SaveChanges clears the modified flags.
+                if (HasMaterialChange(ctx, existing))
+                    materiallyChanged.Add(existing);
             }
             else
             {
@@ -278,7 +289,7 @@ public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepos
             await ctx.SaveChangesAsync(ct);
         }
 
-        return (updatedEntities, toInsert);
+        return new UpsertSplit(updatedEntities, materiallyChanged, toInsert);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
@@ -9,6 +9,7 @@ using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
@@ -153,7 +154,7 @@ public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepos
     /// <param name="model">The bolus to create.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The created or updated bolus record.</returns>
-    public override async Task<Bolus> CreateAsync(Bolus model, CancellationToken ct = default)
+    public override async Task<Bolus> CreateAsync(Bolus model, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         if (!string.IsNullOrEmpty(model.DataSource) && !string.IsNullOrEmpty(model.SyncIdentifier))
@@ -183,7 +184,7 @@ public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepos
     /// <param name="syncIdentifier">The external sync identifier.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, CancellationToken ct = default)
+    public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
@@ -287,7 +288,7 @@ public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepos
     /// linked when first inserted.
     /// </summary>
     protected override async Task PostCommitDedupAsync(
-        NocturneDbContext ctx, IReadOnlyList<BolusEntity> inserted, CancellationToken ct)
+        NocturneDbContext ctx, IReadOnlyList<BolusEntity> inserted, WriteOrigin origin, CancellationToken ct)
     {
         if (inserted.Count == 0)
             return;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CalibrationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CalibrationRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
@@ -23,8 +24,8 @@ public class CalibrationRepository : V4RepositoryBase<Calibration, CalibrationEn
     /// <param name="auditContext">The audit context for tracking mutations (used by the base soft-delete path).</param>
     /// <param name="logger">The logger instance.</param>
     // logger is unused for this LegacyId-only type but retained for DI + direct test construction.
-    public CalibrationRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext, ILogger<CalibrationRepository> logger)
-        : base(contextFactory, auditContext)
+    public CalibrationRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext, ILogger<CalibrationRepository> logger, IV4RecordBroadcaster<Calibration>? broadcaster = null)
+        : base(contextFactory, auditContext, broadcaster)
     {
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
@@ -9,6 +9,7 @@ using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
@@ -152,7 +153,7 @@ public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntit
     /// <param name="model">The carbohydrate intake to create.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The created or updated carbohydrate intake.</returns>
-    public override async Task<CarbIntake> CreateAsync(CarbIntake model, CancellationToken ct = default)
+    public override async Task<CarbIntake> CreateAsync(CarbIntake model, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         if (!string.IsNullOrEmpty(model.DataSource) && !string.IsNullOrEmpty(model.SyncIdentifier))
@@ -201,7 +202,7 @@ public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntit
     /// <param name="syncIdentifier">The external sync identifier.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, CancellationToken ct = default)
+    public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
@@ -286,7 +287,7 @@ public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntit
     /// linked when first inserted.
     /// </summary>
     protected override async Task PostCommitDedupAsync(
-        NocturneDbContext ctx, IReadOnlyList<CarbIntakeEntity> inserted, CancellationToken ct)
+        NocturneDbContext ctx, IReadOnlyList<CarbIntakeEntity> inserted, WriteOrigin origin, CancellationToken ct)
     {
         if (inserted.Count == 0)
             return;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.Infrastructure;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
@@ -37,8 +38,9 @@ public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntit
         ITenantDbContextFactory contextFactory,
         IDeduplicationService deduplicationService,
         IAuditContext auditContext,
-        ILogger<CarbIntakeRepository> logger)
-        : base(contextFactory, auditContext)
+        ILogger<CarbIntakeRepository> logger,
+        IV4RecordBroadcaster<CarbIntake>? broadcaster = null)
+        : base(contextFactory, auditContext, broadcaster)
     {
         _deduplicationService = deduplicationService;
         _logger = logger;
@@ -166,14 +168,19 @@ public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntit
             {
                 CarbIntakeMapper.UpdateEntity(existing, model);
                 await ctx.SaveChangesAsync(ct);
-                return CarbIntakeMapper.ToDomainModel(existing);
+                var upserted = CarbIntakeMapper.ToDomainModel(existing);
+                // A single explicit upsert always broadcasts (no material-change gate on the single path).
+                await RaiseBroadcastAsync([], [upserted], [], origin, ct);
+                return upserted;
             }
         }
 
         var entity = CarbIntakeMapper.ToEntity(model);
         ctx.CarbIntakes.Add(entity);
         await ctx.SaveChangesAsync(ct);
-        return CarbIntakeMapper.ToDomainModel(entity);
+        var created = CarbIntakeMapper.ToDomainModel(entity);
+        await RaiseBroadcastAsync([created], [], [], origin, ct);
+        return created;
     }
 
     /// <summary>
@@ -215,7 +222,7 @@ public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntit
     /// rows in the DB by that key and update them in place. Persists the updates inside the transaction
     /// before returning so the base's insert loop (which clears the tracker) doesn't lose them.
     /// </summary>
-    protected override async Task<(List<CarbIntakeEntity> Updated, List<CarbIntakeEntity> ToInsert)> SplitUpsertsAsync(
+    protected override async Task<UpsertSplit> SplitUpsertsAsync(
         NocturneDbContext ctx, List<CarbIntakeEntity> entities, CancellationToken ct)
     {
         // Intra-batch SyncIdentifier dedup: keep last occurrence per
@@ -236,8 +243,9 @@ public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntit
             .ToList();
 
         var updatedEntities = new List<CarbIntakeEntity>();
+        var materiallyChanged = new List<CarbIntakeEntity>();
         if (syncKeyed.Count == 0)
-            return (updatedEntities, entities);
+            return new UpsertSplit(updatedEntities, materiallyChanged, entities);
 
         var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
         var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
@@ -264,6 +272,9 @@ public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntit
                 var domain = CarbIntakeMapper.ToDomainModel(entity);
                 CarbIntakeMapper.UpdateEntity(existing, domain);
                 updatedEntities.Add(existing);
+                // Capture material changes now, before SaveChanges clears the modified flags.
+                if (HasMaterialChange(ctx, existing))
+                    materiallyChanged.Add(existing);
             }
             else
             {
@@ -277,7 +288,7 @@ public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntit
             await ctx.SaveChangesAsync(ct);
         }
 
-        return (updatedEntities, toInsert);
+        return new UpsertSplit(updatedEntities, materiallyChanged, toInsert);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbRatioScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbRatioScheduleRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
@@ -25,8 +26,8 @@ public class CarbRatioScheduleRepository : V4RepositoryBase<CarbRatioSchedule, C
     /// <param name="auditContext">The audit context for tracking mutations (used by the base soft-delete path).</param>
     /// <param name="logger">The logger instance.</param>
     // logger is unused for this LegacyId-only type but retained for DI + direct test construction.
-    public CarbRatioScheduleRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext, ILogger<CarbRatioScheduleRepository> logger)
-        : base(contextFactory, auditContext)
+    public CarbRatioScheduleRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext, ILogger<CarbRatioScheduleRepository> logger, IV4RecordBroadcaster<CarbRatioSchedule>? broadcaster = null)
+        : base(contextFactory, auditContext, broadcaster)
     {
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbRatioScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbRatioScheduleRepository.cs
@@ -6,6 +6,7 @@ using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
@@ -85,7 +86,7 @@ public class CarbRatioScheduleRepository : V4RepositoryBase<CarbRatioSchedule, C
     /// <param name="prefix">The legacy identifier prefix.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdPrefixAsync(string prefix, CancellationToken ct = default)
+    public async Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.Infrastructure;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
@@ -36,8 +37,9 @@ public class DeviceEventRepository : V4RepositoryBase<DeviceEvent, DeviceEventEn
         ITenantDbContextFactory contextFactory,
         IDeduplicationService deduplicationService,
         IAuditContext auditContext,
-        ILogger<DeviceEventRepository> logger)
-        : base(contextFactory, auditContext)
+        ILogger<DeviceEventRepository> logger,
+        IV4RecordBroadcaster<DeviceEvent>? broadcaster = null)
+        : base(contextFactory, auditContext, broadcaster)
     {
         _deduplicationService = deduplicationService;
         _logger = logger;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
@@ -9,6 +9,7 @@ using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
@@ -142,7 +143,7 @@ public class DeviceEventRepository : V4RepositoryBase<DeviceEvent, DeviceEventEn
     /// <param name="syncIdentifier">The external sync identifier.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, CancellationToken ct = default)
+    public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
@@ -154,7 +155,7 @@ public class DeviceEventRepository : V4RepositoryBase<DeviceEvent, DeviceEventEn
     /// Insert-time deduplication: link saved records to canonical groups (runs after commit).
     /// </summary>
     protected override async Task PostCommitDedupAsync(
-        NocturneDbContext ctx, IReadOnlyList<DeviceEventEntity> inserted, CancellationToken ct)
+        NocturneDbContext ctx, IReadOnlyList<DeviceEventEntity> inserted, WriteOrigin origin, CancellationToken ct)
     {
         if (inserted.Count == 0)
             return;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceRepository.cs
@@ -3,6 +3,7 @@ using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
@@ -58,7 +59,7 @@ public class DeviceRepository : IDeviceRepository
     /// <param name="model">The device to create.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The created device.</returns>
-    public async Task<Device> CreateAsync(Device model, CancellationToken ct = default)
+    public async Task<Device> CreateAsync(Device model, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = DeviceMapper.ToEntity(model);
@@ -74,7 +75,7 @@ public class DeviceRepository : IDeviceRepository
     /// <param name="model">The updated device data.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The updated device.</returns>
-    public async Task<Device> UpdateAsync(Guid id, Device model, CancellationToken ct = default)
+    public async Task<Device> UpdateAsync(Guid id, Device model, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity =

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceStatusExtrasRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceStatusExtrasRepository.cs
@@ -4,6 +4,7 @@ using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
@@ -29,7 +30,7 @@ public class DeviceStatusExtrasRepository : IDeviceStatusExtrasRepository
     /// <param name="model">The device status extras to create.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The created device status extras.</returns>
-    public async Task<DeviceStatusExtras> CreateAsync(DeviceStatusExtras model, CancellationToken ct = default)
+    public async Task<DeviceStatusExtras> CreateAsync(DeviceStatusExtras model, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = DeviceStatusExtrasMapper.ToEntity(model);
@@ -75,7 +76,7 @@ public class DeviceStatusExtrasRepository : IDeviceStatusExtrasRepository
     /// <inheritdoc />
     public async Task<IEnumerable<DeviceStatusExtras>> BulkCreateAsync(
         IEnumerable<DeviceStatusExtras> records,
-        CancellationToken ct = default)
+        WriteOrigin origin, CancellationToken ct = default)
     {
         var entities = records.Select(DeviceStatusExtrasMapper.ToEntity).ToList();
         if (entities.Count == 0)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/MeterGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/MeterGlucoseRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
@@ -24,8 +25,8 @@ public class MeterGlucoseRepository : V4RepositoryBase<MeterGlucose, MeterGlucos
     /// <param name="auditContext">The audit context for tracking mutations (used by the base soft-delete path).</param>
     /// <param name="logger">The logger instance.</param>
     // logger is unused for this LegacyId-only type but retained for DI + direct test construction.
-    public MeterGlucoseRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext, ILogger<MeterGlucoseRepository> logger)
-        : base(contextFactory, auditContext)
+    public MeterGlucoseRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext, ILogger<MeterGlucoseRepository> logger, IV4RecordBroadcaster<MeterGlucose>? broadcaster = null)
+        : base(contextFactory, auditContext, broadcaster)
     {
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
@@ -9,6 +9,7 @@ using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
@@ -142,7 +143,7 @@ public class NoteRepository : V4RepositoryBase<Note, NoteEntity>, INoteRepositor
     /// <param name="syncIdentifier">The external sync identifier.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, CancellationToken ct = default)
+    public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.Notes.Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier)
@@ -153,7 +154,7 @@ public class NoteRepository : V4RepositoryBase<Note, NoteEntity>, INoteRepositor
     /// Insert-time deduplication: link saved records to canonical groups (runs after commit).
     /// </summary>
     protected override async Task PostCommitDedupAsync(
-        NocturneDbContext ctx, IReadOnlyList<NoteEntity> inserted, CancellationToken ct)
+        NocturneDbContext ctx, IReadOnlyList<NoteEntity> inserted, WriteOrigin origin, CancellationToken ct)
     {
         if (inserted.Count == 0)
             return;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.Infrastructure;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
@@ -36,8 +37,9 @@ public class NoteRepository : V4RepositoryBase<Note, NoteEntity>, INoteRepositor
         ITenantDbContextFactory contextFactory,
         IDeduplicationService deduplicationService,
         IAuditContext auditContext,
-        ILogger<NoteRepository> logger)
-        : base(contextFactory, auditContext)
+        ILogger<NoteRepository> logger,
+        IV4RecordBroadcaster<Note>? broadcaster = null)
+        : base(contextFactory, auditContext, broadcaster)
     {
         _deduplicationService = deduplicationService;
         _logger = logger;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PatientDeviceRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PatientDeviceRepository.cs
@@ -4,6 +4,7 @@ using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
@@ -121,7 +122,7 @@ public class PatientDeviceRepository : IPatientDeviceRepository
     /// <param name="model">The patient device to create.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The created patient device record.</returns>
-    public async Task<PatientDevice> CreateAsync(PatientDevice model, CancellationToken ct = default)
+    public async Task<PatientDevice> CreateAsync(PatientDevice model, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = PatientDeviceMapper.ToEntity(model);
@@ -137,7 +138,7 @@ public class PatientDeviceRepository : IPatientDeviceRepository
     /// <param name="model">The updated record data.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The updated patient device record.</returns>
-    public async Task<PatientDevice> UpdateAsync(Guid id, PatientDevice model, CancellationToken ct = default)
+    public async Task<PatientDevice> UpdateAsync(Guid id, PatientDevice model, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.PatientDevices.FindAsync([id], ct)
@@ -153,7 +154,7 @@ public class PatientDeviceRepository : IPatientDeviceRepository
     /// </summary>
     /// <param name="id">The unique identifier.</param>
     /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+    public async Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.PatientDevices.FindAsync([id], ct)
@@ -164,7 +165,7 @@ public class PatientDeviceRepository : IPatientDeviceRepository
     }
 
     /// <inheritdoc />
-    public async Task<PatientDevice> RestoreAsync(Guid id, CancellationToken ct = default)
+    public async Task<PatientDevice> RestoreAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.PatientDevices.IgnoreQueryFilters()
@@ -177,7 +178,7 @@ public class PatientDeviceRepository : IPatientDeviceRepository
     }
 
     /// <inheritdoc />
-    public async Task<IEnumerable<PatientDevice>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    public async Task<IEnumerable<PatientDevice>> BulkRestoreAsync(IEnumerable<Guid> ids, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var idSet = ids.ToHashSet();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PatientInsulinRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PatientInsulinRepository.cs
@@ -4,6 +4,7 @@ using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
@@ -81,7 +82,7 @@ public class PatientInsulinRepository : IPatientInsulinRepository
     /// <param name="model">The patient insulin to create.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The created patient insulin record.</returns>
-    public async Task<PatientInsulin> CreateAsync(PatientInsulin model, CancellationToken ct = default)
+    public async Task<PatientInsulin> CreateAsync(PatientInsulin model, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = PatientInsulinMapper.ToEntity(model);
@@ -97,7 +98,7 @@ public class PatientInsulinRepository : IPatientInsulinRepository
     /// <param name="model">The updated record data.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The updated patient insulin record.</returns>
-    public async Task<PatientInsulin> UpdateAsync(Guid id, PatientInsulin model, CancellationToken ct = default)
+    public async Task<PatientInsulin> UpdateAsync(Guid id, PatientInsulin model, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.PatientInsulins.FindAsync([id], ct)
@@ -113,7 +114,7 @@ public class PatientInsulinRepository : IPatientInsulinRepository
     /// </summary>
     /// <param name="id">The unique identifier.</param>
     /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+    public async Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.PatientInsulins.FindAsync([id], ct)
@@ -124,7 +125,7 @@ public class PatientInsulinRepository : IPatientInsulinRepository
     }
 
     /// <inheritdoc />
-    public async Task<PatientInsulin> RestoreAsync(Guid id, CancellationToken ct = default)
+    public async Task<PatientInsulin> RestoreAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.PatientInsulins.IgnoreQueryFilters()
@@ -137,7 +138,7 @@ public class PatientInsulinRepository : IPatientInsulinRepository
     }
 
     /// <inheritdoc />
-    public async Task<IEnumerable<PatientInsulin>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    public async Task<IEnumerable<PatientInsulin>> BulkRestoreAsync(IEnumerable<Guid> ids, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var idSet = ids.ToHashSet();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PatientRecordRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PatientRecordRepository.cs
@@ -4,6 +4,7 @@ using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
@@ -78,7 +79,7 @@ public class PatientRecordRepository : IPatientRecordRepository
     /// <param name="model">The updated patient record data.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The updated patient record.</returns>
-    public async Task<PatientRecord> UpdateAsync(PatientRecord model, CancellationToken ct = default)
+    public async Task<PatientRecord> UpdateAsync(PatientRecord model, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.PatientRecords.FirstOrDefaultAsync(ct)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
@@ -6,6 +6,7 @@ using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
@@ -111,7 +112,7 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
     /// <param name="model">The pump snapshot to create.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The created pump snapshot.</returns>
-    public async Task<PumpSnapshot> CreateAsync(PumpSnapshot model, CancellationToken ct = default)
+    public async Task<PumpSnapshot> CreateAsync(PumpSnapshot model, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = PumpSnapshotMapper.ToEntity(model);
@@ -127,7 +128,7 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
     /// <param name="model">The updated snapshot data.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The updated pump snapshot.</returns>
-    public async Task<PumpSnapshot> UpdateAsync(Guid id, PumpSnapshot model, CancellationToken ct = default)
+    public async Task<PumpSnapshot> UpdateAsync(Guid id, PumpSnapshot model, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.PumpSnapshots.FindAsync([id], ct)
@@ -142,7 +143,7 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
     /// </summary>
     /// <param name="id">The unique identifier.</param>
     /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+    public async Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.PumpSnapshots.FindAsync([id], ct)
@@ -152,7 +153,7 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
     }
 
     /// <inheritdoc />
-    public async Task<PumpSnapshot> RestoreAsync(Guid id, CancellationToken ct = default)
+    public async Task<PumpSnapshot> RestoreAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.PumpSnapshots.IgnoreQueryFilters()
@@ -165,7 +166,7 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
     }
 
     /// <inheritdoc />
-    public async Task<IEnumerable<PumpSnapshot>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    public async Task<IEnumerable<PumpSnapshot>> BulkRestoreAsync(IEnumerable<Guid> ids, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var idSet = ids.ToHashSet();
@@ -243,7 +244,7 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
     /// <param name="legacyId">The legacy identifier.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
+    public async Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         return await ctx.PumpSnapshots
@@ -254,7 +255,7 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
     /// <inheritdoc />
     public async Task<IEnumerable<PumpSnapshot>> BulkCreateAsync(
         IEnumerable<PumpSnapshot> records,
-        CancellationToken ct = default)
+        WriteOrigin origin, CancellationToken ct = default)
     {
         var entities = records.Select(PumpSnapshotMapper.ToEntity).ToList();
         if (entities.Count == 0)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensitivityScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensitivityScheduleRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
@@ -25,8 +26,8 @@ public class SensitivityScheduleRepository : V4RepositoryBase<SensitivitySchedul
     /// <param name="auditContext">The audit context for tracking mutations (used by the base soft-delete path).</param>
     /// <param name="logger">The logger instance.</param>
     // logger is unused for this LegacyId-only type but retained for DI + direct test construction.
-    public SensitivityScheduleRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext, ILogger<SensitivityScheduleRepository> logger)
-        : base(contextFactory, auditContext)
+    public SensitivityScheduleRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext, ILogger<SensitivityScheduleRepository> logger, IV4RecordBroadcaster<SensitivitySchedule>? broadcaster = null)
+        : base(contextFactory, auditContext, broadcaster)
     {
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensitivityScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensitivityScheduleRepository.cs
@@ -6,6 +6,7 @@ using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
@@ -85,7 +86,7 @@ public class SensitivityScheduleRepository : V4RepositoryBase<SensitivitySchedul
     /// <param name="prefix">The legacy identifier prefix.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdPrefixAsync(string prefix, CancellationToken ct = default)
+    public async Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.Infrastructure;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
@@ -36,9 +37,10 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
         ITenantDbContextFactory contextFactory,
         IDeduplicationService deduplicationService,
         IAuditContext auditContext,
-        ILogger<SensorGlucoseRepository> logger
+        ILogger<SensorGlucoseRepository> logger,
+        IV4RecordBroadcaster<SensorGlucose>? broadcaster = null
     )
-        : base(contextFactory, auditContext)
+        : base(contextFactory, auditContext, broadcaster)
     {
         _deduplicationService = deduplicationService;
         _logger = logger;
@@ -164,14 +166,19 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
             {
                 SensorGlucoseMapper.UpdateEntity(existing, model);
                 await ctx.SaveChangesAsync(ct);
-                return SensorGlucoseMapper.ToDomainModel(existing);
+                var upserted = SensorGlucoseMapper.ToDomainModel(existing);
+                // A single explicit upsert always broadcasts (no material-change gate on the single path).
+                await RaiseBroadcastAsync([], [upserted], [], origin, ct);
+                return upserted;
             }
         }
 
         var entity = SensorGlucoseMapper.ToEntity(model);
         ctx.SensorGlucose.Add(entity);
         await ctx.SaveChangesAsync(ct);
-        return SensorGlucoseMapper.ToDomainModel(entity);
+        var created = SensorGlucoseMapper.ToDomainModel(entity);
+        await RaiseBroadcastAsync([created], [], [], origin, ct);
+        return created;
     }
 
     /// <summary>
@@ -199,7 +206,7 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
     /// timestamp instead of duplicating it. Persists the updates inside the transaction before returning
     /// so the base's insert loop (which clears the tracker) doesn't lose them. Mirrors BolusRepository.
     /// </summary>
-    protected override async Task<(List<SensorGlucoseEntity> Updated, List<SensorGlucoseEntity> ToInsert)> SplitUpsertsAsync(
+    protected override async Task<UpsertSplit> SplitUpsertsAsync(
         NocturneDbContext ctx, List<SensorGlucoseEntity> entities, CancellationToken ct)
     {
         // Intra-batch SyncIdentifier dedup: keep last occurrence per (DataSource, SyncIdentifier).
@@ -214,12 +221,13 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
         // DB-level SyncIdentifier upsert: rows matched by (DataSource, SyncIdentifier) are updated
         // in place. Everything else falls through to the LegacyId/insert path below.
         var updatedEntities = new List<SensorGlucoseEntity>();
+        var materiallyChanged = new List<SensorGlucoseEntity>();
         var syncKeyed = entities
             .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
             .ToList();
 
         if (syncKeyed.Count == 0)
-            return (updatedEntities, entities);
+            return new UpsertSplit(updatedEntities, materiallyChanged, entities);
 
         var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
         var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
@@ -243,6 +251,9 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
                 var domain = SensorGlucoseMapper.ToDomainModel(entity);
                 SensorGlucoseMapper.UpdateEntity(existing, domain);
                 updatedEntities.Add(existing);
+                // Capture material changes now, before SaveChanges clears the modified flags.
+                if (HasMaterialChange(ctx, existing))
+                    materiallyChanged.Add(existing);
             }
             else
             {
@@ -253,7 +264,7 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
         if (updatedEntities.Count > 0)
             await ctx.SaveChangesAsync(ct);
 
-        return (updatedEntities, toInsert);
+        return new UpsertSplit(updatedEntities, materiallyChanged, toInsert);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -9,6 +9,7 @@ using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
@@ -150,7 +151,7 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
     /// <param name="model">The sensor glucose record to create.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The created or updated sensor glucose record.</returns>
-    public override async Task<SensorGlucose> CreateAsync(SensorGlucose model, CancellationToken ct = default)
+    public override async Task<SensorGlucose> CreateAsync(SensorGlucose model, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         if (!string.IsNullOrEmpty(model.DataSource) && !string.IsNullOrEmpty(model.SyncIdentifier))
@@ -262,7 +263,7 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
     /// rows skip self-relinking and add no match candidates.
     /// </summary>
     protected override async Task PostCommitDedupAsync(
-        NocturneDbContext ctx, IReadOnlyList<SensorGlucoseEntity> inserted, CancellationToken ct)
+        NocturneDbContext ctx, IReadOnlyList<SensorGlucoseEntity> inserted, WriteOrigin origin, CancellationToken ct)
     {
         if (inserted.Count == 0) return;
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TargetRangeScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TargetRangeScheduleRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
@@ -25,8 +26,8 @@ public class TargetRangeScheduleRepository : V4RepositoryBase<TargetRangeSchedul
     /// <param name="auditContext">The audit context for tracking mutations (used by the base soft-delete path).</param>
     /// <param name="logger">The logger instance.</param>
     // logger is unused for this LegacyId-only type but retained for DI + direct test construction.
-    public TargetRangeScheduleRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext, ILogger<TargetRangeScheduleRepository> logger)
-        : base(contextFactory, auditContext)
+    public TargetRangeScheduleRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext, ILogger<TargetRangeScheduleRepository> logger, IV4RecordBroadcaster<TargetRangeSchedule>? broadcaster = null)
+        : base(contextFactory, auditContext, broadcaster)
     {
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TargetRangeScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TargetRangeScheduleRepository.cs
@@ -6,6 +6,7 @@ using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
@@ -85,7 +86,7 @@ public class TargetRangeScheduleRepository : V4RepositoryBase<TargetRangeSchedul
     /// <param name="prefix">The legacy identifier prefix.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdPrefixAsync(string prefix, CancellationToken ct = default)
+    public async Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.Infrastructure;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
@@ -23,6 +24,7 @@ public class TempBasalRepository : ITempBasalRepository
     private readonly IDeduplicationService _deduplicationService;
     private readonly IAuditContext _auditContext;
     private readonly ILogger<TempBasalRepository> _logger;
+    private readonly IV4RecordBroadcaster<TempBasal>? _broadcaster;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TempBasalRepository"/> class.
@@ -31,17 +33,32 @@ public class TempBasalRepository : ITempBasalRepository
     /// <param name="deduplicationService">The deduplication service.</param>
     /// <param name="auditContext">The audit context for tracking mutations.</param>
     /// <param name="logger">The logger instance.</param>
+    /// <param name="broadcaster">Optional native V4 broadcaster; null disables broadcasting.</param>
     public TempBasalRepository(
         ITenantDbContextFactory contextFactory,
         IDeduplicationService deduplicationService,
         IAuditContext auditContext,
-        ILogger<TempBasalRepository> logger)
+        ILogger<TempBasalRepository> logger,
+        IV4RecordBroadcaster<TempBasal>? broadcaster = null)
     {
         _contextFactory = contextFactory;
         _deduplicationService = deduplicationService;
         _auditContext = auditContext;
         _logger = logger;
+        _broadcaster = broadcaster;
     }
+
+    /// <summary>
+    /// Fires the native V4 broadcast for a just-committed write — but only for <see cref="WriteOrigin.Live"/>
+    /// writes (backfill imports stay silent). Mirrors the gate in <c>V4RepositoryBase.RaiseBroadcastAsync</c>.
+    /// </summary>
+    private Task RaiseBroadcastAsync(
+        IReadOnlyList<TempBasal> created,
+        IReadOnlyList<TempBasal> updated,
+        IReadOnlyList<Guid> deletedIds,
+        WriteOrigin origin,
+        CancellationToken ct)
+        => V4RecordBroadcast.RaiseAsync(_broadcaster, created, updated, deletedIds, origin, ct);
 
     /// <summary>
     /// Gets temporary basal records based on filter criteria.
@@ -127,7 +144,9 @@ public class TempBasalRepository : ITempBasalRepository
         var entity = TempBasalMapper.ToEntity(model);
         ctx.TempBasals.Add(entity);
         await ctx.SaveChangesAsync(ct);
-        return TempBasalMapper.ToDomainModel(entity);
+        var created = TempBasalMapper.ToDomainModel(entity);
+        await RaiseBroadcastAsync([created], [], [], origin, ct);
+        return created;
     }
 
     /// <summary>
@@ -145,7 +164,9 @@ public class TempBasalRepository : ITempBasalRepository
             ?? throw new KeyNotFoundException($"TempBasal {id} not found");
         TempBasalMapper.UpdateEntity(entity, model);
         await ctx.SaveChangesAsync(ct);
-        return TempBasalMapper.ToDomainModel(entity);
+        var updated = TempBasalMapper.ToDomainModel(entity);
+        await RaiseBroadcastAsync([], [updated], [], origin, ct);
+        return updated;
     }
 
     /// <summary>
@@ -161,6 +182,7 @@ public class TempBasalRepository : ITempBasalRepository
             ?? throw new KeyNotFoundException($"TempBasal {id} not found");
         entity.DeletedAt = DateTime.UtcNow;
         await ctx.SaveChangesAsync(ct);
+        await RaiseBroadcastAsync([], [], [id], origin, ct);
     }
 
     /// <inheritdoc />
@@ -173,7 +195,10 @@ public class TempBasalRepository : ITempBasalRepository
             ?? throw new KeyNotFoundException($"Soft-deleted TempBasal {id} not found");
         entity.DeletedAt = null;
         await ctx.SaveChangesAsync(ct);
-        return TempBasalMapper.ToDomainModel(entity);
+        // A restored record reappears in the dataset: broadcast it as a create so clients re-add it.
+        var restored = TempBasalMapper.ToDomainModel(entity);
+        await RaiseBroadcastAsync([restored], [], [], origin, ct);
+        return restored;
     }
 
     /// <inheritdoc />
@@ -187,7 +212,9 @@ public class TempBasalRepository : ITempBasalRepository
         foreach (var entity in entities)
             entity.DeletedAt = null;
         await ctx.SaveChangesAsync(ct);
-        return entities.Select(TempBasalMapper.ToDomainModel);
+        var restored = entities.Select(TempBasalMapper.ToDomainModel).ToList();
+        await RaiseBroadcastAsync(restored, [], [], origin, ct);
+        return restored;
     }
 
     /// <inheritdoc />
@@ -221,8 +248,10 @@ public class TempBasalRepository : ITempBasalRepository
     public async Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.AuditedSoftDeleteAsync(
+        var deletedIds = await ctx.AuditedSoftDeleteWithIdsAsync(
             ctx.TempBasals.Where(e => e.LegacyId == legacyId), _auditContext, ct);
+        await RaiseBroadcastAsync([], [], deletedIds, origin, ct);
+        return deletedIds.Count;
     }
 
     /// <summary>
@@ -333,7 +362,9 @@ public class TempBasalRepository : ITempBasalRepository
                 _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "TempBasal", entities.Count);
             }
 
-            return entities.Select(TempBasalMapper.ToDomainModel);
+            var created = entities.Select(TempBasalMapper.ToDomainModel).ToList();
+            await RaiseBroadcastAsync(created, [], [], origin, ct);
+            return created;
         });
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
@@ -9,6 +9,7 @@ using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
@@ -120,7 +121,7 @@ public class TempBasalRepository : ITempBasalRepository
     /// <param name="model">The temporary basal record to create.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The created temporary basal record.</returns>
-    public async Task<TempBasal> CreateAsync(TempBasal model, CancellationToken ct = default)
+    public async Task<TempBasal> CreateAsync(TempBasal model, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = TempBasalMapper.ToEntity(model);
@@ -136,7 +137,7 @@ public class TempBasalRepository : ITempBasalRepository
     /// <param name="model">The updated record data.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The updated temporary basal record.</returns>
-    public async Task<TempBasal> UpdateAsync(Guid id, TempBasal model, CancellationToken ct = default)
+    public async Task<TempBasal> UpdateAsync(Guid id, TempBasal model, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity =
@@ -152,7 +153,7 @@ public class TempBasalRepository : ITempBasalRepository
     /// </summary>
     /// <param name="id">The unique identifier.</param>
     /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+    public async Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity =
@@ -163,7 +164,7 @@ public class TempBasalRepository : ITempBasalRepository
     }
 
     /// <inheritdoc />
-    public async Task<TempBasal> RestoreAsync(Guid id, CancellationToken ct = default)
+    public async Task<TempBasal> RestoreAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.TempBasals.IgnoreQueryFilters()
@@ -176,7 +177,7 @@ public class TempBasalRepository : ITempBasalRepository
     }
 
     /// <inheritdoc />
-    public async Task<IEnumerable<TempBasal>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    public async Task<IEnumerable<TempBasal>> BulkRestoreAsync(IEnumerable<Guid> ids, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var idSet = ids.ToHashSet();
@@ -217,7 +218,7 @@ public class TempBasalRepository : ITempBasalRepository
     /// <param name="legacyId">The legacy identifier.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
+    public async Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
@@ -263,7 +264,7 @@ public class TempBasalRepository : ITempBasalRepository
     /// <returns>A collection of created records.</returns>
     public async Task<IEnumerable<TempBasal>> BulkCreateAsync(
         IEnumerable<TempBasal> records,
-        CancellationToken ct = default
+        WriteOrigin origin, CancellationToken ct = default
     )
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TherapySettingsRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TherapySettingsRepository.cs
@@ -6,6 +6,7 @@ using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
@@ -85,7 +86,7 @@ public class TherapySettingsRepository : V4RepositoryBase<TherapySettings, Thera
     /// <param name="prefix">The legacy identifier prefix.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdPrefixAsync(string prefix, CancellationToken ct = default)
+    public async Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TherapySettingsRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TherapySettingsRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
@@ -25,8 +26,8 @@ public class TherapySettingsRepository : V4RepositoryBase<TherapySettings, Thera
     /// <param name="auditContext">The audit context for tracking mutations (used by the base soft-delete path).</param>
     /// <param name="logger">The logger instance.</param>
     // logger is unused for this LegacyId-only type but retained for DI + direct test construction.
-    public TherapySettingsRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext, ILogger<TherapySettingsRepository> logger)
-        : base(contextFactory, auditContext)
+    public TherapySettingsRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext, ILogger<TherapySettingsRepository> logger, IV4RecordBroadcaster<TherapySettings>? broadcaster = null)
+        : base(contextFactory, auditContext, broadcaster)
     {
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
@@ -6,6 +6,7 @@ using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
@@ -87,7 +88,7 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
     /// <param name="model">The uploader snapshot to create.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The created uploader snapshot.</returns>
-    public async Task<UploaderSnapshot> CreateAsync(UploaderSnapshot model, CancellationToken ct = default)
+    public async Task<UploaderSnapshot> CreateAsync(UploaderSnapshot model, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = UploaderSnapshotMapper.ToEntity(model);
@@ -103,7 +104,7 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
     /// <param name="model">The updated snapshot data.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The updated uploader snapshot.</returns>
-    public async Task<UploaderSnapshot> UpdateAsync(Guid id, UploaderSnapshot model, CancellationToken ct = default)
+    public async Task<UploaderSnapshot> UpdateAsync(Guid id, UploaderSnapshot model, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.UploaderSnapshots.FindAsync([id], ct)
@@ -118,7 +119,7 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
     /// </summary>
     /// <param name="id">The unique identifier.</param>
     /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+    public async Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.UploaderSnapshots.FindAsync([id], ct)
@@ -128,7 +129,7 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
     }
 
     /// <inheritdoc />
-    public async Task<UploaderSnapshot> RestoreAsync(Guid id, CancellationToken ct = default)
+    public async Task<UploaderSnapshot> RestoreAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.UploaderSnapshots.IgnoreQueryFilters()
@@ -141,7 +142,7 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
     }
 
     /// <inheritdoc />
-    public async Task<IEnumerable<UploaderSnapshot>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    public async Task<IEnumerable<UploaderSnapshot>> BulkRestoreAsync(IEnumerable<Guid> ids, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var idSet = ids.ToHashSet();
@@ -219,7 +220,7 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
     /// <param name="legacyId">The legacy identifier.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
+    public async Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         return await ctx.UploaderSnapshots
@@ -244,7 +245,7 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
     /// <inheritdoc />
     public async Task<IEnumerable<UploaderSnapshot>> BulkCreateAsync(
         IEnumerable<UploaderSnapshot> records,
-        CancellationToken ct = default)
+        WriteOrigin origin, CancellationToken ct = default)
     {
         var entities = records.Select(UploaderSnapshotMapper.ToEntity).ToList();
         if (entities.Count == 0)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4MaterialChange.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4MaterialChange.cs
@@ -20,16 +20,11 @@ internal static class V4MaterialChange
     /// <summary>True if the tracked entity has at least one material (non-PK, non-[AuditIgnored]) modified property.</summary>
     public static bool HasMaterialChange(EntityEntry entry)
     {
-        foreach (var prop in entry.Properties)
-        {
-            if (!prop.IsModified || prop.Metadata.IsPrimaryKey())
-                continue;
-            if (IsAuditIgnored(entry.Entity.GetType(), prop.Metadata.Name))
-                continue;
-            return true;
-        }
-
-        return false;
+        var entityType = entry.Entity.GetType();
+        return entry.Properties.Any(prop =>
+            prop.IsModified
+            && !prop.Metadata.IsPrimaryKey()
+            && !IsAuditIgnored(entityType, prop.Metadata.Name));
     }
 
     private static bool IsAuditIgnored(Type entityType, string propertyName)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4MaterialChange.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4MaterialChange.cs
@@ -1,0 +1,39 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Nocturne.Infrastructure.Data.Entities;
+
+namespace Nocturne.Infrastructure.Data.Repositories.V4;
+
+/// <summary>
+/// Decides whether an upserted-in-place entity changed materially — i.e. worth broadcasting as an
+/// <c>update</c>. Uses the SAME predicate the <c>MutationAuditInterceptor</c> applies when deciding
+/// whether to write an audit row: some non-primary-key, non-<see cref="AuditIgnoredAttribute"/>
+/// property is modified. This keeps the invariant "we broadcast an update iff we audited a change", so
+/// connector re-polls that re-send byte-identical rows (no modified property) broadcast nothing, while
+/// genuine value/timestamp re-corrections do.
+/// </summary>
+internal static class V4MaterialChange
+{
+    private static readonly ConcurrentDictionary<(Type, string), bool> AuditIgnoredCache = new();
+
+    /// <summary>True if the tracked entity has at least one material (non-PK, non-[AuditIgnored]) modified property.</summary>
+    public static bool HasMaterialChange(EntityEntry entry)
+    {
+        foreach (var prop in entry.Properties)
+        {
+            if (!prop.IsModified || prop.Metadata.IsPrimaryKey())
+                continue;
+            if (IsAuditIgnored(entry.Entity.GetType(), prop.Metadata.Name))
+                continue;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsAuditIgnored(Type entityType, string propertyName)
+        => AuditIgnoredCache.GetOrAdd((entityType, propertyName), key =>
+            key.Item1.GetProperty(key.Item2, BindingFlags.Public | BindingFlags.Instance)
+                ?.GetCustomAttribute<AuditIgnoredAttribute>() is not null);
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RecordBroadcast.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RecordBroadcast.cs
@@ -1,0 +1,27 @@
+using Nocturne.Core.Contracts.Events;
+using Nocturne.Core.Contracts.V4;
+
+namespace Nocturne.Infrastructure.Data.Repositories.V4;
+
+/// <summary>
+/// The single origin-gated fan-out used by every V4 write chokepoint — <see cref="V4RepositoryBase{TModel,TEntity}"/>
+/// and the two off-base repositories (TempBasal, BasalInjection) that can't inherit it. Broadcasts only
+/// for <see cref="WriteOrigin.Live"/> writes (backfill stays silent) and no-ops when no broadcaster is wired.
+/// </summary>
+internal static class V4RecordBroadcast
+{
+    public static async Task RaiseAsync<TModel>(
+        IV4RecordBroadcaster<TModel>? broadcaster,
+        IReadOnlyList<TModel> created,
+        IReadOnlyList<TModel> updated,
+        IReadOnlyList<Guid> deletedIds,
+        WriteOrigin origin,
+        CancellationToken ct) where TModel : class
+    {
+        if (origin != WriteOrigin.Live || broadcaster is null)
+            return;
+        if (created.Count > 0) await broadcaster.BroadcastCreatedAsync(created, ct);
+        if (updated.Count > 0) await broadcaster.BroadcastUpdatedAsync(updated, ct);
+        if (deletedIds.Count > 0) await broadcaster.BroadcastDeletedAsync(deletedIds, ct);
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities;
@@ -38,12 +39,43 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     /// </summary>
     protected IAuditContext AuditContext { get; }
 
-    /// <summary>Initializes the base with the tenant-scoped context factory and audit context.</summary>
-    protected V4RepositoryBase(ITenantDbContextFactory contextFactory, IAuditContext auditContext)
+    /// <summary>
+    /// Broadcasts native V4 record shapes to the chokepoint's realtime category. Optional: when null
+    /// (e.g. a repo constructed without DI) writes simply broadcast nothing. Fired for live writes only —
+    /// the <see cref="WriteOrigin"/> gate is applied in <see cref="RaiseBroadcastAsync"/>.
+    /// </summary>
+    private readonly IV4RecordBroadcaster<TModel>? _broadcaster;
+
+    /// <summary>Initializes the base with the tenant-scoped context factory, audit context, and (optional) broadcaster.</summary>
+    protected V4RepositoryBase(
+        ITenantDbContextFactory contextFactory,
+        IAuditContext auditContext,
+        IV4RecordBroadcaster<TModel>? broadcaster = null)
     {
         ContextFactory = contextFactory;
         AuditContext = auditContext;
+        _broadcaster = broadcaster;
     }
+
+    /// <summary>
+    /// Fires the native V4 broadcast for a just-committed write — but only for <see cref="WriteOrigin.Live"/>
+    /// writes (backfill imports stay silent so clients aren't flooded). The single gate every mutating
+    /// method routes through, so the origin rule lives in exactly one place.
+    /// </summary>
+    protected Task RaiseBroadcastAsync(
+        IReadOnlyList<TModel> created,
+        IReadOnlyList<TModel> updated,
+        IReadOnlyList<Guid> deletedIds,
+        WriteOrigin origin,
+        CancellationToken ct)
+        => V4RecordBroadcast.RaiseAsync(_broadcaster, created, updated, deletedIds, origin, ct);
+
+    /// <summary>
+    /// True if an upserted-in-place tracked entity changed materially (worth an <c>update</c> broadcast).
+    /// Same predicate the audit interceptor uses, so "broadcast update" ⟺ "audited change".
+    /// </summary>
+    protected static bool HasMaterialChange(NocturneDbContext ctx, TEntity entity)
+        => V4MaterialChange.HasMaterialChange(ctx.Entry(entity));
 
     // ── Per-type static-mapper bridges (the only code the base needs from each repository) ──
 
@@ -102,7 +134,9 @@ public abstract class V4RepositoryBase<TModel, TEntity>
         var entity = ToEntity(model);
         ctx.Set<TEntity>().Add(entity);
         await ctx.SaveChangesAsync(ct);
-        return ToDomain(entity);
+        var created = ToDomain(entity);
+        await RaiseBroadcastAsync([created], [], [], origin, ct);
+        return created;
     }
 
     /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.UpdateAsync" />
@@ -113,7 +147,10 @@ public abstract class V4RepositoryBase<TModel, TEntity>
             ?? throw new KeyNotFoundException($"{typeof(TModel).Name} {id} not found");
         ApplyUpdate(entity, model);
         await ctx.SaveChangesAsync(ct);
-        return ToDomain(entity);
+        var updated = ToDomain(entity);
+        // A single explicit update is always a material change worth broadcasting.
+        await RaiseBroadcastAsync([], [updated], [], origin, ct);
+        return updated;
     }
 
     /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.DeleteAsync" />
@@ -124,6 +161,7 @@ public abstract class V4RepositoryBase<TModel, TEntity>
             ?? throw new KeyNotFoundException($"{typeof(TModel).Name} {id} not found");
         entity.DeletedAt = DateTime.UtcNow;
         await ctx.SaveChangesAsync(ct);
+        await RaiseBroadcastAsync([], [], [id], origin, ct);
     }
 
     /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.RestoreAsync" />
@@ -136,7 +174,10 @@ public abstract class V4RepositoryBase<TModel, TEntity>
             ?? throw new KeyNotFoundException($"Soft-deleted {typeof(TModel).Name} {id} not found");
         entity.DeletedAt = null;
         await ctx.SaveChangesAsync(ct);
-        return ToDomain(entity);
+        // A restored record reappears in the dataset: broadcast it as a create so clients re-add it.
+        var restored = ToDomain(entity);
+        await RaiseBroadcastAsync([restored], [], [], origin, ct);
+        return restored;
     }
 
     /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.BulkRestoreAsync" />
@@ -150,7 +191,9 @@ public abstract class V4RepositoryBase<TModel, TEntity>
         foreach (var entity in entities)
             entity.DeletedAt = null;
         await ctx.SaveChangesAsync(ct);
-        return entities.Select(ToDomain);
+        var restored = entities.Select(ToDomain).ToList();
+        await RaiseBroadcastAsync(restored, [], [], origin, ct);
+        return restored;
     }
 
     /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.GetDeletedAsync" />
@@ -202,8 +245,10 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     public virtual async Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
-        return await ctx.AuditedSoftDeleteAsync(
+        var deletedIds = await ctx.AuditedSoftDeleteWithIdsAsync(
             ctx.Set<TEntity>().Where(e => e.LegacyId == legacyId), AuditContext, ct);
+        await RaiseBroadcastAsync([], [], deletedIds, origin, ct);
+        return deletedIds.Count;
     }
 
     /// <summary>Latest stored record timestamp, optionally scoped to a data source (connector watermark).</summary>
@@ -224,11 +269,22 @@ public abstract class V4RepositoryBase<TModel, TEntity>
         return await query.MinAsync(e => (DateTime?)e.Timestamp, ct);
     }
 
+    /// <summary>
+    /// The result of <see cref="SplitUpsertsAsync"/>: rows upserted in place (returned to the caller),
+    /// the subset of those that changed materially (broadcast as <c>update</c>), and the rows still to
+    /// insert. <see cref="MateriallyChanged"/> must be a subset of <see cref="UpdatedInPlace"/>.
+    /// </summary>
+    protected readonly record struct UpsertSplit(
+        List<TEntity> UpdatedInPlace,
+        List<TEntity> MateriallyChanged,
+        List<TEntity> ToInsert);
+
     /// <summary>SyncId-upsert types override: match existing rows by (DataSource, SyncIdentifier), update them in
-    /// place, and return (rows updated in place, rows still to insert). Default: nothing upserted.</summary>
-    protected virtual Task<(List<TEntity> Updated, List<TEntity> ToInsert)> SplitUpsertsAsync(
+    /// place, and return the upserted rows, those that changed materially, and the rows still to insert.
+    /// Default: nothing upserted.</summary>
+    protected virtual Task<UpsertSplit> SplitUpsertsAsync(
         NocturneDbContext ctx, List<TEntity> entities, CancellationToken ct)
-        => Task.FromResult((new List<TEntity>(), entities));
+        => Task.FromResult(new UpsertSplit([], [], entities));
 
     /// <summary>DeduplicationService participants override: link the just-inserted rows into canonical groups
     /// (runs AFTER commit). Default: no-op.</summary>
@@ -254,7 +310,8 @@ public abstract class V4RepositoryBase<TModel, TEntity>
             await using var tx = await ctx.Database.BeginTransactionAsync(ct);
             var entities = records.Select(ToEntity).ToList();
 
-            var (updated, toInsert) = await SplitUpsertsAsync(ctx, entities, ct);
+            var split = await SplitUpsertsAsync(ctx, entities, ct);
+            var toInsert = split.ToInsert;
 
             // Batch-level LegacyId dedup
             toInsert = toInsert.GroupBy(e => e.LegacyId ?? e.Id.ToString()).Select(g => g.First()).ToList();
@@ -265,7 +322,7 @@ public abstract class V4RepositoryBase<TModel, TEntity>
                 toInsert = toInsert.Where(e => string.IsNullOrEmpty(e.LegacyId) || !blocked.Contains(e.LegacyId)).ToList();
             }
 
-            if (toInsert.Count == 0 && updated.Count == 0) { await tx.CommitAsync(ct); return Enumerable.Empty<TModel>(); }
+            if (toInsert.Count == 0 && split.UpdatedInPlace.Count == 0) { await tx.CommitAsync(ct); return Enumerable.Empty<TModel>(); }
 
             const int batchSize = 500;
             foreach (var batch in toInsert.Chunk(batchSize))
@@ -277,7 +334,14 @@ public abstract class V4RepositoryBase<TModel, TEntity>
 
             await tx.CommitAsync(ct);
             await PostCommitDedupAsync(ctx, toInsert, origin, ct);
-            return updated.Concat(toInsert).Select(ToDomain);
+            // Inserts broadcast as create; upserts broadcast as update only when materially changed
+            // (a connector re-poll of byte-identical rows changes nothing, so it stays silent).
+            await RaiseBroadcastAsync(
+                toInsert.Select(ToDomain).ToList(),
+                split.MateriallyChanged.Select(ToDomain).ToList(),
+                [],
+                origin, ct);
+            return split.UpdatedInPlace.Concat(toInsert).Select(ToDomain);
         });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Extensions;
@@ -95,7 +96,7 @@ public abstract class V4RepositoryBase<TModel, TEntity>
 
     /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.CreateAsync" />
     /// <remarks>Virtual: SyncId-upsert types (Bolus, CarbIntake) override to upsert in place.</remarks>
-    public virtual async Task<TModel> CreateAsync(TModel model, CancellationToken ct = default)
+    public virtual async Task<TModel> CreateAsync(TModel model, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         var entity = ToEntity(model);
@@ -105,7 +106,7 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     }
 
     /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.UpdateAsync" />
-    public async Task<TModel> UpdateAsync(Guid id, TModel model, CancellationToken ct = default)
+    public async Task<TModel> UpdateAsync(Guid id, TModel model, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         var entity = await ctx.Set<TEntity>().FindAsync([id], ct)
@@ -116,7 +117,7 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     }
 
     /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.DeleteAsync" />
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+    public async Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         var entity = await ctx.Set<TEntity>().FindAsync([id], ct)
@@ -126,7 +127,7 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     }
 
     /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.RestoreAsync" />
-    public async Task<TModel> RestoreAsync(Guid id, CancellationToken ct = default)
+    public async Task<TModel> RestoreAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         var entity = await ctx.Set<TEntity>().IgnoreQueryFilters()
@@ -139,7 +140,7 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     }
 
     /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.BulkRestoreAsync" />
-    public async Task<IEnumerable<TModel>> BulkRestoreAsync(IEnumerable<Guid> ids, CancellationToken ct = default)
+    public async Task<IEnumerable<TModel>> BulkRestoreAsync(IEnumerable<Guid> ids, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         var idSet = ids.ToHashSet();
@@ -198,7 +199,7 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     /// and carries the user-delete dedup discriminator. Virtual so types with a type-specific delete
     /// surface can still override.
     /// </remarks>
-    public virtual async Task<int> DeleteByLegacyIdAsync(string legacyId, CancellationToken ct = default)
+    public virtual async Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
@@ -232,7 +233,7 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     /// <summary>DeduplicationService participants override: link the just-inserted rows into canonical groups
     /// (runs AFTER commit). Default: no-op.</summary>
     protected virtual Task PostCommitDedupAsync(
-        NocturneDbContext ctx, IReadOnlyList<TEntity> inserted, CancellationToken ct)
+        NocturneDbContext ctx, IReadOnlyList<TEntity> inserted, WriteOrigin origin, CancellationToken ct)
         => Task.CompletedTask;
 
     /// <summary>
@@ -242,7 +243,7 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     /// whole method.
     /// </summary>
     public virtual async Task<IEnumerable<TModel>> BulkCreateAsync(
-        IEnumerable<TModel> recordsParam, CancellationToken ct = default)
+        IEnumerable<TModel> recordsParam, WriteOrigin origin, CancellationToken ct = default)
     {
         var records = recordsParam.ToList();
         if (records.Count == 0) return [];
@@ -275,7 +276,7 @@ public abstract class V4RepositoryBase<TModel, TEntity>
             }
 
             await tx.CommitAsync(ct);
-            await PostCommitDedupAsync(ctx, toInsert, ct);
+            await PostCommitDedupAsync(ctx, toInsert, origin, ct);
             return updated.Concat(toInsert).Select(ToDomain);
         });
     }

--- a/tests/Integration/Nocturne.Connectors.Tests/BaseConnectorServiceTests.cs
+++ b/tests/Integration/Nocturne.Connectors.Tests/BaseConnectorServiceTests.cs
@@ -11,6 +11,7 @@ using Nocturne.Connectors.Core.Models;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Core.Models;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Connectors.Tests.Integration;
 
@@ -64,7 +65,7 @@ public class BaseConnectorServiceTests
                 m.PublishEntriesAsync(
                     It.IsAny<IEnumerable<Entry>>(),
                     It.IsAny<string>(),
-                    It.IsAny<CancellationToken>()
+                    It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()
                 )
             )
             .ReturnsAsync(true);
@@ -80,7 +81,7 @@ public class BaseConnectorServiceTests
                 m.PublishEntriesAsync(
                     It.Is<IEnumerable<Entry>>(e => e.Count() == 2),
                     It.Is<string>(s => s == "test-connector"),
-                    It.IsAny<CancellationToken>()
+                    It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()
                 ),
             Times.Once
         );

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/AuditDeltaGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/AuditDeltaGoldenTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
 
@@ -39,10 +40,10 @@ public class AuditDeltaGoldenTests
         var repo = scope.ServiceProvider.GetRequiredService<IBGCheckRepository>();
 
         var created = await repo.CreateAsync(
-            new BGCheck { Timestamp = T0, Glucose = 95, DataSource = "manual", LegacyId = "bg-del" },
+            new BGCheck { Timestamp = T0, Glucose = 95, DataSource = "manual", LegacyId = "bg-del" }, WriteOrigin.Live,
             CancellationToken.None);
 
-        var deleted = await repo.DeleteByLegacyIdAsync("bg-del", CancellationToken.None);
+        var deleted = await repo.DeleteByLegacyIdAsync("bg-del", WriteOrigin.Live, CancellationToken.None);
         deleted.Should().Be(1);
 
         // D5 re-baseline (was 0): the base DeleteByLegacyIdAsync now routes through the audited
@@ -58,10 +59,10 @@ public class AuditDeltaGoldenTests
         var repo = scope.ServiceProvider.GetRequiredService<IDeviceEventRepository>();
 
         var created = await repo.CreateAsync(
-            new DeviceEvent { Timestamp = T0, EventType = DeviceEventType.SiteChange, DataSource = "aaps", LegacyId = "de-del" },
+            new DeviceEvent { Timestamp = T0, EventType = DeviceEventType.SiteChange, DataSource = "aaps", LegacyId = "de-del" }, WriteOrigin.Live,
             CancellationToken.None);
 
-        var deleted = await repo.DeleteByLegacyIdAsync("de-del", CancellationToken.None);
+        var deleted = await repo.DeleteByLegacyIdAsync("de-del", WriteOrigin.Live, CancellationToken.None);
         deleted.Should().Be(1);
 
         // An AUDITED type wrote an audit row before D5 and still does after (unchanged).

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/BolusGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/BolusGoldenTests.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
 
@@ -31,7 +32,7 @@ public class BolusGoldenTests
             {
                 new Bolus { Timestamp = t0, Insulin = 5.0, DataSource = "aaps", LegacyId = "a1" },
                 new Bolus { Timestamp = t0.AddSeconds(10), Insulin = 5.02, DataSource = "loop", LegacyId = "b1" },
-            },
+            }, WriteOrigin.Live,
             CancellationToken.None);
 
         // Dedup links rows into canonical groups; it never deletes — both rows persist physically.
@@ -59,13 +60,13 @@ public class BolusGoldenTests
 
         var t0 = new DateTime(2026, 3, 2, 8, 0, 0, DateTimeKind.Utc);
         await repo.BulkCreateAsync(
-            new[] { new Bolus { Timestamp = t0, Insulin = 4.0, DataSource = "aaps", SyncIdentifier = "sync-1" } },
+            new[] { new Bolus { Timestamp = t0, Insulin = 4.0, DataSource = "aaps", SyncIdentifier = "sync-1" } }, WriteOrigin.Live,
             CancellationToken.None);
 
         // Connector replay of the same (DataSource, SyncIdentifier) with a corrected dose upserts in
         // place rather than inserting a second row.
         await repo.BulkCreateAsync(
-            new[] { new Bolus { Timestamp = t0, Insulin = 4.6, DataSource = "aaps", SyncIdentifier = "sync-1" } },
+            new[] { new Bolus { Timestamp = t0, Insulin = 4.6, DataSource = "aaps", SyncIdentifier = "sync-1" } }, WriteOrigin.Live,
             CancellationToken.None);
 
         var rows = await _fx.QueryAsync(tenant, ctx =>
@@ -92,7 +93,7 @@ public class BolusGoldenTests
             {
                 new Bolus { Timestamp = t0, Insulin = 5.0, DataSource = "aaps", LegacyId = "p-a" },
                 new Bolus { Timestamp = t0.AddSeconds(10), Insulin = 5.02, DataSource = "loop", LegacyId = "p-b" },
-            },
+            }, WriteOrigin.Live,
             CancellationToken.None);
 
         // Two physical rows, linked into one canonical group (one primary, one non-primary).

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/BroadcastGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/BroadcastGoldenTests.cs
@@ -1,0 +1,140 @@
+using Microsoft.Extensions.DependencyInjection;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
+
+/// <summary>
+/// Goldens pinning the V4 repository chokepoint's broadcast firing behaviour against real Postgres: the
+/// origin gate (Live broadcasts, Backfill stays silent), inserts vs material upserts, the
+/// no-material-change silence on identical re-upload, and delete-by-id fan-out. Asserts only the
+/// captured broadcasts (via <see cref="V4GoldenFixture.Capture"/>) plus persistence where it proves
+/// silence didn't mean "no write".
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("V4 goldens")]
+public class BroadcastGoldenTests
+{
+    private readonly V4GoldenFixture _fx;
+
+    public BroadcastGoldenTests(V4GoldenFixture fx) => _fx = fx;
+
+    private static readonly DateTime T0 = new(2026, 5, 1, 9, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task LiveBulkCreate_BroadcastsCreated()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<ISensorGlucoseRepository>();
+        _fx.Capture.Clear();
+
+        await repo.BulkCreateAsync(
+            new[]
+            {
+                new SensorGlucose { Timestamp = T0, Mgdl = 120, DataSource = "dexcom", LegacyId = "bc-a" },
+                new SensorGlucose { Timestamp = T0.AddMinutes(5), Mgdl = 122, DataSource = "dexcom", LegacyId = "bc-b" },
+            }, WriteOrigin.Live, CancellationToken.None);
+
+        var entries = _fx.Capture.Snapshot();
+        entries.Should().ContainSingle(e => e.Kind == "created" && e.ModelType == typeof(SensorGlucose))
+            .Which.Count.Should().Be(2, "both inserted rows broadcast as created");
+        entries.Should().NotContain(e => e.Kind == "updated");
+    }
+
+    [Fact]
+    public async Task BackfillBulkCreate_IsSilent_ButPersists()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<ISensorGlucoseRepository>();
+        _fx.Capture.Clear();
+
+        await repo.BulkCreateAsync(
+            new[]
+            {
+                new SensorGlucose { Timestamp = T0, Mgdl = 130, DataSource = "dexcom", LegacyId = "bf-a" },
+                new SensorGlucose { Timestamp = T0.AddMinutes(5), Mgdl = 131, DataSource = "dexcom", LegacyId = "bf-b" },
+            }, WriteOrigin.Backfill, CancellationToken.None);
+
+        _fx.Capture.Snapshot().Should().BeEmpty("backfill imports never broadcast");
+
+        // Silence must not mean "didn't write" — the rows are persisted.
+        var rowCount = await _fx.QueryAsync(tenant, ctx =>
+            ctx.SensorGlucose.AsNoTracking().Where(g => g.LegacyId == "bf-a" || g.LegacyId == "bf-b").CountAsync());
+        rowCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task MaterialUpsert_BroadcastsUpdated_IdenticalReuploadDoesNot()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IBolusRepository>();
+
+        await repo.BulkCreateAsync(
+            new[] { new Bolus { Timestamp = T0, Insulin = 4.0, DataSource = "aaps", SyncIdentifier = "u-1" } },
+            WriteOrigin.Live, CancellationToken.None);
+
+        // Live re-upload of the SAME sync id with a CHANGED dose upserts in place → broadcasts updated.
+        _fx.Capture.Clear();
+        await repo.BulkCreateAsync(
+            new[] { new Bolus { Timestamp = T0, Insulin = 4.6, DataSource = "aaps", SyncIdentifier = "u-1" } },
+            WriteOrigin.Live, CancellationToken.None);
+
+        var afterChange = _fx.Capture.Snapshot();
+        afterChange.Should().ContainSingle(e => e.Kind == "updated" && e.ModelType == typeof(Bolus))
+            .Which.Count.Should().Be(1);
+        afterChange.Should().NotContain(e => e.Kind == "created");
+
+        // Live re-upload of the SAME sync id with IDENTICAL fields → no material change → silent.
+        _fx.Capture.Clear();
+        await repo.BulkCreateAsync(
+            new[] { new Bolus { Timestamp = T0, Insulin = 4.6, DataSource = "aaps", SyncIdentifier = "u-1" } },
+            WriteOrigin.Live, CancellationToken.None);
+
+        var afterIdentical = _fx.Capture.Snapshot();
+        afterIdentical.Should().NotContain(e => e.Kind == "updated", "an identical re-upload changes nothing");
+        afterIdentical.Should().NotContain(e => e.Kind == "created");
+    }
+
+    [Fact]
+    public async Task DeleteByLegacyId_BroadcastsDeletedIds()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<ISensorGlucoseRepository>();
+
+        await repo.BulkCreateAsync(
+            new[] { new SensorGlucose { Timestamp = T0, Mgdl = 140, DataSource = "dexcom", LegacyId = "del-1" } },
+            WriteOrigin.Live, CancellationToken.None);
+
+        var rowId = await _fx.QueryAsync(tenant, ctx =>
+            ctx.SensorGlucose.AsNoTracking().Where(g => g.LegacyId == "del-1").Select(g => g.Id).FirstAsync());
+
+        _fx.Capture.Clear();
+        await repo.DeleteByLegacyIdAsync("del-1", WriteOrigin.Live, CancellationToken.None);
+
+        var entry = _fx.Capture.Snapshot()
+            .Should().ContainSingle(e => e.Kind == "deleted" && e.ModelType == typeof(SensorGlucose)).Which;
+        entry.Ids.Should().Contain(rowId);
+    }
+
+    [Fact]
+    public async Task LiveSingleCreate_BroadcastsCreated()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<ISensorGlucoseRepository>();
+        _fx.Capture.Clear();
+
+        await repo.CreateAsync(
+            new SensorGlucose { Timestamp = T0, Mgdl = 150, DataSource = "dexcom", LegacyId = "single-1" },
+            WriteOrigin.Live, CancellationToken.None);
+
+        _fx.Capture.Snapshot()
+            .Should().ContainSingle(e => e.Kind == "created" && e.ModelType == typeof(SensorGlucose))
+            .Which.Count.Should().Be(1);
+    }
+}

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupDeltaGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupDeltaGoldenTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
 
@@ -67,7 +68,7 @@ public class DedupDeltaGoldenTests
             Bi(10, "aaps", legacyId: "bi-1"),
             Bi(11, "loop", legacyId: "bi-2"),
             Bi(10, "aaps", legacyId: "bi-1"),
-        }, CancellationToken.None);
+        }, WriteOrigin.Live, CancellationToken.None);
 
         (await _fx.QueryAsync(tenant, ctx => ctx.BasalInjections.AsNoTracking().CountAsync()))
             .Should().Be(2, "intra-batch LegacyId dedup collapses the duplicate");
@@ -90,7 +91,7 @@ public class DedupDeltaGoldenTests
         {
             Bi(10, "aaps", legacyId: "bi-a", syncId: "bi-sync"),
             Bi(14, "aaps", legacyId: "bi-b", syncId: "bi-sync"),
-        }, CancellationToken.None);
+        }, WriteOrigin.Live, CancellationToken.None);
 
         var rows = await _fx.QueryAsync(tenant, ctx => ctx.BasalInjections.AsNoTracking().ToListAsync());
         rows.Should().HaveCount(1, "bulk now upserts on SyncIdentifier (D1 fix)");
@@ -104,8 +105,8 @@ public class DedupDeltaGoldenTests
         using var scope = await _fx.BeginTenantScopeAsync(tenant);
         var repo = scope.ServiceProvider.GetRequiredService<IBasalInjectionRepository>();
 
-        await repo.CreateAsync(Bi(10, "aaps", syncId: "bi-sync"), CancellationToken.None);
-        await repo.CreateAsync(Bi(14, "aaps", syncId: "bi-sync"), CancellationToken.None);
+        await repo.CreateAsync(Bi(10, "aaps", syncId: "bi-sync"), WriteOrigin.Live, CancellationToken.None);
+        await repo.CreateAsync(Bi(14, "aaps", syncId: "bi-sync"), WriteOrigin.Live, CancellationToken.None);
 
         var rows = await _fx.QueryAsync(tenant, ctx => ctx.BasalInjections.AsNoTracking().ToListAsync());
         rows.Should().HaveCount(1, "single CreateAsync upserts on SyncIdentifier");
@@ -121,8 +122,8 @@ public class DedupDeltaGoldenTests
         using var scope = await _fx.BeginTenantScopeAsync(tenant);
         var repo = scope.ServiceProvider.GetRequiredService<ISensorGlucoseRepository>();
 
-        await repo.CreateAsync(new SensorGlucose { Timestamp = T0, Mgdl = 100, DataSource = "dexcom", SyncIdentifier = "sg-s" }, CancellationToken.None);
-        await repo.CreateAsync(new SensorGlucose { Timestamp = T0, Mgdl = 142, DataSource = "dexcom", SyncIdentifier = "sg-s" }, CancellationToken.None);
+        await repo.CreateAsync(new SensorGlucose { Timestamp = T0, Mgdl = 100, DataSource = "dexcom", SyncIdentifier = "sg-s" }, WriteOrigin.Live, CancellationToken.None);
+        await repo.CreateAsync(new SensorGlucose { Timestamp = T0, Mgdl = 142, DataSource = "dexcom", SyncIdentifier = "sg-s" }, WriteOrigin.Live, CancellationToken.None);
 
         // D3 re-baseline: SensorGlucose single CreateAsync now upserts on (DataSource, SyncIdentifier)
         // in place (mirroring Bolus/CarbIntake), so the duplicate SyncId updates the existing row
@@ -139,8 +140,8 @@ public class DedupDeltaGoldenTests
         using var scope = await _fx.BeginTenantScopeAsync(tenant);
         var repo = scope.ServiceProvider.GetRequiredService<IBolusRepository>();
 
-        await repo.CreateAsync(new Bolus { Timestamp = T0, Insulin = 4.0, DataSource = "aaps", SyncIdentifier = "b-s" }, CancellationToken.None);
-        await repo.CreateAsync(new Bolus { Timestamp = T0, Insulin = 4.6, DataSource = "aaps", SyncIdentifier = "b-s" }, CancellationToken.None);
+        await repo.CreateAsync(new Bolus { Timestamp = T0, Insulin = 4.0, DataSource = "aaps", SyncIdentifier = "b-s" }, WriteOrigin.Live, CancellationToken.None);
+        await repo.CreateAsync(new Bolus { Timestamp = T0, Insulin = 4.6, DataSource = "aaps", SyncIdentifier = "b-s" }, WriteOrigin.Live, CancellationToken.None);
 
         var rows = await _fx.QueryAsync(tenant, ctx => ctx.Boluses.AsNoTracking().ToListAsync());
         rows.Should().HaveCount(1, "Bolus single CreateAsync upserts on SyncId (the consistent reference)");
@@ -160,21 +161,21 @@ public class DedupDeltaGoldenTests
         {
             new CarbIntake { Timestamp = T0, Carbs = 30, DataSource = "aaps", LegacyId = "c-a" },
             new CarbIntake { Timestamp = T0.AddSeconds(10), Carbs = 30.5, DataSource = "loop", LegacyId = "c-b" },
-        }, CancellationToken.None);
+        }, WriteOrigin.Live, CancellationToken.None);
 
         var bolus = scope.ServiceProvider.GetRequiredService<IBolusRepository>();
         await bolus.BulkCreateAsync(new[]
         {
             new Bolus { Timestamp = T0, Insulin = 5.0, DataSource = "aaps", LegacyId = "b-a" },
             new Bolus { Timestamp = T0.AddSeconds(10), Insulin = 5.02, DataSource = "loop", LegacyId = "b-b" },
-        }, CancellationToken.None);
+        }, WriteOrigin.Live, CancellationToken.None);
 
         var sg = scope.ServiceProvider.GetRequiredService<ISensorGlucoseRepository>();
         await sg.BulkCreateAsync(new[]
         {
             new SensorGlucose { Timestamp = T0, Mgdl = 120, DataSource = "dexcom", LegacyId = "g-a" },
             new SensorGlucose { Timestamp = T0.AddSeconds(10), Mgdl = 120.5, DataSource = "libre", LegacyId = "g-b" },
-        }, CancellationToken.None);
+        }, WriteOrigin.Live, CancellationToken.None);
 
         // D7 re-baseline: each pair links into one canonical group, and ALL dedup participants now
         // exclude the non-primary via the base CountAsync + ApplyReadVisibility hook (was: only
@@ -217,14 +218,14 @@ public class DedupDeltaGoldenTests
         await repo.BulkCreateAsync(new[]
         {
             new SensorGlucose { Timestamp = T0, Mgdl = 100, DataSource = "dexcom", SyncIdentifier = "sg-B" },
-        }, CancellationToken.None);
+        }, WriteOrigin.Live, CancellationToken.None);
 
         // 2. C is a fresh insert at T0+10s; B is SyncId-upserted onto T0+10s with C's value.
         await repo.BulkCreateAsync(new[]
         {
             new SensorGlucose { Timestamp = T0.AddSeconds(10), Mgdl = 120, DataSource = "libre", LegacyId = "sg-C" },
             new SensorGlucose { Timestamp = T0.AddSeconds(10), Mgdl = 120, DataSource = "dexcom", SyncIdentifier = "sg-B" },
-        }, CancellationToken.None);
+        }, WriteOrigin.Live, CancellationToken.None);
 
         (await _fx.QueryAsync(tenant, ctx => ctx.SensorGlucose.AsNoTracking().CountAsync()))
             .Should().Be(2, "B upserts in place; C inserts — two physical rows");
@@ -246,7 +247,7 @@ public class DedupDeltaGoldenTests
         await repo.BulkCreateAsync(new[]
         {
             new Bolus { Timestamp = T0, Insulin = 4.0, DataSource = "aaps", SyncIdentifier = "b-B" },
-        }, CancellationToken.None);
+        }, WriteOrigin.Live, CancellationToken.None);
 
         // 2. C is a fresh insert at T0+10s; B is SyncId-upserted onto T0+10s with C's value — byte-for
         //    byte the SensorGlucose scenario above. After D4 moved Bolus's dedup to run post-commit,
@@ -257,7 +258,7 @@ public class DedupDeltaGoldenTests
         {
             new Bolus { Timestamp = T0.AddSeconds(10), Insulin = 5.0, DataSource = "loop", LegacyId = "b-C" },
             new Bolus { Timestamp = T0.AddSeconds(10), Insulin = 5.0, DataSource = "aaps", SyncIdentifier = "b-B" },
-        }, CancellationToken.None);
+        }, WriteOrigin.Live, CancellationToken.None);
 
         (await _fx.QueryAsync(tenant, ctx => ctx.Boluses.AsNoTracking().CountAsync()))
             .Should().Be(2, "B upserts in place; C inserts — two physical rows");
@@ -281,7 +282,7 @@ public class DedupDeltaGoldenTests
         await repo.BulkCreateAsync(new[]
         {
             new CarbIntake { Timestamp = T0, Carbs = 30, DataSource = "aaps", SyncIdentifier = "c-B" },
-        }, CancellationToken.None);
+        }, WriteOrigin.Live, CancellationToken.None);
 
         // 2. C is a fresh insert at T0+10s; B is SyncId-upserted onto T0+10s with C's value — byte-for
         //    byte the Bolus/SensorGlucose scenarios above. CarbIntake had the same D4 post-commit flip
@@ -291,7 +292,7 @@ public class DedupDeltaGoldenTests
         {
             new CarbIntake { Timestamp = T0.AddSeconds(10), Carbs = 45, DataSource = "loop", LegacyId = "c-C" },
             new CarbIntake { Timestamp = T0.AddSeconds(10), Carbs = 45, DataSource = "aaps", SyncIdentifier = "c-B" },
-        }, CancellationToken.None);
+        }, WriteOrigin.Live, CancellationToken.None);
 
         (await _fx.QueryAsync(tenant, ctx => ctx.CarbIntakes.AsNoTracking().CountAsync()))
             .Should().Be(2, "B upserts in place; C inserts — two physical rows");

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupParticipantGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupParticipantGoldenTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
 
@@ -51,7 +52,7 @@ public class DedupParticipantGoldenTests
             {
                 new SensorGlucose { Timestamp = T0, Mgdl = 120, DataSource = "dexcom", LegacyId = "g-a" },
                 new SensorGlucose { Timestamp = T0.AddSeconds(10), Mgdl = 120.5, DataSource = "libre", LegacyId = "g-b" },
-            },
+            }, WriteOrigin.Live,
             CancellationToken.None);
 
         await AssertOneCanonicalGroupAsync(tenant, 2, "sensorglucose", ctx => ctx.SensorGlucose.AsNoTracking().CountAsync());
@@ -64,8 +65,8 @@ public class DedupParticipantGoldenTests
         using var scope = await _fx.BeginTenantScopeAsync(tenant);
         var repo = scope.ServiceProvider.GetRequiredService<ISensorGlucoseRepository>();
 
-        await repo.BulkCreateAsync(new[] { new SensorGlucose { Timestamp = T0, Mgdl = 100, DataSource = "dexcom", SyncIdentifier = "s-1" } }, CancellationToken.None);
-        await repo.BulkCreateAsync(new[] { new SensorGlucose { Timestamp = T0, Mgdl = 142, DataSource = "dexcom", SyncIdentifier = "s-1" } }, CancellationToken.None);
+        await repo.BulkCreateAsync(new[] { new SensorGlucose { Timestamp = T0, Mgdl = 100, DataSource = "dexcom", SyncIdentifier = "s-1" } }, WriteOrigin.Live, CancellationToken.None);
+        await repo.BulkCreateAsync(new[] { new SensorGlucose { Timestamp = T0, Mgdl = 142, DataSource = "dexcom", SyncIdentifier = "s-1" } }, WriteOrigin.Live, CancellationToken.None);
 
         var rows = await _fx.QueryAsync(tenant, ctx => ctx.SensorGlucose.AsNoTracking().Where(g => g.DataSource == "dexcom").ToListAsync());
         rows.Should().HaveCount(1);
@@ -84,7 +85,7 @@ public class DedupParticipantGoldenTests
             {
                 new CarbIntake { Timestamp = T0, Carbs = 30, DataSource = "aaps", LegacyId = "c-a" },
                 new CarbIntake { Timestamp = T0.AddSeconds(10), Carbs = 30.5, DataSource = "loop", LegacyId = "c-b" },
-            },
+            }, WriteOrigin.Live,
             CancellationToken.None);
 
         await AssertOneCanonicalGroupAsync(tenant, 2, "carbintake", ctx => ctx.CarbIntakes.AsNoTracking().CountAsync());
@@ -97,8 +98,8 @@ public class DedupParticipantGoldenTests
         using var scope = await _fx.BeginTenantScopeAsync(tenant);
         var repo = scope.ServiceProvider.GetRequiredService<ICarbIntakeRepository>();
 
-        await repo.BulkCreateAsync(new[] { new CarbIntake { Timestamp = T0, Carbs = 20, DataSource = "aaps", SyncIdentifier = "c-1" } }, CancellationToken.None);
-        await repo.BulkCreateAsync(new[] { new CarbIntake { Timestamp = T0, Carbs = 45, DataSource = "aaps", SyncIdentifier = "c-1" } }, CancellationToken.None);
+        await repo.BulkCreateAsync(new[] { new CarbIntake { Timestamp = T0, Carbs = 20, DataSource = "aaps", SyncIdentifier = "c-1" } }, WriteOrigin.Live, CancellationToken.None);
+        await repo.BulkCreateAsync(new[] { new CarbIntake { Timestamp = T0, Carbs = 45, DataSource = "aaps", SyncIdentifier = "c-1" } }, WriteOrigin.Live, CancellationToken.None);
 
         var rows = await _fx.QueryAsync(tenant, ctx => ctx.CarbIntakes.AsNoTracking().Where(c => c.DataSource == "aaps").ToListAsync());
         rows.Should().HaveCount(1);
@@ -117,7 +118,7 @@ public class DedupParticipantGoldenTests
             {
                 new BGCheck { Timestamp = T0, Glucose = 95, DataSource = "manual", LegacyId = "b-a" },
                 new BGCheck { Timestamp = T0.AddSeconds(10), Glucose = 95.5, DataSource = "meter", LegacyId = "b-b" },
-            },
+            }, WriteOrigin.Live,
             CancellationToken.None);
 
         await AssertOneCanonicalGroupAsync(tenant, 2, "bgcheck", ctx => ctx.BGChecks.AsNoTracking().CountAsync());
@@ -135,7 +136,7 @@ public class DedupParticipantGoldenTests
             {
                 new DeviceEvent { Timestamp = T0, EventType = DeviceEventType.SiteChange, DataSource = "aaps", LegacyId = "d-a" },
                 new DeviceEvent { Timestamp = T0.AddSeconds(10), EventType = DeviceEventType.SiteChange, DataSource = "loop", LegacyId = "d-b" },
-            },
+            }, WriteOrigin.Live,
             CancellationToken.None);
 
         await AssertOneCanonicalGroupAsync(tenant, 2, "deviceevent", ctx => ctx.DeviceEvents.AsNoTracking().CountAsync());
@@ -154,7 +155,7 @@ public class DedupParticipantGoldenTests
             {
                 new Note { Timestamp = T0, Text = "exercise", DataSource = "aaps", LegacyId = "n-a" },
                 new Note { Timestamp = T0.AddSeconds(10), Text = "walk", DataSource = "loop", LegacyId = "n-b" },
-            },
+            }, WriteOrigin.Live,
             CancellationToken.None);
 
         await AssertOneCanonicalGroupAsync(tenant, 2, "note", ctx => ctx.Notes.AsNoTracking().CountAsync());
@@ -172,7 +173,7 @@ public class DedupParticipantGoldenTests
             {
                 new BolusCalculation { Timestamp = T0, CarbInput = 40, DataSource = "aaps", LegacyId = "bc-a" },
                 new BolusCalculation { Timestamp = T0.AddSeconds(10), CarbInput = 40.5, DataSource = "loop", LegacyId = "bc-b" },
-            },
+            }, WriteOrigin.Live,
             CancellationToken.None);
 
         await AssertOneCanonicalGroupAsync(tenant, 2, "boluscalculation", ctx => ctx.BolusCalculations.AsNoTracking().CountAsync());
@@ -191,7 +192,7 @@ public class DedupParticipantGoldenTests
             {
                 new TempBasal { StartTimestamp = T0, Rate = 0.80, Origin = TempBasalOrigin.Algorithm, DataSource = "aaps", LegacyId = "tb-a" },
                 new TempBasal { StartTimestamp = T0.AddSeconds(10), Rate = 0.82, Origin = TempBasalOrigin.Algorithm, DataSource = "loop", LegacyId = "tb-b" },
-            },
+            }, WriteOrigin.Live,
             CancellationToken.None);
 
         await AssertOneCanonicalGroupAsync(tenant, 2, "tempbasal", ctx => ctx.TempBasals.AsNoTracking().CountAsync());

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/GoldenTestDoubles.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/GoldenTestDoubles.cs
@@ -1,4 +1,6 @@
+using System.Collections.Concurrent;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.Multitenancy;
 
 namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
@@ -30,4 +32,57 @@ internal sealed class SystemAuditContext : IAuditContext
     public string? CorrelationId => null;
     public string? Endpoint => null;
     public bool IsSystem => true;
+}
+
+/// <summary>
+/// One recorded fan-out from the V4 repository chokepoint: the broadcast <paramref name="Kind"/>
+/// (<c>created</c>/<c>updated</c>/<c>deleted</c>), the model <paramref name="ModelType"/>, the item
+/// <paramref name="Count"/>, and the deleted record <paramref name="Ids"/> (empty for create/update).
+/// </summary>
+public sealed record BroadcastEntry(string Kind, Type ModelType, int Count, IReadOnlyList<Guid> Ids);
+
+/// <summary>
+/// Thread-safe singleton collector that the per-type <see cref="CapturingV4RecordBroadcaster{TModel}"/>
+/// instances record into. Lets a golden assert exactly which broadcasts the chokepoint fired (and that
+/// backfill / no-material-change writes fire none). Additive: goldens that don't read it are unaffected.
+/// </summary>
+public sealed class BroadcastCapture
+{
+    private readonly ConcurrentQueue<BroadcastEntry> _entries = new();
+
+    /// <summary>Record a single broadcast fan-out.</summary>
+    public void Add(BroadcastEntry entry) => _entries.Enqueue(entry);
+
+    /// <summary>Drop all captured entries — call at the start of each scenario.</summary>
+    public void Clear() => _entries.Clear();
+
+    /// <summary>Point-in-time snapshot of the captured entries in fire order.</summary>
+    public IReadOnlyList<BroadcastEntry> Snapshot() => _entries.ToArray();
+}
+
+/// <summary>
+/// Capturing <see cref="IV4RecordBroadcaster{TModel}"/> that records every fan-out into the shared
+/// <see cref="BroadcastCapture"/> instead of touching SignalR. Registered as an open generic so every V4
+/// repository resolves one, exercising the real <c>V4RepositoryBase</c> origin gate end-to-end.
+/// </summary>
+internal sealed class CapturingV4RecordBroadcaster<TModel>(BroadcastCapture capture)
+    : IV4RecordBroadcaster<TModel> where TModel : class
+{
+    public Task BroadcastCreatedAsync(IReadOnlyList<TModel> items, CancellationToken ct = default)
+    {
+        if (items.Count > 0) capture.Add(new BroadcastEntry("created", typeof(TModel), items.Count, []));
+        return Task.CompletedTask;
+    }
+
+    public Task BroadcastUpdatedAsync(IReadOnlyList<TModel> items, CancellationToken ct = default)
+    {
+        if (items.Count > 0) capture.Add(new BroadcastEntry("updated", typeof(TModel), items.Count, []));
+        return Task.CompletedTask;
+    }
+
+    public Task BroadcastDeletedAsync(IReadOnlyList<Guid> ids, CancellationToken ct = default)
+    {
+        if (ids.Count > 0) capture.Add(new BroadcastEntry("deleted", typeof(TModel), ids.Count, ids));
+        return Task.CompletedTask;
+    }
 }

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/LegacyIdOnlyGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/LegacyIdOnlyGoldenTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
 
@@ -41,7 +42,7 @@ public class LegacyIdOnlyGoldenTests
             new MeterGlucose { Timestamp = T0, Mgdl = 100, DataSource = "aaps", LegacyId = "m-1" },
             new MeterGlucose { Timestamp = T0.AddSeconds(5), Mgdl = 101, DataSource = "loop", LegacyId = "m-2" },
             new MeterGlucose { Timestamp = T0, Mgdl = 100, DataSource = "aaps", LegacyId = "m-1" },
-        }, CancellationToken.None);
+        }, WriteOrigin.Live, CancellationToken.None);
         await AssertLegacyIdDedupAndNoLinksAsync(tenant, ctx => ctx.MeterGlucose.AsNoTracking().CountAsync());
     }
 
@@ -56,7 +57,7 @@ public class LegacyIdOnlyGoldenTests
             new Calibration { Timestamp = T0, DataSource = "dexcom", LegacyId = "cal-1" },
             new Calibration { Timestamp = T0.AddSeconds(5), DataSource = "dexcom", LegacyId = "cal-2" },
             new Calibration { Timestamp = T0, DataSource = "dexcom", LegacyId = "cal-1" },
-        }, CancellationToken.None);
+        }, WriteOrigin.Live, CancellationToken.None);
         await AssertLegacyIdDedupAndNoLinksAsync(tenant, ctx => ctx.Calibrations.AsNoTracking().CountAsync());
     }
 
@@ -71,7 +72,7 @@ public class LegacyIdOnlyGoldenTests
             new ApsSnapshot { Timestamp = T0, DataSource = "loop", LegacyId = "aps-1" },
             new ApsSnapshot { Timestamp = T0.AddSeconds(5), DataSource = "loop", LegacyId = "aps-2" },
             new ApsSnapshot { Timestamp = T0, DataSource = "loop", LegacyId = "aps-1" },
-        }, CancellationToken.None);
+        }, WriteOrigin.Live, CancellationToken.None);
         await AssertLegacyIdDedupAndNoLinksAsync(tenant, ctx => ctx.ApsSnapshots.AsNoTracking().CountAsync());
     }
 
@@ -86,7 +87,7 @@ public class LegacyIdOnlyGoldenTests
             new PumpSnapshot { Timestamp = T0, DataSource = "loop", LegacyId = "pump-1" },
             new PumpSnapshot { Timestamp = T0.AddSeconds(5), DataSource = "loop", LegacyId = "pump-2" },
             new PumpSnapshot { Timestamp = T0, DataSource = "loop", LegacyId = "pump-1" },
-        }, CancellationToken.None);
+        }, WriteOrigin.Live, CancellationToken.None);
         await AssertLegacyIdDedupAndNoLinksAsync(tenant, ctx => ctx.PumpSnapshots.AsNoTracking().CountAsync());
     }
 
@@ -101,7 +102,7 @@ public class LegacyIdOnlyGoldenTests
             new UploaderSnapshot { Timestamp = T0, DataSource = "xdrip", LegacyId = "up-1" },
             new UploaderSnapshot { Timestamp = T0.AddSeconds(5), DataSource = "xdrip", LegacyId = "up-2" },
             new UploaderSnapshot { Timestamp = T0, DataSource = "xdrip", LegacyId = "up-1" },
-        }, CancellationToken.None);
+        }, WriteOrigin.Live, CancellationToken.None);
         await AssertLegacyIdDedupAndNoLinksAsync(tenant, ctx => ctx.UploaderSnapshots.AsNoTracking().CountAsync());
     }
 
@@ -116,7 +117,7 @@ public class LegacyIdOnlyGoldenTests
             new BasalSchedule { Timestamp = T0, DataSource = "aaps", LegacyId = "bs-1" },
             new BasalSchedule { Timestamp = T0.AddSeconds(5), DataSource = "aaps", LegacyId = "bs-2" },
             new BasalSchedule { Timestamp = T0, DataSource = "aaps", LegacyId = "bs-1" },
-        }, CancellationToken.None);
+        }, WriteOrigin.Live, CancellationToken.None);
         await AssertLegacyIdDedupAndNoLinksAsync(tenant, ctx => ctx.BasalSchedules.AsNoTracking().CountAsync());
     }
 
@@ -131,7 +132,7 @@ public class LegacyIdOnlyGoldenTests
             new CarbRatioSchedule { Timestamp = T0, DataSource = "aaps", LegacyId = "cr-1" },
             new CarbRatioSchedule { Timestamp = T0.AddSeconds(5), DataSource = "aaps", LegacyId = "cr-2" },
             new CarbRatioSchedule { Timestamp = T0, DataSource = "aaps", LegacyId = "cr-1" },
-        }, CancellationToken.None);
+        }, WriteOrigin.Live, CancellationToken.None);
         await AssertLegacyIdDedupAndNoLinksAsync(tenant, ctx => ctx.CarbRatioSchedules.AsNoTracking().CountAsync());
     }
 
@@ -146,7 +147,7 @@ public class LegacyIdOnlyGoldenTests
             new SensitivitySchedule { Timestamp = T0, DataSource = "aaps", LegacyId = "ss-1" },
             new SensitivitySchedule { Timestamp = T0.AddSeconds(5), DataSource = "aaps", LegacyId = "ss-2" },
             new SensitivitySchedule { Timestamp = T0, DataSource = "aaps", LegacyId = "ss-1" },
-        }, CancellationToken.None);
+        }, WriteOrigin.Live, CancellationToken.None);
         await AssertLegacyIdDedupAndNoLinksAsync(tenant, ctx => ctx.SensitivitySchedules.AsNoTracking().CountAsync());
     }
 
@@ -161,7 +162,7 @@ public class LegacyIdOnlyGoldenTests
             new TargetRangeSchedule { Timestamp = T0, DataSource = "aaps", LegacyId = "tr-1" },
             new TargetRangeSchedule { Timestamp = T0.AddSeconds(5), DataSource = "aaps", LegacyId = "tr-2" },
             new TargetRangeSchedule { Timestamp = T0, DataSource = "aaps", LegacyId = "tr-1" },
-        }, CancellationToken.None);
+        }, WriteOrigin.Live, CancellationToken.None);
         await AssertLegacyIdDedupAndNoLinksAsync(tenant, ctx => ctx.TargetRangeSchedules.AsNoTracking().CountAsync());
     }
 
@@ -176,7 +177,7 @@ public class LegacyIdOnlyGoldenTests
             new TherapySettings { Timestamp = T0, DataSource = "aaps", LegacyId = "th-1" },
             new TherapySettings { Timestamp = T0.AddSeconds(5), DataSource = "aaps", LegacyId = "th-2" },
             new TherapySettings { Timestamp = T0, DataSource = "aaps", LegacyId = "th-1" },
-        }, CancellationToken.None);
+        }, WriteOrigin.Live, CancellationToken.None);
         await AssertLegacyIdDedupAndNoLinksAsync(tenant, ctx => ctx.TherapySettings.AsNoTracking().CountAsync());
     }
 }

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/V4GoldenFixture.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/V4GoldenFixture.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Infrastructure.Data.Entities;
@@ -84,9 +85,16 @@ public class V4GoldenFixture : IAsyncLifetime
         services.AddSingleton<ITenantAccessor>(_accessor);
         services.AddSingleton<IAuditContext, SystemAuditContext>();
         services.AddPostgreSqlInfrastructure(config);
+        // Capturing broadcaster: the V4 repos resolve IV4RecordBroadcaster<T> via the open generic, so
+        // the real chokepoint fires into BroadcastCapture (additive — existing goldens ignore it).
+        services.AddSingleton<BroadcastCapture>();
+        services.AddScoped(typeof(IV4RecordBroadcaster<>), typeof(CapturingV4RecordBroadcaster<>));
         RegisterV4Repositories(services);
         _provider = services.BuildServiceProvider();
     }
+
+    /// <summary>The shared broadcast collector recording every chokepoint fan-out across all V4 repos.</summary>
+    public BroadcastCapture Capture => _provider!.GetRequiredService<BroadcastCapture>();
 
     /// <summary>
     /// Registers the V4 record repositories under test. In production these are registered by the API

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4CrudControllerBaseTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4CrudControllerBaseTests.cs
@@ -6,6 +6,7 @@ using Nocturne.API.Controllers.V4.Base;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Tests.Controllers.V4.Base;
 
@@ -154,7 +155,7 @@ public class V4CrudControllerBaseTests
     {
         var request = new TestCreateRequest { Timestamp = DateTime.UtcNow, Device = "test" };
         var model = new TestRecord { Id = Guid.NewGuid(), Timestamp = request.Timestamp, Device = request.Device };
-        _repo.Setup(r => r.CreateAsync(It.IsAny<TestRecord>(), It.IsAny<CancellationToken>()))
+        _repo.Setup(r => r.CreateAsync(It.IsAny<TestRecord>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(model);
 
         var result = await _controller.Create(request);
@@ -186,7 +187,7 @@ public class V4CrudControllerBaseTests
 
         _repo.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(existing);
-        _repo.Setup(r => r.UpdateAsync(id, It.IsAny<TestRecord>(), It.IsAny<CancellationToken>()))
+        _repo.Setup(r => r.UpdateAsync(id, It.IsAny<TestRecord>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(updated);
 
         var result = await _controller.Update(id, request);
@@ -227,7 +228,7 @@ public class V4CrudControllerBaseTests
     public async Task Delete_Exists_ReturnsNoContent()
     {
         var id = Guid.NewGuid();
-        _repo.Setup(r => r.DeleteAsync(id, It.IsAny<CancellationToken>()))
+        _repo.Setup(r => r.DeleteAsync(id, It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         var result = await _controller.Delete(id);
@@ -239,7 +240,7 @@ public class V4CrudControllerBaseTests
     public async Task Delete_NotFound_Returns404()
     {
         var id = Guid.NewGuid();
-        _repo.Setup(r => r.DeleteAsync(id, It.IsAny<CancellationToken>()))
+        _repo.Setup(r => r.DeleteAsync(id, It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new KeyNotFoundException());
 
         var result = await _controller.Delete(id);

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/BolusControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/BolusControllerTests.cs
@@ -7,6 +7,7 @@ using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Tests.Controllers.V4;
 
@@ -29,7 +30,7 @@ public class BolusControllerTests
     private void SetupCreatePassthrough(Action<Bolus> onCreate)
     {
         _repoMock
-            .Setup(r => r.CreateAsync(It.IsAny<Bolus>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.CreateAsync(It.IsAny<Bolus>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .Callback<Bolus, CancellationToken>((b, _) => onCreate(b))
             .ReturnsAsync((Bolus b, CancellationToken _) => b);
     }
@@ -74,7 +75,7 @@ public class BolusControllerTests
             .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(existing);
         _repoMock
-            .Setup(r => r.UpdateAsync(id, It.IsAny<Bolus>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.UpdateAsync(id, It.IsAny<Bolus>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .Callback<Guid, Bolus, CancellationToken>((_, b, _) => captured = b)
             .ReturnsAsync((Guid _, Bolus b, CancellationToken _) => b);
 
@@ -130,7 +131,7 @@ public class BolusControllerTests
             .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(existing);
         _repoMock
-            .Setup(r => r.UpdateAsync(id, It.IsAny<Bolus>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.UpdateAsync(id, It.IsAny<Bolus>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .Callback<Guid, Bolus, CancellationToken>((_, b, _) => captured = b)
             .ReturnsAsync((Guid _, Bolus b, CancellationToken _) => b);
 

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/BolusControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/BolusControllerTests.cs
@@ -31,8 +31,8 @@ public class BolusControllerTests
     {
         _repoMock
             .Setup(r => r.CreateAsync(It.IsAny<Bolus>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback<Bolus, CancellationToken>((b, _) => onCreate(b))
-            .ReturnsAsync((Bolus b, CancellationToken _) => b);
+            .Callback<Bolus, WriteOrigin, CancellationToken>((b, _, _) => onCreate(b))
+            .ReturnsAsync((Bolus b, WriteOrigin origin, CancellationToken _) => b);
     }
 
     [Fact]
@@ -76,8 +76,8 @@ public class BolusControllerTests
             .ReturnsAsync(existing);
         _repoMock
             .Setup(r => r.UpdateAsync(id, It.IsAny<Bolus>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback<Guid, Bolus, CancellationToken>((_, b, _) => captured = b)
-            .ReturnsAsync((Guid _, Bolus b, CancellationToken _) => b);
+            .Callback<Guid, Bolus, WriteOrigin, CancellationToken>((_, b, _, _) => captured = b)
+            .ReturnsAsync((Guid _, Bolus b, WriteOrigin origin, CancellationToken _) => b);
 
         var controller = CreateController();
         var request = new UpdateBolusRequest
@@ -132,8 +132,8 @@ public class BolusControllerTests
             .ReturnsAsync(existing);
         _repoMock
             .Setup(r => r.UpdateAsync(id, It.IsAny<Bolus>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback<Guid, Bolus, CancellationToken>((_, b, _) => captured = b)
-            .ReturnsAsync((Guid _, Bolus b, CancellationToken _) => b);
+            .Callback<Guid, Bolus, WriteOrigin, CancellationToken>((_, b, _, _) => captured = b)
+            .ReturnsAsync((Guid _, Bolus b, WriteOrigin origin, CancellationToken _) => b);
 
         var controller = CreateController();
         var request = new UpdateBolusRequest

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/NutritionControllerMealsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/NutritionControllerMealsTests.cs
@@ -19,6 +19,7 @@ using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Tests.Controllers.V4;
 
@@ -216,7 +217,7 @@ public class NutritionControllerMealsTests : IDisposable
             Insulin = 5.5,
             Kind = BolusKind.Manual,
             CorrelationId = existingCid,
-        });
+        }, WriteOrigin.Live);
 
         // Act: a meal is posted with the same (DataSource, SyncIdentifier) but a
         // different supplied CorrelationId. The existing bolus's CorrelationId

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/NutritionControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/NutritionControllerTests.cs
@@ -14,6 +14,7 @@ using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Tests.Controllers.V4;
 
@@ -71,7 +72,7 @@ public class NutritionControllerTests : IDisposable
     private void SetupCreatePassthrough(Action<CarbIntake> onCreate)
     {
         _repoMock
-            .Setup(r => r.CreateAsync(It.IsAny<CarbIntake>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.CreateAsync(It.IsAny<CarbIntake>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .Callback<CarbIntake, CancellationToken>((c, _) => onCreate(c))
             .ReturnsAsync((CarbIntake c, CancellationToken _) => c);
     }
@@ -136,7 +137,7 @@ public class NutritionControllerTests : IDisposable
             .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(existing);
         _repoMock
-            .Setup(r => r.UpdateAsync(id, It.IsAny<CarbIntake>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.UpdateAsync(id, It.IsAny<CarbIntake>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .Callback<Guid, CarbIntake, CancellationToken>((_, c, _) => captured = c)
             .ReturnsAsync((Guid _, CarbIntake c, CancellationToken _) => c);
 
@@ -172,7 +173,7 @@ public class NutritionControllerTests : IDisposable
             .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(existing);
         _repoMock
-            .Setup(r => r.UpdateAsync(id, It.IsAny<CarbIntake>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.UpdateAsync(id, It.IsAny<CarbIntake>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .Callback<Guid, CarbIntake, CancellationToken>((_, c, _) => captured = c)
             .ReturnsAsync((Guid _, CarbIntake c, CancellationToken _) => c);
 

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/NutritionControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/NutritionControllerTests.cs
@@ -73,8 +73,8 @@ public class NutritionControllerTests : IDisposable
     {
         _repoMock
             .Setup(r => r.CreateAsync(It.IsAny<CarbIntake>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback<CarbIntake, CancellationToken>((c, _) => onCreate(c))
-            .ReturnsAsync((CarbIntake c, CancellationToken _) => c);
+            .Callback<CarbIntake, WriteOrigin, CancellationToken>((c, _, _) => onCreate(c))
+            .ReturnsAsync((CarbIntake c, WriteOrigin origin, CancellationToken _) => c);
     }
 
     [Fact]
@@ -138,8 +138,8 @@ public class NutritionControllerTests : IDisposable
             .ReturnsAsync(existing);
         _repoMock
             .Setup(r => r.UpdateAsync(id, It.IsAny<CarbIntake>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback<Guid, CarbIntake, CancellationToken>((_, c, _) => captured = c)
-            .ReturnsAsync((Guid _, CarbIntake c, CancellationToken _) => c);
+            .Callback<Guid, CarbIntake, WriteOrigin, CancellationToken>((_, c, _, _) => captured = c)
+            .ReturnsAsync((Guid _, CarbIntake c, WriteOrigin origin, CancellationToken _) => c);
 
         var controller = CreateController();
         var request = new UpdateCarbIntakeRequest
@@ -174,8 +174,8 @@ public class NutritionControllerTests : IDisposable
             .ReturnsAsync(existing);
         _repoMock
             .Setup(r => r.UpdateAsync(id, It.IsAny<CarbIntake>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback<Guid, CarbIntake, CancellationToken>((_, c, _) => captured = c)
-            .ReturnsAsync((Guid _, CarbIntake c, CancellationToken _) => c);
+            .Callback<Guid, CarbIntake, WriteOrigin, CancellationToken>((_, c, _, _) => captured = c)
+            .ReturnsAsync((Guid _, CarbIntake c, WriteOrigin origin, CancellationToken _) => c);
 
         var controller = CreateController();
         var request = new UpdateCarbIntakeRequest

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/PatientRecordControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/PatientRecordControllerTests.cs
@@ -6,6 +6,7 @@ using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Tests.Controllers.V4;
 
@@ -54,7 +55,7 @@ public class PatientRecordControllerTests
             .ReturnsAsync(expectedDeviceId);
 
         _deviceRepo
-            .Setup(x => x.CreateAsync(It.IsAny<PatientDevice>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.CreateAsync(It.IsAny<PatientDevice>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((PatientDevice m, CancellationToken _) => m);
 
         // Act
@@ -86,7 +87,7 @@ public class PatientRecordControllerTests
         };
 
         _deviceRepo
-            .Setup(x => x.CreateAsync(It.IsAny<PatientDevice>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.CreateAsync(It.IsAny<PatientDevice>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((PatientDevice m, CancellationToken _) => m);
 
         // Act
@@ -125,7 +126,7 @@ public class PatientRecordControllerTests
             .ReturnsAsync(expectedDeviceId);
 
         _deviceRepo
-            .Setup(x => x.UpdateAsync(deviceId, It.IsAny<PatientDevice>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.UpdateAsync(deviceId, It.IsAny<PatientDevice>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((Guid _, PatientDevice m, CancellationToken _) => m);
 
         // Act
@@ -157,7 +158,7 @@ public class PatientRecordControllerTests
         };
 
         _deviceRepo
-            .Setup(x => x.CreateAsync(It.IsAny<PatientDevice>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.CreateAsync(It.IsAny<PatientDevice>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((PatientDevice m, CancellationToken _) => m);
 
         // Act

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/PatientRecordControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/PatientRecordControllerTests.cs
@@ -56,7 +56,7 @@ public class PatientRecordControllerTests
 
         _deviceRepo
             .Setup(x => x.CreateAsync(It.IsAny<PatientDevice>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((PatientDevice m, CancellationToken _) => m);
+            .ReturnsAsync((PatientDevice m, WriteOrigin origin, CancellationToken _) => m);
 
         // Act
         var result = await _controller.CreateDevice(model);
@@ -88,7 +88,7 @@ public class PatientRecordControllerTests
 
         _deviceRepo
             .Setup(x => x.CreateAsync(It.IsAny<PatientDevice>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((PatientDevice m, CancellationToken _) => m);
+            .ReturnsAsync((PatientDevice m, WriteOrigin origin, CancellationToken _) => m);
 
         // Act
         await _controller.CreateDevice(model);
@@ -127,7 +127,7 @@ public class PatientRecordControllerTests
 
         _deviceRepo
             .Setup(x => x.UpdateAsync(deviceId, It.IsAny<PatientDevice>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Guid _, PatientDevice m, CancellationToken _) => m);
+            .ReturnsAsync((Guid _, PatientDevice m, WriteOrigin origin, CancellationToken _) => m);
 
         // Act
         var result = await _controller.UpdateDevice(deviceId, model);
@@ -159,7 +159,7 @@ public class PatientRecordControllerTests
 
         _deviceRepo
             .Setup(x => x.CreateAsync(It.IsAny<PatientDevice>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((PatientDevice m, CancellationToken _) => m);
+            .ReturnsAsync((PatientDevice m, WriteOrigin origin, CancellationToken _) => m);
 
         // Act
         await _controller.CreateDevice(model);

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/SensorGlucoseControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/SensorGlucoseControllerTests.cs
@@ -11,6 +11,7 @@ using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Tests.Controllers.V4;
 
@@ -58,11 +59,11 @@ public class SensorGlucoseControllerTests
         };
 
         _repoMock
-            .Setup(r => r.CreateAsync(It.IsAny<SensorGlucose>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.CreateAsync(It.IsAny<SensorGlucose>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(created);
 
         _repoMock.As<IV4Repository<SensorGlucose>>()
-            .Setup(r => r.CreateAsync(It.IsAny<SensorGlucose>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.CreateAsync(It.IsAny<SensorGlucose>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(created);
 
         var controller = CreateController();
@@ -84,10 +85,10 @@ public class SensorGlucoseControllerTests
         var created = new SensorGlucose { Id = Guid.NewGuid(), Timestamp = input.Timestamp.UtcDateTime, Mgdl = 120 };
 
         _repoMock
-            .Setup(r => r.CreateAsync(It.IsAny<SensorGlucose>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.CreateAsync(It.IsAny<SensorGlucose>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(created);
         _repoMock.As<IV4Repository<SensorGlucose>>()
-            .Setup(r => r.CreateAsync(It.IsAny<SensorGlucose>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.CreateAsync(It.IsAny<SensorGlucose>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(created);
 
         var controller = CreateController();
@@ -119,7 +120,7 @@ public class SensorGlucoseControllerTests
         };
 
         _repoMock
-            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(created);
 
         var controller = CreateController();
@@ -148,7 +149,7 @@ public class SensorGlucoseControllerTests
             .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(existing);
         _repoMock
-            .Setup(r => r.UpdateAsync(id, It.IsAny<SensorGlucose>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.UpdateAsync(id, It.IsAny<SensorGlucose>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(updated);
 
         var controller = CreateController();
@@ -170,7 +171,7 @@ public class SensorGlucoseControllerTests
         var restored = new SensorGlucose { Id = id, Timestamp = DateTime.UtcNow, Mgdl = 110 };
 
         _repoMock
-            .Setup(r => r.RestoreAsync(id, It.IsAny<CancellationToken>()))
+            .Setup(r => r.RestoreAsync(id, It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(restored);
 
         var controller = CreateController();

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Treatments/BasalInjectionControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Treatments/BasalInjectionControllerTests.cs
@@ -7,6 +7,7 @@ using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Tests.Controllers.V4.Treatments;
 
@@ -46,7 +47,7 @@ public class BasalInjectionControllerTests
     private void SetupCreatePassthrough(Action<BasalInjection> onCreate)
     {
         _repoMock
-            .Setup(r => r.CreateAsync(It.IsAny<BasalInjection>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.CreateAsync(It.IsAny<BasalInjection>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .Callback<BasalInjection, CancellationToken>((b, _) => onCreate(b))
             .ReturnsAsync((BasalInjection b, CancellationToken _) => b);
     }
@@ -66,7 +67,7 @@ public class BasalInjectionControllerTests
 
         var objectResult = result.Result.Should().BeOfType<ObjectResult>().Subject;
         objectResult.StatusCode.Should().Be(400);
-        _repoMock.Verify(r => r.CreateAsync(It.IsAny<BasalInjection>(), It.IsAny<CancellationToken>()), Times.Never);
+        _repoMock.Verify(r => r.CreateAsync(It.IsAny<BasalInjection>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
 
         var negativeRequest = new CreateBasalInjectionRequest
         {
@@ -95,7 +96,7 @@ public class BasalInjectionControllerTests
 
         var objectResult = result.Result.Should().BeOfType<ObjectResult>().Subject;
         objectResult.StatusCode.Should().Be(400);
-        _repoMock.Verify(r => r.CreateAsync(It.IsAny<BasalInjection>(), It.IsAny<CancellationToken>()), Times.Never);
+        _repoMock.Verify(r => r.CreateAsync(It.IsAny<BasalInjection>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -113,7 +114,7 @@ public class BasalInjectionControllerTests
 
         var objectResult = result.Result.Should().BeOfType<ObjectResult>().Subject;
         objectResult.StatusCode.Should().Be(400);
-        _repoMock.Verify(r => r.CreateAsync(It.IsAny<BasalInjection>(), It.IsAny<CancellationToken>()), Times.Never);
+        _repoMock.Verify(r => r.CreateAsync(It.IsAny<BasalInjection>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -135,7 +136,7 @@ public class BasalInjectionControllerTests
 
         var objectResult = result.Result.Should().BeOfType<ObjectResult>().Subject;
         objectResult.StatusCode.Should().Be(400);
-        _repoMock.Verify(r => r.CreateAsync(It.IsAny<BasalInjection>(), It.IsAny<CancellationToken>()), Times.Never);
+        _repoMock.Verify(r => r.CreateAsync(It.IsAny<BasalInjection>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -158,7 +159,7 @@ public class BasalInjectionControllerTests
 
         var objectResult = result.Result.Should().BeOfType<ObjectResult>().Subject;
         objectResult.StatusCode.Should().Be(400);
-        _repoMock.Verify(r => r.CreateAsync(It.IsAny<BasalInjection>(), It.IsAny<CancellationToken>()), Times.Never);
+        _repoMock.Verify(r => r.CreateAsync(It.IsAny<BasalInjection>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -187,7 +188,7 @@ public class BasalInjectionControllerTests
 
         var objectResult = result.Result.Should().BeOfType<ObjectResult>().Subject;
         objectResult.StatusCode.Should().Be(400);
-        _repoMock.Verify(r => r.CreateAsync(It.IsAny<BasalInjection>(), It.IsAny<CancellationToken>()), Times.Never);
+        _repoMock.Verify(r => r.CreateAsync(It.IsAny<BasalInjection>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -220,7 +221,7 @@ public class BasalInjectionControllerTests
         var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
         ok.Value.Should().BeSameAs(existing);
 
-        _repoMock.Verify(r => r.CreateAsync(It.IsAny<BasalInjection>(), It.IsAny<CancellationToken>()), Times.Never);
+        _repoMock.Verify(r => r.CreateAsync(It.IsAny<BasalInjection>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
         _insulinRepoMock.Verify(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Treatments/BasalInjectionControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Treatments/BasalInjectionControllerTests.cs
@@ -48,8 +48,8 @@ public class BasalInjectionControllerTests
     {
         _repoMock
             .Setup(r => r.CreateAsync(It.IsAny<BasalInjection>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback<BasalInjection, CancellationToken>((b, _) => onCreate(b))
-            .ReturnsAsync((BasalInjection b, CancellationToken _) => b);
+            .Callback<BasalInjection, WriteOrigin, CancellationToken>((b, _, _) => onCreate(b))
+            .ReturnsAsync((BasalInjection b, WriteOrigin origin, CancellationToken _) => b);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/CacheIntegrationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/CacheIntegrationTests.cs
@@ -169,7 +169,7 @@ public class CacheIntegrationTests
         };
 
         _mockEntryDecomposer
-            .Setup(x => x.DecomposeAsync(It.IsAny<Entry>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.DecomposeAsync(It.IsAny<Entry>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Core.Models.V4.DecompositionResult());
 
         var entryService = new EntryService(
@@ -189,7 +189,7 @@ public class CacheIntegrationTests
 
         // Verify decomposition happened and events fired (cache invalidation is handled by the event sink)
         _mockEntryDecomposer.Verify(
-            x => x.DecomposeAsync(It.IsAny<Entry>(), It.IsAny<CancellationToken>()),
+            x => x.DecomposeAsync(It.IsAny<Entry>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once
         );
         _mockEntryEvents.Verify(

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/DevicePublisherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/DevicePublisherTests.cs
@@ -40,11 +40,11 @@ public class DevicePublisherTests
     {
         var statuses = new List<DeviceStatus> { new() };
 
-        var result = await _publisher.PublishDeviceStatusAsync(statuses, "test-source");
+        var result = await _publisher.PublishDeviceStatusAsync(statuses, "test-source", WriteOrigin.Live);
 
         result.Should().BeTrue();
         _mockDecomposer.Verify(
-            s => s.DecomposeAsync(It.IsAny<DeviceStatus>(), It.IsAny<CancellationToken>()),
+            s => s.DecomposeAsync(It.IsAny<DeviceStatus>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once
         );
     }
@@ -53,10 +53,10 @@ public class DevicePublisherTests
     public async Task PublishDeviceStatusAsync_ReturnsFalse_OnException()
     {
         _mockDecomposer
-            .Setup(s => s.DecomposeAsync(It.IsAny<DeviceStatus>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.DecomposeAsync(It.IsAny<DeviceStatus>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("test error"));
 
-        var result = await _publisher.PublishDeviceStatusAsync(new List<DeviceStatus> { new() }, "test-source");
+        var result = await _publisher.PublishDeviceStatusAsync(new List<DeviceStatus> { new() }, "test-source", WriteOrigin.Live);
 
         result.Should().BeFalse();
     }

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/GlucosePublisherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/GlucosePublisherTests.cs
@@ -15,6 +15,7 @@ using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Tests.Services.ConnectorPublishing;
 
@@ -55,7 +56,7 @@ public class GlucosePublisherTests
             .Setup(s => s.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(entries);
 
-        var result = await _publisher.PublishEntriesAsync(entries, "test-source");
+        var result = await _publisher.PublishEntriesAsync(entries, "test-source", WriteOrigin.Live);
 
         result.Should().BeTrue();
         _mockEntryService.Verify(
@@ -71,7 +72,7 @@ public class GlucosePublisherTests
             .Setup(s => s.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("test error"));
 
-        var result = await _publisher.PublishEntriesAsync(new List<Entry>(), "test-source");
+        var result = await _publisher.PublishEntriesAsync(new List<Entry>(), "test-source", WriteOrigin.Live);
 
         result.Should().BeFalse();
     }
@@ -93,10 +94,10 @@ public class GlucosePublisherTests
         // subset (the second reading); the first overlaps an already-stored reading from a prior poll.
         var inserted = new List<SensorGlucose> { records[1] };
         _mockSensorGlucoseRepository
-            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(inserted);
 
-        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector);
+        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector, WriteOrigin.Live);
 
         result.Should().BeTrue();
         // The broadcast must be the deduped insert result, not the raw input list, so already-stored
@@ -170,7 +171,7 @@ public class GlucosePublisherTests
 
         List<SensorGlucose>? captured = null;
         _mockSensorGlucoseRepository
-            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .Callback<IEnumerable<SensorGlucose>, CancellationToken>((records, _) => captured = records.ToList())
             .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
 
@@ -179,7 +180,7 @@ public class GlucosePublisherTests
             new() { Mgdl = 120, Timestamp = DateTime.UtcNow, DataSource = DataSources.DexcomConnector },
         };
 
-        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector);
+        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector, WriteOrigin.Live);
 
         result.Should().BeTrue();
         captured.Should().NotBeNull();
@@ -195,7 +196,7 @@ public class GlucosePublisherTests
 
         List<SensorGlucose>? captured = null;
         _mockSensorGlucoseRepository
-            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .Callback<IEnumerable<SensorGlucose>, CancellationToken>((records, _) => captured = records.ToList())
             .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
 
@@ -204,7 +205,7 @@ public class GlucosePublisherTests
             new() { Mgdl = 120, Timestamp = DateTime.UtcNow, DataSource = DataSources.DexcomConnector },
         };
 
-        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector);
+        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector, WriteOrigin.Live);
 
         result.Should().BeTrue();
         captured.Should().NotBeNull();
@@ -231,7 +232,7 @@ public class GlucosePublisherTests
 
         List<SensorGlucose>? captured = null;
         _mockSensorGlucoseRepository
-            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .Callback<IEnumerable<SensorGlucose>, CancellationToken>((records, _) => captured = records.ToList())
             .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
 
@@ -240,7 +241,7 @@ public class GlucosePublisherTests
             new() { Mgdl = 95, Timestamp = DateTime.UtcNow, DataSource = DataSources.LibreConnector },
         };
 
-        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.LibreConnector);
+        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.LibreConnector, WriteOrigin.Live);
 
         result.Should().BeTrue();
         captured![0].PatientDeviceId.Should().Be(deviceId);
@@ -266,7 +267,7 @@ public class GlucosePublisherTests
 
         List<SensorGlucose>? captured = null;
         _mockSensorGlucoseRepository
-            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .Callback<IEnumerable<SensorGlucose>, CancellationToken>((records, _) => captured = records.ToList())
             .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
 
@@ -275,7 +276,7 @@ public class GlucosePublisherTests
             new() { Mgdl = 110, Timestamp = DateTime.UtcNow, DataSource = null },
         };
 
-        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector);
+        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector, WriteOrigin.Live);
 
         result.Should().BeTrue();
         captured![0].PatientDeviceId.Should().Be(deviceId);
@@ -303,7 +304,7 @@ public class GlucosePublisherTests
 
         List<SensorGlucose>? captured = null;
         _mockSensorGlucoseRepository
-            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .Callback<IEnumerable<SensorGlucose>, CancellationToken>((records, _) => captured = records.ToList())
             .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
 
@@ -312,7 +313,7 @@ public class GlucosePublisherTests
             new() { Mgdl = 100, Timestamp = DateTime.UtcNow, DataSource = DataSources.DexcomConnector, PatientDeviceId = existingDeviceId },
         };
 
-        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector);
+        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector, WriteOrigin.Live);
 
         result.Should().BeTrue();
         captured![0].PatientDeviceId.Should().Be(existingDeviceId);
@@ -339,7 +340,7 @@ public class GlucosePublisherTests
 
         List<SensorGlucose>? captured = null;
         _mockSensorGlucoseRepository
-            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .Callback<IEnumerable<SensorGlucose>, CancellationToken>((records, _) => captured = records.ToList())
             .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
 
@@ -348,7 +349,7 @@ public class GlucosePublisherTests
             new() { Mgdl = 130, Timestamp = DateTime.UtcNow, DataSource = DataSources.DexcomConnector },
         };
 
-        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector);
+        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector, WriteOrigin.Live);
 
         result.Should().BeTrue();
         captured![0].PatientDeviceId.Should().Be(deviceId);
@@ -374,7 +375,7 @@ public class GlucosePublisherTests
 
         List<SensorGlucose>? captured = null;
         _mockSensorGlucoseRepository
-            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .Callback<IEnumerable<SensorGlucose>, CancellationToken>((records, _) => captured = records.ToList())
             .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
 
@@ -383,7 +384,7 @@ public class GlucosePublisherTests
             new() { Mgdl = 100, Timestamp = DateTime.UtcNow, DataSource = DataSources.DexcomConnector },
         };
 
-        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector);
+        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector, WriteOrigin.Live);
 
         result.Should().BeTrue();
         captured![0].PatientDeviceId.Should().BeNull();
@@ -397,7 +398,7 @@ public class GlucosePublisherTests
             .ThrowsAsync(new InvalidOperationException("DB error"));
 
         _mockSensorGlucoseRepository
-            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
 
         var records = new List<SensorGlucose>
@@ -405,11 +406,11 @@ public class GlucosePublisherTests
             new() { Mgdl = 100, Timestamp = DateTime.UtcNow, DataSource = DataSources.DexcomConnector },
         };
 
-        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector);
+        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector, WriteOrigin.Live);
 
         result.Should().BeTrue();
         _mockSensorGlucoseRepository.Verify(
-            r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<CancellationToken>()),
+            r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/GlucosePublisherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/GlucosePublisherTests.cs
@@ -172,7 +172,7 @@ public class GlucosePublisherTests
         List<SensorGlucose>? captured = null;
         _mockSensorGlucoseRepository
             .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback<IEnumerable<SensorGlucose>, CancellationToken>((records, _) => captured = records.ToList())
+            .Callback<IEnumerable<SensorGlucose>, WriteOrigin, CancellationToken>((records, _, _) => captured = records.ToList())
             .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
 
         var records = new List<SensorGlucose>
@@ -197,7 +197,7 @@ public class GlucosePublisherTests
         List<SensorGlucose>? captured = null;
         _mockSensorGlucoseRepository
             .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback<IEnumerable<SensorGlucose>, CancellationToken>((records, _) => captured = records.ToList())
+            .Callback<IEnumerable<SensorGlucose>, WriteOrigin, CancellationToken>((records, _, _) => captured = records.ToList())
             .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
 
         var records = new List<SensorGlucose>
@@ -233,7 +233,7 @@ public class GlucosePublisherTests
         List<SensorGlucose>? captured = null;
         _mockSensorGlucoseRepository
             .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback<IEnumerable<SensorGlucose>, CancellationToken>((records, _) => captured = records.ToList())
+            .Callback<IEnumerable<SensorGlucose>, WriteOrigin, CancellationToken>((records, _, _) => captured = records.ToList())
             .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
 
         var records = new List<SensorGlucose>
@@ -268,7 +268,7 @@ public class GlucosePublisherTests
         List<SensorGlucose>? captured = null;
         _mockSensorGlucoseRepository
             .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback<IEnumerable<SensorGlucose>, CancellationToken>((records, _) => captured = records.ToList())
+            .Callback<IEnumerable<SensorGlucose>, WriteOrigin, CancellationToken>((records, _, _) => captured = records.ToList())
             .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
 
         var records = new List<SensorGlucose>
@@ -305,7 +305,7 @@ public class GlucosePublisherTests
         List<SensorGlucose>? captured = null;
         _mockSensorGlucoseRepository
             .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback<IEnumerable<SensorGlucose>, CancellationToken>((records, _) => captured = records.ToList())
+            .Callback<IEnumerable<SensorGlucose>, WriteOrigin, CancellationToken>((records, _, _) => captured = records.ToList())
             .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
 
         var records = new List<SensorGlucose>
@@ -341,7 +341,7 @@ public class GlucosePublisherTests
         List<SensorGlucose>? captured = null;
         _mockSensorGlucoseRepository
             .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback<IEnumerable<SensorGlucose>, CancellationToken>((records, _) => captured = records.ToList())
+            .Callback<IEnumerable<SensorGlucose>, WriteOrigin, CancellationToken>((records, _, _) => captured = records.ToList())
             .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
 
         var records = new List<SensorGlucose>
@@ -376,7 +376,7 @@ public class GlucosePublisherTests
         List<SensorGlucose>? captured = null;
         _mockSensorGlucoseRepository
             .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback<IEnumerable<SensorGlucose>, CancellationToken>((records, _) => captured = records.ToList())
+            .Callback<IEnumerable<SensorGlucose>, WriteOrigin, CancellationToken>((records, _, _) => captured = records.ToList())
             .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
 
         var records = new List<SensorGlucose>

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/MetadataPublisherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/MetadataPublisherTests.cs
@@ -12,6 +12,7 @@ using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Contracts.Repositories;
 using Nocturne.Core.Models;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Tests.Services.ConnectorPublishing;
 
@@ -57,7 +58,7 @@ public class MetadataPublisherTests
         var profiles = new List<Profile> { new() };
 
         var publisher = CreatePublisher();
-        var result = await publisher.PublishProfilesAsync(profiles, "test-source");
+        var result = await publisher.PublishProfilesAsync(profiles, "test-source", WriteOrigin.Live);
 
         result.Should().BeTrue();
         _mockProfileDataService.Verify(
@@ -72,7 +73,7 @@ public class MetadataPublisherTests
         var foods = new List<Food> { new() };
 
         var publisher = CreatePublisher();
-        var result = await publisher.PublishFoodAsync(foods, "test-source");
+        var result = await publisher.PublishFoodAsync(foods, "test-source", WriteOrigin.Live);
 
         result.Should().BeTrue();
         _mockFoodService.Verify(
@@ -90,7 +91,7 @@ public class MetadataPublisherTests
             .ReturnsAsync(new List<ConnectorFoodEntry> { new() });
 
         var publisher = CreatePublisher();
-        var result = await publisher.PublishConnectorFoodEntriesAsync(entries, "test-source");
+        var result = await publisher.PublishConnectorFoodEntriesAsync(entries, "test-source", WriteOrigin.Live);
 
         result.Should().NotBeNull();
         result.Should().HaveCount(1);
@@ -106,7 +107,7 @@ public class MetadataPublisherTests
         var activities = new List<Activity> { new() };
 
         var publisher = CreatePublisher();
-        var result = await publisher.PublishActivityAsync(activities, "test-source");
+        var result = await publisher.PublishActivityAsync(activities, "test-source", WriteOrigin.Live);
 
         result.Should().BeTrue();
         _mockActivityService.Verify(
@@ -121,7 +122,7 @@ public class MetadataPublisherTests
         var spans = new List<StateSpan> { new(), new(), new() };
         var publisher = CreatePublisher();
 
-        var result = await publisher.PublishStateSpansAsync(spans, "test-source");
+        var result = await publisher.PublishStateSpansAsync(spans, "test-source", WriteOrigin.Live);
 
         result.Should().BeTrue();
         _mockStateSpanService.Verify(
@@ -138,7 +139,7 @@ public class MetadataPublisherTests
             .ThrowsAsync(new InvalidOperationException("test error"));
         var publisher = CreatePublisher();
 
-        var result = await publisher.PublishStateSpansAsync(new List<StateSpan> { new() }, "test-source");
+        var result = await publisher.PublishStateSpansAsync(new List<StateSpan> { new() }, "test-source", WriteOrigin.Live);
 
         result.Should().BeFalse();
     }

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/TreatmentPublisherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/TreatmentPublisherTests.cs
@@ -467,10 +467,10 @@ public class TreatmentPublisherTests
             .ReturnsAsync([]);
         _mockPatientInsulinRepository
             .Setup(r => r.CreateAsync(It.IsAny<PatientInsulin>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((PatientInsulin m, CancellationToken _) => m);
+            .ReturnsAsync((PatientInsulin m, WriteOrigin _, CancellationToken _) => m);
         _mockBasalInjectionRepository
             .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<BasalInjection>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<BasalInjection> records, CancellationToken _) => records);
+            .ReturnsAsync((IEnumerable<BasalInjection> records, WriteOrigin _, CancellationToken _) => records);
 
         var records = new List<BasalInjection>
         {
@@ -508,10 +508,10 @@ public class TreatmentPublisherTests
             .ReturnsAsync([]);
         _mockPatientInsulinRepository
             .Setup(r => r.CreateAsync(It.IsAny<PatientInsulin>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((PatientInsulin m, CancellationToken _) => m);
+            .ReturnsAsync((PatientInsulin m, WriteOrigin _, CancellationToken _) => m);
         _mockBasalInjectionRepository
             .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<BasalInjection>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<BasalInjection> records, CancellationToken _) => records);
+            .ReturnsAsync((IEnumerable<BasalInjection> records, WriteOrigin _, CancellationToken _) => records);
 
         var records = new List<BasalInjection>
         {
@@ -569,7 +569,7 @@ public class TreatmentPublisherTests
             ]);
         _mockBasalInjectionRepository
             .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<BasalInjection>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<BasalInjection> records, CancellationToken _) => records);
+            .ReturnsAsync((IEnumerable<BasalInjection> records, WriteOrigin _, CancellationToken _) => records);
 
         var records = new List<BasalInjection>
         {
@@ -608,7 +608,7 @@ public class TreatmentPublisherTests
         var existingId = Guid.NewGuid();
         _mockBasalInjectionRepository
             .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<BasalInjection>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<BasalInjection> records, CancellationToken _) => records);
+            .ReturnsAsync((IEnumerable<BasalInjection> records, WriteOrigin _, CancellationToken _) => records);
 
         var records = new List<BasalInjection>
         {

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/TreatmentPublisherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/TreatmentPublisherTests.cs
@@ -14,6 +14,7 @@ using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Services;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Tests.Services.ConnectorPublishing;
 
@@ -103,7 +104,7 @@ public class TreatmentPublisherTests
             .Setup(s => s.CreateTreatmentsAsync(It.IsAny<IEnumerable<Treatment>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(treatments);
 
-        var result = await _publisher.PublishTreatmentsAsync(treatments, "test-source");
+        var result = await _publisher.PublishTreatmentsAsync(treatments, "test-source", WriteOrigin.Live);
 
         result.Should().BeTrue();
         _mockTreatmentService.Verify(
@@ -119,7 +120,7 @@ public class TreatmentPublisherTests
             .Setup(s => s.CreateTreatmentsAsync(It.IsAny<IEnumerable<Treatment>>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("test error"));
 
-        var result = await _publisher.PublishTreatmentsAsync(new List<Treatment>(), "test-source");
+        var result = await _publisher.PublishTreatmentsAsync(new List<Treatment>(), "test-source", WriteOrigin.Live);
 
         result.Should().BeFalse();
     }
@@ -139,7 +140,7 @@ public class TreatmentPublisherTests
                         CreatedAt = DateTime.UtcNow,
                     },
                 },
-                "test-source"));
+                "test-source", WriteOrigin.Live));
 
         var results = await Task.WhenAll(calls);
 
@@ -223,14 +224,14 @@ public class TreatmentPublisherTests
             }
         };
 
-        var result = await _publisher.PublishTempBasalsAsync(records, "glooko-connector");
+        var result = await _publisher.PublishTempBasalsAsync(records, "glooko-connector", WriteOrigin.Live);
 
         result.Should().BeTrue();
         records[0].Origin.Should().Be(TempBasalOrigin.Algorithm);
         records[0].ScheduledRate.Should().Be(1.0);
         records[0].Rate.Should().Be(0.4);
         _mockTempBasalRepository.Verify(
-            r => r.BulkCreateAsync(records, It.IsAny<CancellationToken>()),
+            r => r.BulkCreateAsync(records, It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -254,7 +255,7 @@ public class TreatmentPublisherTests
             }
         };
 
-        var result = await _publisher.PublishTempBasalsAsync(records, "glooko-connector");
+        var result = await _publisher.PublishTempBasalsAsync(records, "glooko-connector", WriteOrigin.Live);
 
         result.Should().BeTrue();
         records[0].Origin.Should().Be(TempBasalOrigin.Scheduled);
@@ -282,7 +283,7 @@ public class TreatmentPublisherTests
             }
         };
 
-        var result = await _publisher.PublishTempBasalsAsync(records, "glooko-connector");
+        var result = await _publisher.PublishTempBasalsAsync(records, "glooko-connector", WriteOrigin.Live);
 
         result.Should().BeTrue();
         records[0].Origin.Should().Be(TempBasalOrigin.Scheduled);
@@ -303,7 +304,7 @@ public class TreatmentPublisherTests
             new() { Id = Guid.NewGuid(), StartTimestamp = ts.AddMinutes(10), Rate = 0, ScheduledRate = null, Origin = TempBasalOrigin.Suspended },
         };
 
-        var result = await _publisher.PublishTempBasalsAsync(records, "loop-connector");
+        var result = await _publisher.PublishTempBasalsAsync(records, "loop-connector", WriteOrigin.Live);
 
         result.Should().BeTrue();
         records[0].Origin.Should().Be(TempBasalOrigin.Algorithm);
@@ -335,7 +336,7 @@ public class TreatmentPublisherTests
             }
         };
 
-        var result = await _publisher.PublishTempBasalsAsync(records, "glooko-connector");
+        var result = await _publisher.PublishTempBasalsAsync(records, "glooko-connector", WriteOrigin.Live);
 
         result.Should().BeTrue();
         records[0].Origin.Should().Be(TempBasalOrigin.Scheduled);
@@ -386,7 +387,7 @@ public class TreatmentPublisherTests
             }
         };
 
-        var result = await publisher.PublishTempBasalsAsync(records, "glooko-connector");
+        var result = await publisher.PublishTempBasalsAsync(records, "glooko-connector", WriteOrigin.Live);
 
         result.Should().BeTrue();
         authTypeDuringDelete.Should().BeNull("the reconcile delete must be system-attributed");
@@ -422,13 +423,13 @@ public class TreatmentPublisherTests
             new() { Id = Guid.NewGuid(), LegacyId = null, StartTimestamp = ts.AddMinutes(10), Rate = 0.7, Origin = TempBasalOrigin.Algorithm, DataSource = "glooko-connector" },
         };
 
-        var result = await _publisher.PublishTempBasalsAsync(records, "glooko-connector");
+        var result = await _publisher.PublishTempBasalsAsync(records, "glooko-connector", WriteOrigin.Live);
 
         result.Should().BeTrue();
         keepLegacyIds.Should().BeEquivalentTo(new[] { "glooko_tempbasal_1", "glooko_tempbasal_2" },
             "only non-null incoming legacy ids form the keep-set");
         _mockTempBasalRepository.Verify(
-            r => r.BulkCreateAsync(records, It.IsAny<CancellationToken>()), Times.Once);
+            r => r.BulkCreateAsync(records, It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -440,7 +441,7 @@ public class TreatmentPublisherTests
             new() { Id = Guid.NewGuid(), StartTimestamp = ts, Rate = 0.5, Origin = TempBasalOrigin.Algorithm },
         };
 
-        var result = await _publisher.PublishTempBasalsAsync(records, "loop-connector");
+        var result = await _publisher.PublishTempBasalsAsync(records, "loop-connector", WriteOrigin.Live);
 
         result.Should().BeTrue();
         _mockBasalRateResolver.Verify(
@@ -453,7 +454,7 @@ public class TreatmentPublisherTests
     [Fact]
     public async Task PublishBasalInjectionsAsync_EmptyList_ReturnsTrue()
     {
-        var result = await _publisher.PublishBasalInjectionsAsync([], "glooko-connector");
+        var result = await _publisher.PublishBasalInjectionsAsync([], "glooko-connector", WriteOrigin.Live);
 
         result.Should().BeTrue();
     }
@@ -465,10 +466,10 @@ public class TreatmentPublisherTests
             .Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
         _mockPatientInsulinRepository
-            .Setup(r => r.CreateAsync(It.IsAny<PatientInsulin>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.CreateAsync(It.IsAny<PatientInsulin>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((PatientInsulin m, CancellationToken _) => m);
         _mockBasalInjectionRepository
-            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<BasalInjection>>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<BasalInjection>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<BasalInjection> records, CancellationToken _) => records);
 
         var records = new List<BasalInjection>
@@ -491,11 +492,11 @@ public class TreatmentPublisherTests
             }
         };
 
-        var result = await _publisher.PublishBasalInjectionsAsync(records, "glooko-connector");
+        var result = await _publisher.PublishBasalInjectionsAsync(records, "glooko-connector", WriteOrigin.Live);
 
         result.Should().BeTrue();
         _mockBasalInjectionRepository.Verify(
-            r => r.BulkCreateAsync(It.IsAny<IEnumerable<BasalInjection>>(), It.IsAny<CancellationToken>()),
+            r => r.BulkCreateAsync(It.IsAny<IEnumerable<BasalInjection>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -506,10 +507,10 @@ public class TreatmentPublisherTests
             .Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
         _mockPatientInsulinRepository
-            .Setup(r => r.CreateAsync(It.IsAny<PatientInsulin>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.CreateAsync(It.IsAny<PatientInsulin>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((PatientInsulin m, CancellationToken _) => m);
         _mockBasalInjectionRepository
-            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<BasalInjection>>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<BasalInjection>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<BasalInjection> records, CancellationToken _) => records);
 
         var records = new List<BasalInjection>
@@ -532,7 +533,7 @@ public class TreatmentPublisherTests
             }
         };
 
-        await _publisher.PublishBasalInjectionsAsync(records, "glooko-connector");
+        await _publisher.PublishBasalInjectionsAsync(records, "glooko-connector", WriteOrigin.Live);
 
         // Should auto-create a PatientInsulin record
         _mockPatientInsulinRepository.Verify(
@@ -540,7 +541,7 @@ public class TreatmentPublisherTests
                 pi.Name == "Tresiba (Insulin Degludec)" &&
                 pi.Role == InsulinRole.Basal &&
                 pi.IsCurrent == true),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         // The record should now have a real PatientInsulinId (not Guid.Empty)
@@ -567,7 +568,7 @@ public class TreatmentPublisherTests
                 }
             ]);
         _mockBasalInjectionRepository
-            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<BasalInjection>>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<BasalInjection>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<BasalInjection> records, CancellationToken _) => records);
 
         var records = new List<BasalInjection>
@@ -590,11 +591,11 @@ public class TreatmentPublisherTests
             }
         };
 
-        await _publisher.PublishBasalInjectionsAsync(records, "glooko-connector");
+        await _publisher.PublishBasalInjectionsAsync(records, "glooko-connector", WriteOrigin.Live);
 
         // Should NOT create a new PatientInsulin — reuses existing
         _mockPatientInsulinRepository.Verify(
-            r => r.CreateAsync(It.IsAny<PatientInsulin>(), It.IsAny<CancellationToken>()),
+            r => r.CreateAsync(It.IsAny<PatientInsulin>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
 
         // Should resolve to the existing ID
@@ -606,7 +607,7 @@ public class TreatmentPublisherTests
     {
         var existingId = Guid.NewGuid();
         _mockBasalInjectionRepository
-            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<BasalInjection>>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<BasalInjection>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<BasalInjection> records, CancellationToken _) => records);
 
         var records = new List<BasalInjection>
@@ -629,7 +630,7 @@ public class TreatmentPublisherTests
             }
         };
 
-        await _publisher.PublishBasalInjectionsAsync(records, "glooko-connector");
+        await _publisher.PublishBasalInjectionsAsync(records, "glooko-connector", WriteOrigin.Live);
 
         // Should not touch PatientInsulin repo at all
         _mockPatientInsulinRepository.Verify(

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutConnectorPaginationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutConnectorPaginationTests.cs
@@ -9,6 +9,7 @@ using Nocturne.Connectors.Nightscout.Configurations;
 using Nocturne.Connectors.Nightscout.Services;
 using Nocturne.Core.Models;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Tests.Services.Connectors;
 
@@ -41,12 +42,12 @@ public class NightscoutConnectorPaginationTests
         {
             var glucoseMock = new Mock<IGlucosePublisher>();
             glucoseMock.Setup(p => p.PublishEntriesAsync(
-                    It.IsAny<IEnumerable<Entry>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    It.IsAny<IEnumerable<Entry>>(), It.IsAny<string>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
 
             var treatmentMock = new Mock<ITreatmentPublisher>();
             treatmentMock.Setup(p => p.PublishTreatmentsAsync(
-                    It.IsAny<IEnumerable<Treatment>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    It.IsAny<IEnumerable<Treatment>>(), It.IsAny<string>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
 
             var mock = new Mock<IConnectorPublisher>();

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutPerTypeCursorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutPerTypeCursorTests.cs
@@ -12,6 +12,7 @@ using Nocturne.Connectors.Nightscout.Configurations;
 using Nocturne.Connectors.Nightscout.Services;
 using Nocturne.Core.Models;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Tests.Services.Connectors;
 
@@ -37,19 +38,19 @@ public class NightscoutPerTypeCursorTests
         var glucose = new Mock<IGlucosePublisher>();
         glucose.Setup(p => p.GetLatestEntryTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(latestEntry);
-        glucose.Setup(p => p.PublishEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        glucose.Setup(p => p.PublishEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<string>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
         var treatments = new Mock<ITreatmentPublisher>();
         treatments.Setup(p => p.GetLatestTreatmentTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(latestTreatment);
-        treatments.Setup(p => p.PublishTreatmentsAsync(It.IsAny<IEnumerable<Treatment>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        treatments.Setup(p => p.PublishTreatmentsAsync(It.IsAny<IEnumerable<Treatment>>(), It.IsAny<string>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
         var device = new Mock<IDevicePublisher>();
         device.Setup(p => p.GetLatestDeviceStatusTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(latestDeviceStatus);
-        device.Setup(p => p.PublishDeviceStatusAsync(It.IsAny<IEnumerable<DeviceStatus>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        device.Setup(p => p.PublishDeviceStatusAsync(It.IsAny<IEnumerable<DeviceStatus>>(), It.IsAny<string>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
         var metadata = new Mock<IMetadataPublisher>();

--- a/tests/Unit/Nocturne.API.Tests/Services/Devices/DeviceServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Devices/DeviceServiceTests.cs
@@ -83,7 +83,7 @@ public class DeviceServiceTests
 
         _mockRepository
             .Setup(r => r.CreateAsync(It.IsAny<Device>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Device device, CancellationToken _) => device);
+            .ReturnsAsync((Device device, WriteOrigin _, CancellationToken _) => device);
 
         // Act
         var result = await _service.ResolveAsync(category, type, serial, mills);
@@ -165,7 +165,7 @@ public class DeviceServiceTests
 
         _mockRepository
             .Setup(r => r.UpdateAsync(existingId, It.IsAny<Device>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Guid _, Device d, CancellationToken _) => d);
+            .ReturnsAsync((Guid _, Device d, WriteOrigin _, CancellationToken _) => d);
 
         // Act
         var result = await _service.ResolveAsync(category, type, serial, newerMills);

--- a/tests/Unit/Nocturne.API.Tests/Services/Devices/DeviceServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Devices/DeviceServiceTests.cs
@@ -5,6 +5,7 @@ using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Tests.Shared.Mocks;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Tests.Services.Devices;
 
@@ -81,7 +82,7 @@ public class DeviceServiceTests
             .ReturnsAsync((Device?)null);
 
         _mockRepository
-            .Setup(r => r.CreateAsync(It.IsAny<Device>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.CreateAsync(It.IsAny<Device>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((Device device, CancellationToken _) => device);
 
         // Act
@@ -97,7 +98,7 @@ public class DeviceServiceTests
                     d.Serial == serial &&
                     d.FirstSeenTimestamp == DateTimeOffset.FromUnixTimeMilliseconds(mills).UtcDateTime &&
                     d.LastSeenTimestamp == DateTimeOffset.FromUnixTimeMilliseconds(mills).UtcDateTime),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -132,7 +133,7 @@ public class DeviceServiceTests
         // Assert
         result.Should().Be(existingId);
         _mockRepository.Verify(
-            r => r.CreateAsync(It.IsAny<Device>(), It.IsAny<CancellationToken>()),
+            r => r.CreateAsync(It.IsAny<Device>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -163,7 +164,7 @@ public class DeviceServiceTests
             .ReturnsAsync(existingDevice);
 
         _mockRepository
-            .Setup(r => r.UpdateAsync(existingId, It.IsAny<Device>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.UpdateAsync(existingId, It.IsAny<Device>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((Guid _, Device d, CancellationToken _) => d);
 
         // Act
@@ -175,7 +176,7 @@ public class DeviceServiceTests
             r => r.UpdateAsync(
                 existingId,
                 It.Is<Device>(d => d.LastSeenTimestamp == DateTimeOffset.FromUnixTimeMilliseconds(newerMills).UtcDateTime),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -211,7 +212,7 @@ public class DeviceServiceTests
         // Assert
         result.Should().Be(existingId);
         _mockRepository.Verify(
-            r => r.UpdateAsync(It.IsAny<Guid>(), It.IsAny<Device>(), It.IsAny<CancellationToken>()),
+            r => r.UpdateAsync(It.IsAny<Guid>(), It.IsAny<Device>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Effects/WriteSideEffectsServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Effects/WriteSideEffectsServiceTests.cs
@@ -76,7 +76,7 @@ public class WriteSideEffectsServiceTests
         await _service.OnCreatedAsync("entries", entries, options);
 
         _mockPipeline.Verify(
-            p => p.DecomposeAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<CancellationToken>()),
+            p => p.DecomposeAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once
         );
     }
@@ -89,7 +89,7 @@ public class WriteSideEffectsServiceTests
         await _service.OnCreatedAsync("entries", entries);
 
         _mockPipeline.Verify(
-            p => p.DecomposeAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<CancellationToken>()),
+            p => p.DecomposeAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never
         );
     }
@@ -116,7 +116,7 @@ public class WriteSideEffectsServiceTests
         await _service.BeforeDeleteAsync<Entry>("entry-123", options);
 
         _mockPipeline.Verify(
-            p => p.DeleteByLegacyIdAsync<Entry>("entry-123", It.IsAny<CancellationToken>()),
+            p => p.DeleteByLegacyIdAsync<Entry>("entry-123", It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once
         );
     }
@@ -158,7 +158,7 @@ public class WriteSideEffectsServiceTests
             Times.Once
         );
         _mockPipeline.Verify(
-            p => p.DecomposeAsync(entry, It.IsAny<CancellationToken>()),
+            p => p.DecomposeAsync(entry, It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once
         );
     }
@@ -194,7 +194,7 @@ public class WriteSideEffectsServiceTests
         await _service.OnCreatedAsync("entries", entries, options);
 
         _mockPipeline.Verify(
-            p => p.DecomposeAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<CancellationToken>()),
+            p => p.DecomposeAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once
         );
     }

--- a/tests/Unit/Nocturne.API.Tests/Services/Glucose/EntryServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Glucose/EntryServiceTests.cs
@@ -26,7 +26,7 @@ public class EntryServiceTests
     public EntryServiceTests()
     {
         _decomposer
-            .Setup(x => x.DecomposeAsync(It.IsAny<Entry>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.DecomposeAsync(It.IsAny<Entry>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new DecompositionResult());
 
         _sut = new EntryService(
@@ -355,7 +355,7 @@ public class EntryServiceTests
         // Assert
         Assert.Equal(2, result.Count());
         _decomposer.Verify(
-            x => x.DecomposeAsync(It.IsAny<Entry>(), It.IsAny<CancellationToken>()),
+            x => x.DecomposeAsync(It.IsAny<Entry>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Exactly(2));
         // Cache invalidation is handled by the EventSink, not the service
         _cache.Verify(x => x.InvalidateAsync(It.IsAny<CancellationToken>()), Times.Never);
@@ -376,7 +376,7 @@ public class EntryServiceTests
         };
 
         _decomposer
-            .Setup(x => x.DecomposeAsync(It.IsAny<Entry>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.DecomposeAsync(It.IsAny<Entry>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("Database error"));
 
         // Act & Assert
@@ -408,7 +408,7 @@ public class EntryServiceTests
         // Assert
         Assert.Single(result);
         _decomposer.Verify(
-            x => x.DecomposeAsync(It.Is<Entry>(e => e.Type == type), It.IsAny<CancellationToken>()),
+            x => x.DecomposeAsync(It.Is<Entry>(e => e.Type == type), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -431,7 +431,7 @@ public class EntryServiceTests
         // Assert — unknown types are silently filtered out
         Assert.Empty(result);
         _decomposer.Verify(
-            x => x.DecomposeAsync(It.IsAny<Entry>(), It.IsAny<CancellationToken>()),
+            x => x.DecomposeAsync(It.IsAny<Entry>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -453,7 +453,7 @@ public class EntryServiceTests
         // Assert
         Assert.Equal(2, result.Count());
         _decomposer.Verify(
-            x => x.DecomposeAsync(It.IsAny<Entry>(), It.IsAny<CancellationToken>()),
+            x => x.DecomposeAsync(It.IsAny<Entry>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Exactly(2));
     }
 
@@ -483,7 +483,7 @@ public class EntryServiceTests
         Assert.Equal(125, result.Sgv);
         // Decomposer performs idempotent upsert via LegacyId
         _decomposer.Verify(
-            x => x.DecomposeAsync(It.Is<Entry>(e => e.Id == entryId && e.Sgv == 125), It.IsAny<CancellationToken>()),
+            x => x.DecomposeAsync(It.Is<Entry>(e => e.Id == entryId && e.Sgv == 125), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
         // Cache invalidation is handled by the EventSink, not the service
         _cache.Verify(x => x.InvalidateAsync(It.IsAny<CancellationToken>()), Times.Never);
@@ -510,7 +510,7 @@ public class EntryServiceTests
         // Assert
         Assert.Null(result);
         _decomposer.Verify(
-            x => x.DecomposeAsync(It.IsAny<Entry>(), It.IsAny<CancellationToken>()),
+            x => x.DecomposeAsync(It.IsAny<Entry>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _cache.Verify(x => x.InvalidateAsync(It.IsAny<CancellationToken>()), Times.Never);
         _events.Verify(
@@ -535,7 +535,7 @@ public class EntryServiceTests
             .Setup(x => x.GetByIdAsync(entryId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(entryToDelete);
         _decomposer
-            .Setup(x => x.DeleteByLegacyIdAsync(entryId, It.IsAny<CancellationToken>()))
+            .Setup(x => x.DeleteByLegacyIdAsync(entryId, It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
 
         // Act
@@ -544,7 +544,7 @@ public class EntryServiceTests
         // Assert
         Assert.True(result);
         _decomposer.Verify(
-            x => x.DeleteByLegacyIdAsync(entryId, It.IsAny<CancellationToken>()),
+            x => x.DeleteByLegacyIdAsync(entryId, It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
         // Cache invalidation is handled by the EventSink, not the service
         _cache.Verify(x => x.InvalidateAsync(It.IsAny<CancellationToken>()), Times.Never);
@@ -565,7 +565,7 @@ public class EntryServiceTests
             .Setup(x => x.GetByIdAsync(entryId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Entry?)null);
         _decomposer
-            .Setup(x => x.DeleteByLegacyIdAsync(entryId, It.IsAny<CancellationToken>()))
+            .Setup(x => x.DeleteByLegacyIdAsync(entryId, It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(0);
 
         // Act
@@ -574,7 +574,7 @@ public class EntryServiceTests
         // Assert
         Assert.False(result);
         _decomposer.Verify(
-            x => x.DeleteByLegacyIdAsync(entryId, It.IsAny<CancellationToken>()),
+            x => x.DeleteByLegacyIdAsync(entryId, It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
         _cache.Verify(x => x.InvalidateAsync(It.IsAny<CancellationToken>()), Times.Never);
         _events.Verify(
@@ -595,7 +595,7 @@ public class EntryServiceTests
         var find = "{\"type\":\"sgv\"}";
 
         _decomposer
-            .Setup(x => x.BulkDeleteAsync(find, It.IsAny<CancellationToken>()))
+            .Setup(x => x.BulkDeleteAsync(find, It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(5L);
 
         // Act
@@ -603,7 +603,7 @@ public class EntryServiceTests
 
         // Assert
         Assert.Equal(5, result);
-        _decomposer.Verify(x => x.BulkDeleteAsync(find, It.IsAny<CancellationToken>()), Times.Once);
+        _decomposer.Verify(x => x.BulkDeleteAsync(find, It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Once);
         // Cache invalidation is handled by the EventSink, not the service
         _cache.Verify(x => x.InvalidateAsync(It.IsAny<CancellationToken>()), Times.Never);
         _events.Verify(
@@ -620,7 +620,7 @@ public class EntryServiceTests
         var find = "{\"type\":\"nonexistent\"}";
 
         _decomposer
-            .Setup(x => x.BulkDeleteAsync(find, It.IsAny<CancellationToken>()))
+            .Setup(x => x.BulkDeleteAsync(find, It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(0L);
 
         // Act
@@ -641,7 +641,7 @@ public class EntryServiceTests
     {
         // Arrange
         _decomposer
-            .Setup(x => x.BulkDeleteAsync(null, It.IsAny<CancellationToken>()))
+            .Setup(x => x.BulkDeleteAsync(null, It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(3L);
 
         // Act
@@ -649,7 +649,7 @@ public class EntryServiceTests
 
         // Assert
         Assert.Equal(3, result);
-        _decomposer.Verify(x => x.BulkDeleteAsync(null, It.IsAny<CancellationToken>()), Times.Once);
+        _decomposer.Verify(x => x.BulkDeleteAsync(null, It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     #endregion

--- a/tests/Unit/Nocturne.API.Tests/Services/Health/ActivityServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Health/ActivityServiceTests.cs
@@ -562,7 +562,7 @@ public class ActivityServiceTests
             Times.Once
         );
         _mockActivityDecomposer.Verify(
-            d => d.DeleteByLegacyIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            d => d.DeleteByLegacyIdAsync(It.IsAny<string>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Exactly(2)
         );
         _mockSignalRBroadcastService.Verify(

--- a/tests/Unit/Nocturne.API.Tests/Services/Realtime/RealtimeCategoriesTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Realtime/RealtimeCategoriesTests.cs
@@ -1,0 +1,24 @@
+using Nocturne.API.Services.Realtime;
+
+namespace Nocturne.API.Tests.Unit.Services.Realtime;
+
+/// <summary>
+/// Unit tests for <see cref="RealtimeCategories"/> — the SignalR group allowlist. Pins the invariant
+/// that the native V4 categories never collide with the legacy v1 collection names, so a v4 broadcast
+/// can never land on a v1 group (and vice versa).
+/// </summary>
+public class RealtimeCategoriesTests
+{
+    [Fact]
+    public void V1AndV4Categories_AreDisjoint()
+    {
+        RealtimeCategories.V1.Intersect(RealtimeCategories.V4).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void All_IsUnionOfV1AndV4()
+    {
+        RealtimeCategories.All.Should().HaveCount(RealtimeCategories.V1.Length + RealtimeCategories.V4.Length);
+        RealtimeCategories.All.Should().BeEquivalentTo([.. RealtimeCategories.V1, .. RealtimeCategories.V4]);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Realtime/SignalRV4RecordBroadcasterTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Realtime/SignalRV4RecordBroadcasterTests.cs
@@ -1,0 +1,107 @@
+using Nocturne.API.Services.Realtime;
+using Nocturne.Core.Contracts.Events;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.API.Tests.Unit.Services.Realtime;
+
+/// <summary>
+/// Unit tests for <see cref="SignalRV4RecordBroadcaster{TModel}"/> — the SignalR adapter that turns a
+/// native V4 record write into a <c>BroadcastStorage*Async(category, {recordType, doc})</c> call. Mapped
+/// types fan out to their category; unmapped (dormant <c>therapy</c>) types and empty lists broadcast
+/// nothing. The anonymous payload is inspected by reflection so a payload-shape regression fails here.
+/// </summary>
+public class SignalRV4RecordBroadcasterTests
+{
+    private readonly Mock<ISignalRBroadcastService> _broadcast = new();
+
+    private SignalRV4RecordBroadcaster<TModel> Adapter<TModel>() where TModel : class
+        => new(_broadcast.Object);
+
+    private static object? GetProp(object payload, string name)
+        => payload.GetType().GetProperty(name)!.GetValue(payload);
+
+    [Fact]
+    public async Task BroadcastCreatedAsync_MappedType_BroadcastsCreateWithRecordTypeAndDoc()
+    {
+        var bolus = new Bolus { Id = Guid.NewGuid(), Insulin = 5.0 };
+
+        await Adapter<Bolus>().BroadcastCreatedAsync([bolus]);
+
+        _broadcast.Verify(b => b.BroadcastStorageCreateAsync(
+            RealtimeCategories.Care,
+            It.Is<object>(p => (string)GetProp(p, "recordType")! == "bolus"
+                               && ReferenceEquals(GetProp(p, "doc"), bolus))),
+            Times.Once);
+        _broadcast.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task BroadcastUpdatedAsync_MappedType_BroadcastsUpdateWithRecordTypeAndDoc()
+    {
+        var bolus = new Bolus { Id = Guid.NewGuid(), Insulin = 4.6 };
+
+        await Adapter<Bolus>().BroadcastUpdatedAsync([bolus]);
+
+        _broadcast.Verify(b => b.BroadcastStorageUpdateAsync(
+            RealtimeCategories.Care,
+            It.Is<object>(p => (string)GetProp(p, "recordType")! == "bolus"
+                               && ReferenceEquals(GetProp(p, "doc"), bolus))),
+            Times.Once);
+        _broadcast.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task BroadcastDeletedAsync_MappedType_BroadcastsDeleteWithRecordTypeAndId()
+    {
+        var id = Guid.NewGuid();
+
+        await Adapter<Bolus>().BroadcastDeletedAsync([id]);
+
+        _broadcast.Verify(b => b.BroadcastStorageDeleteAsync(
+            RealtimeCategories.Care,
+            It.Is<object>(p => (string)GetProp(p, "recordType")! == "bolus"
+                               && (Guid)GetProp(p, "id")! == id)),
+            Times.Once);
+        _broadcast.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task BroadcastCreatedAsync_UnmappedType_DoesNotBroadcast()
+    {
+        await Adapter<BasalSchedule>().BroadcastCreatedAsync([new BasalSchedule { Id = Guid.NewGuid() }]);
+
+        _broadcast.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task BroadcastUpdatedAsync_UnmappedType_DoesNotBroadcast()
+    {
+        await Adapter<BasalSchedule>().BroadcastUpdatedAsync([new BasalSchedule { Id = Guid.NewGuid() }]);
+
+        _broadcast.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task BroadcastDeletedAsync_UnmappedType_DoesNotBroadcast()
+    {
+        await Adapter<BasalSchedule>().BroadcastDeletedAsync([Guid.NewGuid()]);
+
+        _broadcast.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task BroadcastCreatedAsync_EmptyList_DoesNotBroadcast()
+    {
+        await Adapter<Bolus>().BroadcastCreatedAsync([]);
+
+        _broadcast.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task BroadcastDeletedAsync_EmptyList_DoesNotBroadcast()
+    {
+        await Adapter<Bolus>().BroadcastDeletedAsync([]);
+
+        _broadcast.VerifyNoOtherCalls();
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Realtime/V4BroadcastMapTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Realtime/V4BroadcastMapTests.cs
@@ -1,0 +1,51 @@
+using Nocturne.API.Services.Realtime;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.API.Tests.Unit.Services.Realtime;
+
+/// <summary>
+/// Unit tests for <see cref="V4BroadcastMap"/> — the static map from a V4 model type to its broadcast
+/// category and <c>recordType</c> discriminator. Pins the mapped types and confirms the dormant
+/// <c>therapy</c> family (schedules / therapy settings) is intentionally unmapped.
+/// </summary>
+public class V4BroadcastMapTests
+{
+    [Theory]
+    // Every mapped type is pinned: the recordType strings are the wire contract the SDK consumers
+    // (companion + Prelude) depend on, so a typo here must fail the build, not ship silently.
+    [InlineData(typeof(SensorGlucose), RealtimeCategories.Glucose, "sensorGlucose")]
+    [InlineData(typeof(MeterGlucose), RealtimeCategories.Glucose, "meterGlucose")]
+    [InlineData(typeof(Calibration), RealtimeCategories.Glucose, "calibration")]
+    [InlineData(typeof(Bolus), RealtimeCategories.Care, "bolus")]
+    [InlineData(typeof(CarbIntake), RealtimeCategories.Care, "carbIntake")]
+    [InlineData(typeof(BGCheck), RealtimeCategories.Care, "bgCheck")]
+    [InlineData(typeof(BolusCalculation), RealtimeCategories.Care, "bolusCalculation")]
+    [InlineData(typeof(BasalInjection), RealtimeCategories.Care, "basalInjection")]
+    [InlineData(typeof(TempBasal), RealtimeCategories.Care, "tempBasal")]
+    [InlineData(typeof(Note), RealtimeCategories.Care, "note")]
+    [InlineData(typeof(DeviceEvent), RealtimeCategories.Care, "deviceEvent")]
+    [InlineData(typeof(ApsSnapshot), RealtimeCategories.Device, "apsSnapshot")]
+    [InlineData(typeof(PumpSnapshot), RealtimeCategories.Device, "pumpSnapshot")]
+    [InlineData(typeof(UploaderSnapshot), RealtimeCategories.Device, "uploaderSnapshot")]
+    public void TryGet_MappedType_ReturnsCategoryAndRecordType(
+        Type modelType, string expectedCategory, string expectedRecordType)
+    {
+        var found = V4BroadcastMap.TryGet(modelType, out var category, out var recordType);
+
+        found.Should().BeTrue();
+        category.Should().Be(expectedCategory);
+        recordType.Should().Be(expectedRecordType);
+    }
+
+    [Theory]
+    [InlineData(typeof(BasalSchedule))]
+    [InlineData(typeof(TherapySettings))]
+    public void TryGet_UnmappedTherapyType_ReturnsFalse(Type modelType)
+    {
+        var found = V4BroadcastMap.TryGet(modelType, out var category, out var recordType);
+
+        found.Should().BeFalse();
+        category.Should().BeEmpty();
+        recordType.Should().BeEmpty();
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Treatments/TreatmentReadServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Treatments/TreatmentReadServiceTests.cs
@@ -167,20 +167,20 @@ public class TreatmentReadServiceTests
         });
 
         _decomposer
-            .Setup(d => d.DecomposeAsync(treatment, It.IsAny<CancellationToken>()))
+            .Setup(d => d.DecomposeAsync(treatment, It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(decompositionResult);
 
         var result = await _service.CreateAsync([treatment]);
 
         result.Should().HaveCount(1);
-        _decomposer.Verify(d => d.DecomposeAsync(treatment, It.IsAny<CancellationToken>()), Times.Once);
+        _decomposer.Verify(d => d.DecomposeAsync(treatment, It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task DeleteAsync_CallsPipelineAndChecksTemp()
     {
         _pipeline
-            .Setup(p => p.DeleteByLegacyIdAsync<Treatment>("t1", It.IsAny<CancellationToken>()))
+            .Setup(p => p.DeleteByLegacyIdAsync<Treatment>("t1", It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(3);
         _tempBasalRepo
             .Setup(r => r.GetByLegacyIdAsync("t1", It.IsAny<CancellationToken>()))
@@ -189,6 +189,6 @@ public class TreatmentReadServiceTests
         var result = await _service.DeleteAsync("t1");
 
         result.Should().BeTrue();
-        _pipeline.Verify(p => p.DeleteByLegacyIdAsync<Treatment>("t1", It.IsAny<CancellationToken>()), Times.Once);
+        _pipeline.Verify(p => p.DeleteByLegacyIdAsync<Treatment>("t1", It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Treatments/TreatmentServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Treatments/TreatmentServiceTests.cs
@@ -135,7 +135,7 @@ public class TreatmentServiceTests
     [Fact]
     public async Task DeleteTreatmentsAsync_ShouldInvalidateCacheWhenDeleted()
     {
-        _mockDecomposer.Setup(x => x.BulkDeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(5);
+        _mockDecomposer.Setup(x => x.BulkDeleteAsync(It.IsAny<string>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>())).ReturnsAsync(5);
         var result = await _treatmentService.DeleteTreatmentsAsync("q", CancellationToken.None);
         result.Should().Be(5);
         _mockCache.Verify(x => x.InvalidateAsync(It.IsAny<CancellationToken>()), Times.Once);
@@ -144,7 +144,7 @@ public class TreatmentServiceTests
     [Fact]
     public async Task DeleteTreatmentsAsync_WhenNoneDeleted_ShouldNotInvalidateCache()
     {
-        _mockDecomposer.Setup(x => x.BulkDeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(0);
+        _mockDecomposer.Setup(x => x.BulkDeleteAsync(It.IsAny<string>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>())).ReturnsAsync(0);
         var result = await _treatmentService.DeleteTreatmentsAsync("q", CancellationToken.None);
         result.Should().Be(0);
         _mockCache.Verify(x => x.InvalidateAsync(It.IsAny<CancellationToken>()), Times.Never);
@@ -155,7 +155,7 @@ public class TreatmentServiceTests
     {
         var existing = new Treatment { Id = "t1", Mills = 1000, EventType = "Note", Notes = "old" };
         _mockStore.Setup(x => x.GetByIdAsync("t1", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
-        _mockDecomposer.Setup(x => x.DecomposeAsync(It.IsAny<Treatment>(), It.IsAny<CancellationToken>()))
+        _mockDecomposer.Setup(x => x.DecomposeAsync(It.IsAny<Treatment>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new DecompositionResult());
 
         var patchJson = JsonSerializer.Deserialize<JsonElement>("{\"notes\":\"updated\"}");
@@ -163,7 +163,7 @@ public class TreatmentServiceTests
 
         result.Should().NotBeNull();
         result!.Notes.Should().Be("updated");
-        _mockDecomposer.Verify(x => x.DecomposeAsync(It.IsAny<Treatment>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockDecomposer.Verify(x => x.DecomposeAsync(It.IsAny<Treatment>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Once);
         _mockCache.Verify(x => x.InvalidateAsync(It.IsAny<CancellationToken>()), Times.Once);
         _mockEvents.Verify(x => x.OnUpdatedAsync(It.IsAny<Treatment>(), It.IsAny<CancellationToken>()), Times.Once);
     }
@@ -177,7 +177,7 @@ public class TreatmentServiceTests
         var result = await _treatmentService.PatchTreatmentAsync("x", patchJson, CancellationToken.None);
 
         result.Should().BeNull();
-        _mockDecomposer.Verify(x => x.DecomposeAsync(It.IsAny<Treatment>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockDecomposer.Verify(x => x.DecomposeAsync(It.IsAny<Treatment>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     #region Insulin Context Auto-Population

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/ActivityDecomposerBatchTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/ActivityDecomposerBatchTests.cs
@@ -4,6 +4,7 @@ using Nocturne.Core.Contracts.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Tests.Shared.Infrastructure;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Tests.Services.V4;
 
@@ -47,7 +48,7 @@ public class ActivityDecomposerBatchTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeBatchAsync(activities);
+        var result = await _decomposer.DecomposeBatchAsync(activities, WriteOrigin.Live);
 
         // Assert - heart rates stored via DbContext
         _context.HeartRates.Should().HaveCount(2);
@@ -70,7 +71,7 @@ public class ActivityDecomposerBatchTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeBatchAsync(activities);
+        var result = await _decomposer.DecomposeBatchAsync(activities, WriteOrigin.Live);
 
         // Assert - step counts stored via DbContext
         _context.StepCounts.Should().HaveCount(1);
@@ -92,7 +93,7 @@ public class ActivityDecomposerBatchTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeBatchAsync(activities);
+        var result = await _decomposer.DecomposeBatchAsync(activities, WriteOrigin.Live);
 
         // Assert
         _stateSpanRepoMock.Verify(
@@ -110,7 +111,7 @@ public class ActivityDecomposerBatchTests : IDisposable
     public async Task DecomposeBatchAsync_EmptyBatch_NoRepositoryCalls()
     {
         // Act
-        var result = await _decomposer.DecomposeBatchAsync([]);
+        var result = await _decomposer.DecomposeBatchAsync([], WriteOrigin.Live);
 
         // Assert
         _context.HeartRates.Should().BeEmpty();
@@ -136,7 +137,7 @@ public class ActivityDecomposerBatchTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeBatchAsync(activities);
+        var result = await _decomposer.DecomposeBatchAsync(activities, WriteOrigin.Live);
 
         // Assert - correct routing
         _context.HeartRates.Should().HaveCount(1);

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/DecompositionPipelineTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/DecompositionPipelineTests.cs
@@ -32,10 +32,10 @@ public class DecompositionPipelineTests
     {
         var entry = new Entry { Id = "test-1", Type = "sgv" };
         _mockEntryDecomposer
-            .Setup(x => x.DecomposeAsync(entry, It.IsAny<CancellationToken>()))
+            .Setup(x => x.DecomposeAsync(entry, It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new DecompositionResult { CorrelationId = Guid.NewGuid() });
 
-        var result = await _pipeline.DecomposeAsync(entry);
+        var result = await _pipeline.DecomposeAsync(entry, WriteOrigin.Live);
 
         result.Succeeded.Should().Be(1);
         result.Failed.Should().Be(0);
@@ -47,10 +47,10 @@ public class DecompositionPipelineTests
     {
         var entry = new Entry { Id = "test-1", Type = "sgv" };
         _mockEntryDecomposer
-            .Setup(x => x.DecomposeAsync(entry, It.IsAny<CancellationToken>()))
+            .Setup(x => x.DecomposeAsync(entry, It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("test error"));
 
-        var result = await _pipeline.DecomposeAsync(entry);
+        var result = await _pipeline.DecomposeAsync(entry, WriteOrigin.Live);
 
         result.Succeeded.Should().Be(0);
         result.Failed.Should().Be(1);
@@ -68,10 +68,10 @@ public class DecompositionPipelineTests
         };
 
         _mockEntryDecomposer
-            .Setup(x => x.DecomposeAsync(It.IsAny<Entry>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.DecomposeAsync(It.IsAny<Entry>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new DecompositionResult { CorrelationId = Guid.NewGuid() });
 
-        var result = await _pipeline.DecomposeAsync<Entry>(entries);
+        var result = await _pipeline.DecomposeAsync<Entry>(entries, WriteOrigin.Live);
 
         result.Succeeded.Should().Be(3);
         result.Failed.Should().Be(0);
@@ -91,16 +91,16 @@ public class DecompositionPipelineTests
         _mockEntryDecomposer
             .Setup(x => x.DecomposeAsync(
                 It.Is<Entry>(e => e.Id!.StartsWith("good")),
-                It.IsAny<CancellationToken>()))
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new DecompositionResult { CorrelationId = Guid.NewGuid() });
 
         _mockEntryDecomposer
             .Setup(x => x.DecomposeAsync(
                 It.Is<Entry>(e => e.Id!.StartsWith("bad")),
-                It.IsAny<CancellationToken>()))
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("decomposition failed"));
 
-        var result = await _pipeline.DecomposeAsync<Entry>(entries);
+        var result = await _pipeline.DecomposeAsync<Entry>(entries, WriteOrigin.Live);
 
         result.Succeeded.Should().Be(2);
         result.Failed.Should().Be(1);
@@ -119,21 +119,21 @@ public class DecompositionPipelineTests
         _mockEntryDecomposer
             .Setup(x => x.DecomposeAsync(
                 It.Is<Entry>(e => e.Id == "bad-1"),
-                It.IsAny<CancellationToken>()))
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("first fails"));
 
         _mockEntryDecomposer
             .Setup(x => x.DecomposeAsync(
                 It.Is<Entry>(e => e.Id == "good-1"),
-                It.IsAny<CancellationToken>()))
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new DecompositionResult { CorrelationId = Guid.NewGuid() });
 
-        var result = await _pipeline.DecomposeAsync<Entry>(entries);
+        var result = await _pipeline.DecomposeAsync<Entry>(entries, WriteOrigin.Live);
 
         result.Succeeded.Should().Be(1);
         result.Failed.Should().Be(1);
         _mockEntryDecomposer.Verify(
-            x => x.DecomposeAsync(It.Is<Entry>(e => e.Id == "good-1"), It.IsAny<CancellationToken>()),
+            x => x.DecomposeAsync(It.Is<Entry>(e => e.Id == "good-1"), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -141,10 +141,10 @@ public class DecompositionPipelineTests
     public async Task DeleteByLegacyIdAsync_DelegatesToDecomposer()
     {
         _mockEntryDecomposer
-            .Setup(x => x.DeleteByLegacyIdAsync("legacy-123", It.IsAny<CancellationToken>()))
+            .Setup(x => x.DeleteByLegacyIdAsync("legacy-123", It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(3);
 
-        var result = await _pipeline.DeleteByLegacyIdAsync<Entry>("legacy-123");
+        var result = await _pipeline.DeleteByLegacyIdAsync<Entry>("legacy-123", WriteOrigin.Live);
 
         result.Should().Be(3);
     }
@@ -153,10 +153,10 @@ public class DecompositionPipelineTests
     public async Task DeleteByLegacyIdAsync_WhenDecomposerThrows_ReturnsZero()
     {
         _mockEntryDecomposer
-            .Setup(x => x.DeleteByLegacyIdAsync("legacy-123", It.IsAny<CancellationToken>()))
+            .Setup(x => x.DeleteByLegacyIdAsync("legacy-123", It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("delete failed"));
 
-        var result = await _pipeline.DeleteByLegacyIdAsync<Entry>("legacy-123");
+        var result = await _pipeline.DeleteByLegacyIdAsync<Entry>("legacy-123", WriteOrigin.Live);
 
         result.Should().Be(0);
     }
@@ -164,7 +164,7 @@ public class DecompositionPipelineTests
     [Fact]
     public async Task DecomposeAsync_EmptyBatch_ReturnsZeroCounts()
     {
-        var result = await _pipeline.DecomposeAsync<Entry>(Array.Empty<Entry>());
+        var result = await _pipeline.DecomposeAsync<Entry>(Array.Empty<Entry>(), WriteOrigin.Live);
 
         result.Succeeded.Should().Be(0);
         result.Failed.Should().Be(0);

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerBatchTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerBatchTests.cs
@@ -262,7 +262,7 @@ public class DeviceStatusDecomposerBatchTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeBatchAsync(statuses, WriteOrigin.Live);
+        await _decomposer.DecomposeBatchAsync(statuses, WriteOrigin.Live);
 
         // Assert
         _extrasRepoMock.Verify(

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerBatchTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerBatchTests.cs
@@ -42,16 +42,16 @@ public class DeviceStatusDecomposerBatchTests : IDisposable
         // BulkCreateAsync returns the input records
         _apsRepoMock
             .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.ApsSnapshot>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<V4Models.ApsSnapshot> records, CancellationToken _) => records);
+            .ReturnsAsync((IEnumerable<V4Models.ApsSnapshot> records, WriteOrigin origin, CancellationToken _) => records);
         _pumpRepoMock
             .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.PumpSnapshot>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<V4Models.PumpSnapshot> records, CancellationToken _) => records);
+            .ReturnsAsync((IEnumerable<V4Models.PumpSnapshot> records, WriteOrigin origin, CancellationToken _) => records);
         _uploaderRepoMock
             .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.UploaderSnapshot>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<V4Models.UploaderSnapshot> records, CancellationToken _) => records);
+            .ReturnsAsync((IEnumerable<V4Models.UploaderSnapshot> records, WriteOrigin origin, CancellationToken _) => records);
         _extrasRepoMock
             .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.DeviceStatusExtras>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<V4Models.DeviceStatusExtras> records, CancellationToken _) => records);
+            .ReturnsAsync((IEnumerable<V4Models.DeviceStatusExtras> records, WriteOrigin origin, CancellationToken _) => records);
 
         _decomposer = new DeviceStatusDecomposer(
             _context,

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerBatchTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerBatchTests.cs
@@ -12,6 +12,7 @@ using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
 
 using V4Models = Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Tests.Services.V4;
 
@@ -40,16 +41,16 @@ public class DeviceStatusDecomposerBatchTests : IDisposable
 
         // BulkCreateAsync returns the input records
         _apsRepoMock
-            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.ApsSnapshot>>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.ApsSnapshot>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<V4Models.ApsSnapshot> records, CancellationToken _) => records);
         _pumpRepoMock
-            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.PumpSnapshot>>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.PumpSnapshot>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<V4Models.PumpSnapshot> records, CancellationToken _) => records);
         _uploaderRepoMock
-            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.UploaderSnapshot>>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.UploaderSnapshot>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<V4Models.UploaderSnapshot> records, CancellationToken _) => records);
         _extrasRepoMock
-            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.DeviceStatusExtras>>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.DeviceStatusExtras>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<V4Models.DeviceStatusExtras> records, CancellationToken _) => records);
 
         _decomposer = new DeviceStatusDecomposer(
@@ -112,25 +113,25 @@ public class DeviceStatusDecomposerBatchTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeBatchAsync(statuses);
+        var result = await _decomposer.DecomposeBatchAsync(statuses, WriteOrigin.Live);
 
         // Assert
         _apsRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<V4Models.ApsSnapshot>>(list => list.Count() == 1),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         _pumpRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<V4Models.PumpSnapshot>>(list => list.Count() == 1),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         _uploaderRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<V4Models.UploaderSnapshot>>(list => list.Count() == 1),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         result.CreatedRecords.Should().HaveCount(3);
@@ -141,20 +142,20 @@ public class DeviceStatusDecomposerBatchTests : IDisposable
     public async Task DecomposeBatchAsync_EmptyBatch_NoRepositoryCalls()
     {
         // Act
-        var result = await _decomposer.DecomposeBatchAsync([]);
+        var result = await _decomposer.DecomposeBatchAsync([], WriteOrigin.Live);
 
         // Assert
         _apsRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.ApsSnapshot>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.ApsSnapshot>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _pumpRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.PumpSnapshot>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.PumpSnapshot>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _uploaderRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.UploaderSnapshot>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.UploaderSnapshot>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _extrasRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.DeviceStatusExtras>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.DeviceStatusExtras>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
 
         result.CreatedRecords.Should().BeEmpty();
@@ -177,7 +178,7 @@ public class DeviceStatusDecomposerBatchTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeBatchAsync(statuses);
+        var result = await _decomposer.DecomposeBatchAsync(statuses, WriteOrigin.Live);
 
         // Assert
         var batch = _context.DecompositionBatches.SingleOrDefault(b => b.Id == result.CorrelationId);
@@ -217,25 +218,25 @@ public class DeviceStatusDecomposerBatchTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeBatchAsync(statuses);
+        var result = await _decomposer.DecomposeBatchAsync(statuses, WriteOrigin.Live);
 
         // Assert - all three snapshot types extracted from one device status
         _apsRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<V4Models.ApsSnapshot>>(list => list.Count() == 1),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         _pumpRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<V4Models.PumpSnapshot>>(list => list.Count() == 1),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         _uploaderRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<V4Models.UploaderSnapshot>>(list => list.Count() == 1),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         result.CreatedRecords.Should().HaveCount(3);
@@ -261,7 +262,7 @@ public class DeviceStatusDecomposerBatchTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeBatchAsync(statuses);
+        var result = await _decomposer.DecomposeBatchAsync(statuses, WriteOrigin.Live);
 
         // Assert
         _extrasRepoMock.Verify(
@@ -269,7 +270,7 @@ public class DeviceStatusDecomposerBatchTests : IDisposable
                 It.Is<IEnumerable<V4Models.DeviceStatusExtras>>(list =>
                     list.Count() == 1
                     && list.First().Extras!.ContainsKey("xdripjs")),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -306,7 +307,7 @@ public class DeviceStatusDecomposerBatchTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeBatchAsync(statuses);
+        var result = await _decomposer.DecomposeBatchAsync(statuses, WriteOrigin.Live);
 
         // Assert
         _stateSpanServiceMock.Verify(

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerPumpSuspensionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerPumpSuspensionTests.cs
@@ -65,14 +65,14 @@ public class DeviceStatusDecomposerPumpSuspensionTests : IDisposable
         // CreateAsync echoes the model with an Id assigned, like a real repo.
         _pumpRepoMock
             .Setup(r => r.CreateAsync(It.IsAny<V4Models.PumpSnapshot>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((V4Models.PumpSnapshot m, CancellationToken _) =>
+            .ReturnsAsync((V4Models.PumpSnapshot m, WriteOrigin origin, CancellationToken _) =>
             {
                 if (m.Id == Guid.Empty) m.Id = Guid.NewGuid();
                 return m;
             });
         _pumpRepoMock
             .Setup(r => r.UpdateAsync(It.IsAny<Guid>(), It.IsAny<V4Models.PumpSnapshot>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Guid id, V4Models.PumpSnapshot m, CancellationToken _) =>
+            .ReturnsAsync((Guid id, V4Models.PumpSnapshot m, WriteOrigin origin, CancellationToken _) =>
             {
                 m.Id = id;
                 return m;
@@ -311,7 +311,7 @@ public class DeviceStatusDecomposerPumpSuspensionTests : IDisposable
         var pinnedId = Guid.NewGuid();
         _pumpRepoMock
             .Setup(r => r.CreateAsync(It.IsAny<V4Models.PumpSnapshot>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((V4Models.PumpSnapshot m, CancellationToken _) =>
+            .ReturnsAsync((V4Models.PumpSnapshot m, WriteOrigin origin, CancellationToken _) =>
             {
                 m.Id = pinnedId;
                 return m;

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerPumpSuspensionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerPumpSuspensionTests.cs
@@ -12,6 +12,7 @@ using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
 
 using V4Models = Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Tests.Services.V4;
 
@@ -63,14 +64,14 @@ public class DeviceStatusDecomposerPumpSuspensionTests : IDisposable
 
         // CreateAsync echoes the model with an Id assigned, like a real repo.
         _pumpRepoMock
-            .Setup(r => r.CreateAsync(It.IsAny<V4Models.PumpSnapshot>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.CreateAsync(It.IsAny<V4Models.PumpSnapshot>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((V4Models.PumpSnapshot m, CancellationToken _) =>
             {
                 if (m.Id == Guid.Empty) m.Id = Guid.NewGuid();
                 return m;
             });
         _pumpRepoMock
-            .Setup(r => r.UpdateAsync(It.IsAny<Guid>(), It.IsAny<V4Models.PumpSnapshot>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.UpdateAsync(It.IsAny<Guid>(), It.IsAny<V4Models.PumpSnapshot>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((Guid id, V4Models.PumpSnapshot m, CancellationToken _) =>
             {
                 m.Id = id;
@@ -123,7 +124,7 @@ public class DeviceStatusDecomposerPumpSuspensionTests : IDisposable
         var ds = MakeDeviceStatus("legacy1", 1704110400000 /* 2024-01-01T12:00:00Z */, suspended: true);
 
         // Act
-        await _decomposer.DecomposeAsync(ds);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         _stateSpanServiceMock.Verify(s => s.UpsertStateSpanAsync(
@@ -162,7 +163,7 @@ public class DeviceStatusDecomposerPumpSuspensionTests : IDisposable
         var ds = MakeDeviceStatus("legacy2", 1704110400000, suspended: false);
 
         // Act
-        await _decomposer.DecomposeAsync(ds);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert: upsert called with EndTimestamp populated on the same span
         _stateSpanServiceMock.Verify(s => s.UpsertStateSpanAsync(
@@ -181,7 +182,7 @@ public class DeviceStatusDecomposerPumpSuspensionTests : IDisposable
             .ReturnsAsync(prior);
 
         var ds = MakeDeviceStatus("legacy3", 1704110400000, suspended: true);
-        await _decomposer.DecomposeAsync(ds);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         _stateSpanServiceMock.Verify(s => s.UpsertStateSpanAsync(It.IsAny<StateSpan>(), It.IsAny<CancellationToken>()), Times.Never);
     }
@@ -194,7 +195,7 @@ public class DeviceStatusDecomposerPumpSuspensionTests : IDisposable
             .ReturnsAsync(prior);
 
         var ds = MakeDeviceStatus("legacy4", 1704110400000, suspended: false);
-        await _decomposer.DecomposeAsync(ds);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         _stateSpanServiceMock.Verify(s => s.UpsertStateSpanAsync(It.IsAny<StateSpan>(), It.IsAny<CancellationToken>()), Times.Never);
     }
@@ -207,7 +208,7 @@ public class DeviceStatusDecomposerPumpSuspensionTests : IDisposable
             .ReturnsAsync((V4Models.PumpSnapshot?)null);
 
         var ds = MakeDeviceStatus("legacy5", 1704110400000, suspended: true);
-        await _decomposer.DecomposeAsync(ds);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         _stateSpanServiceMock.Verify(s => s.UpsertStateSpanAsync(
             It.Is<StateSpan>(span =>
@@ -225,7 +226,7 @@ public class DeviceStatusDecomposerPumpSuspensionTests : IDisposable
             .ReturnsAsync((V4Models.PumpSnapshot?)null);
 
         var ds = MakeDeviceStatus("legacy6", 1704110400000, suspended: false);
-        await _decomposer.DecomposeAsync(ds);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         _stateSpanServiceMock.Verify(s => s.UpsertStateSpanAsync(It.IsAny<StateSpan>(), It.IsAny<CancellationToken>()), Times.Never);
     }
@@ -243,7 +244,7 @@ public class DeviceStatusDecomposerPumpSuspensionTests : IDisposable
 
         var ds = MakeDeviceStatus("legacy7", 1704110400000 /* 12:00 ingest */, suspended: true, clockIso: pumpClock);
 
-        await _decomposer.DecomposeAsync(ds);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         _stateSpanServiceMock.Verify(s => s.UpsertStateSpanAsync(
             It.Is<StateSpan>(span =>
@@ -286,7 +287,7 @@ public class DeviceStatusDecomposerPumpSuspensionTests : IDisposable
         // 2024-01-01T11:00:00Z = 1704106800000 mills
         var ds = MakeDeviceStatus("legacy-ooo", 1704106800000, suspended: false);
 
-        await _decomposer.DecomposeAsync(ds);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Strict-`<` filter selected the T=10:00 row, both sides false → no transition, no upsert.
         _stateSpanServiceMock.Verify(
@@ -309,7 +310,7 @@ public class DeviceStatusDecomposerPumpSuspensionTests : IDisposable
         // Pin the snapshot id on the second call so OriginalId is deterministic across both invocations.
         var pinnedId = Guid.NewGuid();
         _pumpRepoMock
-            .Setup(r => r.CreateAsync(It.IsAny<V4Models.PumpSnapshot>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.CreateAsync(It.IsAny<V4Models.PumpSnapshot>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((V4Models.PumpSnapshot m, CancellationToken _) =>
             {
                 m.Id = pinnedId;
@@ -318,8 +319,8 @@ public class DeviceStatusDecomposerPumpSuspensionTests : IDisposable
 
         var ds = MakeDeviceStatus("legacy8", 1704110400000, suspended: true);
 
-        await _decomposer.DecomposeAsync(ds);
-        await _decomposer.DecomposeAsync(ds);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         var expectedOriginalId = $"pump-suspended:{pinnedId}";
         _stateSpanServiceMock.Verify(s => s.UpsertStateSpanAsync(
@@ -360,7 +361,7 @@ public class DeviceStatusDecomposerPumpSuspensionTests : IDisposable
 
         var ds = MakeDeviceStatus("legacy-dup", 1704110400000, suspended: true);
 
-        await _decomposer.DecomposeAsync(ds);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // A suspension is already active; no new span should be opened.
         _stateSpanServiceMock.Verify(
@@ -403,7 +404,7 @@ public class DeviceStatusDecomposerPumpSuspensionTests : IDisposable
 
         var ds = MakeDeviceStatus("legacy-close-all", 1704110400000, suspended: false);
 
-        await _decomposer.DecomposeAsync(ds);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         _stateSpanServiceMock.Verify(s => s.UpsertStateSpanAsync(
             It.Is<StateSpan>(span => span.Id == "open-1" && span.EndTimestamp != null),

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerTests.cs
@@ -1956,7 +1956,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         var ds = JsonSerializer.Deserialize<DeviceStatus>(json)!;
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert — configuration should end up in extras
         var extrasEntities = _context.DeviceStatusExtras.ToList();
@@ -1986,7 +1986,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         var extrasEntities = _context.DeviceStatusExtras.ToList();
@@ -2008,7 +2008,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         var extrasEntities = _context.DeviceStatusExtras.ToList();
@@ -2040,7 +2040,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert — no extras record should be created
         var extrasEntities = _context.DeviceStatusExtras.ToList();
@@ -2063,7 +2063,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         var ds = JsonSerializer.Deserialize<DeviceStatus>(json)!;
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         var extrasEntities = _context.DeviceStatusExtras.ToList();

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerTests.cs
@@ -15,6 +15,7 @@ using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
 
 using V4Models = Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Tests.Services.V4;
 
@@ -105,7 +106,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -160,7 +161,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -204,7 +205,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -246,7 +247,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -276,7 +277,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -319,7 +320,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             .ReturnsAsync(expectedStateSpan);
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -357,7 +358,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().BeEmpty();
@@ -391,12 +392,12 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act - first call creates
-        var firstResult = await _decomposer.DecomposeAsync(ds);
+        var firstResult = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
         firstResult.CreatedRecords.Should().HaveCount(1);
         firstResult.UpdatedRecords.Should().BeEmpty();
 
         // Act - second call should update
-        var secondResult = await _decomposer.DecomposeAsync(ds);
+        var secondResult = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         secondResult.UpdatedRecords.Should().HaveCount(1);
@@ -441,7 +442,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(3);
@@ -485,7 +486,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         var aps = result.CreatedRecords[0].Should().BeOfType<V4Models.ApsSnapshot>().Subject;
@@ -523,7 +524,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert - Enacted object exists but Received is false
         var aps = result.CreatedRecords[0].Should().BeOfType<V4Models.ApsSnapshot>().Subject;
@@ -558,7 +559,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         var aps = result.CreatedRecords[0].Should().BeOfType<V4Models.ApsSnapshot>().Subject;
@@ -591,7 +592,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert - top-level Cob takes priority via null-coalescing
         var aps = result.CreatedRecords[0].Should().BeOfType<V4Models.ApsSnapshot>().Subject;
@@ -619,7 +620,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             }
         };
 
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         var aps = result.CreatedRecords[0].Should().BeOfType<V4Models.ApsSnapshot>().Subject;
         aps.Cob.Should().Be(35.0);
@@ -649,7 +650,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             }
         };
 
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         var aps = result.CreatedRecords[0].Should().BeOfType<V4Models.ApsSnapshot>().Subject;
         aps.PredictedDefaultJson.Should().BeNull();
@@ -677,7 +678,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             }
         };
 
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         var aps = result.CreatedRecords[0].Should().BeOfType<V4Models.ApsSnapshot>().Subject;
         aps.PredictedStartMills.Should().BeNull();
@@ -701,7 +702,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             }
         };
 
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         var aps = result.CreatedRecords[0].Should().BeOfType<V4Models.ApsSnapshot>().Subject;
         aps.PredictedStartMills.Should().BeNull();
@@ -732,7 +733,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         var aps = result.CreatedRecords[0].Should().BeOfType<V4Models.ApsSnapshot>().Subject;
@@ -756,7 +757,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             }
         };
 
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         var aps = result.CreatedRecords[0].Should().BeOfType<V4Models.ApsSnapshot>().Subject;
         aps.CurrentBg.Should().BeNull();
@@ -783,7 +784,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             }
         };
 
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         var aps = result.CreatedRecords[0].Should().BeOfType<V4Models.ApsSnapshot>().Subject;
         aps.CurrentBg.Should().Be(115.0);
@@ -809,7 +810,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             }
         };
 
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         var aps = result.CreatedRecords[0].Should().BeOfType<V4Models.ApsSnapshot>().Subject;
         aps.Enacted.Should().BeFalse();
@@ -837,7 +838,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             }
         };
 
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         var aps = result.CreatedRecords[0].Should().BeOfType<V4Models.ApsSnapshot>().Subject;
         aps.Enacted.Should().BeFalse();
@@ -875,7 +876,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             }
         };
 
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert - only one APS snapshot, and it's OpenAps
         result.CreatedRecords.OfType<V4Models.ApsSnapshot>().Should().HaveCount(1);
@@ -903,7 +904,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             }
         };
 
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         result.CreatedRecords.Should().BeEmpty();
         _stateSpanServiceMock.Verify(
@@ -926,7 +927,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             }
         };
 
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         result.CreatedRecords.Should().BeEmpty();
         _stateSpanServiceMock.Verify(
@@ -955,7 +956,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             .Setup(s => s.UpsertStateSpanAsync(It.IsAny<StateSpan>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedStateSpan);
 
-        await _decomposer.DecomposeAsync(ds);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         _stateSpanServiceMock.Verify(
             s => s.UpsertStateSpanAsync(
@@ -986,7 +987,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             .Setup(s => s.UpsertStateSpanAsync(It.IsAny<StateSpan>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedStateSpan);
 
-        await _decomposer.DecomposeAsync(ds);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         _stateSpanServiceMock.Verify(
             s => s.UpsertStateSpanAsync(
@@ -1017,7 +1018,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             .Setup(s => s.UpsertStateSpanAsync(It.IsAny<StateSpan>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedStateSpan);
 
-        await _decomposer.DecomposeAsync(ds);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         _stateSpanServiceMock.Verify(
             s => s.UpsertStateSpanAsync(
@@ -1050,7 +1051,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             }
         };
 
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         var pump = result.CreatedRecords[0].Should().BeOfType<V4Models.PumpSnapshot>().Subject;
         pump.Manufacturer.Should().Be("Tandem");
@@ -1073,10 +1074,10 @@ public class DeviceStatusDecomposerTests : IDisposable
             Pump = new PumpStatus { Reservoir = 100.0 }
         };
 
-        var first = await _decomposer.DecomposeAsync(ds);
+        var first = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
         first.CreatedRecords.Should().HaveCount(1);
 
-        var second = await _decomposer.DecomposeAsync(ds);
+        var second = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
         second.UpdatedRecords.Should().HaveCount(1);
         second.CreatedRecords.Should().BeEmpty();
     }
@@ -1096,10 +1097,10 @@ public class DeviceStatusDecomposerTests : IDisposable
             Uploader = new UploaderStatus { Battery = 80 }
         };
 
-        var first = await _decomposer.DecomposeAsync(ds);
+        var first = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
         first.CreatedRecords.Should().HaveCount(1);
 
-        var second = await _decomposer.DecomposeAsync(ds);
+        var second = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
         second.UpdatedRecords.Should().HaveCount(1);
         second.CreatedRecords.Should().BeEmpty();
     }
@@ -1120,7 +1121,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         // Setting UploaderBattery when Uploader exists updates Uploader.Battery
         ds.UploaderBattery = 75;
 
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         var uploader = result.CreatedRecords[0].Should().BeOfType<V4Models.UploaderSnapshot>().Subject;
         uploader.Battery.Should().Be(75, "UploaderBattery setter updates Uploader.Battery");
@@ -1149,7 +1150,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             }
         };
 
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         result.CreatedRecords.Should().HaveCount(1);
         var aps = result.CreatedRecords[0].Should().BeOfType<V4Models.ApsSnapshot>().Subject;
@@ -1173,8 +1174,8 @@ public class DeviceStatusDecomposerTests : IDisposable
             }
         };
 
-        var first = await _decomposer.DecomposeAsync(ds);
-        var second = await _decomposer.DecomposeAsync(ds);
+        var first = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
+        var second = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         first.CreatedRecords.Should().HaveCount(1);
         second.CreatedRecords.Should().HaveCount(1);
@@ -1206,10 +1207,10 @@ public class DeviceStatusDecomposerTests : IDisposable
             Uploader = new UploaderStatus { Battery = 55, Name = "Pixel 8" }
         };
 
-        var first = await _decomposer.DecomposeAsync(ds);
+        var first = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
         first.CreatedRecords.Should().HaveCount(3);
 
-        var second = await _decomposer.DecomposeAsync(ds);
+        var second = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
         second.UpdatedRecords.Should().HaveCount(3);
         second.CreatedRecords.Should().BeEmpty();
     }
@@ -1238,7 +1239,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             Uploader = new UploaderStatus { Battery = 60 }
         };
 
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         result.CorrelationId.Should().NotBeNull();
         // All V4 snapshot records don't directly have CorrelationId on the DeviceStatus decomposer,
@@ -1278,7 +1279,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -1311,7 +1312,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             Uploader = new UploaderStatus { Name = "AndroidAPS", Battery = 85 }
         };
 
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         var aps = result.CreatedRecords.OfType<V4Models.ApsSnapshot>().Single();
         aps.AidAlgorithm.Should().Be(V4Models.AidAlgorithm.AndroidAps);
@@ -1336,7 +1337,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             Uploader = new UploaderStatus { Name = "androidaps 3.2.0" }
         };
 
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         var aps = result.CreatedRecords.OfType<V4Models.ApsSnapshot>().Single();
         aps.AidAlgorithm.Should().Be(V4Models.AidAlgorithm.AndroidAps);
@@ -1363,7 +1364,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             }
         };
 
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         var aps = result.CreatedRecords.OfType<V4Models.ApsSnapshot>().Single();
         aps.AidAlgorithm.Should().Be(V4Models.AidAlgorithm.Trio);
@@ -1387,7 +1388,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             }
         };
 
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         var aps = result.CreatedRecords.OfType<V4Models.ApsSnapshot>().Single();
         aps.AidAlgorithm.Should().Be(V4Models.AidAlgorithm.OpenAps);
@@ -1415,7 +1416,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             Uploader = new UploaderStatus { Name = "AndroidAPS 3.2.0" }
         };
 
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         var aps = result.CreatedRecords.OfType<V4Models.ApsSnapshot>().Single();
         aps.AidAlgorithm.Should().Be(V4Models.AidAlgorithm.AndroidAps);
@@ -1467,7 +1468,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             }
         };
 
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         var aps = result.CreatedRecords.OfType<V4Models.ApsSnapshot>().Single();
         aps.AidAlgorithm.Should().Be(V4Models.AidAlgorithm.Trio);
@@ -1501,7 +1502,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             }
         };
 
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         var aps = result.CreatedRecords.OfType<V4Models.ApsSnapshot>().Single();
         aps.AidAlgorithm.Should().Be(V4Models.AidAlgorithm.Trio);
@@ -1545,7 +1546,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         var pump = result.CreatedRecords[0].Should().BeOfType<V4Models.PumpSnapshot>().Subject;
@@ -1580,7 +1581,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         var uploader = result.CreatedRecords[0].Should().BeOfType<V4Models.UploaderSnapshot>().Subject;
@@ -1603,7 +1604,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             }
         };
 
-        await _decomposer.DecomposeAsync(ds);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         _deviceServiceMock.Verify(s => s.ResolveAsync(
             V4Models.DeviceCategory.InsulinPump,
@@ -1629,7 +1630,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             }
         };
 
-        await _decomposer.DecomposeAsync(ds);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         _deviceServiceMock.Verify(s => s.ResolveAsync(
             V4Models.DeviceCategory.CGM,
@@ -1650,7 +1651,7 @@ public class DeviceStatusDecomposerTests : IDisposable
             Pump = new PumpStatus { Manufacturer = "Medtronic", Model = "MMT-1885" }
         };
 
-        await _decomposer.DecomposeAsync(ds);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         _deviceServiceMock.Verify(s => s.ResolveAsync(
             V4Models.DeviceCategory.CGM,
@@ -1690,7 +1691,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         var aps = result.CreatedRecords[0].Should().BeOfType<V4Models.ApsSnapshot>().Subject;
@@ -1715,7 +1716,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         var aps = result.CreatedRecords[0].Should().BeOfType<V4Models.ApsSnapshot>().Subject;
@@ -1746,7 +1747,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         var ds = System.Text.Json.JsonSerializer.Deserialize<DeviceStatus>(json)!;
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         var aps = result.CreatedRecords[0].Should().BeOfType<V4Models.ApsSnapshot>().Subject;
@@ -1782,7 +1783,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert — should use OpenAps.Iob.Time as fallback (most precise APS timestamp)
         var aps = result.CreatedRecords[0].Should().BeOfType<V4Models.ApsSnapshot>().Subject;
@@ -1826,7 +1827,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         var aps = result.CreatedRecords.OfType<V4Models.ApsSnapshot>().Single();
@@ -1861,7 +1862,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         var aps = result.CreatedRecords.OfType<V4Models.ApsSnapshot>().Single();
@@ -1892,7 +1893,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         var aps = result.CreatedRecords.OfType<V4Models.ApsSnapshot>().Single();
@@ -1923,7 +1924,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         var pump = result.CreatedRecords[0].Should().BeOfType<V4Models.PumpSnapshot>().Subject;
@@ -1955,7 +1956,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         var ds = JsonSerializer.Deserialize<DeviceStatus>(json)!;
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert — configuration should end up in extras
         var extrasEntities = _context.DeviceStatusExtras.ToList();
@@ -1985,7 +1986,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         var extrasEntities = _context.DeviceStatusExtras.ToList();
@@ -2007,7 +2008,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         var extrasEntities = _context.DeviceStatusExtras.ToList();
@@ -2039,7 +2040,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert — no extras record should be created
         var extrasEntities = _context.DeviceStatusExtras.ToList();
@@ -2062,7 +2063,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         var ds = JsonSerializer.Deserialize<DeviceStatus>(json)!;
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         var extrasEntities = _context.DeviceStatusExtras.ToList();
@@ -2107,7 +2108,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         var aps = result.CreatedRecords.OfType<V4Models.ApsSnapshot>().Single();
@@ -2134,7 +2135,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         var aps = result.CreatedRecords.OfType<V4Models.ApsSnapshot>().Single();
@@ -2178,7 +2179,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         var pump = result.CreatedRecords.OfType<V4Models.PumpSnapshot>().Single();
@@ -2215,7 +2216,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         var aps = result.CreatedRecords[0].Should().BeOfType<V4Models.ApsSnapshot>().Subject;
@@ -2248,7 +2249,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(ds);
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
 
         // Assert
         var aps = result.CreatedRecords[0].Should().BeOfType<V4Models.ApsSnapshot>().Subject;
@@ -2337,9 +2338,9 @@ public class DeviceStatusDecomposerTests : IDisposable
         var minute = 60_000L;
 
         // Act — three sequential uploads: not suspended, suspended, not suspended
-        await _decomposer.DecomposeAsync(MakeDs("ds-1", t0, suspended: false));
-        await _decomposer.DecomposeAsync(MakeDs("ds-2", t0 + minute, suspended: true));
-        await _decomposer.DecomposeAsync(MakeDs("ds-3", t0 + 2 * minute, suspended: false));
+        await _decomposer.DecomposeAsync(MakeDs("ds-1", t0, suspended: false), WriteOrigin.Live);
+        await _decomposer.DecomposeAsync(MakeDs("ds-2", t0 + minute, suspended: true), WriteOrigin.Live);
+        await _decomposer.DecomposeAsync(MakeDs("ds-3", t0 + 2 * minute, suspended: false), WriteOrigin.Live);
 
         // Assert — exactly one PumpMode/Suspended span, opened then closed
         var pumpModeSpans = spans.Where(s => s.Category == StateSpanCategory.PumpMode).ToList();
@@ -2426,9 +2427,9 @@ public class DeviceStatusDecomposerTests : IDisposable
         var t0 = 1700000000000L;
         var minute = 60_000L;
 
-        await _decomposer.DecomposeAsync(MakePumpModeDs("ds-1", t0, "Manual"));
-        await _decomposer.DecomposeAsync(MakePumpModeDs("ds-2", t0 + minute, "Automatic"));
-        await _decomposer.DecomposeAsync(MakePumpModeDs("ds-3", t0 + 2 * minute, "Manual"));
+        await _decomposer.DecomposeAsync(MakePumpModeDs("ds-1", t0, "Manual"), WriteOrigin.Live);
+        await _decomposer.DecomposeAsync(MakePumpModeDs("ds-2", t0 + minute, "Automatic"), WriteOrigin.Live);
+        await _decomposer.DecomposeAsync(MakePumpModeDs("ds-3", t0 + 2 * minute, "Manual"), WriteOrigin.Live);
 
         var modeSpans = spans.Where(s => s.Category == StateSpanCategory.PumpMode).ToList();
 
@@ -2450,9 +2451,9 @@ public class DeviceStatusDecomposerTests : IDisposable
         var t0 = 1700000000000L;
         var minute = 60_000L;
 
-        await _decomposer.DecomposeAsync(MakePumpModeDs("ds-1", t0, "Automatic"));
-        await _decomposer.DecomposeAsync(MakePumpModeDs("ds-2", t0 + minute, "Automatic"));
-        await _decomposer.DecomposeAsync(MakePumpModeDs("ds-3", t0 + 2 * minute, "Automatic"));
+        await _decomposer.DecomposeAsync(MakePumpModeDs("ds-1", t0, "Automatic"), WriteOrigin.Live);
+        await _decomposer.DecomposeAsync(MakePumpModeDs("ds-2", t0 + minute, "Automatic"), WriteOrigin.Live);
+        await _decomposer.DecomposeAsync(MakePumpModeDs("ds-3", t0 + 2 * minute, "Automatic"), WriteOrigin.Live);
 
         var modeSpans = spans.Where(s => s.Category == StateSpanCategory.PumpMode).ToList();
         modeSpans.Should().ContainSingle();
@@ -2468,8 +2469,8 @@ public class DeviceStatusDecomposerTests : IDisposable
         var t0 = 1700000000000L;
         var minute = 60_000L;
 
-        await _decomposer.DecomposeAsync(MakePumpModeDs("ds-1", t0, "Manual", suspended: false));
-        await _decomposer.DecomposeAsync(MakePumpModeDs("ds-2", t0 + minute, "Automatic", suspended: true));
+        await _decomposer.DecomposeAsync(MakePumpModeDs("ds-1", t0, "Manual", suspended: false), WriteOrigin.Live);
+        await _decomposer.DecomposeAsync(MakePumpModeDs("ds-2", t0 + minute, "Automatic", suspended: true), WriteOrigin.Live);
 
         var open = spans.Where(s => s.Category == StateSpanCategory.PumpMode && s.EndTimestamp == null)
             .Select(s => s.State).ToList();
@@ -2483,7 +2484,7 @@ public class DeviceStatusDecomposerTests : IDisposable
     {
         var spans = SetupInMemoryStateSpans();
 
-        await _decomposer.DecomposeAsync(MakePumpModeDs("ds-1", 1700000000000L, pumpMode: null));
+        await _decomposer.DecomposeAsync(MakePumpModeDs("ds-1", 1700000000000L, pumpMode: null), WriteOrigin.Live);
 
         spans.Where(s => s.Category == StateSpanCategory.PumpMode
                 && (s.State == PumpModeState.Automatic.ToString() || s.State == PumpModeState.Manual.ToString()))

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/EntryDecomposerBatchTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/EntryDecomposerBatchTests.cs
@@ -33,13 +33,13 @@ public class EntryDecomposerBatchTests : IDisposable
         // BulkCreateAsync returns the input records
         _sgRepoMock
             .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<SensorGlucose> records, CancellationToken _) => records);
+            .ReturnsAsync((IEnumerable<SensorGlucose> records, WriteOrigin origin, CancellationToken _) => records);
         _mgRepoMock
             .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<MeterGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<MeterGlucose> records, CancellationToken _) => records);
+            .ReturnsAsync((IEnumerable<MeterGlucose> records, WriteOrigin origin, CancellationToken _) => records);
         _calRepoMock
             .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<Calibration>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<Calibration> records, CancellationToken _) => records);
+            .ReturnsAsync((IEnumerable<Calibration> records, WriteOrigin origin, CancellationToken _) => records);
 
         var mockConfigProvider = new Mock<IGlucoseProcessingConfigProvider>();
         mockConfigProvider.Setup(x => x.GetSourceDefaultsAsync(It.IsAny<CancellationToken>()))

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/EntryDecomposerBatchTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/EntryDecomposerBatchTests.cs
@@ -32,13 +32,13 @@ public class EntryDecomposerBatchTests : IDisposable
 
         // BulkCreateAsync returns the input records
         _sgRepoMock
-            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<SensorGlucose> records, CancellationToken _) => records);
         _mgRepoMock
-            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<MeterGlucose>>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<MeterGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<MeterGlucose> records, CancellationToken _) => records);
         _calRepoMock
-            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<Calibration>>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<Calibration>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<Calibration> records, CancellationToken _) => records);
 
         var mockConfigProvider = new Mock<IGlucoseProcessingConfigProvider>();
@@ -77,25 +77,25 @@ public class EntryDecomposerBatchTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeBatchAsync(entries);
+        var result = await _decomposer.DecomposeBatchAsync(entries, WriteOrigin.Live);
 
         // Assert — correct partition sizes
         _sgRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<SensorGlucose>>(list => list.Count() == 2),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         _mgRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<MeterGlucose>>(list => list.Count() == 1),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         _calRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<Calibration>>(list => list.Count() == 1),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         result.CreatedRecords.Should().HaveCount(4);
@@ -106,17 +106,17 @@ public class EntryDecomposerBatchTests : IDisposable
     public async Task DecomposeBatchAsync_EmptyBatch_NoRepositoryCalls()
     {
         // Act
-        var result = await _decomposer.DecomposeBatchAsync([]);
+        var result = await _decomposer.DecomposeBatchAsync([], WriteOrigin.Live);
 
         // Assert
         _sgRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _mgRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<MeterGlucose>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<MeterGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _calRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<Calibration>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<Calibration>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
 
         result.CreatedRecords.Should().BeEmpty();
@@ -133,7 +133,7 @@ public class EntryDecomposerBatchTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeBatchAsync(entries);
+        var result = await _decomposer.DecomposeBatchAsync(entries, WriteOrigin.Live);
 
         // Assert — a DecompositionBatchEntity was persisted
         var batch = _context.DecompositionBatches.SingleOrDefault(b => b.Id == result.CorrelationId);
@@ -154,19 +154,19 @@ public class EntryDecomposerBatchTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeBatchAsync(entries);
+        var result = await _decomposer.DecomposeBatchAsync(entries, WriteOrigin.Live);
 
         // Assert — only 1 sgv, rawbg skipped
         _sgRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<SensorGlucose>>(list => list.Count() == 1),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
         _mgRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<MeterGlucose>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<MeterGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _calRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<Calibration>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<Calibration>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
 
         result.CreatedRecords.Should().HaveCount(1);

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/EntryDecomposerBulkDeleteTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/EntryDecomposerBulkDeleteTests.cs
@@ -6,6 +6,7 @@ using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Tests.Shared.Infrastructure;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Tests.Services.V4;
 
@@ -42,7 +43,7 @@ public class EntryDecomposerBulkDeleteTests : IDisposable
         _calRepo.Setup(r => r.DeleteByTimeRangeAsync(It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>())).ReturnsAsync(1);
 
         var decomposer = CreateDecomposer();
-        var count = await decomposer.BulkDeleteAsync(find);
+        var count = await decomposer.BulkDeleteAsync(find, WriteOrigin.Live);
 
         count.Should().Be(13);
     }
@@ -56,7 +57,7 @@ public class EntryDecomposerBulkDeleteTests : IDisposable
         _calRepo.Setup(r => r.DeleteByTimeRangeAsync(null, null, It.IsAny<CancellationToken>())).ReturnsAsync(0);
 
         var decomposer = CreateDecomposer();
-        var count = await decomposer.BulkDeleteAsync(null);
+        var count = await decomposer.BulkDeleteAsync(null, WriteOrigin.Live);
 
         count.Should().Be(55);
     }
@@ -70,7 +71,7 @@ public class EntryDecomposerBulkDeleteTests : IDisposable
         _calRepo.Setup(r => r.DeleteByTimeRangeAsync(null, null, It.IsAny<CancellationToken>())).ReturnsAsync(0);
 
         var decomposer = CreateDecomposer();
-        var count = await decomposer.BulkDeleteAsync("{}");
+        var count = await decomposer.BulkDeleteAsync("{}", WriteOrigin.Live);
 
         count.Should().Be(100);
     }
@@ -85,7 +86,7 @@ public class EntryDecomposerBulkDeleteTests : IDisposable
         var find = "{\"sgv\":{\"$gte\":180}}";
 
         var decomposer = CreateDecomposer();
-        var count = await decomposer.BulkDeleteAsync(find);
+        var count = await decomposer.BulkDeleteAsync(find, WriteOrigin.Live);
 
         count.Should().Be(0);
         _sgRepo.Verify(r => r.DeleteByTimeRangeAsync(It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()), Times.Never);
@@ -99,7 +100,7 @@ public class EntryDecomposerBulkDeleteTests : IDisposable
         // The plausibility guard should reject this
         var find = "{\"sgv\":{\"$gte\":180}}";
         var decomposer = CreateDecomposer();
-        var count = await decomposer.BulkDeleteAsync(find);
+        var count = await decomposer.BulkDeleteAsync(find, WriteOrigin.Live);
         count.Should().Be(0);
         _sgRepo.Verify(r => r.DeleteByTimeRangeAsync(It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
@@ -114,7 +115,7 @@ public class EntryDecomposerBulkDeleteTests : IDisposable
         _calRepo.Setup(r => r.DeleteByTimeRangeAsync(It.IsAny<DateTime?>(), null, It.IsAny<CancellationToken>())).ReturnsAsync(0);
 
         var decomposer = CreateDecomposer();
-        var count = await decomposer.BulkDeleteAsync(find);
+        var count = await decomposer.BulkDeleteAsync(find, WriteOrigin.Live);
 
         count.Should().Be(5);
     }

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/EntryDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/EntryDecomposerTests.cs
@@ -10,6 +10,7 @@ using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Tests.Services.V4;
 
@@ -69,7 +70,7 @@ public class EntryDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         result.CorrelationId.Should().NotBeNull();
@@ -106,7 +107,7 @@ public class EntryDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         var sg = result.CreatedRecords[0].Should().BeOfType<SensorGlucose>().Subject;
@@ -127,7 +128,7 @@ public class EntryDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         var sg = result.CreatedRecords[0].Should().BeOfType<SensorGlucose>().Subject;
@@ -157,7 +158,7 @@ public class EntryDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -189,7 +190,7 @@ public class EntryDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         var mg = result.CreatedRecords[0].Should().BeOfType<MeterGlucose>().Subject;
@@ -219,7 +220,7 @@ public class EntryDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -256,7 +257,7 @@ public class EntryDecomposerTests : IDisposable
         };
 
         // Act - first call creates
-        var firstResult = await _decomposer.DecomposeAsync(entry);
+        var firstResult = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
         firstResult.CreatedRecords.Should().HaveCount(1);
         firstResult.UpdatedRecords.Should().BeEmpty();
 
@@ -264,7 +265,7 @@ public class EntryDecomposerTests : IDisposable
         entry.Sgv = 125.0;
 
         // Act - second call updates
-        var secondResult = await _decomposer.DecomposeAsync(entry);
+        var secondResult = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         secondResult.CreatedRecords.Should().BeEmpty();
@@ -288,12 +289,12 @@ public class EntryDecomposerTests : IDisposable
         };
 
         // Act - first call creates
-        var firstResult = await _decomposer.DecomposeAsync(entry);
+        var firstResult = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
         firstResult.CreatedRecords.Should().HaveCount(1);
 
         // Act - second call updates
         entry.Mbg = 145.0;
-        var secondResult = await _decomposer.DecomposeAsync(entry);
+        var secondResult = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         secondResult.CreatedRecords.Should().BeEmpty();
@@ -313,12 +314,12 @@ public class EntryDecomposerTests : IDisposable
         };
 
         // Act - first call creates
-        var firstResult = await _decomposer.DecomposeAsync(entry);
+        var firstResult = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
         firstResult.CreatedRecords.Should().HaveCount(1);
 
         // Act - second call updates
         entry.Slope = 860.0;
-        var secondResult = await _decomposer.DecomposeAsync(entry);
+        var secondResult = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         secondResult.CreatedRecords.Should().BeEmpty();
@@ -341,7 +342,7 @@ public class EntryDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().BeEmpty();
@@ -361,7 +362,7 @@ public class EntryDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().BeEmpty();
@@ -380,7 +381,7 @@ public class EntryDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().BeEmpty();
@@ -400,7 +401,7 @@ public class EntryDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -422,7 +423,7 @@ public class EntryDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -450,7 +451,7 @@ public class EntryDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -471,7 +472,7 @@ public class EntryDecomposerTests : IDisposable
         var entry = new Entry { Id = "zero-sgv", Type = "sgv", Mills = 1700000000000, Sgv = 0.0 };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -486,7 +487,7 @@ public class EntryDecomposerTests : IDisposable
         var entry = new Entry { Id = "negative-sgv", Type = "sgv", Mills = 1700000000000, Sgv = -5.0 };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         var sg = result.CreatedRecords[0].Should().BeOfType<SensorGlucose>().Subject;
@@ -500,7 +501,7 @@ public class EntryDecomposerTests : IDisposable
         var entry = new Entry { Id = "both-null-sgv", Type = "sgv", Mills = 1700000000000 };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         var sg = result.CreatedRecords[0].Should().BeOfType<SensorGlucose>().Subject;
@@ -514,7 +515,7 @@ public class EntryDecomposerTests : IDisposable
         var entry = new Entry { Id = "both-null-mbg", Type = "mbg", Mills = 1700000000000 };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         var mg = result.CreatedRecords[0].Should().BeOfType<MeterGlucose>().Subject;
@@ -528,7 +529,7 @@ public class EntryDecomposerTests : IDisposable
         var entry = new Entry { Id = "minimal-cal", Type = "cal", Mills = 1700000000000 };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         var cal = result.CreatedRecords[0].Should().BeOfType<Calibration>().Subject;
@@ -546,7 +547,7 @@ public class EntryDecomposerTests : IDisposable
         var entry = new Entry { Id = "hi-sgv", Type = "sgv", Mills = 1700000000000, Sgv = 400.0 };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         var sg = result.CreatedRecords[0].Should().BeOfType<SensorGlucose>().Subject;
@@ -560,7 +561,7 @@ public class EntryDecomposerTests : IDisposable
         var entry = new Entry { Id = "zero-mills", Type = "sgv", Mills = 0, Sgv = 100.0 };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         var sg = result.CreatedRecords[0].Should().BeOfType<SensorGlucose>().Subject;
@@ -578,7 +579,7 @@ public class EntryDecomposerTests : IDisposable
         var entry = new Entry { Id = "padded-type", Type = " sgv ", Mills = 1700000000000, Sgv = 100.0 };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert - " sgv " != "sgv" so it's treated as unknown
         result.CreatedRecords.Should().BeEmpty();
@@ -591,7 +592,7 @@ public class EntryDecomposerTests : IDisposable
         var entry = new Entry { Id = "mixedcase-mbg", Type = "MBG", Mills = 1700000000000, Mbg = 140.0 };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -605,7 +606,7 @@ public class EntryDecomposerTests : IDisposable
         var entry = new Entry { Id = "mixedcase-cal", Type = "Cal", Mills = 1700000000000, Slope = 800.0 };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -623,11 +624,11 @@ public class EntryDecomposerTests : IDisposable
         var entry = new Entry { Id = "preserve-id-test", Type = "sgv", Mills = 1700000000000, Sgv = 100.0 };
 
         // Act
-        var firstResult = await _decomposer.DecomposeAsync(entry);
+        var firstResult = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
         var originalId = firstResult.CreatedRecords.OfType<SensorGlucose>().Single().Id;
 
         entry.Sgv = 110.0;
-        var secondResult = await _decomposer.DecomposeAsync(entry);
+        var secondResult = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
         var updatedId = secondResult.UpdatedRecords.OfType<SensorGlucose>().Single().Id;
 
         // Assert - the V4 ID should be preserved across updates
@@ -642,8 +643,8 @@ public class EntryDecomposerTests : IDisposable
         var entry2 = new Entry { Id = null, Type = "sgv", Mills = 1700000001000, Sgv = 110.0 };
 
         // Act
-        var result1 = await _decomposer.DecomposeAsync(entry1);
-        var result2 = await _decomposer.DecomposeAsync(entry2);
+        var result1 = await _decomposer.DecomposeAsync(entry1, WriteOrigin.Live);
+        var result2 = await _decomposer.DecomposeAsync(entry2, WriteOrigin.Live);
 
         // Assert - both should create, neither should update
         result1.CreatedRecords.Should().HaveCount(1);
@@ -697,7 +698,7 @@ public class EntryDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -726,7 +727,7 @@ public class EntryDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         var sg = result.CreatedRecords[0] as SensorGlucose;
@@ -755,7 +756,7 @@ public class EntryDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         var sg = result.CreatedRecords[0] as SensorGlucose;
@@ -777,7 +778,7 @@ public class EntryDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(entry);
+        var result = await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
 
         // Assert
         var sg = result.CreatedRecords[0] as SensorGlucose;

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/ProfileDecomposerBatchTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/ProfileDecomposerBatchTests.cs
@@ -240,31 +240,31 @@ public class ProfileDecomposerBatchTests : IDisposable
     private static void SetupBulkCreateReturnsInput(Mock<ITherapySettingsRepository> mock)
     {
         mock.Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<TherapySettings>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<TherapySettings> records, CancellationToken _) => records);
+            .ReturnsAsync((IEnumerable<TherapySettings> records, WriteOrigin origin, CancellationToken _) => records);
     }
 
     private static void SetupBulkCreateReturnsInput(Mock<IBasalScheduleRepository> mock)
     {
         mock.Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<BasalSchedule>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<BasalSchedule> records, CancellationToken _) => records);
+            .ReturnsAsync((IEnumerable<BasalSchedule> records, WriteOrigin origin, CancellationToken _) => records);
     }
 
     private static void SetupBulkCreateReturnsInput(Mock<ICarbRatioScheduleRepository> mock)
     {
         mock.Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<CarbRatioSchedule>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<CarbRatioSchedule> records, CancellationToken _) => records);
+            .ReturnsAsync((IEnumerable<CarbRatioSchedule> records, WriteOrigin origin, CancellationToken _) => records);
     }
 
     private static void SetupBulkCreateReturnsInput(Mock<ISensitivityScheduleRepository> mock)
     {
         mock.Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<SensitivitySchedule>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<SensitivitySchedule> records, CancellationToken _) => records);
+            .ReturnsAsync((IEnumerable<SensitivitySchedule> records, WriteOrigin origin, CancellationToken _) => records);
     }
 
     private static void SetupBulkCreateReturnsInput(Mock<ITargetRangeScheduleRepository> mock)
     {
         mock.Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<TargetRangeSchedule>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<TargetRangeSchedule> records, CancellationToken _) => records);
+            .ReturnsAsync((IEnumerable<TargetRangeSchedule> records, WriteOrigin origin, CancellationToken _) => records);
     }
 
     #endregion

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/ProfileDecomposerBatchTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/ProfileDecomposerBatchTests.cs
@@ -6,6 +6,7 @@ using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Tests.Shared.Infrastructure;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.API.Tests.Services.V4;
 
@@ -70,37 +71,37 @@ public class ProfileDecomposerBatchTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeBatchAsync(profiles);
+        var result = await _decomposer.DecomposeBatchAsync(profiles, WriteOrigin.Live);
 
         // Assert - 2 profiles x 5 record types = 10 total records
         _therapySettingsRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<TherapySettings>>(list => list.Count() == 2),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         _basalScheduleRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<BasalSchedule>>(list => list.Count() == 2),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         _carbRatioScheduleRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<CarbRatioSchedule>>(list => list.Count() == 2),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         _sensitivityScheduleRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<SensitivitySchedule>>(list => list.Count() == 2),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         _targetRangeScheduleRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<TargetRangeSchedule>>(list => list.Count() == 2),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         result.CreatedRecords.Should().HaveCount(10);
@@ -111,23 +112,23 @@ public class ProfileDecomposerBatchTests : IDisposable
     public async Task DecomposeBatchAsync_EmptyBatch_NoRepositoryCalls()
     {
         // Act
-        var result = await _decomposer.DecomposeBatchAsync([]);
+        var result = await _decomposer.DecomposeBatchAsync([], WriteOrigin.Live);
 
         // Assert
         _therapySettingsRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<TherapySettings>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<TherapySettings>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _basalScheduleRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<BasalSchedule>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<BasalSchedule>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _carbRatioScheduleRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<CarbRatioSchedule>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<CarbRatioSchedule>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _sensitivityScheduleRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<SensitivitySchedule>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<SensitivitySchedule>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _targetRangeScheduleRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<TargetRangeSchedule>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<TargetRangeSchedule>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
 
         result.CreatedRecords.Should().BeEmpty();
@@ -147,7 +148,7 @@ public class ProfileDecomposerBatchTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeBatchAsync(profiles);
+        var result = await _decomposer.DecomposeBatchAsync(profiles, WriteOrigin.Live);
 
         // Assert - verify therapy settings were created with correct values
         _therapySettingsRepoMock.Verify(
@@ -158,7 +159,7 @@ public class ProfileDecomposerBatchTests : IDisposable
                         ts.Dia == 4.0 &&
                         ts.Timezone == "US/Eastern" &&
                         ts.IsDefault == true)),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         // A DecompositionBatchEntity was persisted
@@ -182,7 +183,7 @@ public class ProfileDecomposerBatchTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeBatchAsync(profiles);
+        var result = await _decomposer.DecomposeBatchAsync(profiles, WriteOrigin.Live);
 
         // Assert - 2 stores x 5 record types = 10 total records
         _therapySettingsRepoMock.Verify(
@@ -191,13 +192,13 @@ public class ProfileDecomposerBatchTests : IDisposable
                     list.Count() == 2 &&
                     list.Any(ts => ts.LegacyId == "profile1:Default" && ts.IsDefault == true) &&
                     list.Any(ts => ts.LegacyId == "profile1:Exercise" && ts.IsDefault == false)),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         _basalScheduleRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<BasalSchedule>>(list => list.Count() == 2),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         result.CreatedRecords.Should().HaveCount(10);
@@ -238,31 +239,31 @@ public class ProfileDecomposerBatchTests : IDisposable
 
     private static void SetupBulkCreateReturnsInput(Mock<ITherapySettingsRepository> mock)
     {
-        mock.Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<TherapySettings>>(), It.IsAny<CancellationToken>()))
+        mock.Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<TherapySettings>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<TherapySettings> records, CancellationToken _) => records);
     }
 
     private static void SetupBulkCreateReturnsInput(Mock<IBasalScheduleRepository> mock)
     {
-        mock.Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<BasalSchedule>>(), It.IsAny<CancellationToken>()))
+        mock.Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<BasalSchedule>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<BasalSchedule> records, CancellationToken _) => records);
     }
 
     private static void SetupBulkCreateReturnsInput(Mock<ICarbRatioScheduleRepository> mock)
     {
-        mock.Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<CarbRatioSchedule>>(), It.IsAny<CancellationToken>()))
+        mock.Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<CarbRatioSchedule>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<CarbRatioSchedule> records, CancellationToken _) => records);
     }
 
     private static void SetupBulkCreateReturnsInput(Mock<ISensitivityScheduleRepository> mock)
     {
-        mock.Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<SensitivitySchedule>>(), It.IsAny<CancellationToken>()))
+        mock.Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<SensitivitySchedule>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<SensitivitySchedule> records, CancellationToken _) => records);
     }
 
     private static void SetupBulkCreateReturnsInput(Mock<ITargetRangeScheduleRepository> mock)
     {
-        mock.Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<TargetRangeSchedule>>(), It.IsAny<CancellationToken>()))
+        mock.Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<TargetRangeSchedule>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<TargetRangeSchedule> records, CancellationToken _) => records);
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerBatchTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerBatchTests.cs
@@ -58,25 +58,25 @@ public class TreatmentDecomposerBatchTests : IDisposable
         // BulkCreateAsync returns the input records
         _bolusRepoMock
             .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.Bolus>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<V4Models.Bolus> records, CancellationToken _) => records);
+            .ReturnsAsync((IEnumerable<V4Models.Bolus> records, WriteOrigin origin, CancellationToken _) => records);
         _carbRepoMock
             .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.CarbIntake>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<V4Models.CarbIntake> records, CancellationToken _) => records);
+            .ReturnsAsync((IEnumerable<V4Models.CarbIntake> records, WriteOrigin origin, CancellationToken _) => records);
         _bgCheckRepoMock
             .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.BGCheck>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<V4Models.BGCheck> records, CancellationToken _) => records);
+            .ReturnsAsync((IEnumerable<V4Models.BGCheck> records, WriteOrigin origin, CancellationToken _) => records);
         _noteRepoMock
             .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.Note>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<V4Models.Note> records, CancellationToken _) => records);
+            .ReturnsAsync((IEnumerable<V4Models.Note> records, WriteOrigin origin, CancellationToken _) => records);
         _bolusCalcRepoMock
             .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.BolusCalculation>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<V4Models.BolusCalculation> records, CancellationToken _) => records);
+            .ReturnsAsync((IEnumerable<V4Models.BolusCalculation> records, WriteOrigin origin, CancellationToken _) => records);
         _deviceEventRepoMock
             .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.DeviceEvent>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<V4Models.DeviceEvent> records, CancellationToken _) => records);
+            .ReturnsAsync((IEnumerable<V4Models.DeviceEvent> records, WriteOrigin origin, CancellationToken _) => records);
         _tempBasalRepoMock
             .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.TempBasal>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<V4Models.TempBasal> records, CancellationToken _) => records);
+            .ReturnsAsync((IEnumerable<V4Models.TempBasal> records, WriteOrigin origin, CancellationToken _) => records);
 
         // StateSpanService returns a new StateSpan
         _stateSpanServiceMock
@@ -86,7 +86,7 @@ public class TreatmentDecomposerBatchTests : IDisposable
         // UpdateAsync returns the input bolus (for linking pass)
         _bolusRepoMock
             .Setup(x => x.UpdateAsync(It.IsAny<Guid>(), It.IsAny<V4Models.Bolus>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Guid _, V4Models.Bolus b, CancellationToken _) => b);
+            .ReturnsAsync((Guid _, V4Models.Bolus b, WriteOrigin origin, CancellationToken _) => b);
 
         // DeviceService returns null by default
         _deviceServiceMock

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerBatchTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerBatchTests.cs
@@ -57,25 +57,25 @@ public class TreatmentDecomposerBatchTests : IDisposable
 
         // BulkCreateAsync returns the input records
         _bolusRepoMock
-            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.Bolus>>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.Bolus>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<V4Models.Bolus> records, CancellationToken _) => records);
         _carbRepoMock
-            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.CarbIntake>>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.CarbIntake>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<V4Models.CarbIntake> records, CancellationToken _) => records);
         _bgCheckRepoMock
-            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.BGCheck>>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.BGCheck>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<V4Models.BGCheck> records, CancellationToken _) => records);
         _noteRepoMock
-            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.Note>>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.Note>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<V4Models.Note> records, CancellationToken _) => records);
         _bolusCalcRepoMock
-            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.BolusCalculation>>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.BolusCalculation>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<V4Models.BolusCalculation> records, CancellationToken _) => records);
         _deviceEventRepoMock
-            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.DeviceEvent>>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.DeviceEvent>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<V4Models.DeviceEvent> records, CancellationToken _) => records);
         _tempBasalRepoMock
-            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.TempBasal>>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.TempBasal>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<V4Models.TempBasal> records, CancellationToken _) => records);
 
         // StateSpanService returns a new StateSpan
@@ -85,7 +85,7 @@ public class TreatmentDecomposerBatchTests : IDisposable
 
         // UpdateAsync returns the input bolus (for linking pass)
         _bolusRepoMock
-            .Setup(x => x.UpdateAsync(It.IsAny<Guid>(), It.IsAny<V4Models.Bolus>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.UpdateAsync(It.IsAny<Guid>(), It.IsAny<V4Models.Bolus>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((Guid _, V4Models.Bolus b, CancellationToken _) => b);
 
         // DeviceService returns null by default
@@ -131,42 +131,42 @@ public class TreatmentDecomposerBatchTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeBatchAsync(treatments);
+        var result = await _decomposer.DecomposeBatchAsync(treatments, WriteOrigin.Live);
 
         // Assert — correct partition sizes
         _bolusRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<V4Models.Bolus>>(list => list.Count() == 1),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         _carbRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<V4Models.CarbIntake>>(list => list.Count() == 1),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         _noteRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<V4Models.Note>>(list => list.Count() == 1),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         _bgCheckRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<V4Models.BGCheck>>(list => list.Count() == 1),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         // No bolus calc, device event, or temp basal calls
         _bolusCalcRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.BolusCalculation>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.BolusCalculation>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _deviceEventRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.DeviceEvent>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.DeviceEvent>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _tempBasalRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.TempBasal>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.TempBasal>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
 
         result.CreatedRecords.Should().HaveCount(4);
@@ -177,29 +177,29 @@ public class TreatmentDecomposerBatchTests : IDisposable
     public async Task DecomposeBatchAsync_EmptyBatch_NoRepositoryCalls()
     {
         // Act
-        var result = await _decomposer.DecomposeBatchAsync([]);
+        var result = await _decomposer.DecomposeBatchAsync([], WriteOrigin.Live);
 
         // Assert
         _bolusRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.Bolus>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.Bolus>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _carbRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.CarbIntake>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.CarbIntake>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _bgCheckRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.BGCheck>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.BGCheck>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _noteRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.Note>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.Note>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _bolusCalcRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.BolusCalculation>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.BolusCalculation>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _deviceEventRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.DeviceEvent>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.DeviceEvent>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _tempBasalRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.TempBasal>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.TempBasal>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
 
         result.CreatedRecords.Should().BeEmpty();
@@ -217,13 +217,13 @@ public class TreatmentDecomposerBatchTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeBatchAsync(treatments);
+        var result = await _decomposer.DecomposeBatchAsync(treatments, WriteOrigin.Live);
 
         // Assert — temp basal uses bulk insert
         _tempBasalRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<V4Models.TempBasal>>(list => list.Count() == 1),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         // Temporary target uses individual state span upsert
@@ -255,31 +255,31 @@ public class TreatmentDecomposerBatchTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeBatchAsync(treatments);
+        var result = await _decomposer.DecomposeBatchAsync(treatments, WriteOrigin.Live);
 
         // Assert — both bolus and calculation created
         _bolusRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<V4Models.Bolus>>(list => list.Count() == 1),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         _bolusCalcRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<V4Models.BolusCalculation>>(list => list.Count() == 1),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         // Carb intake also produced (insulin + carbs override rule)
         _carbRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<V4Models.CarbIntake>>(list => list.Count() == 1),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         // Linking pass: UpdateAsync called to set BolusCalculationId on the bolus
         _bolusRepoMock.Verify(
-            x => x.UpdateAsync(It.IsAny<Guid>(), It.IsAny<V4Models.Bolus>(), It.IsAny<CancellationToken>()),
+            x => x.UpdateAsync(It.IsAny<Guid>(), It.IsAny<V4Models.Bolus>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         // Verify the bolus in CreatedRecords has a linked BolusCalculationId
@@ -298,7 +298,7 @@ public class TreatmentDecomposerBatchTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeBatchAsync(treatments);
+        var result = await _decomposer.DecomposeBatchAsync(treatments, WriteOrigin.Live);
 
         // Assert — a DecompositionBatchEntity was persisted
         var batch = _context.DecompositionBatches.SingleOrDefault(b => b.Id == result.CorrelationId);
@@ -318,19 +318,19 @@ public class TreatmentDecomposerBatchTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeBatchAsync(treatments);
+        var result = await _decomposer.DecomposeBatchAsync(treatments, WriteOrigin.Live);
 
         // Assert
         _bolusRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<V4Models.Bolus>>(list => list.Count() == 1),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         _carbRepoMock.Verify(
             x => x.BulkCreateAsync(
                 It.Is<IEnumerable<V4Models.CarbIntake>>(list => list.Count() == 1),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         result.CreatedRecords.Should().HaveCount(2);
@@ -346,7 +346,7 @@ public class TreatmentDecomposerBatchTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeBatchAsync(treatments);
+        var result = await _decomposer.DecomposeBatchAsync(treatments, WriteOrigin.Live);
 
         // Assert — profile switch uses individual upsert, not bulk insert
         _stateSpanServiceMock.Verify(
@@ -356,7 +356,7 @@ public class TreatmentDecomposerBatchTests : IDisposable
             Times.Once);
 
         _tempBasalRepoMock.Verify(
-            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.TempBasal>>(), It.IsAny<CancellationToken>()),
+            x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.TempBasal>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
 
         result.CreatedRecords.Should().HaveCount(1);

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerNotesTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerNotesTests.cs
@@ -85,7 +85,7 @@ public class TreatmentDecomposerNotesTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert — should produce Bolus + CarbIntake + Note
         result.CreatedRecords.OfType<V4Models.Bolus>().Should().HaveCount(1);
@@ -110,7 +110,7 @@ public class TreatmentDecomposerNotesTests : IDisposable
             Notes = "high after lunch"
         };
 
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         result.CreatedRecords.OfType<V4Models.Bolus>().Should().HaveCount(1);
         result.CreatedRecords.OfType<V4Models.Note>().Should().HaveCount(1);
@@ -132,7 +132,7 @@ public class TreatmentDecomposerNotesTests : IDisposable
             Notes = "before dinner"
         };
 
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         result.CreatedRecords.OfType<V4Models.BGCheck>().Should().HaveCount(1);
         result.CreatedRecords.OfType<V4Models.Note>().Should().HaveCount(1);
@@ -153,7 +153,7 @@ public class TreatmentDecomposerNotesTests : IDisposable
             Notes = "regular note text"
         };
 
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         result.CreatedRecords.OfType<V4Models.Note>().Should().HaveCount(1);
     }
@@ -171,7 +171,7 @@ public class TreatmentDecomposerNotesTests : IDisposable
             Notes = ""
         };
 
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         result.CreatedRecords.OfType<V4Models.Bolus>().Should().HaveCount(1);
         result.CreatedRecords.OfType<V4Models.CarbIntake>().Should().HaveCount(1);
@@ -191,7 +191,7 @@ public class TreatmentDecomposerNotesTests : IDisposable
             Notes = "   "
         };
 
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         result.CreatedRecords.OfType<V4Models.Note>().Should().BeEmpty();
     }

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
@@ -102,7 +102,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CorrelationId.Should().NotBeNull();
@@ -143,7 +143,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(2);
@@ -172,7 +172,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -202,7 +202,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -234,7 +234,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -269,7 +269,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -297,7 +297,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -333,11 +333,11 @@ public class TreatmentDecomposerTests : IDisposable
             .ReturnsAsync((V4Models.TempBasal?)null);
 
         _tempBasalRepoMock
-            .Setup(r => r.CreateAsync(It.IsAny<V4Models.TempBasal>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.CreateAsync(It.IsAny<V4Models.TempBasal>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((V4Models.TempBasal tb, CancellationToken _) => tb);
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -349,7 +349,7 @@ public class TreatmentDecomposerTests : IDisposable
         tempBasal.Origin.Should().Be(V4Models.TempBasalOrigin.Manual);
 
         _tempBasalRepoMock.Verify(
-            r => r.CreateAsync(It.IsAny<V4Models.TempBasal>(), It.IsAny<CancellationToken>()),
+            r => r.CreateAsync(It.IsAny<V4Models.TempBasal>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -383,7 +383,7 @@ public class TreatmentDecomposerTests : IDisposable
             .ReturnsAsync(expectedStateSpan);
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -426,7 +426,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert - should produce BolusCalculation + Bolus + CarbIntake (override rule: insulin > 0 AND carbs > 0)
         result.CreatedRecords.OfType<V4Models.BolusCalculation>().Should().HaveCount(1);
@@ -459,7 +459,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -484,7 +484,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.OfType<V4Models.Bolus>().Should().HaveCount(1);
@@ -512,7 +512,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.OfType<V4Models.Bolus>().Should().HaveCount(1);
@@ -536,7 +536,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act - first call creates
-        var firstResult = await _decomposer.DecomposeAsync(treatment);
+        var firstResult = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
         firstResult.CreatedRecords.Should().HaveCount(1);
         firstResult.UpdatedRecords.Should().BeEmpty();
 
@@ -544,7 +544,7 @@ public class TreatmentDecomposerTests : IDisposable
         treatment.Insulin = 3.5;
 
         // Act - second call should update
-        var secondResult = await _decomposer.DecomposeAsync(treatment);
+        var secondResult = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         secondResult.CreatedRecords.Should().BeEmpty();
@@ -570,7 +570,7 @@ public class TreatmentDecomposerTests : IDisposable
             Units = "mg/dl"
         };
 
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         result.CreatedRecords.Should().HaveCount(1);
         var bgCheck = result.CreatedRecords[0].Should().BeOfType<V4Models.BGCheck>().Subject;
@@ -604,11 +604,11 @@ public class TreatmentDecomposerTests : IDisposable
             Units = "mg/dl"
         };
 
-        var firstResult = await _decomposer.DecomposeAsync(firstUpload);
+        var firstResult = await _decomposer.DecomposeAsync(firstUpload, WriteOrigin.Live);
         firstResult.CreatedRecords.Should().HaveCount(1);
         firstResult.UpdatedRecords.Should().BeEmpty();
 
-        var secondResult = await _decomposer.DecomposeAsync(secondUpload);
+        var secondResult = await _decomposer.DecomposeAsync(secondUpload, WriteOrigin.Live);
 
         // No duplicate row — the re-upload updates the existing BGCheck.
         secondResult.CreatedRecords.Should().BeEmpty();
@@ -634,7 +634,7 @@ public class TreatmentDecomposerTests : IDisposable
             EnteredBy = "xDrip4iOS"
         };
 
-        var firstResult = await _decomposer.DecomposeAsync(MakeUpload());
+        var firstResult = await _decomposer.DecomposeAsync(MakeUpload(), WriteOrigin.Live);
         firstResult.CreatedRecords.Should().HaveCount(1);
         firstResult.UpdatedRecords.Should().BeEmpty();
 
@@ -644,7 +644,7 @@ public class TreatmentDecomposerTests : IDisposable
         bgCheck.Mills.Should().Be(DateTimeOffset.Parse("2026-06-13T10:45:28.937Z").ToUnixTimeMilliseconds());
 
         // Re-upload (fresh deserialized object, same fields) must update, not duplicate.
-        var secondResult = await _decomposer.DecomposeAsync(MakeUpload());
+        var secondResult = await _decomposer.DecomposeAsync(MakeUpload(), WriteOrigin.Live);
         secondResult.CreatedRecords.Should().BeEmpty();
         secondResult.UpdatedRecords.Should().HaveCount(1);
     }
@@ -664,7 +664,7 @@ public class TreatmentDecomposerTests : IDisposable
             // no Mills / Created_at / EventTime / Timestamp / Date
         };
 
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         result.CreatedRecords.Should().HaveCount(1);
         result.CreatedRecords[0].Should().BeOfType<V4Models.Note>()
@@ -687,8 +687,8 @@ public class TreatmentDecomposerTests : IDisposable
             EventTime = "2026-06-13T10:45:05.000Z", Insulin = 1.0, EnteredBy = "xDrip4iOS"
         };
 
-        var r1 = await _decomposer.DecomposeAsync(first);
-        var r2 = await _decomposer.DecomposeAsync(second);
+        var r1 = await _decomposer.DecomposeAsync(first, WriteOrigin.Live);
+        var r2 = await _decomposer.DecomposeAsync(second, WriteOrigin.Live);
 
         r1.CreatedRecords.OfType<V4Models.Bolus>().Should().HaveCount(1);
         r2.CreatedRecords.OfType<V4Models.Bolus>().Should().HaveCount(1);
@@ -712,7 +712,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act - first call creates
-        var firstResult = await _decomposer.DecomposeAsync(treatment);
+        var firstResult = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
         firstResult.CreatedRecords.Should().HaveCount(2);
 
         // Modify values
@@ -720,7 +720,7 @@ public class TreatmentDecomposerTests : IDisposable
         treatment.Carbs = 50;
 
         // Act - second call should update both
-        var secondResult = await _decomposer.DecomposeAsync(treatment);
+        var secondResult = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         secondResult.CreatedRecords.Should().BeEmpty();
@@ -749,7 +749,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().BeEmpty();
@@ -769,7 +769,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().BeEmpty();
@@ -788,7 +788,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().BeEmpty();
@@ -809,7 +809,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -831,7 +831,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         var note = result.CreatedRecords[0].Should().BeOfType<V4Models.Note>().Subject;
@@ -935,7 +935,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.OfType<V4Models.Bolus>().Should().HaveCount(1);
@@ -961,7 +961,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         var bgCheck = result.CreatedRecords[0].Should().BeOfType<V4Models.BGCheck>().Subject;
@@ -997,7 +997,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         var bolus = result.CreatedRecords[0].Should().BeOfType<V4Models.Bolus>().Subject;
@@ -1045,7 +1045,7 @@ public class TreatmentDecomposerTests : IDisposable
             .ReturnsAsync(expectedStateSpan);
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -1245,7 +1245,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert - fallback produces a Bolus when insulin > 0
         result.CreatedRecords.Should().ContainSingle()
@@ -1267,7 +1267,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert - fallback produces a CarbIntake when carbs > 0
         result.CreatedRecords.Should().ContainSingle()
@@ -1290,7 +1290,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert - Correction Bolus sets produceBolus; override doesn't fire
         result.CreatedRecords.OfType<V4Models.Bolus>().Should().HaveCount(1);
@@ -1310,7 +1310,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.OfType<V4Models.CarbIntake>().Should().HaveCount(1);
@@ -1331,7 +1331,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert - override rule needs insulin > 0, but fallback produces CarbIntake for carbs > 0
         result.CreatedRecords.Should().ContainSingle()
@@ -1353,7 +1353,7 @@ public class TreatmentDecomposerTests : IDisposable
             EnteredBy = "Trio"
         };
 
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         var bolus = result.CreatedRecords.Should().ContainSingle()
             .Which.Should().BeOfType<V4Models.Bolus>().Subject;
@@ -1374,7 +1374,7 @@ public class TreatmentDecomposerTests : IDisposable
             EnteredBy = "Trio"
         };
 
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         var bolus = result.CreatedRecords.Should().ContainSingle()
             .Which.Should().BeOfType<V4Models.Bolus>().Subject;
@@ -1394,7 +1394,7 @@ public class TreatmentDecomposerTests : IDisposable
             EnteredBy = "Trio"
         };
 
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         var bolus = result.CreatedRecords.Should().ContainSingle()
             .Which.Should().BeOfType<V4Models.Bolus>().Subject;
@@ -1413,7 +1413,7 @@ public class TreatmentDecomposerTests : IDisposable
             EnteredBy = "manual"
         };
 
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         var note = result.CreatedRecords.Should().ContainSingle()
             .Which.Should().BeOfType<V4Models.Note>().Subject;
@@ -1433,7 +1433,7 @@ public class TreatmentDecomposerTests : IDisposable
             EnteredBy = "pump"
         };
 
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         result.CreatedRecords.OfType<V4Models.Bolus>().Should().HaveCount(1);
         result.CreatedRecords.OfType<V4Models.CarbIntake>().Should().HaveCount(1);
@@ -1452,7 +1452,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert - Meal Bolus always produces Bolus+CarbIntake by EventType match
         result.CreatedRecords.OfType<V4Models.Bolus>().Should().HaveCount(1);
@@ -1484,7 +1484,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert - Bolus Wizard sets produceBolusCalc. No insulin means no Bolus.
         // Override doesn't fire (needs both). CarbIntake not produced.
@@ -1508,7 +1508,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert - BolusCalc + Bolus (from wizard + insulin) + CarbIntake (from override rule)
         result.CreatedRecords.OfType<V4Models.BolusCalculation>().Should().HaveCount(1);
@@ -1530,7 +1530,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -1555,11 +1555,11 @@ public class TreatmentDecomposerTests : IDisposable
             Units = "mg/dl"
         };
 
-        var first = await _decomposer.DecomposeAsync(treatment);
+        var first = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
         first.CreatedRecords.Should().HaveCount(1);
 
         treatment.Glucose = 125;
-        var second = await _decomposer.DecomposeAsync(treatment);
+        var second = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         second.CreatedRecords.Should().BeEmpty();
@@ -1579,11 +1579,11 @@ public class TreatmentDecomposerTests : IDisposable
             Notes = "Original note"
         };
 
-        var first = await _decomposer.DecomposeAsync(treatment);
+        var first = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
         first.CreatedRecords.Should().HaveCount(1);
 
         treatment.Notes = "Updated note";
-        var second = await _decomposer.DecomposeAsync(treatment);
+        var second = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         second.CreatedRecords.Should().BeEmpty();
         second.UpdatedRecords.Should().HaveCount(1);
@@ -1602,11 +1602,11 @@ public class TreatmentDecomposerTests : IDisposable
             BloodGlucoseInput = 150
         };
 
-        var first = await _decomposer.DecomposeAsync(treatment);
+        var first = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
         first.CreatedRecords.Should().HaveCount(1);
 
         treatment.BloodGlucoseInput = 180;
-        var second = await _decomposer.DecomposeAsync(treatment);
+        var second = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         second.CreatedRecords.Should().BeEmpty();
         second.UpdatedRecords.Should().HaveCount(1);
@@ -1625,8 +1625,8 @@ public class TreatmentDecomposerTests : IDisposable
             Insulin = 2.0
         };
 
-        var first = await _decomposer.DecomposeAsync(Make());
-        var second = await _decomposer.DecomposeAsync(Make());
+        var first = await _decomposer.DecomposeAsync(Make(), WriteOrigin.Live);
+        var second = await _decomposer.DecomposeAsync(Make(), WriteOrigin.Live);
 
         first.CreatedRecords.Should().HaveCount(1);
         first.UpdatedRecords.Should().BeEmpty();
@@ -1651,7 +1651,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.OfType<V4Models.Bolus>().Should().HaveCount(1);
@@ -1684,7 +1684,7 @@ public class TreatmentDecomposerTests : IDisposable
             .Setup(s => s.UpsertStateSpanAsync(It.IsAny<StateSpan>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedStateSpan);
 
-        await _decomposer.DecomposeAsync(treatment);
+        await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         _stateSpanServiceMock.Verify(
             s => s.UpsertStateSpanAsync(
@@ -1710,7 +1710,7 @@ public class TreatmentDecomposerTests : IDisposable
             .Setup(s => s.UpsertStateSpanAsync(It.IsAny<StateSpan>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedStateSpan);
 
-        await _decomposer.DecomposeAsync(treatment);
+        await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Duration defaults to 0 in Treatment; 0 is NOT > 0, so EndMills should be null
         _stateSpanServiceMock.Verify(
@@ -1741,7 +1741,7 @@ public class TreatmentDecomposerTests : IDisposable
             .Setup(s => s.UpsertStateSpanAsync(It.IsAny<StateSpan>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedStateSpan);
 
-        await _decomposer.DecomposeAsync(treatment);
+        await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         _stateSpanServiceMock.Verify(
             s => s.UpsertStateSpanAsync(
@@ -1858,7 +1858,7 @@ public class TreatmentDecomposerTests : IDisposable
             Mills = 1700000000000
         };
 
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         result.CreatedRecords.Should().HaveCount(1);
         var de = result.CreatedRecords[0].Should().BeOfType<V4Models.DeviceEvent>().Subject;
@@ -1882,7 +1882,7 @@ public class TreatmentDecomposerTests : IDisposable
             BloodGlucoseInput = 200
         };
 
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         var calc = result.CreatedRecords.OfType<V4Models.BolusCalculation>().Single();
         var bolus = result.CreatedRecords.OfType<V4Models.Bolus>().Single();
@@ -1914,7 +1914,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         var bolusCalc = result.CreatedRecords.OfType<V4Models.BolusCalculation>().Single();
@@ -1942,7 +1942,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         var bolus = result.CreatedRecords.OfType<V4Models.Bolus>().Single();
@@ -1970,7 +1970,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         var bolusCalc = result.CreatedRecords.OfType<V4Models.BolusCalculation>().Single();
@@ -1997,7 +1997,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         var bolus = result.CreatedRecords.OfType<V4Models.Bolus>().Single();
@@ -2023,7 +2023,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         var note = result.CreatedRecords[0].Should().BeOfType<V4Models.Note>().Subject;
@@ -2062,7 +2062,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert — DeviceEvent + Note (because Notes is non-empty)
         result.CreatedRecords.OfType<V4Models.DeviceEvent>().Should().HaveCount(1);
@@ -2095,7 +2095,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act - first call creates DeviceEvent + Note (because Notes is non-empty)
-        var firstResult = await _decomposer.DecomposeAsync(treatment);
+        var firstResult = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
         firstResult.CreatedRecords.Should().HaveCount(2);
         firstResult.CreatedRecords.OfType<V4Models.DeviceEvent>().Should().HaveCount(1);
         firstResult.CreatedRecords.OfType<V4Models.Note>().Should().HaveCount(1);
@@ -2105,7 +2105,7 @@ public class TreatmentDecomposerTests : IDisposable
         treatment.Notes = "Left arm";
 
         // Act - second call should update both
-        var secondResult = await _decomposer.DecomposeAsync(treatment);
+        var secondResult = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert — both DeviceEvent and Note updated
         secondResult.CreatedRecords.Should().BeEmpty();
@@ -2129,7 +2129,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         var deviceEvent = result.CreatedRecords[0].Should().BeOfType<V4Models.DeviceEvent>().Subject;
@@ -2167,7 +2167,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert — DeviceEvent + Note + StateSpan
         var deviceEvent = result.CreatedRecords.OfType<V4Models.DeviceEvent>().Single();
@@ -2221,7 +2221,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert — DeviceEvent created, StateSpan closed
         var deviceEvent = result.CreatedRecords.OfType<V4Models.DeviceEvent>().Single();
@@ -2257,7 +2257,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert — DeviceEvent created, no StateSpan upserted
         result.CreatedRecords.OfType<V4Models.DeviceEvent>().Should().HaveCount(1);
@@ -2300,7 +2300,7 @@ public class TreatmentDecomposerTests : IDisposable
             .ReturnsAsync(expectedStateSpan);
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -2347,7 +2347,7 @@ public class TreatmentDecomposerTests : IDisposable
             .ReturnsAsync(expectedStateSpan);
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -2386,7 +2386,7 @@ public class TreatmentDecomposerTests : IDisposable
             .ReturnsAsync(expectedStateSpan);
 
         // Act
-        await _decomposer.DecomposeAsync(treatment);
+        await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         _stateSpanServiceMock.Verify(
@@ -2438,7 +2438,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -2462,7 +2462,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         result.CreatedRecords.Should().HaveCount(1);
@@ -2495,7 +2495,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         var deviceEvent = result.CreatedRecords.OfType<V4Models.DeviceEvent>().Single();
@@ -2536,7 +2536,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         var bolus = result.CreatedRecords.OfType<V4Models.Bolus>().Single();
@@ -2675,7 +2675,7 @@ public class TreatmentDecomposerTests : IDisposable
             .ReturnsAsync((StateSpan ss, CancellationToken _) => ss);
 
         // Act
-        await _decomposer.DecomposeAsync(treatment);
+        await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         capturedSpan.Should().NotBeNull();
@@ -2720,11 +2720,11 @@ public class TreatmentDecomposerTests : IDisposable
         profileDecompResult.CreatedRecords.Add(new V4Models.TherapySettings { ProfileName = "Day Profile@@@@@1700000000000" });
 
         _profileDecomposerMock
-            .Setup(d => d.DecomposeAsync(It.IsAny<Profile>(), It.IsAny<CancellationToken>()))
+            .Setup(d => d.DecomposeAsync(It.IsAny<Profile>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(profileDecompResult);
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert -- StateSpan + TherapySettings from profile decomposer
         result.CreatedRecords.Should().HaveCount(2);
@@ -2748,7 +2748,7 @@ public class TreatmentDecomposerTests : IDisposable
                     && p.Mills == 1700000000000
                     && p.Store.Count == 1
                     && p.Store.ContainsKey("Day Profile@@@@@1700000000000")),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -2777,11 +2777,11 @@ public class TreatmentDecomposerTests : IDisposable
             .ReturnsAsync(expectedStateSpan);
 
         // Act
-        await _decomposer.DecomposeAsync(treatment);
+        await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert -- profile decomposer should NOT be called
         _profileDecomposerMock.Verify(
-            d => d.DecomposeAsync(It.IsAny<Profile>(), It.IsAny<CancellationToken>()),
+            d => d.DecomposeAsync(It.IsAny<Profile>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -2868,7 +2868,7 @@ public class TreatmentDecomposerTests : IDisposable
             .Setup(r => r.GetByLegacyIdAsync("tb-ps-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync((V4Models.TempBasal?)null);
         _tempBasalRepoMock
-            .Setup(r => r.CreateAsync(It.IsAny<V4Models.TempBasal>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.CreateAsync(It.IsAny<V4Models.TempBasal>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((V4Models.TempBasal tb, CancellationToken _) => tb);
 
         var treatment = new Treatment
@@ -2881,7 +2881,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         var tempBasal = result.CreatedRecords.OfType<V4Models.TempBasal>().Single();
@@ -2917,7 +2917,7 @@ public class TreatmentDecomposerTests : IDisposable
             .Setup(r => r.GetByLegacyIdAsync("tb-fallback-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync((V4Models.TempBasal?)null);
         _tempBasalRepoMock
-            .Setup(r => r.CreateAsync(It.IsAny<V4Models.TempBasal>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.CreateAsync(It.IsAny<V4Models.TempBasal>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((V4Models.TempBasal tb, CancellationToken _) => tb);
 
         var treatment = new Treatment
@@ -2930,7 +2930,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert
         var tempBasal = result.CreatedRecords.OfType<V4Models.TempBasal>().Single();
@@ -2959,7 +2959,7 @@ public class TreatmentDecomposerTests : IDisposable
             .Setup(r => r.GetByLegacyIdAsync("tb-notiers-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync((V4Models.TempBasal?)null);
         _tempBasalRepoMock
-            .Setup(r => r.CreateAsync(It.IsAny<V4Models.TempBasal>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.CreateAsync(It.IsAny<V4Models.TempBasal>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((V4Models.TempBasal tb, CancellationToken _) => tb);
 
         var treatment = new Treatment
@@ -2972,7 +2972,7 @@ public class TreatmentDecomposerTests : IDisposable
         };
 
         // Act
-        var result = await _decomposer.DecomposeAsync(treatment);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
 
         // Assert — record is created but InsulinContext is null; IOB falls back to profile DIA
         var tempBasal = result.CreatedRecords.OfType<V4Models.TempBasal>().Single();
@@ -3019,12 +3019,12 @@ public class TreatmentDecomposerTests : IDisposable
             .ReturnsAsync((StateSpan ss, CancellationToken _) => ss);
 
         _tempBasalRepoMock
-            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.TempBasal>>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.TempBasal>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<V4Models.TempBasal> list, CancellationToken _) => list.ToList());
 
         // Act
         var result = await _decomposer.DecomposeBatchAsync(
-            new List<Treatment> { profileSwitchTreatment, tempBasalTreatment });
+            new List<Treatment> { profileSwitchTreatment, tempBasalTreatment }, WriteOrigin.Live);
 
         // Assert
         var tempBasal = result.CreatedRecords.OfType<V4Models.TempBasal>().Single();

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
@@ -334,7 +334,7 @@ public class TreatmentDecomposerTests : IDisposable
 
         _tempBasalRepoMock
             .Setup(r => r.CreateAsync(It.IsAny<V4Models.TempBasal>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((V4Models.TempBasal tb, CancellationToken _) => tb);
+            .ReturnsAsync((V4Models.TempBasal tb, WriteOrigin origin, CancellationToken _) => tb);
 
         // Act
         var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
@@ -2869,7 +2869,7 @@ public class TreatmentDecomposerTests : IDisposable
             .ReturnsAsync((V4Models.TempBasal?)null);
         _tempBasalRepoMock
             .Setup(r => r.CreateAsync(It.IsAny<V4Models.TempBasal>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((V4Models.TempBasal tb, CancellationToken _) => tb);
+            .ReturnsAsync((V4Models.TempBasal tb, WriteOrigin origin, CancellationToken _) => tb);
 
         var treatment = new Treatment
         {
@@ -2918,7 +2918,7 @@ public class TreatmentDecomposerTests : IDisposable
             .ReturnsAsync((V4Models.TempBasal?)null);
         _tempBasalRepoMock
             .Setup(r => r.CreateAsync(It.IsAny<V4Models.TempBasal>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((V4Models.TempBasal tb, CancellationToken _) => tb);
+            .ReturnsAsync((V4Models.TempBasal tb, WriteOrigin origin, CancellationToken _) => tb);
 
         var treatment = new Treatment
         {
@@ -2960,7 +2960,7 @@ public class TreatmentDecomposerTests : IDisposable
             .ReturnsAsync((V4Models.TempBasal?)null);
         _tempBasalRepoMock
             .Setup(r => r.CreateAsync(It.IsAny<V4Models.TempBasal>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((V4Models.TempBasal tb, CancellationToken _) => tb);
+            .ReturnsAsync((V4Models.TempBasal tb, WriteOrigin origin, CancellationToken _) => tb);
 
         var treatment = new Treatment
         {
@@ -3020,7 +3020,7 @@ public class TreatmentDecomposerTests : IDisposable
 
         _tempBasalRepoMock
             .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.TempBasal>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<V4Models.TempBasal> list, CancellationToken _) => list.ToList());
+            .ReturnsAsync((IEnumerable<V4Models.TempBasal> list, WriteOrigin origin, CancellationToken _) => list.ToList());
 
         // Act
         var result = await _decomposer.DecomposeBatchAsync(

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/BaseConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/BaseConnectorServiceTests.cs
@@ -5,6 +5,7 @@ using Moq;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
 using Nocturne.Connectors.Core.Services;
+using Nocturne.Core.Contracts.V4;
 using Xunit;
 
 namespace Nocturne.Connectors.Core.Tests.Services;
@@ -36,6 +37,11 @@ public class BaseConnectorServiceTests
             IRetryDelayStrategy retryDelayStrategy,
             int maxRetries)
             => ExecuteWithRetryAsync(operation, retryDelayStrategy, maxRetries: maxRetries);
+
+        // Expose the protected per-run publish-origin resolvers so the watermark→origin mapping
+        // and the per-run memoization (anti-flood guard) can be asserted directly.
+        public Task<WriteOrigin> CallGlucoseOrigin() => GlucosePublishOriginAsync();
+        public Task<WriteOrigin> CallTreatmentOrigin() => TreatmentPublishOriginAsync();
     }
 
     public class TestConfig : BaseConnectorConfiguration
@@ -123,5 +129,143 @@ public class BaseConnectorServiceTests
         // Assert
         await act.Should().ThrowAsync<HttpRequestException>();
         attempts.Should().Be(1, "0 is clamped to a single attempt");
+    }
+
+    private static (TestConnectorService service, Mock<IConnectorPublisher> publisher,
+        Mock<IGlucosePublisher> glucose, Mock<ITreatmentPublisher> treatments) BuildServiceWithPublisher(
+        bool isAvailable = true)
+    {
+        var glucose = new Mock<IGlucosePublisher>();
+        var treatments = new Mock<ITreatmentPublisher>();
+        var publisher = new Mock<IConnectorPublisher>();
+        publisher.SetupGet(p => p.IsAvailable).Returns(isAvailable);
+        publisher.SetupGet(p => p.Glucose).Returns(glucose.Object);
+        publisher.SetupGet(p => p.Treatments).Returns(treatments.Object);
+
+        var service = new TestConnectorService(
+            new HttpClient(), Mock.Of<ILogger<TestConnectorService>>(), publisher.Object);
+        return (service, publisher, glucose, treatments);
+    }
+
+    [Fact]
+    public async Task GlucosePublishOriginAsync_NoPriorData_ReturnsBackfill()
+    {
+        // Arrange: null watermark = no prior glucose for this source = first-ever sync
+        var (service, _, glucose, _) = BuildServiceWithPublisher();
+        glucose
+            .Setup(g => g.GetLatestEntryTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DateTime?)null);
+
+        // Act
+        var origin = await service.CallGlucoseOrigin();
+
+        // Assert
+        origin.Should().Be(WriteOrigin.Backfill);
+    }
+
+    [Fact]
+    public async Task GlucosePublishOriginAsync_PriorDataExists_ReturnsLive()
+    {
+        // Arrange: a non-null watermark means the source already has glucose, so this is a live catch-up
+        var (service, _, glucose, _) = BuildServiceWithPublisher();
+        glucose
+            .Setup(g => g.GetLatestEntryTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DateTime.UtcNow);
+
+        // Act
+        var origin = await service.CallGlucoseOrigin();
+
+        // Assert
+        origin.Should().Be(WriteOrigin.Live);
+    }
+
+    [Fact]
+    public async Task GlucosePublishOriginAsync_CalledTwice_MemoizesAndQueriesWatermarkOnce()
+    {
+        // Arrange
+        var (service, _, glucose, _) = BuildServiceWithPublisher();
+        glucose
+            .Setup(g => g.GetLatestEntryTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DateTime?)null);
+
+        // Act: two calls within the same run
+        var first = await service.CallGlucoseOrigin();
+        var second = await service.CallGlucoseOrigin();
+
+        // Assert: identical result, and the watermark was queried only once (the anti-flood memo)
+        first.Should().Be(WriteOrigin.Backfill);
+        second.Should().Be(first);
+        glucose.Verify(
+            g => g.GetLatestEntryTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GlucosePublishOriginAsync_PublisherUnavailable_ReturnsLiveWithoutQuerying()
+    {
+        // Arrange: an unavailable publisher can't publish anyway, so origin defaults to Live and skips the query
+        var (service, _, glucose, _) = BuildServiceWithPublisher(isAvailable: false);
+
+        // Act
+        var origin = await service.CallGlucoseOrigin();
+
+        // Assert
+        origin.Should().Be(WriteOrigin.Live);
+        glucose.Verify(
+            g => g.GetLatestEntryTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task TreatmentPublishOriginAsync_NoPriorData_ReturnsBackfill()
+    {
+        // Arrange
+        var (service, _, _, treatments) = BuildServiceWithPublisher();
+        treatments
+            .Setup(t => t.GetLatestTreatmentTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DateTime?)null);
+
+        // Act
+        var origin = await service.CallTreatmentOrigin();
+
+        // Assert
+        origin.Should().Be(WriteOrigin.Backfill);
+    }
+
+    [Fact]
+    public async Task TreatmentPublishOriginAsync_PriorDataExists_ReturnsLive()
+    {
+        // Arrange
+        var (service, _, _, treatments) = BuildServiceWithPublisher();
+        treatments
+            .Setup(t => t.GetLatestTreatmentTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DateTime.UtcNow);
+
+        // Act
+        var origin = await service.CallTreatmentOrigin();
+
+        // Assert
+        origin.Should().Be(WriteOrigin.Live);
+    }
+
+    [Fact]
+    public async Task TreatmentPublishOriginAsync_CalledTwice_MemoizesAndQueriesWatermarkOnce()
+    {
+        // Arrange
+        var (service, _, _, treatments) = BuildServiceWithPublisher();
+        treatments
+            .Setup(t => t.GetLatestTreatmentTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DateTime?)null);
+
+        // Act
+        var first = await service.CallTreatmentOrigin();
+        var second = await service.CallTreatmentOrigin();
+
+        // Assert: identical result, and the watermark was queried only once (the anti-flood memo)
+        first.Should().Be(WriteOrigin.Backfill);
+        second.Should().Be(first);
+        treatments.Verify(
+            t => t.GetLatestTreatmentTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 }

--- a/tests/Unit/Nocturne.Connectors.Eversense.Tests/Services/EversenseConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Eversense.Tests/Services/EversenseConnectorServiceTests.cs
@@ -12,6 +12,7 @@ using Nocturne.Core.Models.V4;
 using Nocturne.Connectors.Eversense.Models;
 using Nocturne.Connectors.Eversense.Services;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Connectors.Eversense.Tests.Services;
 
@@ -145,7 +146,7 @@ public class EversenseConnectorServiceTests
         publisherMock.Setup(p => p.Glucose.PublishSensorGlucoseAsync(
                 It.IsAny<IEnumerable<SensorGlucose>>(),
                 It.IsAny<string>(),
-                It.IsAny<CancellationToken>()))
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
         var fixture = new ServiceFixture(
@@ -168,7 +169,7 @@ public class EversenseConnectorServiceTests
         publisherMock.Verify(p => p.Glucose.PublishSensorGlucoseAsync(
             It.Is<IEnumerable<SensorGlucose>>(sg => sg.Count() == 1),
             It.IsAny<string>(),
-            It.IsAny<CancellationToken>()), Times.Once);
+            It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -211,7 +212,7 @@ public class EversenseConnectorServiceTests
         publisherMock.Verify(p => p.Glucose.PublishSensorGlucoseAsync(
             It.IsAny<IEnumerable<SensorGlucose>>(),
             It.IsAny<string>(),
-            It.IsAny<CancellationToken>()), Times.Never);
+            It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -243,7 +244,7 @@ public class EversenseConnectorServiceTests
         publisherMock.Verify(p => p.Glucose.PublishSensorGlucoseAsync(
             It.IsAny<IEnumerable<SensorGlucose>>(),
             It.IsAny<string>(),
-            It.IsAny<CancellationToken>()), Times.Never);
+            It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -298,7 +299,7 @@ public class EversenseConnectorServiceTests
         publisherMock.Verify(p => p.Glucose.PublishSensorGlucoseAsync(
             It.IsAny<IEnumerable<SensorGlucose>>(),
             It.IsAny<string>(),
-            It.IsAny<CancellationToken>()), Times.Never);
+            It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     #endregion

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/BolusRepositoryTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/BolusRepositoryTests.cs
@@ -11,6 +11,7 @@ using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Tests.Repositories;
 
@@ -94,7 +95,7 @@ public class BolusRepositoryTests : IDisposable
             DataSource = "aaps",
             SyncIdentifier = "sync-1",
             Insulin = 5.0,
-        });
+        }, WriteOrigin.Live);
 
         // Act: Create again with same (DataSource, SyncIdentifier), different Insulin
         var second = await _repo.CreateAsync(new Bolus
@@ -103,7 +104,7 @@ public class BolusRepositoryTests : IDisposable
             DataSource = "aaps",
             SyncIdentifier = "sync-1",
             Insulin = 6.4,  // updated delivered value
-        });
+        }, WriteOrigin.Live);
 
         // Assert: same Id, new payload, only one row exists
         second.Id.Should().Be(first.Id);
@@ -116,8 +117,8 @@ public class BolusRepositoryTests : IDisposable
     public async Task CreateAsync_WithoutSyncIdentifier_DoesNotDedupe()
     {
         var timestamp = DateTime.UtcNow;
-        await _repo.CreateAsync(new Bolus { Timestamp = timestamp, Insulin = 5.0 });
-        await _repo.CreateAsync(new Bolus { Timestamp = timestamp, Insulin = 5.0 });
+        await _repo.CreateAsync(new Bolus { Timestamp = timestamp, Insulin = 5.0 }, WriteOrigin.Live);
+        await _repo.CreateAsync(new Bolus { Timestamp = timestamp, Insulin = 5.0 }, WriteOrigin.Live);
 
         var count = await _context.Boluses.CountAsync();
         count.Should().Be(2);
@@ -133,9 +134,9 @@ public class BolusRepositoryTests : IDisposable
         var aLatest = new DateTime(2026, 1, 12, 0, 0, 0, DateTimeKind.Utc);
         var bNewer = new DateTime(2026, 1, 20, 0, 0, 0, DateTimeKind.Utc);
 
-        await _repo.CreateAsync(new Bolus { Timestamp = aOld, Insulin = 1.0, DataSource = "connector-a" });
-        await _repo.CreateAsync(new Bolus { Timestamp = aLatest, Insulin = 2.0, DataSource = "connector-a" });
-        await _repo.CreateAsync(new Bolus { Timestamp = bNewer, Insulin = 3.0, DataSource = "connector-b" });
+        await _repo.CreateAsync(new Bolus { Timestamp = aOld, Insulin = 1.0, DataSource = "connector-a" }, WriteOrigin.Live);
+        await _repo.CreateAsync(new Bolus { Timestamp = aLatest, Insulin = 2.0, DataSource = "connector-a" }, WriteOrigin.Live);
+        await _repo.CreateAsync(new Bolus { Timestamp = bNewer, Insulin = 3.0, DataSource = "connector-b" }, WriteOrigin.Live);
 
         (await _repo.GetLatestTimestampAsync("connector-a")).Should().Be(aLatest);
         (await _repo.GetLatestTimestampAsync()).Should().Be(bNewer, "a null source returns the tenant-wide latest");
@@ -144,7 +145,7 @@ public class BolusRepositoryTests : IDisposable
     [Fact]
     public async Task GetLatestTimestampAsync_ReturnsNull_WhenNoRecordsForSource()
     {
-        await _repo.CreateAsync(new Bolus { Timestamp = DateTime.UtcNow, Insulin = 1.0, DataSource = "connector-b" });
+        await _repo.CreateAsync(new Bolus { Timestamp = DateTime.UtcNow, Insulin = 1.0, DataSource = "connector-b" }, WriteOrigin.Live);
 
         (await _repo.GetLatestTimestampAsync("connector-a")).Should().BeNull();
     }
@@ -154,8 +155,8 @@ public class BolusRepositoryTests : IDisposable
     {
         // SyncIdentifier alone is not enough — needs DataSource scoping.
         var timestamp = DateTime.UtcNow;
-        await _repo.CreateAsync(new Bolus { Timestamp = timestamp, SyncIdentifier = "sync-1", Insulin = 5.0 });
-        await _repo.CreateAsync(new Bolus { Timestamp = timestamp, SyncIdentifier = "sync-1", Insulin = 5.0 });
+        await _repo.CreateAsync(new Bolus { Timestamp = timestamp, SyncIdentifier = "sync-1", Insulin = 5.0 }, WriteOrigin.Live);
+        await _repo.CreateAsync(new Bolus { Timestamp = timestamp, SyncIdentifier = "sync-1", Insulin = 5.0 }, WriteOrigin.Live);
 
         var count = await _context.Boluses.CountAsync();
         count.Should().Be(2);
@@ -171,14 +172,14 @@ public class BolusRepositoryTests : IDisposable
             DataSource = "aaps",
             SyncIdentifier = "sync-1",
             Insulin = 5.0,
-        });
+        }, WriteOrigin.Live);
         await _repo.CreateAsync(new Bolus
         {
             Timestamp = timestamp,
             DataSource = "loop",
             SyncIdentifier = "sync-1",
             Insulin = 5.0,
-        });
+        }, WriteOrigin.Live);
 
         var count = await _context.Boluses.CountAsync();
         count.Should().Be(2);
@@ -195,14 +196,14 @@ public class BolusRepositoryTests : IDisposable
             DataSource = "aaps",
             SyncIdentifier = "sync-1",
             Insulin = 5.0,
-        });
+        }, WriteOrigin.Live);
 
         // Bulk insert with one colliding SyncIdentifier + one new
         var results = (await _repo.BulkCreateAsync(new[]
         {
             new Bolus { Timestamp = timestamp, DataSource = "aaps", SyncIdentifier = "sync-1", Insulin = 6.4 },
             new Bolus { Timestamp = timestamp, DataSource = "aaps", SyncIdentifier = "sync-2", Insulin = 3.0 },
-        })).ToList();
+        }, WriteOrigin.Live)).ToList();
 
         results.Should().HaveCount(2);
         var dbCount = await _context.Boluses.CountAsync();
@@ -238,7 +239,7 @@ public class BolusRepositoryTests : IDisposable
         {
             new Bolus { Timestamp = timestamp, DataSource = "aaps", SyncIdentifier = "sync-1", Insulin = 5.0 },
             new Bolus { Timestamp = timestamp, DataSource = "aaps", SyncIdentifier = "sync-1", Insulin = 6.4 },
-        });
+        }, WriteOrigin.Live);
 
         var dbCount = await _context.Boluses.CountAsync();
         dbCount.Should().Be(1);

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/CarbIntakeRepositoryTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/CarbIntakeRepositoryTests.cs
@@ -11,6 +11,7 @@ using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Tests.Repositories;
 
@@ -93,7 +94,7 @@ public class CarbIntakeRepositoryTests : IDisposable
             DataSource = "aaps",
             SyncIdentifier = "sync-1",
             Carbs = 30.0,
-        });
+        }, WriteOrigin.Live);
 
         var second = await _repo.CreateAsync(new CarbIntake
         {
@@ -101,7 +102,7 @@ public class CarbIntakeRepositoryTests : IDisposable
             DataSource = "aaps",
             SyncIdentifier = "sync-1",
             Carbs = 42.0,
-        });
+        }, WriteOrigin.Live);
 
         second.Id.Should().Be(first.Id);
         second.Carbs.Should().Be(42.0);
@@ -113,8 +114,8 @@ public class CarbIntakeRepositoryTests : IDisposable
     public async Task CreateAsync_WithoutSyncIdentifier_DoesNotDedupe()
     {
         var timestamp = DateTime.UtcNow;
-        await _repo.CreateAsync(new CarbIntake { Timestamp = timestamp, Carbs = 30.0 });
-        await _repo.CreateAsync(new CarbIntake { Timestamp = timestamp, Carbs = 30.0 });
+        await _repo.CreateAsync(new CarbIntake { Timestamp = timestamp, Carbs = 30.0 }, WriteOrigin.Live);
+        await _repo.CreateAsync(new CarbIntake { Timestamp = timestamp, Carbs = 30.0 }, WriteOrigin.Live);
 
         var count = await _context.CarbIntakes.CountAsync();
         count.Should().Be(2);
@@ -124,8 +125,8 @@ public class CarbIntakeRepositoryTests : IDisposable
     public async Task CreateAsync_WithoutDataSource_DoesNotDedupe()
     {
         var timestamp = DateTime.UtcNow;
-        await _repo.CreateAsync(new CarbIntake { Timestamp = timestamp, SyncIdentifier = "sync-1", Carbs = 30.0 });
-        await _repo.CreateAsync(new CarbIntake { Timestamp = timestamp, SyncIdentifier = "sync-1", Carbs = 30.0 });
+        await _repo.CreateAsync(new CarbIntake { Timestamp = timestamp, SyncIdentifier = "sync-1", Carbs = 30.0 }, WriteOrigin.Live);
+        await _repo.CreateAsync(new CarbIntake { Timestamp = timestamp, SyncIdentifier = "sync-1", Carbs = 30.0 }, WriteOrigin.Live);
 
         var count = await _context.CarbIntakes.CountAsync();
         count.Should().Be(2);
@@ -141,14 +142,14 @@ public class CarbIntakeRepositoryTests : IDisposable
             DataSource = "aaps",
             SyncIdentifier = "sync-1",
             Carbs = 30.0,
-        });
+        }, WriteOrigin.Live);
         await _repo.CreateAsync(new CarbIntake
         {
             Timestamp = timestamp,
             DataSource = "loop",
             SyncIdentifier = "sync-1",
             Carbs = 30.0,
-        });
+        }, WriteOrigin.Live);
 
         var count = await _context.CarbIntakes.CountAsync();
         count.Should().Be(2);
@@ -164,13 +165,13 @@ public class CarbIntakeRepositoryTests : IDisposable
             DataSource = "aaps",
             SyncIdentifier = "sync-1",
             Carbs = 30.0,
-        });
+        }, WriteOrigin.Live);
 
         var results = (await _repo.BulkCreateAsync(new[]
         {
             new CarbIntake { Timestamp = timestamp, DataSource = "aaps", SyncIdentifier = "sync-1", Carbs = 42.0 },
             new CarbIntake { Timestamp = timestamp, DataSource = "aaps", SyncIdentifier = "sync-2", Carbs = 15.0 },
-        })).ToList();
+        }, WriteOrigin.Live)).ToList();
 
         results.Should().HaveCount(2);
         var dbCount = await _context.CarbIntakes.CountAsync();
@@ -209,14 +210,14 @@ public class CarbIntakeRepositoryTests : IDisposable
             DataSource = "mylife-connector",
             LegacyId = "mylife-1",
             Carbs = 50.0,
-        });
+        }, WriteOrigin.Live);
         var duplicate = await _repo.CreateAsync(new CarbIntake
         {
             Timestamp = timestamp,
             DataSource = "glooko-connector",
             LegacyId = "glooko-1",
             Carbs = 50.0,
-        });
+        }, WriteOrigin.Live);
 
         // Dedup links them into one canonical group; the Glooko row is non-primary.
         var canonicalId = Guid.CreateVersion7();
@@ -264,7 +265,7 @@ public class CarbIntakeRepositoryTests : IDisposable
         {
             new CarbIntake { Timestamp = timestamp, DataSource = "aaps", SyncIdentifier = "sync-1", Carbs = 30.0 },
             new CarbIntake { Timestamp = timestamp, DataSource = "aaps", SyncIdentifier = "sync-1", Carbs = 42.0 },
-        });
+        }, WriteOrigin.Live);
 
         var dbCount = await _context.CarbIntakes.CountAsync();
         dbCount.Should().Be(1);

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/PatientInsulinRepositoryTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/PatientInsulinRepositoryTests.cs
@@ -4,6 +4,7 @@ using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Tests.Repositories;
 
@@ -49,10 +50,10 @@ public class PatientInsulinRepositoryTests : IDisposable
     public async Task SetPrimaryAsync_BolusInsulin_ClearsPreviousPrimaryBolus()
     {
         // Arrange
-        var first = await _repository.CreateAsync(CreateInsulin("Humalog", InsulinRole.Bolus, isPrimary: true));
+        var first = await _repository.CreateAsync(CreateInsulin("Humalog", InsulinRole.Bolus, isPrimary: true), WriteOrigin.Live);
         await _repository.SetPrimaryAsync(first.Id);
 
-        var second = await _repository.CreateAsync(CreateInsulin("NovoRapid", InsulinRole.Bolus, isPrimary: false));
+        var second = await _repository.CreateAsync(CreateInsulin("NovoRapid", InsulinRole.Bolus, isPrimary: false), WriteOrigin.Live);
 
         // Act
         await _repository.SetPrimaryAsync(second.Id);
@@ -70,10 +71,10 @@ public class PatientInsulinRepositoryTests : IDisposable
     public async Task SetPrimaryAsync_BasalInsulin_ClearsPreviousPrimaryBasal()
     {
         // Arrange
-        var first = await _repository.CreateAsync(CreateInsulin("Lantus", InsulinRole.Basal, isPrimary: true));
+        var first = await _repository.CreateAsync(CreateInsulin("Lantus", InsulinRole.Basal, isPrimary: true), WriteOrigin.Live);
         await _repository.SetPrimaryAsync(first.Id);
 
-        var second = await _repository.CreateAsync(CreateInsulin("Levemir", InsulinRole.Basal, isPrimary: false));
+        var second = await _repository.CreateAsync(CreateInsulin("Levemir", InsulinRole.Basal, isPrimary: false), WriteOrigin.Live);
 
         // Act
         await _repository.SetPrimaryAsync(second.Id);
@@ -91,7 +92,7 @@ public class PatientInsulinRepositoryTests : IDisposable
     public async Task SetPrimaryAsync_BothRole_SatisfiesBolusAndBasalLookups()
     {
         // Arrange
-        var insulin = await _repository.CreateAsync(CreateInsulin("Fiasp", InsulinRole.Both, isPrimary: false));
+        var insulin = await _repository.CreateAsync(CreateInsulin("Fiasp", InsulinRole.Both, isPrimary: false), WriteOrigin.Live);
 
         // Act
         await _repository.SetPrimaryAsync(insulin.Id);
@@ -110,12 +111,12 @@ public class PatientInsulinRepositoryTests : IDisposable
     public async Task SetPrimaryAsync_BothRole_ClearsBolusAndBasalPrimaries()
     {
         // Arrange - set up separate bolus and basal primaries
-        var bolus = await _repository.CreateAsync(CreateInsulin("Humalog", InsulinRole.Bolus, isPrimary: true));
+        var bolus = await _repository.CreateAsync(CreateInsulin("Humalog", InsulinRole.Bolus, isPrimary: true), WriteOrigin.Live);
         await _repository.SetPrimaryAsync(bolus.Id);
-        var basal = await _repository.CreateAsync(CreateInsulin("Lantus", InsulinRole.Basal, isPrimary: true));
+        var basal = await _repository.CreateAsync(CreateInsulin("Lantus", InsulinRole.Basal, isPrimary: true), WriteOrigin.Live);
         await _repository.SetPrimaryAsync(basal.Id);
 
-        var both = await _repository.CreateAsync(CreateInsulin("Fiasp", InsulinRole.Both, isPrimary: false));
+        var both = await _repository.CreateAsync(CreateInsulin("Fiasp", InsulinRole.Both, isPrimary: false), WriteOrigin.Live);
 
         // Act
         await _repository.SetPrimaryAsync(both.Id);
@@ -138,8 +139,8 @@ public class PatientInsulinRepositoryTests : IDisposable
     public async Task GetPrimaryBolusInsulinAsync_NoPrimarySet_ReturnsNull()
     {
         // Arrange - create insulins but none are primary
-        await _repository.CreateAsync(CreateInsulin("Humalog", InsulinRole.Bolus, isPrimary: false));
-        await _repository.CreateAsync(CreateInsulin("NovoRapid", InsulinRole.Bolus, isPrimary: false));
+        await _repository.CreateAsync(CreateInsulin("Humalog", InsulinRole.Bolus, isPrimary: false), WriteOrigin.Live);
+        await _repository.CreateAsync(CreateInsulin("NovoRapid", InsulinRole.Bolus, isPrimary: false), WriteOrigin.Live);
 
         // Act
         var result = await _repository.GetPrimaryBolusInsulinAsync();
@@ -152,7 +153,7 @@ public class PatientInsulinRepositoryTests : IDisposable
     public async Task GetPrimaryBasalInsulinAsync_NoPrimarySet_ReturnsNull()
     {
         // Arrange
-        await _repository.CreateAsync(CreateInsulin("Lantus", InsulinRole.Basal, isPrimary: false));
+        await _repository.CreateAsync(CreateInsulin("Lantus", InsulinRole.Basal, isPrimary: false), WriteOrigin.Live);
 
         // Act
         var result = await _repository.GetPrimaryBasalInsulinAsync();
@@ -167,7 +168,7 @@ public class PatientInsulinRepositoryTests : IDisposable
         // Arrange - create a primary bolus that is not current
         var insulin = CreateInsulin("Humalog", InsulinRole.Bolus, isPrimary: true);
         insulin.IsCurrent = false;
-        await _repository.CreateAsync(insulin);
+        await _repository.CreateAsync(insulin, WriteOrigin.Live);
         // Manually set primary since SetPrimaryAsync doesn't check IsCurrent
         var entity = await _context.PatientInsulins.FindAsync(
             (await _repository.GetAllAsync()).First().Id);

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/ApsSnapshotRepositoryBulkCreateTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/ApsSnapshotRepositoryBulkCreateTests.cs
@@ -4,6 +4,7 @@ using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
 
@@ -52,7 +53,7 @@ public class ApsSnapshotRepositoryBulkCreateTests : IDisposable
             CreateSnapshot("legacy-3", new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc)),
         };
 
-        var result = (await _repository.BulkCreateAsync(snapshots)).ToList();
+        var result = (await _repository.BulkCreateAsync(snapshots, WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(3);
         var dbCount = _context.ApsSnapshots.Count();
@@ -63,7 +64,7 @@ public class ApsSnapshotRepositoryBulkCreateTests : IDisposable
     public async Task BulkCreateAsync_DeduplicatesByLegacyId_SkipsExisting()
     {
         // Pre-insert a record with legacy-1
-        await _repository.CreateAsync(CreateSnapshot("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)));
+        await _repository.CreateAsync(CreateSnapshot("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)), WriteOrigin.Live);
 
         var snapshots = new[]
         {
@@ -71,7 +72,7 @@ public class ApsSnapshotRepositoryBulkCreateTests : IDisposable
             CreateSnapshot("legacy-new", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
         };
 
-        var result = (await _repository.BulkCreateAsync(snapshots)).ToList();
+        var result = (await _repository.BulkCreateAsync(snapshots, WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(1);
         result[0].LegacyId.Should().Be("legacy-new");
@@ -88,7 +89,7 @@ public class ApsSnapshotRepositoryBulkCreateTests : IDisposable
             CreateSnapshot("legacy-dup", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
         };
 
-        var result = (await _repository.BulkCreateAsync(snapshots)).ToList();
+        var result = (await _repository.BulkCreateAsync(snapshots, WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(1);
         var dbCount = _context.ApsSnapshots.Count();
@@ -98,7 +99,7 @@ public class ApsSnapshotRepositoryBulkCreateTests : IDisposable
     [Fact]
     public async Task BulkCreateAsync_EmptyInput_ReturnsEmpty()
     {
-        var result = (await _repository.BulkCreateAsync([])).ToList();
+        var result = (await _repository.BulkCreateAsync([], WriteOrigin.Live)).ToList();
 
         result.Should().BeEmpty();
         var dbCount = _context.ApsSnapshots.Count();

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/BasalInjectionRepositoryTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/BasalInjectionRepositoryTests.cs
@@ -9,6 +9,7 @@ using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
 
@@ -79,7 +80,7 @@ public class BasalInjectionRepositoryTests : IDisposable
     [Fact]
     public async Task FindBySyncIdentifierAsync_returns_live_row_when_present()
     {
-        var created = await _repo.CreateAsync(MakeInjection("aaps", "sync-1"));
+        var created = await _repo.CreateAsync(MakeInjection("aaps", "sync-1"), WriteOrigin.Live);
 
         var found = await _repo.FindBySyncIdentifierAsync("aaps", "sync-1");
 
@@ -92,9 +93,9 @@ public class BasalInjectionRepositoryTests : IDisposable
     [Fact]
     public async Task FindBySyncIdentifierAsync_returns_null_for_soft_deleted_row()
     {
-        var created = await _repo.CreateAsync(MakeInjection("aaps", "sync-2"));
+        var created = await _repo.CreateAsync(MakeInjection("aaps", "sync-2"), WriteOrigin.Live);
 
-        await _repo.DeleteAsync(created.Id);
+        await _repo.DeleteAsync(created.Id, WriteOrigin.Live);
 
         var found = await _repo.FindBySyncIdentifierAsync("aaps", "sync-2");
         found.Should().BeNull();
@@ -109,9 +110,9 @@ public class BasalInjectionRepositoryTests : IDisposable
     [Fact]
     public async Task DeleteAsync_sets_DeletedAt()
     {
-        var created = await _repo.CreateAsync(MakeInjection("aaps", "sync-3"));
+        var created = await _repo.CreateAsync(MakeInjection("aaps", "sync-3"), WriteOrigin.Live);
 
-        await _repo.DeleteAsync(created.Id);
+        await _repo.DeleteAsync(created.Id, WriteOrigin.Live);
 
         // Normal queries (with global filter) must not return the row.
         var visible = await _context.BasalInjections.FirstOrDefaultAsync(e => e.Id == created.Id);

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/CalibrationRepositoryBulkCreateTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/CalibrationRepositoryBulkCreateTests.cs
@@ -5,6 +5,7 @@ using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
 
@@ -51,7 +52,7 @@ public class CalibrationRepositoryBulkCreateTests : IDisposable
             CreateRecord("legacy-3", new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc)),
         };
 
-        var result = (await _repository.BulkCreateAsync(records)).ToList();
+        var result = (await _repository.BulkCreateAsync(records, WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(3);
         var dbCount = _context.Calibrations.Count();
@@ -62,7 +63,7 @@ public class CalibrationRepositoryBulkCreateTests : IDisposable
     public async Task BulkCreateAsync_DeduplicatesByLegacyId_SkipsExisting()
     {
         // Pre-insert a record with legacy-1
-        await _repository.CreateAsync(CreateRecord("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)));
+        await _repository.CreateAsync(CreateRecord("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)), WriteOrigin.Live);
 
         var records = new[]
         {
@@ -70,7 +71,7 @@ public class CalibrationRepositoryBulkCreateTests : IDisposable
             CreateRecord("legacy-new", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
         };
 
-        var result = (await _repository.BulkCreateAsync(records)).ToList();
+        var result = (await _repository.BulkCreateAsync(records, WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(1);
         result[0].LegacyId.Should().Be("legacy-new");
@@ -87,7 +88,7 @@ public class CalibrationRepositoryBulkCreateTests : IDisposable
             CreateRecord("legacy-dup", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
         };
 
-        var result = (await _repository.BulkCreateAsync(records)).ToList();
+        var result = (await _repository.BulkCreateAsync(records, WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(1);
         var dbCount = _context.Calibrations.Count();
@@ -97,7 +98,7 @@ public class CalibrationRepositoryBulkCreateTests : IDisposable
     [Fact]
     public async Task BulkCreateAsync_EmptyInput_ReturnsEmpty()
     {
-        var result = (await _repository.BulkCreateAsync([])).ToList();
+        var result = (await _repository.BulkCreateAsync([], WriteOrigin.Live)).ToList();
 
         result.Should().BeEmpty();
         var dbCount = _context.Calibrations.Count();

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/DeviceStatusExtrasRepositoryBulkCreateTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/DeviceStatusExtrasRepositoryBulkCreateTests.cs
@@ -3,6 +3,7 @@ using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
 
@@ -48,7 +49,7 @@ public class DeviceStatusExtrasRepositoryBulkCreateTests : IDisposable
             CreateRecord(Guid.NewGuid(), new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc)),
         };
 
-        var result = (await _repository.BulkCreateAsync(records)).ToList();
+        var result = (await _repository.BulkCreateAsync(records, WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(3);
         var dbCount = _context.DeviceStatusExtras.Count();
@@ -62,7 +63,7 @@ public class DeviceStatusExtrasRepositoryBulkCreateTests : IDisposable
         var newCorrelationId = Guid.NewGuid();
 
         // Pre-insert a record
-        await _repository.CreateAsync(CreateRecord(existingCorrelationId, new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)));
+        await _repository.CreateAsync(CreateRecord(existingCorrelationId, new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)), WriteOrigin.Live);
 
         var records = new[]
         {
@@ -70,7 +71,7 @@ public class DeviceStatusExtrasRepositoryBulkCreateTests : IDisposable
             CreateRecord(newCorrelationId, new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
         };
 
-        var result = (await _repository.BulkCreateAsync(records)).ToList();
+        var result = (await _repository.BulkCreateAsync(records, WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(1);
         result[0].CorrelationId.Should().Be(newCorrelationId);
@@ -88,7 +89,7 @@ public class DeviceStatusExtrasRepositoryBulkCreateTests : IDisposable
             CreateRecord(sharedCorrelationId, new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
         };
 
-        var result = (await _repository.BulkCreateAsync(records)).ToList();
+        var result = (await _repository.BulkCreateAsync(records, WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(1);
         var dbCount = _context.DeviceStatusExtras.Count();
@@ -98,7 +99,7 @@ public class DeviceStatusExtrasRepositoryBulkCreateTests : IDisposable
     [Fact]
     public async Task BulkCreateAsync_EmptyInput_ReturnsEmpty()
     {
-        var result = (await _repository.BulkCreateAsync([])).ToList();
+        var result = (await _repository.BulkCreateAsync([], WriteOrigin.Live)).ToList();
 
         result.Should().BeEmpty();
         var dbCount = _context.DeviceStatusExtras.Count();

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/MeterGlucoseRepositoryBulkCreateTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/MeterGlucoseRepositoryBulkCreateTests.cs
@@ -5,6 +5,7 @@ using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
 
@@ -52,7 +53,7 @@ public class MeterGlucoseRepositoryBulkCreateTests : IDisposable
             CreateRecord("legacy-3", new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc)),
         };
 
-        var result = (await _repository.BulkCreateAsync(records)).ToList();
+        var result = (await _repository.BulkCreateAsync(records, WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(3);
         var dbCount = _context.MeterGlucose.Count();
@@ -63,7 +64,7 @@ public class MeterGlucoseRepositoryBulkCreateTests : IDisposable
     public async Task BulkCreateAsync_DeduplicatesByLegacyId_SkipsExisting()
     {
         // Pre-insert a record with legacy-1
-        await _repository.CreateAsync(CreateRecord("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)));
+        await _repository.CreateAsync(CreateRecord("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)), WriteOrigin.Live);
 
         var records = new[]
         {
@@ -71,7 +72,7 @@ public class MeterGlucoseRepositoryBulkCreateTests : IDisposable
             CreateRecord("legacy-new", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
         };
 
-        var result = (await _repository.BulkCreateAsync(records)).ToList();
+        var result = (await _repository.BulkCreateAsync(records, WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(1);
         result[0].LegacyId.Should().Be("legacy-new");
@@ -88,7 +89,7 @@ public class MeterGlucoseRepositoryBulkCreateTests : IDisposable
             CreateRecord("legacy-dup", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
         };
 
-        var result = (await _repository.BulkCreateAsync(records)).ToList();
+        var result = (await _repository.BulkCreateAsync(records, WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(1);
         var dbCount = _context.MeterGlucose.Count();
@@ -98,7 +99,7 @@ public class MeterGlucoseRepositoryBulkCreateTests : IDisposable
     [Fact]
     public async Task BulkCreateAsync_EmptyInput_ReturnsEmpty()
     {
-        var result = (await _repository.BulkCreateAsync([])).ToList();
+        var result = (await _repository.BulkCreateAsync([], WriteOrigin.Live)).ToList();
 
         result.Should().BeEmpty();
         var dbCount = _context.MeterGlucose.Count();

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/PumpSnapshotRepositoryBulkCreateTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/PumpSnapshotRepositoryBulkCreateTests.cs
@@ -4,6 +4,7 @@ using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
 
@@ -50,7 +51,7 @@ public class PumpSnapshotRepositoryBulkCreateTests : IDisposable
             CreateSnapshot("legacy-3", new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc)),
         };
 
-        var result = (await _repository.BulkCreateAsync(snapshots)).ToList();
+        var result = (await _repository.BulkCreateAsync(snapshots, WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(3);
         var dbCount = _context.PumpSnapshots.Count();
@@ -61,7 +62,7 @@ public class PumpSnapshotRepositoryBulkCreateTests : IDisposable
     public async Task BulkCreateAsync_DeduplicatesByLegacyId_SkipsExisting()
     {
         // Pre-insert a record with legacy-1
-        await _repository.CreateAsync(CreateSnapshot("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)));
+        await _repository.CreateAsync(CreateSnapshot("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)), WriteOrigin.Live);
 
         var snapshots = new[]
         {
@@ -69,7 +70,7 @@ public class PumpSnapshotRepositoryBulkCreateTests : IDisposable
             CreateSnapshot("legacy-new", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
         };
 
-        var result = (await _repository.BulkCreateAsync(snapshots)).ToList();
+        var result = (await _repository.BulkCreateAsync(snapshots, WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(1);
         result[0].LegacyId.Should().Be("legacy-new");
@@ -86,7 +87,7 @@ public class PumpSnapshotRepositoryBulkCreateTests : IDisposable
             CreateSnapshot("legacy-dup", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
         };
 
-        var result = (await _repository.BulkCreateAsync(snapshots)).ToList();
+        var result = (await _repository.BulkCreateAsync(snapshots, WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(1);
         var dbCount = _context.PumpSnapshots.Count();
@@ -96,7 +97,7 @@ public class PumpSnapshotRepositoryBulkCreateTests : IDisposable
     [Fact]
     public async Task BulkCreateAsync_EmptyInput_ReturnsEmpty()
     {
-        var result = (await _repository.BulkCreateAsync([])).ToList();
+        var result = (await _repository.BulkCreateAsync([], WriteOrigin.Live)).ToList();
 
         result.Should().BeEmpty();
         var dbCount = _context.PumpSnapshots.Count();

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/TempBasalRepositoryBulkCreateTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/TempBasalRepositoryBulkCreateTests.cs
@@ -10,6 +10,7 @@ using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
 
@@ -63,9 +64,9 @@ public class TempBasalRepositoryBulkCreateTests : IDisposable
     [Fact]
     public async Task BulkCreateAsync_ActiveLegacyId_Skipped()
     {
-        await _repository.CreateAsync(CreateRecord("legacy-1"));
+        await _repository.CreateAsync(CreateRecord("legacy-1"), WriteOrigin.Live);
 
-        var result = (await _repository.BulkCreateAsync([CreateRecord("legacy-1")])).ToList();
+        var result = (await _repository.BulkCreateAsync([CreateRecord("legacy-1")], WriteOrigin.Live)).ToList();
 
         result.Should().BeEmpty();
         _context.TempBasals.Count().Should().Be(1);
@@ -74,10 +75,10 @@ public class TempBasalRepositoryBulkCreateTests : IDisposable
     [Fact]
     public async Task BulkCreateAsync_SystemSoftDeleted_ReImports()
     {
-        var existing = await _repository.CreateAsync(CreateRecord("legacy-1"));
+        var existing = await _repository.CreateAsync(CreateRecord("legacy-1"), WriteOrigin.Live);
         SoftDelete(existing.Id, deletedByUser: false);
 
-        var result = (await _repository.BulkCreateAsync([CreateRecord("legacy-1")])).ToList();
+        var result = (await _repository.BulkCreateAsync([CreateRecord("legacy-1")], WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(1);
         result[0].Id.Should().NotBe(existing.Id);
@@ -87,10 +88,10 @@ public class TempBasalRepositoryBulkCreateTests : IDisposable
     [Fact]
     public async Task BulkCreateAsync_UserSoftDeleted_DoesNotReImport()
     {
-        var existing = await _repository.CreateAsync(CreateRecord("legacy-1"));
+        var existing = await _repository.CreateAsync(CreateRecord("legacy-1"), WriteOrigin.Live);
         SoftDelete(existing.Id, deletedByUser: true);
 
-        var result = (await _repository.BulkCreateAsync([CreateRecord("legacy-1")])).ToList();
+        var result = (await _repository.BulkCreateAsync([CreateRecord("legacy-1")], WriteOrigin.Live)).ToList();
 
         result.Should().BeEmpty();
         _context.TempBasals.IgnoreQueryFilters().Count().Should().Be(1);
@@ -99,11 +100,11 @@ public class TempBasalRepositoryBulkCreateTests : IDisposable
     [Fact]
     public async Task BulkCreateAsync_PreAuditSoftDeleted_ReImports()
     {
-        var existing = await _repository.CreateAsync(CreateRecord("legacy-1"));
+        var existing = await _repository.CreateAsync(CreateRecord("legacy-1"), WriteOrigin.Live);
         SoftDelete(existing.Id);
         // No audit row seeded — represents pre-audit legacy data.
 
-        var result = (await _repository.BulkCreateAsync([CreateRecord("legacy-1")])).ToList();
+        var result = (await _repository.BulkCreateAsync([CreateRecord("legacy-1")], WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(1);
         _context.TempBasals.IgnoreQueryFilters().Count().Should().Be(2);
@@ -112,7 +113,7 @@ public class TempBasalRepositoryBulkCreateTests : IDisposable
     [Fact]
     public async Task BulkCreateAsync_NewLegacyId_Inserts()
     {
-        var result = (await _repository.BulkCreateAsync([CreateRecord("legacy-new")])).ToList();
+        var result = (await _repository.BulkCreateAsync([CreateRecord("legacy-new")], WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(1);
         result[0].LegacyId.Should().Be("legacy-new");

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/UploaderSnapshotRepositoryBulkCreateTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/UploaderSnapshotRepositoryBulkCreateTests.cs
@@ -4,6 +4,7 @@ using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
+using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
 
@@ -50,7 +51,7 @@ public class UploaderSnapshotRepositoryBulkCreateTests : IDisposable
             CreateSnapshot("legacy-3", new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc)),
         };
 
-        var result = (await _repository.BulkCreateAsync(snapshots)).ToList();
+        var result = (await _repository.BulkCreateAsync(snapshots, WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(3);
         var dbCount = _context.UploaderSnapshots.Count();
@@ -61,7 +62,7 @@ public class UploaderSnapshotRepositoryBulkCreateTests : IDisposable
     public async Task BulkCreateAsync_DeduplicatesByLegacyId_SkipsExisting()
     {
         // Pre-insert a record with legacy-1
-        await _repository.CreateAsync(CreateSnapshot("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)));
+        await _repository.CreateAsync(CreateSnapshot("legacy-1", new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)), WriteOrigin.Live);
 
         var snapshots = new[]
         {
@@ -69,7 +70,7 @@ public class UploaderSnapshotRepositoryBulkCreateTests : IDisposable
             CreateSnapshot("legacy-new", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
         };
 
-        var result = (await _repository.BulkCreateAsync(snapshots)).ToList();
+        var result = (await _repository.BulkCreateAsync(snapshots, WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(1);
         result[0].LegacyId.Should().Be("legacy-new");
@@ -86,7 +87,7 @@ public class UploaderSnapshotRepositoryBulkCreateTests : IDisposable
             CreateSnapshot("legacy-dup", new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
         };
 
-        var result = (await _repository.BulkCreateAsync(snapshots)).ToList();
+        var result = (await _repository.BulkCreateAsync(snapshots, WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(1);
         var dbCount = _context.UploaderSnapshots.Count();
@@ -96,7 +97,7 @@ public class UploaderSnapshotRepositoryBulkCreateTests : IDisposable
     [Fact]
     public async Task BulkCreateAsync_EmptyInput_ReturnsEmpty()
     {
-        var result = (await _repository.BulkCreateAsync([])).ToList();
+        var result = (await _repository.BulkCreateAsync([], WriteOrigin.Live)).ToList();
 
         result.Should().BeEmpty();
         var dbCount = _context.UploaderSnapshots.Count();


### PR DESCRIPTION
## What

Lets modern clients (the desktop companion + Prelude, an xDrip rewrite) consume **native V4 record shapes** (Bolus, SensorGlucose, …) over SignalR in real time, instead of the legacy v1 `entries`/`treatments` projections the web client uses.

Broadcasts fire from the **V4 repository chokepoint** — the single point every ingestion path funnels through, including the dominant v1-upload → decomposer → V4-repo firehose — so no live write is ever missed and no controller has to remember to broadcast.

**Purely additive: zero behaviour change to the existing web client.** The legacy v1 groups (`entries`/`treatments`/`devicestatus`/`profiles`) and the socket.io bridge are untouched.

## How

- **`WriteOrigin` (Live | Backfill)** — a required parameter (no default; no ambient/AsyncLocal — pooled-context carrier staleness has bitten us before) threaded through every mutating V4 repo method, the decomposers, and the connector publishers. The chokepoint broadcasts **Live** writes and stays **silent** on backfill imports.
- **Four additive categories** in `DataHub`: `glucose` / `care` / `device` / `therapy` (`care` is the treatment family, named distinctly to avoid colliding with the v1 `treatments` group). Each payload carries a `recordType` discriminator. `device`/`therapy` are defined but dormant.
- **Firing** from `V4RepositoryBase` (+ off-base TempBasal/BasalInjection) after commit: inserts → `create`; bulk upserts → `update` **only on a material change** (reusing the `MutationAuditInterceptor` predicate, so "broadcast update" ⟺ "audited change" and identical connector re-polls stay silent); deletes carry the affected ids.
- **Connector flood-guard** — a connector's first sync backfills months of history. The origin is resolved **once per run per family** from the source-scoped resume watermark (no prior data = `Backfill`) and memoized, so a paginated/multi-call first sync can't flip to Live mid-backfill and flood clients.

## Tests

- Testcontainers **broadcast goldens** (real Postgres): Live fires, Backfill is silent-but-persists, material upsert fires while an identical re-upload doesn't, deletes carry ids.
- **Unit:** every `V4BroadcastMap` entry pinned (the `recordType` strings are the SDK wire contract), the SignalR adapter's payload + dormant-type no-broadcast, the connector memoization (watermark queried once across calls), and v1/v4 category disjointness.
- Full suite green: **3476 API + 402 Infra unit + 38 V4 goldens**.

## Deferred to a follow-up PR

**Glucose-family unification** (making the chokepoint the *sole* `entries` broadcaster). The legacy `entries` **delete** is entry-level (`IDataEventSink<Entry>.OnDeletedAsync(entry)` with the full doc) but the chokepoint only knows record ids — resolving that delete-projection contract + the gating change deserves its own focused review.
