### PR TITLE
fix(v4): map nested uploader.isCharging from Trio devicestatus

### DIFF
--- a/src/API/Nocturne.API/Services/Devices/DeviceStatusProjectionService.cs
+++ b/src/API/Nocturne.API/Services/Devices/DeviceStatusProjectionService.cs
@@ -438,6 +438,7 @@ public class DeviceStatusProjectionService
             Temperature = uploaderSnapshot.Temperature,
             Name = uploaderSnapshot.Name,
             Type = uploaderSnapshot.Type,
+            IsCharging = uploaderSnapshot.IsCharging,
         };
 
         ds.IsCharging = uploaderSnapshot.IsCharging;

--- a/src/API/Nocturne.API/Services/V4/DeviceStatusDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/DeviceStatusDecomposer.cs
@@ -911,7 +911,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
             Name = ds.Uploader?.Name,
             Battery = ds.Uploader?.Battery ?? ds.UploaderBattery,
             BatteryVoltage = ds.Uploader?.BatteryVoltage,
-            IsCharging = ds.IsCharging,
+            IsCharging = ds.IsCharging ?? ds.Uploader?.IsCharging,
             Temperature = ds.Uploader?.Temperature,
             Type = ds.Uploader?.Type,
         };

--- a/src/Core/Nocturne.Core.Models/DeviceStatus.cs
+++ b/src/Core/Nocturne.Core.Models/DeviceStatus.cs
@@ -183,6 +183,13 @@ public class UploaderStatus
     public double? BatteryVoltage { get; set; }
 
     /// <summary>
+    /// Gets or sets whether the uploader device is charging.
+    /// Trio nests this in the uploader object; xDrip-style uploaders send it top-level.
+    /// </summary>
+    [JsonPropertyName("isCharging")]
+    public bool? IsCharging { get; set; }
+
+    /// <summary>
     /// Gets or sets the device temperature
     /// </summary>
     [JsonPropertyName("temperature")]

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerTests.cs
@@ -259,6 +259,28 @@ public class DeviceStatusDecomposerTests : IDisposable
         uploader.IsCharging.Should().BeTrue();
     }
 
+    [Fact]
+    public async Task DecomposeAsync_NestedUploaderIsCharging_MapsToSnapshot()
+    {
+        // Trio sends isCharging inside the uploader object, not top-level
+        var json = """
+            {
+                "_id": "trio-ischarging",
+                "mills": 1700000000000,
+                "device": "Trio",
+                "uploader": { "battery": 75, "batteryVoltage": 4.0, "isCharging": true }
+            }
+            """;
+        var ds = System.Text.Json.JsonSerializer.Deserialize<DeviceStatus>(json)!;
+
+        var result = await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
+
+        result.CreatedRecords.Should().HaveCount(1);
+        var uploader = result.CreatedRecords[0].Should().BeOfType<V4Models.UploaderSnapshot>().Subject;
+        uploader.Battery.Should().Be(75);
+        uploader.IsCharging.Should().BeTrue();
+    }
+
     #endregion
 
     #region UploaderBattery fallback → UploaderSnapshot


### PR DESCRIPTION
Trio sends charging state inside the `uploader` object (`uploader.isCharging`, see [NightscoutStatus.swift](https://github.com/nightscout/Trio/blob/dev/Trio/Sources/Models/NightscoutStatus.swift)), while xDrip-style uploaders send it top-level. `UploaderStatus` had no `isCharging` property, so the field was silently dropped during deserialization and `uploader_snapshots.is_charging` was always null for Trio users (confirmed against a production tenant: 45k+ uploader snapshots, all null, battery populated).

## Changes
- Add `isCharging` to `UploaderStatus` (`[JsonPropertyName("isCharging")]`)
- `DeviceStatusDecomposer` falls back to `uploader.isCharging` when top-level `isCharging` is absent
- `DeviceStatusProjectionService` mirrors `is_charging` back into the projected uploader object for round-trip fidelity
- Test: Trio-shaped JSON payload with nested `isCharging` decomposes into an `UploaderSnapshot` with `IsCharging = true`

Part of #354 (Trio compatibility).