### PR TITLE
ci: fix publish jobs gated on non-existent master branch

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -375,7 +375,7 @@ jobs:
   publish-glucose-chart:
     needs: [build-and-push]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: read
       packages: write
@@ -401,7 +401,7 @@ jobs:
   publish-ui:
     needs: [build-and-push]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: read
       packages: write
@@ -427,7 +427,7 @@ jobs:
   publish-cms:
     needs: [build-and-push]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Problem

`publish-glucose-chart`, `publish-ui`, and `publish-cms` in `docker-publish.yml` are gated on:

```yaml
if: github.ref == 'refs/heads/master'
```

But this repo's default branch is **`main`**. Every push lands on `main`, so all three jobs have been **skipped on every run**. Confirmed on the latest `main`-push run — `build-and-push` succeeds, all three publish jobs report `skipped`.

Net effect: **none** of `@nightscout/glucose-chart`, `@nocturne/ui`, or `@nocturne/cms` has ever been published by CI. The only time any of these jobs even attempted to run was on a short-lived `master` ref on 2026-04-05 (`publish-glucose-chart`), and it failed.

## Fix

Point all three gates at `refs/heads/main`.

## Heads-up for after merge

- The **next push to `main`** will now actually run these publish jobs.
- There is **no version-change guard** — each job runs `pnpm publish` unconditionally, so any `main` push where a package's `version` hasn't been bumped will fail the job on "version already exists". Worth adding a guard (or collapsing the three near-identical jobs into a matrix with an existence check) as a follow-up.
- The `@nocturne`-scoped packages publish to GitHub Packages under the `nightscout` org — the scope/owner mismatch is untested since these jobs have never run; watch the first real run.