### PR TITLE
fix(web): finish layerchart 2.0.1 API migration for charts

### DIFF
--- a/src/Web/packages/app/src/lib/components/actogram/ActogramRow.svelte
+++ b/src/Web/packages/app/src/lib/components/actogram/ActogramRow.svelte
@@ -54,7 +54,7 @@
   xDomain={[day, xDomainEnd]}
   yDomain={[0, thresholds?.glucoseYMax ?? 300]}
   padding={{ left: 0, top: 0, bottom: 0, right: 0 }}
-  tooltip={{ mode: "manual" }}
+  tooltipContext={{ mode: "manual" }}
 >
   {#snippet children({ context })}
     {@const rowContext: ActogramRowContext = {

--- a/src/Web/packages/app/src/lib/components/ambulatory-glucose-profile/AmbulatoryGlucoseProfile.svelte
+++ b/src/Web/packages/app/src/lib/components/ambulatory-glucose-profile/AmbulatoryGlucoseProfile.svelte
@@ -12,6 +12,7 @@
     formatHour as _formatHour,
     transformStats,
     AGP_LOW_THRESHOLD,
+    type AgpDataPoint,
   } from "./agp-utils";
 
   let {
@@ -60,24 +61,29 @@
     {data}
     x={(d) => d.hour}
     y={(d) => d.median}
-    renderContext="svg"
     legend
     series={[
       {
         key: "p10",
-        value: [(d) => d.percentiles?.p25, (d) => d.percentiles?.p10],
+        value: [
+          (d: AgpDataPoint) => d.percentiles?.p25,
+          (d: AgpDataPoint) => d.percentiles?.p10,
+        ],
         color: BAND_OUTER,
         label: "P10",
       },
       {
         key: "p25",
-        value: [(d) => d.median, (d) => d.percentiles?.p25],
+        value: [
+          (d: AgpDataPoint) => d.median,
+          (d: AgpDataPoint) => d.percentiles?.p25,
+        ],
         color: BAND_INNER,
         label: "P25",
       },
       {
         key: "median",
-        value: [(d) => d.median, (d) => d.median],
+        value: [(d: AgpDataPoint) => d.median, (d: AgpDataPoint) => d.median],
         color: MEDIAN_COLOR,
         props: {
           line: { strokeWidth: 1.75 },
@@ -86,13 +92,19 @@
       },
       {
         key: "percentiles.p75",
-        value: [(d) => d.median, (d) => d.percentiles?.p75],
+        value: [
+          (d: AgpDataPoint) => d.median,
+          (d: AgpDataPoint) => d.percentiles?.p75,
+        ],
         color: BAND_INNER,
         label: "P75",
       },
       {
         key: "p90",
-        value: [(d) => d.percentiles?.p75, (d) => d.percentiles?.p90],
+        value: [
+          (d: AgpDataPoint) => d.percentiles?.p75,
+          (d: AgpDataPoint) => d.percentiles?.p90,
+        ],
         color: BAND_OUTER,
         label: "P90",
       },
@@ -152,16 +164,7 @@
     {#snippet tooltip({ context })}
       <Tooltip.Root {context}>
         {#snippet children({ data })}
-          {@const d = data as (typeof data) & {
-            hour: number;
-            median: number;
-            percentiles?: {
-              p10: number;
-              p25: number;
-              p75: number;
-              p90: number;
-            };
-          }}
+          {@const d = data as AgpDataPoint & { hour: number }}
           <Tooltip.Header value={`${formatHour(d.hour)} · ${bgLabel()}`} />
           <Tooltip.List>
             <Tooltip.Item

--- a/src/Web/packages/app/src/lib/components/ambulatory-glucose-profile/agp-utils.ts
+++ b/src/Web/packages/app/src/lib/components/ambulatory-glucose-profile/agp-utils.ts
@@ -7,31 +7,33 @@ export const AGP_LOW_THRESHOLD = 70;
 
 /** Format an hour (0-23) as a time string */
 export function formatHour(hour: number, is24Hour: boolean): string {
-	// Axis ticks can arrive fractional during interpolation; snap to the nearest
-	// hour so labels never render as decimals like "8.4pm". Wrap at 24 so a tick
-	// rounding up to 24 reads as midnight, not "24:00".
-	hour = Math.round(hour) % 24;
-	if (is24Hour) {
-		return `${hour.toString().padStart(2, "0")}:00`;
-	}
-	if (hour === 0) return "12am";
-	if (hour === 12) return "12pm";
-	if (hour < 12) return `${hour}am`;
-	return `${hour - 12}pm`;
+  // Axis ticks can arrive fractional during interpolation; snap to the nearest
+  // hour so labels never render as decimals like "8.4pm". Wrap at 24 so a tick
+  // rounding up to 24 reads as midnight, not "24:00".
+  hour = Math.round(hour) % 24;
+  if (is24Hour) {
+    return `${hour.toString().padStart(2, "0")}:00`;
+  }
+  if (hour === 0) return "12am";
+  if (hour === 12) return "12pm";
+  if (hour < 12) return `${hour}am`;
+  return `${hour - 12}pm`;
 }
 
 /** Transform raw AveragedStats into display-unit-aware chart data */
 export function transformStats(rawData: AveragedStats[], units: GlucoseUnits) {
-	return rawData.map((d) => ({
-		...d,
-		median: convertToDisplayUnits(d.median ?? 0, units),
-		percentiles: d.percentiles
-			? {
-					p10: convertToDisplayUnits(d.percentiles.p10 ?? 0, units),
-					p25: convertToDisplayUnits(d.percentiles.p25 ?? 0, units),
-					p75: convertToDisplayUnits(d.percentiles.p75 ?? 0, units),
-					p90: convertToDisplayUnits(d.percentiles.p90 ?? 0, units),
-				}
-			: undefined,
-	}));
+  return rawData.map((d) => ({
+    ...d,
+    median: convertToDisplayUnits(d.median ?? 0, units),
+    percentiles: d.percentiles
+      ? {
+          p10: convertToDisplayUnits(d.percentiles.p10 ?? 0, units),
+          p25: convertToDisplayUnits(d.percentiles.p25 ?? 0, units),
+          p75: convertToDisplayUnits(d.percentiles.p75 ?? 0, units),
+          p90: convertToDisplayUnits(d.percentiles.p90 ?? 0, units),
+        }
+      : undefined,
+  }));
 }
+
+export type AgpDataPoint = ReturnType<typeof transformStats>[number];

--- a/src/Web/packages/app/src/lib/components/calendar/DayStackedBar.svelte
+++ b/src/Web/packages/app/src/lib/components/calendar/DayStackedBar.svelte
@@ -47,7 +47,7 @@
     axis={false}
     grid={false}
     legend={false}
-    tooltip={false}
+    tooltipContext={false}
     padding={{ left: 0, right: 0, top: 0, bottom: 0 }}
     props={{
       bars: {

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/GlucoseChartShell.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/GlucoseChartShell.svelte
@@ -100,7 +100,7 @@
     xDomain={[chartXDomain.from, chartXDomain.to]}
     yDomain={[0, engine.glucoseYMax]}
     {padding}
-    tooltip={{ mode: "quadtree-x" }}
+    tooltipContext={{ mode: "quadtree-x" }}
   >
     {#snippet children({ context })}
       {(chartHeight = context.height, chartWidth = context.width, "")}
@@ -126,18 +126,11 @@
       {#if onSelectionChange}
         <BrushContext
           axis="x"
-          mode="separated"
-          xDomain={selectionDomain ?? [chartXDomain.from, chartXDomain.to]}
+          x={selectionDomain ?? [chartXDomain.from, chartXDomain.to]}
           onChange={(e) => {
-            if (
-              e.xDomain &&
-              Array.isArray(e.xDomain) &&
-              e.xDomain.length === 2
-            ) {
-              onSelectionChange?.([
-                new Date(e.xDomain[0]!),
-                new Date(e.xDomain[1]!),
-              ]);
+            const [start, end] = e.brush.x ?? [];
+            if (start != null && end != null) {
+              onSelectionChange?.([new Date(start), new Date(end)]);
             }
           }}
           classes={{

--- a/src/Web/packages/app/src/lib/components/dashboard/widgets/TddWidget.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/widgets/TddWidget.svelte
@@ -87,7 +87,6 @@
               innerRadius={-20}
               cornerRadius={2}
               padAngle={0.02}
-              renderContext={"svg"}
             >
               {#snippet aboveMarks()}
                 <Text

--- a/src/Web/packages/app/src/lib/components/reports/BasalBolusRatioChart.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/BasalBolusRatioChart.svelte
@@ -76,9 +76,7 @@
         ]}
         seriesLayout="stack"
         legend
-        tooltip={{
-          mode: "band",
-        }}
+        tooltipContext={{ mode: "band" }}
         props={{
           xAxis: {
             tickMultiline: true,

--- a/src/Web/packages/app/src/lib/components/reports/BasalRatePercentileChart.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/BasalRatePercentileChart.svelte
@@ -67,7 +67,6 @@
         data={chartData}
         x={(d) => d.hour}
         y={(d) => d.median}
-        renderContext="svg"
         series={[
           {
             key: "p10",
@@ -121,7 +120,7 @@
         xDomain={[0, 23]}
         yDomain={[0, maxRate]}
         seriesLayout="overlap"
-        tooltip={{ mode: "bisect-x" }}
+        tooltipContext={{ mode: "bisect-x" }}
         props={{
           xAxis: {
             tickMultiline: true,

--- a/src/Web/packages/app/src/lib/components/reports/GlycemicRiskIndexChart.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/GlycemicRiskIndexChart.svelte
@@ -200,7 +200,7 @@
           yDomain={[0, HYPER_MAX]}
           yReverse
           padding={{ top: 10, right: 10, bottom: 36, left: 46 }}
-          tooltip={{ mode: "manual" }}
+          tooltipContext={{ mode: "manual" }}
         >
           {#snippet children({ context })}
             <Svg>

--- a/src/Web/packages/app/src/lib/components/reports/HourlyGlucosePercentileChart.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/HourlyGlucosePercentileChart.svelte
@@ -27,30 +27,30 @@
         series={[
           {
             key: "p10",
-            value: (d) => d.p10,
+            value: (d: HourlyPercentileData) => d.p10,
             color: "#a0a0FF",
             label: "10th-90th percentile",
           },
           {
             key: "p25",
-            value: (d) => d.p25,
+            value: (d: HourlyPercentileData) => d.p25,
             color: "#000055",
             label: "25th-75th percentile",
           },
           {
             key: "median",
-            value: (d) => d.median,
+            value: (d: HourlyPercentileData) => d.median,
             color: "#000000",
             label: "Median",
           },
           {
             key: "p75",
-            value: (d) => d.p75,
+            value: (d: HourlyPercentileData) => d.p75,
             color: "#000055",
           },
           {
             key: "p90",
-            value: (d) => d.p90,
+            value: (d: HourlyPercentileData) => d.p90,
             color: "#a0a0FF",
           },
         ]}

--- a/src/Web/packages/app/src/lib/components/reports/InsulinDeliveryChart.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/InsulinDeliveryChart.svelte
@@ -158,7 +158,6 @@
         data={chartData}
         x={(d) => d.hour}
         y={(d) => d.total}
-        renderContext="svg"
         series={showStacked
           ? [
               // Show scheduled basal, temp basal adjustments, and bolus as stacked
@@ -215,7 +214,7 @@
         xDomain={[0, 23]}
         yDomain={[0, maxInsulin]}
         seriesLayout={showStacked ? "stack" : "overlap"}
-        tooltip={{ mode: "bisect-x" }}
+        tooltipContext={{ mode: "bisect-x" }}
         props={{
           xAxis: {
             format: formatHour,

--- a/src/Web/packages/app/src/lib/components/reports/InsulinDonutChart.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/InsulinDonutChart.svelte
@@ -140,7 +140,6 @@
         innerRadius={-30}
         cornerRadius={3}
         padAngle={0.02}
-        renderContext={"svg"}
         onArcClick={handleArcClick}
         props={{
           arc: {

--- a/src/Web/packages/app/src/lib/components/reports/ScheduledBasalRateChart.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/ScheduledBasalRateChart.svelte
@@ -63,7 +63,6 @@
     ]}
     xDomain={[0, 23]}
     yDomain={[0, yMax]}
-    renderContext="svg"
     padding={{ top: 4, right: 20, bottom: 2, left: 20 }}
     props={{
       area: { curve: curveStepAfter, fillOpacity: 0.2 },

--- a/src/Web/packages/app/src/lib/components/reports/SiteChangeImpactChart.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/SiteChangeImpactChart.svelte
@@ -157,7 +157,6 @@
         data={chartData}
         x={(d) => d.minutesFromChange}
         y={(d) => d.medianGlucose}
-        renderContext="svg"
         {xDomain}
         {yDomain}
         series={[
@@ -211,7 +210,7 @@
           },
         ]}
         seriesLayout="overlap"
-        tooltip={{ mode: "bisect-x" }}
+        tooltipContext={{ mode: "bisect-x" }}
         props={{
           area: { motion: { type: "tween", duration: 200 } },
           xAxis: {

--- a/src/Web/packages/app/src/lib/components/reports/TIRStackedChart.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/TIRStackedChart.svelte
@@ -215,7 +215,7 @@
       cDomain={[...rangeKeys]}
       cRange={rangeKeys.map((k) => rangeMeta[k].color)}
       padding={chartPadding}
-      tooltip={{ mode: "band" }}
+      tooltipContext={{ mode: "band" }}
     >
       {#snippet children({ context })}
         {@const rawLabelYs = rangeKeys.map((key) => {

--- a/src/Web/packages/app/src/lib/components/reports/sleep/SleepCompositionChart.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/sleep/SleepCompositionChart.svelte
@@ -149,7 +149,7 @@
           yScale={scaleLinear()}
           yDomain={[0, yMaxMinutes]}
           padding={{ top: 10, right: 8, bottom: 30, left: 40 }}
-          tooltip={{ mode: "manual" }}
+          tooltipContext={{ mode: "manual" }}
         >
           {#snippet children({ context })}
             {@const xBandScale = context.xScale as unknown as ScaleBand<string>}

--- a/src/Web/packages/app/src/lib/components/reports/year-overview/YearHeatmap.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/year-overview/YearHeatmap.svelte
@@ -97,7 +97,7 @@
             "var(--glucose-high)",
             "var(--glucose-very-high)",
           ]}
-          tooltip={{ mode: "manual" }}
+          tooltipContext={{ mode: "manual" }}
         >
           {#snippet children({ context })}
             <Layer type="svg">
@@ -107,7 +107,6 @@
                 cellSize={24}
                 monthPath
                 monthLabel={false}
-                tooltipContext={context.tooltip}
               >
                 {#snippet children({ cells, cellSize })}
                   <!-- Month labels (clickable → calendar) -->

--- a/src/Web/packages/glucose-chart/src/GlucoseChartCard.svelte
+++ b/src/Web/packages/glucose-chart/src/GlucoseChartCard.svelte
@@ -392,7 +392,7 @@
       xDomain={xDomain}
       yDomain={[0, glucoseYMax]}
       padding={{ left: 48, top: 8, bottom: 30, right: 48 }}
-      tooltip={{ mode: 'quadtree-x' }}
+      tooltipContext={{ mode: 'quadtree-x' }}
     >
       {#snippet children({ context })}
         {@const trackHeight = context.height}

--- a/src/Web/packages/ui/src/lib/components/ui/chart/chart-tooltip.svelte
+++ b/src/Web/packages/ui/src/lib/components/ui/chart/chart-tooltip.svelte
@@ -1,12 +1,16 @@
 <script lang="ts">
-  import { cn, type WithElementRef, type WithoutChildren } from "../../../utils";
+  import {
+    cn,
+    type WithElementRef,
+    type WithoutChildren,
+  } from "../../../utils";
   import type { HTMLAttributes } from "svelte/elements";
   import {
     getPayloadConfigFromPayload,
     useChart,
     type TooltipPayload,
   } from "./chart-utils.js";
-  import { getTooltipContext, Tooltip as TooltipPrimitive } from "layerchart";
+  import { getChartContext, Tooltip as TooltipPrimitive } from "layerchart";
   import type { Snippet } from "svelte";
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -37,7 +41,7 @@
     hideIndicator?: boolean;
     labelClassName?: string;
     labelFormatter?: // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    | ((value: any, payload: TooltipPayload[]) => string | number | Snippet)
+      | ((value: any, payload: TooltipPayload[]) => string | number | Snippet)
       | null;
     formatter?: Snippet<
       [
@@ -53,29 +57,46 @@
   } = $props();
 
   const chart = useChart();
-  const tooltipCtx = getTooltipContext();
+  const chartCtx = getChartContext();
+
+  // Filter to series with defined values (important for item-based charts like Pie/Arc
+  // where only the hovered item has a value)
+  const visibleSeries = $derived(
+    chartCtx.tooltip.series.filter((s: TooltipPayload) => s.value !== undefined)
+  );
 
   const formattedLabel = $derived.by(() => {
-    if (hideLabel || !tooltipCtx.payload?.length) return null;
+    if (hideLabel || !visibleSeries?.length) return null;
 
-    const [item] = tooltipCtx.payload;
-    const key = labelKey || item?.label || item?.name || "value";
+    const [item] = visibleSeries;
+    const tooltipData = chartCtx.tooltip.data;
 
-    const itemConfig = getPayloadConfigFromPayload(chart.config, item, key);
+    // Get the x-axis label value from the raw tooltip data (e.g. a Date or month string)
+    const dataLabel = tooltipData != null ? chartCtx.x(tooltipData) : undefined;
 
-    const value =
-      !labelKey && typeof label === "string"
-        ? chart.config[label as keyof typeof chart.config]?.label || label
-        : (itemConfig?.label ?? item.label);
+    const key = labelKey ?? item?.label ?? item?.key ?? "value";
+    const itemConfig = getPayloadConfigFromPayload(
+      chart.config,
+      item,
+      key,
+      tooltipData as Record<string, unknown> | null
+    );
 
-    if (!value) return null;
+    let value: unknown;
+    if (!labelKey && typeof label === "string") {
+      value = chart.config[label as keyof typeof chart.config]?.label ?? label;
+    } else if (labelKey) {
+      value = itemConfig?.label ?? dataLabel;
+    } else {
+      value = dataLabel;
+    }
+
+    if (value === undefined) return null;
     if (!labelFormatter) return value;
-    return labelFormatter(value, tooltipCtx.payload);
+    return labelFormatter(value, visibleSeries);
   });
 
-  const nestLabel = $derived(
-    tooltipCtx.payload.length === 1 && indicator !== "dot"
-  );
+  const nestLabel = $derived(visibleSeries.length === 1 && indicator !== "dot");
 </script>
 
 {#snippet TooltipLabel()}
@@ -92,6 +113,7 @@
 
 <TooltipPrimitive.Root variant="none">
   <div
+    bind:this={ref}
     class={cn(
       "border-border/50 bg-background grid min-w-[9rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl",
       className
@@ -102,27 +124,28 @@
       {@render TooltipLabel()}
     {/if}
     <div class="grid gap-1.5">
-      {#each tooltipCtx.payload as item, i (item.key + i)}
-        {@const key = `${nameKey || item.key || item.name || "value"}`}
+      {#each visibleSeries as item, i (item.key + i)}
+        {@const key = `${nameKey || item.key || item.label || "value"}`}
         {@const itemConfig = getPayloadConfigFromPayload(
           chart.config,
           item,
-          key
+          key,
+          chartCtx.tooltip.data
         )}
-        {@const indicatorColor = color || item.payload?.color || item.color}
+        {@const indicatorColor = color || item.config?.color || item.color}
         <div
           class={cn(
             "[&>svg]:text-muted-foreground flex w-full flex-wrap items-stretch gap-2 [&>svg]:size-2.5",
             indicator === "dot" && "items-center"
           )}
         >
-          {#if formatter && item.value !== undefined && item.name}
+          {#if formatter && item.value !== undefined && item.label}
             {@render formatter({
               value: item.value,
-              name: item.name,
+              name: item.label,
               item,
               index: i,
-              payload: tooltipCtx.payload,
+              payload: visibleSeries,
             })}
           {:else}
             {#if itemConfig?.icon}
@@ -131,7 +154,7 @@
               <div
                 style="--color-bg: {indicatorColor}; --color-border: {indicatorColor};"
                 class={cn(
-                  "border-(--color-border) bg-(--color-bg) shrink-0 rounded-[2px]",
+                  "shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)",
                   {
                     "size-2.5": indicator === "dot",
                     "h-full w-1": indicator === "line",
@@ -153,10 +176,10 @@
                   {@render TooltipLabel()}
                 {/if}
                 <span class="text-muted-foreground">
-                  {itemConfig?.label || item.name}
+                  {itemConfig?.label || item.label}
                 </span>
               </div>
-              {#if item.value}
+              {#if item.value !== undefined}
                 <span
                   class="text-foreground font-mono font-medium tabular-nums"
                 >

--- a/src/Web/packages/ui/src/lib/components/ui/chart/chart-utils.ts
+++ b/src/Web/packages/ui/src/lib/components/ui/chart/chart-utils.ts
@@ -1,66 +1,75 @@
 import type { Tooltip } from "layerchart";
-import { getContext, setContext, type Component, type ComponentProps, type Snippet } from "svelte";
+import { getContext, setContext, type Component, type Snippet } from "svelte";
 
 export const THEMES = { light: "", dark: ".dark" } as const;
 
 export type ChartConfig = {
-	[k in string]: {
-		label?: string;
-		icon?: Component;
-	} & (
-		| { color?: string; theme?: never }
-		| { color?: never; theme: Record<keyof typeof THEMES, string> }
-	);
+  [k in string]: {
+    label?: string;
+    icon?: Component;
+  } & (
+    | { color?: string; theme?: never }
+    | { color?: never; theme: Record<keyof typeof THEMES, string> }
+  );
 };
 
 export type ExtractSnippetParams<T> = T extends Snippet<[infer P]> ? P : never;
 
-export type TooltipPayload = ExtractSnippetParams<
-	ComponentProps<typeof Tooltip.Root>["children"]
->["payload"][number];
+export type TooltipPayload = Tooltip.TooltipSeries;
 
 // Helper to extract item config from a payload.
 export function getPayloadConfigFromPayload(
-	config: ChartConfig,
-	payload: TooltipPayload,
-	key: string
+  config: ChartConfig,
+  payload: TooltipPayload,
+  key: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data?: Record<string, any> | null
 ) {
-	if (typeof payload !== "object" || payload === null) return undefined;
+  if (typeof payload !== "object" || payload === null) return undefined;
 
-	const payloadPayload =
-		"payload" in payload && typeof payload.payload === "object" && payload.payload !== null
-			? payload.payload
-			: undefined;
+  const payloadConfig =
+    "config" in payload &&
+    typeof payload.config === "object" &&
+    payload.config !== null
+      ? payload.config
+      : undefined;
 
-	let configLabelKey: string = key;
+  let configLabelKey: string = key;
 
-	if (payload.key === key) {
-		configLabelKey = payload.key;
-	} else if (payload.name === key) {
-		configLabelKey = payload.name;
-	} else if (key in payload && typeof payload[key as keyof typeof payload] === "string") {
-		configLabelKey = payload[key as keyof typeof payload] as string;
-	} else if (
-		payloadPayload &&
-		key in payloadPayload &&
-		typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
-	) {
-		configLabelKey = payloadPayload[key as keyof typeof payloadPayload] as string;
-	}
+  if (payload.key === key) {
+    configLabelKey = payload.key;
+  } else if (payload.label === key) {
+    configLabelKey = payload.label;
+  } else if (
+    key in payload &&
+    typeof payload[key as keyof typeof payload] === "string"
+  ) {
+    configLabelKey = payload[key as keyof typeof payload] as string;
+  } else if (
+    payloadConfig !== undefined &&
+    key in payloadConfig &&
+    typeof payloadConfig[key as keyof typeof payloadConfig] === "string"
+  ) {
+    configLabelKey = payloadConfig[key as keyof typeof payloadConfig] as string;
+  } else if (data != null && key in data && typeof data[key] === "string") {
+    configLabelKey = data[key] as string;
+  }
 
-	return configLabelKey in config ? config[configLabelKey] : config[key as keyof typeof config];
+  return configLabelKey in config
+    ? config[configLabelKey]
+    : config[key as keyof typeof config];
 }
 
 type ChartContextValue = {
-	config: ChartConfig;
+  config: ChartConfig;
 };
 
 const chartContextKey = Symbol("chart-context");
 
 export function setChartContext(value: ChartContextValue) {
-	return setContext(chartContextKey, value);
+  return setContext(chartContextKey, value);
 }
 
 export function useChart() {
-	return getContext<ChartContextValue>(chartContextKey);
+  return getContext<ChartContextValue>(chartContextKey);
 }


### PR DESCRIPTION
## Summary

The bump from layerchart `2.0.0-next.43` to `2.0.1` stable landed without migrating several call sites to the renamed APIs. Because unknown Svelte props fall into `restProps` and are ignored, none of this errored at runtime — the features just silently stopped working, and `pnpm check` picked up ~20 new type errors.

What was actually broken in the app:

- **Hover tooltips dead** on the dashboard glucose chart, TIR stacked chart, and `GlucoseChartCard` — `<Chart tooltip={{ mode }}>` was renamed to `tooltipContext`, so the context fell back to `mode: 'manual'`.
- **Drag-to-select dead** on `GlucoseChartShell` (alert replay, compression-lows review) — `BrushContext` renamed `xDomain`→`x`, dropped `mode="separated"`, and its event payload is now `{ brush }` (read `e.brush.x`, the same shape `MiniOverviewChart` already uses).
- **Calendar day bars regained an unwanted default tooltip** — `tooltip` on simplified charts is now snippet-only, so `tooltip={false}` no longer suppresses it → `tooltipContext={false}`.
- **AreaChart hit-testing drifted** from `bisect-x` to the `quadtree-x` default on three report charts.

Plus check-time fixes with no behavior change:

- Drop the removed `renderContext="svg"` prop (the agnostic imports already render SVG).
- Annotate series `value` accessor params (stable's types no longer flow `TData` contextually); `AgpDataPoint` is exported from `agp-utils` and reused by the AGP tooltip cast.
- Re-sync `ui/chart` `chart-tooltip.svelte` / `chart-utils.ts` from upstream shadcn-svelte (`getTooltipContext` was removed; tooltip state now lives on `getChartContext().tooltip`).
- Drop the stale `tooltipContext={context.tooltip}` prop from `YearHeatmap`'s `<Calendar>` (cells drive the tooltip manually).

`svelte-check` on `packages/app` goes **64 → 26 errors**; the remainder are pre-existing generated-client noise plus two type errors from the sleep merge, unrelated to layerchart.

## Verification

Ran the stack via `aspire start --isolated` against a seeded sample-data tenant and drove it with Playwright:

- Dashboard tooltip renders with glucose/IOB/COB/basal rows + time-axis tooltip; highlight points and crosshair back.
- AGP percentile tooltip, TIR band tooltip, insulin-delivery `bisect-x` crosshair, and year-heatmap cell tooltip all render.
- Calendar day bars show only the app's own day-summary popover, no layerchart tooltip.
- Overview brush drag re-zooms the main chart (exercises the new `{ brush }` payload end-to-end).
- Zero console errors on every report route.

Also confirmed against the `next.43` dist that `BrushContext`'s domain prop was construction-time-only there too, so the `x={...}` swap preserves semantics.
