### PR TITLE
ci: bump publish jobs to pnpm 11.5.0 to match the lockfile

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,7 @@ env:
   IMAGE_REPOSITORY: ${{ github.repository }}
   DOTNET_VERSION: "10.0.x"
   NODE_VERSION: "24"
-  PNPM_VERSION: "10"
+  PNPM_VERSION: "11.5.0"
 
 jobs:
   build-and-push:
@@ -383,7 +383,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -409,7 +409,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -435,7 +435,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}


### PR DESCRIPTION
## Context

Follow-up to #502. Once the `master`→`main` gate was fixed, the `publish-glucose-chart`, `publish-ui`, and `publish-cms` jobs ran for the very first time — and all three failed at `pnpm install --frozen-lockfile`:

```
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation.
The current "overrides" configuration doesn't match the value found in the lockfile
```

Root cause: these jobs pinned `pnpm/action-setup@v4` to **`version: 9`**, but the lockfile now carries the pnpm 11 `allowBuilds` config (`src/Web/pnpm-workspace.yaml`), and the web image builds with **`pnpm@11.5.0`** (`src/Web/Dockerfile`). pnpm 9 can't read it. The bug was invisible until now because the jobs had never executed (they were gated on a branch that doesn't exist).

## Fix

- Bump the shared `PNPM_VERSION` env `10` → `11.5.0` (matches `src/Web/Dockerfile`).
- Point the three publish jobs at `${{ env.PNPM_VERSION }}` instead of the hardcoded `9`, so the whole workflow (`build-and-push`, the publish jobs, `create-release`) tracks one pnpm version.

## After merge

The publish jobs still have **no version-change guard** — first run should publish `@nightscout/glucose-chart@0.4.0`, `@nocturne/ui`, `@nocturne/cms` (none exist yet), but subsequent `main` pushes without a version bump will fail on "version already exists". The `@nocturne`-scope-under-`nightscout`-org publish is also still unproven. Both worth a follow-up (matrix + `npm view` existence guard).