### PR TITLE
fix(support): make in-app issue reporting deliver screenshots

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Platform/SupportController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/SupportController.cs
@@ -23,8 +23,10 @@ public class SupportController(
     private const long MaxImageBytes = 10 * 1024 * 1024; // 10 MB per image
     private const long MaxTotalBytes = 40 * 1024 * 1024; // 40 MB total
 
+    // No [RemoteCommand]: command arguments are devalue-serialised and cannot
+    // carry File objects. The frontend submits through the hand-maintained
+    // form remote in support.remote.ts, which models the multipart upload.
     [HttpPost("issues")]
-    [RemoteCommand]
     [EnableRateLimiting("support-issues")]
     [RequestSizeLimit(MaxTotalBytes)]
     [ProducesResponseType(typeof(CreateIssueResponse), StatusCodes.Status201Created)]

--- a/src/API/Nocturne.API/Services/GitHubIssueService.cs
+++ b/src/API/Nocturne.API/Services/GitHubIssueService.cs
@@ -12,6 +12,17 @@ public class GitHubIssueOptions
     public string RelayUrl { get; set; } = "https://nocturne.run/api/v4/support/issues";
     public string Owner { get; set; } = "nightscout";
     public string Repo { get; set; } = "nocturne";
+
+    /// <summary>
+    /// Branch of <see cref="Repo"/> that screenshot attachments are committed
+    /// to via the contents API, then embedded in the issue body by raw URL.
+    /// GitHub has no API for uploading images directly into an issue, so this
+    /// is the only way to make screenshots render inline. The branch must
+    /// exist (an orphan branch keeps the history separate) and the PAT needs
+    /// contents write access. When empty, screenshots are not uploaded and the
+    /// issue body notes how many were attached.
+    /// </summary>
+    public string? AssetsBranch { get; set; } = "support-assets";
 }
 
 public record CreateIssueRequest
@@ -71,7 +82,7 @@ public class GitHubIssueService(
         CancellationToken ct)
     {
         var imageUrls = await UploadImagesAsync(images, ct);
-        var body = BuildIssueBody(request, imageUrls);
+        var body = BuildIssueBody(request, imageUrls, images.Count);
         var label = TemplateLabels.GetValueOrDefault(request.Template, "bug");
 
         using var client = CreateGitHubClient();
@@ -127,6 +138,14 @@ public class GitHubIssueService(
             ?? throw new InvalidOperationException("Failed to deserialize relay response");
     }
 
+    /// <summary>
+    /// Commits each image to the assets branch of the issues repo via the
+    /// GitHub contents API and returns the resulting raw URLs for embedding.
+    /// GitHub has no API for uploading images directly into an issue, so this
+    /// is the only way to make screenshots render inline. Returns an empty
+    /// list when no assets branch is configured; the issue body then records
+    /// the attachment count.
+    /// </summary>
     private async Task<List<string>> UploadImagesAsync(
         IReadOnlyList<(string FileName, string ContentType, Stream Content)> images,
         CancellationToken ct)
@@ -134,39 +153,73 @@ public class GitHubIssueService(
         var urls = new List<string>();
         if (images.Count == 0) return urls;
 
-        using var client = CreateGitHubClient();
         var opts = options.Value;
-
-        foreach (var (fileName, contentType, imageContent) in images)
+        if (string.IsNullOrEmpty(opts.AssetsBranch))
         {
-            var uploadContent = new MultipartFormDataContent();
-            var streamContent = new StreamContent(imageContent);
-            streamContent.Headers.ContentType = new MediaTypeHeaderValue(contentType);
-            uploadContent.Add(streamContent, "file", fileName);
+            logger.LogWarning(
+                "GitHub:AssetsBranch is not configured; {Count} screenshot(s) will not be uploaded",
+                images.Count);
+            return urls;
+        }
 
-            var uploadUrl = $"https://uploads.github.com/repos/{opts.Owner}/{opts.Repo}/upload/assets";
-            var response = await client.PostAsync(uploadUrl, uploadContent, ct);
+        using var client = CreateGitHubClient();
+
+        foreach (var (fileName, _, imageContent) in images)
+        {
+            using var buffer = new MemoryStream();
+            await imageContent.CopyToAsync(buffer, ct);
+
+            var path = $"screenshots/{DateTime.UtcNow:yyyy-MM}/{Guid.NewGuid():N}-{SanitizeFileName(fileName)}";
+            var payload = JsonSerializer.Serialize(new GitHubCreateContentRequest
+            {
+                Message = $"Add support issue screenshot {fileName}",
+                Content = Convert.ToBase64String(buffer.ToArray()),
+                Branch = opts.AssetsBranch,
+            });
+
+            var response = await client.PutAsync(
+                $"/repos/{opts.Owner}/{opts.Repo}/contents/{path}",
+                new StringContent(payload, Encoding.UTF8, "application/json"),
+                ct);
 
             if (response.IsSuccessStatusCode)
             {
                 var result = await response.Content.ReadAsStringAsync(ct);
                 using var doc = JsonDocument.Parse(result);
-                if (doc.RootElement.TryGetProperty("browser_download_url", out var urlProp))
+                if (doc.RootElement.TryGetProperty("content", out var contentProp)
+                    && contentProp.TryGetProperty("download_url", out var urlProp)
+                    && urlProp.GetString() is { Length: > 0 } url)
                 {
-                    urls.Add(urlProp.GetString() ?? "");
+                    urls.Add(url);
                 }
             }
             else
             {
-                logger.LogWarning("Failed to upload image {FileName}: {Status}",
-                    fileName, response.StatusCode);
+                var error = await response.Content.ReadAsStringAsync(ct);
+                logger.LogWarning("Failed to upload image {FileName}: {Status} {Error}",
+                    fileName, response.StatusCode, error);
             }
         }
 
         return urls;
     }
 
-    internal static string BuildIssueBody(CreateIssueRequest request, List<string> imageUrls)
+    /// <summary>
+    /// Restricts a client-supplied file name to characters that are safe in a
+    /// repository path (the unique prefix comes from the caller's GUID).
+    /// </summary>
+    internal static string SanitizeFileName(string fileName)
+    {
+        var sanitized = new string(fileName
+            .Where(c => char.IsLetterOrDigit(c) || c is '.' or '-' or '_')
+            .ToArray());
+        return string.IsNullOrEmpty(sanitized.Trim('.')) ? "screenshot" : sanitized;
+    }
+
+    internal static string BuildIssueBody(
+        CreateIssueRequest request,
+        List<string> imageUrls,
+        int attachedImageCount = 0)
     {
         var sb = new StringBuilder();
 
@@ -218,6 +271,13 @@ public class GitHubIssueService(
             }
         }
 
+        if (attachedImageCount > imageUrls.Count)
+        {
+            var missing = attachedImageCount - imageUrls.Count;
+            sb.AppendLine($"*{missing} screenshot(s) were attached but could not be uploaded.*");
+            sb.AppendLine();
+        }
+
         sb.AppendLine("---");
         sb.AppendLine();
         sb.AppendLine("<details>");
@@ -262,5 +322,15 @@ public class GitHubIssueService(
         public int Number { get; init; }
         [JsonPropertyName("html_url")]
         public string HtmlUrl { get; init; } = "";
+    }
+
+    private record GitHubCreateContentRequest
+    {
+        [JsonPropertyName("message")]
+        public string Message { get; init; } = "";
+        [JsonPropertyName("content")]
+        public string Content { get; init; } = "";
+        [JsonPropertyName("branch")]
+        public string? Branch { get; init; }
     }
 }

--- a/src/API/Nocturne.API/Services/GitHubIssueService.cs
+++ b/src/API/Nocturne.API/Services/GitHubIssueService.cs
@@ -177,9 +177,10 @@ public class GitHubIssueService(
                 Branch = opts.AssetsBranch,
             });
 
-            var response = await client.PutAsync(
+            using var payloadContent = new StringContent(payload, Encoding.UTF8, "application/json");
+            using var response = await client.PutAsync(
                 $"/repos/{opts.Owner}/{opts.Repo}/contents/{path}",
-                new StringContent(payload, Encoding.UTF8, "application/json"),
+                payloadContent,
                 ct);
 
             if (response.IsSuccessStatusCode)

--- a/src/Web/Dockerfile
+++ b/src/Web/Dockerfile
@@ -32,6 +32,9 @@ FROM node:24-alpine AS runtime
 RUN corepack enable && corepack prepare pnpm@11.5.0 --activate
 WORKDIR /app
 ENV NODE_ENV=production
+# adapter-node caps request bodies at 512K by default, which rejects support
+# issue screenshot uploads (up to 4 x 10 MB) before they reach the app.
+ENV BODY_SIZE_LIMIT=44M
 
 # Copy workspace structure — server.js must stay in packages/app for pnpm resolution
 COPY --from=build /app/pnpm-workspace.yaml ./

--- a/src/Web/packages/app/src/lib/api/support.remote.ts
+++ b/src/Web/packages/app/src/lib/api/support.remote.ts
@@ -1,4 +1,4 @@
-import { getRequestEvent, command } from "$app/server";
+import { getRequestEvent, form } from "$app/server";
 import { error, redirect } from "@sveltejs/kit";
 
 export {
@@ -6,7 +6,13 @@ export {
   getSupportConfig,
 } from "$api/generated/supports.generated.remote";
 
-interface IssueParams {
+/**
+ * Shape of the issue form submission. Field names match the `name` attributes
+ * in IssueCreatorDialog; `images[]` arrives as a File array. A type alias
+ * (not an interface) so it satisfies the RemoteFormInput index constraint.
+ */
+type IssueFormInput = {
+  channel?: "github" | "operator";
   template: string;
   title: string;
   description: string;
@@ -16,48 +22,87 @@ interface IssueParams {
   cgmSource?: string;
   timeRange?: string;
   diagnosticInfo: string;
-  images: File[];
-}
+  images?: File[];
+};
 
-function buildIssueFormData(params: IssueParams): FormData {
-  const formData = new FormData();
-  formData.append("template", params.template);
-  formData.append("title", params.title);
-  formData.append("description", params.description);
-  if (params.stepsToReproduce)
-    formData.append("stepsToReproduce", params.stepsToReproduce);
-  if (params.expectedBehavior)
-    formData.append("expectedBehavior", params.expectedBehavior);
-  if (params.actualBehavior)
-    formData.append("actualBehavior", params.actualBehavior);
-  if (params.cgmSource) formData.append("cgmSource", params.cgmSource);
-  if (params.timeRange) formData.append("timeRange", params.timeRange);
-  formData.append("diagnosticInfo", params.diagnosticInfo);
-  for (const image of params.images) {
-    formData.append("images", image);
+/**
+ * Submit a support issue with optional screenshot attachments.
+ *
+ * This is a `form` remote (not a `command`) because the payload carries File
+ * objects: command arguments are devalue-serialised, which cannot represent a
+ * File, whereas form submissions transport files natively.
+ */
+export const submitIssue = form("unchecked", async (data: IssueFormInput) => {
+  const { apiClient } = getRequestEvent().locals;
+
+  if (!data.title?.trim() || !data.description?.trim()) {
+    throw error(400, "Title and description are required");
   }
-  return formData;
-}
 
-export const createIssue = command("unchecked", async (params: IssueParams) => {
-  const apiClient = getRequestEvent().locals.apiClient;
+  // Files arrive as SvelteKit's lazy file proxies; materialise them into real
+  // File objects so undici's multipart encoder accepts them.
+  const images = await Promise.all(
+    (data.images ?? []).map(
+      async (f) => new File([await f.arrayBuffer()], f.name, { type: f.type })
+    )
+  );
+
+  if (data.channel === "operator") {
+    // Resolve operator URL server-side to prevent SSRF via client-supplied URLs
+    const config = await apiClient.support.getSupportConfig();
+    const url = config.accountBilling?.url;
+    if (!url) throw error(400, "Operator support not configured");
+
+    const formData = new FormData();
+    formData.append("template", data.template);
+    formData.append("title", data.title);
+    formData.append("description", data.description);
+    if (data.stepsToReproduce)
+      formData.append("stepsToReproduce", data.stepsToReproduce);
+    if (data.expectedBehavior)
+      formData.append("expectedBehavior", data.expectedBehavior);
+    if (data.actualBehavior)
+      formData.append("actualBehavior", data.actualBehavior);
+    if (data.cgmSource) formData.append("cgmSource", data.cgmSource);
+    if (data.timeRange) formData.append("timeRange", data.timeRange);
+    formData.append("diagnosticInfo", data.diagnosticInfo);
+    for (const image of images) {
+      formData.append("images", image, image.name);
+    }
+
+    const response = await fetch(url, {
+      body: formData,
+      method: "POST",
+      headers: { Accept: "application/json" },
+    });
+
+    if (!response.ok) {
+      console.error(
+        `Error in support.submitIssue: operator endpoint returned ${response.status}`
+      );
+      throw error(502, "Operator support endpoint rejected the issue");
+    }
+
+    return await response.json();
+  }
+
   try {
     // The generated remote can't model this endpoint's multipart file upload,
     // so call the NSwag client method directly (it builds the multipart body).
     return await apiClient.support.createIssue(
-      params.template,
-      params.title,
-      params.description,
-      params.stepsToReproduce,
-      params.expectedBehavior,
-      params.actualBehavior,
-      params.cgmSource,
-      params.timeRange,
-      params.diagnosticInfo,
-      params.images.map((file) => ({ data: file, fileName: file.name })),
+      data.template,
+      data.title,
+      data.description,
+      data.stepsToReproduce || undefined,
+      data.expectedBehavior || undefined,
+      data.actualBehavior || undefined,
+      data.cgmSource || undefined,
+      data.timeRange || undefined,
+      data.diagnosticInfo,
+      images.map((file) => ({ data: file, fileName: file.name }))
     );
   } catch (err) {
-    const status = (err as any)?.status;
+    const status = (err as { status?: number })?.status;
     if (status === 401) {
       const { url } = getRequestEvent();
       throw redirect(
@@ -66,35 +111,7 @@ export const createIssue = command("unchecked", async (params: IssueParams) => {
       );
     }
     if (status === 403) throw error(403, "Forbidden");
-    console.error("Error in support.createIssue:", err);
-    throw error(500, "Failed to create issue");
-  }
-});
-
-export const createOperatorIssue = command(
-  "unchecked",
-  async (params: IssueParams) => {
-  const apiClient = getRequestEvent().locals.apiClient;
-  try {
-    // Resolve operator URL server-side to prevent SSRF via client-supplied URLs
-    const config = await apiClient.support.getSupportConfig();
-    const url = config.accountBilling?.url;
-    if (!url) throw error(400, "Operator support not configured");
-
-    const formData = buildIssueFormData(params);
-    const response = await fetch(url, {
-      body: formData,
-      method: "POST",
-      headers: { Accept: "application/json" },
-    });
-
-    if (!response.ok) {
-      throw new Error(`Operator support endpoint returned ${response.status}`);
-    }
-
-    return await response.json();
-  } catch (err) {
-    console.error("Error in support.createOperatorIssue:", err);
-    throw err;
+    console.error("Error in support.submitIssue:", err);
+    throw error(502, "Failed to create issue");
   }
 });

--- a/src/Web/packages/app/src/lib/components/support/IssueCreatorDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/support/IssueCreatorDialog.svelte
@@ -21,7 +21,7 @@
     ArrowLeft,
     Copy,
   } from "lucide-svelte";
-  import { createIssue, createOperatorIssue, getFallbackUrl } from "$lib/api/support.remote";
+  import { submitIssue, getFallbackUrl } from "$lib/api/support.remote";
   import type { CreateIssueResponse } from "$api-clients";
 
   interface Props {
@@ -123,6 +123,18 @@
       description.trim().length > 0,
   );
 
+  // The file input is the single source the browser submits; keep it in sync
+  // with the `images` state (drag-drop additions, removals, remounts).
+  function syncInputFiles(input: HTMLInputElement) {
+    const dataTransfer = new DataTransfer();
+    for (const file of images) dataTransfer.items.add(file);
+    input.files = dataTransfer.files;
+  }
+
+  $effect(() => {
+    if (fileInput) syncInputFiles(fileInput);
+  });
+
   function resetState() {
     title = "";
     description = "";
@@ -151,7 +163,14 @@
   }
 
   function handleClose() {
-    resetState();
+    // Keep the draft (fields + screenshots) unless the issue was submitted, so
+    // a failed attempt can be retried without retyping everything.
+    if (formState === "success") {
+      resetState();
+    } else {
+      formState = "idle";
+      isDragging = false;
+    }
     open = false;
   }
 
@@ -197,15 +216,16 @@
     const input = e.currentTarget;
     if (input.files) {
       addFiles(input.files);
-      input.value = "";
+      // A browse pick replaces input.files with the raw selection; restore the
+      // validated list unconditionally — when every picked file was rejected,
+      // `images` didn't change and the sync effect won't rerun.
+      syncInputFiles(input);
     }
   }
 
-  function generatePreviewMarkdown(): string {
+  function generateBodyMarkdown(): string {
     const lines: string[] = [];
 
-    lines.push(`# ${title}`);
-    lines.push("");
     lines.push("## Description");
     lines.push("");
     lines.push(description);
@@ -260,6 +280,10 @@
     return lines.join("\n");
   }
 
+  function generatePreviewMarkdown(): string {
+    return `# ${title}\n\n${generateBodyMarkdown()}`;
+  }
+
   async function copyPreview() {
     try {
       await navigator.clipboard.writeText(generatePreviewMarkdown());
@@ -272,51 +296,22 @@
     }
   }
 
-  async function handleSubmit() {
-    if (!isValid || formState === "submitting") return;
-
-    formState = "submitting";
-
+  async function openFallback() {
     try {
-      const params = {
+      const fallback = await getFallbackUrl({
         template,
         title,
-        description,
-        stepsToReproduce: template === "bug" ? stepsToReproduce || undefined : undefined,
-        expectedBehavior: template === "bug" ? expectedBehavior || undefined : undefined,
-        actualBehavior: template === "bug" ? actualBehavior || undefined : undefined,
-        cgmSource: template === "data-issue" ? cgmSource || undefined : undefined,
-        timeRange: template === "data-issue" ? timeRange || undefined : undefined,
-        diagnosticInfo,
-        images,
-      };
-
-      if (useOperatorSupport) {
-        await createOperatorIssue(params);
-        formState = "success";
-      } else {
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- remote command result is typed `unknown`; narrow to the generated response shape
-        const result = (await createIssue(params)) as CreateIssueResponse;
-        issueUrl = result.issueUrl ?? "";
-        issueNumber = result.issueNumber ?? 0;
-        formState = "success";
+        body: generateBodyMarkdown(),
+      }).run();
+      if (fallback?.url) {
+        window.open(fallback.url, "_blank");
       }
     } catch {
-      formState = "error";
-      // Open fallback URL
-      try {
-        const body = `## Description\n\n${description}`;
-        const fallback = await getFallbackUrl({ template, title, body }).run();
-        if (fallback?.url) {
-          window.open(fallback.url, "_blank");
-        }
-      } catch {
-        // Last resort: open generic issue page
-        window.open(
-          "https://github.com/nightscout/nocturne/issues/new",
-          "_blank",
-        );
-      }
+      // Last resort: open generic issue page
+      window.open(
+        "https://github.com/nightscout/nocturne/issues/new",
+        "_blank",
+      );
     }
   }
 </script>
@@ -324,7 +319,15 @@
 <Dialog.Root
   bind:open
   onOpenChange={(isOpen) => {
-    if (!isOpen) handleClose();
+    if (!isOpen) {
+      if (formState === "submitting") {
+        // A submission is in flight; keep the dialog up until it settles so
+        // its outcome (issue created or not) is visible.
+        open = true;
+        return;
+      }
+      handleClose();
+    }
   }}
 >
   <Dialog.Content class="max-w-2xl max-h-[85vh] overflow-hidden flex flex-col">
@@ -366,326 +369,396 @@
         <h3 class="text-lg font-semibold">Couldn't Create Issue</h3>
         <p class="text-sm text-muted-foreground text-center">
           We've opened a pre-filled GitHub issue form in a new tab as a
-          fallback. You can paste your screenshots there manually.
+          fallback. You can paste your screenshots there manually. Your entries
+          are kept here if you'd like to try again.
         </p>
-        <Button variant="ghost" onclick={handleClose}>Close</Button>
-      </div>
-    {:else if formState === "idle"}
-      <div class="flex-1 overflow-y-auto space-y-4 pr-1">
-        <!-- Title -->
-        <div class="space-y-2">
-          <Label for="issue-title">Title *</Label>
-          <Input
-            id="issue-title"
-            bind:value={title}
-            placeholder="Brief summary of the issue"
-            maxlength={256}
-          />
-          <p class="text-xs text-muted-foreground text-right">
-            {title.length}/256
-          </p>
-        </div>
-
-        <!-- Description -->
-        <div class="space-y-2">
-          <Label for="issue-description">Description *</Label>
-          <Textarea
-            id="issue-description"
-            bind:value={description}
-            placeholder={template === "feature"
-              ? "Describe the feature and why it would be useful..."
-              : "Describe the issue in detail..."}
-            rows={4}
-          />
-        </div>
-
-        <!-- Bug-specific fields -->
-        {#if template === "bug"}
-          <div class="space-y-2">
-            <Label for="issue-steps">Steps to Reproduce</Label>
-            <Textarea
-              id="issue-steps"
-              bind:value={stepsToReproduce}
-              placeholder="1. Go to...&#10;2. Click on...&#10;3. Observe..."
-              rows={3}
-            />
-          </div>
-
-          <div class="grid grid-cols-2 gap-4">
-            <div class="space-y-2">
-              <Label for="issue-expected">Expected Behavior</Label>
-              <Textarea
-                id="issue-expected"
-                bind:value={expectedBehavior}
-                placeholder="What should happen..."
-                rows={2}
-              />
-            </div>
-            <div class="space-y-2">
-              <Label for="issue-actual">Actual Behavior</Label>
-              <Textarea
-                id="issue-actual"
-                bind:value={actualBehavior}
-                placeholder="What actually happens..."
-                rows={2}
-              />
-            </div>
-          </div>
-        {/if}
-
-        <!-- Data issue-specific fields -->
-        {#if template === "data-issue"}
-          <div class="grid grid-cols-2 gap-4">
-            <div class="space-y-2">
-              <Label for="issue-cgm">CGM Source</Label>
-              <Input
-                id="issue-cgm"
-                bind:value={cgmSource}
-                placeholder="e.g., Dexcom G7, Libre 3..."
-              />
-            </div>
-            <div class="space-y-2">
-              <Label for="issue-timerange">Time Range Affected</Label>
-              <Input
-                id="issue-timerange"
-                bind:value={timeRange}
-                placeholder="e.g., Last 24 hours, April 25..."
-              />
-            </div>
-          </div>
-        {/if}
-
-        <Separator />
-
-        <!-- Image Drop Zone -->
-        <div class="space-y-2">
-          <Label>Screenshots ({images.length}/4)</Label>
-          <button
-            type="button"
-            class="w-full border-2 border-dashed rounded-lg p-6 text-center transition-colors cursor-pointer {isDragging
-              ? 'border-primary bg-primary/5'
-              : 'border-muted-foreground/25 hover:border-primary/50'}"
-            ondrop={handleDrop}
-            ondragover={handleDragOver}
-            ondragleave={handleDragLeave}
-            onclick={() => fileInput?.click()}
+        <div class="flex items-center gap-2">
+          <Button
+            variant="outline"
+            onclick={() => {
+              formState = "preview";
+            }}
           >
-            <Upload class="h-8 w-8 mx-auto mb-2 text-muted-foreground" />
-            <p class="text-sm text-muted-foreground">
-              Drop images here or click to browse
-            </p>
-            <p class="text-xs text-muted-foreground mt-1">
-              PNG, JPEG, WebP, GIF - max 10 MB each
-            </p>
-          </button>
-          <input
-            bind:this={fileInput}
-            type="file"
-            accept="image/png,image/jpeg,image/webp,image/gif"
-            multiple
-            class="hidden"
-            onchange={handleFileInput}
-          />
-
-          {#if imagePreviews.length > 0}
-            <div class="flex gap-2 flex-wrap">
-              {#each imagePreviews as preview, i (preview)}
-                <div class="relative group">
-                  <img
-                    src={preview}
-                    alt="Screenshot {i + 1}"
-                    class="h-20 w-20 object-cover rounded-md border"
-                  />
-                  <button
-                    type="button"
-                    class="absolute -top-2 -right-2 h-5 w-5 rounded-full bg-destructive text-destructive-foreground flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
-                    onclick={() => removeImage(i)}
-                  >
-                    <X class="h-3 w-3" />
-                  </button>
-                </div>
-              {/each}
-            </div>
-          {/if}
-        </div>
-
-        <Separator />
-
-        <!-- Debug Info Toggles -->
-        <div class="space-y-3">
-          <Label class="text-sm font-medium">Diagnostic Info (included automatically)</Label>
-          <p class="text-xs text-muted-foreground">
-            Browser, screen size, route, and locale are always included. Toggle
-            additional info below:
-          </p>
-
-          <div class="space-y-3">
-            <div class="flex items-center justify-between">
-              <div class="space-y-0.5">
-                <Label class="text-sm">Tenant slug</Label>
-                <p class="text-xs text-muted-foreground">
-                  Your instance identifier
-                </p>
-              </div>
-              <Switch bind:checked={includeTenantSlug} />
-            </div>
-
-            <div class="flex items-center justify-between">
-              <div class="space-y-0.5">
-                <Label class="text-sm">CGM source</Label>
-                <p class="text-xs text-muted-foreground">
-                  Your connector type
-                </p>
-              </div>
-              <Switch bind:checked={includeCgmSource} />
-            </div>
-
-            <div class="flex items-center justify-between">
-              <div class="space-y-0.5">
-                <Label class="text-sm">Recent logs</Label>
-                <p class="text-xs text-muted-foreground">
-                  API calls and debug information
-                </p>
-              </div>
-              <Switch bind:checked={includeRecentLogs} />
-            </div>
-
-            <div class="flex items-center justify-between">
-              <div class="space-y-0.5">
-                <Label class="text-sm">Settings</Label>
-                <p class="text-xs text-muted-foreground">
-                  Your configuration (no passwords/tokens)
-                </p>
-              </div>
-              <Switch bind:checked={includeSettings} />
-            </div>
-          </div>
+            <ArrowLeft class="h-4 w-4 mr-2" />
+            Back
+          </Button>
+          <Button variant="ghost" onclick={handleClose}>Close</Button>
         </div>
       </div>
+    {:else}
+      <form
+        class="contents"
+        enctype="multipart/form-data"
+        {...submitIssue.enhance(async ({ submit }) => {
+          if (formState === "idle") {
+            // Enter in a field advances to the preview step; actual
+            // submission only happens from the preview footer.
+            if (isValid) formState = "preview";
+            return;
+          }
 
-      <Dialog.Footer class="pt-4 border-t mt-4">
-        <Button variant="outline" onclick={handleClose}>Cancel</Button>
-        <Button
-          onclick={() => { formState = "preview"; }}
-          disabled={!isValid}
-        >
-          <Eye class="h-4 w-4 mr-2" />
-          Preview Issue
-        </Button>
-      </Dialog.Footer>
-    {:else if formState === "preview" || formState === "submitting"}
-      <div class="flex-1 overflow-y-auto space-y-4 pr-1">
-        <div class="space-y-1">
-          <p class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Title</p>
-          <h3 class="text-lg font-semibold">{title}</h3>
-        </div>
+          formState = "submitting";
+          try {
+            await submit();
+            const result = submitIssue.result as CreateIssueResponse | undefined;
+            if (!result) {
+              // A redirect (e.g. expired session -> login) resolves submit()
+              // without a result; the navigation is already underway.
+              formState = "preview";
+              return;
+            }
+            issueUrl = result.issueUrl ?? "";
+            issueNumber = result.issueNumber ?? 0;
+            formState = "success";
+          } catch {
+            formState = "error";
+            await openFallback();
+          }
+        })}
+      >
+        <!-- Submitted alongside the named fields; also serves as the browse picker -->
+        <input
+          bind:this={fileInput}
+          type="file"
+          name="images[]"
+          accept="image/png,image/jpeg,image/webp,image/gif"
+          multiple
+          class="hidden"
+          onchange={handleFileInput}
+        />
 
-        <Separator />
-
-        <div class="space-y-1">
-          <p class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Description</p>
-          <p class="text-sm whitespace-pre-wrap">{description}</p>
-        </div>
-
-        {#if template === "bug"}
-          {#if stepsToReproduce.trim()}
-            <Separator />
-            <div class="space-y-1">
-              <p class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Steps to Reproduce</p>
-              <p class="text-sm whitespace-pre-wrap">{stepsToReproduce}</p>
+        {#if formState === "idle"}
+          <div class="flex-1 overflow-y-auto space-y-4 pr-1">
+            <!-- Title -->
+            <div class="space-y-2">
+              <Label for="issue-title">Title *</Label>
+              <Input
+                id="issue-title"
+                bind:value={title}
+                placeholder="Brief summary of the issue"
+                maxlength={256}
+              />
+              <p class="text-xs text-muted-foreground text-right">
+                {title.length}/256
+              </p>
             </div>
-          {/if}
 
-          {#if expectedBehavior.trim() || actualBehavior.trim()}
-            <Separator />
-            <div class="grid grid-cols-2 gap-4">
-              {#if expectedBehavior.trim()}
-                <div class="space-y-1">
-                  <p class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Expected Behavior</p>
-                  <p class="text-sm whitespace-pre-wrap">{expectedBehavior}</p>
-                </div>
-              {/if}
-              {#if actualBehavior.trim()}
-                <div class="space-y-1">
-                  <p class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Actual Behavior</p>
-                  <p class="text-sm whitespace-pre-wrap">{actualBehavior}</p>
-                </div>
-              {/if}
+            <!-- Description -->
+            <div class="space-y-2">
+              <Label for="issue-description">Description *</Label>
+              <Textarea
+                id="issue-description"
+                bind:value={description}
+                placeholder={template === "feature"
+                  ? "Describe the feature and why it would be useful..."
+                  : "Describe the issue in detail..."}
+                rows={4}
+              />
             </div>
-          {/if}
-        {/if}
 
-        {#if template === "data-issue" && (cgmSource.trim() || timeRange.trim())}
-          <Separator />
-          <div class="grid grid-cols-2 gap-4">
-            {#if cgmSource.trim()}
-              <div class="space-y-1">
-                <p class="text-xs font-medium text-muted-foreground uppercase tracking-wide">CGM Source</p>
-                <p class="text-sm">{cgmSource}</p>
-              </div>
-            {/if}
-            {#if timeRange.trim()}
-              <div class="space-y-1">
-                <p class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Time Range</p>
-                <p class="text-sm">{timeRange}</p>
-              </div>
-            {/if}
-          </div>
-        {/if}
-
-        {#if imagePreviews.length > 0}
-          <Separator />
-          <div class="space-y-1">
-            <p class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Screenshots ({images.length})</p>
-            <div class="flex gap-2 flex-wrap">
-              {#each imagePreviews as preview, i (preview)}
-                <img
-                  src={preview}
-                  alt="Screenshot {i + 1}"
-                  class="h-20 w-20 object-cover rounded-md border"
+            <!-- Bug-specific fields -->
+            {#if template === "bug"}
+              <div class="space-y-2">
+                <Label for="issue-steps">Steps to Reproduce</Label>
+                <Textarea
+                  id="issue-steps"
+                  bind:value={stepsToReproduce}
+                  placeholder="1. Go to...&#10;2. Click on...&#10;3. Observe..."
+                  rows={3}
                 />
-              {/each}
+              </div>
+
+              <div class="grid grid-cols-2 gap-4">
+                <div class="space-y-2">
+                  <Label for="issue-expected">Expected Behavior</Label>
+                  <Textarea
+                    id="issue-expected"
+                    bind:value={expectedBehavior}
+                    placeholder="What should happen..."
+                    rows={2}
+                  />
+                </div>
+                <div class="space-y-2">
+                  <Label for="issue-actual">Actual Behavior</Label>
+                  <Textarea
+                    id="issue-actual"
+                    bind:value={actualBehavior}
+                    placeholder="What actually happens..."
+                    rows={2}
+                  />
+                </div>
+              </div>
+            {/if}
+
+            <!-- Data issue-specific fields -->
+            {#if template === "data-issue"}
+              <div class="grid grid-cols-2 gap-4">
+                <div class="space-y-2">
+                  <Label for="issue-cgm">CGM Source</Label>
+                  <Input
+                    id="issue-cgm"
+                    bind:value={cgmSource}
+                    placeholder="e.g., Dexcom G7, Libre 3..."
+                  />
+                </div>
+                <div class="space-y-2">
+                  <Label for="issue-timerange">Time Range Affected</Label>
+                  <Input
+                    id="issue-timerange"
+                    bind:value={timeRange}
+                    placeholder="e.g., Last 24 hours, April 25..."
+                  />
+                </div>
+              </div>
+            {/if}
+
+            <Separator />
+
+            <!-- Image Drop Zone -->
+            <div class="space-y-2">
+              <Label>Screenshots ({images.length}/4)</Label>
+              <button
+                type="button"
+                class="w-full border-2 border-dashed rounded-lg p-6 text-center transition-colors cursor-pointer {isDragging
+                  ? 'border-primary bg-primary/5'
+                  : 'border-muted-foreground/25 hover:border-primary/50'}"
+                ondrop={handleDrop}
+                ondragover={handleDragOver}
+                ondragleave={handleDragLeave}
+                onclick={() => fileInput?.click()}
+              >
+                <Upload class="h-8 w-8 mx-auto mb-2 text-muted-foreground" />
+                <p class="text-sm text-muted-foreground">
+                  Drop images here or click to browse
+                </p>
+                <p class="text-xs text-muted-foreground mt-1">
+                  PNG, JPEG, WebP, GIF - max 10 MB each
+                </p>
+              </button>
+
+              {#if imagePreviews.length > 0}
+                <div class="flex gap-2 flex-wrap">
+                  {#each imagePreviews as preview, i (preview)}
+                    <div class="relative group">
+                      <img
+                        src={preview}
+                        alt="Screenshot {i + 1}"
+                        class="h-20 w-20 object-cover rounded-md border"
+                      />
+                      <button
+                        type="button"
+                        class="absolute -top-2 -right-2 h-5 w-5 rounded-full bg-destructive text-destructive-foreground flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+                        onclick={() => removeImage(i)}
+                      >
+                        <X class="h-3 w-3" />
+                      </button>
+                    </div>
+                  {/each}
+                </div>
+              {/if}
+            </div>
+
+            <Separator />
+
+            <!-- Debug Info Toggles -->
+            <div class="space-y-3">
+              <Label class="text-sm font-medium">Diagnostic Info (included automatically)</Label>
+              <p class="text-xs text-muted-foreground">
+                Browser, screen size, route, and locale are always included. Toggle
+                additional info below:
+              </p>
+
+              <div class="space-y-3">
+                <div class="flex items-center justify-between">
+                  <div class="space-y-0.5">
+                    <Label class="text-sm">Tenant slug</Label>
+                    <p class="text-xs text-muted-foreground">
+                      Your instance identifier
+                    </p>
+                  </div>
+                  <Switch bind:checked={includeTenantSlug} />
+                </div>
+
+                <div class="flex items-center justify-between">
+                  <div class="space-y-0.5">
+                    <Label class="text-sm">CGM source</Label>
+                    <p class="text-xs text-muted-foreground">
+                      Your connector type
+                    </p>
+                  </div>
+                  <Switch bind:checked={includeCgmSource} />
+                </div>
+
+                <div class="flex items-center justify-between">
+                  <div class="space-y-0.5">
+                    <Label class="text-sm">Recent logs</Label>
+                    <p class="text-xs text-muted-foreground">
+                      API calls and debug information
+                    </p>
+                  </div>
+                  <Switch bind:checked={includeRecentLogs} />
+                </div>
+
+                <div class="flex items-center justify-between">
+                  <div class="space-y-0.5">
+                    <Label class="text-sm">Settings</Label>
+                    <p class="text-xs text-muted-foreground">
+                      Your configuration (no passwords/tokens)
+                    </p>
+                  </div>
+                  <Switch bind:checked={includeSettings} />
+                </div>
+              </div>
             </div>
           </div>
+
+          <Dialog.Footer class="pt-4 border-t mt-4">
+            <Button type="button" variant="outline" onclick={handleClose}>Cancel</Button>
+            <Button
+              type="button"
+              onclick={() => { formState = "preview"; }}
+              disabled={!isValid}
+            >
+              <Eye class="h-4 w-4 mr-2" />
+              Preview Issue
+            </Button>
+          </Dialog.Footer>
+        {:else if formState === "preview" || formState === "submitting"}
+          <!-- Named fields the form submits; mirrors the state edited in the idle step -->
+          <input type="hidden" name="channel" value={useOperatorSupport ? "operator" : "github"} />
+          <input type="hidden" name="template" value={template} />
+          <input type="hidden" name="title" value={title} />
+          <input type="hidden" name="description" value={description} />
+          {#if template === "bug"}
+            <input type="hidden" name="stepsToReproduce" value={stepsToReproduce} />
+            <input type="hidden" name="expectedBehavior" value={expectedBehavior} />
+            <input type="hidden" name="actualBehavior" value={actualBehavior} />
+          {/if}
+          {#if template === "data-issue"}
+            <input type="hidden" name="cgmSource" value={cgmSource} />
+            <input type="hidden" name="timeRange" value={timeRange} />
+          {/if}
+          <input type="hidden" name="diagnosticInfo" value={diagnosticInfo} />
+
+          <div class="flex-1 overflow-y-auto space-y-4 pr-1">
+            <div class="space-y-1">
+              <p class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Title</p>
+              <h3 class="text-lg font-semibold">{title}</h3>
+            </div>
+
+            <Separator />
+
+            <div class="space-y-1">
+              <p class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Description</p>
+              <p class="text-sm whitespace-pre-wrap">{description}</p>
+            </div>
+
+            {#if template === "bug"}
+              {#if stepsToReproduce.trim()}
+                <Separator />
+                <div class="space-y-1">
+                  <p class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Steps to Reproduce</p>
+                  <p class="text-sm whitespace-pre-wrap">{stepsToReproduce}</p>
+                </div>
+              {/if}
+
+              {#if expectedBehavior.trim() || actualBehavior.trim()}
+                <Separator />
+                <div class="grid grid-cols-2 gap-4">
+                  {#if expectedBehavior.trim()}
+                    <div class="space-y-1">
+                      <p class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Expected Behavior</p>
+                      <p class="text-sm whitespace-pre-wrap">{expectedBehavior}</p>
+                    </div>
+                  {/if}
+                  {#if actualBehavior.trim()}
+                    <div class="space-y-1">
+                      <p class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Actual Behavior</p>
+                      <p class="text-sm whitespace-pre-wrap">{actualBehavior}</p>
+                    </div>
+                  {/if}
+                </div>
+              {/if}
+            {/if}
+
+            {#if template === "data-issue" && (cgmSource.trim() || timeRange.trim())}
+              <Separator />
+              <div class="grid grid-cols-2 gap-4">
+                {#if cgmSource.trim()}
+                  <div class="space-y-1">
+                    <p class="text-xs font-medium text-muted-foreground uppercase tracking-wide">CGM Source</p>
+                    <p class="text-sm">{cgmSource}</p>
+                  </div>
+                {/if}
+                {#if timeRange.trim()}
+                  <div class="space-y-1">
+                    <p class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Time Range</p>
+                    <p class="text-sm">{timeRange}</p>
+                  </div>
+                {/if}
+              </div>
+            {/if}
+
+            {#if imagePreviews.length > 0}
+              <Separator />
+              <div class="space-y-1">
+                <p class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Screenshots ({images.length})</p>
+                <div class="flex gap-2 flex-wrap">
+                  {#each imagePreviews as preview, i (preview)}
+                    <img
+                      src={preview}
+                      alt="Screenshot {i + 1}"
+                      class="h-20 w-20 object-cover rounded-md border"
+                    />
+                  {/each}
+                </div>
+              </div>
+            {/if}
+
+            <Separator />
+
+            <details class="group">
+              <summary class="text-xs font-medium text-muted-foreground uppercase tracking-wide cursor-pointer select-none hover:text-foreground transition-colors">
+                Diagnostic Info
+              </summary>
+              <pre class="mt-2 text-xs bg-muted rounded-md p-3 overflow-x-auto">{diagnosticInfo}</pre>
+            </details>
+          </div>
+
+          <Dialog.Footer class="pt-4 border-t mt-4">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={formState === "submitting"}
+              onclick={() => { formState = "idle"; }}
+            >
+              <ArrowLeft class="h-4 w-4 mr-2" />
+              Back
+            </Button>
+            <div class="flex-1"></div>
+            <Button type="button" variant="outline" onclick={copyPreview}>
+              {#if previewCopied}
+                <CheckCircle class="h-4 w-4 mr-2" />
+                Copied
+              {:else}
+                <Copy class="h-4 w-4 mr-2" />
+                Copy
+              {/if}
+            </Button>
+            <Button
+              type="submit"
+              disabled={formState === "submitting"}
+            >
+              {#if formState === "submitting"}
+                <Loader2 class="h-4 w-4 mr-2 animate-spin" />
+                Creating Issue...
+              {:else}
+                Submit Issue
+              {/if}
+            </Button>
+          </Dialog.Footer>
         {/if}
-
-        <Separator />
-
-        <details class="group">
-          <summary class="text-xs font-medium text-muted-foreground uppercase tracking-wide cursor-pointer select-none hover:text-foreground transition-colors">
-            Diagnostic Info
-          </summary>
-          <pre class="mt-2 text-xs bg-muted rounded-md p-3 overflow-x-auto">{diagnosticInfo}</pre>
-        </details>
-      </div>
-
-      <Dialog.Footer class="pt-4 border-t mt-4">
-        <Button variant="outline" onclick={() => { formState = "idle"; }}>
-          <ArrowLeft class="h-4 w-4 mr-2" />
-          Back
-        </Button>
-        <div class="flex-1"></div>
-        <Button variant="outline" onclick={copyPreview}>
-          {#if previewCopied}
-            <CheckCircle class="h-4 w-4 mr-2" />
-            Copied
-          {:else}
-            <Copy class="h-4 w-4 mr-2" />
-            Copy
-          {/if}
-        </Button>
-        <Button
-          onclick={handleSubmit}
-          disabled={formState === "submitting"}
-        >
-          {#if formState === "submitting"}
-            <Loader2 class="h-4 w-4 mr-2 animate-spin" />
-            Creating Issue...
-          {:else}
-            Submit Issue
-          {/if}
-        </Button>
-      </Dialog.Footer>
+      </form>
     {/if}
   </Dialog.Content>
 </Dialog.Root>

--- a/tests/Unit/Nocturne.API.Tests/Services/GitHubIssueServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/GitHubIssueServiceTests.cs
@@ -260,9 +260,10 @@ public class GitHubIssueServiceTests
 
         var service = CreateService(handler);
         var imageBytes = "fake-png-bytes"u8.ToArray();
+        using var imageStream = new MemoryStream(imageBytes);
         var images = new List<(string, string, Stream)>
         {
-            ("Screenshot 2026-07-16 at 15.54.43.png", "image/png", new MemoryStream(imageBytes)),
+            ("Screenshot 2026-07-16 at 15.54.43.png", "image/png", imageStream),
         };
 
         var result = await service.CreateIssueAsync(BugRequest(), images, CancellationToken.None);
@@ -299,9 +300,10 @@ public class GitHubIssueServiceTests
         });
 
         var service = CreateService(handler, opts => opts.AssetsBranch = null);
+        using var imageStream = new MemoryStream([1, 2, 3]);
         var images = new List<(string, string, Stream)>
         {
-            ("shot.png", "image/png", new MemoryStream([1, 2, 3])),
+            ("shot.png", "image/png", imageStream),
         };
 
         var result = await service.CreateIssueAsync(BugRequest(), images, CancellationToken.None);
@@ -326,9 +328,10 @@ public class GitHubIssueServiceTests
         });
 
         var service = CreateService(handler);
+        using var imageStream = new MemoryStream([1, 2, 3]);
         var images = new List<(string, string, Stream)>
         {
-            ("shot.png", "image/png", new MemoryStream([1, 2, 3])),
+            ("shot.png", "image/png", imageStream),
         };
 
         var result = await service.CreateIssueAsync(BugRequest(), images, CancellationToken.None);

--- a/tests/Unit/Nocturne.API.Tests/Services/GitHubIssueServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/GitHubIssueServiceTests.cs
@@ -1,3 +1,6 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -187,5 +190,186 @@ public class GitHubIssueServiceTests
         body.Should().Contain("some ` ` `code` ` ` here");
         // The wrapping code fence should still be intact
         body.Should().Contain("```json");
+    }
+
+    [Fact]
+    public void BuildIssueBody_ImagesAttachedButNotUploaded_NotesTheCount()
+    {
+        var request = new CreateIssueRequest
+        {
+            Template = "bug",
+            Title = "Visual bug",
+            Description = "Chart looks wrong",
+            DiagnosticInfo = "{}",
+        };
+
+        var body = GitHubIssueService.BuildIssueBody(request, [], attachedImageCount: 2);
+
+        body.Should().NotContain("## Screenshots");
+        body.Should().Contain("2 screenshot(s) were attached but could not be uploaded.");
+    }
+
+    [Fact]
+    public void BuildIssueBody_AllImagesUploaded_HasNoUploadFailureNote()
+    {
+        var request = new CreateIssueRequest
+        {
+            Template = "bug",
+            Title = "Visual bug",
+            Description = "Chart looks wrong",
+            DiagnosticInfo = "{}",
+        };
+
+        var body = GitHubIssueService.BuildIssueBody(
+            request,
+            ["https://example.com/image1.png"],
+            attachedImageCount: 1);
+
+        body.Should().Contain("## Screenshots");
+        body.Should().NotContain("could not be uploaded");
+    }
+
+    [Theory]
+    [InlineData("Screenshot 2026-07-16 at 15.54.43.png", "Screenshot2026-07-16at15.54.43.png")]
+    [InlineData("../../evil.png", "....evil.png")]
+    [InlineData("...", "screenshot")]
+    [InlineData("", "screenshot")]
+    public void SanitizeFileName_RestrictsToSafeCharacters(string input, string expected)
+    {
+        GitHubIssueService.SanitizeFileName(input).Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task CreateIssueAsync_WithImages_CommitsToAssetsBranchAndEmbedsUrls()
+    {
+        var requests = new List<(HttpRequestMessage Message, string Body)>();
+        var handler = new StubHttpMessageHandler(async request =>
+        {
+            var body = request.Content is null ? "" : await request.Content.ReadAsStringAsync();
+            requests.Add((request, body));
+
+            if (request.Method == HttpMethod.Put)
+            {
+                return Respond(HttpStatusCode.Created,
+                    """{"content":{"download_url":"https://raw.githubusercontent.com/nightscout/nocturne/support-assets/screenshots/test.png"}}""");
+            }
+
+            return Respond(HttpStatusCode.Created,
+                """{"number":123,"html_url":"https://github.com/nightscout/nocturne/issues/123"}""");
+        });
+
+        var service = CreateService(handler);
+        var imageBytes = "fake-png-bytes"u8.ToArray();
+        var images = new List<(string, string, Stream)>
+        {
+            ("Screenshot 2026-07-16 at 15.54.43.png", "image/png", new MemoryStream(imageBytes)),
+        };
+
+        var result = await service.CreateIssueAsync(BugRequest(), images, CancellationToken.None);
+
+        result.IssueNumber.Should().Be(123);
+        result.IssueUrl.Should().Be("https://github.com/nightscout/nocturne/issues/123");
+
+        var upload = requests.Should().ContainSingle(r => r.Message.Method == HttpMethod.Put).Subject;
+        upload.Message.RequestUri!.AbsolutePath.Should().StartWith("/repos/nightscout/nocturne/contents/screenshots/");
+        upload.Message.RequestUri.AbsolutePath.Should().EndWith("-Screenshot2026-07-16at15.54.43.png");
+        using (var doc = JsonDocument.Parse(upload.Body))
+        {
+            doc.RootElement.GetProperty("branch").GetString().Should().Be("support-assets");
+            doc.RootElement.GetProperty("content").GetString().Should()
+                .Be(Convert.ToBase64String(imageBytes));
+        }
+
+        var issue = requests.Should().ContainSingle(r => r.Message.Method == HttpMethod.Post).Subject;
+        issue.Message.RequestUri!.AbsolutePath.Should().Be("/repos/nightscout/nocturne/issues");
+        issue.Body.Should().Contain(
+            "https://raw.githubusercontent.com/nightscout/nocturne/support-assets/screenshots/test.png");
+    }
+
+    [Fact]
+    public async Task CreateIssueAsync_AssetsBranchUnset_SkipsUploadAndNotesAttachments()
+    {
+        var requests = new List<(HttpMethod Method, string Body)>();
+        var handler = new StubHttpMessageHandler(async request =>
+        {
+            var body = request.Content is null ? "" : await request.Content.ReadAsStringAsync();
+            requests.Add((request.Method, body));
+            return Respond(HttpStatusCode.Created,
+                """{"number":7,"html_url":"https://github.com/nightscout/nocturne/issues/7"}""");
+        });
+
+        var service = CreateService(handler, opts => opts.AssetsBranch = null);
+        var images = new List<(string, string, Stream)>
+        {
+            ("shot.png", "image/png", new MemoryStream([1, 2, 3])),
+        };
+
+        var result = await service.CreateIssueAsync(BugRequest(), images, CancellationToken.None);
+
+        result.IssueNumber.Should().Be(7);
+        var issue = requests.Should().ContainSingle().Subject;
+        issue.Method.Should().Be(HttpMethod.Post);
+        issue.Body.Should().Contain("1 screenshot(s) were attached but could not be uploaded.");
+    }
+
+    [Fact]
+    public async Task CreateIssueAsync_UploadFails_StillCreatesIssueWithNote()
+    {
+        var handler = new StubHttpMessageHandler(request =>
+        {
+            if (request.Method == HttpMethod.Put)
+            {
+                return Task.FromResult(Respond(HttpStatusCode.NotFound, """{"message":"Branch not found"}"""));
+            }
+            return Task.FromResult(Respond(HttpStatusCode.Created,
+                """{"number":8,"html_url":"https://github.com/nightscout/nocturne/issues/8"}"""));
+        });
+
+        var service = CreateService(handler);
+        var images = new List<(string, string, Stream)>
+        {
+            ("shot.png", "image/png", new MemoryStream([1, 2, 3])),
+        };
+
+        var result = await service.CreateIssueAsync(BugRequest(), images, CancellationToken.None);
+
+        result.IssueNumber.Should().Be(8);
+    }
+
+    private static CreateIssueRequest BugRequest() => new()
+    {
+        Template = "bug",
+        Title = "Visual bug",
+        Description = "Chart looks wrong",
+        DiagnosticInfo = "{}",
+    };
+
+    private static HttpResponseMessage Respond(HttpStatusCode status, string json) => new(status)
+    {
+        Content = new StringContent(json, Encoding.UTF8, "application/json"),
+    };
+
+    private static GitHubIssueService CreateService(
+        HttpMessageHandler handler,
+        Action<GitHubIssueOptions>? configure = null)
+    {
+        var options = new GitHubIssueOptions { IssuesPat = "ghp_test123" };
+        configure?.Invoke(options);
+
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(() => new HttpClient(handler, disposeHandler: false));
+
+        return new GitHubIssueService(
+            factory.Object,
+            Options.Create(options),
+            NullLogger<GitHubIssueService>.Instance);
+    }
+
+    private sealed class StubHttpMessageHandler(
+        Func<HttpRequestMessage, Task<HttpResponseMessage>> respond) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken) => respond(request);
     }
 }


### PR DESCRIPTION
## Summary

Fixes the bug-report-form half of #509 (the wrong report values are a separate fix). The reporter's experience decomposed into four defects, all addressed here:

1. **Submitting with a screenshot attached has never worked.** `createIssue` was a remote *command* carrying `File[]`; command arguments are devalue-serialised, and devalue throws `Cannot stringify arbitrary non-POJOs` on a File — client-side, before any request is sent. Replaced with a `form(...)` remote (`submitIssue`), which transports files natively. The dialog now wraps its idle/preview steps in a real `<form enctype=multipart/form-data>`: the preview step mounts named hidden fields mirroring the edited state, and a persistent `images[]` file input (also the browse picker) is kept in sync with the drag-drop state via DataTransfer. The operator channel folds into the same form via a hidden `channel` field.
2. **Screenshots were silently dropped even when issue creation succeeded.** `UploadImagesAsync` posted to `uploads.github.com/repos/{o}/{r}/upload/assets` — an endpoint that does not exist (GitHub has no API for uploading images into an issue). Screenshots are now committed to a `support-assets` branch of the issues repo via the contents API and embedded in the issue body with their `raw.githubusercontent.com` URLs, so they render inline in the issue. When upload is unconfigured or fails, the body states how many screenshots were attached but not uploaded instead of staying silent.
3. **A failed attempt destroyed the draft** — closing the error screen reset every field (this is the "when I filled it in again, the description and screenshots disappeared" from #509). The draft is now kept unless the issue was submitted; the error screen gains a Back button; Back is disabled and dialog dismissal blocked while a submission is in flight (prevents duplicate issues from close-and-retry races); and the fallback GitHub URL now carries steps/expected/actual and diagnostics, not just the description.
4. **Even with working transport, uploads would have been rejected downstream**: adapter-node's default `BODY_SIZE_LIMIT` is 512K. The web image now sets 44M (controller already enforces 4 x 10 MB per-request limits).

Also drops `[RemoteCommand]` from `CreateIssue` — the generated wrapper couldn't model the multipart body and called the client with no arguments.

## Tests

- New `GitHubIssueServiceTests`: contents-API upload path (URL/branch/base64/download_url handling), unset-assets-branch note, upload-failure note, filename sanitisation. 19/19 pass.
- `pnpm run check`: no errors in touched files (repo baseline unchanged).
- Reviewed by a fresh-context agent against the kit 2.59 runtime source; all four of its findings (missing enctype, file-input desync on rejected picks, redirect-resolves-submit false success, submit-race on close) are fixed in this diff.

## Ops notes (nocturne.run)

- Create the orphan branch once: `git switch --orphan support-assets && git commit --allow-empty -m 'support assets' && git push origin support-assets`.
- The issues PAT needs **Contents: write** on this repo for screenshot upload (branch protection keeps main/master out of reach). Until then, issues are created with a "N screenshot(s) could not be uploaded" note.
- Self-hosted instances without a PAT are unaffected (relay path forwards multipart as before).

## Follow-up (separate issue)

`openapi-remote-codegen` emits the same broken pattern (`command(async (file: File))`) for every `IFormFile` endpoint — avatar upload and custom alert sounds are equally unable to submit files and need the same treatment or a codegen fix.