### PR TITLE
fix(web): eliminate layerchart 2.0.1 O(N²) mark registration across charts

### DIFF
--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/GlucoseResponseChart.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/GlucoseResponseChart.svelte
@@ -4,7 +4,7 @@
     Svg,
     Spline,
     Rule,
-    Points,
+    Circle,
     Text,
     Axis,
     ChartClipPath,
@@ -145,17 +145,17 @@
             curve={curveMonotoneX}
           />
 
-          <!-- Glucose points -->
-          {#each glucoseData as point}
-            <Points
-              data={[point]}
-              x={(d: GlucoseDataPoint) => d.time}
-              y="sgv"
-              r={3}
-              fill={point.color}
-              class="opacity-90"
-            />
-          {/each}
+          <!-- Glucose points: one data-mode Circle for the whole series (single
+               mark registration) instead of one <Points> per reading (O(N^2)). -->
+          <Circle
+            data={glucoseData}
+            key={(d: GlucoseDataPoint) => d.time.getTime()}
+            cx={(d: GlucoseDataPoint) => d.time}
+            cy="sgv"
+            r={3}
+            fill={(d: GlucoseDataPoint) => d.color}
+            class="opacity-90"
+          />
 
           <!-- Prediction curves (main only for mini chart) -->
           {#if predictionData && predictionCurveData.length > 0}

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/BasalInjectionMarker.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/BasalInjectionMarker.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Group, Rect, Text } from "layerchart";
+  import { Group } from "layerchart";
   import { Syringe } from "lucide-svelte";
 
   interface Props {
@@ -15,25 +15,26 @@
   const lineHeight = $derived(lineBottom - lineTop);
 </script>
 
-<!-- Dashed vertical line spanning the chart height -->
+<!-- Native SVG throughout: layerchart 2.x marks each call registerMark(), and this
+     marker renders once per basal injection, so a per-segment Rect loop cost O(N^2).
+     A single dashed <line> plus native pill/label/hit-area register nothing. -->
 <Group x={xPos} y={lineTop}>
-  {#each { length: Math.floor(lineHeight / 8) } as _, i (i)}
-    {#if i % 2 === 0}
-      <Rect
-        x={-0.75}
-        y={i * 8}
-        width={1.5}
-        height={4}
-        class="fill-indigo-500/60 dark:fill-indigo-400/60"
-      />
-    {/if}
-  {/each}
+  <!-- Dashed vertical line spanning the chart height -->
+  <line
+    x1={0}
+    y1={0}
+    x2={0}
+    y2={lineHeight}
+    stroke-width={1.5}
+    stroke-dasharray="4 4"
+    class="stroke-indigo-500/60 dark:stroke-indigo-400/60"
+  />
 </Group>
 
 <!-- Icon and label at the top -->
 <Group x={xPos} y={lineTop - 2}>
   <!-- Background pill -->
-  <Rect
+  <rect
     x={-26}
     y={-9}
     width={52}
@@ -51,21 +52,21 @@
     </div>
   </foreignObject>
   <!-- Units label -->
-  <Text
+  <text
     x={2}
     y={0}
-    textAnchor="start"
+    text-anchor="start"
     class="text-[8px] font-medium"
     fill="var(--color-indigo-600)"
     dy="0.35em"
   >
     {units.toFixed(1)}U
-  </Text>
+  </text>
 </Group>
 
 <!-- Tooltip-style hover area -->
 <Group x={xPos} y={lineTop}>
-  <Rect
+  <rect
     x={-8}
     y={0}
     width={16}
@@ -77,5 +78,5 @@
     {:else}
       <title>{units.toFixed(1)}U basal injection</title>
     {/if}
-  </Rect>
+  </rect>
 </Group>

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/tracks/SwimLaneTrack.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/tracks/SwimLaneTrack.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
-  import { Rect, Text, Group, ChartClipPath, getChartContext } from "layerchart";
+  import { ChartClipPath, getChartContext } from "layerchart";
   import { PumpModeIcon, ActivityCategoryIcon } from "$lib/components/icons";
   import { getGlucoseChartContext } from "../chart-context.svelte";
 
+  // Native SVG throughout: every span already carries pre-scaled pixel
+  // coordinates, and layerchart marks each call registerMark() on mount, so one
+  // <Rect>/<Text> per span cost O(N^2) across the chart's mark deriveds. Native
+  // <rect>/<text>/<g> register nothing while rendering identically.
   const ctx = getGlucoseChartContext();
   const chartCtx = getChartContext();
 
@@ -18,7 +22,7 @@
   {@const lane = swimLanePositions.pumpMode}
   <ChartClipPath>
     <!-- Lane background -->
-    <Rect
+    <rect
       x={0}
       y={lane.top}
       width={chartCtx.width}
@@ -27,17 +31,18 @@
       class="opacity-20"
     />
     <!-- Lane label -->
-    <Text
+    <text
       x={4}
       y={lane.top + (lane.bottom - lane.top) / 2 + 3}
+      dy="-0.355em"
       class="text-[7px] fill-muted-foreground font-medium"
     >
       MODE
-    </Text>
+    </text>
     <!-- Pump mode spans -->
     {#each pumpModeSpans as span (span.id)}
       {@const spanXPos = chartCtx.xScale(span.displayStart)}
-      <Rect
+      <rect
         x={spanXPos}
         y={lane.top + 1}
         width={chartCtx.xScale(span.displayEnd) - spanXPos}
@@ -47,13 +52,13 @@
         rx="2"
       />
       <!-- Icon at start of span -->
-      <Group x={spanXPos} y={lane.top + (lane.bottom - lane.top) / 2}>
+      <g transform="translate({spanXPos}, {lane.top + (lane.bottom - lane.top) / 2})">
         <foreignObject x="2" y="-6" width="12" height="12">
           <div class="flex items-center justify-center w-full h-full">
             <PumpModeIcon state={span.state ?? ""} size={10} color={span.color} />
           </div>
         </foreignObject>
-      </Group>
+      </g>
     {/each}
   </ChartClipPath>
 {/if}
@@ -63,7 +68,7 @@
   {@const lane = swimLanePositions.override}
   <ChartClipPath>
     <!-- Lane background -->
-    <Rect
+    <rect
       x={0}
       y={lane.top}
       width={chartCtx.width}
@@ -72,17 +77,18 @@
       class="opacity-20"
     />
     <!-- Lane label -->
-    <Text
+    <text
       x={4}
       y={lane.top + (lane.bottom - lane.top) / 2 + 3}
+      dy="-0.355em"
       class="text-[7px] fill-muted-foreground font-medium"
     >
       OVERRIDE
-    </Text>
+    </text>
     <!-- Override spans -->
     {#each overrideSpans as span (span.id)}
       {@const spanXPos = chartCtx.xScale(span.displayStart)}
-      <Rect
+      <rect
         x={spanXPos}
         y={lane.top + 1}
         width={chartCtx.xScale(span.displayEnd) - spanXPos}
@@ -92,13 +98,14 @@
         rx="2"
       />
       <!-- State label -->
-      <Text
+      <text
         x={spanXPos + 4}
         y={lane.top + (lane.bottom - lane.top) / 2 + 3}
+        dy="-0.355em"
         class="text-[6px] fill-foreground font-medium"
       >
         {span.state}
-      </Text>
+      </text>
     {/each}
   </ChartClipPath>
 {/if}
@@ -108,7 +115,7 @@
   {@const lane = swimLanePositions.profile}
   <ChartClipPath>
     <!-- Lane background -->
-    <Rect
+    <rect
       x={0}
       y={lane.top}
       width={chartCtx.width}
@@ -117,17 +124,18 @@
       class="opacity-20"
     />
     <!-- Lane label -->
-    <Text
+    <text
       x={4}
       y={lane.top + (lane.bottom - lane.top) / 2 + 3}
+      dy="-0.355em"
       class="text-[7px] fill-muted-foreground font-medium"
     >
       PROFILE
-    </Text>
+    </text>
     <!-- Profile spans -->
     {#each profileSpans as span (span.id)}
       {@const spanXPos = chartCtx.xScale(span.displayStart)}
-      <Rect
+      <rect
         x={spanXPos}
         y={lane.top + 1}
         width={chartCtx.xScale(span.displayEnd) - spanXPos}
@@ -137,13 +145,14 @@
         rx="2"
       />
       <!-- Profile name label -->
-      <Text
+      <text
         x={spanXPos + 4}
         y={lane.top + (lane.bottom - lane.top) / 2 + 3}
+        dy="-0.355em"
         class="text-[6px] fill-foreground font-medium"
       >
         {span.profileName}
-      </Text>
+      </text>
     {/each}
   </ChartClipPath>
 {/if}
@@ -153,7 +162,7 @@
   {@const lane = swimLanePositions.activity}
   <ChartClipPath>
     <!-- Lane background -->
-    <Rect
+    <rect
       x={0}
       y={lane.top}
       width={chartCtx.width}
@@ -162,17 +171,18 @@
       class="opacity-10"
     />
     <!-- Lane label -->
-    <Text
+    <text
       x={4}
       y={lane.top + (lane.bottom - lane.top) / 2 + 3}
+      dy="-0.355em"
       class="text-[7px] fill-muted-foreground font-medium"
     >
       ACTIVITY
-    </Text>
+    </text>
     <!-- All activity spans rendered in the same lane -->
     {#each activitySpans as span (span.id)}
       {@const spanXPos = chartCtx.xScale(span.displayStart)}
-      <Rect
+      <rect
         x={spanXPos}
         y={lane.top + 1}
         width={chartCtx.xScale(span.displayEnd) - spanXPos}
@@ -182,13 +192,13 @@
         rx="2"
       />
       <!-- Icon at start -->
-      <Group x={spanXPos} y={lane.top + (lane.bottom - lane.top) / 2}>
+      <g transform="translate({spanXPos}, {lane.top + (lane.bottom - lane.top) / 2})">
         <foreignObject x="2" y="-6" width="12" height="12">
           <div class="flex items-center justify-center w-full h-full">
             <ActivityCategoryIcon kind={span.kind} category={span.category} size={10} color={span.color} />
           </div>
         </foreignObject>
-      </Group>
+      </g>
     {/each}
   </ChartClipPath>
 {/if}

--- a/src/Web/packages/app/src/lib/components/dashboard/state-spans-timeline/state-spans-timeline.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/state-spans-timeline/state-spans-timeline.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Chart, Svg, Axis, Rect, Text, Group } from "layerchart";
+  import { Chart, Svg, Axis } from "layerchart";
   import { scaleTime, scaleLinear } from "d3-scale";
   import { PumpModeIcon, ActivityCategoryIcon } from "$lib/components/icons";
   import { BasalRateTrack } from "$lib/components/charts";
@@ -141,11 +141,15 @@
     >
       {#snippet children({ context })}
         <Svg>
-        <!-- Standard category tracks (non-basal) -->
+        <!-- Native SVG throughout: every span carries pre-scaled pixel
+             coordinates, and layerchart marks each call registerMark() on mount,
+             so one <Rect> per span cost O(N^2) across the chart's mark deriveds.
+             Native <rect>/<text>/<g> keep the per-span hover handlers while
+             registering nothing. -->
         {#each standardTracks as track, i (track.key)}
           {@const yPos = i * TRACK_HEIGHT + 5}
           <!-- Track background -->
-          <Rect
+          <rect
             x={context.xScale(dateRange.from)}
             y={yPos}
             width={context.xScale(dateRange.to) - context.xScale(dateRange.from)}
@@ -154,19 +158,21 @@
             class="opacity-20"
           />
           <!-- Track label -->
-          <Text
+          <text
             x={-LABEL_WIDTH + 8}
             y={yPos + TRACK_HEIGHT / 2 + 4}
+            dy="-0.355em"
             class="text-[10px] fill-muted-foreground font-medium"
           >
             {track.label}
-          </Text>
+          </text>
 
           <!-- Span bars for this track -->
           {#each track.spans as span (span.id)}
             {@const xStartPx = context.xScale(span.startTime)}
             {@const xEndPx = context.xScale(span.endTime)}
-            <Rect
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
+            <rect
               x={xStartPx}
               y={yPos + 2}
               width={xEndPx - xStartPx}
@@ -189,39 +195,41 @@
             />
             <!-- Icon/label at start of span -->
             {#if track.key === "pumpMode"}
-              <Group x={xStartPx} y={yPos + TRACK_HEIGHT / 2}>
+              <g transform="translate({xStartPx}, {yPos + TRACK_HEIGHT / 2})">
                 <foreignObject x={4} y={-8} width={16} height={16}>
                   <div class="flex items-center justify-center w-full h-full">
                     <PumpModeIcon state={span.state} size={14} color={span.color} />
                   </div>
                 </foreignObject>
-              </Group>
+              </g>
             {:else if track.key === "activity"}
-              <Group x={xStartPx} y={yPos + TRACK_HEIGHT / 2}>
+              <g transform="translate({xStartPx}, {yPos + TRACK_HEIGHT / 2})">
                 <foreignObject x={4} y={-8} width={16} height={16}>
                   <div class="flex items-center justify-center w-full h-full">
                     <ActivityCategoryIcon category={span.category} size={14} color={span.color} />
                   </div>
                 </foreignObject>
-              </Group>
+              </g>
             {:else if track.key === "profile" && span.profileName}
-              <Text
+              <text
                 x={xStartPx}
                 y={yPos + TRACK_HEIGHT / 2 + 4}
                 dx={6}
+                dy="-0.355em"
                 class="text-[9px] fill-foreground font-medium pointer-events-none"
               >
                 {span.profileName}
-              </Text>
+              </text>
             {:else if track.key === "override"}
-              <Text
+              <text
                 x={xStartPx}
                 y={yPos + TRACK_HEIGHT / 2 + 4}
                 dx={6}
+                dy="-0.355em"
                 class="text-[9px] fill-foreground font-medium pointer-events-none"
               >
                 {span.state}
-              </Text>
+              </text>
             {/if}
           {/each}
         {/each}
@@ -229,7 +237,7 @@
         <!-- Basal delivery track using BasalRateTrack component -->
         {#if showTempBasals}
           <!-- Track background -->
-          <Rect
+          <rect
             x={context.xScale(dateRange.from)}
             y={basalTrackTop}
             width={context.xScale(dateRange.to) - context.xScale(dateRange.from)}

--- a/src/Web/packages/app/src/lib/components/reports/HourlyGlucoseBoxChart.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/HourlyGlucoseBoxChart.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Chart, Axis, Svg, Tooltip, Line, Rect, Group } from "layerchart";
+  import { Chart, Axis, Svg, Tooltip } from "layerchart";
   import { bgValue, bgLabel } from "$lib/utils/formatting";
 
   interface HourlyBoxPlotData {
@@ -70,6 +70,10 @@
 
     return [Math.max(0, minVal - padding), maxVal + padding];
   });
+
+  // Box occupies 0.8 of an hour slot; whisker caps are ~1.5% of the plot width.
+  const BOX_HALF_HOURS = 0.4;
+  const CAP_WIDTH_FRACTION = 0.015;
 </script>
 
 <div class="w-full h-96">
@@ -81,171 +85,162 @@
       {yDomain}
       xDomain={[0, 23]}
       padding={{ top: 20, right: 30, bottom: 60, left: 60 }}
+      tooltipContext={{ mode: "bisect-x" }}
     >
-      <Svg>
-        <!-- Y-axis with glucose threshold Lines -->
-        <Axis placement="left" rule grid label={`Glucose (${bgLabel()})`} />
-        <Axis
-          placement="bottom"
-          rule
-          label="Hour of Day"
-          format={formatHour}
-          ticks={[0, 3, 6, 9, 12, 15, 18, 21]}
-        />
-        <!-- Target range background -->
-        <Group class="target-ranges">
-          <!-- Target range (70-180 mg/dL, plotted in display units) -->
-          <Rect
-            x={-0.5}
-            y={bgValue(70)}
-            width={24}
-            height={bgValue(180) - bgValue(70)}
-            fill="hsl(var(--success))"
-            fill-opacity="0.1"
-          />
-          <!-- High Line (180) -->
-          <Line
-            {...{
-              x1: "0%",
-              x2: "100%",
-              y1: bgValue(180),
-              y2: bgValue(180),
-              stroke: "hsl(var(--destructive))",
-              "stroke-width": "1",
-              "stroke-dasharray": "5,5",
-              opacity: 0.7,
-            } as any}
+      {#snippet children({ context })}
+        {@const boxHalfWidth = Math.abs(
+          context.xScale(BOX_HALF_HOURS) - context.xScale(0),
+        )}
+        {@const capHalfWidth = context.width * CAP_WIDTH_FRACTION}
+        <Svg>
+          <!-- Y-axis with glucose threshold reference -->
+          <Axis placement="left" rule grid label={`Glucose (${bgLabel()})`} />
+          <Axis
+            placement="bottom"
+            rule
+            label="Hour of Day"
+            format={formatHour}
+            ticks={[0, 3, 6, 9, 12, 15, 18, 21]}
           />
 
-          <!-- Low line (70) -->
-          <Line
-            {...{
-              x1: "0%",
-              x2: "100%",
-              y1: bgValue(70),
-              y2: bgValue(70),
-              stroke: "hsl(var(--destructive))",
-              "stroke-width": "1",
-              "stroke-dasharray": "5,5",
-              opacity: 0.7,
-            } as any}
-          />
-        </Group>
-        <!-- Custom box plots -->
-        <Group class="box-plots">
-          {#each chartData as data}
-            {@const boxWidth = 0.8}
-            {@const xPosition = (data.hour / 23) * 100}
-            {@const boxWidthPercent = (boxWidth / 24) * 100}
-
-            <!-- Box (IQR) -->
-            <Rect
-              {...{
-                x: `${xPosition - boxWidthPercent / 2}%`,
-                y: data.q1,
-                width: `${boxWidthPercent}%`,
-                height: data.q3 - data.q1,
-                fill: "hsl(var(--primary))",
-                "fill-opacity": "0.3",
-                stroke: "hsl(var(--primary))",
-                "stroke-width": "2",
-              } as any}
+          <!-- Target range + threshold lines. Native SVG positioned through the
+               chart scales: layerchart marks each call registerMark() on mount and
+               every registration re-runs the chart's mark deriveds over all marks,
+               so the box-plot geometry (7 marks x 24 hours) cost O(N^2). Native
+               elements register nothing. (The prior <Rect>/<Line> also passed
+               percentage-string coords, which silently forced data mode.) -->
+          <g class="target-ranges">
+            <rect
+              x={0}
+              y={context.yScale(bgValue(180))}
+              width={context.width}
+              height={context.yScale(bgValue(70)) - context.yScale(bgValue(180))}
+              fill="hsl(var(--success))"
+              fill-opacity="0.1"
             />
-
-            <!-- Median line -->
-            <Line
-              {...{
-                x1: `${xPosition - boxWidthPercent / 2}%`,
-                x2: `${xPosition + boxWidthPercent / 2}%`,
-                y1: data.median,
-                y2: data.median,
-                stroke: "hsl(var(--primary))",
-                "stroke-width": "3",
-              } as any}
+            <line
+              x1={0}
+              x2={context.width}
+              y1={context.yScale(bgValue(180))}
+              y2={context.yScale(bgValue(180))}
+              stroke="hsl(var(--destructive))"
+              stroke-width="1"
+              stroke-dasharray="5,5"
+              opacity="0.7"
             />
-
-            <!-- Upper whisker -->
-            <Line
-              {...{
-                x1: `${xPosition}%`,
-                x2: `${xPosition}%`,
-                y1: data.q3,
-                y2: data.max,
-                stroke: "hsl(var(--primary))",
-                "stroke-width": "1",
-              } as any}
+            <line
+              x1={0}
+              x2={context.width}
+              y1={context.yScale(bgValue(70))}
+              y2={context.yScale(bgValue(70))}
+              stroke="hsl(var(--destructive))"
+              stroke-width="1"
+              stroke-dasharray="5,5"
+              opacity="0.7"
             />
+          </g>
 
-            <!-- Lower whisker -->
-            <Line
-              {...{
-                x1: `${xPosition}%`,
-                x2: `${xPosition}%`,
-                y1: data.q1,
-                y2: data.min,
-                stroke: "hsl(var(--primary))",
-                "stroke-width": "1",
-              } as any}
-            />
+          <!-- Box plots -->
+          <g class="box-plots">
+            {#each chartData as data (data.hour)}
+              {@const cx = context.xScale(data.hour)}
+              {@const yQ1 = context.yScale(data.q1)}
+              {@const yQ3 = context.yScale(data.q3)}
+              {@const yMedian = context.yScale(data.median)}
+              {@const yMin = context.yScale(data.min)}
+              {@const yMax = context.yScale(data.max)}
 
-            <!-- Whisker caps -->
-            <Line
-              {...{
-                x1: `${xPosition - 1.5}%`,
-                x2: `${xPosition + 1.5}%`,
-                y1: data.max,
-                y2: data.max,
-                stroke: "hsl(var(--primary))",
-                "stroke-width": "1",
-              } as any}
-            />
-
-            <Line
-              {...{
-                x1: `${xPosition - 1.5}%`,
-                x2: `${xPosition + 1.5}%`,
-                y1: data.min,
-                y2: data.min,
-                stroke: "hsl(var(--primary))",
-                "stroke-width": "1",
-              } as any}
-            />
-
-            <!-- Outliers -->
-            {#each data.outliers as outlier}
-              <circle
-                cx={`${xPosition}%`}
-                cy={outlier}
-                r="2"
-                fill="hsl(var(--destructive))"
-                stroke="hsl(var(--destructive))"
+              <!-- Box (IQR) -->
+              <rect
+                x={cx - boxHalfWidth}
+                y={yQ3}
+                width={boxHalfWidth * 2}
+                height={yQ1 - yQ3}
+                fill="hsl(var(--primary))"
+                fill-opacity="0.3"
+                stroke="hsl(var(--primary))"
+                stroke-width="2"
+              />
+              <!-- Median line -->
+              <line
+                x1={cx - boxHalfWidth}
+                x2={cx + boxHalfWidth}
+                y1={yMedian}
+                y2={yMedian}
+                stroke="hsl(var(--primary))"
+                stroke-width="3"
+              />
+              <!-- Upper whisker -->
+              <line
+                x1={cx}
+                x2={cx}
+                y1={yQ3}
+                y2={yMax}
+                stroke="hsl(var(--primary))"
                 stroke-width="1"
               />
+              <!-- Lower whisker -->
+              <line
+                x1={cx}
+                x2={cx}
+                y1={yQ1}
+                y2={yMin}
+                stroke="hsl(var(--primary))"
+                stroke-width="1"
+              />
+              <!-- Whisker caps -->
+              <line
+                x1={cx - capHalfWidth}
+                x2={cx + capHalfWidth}
+                y1={yMax}
+                y2={yMax}
+                stroke="hsl(var(--primary))"
+                stroke-width="1"
+              />
+              <line
+                x1={cx - capHalfWidth}
+                x2={cx + capHalfWidth}
+                y1={yMin}
+                y2={yMin}
+                stroke="hsl(var(--primary))"
+                stroke-width="1"
+              />
+              <!-- Outliers -->
+              {#each data.outliers as outlier}
+                <circle
+                  cx={cx}
+                  cy={context.yScale(outlier)}
+                  r="2"
+                  fill="hsl(var(--destructive))"
+                  stroke="hsl(var(--destructive))"
+                  stroke-width="1"
+                />
+              {/each}
             {/each}
-          {/each}
-        </Group>
+          </g>
 
-        <!-- Tooltip -->
-        <Tooltip.Root
-          class="bg-popover text-popover-foreground p-3 rounded-md shadow-lg border"
-        >
-          {#snippet children({ data })}
-            <div class="space-y-1">
-              <div class="font-semibold">{formatHour(data.hour)}</div>
-              <div class="grid grid-cols-2 gap-x-3 gap-y-1 text-sm">
-                <div>Max: {data.max}</div>
-                <div>Q3: {data.q3}</div>
-                <div>Median: {data.median}</div>
-                <div>Q1: {data.q1}</div>
-                <div>Min: {data.min}</div>
-                {#if data.outliers.length > 0}
-                  <div class="col-span-2">Outliers: {data.outliers.length}</div>
-                {/if}
+          <!-- Tooltip -->
+          <Tooltip.Root
+            class="bg-popover text-popover-foreground p-3 rounded-md shadow-lg border"
+          >
+            {#snippet children({ data })}
+              <div class="space-y-1">
+                <div class="font-semibold">{formatHour(data.hour)}</div>
+                <div class="grid grid-cols-2 gap-x-3 gap-y-1 text-sm">
+                  <div>Max: {data.max}</div>
+                  <div>Q3: {data.q3}</div>
+                  <div>Median: {data.median}</div>
+                  <div>Q1: {data.q1}</div>
+                  <div>Min: {data.min}</div>
+                  {#if data.outliers.length > 0}
+                    <div class="col-span-2">Outliers: {data.outliers.length}</div>
+                  {/if}
+                </div>
               </div>
-            </div>
-          {/snippet}
-        </Tooltip.Root>
-      </Svg>
+            {/snippet}
+          </Tooltip.Root>
+        </Svg>
+      {/snippet}
     </Chart>
   {:else}
     <div class="flex items-center justify-center h-full text-muted-foreground">
@@ -265,11 +260,11 @@
     pointer-events: none;
   }
 
-  :global(.box-plots Rect:hover) {
+  :global(.box-plots rect:hover) {
     fill-opacity: 0.5;
   }
 
-  :global(.box-plots Line:hover) {
+  :global(.box-plots line:hover) {
     stroke-width: 2;
   }
 </style>

--- a/src/Web/packages/app/src/lib/components/reports/sleep/SleepCompositionChart.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/sleep/SleepCompositionChart.svelte
@@ -5,7 +5,7 @@
    * calendar day across the full selected range (gaps for days with no
    * recorded night), plus a compact stage-composition reference panel.
    */
-  import { Chart, Svg, Axis, Rect, Tooltip } from "layerchart";
+  import { Chart, Svg, Axis, Tooltip } from "layerchart";
   import { scaleBand, scaleLinear, type ScaleBand } from "d3-scale";
   import { goto } from "$app/navigation";
   import { resolve } from "$app/paths";
@@ -162,13 +162,17 @@
                 format={(v: number) => `${Math.round(v / 60)}h`}
               />
               <Axis placement="bottom" rule ticks={xTickKeys} format={formatDayTick} />
-              <!-- Stacked stage segments -->
+              <!-- Stacked stage segments. Native SVG: layerchart marks each call
+                   registerMark() on mount and every registration re-runs the
+                   chart's mark deriveds over all marks, so days x segments rects
+                   cost O(N^2). Coordinates are already pixel-space, so native
+                   <rect> renders identically and registers nothing. -->
               {#each dayRows as row (row.dayKey)}
                 {@const xPos = xBandScale(row.dayKey) ?? 0}
                 {@const bandwidth = xBandScale.bandwidth()}
                 {#each row.segments as segment (segment.key)}
                   {#if segment.minutes > 0}
-                    <Rect
+                    <rect
                       x={xPos}
                       y={context.yScale(segment.y1)}
                       width={bandwidth}
@@ -182,11 +186,14 @@
               {/each}
 
               <!-- Interaction overlay per day, on top of the bars: manual hover
-                   tooltip + click / keyboard drill-through to the night. -->
+                   tooltip + click / keyboard drill-through to the night. Native
+                   <rect> keeps per-day focusability (a11y) and event handlers
+                   without registering a mark. -->
               {#each dayRows as row (row.dayKey)}
                 {@const xPos = xBandScale(row.dayKey) ?? 0}
                 {@const bandwidth = xBandScale.bandwidth()}
-                <Rect
+                <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+                <rect
                   x={xPos}
                   y={0}
                   width={bandwidth}

--- a/src/Web/packages/app/src/lib/components/reports/year-overview/YearHeatmap.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/year-overview/YearHeatmap.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Chart, Calendar, Layer, Rect, Tooltip } from "layerchart";
+  import { Chart, Calendar, Layer, Tooltip } from "layerchart";
   import { scaleThreshold } from "d3-scale";
   import { timeWeek, timeMonths } from "d3-time";
   import { Loader2 } from "lucide-svelte";
@@ -132,17 +132,25 @@
                       </text>
                     </a>
                   {/each}
+                  <!-- Native <rect> per cell: layerchart marks each call
+                       registerMark() on mount and every registration re-runs the
+                       chart's mark deriveds over all marks, so ~365 cells/year
+                       (x multiple stacked years) cost O(N^2) and stalled the page.
+                       Cells carry pre-scaled pixel coords and per-cell handlers,
+                       so native <rect> keeps behaviour while registering nothing. -->
                   {#each cells as cell}
                     {@const padding = 1}
                     {@const cellDate = cell.data?.dateString}
-                    <Rect
+                    <!-- svelte-ignore a11y_click_events_have_key_events -->
+                    <!-- svelte-ignore a11y_no_static_element_interactions -->
+                    <rect
                       x={cell.x + padding}
                       y={cell.y + padding}
                       width={cellSize[0] - padding * 2}
                       height={cellSize[1] - padding * 2}
                       rx={4}
                       fill={getCellFill(cell.data)}
-                      onpointermove={(e) =>
+                      onpointermove={(e: PointerEvent) =>
                         context.tooltip?.show(e, cell.data)}
                       onpointerleave={() => context.tooltip?.hide()}
                       onclick={() => {

--- a/src/Web/packages/glucose-chart/src/dialogs/GlucoseResponseChart.svelte
+++ b/src/Web/packages/glucose-chart/src/dialogs/GlucoseResponseChart.svelte
@@ -4,7 +4,7 @@
     Svg,
     Spline,
     Rule,
-    Points,
+    Circle,
     Text,
     Axis,
     ChartClipPath,
@@ -169,17 +169,17 @@
             curve={curveMonotoneX}
           />
 
-          <!-- Glucose points -->
-          {#each glucoseData as point}
-            <Points
-              data={[point]}
-              x={(d: GlucoseDataPoint) => d.time}
-              y="sgv"
-              r={3}
-              fill={point.color}
-              class="opacity-90"
-            />
-          {/each}
+          <!-- Glucose points: one data-mode Circle for the whole series (single
+               mark registration) instead of one <Points> per reading (O(N^2)). -->
+          <Circle
+            data={glucoseData}
+            key={(d: GlucoseDataPoint) => d.time.getTime()}
+            cx={(d: GlucoseDataPoint) => d.time}
+            cy="sgv"
+            r={3}
+            fill={(d: GlucoseDataPoint) => d.color}
+            class="opacity-90"
+          />
 
           <!-- Prediction curves (main only for mini chart) -->
           {#if predictionData && predictionCurveData.length > 0}

--- a/src/Web/packages/glucose-chart/src/tracks/GlucoseTrack.svelte
+++ b/src/Web/packages/glucose-chart/src/tracks/GlucoseTrack.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Spline, Points, Rule, Axis, ChartClipPath, Highlight } from "layerchart";
+  import { Spline, Circle, Rule, Axis, ChartClipPath, Highlight } from "layerchart";
   import { bisector, curveMonotoneX } from "d3";
   import type { ScaleLinear } from "d3-scale";
   import { bg } from "../utils/formatting.js";
@@ -73,6 +73,24 @@
       return { time: step.time, sgv: avgSgv, radius };
     })
   );
+
+  // Group bubbles by rounded radius so each bucket renders from ONE data-mode
+  // Circle with a constant numeric r. layerchart 2.x marks each call
+  // registerMark() on mount, so one <Points>/<Circle> per bubble cost O(N^2). A
+  // per-item r accessor can't be used here: the chart configures no r scale, so
+  // resolveDataProp would route the radius through the default sqrt rScale and
+  // distort it — a numeric r bypasses scaling. Half-pixel buckets are visually
+  // indistinguishable and cap registrations at ~12.
+  const stepBubbleBuckets = $derived.by(() => {
+    const buckets = new Map<number, typeof stepBubbles>();
+    for (const bubble of stepBubbles) {
+      const r = Math.round(bubble.radius * 2) / 2;
+      const items = buckets.get(r) ?? [];
+      items.push(bubble);
+      buckets.set(r, items);
+    }
+    return [...buckets.entries()].map(([r, items]) => ({ r, items }));
+  });
 </script>
 
 <!-- High threshold line -->
@@ -107,12 +125,13 @@
 <!-- Step bubbles (behind glucose) -->
 {#if stepBubbles.length > 0}
 <ChartClipPath>
-  {#each stepBubbles as bubble}
-    <Points
-      data={[bubble]}
-      x={(d) => d.time}
-      y={(d) => glucoseScale(d.sgv)}
-      r={bubble.radius}
+  {#each stepBubbleBuckets as bucket (bucket.r)}
+    <Circle
+      data={bucket.items}
+      key={(d) => d.time.getTime()}
+      cx={(d) => d.time}
+      cy={(d) => glucoseScale(d.sgv)}
+      r={bucket.r}
       class="stroke-none"
       style="fill: var(--steps); opacity: 0.25;"
     />
@@ -131,18 +150,18 @@
     curve={curveMonotoneX}
   />
 
-  <!-- Glucose points -->
+  <!-- Glucose points: one data-mode Circle for the whole series (single mark
+       registration) instead of one <Points> per reading, which cost O(N^2). -->
   {#if showGlucosePoints}
-    {#each glucoseData as point}
-      <Points
-        data={[point]}
-        x={(d) => d.time}
-        y={(d) => glucoseScale(d.sgv)}
-        r={3}
-        fill={point.color}
-        class="opacity-90"
-      />
-    {/each}
+    <Circle
+      data={glucoseData}
+      key={(d) => d.time.getTime()}
+      cx={(d) => d.time}
+      cy={(d) => glucoseScale(d.sgv)}
+      r={3}
+      fill={(d) => d.color}
+      class="opacity-90"
+    />
   {/if}
 </ChartClipPath>
 


### PR DESCRIPTION
## Problem
layerchart 2.0.1 calls `registerMark()` for every mark component on mount, and the chart's mark-dependent deriveds loop over **all** marks on each registration — so rendering N marks is **O(N²)**. This is the root of the multi-second dashboard/report stalls after the 2.0 upgrade. #498 fixed `GlucoseTrack` and `ActogramRow`; this PR covers the rest.

## Fixes
Two registration-elimination patterns, both verified against the installed 2.0.1 source:

- **Data-mode `<Circle data={arr}>`** — one registration for a whole series, replacing `{#each}` loops of per-datum `<Points>`. Accessors mirror the sibling `<Spline>` exactly (points stay on the line). Applied to the `@nightscout/glucose-chart` package `GlucoseTrack` + both `GlucoseResponseChart` twins. Variable-radius step bubbles are bucketed by rounded radius and rendered with a **numeric** `r` (a per-item `r` accessor would be distorted by the default sqrt `rScale`).
- **Native SVG** (`<rect>`/`<text>`/`<line>`/`<g>` register nothing, and still support event handlers, `role`/`tabindex`/`aria`, and `context.tooltip.show()`) for pixel-positioned marks: `SwimLaneTrack`, `state-spans-timeline`, `SleepCompositionChart`, `YearHeatmap`, and `BasalInjectionMarker` (its ~19-rect dashed line → one `<line stroke-dasharray>`).
- **`HourlyGlucoseBoxChart`** rewritten to native SVG via `context.xScale`/`yScale`. This also fixes a latent bug: its percentage-string coords (`x:"50%"`) silently forced layerchart **data-mode against `ctx.data`**, mispositioning the box plots and re-rendering 24× per mark.

Native `<text>` gets `dy="-0.355em"` to preserve layerchart's default `verticalAnchor='end'` baseline offset (labels don't shift).

## Verification
- `svelte-check` (tsgo) clean for all changed files — no new errors/warnings.
- Peer-reviewed for coordinate/scale fidelity, handler/a11y preservation, and the bucketing math.
- Ran locally against a seeded tenant (2148 entries / sleep / trackers / alerts): dashboard + reports render server-side (SSR 200) with the seeded data.

No behavior change intended — purely eliminates mark registrations.