### PR TITLE
fix(web): make the basal-analysis report show data

### DIFF
--- a/src/Web/packages/app/src/lib/components/reports/BasalRatePercentileChart.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/BasalRatePercentileChart.svelte
@@ -123,9 +123,7 @@
         seriesLayout="overlap"
         tooltip={{ mode: "bisect-x" }}
         props={{
-          area: { motion: { type: "tween", duration: 200 } },
           xAxis: {
-            motion: { type: "tween", duration: 200 },
             tickMultiline: true,
             format: formatHour,
           },

--- a/src/Web/packages/app/src/lib/components/reports/BasalRatePercentileChart.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/BasalRatePercentileChart.svelte
@@ -47,7 +47,7 @@
     .range([
       "var(--chart-1)",
       "var(--chart-2)",
-      "hsl(var(--primary))",
+      "var(--primary)",
     ]);
 </script>
 
@@ -93,7 +93,7 @@
               (d: HourlyBasalPercentileData) => d.median,
               (d: HourlyBasalPercentileData) => d.median,
             ],
-            color: "hsl(var(--primary))",
+            color: "var(--primary)",
             props: {
               line: { strokeWidth: 2 },
             },

--- a/src/Web/packages/app/src/lib/components/reports/InsulinDeliveryChart.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/InsulinDeliveryChart.svelte
@@ -159,7 +159,6 @@
         x={(d) => d.hour}
         y={(d) => d.total}
         renderContext="svg"
-        legend
         series={showStacked
           ? [
               // Show scheduled basal, temp basal adjustments, and bolus as stacked
@@ -218,9 +217,7 @@
         seriesLayout={showStacked ? "stack" : "overlap"}
         tooltip={{ mode: "bisect-x" }}
         props={{
-          area: { motion: { type: "tween", duration: 200 } },
           xAxis: {
-            motion: { type: "tween", duration: 200 },
             format: formatHour,
           },
           yAxis: {

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/basal-analysis/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/basal-analysis/+page.svelte
@@ -1,78 +1,33 @@
 <script lang="ts">
-  import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardHeader,
-    CardTitle,
-  } from "$lib/components/ui/card";
-  import { Button } from "$lib/components/ui/button";
-  import { Separator } from "$lib/components/ui/separator";
-  import {
-    Layers,
-    Calendar,
-    Info,
-    TrendingUp,
-    TrendingDown,
-    ArrowRight,
-    Printer,
-    HelpCircle,
-    Clock,
-    Gauge,
-  } from "lucide-svelte";
-  import BasalRatePercentileChart from "$lib/components/reports/BasalRatePercentileChart.svelte";
-  import InsulinDeliveryChart from "$lib/components/reports/InsulinDeliveryChart.svelte";
-  import { getBasalReportData } from "$api/reports.remote";
+  import BasalAnalysisContent from "./BasalAnalysisContent.svelte";
   import { requireDateParamsContext } from "$lib/hooks/date-params.svelte";
-  import { contextResource } from "$lib/hooks/resource-context.svelte";
 
   // Get shared date params from context (set by reports layout)
   // Default: 14 days for basal pattern analysis
   const reportsParams = requireDateParamsContext(14);
 
-  // Use contextResource - it syncs to layout's ResourceGuard automatically
-  // dateParams provides .date.from, .date.to, .date.dayCount derived from URL params
-  const reportsResource = contextResource(
-    () => getBasalReportData(reportsParams.dateRangeInput),
-    { errorTitle: "Error Loading Basal Analysis", dateParams: reportsParams }
-  );
-
-  // Derived data from reportsResource
-  const boluses = $derived(reportsResource.current?.boluses ?? []);
-  const basalSeries = $derived(reportsResource.current?.basalSeries ?? []);
-
-  // Basal stats — no dedicated endpoint available; defaults used until backend exposes one
-  const basalStats = $derived({
-    count: 0,
-    avgRate: 0,
-    minRate: 0,
-    maxRate: 0,
-    totalDelivered: 0,
+  // Date info derived from the URL params (same shape contextResource.date exposed).
+  const dateInfo = $derived.by(() => {
+    const range = reportsParams.getDateRange();
+    const ms = range.end.getTime() - range.start.getTime();
+    return {
+      from: range.start,
+      to: range.end,
+      dayCount: Math.max(1, Math.round(ms / (1000 * 60 * 60 * 24))),
+    };
   });
 
-  const tempBasalInfo = $derived({
-    total: 0,
-    perDay: 0,
-    highTemps: 0,
-    lowTemps: 0,
-    zeroTemps: 0,
+  // ISO strings rather than Date objects: remote-query arguments are devalue
+  // serialised and the server schema is z.coerce.date(), which parses them back.
+  const analysisDates = $derived.by(() => {
+    const range = reportsParams.getDateRange();
+    return {
+      startDate: range.start.toISOString() as unknown as Date,
+      endDate: range.end.toISOString() as unknown as Date,
+    };
   });
 
-  // Define the HourlyBasalPercentileData type locally (matches BasalRatePercentileChart)
-  type HourlyBasalPercentileData = {
-    hour?: number;
-    p10?: number;
-    p25?: number;
-    median?: number;
-    p75?: number;
-    p90?: number;
-    count?: number;
-  };
-
-  const hourlyPercentiles = $derived([] as HourlyBasalPercentileData[]);
-
-  // Loading state for child components
-  const isLoading = $derived(reportsResource.loading);
+  const rangeKey = $derived(JSON.stringify(reportsParams.dateRangeInput ?? {}));
 </script>
 
 <svelte:head>
@@ -83,316 +38,10 @@
   />
 </svelte:head>
 
-{#if reportsResource.current}
-  <div class="@container container mx-auto max-w-7xl space-y-8 p-3 @md:p-6">
-    <!-- Header -->
-    <div class="space-y-4">
-      <div class="flex flex-wrap items-center justify-between gap-4">
-        <div>
-          <h1 class="flex items-center gap-3 text-2xl font-bold @md:text-3xl">
-            <Layers class="h-6 w-6 text-amber-600 @md:h-8 @md:w-8" />
-            Basal Rate Analysis
-          </h1>
-          <p class="mt-1 text-muted-foreground">
-            Understand your background insulin delivery patterns over time
-          </p>
-        </div>
-        <div class="flex items-center gap-2 print:hidden">
-          <Button
-            variant="outline"
-            size="sm"
-            class="gap-2"
-            onclick={() => window.print()}
-          >
-            <Printer class="h-4 w-4" />
-            Print
-          </Button>
-          <Button
-            href="/reports/insulin-delivery"
-            variant="outline"
-            size="sm"
-            class="gap-2"
-          >
-            Insulin Delivery
-            <ArrowRight class="h-4 w-4" />
-          </Button>
-        </div>
-      </div>
-
-      <!-- Period info -->
-      <div
-        class="flex flex-wrap items-center gap-2 text-sm text-muted-foreground"
-      >
-        <Calendar class="h-4 w-4" />
-        <span>
-          {reportsResource.date.from.toLocaleDateString()} – {reportsResource.date.to.toLocaleDateString()}
-        </span>
-        <span class="text-muted-foreground/50">•</span>
-        <span>{reportsResource.date.dayCount} days</span>
-        <span class="text-muted-foreground/50">•</span>
-        <span>{basalStats.count} basal events</span>
-      </div>
-    </div>
-
-    <!-- What is this report - Educational Card -->
-    <Card
-      class="border-2 border-amber-200 bg-amber-50/50 dark:border-amber-800 dark:bg-amber-950/30"
-    >
-      <CardHeader class="pb-3">
-        <CardTitle class="flex items-center gap-2 text-base">
-          <HelpCircle class="h-5 w-5 text-amber-600" />
-          Understanding This Report
-        </CardTitle>
-      </CardHeader>
-      <CardContent class="space-y-2 text-sm">
-        <p>
-          This report shows how your <strong>
-            basal (background) insulin delivery
-          </strong>
-          varies throughout the day. The percentile chart shows your typical patterns:
-        </p>
-        <ul class="list-inside list-disc space-y-1 pl-2 text-muted-foreground">
-          <li>
-            The <strong>median line</strong>
-            shows your most common basal rate at each hour
-          </li>
-          <li>
-            The <strong>shaded bands</strong>
-            show the range of variation (10th-90th percentile)
-          </li>
-          <li>Wider bands indicate more variability in your basal needs</li>
-        </ul>
-        <p class="text-muted-foreground">
-          Use this to identify times when your basal insulin may need
-          adjustment, or to discuss temp basal patterns with your healthcare
-          provider.
-        </p>
-      </CardContent>
-    </Card>
-
-    <!-- Key Stats Cards -->
-    <div class="grid grid-cols-2 gap-4 @lg:grid-cols-4">
-      <Card class="border">
-        <CardContent class="pt-6 text-center">
-          <div class="text-2xl font-bold tabular-nums">
-            {basalStats.avgRate.toFixed(2)}
-          </div>
-          <div class="text-xs font-medium text-muted-foreground">Avg Rate</div>
-          <div class="text-[10px] text-muted-foreground/60">U/hr</div>
-        </CardContent>
-      </Card>
-      <Card class="border">
-        <CardContent class="pt-6 text-center">
-          <div class="text-2xl font-bold tabular-nums">
-            {basalStats.totalDelivered.toFixed(1)}
-          </div>
-          <div class="text-xs font-medium text-muted-foreground">
-            Total Basal
-          </div>
-          <div class="text-[10px] text-muted-foreground/60">
-            units delivered
-          </div>
-        </CardContent>
-      </Card>
-      <Card class="border">
-        <CardContent class="pt-6 text-center">
-          <div class="text-2xl font-bold tabular-nums">
-            {tempBasalInfo.perDay.toFixed(1)}
-          </div>
-          <div class="text-xs font-medium text-muted-foreground">
-            Temp Basals
-          </div>
-          <div class="text-[10px] text-muted-foreground/60">per day avg</div>
-        </CardContent>
-      </Card>
-      <Card class="border">
-        <CardContent class="pt-6 text-center">
-          <div class="flex items-center justify-center gap-2">
-            <span class="text-lg font-bold text-green-600">
-              {tempBasalInfo.highTemps}
-            </span>
-            <span class="text-muted-foreground">/</span>
-            <span class="text-lg font-bold text-red-600">
-              {tempBasalInfo.lowTemps}
-            </span>
-          </div>
-          <div class="text-xs font-medium text-muted-foreground">
-            High / Low
-          </div>
-          <div class="text-[10px] text-muted-foreground/60">temp basals</div>
-        </CardContent>
-      </Card>
-    </div>
-
-    <!-- Main Percentile Chart -->
-    <Card class="border">
-      <CardHeader>
-        <CardTitle class="flex items-center gap-2">
-          <Gauge class="h-5 w-5 text-muted-foreground" />
-          Basal Rate Percentile Chart
-        </CardTitle>
-        <CardDescription>
-          Your typical basal delivery pattern across 24 hours (like an AGP for
-          basal rates)
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <BasalRatePercentileChart
-          data={hourlyPercentiles}
-          loading={isLoading}
-        />
-      </CardContent>
-    </Card>
-
-    <!-- Hourly Insulin Delivery -->
-    <Card class="border">
-      <CardHeader>
-        <CardTitle class="flex items-center gap-2">
-          <Clock class="h-5 w-5 text-muted-foreground" />
-          Average Hourly Basal Delivery
-        </CardTitle>
-        <CardDescription>
-          Average basal insulin delivered per hour of the day
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <InsulinDeliveryChart {boluses} {basalSeries} showStacked={false} />
-      </CardContent>
-    </Card>
-
-    <!-- Insights Section -->
-    {#if basalStats.count > 0}
-      <Card class="border">
-        <CardHeader>
-          <CardTitle class="flex items-center gap-2">
-            <Info class="h-5 w-5 text-muted-foreground" />
-            Basal Insights
-          </CardTitle>
-        </CardHeader>
-        <CardContent class="space-y-4">
-          <div class="grid gap-4 @3xl:grid-cols-2">
-            <!-- Rate Range -->
-            <div class="rounded-lg border bg-card p-4">
-              <div class="flex items-start gap-3">
-                <div class="rounded-lg bg-primary/10 p-2">
-                  <TrendingUp class="h-4 w-4 text-primary" />
-                </div>
-                <div>
-                  <h4 class="font-medium">Basal Rate Range</h4>
-                  <p class="text-sm text-muted-foreground">
-                    Your basal rates ranged from <strong>
-                      {basalStats.minRate.toFixed(2)} U/hr
-                    </strong>
-                    to
-                    <strong>{basalStats.maxRate.toFixed(2)} U/hr</strong>
-                    .
-                    {#if basalStats.maxRate - basalStats.minRate > 0.5}
-                      This indicates significant variation in your basal needs
-                      throughout the day.
-                    {:else}
-                      Your basal rates are relatively consistent.
-                    {/if}
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            <!-- Temp Basal Usage -->
-            <div class="rounded-lg border bg-card p-4">
-              <div class="flex items-start gap-3">
-                <div class="rounded-lg bg-amber-500/10 p-2">
-                  <Layers class="h-4 w-4 text-amber-600" />
-                </div>
-                <div>
-                  <h4 class="font-medium">Temp Basal Activity</h4>
-                  <p class="text-sm text-muted-foreground">
-                    {#if tempBasalInfo.perDay > 10}
-                      High temp basal activity ({tempBasalInfo.perDay.toFixed(
-                        1
-                      )}/day) suggests active automated or manual adjustments.
-                    {:else if tempBasalInfo.perDay > 3}
-                      Moderate temp basal activity — typical for automated
-                      insulin delivery systems.
-                    {:else if tempBasalInfo.perDay > 0}
-                      Low temp basal activity — your basal rates may be
-                      well-tuned.
-                    {:else}
-                      No temp basal activity recorded in this period.
-                    {/if}
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            <!-- Zero Temps -->
-            {#if tempBasalInfo.zeroTemps > 0}
-              <div
-                class="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-950/30"
-              >
-                <div class="flex items-start gap-3">
-                  <div class="rounded-lg bg-red-500/10 p-2">
-                    <TrendingDown class="h-4 w-4 text-red-600" />
-                  </div>
-                  <div>
-                    <h4 class="font-medium text-red-700 dark:text-red-400">
-                      Suspend/Zero Temp Basals
-                    </h4>
-                    <p class="text-sm text-muted-foreground">
-                      <strong>{tempBasalInfo.zeroTemps}</strong>
-                      zero or suspend temp basals were recorded. This often indicates
-                      low glucose prevention or manual suspensions.
-                    </p>
-                  </div>
-                </div>
-              </div>
-            {/if}
-
-            <!-- Daily Average -->
-            <div class="rounded-lg border bg-card p-4">
-              <div class="flex items-start gap-3">
-                <div class="rounded-lg bg-blue-500/10 p-2">
-                  <Calendar class="h-4 w-4 text-blue-600" />
-                </div>
-                <div>
-                  <h4 class="font-medium">Daily Basal Insulin</h4>
-                  <p class="text-sm text-muted-foreground">
-                    Average of <strong>
-                      {(basalStats.totalDelivered / reportsResource.date.dayCount).toFixed(1)} units
-                    </strong>
-                    of basal insulin delivered per day over this {reportsResource.date.dayCount}-day
-                    period.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-    {/if}
-
-    <!-- Navigation -->
-    <Separator class="print:hidden" />
-    <div class="flex flex-wrap items-center justify-center gap-2 print:hidden">
-      <Button href="/reports" variant="outline" size="sm">← All Reports</Button>
-      <Button href="/reports/insulin-delivery" size="sm" class="gap-2">
-        Insulin Delivery Report
-        <ArrowRight class="h-4 w-4" />
-      </Button>
-      <Button href="/reports/treatments" variant="outline" size="sm">
-        Treatment Log
-      </Button>
-    </div>
-
-    <!-- Footer -->
-    <div class="space-y-1 text-center text-xs text-muted-foreground">
-      <p>
-        Report generated from {boluses.length.toLocaleString()} boluses between
-        {reportsResource.date.from.toLocaleDateString()} and {reportsResource.date.to.toLocaleDateString()}
-      </p>
-      <p class="text-muted-foreground/60">
-        This report is for informational purposes only. Always consult your
-        healthcare provider for medical advice.
-      </p>
-    </div>
-  </div>
-{/if}
+{#key rangeKey}
+  <BasalAnalysisContent
+    rangeInput={reportsParams.dateRangeInput}
+    {analysisDates}
+    {dateInfo}
+  />
+{/key}

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/basal-analysis/BasalAnalysisContent.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/basal-analysis/BasalAnalysisContent.svelte
@@ -1,0 +1,406 @@
+<script lang="ts">
+  import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+  } from "$lib/components/ui/card";
+  import { Button } from "$lib/components/ui/button";
+  import { Separator } from "$lib/components/ui/separator";
+  import {
+    Layers,
+    Calendar,
+    Info,
+    TrendingUp,
+    TrendingDown,
+    ArrowRight,
+    Printer,
+    HelpCircle,
+    Clock,
+    Gauge,
+  } from "lucide-svelte";
+  import BasalRatePercentileChart from "$lib/components/reports/BasalRatePercentileChart.svelte";
+  import InsulinDeliveryChart from "$lib/components/reports/InsulinDeliveryChart.svelte";
+  import ReportsSkeleton from "$lib/components/reports/ReportsSkeleton.svelte";
+  import { getBasalReportData } from "$api/reports.remote";
+  import { getBasalAnalysis } from "$api/generated/statistics.generated.remote";
+  import type { DateRangeInput } from "$lib/hooks/date-params.svelte";
+
+  interface Props {
+    rangeInput: DateRangeInput | undefined;
+    analysisDates: { startDate: Date; endDate: Date };
+    dateInfo: { from: Date; to: Date; dayCount: number };
+  }
+  let { rangeInput, analysisDates, dateInfo }: Props = $props();
+
+  // Query instances are created once per component instance (the parent remounts
+  // this component via {#key} when the date range changes). Creating a query
+  // inside $derived and polling .loading/.current can strand the resolved
+  // response on a superseded instance (sveltejs/kit#14915) — with this report's
+  // large getBasalReportData payload that reliably left .loading stuck at true
+  // and the page blank. Component-level instances avoid the race.
+  const reportsQuery = getBasalReportData(rangeInput);
+  const analysisQuery = getBasalAnalysis(analysisDates);
+
+  const boluses = $derived(reportsQuery.current?.boluses ?? []);
+  const basalSeries = $derived(reportsQuery.current?.basalSeries ?? []);
+
+  const basalStats = $derived.by(() => {
+    const s = analysisQuery.current?.stats;
+    return {
+      count: s?.count ?? 0,
+      avgRate: s?.avgRate ?? 0,
+      minRate: s?.minRate ?? 0,
+      maxRate: s?.maxRate ?? 0,
+      totalDelivered: s?.totalDelivered ?? 0,
+    };
+  });
+
+  const tempBasalInfo = $derived.by(() => {
+    const t = analysisQuery.current?.tempBasalInfo;
+    return {
+      total: t?.total ?? 0,
+      perDay: t?.perDay ?? 0,
+      highTemps: t?.highTemps ?? 0,
+      lowTemps: t?.lowTemps ?? 0,
+      zeroTemps: t?.zeroTemps ?? 0,
+    };
+  });
+
+  const hourlyPercentiles = $derived(analysisQuery.current?.hourlyPercentiles ?? []);
+</script>
+
+{#if reportsQuery.error || analysisQuery.error}
+  <div class="@container container mx-auto max-w-7xl p-3 @md:p-6">
+    <Card
+      class="border-2 border-red-200 bg-red-50/50 dark:border-red-800 dark:bg-red-950/30"
+    >
+      <CardHeader>
+        <CardTitle
+          class="flex items-center gap-2 text-base text-red-700 dark:text-red-400"
+        >
+          <Info class="h-5 w-5" />
+          Error Loading Basal Analysis
+        </CardTitle>
+      </CardHeader>
+      <CardContent class="text-sm text-muted-foreground">
+        {String(reportsQuery.error ?? analysisQuery.error)}
+      </CardContent>
+    </Card>
+  </div>
+{:else if !reportsQuery.current}
+  <ReportsSkeleton />
+{:else}
+  <div class="@container container mx-auto max-w-7xl space-y-8 p-3 @md:p-6">
+    <!-- Header -->
+    <div class="space-y-4">
+      <div class="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 class="flex items-center gap-3 text-2xl font-bold @md:text-3xl">
+            <Layers class="h-6 w-6 text-amber-600 @md:h-8 @md:w-8" />
+            Basal Rate Analysis
+          </h1>
+          <p class="mt-1 text-muted-foreground">
+            Understand your background insulin delivery patterns over time
+          </p>
+        </div>
+        <div class="flex items-center gap-2 print:hidden">
+          <Button
+            variant="outline"
+            size="sm"
+            class="gap-2"
+            onclick={() => window.print()}
+          >
+            <Printer class="h-4 w-4" />
+            Print
+          </Button>
+          <Button
+            href="/reports/insulin-delivery"
+            variant="outline"
+            size="sm"
+            class="gap-2"
+          >
+            Insulin Delivery
+            <ArrowRight class="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      <!-- Period info -->
+      <div
+        class="flex flex-wrap items-center gap-2 text-sm text-muted-foreground"
+      >
+        <Calendar class="h-4 w-4" />
+        <span>
+          {dateInfo.from.toLocaleDateString()} – {dateInfo.to.toLocaleDateString()}
+        </span>
+        <span class="text-muted-foreground/50">•</span>
+        <span>{dateInfo.dayCount} days</span>
+        <span class="text-muted-foreground/50">•</span>
+        <span>{basalStats.count} basal events</span>
+      </div>
+    </div>
+
+    <!-- What is this report - Educational Card -->
+    <Card
+      class="border-2 border-amber-200 bg-amber-50/50 dark:border-amber-800 dark:bg-amber-950/30"
+    >
+      <CardHeader class="pb-3">
+        <CardTitle class="flex items-center gap-2 text-base">
+          <HelpCircle class="h-5 w-5 text-amber-600" />
+          Understanding This Report
+        </CardTitle>
+      </CardHeader>
+      <CardContent class="space-y-2 text-sm">
+        <p>
+          This report shows how your <strong>
+            basal (background) insulin delivery
+          </strong>
+          varies throughout the day. The percentile chart shows your typical patterns:
+        </p>
+        <ul class="list-inside list-disc space-y-1 pl-2 text-muted-foreground">
+          <li>
+            The <strong>median line</strong>
+            shows your most common basal rate at each hour
+          </li>
+          <li>
+            The <strong>shaded bands</strong>
+            show the range of variation (10th-90th percentile)
+          </li>
+          <li>Wider bands indicate more variability in your basal needs</li>
+        </ul>
+        <p class="text-muted-foreground">
+          Use this to identify times when your basal insulin may need
+          adjustment, or to discuss temp basal patterns with your healthcare
+          provider.
+        </p>
+      </CardContent>
+    </Card>
+
+    <!-- Key Stats Cards -->
+    <div class="grid grid-cols-2 gap-4 @lg:grid-cols-4">
+      <Card class="border">
+        <CardContent class="pt-6 text-center">
+          <div class="text-2xl font-bold tabular-nums">
+            {basalStats.avgRate.toFixed(2)}
+          </div>
+          <div class="text-xs font-medium text-muted-foreground">Avg Rate</div>
+          <div class="text-[10px] text-muted-foreground/60">U/hr</div>
+        </CardContent>
+      </Card>
+      <Card class="border">
+        <CardContent class="pt-6 text-center">
+          <div class="text-2xl font-bold tabular-nums">
+            {basalStats.totalDelivered.toFixed(1)}
+          </div>
+          <div class="text-xs font-medium text-muted-foreground">
+            Total Basal
+          </div>
+          <div class="text-[10px] text-muted-foreground/60">
+            units delivered
+          </div>
+        </CardContent>
+      </Card>
+      <Card class="border">
+        <CardContent class="pt-6 text-center">
+          <div class="text-2xl font-bold tabular-nums">
+            {tempBasalInfo.perDay.toFixed(1)}
+          </div>
+          <div class="text-xs font-medium text-muted-foreground">
+            Temp Basals
+          </div>
+          <div class="text-[10px] text-muted-foreground/60">per day avg</div>
+        </CardContent>
+      </Card>
+      <Card class="border">
+        <CardContent class="pt-6 text-center">
+          <div class="flex items-center justify-center gap-2">
+            <span class="text-lg font-bold text-green-600">
+              {tempBasalInfo.highTemps}
+            </span>
+            <span class="text-muted-foreground">/</span>
+            <span class="text-lg font-bold text-red-600">
+              {tempBasalInfo.lowTemps}
+            </span>
+          </div>
+          <div class="text-xs font-medium text-muted-foreground">
+            High / Low
+          </div>
+          <div class="text-[10px] text-muted-foreground/60">temp basals</div>
+        </CardContent>
+      </Card>
+    </div>
+
+    <!-- Main Percentile Chart -->
+    <Card class="border">
+      <CardHeader>
+        <CardTitle class="flex items-center gap-2">
+          <Gauge class="h-5 w-5 text-muted-foreground" />
+          Basal Rate Percentile Chart
+        </CardTitle>
+        <CardDescription>
+          Your typical basal delivery pattern across 24 hours (like an AGP for
+          basal rates)
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <BasalRatePercentileChart
+          data={hourlyPercentiles}
+          loading={analysisQuery.loading}
+        />
+      </CardContent>
+    </Card>
+
+    <!-- Hourly Insulin Delivery -->
+    <Card class="border">
+      <CardHeader>
+        <CardTitle class="flex items-center gap-2">
+          <Clock class="h-5 w-5 text-muted-foreground" />
+          Average Hourly Basal Delivery
+        </CardTitle>
+        <CardDescription>
+          Average basal insulin delivered per hour of the day
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <InsulinDeliveryChart {boluses} {basalSeries} showStacked={false} />
+      </CardContent>
+    </Card>
+
+    <!-- Insights Section -->
+    {#if basalStats.count > 0}
+      <Card class="border">
+        <CardHeader>
+          <CardTitle class="flex items-center gap-2">
+            <Info class="h-5 w-5 text-muted-foreground" />
+            Basal Insights
+          </CardTitle>
+        </CardHeader>
+        <CardContent class="space-y-4">
+          <div class="grid gap-4 @3xl:grid-cols-2">
+            <!-- Rate Range -->
+            <div class="rounded-lg border bg-card p-4">
+              <div class="flex items-start gap-3">
+                <div class="rounded-lg bg-primary/10 p-2">
+                  <TrendingUp class="h-4 w-4 text-primary" />
+                </div>
+                <div>
+                  <h4 class="font-medium">Basal Rate Range</h4>
+                  <p class="text-sm text-muted-foreground">
+                    Your basal rates ranged from <strong>
+                      {basalStats.minRate.toFixed(2)} U/hr
+                    </strong>
+                    to
+                    <strong>{basalStats.maxRate.toFixed(2)} U/hr</strong>
+                    .
+                    {#if basalStats.maxRate - basalStats.minRate > 0.5}
+                      This indicates significant variation in your basal needs
+                      throughout the day.
+                    {:else}
+                      Your basal rates are relatively consistent.
+                    {/if}
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <!-- Temp Basal Usage -->
+            <div class="rounded-lg border bg-card p-4">
+              <div class="flex items-start gap-3">
+                <div class="rounded-lg bg-amber-500/10 p-2">
+                  <Layers class="h-4 w-4 text-amber-600" />
+                </div>
+                <div>
+                  <h4 class="font-medium">Temp Basal Activity</h4>
+                  <p class="text-sm text-muted-foreground">
+                    {#if tempBasalInfo.perDay > 10}
+                      High temp basal activity ({tempBasalInfo.perDay.toFixed(
+                        1
+                      )}/day) suggests active automated or manual adjustments.
+                    {:else if tempBasalInfo.perDay > 3}
+                      Moderate temp basal activity — typical for automated
+                      insulin delivery systems.
+                    {:else if tempBasalInfo.perDay > 0}
+                      Low temp basal activity — your basal rates may be
+                      well-tuned.
+                    {:else}
+                      No temp basal activity recorded in this period.
+                    {/if}
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <!-- Zero Temps -->
+            {#if tempBasalInfo.zeroTemps > 0}
+              <div
+                class="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-950/30"
+              >
+                <div class="flex items-start gap-3">
+                  <div class="rounded-lg bg-red-500/10 p-2">
+                    <TrendingDown class="h-4 w-4 text-red-600" />
+                  </div>
+                  <div>
+                    <h4 class="font-medium text-red-700 dark:text-red-400">
+                      Suspend/Zero Temp Basals
+                    </h4>
+                    <p class="text-sm text-muted-foreground">
+                      <strong>{tempBasalInfo.zeroTemps}</strong>
+                      zero or suspend temp basals were recorded. This often indicates
+                      low glucose prevention or manual suspensions.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            {/if}
+
+            <!-- Daily Average -->
+            <div class="rounded-lg border bg-card p-4">
+              <div class="flex items-start gap-3">
+                <div class="rounded-lg bg-blue-500/10 p-2">
+                  <Calendar class="h-4 w-4 text-blue-600" />
+                </div>
+                <div>
+                  <h4 class="font-medium">Daily Basal Insulin</h4>
+                  <p class="text-sm text-muted-foreground">
+                    Average of <strong>
+                      {(basalStats.totalDelivered / dateInfo.dayCount).toFixed(1)} units
+                    </strong>
+                    of basal insulin delivered per day over this {dateInfo.dayCount}-day
+                    period.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    {/if}
+
+    <!-- Navigation -->
+    <Separator class="print:hidden" />
+    <div class="flex flex-wrap items-center justify-center gap-2 print:hidden">
+      <Button href="/reports" variant="outline" size="sm">← All Reports</Button>
+      <Button href="/reports/insulin-delivery" size="sm" class="gap-2">
+        Insulin Delivery Report
+        <ArrowRight class="h-4 w-4" />
+      </Button>
+      <Button href="/reports/treatments" variant="outline" size="sm">
+        Treatment Log
+      </Button>
+    </div>
+
+    <!-- Footer -->
+    <div class="space-y-1 text-center text-xs text-muted-foreground">
+      <p>
+        Report generated from {boluses.length.toLocaleString()} boluses between
+        {dateInfo.from.toLocaleDateString()} and {dateInfo.to.toLocaleDateString()}
+      </p>
+      <p class="text-muted-foreground/60">
+        This report is for informational purposes only. Always consult your
+        healthcare provider for medical advice.
+      </p>
+    </div>
+  </div>
+{/if}


### PR DESCRIPTION
## Problem

The `/reports/basal-analysis` page never shows data, for a chain of reasons:

1. **The page is a stub.** `basalStats`, `tempBasalInfo` and `hourlyPercentiles` are hard-coded to zeros/empty with a comment saying "no dedicated endpoint available" — but `GET /api/v4/statistics/basal-analysis` exists and is fully implemented in `StatisticsController`, and the generated client already ships `getBasalAnalysis`. The stat cards and the percentile chart are therefore always empty.

2. **On instances with realistic data volumes the page renders completely blank** (dark content area, no error, no console output). `getBasalReportData` returns ~1.3 MB here, and consuming a query created inside `$derived` through `.loading`/`.current` (the `contextResource` pattern) hits sveltejs/kit#14915: the resolved response lands on a superseded query instance, `.loading` sticks at `true` forever, and the `{#if reportsResource.current}` guard never opens. Smaller payloads (e.g. the AGP report) usually win the race, which is why only this report appears broken. `insulin-delivery` uses the same query and can hit the same wall.

3. **With data finally flowing, both charts still fail to render.** layerchart `2.0.0-next.43`'s motion tracking is broken on svelte ≥ 5.35.4 (sveltejs/svelte#16548, techniq/layerchart#630): combined with the built-in `legend` prop the page dies with `effect_update_depth_exceeded`; without it the area paths silently stay empty. The AGP chart renders fine because it never passes `motion`.

4. **The percentile chart's median is invisible on every theme**: it uses `hsl(var(--primary))`, but `--primary` is an oklch value, so the color is invalid.

## Changes

- Wire the page to `getBasalAnalysis` and derive `basalStats` / `tempBasalInfo` / `hourlyPercentiles` from the response.
- Move the report body into `BasalAnalysisContent.svelte`, which creates its two query instances once at component init and is remounted via `{#key}` when the date range changes — sidestepping kit#14915 while keeping the `.loading`/`.current` consumption style used elsewhere.
- Drop the `motion` tween props on both report charts (matching the AGP chart, which already renders without motion) and the redundant built-in `legend` on the single-series delivery chart — a workaround until layerchart is bumped to a 2.0.x release containing the motion fix, at which point the tweens can come back.
- `hsl(var(--primary))` → `var(--primary)` for the median line and legend swatch.

## Testing

Built the web image from this branch and ran it against a production instance (API 0.1.6, Nightscout connector, ~16k temp basals / ~5k boluses from a Trio loop):

- stat cards, temp-basal metrics, percentile bands + median line, hourly delivery chart and period insights all render with real data;
- date-range changes remount cleanly;
- no console errors, no server-side errors;
- cross-checked the rendered numbers against raw `GET /api/v4/statistics/basal-analysis` output.

Happy to split this into separate PRs if that's easier to review.
