### PR TITLE
fix(auth): make exchanged legacy JWTs usable and accept noc_ tokens on token exchange

### DIFF
--- a/src/API/Nocturne.API/Controllers/V2/AuthorizationController.cs
+++ b/src/API/Nocturne.API/Controllers/V2/AuthorizationController.cs
@@ -46,6 +46,10 @@ public class AuthorizationController : ControllerBase
     /// class-level <c>[Authorize]</c> would otherwise reject the request with 401 before the
     /// method can validate the token. The action validates the token itself and returns 401
     /// when it is missing or invalid.
+    ///
+    /// Accepts both legacy subject access tokens (<c>name-hexstring</c>, resolved against
+    /// subjects) and <c>noc_</c> direct-grant tokens (resolved against oauth_grants; the
+    /// minted JWT carries the grant's scopes and tenant pin).
     /// </remarks>
     [AllowAnonymous]
     [HttpGet("request/{accessToken}")]

--- a/src/API/Nocturne.API/Middleware/Handlers/LegacyJwtHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/LegacyJwtHandler.cs
@@ -1,21 +1,27 @@
-using System.IdentityModel.Tokens.Jwt;
-using System.Text;
-using Microsoft.Extensions.Options;
-using Microsoft.IdentityModel.Tokens;
+using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Authorization;
-using Nocturne.Core.Models.Configuration;
 
 namespace Nocturne.API.Middleware.Handlers;
 
 /// <summary>
 /// Authentication handler for legacy Nightscout JWT tokens.
 /// These are self-issued JWTs exchanged from access tokens via
-/// /api/v2/authorization/request/:accessToken
+/// /api/v2/authorization/request/:accessToken. Runs after
+/// <see cref="OAuthAccessTokenHandler"/>, so it only sees JWTs without OAuth
+/// claims (scope/client_id).
 /// </summary>
+/// <remarks>
+/// Validation and claim extraction are delegated to <see cref="IJwtService"/>.
+/// Claim lookups must not use literal JWT claim names: JwtSecurityTokenHandler's
+/// inbound claim-type map rewrites <c>sub</c> to <c>ClaimTypes.NameIdentifier</c>
+/// and <c>role</c> to <c>ClaimTypes.Role</c> during validation, and permissions
+/// are emitted as repeated singular <c>permission</c> claims. IJwtService owns
+/// that mapping in one place.
+/// </remarks>
 public class LegacyJwtHandler : IAuthHandler
 {
     /// <summary>
-    /// Handler priority (200 - after OIDC, before access token)
+    /// Handler priority (200 - after OIDC and OAuth access tokens)
     /// </summary>
     public int Priority => 200;
 
@@ -24,47 +30,21 @@ public class LegacyJwtHandler : IAuthHandler
     /// </summary>
     public string Name => "LegacyJwtHandler";
 
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<LegacyJwtHandler> _logger;
-    private readonly TokenValidationParameters? _validationParameters;
 
     /// <summary>
     /// Creates a new instance of LegacyJwtHandler
     /// </summary>
-    public LegacyJwtHandler(IOptions<JwtOptions> jwtOptions, ILogger<LegacyJwtHandler> logger)
+    public LegacyJwtHandler(IServiceScopeFactory scopeFactory, ILogger<LegacyJwtHandler> logger)
     {
+        _scopeFactory = scopeFactory;
         _logger = logger;
-
-        var secretKey = jwtOptions.Value.SecretKey;
-        if (!string.IsNullOrEmpty(secretKey))
-        {
-            var jwtKey = Encoding.UTF8.GetBytes(secretKey);
-            _validationParameters = new TokenValidationParameters
-            {
-                ValidateIssuerSigningKey = true,
-                IssuerSigningKey = new SymmetricSecurityKey(jwtKey),
-                ValidateIssuer = false,
-                ValidateAudience = false,
-                ValidateLifetime = true,
-                ClockSkew = TimeSpan.FromMinutes(1),
-            };
-        }
-        else
-        {
-            _logger.LogWarning(
-                "JWT secret key not configured - legacy JWT authentication will be disabled"
-            );
-        }
     }
 
     /// <inheritdoc />
     public Task<AuthResult> AuthenticateAsync(HttpContext context)
     {
-        // If no JWT secret is configured, skip this handler
-        if (_validationParameters is null)
-        {
-            return Task.FromResult(AuthResult.Skip());
-        }
-
         // Check for Bearer token in Authorization header
         var authHeader = context.Request.Headers.Authorization.FirstOrDefault();
 
@@ -86,106 +66,54 @@ public class LegacyJwtHandler : IAuthHandler
             return Task.FromResult(AuthResult.Skip());
         }
 
-        try
+        using var scope = _scopeFactory.CreateScope();
+        var jwtService = scope.ServiceProvider.GetRequiredService<IJwtService>();
+
+        var validationResult = jwtService.ValidateAccessToken(token);
+
+        if (!validationResult.IsValid || validationResult.Claims is null)
         {
-            var tokenHandler = new JwtSecurityTokenHandler();
-            var principal = tokenHandler.ValidateToken(
-                token,
-                _validationParameters,
-                out var validatedToken
-            );
-
-            if (validatedToken is not JwtSecurityToken jwtToken)
-            {
-                return Task.FromResult(AuthResult.Failure("Invalid JWT token format"));
-            }
-
-            // Extract claims
-            var subjectId = principal.FindFirst("sub")?.Value;
-            var subjectName = principal.FindFirst("name")?.Value ?? subjectId;
-            var permissionsClaim = principal.FindFirst("permissions")?.Value;
-            var rolesClaim = principal.FindFirst("roles")?.Value;
-
-            if (string.IsNullOrEmpty(subjectId))
-            {
-                _logger.LogWarning("JWT token missing 'sub' claim");
-                return Task.FromResult(AuthResult.Failure("JWT token missing subject claim"));
-            }
-
-            // Parse permissions (comma-separated or JSON array)
-            var permissions = ParseListClaim(permissionsClaim);
-            var roles = ParseListClaim(rolesClaim);
-
-            // Extract OAuth scopes if present (space-delimited per RFC 6749)
-            var scopeClaim = principal.FindFirst("scope")?.Value;
-            var scopes = string.IsNullOrEmpty(scopeClaim)
-                ? new List<string>()
-                : scopeClaim
-                    .Split(' ', StringSplitOptions.RemoveEmptyEntries)
-                    .ToList();
-
-            // Create auth context
-            var authContext = new AuthContext
-            {
-                IsAuthenticated = true,
-                AuthType = AuthType.LegacyJwt,
-                SubjectId = Guid.TryParse(subjectId, out var guid) ? guid : null,
-                SubjectName = subjectName,
-                Permissions = permissions,
-                Roles = roles,
-                Scopes = scopes,
-                RawToken = token,
-                ExpiresAt = jwtToken.ValidTo,
-            };
-
             _logger.LogDebug(
-                "Legacy JWT authentication successful for subject {SubjectName}",
-                subjectName
+                "Legacy JWT validation failed: {Error}",
+                validationResult.Error
             );
-            return Task.FromResult(AuthResult.Success(authContext));
+            return Task.FromResult(
+                AuthResult.Failure(validationResult.Error ?? "Invalid token")
+            );
         }
-        catch (SecurityTokenExpiredException)
-        {
-            _logger.LogDebug("JWT token has expired");
-            return Task.FromResult(AuthResult.Failure("Token has expired"));
-        }
-        catch (SecurityTokenValidationException ex)
-        {
-            _logger.LogWarning(ex, "JWT token validation failed");
-            return Task.FromResult(AuthResult.Failure("Invalid token"));
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Unexpected error validating JWT token");
-            return Task.FromResult(AuthResult.Failure("Token validation error"));
-        }
-    }
 
-    /// <summary>
-    /// Parse a claim that may be comma-separated or JSON array format
-    /// </summary>
-    private static List<string> ParseListClaim(string? claimValue)
-    {
-        if (string.IsNullOrEmpty(claimValue))
-            return [];
+        var claims = validationResult.Claims;
 
-        // Try JSON array format first
-        if (claimValue.StartsWith('['))
+        // Enforce tenant pin: reject tokens issued for a different tenant
+        if (claims.TenantId.HasValue)
         {
-            try
+            var tenantCtx = context.Items["TenantContext"] as TenantContext;
+            if (tenantCtx is null || tenantCtx.TenantId != claims.TenantId.Value)
             {
-                var parsed = System.Text.Json.JsonSerializer.Deserialize<List<string>>(claimValue);
-                return parsed ?? [];
-            }
-            catch
-            {
-                // Fall through to comma-separated parsing
+                _logger.LogWarning(
+                    "Legacy JWT tenant mismatch: token tenant {TokenTenant}, request tenant {RequestTenant}",
+                    claims.TenantId, tenantCtx?.TenantId);
+                return Task.FromResult(AuthResult.Failure("Token is not valid for this tenant"));
             }
         }
 
-        // Comma-separated format
-        return claimValue
-            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .ToList();
+        var authContext = new AuthContext
+        {
+            IsAuthenticated = true,
+            AuthType = AuthType.LegacyJwt,
+            SubjectId = claims.SubjectId,
+            SubjectName = claims.Name ?? claims.SubjectId.ToString(),
+            Permissions = claims.Permissions,
+            Roles = claims.Roles,
+            Scopes = claims.Scopes,
+            RawToken = token,
+            ExpiresAt = claims.ExpiresAt,
+        };
+
+        _logger.LogDebug(
+            "Legacy JWT authentication successful for subject {SubjectName}",
+            authContext.SubjectName
+        );
+        return Task.FromResult(AuthResult.Success(authContext));
     }
 }

--- a/src/API/Nocturne.API/Services/Identity/AuthorizationService.cs
+++ b/src/API/Nocturne.API/Services/Identity/AuthorizationService.cs
@@ -1,11 +1,15 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
+using Nocturne.API.Middleware.Handlers;
 using Nocturne.Core.Contracts.Identity;
 using Nocturne.Core.Models;
+using Nocturne.Infrastructure.Data;
 using AuthRole = Nocturne.Core.Models.Authorization.Role;
 using AuthSubject = Nocturne.Core.Models.Authorization.Subject;
+using OAuthGrantTypes = Nocturne.Infrastructure.Data.Entities.OAuthGrantTypes;
 
 namespace Nocturne.API.Services.Identity;
 
@@ -23,6 +27,7 @@ public class AuthorizationService : IAuthorizationService, IDisposable
     private readonly ISubjectService _subjectService;
     private readonly IRoleService _roleService;
     private readonly IJwtService _jwtService;
+    private readonly NocturneDbContext _dbContext;
     private readonly PermissionTrie _permissionTrie;
     private readonly Dictionary<string, Permission> _seenPermissions = new();
     private readonly object _permissionsLock = new();
@@ -31,12 +36,19 @@ public class AuthorizationService : IAuthorizationService, IDisposable
     private const int MAX_PERMISSIONS_CACHE_SIZE = 5000;
     private bool _disposed;
 
+    /// <summary>
+    /// Lifetime of JWTs minted by the token-exchange endpoint (1 hour for legacy
+    /// Nightscout compatibility; the response's Exp field reports the same value).
+    /// </summary>
+    private static readonly TimeSpan ExchangedJwtLifetime = TimeSpan.FromHours(1);
+
     public AuthorizationService(
         IConfiguration configuration,
         ILogger<AuthorizationService> logger,
         ISubjectService subjectService,
         IRoleService roleService,
-        IJwtService jwtService
+        IJwtService jwtService,
+        NocturneDbContext dbContext
     )
     {
         _configuration = configuration;
@@ -44,6 +56,7 @@ public class AuthorizationService : IAuthorizationService, IDisposable
         _subjectService = subjectService;
         _roleService = roleService;
         _jwtService = jwtService;
+        _dbContext = dbContext;
         _permissionTrie = new PermissionTrie();
 
         // Initialize with common permissions
@@ -60,6 +73,12 @@ public class AuthorizationService : IAuthorizationService, IDisposable
         try
         {
             _logger.LogDebug("Generating JWT for access token");
+
+            // noc_ direct-grant tokens live in oauth_grants, not subjects
+            if (accessToken.StartsWith("noc_", StringComparison.Ordinal))
+            {
+                return await GenerateJwtFromDirectGrantAsync(accessToken);
+            }
 
             // Hash the access token to look it up
             var tokenHash = ComputeSha256Hash(accessToken);
@@ -91,14 +110,16 @@ public class AuthorizationService : IAuthorizationService, IDisposable
                 Email = subject.Email,
             };
 
-            var jwt = _jwtService.GenerateAccessToken(subjectInfo, permissions, roles);
+            // 1 hour for legacy compatibility — explicit so the token's actual exp matches
+            // the response's Exp field (the configured default lifetime is shorter)
+            var jwt = _jwtService.GenerateAccessToken(
+                subjectInfo, permissions, roles, lifetime: ExchangedJwtLifetime);
 
             // Update last login
             _ = _subjectService.UpdateLastLoginAsync(subject.Id);
 
-            // Calculate expiration (default 1 hour from now for legacy compatibility)
             var now = DateTimeOffset.UtcNow;
-            var exp = now.AddHours(1);
+            var exp = now.Add(ExchangedJwtLifetime);
 
             return new AuthorizationResponse
             {
@@ -113,6 +134,81 @@ public class AuthorizationService : IAuthorizationService, IDisposable
             _logger.LogError(ex, "Error generating JWT from access token");
             return null;
         }
+    }
+
+    /// <summary>
+    /// Exchange a noc_ direct-grant token for a JWT. Direct grants authorize by scope,
+    /// so the minted JWT carries the grant's scopes and tenant pin rather than the
+    /// subject's roles/permissions, and downstream requests authenticate through
+    /// <see cref="Middleware.Handlers.OAuthAccessTokenHandler"/>.
+    /// The grants query relies on the tenant-pinned scoped context's global query
+    /// filter, matching how subject lookups are tenant-scoped on this endpoint.
+    /// </summary>
+    private async Task<AuthorizationResponse?> GenerateJwtFromDirectGrantAsync(string accessToken)
+    {
+        var tokenHash = DirectGrantTokenHandler.ComputeSha256Hex(accessToken);
+
+        var grant = await _dbContext.OAuthGrants
+            .AsNoTracking()
+            .Where(g => g.TokenHash == tokenHash
+                     && g.GrantType == OAuthGrantTypes.Direct
+                     && g.RevokedAt == null)
+            .FirstOrDefaultAsync();
+
+        if (grant == null)
+        {
+            _logger.LogDebug("Direct grant token not found");
+            return null;
+        }
+
+        var subject = await _subjectService.GetSubjectByIdAsync(grant.SubjectId);
+
+        if (subject == null || !subject.IsActive)
+        {
+            _logger.LogDebug("Subject {SubjectId} for direct grant not found or deactivated", grant.SubjectId);
+            return null;
+        }
+
+        var subjectInfo = new SubjectInfo
+        {
+            Id = subject.Id,
+            Name = subject.Name,
+            Email = subject.Email,
+        };
+
+        var jwt = _jwtService.GenerateAccessToken(
+            subjectInfo,
+            permissions: [],
+            roles: [],
+            scopes: grant.Scopes,
+            tenantId: grant.TenantId,
+            lifetime: ExchangedJwtLifetime
+        );
+
+        // Stamp last-used so grants exchanged for JWTs don't show as never used.
+        // Awaited (not fire-and-forget like the auth handlers) because the scoped
+        // context is disposed at request end; failure must not block the exchange.
+        try
+        {
+            await _dbContext.OAuthGrants
+                .Where(g => g.Id == grant.Id)
+                .ExecuteUpdateAsync(s => s.SetProperty(g => g.LastUsedAt, DateTime.UtcNow));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to update last used metadata for grant {GrantId}", grant.Id);
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var exp = now.Add(ExchangedJwtLifetime);
+
+        return new AuthorizationResponse
+        {
+            Token = jwt,
+            Sub = subject.Name,
+            Iat = now.ToUnixTimeSeconds(),
+            Exp = exp.ToUnixTimeSeconds(),
+        };
     }
 
     /// <summary>

--- a/tests/Integration/Nocturne.API.Tests/AuthenticationHandlerIntegrationTests.cs
+++ b/tests/Integration/Nocturne.API.Tests/AuthenticationHandlerIntegrationTests.cs
@@ -208,38 +208,40 @@ public class AuthenticationHandlerIntegrationTests : AspireIntegrationTestBase
             newSubject
         );
 
-        if (createResponse.IsSuccessStatusCode)
-        {
-            var subject = await createResponse.Content.ReadFromJsonAsync<SubjectResponse>();
+        // Every step asserts: silent early-outs previously masked a broken exchange
+        // (the anonymous-exchange 401 fixed in #473, and the exchanged JWT failing all
+        // subsequent requests through LegacyJwtHandler claim mapping, #474).
+        Assert.True(
+            createResponse.IsSuccessStatusCode,
+            $"Subject creation failed: {createResponse.StatusCode}"
+        );
+        var subject = await createResponse.Content.ReadFromJsonAsync<SubjectResponse>();
+        Assert.NotNull(subject?.AccessToken);
 
-            if (subject?.AccessToken != null)
-            {
-                // Exchange access token for JWT
-                var exchangeClient = ApiClient;
-                var exchangeResponse = await exchangeClient.GetAsync(
-                    $"/api/v2/authorization/request/{subject.AccessToken}"
-                );
+        // Exchange access token for JWT anonymously — the access token in the URL is
+        // the caller's only credential (the NSClientV3/AAPS bootstrap).
+        var exchangeClient = ApiClient;
+        var exchangeResponse = await exchangeClient.GetAsync(
+            $"/api/v2/authorization/request/{subject!.AccessToken}"
+        );
 
-                if (exchangeResponse.IsSuccessStatusCode)
-                {
-                    var tokenResponse =
-                        await exchangeResponse.Content.ReadFromJsonAsync<TokenExchangeResponse>();
+        Assert.True(
+            exchangeResponse.IsSuccessStatusCode,
+            $"Token exchange failed: {exchangeResponse.StatusCode}"
+        );
+        var tokenResponse =
+            await exchangeResponse.Content.ReadFromJsonAsync<TokenExchangeResponse>();
+        Assert.NotNull(tokenResponse?.Token);
 
-                    if (tokenResponse?.Token != null)
-                    {
-                        // Use JWT for authentication
-                        var jwtClient = ApiClient;
-                        jwtClient.DefaultRequestHeaders.Authorization =
-                            new AuthenticationHeaderValue("Bearer", tokenResponse.Token);
+        // Use JWT for authentication
+        var jwtClient = ApiClient;
+        jwtClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", tokenResponse!.Token);
 
-                        var response = await jwtClient.GetAsync("/api/v1/entries/current");
+        var response = await jwtClient.GetAsync("/api/v1/entries/current");
 
-                        Assert.NotEqual(HttpStatusCode.Unauthorized, response.StatusCode);
-                        Output.WriteLine($"JWT auth returned: {response.StatusCode}");
-                    }
-                }
-            }
-        }
+        Assert.NotEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+        Output.WriteLine($"JWT auth returned: {response.StatusCode}");
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/LegacyJwtHandlerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/LegacyJwtHandlerTests.cs
@@ -1,0 +1,218 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Nocturne.API.Middleware.Handlers;
+using Nocturne.API.Services.Auth;
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Core.Models.Configuration;
+using Xunit;
+
+namespace Nocturne.API.Tests.Middleware.Handlers;
+
+/// <summary>
+/// Round-trip tests: tokens are minted with the real <see cref="JwtService"/> (as the
+/// token-exchange endpoint does) and presented back to <see cref="LegacyJwtHandler"/>.
+/// Literal-name claim lookups ("sub", "roles", "permissions") pass a hand-rolled unit
+/// test but fail on real tokens, because JwtSecurityTokenHandler's inbound claim-type
+/// map rewrites sub/role during validation — so these tests must use the real service
+/// on both sides.
+/// </summary>
+public class LegacyJwtHandlerTests
+{
+    private readonly JwtService _jwtService;
+    private readonly LegacyJwtHandler _handler;
+
+    private readonly Guid _subjectId = Guid.CreateVersion7();
+    private readonly Guid _tenantId = Guid.CreateVersion7();
+
+    public LegacyJwtHandlerTests()
+    {
+        _jwtService = CreateJwtService("test-secret-key-with-at-least-32-characters!");
+
+        var services = new ServiceCollection();
+        services.AddScoped<IJwtService>(_ => _jwtService);
+        var serviceProvider = services.BuildServiceProvider();
+
+        _handler = new LegacyJwtHandler(
+            serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            Mock.Of<ILogger<LegacyJwtHandler>>());
+    }
+
+    private static JwtService CreateJwtService(string secretKey)
+    {
+        return new JwtService(
+            Options.Create(new JwtOptions { SecretKey = secretKey }),
+            Mock.Of<ILogger<JwtService>>());
+    }
+
+    private static DefaultHttpContext CreateHttpContext(string? bearerToken = null)
+    {
+        var context = new DefaultHttpContext();
+        if (bearerToken != null)
+        {
+            context.Request.Headers.Authorization = $"Bearer {bearerToken}";
+        }
+        return context;
+    }
+
+    private SubjectInfo TestSubject => new()
+    {
+        Id = _subjectId,
+        Name = "aaps-uploader",
+    };
+
+    [Fact]
+    public async Task AuthenticateAsync_ExchangeMintedJwt_ParsesSubjectRolesAndPermissions()
+    {
+        // The exact token shape minted by /api/v2/authorization/request/{accessToken}:
+        // permissions + roles, no OAuth scope/client_id claims.
+        var token = _jwtService.GenerateAccessToken(
+            TestSubject,
+            permissions: ["api:treatments:read", "api:entries:read"],
+            roles: ["readable", "careportal"]);
+
+        var result = await _handler.AuthenticateAsync(CreateHttpContext(token));
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(result.AuthContext);
+        Assert.Equal(AuthType.LegacyJwt, result.AuthContext!.AuthType);
+        Assert.Equal(_subjectId, result.AuthContext.SubjectId);
+        Assert.Equal("aaps-uploader", result.AuthContext.SubjectName);
+        Assert.Equal(["readable", "careportal"], result.AuthContext.Roles);
+        Assert.Equal(["api:treatments:read", "api:entries:read"], result.AuthContext.Permissions);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_ScopedJwtWithoutOAuthClaims_ParsesScopes()
+    {
+        // A tenant-pinned scoped token with no scopes granted carries neither scope nor
+        // client_id, so OAuthAccessTokenHandler skips it and it lands here.
+        var token = _jwtService.GenerateAccessToken(
+            TestSubject,
+            permissions: [],
+            roles: ["readable"],
+            scopes: []);
+
+        var result = await _handler.AuthenticateAsync(CreateHttpContext(token));
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(_subjectId, result.AuthContext!.SubjectId);
+        Assert.Empty(result.AuthContext.Scopes);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_NoAuthorizationHeader_Skips()
+    {
+        var result = await _handler.AuthenticateAsync(CreateHttpContext());
+
+        Assert.True(result.ShouldSkip);
+        Assert.False(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_OpaqueBearerToken_Skips()
+    {
+        var result = await _handler.AuthenticateAsync(CreateHttpContext("noc_opaquetokenvalue"));
+
+        Assert.True(result.ShouldSkip);
+        Assert.False(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_ExpiredToken_Fails()
+    {
+        // JwtService refuses to mint an already-expired token (Expires must be after
+        // NotBefore), so craft one directly with the same key, issuer, and audience.
+        var tokenHandler = new System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler();
+        var descriptor = new Microsoft.IdentityModel.Tokens.SecurityTokenDescriptor
+        {
+            Subject = new System.Security.Claims.ClaimsIdentity(
+                [new System.Security.Claims.Claim("sub", _subjectId.ToString())]),
+            NotBefore = DateTime.UtcNow.AddHours(-2),
+            Expires = DateTime.UtcNow.AddHours(-1),
+            Issuer = "nocturne",
+            Audience = "nocturne-api",
+            SigningCredentials = new Microsoft.IdentityModel.Tokens.SigningCredentials(
+                new Microsoft.IdentityModel.Tokens.SymmetricSecurityKey(
+                    System.Text.Encoding.UTF8.GetBytes("test-secret-key-with-at-least-32-characters!")),
+                Microsoft.IdentityModel.Tokens.SecurityAlgorithms.HmacSha256Signature),
+        };
+        var token = tokenHandler.WriteToken(tokenHandler.CreateToken(descriptor));
+
+        var result = await _handler.AuthenticateAsync(CreateHttpContext(token));
+
+        Assert.False(result.Succeeded);
+        Assert.False(result.ShouldSkip);
+        Assert.NotNull(result.Error);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_WrongSigningKey_Fails()
+    {
+        var foreignService = CreateJwtService("another-secret-key-with-32-characters!!");
+        var token = foreignService.GenerateAccessToken(
+            TestSubject,
+            permissions: [],
+            roles: ["readable"]);
+
+        var result = await _handler.AuthenticateAsync(CreateHttpContext(token));
+
+        Assert.False(result.Succeeded);
+        Assert.False(result.ShouldSkip);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_TenantPinnedToken_WrongTenant_Fails()
+    {
+        var token = _jwtService.GenerateAccessToken(
+            TestSubject,
+            permissions: [],
+            roles: [],
+            scopes: [],
+            tenantId: _tenantId);
+
+        var context = CreateHttpContext(token);
+        context.Items["TenantContext"] = new TenantContext(
+            Guid.CreateVersion7(), "other", "Other", true);
+
+        var result = await _handler.AuthenticateAsync(context);
+
+        Assert.False(result.Succeeded);
+        Assert.False(result.ShouldSkip);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_TenantPinnedToken_MatchingTenant_Succeeds()
+    {
+        var token = _jwtService.GenerateAccessToken(
+            TestSubject,
+            permissions: [],
+            roles: [],
+            scopes: [],
+            tenantId: _tenantId);
+
+        var context = CreateHttpContext(token);
+        context.Items["TenantContext"] = new TenantContext(_tenantId, "default", "Default", true);
+
+        var result = await _handler.AuthenticateAsync(context);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(_subjectId, result.AuthContext!.SubjectId);
+    }
+
+    [Fact]
+    public void Priority_Is200()
+    {
+        Assert.Equal(200, _handler.Priority);
+    }
+
+    [Fact]
+    public void Name_IsLegacyJwtHandler()
+    {
+        Assert.Equal("LegacyJwtHandler", _handler.Name);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Identity/AuthorizationServiceCrudTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Identity/AuthorizationServiceCrudTests.cs
@@ -1,3 +1,6 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -6,6 +9,7 @@ using Nocturne.API.Services.Identity;
 using Nocturne.Core.Contracts.Identity;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Authorization;
+using Nocturne.Infrastructure.Data;
 using AuthSubjectModel = Nocturne.Core.Models.Authorization.Subject;
 using AuthRoleModel = Nocturne.Core.Models.Authorization.Role;
 using LegacySubject = Nocturne.Core.Models.Subject;
@@ -17,13 +21,15 @@ namespace Nocturne.API.Tests.Services.Identity;
 /// <summary>
 /// Tests for authorization service CRUD operations
 /// </summary>
-public class AuthorizationServiceCrudTests
+public class AuthorizationServiceCrudTests : IDisposable
 {
     private readonly Mock<IConfiguration> _mockConfiguration;
     private readonly Mock<ILogger<AuthorizationService>> _mockLogger;
     private readonly Mock<ISubjectService> _mockSubjectService;
     private readonly Mock<IRoleService> _mockRoleService;
     private readonly Mock<IJwtService> _mockJwtService;
+    private readonly SqliteConnection _connection;
+    private readonly NocturneDbContext _dbContext;
     private readonly AuthorizationService _authorizationService;
 
     public AuthorizationServiceCrudTests()
@@ -33,6 +39,15 @@ public class AuthorizationServiceCrudTests
         _mockSubjectService = new Mock<ISubjectService>();
         _mockRoleService = new Mock<IRoleService>();
         _mockJwtService = new Mock<IJwtService>();
+
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        var dbOptions = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+        _dbContext = new NocturneDbContext(dbOptions);
+        _dbContext.Database.EnsureCreated();
 
         // Setup configuration
         _mockConfiguration
@@ -44,8 +59,15 @@ public class AuthorizationServiceCrudTests
             _mockLogger.Object,
             _mockSubjectService.Object,
             _mockRoleService.Object,
-            _mockJwtService.Object
+            _mockJwtService.Object,
+            _dbContext
         );
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        _connection.Dispose();
     }
 
     #region Subject CRUD Tests

--- a/tests/Unit/Nocturne.API.Tests/Services/Identity/AuthorizationServiceTokenExchangeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Identity/AuthorizationServiceTokenExchangeTests.cs
@@ -1,0 +1,224 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Nocturne.API.Middleware.Handlers;
+using Nocturne.API.Services.Identity;
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Contracts.Identity;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Xunit;
+using AuthSubject = Nocturne.Core.Models.Authorization.Subject;
+
+namespace Nocturne.API.Tests.Services.Identity;
+
+/// <summary>
+/// Tests for the token-exchange path (/api/v2/authorization/request/{accessToken}):
+/// legacy subject access tokens resolve against subjects, noc_ direct-grant tokens
+/// resolve against oauth_grants.
+/// </summary>
+public class AuthorizationServiceTokenExchangeTests : IDisposable
+{
+    private readonly Mock<ISubjectService> _mockSubjectService;
+    private readonly Mock<IJwtService> _mockJwtService;
+    private readonly SqliteConnection _connection;
+    private readonly NocturneDbContext _dbContext;
+    private readonly AuthorizationService _authorizationService;
+
+    private readonly Guid _testTenantId = Guid.CreateVersion7();
+    private readonly Guid _subjectId = Guid.CreateVersion7();
+
+    public AuthorizationServiceTokenExchangeTests()
+    {
+        _mockSubjectService = new Mock<ISubjectService>();
+        _mockJwtService = new Mock<IJwtService>();
+
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        var dbOptions = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+
+        _dbContext = new NocturneDbContext(dbOptions) { TenantId = _testTenantId };
+        _dbContext.Database.EnsureCreated();
+        _dbContext.Tenants.Add(new TenantEntity
+        {
+            Id = _testTenantId,
+            Slug = "default",
+            DisplayName = "Default",
+            IsActive = true,
+        });
+        _dbContext.Subjects.Add(new SubjectEntity
+        {
+            Id = _subjectId,
+            Name = "aaps-uploader",
+            IsActive = true,
+        });
+        _dbContext.SaveChanges();
+
+        _authorizationService = new AuthorizationService(
+            new Mock<IConfiguration>().Object,
+            Mock.Of<ILogger<AuthorizationService>>(),
+            _mockSubjectService.Object,
+            new Mock<IRoleService>().Object,
+            _mockJwtService.Object,
+            _dbContext
+        );
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        _connection.Dispose();
+    }
+
+    private void SeedGrant(string token, DateTime? revokedAt = null, List<string>? scopes = null)
+    {
+        _dbContext.OAuthGrants.Add(new OAuthGrantEntity
+        {
+            Id = Guid.CreateVersion7(),
+            SubjectId = _subjectId,
+            TenantId = _testTenantId,
+            GrantType = OAuthGrantTypes.Direct,
+            TokenHash = DirectGrantTokenHandler.ComputeSha256Hex(token),
+            Scopes = scopes ?? ["glucose.read", "treatments.readwrite"],
+            CreatedAt = DateTime.UtcNow,
+            RevokedAt = revokedAt,
+        });
+        _dbContext.SaveChanges();
+    }
+
+    private void SetupActiveSubject()
+    {
+        _mockSubjectService
+            .Setup(s => s.GetSubjectByIdAsync(_subjectId))
+            .ReturnsAsync(new AuthSubject
+            {
+                Id = _subjectId,
+                Name = "aaps-uploader",
+                IsActive = true,
+            });
+    }
+
+    private void SetupMintedJwt(string jwt = "minted.jwt.token")
+    {
+        _mockJwtService
+            .Setup(j => j.GenerateAccessToken(
+                It.IsAny<SubjectInfo>(),
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<string?>(),
+                It.IsAny<bool>(),
+                It.IsAny<Guid?>(),
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<bool>()))
+            .Returns(jwt);
+    }
+
+    [Fact]
+    public async Task GenerateJwtFromAccessTokenAsync_NocToken_MintsJwtWithGrantScopesAndTenantPin()
+    {
+        var token = "noc_uploadertoken123";
+        SeedGrant(token);
+        SetupActiveSubject();
+        SetupMintedJwt();
+
+        var result = await _authorizationService.GenerateJwtFromAccessTokenAsync(token);
+
+        Assert.NotNull(result);
+        Assert.Equal("minted.jwt.token", result!.Token);
+        Assert.Equal("aaps-uploader", result.Sub);
+
+        _mockJwtService.Verify(j => j.GenerateAccessToken(
+            It.Is<SubjectInfo>(s => s.Id == _subjectId && s.Name == "aaps-uploader"),
+            It.Is<IEnumerable<string>>(p => !p.Any()),
+            It.Is<IEnumerable<string>>(r => !r.Any()),
+            It.Is<IEnumerable<string>>(sc =>
+                sc.Contains("glucose.read") && sc.Contains("treatments.readwrite")),
+            It.IsAny<string?>(),
+            It.IsAny<bool>(),
+            _testTenantId,
+            It.IsAny<TimeSpan?>(),
+            It.IsAny<bool>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GenerateJwtFromAccessTokenAsync_NocToken_RevokedGrant_ReturnsNull()
+    {
+        var token = "noc_revokedtoken456";
+        SeedGrant(token, revokedAt: DateTime.UtcNow);
+        SetupActiveSubject();
+        SetupMintedJwt();
+
+        var result = await _authorizationService.GenerateJwtFromAccessTokenAsync(token);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GenerateJwtFromAccessTokenAsync_NocToken_UnknownToken_ReturnsNull()
+    {
+        var result = await _authorizationService.GenerateJwtFromAccessTokenAsync("noc_nonexistent");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GenerateJwtFromAccessTokenAsync_NocToken_InactiveSubject_ReturnsNull()
+    {
+        var token = "noc_inactivesubject789";
+        SeedGrant(token);
+        _mockSubjectService
+            .Setup(s => s.GetSubjectByIdAsync(_subjectId))
+            .ReturnsAsync(new AuthSubject
+            {
+                Id = _subjectId,
+                Name = "aaps-uploader",
+                IsActive = false,
+            });
+
+        var result = await _authorizationService.GenerateJwtFromAccessTokenAsync(token);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GenerateJwtFromAccessTokenAsync_LegacyToken_StillResolvesViaSubjects()
+    {
+        var legacyToken = "uploader-0123456789abcdef";
+        var subject = new AuthSubject
+        {
+            Id = _subjectId,
+            Name = "aaps-uploader",
+            IsActive = true,
+        };
+        _mockSubjectService
+            .Setup(s => s.GetSubjectByAccessTokenHashAsync(It.IsAny<string>()))
+            .ReturnsAsync(subject);
+        _mockSubjectService
+            .Setup(s => s.GetSubjectPermissionsAsync(_subjectId))
+            .ReturnsAsync(["api:*:read"]);
+        _mockSubjectService
+            .Setup(s => s.GetSubjectRolesAsync(_subjectId))
+            .ReturnsAsync(["readable"]);
+        _mockJwtService
+            .Setup(j => j.GenerateAccessToken(
+                It.IsAny<SubjectInfo>(),
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<TimeSpan?>()))
+            .Returns("legacy.jwt.token");
+
+        var result = await _authorizationService.GenerateJwtFromAccessTokenAsync(legacyToken);
+
+        Assert.NotNull(result);
+        Assert.Equal("legacy.jwt.token", result!.Token);
+        Assert.Equal("aaps-uploader", result.Sub);
+    }
+}


### PR DESCRIPTION
Completes the AAPS/NSClientV3 compatibility work from #473. Addresses items 4 and 5 of #474 (items 1–3 shipped in #473).

## Item 5: exchanged JWTs failed every subsequent request

`LegacyJwtHandler` extracted claims with literal-name lookups (`FindFirst("sub")`, `"roles"`, `"permissions"`) on a principal validated by `JwtSecurityTokenHandler` — whose inbound claim-type map rewrites `sub` → `ClaimTypes.NameIdentifier` and `role` → `ClaimTypes.Role`. `FindFirst("sub")` returned null, so the handler returned a **terminal** `Failure` for every JWT the exchange endpoint mints (they carry no `scope`/`client_id`, so `OAuthAccessTokenHandler` skips them). Net effect: #473 unblocked the exchange, but AAPS still got 401 on every request after it. Verified empirically against `System.IdentityModel.Tokens.Jwt` 8.15.0 before writing the fix.

The issue's suggested fix (check singular *and* plural literal names) wouldn't have worked — roles surface as `ClaimTypes.Role`, and permissions are repeated singular `permission` claims needing `FindAll`. Instead the handler now delegates validation and claim extraction to `IJwtService.ValidateAccessToken`, which already handles all of this for the OAuth path (DRY). It also now enforces the `tenant_id` claim pin like `OAuthAccessTokenHandler`, closing the gap where a tenant-pinned but scope-less JWT was accepted on any tenant.

## Item 4: `noc_` tokens rejected by the exchange route

The exchange only looked up `subjects.AccessTokenHash`; `noc_` direct-grant tokens live in `oauth_grants`. A `noc_` token now resolves its grant on the tenant-pinned scoped context (fail-closed via the `ITenantScoped` global query filter — an unresolved tenant matches nothing) and mints a JWT carrying the grant's **scopes** and tenant pin, authorizing by scope like the grant itself (empty permissions/roles). `LastUsedAt` is stamped on exchange.

Also: exchange-minted JWTs are now explicitly 1-hour so the response's `Exp` matches the token's real `exp` (previously reported 1h while the token lived `AccessTokenLifetimeMinutes`).

## Tests

- `LegacyJwtHandlerTests` round-trips **real `JwtService`-minted tokens** through the handler — a hand-rolled token with literal claim names passes against the old code, which is exactly how this was missed. The old handler fails this suite.
- `AuthorizationServiceTokenExchangeTests` covers the `noc_` path (grant scopes + tenant pin on the minted JWT, revoked/unknown/inactive-subject → null) and the legacy subject path.
- The integration test's silent `if`-guards (which masked both this and the #473 bug) are now hard asserts.

Adversarial review notes: apex-host exchange is fail-closed (strict `TenantId` equality filter, no empty-Guid escape); no `Failure`-vs-`Skip` regression for handlers later in the chain (the old handler already hard-failed every 3-part JWT that reached it); `limit_24h` tokens always carry `client_id` and never land in this handler.

Fixes #474
