### PR TITLE
Restrict CORS to configured base domain and dev origins

### DIFF
--- a/src/API/Nocturne.API/Multitenancy/CorsOriginPolicy.cs
+++ b/src/API/Nocturne.API/Multitenancy/CorsOriginPolicy.cs
@@ -1,0 +1,59 @@
+namespace Nocturne.API.Multitenancy;
+
+/// <summary>
+/// Decides whether a browser <c>Origin</c> is allowed by the default CORS policy.
+/// Because the platform serves tenants and public shares on open-ended wildcard
+/// subdomains (<c>{slug}.{BaseDomain}</c> and <c>{token}.share.{BaseDomain}</c>),
+/// a static allow-list can't work: the origin is validated against the configured
+/// base domain instead. Matching is done on the parsed <see cref="Uri.Host"/> —
+/// never a substring check — so look-alikes such as <c>basedomain.com.evil.com</c>
+/// or <c>evilbasedomain.com</c> are rejected.
+/// </summary>
+public static class CorsOriginPolicy
+{
+    /// <summary>
+    /// Returns true when <paramref name="origin"/> is the apex of
+    /// <paramref name="baseDomain"/> or any subdomain of it (covering tenant and
+    /// share hosts). When <paramref name="allowLocalhost"/> is set (development),
+    /// loopback origins on any port are also allowed. Everything else — including
+    /// loopback origins in production — is rejected.
+    /// </summary>
+    public static bool IsAllowed(string? origin, string baseDomain, bool allowLocalhost)
+    {
+        if (string.IsNullOrWhiteSpace(origin))
+            return false;
+
+        if (!Uri.TryCreate(origin, UriKind.Absolute, out var uri))
+            return false;
+
+        // Only real browser CORS origins are meaningful here.
+        if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+            return false;
+
+        var host = uri.Host;
+        if (string.IsNullOrEmpty(host))
+            return false;
+
+        if (allowLocalhost && IsLoopback(host))
+            return true;
+
+        // BaseDomain may carry a port for local URL construction (e.g. localhost:1612);
+        // the origin host never does. Compare hostnames only.
+        var baseHost = baseDomain.Split(':')[0];
+        if (string.IsNullOrEmpty(baseHost))
+            return false;
+
+        // Apex (exact match) or a subdomain at any depth. The leading dot enforces a
+        // real label boundary, so "evilbasedomain.com" and "basedomain.com.evil.com"
+        // do not match "basedomain.com".
+        return host.Equals(baseHost, StringComparison.OrdinalIgnoreCase)
+            || host.EndsWith($".{baseHost}", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsLoopback(string host) =>
+        host.Equals("localhost", StringComparison.OrdinalIgnoreCase)
+        || host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase)
+        || host == "127.0.0.1"
+        || host == "[::1]"
+        || host == "::1";
+}

--- a/src/API/Nocturne.API/Multitenancy/CorsOriginPolicy.cs
+++ b/src/API/Nocturne.API/Multitenancy/CorsOriginPolicy.cs
@@ -18,6 +18,13 @@ public static class CorsOriginPolicy
     /// loopback origins on any port are also allowed. Everything else — including
     /// loopback origins in production — is rejected.
     /// </summary>
+    /// <remarks>
+    /// The base domain is normalized (scheme, path, port, and stray dots/wildcards
+    /// stripped) and must resolve to a real multi-label host. A bare public suffix
+    /// or single-label value (<c>com</c>, <c>localhost</c>, empty) is not usable as
+    /// a credentialed-CORS base and disables base-domain matching entirely, so it
+    /// can never widen the allow-list.
+    /// </remarks>
     public static bool IsAllowed(string? origin, string baseDomain, bool allowLocalhost)
     {
         if (string.IsNullOrWhiteSpace(origin))
@@ -30,6 +37,17 @@ public static class CorsOriginPolicy
         if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
             return false;
 
+        // A browser Origin is only ever scheme://host[:port] — never userinfo, a
+        // path, a query, or a fragment. Reject anything richer; those are spoofing
+        // attempts, not real Origin headers (e.g. "http://nocturne.run@evil.com",
+        // "http://nocturne.run\@evil.com", "https://evil.com#.nocturne.run").
+        if (!string.IsNullOrEmpty(uri.UserInfo))
+            return false;
+        if (uri.AbsolutePath is not ("" or "/"))
+            return false;
+        if (!string.IsNullOrEmpty(uri.Query) || !string.IsNullOrEmpty(uri.Fragment))
+            return false;
+
         var host = uri.Host;
         if (string.IsNullOrEmpty(host))
             return false;
@@ -37,10 +55,14 @@ public static class CorsOriginPolicy
         if (allowLocalhost && IsLoopback(host))
             return true;
 
-        // BaseDomain may carry a port for local URL construction (e.g. localhost:1612);
-        // the origin host never does. Compare hostnames only.
-        var baseHost = baseDomain.Split(':')[0];
-        if (string.IsNullOrEmpty(baseHost))
+        var baseHost = NormalizeBaseHost(baseDomain);
+
+        // A credentialed CORS base must be a real multi-label domain. A bare public
+        // suffix or single-label host ("com", "localhost", "") is not usable —
+        // otherwise every "*.com" origin would be trusted with credentials. When the
+        // base is unusable, base-domain matching is disabled (fail closed); in
+        // development loopback origins are still admitted by the branch above.
+        if (baseHost.Length == 0 || !baseHost.Contains('.'))
             return false;
 
         // Apex (exact match) or a subdomain at any depth. The leading dot enforces a
@@ -48,6 +70,52 @@ public static class CorsOriginPolicy
         // do not match "basedomain.com".
         return host.Equals(baseHost, StringComparison.OrdinalIgnoreCase)
             || host.EndsWith($".{baseHost}", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Normalizes a configured base-domain value to a bare host suitable for CORS
+    /// origin matching. Strips a leading <c>http(s)://</c> scheme, any path or
+    /// trailing slash, a leading <c>*.</c> wildcard, a port, and leading/trailing
+    /// dots. Returns an empty string when the input is null/blank or normalizes to
+    /// nothing. The result is not guaranteed to be a valid base — callers must still
+    /// require a dot (multi-label) before trusting it (see <see cref="IsAllowed"/>).
+    /// </summary>
+    /// <remarks>
+    /// Tolerates misformatted configuration (<c>https://nocturne.run</c>,
+    /// <c>nocturne.run/</c>, <c>.nocturne.run</c>, <c>nocturne.run.</c>,
+    /// <c>*.nocturne.run</c>) so an operator typo doesn't silently disable
+    /// cross-origin CORS.
+    /// </remarks>
+    public static string NormalizeBaseHost(string? baseDomain)
+    {
+        if (string.IsNullOrWhiteSpace(baseDomain))
+            return "";
+
+        var value = baseDomain.Trim();
+
+        // Strip a leading scheme, e.g. "https://nocturne.run" -> "nocturne.run".
+        var schemeIndex = value.IndexOf("://", StringComparison.Ordinal);
+        if (schemeIndex >= 0)
+            value = value[(schemeIndex + 3)..];
+
+        // Drop any path/trailing slash, e.g. "nocturne.run/" -> "nocturne.run".
+        var slashIndex = value.IndexOf('/');
+        if (slashIndex >= 0)
+            value = value[..slashIndex];
+
+        // Drop a leading wildcard label, e.g. "*.nocturne.run" -> ".nocturne.run".
+        if (value.StartsWith('*'))
+            value = value[1..];
+
+        // Drop a port, e.g. "nocturne.run:1612" -> "nocturne.run". Hostnames never
+        // contain a colon (IPv6 literals aren't valid base domains here).
+        var colonIndex = value.IndexOf(':');
+        if (colonIndex >= 0)
+            value = value[..colonIndex];
+
+        // Drop leading/trailing dots, e.g. ".nocturne.run" / "nocturne.run." ->
+        // "nocturne.run".
+        return value.Trim('.');
     }
 
     private static bool IsLoopback(string host) =>

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -280,15 +280,20 @@ builder
 
 builder.Services.AddNocturneAuthorization();
 
-// Configure CORS for frontend with credentials support
-// Note: AllowAnyOrigin() cannot be combined with AllowCredentials() per CORS spec
-// Using SetIsOriginAllowed to dynamically allow origins while supporting cookies
+// Configure CORS for frontend with credentials support.
+// AllowAnyOrigin() cannot be combined with AllowCredentials() per the CORS spec, and a
+// static allow-list can't cover the open-ended per-tenant wildcard subdomains
+// ({slug}.{BaseDomain}) or public shares ({token}.share.{BaseDomain}). Instead validate the
+// origin against the configured base domain: apex + any subdomain are allowed, loopback
+// origins only in development. See CorsOriginPolicy.
+var corsBaseDomain = builder.Configuration[BaseDomainOptions.ConfigKey] ?? "";
+var corsAllowLocalhost = builder.Environment.IsDevelopment();
 builder.Services.AddCors(options =>
 {
     options.AddDefaultPolicy(policy =>
     {
         policy
-            .SetIsOriginAllowed(_ => true) // Allow any origin (development-friendly, restrict in production)
+            .SetIsOriginAllowed(origin => CorsOriginPolicy.IsAllowed(origin, corsBaseDomain, corsAllowLocalhost))
             .AllowAnyMethod()
             .AllowAnyHeader()
             .AllowCredentials(); // Required for cookies/auth to work cross-origin

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -286,8 +286,16 @@ builder.Services.AddNocturneAuthorization();
 // ({slug}.{BaseDomain}) or public shares ({token}.share.{BaseDomain}). Instead validate the
 // origin against the configured base domain: apex + any subdomain are allowed, loopback
 // origins only in development. See CorsOriginPolicy.
-var corsBaseDomain = builder.Configuration[BaseDomainOptions.ConfigKey] ?? "";
+// Normalize the configured base domain once (strip scheme/path/port/stray dots) so
+// misformatted values like "https://nocturne.run" or "nocturne.run/" still resolve to
+// a matchable host instead of silently disabling cross-origin CORS. See CorsOriginPolicy.
+var rawCorsBaseDomain = builder.Configuration[BaseDomainOptions.ConfigKey] ?? "";
+var corsBaseDomain = CorsOriginPolicy.NormalizeBaseHost(rawCorsBaseDomain);
 var corsAllowLocalhost = builder.Environment.IsDevelopment();
+// A credentialed CORS base must be a real multi-label domain; a bare suffix ("com") or
+// single-label/empty value would either widen the allow-list or disable it. The predicate
+// already fails closed on such values — validity is surfaced at startup below.
+var corsBaseDomainIsValid = corsBaseDomain.Length > 0 && corsBaseDomain.Contains('.');
 builder.Services.AddCors(options =>
 {
     options.AddDefaultPolicy(policy =>
@@ -311,6 +319,29 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
 });
 
 var app = builder.Build();
+
+// Surface the effective credentialed-CORS base domain so operators can see what's active.
+// An invalid base (bare suffix, single-label, or empty) fails closed: cross-origin CORS is
+// disabled and only same-origin (plus loopback in Development) requests are admitted.
+if (corsBaseDomainIsValid)
+{
+    app.Logger.LogInformation("CORS base domain: {CorsBaseDomain}", corsBaseDomain);
+}
+else if (app.Environment.IsDevelopment())
+{
+    app.Logger.LogInformation(
+        "CORS base domain '{RawCorsBaseDomain}' is not a multi-label host; cross-origin CORS is "
+        + "disabled (loopback origins are still allowed in Development).",
+        rawCorsBaseDomain);
+}
+else
+{
+    app.Logger.LogError(
+        "CORS base domain '{RawCorsBaseDomain}' is not a valid multi-label host ({ConfigKey}). "
+        + "Cross-origin CORS is disabled (fail closed) — tenant and share subdomains will be "
+        + "rejected until this is corrected.",
+        rawCorsBaseDomain, BaseDomainOptions.ConfigKey);
+}
 
 // Configure middleware pipeline
 app.UseExceptionHandler();

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/CorsOriginPolicyTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/CorsOriginPolicyTests.cs
@@ -54,7 +54,7 @@ public sealed class CorsOriginPolicyTests
     public void Ignores_a_port_on_the_configured_base_domain()
     {
         // BaseDomain carries a port for local URL construction; the origin host never does.
-        CorsOriginPolicy.IsAllowed("http://acme.localhost", "localhost:1612", allowLocalhost: false)
+        CorsOriginPolicy.IsAllowed("https://acme.nocturne.run", "nocturne.run:1612", allowLocalhost: false)
             .Should().BeTrue();
     }
 
@@ -62,6 +62,68 @@ public sealed class CorsOriginPolicyTests
     public void Rejects_everything_when_the_base_domain_is_empty_and_localhost_is_disallowed()
     {
         CorsOriginPolicy.IsAllowed("https://acme.nocturne.run", "", allowLocalhost: false)
+            .Should().BeFalse();
+    }
+
+    [Theory]
+    // Userinfo spoof: the parsed host is evil.com and userinfo is present — reject.
+    [InlineData("http://nocturne.run@evil.com")]
+    // Backslash authority: some parsers fold "\" to "/", stranding a path — reject.
+    [InlineData("http://nocturne.run\\@evil.com")]
+    // Fragment/query smuggling: the base domain only appears after "#"/"?" — reject.
+    [InlineData("https://evil.com#.nocturne.run")]
+    [InlineData("https://evil.com?.nocturne.run")]
+    [InlineData("https://evil.com/.nocturne.run")]
+    // Non-http(s) schemes are never real CORS origins — reject.
+    [InlineData("file:///etc/passwd")]
+    [InlineData("data:text/html;base64,PHNjcmlwdD4=")]
+    [InlineData("blob:https://acme.nocturne.run/1234")]
+    public void Rejects_spoofed_or_non_origin_urls(string origin)
+    {
+        CorsOriginPolicy.IsAllowed(origin, BaseDomain, allowLocalhost: false).Should().BeFalse();
+    }
+
+    [Theory]
+    // A trailing dot on the origin host is a distinct (absolute-DNS) label and does not
+    // match the configured base domain. Documenting current behavior: these are rejected.
+    [InlineData("https://app.nocturne.run.")]   // trailing-dot subdomain
+    [InlineData("https://nocturne.run.")]        // trailing-dot apex
+    public void Rejects_trailing_dot_origins(string origin)
+    {
+        CorsOriginPolicy.IsAllowed(origin, BaseDomain, allowLocalhost: false).Should().BeFalse();
+    }
+
+    [Theory]
+    // A bare public suffix (or any single-label / empty value) must NOT be usable as a
+    // credentialed-CORS base: it would otherwise trust every "*.com" origin.
+    [InlineData("https://evil.com", "com")]
+    [InlineData("https://anything.com", "com")]
+    [InlineData("https://evil.org", "org")]
+    [InlineData("https://acme.nocturne.run", "localhost")]  // single-label, no loopback in prod
+    public void Rejects_when_the_base_domain_is_a_bare_suffix_or_single_label(string origin, string baseDomain)
+    {
+        CorsOriginPolicy.IsAllowed(origin, baseDomain, allowLocalhost: false).Should().BeFalse();
+    }
+
+    [Theory]
+    // Misformatted but well-intentioned base-domain values must normalize to the real host
+    // and still admit genuine subdomains (not silently disable cross-origin CORS).
+    [InlineData("https://nocturne.run")]   // leading scheme
+    [InlineData("http://nocturne.run")]    // leading scheme (http)
+    [InlineData("nocturne.run/")]          // trailing slash
+    [InlineData("nocturne.run/path")]      // stray path
+    [InlineData(".nocturne.run")]          // leading dot
+    [InlineData("nocturne.run.")]          // trailing dot
+    [InlineData("*.nocturne.run")]         // wildcard prefix
+    [InlineData("nocturne.run:1612")]      // port
+    public void Normalizes_misformatted_base_domains_and_admits_real_subdomains(string baseDomain)
+    {
+        CorsOriginPolicy.IsAllowed("https://acme.nocturne.run", baseDomain, allowLocalhost: false)
+            .Should().BeTrue();
+        CorsOriginPolicy.IsAllowed("https://nocturne.run", baseDomain, allowLocalhost: false)
+            .Should().BeTrue();
+        // Look-alikes are still rejected after normalization.
+        CorsOriginPolicy.IsAllowed("https://evilnocturne.run", baseDomain, allowLocalhost: false)
             .Should().BeFalse();
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/CorsOriginPolicyTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/CorsOriginPolicyTests.cs
@@ -1,0 +1,67 @@
+using FluentAssertions;
+using Nocturne.API.Multitenancy;
+using Xunit;
+
+namespace Nocturne.API.Tests.Multitenancy;
+
+/// <summary>
+/// Verifies <see cref="CorsOriginPolicy.IsAllowed"/>, the default CORS policy's origin
+/// predicate. Origins are matched against the configured base domain by parsed host so
+/// tenant and share subdomains are admitted while look-alike domains are not.
+/// </summary>
+public sealed class CorsOriginPolicyTests
+{
+    private const string BaseDomain = "nocturne.run";
+
+    [Theory]
+    [InlineData("https://nocturne.run")]                 // apex
+    [InlineData("https://acme.nocturne.run")]            // tenant subdomain
+    [InlineData("https://ACME.NOCTURNE.RUN")]            // case-insensitive
+    [InlineData("https://abc123.share.nocturne.run")]    // public share (two-label) subdomain
+    [InlineData("http://acme.nocturne.run")]             // http scheme still matches by host
+    public void Allows_the_apex_and_subdomains_of_the_base_domain(string origin)
+    {
+        CorsOriginPolicy.IsAllowed(origin, BaseDomain, allowLocalhost: false).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("https://evil.com")]                     // unrelated domain
+    [InlineData("https://nocturne.run.evil.com")]        // base domain as a left label of another domain
+    [InlineData("https://evilnocturne.run")]             // suffix without a label boundary
+    [InlineData("https://notnocturne.run")]              // suffix without a label boundary
+    [InlineData("https://nocturne.run.attacker.net")]    // apex embedded, real host elsewhere
+    [InlineData("")]                                     // empty origin
+    [InlineData("not-a-uri")]                            // unparseable
+    [InlineData("ftp://acme.nocturne.run")]              // non-http(s) scheme
+    public void Rejects_unrelated_and_look_alike_origins(string origin)
+    {
+        CorsOriginPolicy.IsAllowed(origin, BaseDomain, allowLocalhost: false).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("http://localhost:5173")]                // SvelteKit dev server
+    [InlineData("http://localhost")]
+    [InlineData("http://127.0.0.1:5173")]
+    [InlineData("http://acme.localhost:5173")]           // subdomain of localhost
+    [InlineData("http://[::1]:5173")]                    // IPv6 loopback
+    public void Allows_loopback_origins_only_in_development(string origin)
+    {
+        CorsOriginPolicy.IsAllowed(origin, BaseDomain, allowLocalhost: true).Should().BeTrue();
+        CorsOriginPolicy.IsAllowed(origin, BaseDomain, allowLocalhost: false).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Ignores_a_port_on_the_configured_base_domain()
+    {
+        // BaseDomain carries a port for local URL construction; the origin host never does.
+        CorsOriginPolicy.IsAllowed("http://acme.localhost", "localhost:1612", allowLocalhost: false)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void Rejects_everything_when_the_base_domain_is_empty_and_localhost_is_disallowed()
+    {
+        CorsOriginPolicy.IsAllowed("https://acme.nocturne.run", "", allowLocalhost: false)
+            .Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

The default CORS policy used `SetIsOriginAllowed(_ => true)` together with `AllowCredentials()` in every environment (the inline comment noted "restrict in production" but never did). This change replaces the blanket predicate with a base-domain-aware one.

Because tenants and public shares are served on open-ended wildcard subdomains (`{slug}.{BaseDomain}` and `{token}.share.{BaseDomain}`), a static allow-list can't work. The new `CorsOriginPolicy` validates the request origin's parsed host against the configured base domain:

- **Apex and any subdomain** of `BASE_DOMAIN` are allowed (covers the marketing/portal apex, tenant subdomains, and share subdomains).
- **Loopback origins** (`localhost`, `*.localhost`, `127.0.0.1`, `[::1]`) are allowed **only in Development** (SvelteKit/Aspire dev servers), gated by `IHostEnvironment.IsDevelopment()`.
- Everything else is rejected.

Host matching uses `Uri.Host` with a label-boundary check, not a substring test, so look-alikes like `basedomain.com.evil.com` and `evilbasedomain.com` are rejected. `AllowAnyMethod()` / `AllowAnyHeader()` / `AllowCredentials()` are unchanged.

## Configuration

Reuses the existing `BASE_DOMAIN` key (`BaseDomainOptions.ConfigKey`) that already drives tenant resolution and WebAuthn RP config — no new config key, and it's already supplied in all deployments. In Development the policy also admits loopback regardless of base domain.

## Tests

Adds `CorsOriginPolicyTests` (20 cases): apex/tenant/share pass; unrelated and look-alike domains reject; loopback passes in dev and is rejected in prod; base-domain port is ignored; empty base domain fails closed. All multitenancy unit tests pass (99 total).
