### PR TITLE
fix(api): v1 entries duplicate check must see non-primary linked copies

### DIFF
--- a/src/API/Nocturne.API/Services/Entries/EntryReadService.cs
+++ b/src/API/Nocturne.API/Services/Entries/EntryReadService.cs
@@ -260,10 +260,10 @@ public class EntryReadService : IEntryStore
     private async Task<Entry?> CheckSgvDuplicateAsync(
         string? device, double? sgv, DateTime from, DateTime to, CancellationToken ct)
     {
-        var results = await _sgRepo.GetAsync(from, to, device, source: null, limit: 100, offset: 0, descending: true, nativeOnly: false, ct: ct);
-        var match = sgv.HasValue
-            ? results.FirstOrDefault(r => Math.Abs(r.Mgdl - sgv.Value) < 0.01)
-            : results.FirstOrDefault();
+        // Probe raw storage rather than the visibility-filtered GetAsync: copies linked as
+        // non-primary cross-connector duplicates are hidden from reads, but they still mean the
+        // reading is already stored — a filtered check re-inserts them on every upload.
+        var match = await _sgRepo.FindStoredDuplicateAsync(device, sgv, from, to, ct);
         return match is null ? null : EntryProjection.FromSensorGlucose(match);
     }
 

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ISensorGlucoseRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ISensorGlucoseRepository.cs
@@ -113,6 +113,25 @@ public interface ISensorGlucoseRepository : IV4Repository<SensorGlucose>
     );
 
     /// <summary>
+    /// Raw-storage duplicate probe for upload idempotency: returns a stored reading matching the
+    /// device, value (±0.01 mg/dL), and time window, or <c>null</c>.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="GetAsync(DateTime?, DateTime?, string?, string?, int, int, bool, bool, DateTime?, Guid?, CancellationToken, Guid?)"/>,
+    /// this deliberately includes rows hidden from reads as non-primary cross-connector duplicates.
+    /// A hidden copy still means "already stored" — when a second source re-uploads readings whose
+    /// copies have all been linked non-primary, a visibility-filtered check finds nothing and the
+    /// same readings are re-inserted on every upload cycle.
+    /// </remarks>
+    /// <param name="device">Optional device identifier filter.</param>
+    /// <param name="mgdl">Optional glucose value to match within ±0.01 mg/dL.</param>
+    /// <param name="from">Inclusive start of the time window.</param>
+    /// <param name="to">Inclusive end of the time window.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<SensorGlucose?> FindStoredDuplicateAsync(
+        string? device, double? mgdl, DateTime from, DateTime to, CancellationToken ct = default);
+
+    /// <summary>
     /// Retrieve the timestamp of the most recently stored <see cref="SensorGlucose"/> reading, optionally scoped to a data source.
     /// </summary>
     /// <remarks>Used by connectors to determine the last sync time and avoid re-fetching already-stored data.</remarks>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -249,6 +249,29 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
         return created;
     }
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// Queries raw storage without the non-primary LinkedRecords exclusion: a reading whose copies
+    /// are all linked non-primary is still a stored duplicate, and hiding it here caused uploads
+    /// from a second source to re-insert their whole window on every cycle.
+    /// </remarks>
+    public async Task<SensorGlucose?> FindStoredDuplicateAsync(
+        string? device, double? mgdl, DateTime from, DateTime to, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var query = ctx.SensorGlucose.AsNoTracking()
+            .Where(e => e.Timestamp >= from && e.Timestamp <= to);
+        if (device != null)
+            query = query.Where(e => e.Device == device);
+        if (mgdl.HasValue)
+            query = query.Where(e => Math.Abs(e.Mgdl - mgdl.Value) < 0.01);
+
+        var entity = await query
+            .OrderByDescending(e => e.Timestamp).ThenByDescending(e => e.Id)
+            .FirstOrDefaultAsync(ct);
+        return entity is null ? null : SensorGlucoseMapper.ToDomainModel(entity);
+    }
+
     /// <summary>
     /// Gets sensor glucose records by correlation identifier.
     /// </summary>

--- a/tests/Unit/Nocturne.API.Tests/Services/Entries/EntryReadServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Entries/EntryReadServiceTests.cs
@@ -313,10 +313,9 @@ public class EntryReadServiceTests
     public async Task CheckDuplicateAsync_MatchFound_ReturnsEntry()
     {
         var sg = MakeSg(Now, 120);
-        _sgRepo.Setup(r => r.GetAsync(
-                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), "xdrip", It.IsAny<string?>(),
-                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { sg });
+        _sgRepo.Setup(r => r.FindStoredDuplicateAsync(
+                "xdrip", 120, It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sg);
 
         var result = await _sut.CheckDuplicateAsync("xdrip", "sgv", 120, sg.Mills, 5);
 
@@ -328,10 +327,9 @@ public class EntryReadServiceTests
     [Trait("Category", "Unit")]
     public async Task CheckDuplicateAsync_NoMatch_ReturnsNull()
     {
-        _sgRepo.Setup(r => r.GetAsync(
-                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), "xdrip", It.IsAny<string?>(),
-                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Enumerable.Empty<SensorGlucose>());
+        _sgRepo.Setup(r => r.FindStoredDuplicateAsync(
+                "xdrip", 120, It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SensorGlucose?)null);
 
         var mills = new DateTimeOffset(Now, TimeSpan.Zero).ToUnixTimeMilliseconds();
         var result = await _sut.CheckDuplicateAsync("xdrip", "sgv", 120, mills, 5);

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SensorGlucoseRepositoryDuplicateProbeTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SensorGlucoseRepositoryDuplicateProbeTests.cs
@@ -118,14 +118,57 @@ public class SensorGlucoseRepositoryDuplicateProbeTests : IDisposable
         match!.Id.Should().Be(hiddenId);
     }
 
-    [Fact]
-    public async Task FindStoredDuplicateAsync_ValueOutsideTolerance_ReturnsNull()
+    [Theory]
+    [InlineData(134.005, true)]  // inside ±0.01
+    [InlineData(134.02, false)]  // just outside
+    [InlineData(135, false)]
+    public async Task FindStoredDuplicateAsync_MatchesValueWithinTolerance(double probeValue, bool expectMatch)
     {
         var now = DateTime.UtcNow;
         SeedReading(now, 134, "Dexcom G7 DXCMRf");
 
         var match = await _repo.FindStoredDuplicateAsync(
-            "Dexcom G7 DXCMRf", 135, now.AddMinutes(-5), now.AddMinutes(5));
+            "Dexcom G7 DXCMRf", probeValue, now.AddMinutes(-5), now.AddMinutes(5));
+
+        (match != null).Should().Be(expectMatch);
+    }
+
+    [Fact]
+    public async Task FindStoredDuplicateAsync_SoftDeletedRow_ReturnsNull()
+    {
+        // Guardrail: the probe skips the LinkedRecords visibility exclusion, but must keep the
+        // global query filters — a soft-deleted reading is not a stored duplicate, and widening
+        // the probe with IgnoreQueryFilters would also breach tenant isolation.
+        var now = DateTime.UtcNow;
+        var id = SeedReading(now, 134, "Dexcom G7 DXCMRf");
+        var entity = _context.SensorGlucose.IgnoreQueryFilters().Single(e => e.Id == id);
+        entity.DeletedAt = now;
+        _context.SaveChanges();
+
+        var match = await _repo.FindStoredDuplicateAsync(
+            "Dexcom G7 DXCMRf", 134, now.AddMinutes(-5), now.AddMinutes(5));
+
+        match.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task FindStoredDuplicateAsync_OtherTenantsRow_ReturnsNull()
+    {
+        var otherTenant = Guid.Parse("00000000-0000-0000-0000-000000000002");
+        var now = DateTime.UtcNow;
+        _context.Tenants.Add(new TenantEntity { Id = otherTenant, Slug = "other" });
+        _context.SensorGlucose.Add(new SensorGlucoseEntity
+        {
+            Id = Guid.NewGuid(),
+            TenantId = otherTenant,
+            Timestamp = now,
+            Mgdl = 134,
+            Device = "Dexcom G7 DXCMRf",
+        });
+        _context.SaveChanges();
+
+        var match = await _repo.FindStoredDuplicateAsync(
+            "Dexcom G7 DXCMRf", 134, now.AddMinutes(-5), now.AddMinutes(5));
 
         match.Should().BeNull();
     }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SensorGlucoseRepositoryDuplicateProbeTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SensorGlucoseRepositoryDuplicateProbeTests.cs
@@ -1,0 +1,169 @@
+using System.Data.Common;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Infrastructure;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+/// <summary>
+/// Covers <see cref="SensorGlucoseRepository.FindStoredDuplicateAsync"/>, the raw-storage duplicate
+/// probe backing the v1 upload duplicate check. The probe must see readings whose copies are linked
+/// as non-primary cross-connector duplicates — <c>GetAsync</c> hides those, and checking through it
+/// made a second source (e.g. a Share bridge posting alongside the Dexcom connector) re-insert its
+/// whole upload window on every cycle because none of its earlier copies were ever visible.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+[Trait("Category", "SensorGlucose")]
+public class SensorGlucoseRepositoryDuplicateProbeTests : IDisposable
+{
+    private static readonly Guid TestTenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+    private readonly DbConnection _connection;
+    private readonly NocturneDbContext _context;
+    private readonly SensorGlucoseRepository _repo;
+
+    public SensorGlucoseRepositoryDuplicateProbeTests()
+    {
+        _connection = new SqliteConnection("Filename=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        using (var seedContext = new NocturneDbContext(options))
+        {
+            seedContext.TenantId = TestTenantId;
+            seedContext.Database.EnsureCreated();
+            seedContext.Tenants.Add(new TenantEntity { Id = TestTenantId, Slug = "test" });
+            seedContext.SaveChanges();
+        }
+
+        _context = new NocturneDbContext(options) { TenantId = TestTenantId };
+
+        var dedup = new Mock<IDeduplicationService>();
+        _repo = new SensorGlucoseRepository(
+            new TestTenantDbContextFactory(_context),
+            dedup.Object,
+            new Mock<IAuditContext>().Object,
+            NullLogger<SensorGlucoseRepository>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private Guid SeedReading(DateTime timestamp, double mgdl, string device)
+    {
+        var id = Guid.NewGuid();
+        _context.SensorGlucose.Add(new SensorGlucoseEntity
+        {
+            Id = id,
+            TenantId = TestTenantId,
+            Timestamp = timestamp,
+            Mgdl = mgdl,
+            Device = device,
+        });
+        _context.SaveChanges();
+        return id;
+    }
+
+    private void LinkNonPrimary(Guid recordId, DateTime timestamp)
+    {
+        _context.LinkedRecords.Add(new LinkedRecordEntity
+        {
+            Id = Guid.NewGuid(),
+            TenantId = TestTenantId,
+            CanonicalId = Guid.NewGuid(),
+            RecordType = "sensorglucose",
+            RecordId = recordId,
+            SourceTimestamp = new DateTimeOffset(timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
+            DataSource = "unknown",
+            IsPrimary = false,
+        });
+        _context.SaveChanges();
+    }
+
+    [Fact]
+    public async Task FindStoredDuplicateAsync_NonPrimaryLinkedCopy_IsStillFound()
+    {
+        var now = DateTime.UtcNow;
+        var hiddenId = SeedReading(now, 134, "Dexcom G7 DXCMRf");
+        LinkNonPrimary(hiddenId, now);
+
+        // Sanity: the read path hides the non-primary copy…
+        var visible = (await _repo.GetAsync(
+            from: now.AddMinutes(-5), to: now.AddMinutes(5), device: "Dexcom G7 DXCMRf", source: null,
+            limit: 100, offset: 0, descending: true,
+            nativeOnly: false, afterTimestamp: null, afterId: null)).ToList();
+        visible.Should().BeEmpty();
+
+        // …but the duplicate probe must not: the reading is already stored.
+        var match = await _repo.FindStoredDuplicateAsync(
+            "Dexcom G7 DXCMRf", 134, now.AddMinutes(-5), now.AddMinutes(5));
+        match.Should().NotBeNull();
+        match!.Id.Should().Be(hiddenId);
+    }
+
+    [Fact]
+    public async Task FindStoredDuplicateAsync_ValueOutsideTolerance_ReturnsNull()
+    {
+        var now = DateTime.UtcNow;
+        SeedReading(now, 134, "Dexcom G7 DXCMRf");
+
+        var match = await _repo.FindStoredDuplicateAsync(
+            "Dexcom G7 DXCMRf", 135, now.AddMinutes(-5), now.AddMinutes(5));
+
+        match.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task FindStoredDuplicateAsync_DifferentDevice_ReturnsNull()
+    {
+        var now = DateTime.UtcNow;
+        SeedReading(now, 134, "dexcom-connector");
+
+        var match = await _repo.FindStoredDuplicateAsync(
+            "Dexcom G7 DXCMRf", 134, now.AddMinutes(-5), now.AddMinutes(5));
+
+        match.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task FindStoredDuplicateAsync_NullDeviceAndValue_MatchesAnyInWindow()
+    {
+        var now = DateTime.UtcNow;
+        var id = SeedReading(now, 134, "Dexcom G7 DXCMRf");
+
+        var match = await _repo.FindStoredDuplicateAsync(
+            device: null, mgdl: null, now.AddMinutes(-5), now.AddMinutes(5));
+
+        match.Should().NotBeNull();
+        match!.Id.Should().Be(id);
+    }
+
+    [Fact]
+    public async Task FindStoredDuplicateAsync_OutsideWindow_ReturnsNull()
+    {
+        var now = DateTime.UtcNow;
+        SeedReading(now.AddMinutes(-30), 134, "Dexcom G7 DXCMRf");
+
+        var match = await _repo.FindStoredDuplicateAsync(
+            "Dexcom G7 DXCMRf", 134, now.AddMinutes(-5), now.AddMinutes(5));
+
+        match.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Problem

The v1 `POST /api/v1/entries` duplicate check probes sensor glucose through the visibility-filtered `GetAsync`, which excludes rows linked as **non-primary cross-connector duplicates**.

When a tenant runs two sources for the same CGM — e.g. the Dexcom connector **plus** a Share bridge posting the same readings via v1 — the bridge's copies all get linked non-primary to the connector's primary row. The primary is invisible to the check too (the check filters by the *bridge's* device string, the primary carries the connector's). Result: the check finds nothing, and the bridge's entire upload window is re-inserted on **every** upload cycle.

Observed in production (nocturne.run): one tenant's `sensor_glucose` grew to **2.17M rows for ~17k distinct readings** (123× duplication; one canonical group reached 2,225 members), inserting 20–33k rows/hour at peak — flooding per-record storage broadcasts, audit, and telemetry (Grafana Cloud 429 ingestion-rate limit).

## Fix

- Add `ISensorGlucoseRepository.FindStoredDuplicateAsync(device, mgdl, from, to)` — a raw-storage duplicate probe that deliberately skips the non-primary `LinkedRecords` exclusion. A hidden copy still means "already stored".
- `EntryReadService.CheckSgvDuplicateAsync` uses it instead of the filtered `GetAsync`.
- The value match (±0.01 mg/dL) is pushed into the query, which also removes the old `limit: 100` page that could miss matches in dense windows.

mbg/cal check paths are unchanged — `MeterGlucoseRepository`/`CalibrationRepository` don't apply the LinkedRecords exclusion.

## Tests

- `SensorGlucoseRepositoryDuplicateProbeTests` (SQLite): asserts `GetAsync` hides a non-primary-linked copy while `FindStoredDuplicateAsync` still finds it (the regression), plus tolerance/device/window behaviour.
- `EntryReadServiceTests` sgv duplicate tests updated to the new probe.

Note: `CacheIntegrationTests.CreateEntriesAsync_DecomposesToV4AndFiresEvents` fails on a clean `main` checkout too (decomposer mock expects per-entry `DecomposeAsync`, service batches) — unrelated, not touched here.