### PR TITLE
fix(trackers): stop settings page bouncing actions to login

### DIFF
--- a/src/Web/packages/app/src/routes/(authenticated)/settings/trackers/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/trackers/+page.svelte
@@ -34,7 +34,7 @@
   } from "lucide-svelte";
   import { tick } from "svelte";
   import { goto } from "$app/navigation";
-  import { getAuthStore } from "$lib/stores/auth-store.svelte";
+  import { page } from "$app/state";
   import * as trackersRemote from "$api/generated/trackers.generated.remote";
   import {
     NotificationUrgency,
@@ -48,9 +48,11 @@
     type TrackerPresetDto,
   } from "$api";
 
-  // Auth state
-  const authStore = getAuthStore();
-  const isAuthenticated = $derived(authStore.isAuthenticated);
+  // Auth state from the server-resolved session. This route sits behind the
+  // authenticated + settings layout guards, so page.data.user is populated for
+  // every visitor. The client auth store is unauthenticated until its async
+  // session load resolves, so gating actions on it bounces fast clicks to login.
+  const isAuthenticated = $derived(!!page.data.user);
 
   // State
   let activeTab = $state("active");


### PR DESCRIPTION
The trackers settings page gated its action handlers (New Definition, Edit, Start, etc.) on the client-side auth store via `requireAuth()`. That store resolves the session asynchronously after page load, so it reports unauthenticated during the initial load window and a fast click on an action ran `goto('/auth/login')`.

This route is already behind the authenticated + settings layout guards, so derive auth from the server-resolved `page.data.user` instead, matching every other page.