### PR TITLE
fix(invites): emit member invite links as /join?token= instead of /invite/

### DIFF
--- a/src/API/Nocturne.API/Services/Identity/MemberInviteService.cs
+++ b/src/API/Nocturne.API/Services/Identity/MemberInviteService.cs
@@ -86,7 +86,7 @@ public class MemberInviteService : IMemberInviteService
 
         // Build invite URL
         var baseUrl = _configuration[ServiceNames.ConfigKeys.BaseUrl]?.TrimEnd('/') ?? "";
-        var inviteUrl = $"{baseUrl}/invite/{token}";
+        var inviteUrl = $"{baseUrl}/join?token={token}";
 
         return new MemberInviteResult(
             entity.Id,

--- a/tests/Unit/Nocturne.API.Tests/Services/Identity/MemberInviteServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Identity/MemberInviteServiceTests.cs
@@ -121,7 +121,7 @@ public class MemberInviteServiceTests : IDisposable
             [_followerRoleId]);
 
         result.Token.Should().Be(FakeToken);
-        result.InviteUrl.Should().Be($"{BaseUrl}/invite/{FakeToken}");
+        result.InviteUrl.Should().Be($"{BaseUrl}/join?token={FakeToken}");
         result.Id.Should().NotBeEmpty();
         result.ExpiresAt.Should().BeAfter(DateTime.UtcNow);
 


### PR DESCRIPTION
## Summary
- Member invite URLs built by `MemberInviteService.CreateInviteAsync` pointed at `/invite/{token}`, but the web app's only redemption page is `/join?token={token}` — there is no `/invite` route, so every invite link copied from Settings → Members landed on the SvelteKit error page (the "Error ID: …" screen in #507).
- The mismatch dates back to the original v4 API commit; the link format and the web route never matched.

## Repro (verified on `:latest` images)
Created an Administrator-role invite via `POST /api/v4/admin/tenants/{id}/invites` and opened both URLs on the tenant subdomain:
- `/invite/<token>` → **404** error page (reporter's screenshot)
- `/join?token=<token>` → **200**, invite accept flow renders

## Changes
- `MemberInviteService` now emits `{baseUrl}/join?token={token}` (token is Base64Url, query-safe)
- Updated the existing `CreateInviteAsync_ReturnsTokenAndUrl` assertion, which was locking in the broken URL

Fixes #507