### PR TITLE
fix: native-SVG glucose-chart markers (app + package)

### DIFF
--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/BasalInjectionMarker.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/BasalInjectionMarker.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { Group } from "layerchart";
   import { Syringe } from "lucide-svelte";
 
   interface Props {
@@ -15,10 +14,11 @@
   const lineHeight = $derived(lineBottom - lineTop);
 </script>
 
-<!-- Native SVG throughout: layerchart 2.x marks each call registerMark(), and this
-     marker renders once per basal injection, so a per-segment Rect loop cost O(N^2).
-     A single dashed <line> plus native pill/label/hit-area register nothing. -->
-<Group x={xPos} y={lineTop}>
+<!-- Native SVG throughout: layerchart 2.x marks (incl. Group) each call
+     registerMark() on mount, and this marker renders once per basal injection,
+     so a component per injection cost O(N^2) across the chart's mark deriveds.
+     Native <g>/<line>/<rect>/<text> register nothing. -->
+<g transform="translate({xPos}, {lineTop})">
   <!-- Dashed vertical line spanning the chart height -->
   <line
     x1={0}
@@ -29,10 +29,10 @@
     stroke-dasharray="4 4"
     class="stroke-indigo-500/60 dark:stroke-indigo-400/60"
   />
-</Group>
+</g>
 
 <!-- Icon and label at the top -->
-<Group x={xPos} y={lineTop - 2}>
+<g transform="translate({xPos}, {lineTop - 2})">
   <!-- Background pill -->
   <rect
     x={-26}
@@ -62,10 +62,10 @@
   >
     {units.toFixed(1)}U
   </text>
-</Group>
+</g>
 
 <!-- Tooltip-style hover area -->
-<Group x={xPos} y={lineTop}>
+<g transform="translate({xPos}, {lineTop})">
   <rect
     x={-8}
     y={0}
@@ -79,4 +79,4 @@
       <title>{units.toFixed(1)}U basal injection</title>
     {/if}
   </rect>
-</Group>
+</g>

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/BolusMarker.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/BolusMarker.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-  import { Group, Polygon, Text } from "layerchart";
-
+  // Native SVG throughout: layerchart 2.x marks (Group/Text/Polygon) each call
+  // registerMark() on mount, and this renders once per bolus, so a component per
+  // treatment cost O(N^2) across the chart's mark deriveds. Native <g>/<text>/
+  // <polygon> render identically while registering nothing.
   interface Props {
     xPos: number;
     yPos: number;
@@ -14,20 +16,20 @@
     $props();
 </script>
 
-<Group
-  x={xPos}
-  y={yPos + 0}
+<!-- Mouse-only click, matching the original <Group onclick>; the chart is not a
+     keyboard tab-stop surface (treatments are reachable via the data table). -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<g
+  transform="translate({xPos}, {yPos})"
+  role="button"
+  aria-label="{insulin.toFixed(1)}U bolus"
   onclick={() => onMarkerClick(treatmentId)}
   class="cursor-pointer"
 >
   {#if isOverride}
     <!-- Triangle for manual override -->
-    <Polygon
-      points={[
-        { x: 0, y: 12 },
-        { x: -8, y: 0 },
-        { x: 8, y: 0 },
-      ]}
+    <polygon
+      points="0,12 -8,0 8,0"
       class="opacity-90 fill-insulin-bolus hover:opacity-100 transition-opacity"
     />
   {:else}
@@ -37,11 +39,11 @@
       class="opacity-90 fill-insulin-bolus hover:opacity-100 transition-opacity"
     />
   {/if}
-  <Text
+  <text
     y={-14}
-    textAnchor="middle"
+    text-anchor="middle"
     class="text-[8px] fill-insulin-bolus font-medium"
   >
     {insulin.toFixed(1)}U
-  </Text>
-</Group>
+  </text>
+</g>

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/CarbMarker.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/CarbMarker.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-  import { Group, Text } from "layerchart";
-
+  // Native SVG throughout: layerchart 2.x marks (Group/Text) each call
+  // registerMark() on mount, and this renders once per carb entry, so a
+  // component per treatment cost O(N^2) across the chart's mark deriveds.
+  // Native <g>/<text> render identically while registering nothing.
   interface Props {
     xPos: number;
     yPos: number;
@@ -14,21 +16,25 @@
     $props();
 </script>
 
-<Group
-  x={xPos}
-  y={yPos}
+<!-- Mouse-only click, matching the original <Group onclick>; the chart is not a
+     keyboard tab-stop surface (treatments are reachable via the data table). -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<g
+  transform="translate({xPos}, {yPos})"
+  role="button"
+  aria-label="{carbs}g carbs"
   onclick={() => onMarkerClick(treatmentId)}
   class="cursor-pointer"
 >
   <!-- Food/meal label above the marker -->
   {#if label}
-    <Text
+    <text
       y={-18}
-      textAnchor="middle"
+      text-anchor="middle"
       class="text-[7px] fill-carbs font-medium opacity-80"
     >
       {label}
-    </Text>
+    </text>
   {/if}
   <!-- Hemisphere (bowl shape - curves below baseline) -->
   <path
@@ -36,7 +42,7 @@
     fill="var(--carbs)"
     class="opacity-90 hover:opacity-100 transition-opacity"
   />
-  <Text y={18} textAnchor="middle" class="text-[8px] fill-carbs font-medium">
+  <text y={18} text-anchor="middle" class="text-[8px] fill-carbs font-medium">
     {carbs}g
-  </Text>
-</Group>
+  </text>
+</g>

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/DeviceEventMarker.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/DeviceEventMarker.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import { Group } from "layerchart";
+  // Native <g> instead of layerchart's Group: Group calls registerMark() on
+  // mount and this renders once per device event, so a component per event cost
+  // O(N^2) across the chart's mark deriveds. <g> registers nothing.
   import { DeviceEventIcon } from "$lib/components/icons";
   import type { DeviceEventType } from "$lib/api";
 
@@ -14,15 +16,19 @@
 
   let { xPos, yPos, eventType, color, treatmentId, onMarkerClick }: Props =
     $props();
+
+  const clickable = $derived(Boolean(treatmentId && onMarkerClick));
 </script>
 
-<Group
-  x={xPos}
-  y={yPos}
-  onclick={treatmentId && onMarkerClick
-    ? () => onMarkerClick(treatmentId)
-    : undefined}
-  class={treatmentId && onMarkerClick ? "cursor-pointer" : ""}
+<!-- Mouse-only click, matching the original <Group onclick>; the chart is not a
+     keyboard tab-stop surface (events are reachable via the data table). -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<g
+  transform="translate({xPos}, {yPos})"
+  role={clickable ? "button" : undefined}
+  aria-label={clickable ? `${eventType ?? "device"} event` : undefined}
+  onclick={clickable ? () => onMarkerClick?.(treatmentId ?? "") : undefined}
+  class={clickable ? "cursor-pointer" : ""}
 >
   <!-- Background circle -->
   <circle
@@ -40,4 +46,4 @@
       <DeviceEventIcon {eventType} size={16} {color} />
     </div>
   </foreignObject>
-</Group>
+</g>

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/SystemEventMarker.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/SystemEventMarker.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import { Group } from "layerchart";
+  // Native <g> instead of layerchart's Group: Group calls registerMark() on
+  // mount and this renders once per system event, so a component per event cost
+  // O(N^2) across the chart's mark deriveds. <g> registers nothing.
   import { SystemEventIcon } from "$lib/components/icons";
   import { SystemEventType } from "$lib/api";
 
@@ -13,11 +15,11 @@
   let { xPos, yPos, eventType, color }: Props = $props();
 </script>
 
-<Group x={xPos} y={yPos}>
+<g transform="translate({xPos}, {yPos})">
   <!-- Icon using foreignObject to embed Lucide component -->
   <foreignObject x="-8" y="-8" width="16" height="16">
     <div class="flex items-center justify-center w-full h-full">
       <SystemEventIcon {eventType} size={16} {color} />
     </div>
   </foreignObject>
-</Group>
+</g>

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/TrackerExpirationMarker.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/TrackerExpirationMarker.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
-  import { Group, Rect, Text } from "layerchart";
+  // Native SVG throughout: layerchart 2.x marks (Group/Rect/Text) each call
+  // registerMark() on mount, and this renders once per tracker expiration, so a
+  // component per marker cost O(N^2) across the chart's mark deriveds. Native
+  // <g>/<rect>/<text> render identically while registering nothing.
   import { TrackerCategoryIcon } from "$lib/components/icons";
   import type { TrackerCategory } from "$lib/api";
 
@@ -29,9 +32,9 @@
   class="opacity-60"
 />
 <!-- Icon and label at the top of the basal track -->
-<Group x={xPos} y={basalTrackTop + 10}>
+<g transform="translate({xPos}, {basalTrackTop + 10})">
   <!-- Background pill -->
-  <Rect
+  <rect
     x={-24}
     y={-8}
     width={48}
@@ -49,10 +52,10 @@
     </div>
   </foreignObject>
   <!-- Time label -->
-  <Text
+  <text
     x={3}
     y={0}
-    textAnchor="start"
+    text-anchor="start"
     class="text-[7px] fill-muted-foreground font-medium"
     dy="0.35em"
   >
@@ -60,5 +63,5 @@
       hour: "numeric",
       minute: "2-digit",
     })}
-  </Text>
-</Group>
+  </text>
+</g>

--- a/src/Web/packages/glucose-chart/package.json
+++ b/src/Web/packages/glucose-chart/package.json
@@ -22,6 +22,7 @@
     "svelte": "^5.54.0",
     "typescript": "^5.9.3",
     "svelte-check-native": "^0.2.0",
+    "@typescript/native-preview": "7.0.0-dev.20260513.1",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "@types/d3": "^7.4.3",
     "@types/d3-scale": "^4.0.9",

--- a/src/Web/packages/glucose-chart/src/markers/BolusMarker.svelte
+++ b/src/Web/packages/glucose-chart/src/markers/BolusMarker.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-  import { Group, Polygon, Text } from "layerchart";
-
+  // Native SVG throughout: layerchart 2.x marks (Group/Text/Polygon) each call
+  // registerMark() on mount, and this renders once per bolus, so a component per
+  // treatment cost O(N^2) across the chart's mark deriveds. Native <g>/<text>/
+  // <polygon> render identically while registering nothing.
   interface Props {
     xPos: number;
     yPos: number;
@@ -14,34 +16,34 @@
     $props();
 </script>
 
-<Group
-  x={xPos}
-  y={yPos + 0}
+<!-- Mouse-only click, matching the original <Group onclick>; the chart is not a
+     keyboard tab-stop surface (treatments are reachable via the data table). -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<g
+  transform="translate({xPos}, {yPos})"
+  role="button"
+  aria-label="{insulin.toFixed(1)}U bolus"
   onclick={() => onMarkerClick(treatmentId)}
   class="cursor-pointer"
 >
   {#if isOverride}
     <!-- Triangle for manual override -->
-    <Polygon
-      points={[
-        { x: 0, y: 12 },
-        { x: -8, y: 0 },
-        { x: 8, y: 0 },
-      ]}
+    <polygon
+      points="0,12 -8,0 8,0"
       class="opacity-90 fill-insulin-bolus hover:opacity-100 transition-opacity"
     />
   {:else}
     <!-- Hemisphere (dome shape - curves above baseline) -->
     <path
-      d="M -8,0 A 8,8 0 0,0 8,0 Z"
+      d="M -8,0 A 8,8 0 0,1 8,0 Z"
       class="opacity-90 fill-insulin-bolus hover:opacity-100 transition-opacity"
     />
   {/if}
-  <Text
+  <text
     y={-14}
-    textAnchor="middle"
+    text-anchor="middle"
     class="text-[8px] fill-insulin-bolus font-medium"
   >
     {insulin.toFixed(1)}U
-  </Text>
-</Group>
+  </text>
+</g>

--- a/src/Web/packages/glucose-chart/src/markers/CarbMarker.svelte
+++ b/src/Web/packages/glucose-chart/src/markers/CarbMarker.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-  import { Group, Text } from "layerchart";
-
+  // Native SVG throughout: layerchart 2.x marks (Group/Text) each call
+  // registerMark() on mount, and this renders once per carb entry, so a
+  // component per treatment cost O(N^2) across the chart's mark deriveds.
+  // Native <g>/<text> render identically while registering nothing.
   interface Props {
     xPos: number;
     yPos: number;
@@ -14,29 +16,33 @@
     $props();
 </script>
 
-<Group
-  x={xPos}
-  y={yPos}
+<!-- Mouse-only click, matching the original <Group onclick>; the chart is not a
+     keyboard tab-stop surface (treatments are reachable via the data table). -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<g
+  transform="translate({xPos}, {yPos})"
+  role="button"
+  aria-label="{carbs}g carbs"
   onclick={() => onMarkerClick(treatmentId)}
   class="cursor-pointer"
 >
   <!-- Food/meal label above the marker -->
   {#if label}
-    <Text
+    <text
       y={-18}
-      textAnchor="middle"
+      text-anchor="middle"
       class="text-[7px] fill-carbs font-medium opacity-80"
     >
       {label}
-    </Text>
+    </text>
   {/if}
   <!-- Hemisphere (bowl shape - curves below baseline) -->
   <path
-    d="M -8,0 A 8,8 0 0,1 8,0 Z"
+    d="M -8,0 A 8,8 0 0,0 8,0 Z"
     fill="var(--color-carbs)"
     class="opacity-90 hover:opacity-100 transition-opacity"
   />
-  <Text y={18} textAnchor="middle" class="text-[8px] fill-carbs font-medium">
+  <text y={18} text-anchor="middle" class="text-[8px] fill-carbs font-medium">
     {carbs}g
-  </Text>
-</Group>
+  </text>
+</g>

--- a/src/Web/pnpm-lock.yaml
+++ b/src/Web/pnpm-lock.yaml
@@ -583,6 +583,9 @@ importers:
       '@types/d3-scale':
         specifier: ^4.0.9
         version: 4.0.9
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260513.1
+        version: 7.0.0-dev.20260513.1
       d3:
         specifier: ^7.9.0
         version: 7.9.0


### PR DESCRIPTION
Converts the per-datum glucose-chart treatment/event markers from layerchart marks to native SVG, in **both** the live app copy and the extracted `@nightscout/glucose-chart` package. Follow-up to #499/#501.

## Why
layerchart marks (`Group`/`Text`/`Rect`/`Polygon`) each call `registerMark()` on mount. One component per treatment/event made the chart's mark-derived reconciliation O(N²) — a measurable share of dashboard-load CPU after the `$state.raw` fix (#501) removed the larger reactivity cost. Native `<g>`/`<text>`/`<rect>`/`<polygon>` render identically and register nothing (same pattern already used by `GlucoseTrack` and `SwimLaneTrack`).

## Commits
1. **app markers → native SVG** — Bolus, Carb, DeviceEvent, SystemEvent, TrackerExpiration, BasalInjection. Clickable markers keep mouse-only behaviour via `role="button"` + `aria-label` (matching the prior `<Group onclick>`; the chart is not a keyboard tab-stop surface).
2. **package markers → native SVG + geometry fix** — mirrors the conversion in `@nightscout/glucose-chart`, and fixes a stale divergence where the package's bolus/carb arc-sweep flags were swapped (bolus dome curved down, carb bowl curved up).
3. **package devDep** — adds `@typescript/native-preview` so the package's `svelte-check-native` finds `tsgo` and typechecks standalone (was failing with "could not find tsgo").

## Verification
- App: `svelte-check` clean (0 new errors/warnings); markers confirmed rendering correctly in a live dashboard screenshot.
- Package: `svelte-check-native` — 12 files, 0 errors, 0 warnings (now passes natively with the devDep).

## Notes
- Text labels now sit at the true baseline (`y`) rather than layerchart's `-capHeight/2` offset — a uniform ~5.7px shift, accepted as-is (arguably more correct; not compensated with `dy`).
- Not included: `BasalTrack`'s per-datum `AnnotationRange` loop (present in both copies) — a more involved step-area conversion left as a follow-up.