### PR TITLE
fix(web): entering a patient weight threw "this.weightKg.trim is not a function"

### DIFF
--- a/src/Web/packages/app/src/lib/components/patient/state.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/patient/state.svelte.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { flushSync } from "svelte";
+
+// Mock the generated remote functions before importing the state module. WeightState reads
+// getBodyWeights() as a reactive query (`.current`) and calls create() on save. The sibling
+// classes (ClinicalState et al.) only touch their remote modules at instantiation, so empty
+// mocks suffice.
+const create = vi.fn().mockResolvedValue({});
+let bodyWeightsCurrent: unknown[] | undefined;
+
+vi.mock("$api/generated/bodyWeights.generated.remote", () => ({
+  getBodyWeights: () => ({
+    get current() {
+      return bodyWeightsCurrent;
+    },
+  }),
+  create: (...args: unknown[]) => create(...args),
+}));
+vi.mock("$api/generated/patientRecords.generated.remote", () => ({}));
+vi.mock("$api/generated/insulinCatalogs.generated.remote", () => ({
+  getCatalog: () => ({ current: undefined }),
+}));
+
+import { WeightState } from "./state.svelte";
+
+/**
+ * Instantiate WeightState inside an effect root (its constructor registers a
+ * $effect) and flush so the loaded BodyWeight lands in the field before
+ * assertions run.
+ */
+function makeWeightState(): { w: WeightState; cleanup: () => void } {
+  let w!: WeightState;
+  const cleanup = $effect.root(() => {
+    w = new WeightState();
+  });
+  flushSync();
+  return { w, cleanup };
+}
+
+describe("WeightState", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    bodyWeightsCurrent = [{ weightKg: 70 }];
+  });
+
+  // Regression for nightscout/nocturne#481: bind:value on a type="number" input assigns a
+  // number, and dirty's string handling threw "this.weightKg.trim is not a function".
+  it("tracks dirty against numeric values from the input binding", () => {
+    const { w, cleanup } = makeWeightState();
+    expect(w.dirty).toBe(false);
+
+    w.weightKg = 70.5;
+    expect(w.dirty).toBe(true);
+
+    w.weightKg = 70;
+    expect(w.dirty).toBe(false);
+    cleanup();
+  });
+
+  it("saves the changed value and resets dirty", async () => {
+    const { w, cleanup } = makeWeightState();
+    w.weightKg = 72.5;
+
+    await expect(w.save()).resolves.toBe(true);
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(create).toHaveBeenCalledWith({
+      weightKg: 72.5,
+      mills: expect.any(Number),
+    });
+    expect(w.dirty).toBe(false);
+    cleanup();
+  });
+
+  it("does not create an entry when the input is cleared (null)", async () => {
+    const { w, cleanup } = makeWeightState();
+    w.weightKg = null;
+    expect(w.dirty).toBe(true);
+
+    await expect(w.save()).resolves.toBe(true);
+
+    expect(create).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it("does not create an entry when the value is unchanged", async () => {
+    const { w, cleanup } = makeWeightState();
+
+    await expect(w.save()).resolves.toBe(true);
+
+    expect(create).not.toHaveBeenCalled();
+    cleanup();
+  });
+});

--- a/src/Web/packages/app/src/lib/components/patient/state.svelte.ts
+++ b/src/Web/packages/app/src/lib/components/patient/state.svelte.ts
@@ -172,10 +172,11 @@ user can freely retype; `save()` only fires on explicit commit (e.g. the clinica
 button) and only inserts a new history entry when the value actually changed, so typing "75",
 backspacing, and retyping "75" doesn't create a run of spurious same-day weight changes. */
 export class WeightState {
-  weightKg = $state("");
+  /** Bound to a `type="number"` input — null when the field is empty. */
+  weightKg = $state<number | null>(null);
   saving = $state(false);
   saveError = $state<string | null>(null);
-  #initialWeightKg = $state("");
+  #initialWeightKg = $state<number | null>(null);
 
   readonly #existing = getBodyWeights({ count: 1, skip: 0 });
 
@@ -183,7 +184,7 @@ export class WeightState {
     $effect(() => {
       const records = this.#existing.current;
       if (records && records.length > 0) {
-        const kg = String(records[0].weightKg ?? "");
+        const kg = records[0].weightKg ?? null;
         this.weightKg = kg;
         this.#initialWeightKg = kg;
       }
@@ -191,16 +192,16 @@ export class WeightState {
   }
 
   get dirty(): boolean {
-    return this.weightKg.trim() !== this.#initialWeightKg;
+    return this.weightKg !== this.#initialWeightKg;
   }
 
   save = async (): Promise<boolean> => {
-    if (!this.dirty || !this.weightKg) return true;
+    if (!this.dirty || this.weightKg == null) return true;
     this.saving = true;
     this.saveError = null;
     try {
       await createBodyWeight({
-        weightKg: Number(this.weightKg),
+        weightKg: this.weightKg,
         mills: Date.now(),
       });
       this.#initialWeightKg = this.weightKg;

--- a/src/Web/packages/app/vitest.browser.config.ts
+++ b/src/Web/packages/app/vitest.browser.config.ts
@@ -6,6 +6,9 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   plugins: [svelte(), tailwindcss()],
   resolve: { dedupe: ["@internationalized/date", "bits-ui"] },
+  // pnpm 11's global links store lives outside the workspace root, so vite's strict fs
+  // allow-list blocks serving vitest-browser-svelte to the browser runner.
+  server: { fs: { strict: false } },
   test: {
     include: ["src/**/*.svelte.test.ts"],
     setupFiles: ["vitest-browser-svelte", "./vitest.browser.setup.ts"],


### PR DESCRIPTION
Fixes #481.

## Problem

The clinical form (Settings → Patient Record) binds the weight field to a `type="number"` input:

```svelte
<Input id="weight" type="number" step="0.1" min="0" bind:value={clinical.weight.weightKg} />
```

Svelte coerces `bind:value` on a numeric input to a number (or `null` when cleared), but `WeightState` typed `weightKg` as a string and called `.trim()` in its `dirty` getter — so typing any digit threw `this.weightKg.trim is not a function`.

## Fix

Treat the value as a number end to end: `weightKg` is `number | null`, `dirty` compares numbers, and `save()` posts the value directly. A cleared input (`null`) never creates a BodyWeight entry.

Added a co-located browser test for `WeightState` covering the numeric-binding regression, save, cleared input, and unchanged value (4 tests, passing locally).

Also includes a one-line test-runner fix: pnpm 11's global links store lives outside the workspace root, so vite's strict fs allow-list refused to serve `vitest-browser-svelte` and every `pnpm test:browser` file failed to import. `server.fs.strict: false` on the test-only vite server unblocks it.
