### PR TITLE
fix(audit): stop connector no-op churn in mutation_audit_log (24GB, ~1.5M rows/day)

### DIFF
--- a/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Nocturne.API.Services.Audit;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
 using Nocturne.Core.Contracts.Audit;
@@ -291,6 +292,13 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
         // Populate audit context so mutations are attributed to this connector
         var dbContext = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
         dbContext.AuditContext = SystemAuditContext.ForService($"connector:{ConnectorName}");
+
+        // TenantDbContextFactory stamps the scoped IAuditContext onto every context it
+        // creates for the V4 repositories, and in a background scope that context is a
+        // blank user context (IsSystem = false) — without this push, their writes are
+        // audited as null-attributed user mutations instead of being skipped as system.
+        using var systemScope = SystemAuditScope.Push(
+            scope.ServiceProvider.GetRequiredService<IAuditContext>());
 
         // Pin the RLS tenant on the scoped DbContext. NocturneDbContext is pooled and the
         // CarrierResettingDbContextFactory leases it with TenantId reset to Guid.Empty; the scoped

--- a/src/API/Nocturne.API/Services/V4/ProfileDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/ProfileDecomposer.cs
@@ -69,6 +69,11 @@ public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
             return result;
         }
 
+        // No SystemAuditScope here: profiles persist ONLY as these five granular records,
+        // so on the HTTP path (v1/v3 profile create/update) their audit rows are the entire
+        // mutation trail for a user's profile edit. Connector re-syncs are suppressed by the
+        // sync scope's system audit context instead, and byte-identical re-upserts diff to
+        // empty (bookkeeping columns are [AuditIgnored]) and are skipped.
         foreach (var (storeName, profileData) in profile.Store)
         {
             var legacyId = $"{profile.Id}:{storeName}";

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/ApsSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/ApsSnapshotEntity.cs
@@ -46,6 +46,7 @@ public class ApsSnapshotEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISyst
     /// <summary>
     /// Links records that were decomposed from the same legacy DeviceStatus
     /// </summary>
+    [AuditIgnored]
     [Column("correlation_id")]
     public Guid? CorrelationId { get; set; }
 
@@ -65,12 +66,14 @@ public class ApsSnapshotEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISyst
     /// <summary>
     /// System tracking: when record was inserted
     /// </summary>
+    [AuditIgnored]
     [Column("sys_created_at")]
     public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>
     /// System tracking: when record was last updated
     /// </summary>
+    [AuditIgnored]
     [Column("sys_updated_at")]
     public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
 
@@ -242,6 +245,7 @@ public class ApsSnapshotEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISyst
     /// Soft-delete timestamp. When non-null the record is treated as deleted
     /// by the global query filter and is invisible above the repository layer.
     /// </summary>
+    [AuditIgnored]
     [Column("deleted_at")]
     public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BGCheckEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BGCheckEntity.cs
@@ -60,6 +60,7 @@ public class BGCheckEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeS
     /// <summary>
     /// Links records that were split from the same legacy Treatment
     /// </summary>
+    [AuditIgnored]
     [Column("correlation_id")]
     public Guid? CorrelationId { get; set; }
 
@@ -73,12 +74,14 @@ public class BGCheckEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeS
     /// <summary>
     /// System tracking: when record was inserted
     /// </summary>
+    [AuditIgnored]
     [Column("sys_created_at")]
     public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>
     /// System tracking: when record was last updated
     /// </summary>
+    [AuditIgnored]
     [Column("sys_updated_at")]
     public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
 
@@ -119,6 +122,7 @@ public class BGCheckEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeS
     /// Soft-delete timestamp. When non-null the record is treated as deleted
     /// by the global query filter and is invisible above the repository layer.
     /// </summary>
+    [AuditIgnored]
     [Column("deleted_at")]
     public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalInjectionEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalInjectionEntity.cs
@@ -67,6 +67,7 @@ public class BasalInjectionEntity : ITenantScoped, IAuditable, ISoftDeletable, I
     /// <summary>
     /// Links records that were split from the same legacy Treatment
     /// </summary>
+    [AuditIgnored]
     [Column("correlation_id")]
     public Guid? CorrelationId { get; set; }
 
@@ -126,6 +127,7 @@ public class BasalInjectionEntity : ITenantScoped, IAuditable, ISoftDeletable, I
     /// Soft-delete timestamp. When non-null, the record is treated as deleted
     /// by the global query filter and is invisible above the repository layer.
     /// </summary>
+    [AuditIgnored]
     [Column("deleted_at")]
     public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalScheduleEntity.cs
@@ -60,6 +60,7 @@ public class BasalScheduleEntity : ITenantScoped, IAuditable, ISoftDeletable, IV
     /// <summary>
     /// Links records that were split from the same legacy Treatment
     /// </summary>
+    [AuditIgnored]
     [Column("correlation_id")]
     public Guid? CorrelationId { get; set; }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusCalculationEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusCalculationEntity.cs
@@ -60,6 +60,7 @@ public class BolusCalculationEntity : ITenantScoped, IAuditable, ISoftDeletable,
     /// <summary>
     /// Links records that were split from the same legacy Treatment
     /// </summary>
+    [AuditIgnored]
     [Column("correlation_id")]
     public Guid? CorrelationId { get; set; }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusEntity.cs
@@ -60,6 +60,7 @@ public class BolusEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSer
     /// <summary>
     /// Links records that were split from the same legacy Treatment
     /// </summary>
+    [AuditIgnored]
     [Column("correlation_id")]
     public Guid? CorrelationId { get; set; }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CalibrationEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CalibrationEntity.cs
@@ -60,6 +60,7 @@ public class CalibrationEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4T
     /// <summary>
     /// Links records that were split from the same legacy Treatment
     /// </summary>
+    [AuditIgnored]
     [Column("correlation_id")]
     public Guid? CorrelationId { get; set; }
 
@@ -73,12 +74,14 @@ public class CalibrationEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4T
     /// <summary>
     /// System tracking: when record was inserted
     /// </summary>
+    [AuditIgnored]
     [Column("sys_created_at")]
     public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>
     /// System tracking: when record was last updated
     /// </summary>
+    [AuditIgnored]
     [Column("sys_updated_at")]
     public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
 
@@ -110,6 +113,7 @@ public class CalibrationEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4T
     /// Soft-delete timestamp. When non-null the record is treated as deleted
     /// by the global query filter and is invisible above the repository layer.
     /// </summary>
+    [AuditIgnored]
     [Column("deleted_at")]
     public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbIntakeEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbIntakeEntity.cs
@@ -60,6 +60,7 @@ public class CarbIntakeEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Ti
     /// <summary>
     /// Links records that were split from the same legacy Treatment
     /// </summary>
+    [AuditIgnored]
     [Column("correlation_id")]
     public Guid? CorrelationId { get; set; }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbRatioScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbRatioScheduleEntity.cs
@@ -60,6 +60,7 @@ public class CarbRatioScheduleEntity : ITenantScoped, IAuditable, ISoftDeletable
     /// <summary>
     /// Links records that were split from the same legacy Treatment
     /// </summary>
+    [AuditIgnored]
     [Column("correlation_id")]
     public Guid? CorrelationId { get; set; }
 
@@ -73,12 +74,14 @@ public class CarbRatioScheduleEntity : ITenantScoped, IAuditable, ISoftDeletable
     /// <summary>
     /// System tracking: when record was inserted
     /// </summary>
+    [AuditIgnored]
     [Column("sys_created_at")]
     public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>
     /// System tracking: when record was last updated
     /// </summary>
+    [AuditIgnored]
     [Column("sys_updated_at")]
     public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
 
@@ -105,6 +108,7 @@ public class CarbRatioScheduleEntity : ITenantScoped, IAuditable, ISoftDeletable
     /// Soft-delete timestamp. When non-null the record is treated as deleted
     /// by the global query filter and is invisible above the repository layer.
     /// </summary>
+    [AuditIgnored]
     [Column("deleted_at")]
     public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceEntity.cs
@@ -68,6 +68,7 @@ public class DeviceEntity : ITenantScoped, ISoftDeletable
     /// Soft-delete timestamp. When non-null the record is treated as deleted
     /// by the global query filter and is invisible above the repository layer.
     /// </summary>
+    [AuditIgnored]
     [Column("deleted_at")]
     public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceEventEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceEventEntity.cs
@@ -60,6 +60,7 @@ public class DeviceEventEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4T
     /// <summary>
     /// Links records that were split from the same legacy Treatment
     /// </summary>
+    [AuditIgnored]
     [Column("correlation_id")]
     public Guid? CorrelationId { get; set; }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceStatusExtrasEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceStatusExtrasEntity.cs
@@ -27,6 +27,7 @@ public class DeviceStatusExtrasEntity : ITenantScoped, IAuditable, ISoftDeletabl
     /// <summary>
     /// Links back to the originating DeviceStatus decomposition batch
     /// </summary>
+    [AuditIgnored]
     [Column("correlation_id")]
     public Guid CorrelationId { get; set; }
 
@@ -45,12 +46,14 @@ public class DeviceStatusExtrasEntity : ITenantScoped, IAuditable, ISoftDeletabl
     /// <summary>
     /// System tracking: when record was inserted
     /// </summary>
+    [AuditIgnored]
     [Column("sys_created_at")]
     public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>
     /// System tracking: when record was last updated
     /// </summary>
+    [AuditIgnored]
     [Column("sys_updated_at")]
     public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/MeterGlucoseEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/MeterGlucoseEntity.cs
@@ -60,6 +60,7 @@ public class MeterGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4
     /// <summary>
     /// Links records that were split from the same legacy Treatment
     /// </summary>
+    [AuditIgnored]
     [Column("correlation_id")]
     public Guid? CorrelationId { get; set; }
 
@@ -79,12 +80,14 @@ public class MeterGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4
     /// <summary>
     /// System tracking: when record was inserted
     /// </summary>
+    [AuditIgnored]
     [Column("sys_created_at")]
     public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>
     /// System tracking: when record was last updated
     /// </summary>
+    [AuditIgnored]
     [Column("sys_updated_at")]
     public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
 
@@ -104,6 +107,7 @@ public class MeterGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4
     /// Soft-delete timestamp. When non-null the record is treated as deleted
     /// by the global query filter and is invisible above the repository layer.
     /// </summary>
+    [AuditIgnored]
     [Column("deleted_at")]
     public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/NoteEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/NoteEntity.cs
@@ -60,6 +60,7 @@ public class NoteEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeri
     /// <summary>
     /// Links records that were split from the same legacy Treatment
     /// </summary>
+    [AuditIgnored]
     [Column("correlation_id")]
     public Guid? CorrelationId { get; set; }
 
@@ -73,12 +74,14 @@ public class NoteEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeri
     /// <summary>
     /// System tracking: when record was inserted
     /// </summary>
+    [AuditIgnored]
     [Column("sys_created_at")]
     public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>
     /// System tracking: when record was last updated
     /// </summary>
+    [AuditIgnored]
     [Column("sys_updated_at")]
     public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
 
@@ -119,6 +122,7 @@ public class NoteEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeri
     /// Soft-delete timestamp. When non-null the record is treated as deleted
     /// by the global query filter and is invisible above the repository layer.
     /// </summary>
+    [AuditIgnored]
     [Column("deleted_at")]
     public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PatientDeviceEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PatientDeviceEntity.cs
@@ -106,12 +106,14 @@ public class PatientDeviceEntity : ITenantScoped, ISoftDeletable, ISystemTimesta
     /// <summary>
     /// System tracking: when record was inserted
     /// </summary>
+    [AuditIgnored]
     [Column("sys_created_at")]
     public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>
     /// System tracking: when record was last updated
     /// </summary>
+    [AuditIgnored]
     [Column("sys_updated_at")]
     public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
 
@@ -119,6 +121,7 @@ public class PatientDeviceEntity : ITenantScoped, ISoftDeletable, ISystemTimesta
     /// Soft-delete timestamp. When non-null the record is treated as deleted
     /// by the global query filter and is invisible above the repository layer.
     /// </summary>
+    [AuditIgnored]
     [Column("deleted_at")]
     public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PatientInsulinEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PatientInsulinEntity.cs
@@ -111,12 +111,14 @@ public class PatientInsulinEntity : ITenantScoped, ISoftDeletable, ISystemTimest
     /// <summary>
     /// System tracking: when record was inserted
     /// </summary>
+    [AuditIgnored]
     [Column("sys_created_at")]
     public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>
     /// System tracking: when record was last updated
     /// </summary>
+    [AuditIgnored]
     [Column("sys_updated_at")]
     public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
 
@@ -124,6 +126,7 @@ public class PatientInsulinEntity : ITenantScoped, ISoftDeletable, ISystemTimest
     /// Soft-delete timestamp. When non-null the record is treated as deleted
     /// by the global query filter and is invisible above the repository layer.
     /// </summary>
+    [AuditIgnored]
     [Column("deleted_at")]
     public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PatientRecordEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PatientRecordEntity.cs
@@ -93,12 +93,14 @@ public class PatientRecordEntity : ITenantScoped, ISoftDeletable, ISystemTimesta
     /// <summary>
     /// System tracking: when record was inserted
     /// </summary>
+    [AuditIgnored]
     [Column("sys_created_at")]
     public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>
     /// System tracking: when record was last updated
     /// </summary>
+    [AuditIgnored]
     [Column("sys_updated_at")]
     public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
 
@@ -106,6 +108,7 @@ public class PatientRecordEntity : ITenantScoped, ISoftDeletable, ISystemTimesta
     /// Soft-delete timestamp. When non-null the record is treated as deleted
     /// by the global query filter and is invisible above the repository layer.
     /// </summary>
+    [AuditIgnored]
     [Column("deleted_at")]
     public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PumpSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PumpSnapshotEntity.cs
@@ -46,6 +46,7 @@ public class PumpSnapshotEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISys
     /// <summary>
     /// Links records that were decomposed from the same legacy DeviceStatus
     /// </summary>
+    [AuditIgnored]
     [Column("correlation_id")]
     public Guid? CorrelationId { get; set; }
 
@@ -65,12 +66,14 @@ public class PumpSnapshotEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISys
     /// <summary>
     /// System tracking: when record was inserted
     /// </summary>
+    [AuditIgnored]
     [Column("sys_created_at")]
     public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>
     /// System tracking: when record was last updated
     /// </summary>
+    [AuditIgnored]
     [Column("sys_updated_at")]
     public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
 
@@ -180,6 +183,7 @@ public class PumpSnapshotEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISys
     /// Soft-delete timestamp. When non-null the record is treated as deleted
     /// by the global query filter and is invisible above the repository layer.
     /// </summary>
+    [AuditIgnored]
     [Column("deleted_at")]
     public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensitivityScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensitivityScheduleEntity.cs
@@ -60,6 +60,7 @@ public class SensitivityScheduleEntity : ITenantScoped, IAuditable, ISoftDeletab
     /// <summary>
     /// Links records that were split from the same legacy Treatment
     /// </summary>
+    [AuditIgnored]
     [Column("correlation_id")]
     public Guid? CorrelationId { get; set; }
 
@@ -73,12 +74,14 @@ public class SensitivityScheduleEntity : ITenantScoped, IAuditable, ISoftDeletab
     /// <summary>
     /// System tracking: when record was inserted
     /// </summary>
+    [AuditIgnored]
     [Column("sys_created_at")]
     public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>
     /// System tracking: when record was last updated
     /// </summary>
+    [AuditIgnored]
     [Column("sys_updated_at")]
     public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
 
@@ -105,6 +108,7 @@ public class SensitivityScheduleEntity : ITenantScoped, IAuditable, ISoftDeletab
     /// Soft-delete timestamp. When non-null the record is treated as deleted
     /// by the global query filter and is invisible above the repository layer.
     /// </summary>
+    [AuditIgnored]
     [Column("deleted_at")]
     public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensorGlucoseEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensorGlucoseEntity.cs
@@ -60,6 +60,7 @@ public class SensorGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable, IV
     /// <summary>
     /// Links records that were split from the same legacy Treatment
     /// </summary>
+    [AuditIgnored]
     [Column("correlation_id")]
     public Guid? CorrelationId { get; set; }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TargetRangeScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TargetRangeScheduleEntity.cs
@@ -60,6 +60,7 @@ public class TargetRangeScheduleEntity : ITenantScoped, IAuditable, ISoftDeletab
     /// <summary>
     /// Links records that were split from the same legacy Treatment
     /// </summary>
+    [AuditIgnored]
     [Column("correlation_id")]
     public Guid? CorrelationId { get; set; }
 
@@ -73,12 +74,14 @@ public class TargetRangeScheduleEntity : ITenantScoped, IAuditable, ISoftDeletab
     /// <summary>
     /// System tracking: when record was inserted
     /// </summary>
+    [AuditIgnored]
     [Column("sys_created_at")]
     public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>
     /// System tracking: when record was last updated
     /// </summary>
+    [AuditIgnored]
     [Column("sys_updated_at")]
     public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
 
@@ -105,6 +108,7 @@ public class TargetRangeScheduleEntity : ITenantScoped, IAuditable, ISoftDeletab
     /// Soft-delete timestamp. When non-null the record is treated as deleted
     /// by the global query filter and is invisible above the repository layer.
     /// </summary>
+    [AuditIgnored]
     [Column("deleted_at")]
     public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TempBasalEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TempBasalEntity.cs
@@ -66,6 +66,7 @@ public class TempBasalEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Ent
     /// <summary>
     /// Links records that were split from the same legacy Treatment
     /// </summary>
+    [AuditIgnored]
     [Column("correlation_id")]
     public Guid? CorrelationId { get; set; }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TherapySettingsEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TherapySettingsEntity.cs
@@ -60,6 +60,7 @@ public class TherapySettingsEntity : ITenantScoped, IAuditable, ISoftDeletable, 
     /// <summary>
     /// Links records that were split from the same legacy Treatment
     /// </summary>
+    [AuditIgnored]
     [Column("correlation_id")]
     public Guid? CorrelationId { get; set; }
 
@@ -73,12 +74,14 @@ public class TherapySettingsEntity : ITenantScoped, IAuditable, ISoftDeletable, 
     /// <summary>
     /// System tracking: when record was inserted
     /// </summary>
+    [AuditIgnored]
     [Column("sys_created_at")]
     public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>
     /// System tracking: when record was last updated
     /// </summary>
+    [AuditIgnored]
     [Column("sys_updated_at")]
     public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
 
@@ -205,6 +208,7 @@ public class TherapySettingsEntity : ITenantScoped, IAuditable, ISoftDeletable, 
     /// Soft-delete timestamp. When non-null the record is treated as deleted
     /// by the global query filter and is invisible above the repository layer.
     /// </summary>
+    [AuditIgnored]
     [Column("deleted_at")]
     public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/UploaderSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/UploaderSnapshotEntity.cs
@@ -46,6 +46,7 @@ public class UploaderSnapshotEntity : ITenantScoped, ISoftDeletable, IV4Entity, 
     /// <summary>
     /// Links records that were decomposed from the same legacy DeviceStatus
     /// </summary>
+    [AuditIgnored]
     [Column("correlation_id")]
     public Guid? CorrelationId { get; set; }
 
@@ -65,12 +66,14 @@ public class UploaderSnapshotEntity : ITenantScoped, ISoftDeletable, IV4Entity, 
     /// <summary>
     /// System tracking: when record was inserted
     /// </summary>
+    [AuditIgnored]
     [Column("sys_created_at")]
     public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>
     /// System tracking: when record was last updated
     /// </summary>
+    [AuditIgnored]
     [Column("sys_updated_at")]
     public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
 
@@ -128,6 +131,7 @@ public class UploaderSnapshotEntity : ITenantScoped, ISoftDeletable, IV4Entity, 
     /// Soft-delete timestamp. When non-null the record is treated as deleted
     /// by the global query filter and is invisible above the repository layer.
     /// </summary>
+    [AuditIgnored]
     [Column("deleted_at")]
     public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/TenantDbContextFactory.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/TenantDbContextFactory.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Multitenancy;
 
 namespace Nocturne.Infrastructure.Data.Services;
@@ -22,13 +23,21 @@ public interface ITenantDbContextFactory
 internal sealed class TenantDbContextFactory(
     IDbContextFactory<NocturneDbContext> pool,
     ITenantAccessor? tenantAccessor,
-    ICategoryReadContext? categoryReadContext) : ITenantDbContextFactory
+    ICategoryReadContext? categoryReadContext,
+    IAuditContext? auditContext = null) : ITenantDbContextFactory
 {
     public async ValueTask<NocturneDbContext> CreateAsync(CancellationToken ct = default)
     {
         var ctx = await pool.CreateDbContextAsync(ct);
         if (tenantAccessor?.IsResolved == true)
             ctx.TenantId = tenantAccessor.TenantId;
+
+        // Carry the scope's audit context. The MutationAuditInterceptor resolves the
+        // audit context via IHttpContextAccessor, which is null in background services
+        // (connector syncs), where it falls back to this property — without it, every
+        // V4 repository write from a background scope is audited as a null-attributed
+        // user mutation instead of being skipped as a system one.
+        ctx.AuditContext = auditContext;
 
         // Carry the real share flag and category CSV for this request; the CSV is resolved
         // post-auth and is carried only on this factory path. Carrier defaults are already set by

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
@@ -4,9 +4,11 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using Nocturne.API.Services.Audit;
 using Nocturne.API.Services.BackgroundServices;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Connectors;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Infrastructure.Data;
@@ -213,6 +215,10 @@ public class ConnectorBackgroundServiceTests
         });
 
         services.AddScoped<IConnectorConfigurationService>(_ => configServiceMock.Object);
+
+        // Mirrors the production registration (Program.cs) — the sync scope resolves
+        // the mutable scoped AuditContext to mark it system for the sync's duration.
+        services.AddScoped<IAuditContext, AuditContext>();
 
         // Register config loader that returns the test config
         services.AddScoped<IConnectorConfigurationLoader<TestConnectorConfig>>(
@@ -553,6 +559,56 @@ public class ConnectorBackgroundServiceTests
         // Assert — the scoped DbContext the connector services share must be pinned to the synced
         // tenant so RLS scopes correctly.
         Assert.Equal(tenantId, capturedTenantId);
+    }
+
+    [Fact]
+    public async Task SyncForTenant_MarksScopedAuditContextAsSystem()
+    {
+        // Regression test for the mutation_audit_log firehose: V4 repositories stamp their
+        // factory-created DbContexts from the scoped IAuditContext (V4RepositoryBase), not from
+        // the scoped NocturneDbContext the sync annotates. A background scope's AuditContext is
+        // a blank user context (IsSystem = false), so every connector upsert was audited with
+        // null attribution — ~1.5M rows/day in production — instead of being skipped as a
+        // system mutation.
+        var (cleanup, connStr) = CreateSqliteDb();
+        using var _ = cleanup;
+
+        var syncResult = new SyncResult { Success = true, Message = "OK" };
+
+        var configServiceMock = new Mock<IConnectorConfigurationService>();
+        configServiceMock
+            .Setup(x => x.GetConfigurationAsync("TestConnector", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConnectorConfigurationResponse
+            {
+                ConnectorName = "TestConnector",
+                IsActive = true,
+                Configuration = JsonDocument.Parse("{\"enabled\": true, \"syncIntervalMinutes\": 5}")
+            });
+        configServiceMock
+            .Setup(x => x.GetSecretsAsync("TestConnector", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, string>());
+        configServiceMock
+            .Setup(x => x.UpdateHealthStateAsync(
+                It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<string?>(), It.IsAny<DateTime?>(), It.IsAny<bool?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var config = new TestConnectorConfig { Enabled = true, SyncIntervalMinutes = 5 };
+        var serviceProvider = BuildServiceProvider(connStr, configServiceMock, config);
+
+        bool? capturedIsSystem = null;
+        var sut = new TestConnectorBackgroundService(
+            serviceProvider,
+            syncResult,
+            NullLogger<TestConnectorBackgroundService>.Instance,
+            onSyncScope: sp => capturedIsSystem = sp.GetRequiredService<IAuditContext>().IsSystem);
+
+        // Act
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+
+        // Assert — everything written during the sync must carry system attribution.
+        Assert.True(capturedIsSystem);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/ProfileDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/ProfileDecomposerTests.cs
@@ -1,0 +1,97 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Audit;
+using Nocturne.API.Services.V4;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
+
+namespace Nocturne.API.Tests.Services.V4;
+
+public class ProfileDecomposerTests
+{
+    /// <summary>
+    /// Profiles persist ONLY as the five decomposed granular records, so on the HTTP path
+    /// (v1/v3 profile create/update) their audit rows are the entire mutation trail for a
+    /// user's profile edit. DecomposeAsync must NOT push a SystemAuditScope — connector
+    /// re-syncs are suppressed by the sync scope's system audit context instead, and
+    /// byte-identical re-upserts diff to empty ([AuditIgnored] bookkeeping) and are skipped.
+    /// </summary>
+    [Fact]
+    public async Task DecomposeAsync_PreservesCallerAuditAttribution()
+    {
+        var auditContext = new AuditContext { AuthType = "ApiKey", SubjectName = "someone" };
+
+        var attributionDuringUpsert = new List<(bool IsSystem, string? AuthType)>();
+        void Capture() => attributionDuringUpsert.Add((auditContext.IsSystem, auditContext.AuthType));
+
+        var therapySettingsRepo = new Mock<ITherapySettingsRepository>();
+        therapySettingsRepo
+            .Setup(x => x.CreateAsync(It.IsAny<TherapySettings>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback(Capture)
+            .ReturnsAsync((TherapySettings m, WriteOrigin _, CancellationToken _) => m);
+
+        var basalScheduleRepo = new Mock<IBasalScheduleRepository>();
+        basalScheduleRepo
+            .Setup(x => x.CreateAsync(It.IsAny<BasalSchedule>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback(Capture)
+            .ReturnsAsync((BasalSchedule m, WriteOrigin _, CancellationToken _) => m);
+
+        var carbRatioScheduleRepo = new Mock<ICarbRatioScheduleRepository>();
+        carbRatioScheduleRepo
+            .Setup(x => x.CreateAsync(It.IsAny<CarbRatioSchedule>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback(Capture)
+            .ReturnsAsync((CarbRatioSchedule m, WriteOrigin _, CancellationToken _) => m);
+
+        var sensitivityScheduleRepo = new Mock<ISensitivityScheduleRepository>();
+        sensitivityScheduleRepo
+            .Setup(x => x.CreateAsync(It.IsAny<SensitivitySchedule>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback(Capture)
+            .ReturnsAsync((SensitivitySchedule m, WriteOrigin _, CancellationToken _) => m);
+
+        var targetRangeScheduleRepo = new Mock<ITargetRangeScheduleRepository>();
+        targetRangeScheduleRepo
+            .Setup(x => x.CreateAsync(It.IsAny<TargetRangeSchedule>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback(Capture)
+            .ReturnsAsync((TargetRangeSchedule m, WriteOrigin _, CancellationToken _) => m);
+
+        var decomposer = new ProfileDecomposer(
+            therapySettingsRepo.Object,
+            basalScheduleRepo.Object,
+            carbRatioScheduleRepo.Object,
+            sensitivityScheduleRepo.Object,
+            targetRangeScheduleRepo.Object,
+            auditContext,
+            NullLogger<ProfileDecomposer>.Instance);
+
+        var profile = new Profile
+        {
+            Id = "profile1",
+            Mills = 1700000000000,
+            DefaultProfile = "Default",
+            EnteredBy = "test",
+            Store = new Dictionary<string, ProfileData>
+            {
+                ["Default"] = new ProfileData
+                {
+                    Dia = 3.0,
+                    Timezone = "UTC",
+                    Basal = [new TimeValue { Time = "00:00", Value = 1.0 }],
+                    CarbRatio = [new TimeValue { Time = "00:00", Value = 10.0 }],
+                    Sens = [new TimeValue { Time = "00:00", Value = 50.0 }],
+                    TargetLow = [new TimeValue { Time = "00:00", Value = 80.0 }],
+                    TargetHigh = [new TimeValue { Time = "00:00", Value = 120.0 }],
+                },
+            },
+        };
+
+        var result = await decomposer.DecomposeAsync(profile, WriteOrigin.Live);
+
+        result.CreatedRecords.Should().HaveCount(5);
+        attributionDuringUpsert.Should().HaveCount(5).And.AllSatisfy(a =>
+        {
+            a.IsSystem.Should().BeFalse("a user's profile edit must stay user-attributed in the audit log");
+            a.AuthType.Should().Be("ApiKey");
+        });
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Entities/V4AuditIgnoredConventionTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Entities/V4AuditIgnoredConventionTests.cs
@@ -1,0 +1,52 @@
+using System.Reflection;
+
+namespace Nocturne.Infrastructure.Data.Tests.Entities;
+
+/// <summary>
+/// Convention guard: bookkeeping columns on V4 auditable entities must carry
+/// <see cref="AuditIgnoredAttribute"/>. The connector pipeline rewrites
+/// <c>CorrelationId</c> (a fresh per-decomposition-run GUID) and the system
+/// timestamps on every re-upsert of unchanged data; without the attribute each
+/// re-sync produces a mutation_audit_log "update" row whose only diff is that
+/// bookkeeping — ~1.5M no-op rows/day in production. The attribute also feeds
+/// V4MaterialChange, so a bookkeeping-only rewrite must not broadcast an update.
+/// </summary>
+public class V4AuditIgnoredConventionTests
+{
+    private static readonly string[] BookkeepingProperties =
+    [
+        "CorrelationId",
+        "SysCreatedAt",
+        "SysUpdatedAt",
+        "DeletedAt",
+    ];
+
+    public static TheoryData<Type> V4AuditableEntityTypes()
+    {
+        var data = new TheoryData<Type>();
+        var types = typeof(NocturneDbContext).Assembly.GetTypes()
+            .Where(t => t.IsClass && !t.IsAbstract
+                        && t.Namespace == "Nocturne.Infrastructure.Data.Entities.V4"
+                        && typeof(IAuditable).IsAssignableFrom(t));
+
+        foreach (var type in types)
+            data.Add(type);
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(V4AuditableEntityTypes))]
+    public void BookkeepingProperties_AreAuditIgnored(Type entityType)
+    {
+        var unannotated = BookkeepingProperties
+            .Select(name => entityType.GetProperty(name, BindingFlags.Public | BindingFlags.Instance))
+            .Where(p => p is not null && p.GetCustomAttribute<AuditIgnoredAttribute>() is null)
+            .Select(p => p!.Name)
+            .ToList();
+
+        unannotated.Should().BeEmpty(
+            $"{entityType.Name} bookkeeping columns are rewritten on every connector re-sync " +
+            "and must be [AuditIgnored] so unchanged re-upserts do not produce audit rows or broadcasts");
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/TenantDbContextFactoryTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/TenantDbContextFactoryTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Moq;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Infrastructure.Data.Services;
 using Xunit;
@@ -126,6 +127,46 @@ public class TenantDbContextFactoryTests
         await using var result = await factory.CreateAsync();
 
         result.IsShareContext.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CreateAsync_StampsScopedAuditContext()
+    {
+        // The MutationAuditInterceptor resolves the audit context via IHttpContextAccessor,
+        // which is null in background services (connector syncs), where it falls back to
+        // NocturneDbContext.AuditContext. Without this stamping, every V4 repository write
+        // from a background scope was audited as a null-attributed user mutation (~1.5M
+        // mutation_audit_log rows/day in production) instead of being skipped as system.
+        var auditContext = Mock.Of<IAuditContext>(a => a.IsSystem == true);
+
+        var factory = new TenantDbContextFactory(
+            NewPool().Object, ResolvedAccessor(Guid.NewGuid()).Object, categoryReadContext: null,
+            auditContext: auditContext);
+        await using var result = await factory.CreateAsync();
+
+        result.AuditContext.Should().BeSameAs(auditContext);
+    }
+
+    [Fact]
+    public async Task CreateAsync_NoAuditContext_ClearsStaleAuditContextFromPooledContext()
+    {
+        // Pooling does not reset custom properties: assign unconditionally so a context that
+        // last served an attributed scope cannot leak that attribution into the next lease.
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        var pooled = new NocturneDbContext(options)
+        {
+            AuditContext = Mock.Of<IAuditContext>(),
+        };
+        var pool = new Mock<IDbContextFactory<NocturneDbContext>>();
+        pool.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>())).ReturnsAsync(pooled);
+
+        var factory = new TenantDbContextFactory(
+            pool.Object, ResolvedAccessor(Guid.NewGuid()).Object, categoryReadContext: null);
+        await using var result = await factory.CreateAsync();
+
+        result.AuditContext.Should().BeNull();
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

Production `mutation_audit_log` reached **24 GB / 31.8M rows, growing ~1.5M rows/day**. 96% of it is "update" rows with null attribution whose only diff is `SysUpdatedAt` + `CorrelationId` — five rows (TherapySettings + the four schedules) per tenant per 5-minute connector sync. The nightly `pg_dump` spends 2–6 minutes on that one table (COPY mean 137s, max 381s), saturating disk I/O and spiking query latency platform-wide.

Sample row:

```
entity_type | TherapySettings   auth_type | (null)   endpoint | (null)
changes     | {"SysUpdatedAt": {...}, "CorrelationId": {"new": "019f...", "old": "019f..."}}
```

## Root causes

**1. Bookkeeping columns weren't `[AuditIgnored]`.** `CorrelationId` is a fresh GUID per decomposition run (a free in-memory value since #440), so a byte-identical profile/treatment re-upsert always produced a non-empty audit diff. Some entities also missed the attribute on `SysCreatedAt`/`SysUpdatedAt`/`DeletedAt`. This also affected the user (ApiKey) path — 54k/day CarbIntake "updates" whose only change was the correlation id.

**2. Background scopes never delivered a system audit context to the interceptor.** `MutationAuditInterceptor` resolves `IAuditContext` via `IHttpContextAccessor` (null in background services) and falls back to `NocturneDbContext.AuditContext` — but the V4 repositories create their contexts through `TenantDbContextFactory`, which never set it. So the `IsSystem` skip (#390) could not fire for any V4 repository write from a connector sync, and creates/updates were audited as null-attributed user mutations.

## Fix

- `[AuditIgnored]` on `CorrelationId`, `SysCreatedAt`, `SysUpdatedAt`, `DeletedAt` across all V4 auditable entities; a convention test (`V4AuditIgnoredConventionTests`) guards future entities. Empty diffs now hit the existing no-change skip. This also stops `V4MaterialChange` treating bookkeeping-only rewrites as broadcast-worthy updates.
- `TenantDbContextFactory.CreateAsync` stamps the scoped `IAuditContext` onto every context it creates (unconditionally, so pooled contexts can't leak a prior lease's attribution).
- `ConnectorBackgroundService.SyncForTenantAsync` pushes a `SystemAuditScope` on the scoped `IAuditContext` for the sync duration, so all V4 repository writes in a sync scope are system-attributed and skipped.

**Deliberately not changed:** `ProfileDecomposer.DecomposeAsync` does *not* push a `SystemAuditScope` (unlike `DecomposeBatchAsync`). Profiles persist only as the five granular records, so on the HTTP path (v1/v3 profile create/update) their audit rows are the entire mutation trail for a user's profile edit. A test pins that user attribution survives the decomposer.

## Coverage

- `V4AuditIgnoredConventionTests` — every V4 auditable entity's bookkeeping columns carry the attribute (caught 6 partially-annotated entities while writing it).
- `TenantDbContextFactoryTests` — the factory stamps the scoped audit context / clears stale pooled state.
- `ConnectorBackgroundServiceTests.SyncForTenant_MarksScopedAuditContextAsSystem` — the sync scope is system-marked (the factory + interceptor legs of the chain are covered by the two tests above and the existing `Create_UnderSystemAuditContext_ProducesNoAuditRecord`).
- `ProfileDecomposerTests.DecomposeAsync_PreservesCallerAuditAttribution` — guards against re-adding the scope and erasing the user profile-edit trail.

Unit suites: Infrastructure.Data 468/468, API 4005/4005 (5 pre-existing skips).

## Aftermath (not in this PR)

Once deployed, the existing 24 GB of no-op rows still needs pruning (`DELETE WHERE auth_type IS NULL AND action = 'update'` in batches, or a copy-keep/TRUNCATE cycle given disk headroom). `DecomposeBatchAsync`'s pre-existing unconditional `SystemAuditScope` has the same user-attribution question as the singular path — left as-is here.
