### PR TITLE
CMS content contributions as pull requests

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Platform/ContentContributionsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/ContentContributionsController.cs
@@ -14,7 +14,7 @@ namespace Nocturne.API.Controllers.V4.Platform;
 [Route("api/v4/content")]
 public class ContentContributionsController(
     IContentContributionService contentService,
-    IOptions<GitHubTranslationOptions> options,
+    IOptions<GitHubContributionOptions> options,
     ILogger<ContentContributionsController> logger) : ControllerBase
 {
     private const int MaxContentBytes = 512 * 1024;

--- a/src/API/Nocturne.API/Controllers/V4/Platform/ContentContributionsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/ContentContributionsController.cs
@@ -42,7 +42,7 @@ public class ContentContributionsController(
 
             return StatusCode(201, result);
         }
-        catch (TranslationContributionRejectedException ex)
+        catch (ContributionRejectedException ex)
         {
             return Problem(detail: ex.Message, statusCode: 422, title: "Unprocessable Entity");
         }
@@ -78,7 +78,7 @@ public class ContentContributionsController(
             var result = await contentService.SubmitAsync(request, ct);
             return StatusCode(201, result);
         }
-        catch (TranslationContributionRejectedException ex)
+        catch (ContributionRejectedException ex)
         {
             return Problem(detail: ex.Message, statusCode: 422, title: "Unprocessable Entity");
         }
@@ -92,7 +92,11 @@ public class ContentContributionsController(
 
     private ObjectResult? Validate(ContentContributionRequest request)
     {
-        if (!GitHubContentService.AllowedPathPattern().IsMatch(request.Path))
+        // Bound the path before the regex sees it: the allowlist accepts
+        // arbitrarily long repeated segments, and the value is echoed into a
+        // branch name, a commit message and a PR body.
+        if (request.Path.Length > ContributionValidation.MaxPathLength
+            || !GitHubContentService.AllowedPathPattern().IsMatch(request.Path))
             return Problem(detail: "Path must be a portal blog or docs .svx file", statusCode: 400, title: "Bad Request");
 
         if (string.IsNullOrWhiteSpace(request.Content)
@@ -102,27 +106,10 @@ public class ContentContributionsController(
         if (string.IsNullOrWhiteSpace(request.Title)
             || request.Title.Length > MaxTitleLength
             || request.Title.Any(char.IsControl))
-            return Problem(detail: "Title is required, must be under 200 characters, and cannot contain control characters", statusCode: 400, title: "Bad Request");
+            return Problem(detail: $"Title is required, must be under {MaxTitleLength} characters, and cannot contain control characters", statusCode: 400, title: "Bad Request");
 
-        // Contributor identity ends up in the commit message (Co-authored-by
-        // trailer) and PR body; same constraints as translation contributions.
-        if (string.IsNullOrWhiteSpace(request.Contributor.Name)
-            || request.Contributor.Name.Length > 128
-            || request.Contributor.Name.Any(char.IsControl))
-            return Problem(detail: "Contributor name is required, must be under 128 characters, and cannot contain control characters", statusCode: 400, title: "Bad Request");
-
-        if (request.Contributor.GitHubUsername is { Length: > 0 } username
-            && !System.Text.RegularExpressions.Regex.IsMatch(username, "^[A-Za-z0-9](?:-?[A-Za-z0-9]){0,38}$"))
-            return Problem(detail: "Invalid GitHub username", statusCode: 400, title: "Bad Request");
-
-        if (request.Contributor.Email is { Length: > 0 } email
-            && (email.Length > 254 || !System.Text.RegularExpressions.Regex.IsMatch(email, @"^[^\s<>@]+@[^\s<>@]+\.[^\s<>@]+$")))
-            return Problem(detail: "Invalid contributor email", statusCode: 400, title: "Bad Request");
-
-        if (request.Note is { } note
-            && (note.Length > 2000 || note.Any(c => char.IsControl(c) && c != '\n' && c != '\r')))
-            return Problem(detail: "Note must be under 2000 characters and cannot contain control characters", statusCode: 400, title: "Bad Request");
-
-        return null;
+        return ContributionValidation.ValidateContributor(request.Contributor, request.Note) is { } reason
+            ? Problem(detail: reason, statusCode: 400, title: "Bad Request")
+            : null;
     }
 }

--- a/src/API/Nocturne.API/Controllers/V4/Platform/ContentContributionsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/ContentContributionsController.cs
@@ -1,0 +1,127 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Options;
+using Nocturne.API.Services;
+using Nocturne.Core.Contracts.Content;
+using Nocturne.Core.Models.Content;
+using OpenApi.Remote.Attributes;
+
+namespace Nocturne.API.Controllers.V4.Platform;
+
+[ApiController]
+[Authorize]
+[Route("api/v4/content")]
+public class ContentContributionsController(
+    IContentContributionService contentService,
+    IOptions<GitHubTranslationOptions> options,
+    ILogger<ContentContributionsController> logger) : ControllerBase
+{
+    private const int MaxContentBytes = 512 * 1024;
+    private const int MaxTitleLength = 200;
+
+    [HttpPost("contributions")]
+    [RemoteCommand]
+    [EnableRateLimiting("translation-contributions")]
+    [ProducesResponseType(typeof(ContentContributionResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
+    [ProducesResponseType(StatusCodes.Status502BadGateway)]
+    public async Task<ActionResult<ContentContributionResponse>> SubmitContribution(
+        [FromBody] ContentContributionRequest request, CancellationToken ct)
+    {
+        var validationError = Validate(request);
+        if (validationError is not null)
+            return validationError;
+
+        try
+        {
+            var result = contentService.HasLocalPat
+                ? await contentService.SubmitAsync(request, ct)
+                : await contentService.RelayAsync(request, ct);
+
+            return StatusCode(201, result);
+        }
+        catch (TranslationContributionRejectedException ex)
+        {
+            return Problem(detail: ex.Message, statusCode: 422, title: "Unprocessable Entity");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to submit content contribution");
+            return Problem(detail: "Failed to submit the contribution. Try again later.",
+                statusCode: 502, title: "Bad Gateway");
+        }
+    }
+
+    /// <summary>
+    /// Anonymous ingress for contributions relayed from instances or tools
+    /// without their own PAT (the nocturne.run side of the relay). Hidden
+    /// unless this instance explicitly opted in and can open PRs itself.
+    /// </summary>
+    [HttpPost("relay")]
+    [AllowAnonymous]
+    [EnableRateLimiting("translation-contributions")]
+    [ApiExplorerSettings(IgnoreApi = true)]
+    public async Task<ActionResult<ContentContributionResponse>> AcceptRelayedContribution(
+        [FromBody] ContentContributionRequest request, CancellationToken ct)
+    {
+        if (!options.Value.AcceptRelayedContributions || !contentService.HasLocalPat)
+            return NotFound();
+
+        var validationError = Validate(request);
+        if (validationError is not null)
+            return validationError;
+
+        try
+        {
+            var result = await contentService.SubmitAsync(request, ct);
+            return StatusCode(201, result);
+        }
+        catch (TranslationContributionRejectedException ex)
+        {
+            return Problem(detail: ex.Message, statusCode: 422, title: "Unprocessable Entity");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to submit relayed content contribution");
+            return Problem(detail: "Failed to submit the contribution. Try again later.",
+                statusCode: 502, title: "Bad Gateway");
+        }
+    }
+
+    private ObjectResult? Validate(ContentContributionRequest request)
+    {
+        if (!GitHubContentService.AllowedPathPattern().IsMatch(request.Path))
+            return Problem(detail: "Path must be a portal blog or docs .svx file", statusCode: 400, title: "Bad Request");
+
+        if (string.IsNullOrWhiteSpace(request.Content)
+            || System.Text.Encoding.UTF8.GetByteCount(request.Content) > MaxContentBytes)
+            return Problem(detail: "Content is required and must be under 512 KB", statusCode: 400, title: "Bad Request");
+
+        if (string.IsNullOrWhiteSpace(request.Title)
+            || request.Title.Length > MaxTitleLength
+            || request.Title.Any(char.IsControl))
+            return Problem(detail: "Title is required, must be under 200 characters, and cannot contain control characters", statusCode: 400, title: "Bad Request");
+
+        // Contributor identity ends up in the commit message (Co-authored-by
+        // trailer) and PR body; same constraints as translation contributions.
+        if (string.IsNullOrWhiteSpace(request.Contributor.Name)
+            || request.Contributor.Name.Length > 128
+            || request.Contributor.Name.Any(char.IsControl))
+            return Problem(detail: "Contributor name is required, must be under 128 characters, and cannot contain control characters", statusCode: 400, title: "Bad Request");
+
+        if (request.Contributor.GitHubUsername is { Length: > 0 } username
+            && !System.Text.RegularExpressions.Regex.IsMatch(username, "^[A-Za-z0-9](?:-?[A-Za-z0-9]){0,38}$"))
+            return Problem(detail: "Invalid GitHub username", statusCode: 400, title: "Bad Request");
+
+        if (request.Contributor.Email is { Length: > 0 } email
+            && (email.Length > 254 || !System.Text.RegularExpressions.Regex.IsMatch(email, @"^[^\s<>@]+@[^\s<>@]+\.[^\s<>@]+$")))
+            return Problem(detail: "Invalid contributor email", statusCode: 400, title: "Bad Request");
+
+        if (request.Note?.Length > 2000)
+            return Problem(detail: "Note must be under 2000 characters", statusCode: 400, title: "Bad Request");
+
+        return null;
+    }
+}

--- a/src/API/Nocturne.API/Controllers/V4/Platform/ContentContributionsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/ContentContributionsController.cs
@@ -119,8 +119,9 @@ public class ContentContributionsController(
             && (email.Length > 254 || !System.Text.RegularExpressions.Regex.IsMatch(email, @"^[^\s<>@]+@[^\s<>@]+\.[^\s<>@]+$")))
             return Problem(detail: "Invalid contributor email", statusCode: 400, title: "Bad Request");
 
-        if (request.Note?.Length > 2000)
-            return Problem(detail: "Note must be under 2000 characters", statusCode: 400, title: "Bad Request");
+        if (request.Note is { } note
+            && (note.Length > 2000 || note.Any(c => char.IsControl(c) && c != '\n' && c != '\r')))
+            return Problem(detail: "Note must be under 2000 characters and cannot contain control characters", statusCode: 400, title: "Bad Request");
 
         return null;
     }

--- a/src/API/Nocturne.API/Controllers/V4/Platform/ContentContributionsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/ContentContributionsController.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
-using Microsoft.Extensions.Options;
+using Nocturne.API.Extensions;
 using Nocturne.API.Services;
 using Nocturne.Core.Contracts.Content;
 using Nocturne.Core.Models.Content;
@@ -14,15 +14,14 @@ namespace Nocturne.API.Controllers.V4.Platform;
 [Route("api/v4/content")]
 public class ContentContributionsController(
     IContentContributionService contentService,
-    IOptions<GitHubContributionOptions> options,
     ILogger<ContentContributionsController> logger) : ControllerBase
 {
-    private const int MaxContentBytes = 512 * 1024;
-    private const int MaxTitleLength = 200;
+    internal const int MaxContentBytes = 512 * 1024;
+    internal const int MaxTitleLength = 200;
 
     [HttpPost("contributions")]
     [RemoteCommand]
-    [EnableRateLimiting("translation-contributions")]
+    [EnableRateLimiting(ServiceRegistrationExtensions.ContributionsRateLimitPolicy)]
     [ProducesResponseType(typeof(ContentContributionResponse), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
@@ -34,49 +33,45 @@ public class ContentContributionsController(
         if (validationError is not null)
             return validationError;
 
-        try
-        {
-            var result = contentService.HasLocalPat
-                ? await contentService.SubmitAsync(request, ct)
-                : await contentService.RelayAsync(request, ct);
+        Func<Task<ContentContributionResponse>> submit = contentService.HasLocalPat
+            ? () => contentService.SubmitAsync(request, ct)
+            : () => contentService.RelayAsync(request, ct);
 
-            return StatusCode(201, result);
-        }
-        catch (ContributionRejectedException ex)
-        {
-            return Problem(detail: ex.Message, statusCode: 422, title: "Unprocessable Entity");
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to submit content contribution");
-            return Problem(detail: "Failed to submit the contribution. Try again later.",
-                statusCode: 502, title: "Bad Gateway");
-        }
+        return await SubmitAsync(submit, "content contribution");
     }
 
     /// <summary>
     /// Anonymous ingress for contributions relayed from instances or tools
-    /// without their own PAT (the nocturne.run side of the relay). Hidden
-    /// unless this instance explicitly opted in and can open PRs itself.
+    /// without their own PAT (the nocturne.run side of the relay).
     /// </summary>
     [HttpPost("relay")]
     [AllowAnonymous]
-    [EnableRateLimiting("translation-contributions")]
+    [EnableRateLimiting(ServiceRegistrationExtensions.ContributionsRateLimitPolicy)]
     [ApiExplorerSettings(IgnoreApi = true)]
     public async Task<ActionResult<ContentContributionResponse>> AcceptRelayedContribution(
         [FromBody] ContentContributionRequest request, CancellationToken ct)
     {
-        if (!options.Value.AcceptRelayedContributions || !contentService.HasLocalPat)
+        if (!contentService.AcceptsRelay)
             return NotFound();
 
         var validationError = Validate(request);
         if (validationError is not null)
             return validationError;
 
+        return await SubmitAsync(
+            () => contentService.SubmitAsync(request, ct), "relayed content contribution");
+    }
+
+    /// <summary>
+    /// One error policy for both ingresses, so the direct and relayed paths
+    /// cannot answer the same failure differently.
+    /// </summary>
+    private async Task<ActionResult<ContentContributionResponse>> SubmitAsync(
+        Func<Task<ContentContributionResponse>> submit, string logContext)
+    {
         try
         {
-            var result = await contentService.SubmitAsync(request, ct);
-            return StatusCode(201, result);
+            return StatusCode(201, await submit());
         }
         catch (ContributionRejectedException ex)
         {
@@ -84,17 +79,16 @@ public class ContentContributionsController(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to submit relayed content contribution");
+            logger.LogError(ex, "Failed to submit {LogContext}", logContext);
             return Problem(detail: "Failed to submit the contribution. Try again later.",
                 statusCode: 502, title: "Bad Gateway");
         }
     }
 
-    private ObjectResult? Validate(ContentContributionRequest request)
+    internal ObjectResult? Validate(ContentContributionRequest request)
     {
-        // Bound the path before the regex sees it: the allowlist accepts
-        // arbitrarily long repeated segments, and the value is echoed into a
-        // branch name, a commit message and a PR body.
+        // Bound the path independently of the allowlist: the value is echoed
+        // into a branch name, a commit message and a PR body.
         if (request.Path.Length > ContributionValidation.MaxPathLength
             || !GitHubContentService.AllowedPathPattern().IsMatch(request.Path))
             return Problem(detail: "Path must be a portal blog or docs .svx file", statusCode: 400, title: "Bad Request");

--- a/src/API/Nocturne.API/Controllers/V4/Platform/TranslationsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/TranslationsController.cs
@@ -54,16 +54,6 @@ public partial class TranslationsController(
     [GeneratedRegex("^[a-z]{2,3}(-[A-Za-z0-9]{2,8})?\\z")]
     private static partial Regex LocalePattern();
 
-    // GitHub's username grammar: alphanumeric and single hyphens, no
-    // leading/trailing hyphen, max 39 chars.
-    [GeneratedRegex("^[A-Za-z0-9](?:-?[A-Za-z0-9]){0,38}\\z")]
-    private static partial Regex GitHubUsernamePattern();
-
-    // Conservative mailbox shape: the value lands inside a Co-authored-by
-    // trailer, so whitespace and angle brackets must be impossible.
-    [GeneratedRegex(@"^[^\s<>@]+@[^\s<>@]+\.[^\s<>@]+\z")]
-    private static partial Regex EmailPattern();
-
     [HttpPost("contributions")]
     [RemoteCommand]
     [EnableRateLimiting("translation-contributions")]
@@ -120,7 +110,7 @@ public partial class TranslationsController(
         {
             return StatusCode(201, await submit());
         }
-        catch (TranslationContributionRejectedException ex)
+        catch (ContributionRejectedException ex)
         {
             return Problem(detail: ex.Message, statusCode: 422, title: "Unprocessable Entity");
         }
@@ -132,8 +122,6 @@ public partial class TranslationsController(
         }
     }
 
-    private static bool IsDisallowedControlChar(char c) =>
-        char.IsControl(c) && c is not '\n' and not '\t' and not '\r';
 
     [HttpGet("drafts")]
     [RemoteQuery]
@@ -220,7 +208,7 @@ public partial class TranslationsController(
             var result = await draftService.SubmitDraftsAsync(request.Locale, request.Contributor, request.Note, ct);
             return StatusCode(201, result);
         }
-        catch (TranslationContributionRejectedException ex)
+        catch (ContributionRejectedException ex)
         {
             return Problem(detail: ex.Message, statusCode: 422, title: "Unprocessable Entity");
         }
@@ -261,7 +249,7 @@ public partial class TranslationsController(
             // Translation values are written verbatim into the committed .po
             // file, and the catalog escaper only handles \\ \" \n \t \r — any
             // other control character would land raw in the catalog.
-            if (entry.Translations.Any(t => t.Any(IsDisallowedControlChar)))
+            if (entry.Translations.Any(t => t.Any(ContributionValidation.IsDisallowedControlChar)))
                 return Problem(detail: "Translations cannot contain control characters", statusCode: 400, title: "Bad Request");
             if (!seenKeys.Add((entry.Context ?? "", entry.MsgId)))
                 return Problem(detail: "Duplicate entry for the same msgid and context", statusCode: 400, title: "Bad Request");
@@ -270,28 +258,8 @@ public partial class TranslationsController(
         return null;
     }
 
-    private ObjectResult? ValidateContributor(TranslationContributorDto contributor, string? note)
-    {
-        // Contributor identity ends up in the commit message (Co-authored-by
-        // trailer) and PR body; control characters or trailer syntax in any
-        // of these fields would allow commit-metadata injection.
-        if (string.IsNullOrWhiteSpace(contributor.Name)
-            || contributor.Name.Length > 128
-            || contributor.Name.Any(char.IsControl))
-            return Problem(detail: "Contributor name is required, must be under 128 characters, and cannot contain control characters", statusCode: 400, title: "Bad Request");
-
-        if (contributor.GitHubUsername is { Length: > 0 } username
-            && !GitHubUsernamePattern().IsMatch(username))
-            return Problem(detail: "Invalid GitHub username", statusCode: 400, title: "Bad Request");
-
-        if (contributor.Email is { Length: > 0 } email
-            && (email.Length > 254 || !EmailPattern().IsMatch(email)))
-            return Problem(detail: "Invalid contributor email", statusCode: 400, title: "Bad Request");
-
-        if (note is not null
-            && (note.Length > 2000 || note.Any(c => char.IsControl(c) && c != '\n' && c != '\r')))
-            return Problem(detail: "Note must be under 2000 characters and cannot contain control characters", statusCode: 400, title: "Bad Request");
-
-        return null;
-    }
+    private ObjectResult? ValidateContributor(TranslationContributorDto contributor, string? note) =>
+        ContributionValidation.ValidateContributor(contributor, note) is { } reason
+            ? Problem(detail: reason, statusCode: 400, title: "Bad Request")
+            : null;
 }

--- a/src/API/Nocturne.API/Controllers/V4/Platform/TranslationsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/TranslationsController.cs
@@ -288,8 +288,9 @@ public partial class TranslationsController(
             && (email.Length > 254 || !EmailPattern().IsMatch(email)))
             return Problem(detail: "Invalid contributor email", statusCode: 400, title: "Bad Request");
 
-        if (note?.Length > 2000)
-            return Problem(detail: "Note must be under 2000 characters", statusCode: 400, title: "Bad Request");
+        if (note is not null
+            && (note.Length > 2000 || note.Any(c => char.IsControl(c) && c != '\n' && c != '\r')))
+            return Problem(detail: "Note must be under 2000 characters and cannot contain control characters", statusCode: 400, title: "Bad Request");
 
         return null;
     }

--- a/src/API/Nocturne.API/Controllers/V4/Platform/TranslationsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/TranslationsController.cs
@@ -20,7 +20,7 @@ public record UpsertTranslationDraftsRequest
 public record SubmitTranslationDraftsRequest
 {
     public required string Locale { get; init; }
-    public required TranslationContributorDto Contributor { get; init; }
+    public required ContributionContributorDto Contributor { get; init; }
     public string? Note { get; init; }
 }
 
@@ -56,7 +56,7 @@ public partial class TranslationsController(
 
     [HttpPost("contributions")]
     [RemoteCommand]
-    [EnableRateLimiting("translation-contributions")]
+    [EnableRateLimiting(ServiceRegistrationExtensions.ContributionsRateLimitPolicy)]
     [ProducesResponseType(typeof(TranslationContributionResponse), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
@@ -83,7 +83,7 @@ public partial class TranslationsController(
     /// </summary>
     [HttpPost("relay")]
     [AllowAnonymous]
-    [EnableRateLimiting("translation-contributions")]
+    [EnableRateLimiting(ServiceRegistrationExtensions.ContributionsRateLimitPolicy)]
     [ApiExplorerSettings(IgnoreApi = true)]
     public async Task<ActionResult<TranslationContributionResponse>> AcceptRelayedContribution(
         [FromBody] TranslationContributionRequest request, CancellationToken ct)
@@ -121,7 +121,6 @@ public partial class TranslationsController(
                 statusCode: 502, title: "Bad Gateway");
         }
     }
-
 
     [HttpGet("drafts")]
     [RemoteQuery]
@@ -187,7 +186,7 @@ public partial class TranslationsController(
     [HttpPost("drafts/submit")]
     // No Invalidates; see UpsertDrafts.
     [RemoteCommand]
-    [EnableRateLimiting("translation-contributions")]
+    [EnableRateLimiting(ServiceRegistrationExtensions.ContributionsRateLimitPolicy)]
     [ProducesResponseType(typeof(TranslationDraftSubmitResult), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
@@ -258,7 +257,7 @@ public partial class TranslationsController(
         return null;
     }
 
-    private ObjectResult? ValidateContributor(TranslationContributorDto contributor, string? note) =>
+    private ObjectResult? ValidateContributor(ContributionContributorDto contributor, string? note) =>
         ContributionValidation.ValidateContributor(contributor, note) is { } reason
             ? Problem(detail: reason, statusCode: 400, title: "Bad Request")
             : null;

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -120,6 +120,14 @@ public static class ServiceRegistrationExtensions
     /// </summary>
     public const string TranslationDraftsRateLimitPolicy = "translation-drafts";
 
+    /// <summary>
+    /// Rate-limiting policy shared by every contribution flow that opens an
+    /// upstream pull request (translations, CMS content). One bucket on
+    /// purpose: the cost being bounded is PRs on the upstream repository, not
+    /// requests to any one endpoint.
+    /// </summary>
+    public const string ContributionsRateLimitPolicy = "contributions";
+
     /// <summary>Shared bucket for draft requests that present no credential.</summary>
     internal const string AnonymousDraftPartition = "anonymous";
 
@@ -243,8 +251,6 @@ public static class ServiceRegistrationExtensions
         services.Configure<GitHubIssueOptions>(configuration.GetSection("GitHub"));
         services.AddSingleton<GitHubIssueService>();
 
-        // GitHub contribution PRs (translations + CMS content) and per-user
-        // translation draft storage
         services.Configure<GitHubContributionOptions>(configuration.GetSection("GitHub"));
         services.AddSingleton<GitHubPrClient>();
         services.AddSingleton<ITranslationContributionService, GitHubTranslationService>();
@@ -551,10 +557,10 @@ public static class ServiceRegistrationExtensions
                     )
             );
 
-            // Translation contributions: 10 per IP per hour (each opens an
-            // upstream PR, directly or via the relay).
+            // Contributions: 10 per IP per hour (each opens an upstream PR,
+            // directly or via the relay).
             options.AddPolicy(
-                "translation-contributions",
+                ContributionsRateLimitPolicy,
                 context =>
                     RateLimitPartition.GetFixedWindowLimiter(
                         partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -16,6 +16,7 @@ using Nocturne.API.Services.Analytics;
 using Nocturne.API.Services.Auth;
 using Nocturne.API.Services.BackgroundServices;
 using Nocturne.API.Services.CoachMarks;
+using Nocturne.Core.Contracts.Content;
 using Nocturne.Core.Contracts.Translations;
 using Nocturne.API.Services.Timezones;
 using Nocturne.API.Services.ChartData;
@@ -242,9 +243,12 @@ public static class ServiceRegistrationExtensions
         services.Configure<GitHubIssueOptions>(configuration.GetSection("GitHub"));
         services.AddSingleton<GitHubIssueService>();
 
-        // GitHub translation contribution PRs + per-user draft storage
+        // GitHub contribution PRs (translations + CMS content) and per-user
+        // translation draft storage
         services.Configure<GitHubTranslationOptions>(configuration.GetSection("GitHub"));
+        services.AddSingleton<GitHubPrClient>();
         services.AddSingleton<ITranslationContributionService, GitHubTranslationService>();
+        services.AddSingleton<IContentContributionService, GitHubContentService>();
         services.AddScoped<ITranslationDraftService, TranslationDraftService>();
 
         return services;

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -245,7 +245,7 @@ public static class ServiceRegistrationExtensions
 
         // GitHub contribution PRs (translations + CMS content) and per-user
         // translation draft storage
-        services.Configure<GitHubTranslationOptions>(configuration.GetSection("GitHub"));
+        services.Configure<GitHubContributionOptions>(configuration.GetSection("GitHub"));
         services.AddSingleton<GitHubPrClient>();
         services.AddSingleton<ITranslationContributionService, GitHubTranslationService>();
         services.AddSingleton<IContentContributionService, GitHubContentService>();

--- a/src/API/Nocturne.API/Services/ContributionRejectedException.cs
+++ b/src/API/Nocturne.API/Services/ContributionRejectedException.cs
@@ -1,0 +1,9 @@
+namespace Nocturne.API.Services;
+
+/// <summary>
+/// A contribution the upstream repository will not take as submitted — a
+/// stale catalog, a disallowed path, content identical to what is published.
+/// Distinct from a transport failure: the caller surfaces it as 422 and the
+/// message is shown to the contributor.
+/// </summary>
+public class ContributionRejectedException(string message) : Exception(message);

--- a/src/API/Nocturne.API/Services/ContributionValidation.cs
+++ b/src/API/Nocturne.API/Services/ContributionValidation.cs
@@ -29,11 +29,7 @@ public static partial class ContributionValidation
     [GeneratedRegex(@"^[^\s<>@]+@[^\s<>@]+\.[^\s<>@]+\z")]
     public static partial Regex EmailPattern();
 
-    /// <summary>
-    /// Returns the rejection reason, or null when the contributor and note are
-    /// acceptable. Callers turn the reason into their own problem response.
-    /// </summary>
-    public static string? ValidateContributor(TranslationContributorDto contributor, string? note)
+    public static string? ValidateContributor(ContributionContributorDto contributor, string? note)
     {
         // Control characters or trailer syntax in any of these fields would
         // allow commit-metadata injection.
@@ -79,9 +75,8 @@ public static partial class ContributionValidation
     /// <c>#</c> handling covers <c>#12</c> and <c>owner/repo#12</c>, but
     /// GitHub resolves two further reference forms that carry no <c>#</c> and
     /// no <c>@</c>: the <c>GH-12</c> shorthand and a full issue or pull URL.
-    /// Both fit inside <see cref="MaxNameLength"/> and both honour closing
-    /// keywords, so both are removed outright — a person's name legitimately
-    /// contains neither.
+    /// Both honour closing keywords, so both are removed outright — a
+    /// person's name legitimately contains neither.
     /// </summary>
     public static string RenderName(string name, bool markdown)
     {
@@ -110,11 +105,10 @@ public static partial class ContributionValidation
     private static partial Regex GitHubShorthandReference();
 
     /// <summary>
-    /// Renders free-text contributor input inside a fenced code block.
-    /// Nothing inside a code fence is interpreted, which neutralizes the
-    /// references <see cref="RenderName"/> describes plus block markup and
-    /// raw HTML at once — provided the note cannot close the fence, so the
-    /// fence runs one backtick longer than the longest backtick run in it.
+    /// Renders free-text contributor input inside a fenced code block, where
+    /// nothing is interpreted — which covers every markdown vector at once,
+    /// provided the note cannot close the fence. So the fence runs one
+    /// backtick longer than the longest backtick run in the note.
     /// </summary>
     public static string RenderNoteAsCodeFence(string note)
     {
@@ -141,7 +135,6 @@ public static partial class ContributionValidation
         return longest;
     }
 
-    /// <summary>Drops C0/C1 control characters but keeps line structure.</summary>
     private static string StripControlChars(string value) =>
         new([.. value.Where(c => !char.IsControl(c) || c is '\r' or '\n')]);
 }

--- a/src/API/Nocturne.API/Services/ContributionValidation.cs
+++ b/src/API/Nocturne.API/Services/ContributionValidation.cs
@@ -1,0 +1,147 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Nocturne.Core.Models.Translations;
+
+namespace Nocturne.API.Services;
+
+/// <summary>
+/// The contributor identity and free-text note carried by every contribution
+/// flow (translations, CMS content). Both flows put these values in a commit
+/// message and a pull-request body on the upstream repository, reachable from
+/// an anonymous relay ingress — so the rules live here once instead of being
+/// restated per controller.
+/// </summary>
+public static partial class ContributionValidation
+{
+    public const int MaxNameLength = 128;
+    public const int MaxEmailLength = 254;
+    public const int MaxNoteLength = 2000;
+    public const int MaxPathLength = 512;
+
+    // GitHub's username grammar: alphanumeric and single hyphens, no
+    // leading/trailing hyphen, max 39 chars. Anchored with \z, not $: in .NET
+    // $ also matches before a trailing newline.
+    [GeneratedRegex(@"^[A-Za-z0-9](?:-?[A-Za-z0-9]){0,38}\z")]
+    public static partial Regex GitHubUsernamePattern();
+
+    // Conservative mailbox shape: the value lands inside a Co-authored-by
+    // trailer, so whitespace and angle brackets must be impossible.
+    [GeneratedRegex(@"^[^\s<>@]+@[^\s<>@]+\.[^\s<>@]+\z")]
+    public static partial Regex EmailPattern();
+
+    /// <summary>
+    /// Returns the rejection reason, or null when the contributor and note are
+    /// acceptable. Callers turn the reason into their own problem response.
+    /// </summary>
+    public static string? ValidateContributor(TranslationContributorDto contributor, string? note)
+    {
+        // Control characters or trailer syntax in any of these fields would
+        // allow commit-metadata injection.
+        if (string.IsNullOrWhiteSpace(contributor.Name)
+            || contributor.Name.Length > MaxNameLength
+            || contributor.Name.Any(char.IsControl))
+            return $"Contributor name is required, must be under {MaxNameLength} characters, and cannot contain control characters";
+
+        if (contributor.GitHubUsername is { Length: > 0 } username
+            && !GitHubUsernamePattern().IsMatch(username))
+            return "Invalid GitHub username";
+
+        if (contributor.Email is { Length: > 0 } email
+            && (email.Length > MaxEmailLength || !EmailPattern().IsMatch(email)))
+            return "Invalid contributor email";
+
+        if (note is { } value
+            && (value.Length > MaxNoteLength || value.Any(IsDisallowedControlChar)))
+            return $"Note must be under {MaxNoteLength} characters and cannot contain control characters";
+
+        return null;
+    }
+
+    /// <summary>
+    /// Control characters that no contributed text may carry. Line and tab
+    /// structure is kept: it survives both the .po escaper and the note
+    /// renderer.
+    /// </summary>
+    public static bool IsDisallowedControlChar(char c) =>
+        char.IsControl(c) && c is not '\n' and not '\t' and not '\r';
+
+    /// <summary>
+    /// Renders a contributor-supplied display name for a sink GitHub gives
+    /// side effects to. The name arrives from an anonymous relay, so
+    /// <c>Jane fixes #12 cc @someone</c> would otherwise auto-close an issue
+    /// and notify arbitrary users from the upstream PR body and from the
+    /// commit message. A commit message is not markdown — a backslash escape
+    /// would render literally there — so the reference-carrying characters
+    /// are dropped instead of escaped when <paramref name="markdown"/> is
+    /// false. The backslash is escaped first so a submitted <c>\</c> cannot
+    /// consume the escape that follows it.
+    ///
+    /// <c>#</c> handling covers <c>#12</c> and <c>owner/repo#12</c>, but
+    /// GitHub resolves two further reference forms that carry no <c>#</c> and
+    /// no <c>@</c>: the <c>GH-12</c> shorthand and a full issue or pull URL.
+    /// Both fit inside <see cref="MaxNameLength"/> and both honour closing
+    /// keywords, so both are removed outright — a person's name legitimately
+    /// contains neither.
+    /// </summary>
+    public static string RenderName(string name, bool markdown)
+    {
+        var value = GitHubPrClient.SanitizeMetadata(name);
+        value = markdown
+            ? value.Replace("\\", "\\\\").Replace("@", "\\@").Replace("#", "\\#").Replace("`", "\\`")
+            : new string([.. value.Where(c => c is not '@' and not '#')]);
+
+        // Last, because dropping a "#" above can splice a reference back
+        // together ("htt#ps://…", "GH#-1"). Neither pass can recreate the
+        // other's target: URL removal only deletes, and separating "GH" from
+        // its digits cannot produce a "://".
+        value = UrlReference().Replace(value, "");
+        return GitHubShorthandReference().Replace(value, "$1 ").Trim();
+    }
+
+    [GeneratedRegex(@"https?://\S+", RegexOptions.IgnoreCase)]
+    private static partial Regex UrlReference();
+
+    /// <summary>
+    /// The <c>GH-123</c> shorthand. Only the hyphen is replaced: the autolink
+    /// requires <c>GH-</c> immediately followed by a digit, so a space between
+    /// them leaves nothing for GitHub to resolve while the name stays readable.
+    /// </summary>
+    [GeneratedRegex(@"(GH)-(?=\d)", RegexOptions.IgnoreCase)]
+    private static partial Regex GitHubShorthandReference();
+
+    /// <summary>
+    /// Renders free-text contributor input inside a fenced code block.
+    /// Nothing inside a code fence is interpreted, which neutralizes the
+    /// references <see cref="RenderName"/> describes plus block markup and
+    /// raw HTML at once — provided the note cannot close the fence, so the
+    /// fence runs one backtick longer than the longest backtick run in it.
+    /// </summary>
+    public static string RenderNoteAsCodeFence(string note)
+    {
+        var text = StripControlChars(note).ReplaceLineEndings("\n");
+        var fence = new string('`', Math.Max(3, LongestBacktickRun(text) + 1));
+
+        var sb = new StringBuilder();
+        sb.AppendLine(fence);
+        foreach (var line in text.Split('\n'))
+            sb.AppendLine(line);
+        sb.AppendLine(fence);
+        return sb.ToString();
+    }
+
+    private static int LongestBacktickRun(string value)
+    {
+        int longest = 0, run = 0;
+        foreach (var c in value)
+        {
+            run = c == '`' ? run + 1 : 0;
+            if (run > longest)
+                longest = run;
+        }
+        return longest;
+    }
+
+    /// <summary>Drops C0/C1 control characters but keeps line structure.</summary>
+    private static string StripControlChars(string value) =>
+        new([.. value.Where(c => !char.IsControl(c) || c is '\r' or '\n')]);
+}

--- a/src/API/Nocturne.API/Services/GitHubContentService.cs
+++ b/src/API/Nocturne.API/Services/GitHubContentService.cs
@@ -27,15 +27,18 @@ public partial class GitHubContentService(
     /// with conservative path segments. Anything else is rejected before any
     /// GitHub call — the relay ingress is reachable anonymously.
     /// </summary>
-    // \A/\z anchors: $ would also match before a trailing newline, letting
-    // "post.svx\n" through validation.
-    // Each segment alternates alphanumerics and single separators: ".." would
-    // otherwise be admitted and produce "content/a..b-..." , which git refuses
-    // as a ref name and GitHub rejects with a 422.
+    // Each segment alternates alphanumerics and single separators. Traversal
+    // is already impossible — a segment must start [a-z0-9], so "/../" can
+    // never match — and BranchSlug maps every non-alphanumeric to a hyphen, so
+    // even "a..b" would yield the legal ref "content/a--b-...". What the rule
+    // buys is a predictable one-to-one shape: the file stem, the generated
+    // slug and the branch name stay recognisably the same string.
     [GeneratedRegex(@"\Asrc/Web/packages/portal/src/content/(blog|docs)(/[a-z0-9](?:[._-]?[a-z0-9])*)*/[a-z0-9](?:[._-]?[a-z0-9])*\.svx\z")]
     public static partial Regex AllowedPathPattern();
 
     public bool HasLocalPat => !string.IsNullOrEmpty(options.Value.ContributionsPat);
+
+    public bool AcceptsRelay => options.Value.AcceptRelayedContributions && HasLocalPat;
 
     public async Task<ContentContributionResponse> SubmitAsync(
         ContentContributionRequest request, CancellationToken ct)
@@ -98,7 +101,7 @@ public partial class GitHubContentService(
                 // Forward the relay's own reason so the contributor can tell
                 // "identical to published" from "path not allowed".
                 throw new ContributionRejectedException(
-                    RelayRejectionDetail(error) ?? "The contribution was rejected by the relay.");
+                    GitHubPrClient.RelayRejectionDetail(error) ?? "The contribution was rejected by the relay.");
             throw new InvalidOperationException($"Content relay error: {response.StatusCode}");
         }
 
@@ -116,22 +119,6 @@ public partial class GitHubContentService(
         var stem = Path.GetFileNameWithoutExtension(path);
         var slug = new string([.. stem.Select(c => char.IsAsciiLetterOrDigit(c) ? c : '-')]).Trim('-');
         return slug.Length == 0 ? "content" : slug;
-    }
-
-    /// <summary>Reads the ProblemDetails "detail" out of a relay rejection.</summary>
-    private static string? RelayRejectionDetail(string body)
-    {
-        try
-        {
-            var detail = JsonDocument.Parse(body).RootElement;
-            return detail.TryGetProperty("detail", out var value) && value.ValueKind == JsonValueKind.String
-                ? value.GetString()
-                : null;
-        }
-        catch (JsonException)
-        {
-            return null;
-        }
     }
 
     internal static string BuildCommitMessage(ContentContributionRequest request, bool created)

--- a/src/API/Nocturne.API/Services/GitHubContentService.cs
+++ b/src/API/Nocturne.API/Services/GitHubContentService.cs
@@ -11,13 +11,13 @@ namespace Nocturne.API.Services;
 /// Turns a CMS content contribution into an upstream pull request: fetch the
 /// current file (if any), commit the new content to a branch, open a PR with
 /// contributor attribution. Instances without a PAT relay to nocturne.run.
-/// Shares GitHubTranslationOptions ("GitHub" config section): same PAT,
+/// Shares GitHubContributionOptions ("GitHub" config section): same PAT,
 /// repo, base branch and relay opt-in as translation contributions.
 /// </summary>
 public partial class GitHubContentService(
     GitHubPrClient prClient,
     IHttpClientFactory httpClientFactory,
-    IOptions<GitHubTranslationOptions> options,
+    IOptions<GitHubContributionOptions> options,
     ILogger<GitHubContentService> logger) : IContentContributionService
 {
     private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
@@ -32,7 +32,7 @@ public partial class GitHubContentService(
     [GeneratedRegex(@"\Asrc/Web/packages/portal/src/content/(blog|docs)(/[a-z0-9][a-z0-9._-]*)*/[a-z0-9][a-z0-9._-]*\.svx\z")]
     public static partial Regex AllowedPathPattern();
 
-    public bool HasLocalPat => !string.IsNullOrEmpty(options.Value.TranslationsPat);
+    public bool HasLocalPat => !string.IsNullOrEmpty(options.Value.ContributionsPat);
 
     public async Task<ContentContributionResponse> SubmitAsync(
         ContentContributionRequest request, CancellationToken ct)
@@ -41,7 +41,7 @@ public partial class GitHubContentService(
         if (!AllowedPathPattern().IsMatch(request.Path))
             throw new TranslationContributionRejectedException("This path cannot be modified through content contributions.");
 
-        using var client = prClient.CreateClient(opts.TranslationsPat);
+        using var client = prClient.CreateClient(opts.ContributionsPat);
 
         var existing = await prClient.GetFileAsync(client, opts.Owner, opts.Repo, request.Path, opts.BaseBranch, ct);
         if (existing is { } file && file.Text == request.Content)

--- a/src/API/Nocturne.API/Services/GitHubContentService.cs
+++ b/src/API/Nocturne.API/Services/GitHubContentService.cs
@@ -29,7 +29,10 @@ public partial class GitHubContentService(
     /// </summary>
     // \A/\z anchors: $ would also match before a trailing newline, letting
     // "post.svx\n" through validation.
-    [GeneratedRegex(@"\Asrc/Web/packages/portal/src/content/(blog|docs)(/[a-z0-9][a-z0-9._-]*)*/[a-z0-9][a-z0-9._-]*\.svx\z")]
+    // Each segment alternates alphanumerics and single separators: ".." would
+    // otherwise be admitted and produce "content/a..b-..." , which git refuses
+    // as a ref name and GitHub rejects with a 422.
+    [GeneratedRegex(@"\Asrc/Web/packages/portal/src/content/(blog|docs)(/[a-z0-9](?:[._-]?[a-z0-9])*)*/[a-z0-9](?:[._-]?[a-z0-9])*\.svx\z")]
     public static partial Regex AllowedPathPattern();
 
     public bool HasLocalPat => !string.IsNullOrEmpty(options.Value.ContributionsPat);
@@ -39,16 +42,15 @@ public partial class GitHubContentService(
     {
         var opts = options.Value;
         if (!AllowedPathPattern().IsMatch(request.Path))
-            throw new TranslationContributionRejectedException("This path cannot be modified through content contributions.");
+            throw new ContributionRejectedException("This path cannot be modified through content contributions.");
 
         using var client = prClient.CreateClient(opts.ContributionsPat);
 
         var existing = await prClient.GetFileAsync(client, opts.Owner, opts.Repo, request.Path, opts.BaseBranch, ct);
         if (existing is { } file && file.Text == request.Content)
-            throw new TranslationContributionRejectedException("The content is identical to the published version.");
+            throw new ContributionRejectedException("The content is identical to the published version.");
 
-        var slug = Path.GetFileNameWithoutExtension(request.Path);
-        var branch = $"content/{slug}-{Guid.NewGuid().ToString("N")[..12]}";
+        var branch = $"content/{BranchSlug(request.Path)}-{Guid.NewGuid().ToString("N")[..12]}";
         var baseSha = await prClient.GetBranchShaAsync(client, opts.Owner, opts.Repo, opts.BaseBranch, ct);
         await prClient.CreateBranchAsync(client, opts.Owner, opts.Repo, branch, baseSha, ct);
 
@@ -93,12 +95,43 @@ public partial class GitHubContentService(
             var error = await response.Content.ReadAsStringAsync(ct);
             logger.LogError("Content relay error: {StatusCode} {Error}", response.StatusCode, error);
             if (response.StatusCode == System.Net.HttpStatusCode.UnprocessableEntity)
-                throw new TranslationContributionRejectedException("The contribution was rejected by the relay.");
+                // Forward the relay's own reason so the contributor can tell
+                // "identical to published" from "path not allowed".
+                throw new ContributionRejectedException(
+                    RelayRejectionDetail(error) ?? "The contribution was rejected by the relay.");
             throw new InvalidOperationException($"Content relay error: {response.StatusCode}");
         }
 
         return await response.Content.ReadFromJsonAsync<ContentContributionResponse>(JsonOpts, ct)
             ?? throw new InvalidOperationException("Failed to deserialize relay response");
+    }
+
+    /// <summary>
+    /// Git refs cannot contain "..", a leading/trailing dot or a trailing
+    /// ".lock", so the file stem is reduced to alphanumerics and hyphens
+    /// before it becomes a branch name.
+    /// </summary>
+    internal static string BranchSlug(string path)
+    {
+        var stem = Path.GetFileNameWithoutExtension(path);
+        var slug = new string([.. stem.Select(c => char.IsAsciiLetterOrDigit(c) ? c : '-')]).Trim('-');
+        return slug.Length == 0 ? "content" : slug;
+    }
+
+    /// <summary>Reads the ProblemDetails "detail" out of a relay rejection.</summary>
+    private static string? RelayRejectionDetail(string body)
+    {
+        try
+        {
+            var detail = JsonDocument.Parse(body).RootElement;
+            return detail.TryGetProperty("detail", out var value) && value.ValueKind == JsonValueKind.String
+                ? value.GetString()
+                : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
     }
 
     internal static string BuildCommitMessage(ContentContributionRequest request, bool created)
@@ -107,7 +140,7 @@ public partial class GitHubContentService(
         var slug = Path.GetFileNameWithoutExtension(request.Path);
         sb.AppendLine($"content: {(created ? "add" : "update")} {slug}");
         sb.AppendLine();
-        sb.AppendLine($"Contributed by {GitHubPrClient.RenderName(request.Contributor.Name, markdown: false)} via the in-app content studio.");
+        sb.AppendLine($"Contributed by {ContributionValidation.RenderName(request.Contributor.Name, markdown: false)} via the in-app content studio.");
 
         var coAuthor = GitHubPrClient.CoAuthorTrailer(request.Contributor);
         if (coAuthor is not null)
@@ -125,7 +158,7 @@ public partial class GitHubContentService(
         sb.AppendLine($"{(created ? "New" : "Updated")} content proposed through the in-app content studio.");
         sb.AppendLine();
         sb.AppendLine($"- **File:** `{request.Path}`");
-        sb.AppendLine($"- **Contributor:** {GitHubPrClient.RenderName(request.Contributor.Name, markdown: true)}"
+        sb.AppendLine($"- **Contributor:** {ContributionValidation.RenderName(request.Contributor.Name, markdown: true)}"
             + (string.IsNullOrWhiteSpace(request.Contributor.GitHubUsername)
                 ? ""
                 : $" (@{GitHubPrClient.SanitizeMetadata(request.Contributor.GitHubUsername)})"));
@@ -135,7 +168,7 @@ public partial class GitHubContentService(
             sb.AppendLine();
             sb.AppendLine("## Contributor note");
             sb.AppendLine();
-            sb.AppendLine(request.Note);
+            sb.Append(ContributionValidation.RenderNoteAsCodeFence(request.Note));
         }
 
         return sb.ToString();

--- a/src/API/Nocturne.API/Services/GitHubContentService.cs
+++ b/src/API/Nocturne.API/Services/GitHubContentService.cs
@@ -1,0 +1,141 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Options;
+using Nocturne.Core.Contracts.Content;
+using Nocturne.Core.Models.Content;
+
+namespace Nocturne.API.Services;
+
+/// <summary>
+/// Turns a CMS content contribution into an upstream pull request: fetch the
+/// current file (if any), commit the new content to a branch, open a PR with
+/// contributor attribution. Instances without a PAT relay to nocturne.run.
+/// Shares GitHubTranslationOptions ("GitHub" config section): same PAT,
+/// repo, base branch and relay opt-in as translation contributions.
+/// </summary>
+public partial class GitHubContentService(
+    GitHubPrClient prClient,
+    IHttpClientFactory httpClientFactory,
+    IOptions<GitHubTranslationOptions> options,
+    ILogger<GitHubContentService> logger) : IContentContributionService
+{
+    private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+
+    /// <summary>
+    /// Contributions may only touch portal content: blog and docs .svx files
+    /// with conservative path segments. Anything else is rejected before any
+    /// GitHub call — the relay ingress is reachable anonymously.
+    /// </summary>
+    [GeneratedRegex(@"^src/Web/packages/portal/src/content/(blog|docs)(/[a-z0-9][a-z0-9._-]*)*/[a-z0-9][a-z0-9._-]*\.svx$")]
+    public static partial Regex AllowedPathPattern();
+
+    public bool HasLocalPat => !string.IsNullOrEmpty(options.Value.TranslationsPat);
+
+    public async Task<ContentContributionResponse> SubmitAsync(
+        ContentContributionRequest request, CancellationToken ct)
+    {
+        var opts = options.Value;
+        if (!AllowedPathPattern().IsMatch(request.Path))
+            throw new TranslationContributionRejectedException("This path cannot be modified through content contributions.");
+
+        using var client = prClient.CreateClient(opts.TranslationsPat);
+
+        var existing = await prClient.GetFileAsync(client, opts.Owner, opts.Repo, request.Path, opts.BaseBranch, ct);
+        if (existing is { } file && file.Text == request.Content)
+            throw new TranslationContributionRejectedException("The content is identical to the published version.");
+
+        var slug = Path.GetFileNameWithoutExtension(request.Path);
+        var branch = $"content/{slug}-{Guid.NewGuid().ToString("N")[..12]}";
+        var baseSha = await prClient.GetBranchShaAsync(client, opts.Owner, opts.Repo, opts.BaseBranch, ct);
+        await prClient.CreateBranchAsync(client, opts.Owner, opts.Repo, branch, baseSha, ct);
+
+        int prNumber;
+        string prUrl;
+        try
+        {
+            await prClient.CommitFileAsync(
+                client, opts.Owner, opts.Repo, request.Path, branch,
+                existing?.Sha, request.Content, BuildCommitMessage(request, existing is null), ct);
+            (prNumber, prUrl) = await prClient.OpenPullRequestAsync(
+                client, opts.Owner, opts.Repo, branch, opts.BaseBranch,
+                $"content: {GitHubPrClient.SanitizeMetadata(request.Title)}",
+                BuildPrBody(request, existing is null), ct);
+        }
+        catch
+        {
+            await prClient.TryDeleteBranchAsync(client, opts.Owner, opts.Repo, branch);
+            throw;
+        }
+
+        logger.LogInformation(
+            "Opened content PR #{PrNumber} for {Path} ({Mode})",
+            prNumber, request.Path, existing is null ? "create" : "update");
+
+        return new ContentContributionResponse
+        {
+            PrNumber = prNumber,
+            PrUrl = prUrl,
+            Created = existing is null,
+        };
+    }
+
+    public async Task<ContentContributionResponse> RelayAsync(
+        ContentContributionRequest request, CancellationToken ct)
+    {
+        using var client = httpClientFactory.CreateClient();
+        var response = await client.PostAsJsonAsync(options.Value.ContentRelayUrl, request, JsonOpts, ct);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var error = await response.Content.ReadAsStringAsync(ct);
+            logger.LogError("Content relay error: {StatusCode} {Error}", response.StatusCode, error);
+            if (response.StatusCode == System.Net.HttpStatusCode.UnprocessableEntity)
+                throw new TranslationContributionRejectedException("The contribution was rejected by the relay.");
+            throw new InvalidOperationException($"Content relay error: {response.StatusCode}");
+        }
+
+        return await response.Content.ReadFromJsonAsync<ContentContributionResponse>(JsonOpts, ct)
+            ?? throw new InvalidOperationException("Failed to deserialize relay response");
+    }
+
+    internal static string BuildCommitMessage(ContentContributionRequest request, bool created)
+    {
+        var sb = new StringBuilder();
+        var slug = Path.GetFileNameWithoutExtension(request.Path);
+        sb.AppendLine($"content: {(created ? "add" : "update")} {slug}");
+        sb.AppendLine();
+        sb.AppendLine($"Contributed by {GitHubPrClient.RenderName(request.Contributor.Name, markdown: false)} via the in-app content studio.");
+
+        var coAuthor = GitHubPrClient.CoAuthorTrailer(request.Contributor);
+        if (coAuthor is not null)
+        {
+            sb.AppendLine();
+            sb.AppendLine(coAuthor);
+        }
+
+        return sb.ToString();
+    }
+
+    internal static string BuildPrBody(ContentContributionRequest request, bool created)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"{(created ? "New" : "Updated")} content proposed through the in-app content studio.");
+        sb.AppendLine();
+        sb.AppendLine($"- **File:** `{request.Path}`");
+        sb.AppendLine($"- **Contributor:** {GitHubPrClient.RenderName(request.Contributor.Name, markdown: true)}"
+            + (string.IsNullOrWhiteSpace(request.Contributor.GitHubUsername)
+                ? ""
+                : $" (@{GitHubPrClient.SanitizeMetadata(request.Contributor.GitHubUsername)})"));
+
+        if (!string.IsNullOrWhiteSpace(request.Note))
+        {
+            sb.AppendLine();
+            sb.AppendLine("## Contributor note");
+            sb.AppendLine();
+            sb.AppendLine(request.Note);
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/API/Nocturne.API/Services/GitHubContentService.cs
+++ b/src/API/Nocturne.API/Services/GitHubContentService.cs
@@ -27,7 +27,9 @@ public partial class GitHubContentService(
     /// with conservative path segments. Anything else is rejected before any
     /// GitHub call — the relay ingress is reachable anonymously.
     /// </summary>
-    [GeneratedRegex(@"^src/Web/packages/portal/src/content/(blog|docs)(/[a-z0-9][a-z0-9._-]*)*/[a-z0-9][a-z0-9._-]*\.svx$")]
+    // \A/\z anchors: $ would also match before a trailing newline, letting
+    // "post.svx\n" through validation.
+    [GeneratedRegex(@"\Asrc/Web/packages/portal/src/content/(blog|docs)(/[a-z0-9][a-z0-9._-]*)*/[a-z0-9][a-z0-9._-]*\.svx\z")]
     public static partial Regex AllowedPathPattern();
 
     public bool HasLocalPat => !string.IsNullOrEmpty(options.Value.TranslationsPat);

--- a/src/API/Nocturne.API/Services/GitHubContributionOptions.cs
+++ b/src/API/Nocturne.API/Services/GitHubContributionOptions.cs
@@ -1,0 +1,27 @@
+namespace Nocturne.API.Services;
+
+/// <summary>
+/// Shared configuration for the GitHub pull-request contribution flows
+/// (translations and CMS content). Bound to the "GitHub" config section.
+/// </summary>
+public class GitHubContributionOptions
+{
+    /// <summary>
+    /// PAT with contents+pull-request write access. Needs more privilege than
+    /// IssuesPat, so it is a separate key; instances without one relay to
+    /// nocturne.run like the support-issue flow.
+    /// </summary>
+    public string? ContributionsPat { get; set; }
+    public string TranslationsRelayUrl { get; set; } = "https://nocturne.run/api/v4/translations/relay";
+    public string ContentRelayUrl { get; set; } = "https://nocturne.run/api/v4/content/relay";
+    /// <summary>
+    /// Accept anonymous relayed contributions from other instances (the
+    /// nocturne.run side of the relay). Requires ContributionsPat. Off by
+    /// default so a regular instance never exposes an anonymous endpoint.
+    /// </summary>
+    public bool AcceptRelayedContributions { get; set; }
+    public string Owner { get; set; } = GitHubApi.DefaultOwner;
+    public string Repo { get; set; } = GitHubApi.DefaultRepo;
+    public string BaseBranch { get; set; } = "main";
+    public string CatalogDir { get; set; } = "src/Web/locales";
+}

--- a/src/API/Nocturne.API/Services/GitHubPrClient.cs
+++ b/src/API/Nocturne.API/Services/GitHubPrClient.cs
@@ -1,0 +1,222 @@
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using Nocturne.Core.Models.Translations;
+
+namespace Nocturne.API.Services;
+
+/// <summary>
+/// Shared GitHub REST plumbing for contribution flows that open pull
+/// requests (translations, CMS content): fetch a file, branch, commit, open
+/// the PR, and clean up on failure.
+/// </summary>
+public partial class GitHubPrClient(IHttpClientFactory httpClientFactory, ILogger<GitHubPrClient> logger)
+{
+    public HttpClient CreateClient(string? pat) => GitHubApi.CreateClient(httpClientFactory, pat);
+
+    /// <summary>Returns null when the file does not exist on the ref.</summary>
+    public async Task<(string Text, string Sha)?> GetFileAsync(
+        HttpClient client, string owner, string repo, string path, string reference, CancellationToken ct)
+    {
+        // The contents API caps files at 1 MB; large files need the blobs API.
+        var response = await client.GetAsync(
+            $"/repos/{owner}/{repo}/contents/{path}?ref={Uri.EscapeDataString(reference)}", ct);
+
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            return null;
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var error = await response.Content.ReadAsStringAsync(ct);
+            logger.LogError("GitHub API error fetching {Path}: {StatusCode} {Error}", path, response.StatusCode, error);
+            throw new InvalidOperationException($"GitHub API error: {response.StatusCode}");
+        }
+
+        var file = await response.Content.ReadFromJsonAsync<GitHubContentResponse>(ct)
+            ?? throw new InvalidOperationException("Failed to deserialize GitHub content response");
+        var text = Encoding.UTF8.GetString(Convert.FromBase64String(file.Content.Replace("\n", "")));
+        return (text, file.Sha);
+    }
+
+    public async Task<string> GetBranchShaAsync(
+        HttpClient client, string owner, string repo, string branch, CancellationToken ct)
+    {
+        var response = await client.GetAsync($"/repos/{owner}/{repo}/git/ref/heads/{branch}", ct);
+        response.EnsureSuccessStatusCode();
+        var reference = await response.Content.ReadFromJsonAsync<GitHubRefResponse>(ct)
+            ?? throw new InvalidOperationException("Failed to deserialize GitHub ref response");
+        return reference.Object.Sha;
+    }
+
+    public async Task CreateBranchAsync(
+        HttpClient client, string owner, string repo, string branch, string sha, CancellationToken ct)
+    {
+        var response = await client.PostAsJsonAsync(
+            $"/repos/{owner}/{repo}/git/refs",
+            new { @ref = $"refs/heads/{branch}", sha }, ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            var error = await response.Content.ReadAsStringAsync(ct);
+            logger.LogError("GitHub API error creating branch: {StatusCode} {Error}", response.StatusCode, error);
+            throw new InvalidOperationException($"GitHub API error: {response.StatusCode}");
+        }
+    }
+
+    /// <summary>fileSha null creates the file; non-null updates it.</summary>
+    public async Task CommitFileAsync(
+        HttpClient client, string owner, string repo, string path, string branch,
+        string? fileSha, string content, string message, CancellationToken ct)
+    {
+        var response = await client.PutAsJsonAsync(
+            $"/repos/{owner}/{repo}/contents/{path}",
+            new
+            {
+                message,
+                content = Convert.ToBase64String(Encoding.UTF8.GetBytes(content)),
+                sha = fileSha,
+                branch,
+            }, ct);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var error = await response.Content.ReadAsStringAsync(ct);
+            logger.LogError("GitHub API error committing {Path}: {StatusCode} {Error}", path, response.StatusCode, error);
+            throw new InvalidOperationException($"GitHub API error: {response.StatusCode}");
+        }
+    }
+
+    public async Task<(int Number, string Url)> OpenPullRequestAsync(
+        HttpClient client, string owner, string repo, string branch, string baseBranch,
+        string title, string body, CancellationToken ct)
+    {
+        var response = await client.PostAsJsonAsync(
+            $"/repos/{owner}/{repo}/pulls",
+            new
+            {
+                title,
+                head = branch,
+                @base = baseBranch,
+                body,
+                maintainer_can_modify = true,
+            }, ct);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var error = await response.Content.ReadAsStringAsync(ct);
+            logger.LogError("GitHub API error opening PR: {StatusCode} {Error}", response.StatusCode, error);
+            throw new InvalidOperationException($"GitHub API error: {response.StatusCode}");
+        }
+
+        var pr = await response.Content.ReadFromJsonAsync<GitHubPullResponse>(ct)
+            ?? throw new InvalidOperationException("Failed to deserialize GitHub PR response");
+        return (pr.Number, pr.HtmlUrl);
+    }
+
+    public async Task TryDeleteBranchAsync(HttpClient client, string owner, string repo, string branch)
+    {
+        try
+        {
+            await client.DeleteAsync($"/repos/{owner}/{repo}/git/refs/heads/{branch}");
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to clean up branch {Branch} after error", branch);
+        }
+    }
+
+    /// <summary>
+    /// Defense in depth behind controller validation: these values land in
+    /// commit messages and PR bodies, so newlines or angle brackets would
+    /// allow trailer injection regardless of what the caller validated.
+    /// </summary>
+    public static string SanitizeMetadata(string value) =>
+        new([.. value.Trim().Where(c => !char.IsControl(c) && c is not '<' and not '>')]);
+
+    /// <summary>
+    /// Renders a contributor-supplied display name for a sink GitHub gives
+    /// side effects to. The name arrives from an anonymous relay, so
+    /// <c>Jane fixes #12 cc @someone</c> would otherwise auto-close an issue
+    /// and notify arbitrary users from the upstream PR body and from the
+    /// commit message. A commit message is not markdown — a backslash escape
+    /// would render literally there — so the reference-carrying characters
+    /// are dropped instead of escaped when <paramref name="markdown"/> is
+    /// false. The backslash is escaped first so a submitted <c>\</c> cannot
+    /// consume the escape that follows it.
+    ///
+    /// <c>#</c> handling covers <c>#12</c> and <c>owner/repo#12</c>, but
+    /// GitHub resolves two further reference forms that carry no <c>#</c> and
+    /// no <c>@</c>: the <c>GH-12</c> shorthand and a full issue or pull URL.
+    /// Both fit inside a name and both honour closing keywords, so both are
+    /// removed outright — a person's name legitimately contains neither.
+    /// </summary>
+    public static string RenderName(string name, bool markdown)
+    {
+        var value = SanitizeMetadata(name);
+        value = markdown
+            ? value.Replace("\\", "\\\\").Replace("@", "\\@").Replace("#", "\\#").Replace("`", "\\`")
+            : new string([.. value.Where(c => c is not '@' and not '#')]);
+
+        // Last, because dropping a "#" above can splice a reference back
+        // together ("htt#ps://…", "GH#-1"). Neither pass can recreate the
+        // other's target: URL removal only deletes, and separating "GH" from
+        // its digits cannot produce a "://".
+        value = UrlReference().Replace(value, "");
+        return GitHubShorthandReference().Replace(value, "$1 ").Trim();
+    }
+
+    /// <summary>Any absolute http(s) URL, which covers the full issue/PR reference form.</summary>
+    [GeneratedRegex(@"https?://\S+", RegexOptions.IgnoreCase)]
+    private static partial Regex UrlReference();
+
+    /// <summary>
+    /// The <c>GH-123</c> shorthand. Only the hyphen is replaced: the autolink
+    /// requires <c>GH-</c> immediately followed by a digit, so a space between
+    /// them leaves nothing for GitHub to resolve while the name stays readable.
+    /// </summary>
+    [GeneratedRegex(@"(GH)-(?=\d)", RegexOptions.IgnoreCase)]
+    private static partial Regex GitHubShorthandReference();
+
+    public static string? CoAuthorTrailer(TranslationContributorDto contributor)
+    {
+        if (!string.IsNullOrWhiteSpace(contributor.GitHubUsername))
+        {
+            var username = SanitizeMetadata(contributor.GitHubUsername);
+            return $"Co-authored-by: {username} <{username}@users.noreply.github.com>";
+        }
+
+        // The trailer lands in a commit message, so the name gets the same
+        // reference-dropping treatment as the attribution line above it.
+        if (!string.IsNullOrWhiteSpace(contributor.Email))
+            return $"Co-authored-by: {RenderName(contributor.Name, markdown: false)} <{SanitizeMetadata(contributor.Email)}>";
+
+        return null;
+    }
+
+    private record GitHubContentResponse
+    {
+        [JsonPropertyName("content")]
+        public string Content { get; init; } = "";
+        [JsonPropertyName("sha")]
+        public string Sha { get; init; } = "";
+    }
+
+    private record GitHubRefResponse
+    {
+        [JsonPropertyName("object")]
+        public GitHubRefObject Object { get; init; } = new();
+    }
+
+    private record GitHubRefObject
+    {
+        [JsonPropertyName("sha")]
+        public string Sha { get; init; } = "";
+    }
+
+    private record GitHubPullResponse
+    {
+        [JsonPropertyName("number")]
+        public int Number { get; init; }
+        [JsonPropertyName("html_url")]
+        public string HtmlUrl { get; init; } = "";
+    }
+}

--- a/src/API/Nocturne.API/Services/GitHubPrClient.cs
+++ b/src/API/Nocturne.API/Services/GitHubPrClient.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using System.Text.Json.Serialization;
-using System.Text.RegularExpressions;
 using Nocturne.Core.Models.Translations;
 
 namespace Nocturne.API.Services;
@@ -10,7 +9,7 @@ namespace Nocturne.API.Services;
 /// requests (translations, CMS content): fetch a file, branch, commit, open
 /// the PR, and clean up on failure.
 /// </summary>
-public partial class GitHubPrClient(IHttpClientFactory httpClientFactory, ILogger<GitHubPrClient> logger)
+public class GitHubPrClient(IHttpClientFactory httpClientFactory, ILogger<GitHubPrClient> logger)
 {
     public HttpClient CreateClient(string? pat) => GitHubApi.CreateClient(httpClientFactory, pat);
 
@@ -67,14 +66,17 @@ public partial class GitHubPrClient(IHttpClientFactory httpClientFactory, ILogge
         HttpClient client, string owner, string repo, string path, string branch,
         string? fileSha, string content, string message, CancellationToken ct)
     {
+        // sha must be absent, not null, when creating a file: the contents API
+        // 422s on an explicit null. Creating is the headline Studio case (a new
+        // blog post), so a serialized null broke it outright.
         var response = await client.PutAsJsonAsync(
             $"/repos/{owner}/{repo}/contents/{path}",
-            new
+            new CommitFileBody
             {
-                message,
-                content = Convert.ToBase64String(Encoding.UTF8.GetBytes(content)),
-                sha = fileSha,
-                branch,
+                Message = message,
+                Content = Convert.ToBase64String(Encoding.UTF8.GetBytes(content)),
+                Sha = fileSha,
+                Branch = branch,
             }, ct);
 
         if (!response.IsSuccessStatusCode)
@@ -124,57 +126,9 @@ public partial class GitHubPrClient(IHttpClientFactory httpClientFactory, ILogge
         }
     }
 
-    /// <summary>
-    /// Defense in depth behind controller validation: these values land in
-    /// commit messages and PR bodies, so newlines or angle brackets would
-    /// allow trailer injection regardless of what the caller validated.
-    /// </summary>
+    /// <summary>Defense in depth behind controller validation.</summary>
     public static string SanitizeMetadata(string value) =>
         new([.. value.Trim().Where(c => !char.IsControl(c) && c is not '<' and not '>')]);
-
-    /// <summary>
-    /// Renders a contributor-supplied display name for a sink GitHub gives
-    /// side effects to. The name arrives from an anonymous relay, so
-    /// <c>Jane fixes #12 cc @someone</c> would otherwise auto-close an issue
-    /// and notify arbitrary users from the upstream PR body and from the
-    /// commit message. A commit message is not markdown — a backslash escape
-    /// would render literally there — so the reference-carrying characters
-    /// are dropped instead of escaped when <paramref name="markdown"/> is
-    /// false. The backslash is escaped first so a submitted <c>\</c> cannot
-    /// consume the escape that follows it.
-    ///
-    /// <c>#</c> handling covers <c>#12</c> and <c>owner/repo#12</c>, but
-    /// GitHub resolves two further reference forms that carry no <c>#</c> and
-    /// no <c>@</c>: the <c>GH-12</c> shorthand and a full issue or pull URL.
-    /// Both fit inside a name and both honour closing keywords, so both are
-    /// removed outright — a person's name legitimately contains neither.
-    /// </summary>
-    public static string RenderName(string name, bool markdown)
-    {
-        var value = SanitizeMetadata(name);
-        value = markdown
-            ? value.Replace("\\", "\\\\").Replace("@", "\\@").Replace("#", "\\#").Replace("`", "\\`")
-            : new string([.. value.Where(c => c is not '@' and not '#')]);
-
-        // Last, because dropping a "#" above can splice a reference back
-        // together ("htt#ps://…", "GH#-1"). Neither pass can recreate the
-        // other's target: URL removal only deletes, and separating "GH" from
-        // its digits cannot produce a "://".
-        value = UrlReference().Replace(value, "");
-        return GitHubShorthandReference().Replace(value, "$1 ").Trim();
-    }
-
-    /// <summary>Any absolute http(s) URL, which covers the full issue/PR reference form.</summary>
-    [GeneratedRegex(@"https?://\S+", RegexOptions.IgnoreCase)]
-    private static partial Regex UrlReference();
-
-    /// <summary>
-    /// The <c>GH-123</c> shorthand. Only the hyphen is replaced: the autolink
-    /// requires <c>GH-</c> immediately followed by a digit, so a space between
-    /// them leaves nothing for GitHub to resolve while the name stays readable.
-    /// </summary>
-    [GeneratedRegex(@"(GH)-(?=\d)", RegexOptions.IgnoreCase)]
-    private static partial Regex GitHubShorthandReference();
 
     public static string? CoAuthorTrailer(TranslationContributorDto contributor)
     {
@@ -184,12 +138,23 @@ public partial class GitHubPrClient(IHttpClientFactory httpClientFactory, ILogge
             return $"Co-authored-by: {username} <{username}@users.noreply.github.com>";
         }
 
-        // The trailer lands in a commit message, so the name gets the same
-        // reference-dropping treatment as the attribution line above it.
         if (!string.IsNullOrWhiteSpace(contributor.Email))
-            return $"Co-authored-by: {RenderName(contributor.Name, markdown: false)} <{SanitizeMetadata(contributor.Email)}>";
+            return $"Co-authored-by: {ContributionValidation.RenderName(contributor.Name, markdown: false)} <{SanitizeMetadata(contributor.Email)}>";
 
         return null;
+    }
+
+    private record CommitFileBody
+    {
+        [JsonPropertyName("message")]
+        public required string Message { get; init; }
+        [JsonPropertyName("content")]
+        public required string Content { get; init; }
+        [JsonPropertyName("sha")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Sha { get; init; }
+        [JsonPropertyName("branch")]
+        public required string Branch { get; init; }
     }
 
     private record GitHubContentResponse

--- a/src/API/Nocturne.API/Services/GitHubPrClient.cs
+++ b/src/API/Nocturne.API/Services/GitHubPrClient.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Nocturne.Core.Models.Translations;
 
@@ -6,8 +7,9 @@ namespace Nocturne.API.Services;
 
 /// <summary>
 /// Shared GitHub REST plumbing for contribution flows that open pull
-/// requests (translations, CMS content): fetch a file, branch, commit, open
-/// the PR, and clean up on failure.
+/// requests (translations, CMS content). Callers own the <see cref="HttpClient"/>
+/// they pass in, so one flow's sequence of calls reuses a single connection
+/// and a single PAT.
 /// </summary>
 public class GitHubPrClient(IHttpClientFactory httpClientFactory, ILogger<GitHubPrClient> logger)
 {
@@ -17,7 +19,6 @@ public class GitHubPrClient(IHttpClientFactory httpClientFactory, ILogger<GitHub
     public async Task<(string Text, string Sha)?> GetFileAsync(
         HttpClient client, string owner, string repo, string path, string reference, CancellationToken ct)
     {
-        // The contents API caps files at 1 MB; large files need the blobs API.
         var response = await client.GetAsync(
             $"/repos/{owner}/{repo}/contents/{path}?ref={Uri.EscapeDataString(reference)}", ct);
 
@@ -66,9 +67,6 @@ public class GitHubPrClient(IHttpClientFactory httpClientFactory, ILogger<GitHub
         HttpClient client, string owner, string repo, string path, string branch,
         string? fileSha, string content, string message, CancellationToken ct)
     {
-        // sha must be absent, not null, when creating a file: the contents API
-        // 422s on an explicit null. Creating is the headline Studio case (a new
-        // blog post), so a serialized null broke it outright.
         var response = await client.PutAsJsonAsync(
             $"/repos/{owner}/{repo}/contents/{path}",
             new CommitFileBody
@@ -130,7 +128,22 @@ public class GitHubPrClient(IHttpClientFactory httpClientFactory, ILogger<GitHub
     public static string SanitizeMetadata(string value) =>
         new([.. value.Trim().Where(c => !char.IsControl(c) && c is not '<' and not '>')]);
 
-    public static string? CoAuthorTrailer(TranslationContributorDto contributor)
+    public static string? RelayRejectionDetail(string body)
+    {
+        try
+        {
+            var problem = JsonDocument.Parse(body).RootElement;
+            return problem.TryGetProperty("detail", out var value) && value.ValueKind == JsonValueKind.String
+                ? value.GetString()
+                : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    public static string? CoAuthorTrailer(ContributionContributorDto contributor)
     {
         if (!string.IsNullOrWhiteSpace(contributor.GitHubUsername))
         {
@@ -150,6 +163,11 @@ public class GitHubPrClient(IHttpClientFactory httpClientFactory, ILogger<GitHub
         public required string Message { get; init; }
         [JsonPropertyName("content")]
         public required string Content { get; init; }
+        /// <summary>
+        /// Absent creates the file, present updates it. The contents API 422s
+        /// on an explicit null, so this must be omitted rather than serialized
+        /// as null.
+        /// </summary>
         [JsonPropertyName("sha")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Sha { get; init; }

--- a/src/API/Nocturne.API/Services/GitHubTranslationService.cs
+++ b/src/API/Nocturne.API/Services/GitHubTranslationService.cs
@@ -89,17 +89,17 @@ public class GitHubTranslationService(
             var error = await response.Content.ReadAsStringAsync(ct);
             logger.LogError("Translation relay error: {StatusCode} {Error}", response.StatusCode, error);
             if (response.StatusCode == System.Net.HttpStatusCode.UnprocessableEntity)
+                // Forward the relay's own reason: a 422 is just as likely to be
+                // a contributor-validation rejection as an unmatched catalog.
                 throw new ContributionRejectedException(
-                    "No contributed message matched the current catalog. The catalog may have changed; refresh and try again.");
+                    GitHubPrClient.RelayRejectionDetail(error)
+                    ?? "The contribution was rejected by the relay.");
             throw new InvalidOperationException($"Translation relay error: {response.StatusCode}");
         }
 
         return await response.Content.ReadFromJsonAsync<TranslationContributionResponse>(JsonOpts, ct)
             ?? throw new InvalidOperationException("Failed to deserialize relay response");
     }
-
-
-    internal static string SanitizeMetadata(string value) => GitHubPrClient.SanitizeMetadata(value);
 
     internal static string BuildCommitMessage(TranslationContributionRequest request, int applied)
     {
@@ -108,7 +108,7 @@ public class GitHubTranslationService(
         sb.AppendLine();
         sb.AppendLine($"Applies {applied} message{(applied == 1 ? "" : "s")} contributed by {ContributionValidation.RenderName(request.Contributor.Name, markdown: false)}.");
 
-        var coAuthor = CoAuthorTrailer(request.Contributor);
+        var coAuthor = GitHubPrClient.CoAuthorTrailer(request.Contributor);
         if (coAuthor is not null)
         {
             sb.AppendLine();
@@ -118,9 +118,6 @@ public class GitHubTranslationService(
         return sb.ToString();
     }
 
-    internal static string? CoAuthorTrailer(TranslationContributorDto contributor) =>
-        GitHubPrClient.CoAuthorTrailer(contributor);
-
     internal static string BuildPrBody(TranslationContributionRequest request, PoEditResult result)
     {
         var sb = new StringBuilder();
@@ -129,7 +126,7 @@ public class GitHubTranslationService(
         sb.AppendLine($"- **Contributor:** {ContributionValidation.RenderName(request.Contributor.Name, markdown: true)}"
             + (string.IsNullOrWhiteSpace(request.Contributor.GitHubUsername)
                 ? ""
-                : $" (@{SanitizeMetadata(request.Contributor.GitHubUsername)})"));
+                : $" (@{GitHubPrClient.SanitizeMetadata(request.Contributor.GitHubUsername)})"));
         sb.AppendLine($"- **Messages updated:** {result.Applied}");
 
         if (result.Unmatched.Count > 0)
@@ -148,7 +145,7 @@ public class GitHubTranslationService(
                     display = display[..120] + "…";
                 var context = entry.Context.Length == 0
                     ? ""
-                    : $" (context: {SanitizeMetadata(entry.Context)})";
+                    : $" (context: {GitHubPrClient.SanitizeMetadata(entry.Context)})";
                 sb.AppendLine($"- `{display}`{context}");
             }
             sb.AppendLine();
@@ -165,6 +162,4 @@ public class GitHubTranslationService(
 
         return sb.ToString();
     }
-
-
 }

--- a/src/API/Nocturne.API/Services/GitHubTranslationService.cs
+++ b/src/API/Nocturne.API/Services/GitHubTranslationService.cs
@@ -6,40 +6,18 @@ using Nocturne.Core.Models.Translations;
 
 namespace Nocturne.API.Services;
 
-public class GitHubTranslationOptions
-{
-    /// <summary>
-    /// PAT with contents+pull-request write access. Needs more privilege than
-    /// IssuesPat, so it is a separate key; instances without one relay to
-    /// nocturne.run like the support-issue flow.
-    /// </summary>
-    public string? TranslationsPat { get; set; }
-    public string TranslationsRelayUrl { get; set; } = "https://nocturne.run/api/v4/translations/relay";
-    public string ContentRelayUrl { get; set; } = "https://nocturne.run/api/v4/content/relay";
-    /// <summary>
-    /// Accept anonymous relayed contributions from other instances (the
-    /// nocturne.run side of the relay). Requires TranslationsPat. Off by
-    /// default so a regular instance never exposes an anonymous endpoint.
-    /// </summary>
-    public bool AcceptRelayedContributions { get; set; }
-    public string Owner { get; set; } = GitHubApi.DefaultOwner;
-    public string Repo { get; set; } = GitHubApi.DefaultRepo;
-    public string BaseBranch { get; set; } = "main";
-    public string CatalogDir { get; set; } = "src/Web/locales";
-}
-
 /// <summary>
 /// Mirrors GitHubIssueService — keep the two in step.
 /// </summary>
 public class GitHubTranslationService(
     GitHubPrClient prClient,
     IHttpClientFactory httpClientFactory,
-    IOptions<GitHubTranslationOptions> options,
+    IOptions<GitHubContributionOptions> options,
     ILogger<GitHubTranslationService> logger) : ITranslationContributionService
 {
     private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
 
-    public bool HasLocalPat => !string.IsNullOrEmpty(options.Value.TranslationsPat);
+    public bool HasLocalPat => !string.IsNullOrEmpty(options.Value.ContributionsPat);
 
     public bool AcceptsRelay => options.Value.AcceptRelayedContributions && HasLocalPat;
 
@@ -47,7 +25,7 @@ public class GitHubTranslationService(
         TranslationContributionRequest request, CancellationToken ct)
     {
         var opts = options.Value;
-        using var client = prClient.CreateClient(opts.TranslationsPat);
+        using var client = prClient.CreateClient(opts.ContributionsPat);
 
         // The contents API caps files at 1 MB; the largest catalog is ~0.9 MB
         // today. If catalogs outgrow that, switch to the blobs API.

--- a/src/API/Nocturne.API/Services/GitHubTranslationService.cs
+++ b/src/API/Nocturne.API/Services/GitHubTranslationService.cs
@@ -31,7 +31,7 @@ public class GitHubTranslationService(
         // today. If catalogs outgrow that, switch to the blobs API.
         var catalogPath = $"{opts.CatalogDir}/{request.Locale}.po";
         var catalogFile = await prClient.GetFileAsync(client, opts.Owner, opts.Repo, catalogPath, opts.BaseBranch, ct)
-            ?? throw new TranslationContributionRejectedException($"No catalog exists for this locale ({catalogPath}).");
+            ?? throw new ContributionRejectedException($"No catalog exists for this locale ({catalogPath}).");
         var (catalogText, fileSha) = catalogFile;
 
         var edits = request.Entries.ToDictionary(
@@ -40,7 +40,7 @@ public class GitHubTranslationService(
         var result = PoCatalogEditor.ApplyTranslations(catalogText, edits);
 
         if (result.Applied == 0)
-            throw new TranslationContributionRejectedException(
+            throw new ContributionRejectedException(
                 "No contributed message matched the current catalog. The catalog may have changed; refresh and try again.");
 
         var branch = $"translations/{request.Locale}-{Guid.NewGuid().ToString("N")[..12]}";
@@ -89,7 +89,7 @@ public class GitHubTranslationService(
             var error = await response.Content.ReadAsStringAsync(ct);
             logger.LogError("Translation relay error: {StatusCode} {Error}", response.StatusCode, error);
             if (response.StatusCode == System.Net.HttpStatusCode.UnprocessableEntity)
-                throw new TranslationContributionRejectedException(
+                throw new ContributionRejectedException(
                     "No contributed message matched the current catalog. The catalog may have changed; refresh and try again.");
             throw new InvalidOperationException($"Translation relay error: {response.StatusCode}");
         }
@@ -101,51 +101,12 @@ public class GitHubTranslationService(
 
     internal static string SanitizeMetadata(string value) => GitHubPrClient.SanitizeMetadata(value);
 
-    internal static string RenderName(string name, bool markdown) =>
-        GitHubPrClient.RenderName(name, markdown);
-
-    /// <summary>
-    /// Renders free-text contributor input inside a fenced code block.
-    /// Nothing inside a code fence is interpreted, which neutralizes the
-    /// references <see cref="RenderName"/> describes plus block markup and
-    /// raw HTML at once — provided the note cannot close the fence, so the
-    /// fence runs one backtick longer than the longest backtick run in it.
-    /// </summary>
-    internal static string RenderNoteAsCodeFence(string note)
-    {
-        var text = StripControlChars(note).ReplaceLineEndings("\n");
-        var fence = new string('`', Math.Max(3, LongestBacktickRun(text) + 1));
-
-        var sb = new StringBuilder();
-        sb.AppendLine(fence);
-        foreach (var line in text.Split('\n'))
-            sb.AppendLine(line);
-        sb.AppendLine(fence);
-        return sb.ToString();
-    }
-
-    private static int LongestBacktickRun(string value)
-    {
-        int longest = 0, run = 0;
-        foreach (var c in value)
-        {
-            run = c == '`' ? run + 1 : 0;
-            if (run > longest)
-                longest = run;
-        }
-        return longest;
-    }
-
-    /// <summary>Drops C0/C1 control characters but keeps line structure.</summary>
-    private static string StripControlChars(string value) =>
-        new([.. value.Where(c => !char.IsControl(c) || c is '\r' or '\n')]);
-
     internal static string BuildCommitMessage(TranslationContributionRequest request, int applied)
     {
         var sb = new StringBuilder();
         sb.AppendLine($"chore(i18n): {request.Locale} translations via in-app contribution");
         sb.AppendLine();
-        sb.AppendLine($"Applies {applied} message{(applied == 1 ? "" : "s")} contributed by {RenderName(request.Contributor.Name, markdown: false)}.");
+        sb.AppendLine($"Applies {applied} message{(applied == 1 ? "" : "s")} contributed by {ContributionValidation.RenderName(request.Contributor.Name, markdown: false)}.");
 
         var coAuthor = CoAuthorTrailer(request.Contributor);
         if (coAuthor is not null)
@@ -165,7 +126,7 @@ public class GitHubTranslationService(
         var sb = new StringBuilder();
         sb.AppendLine($"Translation contribution for `{request.Locale}` submitted through the in-app translation mode.");
         sb.AppendLine();
-        sb.AppendLine($"- **Contributor:** {RenderName(request.Contributor.Name, markdown: true)}"
+        sb.AppendLine($"- **Contributor:** {ContributionValidation.RenderName(request.Contributor.Name, markdown: true)}"
             + (string.IsNullOrWhiteSpace(request.Contributor.GitHubUsername)
                 ? ""
                 : $" (@{SanitizeMetadata(request.Contributor.GitHubUsername)})"));
@@ -199,7 +160,7 @@ public class GitHubTranslationService(
             sb.AppendLine();
             sb.AppendLine("## Contributor note");
             sb.AppendLine();
-            sb.Append(RenderNoteAsCodeFence(request.Note));
+            sb.Append(ContributionValidation.RenderNoteAsCodeFence(request.Note));
         }
 
         return sb.ToString();
@@ -207,5 +168,3 @@ public class GitHubTranslationService(
 
 
 }
-
-public class TranslationContributionRejectedException(string message) : Exception(message);

--- a/src/API/Nocturne.API/Services/GitHubTranslationService.cs
+++ b/src/API/Nocturne.API/Services/GitHubTranslationService.cs
@@ -1,7 +1,5 @@
 using System.Text;
 using System.Text.Json;
-using System.Text.Json.Serialization;
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.Options;
 using Nocturne.Core.Contracts.Translations;
 using Nocturne.Core.Models.Translations;
@@ -17,6 +15,7 @@ public class GitHubTranslationOptions
     /// </summary>
     public string? TranslationsPat { get; set; }
     public string TranslationsRelayUrl { get; set; } = "https://nocturne.run/api/v4/translations/relay";
+    public string ContentRelayUrl { get; set; } = "https://nocturne.run/api/v4/content/relay";
     /// <summary>
     /// Accept anonymous relayed contributions from other instances (the
     /// nocturne.run side of the relay). Requires TranslationsPat. Off by
@@ -32,7 +31,8 @@ public class GitHubTranslationOptions
 /// <summary>
 /// Mirrors GitHubIssueService — keep the two in step.
 /// </summary>
-public partial class GitHubTranslationService(
+public class GitHubTranslationService(
+    GitHubPrClient prClient,
     IHttpClientFactory httpClientFactory,
     IOptions<GitHubTranslationOptions> options,
     ILogger<GitHubTranslationService> logger) : ITranslationContributionService
@@ -47,10 +47,14 @@ public partial class GitHubTranslationService(
         TranslationContributionRequest request, CancellationToken ct)
     {
         var opts = options.Value;
-        using var client = GitHubApi.CreateClient(httpClientFactory, options.Value.TranslationsPat);
+        using var client = prClient.CreateClient(opts.TranslationsPat);
 
+        // The contents API caps files at 1 MB; the largest catalog is ~0.9 MB
+        // today. If catalogs outgrow that, switch to the blobs API.
         var catalogPath = $"{opts.CatalogDir}/{request.Locale}.po";
-        var (catalogText, fileSha) = await GetCatalogAsync(client, catalogPath, ct);
+        var catalogFile = await prClient.GetFileAsync(client, opts.Owner, opts.Repo, catalogPath, opts.BaseBranch, ct)
+            ?? throw new TranslationContributionRejectedException($"No catalog exists for this locale ({catalogPath}).");
+        var (catalogText, fileSha) = catalogFile;
 
         var edits = request.Entries.ToDictionary(
             e => (e.Context ?? "", e.MsgId),
@@ -62,19 +66,24 @@ public partial class GitHubTranslationService(
                 "No contributed message matched the current catalog. The catalog may have changed; refresh and try again.");
 
         var branch = $"translations/{request.Locale}-{Guid.NewGuid().ToString("N")[..12]}";
-        var baseSha = await GetBranchShaAsync(client, opts.BaseBranch, ct);
-        await CreateBranchAsync(client, branch, baseSha, ct);
+        var baseSha = await prClient.GetBranchShaAsync(client, opts.Owner, opts.Repo, opts.BaseBranch, ct);
+        await prClient.CreateBranchAsync(client, opts.Owner, opts.Repo, branch, baseSha, ct);
 
         int prNumber;
         string prUrl;
         try
         {
-            await CommitCatalogAsync(client, catalogPath, branch, fileSha, result.Text, request, result.Applied, ct);
-            (prNumber, prUrl) = await OpenPullRequestAsync(client, branch, request, result, ct);
+            await prClient.CommitFileAsync(
+                client, opts.Owner, opts.Repo, catalogPath, branch,
+                fileSha, result.Text, BuildCommitMessage(request, result.Applied), ct);
+            (prNumber, prUrl) = await prClient.OpenPullRequestAsync(
+                client, opts.Owner, opts.Repo, branch, opts.BaseBranch,
+                $"i18n({request.Locale}): {result.Applied} translation{(result.Applied == 1 ? "" : "s")} via in-app contribution",
+                BuildPrBody(request, result), ct);
         }
         catch
         {
-            await TryDeleteBranchAsync(client, branch);
+            await prClient.TryDeleteBranchAsync(client, opts.Owner, opts.Repo, branch);
             throw;
         }
 
@@ -111,154 +120,11 @@ public partial class GitHubTranslationService(
             ?? throw new InvalidOperationException("Failed to deserialize relay response");
     }
 
-    private async Task<(string Text, string Sha)> GetCatalogAsync(
-        HttpClient client, string path, CancellationToken ct)
-    {
-        var opts = options.Value;
-        // The contents API caps files at 1 MB; the largest catalog is ~0.9 MB
-        // today. If catalogs outgrow that, switch to the blobs API.
-        var response = await client.GetAsync(
-            $"/repos/{opts.Owner}/{opts.Repo}/contents/{path}?ref={Uri.EscapeDataString(opts.BaseBranch)}", ct);
 
-        if (!response.IsSuccessStatusCode)
-        {
-            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
-                throw new TranslationContributionRejectedException($"No catalog exists for this locale ({path}).");
-            var error = await response.Content.ReadAsStringAsync(ct);
-            logger.LogError("GitHub API error fetching catalog: {StatusCode} {Error}", response.StatusCode, error);
-            throw new InvalidOperationException($"GitHub API error: {response.StatusCode}");
-        }
+    internal static string SanitizeMetadata(string value) => GitHubPrClient.SanitizeMetadata(value);
 
-        var file = await response.Content.ReadFromJsonAsync<GitHubContentResponse>(ct)
-            ?? throw new InvalidOperationException("Failed to deserialize GitHub content response");
-        var text = Encoding.UTF8.GetString(Convert.FromBase64String(file.Content.Replace("\n", "")));
-        return (text, file.Sha);
-    }
-
-    private async Task<string> GetBranchShaAsync(HttpClient client, string branch, CancellationToken ct)
-    {
-        var opts = options.Value;
-        var response = await client.GetAsync(
-            $"/repos/{opts.Owner}/{opts.Repo}/git/ref/heads/{branch}", ct);
-        response.EnsureSuccessStatusCode();
-        var reference = await response.Content.ReadFromJsonAsync<GitHubRefResponse>(ct)
-            ?? throw new InvalidOperationException("Failed to deserialize GitHub ref response");
-        return reference.Object.Sha;
-    }
-
-    private async Task CreateBranchAsync(HttpClient client, string branch, string sha, CancellationToken ct)
-    {
-        var opts = options.Value;
-        var response = await client.PostAsJsonAsync(
-            $"/repos/{opts.Owner}/{opts.Repo}/git/refs",
-            new { @ref = $"refs/heads/{branch}", sha }, ct);
-        if (!response.IsSuccessStatusCode)
-        {
-            var error = await response.Content.ReadAsStringAsync(ct);
-            logger.LogError("GitHub API error creating branch: {StatusCode} {Error}", response.StatusCode, error);
-            throw new InvalidOperationException($"GitHub API error: {response.StatusCode}");
-        }
-    }
-
-    private async Task CommitCatalogAsync(
-        HttpClient client, string path, string branch, string fileSha,
-        string newText, TranslationContributionRequest request, int applied, CancellationToken ct)
-    {
-        var opts = options.Value;
-        var message = BuildCommitMessage(request, applied);
-
-        var response = await client.PutAsJsonAsync(
-            $"/repos/{opts.Owner}/{opts.Repo}/contents/{path}",
-            new
-            {
-                message,
-                content = Convert.ToBase64String(Encoding.UTF8.GetBytes(newText)),
-                sha = fileSha,
-                branch,
-            }, ct);
-
-        if (!response.IsSuccessStatusCode)
-        {
-            var error = await response.Content.ReadAsStringAsync(ct);
-            logger.LogError("GitHub API error committing catalog: {StatusCode} {Error}", response.StatusCode, error);
-            throw new InvalidOperationException($"GitHub API error: {response.StatusCode}");
-        }
-    }
-
-    private async Task<(int Number, string Url)> OpenPullRequestAsync(
-        HttpClient client, string branch, TranslationContributionRequest request,
-        PoEditResult result, CancellationToken ct)
-    {
-        var opts = options.Value;
-        var response = await client.PostAsJsonAsync(
-            $"/repos/{opts.Owner}/{opts.Repo}/pulls",
-            new
-            {
-                title = $"i18n({request.Locale}): {result.Applied} translation{(result.Applied == 1 ? "" : "s")} via in-app contribution",
-                head = branch,
-                @base = opts.BaseBranch,
-                body = BuildPrBody(request, result),
-                maintainer_can_modify = true,
-            }, ct);
-
-        if (!response.IsSuccessStatusCode)
-        {
-            var error = await response.Content.ReadAsStringAsync(ct);
-            logger.LogError("GitHub API error opening PR: {StatusCode} {Error}", response.StatusCode, error);
-            throw new InvalidOperationException($"GitHub API error: {response.StatusCode}");
-        }
-
-        var pr = await response.Content.ReadFromJsonAsync<GitHubPullResponse>(ct)
-            ?? throw new InvalidOperationException("Failed to deserialize GitHub PR response");
-        return (pr.Number, pr.HtmlUrl);
-    }
-
-    /// <summary>Defense in depth behind controller validation.</summary>
-    internal static string SanitizeMetadata(string value) =>
-        new([.. value.Trim().Where(c => !char.IsControl(c) && c is not '<' and not '>')]);
-
-    /// <summary>
-    /// Renders a contributor-supplied display name for a sink GitHub gives
-    /// side effects to. The name arrives from an anonymous relay, so
-    /// <c>Jane fixes #12 cc @someone</c> would otherwise auto-close an issue
-    /// and notify arbitrary users from the upstream PR body and from the
-    /// commit message. A commit message is not markdown — a backslash escape
-    /// would render literally there — so the reference-carrying characters
-    /// are dropped instead of escaped when <paramref name="markdown"/> is
-    /// false. The backslash is escaped first so a submitted <c>\</c> cannot
-    /// consume the escape that follows it.
-    ///
-    /// <c>#</c> handling covers <c>#12</c> and <c>owner/repo#12</c>, but
-    /// GitHub resolves two further reference forms that carry no <c>#</c> and
-    /// no <c>@</c>: the <c>GH-12</c> shorthand and a full issue or pull URL.
-    /// Both fit inside a name and both honour closing keywords, so both are
-    /// removed outright — a person's name legitimately contains neither.
-    /// </summary>
-    internal static string RenderName(string name, bool markdown)
-    {
-        var value = SanitizeMetadata(name);
-        value = markdown
-            ? value.Replace("\\", "\\\\").Replace("@", "\\@").Replace("#", "\\#").Replace("`", "\\`")
-            : new string([.. value.Where(c => c is not '@' and not '#')]);
-
-        // Last, because dropping a "#" above can splice a reference back
-        // together ("htt#ps://…", "GH#-1"). Neither pass can recreate the
-        // other's target: URL removal only deletes, and separating "GH" from
-        // its digits cannot produce a "://".
-        value = UrlReference().Replace(value, "");
-        return GitHubShorthandReference().Replace(value, "$1 ").Trim();
-    }
-
-    [GeneratedRegex(@"https?://\S+", RegexOptions.IgnoreCase)]
-    private static partial Regex UrlReference();
-
-    /// <summary>
-    /// The <c>GH-123</c> shorthand. Only the hyphen is replaced: the autolink
-    /// requires <c>GH-</c> immediately followed by a digit, so a space between
-    /// them leaves nothing for GitHub to resolve while the name stays readable.
-    /// </summary>
-    [GeneratedRegex(@"(GH)-(?=\d)", RegexOptions.IgnoreCase)]
-    private static partial Regex GitHubShorthandReference();
+    internal static string RenderName(string name, bool markdown) =>
+        GitHubPrClient.RenderName(name, markdown);
 
     /// <summary>
     /// Renders free-text contributor input inside a fenced code block.
@@ -313,19 +179,8 @@ public partial class GitHubTranslationService(
         return sb.ToString();
     }
 
-    internal static string? CoAuthorTrailer(TranslationContributorDto contributor)
-    {
-        if (!string.IsNullOrWhiteSpace(contributor.GitHubUsername))
-        {
-            var username = SanitizeMetadata(contributor.GitHubUsername);
-            return $"Co-authored-by: {username} <{username}@users.noreply.github.com>";
-        }
-
-        if (!string.IsNullOrWhiteSpace(contributor.Email))
-            return $"Co-authored-by: {RenderName(contributor.Name, markdown: false)} <{SanitizeMetadata(contributor.Email)}>";
-
-        return null;
-    }
+    internal static string? CoAuthorTrailer(TranslationContributorDto contributor) =>
+        GitHubPrClient.CoAuthorTrailer(contributor);
 
     internal static string BuildPrBody(TranslationContributionRequest request, PoEditResult result)
     {
@@ -372,47 +227,7 @@ public partial class GitHubTranslationService(
         return sb.ToString();
     }
 
-    private async Task TryDeleteBranchAsync(HttpClient client, string branch)
-    {
-        var opts = options.Value;
-        try
-        {
-            await client.DeleteAsync(
-                $"/repos/{opts.Owner}/{opts.Repo}/git/refs/heads/{branch}");
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Failed to clean up branch {Branch} after error", branch);
-        }
-    }
 
-    private record GitHubContentResponse
-    {
-        [JsonPropertyName("content")]
-        public string Content { get; init; } = "";
-        [JsonPropertyName("sha")]
-        public string Sha { get; init; } = "";
-    }
-
-    private record GitHubRefResponse
-    {
-        [JsonPropertyName("object")]
-        public GitHubRefObject Object { get; init; } = new();
-    }
-
-    private record GitHubRefObject
-    {
-        [JsonPropertyName("sha")]
-        public string Sha { get; init; } = "";
-    }
-
-    private record GitHubPullResponse
-    {
-        [JsonPropertyName("number")]
-        public int Number { get; init; }
-        [JsonPropertyName("html_url")]
-        public string HtmlUrl { get; init; } = "";
-    }
 }
 
 public class TranslationContributionRejectedException(string message) : Exception(message);

--- a/src/API/Nocturne.API/Services/TranslationDraftService.cs
+++ b/src/API/Nocturne.API/Services/TranslationDraftService.cs
@@ -123,7 +123,7 @@ public class TranslationDraftService(
     }
 
     public async Task<TranslationDraftSubmitResult> SubmitDraftsAsync(
-        string locale, TranslationContributorDto contributor, string? note, CancellationToken ct = default)
+        string locale, ContributionContributorDto contributor, string? note, CancellationToken ct = default)
     {
         var drafts = await LoadForLocaleAsync(locale, ct);
 

--- a/src/API/Nocturne.API/Services/TranslationDraftService.cs
+++ b/src/API/Nocturne.API/Services/TranslationDraftService.cs
@@ -128,7 +128,7 @@ public class TranslationDraftService(
         var drafts = await LoadForLocaleAsync(locale, ct);
 
         if (drafts.Count == 0)
-            throw new TranslationContributionRejectedException("There are no drafts to submit for this locale.");
+            throw new ContributionRejectedException("There are no drafts to submit for this locale.");
 
         // Remember each draft's revision so an edit that lands while the
         // (multi-second) PR flow runs is kept instead of silently deleted.

--- a/src/Core/Nocturne.Core.Contracts/Content/IContentContributionService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Content/IContentContributionService.cs
@@ -1,0 +1,15 @@
+using Nocturne.Core.Models.Content;
+
+namespace Nocturne.Core.Contracts.Content;
+
+/// <summary>
+/// Turns a CMS content contribution (blog/docs .svx) into an upstream pull
+/// request, either directly (instance has a PAT) or by relaying to
+/// nocturne.run — the same split as translation contributions.
+/// </summary>
+public interface IContentContributionService
+{
+    bool HasLocalPat { get; }
+    Task<ContentContributionResponse> SubmitAsync(ContentContributionRequest request, CancellationToken ct);
+    Task<ContentContributionResponse> RelayAsync(ContentContributionRequest request, CancellationToken ct);
+}

--- a/src/Core/Nocturne.Core.Contracts/Content/IContentContributionService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Content/IContentContributionService.cs
@@ -10,6 +10,9 @@ namespace Nocturne.Core.Contracts.Content;
 public interface IContentContributionService
 {
     bool HasLocalPat { get; }
+
+    /// <summary>Whether the anonymous relay ingress is open on this instance.</summary>
+    bool AcceptsRelay { get; }
     Task<ContentContributionResponse> SubmitAsync(ContentContributionRequest request, CancellationToken ct);
     Task<ContentContributionResponse> RelayAsync(ContentContributionRequest request, CancellationToken ct);
 }

--- a/src/Core/Nocturne.Core.Contracts/Translations/ITranslationDraftService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Translations/ITranslationDraftService.cs
@@ -37,5 +37,5 @@ public interface ITranslationDraftService
     /// the work is not lost.
     /// </summary>
     Task<TranslationDraftSubmitResult> SubmitDraftsAsync(
-        string locale, TranslationContributorDto contributor, string? note, CancellationToken ct = default);
+        string locale, ContributionContributorDto contributor, string? note, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Models/Content/ContentContribution.cs
+++ b/src/Core/Nocturne.Core.Models/Content/ContentContribution.cs
@@ -1,0 +1,23 @@
+using Nocturne.Core.Models.Translations;
+
+namespace Nocturne.Core.Models.Content;
+
+public record ContentContributionRequest
+{
+    /// <summary>Repo-relative path of the .svx file to create or update.</summary>
+    public required string Path { get; init; }
+    /// <summary>Full new file content (frontmatter + body).</summary>
+    public required string Content { get; init; }
+    /// <summary>Short human title for the pull request.</summary>
+    public required string Title { get; init; }
+    public required TranslationContributorDto Contributor { get; init; }
+    public string? Note { get; init; }
+}
+
+public record ContentContributionResponse
+{
+    public int PrNumber { get; init; }
+    public string PrUrl { get; init; } = "";
+    /// <summary>True when the file did not exist on the base branch.</summary>
+    public bool Created { get; init; }
+}

--- a/src/Core/Nocturne.Core.Models/Content/ContentContribution.cs
+++ b/src/Core/Nocturne.Core.Models/Content/ContentContribution.cs
@@ -6,11 +6,9 @@ public record ContentContributionRequest
 {
     /// <summary>Repo-relative path of the .svx file to create or update.</summary>
     public required string Path { get; init; }
-    /// <summary>Full new file content (frontmatter + body).</summary>
     public required string Content { get; init; }
-    /// <summary>Short human title for the pull request.</summary>
     public required string Title { get; init; }
-    public required TranslationContributorDto Contributor { get; init; }
+    public required ContributionContributorDto Contributor { get; init; }
     public string? Note { get; init; }
 }
 

--- a/src/Core/Nocturne.Core.Models/Translations/TranslationContribution.cs
+++ b/src/Core/Nocturne.Core.Models/Translations/TranslationContribution.cs
@@ -8,7 +8,7 @@ public record TranslationEntryDto
     public required List<string> Translations { get; init; }
 }
 
-public record TranslationContributorDto
+public record ContributionContributorDto
 {
     public required string Name { get; init; }
     public string? GitHubUsername { get; init; }
@@ -19,7 +19,7 @@ public record TranslationContributionRequest
 {
     public required string Locale { get; init; }
     public required List<TranslationEntryDto> Entries { get; init; }
-    public required TranslationContributorDto Contributor { get; init; }
+    public required ContributionContributorDto Contributor { get; init; }
     public string? Note { get; init; }
 }
 

--- a/src/Web/packages/portal/src/routes/studio/+page.svelte
+++ b/src/Web/packages/portal/src/routes/studio/+page.svelte
@@ -94,7 +94,10 @@
   }
 
   function cancelProposal() {
-    proposal?.reject(new Error('Proposal cancelled'));
+    // Cancelling is a normal outcome (the local draft is kept), so resolve
+    // rather than reject: ContentEditor awaits publish without a catch and a
+    // rejection would surface as an unhandled promise rejection.
+    proposal?.resolve();
     proposal = null;
     proposeError = null;
   }
@@ -195,6 +198,9 @@
       const title = String(item.metadata.title || slug);
       const svxContent = toSvx(item.metadata, item.content);
 
+      // Settle any dialog already open so its awaiting publish call cannot
+      // leak as a forever-pending promise.
+      proposal?.resolve();
       await new Promise<void>((resolve, reject) => {
         proposal = { slug, title, content: svxContent, resolve, reject };
       });

--- a/src/Web/packages/portal/src/routes/studio/+page.svelte
+++ b/src/Web/packages/portal/src/routes/studio/+page.svelte
@@ -27,7 +27,6 @@
     title: string;
     content: string;
     resolve: () => void;
-    reject: (e: Error) => void;
   }
 
   let proposal = $state<Proposal | null>(null);
@@ -201,8 +200,8 @@
       // Settle any dialog already open so its awaiting publish call cannot
       // leak as a forever-pending promise.
       proposal?.resolve();
-      await new Promise<void>((resolve, reject) => {
-        proposal = { slug, title, content: svxContent, resolve, reject };
+      await new Promise<void>((resolve) => {
+        proposal = { slug, title, content: svxContent, resolve };
       });
     },
 

--- a/src/Web/packages/portal/src/routes/studio/+page.svelte
+++ b/src/Web/packages/portal/src/routes/studio/+page.svelte
@@ -20,6 +20,84 @@
   };
 
   const STORAGE_KEY = 'nocturne-studio-blog';
+  const CONTRIBUTOR_KEY = 'nocturne-studio-contributor';
+
+  interface Proposal {
+    slug: string;
+    title: string;
+    content: string;
+    resolve: () => void;
+    reject: (e: Error) => void;
+  }
+
+  let proposal = $state<Proposal | null>(null);
+  let proposing = $state(false);
+  let proposeError = $state<string | null>(null);
+  let proposedPr = $state<{ url: string; number: number } | null>(null);
+  let contributorName = $state('');
+  let contributorGitHub = $state('');
+  let contributorEmail = $state('');
+  let proposalNote = $state('');
+
+  $effect(() => {
+    try {
+      const stored = JSON.parse(localStorage.getItem(CONTRIBUTOR_KEY) || '{}');
+      contributorName = stored.name ?? '';
+      contributorGitHub = stored.gitHubUsername ?? '';
+      contributorEmail = stored.email ?? '';
+    } catch {
+      // Ignore malformed stored contributor info.
+    }
+  });
+
+  async function submitProposal() {
+    if (!proposal) return;
+    proposing = true;
+    proposeError = null;
+    try {
+      localStorage.setItem(
+        CONTRIBUTOR_KEY,
+        JSON.stringify({
+          name: contributorName,
+          gitHubUsername: contributorGitHub,
+          email: contributorEmail,
+        }),
+      );
+      const res = await fetch('/studio/propose', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          slug: proposal.slug,
+          title: proposal.title,
+          content: proposal.content,
+          contributor: {
+            name: contributorName,
+            gitHubUsername: contributorGitHub || null,
+            email: contributorEmail || null,
+          },
+          note: proposalNote || null,
+        }),
+      });
+      if (!res.ok) {
+        const detail = await res.text().catch(() => '');
+        throw new Error(detail || 'Failed to propose the change');
+      }
+      const result = await res.json();
+      proposedPr = { url: result.prUrl ?? '', number: result.prNumber ?? 0 };
+      proposal.resolve();
+      proposal = null;
+    } catch (e) {
+      proposeError = e instanceof Error ? e.message : 'Failed to propose the change';
+    } finally {
+      proposing = false;
+    }
+  }
+
+  function cancelProposal() {
+    proposal?.reject(new Error('Proposal cancelled'));
+    proposal = null;
+    proposeError = null;
+  }
 
   function getStorage(): Record<string, ContentData> {
     try {
@@ -106,28 +184,20 @@
     },
 
     async publish(id: string) {
-      // Load from localStorage (where edits live)
+      // "Publish" proposes the draft to the Nocturne repo as a pull request
+      // through the content-contribution relay. The local draft is kept: the
+      // published file only changes once the PR merges.
       const storage = getStorage();
       const item = storage[id];
       if (!item) return;
 
       const slug = String(item.metadata.slug || id);
+      const title = String(item.metadata.title || slug);
       const svxContent = toSvx(item.metadata, item.content);
 
-      const res = await fetch('/studio/publish', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ slug, content: svxContent }),
+      await new Promise<void>((resolve, reject) => {
+        proposal = { slug, title, content: svxContent, resolve, reject };
       });
-
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({ message: 'Failed to publish' }));
-        throw new Error(err.message || 'Failed to publish');
-      }
-
-      // Clear from localStorage after successful publish
-      delete storage[id];
-      setStorage(storage);
     },
 
     async create(metadata: Record<string, unknown>): Promise<string> {
@@ -150,4 +220,99 @@
   <title>Studio - Nocturne</title>
 </svelte:head>
 
+{#if proposedPr}
+  <div class="flex items-center justify-between gap-3 border-b border-border bg-muted/50 px-4 py-2 text-sm">
+    <span>
+      Proposed as pull request
+      {#if proposedPr.url}
+        <a
+          href={proposedPr.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-primary underline underline-offset-4"
+        >
+          #{proposedPr.number}
+        </a>
+      {/if}
+      — the post updates once the pull request merges.
+    </span>
+    <button
+      type="button"
+      class="text-muted-foreground hover:text-foreground"
+      onclick={() => (proposedPr = null)}
+    >
+      Dismiss
+    </button>
+  </div>
+{/if}
+
 <ContentEditor {config} {callbacks} components={portalComponents} previewComponentMap={previewComponents} />
+
+{#if proposal}
+  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+    <div class="w-full max-w-lg space-y-4 rounded-lg border border-border bg-background p-6 shadow-lg">
+      <div>
+        <h2 class="text-lg font-semibold">Propose as pull request</h2>
+        <p class="mt-1 text-sm text-muted-foreground">
+          "{proposal.title}" is proposed to the Nocturne project as a pull
+          request. Your name appears in the commit credit.
+        </p>
+      </div>
+      <div class="space-y-3">
+        <label class="block space-y-1 text-sm">
+          <span>Name</span>
+          <input
+            class="w-full rounded-md border border-input bg-background px-3 py-2"
+            bind:value={contributorName}
+            placeholder="Your name"
+          />
+        </label>
+        <label class="block space-y-1 text-sm">
+          <span>GitHub username (optional, used for commit co-author credit)</span>
+          <input
+            class="w-full rounded-md border border-input bg-background px-3 py-2"
+            bind:value={contributorGitHub}
+            placeholder="octocat"
+          />
+        </label>
+        <label class="block space-y-1 text-sm">
+          <span>Email (optional)</span>
+          <input
+            type="email"
+            class="w-full rounded-md border border-input bg-background px-3 py-2"
+            bind:value={contributorEmail}
+          />
+        </label>
+        <label class="block space-y-1 text-sm">
+          <span>Note to reviewers (optional)</span>
+          <textarea
+            class="w-full rounded-md border border-input bg-background px-3 py-2"
+            rows="3"
+            bind:value={proposalNote}
+          ></textarea>
+        </label>
+        {#if proposeError}
+          <p class="text-sm text-destructive">{proposeError}</p>
+        {/if}
+      </div>
+      <div class="flex justify-end gap-2">
+        <button
+          type="button"
+          class="rounded-md border border-input px-4 py-2 text-sm"
+          onclick={cancelProposal}
+          disabled={proposing}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground disabled:opacity-50"
+          onclick={submitProposal}
+          disabled={proposing || contributorName.trim().length === 0}
+        >
+          {proposing ? 'Proposing…' : 'Propose'}
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/src/Web/packages/portal/src/routes/studio/propose/+server.ts
+++ b/src/Web/packages/portal/src/routes/studio/propose/+server.ts
@@ -1,0 +1,48 @@
+import { dev } from '$app/environment';
+import { env } from '$env/dynamic/private';
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const prerender = false;
+
+/**
+ * Dev-only bridge from the Studio to the content-contribution relay: the
+ * portal is a static site with no production server, so proposing a PR from
+ * the Studio goes through this dev-server endpoint, which forwards to
+ * nocturne.run's anonymous content relay (or a local API via
+ * CONTENT_CONTRIBUTION_URL when developing the flow end to end).
+ */
+const CONTENT_DIR_PREFIX = 'src/Web/packages/portal/src/content/blog';
+const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
+export const POST: RequestHandler = async ({ request, fetch }) => {
+	if (!dev) {
+		throw error(403, 'Studio propose API is only available in development mode');
+	}
+
+	const body = await request.json();
+	const slug = String(body.slug ?? '');
+	if (!SLUG_PATTERN.test(slug)) {
+		throw error(400, 'Slug must be lowercase letters, digits and hyphens');
+	}
+
+	const target = env.CONTENT_CONTRIBUTION_URL || 'https://nocturne.run/api/v4/content/relay';
+	const response = await fetch(target, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			path: `${CONTENT_DIR_PREFIX}/${slug}.svx`,
+			content: String(body.content ?? ''),
+			title: String(body.title ?? slug),
+			contributor: body.contributor,
+			note: body.note ?? null,
+		}),
+	});
+
+	if (!response.ok) {
+		const detail = await response.text().catch(() => '');
+		throw error(response.status === 422 ? 422 : 502, detail || 'The contribution was rejected');
+	}
+
+	return json(await response.json());
+};

--- a/src/Web/packages/portal/src/routes/studio/propose/+server.ts
+++ b/src/Web/packages/portal/src/routes/studio/propose/+server.ts
@@ -11,9 +11,13 @@ export const prerender = false;
  * the Studio goes through this dev-server endpoint, which forwards to
  * nocturne.run's anonymous content relay (or a local API via
  * CONTENT_CONTRIBUTION_URL when developing the flow end to end).
+ *
+ * The Studio is a blog editor (blog metadata fields, blog collection), so the
+ * bridge only ever builds a blog path. The API's allowlist also admits
+ * `content/docs/**` because the relay serves any contribution tool, not just
+ * this one; nothing here is missing.
  */
 const CONTENT_DIR_PREFIX = 'src/Web/packages/portal/src/content/blog';
-const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 
 export const POST: RequestHandler = async ({ request, fetch }) => {
 	if (!dev) {
@@ -22,9 +26,6 @@ export const POST: RequestHandler = async ({ request, fetch }) => {
 
 	const body = await request.json();
 	const slug = String(body.slug ?? '');
-	if (!SLUG_PATTERN.test(slug)) {
-		throw error(400, 'Slug must be lowercase letters, digits and hyphens');
-	}
 
 	const target = env.CONTENT_CONTRIBUTION_URL || 'https://nocturne.run/api/v4/content/relay';
 	const response = await fetch(target, {
@@ -40,8 +41,18 @@ export const POST: RequestHandler = async ({ request, fetch }) => {
 	});
 
 	if (!response.ok) {
-		const detail = await response.text().catch(() => '');
-		throw error(response.status === 422 ? 422 : 502, detail || 'The contribution was rejected');
+		// The API owns the path and slug rules, so its rejection reason is the
+		// only useful message here. Unwrap the ProblemDetails so a dev sees the
+		// sentence rather than the envelope.
+		const raw = await response.text().catch(() => '');
+		let detail = raw;
+		try {
+			detail = JSON.parse(raw).detail || raw;
+		} catch {
+			// Not ProblemDetails; the raw body is the best available message.
+		}
+		const status = response.status === 422 || response.status === 400 ? response.status : 502;
+		throw error(status, detail || 'The contribution was rejected');
 	}
 
 	return json(await response.json());

--- a/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
@@ -291,6 +291,11 @@ public class V4WriteScopeGatingTests
 
             ["TranslationsController.SubmitContribution"] = NotDataCategory.OutboundOnly,
             ["TranslationsController.AcceptRelayedContribution"] = NotDataCategory.AnonymousByDeclaration,
+
+            // Same shape as the translation contribution routes: the content studio proposes a
+            // .svx file as an upstream pull request and stores nothing locally.
+            ["ContentContributionsController.SubmitContribution"] = NotDataCategory.OutboundOnly,
+            ["ContentContributionsController.AcceptRelayedContribution"] = NotDataCategory.AnonymousByDeclaration,
         };
 
     /// <summary>

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/ContentContributionsControllerValidationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/ContentContributionsControllerValidationTests.cs
@@ -1,0 +1,252 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Controllers.V4.Platform;
+using Nocturne.API.Services;
+using Nocturne.Core.Contracts.Content;
+using Nocturne.Core.Models.Content;
+using Nocturne.Core.Models.Translations;
+
+namespace Nocturne.API.Tests.Controllers.V4;
+
+/// <summary>
+/// <see cref="ContentContributionsController.Validate"/> is the only gate in
+/// front of the anonymous relay ingress: everything it lets through is
+/// committed to a file and a pull request on the upstream repository.
+/// </summary>
+public class ContentContributionsControllerValidationTests
+{
+    private const string ValidPath = "src/Web/packages/portal/src/content/blog/my-post.svx";
+
+    private static ContentContributionsController CreateController(
+        IContentContributionService? service = null) =>
+        new(
+            service ?? Mock.Of<IContentContributionService>(),
+            NullLogger<ContentContributionsController>.Instance)
+        {
+            ProblemDetailsFactory = new TestProblemDetailsFactory(),
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+        };
+
+    private static ContentContributionRequest Request(
+        string path = ValidPath,
+        string content = "---\ntitle: My Post\n---\n\nBody",
+        string title = "My Post",
+        string name = "Jane Doe",
+        string? note = null) => new()
+        {
+            Path = path,
+            Content = content,
+            Title = title,
+            Contributor = new ContributionContributorDto { Name = name },
+            Note = note,
+        };
+
+    private static string? Reject(ContentContributionRequest request)
+    {
+        var result = CreateController().Validate(request);
+        if (result is null) return null;
+        result.StatusCode.Should().Be(400);
+        return ((ProblemDetails)result.Value!).Detail;
+    }
+
+    [Fact]
+    public void Validate_Accepts_A_Well_Formed_Contribution()
+    {
+        Reject(Request()).Should().BeNull();
+    }
+
+    // --- path ------------------------------------------------------------
+
+    [Theory]
+    [InlineData("src/API/Nocturne.API/Program.cs")]
+    [InlineData(".github/workflows/deploy.yml")]
+    [InlineData("src/Web/packages/portal/src/content/blog/../../../secret.svx")]
+    public void Validate_Rejects_Paths_Outside_Portal_Content(string path)
+    {
+        Reject(Request(path: path)).Should().StartWith("Path must be");
+    }
+
+    [Fact]
+    public void Validate_Accepts_A_Path_At_The_Length_Cap()
+    {
+        Reject(Request(path: PathOfLength(ContributionValidation.MaxPathLength)))
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void Validate_Rejects_A_Path_One_Character_Over_The_Cap()
+    {
+        Reject(Request(path: PathOfLength(ContributionValidation.MaxPathLength + 1)))
+            .Should().StartWith("Path must be");
+    }
+
+    private static string PathOfLength(int length)
+    {
+        const string prefix = "src/Web/packages/portal/src/content/blog/";
+        const string suffix = ".svx";
+        return prefix + new string('a', length - prefix.Length - suffix.Length) + suffix;
+    }
+
+    // --- content ---------------------------------------------------------
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_Rejects_Empty_Content(string content)
+    {
+        Reject(Request(content: content)).Should().StartWith("Content is required");
+    }
+
+    [Fact]
+    public void Validate_Accepts_Content_At_The_Byte_Cap()
+    {
+        var content = new string('a', ContentContributionsController.MaxContentBytes);
+
+        Reject(Request(content: content)).Should().BeNull();
+    }
+
+    [Fact]
+    public void Validate_Rejects_Content_One_Byte_Over_The_Cap()
+    {
+        var content = new string('a', ContentContributionsController.MaxContentBytes + 1);
+
+        Reject(Request(content: content)).Should().StartWith("Content is required");
+    }
+
+    [Fact]
+    public void The_Content_Cap_Counts_Bytes_Not_Characters()
+    {
+        // "é" is one char but two UTF-8 bytes, so a string half the cap in
+        // characters is exactly the cap in bytes — and one more char is over.
+        // A Length check would admit twice the payload GitHub receives.
+        var atCap = new string('é', ContentContributionsController.MaxContentBytes / 2);
+        var overCap = atCap + 'é';
+
+        Reject(Request(content: atCap)).Should().BeNull();
+        Reject(Request(content: overCap)).Should().StartWith("Content is required");
+    }
+
+    // --- title -----------------------------------------------------------
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_Rejects_Empty_Titles(string title)
+    {
+        Reject(Request(title: title)).Should().StartWith("Title is required");
+    }
+
+    [Fact]
+    public void Validate_Accepts_A_Title_At_The_Length_Cap()
+    {
+        var title = new string('t', ContentContributionsController.MaxTitleLength);
+
+        Reject(Request(title: title)).Should().BeNull();
+    }
+
+    [Fact]
+    public void Validate_Rejects_A_Title_One_Character_Over_The_Cap()
+    {
+        var title = new string('t', ContentContributionsController.MaxTitleLength + 1);
+
+        Reject(Request(title: title)).Should().StartWith("Title is required");
+    }
+
+    [Theory]
+    [InlineData("My\nPost")]
+    [InlineData("My\rPost")]
+    [InlineData("My\tPost")]
+    [InlineData("My\u0000Post")]
+    [InlineData("My\u007fPost")]
+    public void Validate_Rejects_Control_Characters_In_The_Title(string title)
+    {
+        // The title becomes the PR title, so a newline would let a submitter
+        // write the body from the title field.
+        Reject(Request(title: title)).Should().StartWith("Title is required");
+    }
+
+    // --- contributor -----------------------------------------------------
+
+    [Fact]
+    public void Validate_Rejects_A_Contributor_The_Shared_Validator_Rejects()
+    {
+        Reject(Request(name: "")).Should().StartWith("Contributor name is required");
+    }
+
+    [Fact]
+    public void Validate_Rejects_An_Overlong_Note()
+    {
+        var note = new string('n', ContributionValidation.MaxNoteLength + 1);
+
+        Reject(Request(note: note)).Should().StartWith("Note must be under");
+    }
+
+    // --- relay gate ------------------------------------------------------
+    // The relay is [AllowAnonymous]. This gate is the only thing keeping an
+    // instance that did not opt in from exposing an anonymous PR-opening
+    // endpoint. The two operands behind AcceptsRelay are pinned on the
+    // service, in GitHubContentServiceTests.
+
+    [Fact]
+    public async Task Relay_Is_NotFound_When_The_Service_Does_Not_Accept_Relay()
+    {
+        var service = new Mock<IContentContributionService>();
+
+        var result = await CreateController(service.Object)
+            .AcceptRelayedContribution(Request(), CancellationToken.None);
+
+        result.Result.Should().BeOfType<NotFoundResult>();
+        service.Verify(
+            s => s.SubmitAsync(It.IsAny<ContentContributionRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Relay_Submits_When_Opted_In_And_Able_To_Open_Prs()
+    {
+        var service = new Mock<IContentContributionService>();
+        service.SetupGet(s => s.AcceptsRelay).Returns(true);
+        service
+            .Setup(s => s.SubmitAsync(It.IsAny<ContentContributionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ContentContributionResponse { PrNumber = 7, PrUrl = "https://x/7", Created = true });
+
+        var result = await CreateController(service.Object)
+            .AcceptRelayedContribution(Request(), CancellationToken.None);
+
+        result.Result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(201);
+    }
+
+    [Fact]
+    public async Task Relay_Validates_Before_Reaching_The_Service()
+    {
+        var service = new Mock<IContentContributionService>();
+        service.SetupGet(s => s.AcceptsRelay).Returns(true);
+
+        var result = await CreateController(service.Object)
+            .AcceptRelayedContribution(Request(path: "src/API/Nocturne.API/Program.cs"), CancellationToken.None);
+
+        result.Result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(400);
+        service.Verify(
+            s => s.SubmitAsync(It.IsAny<ContentContributionRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private sealed class TestProblemDetailsFactory : ProblemDetailsFactory
+    {
+        public override ProblemDetails CreateProblemDetails(
+            HttpContext httpContext, int? statusCode = null, string? title = null,
+            string? type = null, string? detail = null, string? instance = null) =>
+            new() { Status = statusCode, Title = title, Type = type, Detail = detail, Instance = instance };
+
+        public override ValidationProblemDetails CreateValidationProblemDetails(
+            HttpContext httpContext, ModelStateDictionary modelStateDictionary, int? statusCode = null,
+            string? title = null, string? type = null, string? detail = null, string? instance = null) =>
+            new(modelStateDictionary) { Status = statusCode, Title = title, Type = type, Detail = detail, Instance = instance };
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/TranslationsControllerValidationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/TranslationsControllerValidationTests.cs
@@ -40,7 +40,7 @@ public class TranslationsControllerValidationTests
         {
             Locale = locale,
             Entries = entries ?? [new TranslationEntryDto { MsgId = "Hello", Translations = ["Bonjour"] }],
-            Contributor = new TranslationContributorDto
+            Contributor = new ContributionContributorDto
             {
                 Name = name,
                 GitHubUsername = gitHubUsername,

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/TranslationsControllerValidationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/TranslationsControllerValidationTests.cs
@@ -394,7 +394,15 @@ public class TranslationsControllerValidationTests
     [Fact]
     public void Validate_Rejects_Note_Over_The_Length_Cap()
     {
-        Reject(Request(note: new string('n', 2001))).Should().Be("Note must be under 2000 characters");
+        Reject(Request(note: new string('n', 2001)))
+            .Should().StartWith("Note must be under 2000 characters");
+    }
+
+    [Fact]
+    public void Validate_Rejects_Control_Chars_In_The_Note()
+    {
+        Reject(Request(note: "line one\u0000line two"))
+            .Should().StartWith("Note must be under 2000 characters");
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/GitHubContentServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/GitHubContentServiceTests.cs
@@ -19,6 +19,7 @@ public class GitHubContentServiceTests
     [InlineData("src/Web/packages/portal/src/content/blog/UPPER.svx", false)]
     [InlineData("src/Web/packages/portal/src/content/blog/.hidden.svx", false)]
     [InlineData("src/Web/packages/portal/src/content/blog//double.svx", false)]
+    [InlineData("src/Web/packages/portal/src/content/blog/post.svx\n", false)]
     public void AllowedPathPattern_Constrains_To_Portal_Content(string path, bool allowed)
     {
         GitHubContentService.AllowedPathPattern().IsMatch(path).Should().Be(allowed);

--- a/tests/Unit/Nocturne.API.Tests/Services/GitHubContentServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/GitHubContentServiceTests.cs
@@ -19,10 +19,40 @@ public class GitHubContentServiceTests
     [InlineData("src/Web/packages/portal/src/content/blog/UPPER.svx", false)]
     [InlineData("src/Web/packages/portal/src/content/blog/.hidden.svx", false)]
     [InlineData("src/Web/packages/portal/src/content/blog//double.svx", false)]
+    [InlineData("src/Web/packages/portal/src/content/blog/my-post.v2.svx", true)]
+    [InlineData("src/Web/packages/portal/src/content/docs/a_b/c-d.e.svx", true)]
+    // Consecutive separators would produce a branch name git refuses as a ref.
+    [InlineData("src/Web/packages/portal/src/content/blog/a..b.svx", false)]
+    [InlineData("src/Web/packages/portal/src/content/blog/a--b.svx", false)]
+    [InlineData("src/Web/packages/portal/src/content/blog/a._b.svx", false)]
+    [InlineData("src/Web/packages/portal/src/content/blog/post-.svx", false)]
+    [InlineData("src/Web/packages/portal/src/content/b..log/post.svx", false)]
     [InlineData("src/Web/packages/portal/src/content/blog/post.svx\n", false)]
     public void AllowedPathPattern_Constrains_To_Portal_Content(string path, bool allowed)
     {
         GitHubContentService.AllowedPathPattern().IsMatch(path).Should().Be(allowed);
+    }
+
+    /// <summary>
+    /// Every other negative case is rejected with or without the leading
+    /// anchor, so nothing proved the anchor was load-bearing: an unanchored
+    /// pattern would happily match this allowed suffix inside a hostile prefix.
+    /// </summary>
+    [Theory]
+    [InlineData("evil/src/Web/packages/portal/src/content/blog/x.svx")]
+    [InlineData("../src/Web/packages/portal/src/content/blog/x.svx")]
+    [InlineData("xsrc/Web/packages/portal/src/content/blog/x.svx")]
+    public void AllowedPathPattern_Is_Anchored_At_The_Start(string path)
+    {
+        GitHubContentService.AllowedPathPattern().IsMatch(path).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("src/Web/packages/portal/src/content/blog/my-post.svx", "my-post")]
+    [InlineData("src/Web/packages/portal/src/content/blog/post.2024.svx", "post-2024")]
+    public void BranchSlug_Reduces_The_Stem_To_A_Legal_Ref_Segment(string path, string expected)
+    {
+        GitHubContentService.BranchSlug(path).Should().Be(expected);
     }
 
     private static ContentContributionRequest Request() => new()

--- a/tests/Unit/Nocturne.API.Tests/Services/GitHubContentServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/GitHubContentServiceTests.cs
@@ -143,4 +143,42 @@ public class GitHubContentServiceTests
         var lines = message.Split('\n').Select(l => l.TrimEnd('\r')).ToList();
         lines.Should().NotContain(l => l.StartsWith("Signed-off-by"));
     }
+
+    [Fact]
+    public void PrBody_Gets_The_Same_Name_And_Note_Treatment_As_Translations()
+    {
+        const string note = "Fixes https://github.com/nightscout/nocturne/issues/123\n`x`";
+        var request = Request() with
+        {
+            Contributor = new TranslationContributorDto { Name = "Jane fixes #123 cc @someuser" },
+            Note = note,
+        };
+
+        var body = GitHubContentService.BuildPrBody(request, created: false);
+
+        // Both flows render through ContributionValidation, so the content PR
+        // body escapes the name and fences the note identically.
+        body.Should().Contain(@"- **Contributor:** Jane fixes \#123 cc \@someuser");
+        body.ReplaceLineEndings("\n").Should().Contain($"```\n{note}\n```");
+    }
+
+    [Fact]
+    public void CommitMessage_Drops_Mentions_And_References_From_The_Contributor_Name()
+    {
+        var request = Request() with
+        {
+            Contributor = new TranslationContributorDto
+            {
+                Name = "Jane fixes #123 cc @someuser",
+                Email = "jane@example.com",
+            },
+        };
+
+        var message = GitHubContentService.BuildCommitMessage(request, created: false);
+
+        message.Should().Contain("Contributed by Jane fixes 123 cc someuser");
+        message.Should().Contain("Co-authored-by: Jane fixes 123 cc someuser <jane@example.com>");
+        message.Should().NotContain("#123");
+        message.Should().NotContain("@someuser");
+    }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/GitHubContentServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/GitHubContentServiceTests.cs
@@ -1,0 +1,115 @@
+using Nocturne.API.Services;
+using Nocturne.Core.Models.Content;
+using Nocturne.Core.Models.Translations;
+
+namespace Nocturne.API.Tests.Services;
+
+public class GitHubContentServiceTests
+{
+    [Theory]
+    [InlineData("src/Web/packages/portal/src/content/blog/my-post.svx", true)]
+    [InlineData("src/Web/packages/portal/src/content/docs/authentication/github.svx", true)]
+    [InlineData("src/Web/packages/portal/src/content/docs/windows-widget.svx", true)]
+    [InlineData("src/Web/packages/portal/src/content/blog/post.2024.svx", true)]
+    [InlineData("src/Web/packages/portal/src/content/blog/../../../../API/Program.cs", false)]
+    [InlineData("src/Web/packages/portal/src/content/blog/post.md", false)]
+    [InlineData("src/Web/packages/portal/src/content/email/steal.svx", false)]
+    [InlineData("src/API/Nocturne.API/Program.cs", false)]
+    [InlineData(".github/workflows/deploy.yml", false)]
+    [InlineData("src/Web/packages/portal/src/content/blog/UPPER.svx", false)]
+    [InlineData("src/Web/packages/portal/src/content/blog/.hidden.svx", false)]
+    [InlineData("src/Web/packages/portal/src/content/blog//double.svx", false)]
+    public void AllowedPathPattern_Constrains_To_Portal_Content(string path, bool allowed)
+    {
+        GitHubContentService.AllowedPathPattern().IsMatch(path).Should().Be(allowed);
+    }
+
+    private static ContentContributionRequest Request() => new()
+    {
+        Path = "src/Web/packages/portal/src/content/blog/my-post.svx",
+        Content = "---\ntitle: My Post\n---\n\nBody",
+        Title = "My Post",
+        Contributor = new TranslationContributorDto { Name = "Jane Doe", GitHubUsername = "janedoe" },
+        Note = "First draft",
+    };
+
+    [Fact]
+    public void CommitMessage_Includes_Slug_Attribution_And_Trailer()
+    {
+        var message = GitHubContentService.BuildCommitMessage(Request(), created: true);
+
+        message.Should().StartWith("content: add my-post");
+        message.Should().Contain("Contributed by Jane Doe");
+        message.Should().Contain("Co-authored-by: janedoe <janedoe@users.noreply.github.com>");
+    }
+
+    [Fact]
+    public void PrBody_Lists_File_Contributor_And_Note()
+    {
+        var body = GitHubContentService.BuildPrBody(Request(), created: false);
+
+        body.Should().StartWith("Updated content");
+        body.Should().Contain("`src/Web/packages/portal/src/content/blog/my-post.svx`");
+        body.Should().Contain("**Contributor:** Jane Doe (@janedoe)");
+        body.Should().Contain("First draft");
+    }
+
+    [Fact]
+    public void PrBody_Removes_Url_And_Shorthand_References_From_The_Contributor_Name()
+    {
+        var request = Request() with
+        {
+            Contributor = new TranslationContributorDto
+            {
+                Name = "Jane fixes GH-123 see https://github.com/nightscout/nocturne/issues/456",
+            },
+        };
+
+        var body = GitHubContentService.BuildPrBody(request, created: true);
+
+        // Neither form carries a "#" or "@", so the escapes miss both: they
+        // would backlink at PR-open and auto-close on merge.
+        body.Should().Contain("**Contributor:** Jane fixes GH 123 see");
+        body.Should().NotContain("GH-123");
+        body.Should().NotContain("github.com");
+    }
+
+    [Fact]
+    public void CommitMessage_Removes_Url_And_Shorthand_References_From_The_Contributor_Name()
+    {
+        var request = Request() with
+        {
+            Contributor = new TranslationContributorDto
+            {
+                Name = "Jane htt#ps://github.com/nightscout/nocturne/issues/9 GH#-7",
+                Email = "jane@example.com",
+            },
+        };
+
+        var message = GitHubContentService.BuildCommitMessage(request, created: true);
+
+        // Dropping "#" reassembles both forms, so they have to be neutralised
+        // after that pass. The co-author trailer is a commit-message sink too.
+        message.Should().Contain("Contributed by Jane  GH 7 via the in-app content studio.");
+        message.Should().Contain("Co-authored-by: Jane  GH 7 <jane@example.com>");
+        message.Should().NotContain("github.com");
+        message.Should().NotContain("GH-7");
+    }
+
+    [Fact]
+    public void CommitMessage_Sanitizes_Injection_Attempts()
+    {
+        var request = Request() with
+        {
+            Contributor = new TranslationContributorDto
+            {
+                Name = "Jane\nSigned-off-by: maintainer <m@x>",
+            },
+        };
+
+        var message = GitHubContentService.BuildCommitMessage(request, created: false);
+
+        var lines = message.Split('\n').Select(l => l.TrimEnd('\r')).ToList();
+        lines.Should().NotContain(l => l.StartsWith("Signed-off-by"));
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/GitHubContentServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/GitHubContentServiceTests.cs
@@ -1,3 +1,6 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
 using Nocturne.API.Services;
 using Nocturne.Core.Models.Content;
 using Nocturne.Core.Models.Translations;
@@ -6,6 +9,29 @@ namespace Nocturne.API.Tests.Services;
 
 public class GitHubContentServiceTests
 {
+    // The relay is [AllowAnonymous]; each operand of the gate is pinned on its
+    // own, so flipping either sense or the && to an || fails one of these.
+    [Theory]
+    [InlineData(false, null, false)]
+    [InlineData(true, null, false)]
+    [InlineData(false, "pat", false)]
+    [InlineData(true, "pat", true)]
+    public void AcceptsRelay_Needs_Both_The_Opt_In_And_A_Local_Pat(
+        bool optedIn, string? pat, bool expected)
+    {
+        var options = Options.Create(new GitHubContributionOptions
+        {
+            AcceptRelayedContributions = optedIn,
+            ContributionsPat = pat,
+        });
+        var httpClientFactory = Mock.Of<IHttpClientFactory>();
+
+        new GitHubContentService(
+            new GitHubPrClient(httpClientFactory, NullLogger<GitHubPrClient>.Instance),
+            httpClientFactory, options, NullLogger<GitHubContentService>.Instance)
+            .AcceptsRelay.Should().Be(expected);
+    }
+
     [Theory]
     [InlineData("src/Web/packages/portal/src/content/blog/my-post.svx", true)]
     [InlineData("src/Web/packages/portal/src/content/docs/authentication/github.svx", true)]
@@ -21,7 +47,9 @@ public class GitHubContentServiceTests
     [InlineData("src/Web/packages/portal/src/content/blog//double.svx", false)]
     [InlineData("src/Web/packages/portal/src/content/blog/my-post.v2.svx", true)]
     [InlineData("src/Web/packages/portal/src/content/docs/a_b/c-d.e.svx", true)]
-    // Consecutive separators would produce a branch name git refuses as a ref.
+    // Consecutive separators are rejected to keep the stem, the slug and the
+    // branch name the same recognisable string, not because they would be
+    // unsafe: BranchSlug already reduces them to a legal ref.
     [InlineData("src/Web/packages/portal/src/content/blog/a..b.svx", false)]
     [InlineData("src/Web/packages/portal/src/content/blog/a--b.svx", false)]
     [InlineData("src/Web/packages/portal/src/content/blog/a._b.svx", false)]
@@ -34,9 +62,8 @@ public class GitHubContentServiceTests
     }
 
     /// <summary>
-    /// Every other negative case is rejected with or without the leading
-    /// anchor, so nothing proved the anchor was load-bearing: an unanchored
-    /// pattern would happily match this allowed suffix inside a hostile prefix.
+    /// Pins the leading anchor: every one of these carries an allowed suffix
+    /// behind a hostile prefix, so an unanchored pattern would match them all.
     /// </summary>
     [Theory]
     [InlineData("evil/src/Web/packages/portal/src/content/blog/x.svx")]
@@ -50,6 +77,9 @@ public class GitHubContentServiceTests
     [Theory]
     [InlineData("src/Web/packages/portal/src/content/blog/my-post.svx", "my-post")]
     [InlineData("src/Web/packages/portal/src/content/blog/post.2024.svx", "post-2024")]
+    // The allowlist rejects this stem, but only for slug predictability: were
+    // it admitted, the branch name would still be a legal ref.
+    [InlineData("src/Web/packages/portal/src/content/blog/a..b.svx", "a--b")]
     public void BranchSlug_Reduces_The_Stem_To_A_Legal_Ref_Segment(string path, string expected)
     {
         GitHubContentService.BranchSlug(path).Should().Be(expected);
@@ -60,7 +90,7 @@ public class GitHubContentServiceTests
         Path = "src/Web/packages/portal/src/content/blog/my-post.svx",
         Content = "---\ntitle: My Post\n---\n\nBody",
         Title = "My Post",
-        Contributor = new TranslationContributorDto { Name = "Jane Doe", GitHubUsername = "janedoe" },
+        Contributor = new ContributionContributorDto { Name = "Jane Doe", GitHubUsername = "janedoe" },
         Note = "First draft",
     };
 
@@ -90,7 +120,7 @@ public class GitHubContentServiceTests
     {
         var request = Request() with
         {
-            Contributor = new TranslationContributorDto
+            Contributor = new ContributionContributorDto
             {
                 Name = "Jane fixes GH-123 see https://github.com/nightscout/nocturne/issues/456",
             },
@@ -110,7 +140,7 @@ public class GitHubContentServiceTests
     {
         var request = Request() with
         {
-            Contributor = new TranslationContributorDto
+            Contributor = new ContributionContributorDto
             {
                 Name = "Jane htt#ps://github.com/nightscout/nocturne/issues/9 GH#-7",
                 Email = "jane@example.com",
@@ -132,7 +162,7 @@ public class GitHubContentServiceTests
     {
         var request = Request() with
         {
-            Contributor = new TranslationContributorDto
+            Contributor = new ContributionContributorDto
             {
                 Name = "Jane\nSigned-off-by: maintainer <m@x>",
             },
@@ -150,14 +180,12 @@ public class GitHubContentServiceTests
         const string note = "Fixes https://github.com/nightscout/nocturne/issues/123\n`x`";
         var request = Request() with
         {
-            Contributor = new TranslationContributorDto { Name = "Jane fixes #123 cc @someuser" },
+            Contributor = new ContributionContributorDto { Name = "Jane fixes #123 cc @someuser" },
             Note = note,
         };
 
         var body = GitHubContentService.BuildPrBody(request, created: false);
 
-        // Both flows render through ContributionValidation, so the content PR
-        // body escapes the name and fences the note identically.
         body.Should().Contain(@"- **Contributor:** Jane fixes \#123 cc \@someuser");
         body.ReplaceLineEndings("\n").Should().Contain($"```\n{note}\n```");
     }
@@ -167,7 +195,7 @@ public class GitHubContentServiceTests
     {
         var request = Request() with
         {
-            Contributor = new TranslationContributorDto
+            Contributor = new ContributionContributorDto
             {
                 Name = "Jane fixes #123 cc @someuser",
                 Email = "jane@example.com",

--- a/tests/Unit/Nocturne.API.Tests/Services/GitHubPrClientTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/GitHubPrClientTests.cs
@@ -1,0 +1,66 @@
+using System.Net;
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services;
+
+namespace Nocturne.API.Tests.Services;
+
+public class GitHubPrClientTests
+{
+    private static (GitHubPrClient Client, HttpClient Http, List<string> Bodies) CreateClient()
+    {
+        var bodies = new List<string>();
+        var handler = new CapturingHandler(bodies);
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.github.com") };
+
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(http);
+
+        return (new GitHubPrClient(factory.Object, NullLogger<GitHubPrClient>.Instance), http, bodies);
+    }
+
+    [Fact]
+    public async Task CommitFileAsync_Omits_Sha_When_Creating_A_File()
+    {
+        var (prClient, http, bodies) = CreateClient();
+
+        await prClient.CommitFileAsync(
+            http, "nightscout", "nocturne", "src/Web/packages/portal/src/content/blog/new.svx",
+            "content/new-abc", fileSha: null, "body", "content: add new", CancellationToken.None);
+
+        // The contents API rejects an explicit null sha with a 422, so the key
+        // has to be absent — not present-and-null.
+        var payload = JsonDocument.Parse(bodies.Single()).RootElement;
+        payload.TryGetProperty("sha", out _).Should().BeFalse();
+        payload.GetProperty("branch").GetString().Should().Be("content/new-abc");
+    }
+
+    [Fact]
+    public async Task CommitFileAsync_Sends_Sha_When_Updating_A_File()
+    {
+        var (prClient, http, bodies) = CreateClient();
+
+        await prClient.CommitFileAsync(
+            http, "nightscout", "nocturne", "src/Web/locales/fr.po",
+            "translations/fr-abc", fileSha: "deadbeef", "body", "chore(i18n): fr", CancellationToken.None);
+
+        var payload = JsonDocument.Parse(bodies.Single()).RootElement;
+        payload.GetProperty("sha").GetString().Should().Be("deadbeef");
+    }
+
+    private sealed class CapturingHandler(List<string> bodies) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Content is not null)
+                bodies.Add(await request.Content.ReadAsStringAsync(cancellationToken));
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}"),
+            };
+        }
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/GitHubPrClientTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/GitHubPrClientTests.cs
@@ -29,8 +29,6 @@ public class GitHubPrClientTests
             http, "nightscout", "nocturne", "src/Web/packages/portal/src/content/blog/new.svx",
             "content/new-abc", fileSha: null, "body", "content: add new", CancellationToken.None);
 
-        // The contents API rejects an explicit null sha with a 422, so the key
-        // has to be absent — not present-and-null.
         var payload = JsonDocument.Parse(bodies.Single()).RootElement;
         payload.TryGetProperty("sha", out _).Should().BeFalse();
         payload.GetProperty("branch").GetString().Should().Be("content/new-abc");

--- a/tests/Unit/Nocturne.API.Tests/Services/GitHubTranslationServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/GitHubTranslationServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -8,8 +9,9 @@ namespace Nocturne.API.Tests.Services;
 
 public class GitHubTranslationServiceTests
 {
-    private static GitHubTranslationService Service(GitHubTranslationOptions options) =>
-        new(Mock.Of<IHttpClientFactory>(), Options.Create(options),
+    private static GitHubTranslationService Service(GitHubContributionOptions options) =>
+        new(new GitHubPrClient(Mock.Of<IHttpClientFactory>(), NullLogger<GitHubPrClient>.Instance),
+            Mock.Of<IHttpClientFactory>(), Options.Create(options),
             NullLogger<GitHubTranslationService>.Instance);
 
     [Theory]
@@ -20,10 +22,10 @@ public class GitHubTranslationServiceTests
     public void AcceptsRelay_Needs_Both_The_Opt_In_And_A_Local_Pat(
         bool optedIn, string? pat, bool expected)
     {
-        Service(new GitHubTranslationOptions
+        Service(new GitHubContributionOptions
         {
             AcceptRelayedContributions = optedIn,
-            TranslationsPat = pat,
+            ContributionsPat = pat,
         }).AcceptsRelay.Should().Be(expected);
     }
 
@@ -33,7 +35,7 @@ public class GitHubTranslationServiceTests
     {
         Locale = "fr",
         Entries = [new TranslationEntryDto { MsgId = "Hello", Translations = ["Bonjour"] }],
-        Contributor = new TranslationContributorDto
+        Contributor = new ContributionContributorDto
         {
             Name = name,
             GitHubUsername = gitHubUsername,
@@ -59,7 +61,7 @@ public class GitHubTranslationServiceTests
     [Fact]
     public void CoAuthorTrailer_Prefers_GitHub_Username()
     {
-        var trailer = GitHubTranslationService.CoAuthorTrailer(
+        var trailer = GitHubPrClient.CoAuthorTrailer(
             Request(gitHubUsername: "janedoe", email: "jane@example.com").Contributor);
 
         trailer.Should().Be("Co-authored-by: janedoe <janedoe@users.noreply.github.com>");
@@ -68,7 +70,7 @@ public class GitHubTranslationServiceTests
     [Fact]
     public void CoAuthorTrailer_Falls_Back_To_Email()
     {
-        var trailer = GitHubTranslationService.CoAuthorTrailer(
+        var trailer = GitHubPrClient.CoAuthorTrailer(
             Request(email: "jane@example.com").Contributor);
 
         trailer.Should().Be("Co-authored-by: Jane Doe <jane@example.com>");
@@ -77,7 +79,7 @@ public class GitHubTranslationServiceTests
     [Fact]
     public void CoAuthorTrailer_Is_Null_Without_Identity()
     {
-        GitHubTranslationService.CoAuthorTrailer(Request().Contributor).Should().BeNull();
+        GitHubPrClient.CoAuthorTrailer(Request().Contributor).Should().BeNull();
     }
 
     [Fact]
@@ -96,7 +98,7 @@ public class GitHubTranslationServiceTests
     {
         var request = Request() with
         {
-            Contributor = new TranslationContributorDto
+            Contributor = new ContributionContributorDto
             {
                 Name = "Jane\nCo-authored-by: victim <victim@example.com>",
                 Email = "jane@example.com\nSigned-off-by: maintainer <m@x>",
@@ -116,7 +118,7 @@ public class GitHubTranslationServiceTests
     [Fact]
     public void SanitizeMetadata_Removes_Control_Chars_And_Angle_Brackets()
     {
-        GitHubTranslationService.SanitizeMetadata("a\r\nb<c>d\te ")
+        GitHubPrClient.SanitizeMetadata("a\r\nb<c>d\te ")
             .Should().Be("abcde");
     }
 
@@ -304,5 +306,52 @@ public class GitHubTranslationServiceTests
 
         body.Should().Contain("`evil <img src=x> rest`");
         body.Should().NotContain(@"\`");
+    }
+
+    [Fact]
+    public async Task RelayAsync_Forwards_The_Relays_Own_Rejection_Reason()
+    {
+        // A relay 422 is not always an unmatched catalog: contributor
+        // validation on the far side rejects with the same status, and a
+        // hardcoded message would tell the contributor to refresh and retry
+        // when refreshing cannot help.
+        var service = RelayService(HttpStatusCode.UnprocessableEntity,
+            """{"detail":"Invalid GitHub username","status":422}""");
+
+        var act = () => service.RelayAsync(Request(), CancellationToken.None);
+
+        (await act.Should().ThrowAsync<ContributionRejectedException>())
+            .WithMessage("Invalid GitHub username");
+    }
+
+    [Fact]
+    public async Task RelayAsync_Falls_Back_When_The_Rejection_Carries_No_Detail()
+    {
+        var service = RelayService(HttpStatusCode.UnprocessableEntity, "not problem details");
+
+        var act = () => service.RelayAsync(Request(), CancellationToken.None);
+
+        (await act.Should().ThrowAsync<ContributionRejectedException>())
+            .WithMessage("The contribution was rejected by the relay.");
+    }
+
+    private static GitHubTranslationService RelayService(HttpStatusCode status, string body)
+    {
+        var http = new HttpClient(new StubHandler(status, body));
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(http);
+
+        return new GitHubTranslationService(
+            new GitHubPrClient(factory.Object, NullLogger<GitHubPrClient>.Instance),
+            factory.Object,
+            Options.Create(new GitHubContributionOptions()),
+            NullLogger<GitHubTranslationService>.Instance);
+    }
+
+    private sealed class StubHandler(HttpStatusCode status, string body) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(status) { Content = new StringContent(body) });
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/TranslationDraftServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/TranslationDraftServiceTests.cs
@@ -113,7 +113,7 @@ public class TranslationDraftServiceTests
     {
         var act = () => _service.SubmitDraftsAsync("fr", Contributor(), null);
 
-        await act.Should().ThrowAsync<TranslationContributionRejectedException>();
+        await act.Should().ThrowAsync<ContributionRejectedException>();
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/TranslationDraftServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/TranslationDraftServiceTests.cs
@@ -45,7 +45,7 @@ public class TranslationDraftServiceTests
         Translations = translation is null ? [] : [translation],
     };
 
-    private static TranslationContributorDto Contributor() => new() { Name = "Jane Doe" };
+    private static ContributionContributorDto Contributor() => new() { Name = "Jane Doe" };
 
     [Fact]
     public async Task UpsertDraftsAsync_Creates_And_Updates_By_Key()


### PR DESCRIPTION
## Summary

Stacked on #471 (which stacks on #470). Final piece of the contribution initiative: the content Studio's publish flow now proposes drafts to this repo as pull requests, through the same bot-PR machinery as translations.

- **`GitHubPrClient`** extracts the GitHub REST plumbing shared by both flows (fetch file / branch / commit / open PR / cleanup-on-failure, plus the metadata sanitization and Co-authored-by helpers). `GitHubTranslationService` shrinks to catalog logic + delegation — no behavior change (all 32 existing translation tests untouched and green).
- **`POST /api/v4/content/contributions`** (`[Authorize]`, rate-limited) and an anonymous **`/api/v4/content/relay`** ingress gated by the same `GitHub:AcceptRelayedContributions` + PAT opt-in as the translations relay. Direct mode commits the .svx to a `content/{slug}-*` branch (create or update via contents-API sha; identical content is rejected 422) and opens a PR with contributor attribution.
- **Path allowlist**: contributions can only touch `src/Web/packages/portal/src/content/{blog,docs}/**.svx` (conservative segment charset, no traversal), enforced both at validation and again inside the service since the relay is anonymously reachable. Content capped at 512 KB.
- **Studio wiring**: publish opens a contributor dialog (identity persisted locally), serializes the draft via `toSvx`, and posts to a dev-only `/studio/propose` endpoint that forwards to the relay (`CONTENT_CONTRIBUTION_URL` overrides the target for end-to-end local testing). The local draft is kept — the published file only changes once the PR merges — and the opened PR is linked in a banner. Note: the previous publish flow POSTed to a `/studio/publish` endpoint that never existed.

## Verification

- 15 new tests (path allowlist incl. traversal/case/extension attempts, commit/PR body formatting, trailer-injection sanitization); 47 total contribution-related tests green.
- API build clean; portal production build green.