### PR TITLE
fix(auth): unblock NSClientV3/AAPS token-exchange and legacy api-secret

### DIFF
--- a/src/API/Nocturne.API/Controllers/V2/AuthorizationController.cs
+++ b/src/API/Nocturne.API/Controllers/V2/AuthorizationController.cs
@@ -40,6 +40,14 @@ public class AuthorizationController : ControllerBase
     /// </summary>
     /// <param name="accessToken">Access token to exchange for JWT</param>
     /// <returns>JWT token response</returns>
+    /// <remarks>
+    /// The access token in the URL is the caller's only credential — this is the bootstrap
+    /// that exchanges it for a JWT (used by NSClientV3/AAPS). It must be anonymous: the
+    /// class-level <c>[Authorize]</c> would otherwise reject the request with 401 before the
+    /// method can validate the token. The action validates the token itself and returns 401
+    /// when it is missing or invalid.
+    /// </remarks>
+    [AllowAnonymous]
     [HttpGet("request/{accessToken}")]
     [NightscoutEndpoint("/api/v2/authorization/request/:accessToken")]
     [ProducesResponseType(typeof(AuthorizationResponse), 200)]

--- a/src/API/Nocturne.API/Middleware/Handlers/ApiKeyHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/ApiKeyHandler.cs
@@ -33,8 +33,14 @@ public class ApiKeyHandler : IAuthHandler
 
     public async Task<AuthResult> AuthenticateAsync(HttpContext context)
     {
-        // 1. Extract value from api-secret header or ?secret= query param
+        // 1. Extract value from the api-secret header or ?secret= query param.
+        //    Accept the api_secret (underscore) spelling too — some legacy Nightscout
+        //    clients send it, and the V1 OpenAPI docs advertise it as accepted.
         var apiKey = context.Request.Headers["api-secret"].FirstOrDefault();
+        if (string.IsNullOrEmpty(apiKey))
+        {
+            apiKey = context.Request.Headers["api_secret"].FirstOrDefault();
+        }
         if (string.IsNullOrEmpty(apiKey))
         {
             apiKey = context.Request.Query["secret"].FirstOrDefault();
@@ -62,8 +68,11 @@ public class ApiKeyHandler : IAuthHandler
         else
         {
             // Legacy path: the value sent in the header is already a SHA-1 hex hash
-            // (Nightscout clients pre-hash secrets before sending)
-            legacySecretHash = apiKey;
+            // (Nightscout clients pre-hash secrets before sending). Normalize to lowercase
+            // to match the canonical stored form (HashUtils.Sha1Hex is lowercase) — some
+            // clients (e.g. Android) emit uppercase hex, which the case-sensitive column
+            // comparison would otherwise miss.
+            legacySecretHash = apiKey.ToLowerInvariant();
         }
 
         // 5. Query for matching grant

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V2/AuthorizationControllerAttributeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V2/AuthorizationControllerAttributeTests.cs
@@ -1,0 +1,35 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Authorization;
+using Nocturne.API.Controllers.V2;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V2;
+
+/// <summary>
+/// Guards the authorization attributes on <see cref="AuthorizationController"/>. The token-exchange
+/// endpoint is the credential bootstrap for NSClientV3/AAPS: the access token in the URL is the
+/// caller's only credential, so the endpoint must be reachable anonymously. The class carries a
+/// <c>[Authorize]</c> fallback, so a missing <c>[AllowAnonymous]</c> silently 401s every uploader
+/// before the token is ever validated.
+/// </summary>
+public class AuthorizationControllerAttributeTests
+{
+    [Fact]
+    public void GenerateJwtFromAccessToken_IsAllowAnonymous()
+    {
+        var method = typeof(AuthorizationController)
+            .GetMethod(nameof(AuthorizationController.GenerateJwtFromAccessToken));
+
+        Assert.NotNull(method);
+        Assert.NotNull(method!.GetCustomAttribute<AllowAnonymousAttribute>());
+    }
+
+    [Fact]
+    public void Controller_RetainsClassLevelAuthorize()
+    {
+        // The anonymous exception must be scoped to the one bootstrap endpoint; the controller as a
+        // whole (subject/role management, permissions) must still require authentication.
+        var authorize = typeof(AuthorizationController).GetCustomAttribute<AuthorizeAttribute>();
+        Assert.NotNull(authorize);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/ApiKeyHandlerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/ApiKeyHandlerTests.cs
@@ -139,6 +139,73 @@ public class ApiKeyHandlerTests : IDisposable
     }
 
     [Fact]
+    public async Task AuthenticateAsync_UppercaseSha1Hash_StillMatchesLowercaseStoredHash()
+    {
+        // The stored LegacySecretHash is canonical lowercase (HashUtils.Sha1Hex). Some clients
+        // (e.g. Android) send the SHA-1 hex uppercased; the handler must normalize before the
+        // case-sensitive column comparison, or authentication fails despite a valid secret.
+        var legacySecret = "myplaintextsecret";
+        var storedHash = HashUtils.Sha1Hex(legacySecret); // lowercase
+
+        await using (var ctx = new NocturneDbContext(_dbOptions) { TenantId = _testTenantId })
+        {
+            ctx.OAuthGrants.Add(new OAuthGrantEntity
+            {
+                Id = Guid.CreateVersion7(),
+                SubjectId = _subjectId,
+                TenantId = _testTenantId,
+                GrantType = OAuthGrantTypes.Direct,
+                LegacySecretHash = storedHash,
+                Scopes = ["glucose.read"],
+                CreatedAt = DateTime.UtcNow,
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        var context = CreateHttpContext();
+        context.Request.Headers["api-secret"] = storedHash.ToUpperInvariant();
+
+        var result = await _handler.AuthenticateAsync(context);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(_subjectId, result.AuthContext!.SubjectId);
+        Assert.Contains("glucose.read", result.AuthContext.Scopes);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_UnderscoreApiSecretHeader_IsAccepted()
+    {
+        // Some legacy Nightscout clients send the underscore spelling "api_secret" rather than
+        // the canonical "api-secret"; the handler accepts both.
+        var legacySecret = "underscoresecret";
+        var sha1Hash = HashUtils.Sha1Hex(legacySecret);
+
+        await using (var ctx = new NocturneDbContext(_dbOptions) { TenantId = _testTenantId })
+        {
+            ctx.OAuthGrants.Add(new OAuthGrantEntity
+            {
+                Id = Guid.CreateVersion7(),
+                SubjectId = _subjectId,
+                TenantId = _testTenantId,
+                GrantType = OAuthGrantTypes.Direct,
+                LegacySecretHash = sha1Hash,
+                Scopes = ["glucose.read"],
+                CreatedAt = DateTime.UtcNow,
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        var context = CreateHttpContext();
+        context.Request.Headers["api_secret"] = sha1Hash;
+
+        var result = await _handler.AuthenticateAsync(context);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(_subjectId, result.AuthContext!.SubjectId);
+        Assert.Contains("glucose.read", result.AuthContext.Scopes);
+    }
+
+    [Fact]
     public async Task AuthenticateAsync_MintedTokenSentPreHashed_AuthenticatesAndDoesNotNudge()
     {
         // A minted noc_ token carries both a SHA-256 TokenHash (verbatim clients) and a SHA-1


### PR DESCRIPTION
## Problem

AndroidAPS (NSClientV3) fails to upload with `InvalidAccessTokenException: Invalid access token` despite a valid token.

**Root cause:** the token-exchange endpoint `GET /api/v2/authorization/request/{accessToken}` is the credential *bootstrap* — the access token in the URL is the caller's only credential. But `AuthorizationController` carries a class-level `[Authorize]` and the app applies a default-deny fallback policy (`AuthorizationConfiguration`), so the request is rejected with **401 before the action can validate the token**. No auth handler reads the token from the URL path (`AccessTokenHandler` only checks `Authorization`/`?token=`/body), so an AAPS request carrying only the path token authenticates via nothing and is blocked.

The existing integration test masked this: it exchanges the token using a client that already sends `api-secret`, which satisfies `[Authorize]`. Real NSClientV3 doesn't. `AlarmHub` calls the same service method directly and works, confirming the exchange logic is fine — only the HTTP gate was wrong.

## Changes

- **`[AllowAnonymous]` on the token-exchange endpoint** only. The action already validates the token and returns 401 on failure; the rest of the controller keeps `[Authorize]`.
- **`ApiKeyHandler`: normalize the legacy SHA-1 hash to lowercase** before the case-sensitive column comparison. Stored hashes are canonical lowercase (`HashUtils.Sha1Hex`); a client emitting uppercase hex would never match. Applied only on the legacy branch (`noc_` tokens are case-sensitive SHA-256 lookups).
- **`ApiKeyHandler`: accept the `api_secret` (underscore) header** in addition to `api-secret`, matching what the V1 OpenAPI docs already advertise as accepted.

## Tests

Adds unit coverage: an `[AllowAnonymous]` attribute guard, uppercase-hash match, and the underscore header. All affected tests pass (17/17).