### PR TITLE
fix(api): public share links returned no data — normalize scope-vocabulary grants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,10 +158,16 @@ see only the categories the tenant's Public subject was granted. On top of the
 **RESTRICTIVE FOR SELECT** policy (`share_category_read`) gating reads by category:
 
     USING ( current_setting('app.is_share', true) IS DISTINCT FROM 'true'
-         OR '<governing_scope>' = ANY(string_to_array(current_setting('app.visible_categories', true), ',')) )
+         OR ( '<governing_scope>' = ANY(string_to_array(current_setting('app.visible_categories', true), ','))
+              AND ( current_setting('app.share_full_history', true) = 'true'
+                    OR "<recency_column>" >= now() - interval '24 hours' ) ) )
 
-Two extra GUCs carry the request state to the connection (set by
-`TenantConnectionInterceptor` from two `NocturneDbContext` properties):
+(The 24-hour clamp appears only on tables with a recency column in
+`ShareDataCategories.RecencyColumns`; catalog tables with no per-row time, e.g.
+`foods`, carry just the category gate.)
+
+Three extra GUCs carry the request state to the connection (set by
+`TenantConnectionInterceptor` from `NocturneDbContext` properties):
 
 - **`app.is_share`** — `'true'` for a public share, else `'false'`. Known
   **pre-auth** (at tenant resolution), so it is set wherever `TenantId` is set
@@ -172,6 +178,10 @@ Two extra GUCs carry the request state to the connection (set by
   **only on the `ITenantDbContextFactory` path** (`TenantDbContextFactory.CreateAsync`).
   Share-reachable PHI reads must go through the factory; a share that reads PHI on
   a directly-injected scoped context carries no CSV and is **denied** (fail-closed).
+- **`app.share_full_history`** — `'true'` when the share's Public membership has
+  `limit_to_24_hours = false`. Same post-auth, factory-only carriage as the CSV; a
+  share connection that never sets it is **clamped to the last 24 hours** of every
+  time-series category (fail-closed).
 
 Design notes:
 

--- a/src/API/Nocturne.API/Middleware/AuthenticationMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/AuthenticationMiddleware.cs
@@ -230,18 +230,27 @@ public class AuthenticationMiddleware
                 };
                 context.Items["AuthContext"] = publicAuthContext;
 
-                var publicPermissionTrie = new PermissionTrie();
-                publicPermissionTrie.Add(publicAccess.EffectivePermissions);
-                context.Items["PermissionTrie"] = publicPermissionTrie;
-
-                var publicScopes = ScopeTranslator.FromPermissions(publicAccess.EffectivePermissions);
+                // The Public subject's effective permissions are stored in the OAuth scope
+                // vocabulary (glucose.read, ...) — the same vocabulary member grants use — so
+                // normalize them the way MemberScopeMiddleware does for members.
+                // ScopeTranslator.FromPermissions translates legacy api:* trie strings and
+                // silently drops scope-shaped input, which would empty the grant.
+                var publicScopes = OAuthScopes.Normalize(publicAccess.EffectivePermissions);
                 context.Items["GrantedScopes"] = publicScopes;
 
-                // Carry the share's visible categories to the DbContext factory for
-                // per-category RLS. Resolved here (post-auth); a share whose CSV is never
-                // set is denied all categorized data by the policy (fail-closed).
-                context.RequestServices.GetService<ICategoryReadContext>()
-                    ?.SetVisibleCategories(ShareDataCategories.ComputeVisibleCategoriesCsv(publicScopes));
+                // Legacy (HasPermissions-gated) endpoints check the trie, so derive it from the
+                // normalized scopes; a share that resolves to zero scopes gets an empty trie and
+                // is rejected by the policy instead of passing authorization and reading nothing.
+                var publicPermissionTrie = new PermissionTrie();
+                publicPermissionTrie.Add(ScopeTranslator.ToPermissions(publicScopes));
+                context.Items["PermissionTrie"] = publicPermissionTrie;
+
+                // Carry the share's visible categories and history window to the DbContext
+                // factory for the share RLS policies. Resolved here (post-auth); a share whose
+                // CSV is never set is denied all categorized data by the policy (fail-closed).
+                var categoryReadContext = context.RequestServices.GetService<ICategoryReadContext>();
+                categoryReadContext?.SetVisibleCategories(ShareDataCategories.ComputeVisibleCategoriesCsv(publicScopes));
+                categoryReadContext?.SetFullHistory(!publicAccess.LimitTo24Hours);
 
                 context.Items["AuthenticationContext"] = MapToLegacyContext(publicAuthContext);
 

--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -249,6 +249,7 @@ public class TenantResolutionMiddleware
         // pre-auth) and leaves the CSV null, so a share reading PHI on this path is denied.
         db.IsShareContext = context.RequestServices.GetService<ICategoryReadContext>()?.IsShare == true;
         db.VisibleCategories = null;
+        db.ShareFullHistory = false;
     }
 
     private const string ShareSubdomainLabel = "share";

--- a/src/API/Nocturne.API/Services/Auth/ShareTokenCacheService.cs
+++ b/src/API/Nocturne.API/Services/Auth/ShareTokenCacheService.cs
@@ -53,6 +53,12 @@ public sealed class ShareTokenCacheService
         if (tenant == null)
             return null;
 
+        // Stamp last-accessed on the database-hit path only: successful resolutions are
+        // cached for CacheTtl, so the write is debounced to at most once per TTL per token.
+        await dbContext.Tenants
+            .Where(t => t.Id == tenant.Id)
+            .ExecuteUpdateAsync(s => s.SetProperty(t => t.ShareLastAccessedAt, DateTime.UtcNow));
+
         var tenantContext = new TenantContext(tenant.Id, tenant.Slug, tenant.DisplayName, tenant.IsActive, tenant.IsDemo);
         _cache.Set(cacheKey, tenantContext, CacheTtl);
         return tenantContext;

--- a/src/Core/Nocturne.Core.Contracts/Multitenancy/ICategoryReadContext.cs
+++ b/src/Core/Nocturne.Core.Contracts/Multitenancy/ICategoryReadContext.cs
@@ -25,6 +25,13 @@ public interface ICategoryReadContext
     string? VisibleCategoriesCsv { get; }
 
     /// <summary>
+    /// True when the share may see full history instead of the last 24 hours. Defaults to
+    /// false, so a share whose window is never resolved is clamped (fail-closed). Only
+    /// meaningful when <see cref="IsShare"/> is true.
+    /// </summary>
+    bool FullHistory { get; }
+
+    /// <summary>
     /// Marks the request as an anonymous public share. Called by
     /// <c>TenantResolutionMiddleware</c> before the scoped context is pinned.
     /// </summary>
@@ -37,4 +44,12 @@ public interface ICategoryReadContext
     /// </summary>
     /// <param name="csv">The comma-separated governing read scopes (may be empty).</param>
     void SetVisibleCategories(string csv);
+
+    /// <summary>
+    /// Sets whether the share may see full history. Called by <c>AuthenticationMiddleware</c>
+    /// once the share's history window is known. Has no effect unless the request was marked
+    /// as a share.
+    /// </summary>
+    /// <param name="fullHistory">True to lift the 24-hour clamp for this share.</param>
+    void SetFullHistory(bool fullHistory);
 }

--- a/src/Core/Nocturne.Core.Models/Authorization/ShareDataCategories.cs
+++ b/src/Core/Nocturne.Core.Models/Authorization/ShareDataCategories.cs
@@ -61,6 +61,37 @@ public static class ShareDataCategories
             },
         };
 
+    /// <summary>
+    /// Recency column per governed table, driving the share 24-hour clamp: a share without
+    /// full history sees only rows whose recency column is within the last 24 hours. An
+    /// explicit <c>null</c> marks a table as deliberately unclamped (catalog data with no
+    /// per-row time, e.g. the food database). Every governed table must appear here — the
+    /// type initializer throws on a missing entry, so a new governed table cannot silently
+    /// skip the clamp decision.
+    /// </summary>
+    public static readonly IReadOnlyDictionary<string, string?> RecencyColumns =
+        new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["sensor_glucose"] = "timestamp",
+            ["bg_checks"] = "timestamp",
+            ["meter_glucose"] = "timestamp",
+            ["calibrations"] = "timestamp",
+            ["boluses"] = "timestamp",
+            ["carb_intakes"] = "timestamp",
+            ["temp_basals"] = "start_timestamp",
+            ["basal_injections"] = "timestamp",
+            ["bolus_calculations"] = "timestamp",
+            ["device_events"] = "timestamp",
+            ["device_status_extras"] = "timestamp",
+            ["pump_snapshots"] = "timestamp",
+            ["uploader_snapshots"] = "timestamp",
+            ["aps_snapshots"] = "timestamp",
+            ["heart_rates"] = "timestamp",
+            ["step_counts"] = "timestamp",
+            ["foods"] = null,
+            ["connector_food_entries"] = null,
+        };
+
     private static readonly IReadOnlyDictionary<string, string> TableToScope = BuildTableToScope();
 
     /// <summary>The governing scopes that have at least one table (the shareable, table-backed categories).</summary>
@@ -72,6 +103,13 @@ public static class ShareDataCategories
     /// </summary>
     public static string? GoverningScopeFor(string table) =>
         TableToScope.TryGetValue(table, out var scope) ? scope : null;
+
+    /// <summary>
+    /// Returns the recency column the share 24-hour clamp applies to a governed table, or
+    /// <c>null</c> when the table is not governed or is deliberately unclamped.
+    /// </summary>
+    public static string? RecencyColumnFor(string table) =>
+        RecencyColumns.TryGetValue(table, out var column) ? column : null;
 
     /// <summary>
     /// Computes the value for the <c>app.visible_categories</c> GUC carried by a
@@ -98,6 +136,12 @@ public static class ShareDataCategories
             foreach (var table in tables)
             {
                 map.Add(table, scope); // throws on a duplicate table across scopes — a map authoring error
+                if (!RecencyColumns.ContainsKey(table))
+                {
+                    throw new InvalidOperationException(
+                        $"Governed table '{table}' has no entry in {nameof(RecencyColumns)}. " +
+                        "Declare its recency column, or an explicit null to exempt it from the share 24-hour clamp.");
+                }
             }
         }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs
@@ -143,13 +143,14 @@ public static class DatabaseInitializationExtensions
             foreach (var table in tables)
             {
                 var governingScope = ShareDataCategories.GoverningScopeFor(table);
+                var recencyColumn = ShareDataCategories.RecencyColumnFor(table);
                 // Wrap each table's DROP+CREATE in a transaction so the "RLS enabled, no
                 // restrictive policy" state is never observable to a concurrent reader.
                 await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
                 await using (var command = connection.CreateCommand())
                 {
                     command.Transaction = transaction;
-                    command.CommandText = ShareRlsPolicy.BuildPolicySql(table, governingScope);
+                    command.CommandText = ShareRlsPolicy.BuildPolicySql(table, governingScope, recencyColumn);
                     await command.ExecuteNonQueryAsync(cancellationToken);
                 }
                 await transaction.CommitAsync(cancellationToken);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Interceptors/TenantConnectionInterceptor.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Interceptors/TenantConnectionInterceptor.cs
@@ -48,7 +48,7 @@ public class TenantConnectionInterceptor : DbConnectionInterceptor
         }
 
         await using var cmd = connection.CreateCommand();
-        var clauses = new List<string>(3);
+        var clauses = new List<string>(4);
 
         if (ctx.TenantId != Guid.Empty)
         {
@@ -56,15 +56,19 @@ public class TenantConnectionInterceptor : DbConnectionInterceptor
             AddParameter(cmd, "tenant_id", ctx.TenantId.ToString());
         }
 
-        // app.is_share and app.visible_categories gate the per-category public-share RLS
-        // policies. is_share is set on every open so a pooled connection never inherits a
-        // previous lessee's share flag; for a share, a missing/empty visible_categories
-        // denies all categorized data (fail-closed).
+        // app.is_share, app.visible_categories and app.share_full_history gate the
+        // public-share RLS policies. All are set on every open so a pooled connection never
+        // inherits a previous lessee's share state; for a share, a missing/empty
+        // visible_categories denies all categorized data and a missing share_full_history
+        // clamps reads to the last 24 hours (fail-closed).
         clauses.Add("set_config('app.is_share', @is_share, false)");
         AddParameter(cmd, "is_share", ctx.IsShareContext ? "true" : "false");
 
         clauses.Add("set_config('app.visible_categories', @visible_categories, false)");
         AddParameter(cmd, "visible_categories", ctx.VisibleCategories ?? string.Empty);
+
+        clauses.Add("set_config('app.share_full_history', @share_full_history, false)");
+        AddParameter(cmd, "share_full_history", ctx.ShareFullHistory ? "true" : "false");
 
         cmd.CommandText = "SELECT " + string.Join(", ", clauses);
         await cmd.ExecuteNonQueryAsync(cancellationToken);
@@ -97,7 +101,8 @@ public class TenantConnectionInterceptor : DbConnectionInterceptor
         {
             await using var cmd = connection.CreateCommand();
             cmd.CommandText =
-                "RESET app.current_tenant_id; RESET app.is_share; RESET app.visible_categories";
+                "RESET app.current_tenant_id; RESET app.is_share; RESET app.visible_categories; " +
+                "RESET app.share_full_history";
             await cmd.ExecuteNonQueryAsync();
         }
         catch

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -55,6 +55,15 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
     public string? VisibleCategories { get; set; }
 
     /// <summary>
+    /// True when a public share may see full history instead of the last 24 hours. Set only
+    /// on the factory-created context (post-auth, alongside <see cref="VisibleCategories"/>);
+    /// carried to the <c>app.share_full_history</c> GUC. A share context that never sets it
+    /// is clamped to 24 hours (fail-closed). Meaningless for non-shares — the clamp only
+    /// applies when <c>app.is_share</c> is 'true'.
+    /// </summary>
+    public bool ShareFullHistory { get; set; }
+
+    /// <summary>
     /// Gets or sets the Foods table for food database
     /// </summary>
     public DbSet<FoodEntity> Foods { get; set; }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Security/ShareRlsPolicy.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Security/ShareRlsPolicy.cs
@@ -42,24 +42,40 @@ public static class ShareRlsPolicy
     /// Idempotent DDL that enables RLS on the table and (re)creates the share-category policy.
     /// A non-share connection (<c>app.is_share</c> ≠ 'true') is unaffected; a public share sees
     /// the table's rows only when <paramref name="governingScope"/> is present in
-    /// <c>app.visible_categories</c>. A table with no governing scope is hidden from shares
-    /// entirely. The policy is FOR SELECT only, so writes (background ingest) are unaffected.
+    /// <c>app.visible_categories</c> — and, when <paramref name="recencyColumn"/> is given, only
+    /// rows from the last 24 hours unless <c>app.share_full_history</c> is 'true' (fail-closed:
+    /// a share connection that never sets the GUC gets the clamp). A table with no governing
+    /// scope is hidden from shares entirely. The policy is FOR SELECT only, so writes
+    /// (background ingest) are unaffected.
     /// </summary>
     /// <param name="table">The snake_case table name.</param>
     /// <param name="governingScope">The OAuth read scope that unlocks the table for a share,
     /// or <c>null</c> when the table is hidden from shares.</param>
-    public static string BuildPolicySql(string table, string? governingScope)
+    /// <param name="recencyColumn">The timestamp column the 24-hour clamp applies to, or
+    /// <c>null</c> when the table is exempt (catalog data with no per-row time).</param>
+    public static string BuildPolicySql(string table, string? governingScope, string? recencyColumn = null)
     {
         if (!TableNamePattern.IsMatch(table))
             throw new ArgumentException($"Unsafe table identifier '{table}'.", nameof(table));
         if (governingScope is not null && !ScopePattern.IsMatch(governingScope))
             throw new ArgumentException($"Unsafe scope identifier '{governingScope}'.", nameof(governingScope));
+        if (recencyColumn is not null && !TableNamePattern.IsMatch(recencyColumn))
+            throw new ArgumentException($"Unsafe column identifier '{recencyColumn}'.", nameof(recencyColumn));
 
         var usingExpr = "current_setting('app.is_share', true) IS DISTINCT FROM 'true'";
         if (governingScope is not null)
         {
-            usingExpr +=
-                $" OR '{governingScope}' = ANY(string_to_array(current_setting('app.visible_categories', true), ','))";
+            var shareExpr =
+                $"'{governingScope}' = ANY(string_to_array(current_setting('app.visible_categories', true), ','))";
+            if (recencyColumn is not null)
+            {
+                // "timestamp" is quoted: it is a type keyword in PostgreSQL.
+                shareExpr =
+                    $"({shareExpr} AND (current_setting('app.share_full_history', true) = 'true'" +
+                    $" OR \"{recencyColumn}\" >= now() - interval '24 hours'))";
+            }
+
+            usingExpr += $" OR {shareExpr}";
         }
 
         return $"""

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/CarrierResettingDbContextFactory.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/CarrierResettingDbContextFactory.cs
@@ -38,6 +38,7 @@ internal sealed class CarrierResettingDbContextFactory(IDbContextFactory<Nocturn
         context.AuditContext = null;
         context.IsShareContext = false;
         context.VisibleCategories = null;
+        context.ShareFullHistory = false;
         return context;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/CategoryReadContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/CategoryReadContext.cs
@@ -15,6 +15,8 @@ public sealed class CategoryReadContext : ICategoryReadContext
 
     public string? VisibleCategoriesCsv { get; private set; }
 
+    public bool FullHistory { get; private set; }
+
     public void MarkShare() => IsShare = true;
 
     public void SetVisibleCategories(string csv)
@@ -22,6 +24,14 @@ public sealed class CategoryReadContext : ICategoryReadContext
         if (IsShare)
         {
             VisibleCategoriesCsv = csv ?? string.Empty;
+        }
+    }
+
+    public void SetFullHistory(bool fullHistory)
+    {
+        if (IsShare)
+        {
+            FullHistory = fullHistory;
         }
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/TenantDbContextFactory.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/TenantDbContextFactory.cs
@@ -37,6 +37,7 @@ internal sealed class TenantDbContextFactory(
         var isShare = categoryReadContext?.IsShare == true;
         ctx.IsShareContext = isShare;
         ctx.VisibleCategories = isShare ? categoryReadContext!.VisibleCategoriesCsv : null;
+        ctx.ShareFullHistory = isShare && categoryReadContext!.FullHistory;
 
         return ctx;
     }

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/RlsShareCategoryTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/RlsShareCategoryTests.cs
@@ -125,6 +125,40 @@ public class RlsShareCategoryTests
     }
 
     [Fact]
+    public async Task Share_WithoutFullHistory_IsClampedTo24Hours()
+    {
+        var tenant = Guid.NewGuid();
+        await SeedAsync(tenant);
+        await SeedOldGovernedRowAsync(tenant);
+
+        await using var conn = await _fx.OpenAppConnectionAsync();
+
+        // No app.share_full_history set — the clamp must apply (fail-closed).
+        await SetShareContextAsync(conn, tenant, isShare: true, visibleCategories: GovernedScope);
+        (await CountAsync(conn, GovernedTable, tenant)).Should().Be(1,
+            "a share without full history sees only rows from the last 24 hours");
+
+        await SetShareContextAsync(conn, tenant, isShare: false, visibleCategories: string.Empty);
+        (await CountAsync(conn, GovernedTable, tenant)).Should().Be(2,
+            "the owner is never clamped");
+    }
+
+    [Fact]
+    public async Task Share_WithFullHistory_SeesOldRows()
+    {
+        var tenant = Guid.NewGuid();
+        await SeedAsync(tenant);
+        await SeedOldGovernedRowAsync(tenant);
+
+        await using var conn = await _fx.OpenAppConnectionAsync();
+        await SetShareContextAsync(conn, tenant, isShare: true, visibleCategories: GovernedScope,
+            fullHistory: true);
+
+        (await CountAsync(conn, GovernedTable, tenant)).Should().Be(2,
+            "a full-history share sees rows older than 24 hours");
+    }
+
+    [Fact]
     public async Task EveryTenantScopedTable_HasCorrectRestrictiveSelectSharePolicy()
     {
         await using var conn = await _fx.OpenMigratorConnectionAsync();
@@ -160,6 +194,16 @@ public class RlsShareCategoryTests
             else
             {
                 usingExpr.Should().Contain($"'{scope}'", $"{table} must gate on its governing scope {scope}");
+                if (ShareDataCategories.RecencyColumnFor(table) is not null)
+                {
+                    usingExpr.Should().Contain("share_full_history",
+                        $"{table} is time-series data, so its policy must clamp shares without full history to 24 hours");
+                }
+                else
+                {
+                    usingExpr.Should().NotContain("share_full_history",
+                        $"{table} is deliberately unclamped (no per-row time), so its policy must not carry the clamp");
+                }
             }
         }
     }
@@ -202,6 +246,15 @@ public class RlsShareCategoryTests
             "VALUES (gen_random_uuid(), @tid, now(), 1.0, false, 'Manual', now(), now())", tenantId);
     }
 
+    private async Task SeedOldGovernedRowAsync(Guid tenantId)
+    {
+        await using var conn = await _fx.OpenMigratorConnectionAsync();
+        await SetCurrentTenantAsync(conn, tenantId);
+        await ExecuteAsync(conn,
+            $"INSERT INTO {GovernedTable} (id, tenant_id, timestamp, metric, source, sys_created_at, sys_updated_at) " +
+            "VALUES (gen_random_uuid(), @tid, now() - interval '30 hours', 0, 0, now(), now())", tenantId);
+    }
+
     private static async Task InsertTenantAsync(NpgsqlConnection conn, Guid tenantId)
     {
         await using var cmd = conn.CreateCommand();
@@ -231,16 +284,18 @@ public class RlsShareCategoryTests
     }
 
     private static async Task SetShareContextAsync(
-        NpgsqlConnection conn, Guid tenantId, bool isShare, string visibleCategories)
+        NpgsqlConnection conn, Guid tenantId, bool isShare, string visibleCategories, bool fullHistory = false)
     {
         await using var cmd = conn.CreateCommand();
         cmd.CommandText =
             "SELECT set_config('app.current_tenant_id', @tid, false), " +
             "set_config('app.is_share', @share, false), " +
-            "set_config('app.visible_categories', @cats, false)";
+            "set_config('app.visible_categories', @cats, false), " +
+            "set_config('app.share_full_history', @full_history, false)";
         AddParam(cmd, "@tid", tenantId.ToString());
         AddParam(cmd, "@share", isShare ? "true" : "false");
         AddParam(cmd, "@cats", visibleCategories);
+        AddParam(cmd, "@full_history", fullHistory ? "true" : "false");
         await cmd.ExecuteNonQueryAsync();
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Middleware/AuthenticationMiddlewareShareAccessTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/AuthenticationMiddlewareShareAccessTests.cs
@@ -31,18 +31,19 @@ namespace Nocturne.API.Tests.Middleware;
 public sealed class AuthenticationMiddlewareShareAccessTests
 {
     private readonly PublicAccessCacheService _publicAccess;
+    private readonly string _dbName;
 
     public AuthenticationMiddlewareShareAccessTests()
     {
-        var dbName = $"share_gate_{Guid.NewGuid()}";
-        using (var seed = TestDbContextFactory.CreateInMemoryContext(dbName))
+        _dbName = $"share_gate_{Guid.NewGuid()}";
+        using (var seed = TestDbContextFactory.CreateInMemoryContext(_dbName))
         {
             TestDatabaseSeeder.Seed(seed);
         }
 
         var factory = new Mock<IDbContextFactory<NocturneDbContext>>();
         factory.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(() => TestDbContextFactory.CreateInMemoryContext(dbName));
+            .ReturnsAsync(() => TestDbContextFactory.CreateInMemoryContext(_dbName));
 
         _publicAccess = new PublicAccessCacheService(
             new MemoryCache(new MemoryCacheOptions()), factory.Object, NullLogger<PublicAccessCacheService>.Instance);
@@ -87,6 +88,55 @@ public sealed class AuthenticationMiddlewareShareAccessTests
         // The post-auth CSV set-point ran: the share carries a (possibly empty) visible-categories
         // value, never null — null on a share would fail-open at the policy.
         ctx.RequestServices.GetRequiredService<ICategoryReadContext>().VisibleCategoriesCsv.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Share_access_resolves_scope_vocabulary_grants_into_scopes_and_categories()
+    {
+        // Regression: the Public subject's grants are stored in the OAuth scope vocabulary
+        // (glucose.read, ...), the same vocabulary member grants use. Translating them with
+        // ScopeTranslator.FromPermissions (which understands only legacy api:* trie strings)
+        // silently dropped every grant — GrantedScopes and the visible-categories CSV came out
+        // empty, and the share RLS policy denied every row: the whole share dashboard rendered
+        // empty while every request returned 200.
+        var ctx = ContextFor(shareAccess: true);
+
+        await Build().InvokeAsync(ctx);
+
+        var scopes = ctx.Items["GrantedScopes"] as IReadOnlySet<string>;
+        scopes.Should().Contain(OAuthScopes.GlucoseRead,
+            "the seeded Public membership grants glucose.read via the Clinician role");
+
+        var csv = ctx.RequestServices.GetRequiredService<ICategoryReadContext>().VisibleCategoriesCsv;
+        csv.Should().Contain("glucose.read").And.Contain("treatments.read");
+    }
+
+    [Fact]
+    public async Task Share_access_stays_clamped_to_24_hours_when_limited()
+    {
+        var ctx = ContextFor(shareAccess: true);
+
+        await Build().InvokeAsync(ctx);
+
+        ctx.RequestServices.GetRequiredService<ICategoryReadContext>().FullHistory.Should().BeFalse(
+            "the seeded Public membership has LimitTo24Hours=true");
+    }
+
+    [Fact]
+    public async Task Share_access_carries_full_history_when_not_limited()
+    {
+        using (var db = TestDbContextFactory.CreateInMemoryContext(_dbName))
+        {
+            var member = db.TenantMembers.Single(m => m.SubjectId == TestDatabaseSeeder.PublicSubjectId);
+            member.LimitTo24Hours = false;
+            db.SaveChanges();
+        }
+
+        var ctx = ContextFor(shareAccess: true);
+
+        await Build().InvokeAsync(ctx);
+
+        ctx.RequestServices.GetRequiredService<ICategoryReadContext>().FullHistory.Should().BeTrue();
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Middleware/AuthenticationMiddlewareShareAccessTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/AuthenticationMiddlewareShareAccessTests.cs
@@ -104,7 +104,8 @@ public sealed class AuthenticationMiddlewareShareAccessTests
         await Build().InvokeAsync(ctx);
 
         var scopes = ctx.Items["GrantedScopes"] as IReadOnlySet<string>;
-        scopes.Should().Contain(OAuthScopes.GlucoseRead,
+        scopes.Should().NotBeNull();
+        scopes!.Should().Contain(OAuthScopes.GlucoseRead,
             "the seeded Public membership grants glucose.read via the Clinician role");
 
         var csv = ctx.RequestServices.GetRequiredService<ICategoryReadContext>().VisibleCategoriesCsv;

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareTokenCacheServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareTokenCacheServiceTests.cs
@@ -65,6 +65,33 @@ public sealed class ShareTokenCacheServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task ResolveByTokenAsync_stamps_last_accessed_on_a_database_hit()
+    {
+        var before = DateTime.UtcNow;
+
+        await Service().ResolveByTokenAsync(Token);
+
+        using var db = _factory.CreateDbContext();
+        db.Tenants.Single(t => t.Id == _tenantId).ShareLastAccessedAt
+            .Should().NotBeNull().And.BeOnOrAfter(before);
+    }
+
+    [Fact]
+    public async Task ResolveByTokenAsync_cached_hit_does_not_stamp_again()
+    {
+        var service = Service();
+        await service.ResolveByTokenAsync(Token);
+        DateTime? first;
+        using (var db = _factory.CreateDbContext())
+            first = db.Tenants.Single(t => t.Id == _tenantId).ShareLastAccessedAt;
+
+        await service.ResolveByTokenAsync(Token); // served from cache — no write
+
+        using (var db = _factory.CreateDbContext())
+            db.Tenants.Single(t => t.Id == _tenantId).ShareLastAccessedAt.Should().Be(first);
+    }
+
+    [Fact]
     public async Task Evict_makes_a_rotated_token_stop_resolving()
     {
         var service = Service();

--- a/tests/Unit/Nocturne.Core.Models.Tests/Authorization/ShareDataCategoriesTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/Authorization/ShareDataCategoriesTests.cs
@@ -72,4 +72,42 @@ public class ShareDataCategoriesTests
         var allTables = ShareDataCategories.GovernedTables.Values.SelectMany(t => t).ToList();
         allTables.Should().OnlyHaveUniqueItems();
     }
+
+    [Fact]
+    public void RecencyColumnFor_TimeSeriesTable_ReturnsItsColumn()
+    {
+        ShareDataCategories.RecencyColumnFor("boluses").Should().Be("timestamp");
+        ShareDataCategories.RecencyColumnFor("temp_basals").Should().Be("start_timestamp");
+    }
+
+    [Fact]
+    public void RecencyColumnFor_CatalogTable_ReturnsNull()
+    {
+        // The food database is catalog data with no per-row time — deliberately unclamped.
+        ShareDataCategories.RecencyColumnFor("foods").Should().BeNull();
+    }
+
+    [Fact]
+    public void RecencyColumnFor_UngovernedTable_ReturnsNull()
+    {
+        ShareDataCategories.RecencyColumnFor("therapy_settings").Should().BeNull();
+    }
+
+    [Fact]
+    public void EveryGovernedTable_HasARecencyClassification()
+    {
+        // The type initializer enforces this too; the test states the invariant where a
+        // reviewer will see it: a governed table must decide its clamp column (or opt out
+        // with an explicit null) — it cannot be forgotten.
+        var governed = ShareDataCategories.GovernedTables.Values.SelectMany(t => t);
+        governed.Should().OnlyContain(t => ShareDataCategories.RecencyColumns.ContainsKey(t));
+    }
+
+    [Fact]
+    public void RecencyColumns_ReferenceOnlyGovernedTables()
+    {
+        var governed = ShareDataCategories.GovernedTables.Values.SelectMany(t => t).ToHashSet();
+        ShareDataCategories.RecencyColumns.Keys.Should().OnlyContain(t => governed.Contains(t),
+            "a recency entry for an ungoverned table is stale and would mislead");
+    }
 }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Multitenancy/CategoryReadContextTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Multitenancy/CategoryReadContextTests.cs
@@ -12,6 +12,7 @@ public class CategoryReadContextTests
 
         ctx.IsShare.Should().BeFalse();
         ctx.VisibleCategoriesCsv.Should().BeNull();
+        ctx.FullHistory.Should().BeFalse("an unresolved share must stay clamped to 24 hours (fail-closed)");
     }
 
     [Fact]
@@ -46,6 +47,27 @@ public class CategoryReadContextTests
 
         ctx.IsShare.Should().BeFalse();
         ctx.VisibleCategoriesCsv.Should().BeNull();
+    }
+
+    [Fact]
+    public void SetFullHistory_OnShare_LiftsTheClamp()
+    {
+        var ctx = new CategoryReadContext();
+        ctx.MarkShare();
+
+        ctx.SetFullHistory(true);
+
+        ctx.FullHistory.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SetFullHistory_OnNonShare_IsIgnored()
+    {
+        var ctx = new CategoryReadContext();
+
+        ctx.SetFullHistory(true);
+
+        ctx.FullHistory.Should().BeFalse();
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Security/ShareRlsPolicyTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Security/ShareRlsPolicyTests.cs
@@ -64,6 +64,33 @@ public class ShareRlsPolicyTests
     }
 
     [Fact]
+    public void BuildPolicySql_RecencyColumn_AddsThe24HourClampBehindFullHistory()
+    {
+        var sql = ShareRlsPolicy.BuildPolicySql("boluses", OAuthScopes.TreatmentsRead, "timestamp");
+
+        sql.Should().Contain("current_setting('app.share_full_history', true) = 'true'");
+        sql.Should().Contain("\"timestamp\" >= now() - interval '24 hours'");
+        // The clamp narrows the category unlock; it must never widen the is_share gate.
+        sql.Should().Contain("current_setting('app.is_share', true) IS DISTINCT FROM 'true'");
+    }
+
+    [Fact]
+    public void BuildPolicySql_NoRecencyColumn_HasNoClamp()
+    {
+        var sql = ShareRlsPolicy.BuildPolicySql("foods", OAuthScopes.FoodRead);
+
+        sql.Should().NotContain("share_full_history");
+        sql.Should().NotContain("interval");
+    }
+
+    [Fact]
+    public void BuildPolicySql_UnsafeRecencyColumn_Throws()
+    {
+        var act = () => ShareRlsPolicy.BuildPolicySql("boluses", OAuthScopes.TreatmentsRead, "timestamp\"; DROP TABLE x");
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
     public void TenantScopedTableNames_IncludesTenantScoped_ExcludesGlobal()
     {
         var tables = ShareRlsPolicy.TenantScopedTableNames(Model());

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/TenantDbContextFactoryTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/TenantDbContextFactoryTests.cs
@@ -28,11 +28,12 @@ public class TenantDbContextFactoryTests
         return accessor;
     }
 
-    private static Mock<ICategoryReadContext> Category(bool isShare, string? csv)
+    private static Mock<ICategoryReadContext> Category(bool isShare, string? csv, bool fullHistory = false)
     {
         var category = new Mock<ICategoryReadContext>();
         category.Setup(c => c.IsShare).Returns(isShare);
         category.Setup(c => c.VisibleCategoriesCsv).Returns(csv);
+        category.Setup(c => c.FullHistory).Returns(fullHistory);
         return category;
     }
 
@@ -68,6 +69,29 @@ public class TenantDbContextFactoryTests
 
         result.IsShareContext.Should().BeTrue();
         result.VisibleCategories.Should().Be("glucose.read");
+        result.ShareFullHistory.Should().BeFalse("a share whose window was never resolved stays clamped to 24 hours");
+    }
+
+    [Fact]
+    public async Task CreateAsync_CarriesFullHistory_WhenShareAllowsIt()
+    {
+        var factory = new TenantDbContextFactory(
+            NewPool().Object, ResolvedAccessor(Guid.NewGuid()).Object,
+            Category(isShare: true, csv: "glucose.read", fullHistory: true).Object);
+        await using var result = await factory.CreateAsync();
+
+        result.ShareFullHistory.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CreateAsync_NonShare_DoesNotCarryFullHistory()
+    {
+        var factory = new TenantDbContextFactory(
+            NewPool().Object, ResolvedAccessor(Guid.NewGuid()).Object,
+            Category(isShare: false, csv: null, fullHistory: true).Object);
+        await using var result = await factory.CreateAsync();
+
+        result.ShareFullHistory.Should().BeFalse();
     }
 
     [Fact]
@@ -117,6 +141,7 @@ public class TenantDbContextFactoryTests
         {
             IsShareContext = true,
             VisibleCategories = "glucose.read,treatments.read",
+            ShareFullHistory = true,
         };
         var pool = new Mock<IDbContextFactory<NocturneDbContext>>();
         pool.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>())).ReturnsAsync(pooled);
@@ -127,5 +152,6 @@ public class TenantDbContextFactoryTests
 
         result.IsShareContext.Should().BeFalse("a non-share lease must clear a prior share's marker");
         result.VisibleCategories.Should().BeNull("a non-share lease must clear a prior share's CSV");
+        result.ShareFullHistory.Should().BeFalse("a non-share lease must clear a prior share's history window");
     }
 }


### PR DESCRIPTION
## Problem

Every public share link (`{token}.share.{domain}`) rendered an empty dashboard: all data endpoints returned 200 with empty results, regardless of which categories the owner allowed in the Sharing UI.

## Root cause

The Public subject's effective permissions (role + `direct_permissions`) are stored in the OAuth scope vocabulary (`glucose.read`, …), but the share branch of `AuthenticationMiddleware` translated them with `ScopeTranslator.FromPermissions`, which only understands legacy `api:*` trie strings and silently drops scope-shaped input. Both `GrantedScopes` and the visible-categories CSV came out empty, so the `share_category_read` RLS policy — fail-closed for shares by design — denied every row. Authorization still passed because the `HasPermissions` trie was built from the raw (non-empty) permissions, hence 200 + `[]` instead of a 403.

The member path already handled this correctly (`MemberScopeMiddleware` uses `OAuthScopes.Normalize`), but it early-returns for unauthenticated requests, so shares never reached it.

## Fix

- Normalize the Public subject's grants with `OAuthScopes.Normalize`, mirroring the member path, and derive the legacy permission trie from the normalized scopes via `ScopeTranslator.ToPermissions`. A share resolving to zero scopes now fails authorization instead of silently reading nothing.

Two adjacent gaps found while diagnosing are fixed in the same PR:

- **`tenants.share_last_accessed_at` was never written** (displayed in the Sharing UI, always null). `ShareTokenCacheService` now stamps it on the database-hit resolution path — debounced to once per cache TTL per token.
- **`limit_to_24_hours` was never enforced.** The share RLS policy now clamps every time-series category to the last 24 hours unless the new `app.share_full_history` GUC is `'true'`. The GUC is carried post-auth on the `ITenantDbContextFactory` path exactly like `app.visible_categories`, so it is fail-closed: a share connection that never resolves its window stays clamped, and non-shares are never restricted. Recency columns are declared per governed table in `ShareDataCategories.RecencyColumns`; the type initializer rejects a governed table with no clamp decision, and catalog tables (`foods`, `connector_food_entries`) opt out with an explicit `null`. The reconciler recreates the policies on startup — no migration needed.

## Tests

- Regression test: scope-vocabulary grants must resolve into `GrantedScopes` and the RLS category CSV (this is the seam the existing tests missed — they only asserted the CSV was non-null, and the bug produced an empty-but-non-null CSV).
- `ShareTokenCacheService`: last-accessed stamped on DB hit, not re-stamped on cache hit.
- `CategoryReadContext` / `TenantDbContextFactory` / carrier reset: the full-history flag is carried only for shares and cleared on every lease.
- `ShareRlsPolicy`: clamp SQL shape, identifier validation, no clamp for catalog tables.
- Integration (Testcontainers, real Postgres): a share without full history sees only rows from the last 24h while the owner sees everything; a full-history share sees old rows; the policy-inspection test now asserts the clamp is present on every time-series table and absent on catalog tables. All 10 pass locally.

Unit suites: Core.Models 315/315, Infrastructure.Data 430/430, API 3871 passing (two unrelated load-sensitive flakes — `StatusServiceTests` wall-clock ±5s and the `DocumentProcessing` memory benchmark — pass in isolation).
