### PR TITLE
fix(data): stop no-op UPDATE/broadcast churn from jsonb round-trips

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/StateSpanEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/StateSpanEntity.cs
@@ -8,7 +8,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Maps to Nocturne.Core.Models.StateSpan
 /// </summary>
 [Table("state_spans")]
-public class StateSpanEntity : ITenantScoped, IAuditable
+public class StateSpanEntity : ITenantScoped, IAuditable, IEntityTimestamped
 {
     /// <summary>
     /// Identifier of the tenant this state span belongs to

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/JsonbStringComparer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/JsonbStringComparer.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+
+namespace Nocturne.Infrastructure.Data;
+
+/// <summary>
+/// Semantic equality for string properties stored in PostgreSQL <c>jsonb</c> columns. Postgres
+/// normalizes jsonb on write (key order, whitespace, duplicate keys), so a value read back never
+/// matches the app's compact serialization byte-for-byte. Without this comparer, every upsert that
+/// re-serializes an unchanged model marks the property modified — issuing a no-op UPDATE, a false
+/// audit diff, and a false "updated" broadcast on each connector re-sync.
+/// </summary>
+public sealed class JsonbStringComparer : ValueComparer<string?>
+{
+    public static readonly JsonbStringComparer Instance = new();
+
+    private JsonbStringComparer()
+        : base(
+            (a, b) => JsonEquals(a, b),
+            // Ordinal string hash: NOT consistent with JsonEquals across serialization variants.
+            // Acceptable because jsonb columns are never keys, and change detection uses only the
+            // equality expression; a JSON-canonicalizing hash would parse on every snapshot.
+            v => v == null ? 0 : StringComparer.Ordinal.GetHashCode(v),
+            v => v)
+    {
+    }
+
+    private static bool JsonEquals(string? a, string? b)
+    {
+        if (string.Equals(a, b, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (a is null || b is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            // JsonElement (not JsonNode): JsonNode.DeepEquals materializes objects into a
+            // dictionary and throws ArgumentException on duplicate keys, which are legal in
+            // both JSON input and Postgres jsonb (last-wins). JsonElement.DeepEquals compares
+            // duplicate-key objects without throwing (unequal, i.e. falls back to an UPDATE).
+            using var docA = JsonDocument.Parse(a);
+            using var docB = JsonDocument.Parse(b);
+            return JsonElement.DeepEquals(docA.RootElement, docB.RootElement);
+        }
+        catch (JsonException)
+        {
+            // Not valid JSON — the ordinal comparison above already said the strings differ.
+            return false;
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/BodyWeightMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/BodyWeightMapper.cs
@@ -69,6 +69,5 @@ public static class BodyWeightMapper
         entity.UtcOffset = bodyWeight.UtcOffset;
         entity.DataSource = bodyWeight.DataSource;
         entity.SyncIdentifier = bodyWeight.SyncIdentifier;
-        entity.SysUpdatedAt = DateTime.UtcNow;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/FoodMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/FoodMapper.cs
@@ -89,7 +89,6 @@ public static class FoodMapper
         entity.HideAfterUse = food.HideAfterUse;
         entity.Hidden = food.Hidden;
         entity.Position = food.Position;
-        entity.SysUpdatedAt = DateTime.UtcNow;
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/HeartRateMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/HeartRateMapper.cs
@@ -63,6 +63,5 @@ public static class HeartRateMapper
         entity.UtcOffset = heartRate.UtcOffset;
         entity.DataSource = heartRate.DataSource;
         entity.SyncIdentifier = heartRate.SyncIdentifier;
-        entity.SysUpdatedAt = DateTime.UtcNow;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/SettingsMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/SettingsMapper.cs
@@ -95,7 +95,6 @@ public static class SettingsMapper
         entity.Version = settings.Version;
         entity.IsActive = settings.IsActive;
         entity.Notes = settings.Notes;
-        entity.SysUpdatedAt = DateTime.UtcNow;
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/StateSpanMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/StateSpanMapper.cs
@@ -73,6 +73,5 @@ public static class StateSpanMapper
             ? JsonSerializer.Serialize(stateSpan.Metadata)
             : null;
         entity.OriginalId = stateSpan.OriginalId;
-        entity.UpdatedAt = DateTime.UtcNow;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/StepCountMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/StepCountMapper.cs
@@ -63,6 +63,5 @@ public static class StepCountMapper
         entity.UtcOffset = stepCount.UtcOffset;
         entity.DataSource = stepCount.DataSource;
         entity.SyncIdentifier = stepCount.SyncIdentifier;
-        entity.SysUpdatedAt = DateTime.UtcNow;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/ApsSnapshotMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/ApsSnapshotMapper.cs
@@ -124,7 +124,6 @@ public static class ApsSnapshotMapper
         entity.CorrelationId = model.CorrelationId;
         entity.LegacyId = model.LegacyId;
         entity.DataSource = model.DataSource;
-        entity.SysUpdatedAt = DateTime.UtcNow;
         entity.AidAlgorithm = model.AidAlgorithm.ToString();
         entity.Iob = model.Iob;
         entity.BasalIob = model.BasalIob;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BGCheckMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BGCheckMapper.cs
@@ -81,7 +81,6 @@ public static class BGCheckMapper
         entity.DataSource = model.DataSource;
         entity.CorrelationId = model.CorrelationId;
         entity.LegacyId = model.LegacyId;
-        entity.SysUpdatedAt = DateTime.UtcNow;
         entity.Glucose = model.Glucose;
         entity.GlucoseType = model.GlucoseType?.ToString();
         entity.Units = model.Units?.ToString();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BasalInjectionMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BasalInjectionMapper.cs
@@ -98,7 +98,6 @@ public static class BasalInjectionMapper
         entity.CorrelationId = model.CorrelationId;
         entity.LegacyId = model.LegacyId;
         entity.PatientDeviceId = model.PatientDeviceId;
-        entity.SysUpdatedAt = DateTime.UtcNow;
         entity.Units = model.Units;
         entity.Notes = model.Notes;
         entity.InsulinContextJson = JsonSerializer.Serialize(model.InsulinContext);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BasalScheduleMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BasalScheduleMapper.cs
@@ -77,7 +77,6 @@ public static class BasalScheduleMapper
         entity.DataSource = model.DataSource;
         entity.CorrelationId = model.CorrelationId;
         entity.LegacyId = model.LegacyId;
-        entity.SysUpdatedAt = DateTime.UtcNow;
         entity.ProfileName = model.ProfileName;
         entity.EntriesJson = JsonSerializer.Serialize(model.Entries);
         entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BolusCalculationMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BolusCalculationMapper.cs
@@ -99,7 +99,6 @@ public static class BolusCalculationMapper
         entity.DataSource = model.DataSource;
         entity.CorrelationId = model.CorrelationId;
         entity.LegacyId = model.LegacyId;
-        entity.SysUpdatedAt = DateTime.UtcNow;
         entity.BloodGlucoseInput = model.BloodGlucoseInput;
         entity.BloodGlucoseInputSource = model.BloodGlucoseInputSource;
         entity.CarbInput = model.CarbInput;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BolusMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BolusMapper.cs
@@ -109,7 +109,6 @@ public static class BolusMapper
         entity.DataSource = model.DataSource;
         entity.CorrelationId = model.CorrelationId;
         entity.LegacyId = model.LegacyId;
-        entity.SysUpdatedAt = DateTime.UtcNow;
         entity.Insulin = model.Insulin;
         entity.Programmed = model.Programmed;
         entity.Delivered = model.Delivered;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/CalibrationMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/CalibrationMapper.cs
@@ -79,7 +79,6 @@ public static class CalibrationMapper
         entity.DataSource = model.DataSource;
         entity.CorrelationId = model.CorrelationId;
         entity.LegacyId = model.LegacyId;
-        entity.SysUpdatedAt = DateTime.UtcNow;
         entity.Slope = model.Slope;
         entity.Intercept = model.Intercept;
         entity.Scale = model.Scale;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/CarbIntakeMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/CarbIntakeMapper.cs
@@ -81,7 +81,6 @@ public static class CarbIntakeMapper
         entity.DataSource = model.DataSource;
         entity.CorrelationId = model.CorrelationId;
         entity.LegacyId = model.LegacyId;
-        entity.SysUpdatedAt = DateTime.UtcNow;
         entity.Carbs = model.Carbs;
         entity.SyncIdentifier = model.SyncIdentifier;
         entity.CarbTime = model.CarbTime;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/CarbRatioScheduleMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/CarbRatioScheduleMapper.cs
@@ -77,7 +77,6 @@ public static class CarbRatioScheduleMapper
         entity.DataSource = model.DataSource;
         entity.CorrelationId = model.CorrelationId;
         entity.LegacyId = model.LegacyId;
-        entity.SysUpdatedAt = DateTime.UtcNow;
         entity.ProfileName = model.ProfileName;
         entity.EntriesJson = JsonSerializer.Serialize(model.Entries);
         entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/DeviceEventMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/DeviceEventMapper.cs
@@ -88,7 +88,6 @@ public static class DeviceEventMapper
         entity.DataSource = model.DataSource;
         entity.CorrelationId = model.CorrelationId;
         entity.LegacyId = model.LegacyId;
-        entity.SysUpdatedAt = DateTime.UtcNow;
         entity.EventType = model.EventType.ToString();
         entity.Notes = model.Notes;
         entity.SyncIdentifier = model.SyncIdentifier;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/DeviceStatusExtrasMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/DeviceStatusExtrasMapper.cs
@@ -63,6 +63,5 @@ public static class DeviceStatusExtrasMapper
         entity.ExtrasJson = model.Extras is { Count: > 0 }
             ? JsonSerializer.Serialize(model.Extras)
             : null;
-        entity.SysUpdatedAt = DateTime.UtcNow;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/MeterGlucoseMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/MeterGlucoseMapper.cs
@@ -78,7 +78,6 @@ public static class MeterGlucoseMapper
         entity.CorrelationId = model.CorrelationId;
         entity.LegacyId = model.LegacyId;
         entity.PatientDeviceId = model.PatientDeviceId;
-        entity.SysUpdatedAt = DateTime.UtcNow;
         entity.Mgdl = model.Mgdl;
         entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
             ? JsonSerializer.Serialize(model.AdditionalProperties)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/NoteMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/NoteMapper.cs
@@ -81,7 +81,6 @@ public static class NoteMapper
         entity.DataSource = model.DataSource;
         entity.CorrelationId = model.CorrelationId;
         entity.LegacyId = model.LegacyId;
-        entity.SysUpdatedAt = DateTime.UtcNow;
         entity.Text = model.Text;
         entity.EventType = model.EventType;
         entity.IsAnnouncement = model.IsAnnouncement;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/PatientDeviceMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/PatientDeviceMapper.cs
@@ -86,6 +86,5 @@ public static class PatientDeviceMapper
         entity.IsCurrent = model.IsCurrent;
         entity.Rank = model.Rank;
         entity.Notes = model.Notes;
-        entity.SysUpdatedAt = DateTime.UtcNow;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/PatientInsulinMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/PatientInsulinMapper.cs
@@ -88,6 +88,5 @@ public static class PatientInsulinMapper
         entity.Concentration = model.Concentration;
         entity.Role = model.Role.ToString();
         entity.IsPrimary = model.IsPrimary;
-        entity.SysUpdatedAt = DateTime.UtcNow;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/PatientRecordMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/PatientRecordMapper.cs
@@ -78,6 +78,5 @@ public static class PatientRecordMapper
         entity.Pronouns = model.Pronouns;
         entity.AvatarUrl = model.AvatarUrl;
         entity.Timezone = model.Timezone;
-        entity.SysUpdatedAt = DateTime.UtcNow;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/PumpSnapshotMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/PumpSnapshotMapper.cs
@@ -100,7 +100,6 @@ public static class PumpSnapshotMapper
         entity.CorrelationId = model.CorrelationId;
         entity.LegacyId = model.LegacyId;
         entity.DataSource = model.DataSource;
-        entity.SysUpdatedAt = DateTime.UtcNow;
         entity.Manufacturer = model.Manufacturer;
         entity.Model = model.Model;
         entity.Reservoir = model.Reservoir;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/SensitivityScheduleMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/SensitivityScheduleMapper.cs
@@ -77,7 +77,6 @@ public static class SensitivityScheduleMapper
         entity.DataSource = model.DataSource;
         entity.CorrelationId = model.CorrelationId;
         entity.LegacyId = model.LegacyId;
-        entity.SysUpdatedAt = DateTime.UtcNow;
         entity.ProfileName = model.ProfileName;
         entity.EntriesJson = JsonSerializer.Serialize(model.Entries);
         entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/SensorGlucoseMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/SensorGlucoseMapper.cs
@@ -99,7 +99,6 @@ public static class SensorGlucoseMapper
         entity.PatientDeviceId = model.PatientDeviceId;
         entity.LegacyId = model.LegacyId;
         entity.SyncIdentifier = model.SyncIdentifier;
-        entity.SysUpdatedAt = DateTime.UtcNow;
         entity.Mgdl = model.Mgdl;
         entity.Direction = model.Direction?.ToString();
         entity.TrendRate = model.TrendRate;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/TargetRangeScheduleMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/TargetRangeScheduleMapper.cs
@@ -77,7 +77,6 @@ public static class TargetRangeScheduleMapper
         entity.DataSource = model.DataSource;
         entity.CorrelationId = model.CorrelationId;
         entity.LegacyId = model.LegacyId;
-        entity.SysUpdatedAt = DateTime.UtcNow;
         entity.ProfileName = model.ProfileName;
         entity.EntriesJson = JsonSerializer.Serialize(model.Entries);
         entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/TempBasalMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/TempBasalMapper.cs
@@ -98,7 +98,6 @@ public static class TempBasalMapper
         entity.DataSource = model.DataSource;
         entity.CorrelationId = model.CorrelationId;
         entity.LegacyId = model.LegacyId;
-        entity.SysUpdatedAt = DateTime.UtcNow;
         entity.Rate = model.Rate;
         entity.ScheduledRate = model.ScheduledRate;
         entity.Origin = model.Origin.ToString();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/TherapySettingsMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/TherapySettingsMapper.cs
@@ -114,7 +114,6 @@ public static class TherapySettingsMapper
         entity.DataSource = model.DataSource;
         entity.CorrelationId = model.CorrelationId;
         entity.LegacyId = model.LegacyId;
-        entity.SysUpdatedAt = DateTime.UtcNow;
         entity.ProfileName = model.ProfileName;
         entity.Timezone = model.Timezone;
         entity.Units = model.Units;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/UploaderSnapshotMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/UploaderSnapshotMapper.cs
@@ -84,7 +84,6 @@ public static class UploaderSnapshotMapper
         entity.CorrelationId = model.CorrelationId;
         entity.LegacyId = model.LegacyId;
         entity.DataSource = model.DataSource;
-        entity.SysUpdatedAt = DateTime.UtcNow;
         entity.Name = model.Name;
         entity.Battery = model.Battery;
         entity.BatteryVoltage = model.BatteryVoltage;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -621,6 +621,25 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
                 idProperty.SetColumnName("id");
             }
         }
+
+        // Postgres normalizes jsonb on write (key order, whitespace), so a jsonb-backed string
+        // read back never equals the app's compact serialization byte-for-byte. Compare these
+        // columns semantically so an unchanged round-trip is not flagged as a modification.
+        // Guarded on relational: the InMemory test provider has no column types (and no jsonb
+        // normalization to compensate for).
+        if (Database.IsRelational())
+        {
+            foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+            {
+                foreach (var property in entityType.GetProperties())
+                {
+                    if (property.ClrType == typeof(string) && property.GetColumnType() == "jsonb")
+                    {
+                        property.SetValueComparer(JsonbStringComparer.Instance);
+                    }
+                }
+            }
+        }
     }
 
     private static void ConfigureIndexes(ModelBuilder modelBuilder)
@@ -3174,12 +3193,18 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
 
             EnforceTenantOwnership(entry, isAdded);
 
+            // Update timestamps are stamped on insert and on real modifications only. An
+            // unchanged tracked row is left alone rather than rewritten on every save, and a row
+            // whose only modified properties are these bookkeeping timestamps (a deliberate
+            // "touch") keeps the value the caller assigned.
+            var stampUpdated = isAdded || HasNonTimestampModification(entry);
+
             // System tracking columns (sys_created_at / sys_updated_at) on tenant data.
             if (isAdded && entry.Entity is ISystemCreated systemCreated)
             {
                 systemCreated.SysCreatedAt = utcNow;
             }
-            if (entry.Entity is ISystemTimestamped systemTimestamped)
+            if (stampUpdated && entry.Entity is ISystemTimestamped systemTimestamped)
             {
                 systemTimestamped.SysUpdatedAt = utcNow;
             }
@@ -3189,14 +3214,25 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             {
                 entityCreated.CreatedAt = utcNow;
             }
-            if (entry.Entity is IEntityTimestamped entityTimestamped)
+            if (stampUpdated && entry.Entity is IEntityTimestamped entityTimestamped)
             {
                 entityTimestamped.UpdatedAt = utcNow;
             }
 
-            ApplyEntitySpecificTimestamps(entry.Entity, isAdded, utcNow);
+            ApplyEntitySpecificTimestamps(entry.Entity, isAdded, stampUpdated, utcNow);
         }
     }
+
+    /// <summary>
+    /// True if the entry has a modified property other than the update-timestamp bookkeeping
+    /// columns managed by <see cref="UpdateTimestamps"/>.
+    /// </summary>
+    private static bool HasNonTimestampModification(EntityEntry entry)
+        => entry.State == EntityState.Modified
+            && entry.Properties.Any(p =>
+                p.IsModified
+                && p.Metadata.Name != nameof(ISystemTimestamped.SysUpdatedAt)
+                && p.Metadata.Name != nameof(IEntityTimestamped.UpdatedAt));
 
     /// <summary>
     /// Enforces tenant ownership on a tracked entity: stamps the resolved tenant on new
@@ -3236,12 +3272,12 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
     /// Applies timestamps for the few entities whose columns do not follow either the
     /// sys_* or created_at/updated_at conventions covered by the marker interfaces.
     /// </summary>
-    private static void ApplyEntitySpecificTimestamps(object entity, bool isAdded, DateTime utcNow)
+    private static void ApplyEntitySpecificTimestamps(object entity, bool isAdded, bool stampUpdated, DateTime utcNow)
     {
         switch (entity)
         {
-            // Nullable updated_at, set on every save alongside its ISystemTimestamped stamps.
-            case ClockFaceEntity clockFace:
+            // Nullable updated_at, set alongside its ISystemTimestamped stamps.
+            case ClockFaceEntity clockFace when stampUpdated:
                 clockFace.UpdatedAt = utcNow;
                 break;
             // Mirror of sys_created_at on a DateTimeOffset column, set on insert only.

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/BroadcastGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/BroadcastGoldenTests.cs
@@ -100,6 +100,46 @@ public class BroadcastGoldenTests
     }
 
     [Fact]
+    public async Task JsonbRoundTrip_IdenticalReupload_IsSilent_AndDoesNotRewriteTheRow()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IBolusRepository>();
+
+        // AdditionalProperties lands in a jsonb column: Postgres normalizes it on write (key
+        // order, spacing), so the stored string never byte-matches the compact serialization
+        // the mapper re-assigns on the next identical upload.
+        static Bolus Upload() => new()
+        {
+            Timestamp = T0,
+            Insulin = 3.0,
+            DataSource = "aaps",
+            SyncIdentifier = "jsonb-1",
+            AdditionalProperties = new Dictionary<string, object?>
+            {
+                ["pumpSerial"] = "SN123",
+                ["programmed"] = 3.0,
+            },
+        };
+
+        await repo.BulkCreateAsync(new[] { Upload() }, WriteOrigin.Live, CancellationToken.None);
+
+        var stampAfterInsert = await _fx.QueryAsync(tenant, ctx => ctx.Boluses.AsNoTracking()
+            .Where(b => b.SyncIdentifier == "jsonb-1").Select(b => b.SysUpdatedAt).SingleAsync());
+
+        _fx.Capture.Clear();
+        await repo.BulkCreateAsync(new[] { Upload() }, WriteOrigin.Live, CancellationToken.None);
+
+        _fx.Capture.Snapshot().Should().NotContain(e => e.Kind == "updated",
+            "a jsonb-normalized round-trip of identical content is not a material change");
+
+        var stampAfterReupload = await _fx.QueryAsync(tenant, ctx => ctx.Boluses.AsNoTracking()
+            .Where(b => b.SyncIdentifier == "jsonb-1").Select(b => b.SysUpdatedAt).SingleAsync());
+        stampAfterReupload.Should().Be(stampAfterInsert,
+            "an identical re-upload must not rewrite the row");
+    }
+
+    [Fact]
     public async Task DeleteByLegacyId_BroadcastsDeletedIds()
     {
         var tenant = Guid.NewGuid();

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/JsonbStringComparerTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/JsonbStringComparerTests.cs
@@ -1,0 +1,117 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests;
+
+/// <summary>
+/// Pins the jsonb round-trip fix: Postgres normalizes jsonb on write (key order, whitespace), so
+/// a value read back never byte-matches the app's compact serialization. <see cref="JsonbStringComparer"/>
+/// must make EF change tracking treat such round-trips as unmodified — otherwise every connector
+/// re-sync issues a no-op UPDATE and a false "updated" broadcast for every jsonb-backed row.
+/// The model builds offline against the Npgsql provider (no connection needed for change tracking).
+/// </summary>
+[Trait("Category", "Unit")]
+public class JsonbStringComparerTests
+{
+    // Compact C# serialization vs the same content as Postgres jsonb prints it
+    // (space after colon, reordered keys).
+    private const string CompactJson = """[{"Time":"00:00","Value":1.5,"TimeAsSeconds":0}]""";
+    private const string JsonbNormalizedJson = """[{"Time": "00:00", "Value": 1.5, "TimeAsSeconds": 0}]""";
+
+    private static NocturneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseNpgsql("Host=localhost;Database=nocturne;Username=test;Password=test")
+            .Options)
+        { TenantId = Guid.NewGuid() };
+
+    [Fact]
+    public void EveryJsonbStringColumn_UsesTheSemanticComparer()
+    {
+        using var ctx = NewContext();
+
+        var jsonbStringProps = ctx.Model.GetEntityTypes()
+            .SelectMany(t => t.GetProperties())
+            .Where(p => p.ClrType == typeof(string) && p.GetColumnType() == "jsonb")
+            .ToList();
+
+        jsonbStringProps.Should().NotBeEmpty("the model maps many string properties to jsonb columns");
+        jsonbStringProps.Should().OnlyContain(
+            p => p.GetValueComparer() is JsonbStringComparer,
+            "every jsonb-backed string must be compared semantically, not byte-wise");
+    }
+
+    [Fact]
+    public void JsonbNormalizedRoundTrip_IsNotAModification_AndNotMaterial()
+    {
+        using var ctx = NewContext();
+        var entity = TrackedSchedule(ctx, CompactJson);
+
+        // The mapper re-assigns the compact serialization over the jsonb-normalized original.
+        entity.EntriesJson = JsonbNormalizedJson;
+        ctx.ChangeTracker.DetectChanges();
+
+        var entry = ctx.Entry(entity);
+        entry.Property(e => e.EntriesJson).IsModified.Should().BeFalse(
+            "jsonb normalization does not change the value semantically");
+        entry.State.Should().Be(EntityState.Unchanged, "no UPDATE should be issued");
+        V4MaterialChange.HasMaterialChange(entry).Should().BeFalse("no broadcast should fire");
+    }
+
+    [Fact]
+    public void SemanticJsonChange_IsStillAModification()
+    {
+        using var ctx = NewContext();
+        var entity = TrackedSchedule(ctx, CompactJson);
+
+        entity.EntriesJson = """[{"Time":"00:00","Value":2.0,"TimeAsSeconds":0}]""";
+        ctx.ChangeTracker.DetectChanges();
+
+        var entry = ctx.Entry(entity);
+        entry.Property(e => e.EntriesJson).IsModified.Should().BeTrue();
+        V4MaterialChange.HasMaterialChange(entry).Should().BeTrue();
+    }
+
+    [Fact]
+    public void NullToValue_IsAModification()
+    {
+        using var ctx = NewContext();
+        var entity = TrackedSchedule(ctx, CompactJson);
+
+        entity.AdditionalPropertiesJson = """{"a":1}""";
+        ctx.ChangeTracker.DetectChanges();
+
+        ctx.Entry(entity).Property(e => e.AdditionalPropertiesJson).IsModified.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("""{"a":1,"b":2}""", """{"b": 2, "a": 1}""", true)] // key order + spacing
+    [InlineData("""{"a":null}""", """{"a": null}""", true)]
+    [InlineData("""{"a":1}""", """{"a":1,"b":null}""", false)] // explicit null key is a difference
+    [InlineData("""{"a":1,"b":2}""", """{"a": 1.0, "b": 2}""", true)] // numeric equality, like Postgres jsonb
+    [InlineData("""{"a":1,"a":2}""", """{"a": 2}""", false)] // duplicate keys must not throw
+    [InlineData("not json", "not json", true)] // ordinal fast path
+    [InlineData("not json", "also not json", false)] // invalid JSON falls back to ordinal
+    public void Equals_ComparesParsedJson(string a, string b, bool expected)
+    {
+        JsonbStringComparer.Instance.Equals(a, b).Should().Be(expected);
+    }
+
+    private static BasalScheduleEntity TrackedSchedule(NocturneDbContext ctx, string entriesJson)
+    {
+        var entity = new BasalScheduleEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = ctx.TenantId,
+            Timestamp = DateTime.UtcNow,
+            ProfileName = "Default",
+            EntriesJson = entriesJson,
+            AdditionalPropertiesJson = null,
+        };
+        ctx.Attach(entity);
+        return entity;
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/BodyWeightMapperTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/BodyWeightMapperTests.cs
@@ -160,7 +160,7 @@ public class BodyWeightMapperTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public void UpdateEntity_UpdatesAllFieldsAndSetsSysUpdatedAt()
+    public void UpdateEntity_UpdatesAllFields()
     {
         var originalId = Guid.CreateVersion7();
         var originalCreatedAt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -171,8 +171,6 @@ public class BodyWeightMapperTests
             Mills = 1000,
             WeightKg = 70m,
         };
-
-        var beforeUpdate = DateTime.UtcNow;
 
         var model = new BodyWeight
         {
@@ -198,25 +196,26 @@ public class BodyWeightMapperTests
         entity.EnteredBy.Should().Be("admin");
         entity.CreatedAt.Should().Be("2024-11-14T22:13:20.000Z");
         entity.UtcOffset.Should().Be(60);
-        entity.SysUpdatedAt.Should().BeOnOrAfter(beforeUpdate);
     }
 
     [Fact]
     [Trait("Category", "Unit")]
-    public void UpdateEntity_SetsUpdatedAtTimestamp()
+    public void UpdateEntity_DoesNotTouchSysUpdatedAt()
     {
+        var stale = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         var entity = new BodyWeightEntity
         {
             Id = Guid.CreateVersion7(),
-            SysCreatedAt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
-            SysUpdatedAt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            SysCreatedAt = stale,
+            SysUpdatedAt = stale,
         };
-        var beforeUpdate = DateTime.UtcNow;
 
         var model = new BodyWeight { WeightKg = 80m };
         BodyWeightMapper.UpdateEntity(entity, model);
 
-        entity.SysUpdatedAt.Should().BeOnOrAfter(beforeUpdate);
+        // NocturneDbContext.UpdateTimestamps stamps sys_updated_at, and only for rows with a
+        // real modification; a mapper stamp would force an UPDATE on no-op upserts.
+        entity.SysUpdatedAt.Should().Be(stale);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/V4/BolusMapperTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/V4/BolusMapperTests.cs
@@ -296,25 +296,26 @@ public class BolusMapperTests
         entity.DataSource.Should().Be("tidepool");
         entity.CorrelationId.Should().Be(model.CorrelationId);
         entity.LegacyId.Should().Be("upd456");
-        entity.SysUpdatedAt.Should().BeAfter(originalCreatedAt);
     }
 
     [Fact]
     [Trait("Category", "Unit")]
-    public void UpdateEntity_SetsUpdatedAtTimestamp()
+    public void UpdateEntity_DoesNotTouchSysUpdatedAt()
     {
+        var stale = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         var entity = new BolusEntity
         {
             Id = Guid.CreateVersion7(),
-            SysCreatedAt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
-            SysUpdatedAt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+            SysCreatedAt = stale,
+            SysUpdatedAt = stale
         };
-        var beforeUpdate = DateTime.UtcNow;
 
         var model = new Bolus { Insulin = 1.0 };
         BolusMapper.UpdateEntity(entity, model);
 
-        entity.SysUpdatedAt.Should().BeOnOrAfter(beforeUpdate);
+        // NocturneDbContext.UpdateTimestamps stamps sys_updated_at, and only for rows with a
+        // real modification; a mapper stamp would force an UPDATE on no-op upserts.
+        entity.SysUpdatedAt.Should().Be(stale);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/V4/SensorGlucoseMapperTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/V4/SensorGlucoseMapperTests.cs
@@ -237,25 +237,26 @@ public class SensorGlucoseMapperTests
         entity.DataSource.Should().Be("glooko");
         entity.CorrelationId.Should().Be(model.CorrelationId);
         entity.LegacyId.Should().Be("xyz789");
-        entity.SysUpdatedAt.Should().BeAfter(originalCreatedAt);
     }
 
     [Fact]
     [Trait("Category", "Unit")]
-    public void UpdateEntity_SetsUpdatedAtTimestamp()
+    public void UpdateEntity_DoesNotTouchSysUpdatedAt()
     {
+        var stale = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         var entity = new SensorGlucoseEntity
         {
             Id = Guid.CreateVersion7(),
-            SysCreatedAt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
-            SysUpdatedAt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+            SysCreatedAt = stale,
+            SysUpdatedAt = stale
         };
-        var beforeUpdate = DateTime.UtcNow;
 
         var model = new SensorGlucose { Mgdl = 100 };
         SensorGlucoseMapper.UpdateEntity(entity, model);
 
-        entity.SysUpdatedAt.Should().BeOnOrAfter(beforeUpdate);
+        // NocturneDbContext.UpdateTimestamps stamps sys_updated_at, and only for rows with a
+        // real modification; a mapper stamp would force an UPDATE on no-op upserts.
+        entity.SysUpdatedAt.Should().Be(stale);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/V4/TempBasalMapperTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/V4/TempBasalMapperTests.cs
@@ -287,26 +287,27 @@ public class TempBasalMapperTests
         entity.Origin.Should().Be("Algorithm");
         entity.DeviceId.Should().Be(newDeviceId);
         entity.PumpRecordId.Should().Be("pump-rec-002");
-        entity.SysUpdatedAt.Should().BeAfter(originalCreatedAt);
     }
 
     [Fact]
     [Trait("Category", "Unit")]
-    public void UpdateEntity_SetsUpdatedAtTimestamp()
+    public void UpdateEntity_DoesNotTouchSysUpdatedAt()
     {
+        var stale = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         var entity = new TempBasalEntity
         {
             Id = Guid.CreateVersion7(),
-            SysCreatedAt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
-            SysUpdatedAt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            SysCreatedAt = stale,
+            SysUpdatedAt = stale,
             Origin = "Manual"
         };
-        var beforeUpdate = DateTime.UtcNow;
 
         var model = new TempBasal { StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(1700000000000).UtcDateTime, Rate = 1.0 };
         TempBasalMapper.UpdateEntity(entity, model);
 
-        entity.SysUpdatedAt.Should().BeOnOrAfter(beforeUpdate);
+        // NocturneDbContext.UpdateTimestamps stamps sys_updated_at, and only for rows with a
+        // real modification; a mapper stamp would force an UPDATE on no-op upserts.
+        entity.SysUpdatedAt.Should().Be(stale);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/UpdateTimestampsTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/UpdateTimestampsTests.cs
@@ -55,6 +55,64 @@ public class UpdateTimestampsTests
     }
 
     [Fact]
+    public async Task SystemTimestamped_UnchangedTrackedRow_IsNotBumpedByAnotherRowsSave()
+    {
+        var options = NewStore();
+        var tenantId = Guid.NewGuid();
+        var idA = Guid.CreateVersion7();
+        var idB = Guid.CreateVersion7();
+
+        await using (var ctx = new NocturneDbContext(options) { TenantId = tenantId })
+        {
+            ctx.Foods.AddRange(new FoodEntity { Id = idA }, new FoodEntity { Id = idB });
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (var ctx = new NocturneDbContext(options) { TenantId = tenantId })
+        {
+            var changed = await ctx.Foods.SingleAsync(f => f.Id == idA);
+            var untouched = await ctx.Foods.SingleAsync(f => f.Id == idB);
+            var untouchedStamp = untouched.SysUpdatedAt;
+
+            changed.Name = "changed";
+            await Task.Delay(5);
+            await ctx.SaveChangesAsync();
+
+            untouched.SysUpdatedAt.Should().Be(untouchedStamp,
+                "a tracked row with no modifications is not rewritten by an unrelated save");
+        }
+    }
+
+    [Fact]
+    public async Task SystemTimestamped_TimestampOnlyModification_KeepsTheAssignedValue()
+    {
+        var options = NewStore();
+        var tenantId = Guid.NewGuid();
+        var id = Guid.CreateVersion7();
+
+        await using (var ctx = new NocturneDbContext(options) { TenantId = tenantId })
+        {
+            ctx.Foods.Add(new FoodEntity { Id = id });
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (var ctx = new NocturneDbContext(options) { TenantId = tenantId })
+        {
+            var food = await ctx.Foods.SingleAsync();
+            // A deliberate "touch": the caller-assigned value must survive, not be re-stamped.
+            food.SysUpdatedAt = Stale;
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (var verify = new NocturneDbContext(options) { TenantId = tenantId })
+        {
+            var food = await verify.Foods.SingleAsync();
+            food.SysUpdatedAt.Should().Be(Stale,
+                "a modification consisting only of the update timestamp keeps the assigned value");
+        }
+    }
+
+    [Fact]
     public async Task SystemCreated_StampsCreatedOnInsertOnly()
     {
         var options = NewStore();


### PR DESCRIPTION
## Problem

String properties mapped to `jsonb` columns (e.g. `BasalScheduleEntity.EntriesJson`) never compare equal to what EF reads back: Postgres normalizes jsonb on write (key reordering, spacing), while the mappers re-assign a compact `JsonSerializer.Serialize(...)` string on every connector upsert. EF change tracking compares bytes, so semantically identical content was flagged modified on **every sync cycle**, forever:

- a real `UPDATE` per schedule/settings row per 5-minute sync (row + WAL churn, `sys_updated_at` bump),
- a false `updated` SignalR broadcast (websocket clients saw phantom profile updates every 5 min),
- the no-op audit rows fixed in #491 (this PR fixes the remaining causes; #491 fixed the audit sink).

Verified in prod (2026-07-13) from `mutation_audit_log.changes` captured before the prune: old = jsonb-normalized, new = compact serialization, identical content. ~90% of the churn was `EntriesJson` on the four schedule tables, plus `MetadataJson` (StateSpan), `LoopSettingsJson` (TherapySettings), `InsulinContextJson` (TempBasal).

`V4MaterialChange`'s doc claims "connector re-polls that re-send byte-identical rows broadcast nothing" — that invariant did not hold for jsonb-backed fields.

## Fix

**1. Semantic comparison for jsonb-backed strings** — new `JsonbStringComparer` (`ValueComparer<string?>`), applied in `OnModelCreating` to every string property with column type `jsonb` (attribute- and fluent-configured; 70+ columns). Ordinal fast path, then `JsonElement.DeepEquals`, whose semantics match Postgres jsonb equality (key order/whitespace-insensitive, numeric equivalence: `1 == 1.0`). `JsonElement` rather than `JsonNode` deliberately: `JsonNode.DeepEquals` throws `ArgumentException` on duplicate keys, which both JSON input and Postgres jsonb accept (last-wins) — that would turn a legal save into a 500. Fixes change tracking itself, so UPDATE, broadcast, and audit all go quiet centrally. No migration required (comparers are not part of the relational model).

**2. Update timestamps only on real changes** — `UpdateTimestamps` previously stamped `SysUpdatedAt`/`UpdatedAt` on *every tracked entry on any save*, including `Unchanged` rows (which were then pointlessly rewritten). It now stamps on insert and on entries with a non-bookkeeping modified property. The ~29 mapper `UpdateEntity` stamps are removed — the mapper's own stamp is what kept no-op upserts `Modified`; the context is the single stamping point. `StateSpanEntity` adopts `IEntityTimestamped` (its columns already matched) so it stays centrally covered after losing its mapper stamp; every other touched mapper's entity already implements `ISystemTimestamped`.

Deliberate "touches" (e.g. `ShareLinkService` bumping `member.SysUpdatedAt`) still persist: a hand-modified timestamp keeps the entry `Modified` and now keeps the *assigned* value instead of being overwritten with `utcNow`.

## Trade-offs / notes

- A save that changes only JSON formatting or numeric spelling (`1` → `1.0`) is dropped as a non-change — same equality Postgres itself applies to jsonb. All consumers deserialize numerically; none are byte-sensitive.
- The comparer's `GetHashCode` is ordinal (inconsistent with semantic equals). Safe: no jsonb column is a key/alternate key/index anywhere in the model, and non-key change detection uses the equality expression only.
- `StateSpanMapper.ToEntity`'s `CreatedAt = stateSpan.CreatedAt ?? UtcNow` fallback is now always overwritten on insert by the central `IEntityCreated` stamp (uniform platform behavior; no current caller passes a historical CreatedAt).
- Delta/watermark readers of `sys_updated_at` (v3 `srvModified` projection, `GetModifiedSince`) become *more* correct: rows no longer claim modification when nothing changed.

## Verification

- New golden (Testcontainers, real Postgres — the only environment where jsonb normalization manifests): identical Bolus re-upload with `AdditionalProperties` broadcasts nothing **and** leaves `sys_updated_at` untouched. Confirmed it **fails against main** (broadcasts `updated`) and passes with the fix.
- New unit tests: comparer applied to every jsonb string column; jsonb-normalized round-trip is not a modification and not material; semantic changes still are; duplicate keys don't throw; unchanged tracked rows aren't rewritten by unrelated saves; timestamp-only touches keep the assigned value.
- Existing mapper tests asserting `UpdateEntity` stamps `SysUpdatedAt` were updated to pin the inverse contract.
- Suites: Infrastructure.Data unit 481/481, API unit 4005 passed, Infrastructure.Data integration (Testcontainers, PG) 73/73.

Post-deploy check: `SELECT max(sys_updated_at) FROM basal_schedules WHERE tenant_id = '<connector-tenant>'` should stop advancing every 5 minutes.

Sibling of #491 (audit-sink half of the same prod investigation).

