### PR TITLE
feat(api): folder-based markdown OpenAPI tag descriptions

### DIFF
--- a/docs/api-descriptions/README.md
+++ b/docs/api-descriptions/README.md
@@ -1,0 +1,34 @@
+# API tag descriptions
+
+Markdown source for the Scalar API-reference tag overviews. Each `.md` file is one
+OpenAPI tag; `TagDescriptionDocumentTransformer` loads them at startup and renders each
+as that tag's description (GitHub-flavored markdown). ER diagrams from
+`../diagrams/diagrams.yaml` are appended under a **Data Model** heading where mapped.
+
+## Folder convention
+
+- The **top-level folder** is the OpenAPI document the tag belongs to: `nocturne/`
+  (V4 + Auth) or `nightscout/` (legacy V1–V3). Deeper subfolders are purely
+  organizational — `nightscout/model-mapping/` groups the legacy-to-v4 mapping pages.
+- The **file name** (without `.md`) is the exact tag name, e.g. `OIDC Discovery.md` →
+  tag `OIDC Discovery`, `model-mapping/ns-model-entries.md` → tag `ns-model-entries`.
+- The file body is the markdown description.
+
+## Optional YAML frontmatter
+
+```
+---
+displayName: Nightscout V1   # sidebar label override (x-displayName); omit to use the tag name
+standalone: true             # conceptual page with no operations — still rendered as its own sidebar entry
+---
+```
+
+Both keys are optional; a file with no frontmatter is a plain description for a tag that
+already has operations.
+
+Sidebar **grouping** (the "Data Model" / "Health Data" sections) is configured separately
+in `ScalarExtensionsDocumentTransformer` via `x-tagGroups`, not here.
+
+These files are published to `wwwroot/api-descriptions/` by an MSBuild target in
+`Nocturne.API.csproj` so they resolve inside the Docker image where the source tree is
+absent.

--- a/docs/api-descriptions/nightscout/V1.md
+++ b/docs/api-descriptions/nightscout/V1.md
@@ -1,0 +1,12 @@
+---
+displayName: Nightscout V1
+---
+Legacy Nightscout V1 API — **1:1 compatible** with the original JavaScript implementation.
+
+Covers the core Nightscout data model: entries (SGV, MBG, CAL), treatments (bolus, temp basal, carb corrections, site changes), profiles, device status, and food records. Also includes Alexa voice assistant integration and Pebble smartwatch endpoints.
+
+All writes decompose into V4 granular models — there are no standalone legacy tables. Reads project back from V4 data into the legacy shape.
+
+> **Timestamps:** V1 uses a "mills-first" convention. Clients that write entries must provide `date` in epoch milliseconds.
+
+> **Authentication:** V1 endpoints accept the legacy `api_secret` header (SHA-1 hash) or token-based auth via `?token=` query parameter. Both are supported for backwards compatibility.

--- a/docs/api-descriptions/nightscout/V2.md
+++ b/docs/api-descriptions/nightscout/V2.md
@@ -1,0 +1,11 @@
+---
+displayName: Nightscout V2
+---
+Enhanced Nightscout V2 API — maintains compatibility with legacy V2 consumers.
+
+- **Authorization** — Token permission checking.
+- **DData** — Direct data access for aggregated reads.
+- **Loop** — Apple Push Notification Service (APNS) integration for the iOS Loop app.
+- **Notifications** — Enhanced notification system with push support.
+- **Properties** — Client properties and runtime settings.
+- **Summary** — Aggregated data endpoints for dashboard widgets.

--- a/docs/api-descriptions/nightscout/V3.md
+++ b/docs/api-descriptions/nightscout/V3.md
@@ -1,0 +1,12 @@
+---
+displayName: Nightscout V3
+---
+Nightscout V3 RESTful API — full CRUD with `Last-Modified` / `If-Modified-Since` support.
+
+Provides a consistent RESTful interface across all core collections: entries, treatments, device status, food, profiles, and settings. Each collection supports filtering, pagination, field projection, and soft-delete semantics. All writes decompose into V4 granular models — reads project back from V4 data into the legacy shape.
+
+- **Last Modified** — Timestamps for when each collection was last modified, enabling efficient polling via conditional requests.
+- **Status** — Extended status with permissions and authorization details.
+- **Version** — Server version information.
+
+> **Note:** V3 uses `identifier` (a string field) as the primary key for records, not the MongoDB `_id`. When migrating from V1, ensure your client uses the correct identifier field.

--- a/docs/api-descriptions/nightscout/model-mapping/ns-model-devicestatus.md
+++ b/docs/api-descriptions/nightscout/model-mapping/ns-model-devicestatus.md
@@ -1,0 +1,7 @@
+---
+displayName: Device Status
+standalone: true
+---
+How legacy **devicestatus** maps to Nocturne's v4 device model.
+
+A Nightscout devicestatus document bundles several independent status objects (`openaps`/`loop`, `pump`, `uploader`) into one blob. Nocturne decomposes it into separate v4 snapshots — **ApsSnapshot**, **PumpSnapshot**, and **UploaderSnapshot** — sharing a `CorrelationId` so the original document can be reassembled on read. Keeping them separate lets each evolve and be queried on its own.

--- a/docs/api-descriptions/nightscout/model-mapping/ns-model-entries.md
+++ b/docs/api-descriptions/nightscout/model-mapping/ns-model-entries.md
@@ -1,0 +1,15 @@
+---
+displayName: Entries
+standalone: true
+---
+How legacy **entries** map to Nocturne's v4 glucose model.
+
+A Nightscout entry is a single polymorphic document discriminated by `type` (`sgv`, `mbg`, `cal`). Nocturne does not store entries as one table — on write each entry is routed by type into a dedicated v4 glucose table, and reads project those tables back into the legacy entry shape.
+
+| Legacy entry `type` | Nocturne v4 model |
+| --- | --- |
+| `sgv` (sensor glucose) | **SensorGlucose** |
+| `mbg` (meter blood glucose) | **MeterGlucose** / **BGCheck** |
+| `cal` (calibration) | **Calibration** |
+
+Splitting by source preserves each reading's true units, fidelity, provenance, and device linkage rather than flattening everything into one numeric blob.

--- a/docs/api-descriptions/nightscout/model-mapping/ns-model-profile.md
+++ b/docs/api-descriptions/nightscout/model-mapping/ns-model-profile.md
@@ -1,0 +1,7 @@
+---
+displayName: Profile
+standalone: true
+---
+How legacy **profiles** map to Nocturne's v4 therapy model.
+
+A Nightscout profile is a monolithic document holding therapy settings plus four time-of-day schedules. Nocturne decomposes it into granular v4 models — **Therapy Settings** and separate **Basal**, **Carb Ratio**, **Sensitivity**, and **Target Range** schedules — so each can be versioned and validated independently. Reads project them back into the single legacy profile shape.

--- a/docs/api-descriptions/nightscout/model-mapping/ns-model-treatments.md
+++ b/docs/api-descriptions/nightscout/model-mapping/ns-model-treatments.md
@@ -1,0 +1,7 @@
+---
+displayName: Treatments
+standalone: true
+---
+How legacy **treatments** map to Nocturne's v4 treatment model.
+
+A Nightscout treatment is a single polymorphic blob whose `eventType` determines which fields are meaningful. On write, Nocturne routes each treatment by `eventType` into focused v4 domain models (boluses, carb intakes, temp basals, BG checks, notes, site/sensor changes, …); sibling rows that originated from one treatment stay linked by a shared `CorrelationId`. Reads recombine those rows back into the legacy treatment shape.

--- a/docs/api-descriptions/nocturne/Analytics.md
+++ b/docs/api-descriptions/nocturne/Analytics.md
@@ -1,0 +1,12 @@
+Pre-computed data for dashboards, charts, and retrospective analysis.
+
+Key endpoints:
+
+- **Chart Data** — Returns *everything* the glucose chart needs in a single call: readings, IOB/COB series, basal delivery, treatment markers, state spans, system events, and tracker markers. Prefer this over calling individual endpoints.
+- **Correlation** — Query across all V4 repositories by correlation ID to trace related records.
+- **Data Overview** — Year-level availability and day-level record counts for heatmap visualisation.
+- **Predictions** — Glucose forecasts from DeviceStatus sources (AAPS / Trio / Loop) or the OrefWasm engine.
+- **Retrospective** — Day-in-review snapshots combining IOB, COB, glucose, basal timelines, and insulin delivery at specific points in time.
+- **Statistics** — Aggregated statistics including glucose time-in-range, insulin delivery breakdowns, and AID system metrics.
+- **Summary** — Widget-friendly data designed for mobile widgets, watch faces, and other constrained displays.
+- **Analytics** — Transparency controls for analytics collection — view, configure, and opt out.

--- a/docs/api-descriptions/nocturne/Authentication.md
+++ b/docs/api-descriptions/nocturne/Authentication.md
@@ -1,0 +1,11 @@
+Sign-in, token management, and multi-factor authentication.
+
+Covers five authentication mechanisms:
+
+- **OAuth 2.0** — Authorization Code + PKCE and Device Authorization Grant (RFC 8628). All clients are public; PKCE is mandatory — there are no client secrets.
+- **OIDC** — Federated login via external identity providers, callback handling, and session management.
+- **Passkeys** — WebAuthn/FIDO2 registration and login ceremonies (discoverable and non-discoverable credentials), plus recovery codes.
+- **TOTP** — Time-based one-time password setup, verification, and credential lifecycle.
+- **Direct Grants** — Programmatic API tokens (prefixed `noc_`) for headless / automation use cases. These bypass OAuth entirely. Legacy Nightscout API secrets (SHA-1 hashes) are automatically migrated into equivalent direct grants.
+
+> **Footgun:** Direct grant tokens are long-lived and have no automatic expiry. Treat them like passwords.

--- a/docs/api-descriptions/nocturne/Connectors.md
+++ b/docs/api-descriptions/nocturne/Connectors.md
@@ -1,0 +1,3 @@
+Configuration management for data source connectors (Dexcom, Glooko, Libre, etc.).
+
+> **Internal only.** These endpoints are intended for server-to-server use by connector services via mTLS. They are not designed for end-user consumption and will eventually be gated behind mTLS authentication.

--- a/docs/api-descriptions/nocturne/Devices.md
+++ b/docs/api-descriptions/nocturne/Devices.md
@@ -1,0 +1,4 @@
+Device telemetry and consumable age tracking.
+
+- **Battery** — Track and analyse battery status across diabetes devices.
+- **Device Age** — CAGE (cannula), SAGE (sensor), IAGE (insulin reservoir), and BAGE (battery) age tracking, backed by the V4 DeviceEvents system.

--- a/docs/api-descriptions/nocturne/Glucose.md
+++ b/docs/api-descriptions/nocturne/Glucose.md
@@ -1,0 +1,6 @@
+V4 glucose data: sensor readings, meter checks, calibrations, and blood glucose checks.
+
+- **Sensor Glucose** — Continuous glucose monitor (CGM) readings.
+- **Meter Glucose** — Fingerstick blood glucose meter readings.
+- **Calibrations** — CGM calibration records.
+- **BG Checks** — Point-in-time blood glucose checks from any source.

--- a/docs/api-descriptions/nocturne/Health.md
+++ b/docs/api-descriptions/nocturne/Health.md
@@ -1,0 +1,6 @@
+Biometric and activity data beyond glucose.
+
+- **Heart Rate** — Heart rate readings from diabetes apps and wearables.
+- **Step Count** — Step count data from diabetes apps and wearables.
+- **Body Weight** — Weight and body composition time-series.
+- **Patient Record** — Patient metadata: records, devices, and insulin formulations in use.

--- a/docs/api-descriptions/nocturne/Identity.md
+++ b/docs/api-descriptions/nocturne/Identity.md
@@ -1,0 +1,13 @@
+Multi-tenancy, membership, roles, guest access, and cross-platform identity linking.
+
+- **My Tenants** — List tenants the authenticated user belongs to.
+- **My Permissions** — Effective permissions for the current tenant, computed from roles intersected with token scopes.
+- **Roles** — RBAC role and permission management.
+- **Member Invites** — Invite links, member listing, and role assignment.
+- **Guest Links** — Temporary 48-hour read-only access links for data sharing. Recipients activate a short code to receive a scoped session cookie.
+- **Connected Apps** — OAuth app grants ("connected apps") for the authenticated user.
+- **Linked Platforms** — Cross-platform identity linking for the authenticated user.
+- **Chat Identity** — Tenant-scoped linking of chat platform accounts (Discord, Telegram, etc.).
+- **Chat Identity Directory** — Cross-tenant directory for routing chat platform identities to the correct tenant. Server-to-server only.
+
+> **Footgun:** The Chat Identity Directory operates cross-tenant and is authenticated by instance key, not user tokens. Do not expose it to end users.

--- a/docs/api-descriptions/nocturne/Metadata.md
+++ b/docs/api-descriptions/nocturne/Metadata.md
@@ -1,0 +1,6 @@
+Static, read-only reference catalogs for populating app UI with prefilled lists.
+
+- **Device Catalog** — Known pump, CGM, and meter hardware models, filterable by category.
+- **Insulin Catalog** — Insulin formulations with pharmacokinetic profiles (onset, peak, duration).
+
+This is reference data — it is not tenant-specific and cannot be modified via the API.

--- a/docs/api-descriptions/nocturne/Monitoring.md
+++ b/docs/api-descriptions/nocturne/Monitoring.md
@@ -1,0 +1,9 @@
+Alerting, notifications, and flexible tracker management.
+
+- **Alert Rules** — CRUD for alert rules with nested schedules, escalation steps, and notification channels.
+- **Alerts** — Active alert state, history, and acknowledgement.
+- **Alert Invites** — Shareable invite links that grant others permission to receive your alerts.
+- **Alert Custom Sounds** — Upload, list, stream, and delete custom alert audio files.
+- **Tracker Alerts** — Alerts tied to tracker events (e.g. "site change overdue").
+- **Trackers** — Flexible tracker management for consumables, appointments, and reminders.
+- **Notifications** — In-app notification delivery and management.

--- a/docs/api-descriptions/nocturne/OIDC Discovery.md
+++ b/docs/api-descriptions/nocturne/OIDC Discovery.md
@@ -1,0 +1,3 @@
+Standard `.well-known` endpoints that make Nocturne act as its own OAuth 2.0 / OIDC issuer.
+
+Returns the OpenID Provider configuration (`openid-configuration`) and JSON Web Key Set (`jwks.json`). These endpoints are **unauthenticated** by design — they must be publicly reachable for token validation.

--- a/docs/api-descriptions/nocturne/Platform.md
+++ b/docs/api-descriptions/nocturne/Platform.md
@@ -1,0 +1,11 @@
+System-level status, diagnostics, and service metadata.
+
+- **Status** — V4 JSON status endpoint with detailed system information.
+- **System** — Service health and coordination endpoints.
+- **System Events** — Point-in-time system events (alarms, warnings, info).
+- **Services** — Metadata about available data sources, connectors, and integrations.
+- **Compatibility** — Dashboard data for Nightscout compatibility analysis.
+- **Debug** — Query inspection and MongoDB query debugging tools.
+- **API Secret** — Legacy API secret management.
+
+> **Footgun:** Debug endpoints expose raw query details and are intended for development use. They should be disabled or restricted in production deployments.

--- a/docs/api-descriptions/nocturne/PlatformAdmin.md
+++ b/docs/api-descriptions/nocturne/PlatformAdmin.md
@@ -1,0 +1,6 @@
+---
+displayName: Platform Admin
+---
+Super-admin tenant lifecycle management.
+
+Provides tenant creation, listing, and administration for platform operators. These endpoints require platform-level admin privileges — they are not accessible to regular tenant users.

--- a/docs/api-descriptions/nocturne/Profiles.md
+++ b/docs/api-descriptions/nocturne/Profiles.md
@@ -1,0 +1,12 @@
+User and therapy configuration.
+
+- **Therapy Settings** — Core therapy configuration (DIA, units, etc.).
+- **Basal Schedules** — Time-of-day basal rate schedules.
+- **Carb Ratio Schedules** — Time-of-day insulin-to-carb ratio schedules.
+- **Sensitivity Schedules** — Time-of-day insulin sensitivity factor schedules.
+- **Target Range Schedules** — Time-of-day target glucose range schedules.
+- **Glucose Processing Settings** — Glucose data processing configuration (smoothing, calibration, noise filtering).
+- **UI Settings** — Aggregated frontend configuration from multiple sources (units, ranges, display preferences).
+- **User Preferences** — Per-user preference storage.
+- **Clock Faces** — Watch face configuration management.
+- **MyFitnessPal Settings** — Global settings for MyFitnessPal food matching integration.

--- a/docs/api-descriptions/nocturne/State Spans.md
+++ b/docs/api-descriptions/nocturne/State Spans.md
@@ -1,0 +1,5 @@
+Time-ranged system states and user-annotated activity periods.
+
+Records continuous state windows such as pump modes, connectivity periods, temporary targets, overrides, active profile switches, and user-annotated activities (sleep, exercise, illness, travel). State spans are created automatically by connector ingest pipelines or manually via this API.
+
+Convenience sub-routes pre-filter by category: `/pump-modes`, `/connectivity`, `/overrides`, `/temporary-targets`, `/profiles`, `/sleep`, `/exercise`, `/illness`, `/travel`, `/activities`.

--- a/docs/api-descriptions/nocturne/Syncing.md
+++ b/docs/api-descriptions/nocturne/Syncing.md
@@ -1,0 +1,64 @@
+---
+standalone: true
+---
+How Nocturne ingests data from connectors, how it resumes where it left off, and why re-syncing the same data never creates duplicates.
+
+## How connectors sync
+
+Each connector (Nightscout, Dexcom, Glooko, …) runs as a per-tenant background service. The poller wakes on the tenant's configured interval (and, for Nightscout, immediately on real-time socket events from the upstream instance) and pulls any new data since it last ran. There is no stored cursor — Nocturne derives the resume point from the **latest record already stored** for each data type.
+
+## Per-type catch-up cursors
+
+A connection carries several independent streams — glucose, treatments (boluses/carbs/manual BG), device status, activity — and each resumes from **its own** latest record, not a single shared cursor. This matters because one stream can legitimately lag another: a closed-loop user produces a glucose reading every 5 minutes but may bolus only a few times a day. Tying every stream to the glucose cursor would strand the slower streams permanently once glucose caught up.
+
+- On a normal background sync each enabled type fetches from `latest_stored_record − 5min` (a small overlap absorbs clock drift).
+- When a type has **no** data yet, it performs an initial backfill over a bounded window (currently 6 months) so a new connection fills in recent history.
+- Profiles and food are small and fetched in full on every sync rather than windowed.
+
+## Resilient ingestion
+
+Real-world uploader payloads are messy: numeric fields arrive as JSON strings (`"insulin":"1.5"`), booleans as `"true"`/`1`, direction as an integer. Connector deserialization tolerates these variants so one oddly-typed record can't throw and abort an entire page — which would otherwise drop a whole stream's backfill while a sibling stream (e.g. glucose) succeeded.
+
+## Re-syncing and cursor reset
+
+Two endpoints force data in on demand, both reusing the stored connector credentials:
+
+- **Manual sync** — `POST /api/v4/services/connectors/{id}/sync` with a `SyncRequest`. Supplying `to` switches the connector into *explicit-range* mode: it fetches exactly `from`…`to` for the requested `dataTypes`, bypassing the catch-up cursors. Use this to backfill a specific window of a specific type (e.g. treatments only) without re-pulling everything.
+- **Cursor reset (single tenant)** — `POST /api/v4/services/connectors/{id}/reset-cursor`. Re-pulls history (all types, or a subset) from the beginning, or from an optional `from`. Use this after fixing a connector bug to push corrected data to a tenant. This runs **synchronously**: a full-history re-pull (glucose can be tens of thousands of records) is a multi-minute request, so it may approach or exceed reverse-proxy / browser timeouts on data-heavy tenants — scope it with `from` / `dataTypes` when you can.
+- **Cursor reset (cross-tenant, platform admin)** — `POST /api/v4/admin/connectors/{tenantId}/reset-cursors`. Resets *every* connector configured on a target tenant. Because the fan-out can run for minutes, this is **asynchronous**: it returns `202 Accepted` with a job id immediately, then you poll `GET /api/v4/admin/connectors/jobs/{jobId}` for per-connector progress (and `POST …/jobs/{jobId}/cancel` to stop it). The job outlives the request that started it, so it is not affected by proxy timeouts.
+
+All are safe to re-run because of idempotency, below.
+
+## Idempotency
+
+How Nocturne guarantees that writing the same record twice never creates a duplicate — and why there are two separate keys for it.
+
+Diabetes data is written by two very different kinds of client, and **both retry**. A phone app may resend a `POST` after a flaky network; a background connector re-fetches overlapping time windows on every sync. To make writes safe to repeat, every V4 record carries an idempotency key and the database enforces uniqueness on it. Which key is used depends on **who is writing**.
+
+### Two channels
+
+| Channel | Key | Who sets it | Why |
+| --- | --- | --- | --- |
+| **API clients** (apps, uploaders) | `syncIdentifier` | The client | The client owns a stable per-record ID and sends it with every write. |
+| **Connectors** (Glooko, Dexcom, …) | `legacyId` | Nocturne | The upstream source exposes no stable per-record ID, so a deterministic hash of the record's content is derived. |
+
+A given record normally carries **one** of these keys, not both.
+
+#### `syncIdentifier` — client-owned
+
+Clients that integrate over the REST API supply their own stable identifier on each write, scoped by `dataSource`. On create, if a record with the same `(dataSource, syncIdentifier)` already exists, the endpoint returns the existing record unchanged — an idempotent upsert — instead of inserting a duplicate. Enforced by a unique index on `(tenant_id, data_source, sync_identifier)`.
+
+Use this when **you** control the writer and can guarantee a stable ID that survives retries.
+
+#### `legacyId` — content-derived
+
+Connectors pull from upstream platforms that rarely expose a stable per-record ID — Glooko's graph series, for example, are just timestamped points. Rather than a source ID, the connector derives a deterministic fingerprint from the record's own immutable content (event type + timestamp + salient fields). Re-syncing the same window regenerates an identical `legacyId`, so the second write is recognised as a duplicate. Enforced by a unique index on `(tenant_id, legacy_id)`.
+
+`legacyId` also doubles as migration traceability: it ties a V4 record back to the original Nightscout/Mongo document it was decomposed from.
+
+### Guidance for writers
+
+- **Building a client or uploader?** Always send `dataSource` + `syncIdentifier`, and reuse the same `syncIdentifier` when retrying the same logical record.
+- **Building a connector?** Derive a stable `legacyId` from immutable content. The repository bulk-create paths dedupe on it automatically.
+
+> **Footgun:** The two keys are not interchangeable per record type. A writer that populates `legacyId` but is backed by a repository that only dedupes on `syncIdentifier` (or vice-versa) will insert duplicates — or hit a unique-constraint violation on the next retry. When adding a new record type, make sure its repository honours **both** keys.

--- a/docs/api-descriptions/nocturne/TenantAdmin.md
+++ b/docs/api-descriptions/nocturne/TenantAdmin.md
@@ -1,0 +1,16 @@
+---
+displayName: Tenant Admin
+---
+Administrative operations for tenant data management, migration, and maintenance.
+
+- **Migration** — Import data from a Nightscout MongoDB instance.
+- **Nightscout Transition** — Aggregated migration progress and write-compatibility status for the migration dashboard.
+- **Backfill** — Decompose all existing legacy entries and treatments into V4 granular tables.
+- **Deduplication** — Run and monitor deduplication jobs across data tables.
+- **Discrepancy** — Compatibility analysis between legacy and V4 data representations.
+- **Compression Low** — Detect and review compression low artefacts in CGM data.
+- **Processing** — Async processing job status tracking.
+- **OIDC Provider Admin** — Manage OIDC identity provider configurations for the tenant.
+- **Subject Admin** — Manage user/subject records within the tenant.
+
+> **Footgun:** The Backfill endpoint decomposes *all* legacy data. On large datasets this is a long-running operation — it runs asynchronously and progress can be tracked via the Processing endpoints.

--- a/docs/api-descriptions/nocturne/Treatments.md
+++ b/docs/api-descriptions/nocturne/Treatments.md
@@ -1,0 +1,9 @@
+V4 treatment data: boluses, nutrition, notes, and meal tracking.
+
+- **Boluses** — Insulin bolus records with calculator context.
+- **Bolus Calculations** — Bolus calculator input/output records for audit and replay.
+- **Nutrition** — Carbohydrate intakes, food breakdown, and meal records.
+- **Foods** — Food favourites, recent foods, and food lifecycle management.
+- **Connector Food Entries** — Food entries imported by external connectors.
+- **Meal Matching** — Match nutrition data to treatment events.
+- **Notes** — Free-text observation records.

--- a/src/API/Nocturne.API/Configuration/TagDescriptionDocumentTransformer.cs
+++ b/src/API/Nocturne.API/Configuration/TagDescriptionDocumentTransformer.cs
@@ -8,358 +8,45 @@ namespace Nocturne.API.Configuration;
 
 /// <summary>
 /// Adds human-readable descriptions to OpenAPI tags so Scalar displays an overview
-/// for each controller group. Descriptions use GitHub-flavored markdown.
-/// Embeds ER diagrams from the diagram manifest into matching tag descriptions.
+/// for each controller group. Descriptions use GitHub-flavored markdown and are
+/// authored as folder-based markdown files under <c>docs/api-descriptions</c>
+/// (loaded by <see cref="TagDescriptionLoader"/>). Embeds ER diagrams from the diagram
+/// manifest into matching tag descriptions.
 /// </summary>
 public sealed class TagDescriptionDocumentTransformer : IOpenApiDocumentTransformer
 {
     private readonly Dictionary<string, List<DiagramRef>> _tagDiagrams;
 
-    public TagDescriptionDocumentTransformer(IWebHostEnvironment env)
-    {
-        _tagDiagrams = BuildTagDiagramMap(env);
-    }
+    /// <summary>Tag name → markdown description, loaded from <c>docs/api-descriptions</c>.</summary>
+    private readonly Dictionary<string, string> _descriptions;
 
-    private static readonly Dictionary<string, string> DisplayNames = new()
-    {
-        ["PlatformAdmin"] = "Platform Admin",
-        ["TenantAdmin"] = "Tenant Admin",
-        ["V1"] = "Nightscout V1",
-        ["V2"] = "Nightscout V2",
-        ["V3"] = "Nightscout V3",
-        ["ns-model-entries"] = "Entries",
-        ["ns-model-treatments"] = "Treatments",
-        ["ns-model-devicestatus"] = "Device Status",
-        ["ns-model-profile"] = "Profile",
-    };
+    /// <summary>Tag name → sidebar label override (<c>x-displayName</c>).</summary>
+    private readonly Dictionary<string, string> _displayNames;
 
     /// <summary>
     /// Conceptual guide tags that have no operations of their own but still render as a
     /// standalone sidebar page from their description (and any diagrams mapped to them),
     /// keyed by the OpenAPI document they belong to. The Nocturne document carries the
     /// <c>Syncing</c> guide; the Nightscout document carries the legacy-to-v4 model-mapping
-    /// pages, one per legacy collection.
+    /// pages, one per legacy collection. Both are marked <c>standalone: true</c> in their
+    /// markdown frontmatter.
     /// </summary>
-    private static readonly Dictionary<string, string[]> StandaloneDocTagsByDocument = new()
+    private readonly Dictionary<string, string[]> _standaloneDocTagsByDocument;
+
+    public TagDescriptionDocumentTransformer(IWebHostEnvironment env)
     {
-        ["nocturne"] = ["Syncing"],
-        ["nightscout"] =
-            ["ns-model-entries", "ns-model-treatments", "ns-model-devicestatus", "ns-model-profile"],
-    };
-
-    private static readonly Dictionary<string, string> Descriptions = new()
-    {
-        // ── Nocturne document (V4 + Auth) ────────────────────────────────
-
-        ["Authentication"] = """
-            Sign-in, token management, and multi-factor authentication.
-
-            Covers five authentication mechanisms:
-
-            - **OAuth 2.0** — Authorization Code + PKCE and Device Authorization Grant (RFC 8628). All clients are public; PKCE is mandatory — there are no client secrets.
-            - **OIDC** — Federated login via external identity providers, callback handling, and session management.
-            - **Passkeys** — WebAuthn/FIDO2 registration and login ceremonies (discoverable and non-discoverable credentials), plus recovery codes.
-            - **TOTP** — Time-based one-time password setup, verification, and credential lifecycle.
-            - **Direct Grants** — Programmatic API tokens (prefixed `noc_`) for headless / automation use cases. These bypass OAuth entirely. Legacy Nightscout API secrets (SHA-1 hashes) are automatically migrated into equivalent direct grants.
-
-            > **Footgun:** Direct grant tokens are long-lived and have no automatic expiry. Treat them like passwords.
-            """,
-
-        ["OIDC Discovery"] = """
-            Standard `.well-known` endpoints that make Nocturne act as its own OAuth 2.0 / OIDC issuer.
-
-            Returns the OpenID Provider configuration (`openid-configuration`) and JSON Web Key Set (`jwks.json`). These endpoints are **unauthenticated** by design — they must be publicly reachable for token validation.
-            """,
-
-        ["Analytics"] = """
-            Pre-computed data for dashboards, charts, and retrospective analysis.
-
-            Key endpoints:
-
-            - **Chart Data** — Returns *everything* the glucose chart needs in a single call: readings, IOB/COB series, basal delivery, treatment markers, state spans, system events, and tracker markers. Prefer this over calling individual endpoints.
-            - **Correlation** — Query across all V4 repositories by correlation ID to trace related records.
-            - **Data Overview** — Year-level availability and day-level record counts for heatmap visualisation.
-            - **Predictions** — Glucose forecasts from DeviceStatus sources (AAPS / Trio / Loop) or the OrefWasm engine.
-            - **Retrospective** — Day-in-review snapshots combining IOB, COB, glucose, basal timelines, and insulin delivery at specific points in time.
-            - **Statistics** — Aggregated statistics including glucose time-in-range, insulin delivery breakdowns, and AID system metrics.
-            - **Summary** — Widget-friendly data designed for mobile widgets, watch faces, and other constrained displays.
-            - **Analytics** — Transparency controls for analytics collection — view, configure, and opt out.
-            """,
-
-        ["Connectors"] = """
-            Configuration management for data source connectors (Dexcom, Glooko, Libre, etc.).
-
-            > **Internal only.** These endpoints are intended for server-to-server use by connector services via mTLS. They are not designed for end-user consumption and will eventually be gated behind mTLS authentication.
-            """,
-
-        ["Devices"] = """
-            Device telemetry and consumable age tracking.
-
-            - **Battery** — Track and analyse battery status across diabetes devices.
-            - **Device Age** — CAGE (cannula), SAGE (sensor), IAGE (insulin reservoir), and BAGE (battery) age tracking, backed by the V4 DeviceEvents system.
-            """,
-
-        ["Glucose"] = """
-            V4 glucose data: sensor readings, meter checks, calibrations, and blood glucose checks.
-
-            - **Sensor Glucose** — Continuous glucose monitor (CGM) readings.
-            - **Meter Glucose** — Fingerstick blood glucose meter readings.
-            - **Calibrations** — CGM calibration records.
-            - **BG Checks** — Point-in-time blood glucose checks from any source.
-            """,
-
-        ["Health"] = """
-            Biometric and activity data beyond glucose.
-
-            - **Heart Rate** — Heart rate readings from diabetes apps and wearables.
-            - **Step Count** — Step count data from diabetes apps and wearables.
-            - **Body Weight** — Weight and body composition time-series.
-            - **Patient Record** — Patient metadata: records, devices, and insulin formulations in use.
-            """,
-
-        ["Identity"] = """
-            Multi-tenancy, membership, roles, guest access, and cross-platform identity linking.
-
-            - **My Tenants** — List tenants the authenticated user belongs to.
-            - **My Permissions** — Effective permissions for the current tenant, computed from roles intersected with token scopes.
-            - **Roles** — RBAC role and permission management.
-            - **Member Invites** — Invite links, member listing, and role assignment.
-            - **Guest Links** — Temporary 48-hour read-only access links for data sharing. Recipients activate a short code to receive a scoped session cookie.
-            - **Connected Apps** — OAuth app grants ("connected apps") for the authenticated user.
-            - **Linked Platforms** — Cross-platform identity linking for the authenticated user.
-            - **Chat Identity** — Tenant-scoped linking of chat platform accounts (Discord, Telegram, etc.).
-            - **Chat Identity Directory** — Cross-tenant directory for routing chat platform identities to the correct tenant. Server-to-server only.
-
-            > **Footgun:** The Chat Identity Directory operates cross-tenant and is authenticated by instance key, not user tokens. Do not expose it to end users.
-            """,
-
-        ["Monitoring"] = """
-            Alerting, notifications, and flexible tracker management.
-
-            - **Alert Rules** — CRUD for alert rules with nested schedules, escalation steps, and notification channels.
-            - **Alerts** — Active alert state, history, and acknowledgement.
-            - **Alert Invites** — Shareable invite links that grant others permission to receive your alerts.
-            - **Alert Custom Sounds** — Upload, list, stream, and delete custom alert audio files.
-            - **Tracker Alerts** — Alerts tied to tracker events (e.g. "site change overdue").
-            - **Trackers** — Flexible tracker management for consumables, appointments, and reminders.
-            - **Notifications** — In-app notification delivery and management.
-            """,
-
-        ["Platform"] = """
-            System-level status, diagnostics, and service metadata.
-
-            - **Status** — V4 JSON status endpoint with detailed system information.
-            - **System** — Service health and coordination endpoints.
-            - **System Events** — Point-in-time system events (alarms, warnings, info).
-            - **Services** — Metadata about available data sources, connectors, and integrations.
-            - **Compatibility** — Dashboard data for Nightscout compatibility analysis.
-            - **Debug** — Query inspection and MongoDB query debugging tools.
-            - **API Secret** — Legacy API secret management.
-
-            > **Footgun:** Debug endpoints expose raw query details and are intended for development use. They should be disabled or restricted in production deployments.
-            """,
-
-        ["PlatformAdmin"] = """
-            Super-admin tenant lifecycle management.
-
-            Provides tenant creation, listing, and administration for platform operators. These endpoints require platform-level admin privileges — they are not accessible to regular tenant users.
-            """,
-
-        ["State Spans"] = """
-            Time-ranged system states and user-annotated activity periods.
-
-            Records continuous state windows such as pump modes, connectivity periods, temporary targets, overrides, active profile switches, and user-annotated activities (sleep, exercise, illness, travel). State spans are created automatically by connector ingest pipelines or manually via this API.
-
-            Convenience sub-routes pre-filter by category: `/pump-modes`, `/connectivity`, `/overrides`, `/temporary-targets`, `/profiles`, `/sleep`, `/exercise`, `/illness`, `/travel`, `/activities`.
-            """,
-
-        ["Profiles"] = """
-            User and therapy configuration.
-
-            - **Therapy Settings** — Core therapy configuration (DIA, units, etc.).
-            - **Basal Schedules** — Time-of-day basal rate schedules.
-            - **Carb Ratio Schedules** — Time-of-day insulin-to-carb ratio schedules.
-            - **Sensitivity Schedules** — Time-of-day insulin sensitivity factor schedules.
-            - **Target Range Schedules** — Time-of-day target glucose range schedules.
-            - **Glucose Processing Settings** — Glucose data processing configuration (smoothing, calibration, noise filtering).
-            - **UI Settings** — Aggregated frontend configuration from multiple sources (units, ranges, display preferences).
-            - **User Preferences** — Per-user preference storage.
-            - **Clock Faces** — Watch face configuration management.
-            - **MyFitnessPal Settings** — Global settings for MyFitnessPal food matching integration.
-            """,
-
-        ["TenantAdmin"] = """
-            Administrative operations for tenant data management, migration, and maintenance.
-
-            - **Migration** — Import data from a Nightscout MongoDB instance.
-            - **Nightscout Transition** — Aggregated migration progress and write-compatibility status for the migration dashboard.
-            - **Backfill** — Decompose all existing legacy entries and treatments into V4 granular tables.
-            - **Deduplication** — Run and monitor deduplication jobs across data tables.
-            - **Discrepancy** — Compatibility analysis between legacy and V4 data representations.
-            - **Compression Low** — Detect and review compression low artefacts in CGM data.
-            - **Processing** — Async processing job status tracking.
-            - **OIDC Provider Admin** — Manage OIDC identity provider configurations for the tenant.
-            - **Subject Admin** — Manage user/subject records within the tenant.
-
-            > **Footgun:** The Backfill endpoint decomposes *all* legacy data. On large datasets this is a long-running operation — it runs asynchronously and progress can be tracked via the Processing endpoints.
-            """,
-
-        ["Treatments"] = """
-            V4 treatment data: boluses, nutrition, notes, and meal tracking.
-
-            - **Boluses** — Insulin bolus records with calculator context.
-            - **Bolus Calculations** — Bolus calculator input/output records for audit and replay.
-            - **Nutrition** — Carbohydrate intakes, food breakdown, and meal records.
-            - **Foods** — Food favourites, recent foods, and food lifecycle management.
-            - **Connector Food Entries** — Food entries imported by external connectors.
-            - **Meal Matching** — Match nutrition data to treatment events.
-            - **Notes** — Free-text observation records.
-            """,
-
-        ["Metadata"] = """
-            Static, read-only reference catalogs for populating app UI with prefilled lists.
-
-            - **Device Catalog** — Known pump, CGM, and meter hardware models, filterable by category.
-            - **Insulin Catalog** — Insulin formulations with pharmacokinetic profiles (onset, peak, duration).
-
-            This is reference data — it is not tenant-specific and cannot be modified via the API.
-            """,
-
-        ["Syncing"] = """
-            How Nocturne ingests data from connectors, how it resumes where it left off, and why re-syncing the same data never creates duplicates.
-
-            ## How connectors sync
-
-            Each connector (Nightscout, Dexcom, Glooko, …) runs as a per-tenant background service. The poller wakes on the tenant's configured interval (and, for Nightscout, immediately on real-time socket events from the upstream instance) and pulls any new data since it last ran. There is no stored cursor — Nocturne derives the resume point from the **latest record already stored** for each data type.
-
-            ## Per-type catch-up cursors
-
-            A connection carries several independent streams — glucose, treatments (boluses/carbs/manual BG), device status, activity — and each resumes from **its own** latest record, not a single shared cursor. This matters because one stream can legitimately lag another: a closed-loop user produces a glucose reading every 5 minutes but may bolus only a few times a day. Tying every stream to the glucose cursor would strand the slower streams permanently once glucose caught up.
-
-            - On a normal background sync each enabled type fetches from `latest_stored_record − 5min` (a small overlap absorbs clock drift).
-            - When a type has **no** data yet, it performs an initial backfill over a bounded window (currently 6 months) so a new connection fills in recent history.
-            - Profiles and food are small and fetched in full on every sync rather than windowed.
-
-            ## Resilient ingestion
-
-            Real-world uploader payloads are messy: numeric fields arrive as JSON strings (`"insulin":"1.5"`), booleans as `"true"`/`1`, direction as an integer. Connector deserialization tolerates these variants so one oddly-typed record can't throw and abort an entire page — which would otherwise drop a whole stream's backfill while a sibling stream (e.g. glucose) succeeded.
-
-            ## Re-syncing and cursor reset
-
-            Two endpoints force data in on demand, both reusing the stored connector credentials:
-
-            - **Manual sync** — `POST /api/v4/services/connectors/{id}/sync` with a `SyncRequest`. Supplying `to` switches the connector into *explicit-range* mode: it fetches exactly `from`…`to` for the requested `dataTypes`, bypassing the catch-up cursors. Use this to backfill a specific window of a specific type (e.g. treatments only) without re-pulling everything.
-            - **Cursor reset (single tenant)** — `POST /api/v4/services/connectors/{id}/reset-cursor`. Re-pulls history (all types, or a subset) from the beginning, or from an optional `from`. Use this after fixing a connector bug to push corrected data to a tenant. This runs **synchronously**: a full-history re-pull (glucose can be tens of thousands of records) is a multi-minute request, so it may approach or exceed reverse-proxy / browser timeouts on data-heavy tenants — scope it with `from` / `dataTypes` when you can.
-            - **Cursor reset (cross-tenant, platform admin)** — `POST /api/v4/admin/connectors/{tenantId}/reset-cursors`. Resets *every* connector configured on a target tenant. Because the fan-out can run for minutes, this is **asynchronous**: it returns `202 Accepted` with a job id immediately, then you poll `GET /api/v4/admin/connectors/jobs/{jobId}` for per-connector progress (and `POST …/jobs/{jobId}/cancel` to stop it). The job outlives the request that started it, so it is not affected by proxy timeouts.
-
-            All are safe to re-run because of idempotency, below.
-
-            ## Idempotency
-
-            How Nocturne guarantees that writing the same record twice never creates a duplicate — and why there are two separate keys for it.
-
-            Diabetes data is written by two very different kinds of client, and **both retry**. A phone app may resend a `POST` after a flaky network; a background connector re-fetches overlapping time windows on every sync. To make writes safe to repeat, every V4 record carries an idempotency key and the database enforces uniqueness on it. Which key is used depends on **who is writing**.
-
-            ### Two channels
-
-            | Channel | Key | Who sets it | Why |
-            | --- | --- | --- | --- |
-            | **API clients** (apps, uploaders) | `syncIdentifier` | The client | The client owns a stable per-record ID and sends it with every write. |
-            | **Connectors** (Glooko, Dexcom, …) | `legacyId` | Nocturne | The upstream source exposes no stable per-record ID, so a deterministic hash of the record's content is derived. |
-
-            A given record normally carries **one** of these keys, not both.
-
-            #### `syncIdentifier` — client-owned
-
-            Clients that integrate over the REST API supply their own stable identifier on each write, scoped by `dataSource`. On create, if a record with the same `(dataSource, syncIdentifier)` already exists, the endpoint returns the existing record unchanged — an idempotent upsert — instead of inserting a duplicate. Enforced by a unique index on `(tenant_id, data_source, sync_identifier)`.
-
-            Use this when **you** control the writer and can guarantee a stable ID that survives retries.
-
-            #### `legacyId` — content-derived
-
-            Connectors pull from upstream platforms that rarely expose a stable per-record ID — Glooko's graph series, for example, are just timestamped points. Rather than a source ID, the connector derives a deterministic fingerprint from the record's own immutable content (event type + timestamp + salient fields). Re-syncing the same window regenerates an identical `legacyId`, so the second write is recognised as a duplicate. Enforced by a unique index on `(tenant_id, legacy_id)`.
-
-            `legacyId` also doubles as migration traceability: it ties a V4 record back to the original Nightscout/Mongo document it was decomposed from.
-
-            ### Guidance for writers
-
-            - **Building a client or uploader?** Always send `dataSource` + `syncIdentifier`, and reuse the same `syncIdentifier` when retrying the same logical record.
-            - **Building a connector?** Derive a stable `legacyId` from immutable content. The repository bulk-create paths dedupe on it automatically.
-
-            > **Footgun:** The two keys are not interchangeable per record type. A writer that populates `legacyId` but is backed by a repository that only dedupes on `syncIdentifier` (or vice-versa) will insert duplicates — or hit a unique-constraint violation on the next retry. When adding a new record type, make sure its repository honours **both** keys.
-            """,
-
-        // ── Nightscout document (V1 / V2 / V3) ──────────────────────────
-
-        ["V1"] = """
-            Legacy Nightscout V1 API — **1:1 compatible** with the original JavaScript implementation.
-
-            Covers the core Nightscout data model: entries (SGV, MBG, CAL), treatments (bolus, temp basal, carb corrections, site changes), profiles, device status, and food records. Also includes Alexa voice assistant integration and Pebble smartwatch endpoints.
-
-            All writes decompose into V4 granular models — there are no standalone legacy tables. Reads project back from V4 data into the legacy shape.
-
-            > **Timestamps:** V1 uses a "mills-first" convention. Clients that write entries must provide `date` in epoch milliseconds.
-
-            > **Authentication:** V1 endpoints accept the legacy `api_secret` header (SHA-1 hash) or token-based auth via `?token=` query parameter. Both are supported for backwards compatibility.
-            """,
-
-        ["V2"] = """
-            Enhanced Nightscout V2 API — maintains compatibility with legacy V2 consumers.
-
-            - **Authorization** — Token permission checking.
-            - **DData** — Direct data access for aggregated reads.
-            - **Loop** — Apple Push Notification Service (APNS) integration for the iOS Loop app.
-            - **Notifications** — Enhanced notification system with push support.
-            - **Properties** — Client properties and runtime settings.
-            - **Summary** — Aggregated data endpoints for dashboard widgets.
-            """,
-
-        ["V3"] = """
-            Nightscout V3 RESTful API — full CRUD with `Last-Modified` / `If-Modified-Since` support.
-
-            Provides a consistent RESTful interface across all core collections: entries, treatments, device status, food, profiles, and settings. Each collection supports filtering, pagination, field projection, and soft-delete semantics. All writes decompose into V4 granular models — reads project back from V4 data into the legacy shape.
-
-            - **Last Modified** — Timestamps for when each collection was last modified, enabling efficient polling via conditional requests.
-            - **Status** — Extended status with permissions and authorization details.
-            - **Version** — Server version information.
-
-            > **Note:** V3 uses `identifier` (a string field) as the primary key for records, not the MongoDB `_id`. When migrating from V1, ensure your client uses the correct identifier field.
-            """,
-
-        // ── Nightscout document → V4 model mapping (Data Model section) ──────
-
-        ["ns-model-entries"] = """
-            How legacy **entries** map to Nocturne's v4 glucose model.
-
-            A Nightscout entry is a single polymorphic document discriminated by `type` (`sgv`, `mbg`, `cal`). Nocturne does not store entries as one table — on write each entry is routed by type into a dedicated v4 glucose table, and reads project those tables back into the legacy entry shape.
-
-            | Legacy entry `type` | Nocturne v4 model |
-            | --- | --- |
-            | `sgv` (sensor glucose) | **SensorGlucose** |
-            | `mbg` (meter blood glucose) | **MeterGlucose** / **BGCheck** |
-            | `cal` (calibration) | **Calibration** |
-
-            Splitting by source preserves each reading's true units, fidelity, provenance, and device linkage rather than flattening everything into one numeric blob.
-            """,
-
-        ["ns-model-treatments"] = """
-            How legacy **treatments** map to Nocturne's v4 treatment model.
-
-            A Nightscout treatment is a single polymorphic blob whose `eventType` determines which fields are meaningful. On write, Nocturne routes each treatment by `eventType` into focused v4 domain models (boluses, carb intakes, temp basals, BG checks, notes, site/sensor changes, …); sibling rows that originated from one treatment stay linked by a shared `CorrelationId`. Reads recombine those rows back into the legacy treatment shape.
-            """,
-
-        ["ns-model-devicestatus"] = """
-            How legacy **devicestatus** maps to Nocturne's v4 device model.
-
-            A Nightscout devicestatus document bundles several independent status objects (`openaps`/`loop`, `pump`, `uploader`) into one blob. Nocturne decomposes it into separate v4 snapshots — **ApsSnapshot**, **PumpSnapshot**, and **UploaderSnapshot** — sharing a `CorrelationId` so the original document can be reassembled on read. Keeping them separate lets each evolve and be queried on its own.
-            """,
-
-        ["ns-model-profile"] = """
-            How legacy **profiles** map to Nocturne's v4 therapy model.
-
-            A Nightscout profile is a monolithic document holding therapy settings plus four time-of-day schedules. Nocturne decomposes it into granular v4 models — **Therapy Settings** and separate **Basal**, **Carb Ratio**, **Sensitivity**, and **Target Range** schedules — so each can be versioned and validated independently. Reads project them back into the single legacy profile shape.
-            """,
-    };
+        _tagDiagrams = BuildTagDiagramMap(env);
+
+        var loaded = TagDescriptionLoader.Load(env);
+        _descriptions = loaded.ToDictionary(d => d.TagName, d => d.Markdown, StringComparer.Ordinal);
+        _displayNames = loaded
+            .Where(d => d.DisplayName is not null)
+            .ToDictionary(d => d.TagName, d => d.DisplayName!, StringComparer.Ordinal);
+        _standaloneDocTagsByDocument = loaded
+            .Where(d => d.Standalone)
+            .GroupBy(d => d.Document, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.Select(d => d.TagName).ToArray(), StringComparer.Ordinal);
+    }
 
     public Task TransformAsync(
         OpenApiDocument document,
@@ -385,7 +72,7 @@ public sealed class TagDescriptionDocumentTransformer : IOpenApiDocumentTransfor
 
         // Standalone conceptual guide pages have no operations but still render as
         // their own sidebar entry. Surface only the ones belonging to this document.
-        if (StandaloneDocTagsByDocument.TryGetValue(context.DocumentName, out var standaloneTags))
+        if (_standaloneDocTagsByDocument.TryGetValue(context.DocumentName, out var standaloneTags))
         {
             foreach (var docTag in standaloneTags)
                 usedTags.Add(docTag);
@@ -396,7 +83,7 @@ public sealed class TagDescriptionDocumentTransformer : IOpenApiDocumentTransfor
 
         foreach (var tagName in usedTags.OrderBy(t => t, StringComparer.OrdinalIgnoreCase))
         {
-            Descriptions.TryGetValue(tagName, out var description);
+            _descriptions.TryGetValue(tagName, out var description);
 
             // Append any ER diagrams mapped to this tag.
             if (_tagDiagrams.TryGetValue(tagName, out var diagrams))
@@ -432,7 +119,7 @@ public sealed class TagDescriptionDocumentTransformer : IOpenApiDocumentTransfor
                 Description = description,
             };
 
-            if (DisplayNames.TryGetValue(tagName, out var displayName))
+            if (_displayNames.TryGetValue(tagName, out var displayName))
             {
                 tagObj.Extensions ??= new Dictionary<string, IOpenApiExtension>();
                 tagObj.Extensions["x-displayName"] = new JsonNodeExtension(JsonValue.Create(displayName));

--- a/src/API/Nocturne.API/Configuration/TagDescriptionLoader.cs
+++ b/src/API/Nocturne.API/Configuration/TagDescriptionLoader.cs
@@ -1,0 +1,109 @@
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Nocturne.API.Configuration;
+
+/// <summary>
+/// Loads OpenAPI tag descriptions from folder-based markdown sources under
+/// <c>docs/api-descriptions</c>. Each <c>.md</c> file is one tag: the file name (sans
+/// extension) is the tag name, and the top-level folder is the OpenAPI document it
+/// belongs to (<c>nocturne</c> or <c>nightscout</c>). Deeper subfolders are purely
+/// organizational. Optional YAML frontmatter carries <c>displayName</c> (sidebar label
+/// override) and <c>standalone</c> (a conceptual page with no operations of its own).
+/// </summary>
+internal static class TagDescriptionLoader
+{
+    public sealed record TagDescription(
+        string TagName,
+        string Document,
+        string? DisplayName,
+        bool Standalone,
+        string Markdown);
+
+    /// <summary>
+    /// Resolves the descriptions directory. In local dev the source tree is available at
+    /// <c>ContentRootPath/../../../docs/api-descriptions</c>; in Docker the .md files are
+    /// published to <c>wwwroot/api-descriptions</c> via an MSBuild target.
+    /// </summary>
+    public static string ResolveDescriptionsDir(IWebHostEnvironment env)
+    {
+        var devPath = Path.GetFullPath(
+            Path.Combine(env.ContentRootPath, "..", "..", "..", "docs", "api-descriptions"));
+        if (Directory.Exists(devPath))
+            return devPath;
+
+        return Path.Combine(env.WebRootPath, "api-descriptions");
+    }
+
+    public static IReadOnlyList<TagDescription> Load(IWebHostEnvironment env)
+    {
+        var dir = ResolveDescriptionsDir(env);
+        if (!Directory.Exists(dir))
+            return [];
+
+        var deserializer = new DeserializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .IgnoreUnmatchedProperties()
+            .Build();
+
+        var results = new List<TagDescription>();
+
+        foreach (var path in Directory.EnumerateFiles(dir, "*.md", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(dir, path).Replace('\\', '/');
+
+            // The first path segment is the document folder. Files sitting directly in the
+            // root (e.g. README.md) have no document and are skipped.
+            var separator = relative.IndexOf('/');
+            if (separator < 0)
+                continue;
+
+            var document = relative[..separator];
+            var tagName = Path.GetFileNameWithoutExtension(path);
+
+            var (frontmatter, body) = SplitFrontmatter(File.ReadAllText(path));
+
+            var meta = frontmatter is null
+                ? new Frontmatter()
+                : deserializer.Deserialize<Frontmatter>(frontmatter) ?? new Frontmatter();
+
+            results.Add(new TagDescription(
+                tagName,
+                document,
+                string.IsNullOrWhiteSpace(meta.DisplayName) ? null : meta.DisplayName,
+                meta.Standalone,
+                body.Trim()));
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Splits an optional leading <c>---</c>-fenced YAML frontmatter block from the
+    /// markdown body. Returns <c>(null, original)</c> when there is no frontmatter.
+    /// </summary>
+    private static (string? Frontmatter, string Body) SplitFrontmatter(string content)
+    {
+        var text = content.Replace("\r\n", "\n");
+        if (!text.StartsWith("---\n", StringComparison.Ordinal))
+            return (null, text);
+
+        var fenceEnd = text.IndexOf("\n---", 4, StringComparison.Ordinal);
+        if (fenceEnd < 0)
+            return (null, text);
+
+        var frontmatter = text[4..fenceEnd];
+
+        // Body begins on the line after the closing fence.
+        var bodyStart = text.IndexOf('\n', fenceEnd + 1);
+        var body = bodyStart < 0 ? string.Empty : text[(bodyStart + 1)..];
+
+        return (frontmatter, body);
+    }
+
+    private sealed class Frontmatter
+    {
+        public string? DisplayName { get; set; }
+        public bool Standalone { get; set; }
+    }
+}

--- a/src/API/Nocturne.API/Nocturne.API.csproj
+++ b/src/API/Nocturne.API/Nocturne.API.csproj
@@ -97,11 +97,22 @@
     <DiagramSource Include="..\..\..\docs\diagrams\diagrams.yaml;..\..\..\docs\diagrams\*.mmd" />
     <Content Include="@(DiagramSource)" Link="wwwroot\diagrams\%(Filename)%(Extension)" CopyToOutputDirectory="Never" CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
-  <!-- The diagram Content items only exist as virtual Links; the physical wwwroot\diagrams
-       directory is never created. dotnet watch's FileSystemWatcher throws on startup when it
-       tries to watch a directory that doesn't exist, so create it eagerly before build. -->
-  <Target Name="EnsureDiagramsDir" BeforeTargets="BeforeBuild">
+  <!-- API tag descriptions — folder-based markdown published to wwwroot/api-descriptions/
+       (preserving subfolders) so TagDescriptionDocumentTransformer can find them in Docker
+       where the source tree isn't available. -->
+  <ItemGroup>
+    <ApiDescriptionSource Include="..\..\..\docs\api-descriptions\**\*.md" />
+    <Content Include="@(ApiDescriptionSource)" Link="wwwroot\api-descriptions\%(RecursiveDir)%(Filename)%(Extension)" CopyToOutputDirectory="Never" CopyToPublishDirectory="PreserveNewest" />
+  </ItemGroup>
+  <!-- dotnet watch (.NET 10) attaches a FileSystemWatcher to each linked Content item's
+       destination directory under wwwroot\. Those dirs don't exist in dev (the .md/.mmd files
+       are only copied at publish, for Docker), and FileSystemWatcher throws on a missing
+       directory — crashing the AppHost on `aspire start`. Create the destination dirs (derived
+       from the source items, so new doc subfolders are covered automatically) before the build
+       that precedes the watch loop; they stay empty in dev. -->
+  <Target Name="EnsureLinkedContentDirsExist" BeforeTargets="BeforeBuild">
     <MakeDir Directories="$(MSBuildProjectDirectory)\wwwroot\diagrams" />
+    <MakeDir Directories="@(ApiDescriptionSource->'$(MSBuildProjectDirectory)\wwwroot\api-descriptions\%(RecursiveDir)')" />
   </Target>
   <!-- NSwag TypeScript Client Generation -->
   <!-- Runs on `dotnet build` and on initial Aspire startup (first build before watch loop). -->


### PR DESCRIPTION
## Summary

Moves OpenAPI tag descriptions out of inline strings in the C# transformer and into per-tag markdown files under `docs/api-descriptions/`.

- One `.md` file per tag (file name = tag name); the top-level folder is the OpenAPI document it belongs to (`nocturne` or `nightscout`), deeper folders are purely organizational.
- Optional YAML frontmatter carries `displayName` (sidebar label override) and `standalone` (a conceptual page with no operations).
- `TagDescriptionLoader` discovers and parses the markdown + frontmatter, resolving the source dir from the dev tree or the published `wwwroot/api-descriptions` copy.
- `TagDescriptionDocumentTransformer` shrinks to consuming the loaded descriptions instead of ~350 lines of inline strings.
- An MSBuild target publishes the `.md` files to `wwwroot/api-descriptions` so they ship in the Docker image, and the existing `EnsureDiagramsDir` watch-crash fix is generalized to `EnsureLinkedContentDirsExist`, creating all linked-content destination dirs (diagrams + api-descriptions) before build.

The generated API client is intentionally untouched — CI regenerates it on main.

## Test plan

- `dotnet build src/API/Nocturne.API` passes with 0 errors.
- Scalar/OpenAPI docs render the same tag descriptions as before, now sourced from markdown.
