### PR TITLE
Dev auto-login: NOCTURNE_DEV_AUTO_LOGIN skips the login page in local dev

### DIFF
--- a/.claude/skills/dev-tenant-api/SKILL.md
+++ b/.claude/skills/dev-tenant-api/SKILL.md
@@ -55,6 +55,21 @@ mkcert the dev cert doesn't name tenant subdomains).
   `{"tenant":"<slug>","username":null}` → token pair JSON. `username` picks a
   specific member; default is the first owner.
 
+## Auto-login (skip the login page entirely)
+
+Start the stack with `NOCTURNE_DEV_AUTO_LOGIN=true` in the AppHost's
+environment (e.g. `NOCTURNE_DEV_AUTO_LOGIN=true aspire start`) and the web
+login page redirects through the dev login endpoint instead of rendering the
+passkey UI. Every auth guard funnels to `/auth/login`, so any tenant URL —
+`https://<slug>.nocturne.localhost:1612/` included — lands signed in as the
+first owner member, with real session cookies. A torn-down-and-reseeded tenant
+re-authenticates transparently on the next navigation.
+
+Leave the flag **off when testing auth itself** (passkey ceremony, logout,
+recovery mode, share links' anonymous view of the login page) — with it on,
+the unauthenticated login UI is unreachable. It only affects browser
+navigation; headless/bearer flows are unchanged.
+
 ## Dev passkey fixture (real authenticator across DB wipes)
 
 `GET /api/v4/dev-only/auth/passkey-fixture` exports registered passkeys

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,11 @@ curl -X POST http://localhost:1610/api/v4/dev-only/admin/seed-tenant \
 # End-to-end smoke of the local stack (seed -> data -> login link -> tenant UI)
 dotnet run scripts/dev-smoke.cs
 
+# Auto-login: start with NOCTURNE_DEV_AUTO_LOGIN=true and the web login page
+# signs in as the tenant's first owner instead of showing the passkey UI
+# (leave off when testing auth itself). See the dev-tenant-api skill.
+NOCTURNE_DEV_AUTO_LOGIN=true aspire start
+
 # Regenerate just the NSwag TypeScript client (force, e.g. during `aspire start` hot loop)
 dotnet build src/API/Nocturne.API/Nocturne.API.csproj -p:GenerateNSwagClient=true
 

--- a/src/Aspire/Nocturne.Aspire.Host/Program.cs
+++ b/src/Aspire/Nocturne.Aspire.Host/Program.cs
@@ -440,6 +440,18 @@ class Program
                 .WithReference(bridge);
 
             ConfigureWebEnvironment(viteWeb);
+
+            // Dev auto-login opt-in: when the host environment sets
+            // NOCTURNE_DEV_AUTO_LOGIN=true (e.g. `NOCTURNE_DEV_AUTO_LOGIN=true
+            // aspire start`), the web login page redirects through
+            // /api/v4/dev-only/auth/login instead of the passkey UI. Run mode
+            // only — the backing controller exists only in Development.
+            var devAutoLogin = Environment.GetEnvironmentVariable("NOCTURNE_DEV_AUTO_LOGIN");
+            if (!string.IsNullOrEmpty(devAutoLogin))
+            {
+                viteWeb.WithEnvironment("NOCTURNE_DEV_AUTO_LOGIN", devAutoLogin);
+            }
+
             if (postgresServer != null && postgresWebPassword != null)
             {
                 viteWeb.WithNocturneWebDatabase(postgresServer, dbName, postgresWebPassword);

--- a/src/Web/packages/app/src/routes/(unauthenticated)/auth/login/+page.server.ts
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/auth/login/+page.server.ts
@@ -1,0 +1,24 @@
+import { redirect } from "@sveltejs/kit";
+import { env } from "$env/dynamic/private";
+import type { PageServerLoad } from "./$types";
+
+// Dev auto-login. With NOCTURNE_DEV_AUTO_LOGIN=true (forwarded from the host
+// environment by the Aspire AppHost, run mode only), the login page redirects
+// through the dev-only session endpoint instead of rendering the passkey UI.
+// Every auth guard funnels to /auth/login?returnUrl=..., so this one hook
+// covers all of them: the endpoint issues a real session for the tenant's
+// first owner member, sets the normal cookies, and bounces back to returnUrl.
+// The endpoint exists only when the API runs in Development; elsewhere the
+// redirect lands on a 404, never a session.
+export const load: PageServerLoad = async ({ url, locals }) => {
+  if (env.NOCTURNE_DEV_AUTO_LOGIN !== "true") return;
+
+  const raw = url.searchParams.get("returnUrl") || "/";
+  // Same-origin paths only, mirroring the endpoint's own IsLocalUrl guard.
+  const returnUrl = raw.startsWith("/") && !raw.startsWith("//") ? raw : "/";
+
+  if (locals.isAuthenticated) {
+    redirect(303, returnUrl);
+  }
+  redirect(303, `/api/v4/dev-only/auth/login?redirect=${encodeURIComponent(returnUrl)}`);
+};

--- a/src/Web/packages/app/src/routes/(unauthenticated)/auth/login/+page.server.ts
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/auth/login/+page.server.ts
@@ -14,8 +14,10 @@ export const load: PageServerLoad = async ({ url, locals }) => {
   if (env.NOCTURNE_DEV_AUTO_LOGIN !== "true") return;
 
   const raw = url.searchParams.get("returnUrl") || "/";
-  // Same-origin paths only, mirroring the endpoint's own IsLocalUrl guard.
-  const returnUrl = raw.startsWith("/") && !raw.startsWith("//") ? raw : "/";
+  // Same-origin paths only, mirroring the endpoint's IsLocalUrl guard: a
+  // second "/" or "\" would be a protocol-relative URL (browsers normalize
+  // "/\" to "//" in Location headers).
+  const returnUrl = /^\/(?![/\\])/.test(raw) ? raw : "/";
 
   if (locals.isAuthenticated) {
     redirect(303, returnUrl);


### PR DESCRIPTION
## What

Opt-in dev-mode auto-login. Start the stack with `NOCTURNE_DEV_AUTO_LOGIN=true aspire start` and the web login page redirects through the existing `/api/v4/dev-only/auth/login` endpoint instead of rendering the passkey UI.

## Why

Local testing of anything unrelated to auth pays the passkey/session ceremony repeatedly: tenants are constantly torn down and re-seeded, invalidating cookies, and every auth guard bounces to the login page. Since all guards funnel to `/auth/login?returnUrl=...`, one server-load hook there covers them all: the dev endpoint issues a real session (first owner member) via `ISessionService`, sets the normal cookies, and bounces back to `returnUrl` — so the full session/tenant-resolution/RLS path is still exercised exactly as in production, with zero manual steps.

## Design notes

- **Opt-in, not always-on in Development** — with the flag on, the unauthenticated login UI is unreachable, which would break testing the passkey ceremony, logout, recovery mode, and share links. Flip it off when auth is the thing under test.
- **Composes with the existing dev endpoint** rather than duplicating member selection or session issuance; the AppHost forwards the host env var in run mode only, and the backing controller exists only in Development, so a stray flag elsewhere lands on a 404, never a session.
- `returnUrl` is clamped to same-origin paths, mirroring the endpoint's `Url.IsLocalUrl` guard.

## Changes

- `src/Web/.../auth/login/+page.server.ts` (new) — redirect when the flag is set; already-authenticated visitors go straight to `returnUrl`.
- `src/Aspire/Nocturne.Aspire.Host/Program.cs` — forward `NOCTURNE_DEV_AUTO_LOGIN` from the host environment to the vite web app (run mode only).
- `.claude/skills/dev-tenant-api/SKILL.md`, `CLAUDE.md` — document the flag.

## Verification

- AppHost builds clean; `pnpm run check` shows no errors in the new file (the 28 existing errors are all pre-existing, in the stale gitignored generated client and unrelated components).