### PR TITLE
Add missing authorization attributes to V4 controllers + regression test

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Audit/AuditController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Audit/AuditController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
@@ -19,6 +20,7 @@ namespace Nocturne.API.Controllers.V4.Audit;
 [Tags("Platform")]
 [Route("api/v4/audit")]
 [Produces("application/json")]
+[Authorize]
 public class AuditController : ControllerBase
 {
     private readonly IDbContextFactory<NocturneDbContext> _contextFactory;

--- a/src/API/Nocturne.API/Controllers/V4/Connectors/WebhookSettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Connectors/WebhookSettingsController.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using System.Text.Json;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Services.Alerts.Webhooks;
 using Nocturne.Core.Models.Configuration;
@@ -19,6 +20,7 @@ namespace Nocturne.API.Controllers.V4.Connectors;
 [ApiController]
 [Tags("Connectors")]
 [Route("api/v4/ui-settings/notifications/webhooks")]
+[Authorize]
 public class WebhookSettingsController(
     WebhookRequestSender requestSender,
     ILogger<WebhookSettingsController> logger)

--- a/src/API/Nocturne.API/Controllers/V4/Devices/BatteryController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/BatteryController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
 using Nocturne.Core.Contracts.Devices;
@@ -30,6 +31,7 @@ namespace Nocturne.API.Controllers.V4.Devices;
 [ApiController]
 [Tags("Devices")]
 [Route("api/v4/[controller]")]
+[Authorize]
 public class BatteryController : ControllerBase
 {
     private readonly IBatteryService _batteryService;

--- a/src/API/Nocturne.API/Controllers/V4/Health/BodyWeightController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/BodyWeightController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
 using Nocturne.Core.Contracts.Health;
@@ -16,6 +17,7 @@ namespace Nocturne.API.Controllers.V4.Health;
 [ApiController]
 [Tags("Health")]
 [Route("api/v4/body-weight")]
+[Authorize]
 public class BodyWeightController : ControllerBase
 {
     private readonly IBodyWeightService _bodyWeightService;

--- a/src/API/Nocturne.API/Controllers/V4/Identity/RoleController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/RoleController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
 using Nocturne.Core.Contracts.Multitenancy;
@@ -17,6 +18,7 @@ namespace Nocturne.API.Controllers.V4.Identity;
 [Tags("Identity")]
 [Route("api/v4/roles")]
 [Produces("application/json")]
+[Authorize]
 public class RoleController : ControllerBase
 {
     private readonly ITenantRoleService _roleService;

--- a/src/API/Nocturne.API/Controllers/V4/Platform/CompatibilityController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/CompatibilityController.cs
@@ -49,6 +49,7 @@ public class CompatibilityController : ControllerBase
     /// Get current proxy configuration
     /// </summary>
     [HttpGet("config")]
+    [RequireAdmin]
     [ProducesResponseType(typeof(ProxyConfigurationDto), StatusCodes.Status200OK)]
     public ActionResult<ProxyConfigurationDto> GetConfiguration()
     {

--- a/src/API/Nocturne.API/Controllers/V4/Platform/ServicesController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/ServicesController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using OpenApi.Remote.Attributes;
@@ -22,6 +23,7 @@ namespace Nocturne.API.Controllers.V4.Platform;
 [ApiController]
 [Route("api/v4/services")]
 [Produces("application/json")]
+[Authorize]
 public class ServicesController : ControllerBase
 {
     private readonly IDataSourceService _dataSourceService;

--- a/src/API/Nocturne.API/Controllers/V4/Profiles/UISettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Profiles/UISettingsController.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
 using Nocturne.Connectors.Core.Services;
@@ -17,6 +18,7 @@ namespace Nocturne.API.Controllers.V4.Profiles;
 [Tags("Profiles")]
 [Route("api/v4/ui-settings")]
 [ClientPropertyName("uiSettings")]
+[Authorize]
 public class UISettingsController : ControllerBase
 {
     private readonly ILogger<UISettingsController> _logger;

--- a/src/API/Nocturne.API/Controllers/V4/Profiles/UserPreferencesController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Profiles/UserPreferencesController.cs
@@ -14,6 +14,7 @@ namespace Nocturne.API.Controllers.V4.Profiles;
 [ApiController]
 [Tags("Profiles")]
 [Route("api/v4/user/preferences")]
+[Authorize]
 public class UserPreferencesController : ControllerBase
 {
     private readonly NocturneDbContext _dbContext;

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ControllerAuthorizationCoverageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ControllerAuthorizationCoverageTests.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Nocturne.API.Attributes;
+using Nocturne.API.Authorization;
+using Xunit;
+
+namespace Nocturne.API.Tests.Authorization;
+
+/// <summary>
+/// Reflection guard asserting that every MVC controller action carries an explicit authorization
+/// decision. An action passes when it (or its controller) has an <see cref="IAuthorizeData"/>
+/// attribute (<c>[Authorize]</c> and friends), a Nocturne authorization filter
+/// (<c>[RequireAdmin]</c>, <c>[RequireScope]</c>, <c>[RequireInstanceKeyAuth]</c>, …), or an
+/// explicit <c>[AllowAnonymous]</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The <see cref="AuthorizationConfiguration.AddNocturneAuthorization"/> fallback policy
+/// (<see cref="HasPermissionsRequirement"/>) gates every attribute-less endpoint by requiring a
+/// non-empty <see cref="Nocturne.Core.Models.PermissionTrie"/>. That fallback rejects a bare
+/// unauthenticated request (empty trie) but ADMITS the anonymous public-share subject, whose trie
+/// carries the tenant's public read scopes. So relying on the fallback alone leaves a controller
+/// reachable by any public-share visitor — acceptable for the deliberately share-facing read
+/// surfaces (glucose/treatment analytics gated further by per-category share RLS), but not for
+/// member/admin data or any write surface.
+/// </para>
+/// <para>
+/// <see cref="FallbackGatedControllers"/> is the explicit, documented allow-list of controllers
+/// that intentionally lean on the fallback policy (plus per-category share RLS and/or in-handler
+/// permission checks) instead of an attribute. Every other controller action must declare its
+/// gate, so a newly added controller that forgets one fails this test rather than shipping
+/// silently reachable.
+/// </para>
+/// </remarks>
+public class ControllerAuthorizationCoverageTests
+{
+    private static Assembly ApiAssembly => typeof(AuthorizationConfiguration).Assembly;
+
+    /// <summary>
+    /// Controllers whose actions are intentionally gated only by the <see cref="HasPermissionsRequirement"/>
+    /// fallback policy (and, where they read PHI, per-category public-share RLS or in-handler
+    /// <c>HasPermission</c> checks) rather than an authorization attribute. Keyed by full type name
+    /// with the rationale as the value.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> FallbackGatedControllers =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            // ── V4 public-share read analytics ──────────────────────────────────────────────
+            // Read-only (GET) aggregates over glucose/treatment data that the public-share
+            // dashboard renders for an anonymous share visitor. The fallback admits the share
+            // subject; the per-category share RLS policy (ShareDataCategories) then restricts the
+            // underlying rows to the categories the share was granted. Adding [Authorize] here
+            // would 401 the anonymous share dashboard. All actions are GET, so there is no write
+            // surface to expose.
+            ["Nocturne.API.Controllers.V4.Analytics.ActogramController"] = "public-share read analytics (fallback + share RLS)",
+            ["Nocturne.API.Controllers.V4.Analytics.ChartDataController"] = "public-share read analytics (fallback + share RLS)",
+            ["Nocturne.API.Controllers.V4.Analytics.DataOverviewController"] = "public-share read analytics (fallback + share RLS)",
+            ["Nocturne.API.Controllers.V4.Analytics.RetrospectiveController"] = "public-share read analytics (fallback + share RLS)",
+            ["Nocturne.API.Controllers.V4.Analytics.PredictionController"] = "public-share read analytics (fallback + share RLS)",
+
+            // ── Legacy Nightscout v1 surfaces (authorize via OAuth scope in the fallback trie) ──
+            // v1 endpoints authenticate via the api-secret / token trie and are gated by the
+            // fallback policy plus in-handler scope checks, matching upstream Nightscout behaviour.
+            // They deliberately do not use the v4 [Authorize] convention.
+            ["Nocturne.API.Controllers.V1.AlexaController"] = "legacy v1 (fallback trie + in-handler)",
+            ["Nocturne.API.Controllers.V1.CountController"] = "legacy v1 (fallback trie + in-handler)",
+            ["Nocturne.API.Controllers.V1.IobController"] = "legacy v1 (fallback trie + in-handler)",
+            ["Nocturne.API.Controllers.V1.PebbleController"] = "legacy v1 (fallback trie + in-handler)",
+            ["Nocturne.API.Controllers.V1.TimeQueryController"] = "legacy v1 (fallback trie + in-handler)",
+            ["Nocturne.API.Controllers.V1.DebugController"] = "legacy v1 debug (fallback trie)",
+
+            // ── Authentication credential-management surfaces ──────────────────────────────────
+            // These live in the Authentication namespace and mix explicit [AllowAnonymous] public
+            // endpoints (OAuth/OIDC/login/discovery) with authenticated "manage my own
+            // credentials/grants" endpoints that rely on the fallback trie plus in-handler subject
+            // resolution. This is the pre-existing Authentication-namespace convention (unchanged
+            // by the v4 authorization pass); the fallback still rejects a bare unauthenticated
+            // caller (empty trie).
+            ["Nocturne.API.Controllers.Authentication.OAuthController"] = "OAuth: public endpoints [AllowAnonymous], grant management via fallback trie",
+            ["Nocturne.API.Controllers.Authentication.OidcController"] = "OIDC: discovery/login [AllowAnonymous], identity linking/management via fallback trie",
+            ["Nocturne.API.Controllers.Authentication.PasskeyController"] = "Passkey: registration/login [AllowAnonymous], credential management via fallback trie",
+            ["Nocturne.API.Controllers.Authentication.DirectGrantController"] = "manage-my-own API grants via fallback trie",
+            ["Nocturne.API.Controllers.Authentication.TotpController"] = "TOTP: login [AllowAnonymous], enrolment/management via fallback trie",
+        };
+
+    [Fact]
+    public void EveryControllerAction_HasAnExplicitAuthorizationDecision()
+    {
+        var controllers = ApiAssembly.GetTypes()
+            .Where(t => typeof(ControllerBase).IsAssignableFrom(t)
+                        && t is { IsClass: true, IsAbstract: false, IsPublic: true }
+                        && t.GetCustomAttribute<NonControllerAttribute>() is null)
+            .ToList();
+
+        controllers.Should().NotBeEmpty("the API assembly must expose controllers to audit");
+
+        var unprotected = new List<string>();
+
+        foreach (var controller in controllers)
+        {
+            var controllerName = controller.FullName!;
+            var exempt = FallbackGatedControllers.ContainsKey(controllerName);
+
+            foreach (var action in GetActionMethods(controller))
+            {
+                if (HasAnonymous(action, controller))
+                {
+                    continue; // explicitly anonymous — an intentional, visible decision
+                }
+
+                if (HasAuthorizationGate(action, controller))
+                {
+                    continue; // [Authorize*] or a Require* authorization filter
+                }
+
+                if (exempt)
+                {
+                    continue; // documented fallback-gated surface
+                }
+
+                unprotected.Add($"{controllerName}.{action.Name}");
+            }
+        }
+
+        unprotected.Should().BeEmpty(
+            "every controller action must carry [Authorize]/[AllowAnonymous] or a Require* "
+            + "authorization filter, or be listed in FallbackGatedControllers with a rationale. "
+            + "Unprotected actions found:\n  " + string.Join("\n  ", unprotected.OrderBy(x => x)));
+    }
+
+    [Fact]
+    public void FallbackGatedControllers_ListIsNotStale()
+    {
+        // Guard the allow-list itself: every entry must name a real controller that genuinely lacks
+        // an attribute gate. If someone later adds [Authorize] to one of these, its entry should be
+        // removed so the list stays an honest inventory of fallback-only surfaces.
+        foreach (var (typeName, _) in FallbackGatedControllers)
+        {
+            var type = ApiAssembly.GetType(typeName);
+            type.Should().NotBeNull($"{typeName} is listed in FallbackGatedControllers but does not exist");
+
+            var actions = GetActionMethods(type!).ToList();
+            actions.Should().NotBeEmpty($"{typeName} should expose at least one action");
+
+            var everyActionGated = actions.All(a => HasAnonymous(a, type!) || HasAuthorizationGate(a, type!));
+            everyActionGated.Should().BeFalse(
+                $"{typeName} now gates all of its actions explicitly and should be removed from FallbackGatedControllers");
+        }
+    }
+
+    private static IEnumerable<MethodInfo> GetActionMethods(Type controller) =>
+        controller.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .Where(m => !m.IsSpecialName
+                        && m.GetCustomAttributes().OfType<IActionHttpMethodProvider>().Any());
+
+    private static bool HasAnonymous(MethodInfo action, Type controller) =>
+        action.GetCustomAttributes(inherit: true).OfType<IAllowAnonymous>().Any()
+        || controller.GetCustomAttributes(inherit: true).OfType<IAllowAnonymous>().Any();
+
+    private static bool HasAuthorizationGate(MethodInfo action, Type controller) =>
+        HasGate(action.GetCustomAttributes(inherit: true))
+        || HasGate(controller.GetCustomAttributes(inherit: true));
+
+    private static bool HasGate(IEnumerable<object> attributes) =>
+        attributes.Any(a => a is IAuthorizeData
+                            or RequirePermissionAttribute // covers [RequireAdmin]/[RequireRead]/[RequireWrite]
+                            or RequireScopeAttribute
+                            or RequireInstanceKeyAuthAttribute
+                            or RequireAuthenticationAttribute);
+}


### PR DESCRIPTION
## Summary

A handful of V4 controllers carried no authorization metadata, so they were gated only by the `HasPermissions` fallback policy rather than the explicit per-controller convention used by their siblings. This adds the appropriate attributes and a reflection-based regression test so the gap can't reopen silently.

## Changes

Authorization attributes:
- `[Authorize]` on tenant/member-data surfaces that were missing it: `Audit`, `Battery`, `BodyWeight`, `Role`, `UISettings`, `UserPreferences`, `WebhookSettings`, and `Platform/Services` (its mutating actions keep their existing `[RequireAdmin]`).
- `[RequireAdmin]` on `Platform/Compatibility` `GetConfiguration`, matching every other action on that controller.

Regression test — `ControllerAuthorizationCoverageTests`:
- Enumerates every MVC controller action via reflection and asserts each one carries `[Authorize]`/`[AllowAnonymous]` or a `Require*` authorization filter.
- Controllers that intentionally rely on the fallback policy live in an explicit, documented allow-list (`FallbackGatedControllers`): the public-share read analytics (further gated by per-category share RLS), legacy v1 endpoints, and the Authentication credential-management endpoints. A second test keeps that list honest (each entry must exist and still lack an attribute gate).
- A newly added controller that forgets an authorization decision now fails CI.

## Notes

- Several controllers named in the original audit (`Migration`, `Processing`, `Deduplication`, `NightscoutTransition`, `Discrepancy`, `ChatIdentityDirectory`) were already protected by `[RequireAdmin]` / `[RequireInstanceKeyAuth]` filters and were left unchanged.
- The public-share analytics controllers (`ChartData`, `Actogram`, `DataOverview`, `Retrospective`, `Prediction`) are deliberately left on the fallback + RLS path so the anonymous share dashboard keeps working; all are read-only.

## Testing

- `dotnet build -p:GenerateNSwagClient=false`
- `dotnet test tests/Unit/Nocturne.API.Tests` — the new coverage tests and existing `AuthorizationConfigurationTests` pass. (Two unrelated pre-existing failures remain: a memory-usage benchmark threshold and a stale entry-decomposition mock expectation.)