### PR TITLE
fix(dev): pin tenant via DbContext TenantId in dev login

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/DevOnly/DevAuthController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/DevOnly/DevAuthController.cs
@@ -172,10 +172,10 @@ public class DevAuthController : ControllerBase
             tenant = tenants[0];
         }
 
-        // tenant_roles is RLS-scoped; pin the tenant before joining member roles.
-        await _db.Database.ExecuteSqlRawAsync(
-            "SELECT set_config('app.current_tenant_id', {0}, false)",
-            [tenant.Id.ToString()], ct);
+        // tenant_members/tenant_roles carry no RLS policies today, but set the
+        // context's TenantId so the connection interceptor pins the GUC on every
+        // open (a raw set_config would be reset when EF closes the connection).
+        _db.TenantId = tenant.Id;
 
         var members = await _db.TenantMembers
             .AsNoTracking()

--- a/src/API/Nocturne.API/Services/DevOnly/DevTenantMemberSelection.cs
+++ b/src/API/Nocturne.API/Services/DevOnly/DevTenantMemberSelection.cs
@@ -7,7 +7,7 @@ namespace Nocturne.API.Services.DevOnly;
 /// Shared member-picking rules for the dev-only endpoints: which memberships
 /// count as usable identities, and which one to act on when the caller didn't
 /// name one. Callers must have loaded Subject and MemberRoles.TenantRole
-/// navigations (with the tenant GUC pinned — tenant_roles is RLS-scoped).
+/// navigations.
 /// </summary>
 public static class DevTenantMemberSelection
 {


### PR DESCRIPTION
Follow-up to the dev-experience feature that landed inside #487.

- `DevAuthController.IssueSessionAsync` pinned the tenant GUC with a raw `set_config`, which `TenantConnectionInterceptor` resets when EF closes the connection after that command — the pin never survived to the subsequent `TenantMembers` query. Setting `NocturneDbContext.TenantId` instead pins the GUC on every connection open. Inert today (`tenant_members`/`tenant_roles` carry no RLS policies) but correct if policies are ever added.
- Corrects two comments that falsely claimed `tenant_roles` is RLS-scoped.