### PR TITLE
chore(glucose-chart): bump to 0.4.1 to exercise the publish pipeline

### DIFF
--- a/src/Web/packages/glucose-chart/package.json
+++ b/src/Web/packages/glucose-chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nightscout/glucose-chart",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
First version bump since the glucose-chart publish CI was repaired (#502/#504/#505). On merge, `publish-glucose-chart` should publish **0.4.1** to GitHub Packages end-to-end — the first real publish from CI ever. If the package hasn't yet been granted Write access to `nightscout/nocturne` (Package settings → Manage Actions access), this will surface the remaining `403 permission_denied: write_package` instead, confirming that's the last blocker.