### PR TITLE
test(glucose): fix flaky multi-stream canonical test (bucket-boundary)

### DIFF
--- a/tests/Unit/Nocturne.API.Tests/Services/Glucose/CanonicalGlucoseServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Glucose/CanonicalGlucoseServiceTests.cs
@@ -60,7 +60,16 @@ public class CanonicalGlucoseServiceTests
         _deviceRepo.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync([primary, secondary]);
 
-        var readings = new List<SensorGlucose> { Reading(primary.Id, 0), Reading(secondary.Id, 1) };
+        // Pin both readings into the same aligned 5-minute bucket so the shared-bucket premise
+        // (primary outranks secondary within a bucket) doesn't depend on where the wall clock
+        // sits relative to a bucket boundary.
+        var bucketStart = new DateTime(Now.Ticks - Now.Ticks % TimeSpan.FromMinutes(5).Ticks, DateTimeKind.Utc)
+            .AddMinutes(-5);
+        var primaryReading = Reading(primary.Id, 0);
+        primaryReading.Timestamp = bucketStart.AddMinutes(1);
+        var secondaryReading = Reading(secondary.Id, 0);
+        secondaryReading.Timestamp = bucketStart.AddMinutes(2);
+        var readings = new List<SensorGlucose> { primaryReading, secondaryReading };
 
         var first = await _sut.SelectAsync(readings);
         var second = await _sut.SelectAsync(readings);


### PR DESCRIPTION
The `Tests` workflow on main failed (run 28703086402) on `SelectAsync_MultiStream_LoadsDevicesOnce_AndFiltersByRank`.

**Root cause:** wall-clock flake, not a product bug. The test built readings 0 and 1 minutes before `Now` and expected a single canonical item (primary outranks secondary within a shared 5-minute bucket). But readings only share a bucket when `Now` isn't near a bucket boundary. The CI run fired at 10:20:51, so the two readings straddled the 10:20 boundary into separate buckets — each won its own bucket and both were emitted, failing `ContainSingle`.

**Fix:** pin both readings into one fixed aligned bucket, exactly as the sibling `GetLatestAsync_ReturnsCanonicalLatest_NotRawLatest` test already does.

Verified locally: all 4 `CanonicalGlucoseServiceTests` pass.