### PR TITLE
Require permissions on the root info endpoint (follow-up to #475)

### DIFF
--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -442,7 +442,11 @@ app.MapScalarApiReference((options, httpContext) =>
     }
 }).RequireRateLimiting(ServiceRegistrationExtensions.DocsRateLimitPolicy);
 
-// Add root endpoint to serve a basic info page
+// Add root endpoint to serve a basic info page. The payload includes the tenant's latest
+// entry (sgv/mbg/direction), and on an ordinary tenant host the share RLS does not restrict
+// the read (app.is_share is not 'true'), so the endpoint gate is the only protection for that
+// PHI. No AllowAnonymous: the HasPermissions fallback policy applies, as on the rest of the
+// API surface. A public info page would need the latest_entry payload stripped first.
 app.MapGet(
     "/",
     async (IEntryStore entryStore) =>
@@ -498,7 +502,7 @@ app.MapGet(
             }
         );
     }
-).AllowAnonymous();
+);
 
 app.MapDefaultEndpoints();
 

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -458,7 +458,14 @@ app.MapScalarApiReference(options =>
         });
 });
 
-// Add root endpoint to serve a basic info page
+// Add root endpoint to serve a basic info page. Returns the tenant's latest entry
+// (sgv/mbg/direction) as a connectivity indicator, so it exposes PHI and must carry an
+// explicit authorization decision. On an ordinary tenant subdomain the request resolves
+// with app.is_share=false, so the per-category public-share RLS does NOT restrict this read;
+// the endpoint's own gate is the only protection. It is deliberately NOT [AllowAnonymous]:
+// that would return the latest glucose reading to any unauthenticated caller on any tenant.
+// Gated with RequireAuthorization (fallback/default policy) as the safe default — a maintainer
+// who wants a public info page should strip the latest_entry payload rather than relax this.
 app.MapGet(
     "/",
     async (IEntryStore entryStore) =>
@@ -514,7 +521,7 @@ app.MapGet(
             }
         );
     }
-).AllowAnonymous();
+).RequireAuthorization();
 
 app.MapDefaultEndpoints();
 

--- a/tests/Integration/Nocturne.API.Tests/Auth/PublicAccessIntegrationTests.cs
+++ b/tests/Integration/Nocturne.API.Tests/Auth/PublicAccessIntegrationTests.cs
@@ -103,6 +103,26 @@ public class PublicAccessIntegrationTests : AspireIntegrationTestBase
         response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
     }
 
+    [Fact]
+    public async Task RootInfoPage_NoAuth_Returns401()
+    {
+        // The root info page embeds the tenant's latest entry (sgv/mbg/direction), so it
+        // follows the same login-only contract as every other bare-host read.
+        var response = await ApiClient.GetAsync("/");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task RootInfoPage_AuthenticatedMember_Returns200()
+    {
+        using var client = AuthTestHelpers.CreateAuthenticatedSubjectClient(Fixture, _accessToken);
+
+        var response = await client.GetAsync("/");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
     #region Helpers
 
     private async Task EnablePublicAccessAsync()

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ControllerAuthorizationCoverageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ControllerAuthorizationCoverageTests.cs
@@ -21,6 +21,21 @@ namespace Nocturne.API.Tests.Authorization;
 /// </summary>
 /// <remarks>
 /// <para>
+/// SCOPE: this guard covers only <see cref="ControllerBase"/>-derived actions discovered via
+/// reflection. Minimal-API endpoints registered with <c>app.MapGet</c>/<c>app.MapPost</c> in
+/// <c>Program.cs</c> are NOT visible to reflection and are therefore OUT OF SCOPE here — they must
+/// be gated manually at their registration site. The known minimal-API endpoints and their gates:
+/// <list type="bullet">
+///   <item><c>app.MapGet("/")</c> — returns the tenant's latest entry (PHI); explicitly
+///   <c>.RequireAuthorization()</c> (NOT <c>[AllowAnonymous]</c>, which would leak latest glucose
+///   to anonymous callers because <c>GET /</c> resolves with <c>app.is_share=false</c>, so the
+///   per-category share RLS does not restrict it).</item>
+///   <item><c>app.MapDefaultEndpoints()</c> — Aspire health/liveness endpoints (no PHI).</item>
+/// </list>
+/// Adding a new minimal-API endpoint that returns tenant data requires giving it an explicit gate;
+/// this test cannot catch a regression there.
+/// </para>
+/// <para>
 /// The <see cref="AuthorizationConfiguration.AddNocturneAuthorization"/> fallback policy
 /// (<see cref="HasPermissionsRequirement"/>) gates every attribute-less endpoint by requiring a
 /// non-empty <see cref="Nocturne.Core.Models.PermissionTrie"/>. That fallback rejects a bare
@@ -66,13 +81,15 @@ public class ControllerAuthorizationCoverageTests
 
             // ── Legacy Nightscout v1 surfaces (authorize via OAuth scope in the fallback trie) ──
             // v1 endpoints authenticate via the api-secret / token trie and are gated by the
-            // fallback policy plus in-handler scope checks, matching upstream Nightscout behaviour.
-            // They deliberately do not use the v4 [Authorize] convention.
-            ["Nocturne.API.Controllers.V1.AlexaController"] = "legacy v1 (fallback trie + in-handler)",
-            ["Nocturne.API.Controllers.V1.CountController"] = "legacy v1 (fallback trie + in-handler)",
-            ["Nocturne.API.Controllers.V1.IobController"] = "legacy v1 (fallback trie + in-handler)",
-            ["Nocturne.API.Controllers.V1.PebbleController"] = "legacy v1 (fallback trie + in-handler)",
-            ["Nocturne.API.Controllers.V1.TimeQueryController"] = "legacy v1 (fallback trie + in-handler)",
+            // fallback policy plus DB-layer RLS (tenant isolation + per-category share RLS on the
+            // underlying entries/treatments/etc.), matching upstream Nightscout behaviour. Only
+            // AlexaController additionally performs an in-handler CheckPermissionAsync; the others
+            // have no in-handler check. They deliberately do not use the v4 [Authorize] convention.
+            ["Nocturne.API.Controllers.V1.AlexaController"] = "legacy v1 (fallback trie + in-handler CheckPermissionAsync)",
+            ["Nocturne.API.Controllers.V1.CountController"] = "legacy v1 (fallback trie + share RLS; no in-handler check)",
+            ["Nocturne.API.Controllers.V1.IobController"] = "legacy v1 (fallback trie + share RLS; no in-handler check)",
+            ["Nocturne.API.Controllers.V1.PebbleController"] = "legacy v1 (fallback trie + share RLS; no in-handler check)",
+            ["Nocturne.API.Controllers.V1.TimeQueryController"] = "legacy v1 (fallback trie + share RLS; no in-handler check)",
             ["Nocturne.API.Controllers.V1.DebugController"] = "legacy v1 debug (fallback trie)",
 
             // ── Authentication credential-management surfaces ──────────────────────────────────


### PR DESCRIPTION
## The leak

`app.MapGet("/")` returns the tenant's latest entry (`sgv`/`mbg`/`direction`) as a connectivity indicator and was gated `[AllowAnonymous]`. On an ordinary tenant host the request runs with `app.is_share` unset, so the per-category public-share RLS (`share_category_read`, RESTRICTIVE FOR SELECT, gated on `app.is_share='true'`) does **not** restrict the read — the endpoint's own gate is the only protection. `AllowAnonymous` therefore returned the latest glucose reading to any unauthenticated caller.

Exposure in practice is deployments where the API port is reachable directly (local Aspire, docker-network neighbours, anyone publishing :8080) — the cloud gateway and the compose bundle don't route `/` to the API. Still anonymous PHI on any topology where the port is reachable, so defence in depth applies.

## The fix

Drop `.AllowAnonymous()` so the `HasPermissions` fallback policy applies, as on the rest of the API surface. Deliberately **not** a bare `.RequireAuthorization()`: that attaches `IAuthorizeData` and swaps the fallback for the DefaultPolicy (`RequireAuthenticatedUser` only), which re-opens the documented gap where a zero-permission Denied-role member passes.

No legitimate caller breaks: deployment probes use `/health` / `/alive`, and no web/SDK/uploader code requests the bare root.

## Tests

`PublicAccessIntegrationTests` pins both directions: anonymous `GET /` is 401; an authenticated member still gets the info page.

## History

Earlier revision of this PR also rewrote the v1 fallback rationale in `ControllerAuthorizationCoverageTests` — superseded by the scope-enforcement work that has since landed (Iob/Pebble carry `RequireScope`, Count/TimeQuery check storage scopes in-action), so it's dropped; this PR is now the auth change only, rebased onto main.
