### PR TITLE
fix(alerts): treat capped reservoir readings ("50+") as a lower bound

### DIFF
--- a/crates/nocturne-alerts-core/src/context.rs
+++ b/crates/nocturne-alerts-core/src/context.rs
@@ -68,6 +68,9 @@ pub struct SensorContext {
     pub iob_units: Option<Decimal>,
     pub cob_grams: Option<Decimal>,
     pub reservoir_units: Option<Decimal>,
+    /// True when `reservoir_units` is a lower bound rather than an exact reading
+    /// (e.g. an Omnipod reports "50+" while the reservoir holds at least 50 units).
+    pub reservoir_is_lower_bound: bool,
     pub last_site_change_at: Option<DateTime<Utc>>,
     pub last_sensor_start_at: Option<DateTime<Utc>>,
     pub predictions: Vec<PredictedPoint>,
@@ -122,6 +125,8 @@ struct WireContext {
     cob_grams: Option<Number>,
     #[serde(default)]
     reservoir_units: Option<Number>,
+    #[serde(default)]
+    reservoir_is_lower_bound: Option<bool>,
     #[serde(default)]
     last_site_change_at: Option<DateTime<Utc>>,
     #[serde(default)]
@@ -284,6 +289,7 @@ impl SensorContext {
             iob_units: opt_dec(w.iob_units.as_ref(), "iob_units")?,
             cob_grams: opt_dec(w.cob_grams.as_ref(), "cob_grams")?,
             reservoir_units: opt_dec(w.reservoir_units.as_ref(), "reservoir_units")?,
+            reservoir_is_lower_bound: w.reservoir_is_lower_bound.unwrap_or(false),
             last_site_change_at: w.last_site_change_at,
             last_sensor_start_at: w.last_sensor_start_at,
             predictions: w

--- a/crates/nocturne-alerts-core/src/eval/insulin.rs
+++ b/crates/nocturne-alerts-core/src/eval/insulin.rs
@@ -15,7 +15,14 @@ pub(super) fn cob(p: &ComparePayload, env: &Env) -> bool {
     compare_optional(p, env.ctx.cob_grams)
 }
 
+/// A lower-bound reading ("50+") only proves the reservoir holds at least that
+/// much: `>` / `>=` can be confirmed against the bound; `<` / `<=` / `==` cannot.
 pub(super) fn reservoir(p: &ComparePayload, env: &Env) -> bool {
+    if env.ctx.reservoir_is_lower_bound
+        && !matches!(p.operator.as_deref(), Some(">") | Some(">="))
+    {
+        return false;
+    }
     compare_optional(p, env.ctx.reservoir_units)
 }
 

--- a/crates/nocturne-alerts-core/src/eval/insulin.rs
+++ b/crates/nocturne-alerts-core/src/eval/insulin.rs
@@ -18,8 +18,7 @@ pub(super) fn cob(p: &ComparePayload, env: &Env) -> bool {
 /// A lower-bound reading ("50+") only proves the reservoir holds at least that
 /// much: `>` / `>=` can be confirmed against the bound; `<` / `<=` / `==` cannot.
 pub(super) fn reservoir(p: &ComparePayload, env: &Env) -> bool {
-    if env.ctx.reservoir_is_lower_bound
-        && !matches!(p.operator.as_deref(), Some(">") | Some(">="))
+    if env.ctx.reservoir_is_lower_bound && !matches!(p.operator.as_deref(), Some(">") | Some(">="))
     {
         return false;
     }

--- a/src/API/Nocturne.API/Services/Alerts/Engines/RustEnvelopeMapper.cs
+++ b/src/API/Nocturne.API/Services/Alerts/Engines/RustEnvelopeMapper.cs
@@ -122,6 +122,7 @@ internal static class RustEnvelopeMapper
             IobUnits = ctx.IobUnits,
             CobGrams = ctx.CobGrams,
             ReservoirUnits = ctx.ReservoirUnits,
+            ReservoirIsLowerBound = ctx.ReservoirIsLowerBound ? true : null,
             LastSiteChangeAt = Utc(ctx.LastSiteChangeAt),
             LastSensorStartAt = Utc(ctx.LastSensorStartAt),
             Predictions = ctx.Predictions.Count == 0
@@ -253,6 +254,7 @@ internal static class RustEnvelopeMapper
         [JsonPropertyName("iob_units")] public decimal? IobUnits { get; init; }
         [JsonPropertyName("cob_grams")] public decimal? CobGrams { get; init; }
         [JsonPropertyName("reservoir_units")] public decimal? ReservoirUnits { get; init; }
+        [JsonPropertyName("reservoir_is_lower_bound")] public bool? ReservoirIsLowerBound { get; init; }
         [JsonPropertyName("last_site_change_at")] public DateTime? LastSiteChangeAt { get; init; }
         [JsonPropertyName("last_sensor_start_at")] public DateTime? LastSensorStartAt { get; init; }
         [JsonPropertyName("predictions")] public List<WirePrediction>? Predictions { get; init; }

--- a/src/API/Nocturne.API/Services/Alerts/Evaluators/ReservoirEvaluator.cs
+++ b/src/API/Nocturne.API/Services/Alerts/Evaluators/ReservoirEvaluator.cs
@@ -33,6 +33,11 @@ public class ReservoirEvaluator : IConditionEvaluator
         if (condition is null)
             return Task.FromResult(false);
 
+        // A lower-bound reading ("50+") only proves the reservoir holds at least that much:
+        // > / >= can be confirmed against the bound; < / <= / == cannot.
+        if (context.ReservoirIsLowerBound && condition.Operator is not (">" or ">="))
+            return Task.FromResult(false);
+
         return Task.FromResult(ComparisonOps.Compare(context.ReservoirUnits.Value, condition.Operator, condition.Value));
     }
 }

--- a/src/API/Nocturne.API/Services/Alerts/SensorContextEnricher.cs
+++ b/src/API/Nocturne.API/Services/Alerts/SensorContextEnricher.cs
@@ -131,8 +131,8 @@ internal sealed class SensorContextEnricher : ISensorContextEnricher
 
         if (needs.NeedsReservoir)
         {
-            var reservoirUnits = await FetchReservoirAsync(isReplay ? now : null, ct);
-            enriched = enriched with { ReservoirUnits = reservoirUnits };
+            var (reservoirUnits, reservoirIsLowerBound) = await FetchReservoirAsync(isReplay ? now : null, ct);
+            enriched = enriched with { ReservoirUnits = reservoirUnits, ReservoirIsLowerBound = reservoirIsLowerBound };
         }
 
         if (needs.NeedsSiteAge)
@@ -638,7 +638,7 @@ internal sealed class SensorContextEnricher : ISensorContextEnricher
         return points;
     }
 
-    private async Task<decimal?> FetchReservoirAsync(DateTime? asOf, CancellationToken ct)
+    private async Task<(decimal? Units, bool IsLowerBound)> FetchReservoirAsync(DateTime? asOf, CancellationToken ct)
     {
         // Pin the upper bound to `asOf` for replay; live path leaves both bounds null and gets
         // the absolute latest. `to: asOf` upper-bounds the read to the replay tick (inclusive).
@@ -646,8 +646,11 @@ internal sealed class SensorContextEnricher : ISensorContextEnricher
             from: null, to: asOf, device: null, source: null,
             limit: 1, offset: 0, descending: true, ct: ct);
 
-        var reservoir = snapshots.FirstOrDefault()?.Reservoir;
-        return reservoir is null ? null : (decimal)reservoir.Value;
+        var snapshot = snapshots.FirstOrDefault();
+        if (snapshot?.Reservoir is not { } reservoir)
+            return (null, false);
+
+        return ((decimal)reservoir, ReservoirDisplayFormat.IsLowerBound(snapshot.ReservoirDisplay));
     }
 
     private async Task<DateTime?> FetchLatestEventAsync(DeviceEventType eventType, DateTime? asOf, CancellationToken ct)

--- a/src/Core/Nocturne.Core.Models/AlertModels.cs
+++ b/src/Core/Nocturne.Core.Models/AlertModels.cs
@@ -57,6 +57,12 @@ public record SensorContext
     public decimal? ReservoirUnits { get; init; }
 
     /// <summary>
+    /// True when <see cref="ReservoirUnits"/> is a lower bound rather than an exact reading
+    /// (e.g. an Omnipod reports "50+" while the reservoir holds at least 50 units).
+    /// </summary>
+    public bool ReservoirIsLowerBound { get; init; }
+
+    /// <summary>
     /// Timestamp of the most recent infusion site change. Used by the site-age condition.
     /// </summary>
     [ReplayFact("site_age_hours", decimals: 1, conversion: ReplayFactConversion.HoursSinceNow)]

--- a/src/Core/Nocturne.Core.Models/V4/ReservoirDisplayFormat.cs
+++ b/src/Core/Nocturne.Core.Models/V4/ReservoirDisplayFormat.cs
@@ -1,0 +1,20 @@
+using System.Text.RegularExpressions;
+
+namespace Nocturne.Core.Models.V4;
+
+/// <summary>
+/// Interprets pump reservoir display strings (<see cref="PumpSnapshot.ReservoirDisplay"/>).
+/// </summary>
+public static partial class ReservoirDisplayFormat
+{
+    /// <summary>
+    /// True when the display string marks the numeric reservoir value as a lower bound
+    /// rather than an exact reading — e.g. "50+U" from Omnipod pumps, which only report
+    /// exact levels below 50 units.
+    /// </summary>
+    public static bool IsLowerBound(string? display) =>
+        display is not null && LowerBoundPattern().IsMatch(display);
+
+    [GeneratedRegex(@"^\s*\d+(\.\d+)?\s*\+")]
+    private static partial Regex LowerBoundPattern();
+}

--- a/tests/Parity/AlertEngineCorpus/reservoir-lower-bound.expected.json
+++ b/tests/Parity/AlertEngineCorpus/reservoir-lower-bound.expected.json
@@ -1,0 +1,202 @@
+{
+  "schema_version": 1,
+  "scenario": "reservoir-lower-bound",
+  "ticks": [
+    {
+      "at": "2026-01-05T12:00:00Z",
+      "rules": [
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000001",
+          "root": false,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": false
+            }
+          ],
+          "transition": "none",
+          "tracker": {
+            "state": "idle",
+            "confirmation_count": 0
+          }
+        },
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000002",
+          "root": false,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": false
+            }
+          ],
+          "transition": "none",
+          "tracker": {
+            "state": "idle",
+            "confirmation_count": 0
+          }
+        },
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000003",
+          "root": false,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": false
+            }
+          ],
+          "transition": "none",
+          "tracker": {
+            "state": "idle",
+            "confirmation_count": 0
+          }
+        },
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000004",
+          "root": true,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": true
+            }
+          ],
+          "transition": "opened",
+          "tracker": {
+            "state": "active",
+            "confirmation_count": 0,
+            "excursion": 1
+          }
+        },
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000005",
+          "root": true,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": true
+            }
+          ],
+          "transition": "opened",
+          "tracker": {
+            "state": "active",
+            "confirmation_count": 0,
+            "excursion": 2
+          }
+        },
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000006",
+          "root": false,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": false
+            }
+          ],
+          "transition": "none",
+          "tracker": {
+            "state": "idle",
+            "confirmation_count": 0
+          }
+        }
+      ]
+    },
+    {
+      "at": "2026-01-05T12:05:00Z",
+      "rules": [
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000001",
+          "root": true,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": true
+            }
+          ],
+          "transition": "opened",
+          "tracker": {
+            "state": "active",
+            "confirmation_count": 0,
+            "excursion": 3
+          }
+        },
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000002",
+          "root": true,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": true
+            }
+          ],
+          "transition": "opened",
+          "tracker": {
+            "state": "active",
+            "confirmation_count": 0,
+            "excursion": 4
+          }
+        },
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000003",
+          "root": false,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": false
+            }
+          ],
+          "transition": "none",
+          "tracker": {
+            "state": "idle",
+            "confirmation_count": 0
+          }
+        },
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000004",
+          "root": true,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": true
+            }
+          ],
+          "transition": "continues",
+          "tracker": {
+            "state": "active",
+            "confirmation_count": 0,
+            "excursion": 1
+          }
+        },
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000005",
+          "root": false,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": false
+            }
+          ],
+          "transition": "hysteresis_started",
+          "tracker": {
+            "state": "hysteresis",
+            "confirmation_count": 0,
+            "excursion": 2
+          }
+        },
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000006",
+          "root": false,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": false
+            }
+          ],
+          "transition": "none",
+          "tracker": {
+            "state": "idle",
+            "confirmation_count": 0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/Parity/AlertEngineCorpus/reservoir-lower-bound.json
+++ b/tests/Parity/AlertEngineCorpus/reservoir-lower-bound.json
@@ -1,0 +1,110 @@
+{
+  "schema_version": 1,
+  "name": "reservoir-lower-bound",
+  "description": "reservoir_is_lower_bound gates \u003C / \u003C= / == to false while \u003E and \u003E= compare against the bound; exact readings are unaffected",
+  "rules": [
+    {
+      "id": "00000000-0000-0000-0000-000000000001",
+      "name": "rule-1",
+      "condition_type": "reservoir",
+      "condition_params": {
+        "operator": "\u003C",
+        "value": 60
+      },
+      "confirmation_readings": 1,
+      "hysteresis_minutes": 0,
+      "auto_resolve_enabled": false
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000002",
+      "name": "rule-2",
+      "condition_type": "reservoir",
+      "condition_params": {
+        "operator": "\u003C=",
+        "value": 60
+      },
+      "confirmation_readings": 1,
+      "hysteresis_minutes": 0,
+      "auto_resolve_enabled": false
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000003",
+      "name": "rule-3",
+      "condition_type": "reservoir",
+      "condition_params": {
+        "operator": "==",
+        "value": 50
+      },
+      "confirmation_readings": 1,
+      "hysteresis_minutes": 0,
+      "auto_resolve_enabled": false
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000004",
+      "name": "rule-4",
+      "condition_type": "reservoir",
+      "condition_params": {
+        "operator": "\u003E",
+        "value": 40
+      },
+      "confirmation_readings": 1,
+      "hysteresis_minutes": 0,
+      "auto_resolve_enabled": false
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000005",
+      "name": "rule-5",
+      "condition_type": "reservoir",
+      "condition_params": {
+        "operator": "\u003E=",
+        "value": 50
+      },
+      "confirmation_readings": 1,
+      "hysteresis_minutes": 0,
+      "auto_resolve_enabled": false
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000006",
+      "name": "rule-6",
+      "condition_type": "reservoir",
+      "condition_params": {
+        "operator": "\u003E",
+        "value": 50
+      },
+      "confirmation_readings": 1,
+      "hysteresis_minutes": 0,
+      "auto_resolve_enabled": false
+    }
+  ],
+  "ticks": [
+    {
+      "at": "2026-01-05T12:00:00Z",
+      "context": {
+        "latest_value": 100,
+        "latest_timestamp": "2026-01-05T12:00:00Z",
+        "trend_rate": 0,
+        "last_reading_at": "2026-01-05T12:00:00Z",
+        "reservoir_units": 50,
+        "reservoir_is_lower_bound": true,
+        "has_ever_aps_cycled": false,
+        "has_ever_pump_snapshot": false,
+        "has_ever_uploader_snapshot": false,
+        "has_ever_aps_sensitivity": false
+      }
+    },
+    {
+      "at": "2026-01-05T12:05:00Z",
+      "context": {
+        "latest_value": 100,
+        "latest_timestamp": "2026-01-05T12:05:00Z",
+        "trend_rate": 0,
+        "last_reading_at": "2026-01-05T12:05:00Z",
+        "reservoir_units": 42,
+        "has_ever_aps_cycled": false,
+        "has_ever_pump_snapshot": false,
+        "has_ever_uploader_snapshot": false,
+        "has_ever_aps_sensitivity": false
+      }
+    }
+  ]
+}

--- a/tests/Parity/Nocturne.Alerts.ParityCorpus.Generator/Harness/ScenarioConversions.cs
+++ b/tests/Parity/Nocturne.Alerts.ParityCorpus.Generator/Harness/ScenarioConversions.cs
@@ -59,6 +59,7 @@ public static class ScenarioConversions
             IobUnits = ctx.IobUnits,
             CobGrams = ctx.CobGrams,
             ReservoirUnits = ctx.ReservoirUnits,
+            ReservoirIsLowerBound = ctx.ReservoirIsLowerBound ?? false,
             LastSiteChangeAt = Utc(ctx.LastSiteChangeAt),
             LastSensorStartAt = Utc(ctx.LastSensorStartAt),
             Predictions = ctx.Predictions?.Select(p => new PredictedGlucosePoint(p.OffsetMinutes, p.Mgdl)).ToList()

--- a/tests/Parity/Nocturne.Alerts.ParityCorpus.Generator/Harness/ScenarioModels.cs
+++ b/tests/Parity/Nocturne.Alerts.ParityCorpus.Generator/Harness/ScenarioModels.cs
@@ -126,6 +126,7 @@ public sealed record ScenarioContext
     [JsonPropertyName("iob_units")] public decimal? IobUnits { get; init; }
     [JsonPropertyName("cob_grams")] public decimal? CobGrams { get; init; }
     [JsonPropertyName("reservoir_units")] public decimal? ReservoirUnits { get; init; }
+    [JsonPropertyName("reservoir_is_lower_bound")] public bool? ReservoirIsLowerBound { get; init; }
     [JsonPropertyName("last_site_change_at")] public DateTime? LastSiteChangeAt { get; init; }
     [JsonPropertyName("last_sensor_start_at")] public DateTime? LastSensorStartAt { get; init; }
     public List<ScenarioPrediction>? Predictions { get; init; }

--- a/tests/Parity/Nocturne.Alerts.ParityCorpus.Generator/Scenarios/ComparisonLeafScenarios.cs
+++ b/tests/Parity/Nocturne.Alerts.ParityCorpus.Generator/Scenarios/ComparisonLeafScenarios.cs
@@ -72,6 +72,24 @@ public static class ComparisonLeafScenarios
             }
         }
 
+        // A lower-bound reservoir reading ("50+") only proves the reservoir holds at
+        // least that much: > / >= compare against the bound; < / <= / == are false.
+        yield return Scenario(
+            "reservoir-lower-bound",
+            "reservoir_is_lower_bound gates < / <= / == to false while > and >= compare against the bound; exact readings are unaffected",
+            [
+                Rule(1, "reservoir", """{"operator": "<", "value": 60}"""),
+                Rule(2, "reservoir", """{"operator": "<=", "value": 60}"""),
+                Rule(3, "reservoir", """{"operator": "==", "value": 50}"""),
+                Rule(4, "reservoir", """{"operator": ">", "value": 40}"""),
+                Rule(5, "reservoir", """{"operator": ">=", "value": 50}"""),
+                Rule(6, "reservoir", """{"operator": ">", "value": 50}"""),
+            ],
+            [
+                Tick(T(0), Ctx(T(0)) with { ReservoirUnits = 50m, ReservoirIsLowerBound = true }),
+                Tick(T(5), Ctx(T(5)) with { ReservoirUnits = 42m }),
+            ]);
+
         // site_age compares HOURS since LastSiteChangeAt.
         yield return Scenario(
             "site-age-hours-boundaries",

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/Evaluators/ReservoirEvaluatorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/Evaluators/ReservoirEvaluatorTests.cs
@@ -39,6 +39,21 @@ public class ReservoirEvaluatorTests
         (await _sut.EvaluateAsync(json, context, CancellationToken.None)).Should().Be(expected);
     }
 
+    [Theory]
+    [InlineData("<", 60.0, false)]
+    [InlineData("<=", 60.0, false)]
+    [InlineData("==", 50.0, false)]
+    [InlineData(">", 40.0, true)]
+    [InlineData(">=", 50.0, true)]
+    [InlineData(">", 50.0, false)]
+    public async Task LowerBoundReading_OnlyConfirmsGreaterThanComparisons(string op, decimal threshold, bool expected)
+    {
+        var json = $$"""{"operator": "{{op}}", "value": {{threshold}}}""";
+        var context = MakeContext(reservoir: 50m) with { ReservoirIsLowerBound = true };
+
+        (await _sut.EvaluateAsync(json, context, CancellationToken.None)).Should().Be(expected);
+    }
+
     private static SensorContext MakeContext(decimal? reservoir) => new()
     {
         LatestValue = 100m,

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/SensorContextEnricherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/SensorContextEnricherTests.cs
@@ -249,6 +249,21 @@ public class SensorContextEnricherTests
         var enriched = await enricher.EnrichAsync(BaseContext(), new[] { rule }, _tenantId, CancellationToken.None);
 
         enriched.ReservoirUnits.Should().Be(42.5m);
+        enriched.ReservoirIsLowerBound.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Reservoir_lower_bound_display_marks_value_as_lower_bound()
+    {
+        var enricher = BuildEnricher();
+        _pumpSnapshotRepository.Setup(r => r.GetAsync(null, null, null, null, 1, 0, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new PumpSnapshot { Reservoir = 50, ReservoirDisplay = "50+U" } });
+        var rule = MakeRule(AlertConditionType.Reservoir, """{"operator":"<","value":50}""");
+
+        var enriched = await enricher.EnrichAsync(BaseContext(), new[] { rule }, _tenantId, CancellationToken.None);
+
+        enriched.ReservoirUnits.Should().Be(50m);
+        enriched.ReservoirIsLowerBound.Should().BeTrue();
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Core.Models.Tests/V4/ReservoirDisplayFormatTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/V4/ReservoirDisplayFormatTests.cs
@@ -1,0 +1,25 @@
+using FluentAssertions;
+using Nocturne.Core.Models.V4;
+using Xunit;
+
+namespace Nocturne.Core.Models.Tests.V4;
+
+[Trait("Category", "Unit")]
+public class ReservoirDisplayFormatTests
+{
+    [Theory]
+    [InlineData("50+U", true)]
+    [InlineData("50+ U", true)]
+    [InlineData("50 + U", true)]
+    [InlineData(" 50.0+U", true)]
+    [InlineData("50+", true)]
+    [InlineData("42.5U", false)]
+    [InlineData("Low", false)]
+    [InlineData("+50U", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void IsLowerBound(string? display, bool expected)
+    {
+        ReservoirDisplayFormat.IsLowerBound(display).Should().Be(expected);
+    }
+}


### PR DESCRIPTION
Omnipod Dash only reports exact reservoir levels below 50U; above that it sends a numeric 50 with a `50+U` display override. The alert engine read only the numeric value, so a capped reading evaluated as exactly 50 units.

- `ReservoirDisplayFormat.IsLowerBound` derives lower-bound-ness from the persisted `reservoir_display` (no schema change; old rows get correct semantics retroactively)
- `SensorContext.ReservoirIsLowerBound` carried to both engines: a lower-bound reading can confirm `>` / `>=` against the bound but never `<` / `<=` / `==`
- C#/rust parity locked in by a new corpus scenario (`reservoir-lower-bound`) plus unit tests for the parser, evaluator, and enricher

First of a 3-PR reservoir-tracking stack (capped values → manual reports endpoint → estimation).