### PR TITLE
feat(v4): multi-CGM device filters, stats metadata, discovered-sources & rank UI (PR3)

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
@@ -344,6 +344,7 @@ public class StatisticsController : ControllerBase
         [FromQuery] DateTime startDate,
         [FromQuery] DateTime endDate,
         [FromQuery] DiabetesPopulation population = DiabetesPopulation.Type1Adult,
+        [FromQuery] Guid? patientDeviceId = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -354,21 +355,58 @@ public class StatisticsController : ControllerBase
 
             // int.MaxValue limit mirrors ActogramReportService so dense tenants are never
             // silently truncated (the cause of skewed report stats on high-frequency uploads).
-            var glucoseTask = _sensorGlucoseRepository.GetAsync(startDt, endDt, null, null, int.MaxValue, descending: false, ct: cancellationToken);
+            var glucoseTask = _sensorGlucoseRepository.GetAsync(startDt, endDt, null, null, int.MaxValue, descending: false, patientDeviceId: patientDeviceId, ct: cancellationToken);
             var bolusTask   = _bolusRepository.GetAsync(startDt, endDt, null, null, int.MaxValue, descending: false, kind: BolusKind.Manual, ct: cancellationToken);
             var carbTask    = _carbIntakeRepository.GetAsync(startDt, endDt, null, null, int.MaxValue, descending: false, ct: cancellationToken);
+            var devicesTask = _patientDeviceRepository.GetByDateRangeAsync(startDt, endDt, ct: cancellationToken);
 
-            await Task.WhenAll(glucoseTask, bolusTask, carbTask);
+            await Task.WhenAll(glucoseTask, bolusTask, carbTask, devicesTask);
+
+            var rawGlucose = (await glucoseTask).ToList();
 
             // Unfiltered statistics compute over the canonical stream, never blended CGMs.
-            var entries = (await _canonicalGlucose.SelectAsync((await glucoseTask).ToList(), cancellationToken)).ToList();
+            // A patientDeviceId filter already restricts the fetch to one device raw, so there
+            // is nothing left to canonicalize/blend.
+            var entries = patientDeviceId is null
+                ? (await _canonicalGlucose.SelectAsync(rawGlucose, cancellationToken)).ToList()
+                : rawGlucose;
             var boluses = await bolusTask;
             var carbs   = await carbTask;
+            var devices = await devicesTask;
+
+            // Registered devices that contributed readings, for the UI's device picker.
+            var contributingDevices = new List<ContributingDevice>();
+            foreach (var d in devices.Where(d => d.DeviceCategory == DeviceCategory.CGM))
+            {
+                var readingCount = rawGlucose.Count(r => r.PatientDeviceId == d.Id);
+                if (readingCount == 0) continue;
+
+                var name = (d.CatalogId != null ? DeviceCatalog.GetById(d.CatalogId)?.Name : null)
+                    ?? d.Model ?? d.Manufacturer ?? "Unknown device";
+                contributingDevices.Add(new ContributingDevice
+                {
+                    PatientDeviceId = d.Id,
+                    Name = name,
+                    ReadingCount = readingCount,
+                });
+            }
+
+            var unattributedCount = rawGlucose.Count(r => r.PatientDeviceId == null);
+            if (unattributedCount > 0)
+            {
+                contributingDevices.Add(new ContributingDevice
+                {
+                    PatientDeviceId = null,
+                    Name = "Unattributed",
+                    ReadingCount = unattributedCount,
+                });
+            }
 
             var result = new ReportAnalysisResult
             {
                 Analysis = _statisticsService.AnalyzeGlucoseDataExtended(entries, boluses, carbs, population),
                 AveragedStats = _statisticsService.CalculateAveragedStats(entries).ToList(),
+                ContributingDevices = contributingDevices,
             };
             return Ok(result);
         }

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
@@ -374,12 +374,23 @@ public class StatisticsController : ControllerBase
             var carbs   = await carbTask;
             var devices = await devicesTask;
 
-            // Registered devices that contributed readings, for the UI's device picker.
+            // Registered devices that contributed readings, for the UI's device picker. Count in a
+            // single pass over the raw readings rather than re-scanning per device. The unattributed
+            // bucket is tracked separately — a null key can't live in a Dictionary.
+            var countByDevice = new Dictionary<Guid, int>();
+            var unattributedCount = 0;
+            foreach (var r in rawGlucose)
+            {
+                if (r.PatientDeviceId is { } id)
+                    countByDevice[id] = countByDevice.GetValueOrDefault(id) + 1;
+                else
+                    unattributedCount++;
+            }
+
             var contributingDevices = new List<ContributingDevice>();
             foreach (var d in devices.Where(d => d.DeviceCategory == DeviceCategory.CGM))
             {
-                var readingCount = rawGlucose.Count(r => r.PatientDeviceId == d.Id);
-                if (readingCount == 0) continue;
+                if (!countByDevice.TryGetValue(d.Id, out var readingCount) || readingCount == 0) continue;
 
                 var name = (d.CatalogId != null ? DeviceCatalog.GetById(d.CatalogId)?.Name : null)
                     ?? d.Model ?? d.Manufacturer ?? "Unknown device";
@@ -391,7 +402,6 @@ public class StatisticsController : ControllerBase
                 });
             }
 
-            var unattributedCount = rawGlucose.Count(r => r.PatientDeviceId == null);
             if (unattributedCount > 0)
             {
                 contributingDevices.Add(new ContributingDevice

--- a/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
@@ -5,6 +5,7 @@ using Nocturne.API.Models.Requests.V4;
 using Nocturne.API.Services.Glucose;
 using Nocturne.API.Services.V4;
 using Nocturne.Core.Contracts.Alerts;
+using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
@@ -32,17 +33,42 @@ public class SensorGlucoseController(
     ISensorGlucoseRepository repo,
     IGlucoseProcessingResolver glucoseResolver,
     ICanonicalAlertEvaluator alertEvaluator,
+    IPatientDeviceStamper deviceStamper,
     ILogger<SensorGlucoseController> logger)
     : V4CrudControllerBase<SensorGlucose, UpsertSensorGlucoseRequest, UpsertSensorGlucoseRequest, ISensorGlucoseRepository>(repo)
 {
+    /// <summary>
+    /// Lists sensor glucose readings. Adds an optional <c>patientDeviceId</c> query filter on top of the base
+    /// list surface: when set, results are that registered device's raw readings (canonical stream selection is
+    /// bypassed); when unset, the caller sees every stored reading. Pagination totals match the base
+    /// device/source behaviour (the count is unscoped by the device filters).
+    /// </summary>
+    /// <remarks>
+    /// The <c>patientDeviceId</c> query parameter is read directly from the request because the base list
+    /// signature (shared by every V4 read controller) has no device-attribution concept — binding it here keeps
+    /// a single <c>GET</c> action while adding the sensor-glucose-only filter.
+    /// </remarks>
     [ResponseCache(Duration = 90, VaryByQueryKeys = new[] { "*" })]
-    public override Task<ActionResult<PaginatedResponse<SensorGlucose>>> GetAll(
+    public override async Task<ActionResult<PaginatedResponse<SensorGlucose>>> GetAll(
         [FromQuery] DateTime? from, [FromQuery] DateTime? to,
         [FromQuery] int limit = 100, [FromQuery] int offset = 0,
         [FromQuery] string sort = "timestamp_desc",
         [FromQuery] string? device = null, [FromQuery] string? source = null,
         CancellationToken ct = default)
-        => base.GetAll(from, to, limit, offset, sort, device, source, ct);
+    {
+        if (sort is not "timestamp_desc" and not "timestamp_asc")
+            return Problem(detail: $"Invalid sort value '{sort}'. Must be 'timestamp_asc' or 'timestamp_desc'.", statusCode: 400, title: "Bad Request");
+
+        Guid? patientDeviceId = null;
+        if (Request.Query.TryGetValue("patientDeviceId", out var raw) && Guid.TryParse(raw, out var parsed))
+            patientDeviceId = parsed;
+
+        var descending = sort == "timestamp_desc";
+        var data = await Repository.GetAsync(from, to, device, source, limit, offset, descending,
+            nativeOnly: false, afterTimestamp: null, afterId: null, patientDeviceId: patientDeviceId, ct: ct);
+        var total = await Repository.CountAsync(from, to, ct);
+        return Ok(new PaginatedResponse<SensorGlucose> { Data = data, Pagination = new PaginationInfo(limit, offset, total) });
+    }
 
     public override async Task<ActionResult<SensorGlucose>> Create([FromBody] UpsertSensorGlucoseRequest request, CancellationToken ct = default)
     {
@@ -52,6 +78,11 @@ public class SensorGlucoseController(
             return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
 
         await glucoseResolver.ResolveAsync(model, request.GlucoseProcessing, request.SmoothedMgdl, request.UnsmoothedMgdl, ct);
+
+        // V4 REST writes bypass the connector/decomposer ingest paths, so attribute here — otherwise
+        // direct API records stay unstamped and only ever surface as pseudo-devices. Fills only when
+        // the record is unattributed; the canonical stream still governs reads.
+        await deviceStamper.StampAsync([model], [DeviceCategory.CGM], model.DataSource, ct);
 
         var created = await Repository.CreateAsync(model, WriteOrigin.Live, ct);
         created = await OnAfterCreateAsync(created, ct);
@@ -93,6 +124,9 @@ public class SensorGlucoseController(
         LegacyId = existing.LegacyId,
         CreatedAt = existing.CreatedAt,
         AdditionalProperties = existing.AdditionalProperties,
+        // Preserve attribution across edits; the update DTO carries no device identity, so rebuilding
+        // the model without this would silently drop the record to a pseudo-device.
+        PatientDeviceId = existing.PatientDeviceId,
     };
 
     public override async Task<ActionResult<SensorGlucose>> Update(Guid id, [FromBody] UpsertSensorGlucoseRequest request, CancellationToken ct = default)
@@ -107,6 +141,9 @@ public class SensorGlucoseController(
             return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
 
         await glucoseResolver.ResolveAsync(model, request.GlucoseProcessing, request.SmoothedMgdl, request.UnsmoothedMgdl, ct);
+
+        // No-op when attribution was preserved above; re-attributes only records still unstamped.
+        await deviceStamper.StampAsync([model], [DeviceCategory.CGM], model.DataSource, ct);
 
         try
         {
@@ -140,6 +177,10 @@ public class SensorGlucoseController(
 
         for (var i = 0; i < models.Count; i++)
             await glucoseResolver.ResolveAsync(models[i], requests[i].GlucoseProcessing, requests[i].SmoothedMgdl, requests[i].UnsmoothedMgdl, ct);
+
+        // Attribute the batch before persisting (see Create). Per-record DataSource drives matching,
+        // so no batch-level source is needed for a mixed-source bulk upload.
+        await deviceStamper.StampAsync(models, [DeviceCategory.CGM], batchSource: null, ct);
 
         var created = await Repository.BulkCreateAsync(models, WriteOrigin.Live, ct);
         var createdArray = created.ToArray();

--- a/src/API/Nocturne.API/Controllers/V4/Health/PatientRecordController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/PatientRecordController.cs
@@ -1,8 +1,10 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Services.Devices;
 using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.Projections;
 using Nocturne.Core.Models.V4;
 using Nocturne.Core.Contracts.V4;
 
@@ -32,18 +34,27 @@ public class PatientRecordController : ControllerBase
     private readonly IPatientDeviceRepository _deviceRepo;
     private readonly IPatientInsulinRepository _insulinRepo;
     private readonly IDeviceService _deviceService;
+    private readonly ISensorGlucoseRepository _sensorGlucoseRepo;
+    private readonly IDeviceReattributionService _reattribution;
 
     public PatientRecordController(
         IPatientRecordRepository recordRepo,
         IPatientDeviceRepository deviceRepo,
         IPatientInsulinRepository insulinRepo,
-        IDeviceService deviceService)
+        IDeviceService deviceService,
+        ISensorGlucoseRepository sensorGlucoseRepo,
+        IDeviceReattributionService reattribution)
     {
         _recordRepo = recordRepo;
         _deviceRepo = deviceRepo;
         _insulinRepo = insulinRepo;
         _deviceService = deviceService;
+        _sensorGlucoseRepo = sensorGlucoseRepo;
+        _reattribution = reattribution;
     }
+
+    /// <summary>Window scanned for "discovered sources" — distinct unattributed streams seen recently.</summary>
+    private static readonly TimeSpan DiscoveredSourceWindow = TimeSpan.FromDays(30);
 
     #region Patient Record
 
@@ -90,10 +101,24 @@ public class PatientRecordController : ControllerBase
     }
 
     /// <summary>
+    /// Lists distinct <c>(DataSource, Device)</c> combinations seen in recent unattributed readings —
+    /// candidate streams the user can register as devices from the settings UI.
+    /// </summary>
+    [HttpGet("devices/discovered-sources")]
+    [RemoteQuery]
+    [ProducesResponseType(typeof(IReadOnlyList<DiscoveredSource>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IReadOnlyList<DiscoveredSource>>> GetDiscoveredSources(CancellationToken cancellationToken = default)
+    {
+        var since = DateTime.UtcNow - DiscoveredSourceWindow;
+        var sources = await _sensorGlucoseRepo.GetDiscoveredSourcesAsync(since, cancellationToken);
+        return Ok(sources);
+    }
+
+    /// <summary>
     /// Create a new patient device
     /// </summary>
     [HttpPost("devices")]
-    [RemoteForm(Invalidates = ["GetDevices"])]
+    [RemoteForm(Invalidates = ["GetDevices", "GetDiscoveredSources"])]
     [ProducesResponseType(typeof(PatientDevice), StatusCodes.Status201Created)]
     public async Task<ActionResult<PatientDevice>> CreateDevice(
         [FromBody] PatientDevice model,
@@ -101,6 +126,8 @@ public class PatientRecordController : ControllerBase
     {
         await ResolveDeviceIdAsync(model, cancellationToken);
         var created = await _deviceRepo.CreateAsync(model, WriteOrigin.Live, cancellationToken);
+        // Back-stamp existing unattributed readings this device now explains (glucose stream only).
+        await _reattribution.ReattributeForDeviceAsync(created, cancellationToken);
         return CreatedAtAction(nameof(GetDevices), created);
     }
 
@@ -130,6 +157,23 @@ public class PatientRecordController : ControllerBase
     {
         await _deviceRepo.DeleteAsync(id, WriteOrigin.Live, cancellationToken);
         return NoContent();
+    }
+
+    /// <summary>
+    /// Reassigns device priority in a single batch. Drag-to-reorder in the UI sends the full ordered
+    /// list; each entry's position becomes its <see cref="PatientDevice.Rank"/>. One round trip instead
+    /// of one PUT per device.
+    /// </summary>
+    [HttpPut("devices/reorder")]
+    [RemoteForm(Invalidates = ["GetDevices"])]
+    [ProducesResponseType(typeof(IEnumerable<PatientDevice>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IEnumerable<PatientDevice>>> ReorderDevices(
+        [FromBody] IReadOnlyList<DeviceRankAssignment> ranks,
+        CancellationToken cancellationToken = default)
+    {
+        var changed = await _deviceRepo.ReorderAsync(
+            ranks.Select(r => (r.Id, r.Rank)).ToList(), WriteOrigin.Live, cancellationToken);
+        return Ok(changed);
     }
 
     private async Task ResolveDeviceIdAsync(PatientDevice model, CancellationToken ct)
@@ -208,3 +252,8 @@ public class PatientRecordController : ControllerBase
 
     #endregion
 }
+
+/// <summary>A single device→rank assignment in a <see cref="PatientRecordController.ReorderDevices"/> batch.</summary>
+/// <param name="Id">The patient device identifier.</param>
+/// <param name="Rank">Its new priority (lower = higher priority).</param>
+public sealed record DeviceRankAssignment(Guid Id, int Rank);

--- a/src/API/Nocturne.API/Controllers/V4/Health/PatientRecordController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/PatientRecordController.cs
@@ -162,10 +162,10 @@ public class PatientRecordController : ControllerBase
     /// <summary>
     /// Reassigns device priority in a single batch. Drag-to-reorder in the UI sends the full ordered
     /// list; each entry's position becomes its <see cref="PatientDevice.Rank"/>. One round trip instead
-    /// of one PUT per device.
+    /// of one PUT per device. An imperative command (no HTML form), mirroring the delete/restore surface.
     /// </summary>
-    [HttpPut("devices/reorder")]
-    [RemoteForm(Invalidates = ["GetDevices"])]
+    [HttpPost("devices/reorder")]
+    [RemoteCommand(Invalidates = ["GetDevices"])]
     [ProducesResponseType(typeof(IEnumerable<PatientDevice>), StatusCodes.Status200OK)]
     public async Task<ActionResult<IEnumerable<PatientDevice>>> ReorderDevices(
         [FromBody] IReadOnlyList<DeviceRankAssignment> ranks,

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -519,6 +519,7 @@ public static class ServiceRegistrationExtensions
         // Device resolution
         services.AddScoped<IDeviceService, DeviceService>();
         services.AddScoped<IPatientDeviceStamper, PatientDeviceStamper>();
+        services.AddScoped<IDeviceReattributionService, DeviceReattributionService>();
 
         // Canonical glucose stream (single-stream view for v1/v3, alarms, unfiltered analytics)
         services.AddScoped<ICanonicalGlucoseService, CanonicalGlucoseService>();

--- a/src/API/Nocturne.API/Services/Devices/DeviceReattributionService.cs
+++ b/src/API/Nocturne.API/Services/Devices/DeviceReattributionService.cs
@@ -25,7 +25,8 @@ internal sealed class DeviceReattributionService : IDeviceReattributionService
     /// <summary>
     /// Upper bound on readings re-stamped per registration. A multi-year CGM window can hold hundreds
     /// of thousands of rows; capping keeps the registration request bounded. Newest-first, so the most
-    /// relevant history is covered; any remainder is picked up as new data arrives.
+    /// recent history is attributed; readings beyond the cap in the same window stay unattributed
+    /// (consistent with the deliberate no-global-migration design).
     /// </summary>
     private const int MaxReattributeReadings = 50_000;
 

--- a/src/API/Nocturne.API/Services/Devices/DeviceReattributionService.cs
+++ b/src/API/Nocturne.API/Services/Devices/DeviceReattributionService.cs
@@ -1,0 +1,78 @@
+using Nocturne.Core.Contracts.Devices;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.API.Services.Devices;
+
+/// <summary>
+/// Back-stamps existing unattributed readings to a device the moment it is registered, so a
+/// newly-declared <see cref="PatientDevice"/> immediately owns the history it explains instead of
+/// waiting for new data. Registration-scoped by design — there is deliberately no global migration;
+/// each registration re-runs attribution only over its own usage window.
+/// </summary>
+public interface IDeviceReattributionService
+{
+    /// <summary>
+    /// Re-attributes unattributed sensor glucose within the device's usage window, running the same
+    /// matching ladder as ingest. Returns the number of readings whose attribution changed.
+    /// </summary>
+    Task<int> ReattributeForDeviceAsync(PatientDevice device, CancellationToken ct = default);
+}
+
+/// <inheritdoc />
+internal sealed class DeviceReattributionService : IDeviceReattributionService
+{
+    /// <summary>
+    /// Upper bound on readings re-stamped per registration. A multi-year CGM window can hold hundreds
+    /// of thousands of rows; capping keeps the registration request bounded. Newest-first, so the most
+    /// relevant history is covered; any remainder is picked up as new data arrives.
+    /// </summary>
+    private const int MaxReattributeReadings = 50_000;
+
+    private readonly ISensorGlucoseRepository _sensorGlucose;
+    private readonly IPatientDeviceStamper _stamper;
+    private readonly ILogger<DeviceReattributionService> _logger;
+
+    public DeviceReattributionService(
+        ISensorGlucoseRepository sensorGlucose,
+        IPatientDeviceStamper stamper,
+        ILogger<DeviceReattributionService> logger)
+    {
+        _sensorGlucose = sensorGlucose;
+        _stamper = stamper;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<int> ReattributeForDeviceAsync(PatientDevice device, CancellationToken ct = default)
+    {
+        // Glucose stream only. Treatment (pump) re-attribution is a separate follow-up; a CGM
+        // registration cannot own bolus/basal history.
+        if (device.DeviceCategory != DeviceCategory.CGM)
+            return 0;
+
+        // Device usage dates are local; pad ±1 day for local/UTC skew, matching the ingest stamper's
+        // candidate window. Null bounds mean the device has an open-ended window.
+        var from = device.StartDate is { } start ? start.ToDateTime(TimeOnly.MinValue).AddDays(-1) : (DateTime?)null;
+        var to = device.EndDate is { } end ? end.ToDateTime(TimeOnly.MaxValue).AddDays(1) : (DateTime?)null;
+
+        var unattributed = await _sensorGlucose.GetUnattributedAsync(from, to, MaxReattributeReadings, ct);
+        if (unattributed.Count == 0)
+            return 0;
+
+        // Re-run the full matching ladder over all active devices (including the just-registered one),
+        // then persist only the readings that gained an attribution.
+        await _stamper.StampAsync(unattributed, [DeviceCategory.CGM], batchSource: null, ct);
+
+        var attributed = unattributed
+            .Where(r => r.PatientDeviceId.HasValue)
+            .ToDictionary(r => r.Id, r => r.PatientDeviceId!.Value);
+        if (attributed.Count == 0)
+            return 0;
+
+        var updated = await _sensorGlucose.SetPatientDeviceIdsAsync(attributed, ct);
+        _logger.LogInformation(
+            "Back-stamped {Count} sensor glucose reading(s) after registering device {DeviceId}", updated, device.Id);
+        return updated;
+    }
+}

--- a/src/API/Nocturne.API/Services/Entries/EntryReadService.cs
+++ b/src/API/Nocturne.API/Services/Entries/EntryReadService.cs
@@ -162,7 +162,7 @@ public class EntryReadService : IEntryStore
 
         while (true)
         {
-            var results = (await _sgRepo.GetAsync(from, to, device: null, source, fetchCount, 0, descending, false, null, null, ct)).ToList();
+            var results = (await _sgRepo.GetAsync(from, to, device: null, source, fetchCount, 0, descending, false, null, null, null, ct)).ToList();
             var visible = ExcludeDemoIfNeeded(results, excludeDemo).ToList();
             var canonical = await _canonicalGlucose.SelectAsync(visible, ct);
 

--- a/src/API/Nocturne.API/Services/Entries/EntryReadService.cs
+++ b/src/API/Nocturne.API/Services/Entries/EntryReadService.cs
@@ -162,7 +162,7 @@ public class EntryReadService : IEntryStore
 
         while (true)
         {
-            var results = (await _sgRepo.GetAsync(from, to, device: null, source, fetchCount, 0, descending, false, null, null, null, ct)).ToList();
+            var results = (await _sgRepo.GetAsync(from, to, device: null, source, fetchCount, 0, descending, false, null, null, ct)).ToList();
             var visible = ExcludeDemoIfNeeded(results, excludeDemo).ToList();
             var canonical = await _canonicalGlucose.SelectAsync(visible, ct);
 

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IPatientDeviceRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IPatientDeviceRepository.cs
@@ -34,4 +34,11 @@ public interface IPatientDeviceRepository
 
     /// <summary>Deletes a patient device record by ID.</summary>
     Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
+
+    /// <summary>
+    /// Assigns <see cref="PatientDevice.Rank"/> in a single batch from an ordered id→rank list.
+    /// Ids absent for this tenant are ignored; devices not listed keep their current rank.
+    /// </summary>
+    /// <returns>The devices whose rank changed.</returns>
+    Task<IEnumerable<PatientDevice>> ReorderAsync(IReadOnlyList<(Guid Id, int Rank)> ranks, WriteOrigin origin, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ISensorGlucoseRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ISensorGlucoseRepository.cs
@@ -1,5 +1,6 @@
 using Nocturne.Core.Models.V4;
 using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models.Projections;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -29,6 +30,8 @@ public interface ISensorGlucoseRepository : IV4Repository<SensorGlucose>
     /// <param name="offset">Number of records to skip for pagination (default 0).</param>
     /// <param name="descending">When <c>true</c>, results are ordered newest-first (default).</param>
     /// <param name="nativeOnly">When <c>true</c>, excludes records projected from legacy V1/V2/V3 entries.</param>
+    /// <param name="patientDeviceId">Optional filter restricting results to a single registered <see cref="PatientDevice"/>'s
+    /// attributed readings. Bypasses canonical stream selection at the caller — a filtered read returns that device raw.</param>
     /// <param name="ct">Cancellation token.</param>
     Task<IEnumerable<SensorGlucose>> GetAsync(
         DateTime? from,
@@ -41,6 +44,7 @@ public interface ISensorGlucoseRepository : IV4Repository<SensorGlucose>
         bool nativeOnly = false,
         DateTime? afterTimestamp = null,
         Guid? afterId = null,
+        Guid? patientDeviceId = null,
         CancellationToken ct = default
     );
 
@@ -48,7 +52,7 @@ public interface ISensorGlucoseRepository : IV4Repository<SensorGlucose>
     Task<IEnumerable<SensorGlucose>> IV4Repository<SensorGlucose>.GetAsync(
         DateTime? from, DateTime? to, string? device, string? source,
         int limit, int offset, bool descending, CancellationToken ct)
-        => GetAsync(from, to, device, source, limit, offset, descending, false, null, null, ct);
+        => GetAsync(from, to, device, source, limit, offset, descending, false, null, null, null, ct);
 
     /// <summary>Returns a single <see cref="SensorGlucose"/> by its UUID v7, or <c>null</c> if not found.</summary>
     /// <param name="id">UUID v7 record identifier.</param>
@@ -138,6 +142,26 @@ public interface ISensorGlucoseRepository : IV4Repository<SensorGlucose>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted.</returns>
     Task<int> DeleteBySourceAsync(string source, CancellationToken ct = default);
+
+    /// <summary>
+    /// Lists distinct <c>(DataSource, Device)</c> combinations among unattributed readings
+    /// (<c>PatientDeviceId == null</c>) newer than <paramref name="since"/>, with a reading count and
+    /// last-seen timestamp per combination. Drives the "discovered sources" device-registration UI.
+    /// </summary>
+    Task<IReadOnlyList<DiscoveredSource>> GetDiscoveredSourcesAsync(DateTime since, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns unattributed readings (<c>PatientDeviceId == null</c>) within the time window, capped at
+    /// <paramref name="limit"/>. Used to back-stamp attribution when a device is registered from a discovered source.
+    /// </summary>
+    Task<IReadOnlyList<SensorGlucose>> GetUnattributedAsync(DateTime? from, DateTime? to, int limit, CancellationToken ct = default);
+
+    /// <summary>
+    /// Persists <see cref="SensorGlucose.PatientDeviceId"/> for the given record ids in one batch.
+    /// Ids absent for this tenant are ignored.
+    /// </summary>
+    /// <returns>The number of rows updated.</returns>
+    Task<int> SetPatientDeviceIdsAsync(IReadOnlyDictionary<Guid, Guid> patientDeviceIdByRecordId, CancellationToken ct = default);
 
     /// <summary>
     /// Delete all records within the given time range.

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ISensorGlucoseRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ISensorGlucoseRepository.cs
@@ -30,9 +30,11 @@ public interface ISensorGlucoseRepository : IV4Repository<SensorGlucose>
     /// <param name="offset">Number of records to skip for pagination (default 0).</param>
     /// <param name="descending">When <c>true</c>, results are ordered newest-first (default).</param>
     /// <param name="nativeOnly">When <c>true</c>, excludes records projected from legacy V1/V2/V3 entries.</param>
-    /// <param name="patientDeviceId">Optional filter restricting results to a single registered <see cref="PatientDevice"/>'s
-    /// attributed readings. Bypasses canonical stream selection at the caller — a filtered read returns that device raw.</param>
     /// <param name="ct">Cancellation token.</param>
+    /// <param name="patientDeviceId">Optional filter restricting results to a single registered <see cref="PatientDevice"/>'s
+    /// attributed readings. Bypasses canonical stream selection at the caller — a filtered read returns that device raw.
+    /// Placed after <paramref name="ct"/> so it is additive: existing positional callers (which end at the token) are
+    /// unaffected.</param>
     Task<IEnumerable<SensorGlucose>> GetAsync(
         DateTime? from,
         DateTime? to,
@@ -44,15 +46,15 @@ public interface ISensorGlucoseRepository : IV4Repository<SensorGlucose>
         bool nativeOnly = false,
         DateTime? afterTimestamp = null,
         Guid? afterId = null,
-        Guid? patientDeviceId = null,
-        CancellationToken ct = default
+        CancellationToken ct = default,
+        Guid? patientDeviceId = null
     );
 
     // Explicit base-interface bridge — delegates to the extended overload
     Task<IEnumerable<SensorGlucose>> IV4Repository<SensorGlucose>.GetAsync(
         DateTime? from, DateTime? to, string? device, string? source,
         int limit, int offset, bool descending, CancellationToken ct)
-        => GetAsync(from, to, device, source, limit, offset, descending, false, null, null, null, ct);
+        => GetAsync(from, to, device, source, limit, offset, descending, false, null, null, ct);
 
     /// <summary>Returns a single <see cref="SensorGlucose"/> by its UUID v7, or <c>null</c> if not found.</summary>
     /// <param name="id">UUID v7 record identifier.</param>

--- a/src/Core/Nocturne.Core.Models/Projections/DiscoveredSource.cs
+++ b/src/Core/Nocturne.Core.Models/Projections/DiscoveredSource.cs
@@ -1,0 +1,13 @@
+namespace Nocturne.Core.Models.Projections;
+
+/// <summary>
+/// A distinct <c>(DataSource, Device)</c> combination seen in recent unattributed sensor glucose
+/// readings — a candidate the user can register as a <c>PatientDevice</c>. Mirrors the pseudo-device
+/// identity of <c>CanonicalGlucoseStream.StreamKey</c> so the settings UI and the canonical stream
+/// name the same untracked streams.
+/// </summary>
+/// <param name="DataSource">The reading's data source (connector name, uploader app, etc.).</param>
+/// <param name="Device">The reading's device string, or <c>null</c> when the source supplies none.</param>
+/// <param name="ReadingCount">Number of unattributed readings from this combination in the queried window.</param>
+/// <param name="LastSeen">Timestamp of the most recent unattributed reading from this combination.</param>
+public sealed record DiscoveredSource(string? DataSource, string? Device, int ReadingCount, DateTime LastSeen);

--- a/src/Core/Nocturne.Core.Models/StatisticsModels.cs
+++ b/src/Core/Nocturne.Core.Models/StatisticsModels.cs
@@ -1731,6 +1731,29 @@ public class ReportAnalysisResult
 
     /// <summary>Time-of-day averaged statistics for AGP-style charts.</summary>
     public IEnumerable<AveragedStats> AveragedStats { get; set; } = [];
+
+    /// <summary>Registered devices that contributed readings within the requested window, for device-picker UIs.</summary>
+    [JsonPropertyName("contributingDevices")]
+    public List<ContributingDevice> ContributingDevices { get; set; } = new();
+}
+
+/// <summary>
+/// A registered device (or the unattributed pseudo-device) that contributed CGM readings
+/// within a statistics computation window.
+/// </summary>
+public sealed class ContributingDevice
+{
+    /// <summary>The registered <see cref="PatientDevice"/> id, or <c>null</c> for the unattributed bucket.</summary>
+    [JsonPropertyName("patientDeviceId")]
+    public Guid? PatientDeviceId { get; set; }
+
+    /// <summary>Display name of the device, or "Unattributed" for readings with no <see cref="PatientDeviceId"/>.</summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Number of readings attributed to this device within the requested window.</summary>
+    [JsonPropertyName("readingCount")]
+    public int ReadingCount { get; set; }
 }
 
 /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PatientDeviceRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PatientDeviceRepository.cs
@@ -37,9 +37,14 @@ public class PatientDeviceRepository : IPatientDeviceRepository
     public async Task<IEnumerable<PatientDevice>> GetAllAsync(CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
+        // Rank leads the sort so the management list's order IS the priority order — otherwise
+        // drag/arrow reordering (which persists rank = list index) would snap back on refresh.
+        // Unranked devices fall back to the previous current-then-recent ordering.
         var entities = await ctx.PatientDevices
             .AsNoTracking()
-            .OrderByDescending(e => e.IsCurrent)
+            .OrderBy(e => e.Rank == null)
+            .ThenBy(e => e.Rank)
+            .ThenByDescending(e => e.IsCurrent)
             .ThenByDescending(e => e.StartDate)
             .ToListAsync(ct);
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PatientDeviceRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PatientDeviceRepository.cs
@@ -169,6 +169,33 @@ public class PatientDeviceRepository : IPatientDeviceRepository
     }
 
     /// <inheritdoc />
+    public async Task<IEnumerable<PatientDevice>> ReorderAsync(
+        IReadOnlyList<(Guid Id, int Rank)> ranks, WriteOrigin origin, CancellationToken ct = default)
+    {
+        if (ranks.Count == 0) return [];
+
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var rankById = ranks.ToDictionary(r => r.Id, r => r.Rank);
+        var ids = rankById.Keys.ToList();
+        var entities = await ctx.PatientDevices
+            .Where(e => ids.Contains(e.Id))
+            .ToListAsync(ct);
+
+        var changed = new List<PatientDevice>();
+        foreach (var entity in entities)
+        {
+            var newRank = rankById[entity.Id];
+            if (entity.Rank == newRank) continue;
+            entity.Rank = newRank;
+            changed.Add(PatientDeviceMapper.ToDomainModel(entity));
+        }
+
+        if (changed.Count > 0)
+            await ctx.SaveChangesAsync(ct);
+        return changed;
+    }
+
+    /// <inheritdoc />
     public async Task<PatientDevice> RestoreAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -136,7 +136,7 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
         int limit = 100, int offset = 0, bool descending = true,
         CancellationToken ct = default)
         => GetAsync(from, to, device, source, limit, offset, descending,
-            nativeOnly: false, afterTimestamp: null, afterId: null, patientDeviceId: null, ct);
+            nativeOnly: false, afterTimestamp: null, afterId: null, ct);
 
     /// <summary>
     /// Gets sensor glucose records based on filter criteria.
@@ -165,8 +165,8 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
         bool nativeOnly = false,
         DateTime? afterTimestamp = null,
         Guid? afterId = null,
-        Guid? patientDeviceId = null,
-        CancellationToken ct = default
+        CancellationToken ct = default,
+        Guid? patientDeviceId = null
     )
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
@@ -395,18 +395,24 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
     public async Task<IReadOnlyList<DiscoveredSource>> GetDiscoveredSourcesAsync(DateTime since, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
+        // Project the aggregate into an anonymous type so it translates to SQL GROUP BY; the record
+        // is constructed client-side (EF can't translate a positional-record constructor projection).
         var grouped = await ctx.SensorGlucose
             .AsNoTracking()
             .Where(e => e.PatientDeviceId == null && e.Timestamp >= since)
             .GroupBy(e => new { e.DataSource, e.Device })
-            .Select(g => new DiscoveredSource(
+            .Select(g => new
+            {
                 g.Key.DataSource,
                 g.Key.Device,
-                g.Count(),
-                g.Max(e => e.Timestamp)))
-            .OrderByDescending(d => d.LastSeen)
+                Count = g.Count(),
+                LastSeen = g.Max(e => e.Timestamp),
+            })
             .ToListAsync(ct);
-        return grouped;
+        return grouped
+            .Select(g => new DiscoveredSource(g.DataSource, g.Device, g.Count, g.LastSeen))
+            .OrderByDescending(d => d.LastSeen)
+            .ToList();
     }
 
     /// <inheritdoc />

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -136,7 +136,7 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
         int limit = 100, int offset = 0, bool descending = true,
         CancellationToken ct = default)
         => GetAsync(from, to, device, source, limit, offset, descending,
-            nativeOnly: false, afterTimestamp: null, afterId: null, ct);
+            nativeOnly: false, afterTimestamp: null, afterId: null, patientDeviceId: null, ct);
 
     /// <summary>
     /// Gets sensor glucose records based on filter criteria.
@@ -165,6 +165,7 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
         bool nativeOnly = false,
         DateTime? afterTimestamp = null,
         Guid? afterId = null,
+        Guid? patientDeviceId = null,
         CancellationToken ct = default
     )
     {
@@ -178,6 +179,8 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
             query = query.Where(e => e.Device == device);
         if (source != null)
             query = query.Where(e => e.DataSource == source);
+        if (patientDeviceId.HasValue)
+            query = query.Where(e => e.PatientDeviceId == patientDeviceId.Value);
         if (nativeOnly)
             query = query.Where(e => e.LegacyId == null);
 
@@ -386,6 +389,55 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
             ctx.SensorGlucose.Where(e => e.DataSource == source), AuditContext, ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<DiscoveredSource>> GetDiscoveredSourcesAsync(DateTime since, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var grouped = await ctx.SensorGlucose
+            .AsNoTracking()
+            .Where(e => e.PatientDeviceId == null && e.Timestamp >= since)
+            .GroupBy(e => new { e.DataSource, e.Device })
+            .Select(g => new DiscoveredSource(
+                g.Key.DataSource,
+                g.Key.Device,
+                g.Count(),
+                g.Max(e => e.Timestamp)))
+            .OrderByDescending(d => d.LastSeen)
+            .ToListAsync(ct);
+        return grouped;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<SensorGlucose>> GetUnattributedAsync(DateTime? from, DateTime? to, int limit, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var query = ctx.SensorGlucose.AsNoTracking().Where(e => e.PatientDeviceId == null);
+        if (from.HasValue)
+            query = query.Where(e => e.Timestamp >= from.Value);
+        if (to.HasValue)
+            query = query.Where(e => e.Timestamp <= to.Value);
+
+        var entities = await query
+            .OrderByDescending(e => e.Timestamp)
+            .Take(limit)
+            .ToListAsync(ct);
+        return entities.Select(SensorGlucoseMapper.ToDomainModel).ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task<int> SetPatientDeviceIdsAsync(IReadOnlyDictionary<Guid, Guid> patientDeviceIdByRecordId, CancellationToken ct = default)
+    {
+        if (patientDeviceIdByRecordId.Count == 0) return 0;
+
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var ids = patientDeviceIdByRecordId.Keys.ToList();
+        var entities = await ctx.SensorGlucose.Where(e => ids.Contains(e.Id)).ToListAsync(ct);
+        foreach (var entity in entities)
+            entity.PatientDeviceId = patientDeviceIdByRecordId[entity.Id];
+
+        return entities.Count > 0 ? await ctx.SaveChangesAsync(ct) : 0;
     }
 
     /// <summary>

--- a/src/Web/packages/app/src/lib/api/generated/patientRecords.generated.remote.ts
+++ b/src/Web/packages/app/src/lib/api/generated/patientRecords.generated.remote.ts
@@ -6,8 +6,8 @@ import { getRequestEvent, query, command, form } from '$app/server';
 import { error, redirect } from '@sveltejs/kit';
 import { z } from 'zod';
 import { formCoerce } from './form-utils.generated.js';
-import { PatientRecordSchema, PatientDeviceSchema, PatientInsulinSchema } from '$lib/api/generated/schemas';
-import { type PatientRecord, type PatientDevice, type PatientInsulin } from '$api';
+import { PatientRecordSchema, PatientDeviceSchema, DeviceRankAssignmentSchema, PatientInsulinSchema } from '$lib/api/generated/schemas';
+import { type PatientRecord, type PatientDevice, type DeviceRankAssignment, type PatientInsulin } from '$api';
 
 /** Get or create the patient record */
 export const getPatientRecord = query(async () => {
@@ -85,7 +85,8 @@ export const createDevice = form(formCoerce(PatientDeviceSchema) as any, async (
   try {
     const result = await apiClient.patientRecord.createDevice(request as PatientDevice);
     await Promise.all([
-      getDevices(undefined).refresh()
+      getDevices(undefined).refresh(),
+      getDiscoveredSources(undefined).refresh()
     ]);
     return result;
   } catch (err) {
@@ -100,6 +101,30 @@ export const createDevice = form(formCoerce(PatientDeviceSchema) as any, async (
     const message = flat ?? body?.message ?? body?.title ?? body?.detail ?? e?.message ?? e?.title ?? e?.detail;
     if (status === 400 || status === 409) throw error(status, message ?? 'Request rejected');
     throw error(500, message ?? 'Failed to create device');
+  }
+});
+
+/** Lists distinct (DataSource, Device) combinations seen in recent unattributed readings —
+candidate streams the user can register as devices from the settings UI. */
+export const getDiscoveredSources = query(async () => {
+  const apiClient = getRequestEvent().locals.apiClient;
+  try {
+    return await apiClient.patientRecord.getDiscoveredSources();
+  } catch (err) {
+    const status = (err as any)?.status;
+    if (status === 401) { const { request, url } = getRequestEvent();
+    const shareHost = request.headers.get('x-forwarded-host') ?? request.headers.get('host') ?? '';
+    if (/^[^.]+\.share\./i.test(shareHost)) throw error(401, 'Unauthorized');
+    throw redirect(302, `/auth/login?returnUrl=${encodeURIComponent(url.pathname + url.search)}`); }
+    if (status === 403) throw error(403, (err as any)?.message ?? (err as any)?.detail ?? 'Forbidden');
+    console.error('Error in patientRecord.getDiscoveredSources:', err);
+    const e = err as any;
+    const body = e?.body ?? e?.response;
+    const errors = body?.errors ?? e?.errors;
+    const flat = errors ? Object.entries(errors).map(([, v]: [string, any]) => Array.isArray(v) ? v.join(', ') : v).join('; ') : undefined;
+    const message = flat ?? body?.message ?? body?.title ?? body?.detail ?? e?.message ?? e?.title ?? e?.detail;
+    if (status === 400 || status === 409) throw error(status, message ?? 'Request rejected');
+    throw error(500, message ?? 'Failed to get discovered sources');
   }
 });
 
@@ -148,6 +173,32 @@ export const deleteDevice = command(z.string(), async (id) => {
     const message = flat ?? body?.message ?? body?.title ?? body?.detail ?? e?.message ?? e?.title ?? e?.detail;
     if (status === 400 || status === 409) throw error(status, message ?? 'Request rejected');
     throw error(500, message ?? 'Failed to delete device');
+  }
+});
+
+/** Reassigns device priority in a single batch. Drag-to-reorder in the UI sends the full ordered
+list; each entry's position becomes its Rank. One round trip instead
+of one PUT per device. An imperative command (no HTML form), mirroring the delete/restore surface. */
+export const reorderDevices = command(z.array(DeviceRankAssignmentSchema), async (request) => {
+  const apiClient = getRequestEvent().locals.apiClient;
+  try {
+    const result = await apiClient.patientRecord.reorderDevices(request as DeviceRankAssignment[]);
+    await Promise.all([
+      getDevices(undefined).refresh()
+    ]);
+    return result;
+  } catch (err) {
+    const status = (err as any)?.status;
+    if (status === 401) { throw error(401, 'Unauthorized'); }
+    if (status === 403) throw error(403, (err as any)?.message ?? (err as any)?.detail ?? 'Forbidden');
+    console.error('Error in patientRecord.reorderDevices:', err);
+    const e = err as any;
+    const body = e?.body ?? e?.response;
+    const errors = body?.errors ?? e?.errors;
+    const flat = errors ? Object.entries(errors).map(([, v]: [string, any]) => Array.isArray(v) ? v.join(', ') : v).join('; ') : undefined;
+    const message = flat ?? body?.message ?? body?.title ?? body?.detail ?? e?.message ?? e?.title ?? e?.detail;
+    if (status === 400 || status === 409) throw error(status, message ?? 'Request rejected');
+    throw error(500, message ?? 'Failed to reorder devices');
   }
 });
 

--- a/src/Web/packages/app/src/lib/components/patient/PatientDeviceManager.svelte
+++ b/src/Web/packages/app/src/lib/components/patient/PatientDeviceManager.svelte
@@ -159,7 +159,8 @@
 
   // ── Discovered sources ──────────────────────────────────────────
 
-  function formatLastSeen(value: string | Date): string {
+  function formatLastSeen(value: string | Date | null | undefined): string {
+    if (!value) return "";
     return new Date(value).toLocaleDateString(undefined, {
       year: "numeric",
       month: "short",

--- a/src/Web/packages/app/src/lib/components/patient/PatientDeviceManager.svelte
+++ b/src/Web/packages/app/src/lib/components/patient/PatientDeviceManager.svelte
@@ -20,9 +20,12 @@
     Trash2,
     Save,
     Loader2,
+    ChevronUp,
+    ChevronDown,
   } from "lucide-svelte";
   import {
     type PatientDevice,
+    type DiscoveredSource,
     DeviceCategory,
     AidAlgorithm,
   } from "$api";
@@ -141,6 +144,37 @@
     if (!deleteId) return;
     await deviceList.remove(deleteId);
     deleteId = null;
+  }
+
+  // ── Rank reordering ─────────────────────────────────────────────
+
+  /** Moves the device at {@link index} one slot toward the front (-1) or back (+1) and persists the order. */
+  async function moveDevice(index: number, direction: -1 | 1) {
+    const ids = deviceList.items.map((d) => d.id).filter((id): id is string => !!id);
+    const target = index + direction;
+    if (target < 0 || target >= ids.length) return;
+    [ids[index], ids[target]] = [ids[target], ids[index]];
+    await deviceList.reorder(ids);
+  }
+
+  // ── Discovered sources ──────────────────────────────────────────
+
+  function formatLastSeen(value: string | Date): string {
+    return new Date(value).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  }
+
+  /**
+   * Opens the device dialog pre-filled from a discovered source as a CGM. The user sets the usage
+   * dates before saving; registration back-stamps the source's readings within that window.
+   */
+  function registerDiscovered(source: DiscoveredSource) {
+    openDialog();
+    deviceCategory = DeviceCategory.CGM;
+    deviceModel = source.device ?? source.dataSource ?? "";
   }
 </script>
 
@@ -287,7 +321,7 @@
     </p>
   {:else}
     <div class="space-y-3">
-      {#each deviceList.items as device}
+      {#each deviceList.items as device, i}
         <div
           class="flex items-center justify-between rounded-lg border p-3"
         >
@@ -328,6 +362,30 @@
             </div>
           </div>
           <div class="flex items-center gap-1 ml-2">
+            {#if deviceList.items.length > 1}
+              <div class="flex flex-col">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  class="h-5 w-6"
+                  aria-label="Move device up in priority"
+                  disabled={i === 0}
+                  onclick={() => moveDevice(i, -1)}
+                >
+                  <ChevronUp class="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  class="h-5 w-6"
+                  aria-label="Move device down in priority"
+                  disabled={i === deviceList.items.length - 1}
+                  onclick={() => moveDevice(i, 1)}
+                >
+                  <ChevronDown class="h-4 w-4" />
+                </Button>
+              </div>
+            {/if}
             <Button
               variant="ghost"
               size="icon"
@@ -355,6 +413,47 @@
       Add Device
     </Button>
   </div>
+
+  <!-- Discovered sources: unattributed streams seen recently -->
+  {#if deviceList.discoveredSources.length > 0}
+    <div class="pt-4 space-y-2">
+      <div>
+        <h4 class="text-sm font-medium">Discovered sources</h4>
+        <p class="text-xs text-muted-foreground">
+          Streams seen in recent readings that aren't linked to a device yet. Register one to
+          attribute its readings.
+        </p>
+      </div>
+      <div class="space-y-2">
+        {#each deviceList.discoveredSources as source}
+          <div class="flex items-center justify-between rounded-lg border border-dashed p-3">
+            <div class="space-y-1 min-w-0 flex-1">
+              <div class="flex items-center gap-2 flex-wrap">
+                <span class="font-medium text-sm">
+                  {source.device || source.dataSource || "Unknown source"}
+                </span>
+                {#if source.device && source.dataSource}
+                  <Badge variant="outline" class="text-xs font-mono">{source.dataSource}</Badge>
+                {/if}
+              </div>
+              <div class="flex items-center gap-3 text-xs text-muted-foreground flex-wrap">
+                <span>{source.readingCount} reading{source.readingCount === 1 ? "" : "s"}</span>
+                <span>Last seen {formatLastSeen(source.lastSeen)}</span>
+              </div>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              class="ml-2 shrink-0"
+              onclick={() => registerDiscovered(source)}
+            >
+              Register as device
+            </Button>
+          </div>
+        {/each}
+      </div>
+    </div>
+  {/if}
 
   <!-- Device Dialog -->
   <Dialog.Root bind:open={dialogOpen}>

--- a/src/Web/packages/app/src/lib/components/patient/PatientDeviceManager.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/patient/PatientDeviceManager.svelte.test.ts
@@ -1,0 +1,83 @@
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the generated remote functions before importing the component. DeviceListState reads
+// getDevices()/getDiscoveredSources() as reactive queries (`.current`) and calls reorderDevices()
+// as a command.
+const createDevice = Object.assign((..._args: unknown[]) => Promise.resolve({}), {
+  enhance: () => ({}),
+  pending: 0,
+  result: undefined,
+  fields: { allIssues: () => [] },
+});
+const updateDevice = Object.assign((..._args: unknown[]) => Promise.resolve({}), {
+  enhance: () => ({}),
+  pending: 0,
+  result: undefined,
+  fields: { allIssues: () => [] },
+});
+const reorderDevices = vi.fn().mockResolvedValue([]);
+const deleteDevice = vi.fn().mockResolvedValue(undefined);
+
+let devicesCurrent: unknown[] = [];
+let discoveredCurrent: unknown[] = [];
+
+vi.mock("$api/generated/patientRecords.generated.remote", () => ({
+  getDevices: () => ({ get current() { return devicesCurrent; } }),
+  getDiscoveredSources: () => ({ get current() { return discoveredCurrent; } }),
+  createDevice,
+  updateDevice,
+  deleteDevice: (...args: unknown[]) => deleteDevice(...args),
+  reorderDevices: (...args: unknown[]) => reorderDevices(...args),
+}));
+
+import PatientDeviceManager from "./PatientDeviceManager.svelte";
+
+function makeDevice(id: string, over: Record<string, unknown> = {}) {
+  return {
+    id,
+    deviceCategory: "cgm",
+    manufacturer: "Dexcom",
+    model: "G7",
+    isCurrent: true,
+    rank: null,
+    ...over,
+  };
+}
+
+describe("PatientDeviceManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    devicesCurrent = [];
+    discoveredCurrent = [];
+  });
+
+  it("lists discovered sources with reading count and last-seen", async () => {
+    discoveredCurrent = [
+      { dataSource: "dexcom-connector", device: "G7-ABC", readingCount: 42, lastSeen: new Date().toISOString() },
+    ];
+    render(PatientDeviceManager, { variant: "dialog" });
+
+    await expect.element(page.getByText("Discovered sources")).toBeVisible();
+    await expect.element(page.getByText("G7-ABC")).toBeVisible();
+    await expect.element(page.getByText("42 readings")).toBeVisible();
+    await expect.element(page.getByRole("button", { name: "Register as device" })).toBeVisible();
+  });
+
+  it("reorders devices by persisting rank = new index", async () => {
+    const a = "11111111-1111-1111-1111-111111111111";
+    const b = "22222222-2222-2222-2222-222222222222";
+    devicesCurrent = [makeDevice(a, { rank: 0 }), makeDevice(b, { rank: 1 })];
+    render(PatientDeviceManager, { variant: "dialog" });
+
+    // Move the first device down: [a, b] -> [b, a] -> rank b=0, a=1.
+    await page.getByRole("button", { name: "Move device down in priority" }).first().click();
+
+    expect(reorderDevices).toHaveBeenCalledTimes(1);
+    expect(reorderDevices).toHaveBeenCalledWith([
+      { id: b, rank: 0 },
+      { id: a, rank: 1 },
+    ]);
+  });
+});

--- a/src/Web/packages/app/src/lib/components/patient/state.svelte.ts
+++ b/src/Web/packages/app/src/lib/components/patient/state.svelte.ts
@@ -5,6 +5,7 @@ import {
   type PatientDevice,
   type PatientInsulin,
   type InsulinFormulation,
+  type DiscoveredSource,
   DiabetesType,
 } from "$api";
 import { FormGuard } from "$lib/forms";
@@ -118,16 +119,32 @@ export class ClinicalState {
   }
 }
 
-/** Reactive device list state with CRUD */
+/** Reactive device list state with CRUD, discovered-source registration, and rank reordering */
 export class DeviceListState {
   readonly #devices = patientRemote.getDevices();
+  readonly #discovered = patientRemote.getDiscoveredSources();
   readonly createForm = patientRemote.createDevice;
   readonly updateForm = patientRemote.updateDevice;
 
   get items(): PatientDevice[] { return (this.#devices.current ?? []) as PatientDevice[]; }
 
+  /** Distinct (dataSource, device) combinations seen recently in unattributed readings. */
+  get discoveredSources(): DiscoveredSource[] {
+    return (this.#discovered.current ?? []) as DiscoveredSource[];
+  }
+
   remove = async (id: string): Promise<void> => {
     await patientRemote.deleteDevice(id);
+  };
+
+  /**
+   * Persist the given device order as {@link PatientDevice.rank} — each id's position becomes its
+   * rank. One request for the whole list.
+   */
+  reorder = async (orderedIds: string[]): Promise<void> => {
+    await patientRemote.reorderDevices(
+      orderedIds.map((id, index) => ({ id, rank: index })),
+    );
   };
 }
 

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsControllerTests.cs
@@ -204,9 +204,9 @@ public class StatisticsControllerTests
                 It.IsAny<string?>(), It.IsAny<string?>(),
                 It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(),
                 It.IsAny<bool>(), It.IsAny<DateTime?>(), It.IsAny<Guid?>(),
-                It.IsAny<CancellationToken>()))
-            .Callback<DateTime?, DateTime?, string?, string?, int, int, bool, bool, DateTime?, Guid?, CancellationToken>(
-                (from, to, _, _, _, _, _, _, _, _, _) =>
+                It.IsAny<CancellationToken>(), It.IsAny<Guid?>()))
+            .Callback<DateTime?, DateTime?, string?, string?, int, int, bool, bool, DateTime?, Guid?, CancellationToken, Guid?>(
+                (from, to, _, _, _, _, _, _, _, _, _, _) =>
                 {
                     capturedFrom = from;
                     capturedTo = to;

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/PatientRecordControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/PatientRecordControllerTests.cs
@@ -2,8 +2,10 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Nocturne.API.Controllers.V4.Health;
+using Nocturne.API.Services.Devices;
 using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.Projections;
 using Nocturne.Core.Models.V4;
 using Xunit;
 using Nocturne.Core.Contracts.V4;
@@ -16,6 +18,8 @@ public class PatientRecordControllerTests
     private readonly Mock<IPatientDeviceRepository> _deviceRepo;
     private readonly Mock<IPatientInsulinRepository> _insulinRepo;
     private readonly Mock<IDeviceService> _deviceService;
+    private readonly Mock<ISensorGlucoseRepository> _sensorGlucoseRepo;
+    private readonly Mock<IDeviceReattributionService> _reattribution;
     private readonly PatientRecordController _controller;
 
     public PatientRecordControllerTests()
@@ -24,12 +28,16 @@ public class PatientRecordControllerTests
         _deviceRepo = new Mock<IPatientDeviceRepository>();
         _insulinRepo = new Mock<IPatientInsulinRepository>();
         _deviceService = new Mock<IDeviceService>();
+        _sensorGlucoseRepo = new Mock<ISensorGlucoseRepository>();
+        _reattribution = new Mock<IDeviceReattributionService>();
 
         _controller = new PatientRecordController(
             _recordRepo.Object,
             _deviceRepo.Object,
             _insulinRepo.Object,
-            _deviceService.Object);
+            _deviceService.Object,
+            _sensorGlucoseRepo.Object,
+            _reattribution.Object);
     }
 
     [Fact]
@@ -171,5 +179,68 @@ public class PatientRecordControllerTests
             It.IsAny<string?>(),
             It.IsAny<long>(),
             It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetDiscoveredSources_ReturnsRepositoryResults()
+    {
+        var discovered = new List<DiscoveredSource>
+        {
+            new("xdrip", "DexcomG6", 42, DateTime.UtcNow),
+        };
+        _sensorGlucoseRepo
+            .Setup(r => r.GetDiscoveredSourcesAsync(It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(discovered);
+
+        var result = await _controller.GetDiscoveredSources();
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        ok.Value.Should().BeSameAs(discovered);
+    }
+
+    [Fact]
+    public async Task CreateDevice_ReattributesTheCreatedDevice()
+    {
+        var model = new PatientDevice
+        {
+            DeviceCategory = DeviceCategory.CGM,
+            Manufacturer = "Dexcom",
+            Model = "G7",
+        };
+        PatientDevice? created = null;
+        _deviceRepo
+            .Setup(x => x.CreateAsync(It.IsAny<PatientDevice>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PatientDevice m, WriteOrigin _, CancellationToken _) => { created = m; return m; });
+
+        await _controller.CreateDevice(model);
+
+        _reattribution.Verify(
+            r => r.ReattributeForDeviceAsync(created!, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ReorderDevices_MapsAssignmentsToRepository()
+    {
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        var assignments = new List<DeviceRankAssignment>
+        {
+            new(a, 0),
+            new(b, 1),
+        };
+        var changed = new List<PatientDevice> { new() { Id = a, Rank = 0 } };
+        IReadOnlyList<(Guid Id, int Rank)>? captured = null;
+        _deviceRepo
+            .Setup(x => x.ReorderAsync(It.IsAny<IReadOnlyList<(Guid, int)>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<(Guid, int)>, WriteOrigin, CancellationToken>((r, _, _) => captured = r)
+            .ReturnsAsync(changed);
+
+        var result = await _controller.ReorderDevices(assignments);
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        ok.Value.Should().BeSameAs(changed);
+        captured.Should().NotBeNull();
+        captured.Should().Contain((a, 0));
+        captured.Should().Contain((b, 1));
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/SensorGlucoseControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/SensorGlucoseControllerTests.cs
@@ -7,6 +7,7 @@ using Nocturne.API.Controllers.V4.Glucose;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.API.Services.V4;
 using Nocturne.Core.Contracts.Alerts;
+using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Xunit;
@@ -20,6 +21,7 @@ public class SensorGlucoseControllerTests
     private readonly Mock<ISensorGlucoseRepository> _repoMock = new();
     private readonly Mock<IGlucoseProcessingResolver> _glucoseResolverMock = new();
     private readonly Mock<ICanonicalAlertEvaluator> _alertEvaluatorMock = new();
+    private readonly Mock<IPatientDeviceStamper> _deviceStamperMock = new();
     private readonly Mock<ILogger<SensorGlucoseController>> _loggerMock = new();
 
     private SensorGlucoseController CreateController()
@@ -28,6 +30,7 @@ public class SensorGlucoseControllerTests
             _repoMock.Object,
             _glucoseResolverMock.Object,
             _alertEvaluatorMock.Object,
+            _deviceStamperMock.Object,
             _loggerMock.Object);
 
         controller.ControllerContext = new ControllerContext
@@ -128,5 +131,79 @@ public class SensorGlucoseControllerTests
         // Assert
         var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
         okResult.Value.Should().Be(updated);
+    }
+
+    [Fact]
+    public async Task Create_StampsWithCgmCategory_AndPersistsAttribution()
+    {
+        var deviceId = Guid.NewGuid();
+        var input = new UpsertSensorGlucoseRequest { Timestamp = DateTimeOffset.UtcNow, Mgdl = 120 };
+
+        // Stamper attributes the model in place before it reaches the repository.
+        _deviceStamperMock
+            .Setup(s => s.StampAsync(
+                It.IsAny<IReadOnlyList<IDeviceAttributed>>(),
+                It.IsAny<IReadOnlyList<DeviceCategory>>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<IDeviceAttributed>, IReadOnlyList<DeviceCategory>, string?, CancellationToken>(
+                (records, _, _, _) => records[0].PatientDeviceId = deviceId)
+            .Returns(Task.CompletedTask);
+
+        SensorGlucose? persisted = null;
+        _repoMock
+            .Setup(r => r.CreateAsync(It.IsAny<SensorGlucose>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback<SensorGlucose, WriteOrigin, CancellationToken>((m, _, _) => persisted = m)
+            .ReturnsAsync((SensorGlucose m, WriteOrigin _, CancellationToken _) => m);
+
+        var controller = CreateController();
+
+        await controller.Create(input);
+
+        _deviceStamperMock.Verify(s => s.StampAsync(
+            It.IsAny<IReadOnlyList<IDeviceAttributed>>(),
+            It.Is<IReadOnlyList<DeviceCategory>>(c => c.Contains(DeviceCategory.CGM)),
+            It.IsAny<string?>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+        persisted.Should().NotBeNull();
+        persisted!.PatientDeviceId.Should().Be(deviceId);
+    }
+
+    [Fact]
+    public async Task CreateBulk_StampsWithCgmCategory_AndPersistsAttribution()
+    {
+        var deviceId = Guid.NewGuid();
+        var requests = new[]
+        {
+            new UpsertSensorGlucoseRequest { Timestamp = DateTimeOffset.UtcNow, Mgdl = 120 },
+        };
+
+        _deviceStamperMock
+            .Setup(s => s.StampAsync(
+                It.IsAny<IReadOnlyList<IDeviceAttributed>>(),
+                It.IsAny<IReadOnlyList<DeviceCategory>>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<IDeviceAttributed>, IReadOnlyList<DeviceCategory>, string?, CancellationToken>(
+                (records, _, _, _) => records[0].PatientDeviceId = deviceId)
+            .Returns(Task.CompletedTask);
+
+        IEnumerable<SensorGlucose>? persisted = null;
+        _repoMock
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<SensorGlucose>, WriteOrigin, CancellationToken>((m, _, _) => persisted = m.ToList())
+            .ReturnsAsync((IEnumerable<SensorGlucose> m, WriteOrigin _, CancellationToken _) => m);
+
+        var controller = CreateController();
+
+        await controller.CreateSensorGlucoseBulk(requests);
+
+        _deviceStamperMock.Verify(s => s.StampAsync(
+            It.IsAny<IReadOnlyList<IDeviceAttributed>>(),
+            It.Is<IReadOnlyList<DeviceCategory>>(c => c.Contains(DeviceCategory.CGM)),
+            It.IsAny<string?>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+        persisted.Should().NotBeNull();
+        persisted!.Single().PatientDeviceId.Should().Be(deviceId);
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/SensorIntegrityServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/SensorIntegrityServiceTests.cs
@@ -178,9 +178,9 @@ public class SensorIntegrityServiceTests
             .Setup(r => r.GetAsync(
                 It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string?>(), It.IsAny<string?>(),
                 It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<bool>(),
-                It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+                It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>(), It.IsAny<Guid?>()))
             .ReturnsAsync((DateTime? _, DateTime? _, string? _, string? source, int _, int _, bool _, bool _,
-                DateTime? _, Guid? _, CancellationToken _) =>
+                DateTime? _, Guid? _, CancellationToken _, Guid? _) =>
                 source is null ? readings : readings.Where(r => r.DataSource == source).ToList());
 
         var bolusRepo = new Mock<IBolusRepository>();

--- a/tests/Unit/Nocturne.API.Tests/Services/Devices/DeviceReattributionServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Devices/DeviceReattributionServiceTests.cs
@@ -1,0 +1,136 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Devices;
+using Nocturne.Core.Contracts.Devices;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.V4;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Devices;
+
+[Trait("Category", "Unit")]
+public class DeviceReattributionServiceTests
+{
+    private readonly Mock<ISensorGlucoseRepository> _repo = new();
+    private readonly Mock<IPatientDeviceStamper> _stamper = new();
+    private readonly DeviceReattributionService _service;
+
+    public DeviceReattributionServiceTests()
+    {
+        _service = new DeviceReattributionService(
+            _repo.Object, _stamper.Object, NullLogger<DeviceReattributionService>.Instance);
+    }
+
+    private static PatientDevice CgmDevice(DateOnly? start = null, DateOnly? end = null) => new()
+    {
+        Id = Guid.NewGuid(),
+        DeviceCategory = DeviceCategory.CGM,
+        Manufacturer = "Dexcom",
+        Model = "G7",
+        StartDate = start,
+        EndDate = end,
+    };
+
+    [Fact]
+    public async Task NonCgmDevice_ReturnsZero_AndTouchesNothing()
+    {
+        var pump = new PatientDevice
+        {
+            Id = Guid.NewGuid(),
+            DeviceCategory = DeviceCategory.InsulinPump,
+            Manufacturer = "Tandem",
+            Model = "t:slim X2",
+        };
+
+        var result = await _service.ReattributeForDeviceAsync(pump);
+
+        result.Should().Be(0);
+        _repo.Verify(r => r.GetUnattributedAsync(
+            It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        _stamper.Verify(s => s.StampAsync(
+            It.IsAny<IReadOnlyList<IDeviceAttributed>>(), It.IsAny<IReadOnlyList<DeviceCategory>>(),
+            It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+        _repo.Verify(r => r.SetPatientDeviceIdsAsync(
+            It.IsAny<IReadOnlyDictionary<Guid, Guid>>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CgmWithMatches_PersistsOnlyMatchedReadings_AndReturnsCount()
+    {
+        var device = CgmDevice(start: new DateOnly(2026, 6, 1), end: new DateOnly(2026, 6, 30));
+        var matched = new SensorGlucose { Id = Guid.NewGuid(), Timestamp = DateTime.UtcNow, Mgdl = 120, DataSource = "dexcom" };
+        var unmatched = new SensorGlucose { Id = Guid.NewGuid(), Timestamp = DateTime.UtcNow, Mgdl = 118, DataSource = "libre" };
+
+        _repo.Setup(r => r.GetUnattributedAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SensorGlucose> { matched, unmatched });
+
+        // Simulate the ingest ladder attributing only the matching reading.
+        _stamper.Setup(s => s.StampAsync(
+                It.IsAny<IReadOnlyList<IDeviceAttributed>>(), It.IsAny<IReadOnlyList<DeviceCategory>>(),
+                It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<IDeviceAttributed>, IReadOnlyList<DeviceCategory>, string?, CancellationToken>(
+                (records, _, _, _) => matched.PatientDeviceId = device.Id)
+            .Returns(Task.CompletedTask);
+
+        IReadOnlyDictionary<Guid, Guid>? persisted = null;
+        _repo.Setup(r => r.SetPatientDeviceIdsAsync(
+                It.IsAny<IReadOnlyDictionary<Guid, Guid>>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyDictionary<Guid, Guid>, CancellationToken>((map, _) => persisted = map)
+            .ReturnsAsync(1);
+
+        var result = await _service.ReattributeForDeviceAsync(device);
+
+        result.Should().Be(1);
+        persisted.Should().NotBeNull();
+        persisted.Should().ContainKey(matched.Id).WhoseValue.Should().Be(device.Id);
+        persisted.Should().NotContainKey(unmatched.Id);
+
+        // Usage window is padded ±1 day around the device's local dates.
+        _repo.Verify(r => r.GetUnattributedAsync(
+            It.Is<DateTime?>(d => d == new DateOnly(2026, 6, 1).ToDateTime(TimeOnly.MinValue).AddDays(-1)),
+            It.Is<DateTime?>(d => d == new DateOnly(2026, 6, 30).ToDateTime(TimeOnly.MaxValue).AddDays(1)),
+            It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CgmWithNoUnattributed_ReturnsZero_WithoutStampingOrPersisting()
+    {
+        var device = CgmDevice(start: new DateOnly(2026, 6, 1));
+        _repo.Setup(r => r.GetUnattributedAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SensorGlucose>());
+
+        var result = await _service.ReattributeForDeviceAsync(device);
+
+        result.Should().Be(0);
+        _stamper.Verify(s => s.StampAsync(
+            It.IsAny<IReadOnlyList<IDeviceAttributed>>(), It.IsAny<IReadOnlyList<DeviceCategory>>(),
+            It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+        _repo.Verify(r => r.SetPatientDeviceIdsAsync(
+            It.IsAny<IReadOnlyDictionary<Guid, Guid>>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CgmWithUnattributedButNoMatches_ReturnsZero_WithoutPersisting()
+    {
+        var device = CgmDevice(start: new DateOnly(2026, 6, 1));
+        var reading = new SensorGlucose { Id = Guid.NewGuid(), Timestamp = DateTime.UtcNow, Mgdl = 120, DataSource = "libre" };
+        _repo.Setup(r => r.GetUnattributedAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SensorGlucose> { reading });
+
+        // Stamper leaves the reading unattributed (no match against this device).
+        _stamper.Setup(s => s.StampAsync(
+                It.IsAny<IReadOnlyList<IDeviceAttributed>>(), It.IsAny<IReadOnlyList<DeviceCategory>>(),
+                It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await _service.ReattributeForDeviceAsync(device);
+
+        result.Should().Be(0);
+        _repo.Verify(r => r.SetPatientDeviceIdsAsync(
+            It.IsAny<IReadOnlyDictionary<Guid, Guid>>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/PatientDeviceRepositoryReorderTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/PatientDeviceRepositoryReorderTests.cs
@@ -1,0 +1,138 @@
+using System.Data.Common;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+/// <summary>
+/// Covers <see cref="PatientDeviceRepository.ReorderAsync"/> added for the multi-CGM feature:
+/// batch rank assignment that returns only the devices whose rank actually changed, skips
+/// unchanged ranks, and ignores unknown ids.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+[Trait("Category", "PatientDevice")]
+public class PatientDeviceRepositoryReorderTests : IDisposable
+{
+    private static readonly Guid TestTenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+    private readonly DbConnection _connection;
+    private readonly NocturneDbContext _context;
+    private readonly PatientDeviceRepository _repo;
+
+    public PatientDeviceRepositoryReorderTests()
+    {
+        _connection = new SqliteConnection("Filename=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        using (var seedContext = new NocturneDbContext(options))
+        {
+            seedContext.TenantId = TestTenantId;
+            seedContext.Database.EnsureCreated();
+            seedContext.Tenants.Add(new TenantEntity { Id = TestTenantId, Slug = "test" });
+            seedContext.SaveChanges();
+        }
+
+        _context = new NocturneDbContext(options) { TenantId = TestTenantId };
+        _repo = new PatientDeviceRepository(
+            new TestTenantDbContextFactory(_context),
+            NullLogger<PatientDeviceRepository>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private Guid SeedDevice(int? rank)
+    {
+        var id = Guid.NewGuid();
+        _context.PatientDevices.Add(new PatientDeviceEntity
+        {
+            Id = id,
+            TenantId = TestTenantId,
+            DeviceCategory = "CGM",
+            Manufacturer = "Dexcom",
+            Model = "G7",
+            IsCurrent = true,
+            Rank = rank,
+        });
+        _context.SaveChanges();
+        return id;
+    }
+
+    [Fact]
+    public async Task ReorderAsync_SetsRanks_AndReturnsOnlyChangedDevices()
+    {
+        var a = SeedDevice(rank: 0);
+        var b = SeedDevice(rank: 1);
+
+        var changed = (await _repo.ReorderAsync(
+            new List<(Guid, int)> { (a, 1), (b, 0) }, WriteOrigin.Live)).ToList();
+
+        changed.Should().HaveCount(2);
+        changed.Should().Contain(d => d.Id == a && d.Rank == 1);
+        changed.Should().Contain(d => d.Id == b && d.Rank == 0);
+    }
+
+    [Fact]
+    public async Task ReorderAsync_SkipsUnchangedRanks()
+    {
+        var a = SeedDevice(rank: 0);
+        var b = SeedDevice(rank: 1);
+
+        // a keeps rank 0 (unchanged), b moves 1 → 2.
+        var changed = (await _repo.ReorderAsync(
+            new List<(Guid, int)> { (a, 0), (b, 2) }, WriteOrigin.Live)).ToList();
+
+        changed.Should().ContainSingle();
+        changed[0].Id.Should().Be(b);
+        changed[0].Rank.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ReorderAsync_IgnoresUnknownIds()
+    {
+        var a = SeedDevice(rank: 0);
+
+        var changed = (await _repo.ReorderAsync(
+            new List<(Guid, int)> { (a, 5), (Guid.NewGuid(), 9) }, WriteOrigin.Live)).ToList();
+
+        changed.Should().ContainSingle();
+        changed[0].Id.Should().Be(a);
+        changed[0].Rank.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task ReorderAsync_EmptyList_ReturnsEmpty()
+    {
+        var changed = await _repo.ReorderAsync(new List<(Guid, int)>(), WriteOrigin.Live);
+        changed.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ReorderAsync_PersistsRanks()
+    {
+        var a = SeedDevice(rank: 0);
+
+        await _repo.ReorderAsync(new List<(Guid, int)> { (a, 3) }, WriteOrigin.Live);
+
+        var reloaded = await _repo.GetByIdAsync(a);
+        reloaded!.Rank.Should().Be(3);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/PatientDeviceRepositoryReorderTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/PatientDeviceRepositoryReorderTests.cs
@@ -135,4 +135,17 @@ public class PatientDeviceRepositoryReorderTests : IDisposable
         var reloaded = await _repo.GetByIdAsync(a);
         reloaded!.Rank.Should().Be(3);
     }
+
+    [Fact]
+    public async Task GetAllAsync_OrdersByRank_SoReorderIsStable()
+    {
+        // Insertion order deliberately differs from rank order; unranked device sorts last.
+        var high = SeedDevice(rank: 2);
+        var top = SeedDevice(rank: 0);
+        var unranked = SeedDevice(rank: null);
+
+        var ordered = (await _repo.GetAllAsync()).Select(d => d.Id).ToList();
+
+        ordered.Should().Equal(top, high, unranked);
+    }
 }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SensorGlucoseRepositoryAttributionTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SensorGlucoseRepositoryAttributionTests.cs
@@ -1,0 +1,225 @@
+using System.Data.Common;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Infrastructure;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+/// <summary>
+/// Covers the device-attribution surface added to <see cref="SensorGlucoseRepository"/> for the
+/// multi-CGM feature: the <c>patientDeviceId</c> read filter, discovered-source aggregation,
+/// unattributed windowing, and batch back-stamping. Uses in-memory SQLite so the GroupBy in
+/// <c>GetDiscoveredSourcesAsync</c> and the patient_device_id foreign key are enforced end-to-end.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+[Trait("Category", "SensorGlucose")]
+public class SensorGlucoseRepositoryAttributionTests : IDisposable
+{
+    private static readonly Guid TestTenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+    private readonly DbConnection _connection;
+    private readonly NocturneDbContext _context;
+    private readonly SensorGlucoseRepository _repo;
+
+    public SensorGlucoseRepositoryAttributionTests()
+    {
+        _connection = new SqliteConnection("Filename=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        using (var seedContext = new NocturneDbContext(options))
+        {
+            seedContext.TenantId = TestTenantId;
+            seedContext.Database.EnsureCreated();
+            seedContext.Tenants.Add(new TenantEntity { Id = TestTenantId, Slug = "test" });
+            seedContext.SaveChanges();
+        }
+
+        _context = new NocturneDbContext(options) { TenantId = TestTenantId };
+
+        var dedup = new Mock<IDeduplicationService>();
+        _repo = new SensorGlucoseRepository(
+            new TestTenantDbContextFactory(_context),
+            dedup.Object,
+            new Mock<IAuditContext>().Object,
+            NullLogger<SensorGlucoseRepository>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private Guid SeedDevice()
+    {
+        var id = Guid.NewGuid();
+        _context.PatientDevices.Add(new PatientDeviceEntity
+        {
+            Id = id,
+            TenantId = TestTenantId,
+            DeviceCategory = "CGM",
+            Manufacturer = "Dexcom",
+            Model = "G7",
+            IsCurrent = true,
+        });
+        _context.SaveChanges();
+        return id;
+    }
+
+    private Guid SeedReading(
+        DateTime timestamp,
+        string? dataSource = null,
+        string? device = null,
+        Guid? patientDeviceId = null)
+    {
+        var id = Guid.NewGuid();
+        _context.SensorGlucose.Add(new SensorGlucoseEntity
+        {
+            Id = id,
+            TenantId = TestTenantId,
+            Timestamp = timestamp,
+            Mgdl = 120,
+            DataSource = dataSource,
+            Device = device,
+            PatientDeviceId = patientDeviceId,
+        });
+        _context.SaveChanges();
+        return id;
+    }
+
+    [Fact]
+    public async Task GetAsync_WithPatientDeviceId_ReturnsOnlyThatDevicesReadings()
+    {
+        var deviceId = SeedDevice();
+        var now = DateTime.UtcNow;
+        var attributedId = SeedReading(now, dataSource: "dexcom", patientDeviceId: deviceId);
+        SeedReading(now.AddMinutes(-5), dataSource: "dexcom"); // unattributed
+
+        var result = (await _repo.GetAsync(
+            from: null, to: null, device: null, source: null,
+            limit: 100, offset: 0, descending: true,
+            nativeOnly: false, afterTimestamp: null, afterId: null,
+            patientDeviceId: deviceId)).ToList();
+
+        result.Should().ContainSingle();
+        result[0].Id.Should().Be(attributedId);
+    }
+
+    [Fact]
+    public async Task GetAsync_WithoutPatientDeviceId_ReturnsAllReadings()
+    {
+        var deviceId = SeedDevice();
+        var now = DateTime.UtcNow;
+        SeedReading(now, dataSource: "dexcom", patientDeviceId: deviceId);
+        SeedReading(now.AddMinutes(-5), dataSource: "dexcom");
+
+        var result = (await _repo.GetAsync(from: null, to: null, device: null, source: null)).ToList();
+
+        result.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetDiscoveredSourcesAsync_GroupsUnattributedBySourceAndDevice_ExcludingAttributed()
+    {
+        var deviceId = SeedDevice();
+        var since = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        // Two unattributed readings from the same (source, device) → one group of 2.
+        SeedReading(new DateTime(2026, 6, 10, 8, 0, 0, DateTimeKind.Utc), dataSource: "xdrip", device: "DexcomG6");
+        var latestXdrip = new DateTime(2026, 6, 11, 8, 0, 0, DateTimeKind.Utc);
+        SeedReading(latestXdrip, dataSource: "xdrip", device: "DexcomG6");
+        // A distinct unattributed stream.
+        SeedReading(new DateTime(2026, 6, 12, 8, 0, 0, DateTimeKind.Utc), dataSource: "libre", device: "Libre3");
+        // Attributed reading — must be excluded from discovery.
+        SeedReading(new DateTime(2026, 6, 13, 8, 0, 0, DateTimeKind.Utc), dataSource: "already", device: "Owned", patientDeviceId: deviceId);
+        // Older than the window — excluded.
+        SeedReading(new DateTime(2026, 5, 1, 8, 0, 0, DateTimeKind.Utc), dataSource: "old", device: "Old");
+
+        var sources = await _repo.GetDiscoveredSourcesAsync(since);
+
+        sources.Should().HaveCount(2);
+        // Ordered by lastSeen desc — libre (12th) before xdrip (11th).
+        sources[0].DataSource.Should().Be("libre");
+        sources[1].DataSource.Should().Be("xdrip");
+
+        var xdrip = sources.Single(s => s.DataSource == "xdrip");
+        xdrip.Device.Should().Be("DexcomG6");
+        xdrip.ReadingCount.Should().Be(2);
+        xdrip.LastSeen.Should().Be(latestXdrip);
+
+        sources.Should().NotContain(s => s.DataSource == "already");
+        sources.Should().NotContain(s => s.DataSource == "old");
+    }
+
+    [Fact]
+    public async Task GetUnattributedAsync_ReturnsUnattributedInWindow_NewestFirst_CappedAtLimit()
+    {
+        var deviceId = SeedDevice();
+        var t1 = new DateTime(2026, 6, 10, 8, 0, 0, DateTimeKind.Utc);
+        var t2 = new DateTime(2026, 6, 11, 8, 0, 0, DateTimeKind.Utc);
+        var t3 = new DateTime(2026, 6, 12, 8, 0, 0, DateTimeKind.Utc);
+        SeedReading(t1, dataSource: "a");
+        SeedReading(t2, dataSource: "b");
+        SeedReading(t3, dataSource: "c");
+        SeedReading(t3.AddHours(1), dataSource: "attributed", patientDeviceId: deviceId);
+
+        var result = await _repo.GetUnattributedAsync(
+            from: new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            to: new DateTime(2026, 6, 30, 0, 0, 0, DateTimeKind.Utc),
+            limit: 2);
+
+        result.Should().HaveCount(2);
+        result[0].Timestamp.Should().Be(t3, "results are newest first");
+        result[1].Timestamp.Should().Be(t2);
+        result.Should().NotContain(r => r.DataSource == "attributed");
+    }
+
+    [Fact]
+    public async Task SetPatientDeviceIdsAsync_UpdatesOnlyMappedRows_AndReturnsRowCount()
+    {
+        var deviceId = SeedDevice();
+        var now = DateTime.UtcNow;
+        var a = SeedReading(now, dataSource: "x");
+        var b = SeedReading(now.AddMinutes(-5), dataSource: "x");
+        var untouched = SeedReading(now.AddMinutes(-10), dataSource: "x");
+
+        var map = new Dictionary<Guid, Guid>
+        {
+            [a] = deviceId,
+            [b] = deviceId,
+            [Guid.NewGuid()] = deviceId, // id not present → ignored
+        };
+
+        var updated = await _repo.SetPatientDeviceIdsAsync(map);
+
+        updated.Should().Be(2);
+
+        using var verify = new NocturneDbContext(
+            new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(_connection).Options) { TenantId = TestTenantId };
+        (await verify.SensorGlucose.FindAsync(a))!.PatientDeviceId.Should().Be(deviceId);
+        (await verify.SensorGlucose.FindAsync(b))!.PatientDeviceId.Should().Be(deviceId);
+        (await verify.SensorGlucose.FindAsync(untouched))!.PatientDeviceId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SetPatientDeviceIdsAsync_EmptyMap_ReturnsZero_NoChanges()
+    {
+        var updated = await _repo.SetPatientDeviceIdsAsync(new Dictionary<Guid, Guid>());
+        updated.Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Multi-CGM PR3 — device filters, stats metadata, discovered-sources & rank UI

Third PR in the multi-CGM series (after #449 attribution and #451 canonical stream). Adds the read-side filters, statistics device metadata, and the device-management UX for attributing and prioritising multiple CGMs. Store-everything / attribute-everything / read-time-selection principle is unchanged; nothing here dedupes or drops readings at ingest.

### What's in it

**1. V4 `patientDeviceId` filter**
- Optional `patientDeviceId` on the sensor-glucose `GET` and on statistics range-analytics. Filtered → that registered device's readings **raw** (canonical selection bypassed); unfiltered → canonical (unchanged behaviour). The repo param is a trailing optional after `ct`, so it's additive for existing callers.
- Legacy v1/v3 reads + the legacy broadcast remain canonical-only by design — the filter is V4-only.

**2. Statistics contributing-devices metadata**
- Range-analytics now reports each contributing CGM (`patientDeviceId`, name, reading count) plus an `Unattributed` bucket, so the UI can offer a device picker. Additive response field; counts computed in a single pass.

**3. Discovered sources + registration**
- `GET /api/v4/patient-record/devices/discovered-sources` lists distinct `(DataSource, Device)` combinations seen in recent unattributed readings (identity aligned with `CanonicalGlucoseStream`'s pseudo-device key).
- Registering a device back-stamps its unattributed glucose within the device's usage window (`DeviceReattributionService`, glucose-only, newest-first, capped). Per-registration only — **no global migration**, by design.

**4. Rank management**
- Batch `POST /api/v4/patient-record/devices/reorder` (imperative command) + `ReorderAsync`. The device settings list is drag/arrow-reorderable; `GetAllAsync` now leads its sort with `Rank` so the displayed order *is* the priority order.

**5. Server-side attribution on V4 writes**
- `SensorGlucoseController` `Create`/`Update`/`Bulk` now run the `PatientDeviceStamper` before persisting — direct V4 API writes were previously never attributed. Attribution is preserved across edits; stamping only fills unattributed records.

### UI
- Device settings: "Discovered sources" section with one-click **Register as device** (prefills the dialog as a CGM so the user sets the back-stamp window) and up/down rank reordering.

### Notes for review
- **Generated client** (`nocturne-api-client.ts`/`openapi.json`/`schemas.ts`/`index.ts`) is intentionally **not** committed — only the new `patientRecords.generated.remote.ts` functions are. CI regenerates the rest.
- Scoped decisions (open to feedback): the `patientDeviceId` filter is wired to range-analytics only (the report the picker drives), not every stats endpoint; treatment/pump re-attribution on registration is a follow-up (glucose-only here); filtered pagination `total` is unscoped, matching existing `device`/`source` behaviour.

### Testing
- New unit tests: repo filter / discovered-sources / reorder (incl. `GetAllAsync` rank ordering) / bulk attribution, `DeviceReattributionService`, controller stamping, stats metadata. Full API + Infrastructure.Data unit suites pass (one pre-existing flaky `CanonicalGlucoseServiceTests` case passes in isolation).
- Frontend browser test for discovered-sources listing + reorder (runs in CI).
- A pre-existing `Nocturne.Widget.Infrastructure` build error (`HubException`) is unrelated to this PR (fails identically on `main`).

Reviewed by an adversarial subagent pass; the one HIGH finding (reorder list wasn't rank-ordered → snapped back on refresh) is fixed and covered by a test.
