### PR TITLE
fix(web): render glucose/actogram points as one data-mode mark (O(N^2) load stall)

### DIFF
--- a/src/Web/packages/app/src/lib/components/actogram/ActogramRow.svelte
+++ b/src/Web/packages/app/src/lib/components/actogram/ActogramRow.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
-  import { Chart, Svg, Spline, Points, Circle, Tooltip } from 'layerchart';
+  import { Chart, Svg, Spline, Circle, Tooltip } from 'layerchart';
   import { scaleTime } from 'd3-scale';
   import type { ScaleTime } from 'd3-scale';
   import { curveMonotoneX } from 'd3';
@@ -79,19 +79,19 @@
           class="stroke-muted-foreground/50 fill-none"
           strokeWidth={1.5}
         />
-        <Points data={bgChartData} x={(d) => d.time} y={(d) => d.sgv} r={2}>
-          {#snippet children({ points })}
-            {#each points as point (point.data.time)}
-              <Circle
-                cx={point.x}
-                cy={point.y}
-                r={point.r}
-                fill={point.data.color}
-                class="opacity-80"
-              />
-            {/each}
-          {/snippet}
-        </Points>
+        <!-- One data-mode Circle for the whole row, not a Circle per reading:
+             each layerchart mark registers with the chart and every
+             registration re-runs the chart's mark deriveds, so N points cost
+             O(N^2). Data mode renders all points from a single mark. -->
+        <Circle
+          data={bgChartData}
+          key={(d) => d.time}
+          cx={(d) => d.time}
+          cy={(d) => d.sgv}
+          r={2}
+          fill={(d) => d.color}
+          class="opacity-80"
+        />
       {/if}
 
       <!-- Dimming overlay for the extended (24–48h) half (top layer) -->

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/tracks/GlucoseTrack.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/tracks/GlucoseTrack.svelte
@@ -2,7 +2,7 @@
   import {
     Spline,
     Area,
-    Points,
+    Circle,
     Axis,
     LinearGradient,
     ChartClipPath,
@@ -162,15 +162,19 @@
   {/if}
 
   {#if effectiveShowPoints}
-    {#each glucoseData as point (point.time.getTime())}
-      <Points
-        data={[point]}
-        x={(d) => d.time}
-        y={(d) => glucoseScale(d.sgv)}
-        r={3}
-        fill={pointFill(point.sgv)}
-        class="opacity-90"
-      />
-    {/each}
+    <!-- Single data-mode Circle instead of one <Points> per reading: layerchart
+         marks each register with the chart on mount and every registration
+         re-runs the chart's mark-dependent deriveds over all marks, so N points
+         cost O(N^2) synchronous work. Data mode renders the whole series from
+         one mark with a per-point fill accessor. -->
+    <Circle
+      data={glucoseData}
+      key={(d) => d.time.getTime()}
+      cx={(d) => d.time}
+      cy={(d) => glucoseScale(d.sgv)}
+      r={3}
+      fill={(d) => pointFill(d.sgv)}
+      class="opacity-90"
+    />
   {/if}
 </ChartClipPath>

--- a/src/Web/packages/app/vite.config.ts
+++ b/src/Web/packages/app/vite.config.ts
@@ -50,6 +50,13 @@ export default defineConfig(({ mode }) => {
       // Node can't resolve from pnpm's isolated store, so bundle them for SSR.
       noExternal: ["@resend/chat-sdk-adapter", "layerchart", /^@layerstack\//],
     },
+    optimizeDeps: {
+      // sveltekit-search-params is only imported by the dashboard's
+      // date-range-picker, so Vite doesn't discover it during startup crawl
+      // and re-optimizes mid-navigation on first dashboard load — a multi-second
+      // stall followed by a forced full reload. Pre-bundle it at server start.
+      include: ["sveltekit-search-params"],
+    },
     plugins: [
       tailwindcss(),
       sveltekit(),


### PR DESCRIPTION
## Problem

The dashboard took tens of seconds to load. A Firefox profile of production showed the JS main thread jammed for **~37s in a single synchronous Svelte `flush`** while the network sat idle — every remote-function response returned in <1.3s at the transport layer but the content process couldn't process any of them until the flush finished (they all unblocked at the same instant). The hot symbol was layerchart's `_markInfosVersion`.

## Root cause

In **layerchart 2.0.1**, every mark component (`<Points>`, `<Circle>`, `<Rect>`, …) calls `registerMark()` on mount, bumping a reactive `_markInfosVersion`. Chart deriveds that read `_markInfos` (e.g. `implicitSeries`) loop over **all** marks on every bump, so rendering N marks is O(N²). `<Points>` is not a shortcut — it internally renders one `<Circle>` per datum.

Two charts fed it one mark per datum:
- `GlucoseTrack` — one `<Points data={[point]}>` per reading (~576 over the 48h window)
- `ActogramRow` — one `<Circle>` per reading, per day-row

## Fix

Render the whole series from a single **data-mode** `<Circle data={…} cx={} cy={} r={} fill={} key={} />`: one registration instead of N, with per-point accessors. Coordinate math is unchanged — the chart's x/y scales are applied to the `cx`/`cy` accessors exactly as `<Points>` applied them to `x`/`y`.

## Scope / follow-ups

- `YearHeatmap` has the same shape (~366 `<Rect>` cells) but each cell's `onpointermove`/`onclick` needs its own `cell.data`, and Rect data-mode spreads a single `{...rest}` (handlers included) across all items — collapsing it needs a hit-test-overlay refactor, left as a follow-up.
- Also pre-bundles `sveltekit-search-params` via `optimizeDeps.include` so the Vite **dev** server stops re-optimizing it mid-navigation on first dashboard load (dev-only; no effect on the production build).

`pnpm run check` passes on the changed files.