### PR TITLE
feat(v4): range- and serial-aware patient-device attribution across ingest paths

### DIFF
--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -513,6 +513,7 @@ public static class ServiceRegistrationExtensions
 
         // Device resolution
         services.AddScoped<IDeviceService, DeviceService>();
+        services.AddScoped<IPatientDeviceStamper, PatientDeviceStamper>();
 
         // Coach marks
         services.AddScoped<ICoachMarkService, CoachMarkService>();

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/GlucosePublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/GlucosePublisher.cs
@@ -3,6 +3,7 @@ using Nocturne.API.Services.Audit;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Contracts.Alerts;
 using Nocturne.Core.Contracts.Multitenancy;
@@ -24,7 +25,7 @@ internal sealed class GlucosePublisher : IGlucosePublisher
 {
     private readonly IEntryService _entryService;
     private readonly ISensorGlucoseRepository _sensorGlucoseRepository;
-    private readonly IPatientDeviceRepository _patientDeviceRepository;
+    private readonly IPatientDeviceStamper _patientDeviceStamper;
     private readonly IDbContextFactory<NocturneDbContext> _contextFactory;
     private readonly ITenantAccessor _tenantAccessor;
     private readonly IAlertOrchestrator _alertOrchestrator;
@@ -34,7 +35,7 @@ internal sealed class GlucosePublisher : IGlucosePublisher
     public GlucosePublisher(
         IEntryService entryService,
         ISensorGlucoseRepository sensorGlucoseRepository,
-        IPatientDeviceRepository patientDeviceRepository,
+        IPatientDeviceStamper patientDeviceStamper,
         IDbContextFactory<NocturneDbContext> contextFactory,
         ITenantAccessor tenantAccessor,
         IAlertOrchestrator alertOrchestrator,
@@ -43,7 +44,7 @@ internal sealed class GlucosePublisher : IGlucosePublisher
     {
         _entryService = entryService ?? throw new ArgumentNullException(nameof(entryService));
         _sensorGlucoseRepository = sensorGlucoseRepository ?? throw new ArgumentNullException(nameof(sensorGlucoseRepository));
-        _patientDeviceRepository = patientDeviceRepository ?? throw new ArgumentNullException(nameof(patientDeviceRepository));
+        _patientDeviceStamper = patientDeviceStamper ?? throw new ArgumentNullException(nameof(patientDeviceStamper));
         _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
         _tenantAccessor = tenantAccessor ?? throw new ArgumentNullException(nameof(tenantAccessor));
         _alertOrchestrator = alertOrchestrator ?? throw new ArgumentNullException(nameof(alertOrchestrator));
@@ -82,7 +83,7 @@ internal sealed class GlucosePublisher : IGlucosePublisher
             var recordList = records.ToList();
             if (recordList.Count == 0) return true;
 
-            await StampPatientDeviceIdsAsync(recordList, source, cancellationToken);
+            await _patientDeviceStamper.StampAsync(recordList, [DeviceCategory.CGM], source, cancellationToken);
             using (SystemAuditScope.Push(_auditContext))
                 await _sensorGlucoseRepository.BulkCreateAsync(recordList, origin, cancellationToken);
             await UpdateLastReadingAtAsync(cancellationToken);
@@ -183,67 +184,6 @@ internal sealed class GlucosePublisher : IGlucosePublisher
             _logger.LogWarning(ex, "Alert evaluation failed after entry publish");
         }
     }
-
-    /// <summary>
-    /// Resolves the patient's current CGM device and stamps <see cref="SensorGlucose.PatientDeviceId"/>
-    /// on each record whose <see cref="SensorGlucose.DataSource"/> matches the device's manufacturer.
-    /// Falls back to matching on the <paramref name="source"/> parameter when records lack a DataSource.
-    /// Failures are logged and swallowed — records proceed without a device link.
-    /// </summary>
-    private async Task StampPatientDeviceIdsAsync(
-        List<SensorGlucose> records,
-        string source,
-        CancellationToken ct)
-    {
-        try
-        {
-            var currentDevices = await _patientDeviceRepository.GetCurrentAsync(ct);
-            var cgmDevices = currentDevices.Where(d => d.DeviceCategory == DeviceCategory.CGM).ToList();
-            if (cgmDevices.Count == 0) return;
-
-            // Build connector-source → PatientDevice.Id lookup from current CGM devices.
-            var lookup = new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase);
-            foreach (var device in cgmDevices)
-            {
-                // Prefer CatalogId-based manufacturer, fall back to device's own Manufacturer field.
-                var manufacturer = device.CatalogId is not null
-                    ? DeviceCatalog.GetById(device.CatalogId)?.Manufacturer ?? device.Manufacturer
-                    : device.Manufacturer;
-
-                var connectorSource = ResolveConnectorSource(manufacturer);
-                if (connectorSource is not null)
-                    lookup.TryAdd(connectorSource, device.Id);
-            }
-
-            if (lookup.Count == 0) return;
-
-            foreach (var record in records)
-            {
-                // Skip records that already have a device assigned.
-                if (record.PatientDeviceId.HasValue) continue;
-
-                // Try matching on the record's own DataSource first, then the batch source.
-                var recordSource = record.DataSource ?? source;
-                if (recordSource is not null && lookup.TryGetValue(recordSource, out var deviceId))
-                    record.PatientDeviceId = deviceId;
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to resolve PatientDeviceId for SensorGlucose batch from {Source}", source);
-        }
-    }
-
-    /// <summary>
-    /// Maps a device manufacturer name to the corresponding connector data source identifier.
-    /// </summary>
-    private static string? ResolveConnectorSource(string? manufacturer) => manufacturer?.ToLowerInvariant() switch
-    {
-        "dexcom" => DataSources.DexcomConnector,
-        "abbott" => DataSources.LibreConnector,
-        "medtronic" => DataSources.MiniMedConnector,
-        _ => null,
-    };
 
     /// <summary>
     /// Build a SensorContext from the most recent SensorGlucose record and evaluate alert rules.

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/TreatmentPublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/TreatmentPublisher.cs
@@ -1,6 +1,7 @@
 using Nocturne.API.Services.Audit;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.V4.Repositories;
@@ -33,6 +34,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
     private readonly IPatientInsulinRepository _patientInsulinRepository;
     private readonly IBasalRateResolver _basalRateResolver;
     private readonly ITherapySettingsResolver _therapySettingsResolver;
+    private readonly IPatientDeviceStamper _patientDeviceStamper;
     private readonly IAuditContext _auditContext;
     private readonly ILogger<TreatmentPublisher> _logger;
 
@@ -50,6 +52,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
         IPatientInsulinRepository patientInsulinRepository,
         IBasalRateResolver basalRateResolver,
         ITherapySettingsResolver therapySettingsResolver,
+        IPatientDeviceStamper patientDeviceStamper,
         IAuditContext auditContext,
         ILogger<TreatmentPublisher> logger)
     {
@@ -66,6 +69,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
         _patientInsulinRepository = patientInsulinRepository ?? throw new ArgumentNullException(nameof(patientInsulinRepository));
         _basalRateResolver = basalRateResolver ?? throw new ArgumentNullException(nameof(basalRateResolver));
         _therapySettingsResolver = therapySettingsResolver ?? throw new ArgumentNullException(nameof(therapySettingsResolver));
+        _patientDeviceStamper = patientDeviceStamper ?? throw new ArgumentNullException(nameof(patientDeviceStamper));
         _auditContext = auditContext;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -99,6 +103,8 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
             if (recordList.Count == 0) return true;
 
             await ResolvePatientInsulinsForBolusesAsync(recordList, origin, cancellationToken);
+            await _patientDeviceStamper.StampAsync(
+                recordList, [DeviceCategory.InsulinPump, DeviceCategory.SmartPen], source, cancellationToken);
             using (SystemAuditScope.Push(_auditContext))
                 await _bolusRepository.BulkCreateAsync(recordList, origin, cancellationToken);
             _logger.LogDebug("Published {Count} Bolus records for {Source}", recordList.Count, source);
@@ -190,6 +196,9 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
         {
             var recordList = records.ToList();
             if (recordList.Count == 0) return true;
+
+            await _patientDeviceStamper.StampAsync(
+                recordList, [DeviceCategory.InsulinPump], source, cancellationToken);
 
             var minTimestamp = recordList.Min(r => r.StartTimestamp);
             var maxTimestamp = recordList.Max(r => r.StartTimestamp);
@@ -292,6 +301,8 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
             if (recordList.Count == 0) return true;
 
             await ResolvePatientInsulinsForBasalInjectionsAsync(recordList, origin, cancellationToken);
+            await _patientDeviceStamper.StampAsync(
+                recordList, [DeviceCategory.InsulinPen, DeviceCategory.SmartPen], source, cancellationToken);
             using (SystemAuditScope.Push(_auditContext))
                 await _basalInjectionRepository.BulkCreateAsync(recordList, origin, cancellationToken);
 

--- a/src/API/Nocturne.API/Services/Devices/PatientDeviceStamper.cs
+++ b/src/API/Nocturne.API/Services/Devices/PatientDeviceStamper.cs
@@ -1,6 +1,8 @@
 using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Devices;
+using Nocturne.Core.Contracts.Timezones;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.Timezones;
 using Nocturne.Core.Models.V4;
 
 namespace Nocturne.API.Services.Devices;
@@ -22,6 +24,7 @@ namespace Nocturne.API.Services.Devices;
 internal sealed class PatientDeviceStamper : IPatientDeviceStamper
 {
     private readonly IPatientDeviceRepository _patientDeviceRepository;
+    private readonly ITimezoneTimelineService _timezoneTimelineService;
     private readonly ILogger<PatientDeviceStamper> _logger;
 
     /// <summary>
@@ -46,9 +49,11 @@ internal sealed class PatientDeviceStamper : IPatientDeviceStamper
 
     public PatientDeviceStamper(
         IPatientDeviceRepository patientDeviceRepository,
+        ITimezoneTimelineService timezoneTimelineService,
         ILogger<PatientDeviceStamper> logger)
     {
         _patientDeviceRepository = patientDeviceRepository ?? throw new ArgumentNullException(nameof(patientDeviceRepository));
+        _timezoneTimelineService = timezoneTimelineService ?? throw new ArgumentNullException(nameof(timezoneTimelineService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -79,17 +84,29 @@ internal sealed class PatientDeviceStamper : IPatientDeviceStamper
         var unstamped = records.Where(r => !r.PatientDeviceId.HasValue).ToList();
         if (unstamped.Count == 0) return;
 
-        var min = unstamped.Min(r => r.Timestamp);
-        var max = unstamped.Max(r => r.Timestamp);
+        // Device usage windows are user-entered local dates, so records match on the wearer's local
+        // day. Pad the candidate fetch by a day in each direction: a record's local date can differ
+        // from its UTC date by up to a day either way.
+        var min = unstamped.Min(r => r.Timestamp).AddDays(-1);
+        var max = unstamped.Max(r => r.Timestamp).AddDays(1);
         var candidates = (await _patientDeviceRepository.GetByDateRangeAsync(min, max, ct))
             .Where(d => categories.Contains(d.DeviceCategory))
             .ToList();
         if (candidates.Count == 0) return;
 
+        // Records missing a UtcOffset fall back to the tenant's timezone timeline; an empty
+        // timeline resolves to UTC unchanged.
+        TimezoneTimeline? timeline = null;
+        if (unstamped.Any(r => r.UtcOffset is null))
+            timeline = await _timezoneTimelineService.GetResolverAsync(fallbackOffsetHours: null, ct);
+
         var unresolved = 0;
         foreach (var record in unstamped)
         {
-            var date = DateOnly.FromDateTime(record.Timestamp);
+            var local = record.UtcOffset is { } offsetMinutes
+                ? record.Timestamp.AddMinutes(offsetMinutes)
+                : timeline!.ToLocal(record.Timestamp);
+            var date = DateOnly.FromDateTime(local);
             var active = candidates
                 .Where(d =>
                     (d.StartDate is null || d.StartDate <= date) &&

--- a/src/API/Nocturne.API/Services/Devices/PatientDeviceStamper.cs
+++ b/src/API/Nocturne.API/Services/Devices/PatientDeviceStamper.cs
@@ -1,0 +1,168 @@
+using Nocturne.Core.Constants;
+using Nocturne.Core.Contracts.Devices;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.API.Services.Devices;
+
+/// <summary>
+/// Default <see cref="IPatientDeviceStamper"/>: matches records against the patient devices whose
+/// usage window covers the record's timestamp, strongest signal first.
+/// </summary>
+/// <remarks>
+/// Matching ladder per record: (1) unique serial-number match of a candidate's
+/// <see cref="PatientDevice.SerialNumber"/> inside the record's device string; (2) the single
+/// candidate whose manufacturer is compatible with the record's data source. A source that maps to
+/// a specific manufacturer (e.g. "dexcom-connector") excludes candidates of other manufacturers;
+/// aggregator and uploader sources (Glooko, Nightscout, xDrip) constrain nothing. Records that
+/// remain ambiguous — e.g. two same-manufacturer CGMs on one connector with no serial in the data —
+/// are left unstamped rather than guessed.
+/// </remarks>
+/// <seealso cref="DeviceService"/>
+internal sealed class PatientDeviceStamper : IPatientDeviceStamper
+{
+    private readonly IPatientDeviceRepository _patientDeviceRepository;
+    private readonly ILogger<PatientDeviceStamper> _logger;
+
+    /// <summary>
+    /// Connector data sources that identify a specific device manufacturer, keyed by the
+    /// manufacturer name as it appears in <see cref="DeviceCatalog"/> / <see cref="PatientDevice.Manufacturer"/>.
+    /// Aggregators (Glooko, Nightscout, Tidepool) and uploader apps are intentionally absent —
+    /// they carry data from any manufacturer.
+    /// </summary>
+    private static readonly Dictionary<string, string[]> ManufacturerConnectorSources = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["dexcom"] = [DataSources.DexcomConnector],
+        ["abbott"] = [DataSources.LibreConnector],
+        ["medtronic"] = [DataSources.MiniMedConnector, DataSources.CareLinkConnector],
+        ["tandem"] = [DataSources.TConnectSyncConnector],
+        ["ypsomed"] = [DataSources.MyLifeConnector],
+        ["senseonics"] = [DataSources.EversenseConnector],
+    };
+
+    private static readonly HashSet<string> ManufacturerSpecificSources = new(
+        ManufacturerConnectorSources.Values.SelectMany(s => s),
+        StringComparer.OrdinalIgnoreCase);
+
+    public PatientDeviceStamper(
+        IPatientDeviceRepository patientDeviceRepository,
+        ILogger<PatientDeviceStamper> logger)
+    {
+        _patientDeviceRepository = patientDeviceRepository ?? throw new ArgumentNullException(nameof(patientDeviceRepository));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task StampAsync(
+        IReadOnlyList<IDeviceAttributed> records,
+        IReadOnlyList<DeviceCategory> categories,
+        string? batchSource,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            await StampCoreAsync(records, categories, batchSource, ct);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to resolve PatientDeviceId for batch from {Source}", batchSource);
+        }
+    }
+
+    private async Task StampCoreAsync(
+        IReadOnlyList<IDeviceAttributed> records,
+        IReadOnlyList<DeviceCategory> categories,
+        string? batchSource,
+        CancellationToken ct)
+    {
+        var unstamped = records.Where(r => !r.PatientDeviceId.HasValue).ToList();
+        if (unstamped.Count == 0) return;
+
+        var min = unstamped.Min(r => r.Timestamp);
+        var max = unstamped.Max(r => r.Timestamp);
+        var candidates = (await _patientDeviceRepository.GetByDateRangeAsync(min, max, ct))
+            .Where(d => categories.Contains(d.DeviceCategory))
+            .ToList();
+        if (candidates.Count == 0) return;
+
+        var unresolved = 0;
+        foreach (var record in unstamped)
+        {
+            var date = DateOnly.FromDateTime(record.Timestamp);
+            var active = candidates
+                .Where(d =>
+                    (d.StartDate is null || d.StartDate <= date) &&
+                    (d.EndDate is null || d.EndDate >= date))
+                .ToList();
+            if (active.Count == 0) continue;
+
+            var match = MatchBySerial(record, active) ?? MatchBySource(record, active, batchSource);
+            if (match is not null)
+                record.PatientDeviceId = match.Id;
+            else
+                unresolved++;
+        }
+
+        if (unresolved > 0)
+            _logger.LogDebug(
+                "Left {Count} record(s) from {Source} unattributed: multiple {Categories} devices match and no serial disambiguates",
+                unresolved, batchSource, string.Join("/", categories));
+    }
+
+    /// <summary>
+    /// Serials shorter than this are too likely to occur incidentally inside device strings
+    /// ("G6" in "xDrip-DexcomG6") to be trusted as a substring match.
+    /// </summary>
+    private const int MinSerialMatchLength = 5;
+
+    /// <summary>
+    /// Matches a candidate whose serial number appears in the record's device string. When several
+    /// serials match (one a prefix of another), the longest wins; two distinct devices tying on the
+    /// same matched serial is ambiguous and matches nothing.
+    /// </summary>
+    private static PatientDevice? MatchBySerial(IDeviceAttributed record, List<PatientDevice> active)
+    {
+        if (string.IsNullOrEmpty(record.Device)) return null;
+
+        var matches = active
+            .Where(d => d.SerialNumber is { Length: >= MinSerialMatchLength }
+                && record.Device.Contains(d.SerialNumber, StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(d => d.SerialNumber!.Length)
+            .ToList();
+
+        if (matches.Count == 0) return null;
+        if (matches.Count == 1) return matches[0];
+
+        return matches[0].SerialNumber!.Length > matches[1].SerialNumber!.Length ? matches[0] : null;
+    }
+
+    /// <summary>
+    /// Matches the single candidate compatible with the record's data source. Compatibility only
+    /// constrains manufacturer-specific connector sources; any other source (aggregator, uploader
+    /// app, null) is compatible with every candidate, so a lone active device still matches.
+    /// </summary>
+    private static PatientDevice? MatchBySource(IDeviceAttributed record, List<PatientDevice> active, string? batchSource)
+    {
+        var source = record.DataSource ?? batchSource;
+        var compatible = active.Where(d => IsCompatible(d, source)).ToList();
+        return compatible.Count == 1 ? compatible[0] : null;
+    }
+
+    private static bool IsCompatible(PatientDevice device, string? source)
+    {
+        if (string.IsNullOrEmpty(source) || !ManufacturerSpecificSources.Contains(source))
+            return true;
+
+        var manufacturer = ManufacturerOf(device);
+        return manufacturer is not null
+            && ManufacturerConnectorSources.TryGetValue(manufacturer, out var sources)
+            && sources.Contains(source, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Catalog manufacturer when the device is catalog-linked, else its own Manufacturer field.</summary>
+    private static string? ManufacturerOf(PatientDevice device)
+        => device.CatalogId is not null
+            ? DeviceCatalog.GetById(device.CatalogId)?.Manufacturer ?? device.Manufacturer
+            : device.Manufacturer;
+}

--- a/src/API/Nocturne.API/Services/V4/EntryDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/EntryDecomposer.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Nocturne.API.Services.Audit;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
@@ -28,6 +29,7 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
     private readonly IMeterGlucoseRepository _meterGlucoseRepository;
     private readonly ICalibrationRepository _calibrationRepository;
     private readonly IGlucoseProcessingResolver _glucoseResolver;
+    private readonly IPatientDeviceStamper _patientDeviceStamper;
     private readonly IAuditContext _auditContext;
     private readonly ILogger<EntryDecomposer> _logger;
 
@@ -36,6 +38,7 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
     /// <param name="meterGlucoseRepository">Repository for <see cref="MeterGlucose"/> records.</param>
     /// <param name="calibrationRepository">Repository for <see cref="Calibration"/> records.</param>
     /// <param name="glucoseResolver">Resolves glucose processing type and smoothed/unsmoothed values from v1/v3 hints or source defaults.</param>
+    /// <param name="patientDeviceStamper">Attributes decomposed records to the patient device active at their timestamp.</param>
     /// <param name="logger">Logger instance for this decomposer.</param>
     public EntryDecomposer(
         NocturneDbContext dbContext,
@@ -43,6 +46,7 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
         IMeterGlucoseRepository meterGlucoseRepository,
         ICalibrationRepository calibrationRepository,
         IGlucoseProcessingResolver glucoseResolver,
+        IPatientDeviceStamper patientDeviceStamper,
         IAuditContext auditContext,
         ILogger<EntryDecomposer> logger)
     {
@@ -51,6 +55,7 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
         _meterGlucoseRepository = meterGlucoseRepository;
         _calibrationRepository = calibrationRepository;
         _glucoseResolver = glucoseResolver;
+        _patientDeviceStamper = patientDeviceStamper;
         _auditContext = auditContext;
         _logger = logger;
     }
@@ -108,6 +113,10 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
         }
 
         await _glucoseResolver.ResolveAsync(model, gpHint, smoothedHint, unsmoothedHint, ct);
+        // Carry an earlier attribution forward on re-upload: the rebuilt model starts null and a
+        // later ambiguous stamp (e.g. a second device registered since) must not wipe the stored FK.
+        model.PatientDeviceId = existing?.PatientDeviceId;
+        await _patientDeviceStamper.StampAsync([model], [DeviceCategory.CGM], model.DataSource, ct);
 
         if (existing != null)
         {
@@ -131,6 +140,8 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
             : null;
 
         var model = MapToMeterGlucose(entry, result.CorrelationId);
+        model.PatientDeviceId = existing?.PatientDeviceId;
+        await _patientDeviceStamper.StampAsync([model], [DeviceCategory.GlucoseMeter], model.DataSource, ct);
 
         if (existing != null)
         {
@@ -221,6 +232,11 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
                     break;
             }
         }
+
+        if (sgvList.Count > 0)
+            await _patientDeviceStamper.StampAsync(sgvList, [DeviceCategory.CGM], batchSource: null, ct);
+        if (mbgList.Count > 0)
+            await _patientDeviceStamper.StampAsync(mbgList, [DeviceCategory.GlucoseMeter], batchSource: null, ct);
 
         using (SystemAuditScope.Push(_auditContext))
         {

--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -77,6 +77,24 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
     private static readonly V4Models.DeviceCategory[] TempBasalDeviceCategories =
         [V4Models.DeviceCategory.InsulinPump];
 
+    private static readonly V4Models.DeviceCategory[] PumpEventDeviceCategories =
+        [V4Models.DeviceCategory.InsulinPump];
+
+    private static readonly V4Models.DeviceCategory[] SensorEventDeviceCategories =
+        [V4Models.DeviceCategory.CGM];
+
+    /// <summary>
+    /// Sensor lifecycle events attribute to the CGM; every other device event is pump-originated.
+    /// </summary>
+    private static bool IsSensorEvent(DeviceEventType eventType) => eventType is
+        DeviceEventType.SensorStart or
+        DeviceEventType.SensorChange or
+        DeviceEventType.SensorStop or
+        DeviceEventType.TransmitterSensorInsert;
+
+    private static V4Models.DeviceCategory[] DeviceEventCategories(DeviceEventType eventType) =>
+        IsSensorEvent(eventType) ? SensorEventDeviceCategories : PumpEventDeviceCategories;
+
     /// <param name="dbContext">EF Core context used to look up treatment entity PKs and run bulk deletes.</param>
     /// <param name="bolusRepository">Repository for <see cref="V4Models.Bolus"/> records.</param>
     /// <param name="tempBasalRepository">Repository for <see cref="V4Models.TempBasal"/> records.</param>
@@ -622,6 +640,8 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         model.DeviceId = await _deviceService.ResolveAsync(
             V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
         model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
+        model.PatientDeviceId ??= existing?.PatientDeviceId;
+        await _patientDeviceStamper.StampAsync([model], DeviceEventCategories(model.EventType), model.DataSource, ct);
 
         if (existing != null)
         {
@@ -1363,6 +1383,15 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             await _patientDeviceStamper.StampAsync(bolusList, BolusDeviceCategories, batchSource: null, ct);
         if (tempBasalList.Count > 0)
             await _patientDeviceStamper.StampAsync(tempBasalList, TempBasalDeviceCategories, batchSource: null, ct);
+        if (deviceEventList.Count > 0)
+        {
+            var sensorEvents = deviceEventList.Where(e => IsSensorEvent(e.EventType)).ToList();
+            var pumpEvents = deviceEventList.Where(e => !IsSensorEvent(e.EventType)).ToList();
+            if (sensorEvents.Count > 0)
+                await _patientDeviceStamper.StampAsync(sensorEvents, SensorEventDeviceCategories, batchSource: null, ct);
+            if (pumpEvents.Count > 0)
+                await _patientDeviceStamper.StampAsync(pumpEvents, PumpEventDeviceCategories, batchSource: null, ct);
+        }
 
         // Pre-pass: upsert profile switch StateSpans first (temp basals depend on them for insulin context)
         var batchInsulinTimeline = new SortedDictionary<long, V4Models.TreatmentInsulinContext>();

--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -50,6 +50,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
     private readonly IStateSpanService _stateSpanService;
     private readonly ITreatmentFoodService _treatmentFoodService;
     private readonly IDeviceService _deviceService;
+    private readonly IPatientDeviceStamper _patientDeviceStamper;
     private readonly IProfileDecomposer _profileDecomposer;
     private readonly IActiveProfileResolver _activeProfileResolver;
     private readonly IPatientInsulinRepository _insulinRepo;
@@ -66,6 +67,16 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         "TempBasal"
     ];
 
+    /// <summary>
+    /// Categories eligible for fallback attribution when the upload carries no pump serial
+    /// (serial-based DeviceId → PatientDevice resolution takes precedence).
+    /// </summary>
+    private static readonly V4Models.DeviceCategory[] BolusDeviceCategories =
+        [V4Models.DeviceCategory.InsulinPump, V4Models.DeviceCategory.SmartPen];
+
+    private static readonly V4Models.DeviceCategory[] TempBasalDeviceCategories =
+        [V4Models.DeviceCategory.InsulinPump];
+
     /// <param name="dbContext">EF Core context used to look up treatment entity PKs and run bulk deletes.</param>
     /// <param name="bolusRepository">Repository for <see cref="V4Models.Bolus"/> records.</param>
     /// <param name="tempBasalRepository">Repository for <see cref="V4Models.TempBasal"/> records.</param>
@@ -77,6 +88,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
     /// <param name="stateSpanService">Service used to upsert state spans for TempBasal, ProfileSwitch, Override, and TemporaryTarget treatments.</param>
     /// <param name="treatmentFoodService">Service for preserving legacy <see cref="Treatment.FoodType"/> as a <see cref="TreatmentFood"/> entry.</param>
     /// <param name="deviceService">Service that resolves or creates canonical device references.</param>
+    /// <param name="patientDeviceStamper">Fallback attribution for records whose upload carries no pump serial.</param>
     /// <param name="profileDecomposer">Decomposes inline profile JSON from profile switch treatments into V4 schedule records.</param>
     /// <param name="activeProfileResolver">Resolves insulin context from profile switches active at a given timestamp.</param>
     /// <param name="insulinRepo">Repository for patient insulin records, used as fallback for insulin context resolution.</param>
@@ -93,6 +105,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         IStateSpanService stateSpanService,
         ITreatmentFoodService treatmentFoodService,
         IDeviceService deviceService,
+        IPatientDeviceStamper patientDeviceStamper,
         IProfileDecomposer profileDecomposer,
         IActiveProfileResolver activeProfileResolver,
         IPatientInsulinRepository insulinRepo,
@@ -110,6 +123,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         _stateSpanService = stateSpanService;
         _treatmentFoodService = treatmentFoodService;
         _deviceService = deviceService;
+        _patientDeviceStamper = patientDeviceStamper;
         _profileDecomposer = profileDecomposer;
         _activeProfileResolver = activeProfileResolver;
         _insulinRepo = insulinRepo;
@@ -465,6 +479,8 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         model.DeviceId = await _deviceService.ResolveAsync(
             V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
         model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
+        model.PatientDeviceId ??= existing?.PatientDeviceId;
+        await _patientDeviceStamper.StampAsync([model], BolusDeviceCategories, model.DataSource, ct);
 
         if (existing != null)
         {
@@ -493,6 +509,8 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         model.DeviceId = await _deviceService.ResolveAsync(
             V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
         model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
+        model.PatientDeviceId ??= existing?.PatientDeviceId;
+        await _patientDeviceStamper.StampAsync([model], BolusDeviceCategories, model.DataSource, ct);
 
         if (existing != null)
         {
@@ -712,6 +730,8 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         model.DeviceId = await _deviceService.ResolveAsync(
             V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
         model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
+        model.PatientDeviceId ??= existing?.PatientDeviceId;
+        await _patientDeviceStamper.StampAsync([model], TempBasalDeviceCategories, model.DataSource, ct);
 
         // Resolve insulin context: active profile switch → primary insulin → null
         model.InsulinContext = await _activeProfileResolver.GetActiveInsulinContextAsync(treatment.Mills, ct);
@@ -1337,6 +1357,12 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
                     treatment.EventType, treatment.Id);
             }
         }
+
+        // Fallback attribution for records the serial-based DeviceId resolution left unattributed.
+        if (bolusList.Count > 0)
+            await _patientDeviceStamper.StampAsync(bolusList, BolusDeviceCategories, batchSource: null, ct);
+        if (tempBasalList.Count > 0)
+            await _patientDeviceStamper.StampAsync(tempBasalList, TempBasalDeviceCategories, batchSource: null, ct);
 
         // Pre-pass: upsert profile switch StateSpans first (temp basals depend on them for insulin context)
         var batchInsulinTimeline = new SortedDictionary<long, V4Models.TreatmentInsulinContext>();

--- a/src/Core/Nocturne.Core.Contracts/Devices/IPatientDeviceStamper.cs
+++ b/src/Core/Nocturne.Core.Contracts/Devices/IPatientDeviceStamper.cs
@@ -1,0 +1,27 @@
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.Core.Contracts.Devices;
+
+/// <summary>
+/// Stamps <see cref="IDeviceAttributed.PatientDeviceId"/> on ingested records by matching each
+/// record's timestamp against the usage windows of the patient's registered devices.
+/// </summary>
+/// <seealso cref="IDeviceAttributed"/>
+/// <seealso cref="PatientDevice"/>
+public interface IPatientDeviceStamper
+{
+    /// <summary>
+    /// Attributes each unstamped record to a <see cref="PatientDevice"/> of one of the given
+    /// categories, or leaves it null when no registered device matches or the match is ambiguous.
+    /// Failures are logged and swallowed — records proceed without a device link.
+    /// </summary>
+    /// <param name="records">Records to stamp; already-stamped records are skipped.</param>
+    /// <param name="categories">Device categories eligible to receive the records.</param>
+    /// <param name="batchSource">Data source of the batch, used when a record carries no DataSource.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task StampAsync(
+        IReadOnlyList<IDeviceAttributed> records,
+        IReadOnlyList<DeviceCategory> categories,
+        string? batchSource,
+        CancellationToken ct = default);
+}

--- a/src/Core/Nocturne.Core.Models/Timezones/TimezoneTimeline.cs
+++ b/src/Core/Nocturne.Core.Models/Timezones/TimezoneTimeline.cs
@@ -78,6 +78,26 @@ public sealed class TimezoneTimeline
     public string? ZoneAt(DateTime fakeUtc) =>
         ResolveEntry(DateTime.SpecifyKind(fakeUtc, DateTimeKind.Unspecified))?.Timezone;
 
+    /// <summary>
+    /// Converts a true UTC instant to the local wall-clock in the zone in effect at that time.
+    /// When no entry covers the instant, falls back to the fixed offset; with no offset the UTC
+    /// value is returned unchanged.
+    /// </summary>
+    /// <remarks>
+    /// Entry lookup happens in wall-clock space, so resolving from a UTC instant is off by the
+    /// zone offset within hours of a relocation entry's boundary — acceptable for day-granularity
+    /// consumers such as device usage-window matching.
+    /// </remarks>
+    public DateTime ToLocal(DateTime utc)
+    {
+        var entry = ResolveEntry(DateTime.SpecifyKind(utc, DateTimeKind.Unspecified));
+        if (entry is null)
+            return _fallbackOffsetHours is { } offset ? utc.AddHours(offset) : utc;
+
+        var tz = TimeZoneHelper.GetTimeZoneInfoFromId(entry.Timezone);
+        return TimeZoneInfo.ConvertTimeFromUtc(DateTime.SpecifyKind(utc, DateTimeKind.Utc), tz);
+    }
+
     private TimezoneTimelineEntry? ResolveEntry(DateTime wallUnspecified)
     {
         // Entries are descending by EffectiveFrom, so the first one at or before the instant wins.

--- a/src/Core/Nocturne.Core.Models/V4/BasalInjection.cs
+++ b/src/Core/Nocturne.Core.Models/V4/BasalInjection.cs
@@ -9,7 +9,7 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="PatientInsulin"/>
 /// <seealso cref="TreatmentInsulinContext"/>
 /// <seealso cref="IV4Record"/>
-public class BasalInjection : IV4Record
+public class BasalInjection : IV4Record, IDeviceAttributed
 {
     public Guid Id { get; set; }
     public DateTime Timestamp { get; set; }
@@ -23,6 +23,11 @@ public class BasalInjection : IV4Record
 
     public Guid? CorrelationId { get; set; }
     public string? LegacyId { get; set; }
+
+    /// <summary>
+    /// Foreign key to the <see cref="PatientDevice"/> (pen) this injection is attributed to.
+    /// </summary>
+    public Guid? PatientDeviceId { get; set; }
 
     public DateTime CreatedAt { get; set; }
     public DateTime ModifiedAt { get; set; }

--- a/src/Core/Nocturne.Core.Models/V4/Bolus.cs
+++ b/src/Core/Nocturne.Core.Models/V4/Bolus.cs
@@ -23,7 +23,7 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="BolusType"/>
 /// <seealso cref="ApsSnapshot"/>
 /// <seealso cref="TempBasal"/>
-public class Bolus : IV4Record
+public class Bolus : IV4Record, IDeviceAttributed
 {
     /// <summary>
     /// UUID v7 primary key

--- a/src/Core/Nocturne.Core.Models/V4/DeviceEvent.cs
+++ b/src/Core/Nocturne.Core.Models/V4/DeviceEvent.cs
@@ -14,7 +14,7 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="DeviceEventType"/>
 /// <seealso cref="Device"/>
 /// <seealso cref="Note"/>
-public class DeviceEvent : IV4Record
+public class DeviceEvent : IV4Record, IDeviceAttributed
 {
     /// <summary>
     /// UUID v7 primary key

--- a/src/Core/Nocturne.Core.Models/V4/IDeviceAttributed.cs
+++ b/src/Core/Nocturne.Core.Models/V4/IDeviceAttributed.cs
@@ -17,6 +17,12 @@ public interface IDeviceAttributed
     /// <summary>Timestamp used to match the record against a device's usage window.</summary>
     DateTime Timestamp { get; }
 
+    /// <summary>
+    /// UTC offset in minutes from the originating device's local time. Used to compare against the
+    /// wearer's local date, since device usage windows are user-entered local dates.
+    /// </summary>
+    int? UtcOffset { get; }
+
     /// <summary>Device identifier string that produced or uploaded this record.</summary>
     string? Device { get; }
 

--- a/src/Core/Nocturne.Core.Models/V4/IDeviceAttributed.cs
+++ b/src/Core/Nocturne.Core.Models/V4/IDeviceAttributed.cs
@@ -1,0 +1,28 @@
+namespace Nocturne.Core.Models.V4;
+
+/// <summary>
+/// A time-series record that can be attributed to a specific <see cref="PatientDevice"/>.
+/// </summary>
+/// <remarks>
+/// Implemented by the record types whose data originates from a physical device the patient
+/// wears or carries (CGM readings, boluses, temp basals, pen injections, meter readings).
+/// <see cref="PatientDeviceId"/> is stamped at ingest time by matching <see cref="Timestamp"/>
+/// against the device's usage window; it stays null when no registered device matches or the
+/// match is ambiguous. <see cref="Timestamp"/> is the instant used for that matching — for
+/// span-based records it is the span start.
+/// </remarks>
+/// <seealso cref="PatientDevice"/>
+public interface IDeviceAttributed
+{
+    /// <summary>Timestamp used to match the record against a device's usage window.</summary>
+    DateTime Timestamp { get; }
+
+    /// <summary>Device identifier string that produced or uploaded this record.</summary>
+    string? Device { get; }
+
+    /// <summary>Origin data source identifier (e.g. a connector name).</summary>
+    string? DataSource { get; }
+
+    /// <summary>Foreign key to the <see cref="PatientDevice"/> this record is attributed to.</summary>
+    Guid? PatientDeviceId { get; set; }
+}

--- a/src/Core/Nocturne.Core.Models/V4/MeterGlucose.cs
+++ b/src/Core/Nocturne.Core.Models/V4/MeterGlucose.cs
@@ -18,7 +18,7 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="IV4Record"/>
 /// <seealso cref="BGCheck"/>
 /// <seealso cref="SensorGlucose"/>
-public class MeterGlucose : IV4Record
+public class MeterGlucose : IV4Record, IDeviceAttributed
 {
     /// <summary>
     /// UUID v7 primary key
@@ -64,6 +64,11 @@ public class MeterGlucose : IV4Record
     /// Original v1/v3 record ID for migration traceability
     /// </summary>
     public string? LegacyId { get; set; }
+
+    /// <summary>
+    /// Foreign key to the <see cref="PatientDevice"/> (meter) this reading is attributed to.
+    /// </summary>
+    public Guid? PatientDeviceId { get; set; }
 
     /// <summary>
     /// When this record was created

--- a/src/Core/Nocturne.Core.Models/V4/PatientDevice.cs
+++ b/src/Core/Nocturne.Core.Models/V4/PatientDevice.cs
@@ -91,6 +91,13 @@ public class PatientDevice
     public bool IsCurrent { get; set; }
 
     /// <summary>
+    /// Explicit priority among devices of the same category whose usage windows overlap
+    /// (lower value = higher priority). Null means unranked; unranked devices order after
+    /// ranked ones, most recent <see cref="StartDate"/> first.
+    /// </summary>
+    public int? Rank { get; set; }
+
+    /// <summary>
     /// Optional free-text notes about this device (e.g., reason for switch, warranty info).
     /// </summary>
     public string? Notes { get; set; }

--- a/src/Core/Nocturne.Core.Models/V4/SensorGlucose.cs
+++ b/src/Core/Nocturne.Core.Models/V4/SensorGlucose.cs
@@ -20,7 +20,7 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="GlucoseTrend"/>
 /// <seealso cref="MeterGlucose"/>
 /// <seealso cref="BGCheck"/>
-public class SensorGlucose : IV4Record
+public class SensorGlucose : IV4Record, IDeviceAttributed
 {
     /// <summary>
     /// UUID v7 primary key

--- a/src/Core/Nocturne.Core.Models/V4/TempBasal.cs
+++ b/src/Core/Nocturne.Core.Models/V4/TempBasal.cs
@@ -22,8 +22,13 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="ApsSnapshot"/>
 /// <seealso cref="BasalSchedule"/>
 /// <seealso cref="Device"/>
-public class TempBasal
+public class TempBasal : IDeviceAttributed
 {
+    /// <summary>
+    /// Attribution timestamp for device matching — the span start.
+    /// </summary>
+    DateTime IDeviceAttributed.Timestamp => StartTimestamp;
+
     /// <summary>
     /// UUID v7 primary key
     /// </summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalInjectionEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalInjectionEntity.cs
@@ -78,6 +78,12 @@ public class BasalInjectionEntity : ITenantScoped, IAuditable, ISoftDeletable, I
     public string? LegacyId { get; set; }
 
     /// <summary>
+    /// FK to the PatientDevice (pen) this injection is attributed to
+    /// </summary>
+    [Column("patient_device_id")]
+    public Guid? PatientDeviceId { get; set; }
+
+    /// <summary>
     /// System tracking: when record was inserted
     /// </summary>
     [AuditIgnored]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/MeterGlucoseEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/MeterGlucoseEntity.cs
@@ -71,6 +71,12 @@ public class MeterGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4
     public string? LegacyId { get; set; }
 
     /// <summary>
+    /// FK to the PatientDevice (meter) this reading is attributed to
+    /// </summary>
+    [Column("patient_device_id")]
+    public Guid? PatientDeviceId { get; set; }
+
+    /// <summary>
     /// System tracking: when record was inserted
     /// </summary>
     [Column("sys_created_at")]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PatientDeviceEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PatientDeviceEntity.cs
@@ -91,6 +91,12 @@ public class PatientDeviceEntity : ITenantScoped, ISoftDeletable, ISystemTimesta
     public bool IsCurrent { get; set; }
 
     /// <summary>
+    /// Explicit priority among overlapping devices of the same category (lower = higher priority, null = unranked)
+    /// </summary>
+    [Column("rank")]
+    public int? Rank { get; set; }
+
+    /// <summary>
     /// Free-text notes about the device
     /// </summary>
     [Column("notes")]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BasalInjectionMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BasalInjectionMapper.cs
@@ -32,6 +32,7 @@ public static class BasalInjectionMapper
             SyncIdentifier = model.SyncIdentifier,
             CorrelationId = model.CorrelationId,
             LegacyId = model.LegacyId,
+            PatientDeviceId = model.PatientDeviceId,
             SysCreatedAt = DateTime.UtcNow,
             SysUpdatedAt = DateTime.UtcNow,
             Units = model.Units,
@@ -65,6 +66,7 @@ public static class BasalInjectionMapper
             SyncIdentifier = entity.SyncIdentifier,
             CorrelationId = entity.CorrelationId,
             LegacyId = entity.LegacyId,
+            PatientDeviceId = entity.PatientDeviceId,
             CreatedAt = entity.SysCreatedAt,
             ModifiedAt = entity.SysUpdatedAt,
             Units = entity.Units,
@@ -95,6 +97,7 @@ public static class BasalInjectionMapper
         entity.SyncIdentifier = model.SyncIdentifier;
         entity.CorrelationId = model.CorrelationId;
         entity.LegacyId = model.LegacyId;
+        entity.PatientDeviceId = model.PatientDeviceId;
         entity.SysUpdatedAt = DateTime.UtcNow;
         entity.Units = model.Units;
         entity.Notes = model.Notes;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/MeterGlucoseMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/MeterGlucoseMapper.cs
@@ -26,6 +26,7 @@ public static class MeterGlucoseMapper
             DataSource = model.DataSource,
             CorrelationId = model.CorrelationId,
             LegacyId = model.LegacyId,
+            PatientDeviceId = model.PatientDeviceId,
             SysCreatedAt = DateTime.UtcNow,
             SysUpdatedAt = DateTime.UtcNow,
             Mgdl = model.Mgdl,
@@ -52,6 +53,7 @@ public static class MeterGlucoseMapper
             DataSource = entity.DataSource,
             CorrelationId = entity.CorrelationId,
             LegacyId = entity.LegacyId,
+            PatientDeviceId = entity.PatientDeviceId,
             CreatedAt = entity.SysCreatedAt,
             ModifiedAt = entity.SysUpdatedAt,
             Mgdl = entity.Mgdl,
@@ -75,6 +77,7 @@ public static class MeterGlucoseMapper
         entity.DataSource = model.DataSource;
         entity.CorrelationId = model.CorrelationId;
         entity.LegacyId = model.LegacyId;
+        entity.PatientDeviceId = model.PatientDeviceId;
         entity.SysUpdatedAt = DateTime.UtcNow;
         entity.Mgdl = model.Mgdl;
         entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/PatientDeviceMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/PatientDeviceMapper.cs
@@ -28,6 +28,7 @@ public static class PatientDeviceMapper
             StartDate = model.StartDate,
             EndDate = model.EndDate,
             IsCurrent = model.IsCurrent,
+            Rank = model.Rank,
             Notes = model.Notes,
             SysCreatedAt = DateTime.UtcNow,
             SysUpdatedAt = DateTime.UtcNow,
@@ -59,6 +60,7 @@ public static class PatientDeviceMapper
             StartDate = entity.StartDate,
             EndDate = entity.EndDate,
             IsCurrent = entity.IsCurrent,
+            Rank = entity.Rank,
             Notes = entity.Notes,
             CreatedAt = entity.SysCreatedAt,
             ModifiedAt = entity.SysUpdatedAt,
@@ -82,6 +84,7 @@ public static class PatientDeviceMapper
         entity.StartDate = model.StartDate;
         entity.EndDate = model.EndDate;
         entity.IsCurrent = model.IsCurrent;
+        entity.Rank = model.Rank;
         entity.Notes = model.Notes;
         entity.SysUpdatedAt = DateTime.UtcNow;
     }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260701215357_MultiCgmDeviceAttribution.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260701215357_MultiCgmDeviceAttribution.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260701215357_MultiCgmDeviceAttribution")]
+    partial class MultiCgmDeviceAttribution
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260701215357_MultiCgmDeviceAttribution.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260701215357_MultiCgmDeviceAttribution.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class MultiCgmDeviceAttribution : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "rank",
+                table: "patient_devices",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "patient_device_id",
+                table: "meter_glucose",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "patient_device_id",
+                table: "basal_injections",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_meter_glucose_patient_device_id",
+                table: "meter_glucose",
+                column: "patient_device_id",
+                filter: "patient_device_id IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_basal_injections_patient_device_id",
+                table: "basal_injections",
+                column: "patient_device_id",
+                filter: "patient_device_id IS NOT NULL");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_basal_injections_patient_devices_patient_device_id",
+                table: "basal_injections",
+                column: "patient_device_id",
+                principalTable: "patient_devices",
+                principalColumn: "id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_meter_glucose_patient_devices_patient_device_id",
+                table: "meter_glucose",
+                column: "patient_device_id",
+                principalTable: "patient_devices",
+                principalColumn: "id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_basal_injections_patient_devices_patient_device_id",
+                table: "basal_injections");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_meter_glucose_patient_devices_patient_device_id",
+                table: "meter_glucose");
+
+            migrationBuilder.DropIndex(
+                name: "ix_meter_glucose_patient_device_id",
+                table: "meter_glucose");
+
+            migrationBuilder.DropIndex(
+                name: "ix_basal_injections_patient_device_id",
+                table: "basal_injections");
+
+            migrationBuilder.DropColumn(
+                name: "rank",
+                table: "patient_devices");
+
+            migrationBuilder.DropColumn(
+                name: "patient_device_id",
+                table: "meter_glucose");
+
+            migrationBuilder.DropColumn(
+                name: "patient_device_id",
+                table: "basal_injections");
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -2286,6 +2286,32 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             .OnDelete(DeleteBehavior.SetNull);
 
         modelBuilder
+            .Entity<BasalInjectionEntity>()
+            .HasOne<PatientDeviceEntity>()
+            .WithMany()
+            .HasForeignKey(e => e.PatientDeviceId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        modelBuilder
+            .Entity<BasalInjectionEntity>()
+            .HasIndex(e => e.PatientDeviceId)
+            .HasDatabaseName("ix_basal_injections_patient_device_id")
+            .HasFilter("patient_device_id IS NOT NULL");
+
+        modelBuilder
+            .Entity<MeterGlucoseEntity>()
+            .HasOne<PatientDeviceEntity>()
+            .WithMany()
+            .HasForeignKey(e => e.PatientDeviceId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        modelBuilder
+            .Entity<MeterGlucoseEntity>()
+            .HasIndex(e => e.PatientDeviceId)
+            .HasDatabaseName("ix_meter_glucose_patient_device_id")
+            .HasFilter("patient_device_id IS NOT NULL");
+
+        modelBuilder
             .Entity<UploaderSnapshotEntity>()
             .HasOne<DeviceEntity>()
             .WithMany()

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PatientDeviceRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PatientDeviceRepository.cs
@@ -57,7 +57,9 @@ public class PatientDeviceRepository : IPatientDeviceRepository
         var entities = await ctx.PatientDevices
             .AsNoTracking()
             .Where(e => e.IsCurrent)
-            .OrderByDescending(e => e.StartDate)
+            .OrderBy(e => e.Rank == null)
+            .ThenBy(e => e.Rank)
+            .ThenByDescending(e => e.StartDate)
             .ToListAsync(ct);
 
         return entities.Select(PatientDeviceMapper.ToDomainModel);
@@ -84,7 +86,9 @@ public class PatientDeviceRepository : IPatientDeviceRepository
             .Where(e =>
                 (e.StartDate == null || e.StartDate <= toDate) &&
                 (e.EndDate == null || e.EndDate >= fromDate))
-            .OrderByDescending(e => e.StartDate)
+            .OrderBy(e => e.Rank == null)
+            .ThenBy(e => e.Rank)
+            .ThenByDescending(e => e.StartDate)
             .ToListAsync(ct);
 
         return entities.Select(PatientDeviceMapper.ToDomainModel);

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/GlucosePublisherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/GlucosePublisherTests.cs
@@ -1,11 +1,11 @@
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.API.Services.ConnectorPublishing;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Contracts.Alerts;
 using Nocturne.Core.Contracts.Multitenancy;
@@ -23,19 +23,19 @@ public class GlucosePublisherTests
 {
     private readonly Mock<IEntryService> _mockEntryService;
     private readonly Mock<ISensorGlucoseRepository> _mockSensorGlucoseRepository;
-    private readonly Mock<IPatientDeviceRepository> _mockPatientDeviceRepository;
+    private readonly Mock<IPatientDeviceStamper> _mockPatientDeviceStamper;
     private readonly GlucosePublisher _publisher;
 
     public GlucosePublisherTests()
     {
         _mockEntryService = new Mock<IEntryService>();
         _mockSensorGlucoseRepository = new Mock<ISensorGlucoseRepository>();
-        _mockPatientDeviceRepository = new Mock<IPatientDeviceRepository>();
+        _mockPatientDeviceStamper = new Mock<IPatientDeviceStamper>();
 
         _publisher = new GlucosePublisher(
             _mockEntryService.Object,
             _mockSensorGlucoseRepository.Object,
-            _mockPatientDeviceRepository.Object,
+            _mockPatientDeviceStamper.Object,
             Mock.Of<IDbContextFactory<NocturneDbContext>>(),
             Mock.Of<ITenantAccessor>(),
             Mock.Of<IAlertOrchestrator>(),
@@ -76,10 +76,6 @@ public class GlucosePublisherTests
     [Fact]
     public async Task PublishSensorGlucoseAsync_WritesThroughRepository_ForPublishedReadings()
     {
-        _mockPatientDeviceRepository
-            .Setup(r => r.GetCurrentAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Enumerable.Empty<PatientDevice>());
-
         var records = new List<SensorGlucose>
         {
             new() { Mgdl = 120, Timestamp = DateTime.UtcNow.AddMinutes(-5), DataSource = DataSources.DexcomConnector },
@@ -100,6 +96,29 @@ public class GlucosePublisherTests
             r => r.BulkCreateAsync(
                 It.Is<IEnumerable<SensorGlucose>>(l => l.Count() == 2),
                 It.IsAny<WriteOrigin>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task PublishSensorGlucoseAsync_StampsRecordsAsCgm_BeforeWriting()
+    {
+        var records = new List<SensorGlucose>
+        {
+            new() { Mgdl = 120, Timestamp = DateTime.UtcNow, DataSource = DataSources.DexcomConnector },
+        };
+        _mockSensorGlucoseRepository
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
+
+        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector, WriteOrigin.Live);
+
+        result.Should().BeTrue();
+        _mockPatientDeviceStamper.Verify(
+            s => s.StampAsync(
+                It.Is<IReadOnlyList<IDeviceAttributed>>(l => l.Count == 1),
+                It.Is<IReadOnlyList<DeviceCategory>>(c => c.Single() == DeviceCategory.CGM),
+                DataSources.DexcomConnector,
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -140,272 +159,5 @@ public class GlucosePublisherTests
         var result = await _publisher.GetLatestEntryTimestampAsync("test-source");
 
         result.Should().BeNull();
-    }
-
-    // =========================================================================
-    // PatientDeviceId stamping tests
-    // =========================================================================
-
-    [Fact]
-    public async Task PublishSensorGlucoseAsync_StampsPatientDeviceId_WhenMatchingCgmDeviceExists()
-    {
-        var deviceId = Guid.NewGuid();
-        _mockPatientDeviceRepository
-            .Setup(r => r.GetCurrentAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[]
-            {
-                new PatientDevice
-                {
-                    Id = deviceId,
-                    DeviceCategory = DeviceCategory.CGM,
-                    Manufacturer = "Dexcom",
-                    Model = "Dexcom G7",
-                    IsCurrent = true,
-                },
-            });
-
-        List<SensorGlucose>? captured = null;
-        _mockSensorGlucoseRepository
-            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback<IEnumerable<SensorGlucose>, WriteOrigin, CancellationToken>((records, _, _) => captured = records.ToList())
-            .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
-
-        var records = new List<SensorGlucose>
-        {
-            new() { Mgdl = 120, Timestamp = DateTime.UtcNow, DataSource = DataSources.DexcomConnector },
-        };
-
-        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector, WriteOrigin.Live);
-
-        result.Should().BeTrue();
-        captured.Should().NotBeNull();
-        captured![0].PatientDeviceId.Should().Be(deviceId);
-    }
-
-    [Fact]
-    public async Task PublishSensorGlucoseAsync_LeavesPatientDeviceIdNull_WhenNoCgmDeviceExists()
-    {
-        _mockPatientDeviceRepository
-            .Setup(r => r.GetCurrentAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Enumerable.Empty<PatientDevice>());
-
-        List<SensorGlucose>? captured = null;
-        _mockSensorGlucoseRepository
-            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback<IEnumerable<SensorGlucose>, WriteOrigin, CancellationToken>((records, _, _) => captured = records.ToList())
-            .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
-
-        var records = new List<SensorGlucose>
-        {
-            new() { Mgdl = 120, Timestamp = DateTime.UtcNow, DataSource = DataSources.DexcomConnector },
-        };
-
-        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector, WriteOrigin.Live);
-
-        result.Should().BeTrue();
-        captured.Should().NotBeNull();
-        captured![0].PatientDeviceId.Should().BeNull();
-    }
-
-    [Fact]
-    public async Task PublishSensorGlucoseAsync_MatchesByManufacturer_AbbottToLibreConnector()
-    {
-        var deviceId = Guid.NewGuid();
-        _mockPatientDeviceRepository
-            .Setup(r => r.GetCurrentAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[]
-            {
-                new PatientDevice
-                {
-                    Id = deviceId,
-                    DeviceCategory = DeviceCategory.CGM,
-                    Manufacturer = "Abbott",
-                    Model = "FreeStyle Libre 3",
-                    IsCurrent = true,
-                },
-            });
-
-        List<SensorGlucose>? captured = null;
-        _mockSensorGlucoseRepository
-            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback<IEnumerable<SensorGlucose>, WriteOrigin, CancellationToken>((records, _, _) => captured = records.ToList())
-            .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
-
-        var records = new List<SensorGlucose>
-        {
-            new() { Mgdl = 95, Timestamp = DateTime.UtcNow, DataSource = DataSources.LibreConnector },
-        };
-
-        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.LibreConnector, WriteOrigin.Live);
-
-        result.Should().BeTrue();
-        captured![0].PatientDeviceId.Should().Be(deviceId);
-    }
-
-    [Fact]
-    public async Task PublishSensorGlucoseAsync_FallsBackToSourceParameter_WhenRecordHasNoDataSource()
-    {
-        var deviceId = Guid.NewGuid();
-        _mockPatientDeviceRepository
-            .Setup(r => r.GetCurrentAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[]
-            {
-                new PatientDevice
-                {
-                    Id = deviceId,
-                    DeviceCategory = DeviceCategory.CGM,
-                    Manufacturer = "Dexcom",
-                    Model = "Dexcom G7",
-                    IsCurrent = true,
-                },
-            });
-
-        List<SensorGlucose>? captured = null;
-        _mockSensorGlucoseRepository
-            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback<IEnumerable<SensorGlucose>, WriteOrigin, CancellationToken>((records, _, _) => captured = records.ToList())
-            .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
-
-        var records = new List<SensorGlucose>
-        {
-            new() { Mgdl = 110, Timestamp = DateTime.UtcNow, DataSource = null },
-        };
-
-        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector, WriteOrigin.Live);
-
-        result.Should().BeTrue();
-        captured![0].PatientDeviceId.Should().Be(deviceId);
-    }
-
-    [Fact]
-    public async Task PublishSensorGlucoseAsync_DoesNotOverwrite_ExistingPatientDeviceId()
-    {
-        var existingDeviceId = Guid.NewGuid();
-        var cgmDeviceId = Guid.NewGuid();
-
-        _mockPatientDeviceRepository
-            .Setup(r => r.GetCurrentAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[]
-            {
-                new PatientDevice
-                {
-                    Id = cgmDeviceId,
-                    DeviceCategory = DeviceCategory.CGM,
-                    Manufacturer = "Dexcom",
-                    Model = "Dexcom G7",
-                    IsCurrent = true,
-                },
-            });
-
-        List<SensorGlucose>? captured = null;
-        _mockSensorGlucoseRepository
-            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback<IEnumerable<SensorGlucose>, WriteOrigin, CancellationToken>((records, _, _) => captured = records.ToList())
-            .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
-
-        var records = new List<SensorGlucose>
-        {
-            new() { Mgdl = 100, Timestamp = DateTime.UtcNow, DataSource = DataSources.DexcomConnector, PatientDeviceId = existingDeviceId },
-        };
-
-        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector, WriteOrigin.Live);
-
-        result.Should().BeTrue();
-        captured![0].PatientDeviceId.Should().Be(existingDeviceId);
-    }
-
-    [Fact]
-    public async Task PublishSensorGlucoseAsync_UsesCatalogManufacturer_WhenCatalogIdIsSet()
-    {
-        var deviceId = Guid.NewGuid();
-        _mockPatientDeviceRepository
-            .Setup(r => r.GetCurrentAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[]
-            {
-                new PatientDevice
-                {
-                    Id = deviceId,
-                    DeviceCategory = DeviceCategory.CGM,
-                    Manufacturer = "SomeOldValue",
-                    Model = "Dexcom G7",
-                    CatalogId = "dexcom-g7",
-                    IsCurrent = true,
-                },
-            });
-
-        List<SensorGlucose>? captured = null;
-        _mockSensorGlucoseRepository
-            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback<IEnumerable<SensorGlucose>, WriteOrigin, CancellationToken>((records, _, _) => captured = records.ToList())
-            .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
-
-        var records = new List<SensorGlucose>
-        {
-            new() { Mgdl = 130, Timestamp = DateTime.UtcNow, DataSource = DataSources.DexcomConnector },
-        };
-
-        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector, WriteOrigin.Live);
-
-        result.Should().BeTrue();
-        captured![0].PatientDeviceId.Should().Be(deviceId);
-    }
-
-    [Fact]
-    public async Task PublishSensorGlucoseAsync_IgnoresNonCgmDevices()
-    {
-        var pumpId = Guid.NewGuid();
-        _mockPatientDeviceRepository
-            .Setup(r => r.GetCurrentAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[]
-            {
-                new PatientDevice
-                {
-                    Id = pumpId,
-                    DeviceCategory = DeviceCategory.InsulinPump,
-                    Manufacturer = "Insulet",
-                    Model = "Omnipod 5",
-                    IsCurrent = true,
-                },
-            });
-
-        List<SensorGlucose>? captured = null;
-        _mockSensorGlucoseRepository
-            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback<IEnumerable<SensorGlucose>, WriteOrigin, CancellationToken>((records, _, _) => captured = records.ToList())
-            .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
-
-        var records = new List<SensorGlucose>
-        {
-            new() { Mgdl = 100, Timestamp = DateTime.UtcNow, DataSource = DataSources.DexcomConnector },
-        };
-
-        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector, WriteOrigin.Live);
-
-        result.Should().BeTrue();
-        captured![0].PatientDeviceId.Should().BeNull();
-    }
-
-    [Fact]
-    public async Task PublishSensorGlucoseAsync_ContinuesOnDeviceResolutionFailure()
-    {
-        _mockPatientDeviceRepository
-            .Setup(r => r.GetCurrentAsync(It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new InvalidOperationException("DB error"));
-
-        _mockSensorGlucoseRepository
-            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
-
-        var records = new List<SensorGlucose>
-        {
-            new() { Mgdl = 100, Timestamp = DateTime.UtcNow, DataSource = DataSources.DexcomConnector },
-        };
-
-        var result = await _publisher.PublishSensorGlucoseAsync(records, DataSources.DexcomConnector, WriteOrigin.Live);
-
-        result.Should().BeTrue();
-        _mockSensorGlucoseRepository.Verify(
-            r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
-            Times.Once);
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/TreatmentPublisherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/TreatmentPublisherTests.cs
@@ -6,6 +6,7 @@ using Moq;
 using Nocturne.API.Services.Audit;
 using Nocturne.API.Services.ConnectorPublishing;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.V4.Repositories;
@@ -91,6 +92,7 @@ public class TreatmentPublisherTests
             _mockPatientInsulinRepository.Object,
             _mockBasalRateResolver.Object,
             _mockTherapySettingsResolver.Object,
+            Mock.Of<IPatientDeviceStamper>(),
             auditContext,
             NullLogger<TreatmentPublisher>.Instance
         );

--- a/tests/Unit/Nocturne.API.Tests/Services/Devices/PatientDeviceStamperTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Devices/PatientDeviceStamperTests.cs
@@ -1,0 +1,289 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Devices;
+using Nocturne.Core.Constants;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.V4;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Devices;
+
+[Trait("Category", "Unit")]
+public class PatientDeviceStamperTests
+{
+    private readonly Mock<IPatientDeviceRepository> _mockRepository;
+    private readonly PatientDeviceStamper _stamper;
+
+    private static readonly DateTime Now = new(2026, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+
+    public PatientDeviceStamperTests()
+    {
+        _mockRepository = new Mock<IPatientDeviceRepository>();
+        _stamper = new PatientDeviceStamper(_mockRepository.Object, NullLogger<PatientDeviceStamper>.Instance);
+    }
+
+    private void SetupDevices(params PatientDevice[] devices)
+    {
+        _mockRepository
+            .Setup(r => r.GetByDateRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(devices);
+    }
+
+    private static PatientDevice Cgm(
+        string manufacturer,
+        Guid? id = null,
+        string? serial = null,
+        string? catalogId = null,
+        DateOnly? start = null,
+        DateOnly? end = null,
+        int? rank = null) => new()
+    {
+        Id = id ?? Guid.NewGuid(),
+        DeviceCategory = DeviceCategory.CGM,
+        Manufacturer = manufacturer,
+        Model = manufacturer + " CGM",
+        SerialNumber = serial,
+        CatalogId = catalogId,
+        StartDate = start,
+        EndDate = end,
+        Rank = rank,
+        IsCurrent = end is null,
+    };
+
+    private static SensorGlucose Reading(string? dataSource = null, string? device = null, DateTime? timestamp = null) => new()
+    {
+        Mgdl = 120,
+        Timestamp = timestamp ?? Now,
+        DataSource = dataSource,
+        Device = device,
+    };
+
+    [Fact]
+    public async Task SingleActiveDevice_Stamps_EvenWithoutManufacturerMapping()
+    {
+        var device = Cgm("Custom");
+        SetupDevices(device);
+        var record = Reading(dataSource: DataSources.XDrip);
+
+        await _stamper.StampAsync([record], [DeviceCategory.CGM], DataSources.XDrip);
+
+        record.PatientDeviceId.Should().Be(device.Id);
+    }
+
+    [Fact]
+    public async Task NoRegisteredDevices_LeavesNull()
+    {
+        SetupDevices();
+        var record = Reading(dataSource: DataSources.DexcomConnector);
+
+        await _stamper.StampAsync([record], [DeviceCategory.CGM], DataSources.DexcomConnector);
+
+        record.PatientDeviceId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task WrongCategoryDevices_LeaveNull()
+    {
+        var pump = Cgm("Insulet");
+        pump.DeviceCategory = DeviceCategory.InsulinPump;
+        SetupDevices(pump);
+        var record = Reading(dataSource: DataSources.DexcomConnector);
+
+        await _stamper.StampAsync([record], [DeviceCategory.CGM], DataSources.DexcomConnector);
+
+        record.PatientDeviceId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AlreadyStampedRecord_IsNotOverwritten()
+    {
+        var existing = Guid.NewGuid();
+        SetupDevices(Cgm("Dexcom"));
+        var record = Reading(dataSource: DataSources.DexcomConnector);
+        record.PatientDeviceId = existing;
+
+        await _stamper.StampAsync([record], [DeviceCategory.CGM], DataSources.DexcomConnector);
+
+        record.PatientDeviceId.Should().Be(existing);
+    }
+
+    [Fact]
+    public async Task TwoManufacturers_SourceDisambiguates()
+    {
+        var dexcom = Cgm("Dexcom");
+        var libre = Cgm("Abbott");
+        SetupDevices(dexcom, libre);
+
+        var dexcomRecord = Reading(dataSource: DataSources.DexcomConnector);
+        var libreRecord = Reading(dataSource: DataSources.LibreConnector);
+
+        await _stamper.StampAsync([dexcomRecord, libreRecord], [DeviceCategory.CGM], batchSource: null);
+
+        dexcomRecord.PatientDeviceId.Should().Be(dexcom.Id);
+        libreRecord.PatientDeviceId.Should().Be(libre.Id);
+    }
+
+    [Fact]
+    public async Task TwoSameManufacturerDevices_SameSource_LeavesNull()
+    {
+        SetupDevices(Cgm("Dexcom"), Cgm("Dexcom"));
+        var record = Reading(dataSource: DataSources.DexcomConnector);
+
+        await _stamper.StampAsync([record], [DeviceCategory.CGM], DataSources.DexcomConnector);
+
+        record.PatientDeviceId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TwoSameManufacturerDevices_SerialDisambiguates()
+    {
+        var older = Cgm("Dexcom", serial: "SM12345678");
+        var newer = Cgm("Dexcom", serial: "SM87654321");
+        SetupDevices(older, newer);
+        var record = Reading(dataSource: DataSources.DexcomConnector, device: "Dexcom G7 SM87654321");
+
+        await _stamper.StampAsync([record], [DeviceCategory.CGM], DataSources.DexcomConnector);
+
+        record.PatientDeviceId.Should().Be(newer.Id);
+    }
+
+    [Fact]
+    public async Task OverlappingAggregatorSource_TwoDevices_LeavesNull()
+    {
+        SetupDevices(Cgm("Dexcom"), Cgm("Abbott"));
+        var record = Reading(dataSource: DataSources.GlookoConnector);
+
+        await _stamper.StampAsync([record], [DeviceCategory.CGM], DataSources.GlookoConnector);
+
+        record.PatientDeviceId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task HistoricalRecord_StampsDeviceWornAtThatTime()
+    {
+        var retired = Cgm("Dexcom",
+            start: new DateOnly(2026, 1, 1),
+            end: new DateOnly(2026, 3, 31));
+        var current = Cgm("Abbott",
+            start: new DateOnly(2026, 4, 1));
+        SetupDevices(retired, current);
+
+        var backfilled = Reading(
+            dataSource: DataSources.NightscoutConnector,
+            timestamp: new DateTime(2026, 2, 10, 8, 0, 0, DateTimeKind.Utc));
+
+        await _stamper.StampAsync([backfilled], [DeviceCategory.CGM], DataSources.NightscoutConnector);
+
+        backfilled.PatientDeviceId.Should().Be(retired.Id);
+    }
+
+    [Fact]
+    public async Task ManufacturerSpecificSource_ContradictingSoleDevice_LeavesNull()
+    {
+        SetupDevices(Cgm("Dexcom"));
+        var record = Reading(dataSource: DataSources.LibreConnector);
+
+        await _stamper.StampAsync([record], [DeviceCategory.CGM], DataSources.LibreConnector);
+
+        record.PatientDeviceId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CatalogManufacturer_TakesPrecedenceOverManufacturerField()
+    {
+        var device = Cgm("SomeOldValue", catalogId: "dexcom-g7");
+        var other = Cgm("Abbott");
+        SetupDevices(device, other);
+        var record = Reading(dataSource: DataSources.DexcomConnector);
+
+        await _stamper.StampAsync([record], [DeviceCategory.CGM], DataSources.DexcomConnector);
+
+        record.PatientDeviceId.Should().Be(device.Id);
+    }
+
+    [Fact]
+    public async Task BatchSource_UsedWhenRecordHasNoDataSource()
+    {
+        var dexcom = Cgm("Dexcom");
+        var libre = Cgm("Abbott");
+        SetupDevices(dexcom, libre);
+        var record = Reading(dataSource: null);
+
+        await _stamper.StampAsync([record], [DeviceCategory.CGM], DataSources.DexcomConnector);
+
+        record.PatientDeviceId.Should().Be(dexcom.Id);
+    }
+
+    [Fact]
+    public async Task RepositoryFailure_IsSwallowed_RecordsProceedUnstamped()
+    {
+        _mockRepository
+            .Setup(r => r.GetByDateRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("DB error"));
+        var record = Reading(dataSource: DataSources.DexcomConnector);
+
+        var act = () => _stamper.StampAsync([record], [DeviceCategory.CGM], DataSources.DexcomConnector);
+
+        await act.Should().NotThrowAsync();
+        record.PatientDeviceId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AllRecordsAlreadyStamped_SkipsRepositoryLookup()
+    {
+        var record = Reading(dataSource: DataSources.DexcomConnector);
+        record.PatientDeviceId = Guid.NewGuid();
+
+        await _stamper.StampAsync([record], [DeviceCategory.CGM], DataSources.DexcomConnector);
+
+        _mockRepository.Verify(
+            r => r.GetByDateRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task MedtronicDevice_MatchesBothCareLinkAndMiniMedSources()
+    {
+        var medtronic = Cgm("Medtronic");
+        var dexcom = Cgm("Dexcom");
+        SetupDevices(medtronic, dexcom);
+
+        var carelinkRecord = Reading(dataSource: DataSources.CareLinkConnector);
+        var minimedRecord = Reading(dataSource: DataSources.MiniMedConnector);
+
+        await _stamper.StampAsync([carelinkRecord, minimedRecord], [DeviceCategory.CGM], batchSource: null);
+
+        carelinkRecord.PatientDeviceId.Should().Be(medtronic.Id);
+        minimedRecord.PatientDeviceId.Should().Be(medtronic.Id);
+    }
+
+    [Fact]
+    public async Task ShortSerial_DoesNotSubstringMatch()
+    {
+        // "G6" occurs incidentally in device strings; a 2-char serial must not beat the
+        // source-compatibility check.
+        var wrong = Cgm("Abbott", serial: "G6");
+        var right = Cgm("Dexcom");
+        SetupDevices(wrong, right);
+        var record = Reading(dataSource: DataSources.DexcomConnector, device: "xDrip-DexcomG6");
+
+        await _stamper.StampAsync([record], [DeviceCategory.CGM], DataSources.DexcomConnector);
+
+        record.PatientDeviceId.Should().Be(right.Id);
+    }
+
+    [Fact]
+    public async Task RecordOutsideEveryDeviceWindow_LeavesNull()
+    {
+        var device = Cgm("Dexcom", start: new DateOnly(2026, 6, 1));
+        SetupDevices(device);
+        var record = Reading(
+            dataSource: DataSources.DexcomConnector,
+            timestamp: new DateTime(2026, 1, 10, 0, 0, 0, DateTimeKind.Utc));
+
+        await _stamper.StampAsync([record], [DeviceCategory.CGM], DataSources.DexcomConnector);
+
+        record.PatientDeviceId.Should().BeNull();
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Devices/PatientDeviceStamperTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Devices/PatientDeviceStamperTests.cs
@@ -3,7 +3,9 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.API.Services.Devices;
 using Nocturne.Core.Constants;
+using Nocturne.Core.Contracts.Timezones;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.Timezones;
 using Nocturne.Core.Models.V4;
 using Xunit;
 
@@ -13,6 +15,7 @@ namespace Nocturne.API.Tests.Services.Devices;
 public class PatientDeviceStamperTests
 {
     private readonly Mock<IPatientDeviceRepository> _mockRepository;
+    private readonly Mock<ITimezoneTimelineService> _mockTimezoneTimeline;
     private readonly PatientDeviceStamper _stamper;
 
     private static readonly DateTime Now = new(2026, 6, 15, 12, 0, 0, DateTimeKind.Utc);
@@ -20,7 +23,13 @@ public class PatientDeviceStamperTests
     public PatientDeviceStamperTests()
     {
         _mockRepository = new Mock<IPatientDeviceRepository>();
-        _stamper = new PatientDeviceStamper(_mockRepository.Object, NullLogger<PatientDeviceStamper>.Instance);
+        _mockTimezoneTimeline = new Mock<ITimezoneTimelineService>();
+        // Empty timeline: records without a UtcOffset resolve to their UTC date.
+        _mockTimezoneTimeline
+            .Setup(s => s.GetResolverAsync(It.IsAny<double?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TimezoneTimeline([]));
+        _stamper = new PatientDeviceStamper(
+            _mockRepository.Object, _mockTimezoneTimeline.Object, NullLogger<PatientDeviceStamper>.Instance);
     }
 
     private void SetupDevices(params PatientDevice[] devices)
@@ -51,12 +60,13 @@ public class PatientDeviceStamperTests
         IsCurrent = end is null,
     };
 
-    private static SensorGlucose Reading(string? dataSource = null, string? device = null, DateTime? timestamp = null) => new()
+    private static SensorGlucose Reading(string? dataSource = null, string? device = null, DateTime? timestamp = null, int? utcOffset = null) => new()
     {
         Mgdl = 120,
         Timestamp = timestamp ?? Now,
         DataSource = dataSource,
         Device = device,
+        UtcOffset = utcOffset,
     };
 
     [Fact]
@@ -271,6 +281,44 @@ public class PatientDeviceStamperTests
         await _stamper.StampAsync([record], [DeviceCategory.CGM], DataSources.DexcomConnector);
 
         record.PatientDeviceId.Should().Be(right.Id);
+    }
+
+    [Fact]
+    public async Task UtcOffset_MatchesOnWearerLocalDate_AcrossUtcDayBoundary()
+    {
+        // Device starts 2026-06-15 (wearer-local). 21:00Z on the 14th is already 07:00 on the
+        // 15th at UTC+10, so the offset-carrying record attributes and the UTC one doesn't.
+        var device = Cgm("Dexcom", start: new DateOnly(2026, 6, 15));
+        SetupDevices(device);
+        var beforeMidnightUtc = new DateTime(2026, 6, 14, 21, 0, 0, DateTimeKind.Utc);
+
+        var localRecord = Reading(dataSource: DataSources.DexcomConnector, timestamp: beforeMidnightUtc, utcOffset: 600);
+        var utcRecord = Reading(dataSource: DataSources.DexcomConnector, timestamp: beforeMidnightUtc, utcOffset: 0);
+
+        await _stamper.StampAsync([localRecord, utcRecord], [DeviceCategory.CGM], DataSources.DexcomConnector);
+
+        localRecord.PatientDeviceId.Should().Be(device.Id);
+        utcRecord.PatientDeviceId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task MissingUtcOffset_FallsBackToTenantTimezoneTimeline()
+    {
+        _mockTimezoneTimeline
+            .Setup(s => s.GetResolverAsync(It.IsAny<double?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TimezoneTimeline([
+                new TimezoneTimelineEntry { Timezone = "Australia/Brisbane", EffectiveFrom = new DateTime(2020, 1, 1) },
+            ]));
+
+        var device = Cgm("Dexcom", start: new DateOnly(2026, 6, 15));
+        SetupDevices(device);
+        var record = Reading(
+            dataSource: DataSources.DexcomConnector,
+            timestamp: new DateTime(2026, 6, 14, 21, 0, 0, DateTimeKind.Utc));
+
+        await _stamper.StampAsync([record], [DeviceCategory.CGM], DataSources.DexcomConnector);
+
+        record.PatientDeviceId.Should().Be(device.Id);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/EntryDecomposerBatchTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/EntryDecomposerBatchTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.API.Services.V4;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
@@ -54,6 +55,7 @@ public class EntryDecomposerBatchTests : IDisposable
             _mgRepoMock.Object,
             _calRepoMock.Object,
             glucoseResolver,
+            Mock.Of<IPatientDeviceStamper>(),
             Mock.Of<IAuditContext>(),
             NullLogger<EntryDecomposer>.Instance);
     }

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/EntryDecomposerBulkDeleteTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/EntryDecomposerBulkDeleteTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Nocturne.API.Services.V4;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Tests.Shared.Infrastructure;
@@ -31,7 +32,7 @@ public class EntryDecomposerBulkDeleteTests : IDisposable
     }
 
     private EntryDecomposer CreateDecomposer() =>
-        new(_dbContext, _sgRepo.Object, _mgRepo.Object, _calRepo.Object, new Mock<IGlucoseProcessingResolver>().Object, Mock.Of<IAuditContext>(), _logger.Object);
+        new(_dbContext, _sgRepo.Object, _mgRepo.Object, _calRepo.Object, new Mock<IGlucoseProcessingResolver>().Object, Mock.Of<IPatientDeviceStamper>(), Mock.Of<IAuditContext>(), _logger.Object);
 
     [Fact]
     [Trait("Category", "Unit")]

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/EntryDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/EntryDecomposerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.API.Services.V4;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data;
@@ -36,7 +37,7 @@ public class EntryDecomposerTests : IDisposable
             .ReturnsAsync((GlucoseProcessing?)null);
         var glucoseResolver = new GlucoseProcessingResolver(mockConfigProvider.Object);
 
-        _decomposer = new EntryDecomposer(_context, sgRepo, mgRepo, calRepo, glucoseResolver, Mock.Of<IAuditContext>(), NullLogger<EntryDecomposer>.Instance);
+        _decomposer = new EntryDecomposer(_context, sgRepo, mgRepo, calRepo, glucoseResolver, Mock.Of<IPatientDeviceStamper>(), Mock.Of<IAuditContext>(), NullLogger<EntryDecomposer>.Instance);
     }
 
     public void Dispose()

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerBatchTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerBatchTests.cs
@@ -105,6 +105,7 @@ public class TreatmentDecomposerBatchTests : IDisposable
             _stateSpanServiceMock.Object,
             _treatmentFoodServiceMock.Object,
             _deviceServiceMock.Object,
+            Mock.Of<IPatientDeviceStamper>(),
             _profileDecomposerMock.Object,
             _activeProfileResolverMock.Object,
             _insulinRepoMock.Object,

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerNotesTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerNotesTests.cs
@@ -57,6 +57,7 @@ public class TreatmentDecomposerNotesTests : IDisposable
             stateSpanServiceMock.Object,
             treatmentFoodServiceMock.Object,
             deviceServiceMock.Object,
+            Mock.Of<IPatientDeviceStamper>(),
             profileDecomposerMock.Object,
             activeProfileResolverMock.Object,
             insulinRepoMock.Object,

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
@@ -65,6 +65,7 @@ public class TreatmentDecomposerTests : IDisposable
             _stateSpanServiceMock.Object,
             _treatmentFoodServiceMock.Object,
             _deviceServiceMock.Object,
+            Mock.Of<IPatientDeviceStamper>(),
             _profileDecomposerMock.Object,
             _activeProfileResolverMock.Object,
             _insulinRepoMock.Object,

--- a/tests/Unit/Nocturne.Core.Models.Tests/Timezones/TimezoneTimelineTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/Timezones/TimezoneTimelineTests.cs
@@ -146,4 +146,30 @@ public class TimezoneTimelineTests
         var timeline = new TimezoneTimeline([Entry("America/Toronto", new DateTime(2026, 6, 1))], fallbackOffsetHours: 0);
         timeline.ToUtc(FakeUtc(2026, 1, 1, 7, 0)).Should().Be(Utc(2026, 1, 1, 7, 0));
     }
+
+    // ── ToLocal (UTC → wearer wall-clock) ────────────────────────────────────
+
+    [Fact]
+    public void ToLocal_ConvertsUtcToZoneWallClock_WithDstForTheDate()
+    {
+        var timeline = new TimezoneTimeline([Origin("Australia/Sydney")]);
+
+        // Jan = AEDT (UTC+11); Jun = AEST (UTC+10).
+        timeline.ToLocal(Utc(2026, 1, 9, 13, 0)).Should().Be(new DateTime(2026, 1, 10, 0, 0, 0));
+        timeline.ToLocal(Utc(2026, 6, 5, 14, 0)).Should().Be(new DateTime(2026, 6, 6, 0, 0, 0));
+    }
+
+    [Fact]
+    public void ToLocal_EmptyTimeline_NoOffset_ReturnsUtcUnchanged()
+    {
+        var timeline = new TimezoneTimeline([]);
+        timeline.ToLocal(Utc(2026, 3, 5, 7, 0)).Should().Be(Utc(2026, 3, 5, 7, 0));
+    }
+
+    [Fact]
+    public void ToLocal_NoCoveringEntry_UsesFallbackOffset()
+    {
+        var timeline = new TimezoneTimeline([Entry("America/Toronto", new DateTime(2026, 6, 1))], fallbackOffsetHours: 10);
+        timeline.ToLocal(Utc(2026, 1, 1, 21, 0)).Should().Be(new DateTime(2026, 1, 2, 7, 0, 0));
+    }
 }


### PR DESCRIPTION
Multi-CGM **PR1 of 4**: make `PatientDeviceId` attribution correct and universal at ingest, so the read-time canonical stream selection (PR2) has trustworthy per-device data. Design principle: store everything, attribute everything, never guess — ambiguous matches stay null.

## What changed

**`PatientDevice.Rank`** — explicit priority among devices of the same category with overlapping usage windows (lower = higher priority; null = unranked, ordered after ranked by most recent `StartDate`). `GetCurrentAsync`/`GetByDateRangeAsync` now order rank-first. Exposed through the existing patient-record devices endpoints (domain model is the wire shape).

**`PatientDeviceId` FK on `BasalInjection` + `MeterGlucose`** — the two attributed record types that lacked it (pen doses and meter readings), with the same `SET NULL` FK + filtered index the other V4 types carry. Migration `MultiCgmDeviceAttribution` generated via `dotnet ef`.

**`IDeviceAttributed` + `PatientDeviceStamper`** — one shared attribution service replacing the per-path heuristics. Per record, over the devices whose usage window covers the record's timestamp:
1. skip if already attributed;
2. unique serial-number match (≥5 chars) inside the record's device string;
3. the single candidate compatible with the record's data source — manufacturer-specific connector sources (dexcom/libre/minimed/carelink/tconnectsync/mylife/eversense) constrain candidates, aggregator/uploader sources (Glooko, Nightscout, xDrip…) constrain nothing;
4. otherwise left null (a second same-manufacturer CGM on one connector is not guessable without a serial).

Failures are logged and swallowed; records always proceed.

**Wired into every ingest path:**
- `GlucosePublisher` — replaces the old `IsCurrent`-only, first-match-wins manufacturer lookup (which misattributed backfill to the *currently* worn device and collapsed same-manufacturer overlaps).
- `TreatmentPublisher` — `Bolus`/`TempBasal`/`BasalInjection` on the direct V4 connector path, which previously never attributed.
- `EntryDecomposer` — v1 `sgv`/`mbg` uploads (Loop/AAPS/xDrip), previously never attributed.
- `TreatmentDecomposer` — stamper as fallback when the upload carries no pump serial; the existing serial→`Device`→`PatientDevice` resolution stays first.

**Re-upload safety** — re-decomposition of an existing record carries its stored attribution forward, so a legacy-entry re-send can't wipe a previously stamped FK after matching has become ambiguous.

## Local-day matching
Device usage windows are user-entered local dates, so attribution matches on the wearer's local day: the record's own `UtcOffset` when present, else the tenant timezone timeline (new `TimezoneTimeline.ToLocal`), else UTC. The candidate fetch window is padded ±1 day accordingly.

## Tests
17 new `PatientDeviceStamperTests` covering the full ladder (serial, source, aggregator ambiguity, historical windows, short-serial guard, contradiction → null, failure swallowing). Full unit suite green (4,410 tests).

## Follow-ups (agreed design, next PRs)
PR2: canonical stream projection (rank-based, pseudo-devices for unattributed) serving v1/v3/legacy-broadcast/alarms. PR3: V4 device filters + stats metadata + discovered-sources/rank UI. PR4: per-device comparison.
