### PR TITLE
fix(setup): resume owner setup when a credential-less member exists

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/SetupController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/SetupController.cs
@@ -405,16 +405,19 @@ public partial class SetupController : ControllerBase
             "SELECT set_config('app.current_tenant_id', {0}, false)",
             tenant.Id.ToString());
 
-        var hasNonSystemMembers = await context.TenantMembers
-            .Where(tm => tm.TenantId == tenant.Id)
-            .Join(
-                context.Subjects.Where(s => !s.IsSystemSubject),
-                tm => tm.SubjectId,
-                s => s.Id,
-                (tm, s) => tm)
-            .AnyAsync(ct);
+        // Setup is "complete" only once a member holds real credentials (passkey or
+        // OIDC). A credential-less member is a half-finished setup left behind by an
+        // abandoned or failed WebAuthn/OIDC ceremony — EnsureOwnerSubjectAsync reuses
+        // that subject idempotently, so let the flow resume instead of dead-ending on
+        // owner_already_exists. Mirrors the CreateTenant guard and
+        // TenantSetupMiddleware's hasCredentials check.
+        var hasOwnerWithCredentials = await context.TenantMembers
+            .Where(m => m.TenantId == tenant.Id)
+            .AnyAsync(m =>
+                context.PasskeyCredentials.Any(c => c.SubjectId == m.SubjectId) ||
+                context.SubjectOidcIdentities.Any(o => o.SubjectId == m.SubjectId), ct);
 
-        if (hasNonSystemMembers)
+        if (hasOwnerWithCredentials)
             return (null, Conflict(new { error = "owner_already_exists" }));
 
         return (tenant, null);

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/SetupControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/SetupControllerTests.cs
@@ -40,6 +40,14 @@ public class SetupControllerTests : IDisposable
         _connection = new SqliteConnection("DataSource=:memory:");
         _connection.Open();
 
+        // GetSoleTenantWithoutOwnerAsync/EnsureOwnerSubjectAsync scope their queries
+        // with `SELECT set_config('app.current_tenant_id', ...)`, a PostgreSQL-only
+        // function. Register a no-op stand-in so the sole-tenant guard paths execute
+        // under SQLite (there is no RLS here, so all rows are visible — which is what
+        // we want for asserting the credential-based guard logic).
+        _connection.CreateFunction<string, string, bool, string>(
+            "set_config", (_, value, _) => value);
+
         _dbOptions = new DbContextOptionsBuilder<NocturneDbContext>()
             .UseSqlite(_connection)
             .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
@@ -331,6 +339,65 @@ public class SetupControllerTests : IDisposable
             new SetupTenantRequest("any-slug", "Any Name"), CancellationToken.None);
         var ok = createResult.Should().BeOfType<OkObjectResult>().Subject;
         ok.Value.Should().BeOfType<SetupTenantResponse>().Subject.TenantId.Should().Be(newTenantId);
+    }
+
+    [Fact]
+    public async Task OwnerOptions_WhenSoleTenantHasCredentiallessMember_ProceedsPastGuard()
+    {
+        // The real-world soft-lock: OwnerOptions previously created a subject +
+        // membership, then the WebAuthn ceremony failed/was abandoned so no passkey
+        // was stored. Retrying must resume setup, not dead-end on owner_already_exists.
+        var tenantId = Guid.CreateVersion7();
+        var subjectId = Guid.CreateVersion7();
+
+        _dbContext.Set<TenantEntity>().Add(new TenantEntity
+        {
+            Id = tenantId, Slug = "my-instance", DisplayName = "My Instance",
+        });
+        _dbContext.Subjects.Add(new SubjectEntity
+        {
+            Id = subjectId, Name = "Incomplete Owner", Username = "owner",
+            IsActive = true, IsSystemSubject = false,
+        });
+        _dbContext.TenantMembers.Add(new TenantMemberEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = tenantId,
+            SubjectId = subjectId,
+        });
+        await _dbContext.SaveChangesAsync();
+
+        _passkeyService
+            .Setup(s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>()))
+            .ReturnsAsync(new PasskeyRegistrationOptions("{}", "challenge-token"));
+
+        // Act
+        var result = await _controller.OwnerOptions(
+            new SetupOwnerOptionsRequest { Username = "owner", DisplayName = "Owner" },
+            CancellationToken.None);
+
+        // Assert — guard passed; registration options were issued
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var response = ok.Value.Should().BeOfType<SetupOwnerOptionsResponse>().Subject;
+        response.ChallengeToken.Should().Be("challenge-token");
+        response.TenantId.Should().Be(tenantId);
+    }
+
+    [Fact]
+    public async Task OwnerOptions_WhenSoleTenantHasCredentialedMember_Returns409OwnerAlreadyExists()
+    {
+        // The guard must still block once a member holds real credentials — a
+        // completed setup should not be re-openable.
+        await SeedConfiguredTenantAsync("my-instance", "My Instance");
+
+        // Act
+        var result = await _controller.OwnerOptions(
+            new SetupOwnerOptionsRequest { Username = "someone", DisplayName = "Someone" },
+            CancellationToken.None);
+
+        // Assert
+        var conflict = result.Should().BeOfType<ConflictObjectResult>().Subject;
+        conflict.Value.Should().BeEquivalentTo(new { error = "owner_already_exists" });
     }
 
     // SoftLock_TenantWithOnlySystemMembers_OwnerOptionsSucceeds is an


### PR DESCRIPTION
## Problem

A user hit **Failed to create account** on a fresh setup, with the API returning `owner_already_exists` on both `setup.ownerOptions` and `setup.ownerComplete` — soft-locking the instance out of setup entirely.

**Root cause:** setup is a two-step flow — `owner/options` creates the owner subject + tenant membership and hands back a passkey challenge; `owner/complete` verifies the passkey and stores the credential. If the WebAuthn ceremony fails or is abandoned between the two, the subject + membership exist but **no passkey credential was ever saved**.

`GetSoleTenantWithoutOwnerAsync` treated *any* non-system member as "owner already exists," regardless of credentials, so every retry dead-ended. Meanwhile `CreateTenant` and `TenantSetupMiddleware` both correctly key on **credentials** (passkey or OIDC) — which is why the middleware still reports `setup_required`. This one guard was the outlier.

## Fix

Key the guard on real credentials (passkey or OIDC) instead of raw member existence, matching the other two checks. `EnsureOwnerSubjectAsync` is already idempotent and reuses the orphaned subject, so setup resumes cleanly on retry.

## Tests

- Registered a SQLite `set_config` stand-in so the sole-tenant guard paths (previously untestable under SQLite) can run.
- `OwnerOptions_WhenSoleTenantHasCredentiallessMember_ProceedsPastGuard` — retry resumes.
- `OwnerOptions_WhenSoleTenantHasCredentialedMember_Returns409OwnerAlreadyExists` — a completed setup stays locked.

All 24 `SetupControllerTests` pass.