### PR TITLE
fix(dev-only): give seed-tenant a synthetic passkey so its session can call tenant APIs

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/DevOnly/DevAdminController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/DevOnly/DevAdminController.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -932,8 +933,10 @@ public class DevAdminController : ControllerBase
     // ── Seed Tenant (E2E test bootstrap) ────────────────────────────────
 
     /// <summary>
-    /// Create a tenant, owner subject, owner membership, and a session in one call.
-    /// Used exclusively by the E2E test suite to bypass passkey/OIDC ceremonies.
+    /// Create a tenant, owner subject, synthetic passkey, owner membership, and a session
+    /// in one call. The synthetic passkey satisfies the TenantSetupMiddleware credential
+    /// check so the returned session can immediately call tenant APIs.
+    /// Used by E2E tests and headless dev tooling to bypass passkey/OIDC ceremonies.
     /// </summary>
     [HttpPost("seed-tenant")]
     public async Task<ActionResult<DevSeedTenantResponse>> SeedTenant(
@@ -965,7 +968,22 @@ public class DevAdminController : ControllerBase
             CreatedAt = DateTime.UtcNow,
         });
 
-        // 3. Owner membership with full permissions
+        // 3. Synthetic passkey credential. TenantSetupMiddleware returns 503 until a
+        // member holds a passkey or OIDC identity, so without this the session issued
+        // below cannot call any tenant API. The credential is fake bytes — it can never
+        // complete a WebAuthn assertion — it exists only to mark setup as complete.
+        _db.PasskeyCredentials.Add(new()
+        {
+            Id = Guid.CreateVersion7(),
+            SubjectId = subjectResult.Subject.Id,
+            CredentialId = Encoding.UTF8.GetBytes($"dev-seed-{subjectResult.Subject.Id:N}"),
+            PublicKey = Encoding.UTF8.GetBytes($"dev-seed-pk-{subjectResult.Subject.Id:N}"),
+            SignCount = 0,
+            Label = "dev-seed (synthetic)",
+        });
+        await _db.SaveChangesAsync(ct);
+
+        // 4. Owner membership with full permissions
         await SetTenantGuc(tenant.Id, ct);
         var ownerRole = await _db.TenantRoles
             .Where(r => r.TenantId == tenant.Id && r.IsSystem && r.Slug == TenantPermissions.SeedRoles.Owner)
@@ -974,7 +992,7 @@ public class DevAdminController : ControllerBase
         await _tenantService.AddMemberAsync(
             tenant.Id, subjectResult.Subject.Id, [ownerRole.Id], ct: ct);
 
-        // 4. Session
+        // 5. Session
         var sessionContext = new SessionContext(
             DeviceDescription: "e2e-test",
             IpAddress: "127.0.0.1",


### PR DESCRIPTION
## Problem

`POST /api/v4/dev-only/admin/seed-tenant` creates the tenant, owner subject, membership, and a session — but no credential. `TenantSetupMiddleware` requires at least one member with a passkey or OIDC identity, so every tenant API call with the returned access token gets **503 `setup_required`**. The endpoint exists precisely to bypass the passkey/OIDC ceremony for E2E/headless bootstrap, so its output being unusable defeats its purpose.

The existing E2E assertion already pins the intended behavior and fails without this fix: `TenantSetupTests.SeedingTenantSucceeds` ("the seeded session should authenticate against tenant-scoped /me/tenants").

## Fix

Plant a synthetic passkey credential on the owner subject during seeding, mirroring what the integration suite's `AuthTestHelpers.SeedAuthenticatedSubjectAsync` already does via raw SQL. The credential is fake bytes — it can never complete a WebAuthn assertion — it only satisfies the setup gate (and keeps the owner out of the orphaned-subject recovery check).

## Verification

Ran a locally built image behind nocturne-cloud's AppHost:

- Before: seed-tenant → 200, then `GET /api/v4/status` with the returned Bearer token → **503 setup_required**
- After: same flow → **200**
