### PR TITLE
ci: drop @nocturne publish jobs, guard glucose-chart against republish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -393,62 +393,16 @@ jobs:
         run: pnpm install --frozen-lockfile
         working-directory: src/Web
       - name: Publish @nightscout/glucose-chart
-        run: pnpm publish --access public --no-git-checks
         working-directory: src/Web/packages/glucose-chart
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  publish-ui:
-    needs: [build-and-push]
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@nocturne'
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-        working-directory: src/Web
-      - name: Publish @nocturne/ui
-        run: pnpm publish --access public --no-git-checks
-        working-directory: src/Web/packages/ui
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  publish-cms:
-    needs: [build-and-push]
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@nocturne'
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-        working-directory: src/Web
-      - name: Publish @nocturne/cms
-        run: pnpm publish --access public --no-git-checks
-        working-directory: src/Web/packages/cms
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version=$(node -p "require('./package.json').version")
+          if npm view "@nightscout/glucose-chart@${version}" version > /dev/null 2>&1; then
+            echo "@nightscout/glucose-chart@${version} already published; skipping."
+          else
+            pnpm publish --access public --no-git-checks
+          fi
 
   create-release:
     needs: [build-and-push]


### PR DESCRIPTION
## Context

Third in the series (after #502 gate fix and #504 pnpm bump). With those merged, the publish jobs finally executed and revealed two real, distinct failures at the publish step:

- **`publish-ui` / `publish-cms`** → `403 ... The requested installation does not exist`. They publish **`@nocturne`-scoped** packages to GitHub Packages under the **`nightscout`** org. GitHub Packages requires the npm scope to equal the owning org, so `@nocturne/*` can never publish there. Both packages are **workspace-only** (`workspace:*`, 184 refs / 109 files for ui, 31 / 26 for cms) with **no external consumers** — renaming the whole tree to `@nightscout/*` would be ~135 files of churn for zero benefit today.
- **`publish-glucose-chart`** → it tried to republish **`0.4.0`, which already exists** in GitHub Packages (that's the version nocturne-cloud's marketing site currently installs).

## Changes

- **Remove `publish-ui` and `publish-cms`.** Re-add + rename to `@nightscout/*` later if/when something external needs to consume them.
- **Guard `publish-glucose-chart`** behind an `npm view "@nightscout/glucose-chart@<version>"` existence check, so an unbumped version is a clean skip instead of a red job.

Result: `jobs` is now `build-and-push`, `publish-glucose-chart`, `create-release`. On the next `main` push, `publish-glucose-chart` should go **green** (0.4.0 exists → skips).

## Remaining one-time action (not code)

Publishing a **new** glucose-chart version (e.g. bump to 0.4.1) will still hit `403 permission_denied: write_package` until the package is granted Write access to this repo:

> org `nightscout` → Packages → `glucose-chart` → Package settings → **Manage Actions access** → add `nightscout/nocturne` with **Write**.

The package was created manually and isn't linked to the repo's Actions token, which is why `GITHUB_TOKEN` (with `packages: write`) is denied.