### PR TITLE
fix(v4): widen legacy_id to varchar(255) so long uploader ids persist

### DIFF
--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -176,7 +176,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
 
         var hash = System.Security.Cryptography.SHA256.HashData(
             System.Text.Encoding.UTF8.GetBytes(canonical));
-        // "syn-" marker + 60 hex chars fits the 64-char legacy_id column.
+        // "syn-" marker + 60 hex chars keeps the synthetic id compact (64 chars).
         return "syn-" + Convert.ToHexStringLower(hash)[..60];
 
         static string Fmt(double? value) =>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/ApsSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/ApsSnapshotEntity.cs
@@ -53,7 +53,7 @@ public class ApsSnapshotEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISyst
     /// Original v1/v3 record ID for migration traceability
     /// </summary>
     [Column("legacy_id")]
-    [MaxLength(64)]
+    [MaxLength(255)]
     public string? LegacyId { get; set; }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BGCheckEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BGCheckEntity.cs
@@ -67,7 +67,7 @@ public class BGCheckEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeS
     /// Original v1/v3 record ID for migration traceability
     /// </summary>
     [Column("legacy_id")]
-    [MaxLength(64)]
+    [MaxLength(255)]
     public string? LegacyId { get; set; }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalInjectionEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalInjectionEntity.cs
@@ -74,7 +74,7 @@ public class BasalInjectionEntity : ITenantScoped, IAuditable, ISoftDeletable, I
     /// Original v1/v3 record ID for migration traceability
     /// </summary>
     [Column("legacy_id")]
-    [MaxLength(64)]
+    [MaxLength(255)]
     public string? LegacyId { get; set; }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalScheduleEntity.cs
@@ -67,7 +67,7 @@ public class BasalScheduleEntity : ITenantScoped, IAuditable, ISoftDeletable, IV
     /// Original v1/v3 record ID for migration traceability
     /// </summary>
     [Column("legacy_id")]
-    [MaxLength(64)]
+    [MaxLength(255)]
     public string? LegacyId { get; set; }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusCalculationEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusCalculationEntity.cs
@@ -67,7 +67,7 @@ public class BolusCalculationEntity : ITenantScoped, IAuditable, ISoftDeletable,
     /// Original v1/v3 record ID for migration traceability
     /// </summary>
     [Column("legacy_id")]
-    [MaxLength(64)]
+    [MaxLength(255)]
     public string? LegacyId { get; set; }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusEntity.cs
@@ -67,7 +67,7 @@ public class BolusEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSer
     /// Original v1/v3 record ID for migration traceability
     /// </summary>
     [Column("legacy_id")]
-    [MaxLength(64)]
+    [MaxLength(255)]
     public string? LegacyId { get; set; }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CalibrationEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CalibrationEntity.cs
@@ -67,7 +67,7 @@ public class CalibrationEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4T
     /// Original v1/v3 record ID for migration traceability
     /// </summary>
     [Column("legacy_id")]
-    [MaxLength(64)]
+    [MaxLength(255)]
     public string? LegacyId { get; set; }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbIntakeEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbIntakeEntity.cs
@@ -67,7 +67,7 @@ public class CarbIntakeEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Ti
     /// Original v1/v3 record ID for migration traceability
     /// </summary>
     [Column("legacy_id")]
-    [MaxLength(64)]
+    [MaxLength(255)]
     public string? LegacyId { get; set; }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbRatioScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbRatioScheduleEntity.cs
@@ -67,7 +67,7 @@ public class CarbRatioScheduleEntity : ITenantScoped, IAuditable, ISoftDeletable
     /// Original v1/v3 record ID for migration traceability
     /// </summary>
     [Column("legacy_id")]
-    [MaxLength(64)]
+    [MaxLength(255)]
     public string? LegacyId { get; set; }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceEventEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceEventEntity.cs
@@ -67,7 +67,7 @@ public class DeviceEventEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4T
     /// Original v1/v3 record ID for migration traceability
     /// </summary>
     [Column("legacy_id")]
-    [MaxLength(64)]
+    [MaxLength(255)]
     public string? LegacyId { get; set; }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/MeterGlucoseEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/MeterGlucoseEntity.cs
@@ -67,7 +67,7 @@ public class MeterGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4
     /// Original v1/v3 record ID for migration traceability
     /// </summary>
     [Column("legacy_id")]
-    [MaxLength(64)]
+    [MaxLength(255)]
     public string? LegacyId { get; set; }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/NoteEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/NoteEntity.cs
@@ -67,7 +67,7 @@ public class NoteEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeri
     /// Original v1/v3 record ID for migration traceability
     /// </summary>
     [Column("legacy_id")]
-    [MaxLength(64)]
+    [MaxLength(255)]
     public string? LegacyId { get; set; }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PumpSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PumpSnapshotEntity.cs
@@ -53,7 +53,7 @@ public class PumpSnapshotEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISys
     /// Original v1/v3 record ID for migration traceability
     /// </summary>
     [Column("legacy_id")]
-    [MaxLength(64)]
+    [MaxLength(255)]
     public string? LegacyId { get; set; }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensitivityScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensitivityScheduleEntity.cs
@@ -67,7 +67,7 @@ public class SensitivityScheduleEntity : ITenantScoped, IAuditable, ISoftDeletab
     /// Original v1/v3 record ID for migration traceability
     /// </summary>
     [Column("legacy_id")]
-    [MaxLength(64)]
+    [MaxLength(255)]
     public string? LegacyId { get; set; }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensorGlucoseEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensorGlucoseEntity.cs
@@ -73,7 +73,7 @@ public class SensorGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable, IV
     /// Original v1/v3 record ID for migration traceability
     /// </summary>
     [Column("legacy_id")]
-    [MaxLength(64)]
+    [MaxLength(255)]
     public string? LegacyId { get; set; }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TargetRangeScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TargetRangeScheduleEntity.cs
@@ -67,7 +67,7 @@ public class TargetRangeScheduleEntity : ITenantScoped, IAuditable, ISoftDeletab
     /// Original v1/v3 record ID for migration traceability
     /// </summary>
     [Column("legacy_id")]
-    [MaxLength(64)]
+    [MaxLength(255)]
     public string? LegacyId { get; set; }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TempBasalEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TempBasalEntity.cs
@@ -73,7 +73,7 @@ public class TempBasalEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Ent
     /// Original v1/v3 record ID for migration traceability
     /// </summary>
     [Column("legacy_id")]
-    [MaxLength(64)]
+    [MaxLength(255)]
     public string? LegacyId { get; set; }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TherapySettingsEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TherapySettingsEntity.cs
@@ -67,7 +67,7 @@ public class TherapySettingsEntity : ITenantScoped, IAuditable, ISoftDeletable, 
     /// Original v1/v3 record ID for migration traceability
     /// </summary>
     [Column("legacy_id")]
-    [MaxLength(64)]
+    [MaxLength(255)]
     public string? LegacyId { get; set; }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/UploaderSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/UploaderSnapshotEntity.cs
@@ -53,7 +53,7 @@ public class UploaderSnapshotEntity : ITenantScoped, ISoftDeletable, IV4Entity, 
     /// Original v1/v3 record ID for migration traceability
     /// </summary>
     [Column("legacy_id")]
-    [MaxLength(64)]
+    [MaxLength(255)]
     public string? LegacyId { get; set; }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260630083519_WidenV4LegacyIdTo255.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260630083519_WidenV4LegacyIdTo255.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260630083519_WidenV4LegacyIdTo255")]
+    partial class WidenV4LegacyIdTo255
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260630083519_WidenV4LegacyIdTo255.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260630083519_WidenV4LegacyIdTo255.cs
@@ -1,0 +1,436 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class WidenV4LegacyIdTo255 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "uploader_snapshots",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "therapy_settings",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "temp_basals",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "target_range_schedules",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "sensor_glucose",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "sensitivity_schedules",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "pump_snapshots",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "notes",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "meter_glucose",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "device_events",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "carb_ratio_schedules",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "carb_intakes",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "calibrations",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "boluses",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "bolus_calculations",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "bg_checks",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "basal_schedules",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "basal_injections",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "aps_snapshots",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "uploader_snapshots",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "therapy_settings",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "temp_basals",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "target_range_schedules",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "sensor_glucose",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "sensitivity_schedules",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "pump_snapshots",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "notes",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "meter_glucose",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "device_events",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "carb_ratio_schedules",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "carb_intakes",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "calibrations",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "boluses",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "bolus_calculations",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "bg_checks",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "basal_schedules",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "basal_injections",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "legacy_id",
+                table: "aps_snapshots",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+        }
+    }
+}

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/LegacyIdLengthGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/LegacyIdLengthGoldenTests.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.DependencyInjection;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
+
+/// <summary>
+/// Regression guard for the <c>legacy_id</c> column width. Some uploaders mint treatment <c>_id</c>
+/// values well beyond the original 64-char column (e.g. a temp basal keyed
+/// <c>"tempBasal &lt;full-precision-rate&gt; &lt;ISO-timestamp&gt;"</c>, up to ~104 chars), which used to
+/// fail the insert with Postgres <c>22001: value too long for type character varying(64)</c> and
+/// silently drop the record. The column is now <c>varchar(255)</c>; this test pins that an over-64
+/// legacy id round-trips intact through a real insert + lookup.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("V4 goldens")]
+public class LegacyIdLengthGoldenTests
+{
+    private readonly V4GoldenFixture _fx;
+
+    public LegacyIdLengthGoldenTests(V4GoldenFixture fx) => _fx = fx;
+
+    private static readonly DateTime T0 = new(2026, 5, 1, 9, 0, 0, DateTimeKind.Utc);
+
+    // 104 chars — the longest legacy id observed in production (a full-precision temp-basal key).
+    private const string LongLegacyId =
+        "tempBasal 0.005633353027734491164 2026-06-22T13:45:38Z padding-to-104-chars-aaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    [Fact]
+    public async Task TempBasal_LegacyIdOver64Chars_PersistsAndRoundTrips()
+    {
+        LongLegacyId.Length.Should().BeGreaterThan(64, "the scenario must exceed the old column width");
+
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<ITempBasalRepository>();
+
+        await repo.CreateAsync(new TempBasal
+        {
+            StartTimestamp = T0,
+            EndTimestamp = T0.AddMinutes(30),
+            Rate = 0.005633353027734491164,
+            Origin = TempBasalOrigin.Manual,
+            DataSource = "loop",
+            LegacyId = LongLegacyId,
+        }, CancellationToken.None);
+
+        var fetched = await repo.GetByLegacyIdAsync(LongLegacyId, CancellationToken.None);
+        fetched.Should().NotBeNull("an over-64-char legacy id must persist, not overflow the column");
+        fetched!.LegacyId.Should().Be(LongLegacyId, "the full legacy id must be stored untruncated");
+    }
+}


### PR DESCRIPTION
## Problem

Some uploaders mint treatment/entry `_id` values longer than 64 chars. A real-world example is a temp basal keyed `"tempBasal <full-precision-rate> <ISO-timestamp>"` (transmitted hex-encoded), which runs **68–104 chars**.

The V4 decomposer maps `LegacyId = treatment.Id` into the `legacy_id` column, which was `varchar(64)`. So every over-64 id failed its insert with:

```
Npgsql.PostgresException 22001: value too long for type character varying(64)
```

`TreatmentReadService.CreateAsync` (and the batch path) only **logs** the exception, so the record was **silently dropped**. In production this hit one uploader's temp basals on every upload — ~16 days of temp-basal data lost for that tenant, ~15k errors/day, and millions of orphaned `decomposition_batches` rows.

It's a general latent bug (any `_id` > 64 chars overflows); temp basals just triggered it constantly.

## Fix

Widen `legacy_id` from `varchar(64)` → `varchar(255)` across all 19 V4 entities, via a generated EF migration (`20260630083519_WidenV4LegacyIdTo255`).

`legacy_id` is both the dedup lookup key (`GetByLegacyIdAsync`) and a traceability id, so truncating/hashing would break exact-match dedup and corrupt lineage — widening is the correct fix. 255 comfortably covers the observed ~104-char worst case. The synthetic-id path (`"syn-" + 60 hex`) deliberately stays compact at 64 chars.

In Postgres a `varchar(n)` length **increase** is a metadata-only change — no table rewrite, no index rebuild — so this is safe on large tables (`temp_basals`, `boluses`, `sensor_glucose`, …).

## Test

Adds `LegacyIdLengthGoldenTests` (integration, real Postgres via Testcontainers): persists a TempBasal with a 104-char `LegacyId` and asserts it round-trips untruncated through `CreateAsync`/`GetByLegacyIdAsync`. Fails against the old `varchar(64)` schema (22001), passes after the widen.

## Verification

- API build: 0 errors
- 213 decomposer unit tests pass
- New integration regression test passes against Postgres 17.6
