### PR TITLE
feat(v4): canonical glucose stream for single-stream consumers

### DIFF
--- a/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
@@ -31,7 +31,7 @@ public class EntriesController : ControllerBase
     private readonly IEntryService _entryService;
     private readonly IDocumentProcessingService _documentProcessingService;
     private readonly IProcessingStatusService _processingStatusService;
-    private readonly IAlertOrchestrator _alertOrchestrator;
+    private readonly ICanonicalAlertEvaluator _alertEvaluator;
     private readonly ILogger<EntriesController> _logger;
 
     /// <summary>
@@ -40,20 +40,20 @@ public class EntriesController : ControllerBase
     /// <param name="entryService">Service handling glucose entry operations.</param>
     /// <param name="documentProcessingService">Service for async document processing and ingestion.</param>
     /// <param name="processingStatusService">Service for querying async processing status.</param>
-    /// <param name="alertOrchestrator">Orchestrator for evaluating and dispatching alerts.</param>
+    /// <param name="alertEvaluator">Evaluates alert rules against the canonical stream after writes.</param>
     /// <param name="logger">Logger instance.</param>
     public EntriesController(
         IEntryService entryService,
         IDocumentProcessingService documentProcessingService,
         IProcessingStatusService processingStatusService,
-        IAlertOrchestrator alertOrchestrator,
+        ICanonicalAlertEvaluator alertEvaluator,
         ILogger<EntriesController> logger
     )
     {
         _entryService = entryService;
         _documentProcessingService = documentProcessingService;
         _processingStatusService = processingStatusService;
-        _alertOrchestrator = alertOrchestrator;
+        _alertEvaluator = alertEvaluator;
         _logger = logger;
     }
 
@@ -1260,28 +1260,9 @@ public class EntriesController : ControllerBase
 
     private async Task EvaluateAlertsAsync(Entry[] entries, CancellationToken ct)
     {
-        try
-        {
-            var latest = entries
-                .Where(e => e.Sgv.HasValue && e.Sgv.Value > 0)
-                .OrderByDescending(e => e.Mills)
-                .FirstOrDefault();
-
-            if (latest is null) return;
-
-            var context = new SensorContext
-            {
-                LatestValue = (decimal?)latest.Sgv,
-                LatestTimestamp = latest.Date ?? DateTimeOffset.FromUnixTimeMilliseconds(latest.Mills).UtcDateTime,
-                TrendRate = (decimal?)latest.TrendRate,
-                LastReadingAt = latest.Date ?? DateTimeOffset.FromUnixTimeMilliseconds(latest.Mills).UtcDateTime,
-            };
-
-            await _alertOrchestrator.EvaluateAsync(context, ct);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Alert evaluation failed after V1 entry creation");
-        }
+        // Alarms evaluate against the canonical stream, not the just-uploaded batch — a losing
+        // CGM's readings must not trigger or suppress an alarm.
+        if (entries.Any(e => e.Sgv is > 0))
+            await _alertEvaluator.EvaluateAsync(ct);
     }
 }

--- a/src/API/Nocturne.API/Controllers/V3/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/EntriesController.cs
@@ -27,18 +27,18 @@ namespace Nocturne.API.Controllers.V3;
 public class EntriesController : BaseV3Controller<Entry>
 {
     private readonly IEntryService _entryService;
-    private readonly IAlertOrchestrator _alertOrchestrator;
+    private readonly ICanonicalAlertEvaluator _alertEvaluator;
 
     public EntriesController(
         IDocumentProcessingService documentProcessingService,
         IEntryService entryService,
-        IAlertOrchestrator alertOrchestrator,
+        ICanonicalAlertEvaluator alertEvaluator,
         ILogger<EntriesController> logger
     )
         : base(documentProcessingService, logger)
     {
         _entryService = entryService;
-        _alertOrchestrator = alertOrchestrator;
+        _alertEvaluator = alertEvaluator;
     }
 
     /// <summary>
@@ -663,29 +663,10 @@ public class EntriesController : BaseV3Controller<Entry>
 
     private async Task EvaluateAlertsAsync(Entry[] entries, CancellationToken ct)
     {
-        try
-        {
-            var latest = entries
-                .Where(e => e.Sgv.HasValue && e.Sgv.Value > 0)
-                .OrderByDescending(e => e.Mills)
-                .FirstOrDefault();
-
-            if (latest is null) return;
-
-            var context = new SensorContext
-            {
-                LatestValue = (decimal?)latest.Sgv,
-                LatestTimestamp = latest.Date ?? DateTimeOffset.FromUnixTimeMilliseconds(latest.Mills).UtcDateTime,
-                TrendRate = (decimal?)latest.TrendRate,
-                LastReadingAt = latest.Date ?? DateTimeOffset.FromUnixTimeMilliseconds(latest.Mills).UtcDateTime,
-            };
-
-            await _alertOrchestrator.EvaluateAsync(context, ct);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Alert evaluation failed after V3 entry creation");
-        }
+        // Alarms evaluate against the canonical stream, not the just-uploaded batch — a losing
+        // CGM's readings must not trigger or suppress an alarm.
+        if (entries.Any(e => e.Sgv is > 0))
+            await _alertEvaluator.EvaluateAsync(ct);
     }
 
     #endregion

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Analytics;
+using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Contracts.Profiles;
 using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Contracts.Multitenancy;
@@ -59,6 +60,7 @@ public class StatisticsController : ControllerBase
     private readonly IApsSnapshotRepository _apsSnapshotRepository;
     private readonly IDeviceEventRepository _deviceEventRepository;
     private readonly ITargetRangeScheduleRepository _targetRangeScheduleRepository;
+    private readonly ICanonicalGlucoseService _canonicalGlucose;
 
     private string TenantCacheId =>
         _tenantAccessor.Context?.TenantId.ToString()
@@ -80,7 +82,8 @@ public class StatisticsController : ControllerBase
         IPatientDeviceRepository patientDeviceRepository,
         IApsSnapshotRepository apsSnapshotRepository,
         IDeviceEventRepository deviceEventRepository,
-        ITargetRangeScheduleRepository targetRangeScheduleRepository
+        ITargetRangeScheduleRepository targetRangeScheduleRepository,
+        ICanonicalGlucoseService canonicalGlucose
     )
     {
         _statisticsService = statisticsService;
@@ -99,6 +102,7 @@ public class StatisticsController : ControllerBase
         _apsSnapshotRepository = apsSnapshotRepository;
         _deviceEventRepository = deviceEventRepository;
         _targetRangeScheduleRepository = targetRangeScheduleRepository;
+        _canonicalGlucose = canonicalGlucose;
     }
 
     /// <summary>
@@ -356,7 +360,8 @@ public class StatisticsController : ControllerBase
 
             await Task.WhenAll(glucoseTask, bolusTask, carbTask);
 
-            var entries = (await glucoseTask).ToList();
+            // Unfiltered statistics compute over the canonical stream, never blended CGMs.
+            var entries = (await _canonicalGlucose.SelectAsync((await glucoseTask).ToList(), cancellationToken)).ToList();
             var boluses = await bolusTask;
             var carbs   = await carbTask;
 
@@ -673,7 +678,7 @@ public class StatisticsController : ControllerBase
 
                 await Task.WhenAll(glucoseTask, bolusTask, carbTask);
 
-                var filteredEntries = (await glucoseTask).ToList();
+                var filteredEntries = (await _canonicalGlucose.SelectAsync((await glucoseTask).ToList(), cancellationToken)).ToList();
                 var filteredBoluses = (await bolusTask).ToList();
                 var filteredCarbs   = (await carbTask).ToList();
 
@@ -956,7 +961,7 @@ public class StatisticsController : ControllerBase
 
             await Task.WhenAll(glucoseTask, bolusTask, carbTask, algoTask, tempBasalTask);
 
-            var glucoseData      = (await glucoseTask).ToList();
+            var glucoseData      = (await _canonicalGlucose.SelectAsync((await glucoseTask).ToList(), cancellationToken)).ToList();
             var manualBoluses    = (await bolusTask).ToList();
             var carbs            = (await carbTask).ToList();
             var algorithmBoluses = (await algoTask).ToList();

--- a/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
@@ -15,12 +15,13 @@ namespace Nocturne.API.Controllers.V4.Glucose;
 /// <summary>
 /// Controller for managing CGM sensor glucose readings.
 /// Provides CRUD operations and bulk creation for <see cref="SensorGlucose"/> records.
-/// After creation, evaluates glucose alerts via <see cref="IAlertOrchestrator"/>.
+/// After creation, evaluates glucose alerts against the canonical stream via
+/// <see cref="ICanonicalAlertEvaluator"/>.
 /// </summary>
 /// <seealso cref="ISensorGlucoseRepository"/>
 /// <seealso cref="SensorGlucose"/>
 /// <seealso cref="UpsertSensorGlucoseRequest"/>
-/// <seealso cref="IAlertOrchestrator"/>
+/// <seealso cref="ICanonicalAlertEvaluator"/>
 /// <seealso cref="V4CrudControllerBase{TModel, TCreateRequest, TUpdateRequest, TRepository}"/>
 [ApiController]
 [Tags("Glucose")]
@@ -30,7 +31,7 @@ namespace Nocturne.API.Controllers.V4.Glucose;
 public class SensorGlucoseController(
     ISensorGlucoseRepository repo,
     IGlucoseProcessingResolver glucoseResolver,
-    IAlertOrchestrator alertOrchestrator,
+    ICanonicalAlertEvaluator alertEvaluator,
     ILogger<SensorGlucoseController> logger)
     : V4CrudControllerBase<SensorGlucose, UpsertSensorGlucoseRequest, UpsertSensorGlucoseRequest, ISensorGlucoseRepository>(repo)
 {
@@ -143,51 +144,17 @@ public class SensorGlucoseController(
         var created = await Repository.BulkCreateAsync(models, WriteOrigin.Live, ct);
         var createdArray = created.ToArray();
 
-        // Evaluate alerts for the most recent reading only (not every historical reading during backfill)
-        var mostRecent = createdArray.OrderByDescending(r => r.Timestamp).FirstOrDefault();
-        if (mostRecent is { Mgdl: > 0 })
-        {
-            try
-            {
-                var context = new SensorContext
-                {
-                    LatestValue = (decimal)mostRecent.Mgdl,
-                    LatestTimestamp = mostRecent.Timestamp,
-                    TrendRate = (decimal?)mostRecent.TrendRate,
-                    LastReadingAt = mostRecent.Timestamp,
-                };
-                await alertOrchestrator.EvaluateAsync(context, ct);
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex, "Alert evaluation failed after bulk SensorGlucose creation");
-            }
-        }
+        // Alarms evaluate against the canonical stream, not the just-created batch.
+        if (createdArray.Any(r => r.Mgdl > 0))
+            await alertEvaluator.EvaluateAsync(ct);
 
         return StatusCode(201, createdArray);
     }
 
     protected override async Task<SensorGlucose> OnAfterCreateAsync(SensorGlucose created, CancellationToken ct)
     {
-        try
-        {
-            if (created.Mgdl > 0)
-            {
-                var context = new SensorContext
-                {
-                    LatestValue = (decimal)created.Mgdl,
-                    LatestTimestamp = created.Timestamp,
-                    TrendRate = (decimal?)created.TrendRate,
-                    LastReadingAt = created.Timestamp,
-                };
-
-                await alertOrchestrator.EvaluateAsync(context, ct);
-            }
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Alert evaluation failed after V4 SensorGlucose creation");
-        }
+        if (created.Mgdl > 0)
+            await alertEvaluator.EvaluateAsync(ct);
 
         return created;
     }

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -520,6 +520,10 @@ public static class ServiceRegistrationExtensions
         services.AddScoped<IDeviceService, DeviceService>();
         services.AddScoped<IPatientDeviceStamper, PatientDeviceStamper>();
 
+        // Canonical glucose stream (single-stream view for v1/v3, alarms, unfiltered analytics)
+        services.AddScoped<ICanonicalGlucoseService, CanonicalGlucoseService>();
+        services.AddScoped<ICanonicalAlertEvaluator, CanonicalAlertEvaluator>();
+
         // Coach marks
         services.AddScoped<ICoachMarkService, CoachMarkService>();
 

--- a/src/API/Nocturne.API/Services/Alerts/AlertReplayService.cs
+++ b/src/API/Nocturne.API/Services/Alerts/AlertReplayService.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Nocturne.API.Extensions;
 using Nocturne.API.Services.Alerts.Evaluators;
 using Nocturne.Core.Contracts.Alerts;
+using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
@@ -27,6 +28,7 @@ namespace Nocturne.API.Services.Alerts;
 internal sealed class AlertReplayService(
     IAlertRepository alertRepository,
     ISensorGlucoseRepository glucoseRepository,
+    ICanonicalGlucoseService canonicalGlucose,
     ISensorContextEnricher enricher,
     ITenantAccessor tenantAccessor,
     ILogger<AlertReplayService> logger)
@@ -84,9 +86,12 @@ internal sealed class AlertReplayService(
         // by AlertReferenceService) would short-circuit to insertion order.
         var ordered = TopologicallySort(rules);
 
-        var readings = (await glucoseRepository.GetAsync(
-                from: windowStart, to: windowEnd, device: null, source: null,
-                limit: int.MaxValue, offset: 0, descending: false, nativeOnly: false, ct: ct))
+        // Replay walks the canonical stream — the same series the live engine alarms on.
+        var readings = (await canonicalGlucose.SelectAsync(
+                (await glucoseRepository.GetAsync(
+                    from: windowStart, to: windowEnd, device: null, source: null,
+                    limit: int.MaxValue, offset: 0, descending: false, nativeOnly: false, ct: ct)).ToList(),
+                ct))
             .OrderBy(r => r.Timestamp)
             .ToList();
 

--- a/src/API/Nocturne.API/Services/Alerts/CanonicalAlertEvaluator.cs
+++ b/src/API/Nocturne.API/Services/Alerts/CanonicalAlertEvaluator.cs
@@ -44,7 +44,11 @@ internal sealed class CanonicalAlertEvaluator : ICanonicalAlertEvaluator
             await _alertOrchestrator.EvaluateAsync(context, ct);
         }
         catch (OperationCanceledException) { throw; }
-        catch (Exception ex)
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning(ex, "Alert evaluation against the canonical stream failed");
+        }
+        catch (TimeoutException ex)
         {
             _logger.LogWarning(ex, "Alert evaluation against the canonical stream failed");
         }

--- a/src/API/Nocturne.API/Services/Alerts/CanonicalAlertEvaluator.cs
+++ b/src/API/Nocturne.API/Services/Alerts/CanonicalAlertEvaluator.cs
@@ -1,0 +1,52 @@
+using Nocturne.Core.Contracts.Alerts;
+using Nocturne.Core.Contracts.Glucose;
+using Nocturne.Core.Models;
+
+namespace Nocturne.API.Services.Alerts;
+
+/// <summary>
+/// Default <see cref="ICanonicalAlertEvaluator"/>: resolves the latest canonical reading via
+/// <see cref="ICanonicalGlucoseService"/> and hands a <see cref="SensorContext"/> to the
+/// <see cref="IAlertOrchestrator"/>.
+/// </summary>
+internal sealed class CanonicalAlertEvaluator : ICanonicalAlertEvaluator
+{
+    private readonly ICanonicalGlucoseService _canonicalGlucose;
+    private readonly IAlertOrchestrator _alertOrchestrator;
+    private readonly ILogger<CanonicalAlertEvaluator> _logger;
+
+    public CanonicalAlertEvaluator(
+        ICanonicalGlucoseService canonicalGlucose,
+        IAlertOrchestrator alertOrchestrator,
+        ILogger<CanonicalAlertEvaluator> logger)
+    {
+        _canonicalGlucose = canonicalGlucose ?? throw new ArgumentNullException(nameof(canonicalGlucose));
+        _alertOrchestrator = alertOrchestrator ?? throw new ArgumentNullException(nameof(alertOrchestrator));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task EvaluateAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var latest = await _canonicalGlucose.GetLatestAsync(ct);
+            if (latest is null || latest.Mgdl <= 0) return;
+
+            var context = new SensorContext
+            {
+                LatestValue = (decimal)latest.Mgdl,
+                LatestTimestamp = latest.Timestamp,
+                TrendRate = (decimal?)latest.TrendRate,
+                LastReadingAt = latest.Timestamp,
+            };
+
+            await _alertOrchestrator.EvaluateAsync(context, ct);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Alert evaluation against the canonical stream failed");
+        }
+    }
+}

--- a/src/API/Nocturne.API/Services/ChartData/Stages/DataFetchStage.cs
+++ b/src/API/Nocturne.API/Services/ChartData/Stages/DataFetchStage.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
@@ -39,6 +40,7 @@ namespace Nocturne.API.Services.ChartData.Stages;
 /// <seealso cref="ChartDataContext"/>
 internal sealed class DataFetchStage(
     ISensorGlucoseRepository sensorGlucoseRepository,
+    ICanonicalGlucoseService canonicalGlucose,
     IBolusRepository bolusRepository,
     ICarbIntakeRepository carbIntakeRepository,
     IBGCheckRepository bgCheckRepository,
@@ -74,18 +76,21 @@ internal sealed class DataFetchStage(
         var treatmentLimit = (int)Math.Max(500, Math.Ceiling(treatmentRangeHours * 10));
         var displayRangeLimit = (int)Math.Max(500, Math.Ceiling(rangeHours * 10));
 
-        // Fetch glucose data from v4 SensorGlucose table
+        // Fetch glucose data from v4 SensorGlucose table; the dashboard renders the canonical
+        // stream, not blended concurrent CGMs.
         var sensorGlucoseList = (
-            await sensorGlucoseRepository.GetAsync(
-                from: MillsToDateTime(startTime),
-                to: MillsToDateTime(endTime),
-                device: null,
-                source: null,
-                limit: entryLimit,
-                offset: 0,
-                descending: true,
-                ct: cancellationToken
-            )
+            await canonicalGlucose.SelectAsync(
+                (await sensorGlucoseRepository.GetAsync(
+                    from: MillsToDateTime(startTime),
+                    to: MillsToDateTime(endTime),
+                    device: null,
+                    source: null,
+                    limit: entryLimit,
+                    offset: 0,
+                    descending: true,
+                    ct: cancellationToken
+                )).ToList(),
+                cancellationToken)
         ).ToList();
 
         // Fetch bolus data from v4 Bolus table — extended range for IOB calculation

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/GlucosePublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/GlucosePublisher.cs
@@ -28,7 +28,7 @@ internal sealed class GlucosePublisher : IGlucosePublisher
     private readonly IPatientDeviceStamper _patientDeviceStamper;
     private readonly IDbContextFactory<NocturneDbContext> _contextFactory;
     private readonly ITenantAccessor _tenantAccessor;
-    private readonly IAlertOrchestrator _alertOrchestrator;
+    private readonly ICanonicalAlertEvaluator _alertEvaluator;
     private readonly IAuditContext _auditContext;
     private readonly ILogger<GlucosePublisher> _logger;
 
@@ -38,7 +38,7 @@ internal sealed class GlucosePublisher : IGlucosePublisher
         IPatientDeviceStamper patientDeviceStamper,
         IDbContextFactory<NocturneDbContext> contextFactory,
         ITenantAccessor tenantAccessor,
-        IAlertOrchestrator alertOrchestrator,
+        ICanonicalAlertEvaluator alertEvaluator,
         IAuditContext auditContext,
         ILogger<GlucosePublisher> logger)
     {
@@ -47,7 +47,7 @@ internal sealed class GlucosePublisher : IGlucosePublisher
         _patientDeviceStamper = patientDeviceStamper ?? throw new ArgumentNullException(nameof(patientDeviceStamper));
         _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
         _tenantAccessor = tenantAccessor ?? throw new ArgumentNullException(nameof(tenantAccessor));
-        _alertOrchestrator = alertOrchestrator ?? throw new ArgumentNullException(nameof(alertOrchestrator));
+        _alertEvaluator = alertEvaluator ?? throw new ArgumentNullException(nameof(alertEvaluator));
         _auditContext = auditContext;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -62,7 +62,7 @@ internal sealed class GlucosePublisher : IGlucosePublisher
             var entryList = entries.ToList();
             await _entryService.CreateEntriesAsync(entryList, cancellationToken);
             await UpdateLastReadingAtAsync(cancellationToken);
-            await EvaluateAlertsForEntriesAsync(entryList, cancellationToken);
+            await _alertEvaluator.EvaluateAsync(cancellationToken);
             return true;
         }
         catch (OperationCanceledException) { throw; }
@@ -87,7 +87,7 @@ internal sealed class GlucosePublisher : IGlucosePublisher
             using (SystemAuditScope.Push(_auditContext))
                 await _sensorGlucoseRepository.BulkCreateAsync(recordList, origin, cancellationToken);
             await UpdateLastReadingAtAsync(cancellationToken);
-            await EvaluateAlertsForSensorGlucoseAsync(recordList, cancellationToken);
+            await _alertEvaluator.EvaluateAsync(cancellationToken);
 
             _logger.LogDebug("Published {Count} SensorGlucose records for {Source}", recordList.Count, source);
             return true;
@@ -155,63 +155,4 @@ internal sealed class GlucosePublisher : IGlucosePublisher
         }
     }
 
-    /// <summary>
-    /// Build a SensorContext from the most recent Entry and evaluate alert rules.
-    /// </summary>
-    private async Task EvaluateAlertsForEntriesAsync(List<Entry> entries, CancellationToken ct)
-    {
-        try
-        {
-            var latest = entries
-                .Where(e => e.Sgv.HasValue && e.Sgv.Value > 0)
-                .OrderByDescending(e => e.Mills)
-                .FirstOrDefault();
-
-            if (latest is null) return;
-
-            var context = new SensorContext
-            {
-                LatestValue = (decimal?)latest.Sgv,
-                LatestTimestamp = latest.Date ?? DateTimeOffset.FromUnixTimeMilliseconds(latest.Mills).UtcDateTime,
-                TrendRate = (decimal?)latest.TrendRate,
-                LastReadingAt = latest.Date ?? DateTimeOffset.FromUnixTimeMilliseconds(latest.Mills).UtcDateTime,
-            };
-
-            await _alertOrchestrator.EvaluateAsync(context, ct);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Alert evaluation failed after entry publish");
-        }
-    }
-
-    /// <summary>
-    /// Build a SensorContext from the most recent SensorGlucose record and evaluate alert rules.
-    /// </summary>
-    private async Task EvaluateAlertsForSensorGlucoseAsync(List<SensorGlucose> records, CancellationToken ct)
-    {
-        try
-        {
-            var latest = records
-                .Where(r => r.Mgdl > 0)
-                .OrderByDescending(r => r.Timestamp)
-                .FirstOrDefault();
-
-            if (latest is null) return;
-
-            var context = new SensorContext
-            {
-                LatestValue = (decimal)latest.Mgdl,
-                LatestTimestamp = latest.Timestamp,
-                TrendRate = (decimal?)latest.TrendRate,
-                LastReadingAt = latest.Timestamp,
-            };
-
-            await _alertOrchestrator.EvaluateAsync(context, ct);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Alert evaluation failed after SensorGlucose publish");
-        }
-    }
 }

--- a/src/API/Nocturne.API/Services/Entries/EntryReadService.cs
+++ b/src/API/Nocturne.API/Services/Entries/EntryReadService.cs
@@ -1,6 +1,7 @@
 using Nocturne.API.Services.Platform;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Entries;
+using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Entries;
@@ -10,12 +11,21 @@ namespace Nocturne.API.Services.Entries;
 /// <summary>
 /// Read-only <see cref="IEntryStore"/> that queries V4 repositories exclusively and projects
 /// results into legacy <see cref="Entry"/> shape via <see cref="EntryProjection"/>.
+/// Sgv reads serve the canonical glucose stream: legacy clients get one coherent series even
+/// when multiple CGMs report concurrently.
 /// </summary>
 public class EntryReadService : IEntryStore
 {
+    /// <summary>
+    /// Canonical selection drops losing-stream rows after the DB query, so limit-based sgv
+    /// fetches over-fetch by this factor before selection to keep pages filled.
+    /// </summary>
+    private const int CanonicalOverFetchFactor = 3;
+
     private readonly ISensorGlucoseRepository _sgRepo;
     private readonly IMeterGlucoseRepository _mgRepo;
     private readonly ICalibrationRepository _calRepo;
+    private readonly ICanonicalGlucoseService _canonicalGlucose;
     private readonly IDemoModeService _demoMode;
     private readonly ILogger<EntryReadService> _logger;
 
@@ -26,12 +36,14 @@ public class EntryReadService : IEntryStore
         ISensorGlucoseRepository sgRepo,
         IMeterGlucoseRepository mgRepo,
         ICalibrationRepository calRepo,
+        ICanonicalGlucoseService canonicalGlucose,
         IDemoModeService demoMode,
         ILogger<EntryReadService> logger)
     {
         _sgRepo = sgRepo;
         _mgRepo = mgRepo;
         _calRepo = calRepo;
+        _canonicalGlucose = canonicalGlucose;
         _demoMode = demoMode;
         _logger = logger;
     }
@@ -58,15 +70,17 @@ public class EntryReadService : IEntryStore
     {
         var (source, excludeDemo) = ResolveDemoFilter();
 
-        // When excluding demo data, over-fetch to account for filtered-out demo rows
-        var fetchLimit = excludeDemo ? 10 : 1;
+        // Over-fetch to survive demo filtering and canonical selection dropping the newest rows
+        // when a losing stream reported last — a 1-minute losing cadence can outnumber the
+        // winner five to one on a descending page.
+        const int fetchLimit = 60;
         var results = await _sgRepo.GetAsync(
             from: null, to: null, device: null, source: source,
             limit: fetchLimit, offset: 0, descending: true, nativeOnly: false, ct: ct);
 
-        var sg = excludeDemo
-            ? results.FirstOrDefault(r => !DataSources.IsEphemeral(r.DataSource))
-            : results.FirstOrDefault();
+        var visible = ExcludeDemoIfNeeded(results, excludeDemo).ToList();
+        var canonical = await _canonicalGlucose.SelectAsync(visible, ct);
+        var sg = canonical.FirstOrDefault();
         return sg is null ? null : EntryProjection.FromSensorGlucose(sg);
     }
 
@@ -125,9 +139,39 @@ public class EntryReadService : IEntryStore
         DateTime? from, DateTime? to, string? source, bool excludeDemo,
         int count, int skip, bool descending, CancellationToken ct)
     {
-        // Single-type query: push limit/offset directly to the database
-        var results = await _sgRepo.GetAsync(from, to, device: null, source, count, skip, descending, false, null, null, ct);
-        return ExcludeDemoIfNeeded(results, excludeDemo).Select(EntryProjection.FromSensorGlucose).ToList();
+        // Canonical selection happens after the DB query, so paging cannot be pushed down:
+        // over-fetch from offset 0, select, then page.
+        var canonical = await FetchCanonicalSgvAsync(from, to, source, excludeDemo, (long)count + skip, descending, ct);
+        return canonical.Skip(skip).Take(count).Select(EntryProjection.FromSensorGlucose).ToList();
+    }
+
+    /// <summary>
+    /// Fetches sgv readings with demo filtering and canonical stream selection applied,
+    /// over-fetching so at least <paramref name="needed"/> canonical rows survive when a
+    /// losing stream contributed to the raw page. A losing stream can outnumber the winner by
+    /// cadence (1-minute vs 5-minute), so the fetch grows geometrically until the page fills
+    /// or the raw window is exhausted.
+    /// </summary>
+    private async Task<IReadOnlyList<Core.Models.V4.SensorGlucose>> FetchCanonicalSgvAsync(
+        DateTime? from, DateTime? to, string? source, bool excludeDemo,
+        long needed, bool descending, CancellationToken ct)
+    {
+        const int maxFetch = 100_000;
+        var target = Math.Max(1, needed);
+        var fetchCount = (int)Math.Min(target * CanonicalOverFetchFactor, maxFetch);
+
+        while (true)
+        {
+            var results = (await _sgRepo.GetAsync(from, to, device: null, source, fetchCount, 0, descending, false, null, null, ct)).ToList();
+            var visible = ExcludeDemoIfNeeded(results, excludeDemo).ToList();
+            var canonical = await _canonicalGlucose.SelectAsync(visible, ct);
+
+            var exhausted = results.Count < fetchCount || fetchCount >= maxFetch;
+            if (canonical.Count >= target || exhausted)
+                return canonical;
+
+            fetchCount = (int)Math.Min((long)fetchCount * CanonicalOverFetchFactor, maxFetch);
+        }
     }
 
     private async Task<IReadOnlyList<Entry>> QueryMbgAsync(
@@ -153,14 +197,14 @@ public class EntryReadService : IEntryStore
         int count, int skip, bool descending, CancellationToken ct)
     {
         // Multi-type merge requires over-fetching because we interleave across repos before paginating
-        var fetchCount = count + skip;
+        var fetchCount = (int)Math.Min((long)count + skip, 100_000);
 
         // Sequential to avoid DbContext thread-safety issues with scoped lifetime
-        var sgResults = await _sgRepo.GetAsync(from, to, device: null, source, fetchCount, 0, descending, false, null, null, ct);
+        var sgResults = await FetchCanonicalSgvAsync(from, to, source, excludeDemo, (long)fetchCount, descending, ct);
         var mgResults = await _mgRepo.GetAsync(from, to, device: null, source, fetchCount, 0, descending, ct);
         var calResults = await _calRepo.GetAsync(from, to, device: null, source, fetchCount, 0, descending, ct);
 
-        var entries = ExcludeDemoIfNeeded(sgResults, excludeDemo).Select(EntryProjection.FromSensorGlucose)
+        var entries = sgResults.Select(EntryProjection.FromSensorGlucose)
             .Concat(ExcludeDemoIfNeeded(mgResults, excludeDemo).Select(EntryProjection.FromMeterGlucose))
             .Concat(ExcludeDemoIfNeeded(calResults, excludeDemo).Select(EntryProjection.FromCalibration));
 

--- a/src/API/Nocturne.API/Services/Glucose/CanonicalGlucoseService.cs
+++ b/src/API/Nocturne.API/Services/Glucose/CanonicalGlucoseService.cs
@@ -1,0 +1,78 @@
+using Nocturne.API.Services.Platform;
+using Nocturne.Core.Constants;
+using Nocturne.Core.Contracts.Glucose;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.API.Services.Glucose;
+
+/// <summary>
+/// Default <see cref="ICanonicalGlucoseService"/>: detects multi-stream inputs, loads the
+/// patient's devices once per scope, and delegates selection to <see cref="CanonicalGlucoseStream"/>.
+/// </summary>
+internal sealed class CanonicalGlucoseService : ICanonicalGlucoseService
+{
+    /// <summary>
+    /// Newest rows consulted by <see cref="GetLatestAsync"/> — enough for several concurrent
+    /// streams at 1-minute cadence to still contain the canonical winner's latest bucket.
+    /// </summary>
+    private const int LatestFetchLimit = 60;
+
+    private readonly ISensorGlucoseRepository _sensorGlucoseRepository;
+    private readonly IPatientDeviceRepository _patientDeviceRepository;
+    private readonly IDemoModeService _demoMode;
+
+    private IReadOnlyList<PatientDevice>? _devices;
+
+    public CanonicalGlucoseService(
+        ISensorGlucoseRepository sensorGlucoseRepository,
+        IPatientDeviceRepository patientDeviceRepository,
+        IDemoModeService demoMode)
+    {
+        _sensorGlucoseRepository = sensorGlucoseRepository ?? throw new ArgumentNullException(nameof(sensorGlucoseRepository));
+        _patientDeviceRepository = patientDeviceRepository ?? throw new ArgumentNullException(nameof(patientDeviceRepository));
+        _demoMode = demoMode ?? throw new ArgumentNullException(nameof(demoMode));
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<SensorGlucose>> SelectAsync(
+        IReadOnlyList<SensorGlucose> readings,
+        CancellationToken ct = default)
+    {
+        if (!IsMultiStream(readings))
+            return readings;
+
+        _devices ??= (await _patientDeviceRepository.GetAllAsync(ct)).ToList();
+        return CanonicalGlucoseStream.Select(readings, _devices);
+    }
+
+    /// <inheritdoc />
+    public async Task<SensorGlucose?> GetLatestAsync(CancellationToken ct = default)
+    {
+        // No time window: delayed-sync sources (hours-late connector chunks) must still surface
+        // a latest value, matching the pre-canonical behaviour of using a write batch's newest
+        // reading however old it was.
+        var source = _demoMode.IsEnabled ? DataSources.DemoService : null;
+        var recent = (await _sensorGlucoseRepository.GetAsync(
+            from: null, to: null, device: null, source: source,
+            limit: LatestFetchLimit, offset: 0, descending: true, nativeOnly: false, ct: ct)).ToList();
+
+        if (!_demoMode.IsEnabled)
+            recent = recent.Where(r => !DataSources.IsEphemeral(r.DataSource)).ToList();
+
+        var canonical = await SelectAsync(recent, ct);
+        return canonical.Count > 0 ? canonical[0] : null;
+    }
+
+    private static bool IsMultiStream(IReadOnlyList<SensorGlucose> readings)
+    {
+        if (readings.Count < 2) return false;
+        var first = CanonicalGlucoseStream.StreamKey(readings[0]);
+        for (var i = 1; i < readings.Count; i++)
+        {
+            if (CanonicalGlucoseStream.StreamKey(readings[i]) != first)
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/Core/Nocturne.Core.Contracts/Alerts/ICanonicalAlertEvaluator.cs
+++ b/src/Core/Nocturne.Core.Contracts/Alerts/ICanonicalAlertEvaluator.cs
@@ -1,0 +1,20 @@
+namespace Nocturne.Core.Contracts.Alerts;
+
+/// <summary>
+/// Evaluates glucose alert rules against the latest canonical reading.
+/// </summary>
+/// <remarks>
+/// Alarms follow the canonical stream — the same series the user sees on charts and followers —
+/// so a losing CGM's readings never trigger or suppress an alarm. Callers invoke this after a
+/// glucose write has been persisted; the evaluation reads the canonical latest from storage
+/// rather than trusting the just-written batch.
+/// </remarks>
+public interface ICanonicalAlertEvaluator
+{
+    /// <summary>
+    /// Builds a sensor context from the latest canonical reading and evaluates alert rules.
+    /// No-op when no reading exists in the recent window. Failures are logged and swallowed —
+    /// alert evaluation never fails a write.
+    /// </summary>
+    Task EvaluateAsync(CancellationToken ct = default);
+}

--- a/src/Core/Nocturne.Core.Contracts/Glucose/ICanonicalGlucoseService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Glucose/ICanonicalGlucoseService.cs
@@ -1,0 +1,31 @@
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.Core.Contracts.Glucose;
+
+/// <summary>
+/// Applies canonical stream selection (<see cref="CanonicalGlucoseStream"/>) to fetched glucose
+/// readings, loading the patient's registered devices for the priority order.
+/// </summary>
+/// <remarks>
+/// The canonical view is what single-stream consumers see: v1/v3 REST, the legacy realtime
+/// broadcast, alarms, and unfiltered statistics. Multi-stream access is a V4-only concern.
+/// </remarks>
+/// <seealso cref="CanonicalGlucoseStream"/>
+public interface ICanonicalGlucoseService
+{
+    /// <summary>
+    /// Filters <paramref name="readings"/> to the canonical stream. Input order is preserved;
+    /// a single-stream input is returned unchanged without loading devices.
+    /// </summary>
+    Task<IReadOnlyList<SensorGlucose>> SelectAsync(
+        IReadOnlyList<SensorGlucose> readings,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// The most recent canonical reading, however old — computed over the newest stored readings
+    /// so delayed-sync sources (hours-late connector backfills) still surface a latest value.
+    /// Null only when the tenant has no readings at all. Staleness judgement belongs to the
+    /// caller, exactly as it did when consumers used the newest reading of a write batch.
+    /// </summary>
+    Task<SensorGlucose?> GetLatestAsync(CancellationToken ct = default);
+}

--- a/src/Core/Nocturne.Core.Models/V4/CanonicalGlucoseStream.cs
+++ b/src/Core/Nocturne.Core.Models/V4/CanonicalGlucoseStream.cs
@@ -1,0 +1,125 @@
+namespace Nocturne.Core.Models.V4;
+
+/// <summary>
+/// Selects the canonical glucose stream from readings that may span multiple concurrent CGMs.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Multiple CGMs worn at once (sensor-overlap warmup, n=1 comparisons) produce overlapping
+/// readings that double-count in statistics and jitter single-stream consumers (v1/v3 clients,
+/// alarms). The canonical view resolves this at read time: per aligned 5-minute UTC bucket, the
+/// highest-priority stream that has at least one reading wins, and <b>all</b> of that stream's
+/// readings in the bucket are emitted (preserving 1-minute-cadence density). No data is discarded
+/// at rest — selection is a pure projection over what was fetched.
+/// </para>
+/// <para>
+/// A stream is a registered <see cref="PatientDevice"/> when the reading carries
+/// <see cref="SensorGlucose.PatientDeviceId"/>, otherwise a pseudo-device keyed by
+/// <c>(DataSource, Device)</c>. Registered devices order by <see cref="PatientDevice.Rank"/>
+/// ascending (nulls last), then most recent <see cref="PatientDevice.StartDate"/>, then
+/// <see cref="PatientDevice.CreatedAt"/> descending. Pseudo-devices rank below every registered
+/// device, ordered by key for determinism. A user with a single stream — the overwhelmingly
+/// common case — gets their readings back unchanged.
+/// </para>
+/// </remarks>
+/// <seealso cref="PatientDevice"/>
+/// <seealso cref="SensorGlucose"/>
+public static class CanonicalGlucoseStream
+{
+    /// <summary>Bucket width for stream selection.</summary>
+    public static readonly TimeSpan BucketSize = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Filters <paramref name="readings"/> to the canonical stream. Input order is preserved.
+    /// </summary>
+    /// <param name="readings">Readings fetched for the caller's window, any order.</param>
+    /// <param name="devices">
+    /// The patient's registered devices (any category; only CGM entries participate). Order is
+    /// irrelevant — priority is computed here.
+    /// </param>
+    public static IReadOnlyList<SensorGlucose> Select(
+        IReadOnlyList<SensorGlucose> readings,
+        IReadOnlyList<PatientDevice> devices)
+    {
+        if (readings.Count == 0)
+            return readings;
+
+        // Fast path: one stream present → canonical view is the input itself.
+        var firstKey = StreamKey(readings[0]);
+        var multiStream = false;
+        for (var i = 1; i < readings.Count; i++)
+        {
+            if (StreamKey(readings[i]) != firstKey) { multiStream = true; break; }
+        }
+        if (!multiStream)
+            return readings;
+
+        var priority = BuildPriorityMap(readings, devices);
+
+        // Per bucket, the present stream with the lowest priority value wins.
+        var bucketWinner = new Dictionary<long, (int Priority, string Key)>();
+        foreach (var reading in readings)
+        {
+            var bucket = reading.Timestamp.Ticks / BucketSize.Ticks;
+            var key = StreamKey(reading);
+            var p = priority[key];
+            if (!bucketWinner.TryGetValue(bucket, out var winner) || p < winner.Priority)
+                bucketWinner[bucket] = (p, key);
+        }
+
+        var result = new List<SensorGlucose>(readings.Count);
+        foreach (var reading in readings)
+        {
+            var bucket = reading.Timestamp.Ticks / BucketSize.Ticks;
+            if (bucketWinner[bucket].Key == StreamKey(reading))
+                result.Add(reading);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// The stream identity of a reading: the registered device id, or a pseudo-device key from
+    /// its source fields.
+    /// </summary>
+    public static string StreamKey(SensorGlucose reading) =>
+        reading.PatientDeviceId is { } id
+            ? id.ToString()
+            : $"~{reading.DataSource}|{reading.Device}";
+
+    /// <summary>
+    /// Priority per stream key present in the readings (lower wins). Registered CGM devices order
+    /// by rank/recency; pseudo-devices follow, ordered by key. A reading whose PatientDeviceId is
+    /// not in <paramref name="devices"/> (deleted/foreign) is treated as a pseudo-device.
+    /// </summary>
+    private static Dictionary<string, int> BuildPriorityMap(
+        IReadOnlyList<SensorGlucose> readings,
+        IReadOnlyList<PatientDevice> devices)
+    {
+        var rankedDeviceKeys = devices
+            .Where(d => d.DeviceCategory == DeviceCategory.CGM)
+            .OrderBy(d => d.Rank == null)
+            .ThenBy(d => d.Rank)
+            .ThenByDescending(d => d.StartDate.HasValue)
+            .ThenByDescending(d => d.StartDate)
+            .ThenByDescending(d => d.CreatedAt)
+            .ThenBy(d => d.Id)
+            .Select(d => d.Id.ToString())
+            .ToList();
+
+        var priority = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (var i = 0; i < rankedDeviceKeys.Count; i++)
+            priority.TryAdd(rankedDeviceKeys[i], i);
+
+        var unknown = readings
+            .Select(StreamKey)
+            .Where(k => !priority.ContainsKey(k))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(k => k, StringComparer.Ordinal);
+
+        var next = rankedDeviceKeys.Count;
+        foreach (var key in unknown)
+            priority[key] = next++;
+
+        return priority;
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.Infrastructure;
@@ -50,6 +51,55 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
 
     /// <inheritdoc />
     protected override Entry? ProjectToLegacyEntry(SensorGlucose model) => EntryProjection.FromSensorGlucose(model);
+
+    /// <summary>
+    /// Canonical-stream gate for the legacy entries projection: a live write only reaches v1/v3
+    /// realtime clients if it survives <see cref="CanonicalGlucoseStream"/> selection over the
+    /// recent window plus the just-written batch. Single-stream tenants pass through unchanged
+    /// (the selector's fast path). Failures fail open — a broadcast is better than a silent drop.
+    /// </summary>
+    protected override async Task<IReadOnlyList<SensorGlucose>> FilterLegacyProjectionAsync(
+        IReadOnlyList<SensorGlucose> models, CancellationToken ct)
+    {
+        try
+        {
+            await using var ctx = await ContextFactory.CreateAsync(ct);
+
+            var windowStart = DateTime.UtcNow - TimeSpan.FromMinutes(15);
+            var recentEntities = await ctx.Set<SensorGlucoseEntity>()
+                .AsNoTracking()
+                .Where(e => e.Timestamp >= windowStart)
+                .OrderByDescending(e => e.Timestamp)
+                .Take(500)
+                .ToListAsync(ct);
+
+            var batchIds = models.Select(m => m.Id).ToHashSet();
+            var pool = recentEntities
+                .Where(e => !batchIds.Contains(e.Id))
+                .Select(ToDomain)
+                .Where(m => !DataSources.IsEphemeral(m.DataSource))
+                .Concat(models)
+                .ToList();
+
+            // Devices are only needed when streams actually compete — skip the second query on
+            // the overwhelmingly common single-stream write.
+            if (pool.Select(CanonicalGlucoseStream.StreamKey).Distinct(StringComparer.Ordinal).Skip(1).Any() == false)
+                return models;
+
+            var deviceEntities = await ctx.PatientDevices.AsNoTracking().ToListAsync(ct);
+            var devices = deviceEntities.Select(PatientDeviceMapper.ToDomainModel).ToList();
+
+            var survivors = CanonicalGlucoseStream.Select(pool, devices);
+            var survivorIds = survivors.Select(s => s.Id).ToHashSet();
+            return models.Where(m => survivorIds.Contains(m.Id)).ToList();
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Canonical gate for the legacy entries projection failed; broadcasting unfiltered");
+            return models;
+        }
+    }
 
     /// <inheritdoc />
     protected override SensorGlucoseEntity ToEntity(SensorGlucose model) => SensorGlucoseMapper.ToEntity(model);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -94,7 +94,17 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
             return models.Where(m => survivorIds.Contains(m.Id)).ToList();
         }
         catch (OperationCanceledException) { throw; }
-        catch (Exception ex)
+        catch (DbUpdateException ex)
+        {
+            _logger.LogWarning(ex, "Canonical gate for the legacy entries projection failed; broadcasting unfiltered");
+            return models;
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning(ex, "Canonical gate for the legacy entries projection failed; broadcasting unfiltered");
+            return models;
+        }
+        catch (TimeoutException ex)
         {
             _logger.LogWarning(ex, "Canonical gate for the legacy entries projection failed; broadcasting unfiltered");
             return models;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
@@ -75,6 +75,16 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     protected virtual Entry? ProjectToLegacyEntry(TModel model) => null;
 
     /// <summary>
+    /// Filters the models that reach the legacy <see cref="Entry"/> projection. The legacy surface
+    /// is single-stream: SensorGlucose overrides this with canonical stream selection so a losing
+    /// CGM's live writes don't interleave into v1/v3 clients' dataUpdate feed. Deletes are never
+    /// filtered — a previously-broadcast record must always emit its removal. The native V4
+    /// broadcast is unaffected (multi-stream access is a V4 concern).
+    /// </summary>
+    protected virtual Task<IReadOnlyList<TModel>> FilterLegacyProjectionAsync(
+        IReadOnlyList<TModel> models, CancellationToken ct) => Task.FromResult(models);
+
+    /// <summary>
     /// Fires the native V4 broadcast for a just-committed write — but only for <see cref="WriteOrigin.Live"/>
     /// writes (backfill imports stay silent so clients aren't flooded). The single gate every mutating
     /// method routes through, so the origin rule lives in exactly one place.
@@ -106,11 +116,13 @@ public abstract class V4RepositoryBase<TModel, TEntity>
         if (origin != WriteOrigin.Live || _entrySink is null)
             return;
 
-        var createdEntries = created.Select(ProjectToLegacyEntry).OfType<Entry>().ToList();
+        var visibleCreated = created.Count > 0 ? await FilterLegacyProjectionAsync(created, ct) : created;
+        var createdEntries = visibleCreated.Select(ProjectToLegacyEntry).OfType<Entry>().ToList();
         if (createdEntries.Count > 0)
             await _entrySink.OnCreatedAsync(createdEntries, ct);
 
-        foreach (var m in updated)
+        var visibleUpdated = updated.Count > 0 ? await FilterLegacyProjectionAsync(updated, ct) : updated;
+        foreach (var m in visibleUpdated)
             if (ProjectToLegacyEntry(m) is { } e)
                 await _entrySink.OnUpdatedAsync(e, ct);
 

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/EntriesProjectionGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/EntriesProjectionGoldenTests.cs
@@ -134,6 +134,41 @@ public class EntriesProjectionGoldenTests
     }
 
     [Fact]
+    public async Task LiveMultiStreamCreate_ProjectsOnlyTheCanonicalStream()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<ISensorGlucoseRepository>();
+        var deviceRepo = scope.ServiceProvider.GetRequiredService<IPatientDeviceRepository>();
+
+        var primary = await deviceRepo.CreateAsync(
+            new PatientDevice { DeviceCategory = DeviceCategory.CGM, Manufacturer = "Dexcom", Model = "G7", Rank = 1 },
+            WriteOrigin.Live, CancellationToken.None);
+        var secondary = await deviceRepo.CreateAsync(
+            new PatientDevice { DeviceCategory = DeviceCategory.CGM, Manufacturer = "Abbott", Model = "Libre 3", Rank = 2 },
+            WriteOrigin.Live, CancellationToken.None);
+        _fx.EntryCapture.Clear();
+
+        // Two CGMs report in the same 5-minute bucket: only the rank-1 device's reading reaches
+        // the legacy entries feed; both rows persist.
+        await repo.BulkCreateAsync(
+            new[]
+            {
+                new SensorGlucose { Timestamp = T0, Mgdl = 120, DataSource = "dexcom-connector", LegacyId = "ep-mc-p1", PatientDeviceId = primary.Id },
+                new SensorGlucose { Timestamp = T0.AddMinutes(1), Mgdl = 145, DataSource = "libre-connector", LegacyId = "ep-mc-s1", PatientDeviceId = secondary.Id },
+            },
+            WriteOrigin.Live, CancellationToken.None);
+
+        var ev = _fx.EntryCapture.Snapshot().Should().ContainSingle(e => e.Kind == "created").Which;
+        var entry = ev.Entries.Should().ContainSingle().Which;
+        entry.Id.Should().Be("ep-mc-p1");
+
+        var rowCount = await _fx.QueryAsync(tenant, ctx =>
+            ctx.SensorGlucose.AsNoTracking().Where(g => g.LegacyId == "ep-mc-p1" || g.LegacyId == "ep-mc-s1").CountAsync());
+        rowCount.Should().Be(2, "the gate filters the broadcast, never the data");
+    }
+
+    [Fact]
     public async Task LiveSgvSingleCreate_ProjectsEntriesCreate()
     {
         var tenant = Guid.NewGuid();

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/V4GoldenFixture.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/V4GoldenFixture.cs
@@ -121,6 +121,7 @@ public class V4GoldenFixture : IAsyncLifetime
         services.AddScoped<IBGCheckRepository, BGCheckRepository>();
         services.AddScoped<INoteRepository, NoteRepository>();
         services.AddScoped<IDeviceEventRepository, DeviceEventRepository>();
+        services.AddScoped<IPatientDeviceRepository, PatientDeviceRepository>();
         services.AddScoped<IBolusCalculationRepository, BolusCalculationRepository>();
         services.AddScoped<IApsSnapshotRepository, ApsSnapshotRepository>();
         services.AddScoped<IPumpSnapshotRepository, PumpSnapshotRepository>();

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V1/EntriesControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V1/EntriesControllerTests.cs
@@ -20,7 +20,7 @@ public class EntriesControllerTests
     private readonly Mock<IEntryService> _mockEntryService;
     private readonly Mock<IDocumentProcessingService> _mockDocumentProcessingService;
     private readonly Mock<IProcessingStatusService> _mockProcessingStatusService;
-    private readonly Mock<IAlertOrchestrator> _mockAlertOrchestrator;
+    private readonly Mock<ICanonicalAlertEvaluator> _mockAlertEvaluator;
     private readonly Mock<ILogger<EntriesController>> _mockLogger;
     private readonly EntriesController _controller;
 
@@ -29,14 +29,14 @@ public class EntriesControllerTests
         _mockEntryService = new Mock<IEntryService>();
         _mockDocumentProcessingService = new Mock<IDocumentProcessingService>();
         _mockProcessingStatusService = new Mock<IProcessingStatusService>();
-        _mockAlertOrchestrator = new Mock<IAlertOrchestrator>();
+        _mockAlertEvaluator = new Mock<ICanonicalAlertEvaluator>();
         _mockLogger = new Mock<ILogger<EntriesController>>();
 
         _controller = new EntriesController(
             _mockEntryService.Object,
             _mockDocumentProcessingService.Object,
             _mockProcessingStatusService.Object,
-            _mockAlertOrchestrator.Object,
+            _mockAlertEvaluator.Object,
             _mockLogger.Object
         );
 

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsControllerTests.cs
@@ -43,7 +43,8 @@ public class StatisticsControllerTests
             Mock.Of<IPatientDeviceRepository>(),
             Mock.Of<IApsSnapshotRepository>(),
             Mock.Of<IDeviceEventRepository>(),
-            Mock.Of<ITargetRangeScheduleRepository>());
+            Mock.Of<ITargetRangeScheduleRepository>(),
+            TestDoubles.CanonicalGlucosePassThrough.Create());
 
         controller.ControllerContext = new ControllerContext
         {

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/SensorGlucoseControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/SensorGlucoseControllerTests.cs
@@ -19,7 +19,7 @@ public class SensorGlucoseControllerTests
 {
     private readonly Mock<ISensorGlucoseRepository> _repoMock = new();
     private readonly Mock<IGlucoseProcessingResolver> _glucoseResolverMock = new();
-    private readonly Mock<IAlertOrchestrator> _alertOrchestratorMock = new();
+    private readonly Mock<ICanonicalAlertEvaluator> _alertEvaluatorMock = new();
     private readonly Mock<ILogger<SensorGlucoseController>> _loggerMock = new();
 
     private SensorGlucoseController CreateController()
@@ -27,7 +27,7 @@ public class SensorGlucoseControllerTests
         var controller = new SensorGlucoseController(
             _repoMock.Object,
             _glucoseResolverMock.Object,
-            _alertOrchestratorMock.Object,
+            _alertEvaluatorMock.Object,
             _loggerMock.Object);
 
         controller.ControllerContext = new ControllerContext

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/AlertReplayServiceLeafLogTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/AlertReplayServiceLeafLogTests.cs
@@ -81,6 +81,7 @@ public class AlertReplayServiceLeafLogTests
         _sut = new AlertReplayService(
             _alertRepository.Object,
             _glucoseRepository.Object,
+            TestDoubles.CanonicalGlucosePassThrough.Create(),
             enricher,
             _tenantAccessor.Object,
             NullLogger<AlertReplayService>.Instance);

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/AlertReplayServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/AlertReplayServiceTests.cs
@@ -83,6 +83,7 @@ public class AlertReplayServiceTests
         _sut = new AlertReplayService(
             _alertRepository.Object,
             _glucoseRepository.Object,
+            TestDoubles.CanonicalGlucosePassThrough.Create(),
             enricher,
             _tenantAccessor.Object,
             NullLogger<AlertReplayService>.Instance);

--- a/tests/Unit/Nocturne.API.Tests/Services/ChartData/Stages/DataFetchStageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ChartData/Stages/DataFetchStageTests.cs
@@ -46,6 +46,7 @@ public class DataFetchStageTests
 
         _stage = new DataFetchStage(
             _mockSensorGlucoseRepo.Object,
+            TestDoubles.CanonicalGlucosePassThrough.Create(),
             _mockBolusRepo.Object,
             _mockCarbIntakeRepo.Object,
             _mockBgCheckRepo.Object,

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/GlucosePublisherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/GlucosePublisherTests.cs
@@ -38,7 +38,7 @@ public class GlucosePublisherTests
             _mockPatientDeviceStamper.Object,
             Mock.Of<IDbContextFactory<NocturneDbContext>>(),
             Mock.Of<ITenantAccessor>(),
-            Mock.Of<IAlertOrchestrator>(),
+            Mock.Of<ICanonicalAlertEvaluator>(),
             Mock.Of<IAuditContext>(),
             NullLogger<GlucosePublisher>.Instance
         );

--- a/tests/Unit/Nocturne.API.Tests/Services/Entries/EntryReadServiceCountTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Entries/EntryReadServiceCountTests.cs
@@ -22,6 +22,7 @@ public class EntryReadServiceCountTests
             _sgRepo.Object,
             _mgRepo.Object,
             _calRepo.Object,
+            TestDoubles.CanonicalGlucosePassThrough.Create(),
             _demoMode.Object,
             Mock.Of<ILogger<EntryReadService>>());
     }

--- a/tests/Unit/Nocturne.API.Tests/Services/Entries/EntryReadServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Entries/EntryReadServiceTests.cs
@@ -27,6 +27,7 @@ public class EntryReadServiceTests
             _sgRepo.Object,
             _mgRepo.Object,
             _calRepo.Object,
+            TestDoubles.CanonicalGlucosePassThrough.Create(),
             _demoMode.Object,
             Mock.Of<ILogger<EntryReadService>>());
     }
@@ -135,39 +136,42 @@ public class EntryReadServiceTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task QueryAsync_SingleType_PushesLimitAndOffsetToRepo()
+    public async Task QueryAsync_SingleType_OverFetchesForCanonicalSelectionThenPages()
     {
-        // Single-type queries push limit/offset directly to the database
-        var entries = Enumerable.Range(0, 2)
+        // Canonical stream selection runs after the DB query, so sgv fetches over-fetch
+        // (count+skip)×3 from offset 0 and page in memory.
+        var entries = Enumerable.Range(0, 4)
             .Select(i => MakeSg(Now.AddMinutes(-i), 100 + i))
             .ToArray();
 
         _sgRepo.Setup(r => r.GetAsync(
                 It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string?>(), It.IsAny<string?>(),
-                2, 1, true, false, It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+                9, 0, true, false, It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(entries);
 
         var result = await _sut.QueryAsync(new EntryQuery { Type = "sgv", Count = 2, Skip = 1 });
 
         Assert.Equal(2, result.Count);
-        // Verify the repo was called with limit=count, offset=skip (not count+skip, 0)
+        // Page starts after the skipped newest reading
+        Assert.Equal(entries[1].Mgdl, result[0].Sgv);
         _sgRepo.Verify(r => r.GetAsync(
             It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string?>(), It.IsAny<string?>(),
-            2, 1, true, false, It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()), Times.Once);
+            9, 0, true, false, It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     [Trait("Category", "Unit")]
     public async Task QueryAsync_AllTypes_OverFetchesForMergePagination()
     {
-        // Multi-type merge still needs count+skip from each repo
+        // Multi-type merge needs count+skip from each repo (sgv over-fetches ×3 on top for
+        // canonical selection)
         var sg = MakeSg(Now, 120);
         var mg = MakeMg(Now.AddMinutes(-1), 150);
         var cal = MakeCal(Now.AddMinutes(-2));
 
         _sgRepo.Setup(r => r.GetAsync(
                 It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string?>(), It.IsAny<string?>(),
-                3, 0, true, false, It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+                9, 0, true, false, It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[] { sg });
         _mgRepo.Setup(r => r.GetAsync(
                 It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string?>(), It.IsAny<string?>(),
@@ -182,10 +186,9 @@ public class EntryReadServiceTests
 
         // Skip 1, take 2 from the merged 3
         Assert.Equal(2, result.Count);
-        // Verify repos were called with fetchCount = count+skip = 3, offset = 0
         _sgRepo.Verify(r => r.GetAsync(
             It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string?>(), It.IsAny<string?>(),
-            3, 0, true, false, It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()), Times.Once);
+            9, 0, true, false, It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     #endregion
@@ -382,6 +385,7 @@ public class EntryReadServiceTests
         _demoMode.Setup(d => d.IsEnabled).Returns(true);
         var sut = new EntryReadService(
             _sgRepo.Object, _mgRepo.Object, _calRepo.Object,
+            TestDoubles.CanonicalGlucosePassThrough.Create(),
             _demoMode.Object, Mock.Of<ILogger<EntryReadService>>());
 
         var demoSg = MakeSg(Now, 100, dataSource: "demo-service");

--- a/tests/Unit/Nocturne.API.Tests/Services/Glucose/CanonicalGlucoseServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Glucose/CanonicalGlucoseServiceTests.cs
@@ -1,0 +1,112 @@
+using FluentAssertions;
+using Moq;
+using Nocturne.API.Services.Glucose;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.V4;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Glucose;
+
+[Trait("Category", "Unit")]
+public class CanonicalGlucoseServiceTests
+{
+    private readonly Mock<ISensorGlucoseRepository> _sgRepo = new();
+    private readonly Mock<IPatientDeviceRepository> _deviceRepo = new();
+    private readonly CanonicalGlucoseService _sut;
+
+    private static readonly DateTime Now = DateTime.UtcNow;
+
+    public CanonicalGlucoseServiceTests()
+    {
+        var demoMode = new Mock<Nocturne.API.Services.Platform.IDemoModeService>();
+        demoMode.Setup(d => d.IsEnabled).Returns(false);
+        _sut = new CanonicalGlucoseService(_sgRepo.Object, _deviceRepo.Object, demoMode.Object);
+    }
+
+    private static PatientDevice Cgm(int rank) => new()
+    {
+        Id = Guid.NewGuid(),
+        DeviceCategory = DeviceCategory.CGM,
+        Manufacturer = "Test",
+        Model = "Test CGM",
+        Rank = rank,
+    };
+
+    private static SensorGlucose Reading(Guid deviceId, double minutesAgo, double mgdl = 120) => new()
+    {
+        Id = Guid.NewGuid(),
+        Mgdl = mgdl,
+        Timestamp = Now.AddMinutes(-minutesAgo),
+        PatientDeviceId = deviceId,
+    };
+
+    [Fact]
+    public async Task SelectAsync_SingleStream_ReturnsInputWithoutLoadingDevices()
+    {
+        var deviceId = Guid.NewGuid();
+        var readings = new List<SensorGlucose> { Reading(deviceId, 0), Reading(deviceId, 5) };
+
+        var result = await _sut.SelectAsync(readings);
+
+        result.Should().BeSameAs(readings);
+        _deviceRepo.Verify(r => r.GetAllAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SelectAsync_MultiStream_LoadsDevicesOnce_AndFiltersByRank()
+    {
+        var primary = Cgm(rank: 1);
+        var secondary = Cgm(rank: 2);
+        _deviceRepo.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([primary, secondary]);
+
+        var readings = new List<SensorGlucose> { Reading(primary.Id, 0), Reading(secondary.Id, 1) };
+
+        var first = await _sut.SelectAsync(readings);
+        var second = await _sut.SelectAsync(readings);
+
+        first.Should().ContainSingle().Which.PatientDeviceId.Should().Be(primary.Id);
+        second.Should().ContainSingle();
+        _deviceRepo.Verify(r => r.GetAllAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetLatestAsync_ReturnsCanonicalLatest_NotRawLatest()
+    {
+        var primary = Cgm(rank: 1);
+        var secondary = Cgm(rank: 2);
+        _deviceRepo.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([primary, secondary]);
+
+        // Secondary reported most recently, but in a bucket where the primary also reported —
+        // the canonical latest is the primary's reading. Pin both into the previous full
+        // 5-minute bucket so the shared-bucket premise doesn't depend on the wall clock.
+        var bucketStart = new DateTime(Now.Ticks - Now.Ticks % TimeSpan.FromMinutes(5).Ticks, DateTimeKind.Utc)
+            .AddMinutes(-5);
+        var primaryReading = Reading(primary.Id, 0, mgdl: 110);
+        primaryReading.Timestamp = bucketStart.AddMinutes(1);
+        var secondaryReading = Reading(secondary.Id, 0, mgdl: 160);
+        secondaryReading.Timestamp = bucketStart.AddMinutes(2);
+        _sgRepo.Setup(r => r.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([secondaryReading, primaryReading]);
+
+        var latest = await _sut.GetLatestAsync();
+
+        latest.Should().NotBeNull();
+        latest!.PatientDeviceId.Should().Be(primary.Id);
+        latest.Mgdl.Should().Be(110);
+    }
+
+    [Fact]
+    public async Task GetLatestAsync_NoRecentReadings_ReturnsNull()
+    {
+        _sgRepo.Setup(r => r.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        (await _sut.GetLatestAsync()).Should().BeNull();
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/TestDoubles/CanonicalGlucosePassThrough.cs
+++ b/tests/Unit/Nocturne.API.Tests/TestDoubles/CanonicalGlucosePassThrough.cs
@@ -1,0 +1,20 @@
+using Moq;
+using Nocturne.Core.Contracts.Glucose;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.API.Tests.TestDoubles;
+
+/// <summary>
+/// A canonical glucose service that returns its input unchanged — the single-stream behaviour,
+/// which is what fixtures not exercising multi-CGM scenarios expect.
+/// </summary>
+internal static class CanonicalGlucosePassThrough
+{
+    public static ICanonicalGlucoseService Create()
+    {
+        var mock = new Mock<ICanonicalGlucoseService>();
+        mock.Setup(s => s.SelectAsync(It.IsAny<IReadOnlyList<SensorGlucose>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<SensorGlucose> readings, CancellationToken _) => readings);
+        return mock.Object;
+    }
+}

--- a/tests/Unit/Nocturne.Core.Models.Tests/V4/CanonicalGlucoseStreamTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/V4/CanonicalGlucoseStreamTests.cs
@@ -1,0 +1,223 @@
+using FluentAssertions;
+using Nocturne.Core.Models.V4;
+using Xunit;
+
+namespace Nocturne.Core.Models.Tests.V4;
+
+[Trait("Category", "Unit")]
+public class CanonicalGlucoseStreamTests
+{
+    // 12:00:00Z sits on a 5-minute boundary, so offsets within [0,5) share a bucket.
+    private static readonly DateTime T0 = new(2026, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+
+    private static PatientDevice Cgm(int? rank = null, DateOnly? start = null, DateTime? created = null) => new()
+    {
+        Id = Guid.NewGuid(),
+        DeviceCategory = DeviceCategory.CGM,
+        Manufacturer = "Test",
+        Model = "Test CGM",
+        Rank = rank,
+        StartDate = start,
+        CreatedAt = created ?? T0.AddDays(-30),
+    };
+
+    private static SensorGlucose Reading(double minutes, Guid? deviceId = null, string? source = null, string? device = null) => new()
+    {
+        Id = Guid.NewGuid(),
+        Mgdl = 120,
+        Timestamp = T0.AddMinutes(minutes),
+        PatientDeviceId = deviceId,
+        DataSource = source,
+        Device = device,
+    };
+
+    [Fact]
+    public void EmptyInput_ReturnsEmpty()
+    {
+        CanonicalGlucoseStream.Select([], []).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SingleStream_ReturnsInputUnchanged()
+    {
+        var device = Cgm(rank: 1);
+        var readings = new List<SensorGlucose> { Reading(0, device.Id), Reading(5, device.Id), Reading(10, device.Id) };
+
+        var result = CanonicalGlucoseStream.Select(readings, [device]);
+
+        result.Should().BeSameAs(readings);
+    }
+
+    [Fact]
+    public void TwoDevices_HigherRankWinsEveryContestedBucket()
+    {
+        var primary = Cgm(rank: 1);
+        var secondary = Cgm(rank: 2);
+        var readings = new List<SensorGlucose>
+        {
+            Reading(0, primary.Id), Reading(1, secondary.Id),
+            Reading(5, primary.Id), Reading(6, secondary.Id),
+        };
+
+        var result = CanonicalGlucoseStream.Select(readings, [primary, secondary]);
+
+        result.Should().OnlyContain(r => r.PatientDeviceId == primary.Id);
+        result.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void SecondaryFillsBucketsThePrimaryMisses()
+    {
+        var primary = Cgm(rank: 1);
+        var secondary = Cgm(rank: 2);
+        var readings = new List<SensorGlucose>
+        {
+            Reading(0, primary.Id),
+            Reading(6, secondary.Id),   // primary silent 12:05-12:10 → secondary fills
+            Reading(10, primary.Id),
+        };
+
+        var result = CanonicalGlucoseStream.Select(readings, [primary, secondary]);
+
+        result.Should().HaveCount(3);
+        result[1].PatientDeviceId.Should().Be(secondary.Id);
+    }
+
+    [Fact]
+    public void WinnersFullDensityIsKeptWithinTheBucket()
+    {
+        // 1-minute Libre-style primary vs 5-minute secondary: all five primary readings survive.
+        var primary = Cgm(rank: 1);
+        var secondary = Cgm(rank: 2);
+        var readings = new List<SensorGlucose>
+        {
+            Reading(0, primary.Id), Reading(1, primary.Id), Reading(2, primary.Id),
+            Reading(3, primary.Id), Reading(4, primary.Id),
+            Reading(2.5, secondary.Id),
+        };
+
+        var result = CanonicalGlucoseStream.Select(readings, [primary, secondary]);
+
+        result.Should().HaveCount(5);
+        result.Should().OnlyContain(r => r.PatientDeviceId == primary.Id);
+    }
+
+    [Fact]
+    public void UnrankedDevices_MostRecentStartDateWins()
+    {
+        var older = Cgm(start: new DateOnly(2026, 1, 1));
+        var newer = Cgm(start: new DateOnly(2026, 6, 1));
+        var readings = new List<SensorGlucose> { Reading(0, older.Id), Reading(1, newer.Id) };
+
+        var result = CanonicalGlucoseStream.Select(readings, [older, newer]);
+
+        result.Should().ContainSingle().Which.PatientDeviceId.Should().Be(newer.Id);
+    }
+
+    [Fact]
+    public void RankedDeviceBeatsUnranked_RegardlessOfStartDate()
+    {
+        var ranked = Cgm(rank: 5, start: new DateOnly(2026, 1, 1));
+        var unranked = Cgm(start: new DateOnly(2026, 6, 1));
+        var readings = new List<SensorGlucose> { Reading(0, ranked.Id), Reading(1, unranked.Id) };
+
+        var result = CanonicalGlucoseStream.Select(readings, [ranked, unranked]);
+
+        result.Should().ContainSingle().Which.PatientDeviceId.Should().Be(ranked.Id);
+    }
+
+    [Fact]
+    public void RegisteredDeviceBeatsPseudoDevice()
+    {
+        var device = Cgm(rank: 1);
+        var readings = new List<SensorGlucose>
+        {
+            Reading(0, device.Id),
+            Reading(1, source: "xdrip", device: "xDrip-DexcomG6"),
+        };
+
+        var result = CanonicalGlucoseStream.Select(readings, [device]);
+
+        result.Should().ContainSingle().Which.PatientDeviceId.Should().Be(device.Id);
+    }
+
+    [Fact]
+    public void PseudoDeviceFillsBucketsRegisteredDevicesMiss()
+    {
+        var device = Cgm(rank: 1);
+        var readings = new List<SensorGlucose>
+        {
+            Reading(0, device.Id),
+            Reading(6, source: "xdrip", device: "phone"),
+        };
+
+        var result = CanonicalGlucoseStream.Select(readings, [device]);
+
+        result.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void TwoPseudoDevices_StitchDeterministically_NotBlended()
+    {
+        var readings = new List<SensorGlucose>
+        {
+            Reading(0, source: "dexcom-connector", device: "share"),
+            Reading(1, source: "libre-connector", device: "linkup"),
+            Reading(5, source: "dexcom-connector", device: "share"),
+            Reading(6, source: "libre-connector", device: "linkup"),
+        };
+
+        var result = CanonicalGlucoseStream.Select(readings, []);
+
+        // Ordinal key order: dexcom-connector < libre-connector — same winner both buckets.
+        result.Should().HaveCount(2);
+        result.Should().OnlyContain(r => r.DataSource == "dexcom-connector");
+    }
+
+    [Fact]
+    public void UnknownPatientDeviceId_TreatedAsPseudoDevice_BelowRegistered()
+    {
+        var registered = Cgm(rank: 1);
+        var deleted = Guid.NewGuid();
+        var readings = new List<SensorGlucose> { Reading(0, registered.Id), Reading(1, deleted) };
+
+        var result = CanonicalGlucoseStream.Select(readings, [registered]);
+
+        result.Should().ContainSingle().Which.PatientDeviceId.Should().Be(registered.Id);
+    }
+
+    [Fact]
+    public void InputOrderIsPreserved()
+    {
+        var primary = Cgm(rank: 1);
+        var secondary = Cgm(rank: 2);
+        // Descending order, as v1 queries return.
+        var readings = new List<SensorGlucose>
+        {
+            Reading(10, primary.Id), Reading(6, secondary.Id), Reading(0, primary.Id),
+        };
+
+        var result = CanonicalGlucoseStream.Select(readings, [primary, secondary]);
+
+        result.Select(r => r.Timestamp).Should().BeInDescendingOrder();
+        result.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void BucketBoundary_SplitsAtAlignedFiveMinutes()
+    {
+        var primary = Cgm(rank: 1);
+        var secondary = Cgm(rank: 2);
+        var readings = new List<SensorGlucose>
+        {
+            Reading(4.5, secondary.Id),  // bucket [12:00,12:05): contested, primary wins below
+            Reading(4.0, primary.Id),
+            Reading(5.5, secondary.Id),  // bucket [12:05,12:10): secondary alone → kept
+        };
+
+        var result = CanonicalGlucoseStream.Select(readings, [primary, secondary]);
+
+        result.Should().HaveCount(2);
+        result.Select(r => r.PatientDeviceId).Should().Equal(primary.Id, secondary.Id);
+    }
+}


### PR DESCRIPTION
Multi-CGM **PR2 of 4** (on top of #449). Two CGMs worn at once — sensor-overlap warmup, n=1 comparisons — no longer double-count in statistics, jitter follower apps, or confuse alarms. Single-stream consumers now serve one coherent **canonical stream**, selected at read time. No data is deleted or hidden at rest, and a single-stream tenant's output is byte-identical.

## The canonical stream

Per aligned 5-minute UTC bucket, the highest-priority stream with a reading wins, and **all** of that stream's readings in the bucket are emitted (1-minute Libre density survives). Priority: `PatientDevice.Rank` asc nulls-last → most recent `StartDate` → `CreatedAt`; unattributed readings group by `(DataSource, Device)` as pseudo-devices below every registered device. A user with zero registered devices and one source gets exactly today's behavior; gaps in the winner stitch from the next stream down — promoting a new sensor to rank 1 bridges its warmup from the old one.

Implemented as a pure selector (`CanonicalGlucoseStream`, Core) with a device-aware service wrapper (`ICanonicalGlucoseService`) that fast-paths single-stream inputs without touching the device table.

## Where it's wired

- **v1/v3 REST** (`EntryReadService`): all sgv reads — entries queries, current-entry, Pebble, tray/widgets. Paging over-fetches geometrically after selection so a higher-cadence losing stream can't shorten pages.
- **Legacy realtime broadcast**: new `FilterLegacyProjectionAsync` hook at the V4 repository chokepoint; the sensor-glucose repo gates live created/updated projections through selection over the recent 15-minute window plus the batch. Deletes are never filtered; the gate fails open. The **native V4 broadcast stays multi-stream** — V4 is the multi-stream surface.
- **Alarms**: `ICanonicalAlertEvaluator` replaces latest-of-batch evaluation in `GlucosePublisher`, the v1/v3 entries controllers, and the V4 controller; `AlertReplayService` replays the canonical stream. A losing CGM's readings never trigger or suppress an alarm. The latest canonical reading is resolved with **no staleness window** — delayed-sync sources (Glooko, CareLink periodic chunks) still alarm late-but-always, exactly as before.
- **Unfiltered analytics**: range-analytics, periods, punch-card, and the dashboard chart fetch canonicalize. `aid-system-metrics` intentionally stays raw (it counts readings per device).

## Tests
13 selector unit tests (rank, stitching, density, pseudo-devices, bucket boundaries, order preservation), service tests (fast path skips device load, canonical-latest vs raw-latest, demo filtering), updated read-service paging tests, and a new integration golden (`LiveMultiStreamCreate_ProjectsOnlyTheCanonicalStream`) pinning the broadcast gate against real Postgres. Full unit suite green (4,700+).

## Follow-ups (PR3/PR4)
V4 `patientDeviceId` filters + contributing-devices stats metadata, discovered-sources & rank management UI, then the per-device comparison feature (paired readings, agreement metrics).