### PR TITLE
fix(api): harden public-share grants (follow-up to #484)

### DIFF
--- a/src/API/Nocturne.API/Middleware/AuthenticationMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/AuthenticationMiddleware.cs
@@ -232,17 +232,28 @@ public class AuthenticationMiddleware
 
                 // The Public subject's effective permissions are stored in the OAuth scope
                 // vocabulary (glucose.read, ...) — the same vocabulary member grants use — so
-                // normalize them the way MemberScopeMiddleware does for members.
-                // ScopeTranslator.FromPermissions translates legacy api:* trie strings and
-                // silently drops scope-shaped input, which would empty the grant.
-                var publicScopes = OAuthScopes.Normalize(publicAccess.EffectivePermissions);
-                context.Items["GrantedScopes"] = publicScopes;
+                // normalize them the way MemberScopeMiddleware does for members; the
+                // FromPermissions union also accepts legacy api:* trie strings on old rows.
+                // Then narrow to the shareable read scopes: the share host can never resolve
+                // to more than public read access, so a broader grant on the Public membership
+                // (readwrite, superuser) degrades to its read counterpart via SatisfiesScope.
+                var resolvedGrants = OAuthScopes.Normalize(publicAccess.EffectivePermissions)
+                    .Union(ScopeTranslator.FromPermissions(publicAccess.EffectivePermissions))
+                    .ToHashSet();
+                var publicScopes = TenantPermissions.PublicShareScopes
+                    .Where(scope => OAuthScopes.SatisfiesScope(resolvedGrants, scope))
+                    .ToHashSet();
+                context.Items["GrantedScopes"] = (IReadOnlySet<string>)publicScopes;
 
                 // Legacy (HasPermissions-gated) endpoints check the trie, so derive it from the
-                // normalized scopes; a share that resolves to zero scopes gets an empty trie and
+                // narrowed scopes; a share that resolves to zero scopes gets an empty trie and
                 // is rejected by the policy instead of passing authorization and reading nothing.
+                // The scope atoms are added alongside because heartrate.read/stepcount.read have
+                // no legacy api:* equivalent — without them a share granting only those
+                // categories would carry an empty trie and be rejected outright.
                 var publicPermissionTrie = new PermissionTrie();
                 publicPermissionTrie.Add(ScopeTranslator.ToPermissions(publicScopes));
+                publicPermissionTrie.Add(publicScopes);
                 context.Items["PermissionTrie"] = publicPermissionTrie;
 
                 // Carry the share's visible categories and history window to the DbContext

--- a/src/API/Nocturne.API/Services/Auth/ShareTokenCacheService.cs
+++ b/src/API/Nocturne.API/Services/Auth/ShareTokenCacheService.cs
@@ -68,7 +68,11 @@ public sealed class ShareTokenCacheService
                     .Where(t => t.Id == tenant.Id)
                     .ExecuteUpdateAsync(s => s.SetProperty(t => t.ShareLastAccessedAt, DateTime.UtcNow));
             }
-            catch (Exception ex)
+            catch (DbUpdateException ex)
+            {
+                _logger.LogWarning(ex, "Failed to stamp share_last_accessed_at for tenant {TenantId}", tenant.Id);
+            }
+            catch (InvalidOperationException ex)
             {
                 _logger.LogWarning(ex, "Failed to stamp share_last_accessed_at for tenant {TenantId}", tenant.Id);
             }

--- a/src/API/Nocturne.API/Services/Auth/ShareTokenCacheService.cs
+++ b/src/API/Nocturne.API/Services/Auth/ShareTokenCacheService.cs
@@ -20,15 +20,18 @@ public sealed class ShareTokenCacheService
 {
     private readonly IMemoryCache _cache;
     private readonly IDbContextFactory<NocturneDbContext> _dbContextFactory;
+    private readonly ILogger<ShareTokenCacheService> _logger;
 
     private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(2);
 
     public ShareTokenCacheService(
         IMemoryCache cache,
-        IDbContextFactory<NocturneDbContext> dbContextFactory)
+        IDbContextFactory<NocturneDbContext> dbContextFactory,
+        ILogger<ShareTokenCacheService> logger)
     {
         _cache = cache;
         _dbContextFactory = dbContextFactory;
+        _logger = logger;
     }
 
     /// <summary>
@@ -55,9 +58,21 @@ public sealed class ShareTokenCacheService
 
         // Stamp last-accessed on the database-hit path only: successful resolutions are
         // cached for CacheTtl, so the write is debounced to at most once per TTL per token.
-        await dbContext.Tenants
-            .Where(t => t.Id == tenant.Id)
-            .ExecuteUpdateAsync(s => s.SetProperty(t => t.ShareLastAccessedAt, DateTime.UtcNow));
+        // Skipped for inactive tenants (the middleware rejects those requests, so nothing was
+        // accessed), and non-fatal: the stamp is bookkeeping and must not fail the resolve.
+        if (tenant.IsActive)
+        {
+            try
+            {
+                await dbContext.Tenants
+                    .Where(t => t.Id == tenant.Id)
+                    .ExecuteUpdateAsync(s => s.SetProperty(t => t.ShareLastAccessedAt, DateTime.UtcNow));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to stamp share_last_accessed_at for tenant {TenantId}", tenant.Id);
+            }
+        }
 
         var tenantContext = new TenantContext(tenant.Id, tenant.Slug, tenant.DisplayName, tenant.IsActive, tenant.IsDemo);
         _cache.Set(cacheKey, tenantContext, CacheTtl);

--- a/src/Core/Nocturne.Core.Models/Authorization/ShareDataCategories.cs
+++ b/src/Core/Nocturne.Core.Models/Authorization/ShareDataCategories.cs
@@ -89,7 +89,7 @@ public static class ShareDataCategories
             ["heart_rates"] = "timestamp",
             ["step_counts"] = "timestamp",
             ["foods"] = null,
-            ["connector_food_entries"] = null,
+            ["connector_food_entries"] = "consumed_at",
         };
 
     private static readonly IReadOnlyDictionary<string, string> TableToScope = BuildTableToScope();

--- a/tests/Unit/Nocturne.API.Tests/Middleware/AuthenticationMiddlewareShareAccessTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/AuthenticationMiddlewareShareAccessTests.cs
@@ -13,6 +13,7 @@ using Nocturne.API.Middleware.Handlers;
 using Nocturne.API.Services.Auth;
 using Nocturne.API.Tests.Infrastructure;
 using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.Configuration;
 using Nocturne.Infrastructure.Data;
@@ -110,6 +111,73 @@ public sealed class AuthenticationMiddlewareShareAccessTests
 
         var csv = ctx.RequestServices.GetRequiredService<ICategoryReadContext>().VisibleCategoriesCsv;
         csv.Should().Contain("glucose.read").And.Contain("treatments.read");
+    }
+
+    [Fact]
+    public async Task Share_access_never_grants_beyond_the_shareable_read_scopes()
+    {
+        // The Clinician role also carries therapy.read and alerts.read; a superuser or
+        // readwrite grant on the Public membership is possible via the member-permissions
+        // API. None of that may reach an anonymous visitor: the share host resolves to at
+        // most the shareable read scopes.
+        SetPublicDirectPermissions(["*"]);
+
+        var ctx = ContextFor(shareAccess: true);
+
+        await Build().InvokeAsync(ctx);
+
+        var scopes = ctx.Items["GrantedScopes"] as IReadOnlySet<string>;
+        scopes.Should().NotBeNull();
+        scopes.Should().BeSubsetOf(TenantPermissions.PublicShareScopes,
+            "a superuser grant on the Public membership must degrade to public read access");
+        scopes.Should().Contain(OAuthScopes.GlucoseRead);
+    }
+
+    [Fact]
+    public async Task Share_with_only_heartrate_and_stepcount_still_carries_a_nonempty_trie()
+    {
+        // heartrate.read/stepcount.read have no legacy api:* equivalent, so a trie derived
+        // purely from ScopeTranslator.ToPermissions would be empty and the fallback
+        // HasPermissions policy would 401 the whole share despite valid grants.
+        SetPublicDirectPermissions([OAuthScopes.HeartRateRead, OAuthScopes.StepCountRead]);
+
+        var ctx = ContextFor(shareAccess: true);
+
+        await Build().InvokeAsync(ctx);
+
+        var scopes = ctx.Items["GrantedScopes"] as IReadOnlySet<string>;
+        scopes.Should().BeEquivalentTo([OAuthScopes.HeartRateRead, OAuthScopes.StepCountRead]);
+        var trie = ctx.Items["PermissionTrie"] as PermissionTrie;
+        trie!.IsEmpty.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Share_access_accepts_legacy_trie_vocabulary_grants()
+    {
+        // Pre-scope-era Public memberships (and anything written through the unvalidated
+        // member-permissions API) may carry legacy api:* strings; they resolved before the
+        // scope-vocabulary fix and must keep resolving after it.
+        SetPublicDirectPermissions(["api:entries:read"]);
+
+        var ctx = ContextFor(shareAccess: true);
+
+        await Build().InvokeAsync(ctx);
+
+        var scopes = ctx.Items["GrantedScopes"] as IReadOnlySet<string>;
+        scopes.Should().Contain(OAuthScopes.GlucoseRead);
+        ctx.RequestServices.GetRequiredService<ICategoryReadContext>().VisibleCategoriesCsv
+            .Should().Contain("glucose.read");
+    }
+
+    private void SetPublicDirectPermissions(List<string> permissions)
+    {
+        using var db = TestDbContextFactory.CreateInMemoryContext(_dbName);
+        var member = db.TenantMembers
+            .Include(m => m.MemberRoles)
+            .Single(m => m.SubjectId == TestDatabaseSeeder.PublicSubjectId);
+        db.TenantMemberRoles.RemoveRange(member.MemberRoles);
+        member.DirectPermissions = permissions;
+        db.SaveChanges();
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantResolutionMiddlewareShareTokenTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantResolutionMiddlewareShareTokenTests.cs
@@ -46,6 +46,7 @@ public sealed class TenantResolutionMiddlewareShareTokenTests : IDisposable
         services.AddScoped<ITenantAccessor, HttpContextTenantAccessor>();
         services.AddScoped<ICategoryReadContext, CategoryReadContext>();
         services.AddMemoryCache();
+        services.AddLogging();
         services.AddSingleton<ShareTokenCacheService>();
         _root = services.BuildServiceProvider();
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareLinkServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareLinkServiceTests.cs
@@ -53,7 +53,8 @@ public sealed class ShareLinkServiceTests : IDisposable
         _service = new ShareLinkService(
             _db,
             new ShareTokenGenerator(),
-            new ShareTokenCacheService(new MemoryCache(new MemoryCacheOptions()), factory.Object),
+            new ShareTokenCacheService(
+                new MemoryCache(new MemoryCacheOptions()), factory.Object, NullLogger<ShareTokenCacheService>.Instance),
             new PublicAccessCacheService(
                 new MemoryCache(new MemoryCacheOptions()), factory.Object, NullLogger<PublicAccessCacheService>.Instance),
             Options.Create(new BaseDomainOptions { BaseDomain = "nocturne.run" }));

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareTokenCacheServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareTokenCacheServiceTests.cs
@@ -47,7 +47,8 @@ public sealed class ShareTokenCacheServiceTests : IDisposable
         _connection.Dispose();
     }
 
-    private ShareTokenCacheService Service() => new(_cache, _factory);
+    private ShareTokenCacheService Service() =>
+        new(_cache, _factory, Microsoft.Extensions.Logging.Abstractions.NullLogger<ShareTokenCacheService>.Instance);
 
     [Fact]
     public async Task ResolveByTokenAsync_returns_the_owning_tenant()
@@ -89,6 +90,22 @@ public sealed class ShareTokenCacheServiceTests : IDisposable
 
         using (var db = _factory.CreateDbContext())
             db.Tenants.Single(t => t.Id == _tenantId).ShareLastAccessedAt.Should().Be(first);
+    }
+
+    [Fact]
+    public async Task ResolveByTokenAsync_does_not_stamp_an_inactive_tenant()
+    {
+        using (var db = _factory.CreateDbContext())
+        {
+            db.Tenants.Single(t => t.Id == _tenantId).IsActive = false;
+            db.SaveChanges();
+        }
+
+        await Service().ResolveByTokenAsync(Token);
+
+        using var check = _factory.CreateDbContext();
+        check.Tenants.Single(t => t.Id == _tenantId).ShareLastAccessedAt.Should().BeNull(
+            "the middleware rejects inactive-tenant share requests, so nothing was accessed");
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Core.Models.Tests/Authorization/ShareDataCategoriesTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/Authorization/ShareDataCategoriesTests.cs
@@ -78,6 +78,7 @@ public class ShareDataCategoriesTests
     {
         ShareDataCategories.RecencyColumnFor("boluses").Should().Be("timestamp");
         ShareDataCategories.RecencyColumnFor("temp_basals").Should().Be("start_timestamp");
+        ShareDataCategories.RecencyColumnFor("connector_food_entries").Should().Be("consumed_at");
     }
 
     [Fact]


### PR DESCRIPTION
Follow-up to #484 — it was merged while an adversarial review of the commit was still running; this lands the review's findings.

## Fixes

- **`connector_food_entries` is now clamped by `consumed_at`** (major). It was exempted from the 24h clamp as "catalog data", but it is per-row time-series PHI (meal log with timestamps and carbs). A food-category share with `limit_to_24_hours = true` would have exposed the wearer's entire imported meal history. Only `foods` (the actual catalog) remains exempt.
- **Heartrate/stepcount-only shares no longer 401 everywhere** (major). Those scopes have no legacy `api:*` equivalent, so the trie derived from `ScopeTranslator.ToPermissions` came out empty and the fallback `HasPermissions` policy rejected every request despite valid grants. The narrowed scope atoms are now added to the trie alongside their legacy translations.
- **Share scopes are narrowed to `TenantPermissions.PublicShareScopes`** (hardening). The member-permissions API accepts arbitrary permission strings for the Public member, so a `readwrite` or `*` grant could flow into anonymous `GrantedScopes` verbatim. Broader grants now degrade to their read counterpart via `SatisfiesScope`, enforcing the documented "the share host can never resolve to more than public read access" invariant at the seam.
- **Legacy `api:*` trie grants keep resolving** (regression guard). Pre-scope-era Public memberships worked before the vocabulary fix; `OAuthScopes.Normalize` alone would silently drop them. The share branch now unions `ScopeTranslator.FromPermissions` in.
- **`share_last_accessed_at` is stamped only for active tenants and is non-fatal** — a rejected request accessed nothing, and a bookkeeping UPDATE failure must not 500 the resolve path.

## Tests

New middleware tests: superuser grant degrades to public read scopes; heartrate/stepcount-only share carries a non-empty trie; legacy-vocabulary grants resolve. Cache-service test for the inactive-tenant stamp skip. `ShareDataCategories` recency test updated for `consumed_at`. Share suites green (36 API + 14 Core.Models); the RLS integration policy-inspection test picks up the `connector_food_entries` clamp automatically.
