### PR TITLE
feat(v4): broadcast device-status snapshots on the device category

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -28,6 +28,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     // resolved fresh per sync run, so these are naturally per-run.
     private WriteOrigin? _glucosePublishOrigin;
     private WriteOrigin? _treatmentPublishOrigin;
+    private WriteOrigin? _devicePublishOrigin;
 
     /// <summary>
     ///     Base constructor for connector services using IHttpClientFactory pattern
@@ -560,6 +561,18 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     }
 
     /// <summary>
+    ///     The broadcast origin for this run's device-status (snapshot) publishes — APS, pump, and uploader
+    ///     snapshots. Backfill on the source's first-ever device-status sync (suppress so a first sync of
+    ///     history doesn't flood the device category), else Live. Memoized for the run.
+    /// </summary>
+    protected async Task<WriteOrigin> DevicePublishOriginAsync()
+    {
+        _devicePublishOrigin ??= await ResolvePublishOriginAsync(
+            () => _publisher!.Device.GetLatestDeviceStatusTimestampAsync(ConnectorSource));
+        return _devicePublishOrigin.Value;
+    }
+
+    /// <summary>
     ///     Resolves a publish origin from a resume watermark: Backfill when no prior data exists (initial
     ///     full-history sync), else Live. When the publisher is unavailable the publish will fail anyway,
     ///     so the origin is irrelevant and defaults to Live.
@@ -625,9 +638,9 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
         return await _publisher.Device.PublishDeviceStatusAsync(
             deviceStatuses,
-            ConnectorSource, WriteOrigin.Live,
+            ConnectorSource, await DevicePublishOriginAsync(),
             cancellationToken
-        ); // Dormant broadcast category (snapshots off-base / no V4 category yet) — origin irrelevant until wired.
+        );
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
@@ -17,17 +18,35 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
 {
     private readonly ITenantDbContextFactory _contextFactory;
     private readonly ILogger<ApsSnapshotRepository> _logger;
+    private readonly IV4RecordBroadcaster<ApsSnapshot>? _broadcaster;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ApsSnapshotRepository"/> class.
     /// </summary>
     /// <param name="contextFactory">The tenant database context factory.</param>
     /// <param name="logger">The logger instance.</param>
-    public ApsSnapshotRepository(ITenantDbContextFactory contextFactory, ILogger<ApsSnapshotRepository> logger)
+    /// <param name="broadcaster">Optional native V4 broadcaster; null disables broadcasting.</param>
+    public ApsSnapshotRepository(
+        ITenantDbContextFactory contextFactory,
+        ILogger<ApsSnapshotRepository> logger,
+        IV4RecordBroadcaster<ApsSnapshot>? broadcaster = null)
     {
         _contextFactory = contextFactory;
         _logger = logger;
+        _broadcaster = broadcaster;
     }
+
+    /// <summary>
+    /// Fires the native V4 broadcast for a just-committed write — but only for <see cref="WriteOrigin.Live"/>
+    /// writes (backfill imports stay silent). Mirrors the gate in <c>V4RepositoryBase.RaiseBroadcastAsync</c>.
+    /// </summary>
+    private Task RaiseBroadcastAsync(
+        IReadOnlyList<ApsSnapshot> created,
+        IReadOnlyList<ApsSnapshot> updated,
+        IReadOnlyList<Guid> deletedIds,
+        WriteOrigin origin,
+        CancellationToken ct)
+        => V4RecordBroadcast.RaiseAsync(_broadcaster, created, updated, deletedIds, origin, ct);
 
     /// <summary>
     /// Gets APS snapshots based on filter criteria.
@@ -94,7 +113,9 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
         var entity = ApsSnapshotMapper.ToEntity(model);
         ctx.ApsSnapshots.Add(entity);
         await ctx.SaveChangesAsync(ct);
-        return ApsSnapshotMapper.ToDomainModel(entity);
+        var created = ApsSnapshotMapper.ToDomainModel(entity);
+        await RaiseBroadcastAsync([created], [], [], origin, ct);
+        return created;
     }
 
     /// <summary>
@@ -350,7 +371,10 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
             }
 
             await tx.CommitAsync(ct);
-            return entities.Select(ApsSnapshotMapper.ToDomainModel);
+
+            var created = entities.Select(ApsSnapshotMapper.ToDomainModel).ToList();
+            await RaiseBroadcastAsync(created, [], [], origin, ct);
+            return created;
         });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
@@ -17,17 +18,35 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
 {
     private readonly ITenantDbContextFactory _contextFactory;
     private readonly ILogger<PumpSnapshotRepository> _logger;
+    private readonly IV4RecordBroadcaster<PumpSnapshot>? _broadcaster;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PumpSnapshotRepository"/> class.
     /// </summary>
     /// <param name="contextFactory">The tenant database context factory.</param>
     /// <param name="logger">The logger instance.</param>
-    public PumpSnapshotRepository(ITenantDbContextFactory contextFactory, ILogger<PumpSnapshotRepository> logger)
+    /// <param name="broadcaster">Optional native V4 broadcaster; null disables broadcasting.</param>
+    public PumpSnapshotRepository(
+        ITenantDbContextFactory contextFactory,
+        ILogger<PumpSnapshotRepository> logger,
+        IV4RecordBroadcaster<PumpSnapshot>? broadcaster = null)
     {
         _contextFactory = contextFactory;
         _logger = logger;
+        _broadcaster = broadcaster;
     }
+
+    /// <summary>
+    /// Fires the native V4 broadcast for a just-committed write — but only for <see cref="WriteOrigin.Live"/>
+    /// writes (backfill imports stay silent). Mirrors the gate in <c>V4RepositoryBase.RaiseBroadcastAsync</c>.
+    /// </summary>
+    private Task RaiseBroadcastAsync(
+        IReadOnlyList<PumpSnapshot> created,
+        IReadOnlyList<PumpSnapshot> updated,
+        IReadOnlyList<Guid> deletedIds,
+        WriteOrigin origin,
+        CancellationToken ct)
+        => V4RecordBroadcast.RaiseAsync(_broadcaster, created, updated, deletedIds, origin, ct);
 
     /// <summary>
     /// Gets pump snapshot records based on filter criteria.
@@ -118,7 +137,9 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
         var entity = PumpSnapshotMapper.ToEntity(model);
         ctx.PumpSnapshots.Add(entity);
         await ctx.SaveChangesAsync(ct);
-        return PumpSnapshotMapper.ToDomainModel(entity);
+        var created = PumpSnapshotMapper.ToDomainModel(entity);
+        await RaiseBroadcastAsync([created], [], [], origin, ct);
+        return created;
     }
 
     /// <summary>
@@ -312,7 +333,10 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
             }
 
             await tx.CommitAsync(ct);
-            return entities.Select(PumpSnapshotMapper.ToDomainModel);
+
+            var created = entities.Select(PumpSnapshotMapper.ToDomainModel).ToList();
+            await RaiseBroadcastAsync(created, [], [], origin, ct);
+            return created;
         });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
@@ -17,17 +18,35 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
 {
     private readonly ITenantDbContextFactory _contextFactory;
     private readonly ILogger<UploaderSnapshotRepository> _logger;
+    private readonly IV4RecordBroadcaster<UploaderSnapshot>? _broadcaster;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="UploaderSnapshotRepository"/> class.
     /// </summary>
     /// <param name="contextFactory">The tenant database context factory.</param>
     /// <param name="logger">The logger instance.</param>
-    public UploaderSnapshotRepository(ITenantDbContextFactory contextFactory, ILogger<UploaderSnapshotRepository> logger)
+    /// <param name="broadcaster">Optional native V4 broadcaster; null disables broadcasting.</param>
+    public UploaderSnapshotRepository(
+        ITenantDbContextFactory contextFactory,
+        ILogger<UploaderSnapshotRepository> logger,
+        IV4RecordBroadcaster<UploaderSnapshot>? broadcaster = null)
     {
         _contextFactory = contextFactory;
         _logger = logger;
+        _broadcaster = broadcaster;
     }
+
+    /// <summary>
+    /// Fires the native V4 broadcast for a just-committed write — but only for <see cref="WriteOrigin.Live"/>
+    /// writes (backfill imports stay silent). Mirrors the gate in <c>V4RepositoryBase.RaiseBroadcastAsync</c>.
+    /// </summary>
+    private Task RaiseBroadcastAsync(
+        IReadOnlyList<UploaderSnapshot> created,
+        IReadOnlyList<UploaderSnapshot> updated,
+        IReadOnlyList<Guid> deletedIds,
+        WriteOrigin origin,
+        CancellationToken ct)
+        => V4RecordBroadcast.RaiseAsync(_broadcaster, created, updated, deletedIds, origin, ct);
 
     /// <summary>
     /// Gets uploader snapshot records based on filter criteria.
@@ -94,7 +113,9 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
         var entity = UploaderSnapshotMapper.ToEntity(model);
         ctx.UploaderSnapshots.Add(entity);
         await ctx.SaveChangesAsync(ct);
-        return UploaderSnapshotMapper.ToDomainModel(entity);
+        var created = UploaderSnapshotMapper.ToDomainModel(entity);
+        await RaiseBroadcastAsync([created], [], [], origin, ct);
+        return created;
     }
 
     /// <summary>
@@ -302,7 +323,10 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
             }
 
             await tx.CommitAsync(ct);
-            return entities.Select(UploaderSnapshotMapper.ToDomainModel);
+
+            var created = entities.Select(UploaderSnapshotMapper.ToDomainModel).ToList();
+            await RaiseBroadcastAsync(created, [], [], origin, ct);
+            return created;
         });
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RecordBroadcast.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RecordBroadcast.cs
@@ -5,8 +5,9 @@ namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
 /// The single origin-gated fan-out used by every V4 write chokepoint — <see cref="V4RepositoryBase{TModel,TEntity}"/>
-/// and the two off-base repositories (TempBasal, BasalInjection) that can't inherit it. Broadcasts only
-/// for <see cref="WriteOrigin.Live"/> writes (backfill stays silent) and no-ops when no broadcaster is wired.
+/// and the off-base repositories (TempBasal, BasalInjection, and the device-status snapshot repos) that can't
+/// inherit it. Broadcasts only for <see cref="WriteOrigin.Live"/> writes (backfill stays silent) and no-ops when
+/// no broadcaster is wired.
 /// </summary>
 internal static class V4RecordBroadcast
 {

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/BroadcastGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/BroadcastGoldenTests.cs
@@ -122,6 +122,43 @@ public class BroadcastGoldenTests
     }
 
     [Fact]
+    public async Task ApsSnapshotLiveBulkCreate_BroadcastsCreated()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IApsSnapshotRepository>();
+        _fx.Capture.Clear();
+
+        await repo.BulkCreateAsync(
+            new[] { new ApsSnapshot { Timestamp = T0, DataSource = "loop", LegacyId = "aps-bc-a" } },
+            WriteOrigin.Live, CancellationToken.None);
+
+        _fx.Capture.Snapshot()
+            .Should().ContainSingle(e => e.Kind == "created" && e.ModelType == typeof(ApsSnapshot))
+            .Which.Count.Should().Be(1, "the inserted snapshot broadcasts as created on the device category");
+    }
+
+    [Fact]
+    public async Task ApsSnapshotBackfillBulkCreate_IsSilent_ButPersists()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IApsSnapshotRepository>();
+        _fx.Capture.Clear();
+
+        await repo.BulkCreateAsync(
+            new[] { new ApsSnapshot { Timestamp = T0, DataSource = "loop", LegacyId = "aps-bf-a" } },
+            WriteOrigin.Backfill, CancellationToken.None);
+
+        _fx.Capture.Snapshot().Should().BeEmpty("backfill device-status imports never broadcast");
+
+        // Silence must not mean "didn't write" — the snapshot is persisted.
+        var rowCount = await _fx.QueryAsync(tenant, ctx =>
+            ctx.ApsSnapshots.AsNoTracking().Where(s => s.LegacyId == "aps-bf-a").CountAsync());
+        rowCount.Should().Be(1);
+    }
+
+    [Fact]
     public async Task LiveSingleCreate_BroadcastsCreated()
     {
         var tenant = Guid.NewGuid();

--- a/tests/Unit/Nocturne.API.Tests/Services/Realtime/SignalRV4RecordBroadcasterTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Realtime/SignalRV4RecordBroadcasterTests.cs
@@ -66,6 +66,21 @@ public class SignalRV4RecordBroadcasterTests
     }
 
     [Fact]
+    public async Task BroadcastCreatedAsync_DeviceSnapshotType_BroadcastsToDeviceCategory()
+    {
+        var snapshot = new ApsSnapshot { Id = Guid.NewGuid() };
+
+        await Adapter<ApsSnapshot>().BroadcastCreatedAsync([snapshot]);
+
+        _broadcast.Verify(b => b.BroadcastStorageCreateAsync(
+            RealtimeCategories.Device,
+            It.Is<object>(p => (string)GetProp(p, "recordType")! == "apsSnapshot"
+                               && ReferenceEquals(GetProp(p, "doc"), snapshot))),
+            Times.Once);
+        _broadcast.VerifyNoOtherCalls();
+    }
+
+    [Fact]
     public async Task BroadcastCreatedAsync_UnmappedType_DoesNotBroadcast()
     {
         await Adapter<BasalSchedule>().BroadcastCreatedAsync([new BasalSchedule { Id = Guid.NewGuid() }]);

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/BaseConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/BaseConnectorServiceTests.cs
@@ -42,6 +42,7 @@ public class BaseConnectorServiceTests
         // and the per-run memoization (anti-flood guard) can be asserted directly.
         public Task<WriteOrigin> CallGlucoseOrigin() => GlucosePublishOriginAsync();
         public Task<WriteOrigin> CallTreatmentOrigin() => TreatmentPublishOriginAsync();
+        public Task<WriteOrigin> CallDeviceOrigin() => DevicePublishOriginAsync();
     }
 
     public class TestConfig : BaseConnectorConfiguration
@@ -132,26 +133,29 @@ public class BaseConnectorServiceTests
     }
 
     private static (TestConnectorService service, Mock<IConnectorPublisher> publisher,
-        Mock<IGlucosePublisher> glucose, Mock<ITreatmentPublisher> treatments) BuildServiceWithPublisher(
+        Mock<IGlucosePublisher> glucose, Mock<ITreatmentPublisher> treatments,
+        Mock<IDevicePublisher> device) BuildServiceWithPublisher(
         bool isAvailable = true)
     {
         var glucose = new Mock<IGlucosePublisher>();
         var treatments = new Mock<ITreatmentPublisher>();
+        var device = new Mock<IDevicePublisher>();
         var publisher = new Mock<IConnectorPublisher>();
         publisher.SetupGet(p => p.IsAvailable).Returns(isAvailable);
         publisher.SetupGet(p => p.Glucose).Returns(glucose.Object);
         publisher.SetupGet(p => p.Treatments).Returns(treatments.Object);
+        publisher.SetupGet(p => p.Device).Returns(device.Object);
 
         var service = new TestConnectorService(
             new HttpClient(), Mock.Of<ILogger<TestConnectorService>>(), publisher.Object);
-        return (service, publisher, glucose, treatments);
+        return (service, publisher, glucose, treatments, device);
     }
 
     [Fact]
     public async Task GlucosePublishOriginAsync_NoPriorData_ReturnsBackfill()
     {
         // Arrange: null watermark = no prior glucose for this source = first-ever sync
-        var (service, _, glucose, _) = BuildServiceWithPublisher();
+        var (service, _, glucose, _, _) = BuildServiceWithPublisher();
         glucose
             .Setup(g => g.GetLatestEntryTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((DateTime?)null);
@@ -167,7 +171,7 @@ public class BaseConnectorServiceTests
     public async Task GlucosePublishOriginAsync_PriorDataExists_ReturnsLive()
     {
         // Arrange: a non-null watermark means the source already has glucose, so this is a live catch-up
-        var (service, _, glucose, _) = BuildServiceWithPublisher();
+        var (service, _, glucose, _, _) = BuildServiceWithPublisher();
         glucose
             .Setup(g => g.GetLatestEntryTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(DateTime.UtcNow);
@@ -183,7 +187,7 @@ public class BaseConnectorServiceTests
     public async Task GlucosePublishOriginAsync_CalledTwice_MemoizesAndQueriesWatermarkOnce()
     {
         // Arrange
-        var (service, _, glucose, _) = BuildServiceWithPublisher();
+        var (service, _, glucose, _, _) = BuildServiceWithPublisher();
         glucose
             .Setup(g => g.GetLatestEntryTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((DateTime?)null);
@@ -204,7 +208,7 @@ public class BaseConnectorServiceTests
     public async Task GlucosePublishOriginAsync_PublisherUnavailable_ReturnsLiveWithoutQuerying()
     {
         // Arrange: an unavailable publisher can't publish anyway, so origin defaults to Live and skips the query
-        var (service, _, glucose, _) = BuildServiceWithPublisher(isAvailable: false);
+        var (service, _, glucose, _, _) = BuildServiceWithPublisher(isAvailable: false);
 
         // Act
         var origin = await service.CallGlucoseOrigin();
@@ -220,7 +224,7 @@ public class BaseConnectorServiceTests
     public async Task TreatmentPublishOriginAsync_NoPriorData_ReturnsBackfill()
     {
         // Arrange
-        var (service, _, _, treatments) = BuildServiceWithPublisher();
+        var (service, _, _, treatments, _) = BuildServiceWithPublisher();
         treatments
             .Setup(t => t.GetLatestTreatmentTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((DateTime?)null);
@@ -236,7 +240,7 @@ public class BaseConnectorServiceTests
     public async Task TreatmentPublishOriginAsync_PriorDataExists_ReturnsLive()
     {
         // Arrange
-        var (service, _, _, treatments) = BuildServiceWithPublisher();
+        var (service, _, _, treatments, _) = BuildServiceWithPublisher();
         treatments
             .Setup(t => t.GetLatestTreatmentTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(DateTime.UtcNow);
@@ -252,7 +256,7 @@ public class BaseConnectorServiceTests
     public async Task TreatmentPublishOriginAsync_CalledTwice_MemoizesAndQueriesWatermarkOnce()
     {
         // Arrange
-        var (service, _, _, treatments) = BuildServiceWithPublisher();
+        var (service, _, _, treatments, _) = BuildServiceWithPublisher();
         treatments
             .Setup(t => t.GetLatestTreatmentTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((DateTime?)null);
@@ -266,6 +270,59 @@ public class BaseConnectorServiceTests
         second.Should().Be(first);
         treatments.Verify(
             t => t.GetLatestTreatmentTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DevicePublishOriginAsync_NoPriorData_ReturnsBackfill()
+    {
+        // Arrange: null watermark = no prior device status for this source = first-ever sync
+        var (service, _, _, _, device) = BuildServiceWithPublisher();
+        device
+            .Setup(d => d.GetLatestDeviceStatusTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DateTime?)null);
+
+        // Act
+        var origin = await service.CallDeviceOrigin();
+
+        // Assert
+        origin.Should().Be(WriteOrigin.Backfill);
+    }
+
+    [Fact]
+    public async Task DevicePublishOriginAsync_PriorDataExists_ReturnsLive()
+    {
+        // Arrange: a non-null watermark means the source already has device status, so this is a live catch-up
+        var (service, _, _, _, device) = BuildServiceWithPublisher();
+        device
+            .Setup(d => d.GetLatestDeviceStatusTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DateTime.UtcNow);
+
+        // Act
+        var origin = await service.CallDeviceOrigin();
+
+        // Assert
+        origin.Should().Be(WriteOrigin.Live);
+    }
+
+    [Fact]
+    public async Task DevicePublishOriginAsync_CalledTwice_MemoizesAndQueriesWatermarkOnce()
+    {
+        // Arrange
+        var (service, _, _, _, device) = BuildServiceWithPublisher();
+        device
+            .Setup(d => d.GetLatestDeviceStatusTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DateTime?)null);
+
+        // Act
+        var first = await service.CallDeviceOrigin();
+        var second = await service.CallDeviceOrigin();
+
+        // Assert: identical result, and the watermark was queried only once (the anti-flood memo)
+        first.Should().Be(WriteOrigin.Backfill);
+        second.Should().Be(first);
+        device.Verify(
+            d => d.GetLatestDeviceStatusTimestampAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 }


### PR DESCRIPTION
## What

Lights up the previously-dormant **`device`** SignalR broadcast category, so modern clients (the desktop companion + Prelude) receive native device-status snapshots in real time alongside `glucose` and `care`.

The three device-status snapshot repos (`Aps`/`Pump`/`UploaderSnapshotRepository`) now fire `IV4RecordBroadcaster<TModel>` on create — **only the actually-inserted rows** (after batch + LegacyId dedup), **gated to `WriteOrigin.Live`** — mirroring the existing TempBasal/BasalInjection bespoke pattern. They stay standalone (not migrated onto `V4RepositoryBase`); the JSON-heavy snapshot bulk/dedup logic is unchanged. `V4BroadcastMap` already routes them to `device` with `apsSnapshot`/`pumpSnapshot`/`uploaderSnapshot` discriminators (added with the broadcast base).

## Flood-guard

This was only safe to do **after** the device-status watermark became source-scoped (#439). `BaseConnectorService` now resolves a **memoized per-run device origin** from `GetLatestDeviceStatusTimestampAsync(source)` (Backfill on a source's first sync, else Live), used in `PublishDeviceStatusAsync` — so a connector's first device-status sync is silent rather than flooding the live `device` group with months of history. Device **events** (care family) and the still-dormant placeholders (profile/food/activity) are untouched.

## Tests

- Goldens (real Postgres): a Live snapshot bulk-create fires exactly one `device` `create`; a Backfill one is silent but persists.
- Unit: device-origin Backfill/Live + memoization (watermark queried once per run); snapshot→`device` recordType mapping.
- Build + 48 V4 goldens + connector/API unit suites green.

## Context

Completes the V4 SignalR broadcasting set (`glucose` / `care` / `device`; `therapy` remains intentionally dormant). Builds on #435 (broadcast base) + #439 (device `data_source` source-scoping), both merged.
