### PR TITLE
fix(widget): add SignalR using for HubException

### DIFF
--- a/src/Widgets/Nocturne.Widget.Infrastructure/NocturneApiClient.cs
+++ b/src/Widgets/Nocturne.Widget.Infrastructure/NocturneApiClient.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.Logging;
 using Nocturne.Core.Models;


### PR DESCRIPTION
`NocturneApiClient` catches `HubException` but only imported `Microsoft.AspNetCore.SignalR.Client`; `HubException` lives in the `Microsoft.AspNetCore.SignalR` namespace (SignalR.Common, pulled in transitively). Build failed with CS0246. Add the using.