### PR TITLE
feat(data): cap runtime queries with a server-side statement_timeout

### DIFF
--- a/src/API/Nocturne.API/appsettings.example.json
+++ b/src/API/Nocturne.API/appsettings.example.json
@@ -13,7 +13,8 @@
     "EnableDetailedErrors": false,
     "MaxRetryCount": 3,
     "MaxRetryDelaySeconds": 30,
-    "CommandTimeoutSeconds": 30
+    "CommandTimeoutSeconds": 30,
+    "StatementTimeoutSeconds": 30
   },
 
   // Authentication

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Configuration/PostgreSqlConfiguration.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Configuration/PostgreSqlConfiguration.cs
@@ -46,6 +46,16 @@ public class PostgreSqlConfiguration
     public int CommandTimeoutSeconds { get; set; } = 30;
 
     /// <summary>
+    /// Server-side hard cap on how long any single statement may run, in seconds, applied as a
+    /// PostgreSQL <c>statement_timeout</c> on the runtime connection pool. Backstops the
+    /// client-side <see cref="CommandTimeoutSeconds"/>: a slow or expensive query is reaped by
+    /// the server itself rather than merely abandoned client-side. Not applied to the migrator
+    /// pool, whose DDL (e.g. a large index build) may legitimately run for minutes. A
+    /// non-positive value leaves the server default (no cap).
+    /// </summary>
+    public int StatementTimeoutSeconds { get; set; } = 30;
+
+    /// <summary>
     /// Maximum number of physical connections in the Npgsql connection pool.
     /// Increase alongside Postgres max_connections when deploying at high concurrency.
     /// </summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Configuration/PostgresRuntimeOptions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Configuration/PostgresRuntimeOptions.cs
@@ -1,0 +1,38 @@
+using Npgsql;
+
+namespace Nocturne.Infrastructure.Data.Configuration;
+
+/// <summary>
+/// Runtime-pool connection tuning applied to the app <see cref="NpgsqlDataSource"/> at startup.
+/// Kept separate from the migrator data source, which must remain uncapped.
+/// </summary>
+internal static class PostgresRuntimeOptions
+{
+    /// <summary>
+    /// Appends a server-side <c>statement_timeout</c> to the connection's startup options so every
+    /// statement on the runtime pool is cancelled by PostgreSQL itself once it exceeds the cap —
+    /// the hard backstop behind the client-side command timeout. Applied only to the runtime app
+    /// pool; the migrator pool is left uncapped because migration DDL (e.g. building an index on a
+    /// multi-million-row table) may legitimately run for minutes. A non-positive value is a no-op,
+    /// leaving the server default (0, meaning no cap).
+    /// </summary>
+    /// <param name="builder">Connection string builder for the runtime data source.</param>
+    /// <param name="statementTimeoutSeconds">The cap in seconds; non-positive disables it.</param>
+    internal static void ApplyStatementTimeout(
+        NpgsqlConnectionStringBuilder builder,
+        int statementTimeoutSeconds)
+    {
+        if (statementTimeoutSeconds <= 0)
+        {
+            return;
+        }
+
+        // statement_timeout is USERSET, so nocturne_app may set it via the startup 'options'
+        // packet. Bare integer is milliseconds. Append rather than overwrite so any existing
+        // startup options survive.
+        var option = $"-c statement_timeout={statementTimeoutSeconds * 1000}";
+        builder.Options = string.IsNullOrWhiteSpace(builder.Options)
+            ? option
+            : $"{builder.Options} {option}";
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/ServiceCollectionExtensions.cs
@@ -62,6 +62,9 @@ public static class ServiceCollectionExtensions
             postgreSqlConfig.ConnectionString
         );
         dataSourceBuilder.ConnectionStringBuilder.MaxPoolSize = postgreSqlConfig.MaxPoolSize;
+        PostgresRuntimeOptions.ApplyStatementTimeout(
+            dataSourceBuilder.ConnectionStringBuilder,
+            postgreSqlConfig.StatementTimeoutSeconds);
         var dataSource = dataSourceBuilder.Build();
         services.AddSingleton(dataSource);
 
@@ -220,6 +223,7 @@ public static class ServiceCollectionExtensions
             options.MaxRetryCount = config.MaxRetryCount;
             options.MaxRetryDelaySeconds = config.MaxRetryDelaySeconds;
             options.CommandTimeoutSeconds = config.CommandTimeoutSeconds;
+            options.StatementTimeoutSeconds = config.StatementTimeoutSeconds;
             options.MaxPoolSize = config.MaxPoolSize;
         });
 
@@ -233,6 +237,9 @@ public static class ServiceCollectionExtensions
         // Register NpgsqlDataSource as a singleton - this manages the connection pool
         var dataSourceBuilder = new Npgsql.NpgsqlDataSourceBuilder(config.ConnectionString);
         dataSourceBuilder.ConnectionStringBuilder.MaxPoolSize = config.MaxPoolSize;
+        PostgresRuntimeOptions.ApplyStatementTimeout(
+            dataSourceBuilder.ConnectionStringBuilder,
+            config.StatementTimeoutSeconds);
         var dataSource = dataSourceBuilder.Build();
         services.AddSingleton(dataSource);
 

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/StatementTimeoutTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/StatementTimeoutTests.cs
@@ -1,0 +1,82 @@
+using FluentAssertions;
+using Nocturne.Infrastructure.Data.Configuration;
+using Npgsql;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests.Rls;
+
+/// <summary>
+/// Behavioural assertions that the runtime app connection pool carries a server-side
+/// <c>statement_timeout</c>, so a slow or expensive query is cancelled by PostgreSQL itself and
+/// cannot pin a backend indefinitely — the hard backstop behind the client CommandTimeout.
+///
+/// Reuses the RLS completeness fixture purely for its migrated database and the nocturne_app
+/// connection string; these tests build their own data source so the production wiring
+/// (<see cref="PostgresRuntimeOptions.ApplyStatementTimeout"/>) is what is under test.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("RLS completeness")]
+public class StatementTimeoutTests
+{
+    private readonly RlsCompletenessFixture _fx;
+
+    public StatementTimeoutTests(RlsCompletenessFixture fx)
+    {
+        _fx = fx;
+    }
+
+    private static NpgsqlDataSource BuildAppDataSource(string connectionString, int statementTimeoutSeconds)
+    {
+        var builder = new NpgsqlDataSourceBuilder(connectionString);
+        PostgresRuntimeOptions.ApplyStatementTimeout(
+            builder.ConnectionStringBuilder,
+            statementTimeoutSeconds);
+        return builder.Build();
+    }
+
+    [Fact]
+    public async Task RuntimePool_CarriesConfiguredStatementTimeout()
+    {
+        await using var dataSource = BuildAppDataSource(_fx.AppConnectionString, statementTimeoutSeconds: 2);
+        await using var conn = await dataSource.OpenConnectionAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SHOW statement_timeout";
+        var value = (string?)await cmd.ExecuteScalarAsync();
+
+        value.Should().Be("2s", "the runtime pool must carry the configured statement_timeout");
+    }
+
+    [Fact]
+    public async Task RuntimePool_CancelsQueryExceedingStatementTimeout()
+    {
+        await using var dataSource = BuildAppDataSource(_fx.AppConnectionString, statementTimeoutSeconds: 1);
+        await using var conn = await dataSource.OpenConnectionAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT pg_sleep(5)";
+        // Keep Npgsql's own command timeout well above the 1s server cap so the cancellation
+        // under test comes from PostgreSQL, not the client.
+        cmd.CommandTimeout = 30;
+
+        var act = () => cmd.ExecuteScalarAsync();
+
+        var thrown = await act.Should().ThrowAsync<PostgresException>();
+        thrown.Which.SqlState.Should().Be(
+            "57014",
+            "a statement exceeding statement_timeout must be cancelled by PostgreSQL (SQLSTATE 57014)");
+    }
+
+    [Fact]
+    public async Task NonPositiveTimeout_LeavesServerDefault()
+    {
+        await using var dataSource = BuildAppDataSource(_fx.AppConnectionString, statementTimeoutSeconds: 0);
+        await using var conn = await dataSource.OpenConnectionAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SHOW statement_timeout";
+        var value = (string?)await cmd.ExecuteScalarAsync();
+
+        value.Should().Be("0", "a non-positive config value must leave the server default (no cap)");
+    }
+}


### PR DESCRIPTION
## Problem

The runtime DB pool has a 30s Npgsql `CommandTimeout`, but that only cancels the **client's wait** — it does not guarantee the Postgres backend stops working on a slow or expensive query. Combined with the uncapped `limit`/`offset` on V4 read endpoints and unbounded date ranges, a single request could keep a backend busy well past the point the client abandoned it. There was no server-side ceiling on query cost for the multi-tenant DB.

## Change

Add a PostgreSQL `statement_timeout` to the **runtime app connection pool** via a new `PostgreSqlConfiguration.StatementTimeoutSeconds` (default **30**, `0` disables). Any statement exceeding the cap is now cancelled by Postgres itself with SQLSTATE `57014` — a hard backstop behind the client-side `CommandTimeout`.

It's applied at the `NpgsqlDataSource` level (startup `options`), not in `TenantConnectionInterceptor`, so:

- **The migrator pool is deliberately left uncapped.** It builds its own throwaway data source with a 1-hour timeout because migration DDL (e.g. building an index on a multi-million-row table) may legitimately run for minutes — a timed-out migration would crash-loop startup. Setting the cap at the runtime datasource excludes migrations automatically, with no per-context flag to get wrong.
- No new failure modes in prod: the 30s cap simply makes the server honor the same bound the client `CommandTimeout` already imposes, so nothing that succeeds today starts failing.

## Tests

Three integration tests (Testcontainers, Postgres 17.6, runs in the `integration-db` CI job) assert the runtime pool:
- carries the configured `statement_timeout` (`2s`),
- cancels an over-budget `pg_sleep(5)` query with SQLSTATE `57014`,
- leaves the server default (no cap) when configured to `0`.

## Not in scope

The request-side caps the same audit flagged — enforcing the existing (currently dead) `MaxPageSize` on V4 `limit`/`offset` and V1 `count`, plus a max date-span — are a separate follow-up.