### PR TITLE
feat(alerts): reservoir estimation hardening — truncation warnings + lower-bound replay fact

### DIFF
--- a/src/API/Nocturne.API/Services/Alerts/AlertReplayService.cs
+++ b/src/API/Nocturne.API/Services/Alerts/AlertReplayService.cs
@@ -440,7 +440,8 @@ internal sealed class AlertReplayService(
 
             var projected = binding.Conversion switch
             {
-                ReplayFactConversion.Direct => (decimal?)(decimal)raw,
+                // Direct takes decimal properties; bool flags are projected as 0/1.
+                ReplayFactConversion.Direct => raw is bool flag ? (flag ? 1m : 0m) : (decimal)raw,
                 ReplayFactConversion.MinutesSinceNow => (decimal)(tickUtc - (DateTime)raw).TotalMinutes,
                 ReplayFactConversion.HoursSinceNow => (decimal)(tickUtc - (DateTime)raw).TotalHours,
                 ReplayFactConversion.DaysSinceNow => (decimal)(tickUtc - (DateTime)raw).TotalDays,

--- a/src/API/Nocturne.API/Services/Devices/ReservoirEstimationService.cs
+++ b/src/API/Nocturne.API/Services/Devices/ReservoirEstimationService.cs
@@ -50,7 +50,8 @@ internal sealed class ReservoirEstimationService(
     IBolusRepository boluses,
     ITempBasalRepository tempBasals,
     IBasalSegmentService basalSegments,
-    TimeProvider timeProvider) : IReservoirEstimationService
+    TimeProvider timeProvider,
+    ILogger<ReservoirEstimationService> logger) : IReservoirEstimationService
 {
     private static readonly TimeSpan MaxAnchorAge = TimeSpan.FromDays(14);
 
@@ -69,9 +70,16 @@ internal sealed class ReservoirEstimationService(
         var now = asOf ?? timeProvider.GetUtcNow().UtcDateTime;
         var windowStart = now - MaxAnchorAge;
 
-        var snapshots = await pumpSnapshots.GetAsync(
+        var snapshots = (await pumpSnapshots.GetAsync(
             from: windowStart, to: asOf, device: null, source: null,
-            limit: SnapshotScanLimit, offset: 0, descending: true, ct: ct);
+            limit: SnapshotScanLimit, offset: 0, descending: true, ct: ct)).ToList();
+        if (snapshots.Count == SnapshotScanLimit)
+        {
+            logger.LogWarning(
+                "Pump snapshot fetch returned exactly the scan limit ({Limit}) for window {From:o}..{To:o}; " +
+                "older snapshots were likely truncated and the reservoir estimate may be skewed",
+                SnapshotScanLimit, windowStart, now);
+        }
 
         PumpSnapshot? anchor = null;
         PumpSnapshot? newestBound = null;
@@ -119,9 +127,23 @@ internal sealed class ReservoirEstimationService(
         var bolusRecords = (await boluses.GetAsync(
             from: from.AddMilliseconds(1), to: to, device: null, source: null,
             limit: RecordFetchLimit, offset: 0, descending: false, ct: ct)).ToList();
+        if (bolusRecords.Count == RecordFetchLimit)
+        {
+            logger.LogWarning(
+                "Bolus fetch returned exactly the fetch limit ({Limit}) for window {From:o}..{To:o}; " +
+                "records were likely truncated and the reservoir estimate may be skewed",
+                RecordFetchLimit, from, to);
+        }
         var tempBasalRecords = (await tempBasals.GetAsync(
             from: from - TempBasalStraddleLookback, to: to, device: null, source: null,
             limit: RecordFetchLimit, offset: 0, descending: false, ct: ct)).ToList();
+        if (tempBasalRecords.Count == RecordFetchLimit)
+        {
+            logger.LogWarning(
+                "Temp basal fetch returned exactly the fetch limit ({Limit}) for window {From:o}..{To:o}; " +
+                "records were likely truncated and the reservoir estimate may be skewed",
+                RecordFetchLimit, from - TempBasalStraddleLookback, to);
+        }
 
         var total = bolusRecords.Sum(b => b.Insulin);
 

--- a/src/Core/Nocturne.Core.Models/AlertModels.cs
+++ b/src/Core/Nocturne.Core.Models/AlertModels.cs
@@ -59,7 +59,9 @@ public record SensorContext
     /// <summary>
     /// True when <see cref="ReservoirUnits"/> is a lower bound rather than an exact reading
     /// (e.g. an Omnipod reports "50+" while the reservoir holds at least 50 units).
+    /// Replay emits this fact as 0/1.
     /// </summary>
+    [ReplayFact("reservoir_is_lower_bound", decimals: 0)]
     public bool ReservoirIsLowerBound { get; init; }
 
     /// <summary>

--- a/src/Core/Nocturne.Core.Models/Alerts/FactSnapshotPoint.cs
+++ b/src/Core/Nocturne.Core.Models/Alerts/FactSnapshotPoint.cs
@@ -34,7 +34,8 @@ public sealed class ReplayFactAttribute : Attribute
     public int Decimals { get; }
 
     /// <summary>How to project the property's stored value to the wire value. Direct for
-    /// numeric properties; the time-since variants take a <see cref="DateTime"/>? property
+    /// numeric properties (bool properties emit 0/1); the time-since variants take a
+    /// <see cref="DateTime"/>? property
     /// and emit minutes/hours/days between that timestamp and the current replay tick.</summary>
     public ReplayFactConversion Conversion { get; }
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/AlertReplayServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/AlertReplayServiceTests.cs
@@ -39,6 +39,7 @@ public class AlertReplayServiceTests
     private readonly Mock<ITempBasalRepository> _tempBasalRepository = new();
     private readonly Mock<IUploaderSnapshotRepository> _uploaderSnapshotRepository = new();
     private readonly Mock<IStateSpanService> _stateSpanService = new();
+    private readonly Mock<Nocturne.API.Services.Devices.IReservoirEstimationService> _reservoirEstimation = new();
     private readonly AlertReplayService _sut;
 
     private readonly Guid _tenantId = Guid.NewGuid();
@@ -73,7 +74,7 @@ public class AlertReplayServiceTests
             new Mock<Nocturne.Core.Contracts.Profiles.Resolvers.IActiveProfileResolver>().Object,
             new Mock<Nocturne.Core.Contracts.Profiles.Resolvers.ITherapySettingsResolver>().Object,
             new Mock<Nocturne.Infrastructure.Data.Abstractions.ITrackerRepository>().Object,
-            new Mock<Nocturne.API.Services.Devices.IReservoirEstimationService>().Object,
+            _reservoirEstimation.Object,
             Options.Create(new AlertEvaluationOptions()));
         var enricher = new SensorContextEnricher(
             enricherDeps,
@@ -504,6 +505,36 @@ public class AlertReplayServiceTests
         result.FactTimelines.Should().ContainKey("latest_glucose");
         var glucosePoints = result.FactTimelines["latest_glucose"];
         glucosePoints.Select(p => p.Value).Should().ContainInOrder(65m, 95m, 60m);
+    }
+
+    /// <summary>
+    /// <c>ReservoirIsLowerBound</c> is a bool fact projected to 0/1 by the Direct conversion.
+    /// A capped reading ("50+") must surface in the <c>reservoir_is_lower_bound</c> timeline
+    /// so the FE can distinguish it from an exact 50.0.
+    /// </summary>
+    [Fact]
+    public async Task FactTimelines_ReservoirIsLowerBound_EmitsBoolAsOne()
+    {
+        var rule = new AlertRuleSnapshot(
+            Guid.NewGuid(), Guid.NewGuid(), "reservoir-low", AlertConditionType.Reservoir,
+            """{"operator":"<","value":10}""", AlertRuleSeverity.Warning, "{}", 0,
+            AutoResolveEnabled: false, AutoResolveParams: null);
+        var date = new DateOnly(2026, 4, 28);
+
+        _alertRepository.Setup(r => r.GetEnabledRulesAsync(_tenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { rule });
+        _glucoseRepository.Setup(r => r.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), null, null,
+                It.IsAny<int>(), It.IsAny<int>(), false, false, It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<SensorGlucose>());
+        _reservoirEstimation.Setup(s => s.GetEstimateAsync(It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Nocturne.API.Services.Devices.ReservoirEstimate(
+                50m, IsLowerBound: true, IsEstimated: false));
+
+        var result = await _sut.ReplayAsync(date, "UTC", null, null, CancellationToken.None);
+
+        result.FactTimelines.Should().ContainKey("reservoir_is_lower_bound");
+        result.FactTimelines["reservoir_is_lower_bound"].Select(p => p.Value).Should().Equal(1m);
     }
 
     /// <summary>

--- a/tests/Unit/Nocturne.API.Tests/Services/Devices/ReservoirEstimationServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Devices/ReservoirEstimationServiceTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Nocturne.API.Services.Devices;
@@ -19,6 +20,7 @@ public class ReservoirEstimationServiceTests
     private readonly Mock<IBolusRepository> _boluses = new();
     private readonly Mock<ITempBasalRepository> _tempBasals = new();
     private readonly Mock<IBasalSegmentService> _basalSegments = new();
+    private readonly CapturingLogger _logger = new();
     private readonly ReservoirEstimationService _sut;
 
     public ReservoirEstimationServiceTests()
@@ -29,7 +31,7 @@ public class ReservoirEstimationServiceTests
         SetupSegments();
         _sut = new ReservoirEstimationService(
             _pumpSnapshots.Object, _boluses.Object, _tempBasals.Object, _basalSegments.Object,
-            new FakeTimeProvider(new DateTimeOffset(Now)));
+            new FakeTimeProvider(new DateTimeOffset(Now)), _logger);
     }
 
     [Fact]
@@ -145,6 +147,71 @@ public class ReservoirEstimationServiceTests
         var estimate = await _sut.GetEstimateAsync(null);
 
         estimate.Should().Be(new ReservoirEstimate(0m, IsLowerBound: false, IsEstimated: true));
+    }
+
+    /// <summary>Records warning-level messages. Moq cannot proxy
+    /// <c>ILogger&lt;ReservoirEstimationService&gt;</c> because the generic argument is internal.</summary>
+    private sealed class CapturingLogger : ILogger<ReservoirEstimationService>
+    {
+        public List<string> Warnings { get; } = [];
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning)
+                Warnings.Add(formatter(state, exception));
+        }
+    }
+
+    [Fact]
+    public async Task SnapshotFetchAtScanLimit_LogsTruncationWarning()
+    {
+        // 200 snapshots (the scan limit) — the fetch was likely truncated.
+        var snapshots = Enumerable.Range(0, 200)
+            .Select(i => new PumpSnapshot { Reservoir = i == 0 ? 42.0 : null, Timestamp = Now.AddMinutes(-i) })
+            .ToArray();
+        SetupSnapshots(snapshots);
+
+        await _sut.GetEstimateAsync(null);
+
+        _logger.Warnings.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task BolusFetchAtRecordLimit_LogsTruncationWarning()
+    {
+        SetupSnapshots(new PumpSnapshot { Reservoir = 50, Timestamp = Now.AddHours(-10) });
+        SetupBoluses(Enumerable.Range(0, 5000).Select(_ => MakeBolus(0.001)).ToArray());
+
+        await _sut.GetEstimateAsync(null);
+
+        _logger.Warnings.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task TempBasalFetchAtRecordLimit_LogsTruncationWarning()
+    {
+        SetupSnapshots(new PumpSnapshot { Reservoir = 50, Timestamp = Now.AddHours(-10) });
+        SetupTempBasals(Enumerable.Range(0, 5000)
+            .Select(i => MakeTempBasal(rate: 0.1, start: Now.AddHours(-9).AddSeconds(i), end: Now.AddHours(-9).AddSeconds(i + 1)))
+            .ToArray());
+
+        await _sut.GetEstimateAsync(null);
+
+        _logger.Warnings.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task FetchesBelowLimits_LogNoWarning()
+    {
+        SetupSnapshots(new PumpSnapshot { Reservoir = 50, Timestamp = Now.AddHours(-10) });
+        SetupBoluses(MakeBolus(4));
+        SetupTempBasals(MakeTempBasal(rate: 1.0, start: Now.AddHours(-8), end: Now.AddHours(-6)));
+
+        await _sut.GetEstimateAsync(null);
+
+        _logger.Warnings.Should().BeEmpty();
     }
 
     private static long Mills(DateTime at) => new DateTimeOffset(at, TimeSpan.Zero).ToUnixTimeMilliseconds();


### PR DESCRIPTION
Follow-ups to #452/#454.

- `ReservoirEstimationService` logs a warning when a fetch returns exactly its limit (200 snapshots / 5000 boluses / 5000 temp basals) — a truncated window silently skews the estimate; now it's visible.
- `ReservoirIsLowerBound` is emitted as a replay fact (0/1): a capped "50+" reading was indistinguishable from an exact 50 in replay fact timelines while evaluating differently. The fact collector's Direct conversion now projects bools as 0/1 (host-side replay output only — no FFI/corpus wire impact).