### PR TITLE
fix(reports): compute hourly insulin delivery backend-side from pump-confirmed records

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
@@ -1388,7 +1388,13 @@ public class StatisticsController : ControllerBase
             );
             return Ok(result);
         }
-        catch (Exception ex)
+        // Input-shaped failures only; anything else propagates to the global
+        // handler as a 5xx instead of masquerading as a client error.
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+        catch (InvalidOperationException ex)
         {
             return BadRequest(new { error = ex.Message });
         }

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
@@ -1268,8 +1268,10 @@ public class StatisticsController : ControllerBase
 
             // Fetch TempBasals and algorithm boluses
             // Deduplicate by 30s window + rate to eliminate duplicates from multiple connectors
-            var tempBasalTask = _tempBasalRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, 10000, descending: false);
-            var algoTask      = _bolusRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, 10000, descending: false, kind: BolusKind.Algorithm);
+            // No practical fetch cap — see GetHourlyInsulinDelivery: a 10k cap
+            // silently truncates ~5-minute AID records past ~35 days.
+            var tempBasalTask = _tempBasalRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false);
+            var algoTask      = _bolusRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false, kind: BolusKind.Algorithm);
 
             await Task.WhenAll(tempBasalTask, algoTask);
 
@@ -1301,6 +1303,84 @@ public class StatisticsController : ControllerBase
 
             var result = _statisticsService.CalculateBasalAnalysis(
                 tempBasals,
+                algorithmBoluses,
+                startUtc,
+                endUtc,
+                userTz
+            );
+            return Ok(result);
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Calculates the average insulin delivered per hour of day, split by scheduled
+    /// basal, temp adjustments, and boluses, from pump-confirmed delivery records.
+    /// Basal insulin is duration-weighted across the user-local hours each TempBasal
+    /// overlaps, and averages are taken over the days that have delivery data — a
+    /// window that extends before the first record does not distort the pattern.
+    /// </summary>
+    /// <param name="startDate">Start date of the analysis period (UTC)</param>
+    /// <param name="endDate">End date of the analysis period (UTC)</param>
+    /// <returns>24 hourly averages plus the number of days with data</returns>
+    [HttpGet("hourly-insulin-delivery")]
+    [RemoteQuery]
+    public async Task<ActionResult<HourlyInsulinDeliveryResponse>> GetHourlyInsulinDelivery(
+        [FromQuery] DateTime? startDate = null,
+        [FromQuery] DateTime? endDate = null
+    )
+    {
+        try
+        {
+            if (startDate is null || endDate is null)
+                return BadRequest(new { error = "startDate and endDate are required." });
+
+            var startUtc = DateTime.SpecifyKind(startDate.Value, DateTimeKind.Utc);
+            var endUtc = DateTime.SpecifyKind(endDate.Value, DateTimeKind.Utc);
+
+            // No practical fetch cap: AID pumps write a TempBasal (and often an
+            // SMB) every ~5 minutes, so 90 days is ~26k records per type — a
+            // 10k cap would silently truncate to the oldest ~35 days and
+            // understate every average.
+            var tempBasalTask = _tempBasalRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false);
+            var bolusTask     = _bolusRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false, kind: BolusKind.Manual);
+            var algoTask      = _bolusRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false, kind: BolusKind.Algorithm);
+
+            await Task.WhenAll(tempBasalTask, bolusTask, algoTask);
+
+            var tempBasals       = (await tempBasalTask).ToList();
+            var boluses          = await bolusTask;
+            var algorithmBoluses = await algoTask;
+
+            // Fall back to profile-based scheduled rates when no TempBasals exist,
+            // mirroring GetBasalAnalysis: each segment becomes one synthetic
+            // TempBasal that gets duration-weighted across the hours it overlaps.
+            var hasTherapyData = await _therapySettingsResolver.HasDataAsync(HttpContext.RequestAborted);
+            if (tempBasals.Count == 0 && hasTherapyData)
+            {
+                var fromMs = new DateTimeOffset(startUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
+                var toMs = new DateTimeOffset(endUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
+                await foreach (var seg in _basalSegments.GetSegmentsAsync(fromMs, toMs, HttpContext.RequestAborted))
+                {
+                    tempBasals.Add(new TempBasal
+                    {
+                        StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(seg.StartMills).UtcDateTime,
+                        EndTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(seg.EndMills).UtcDateTime,
+                        Rate = seg.UnitsPerHour,
+                        Origin = TempBasalOrigin.Scheduled,
+                    });
+                }
+            }
+
+            var tzId = await _therapySettingsResolver.GetTimezoneAsync(ct: HttpContext.RequestAborted);
+            var userTz = string.IsNullOrEmpty(tzId) ? null : TimeZoneHelper.GetTimeZoneInfoFromId(tzId);
+
+            var result = _statisticsService.CalculateHourlyInsulinDelivery(
+                tempBasals,
+                boluses,
                 algorithmBoluses,
                 startUtc,
                 endUtc,

--- a/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
@@ -2239,10 +2239,8 @@ public class StatisticsService : IStatisticsService
             counts[LocalHourOfDay(tb.StartMills, tz)]++;
         }
 
-        foreach (var b in boluses)
+        foreach (var b in boluses.Where(b => b.Insulin > 0))
         {
-            if (b.Insulin <= 0)
-                continue;
             var hour = LocalHourOfDay(b.Mills, tz);
             bolus[hour] += b.Insulin;
             counts[hour]++;
@@ -2250,10 +2248,8 @@ public class StatisticsService : IStatisticsService
         }
 
         // Algorithm micro-boluses are basal-replacement doses above schedule
-        foreach (var ab in algorithmBoluses)
+        foreach (var ab in algorithmBoluses.Where(ab => ab.Insulin > 0))
         {
-            if (ab.Insulin <= 0)
-                continue;
             var hour = LocalHourOfDay(ab.Mills, tz);
             tempBasal[hour] += ab.Insulin;
             counts[hour]++;

--- a/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
@@ -2201,6 +2201,139 @@ public class StatisticsService : IStatisticsService
         };
     }
 
+    /// <inheritdoc />
+    public HourlyInsulinDeliveryResponse CalculateHourlyInsulinDelivery(
+        IEnumerable<TempBasal> tempBasals,
+        IEnumerable<Bolus> boluses,
+        IEnumerable<Bolus> algorithmBoluses,
+        DateTime startDate,
+        DateTime endDate,
+        TimeZoneInfo? userTimeZone = null)
+    {
+        var tz = userTimeZone ?? TimeZoneInfo.Utc;
+
+        var scheduledBasal = new double[24];
+        var tempBasal = new double[24];
+        var bolus = new double[24];
+        var counts = new int[24];
+
+        // Basal and bolus averages get separate denominators: profile-derived
+        // scheduled segments can tile the whole requested window, and dividing
+        // the (much sparser) bolus days by that span would understate them.
+        var basalDays = new HashSet<DateOnly>();
+        var bolusDays = new HashSet<DateOnly>();
+
+        foreach (var (tb, effectiveEndMills) in ClipOverlappingTempBasals(tempBasals))
+        {
+            if (effectiveEndMills <= tb.StartMills)
+                continue;
+
+            // Categorize whole segments by origin: what was delivered while a
+            // temp adjustment was active counts as temp, the rest as scheduled.
+            var target = tb.Origin is TempBasalOrigin.Scheduled or TempBasalOrigin.Inferred
+                ? scheduledBasal
+                : tempBasal;
+
+            DistributeInsulinAcrossHourOfDay(
+                tb.StartMills, effectiveEndMills, tb.Rate, tz, target, basalDays);
+            counts[LocalHourOfDay(tb.StartMills, tz)]++;
+        }
+
+        foreach (var b in boluses)
+        {
+            if (b.Insulin <= 0)
+                continue;
+            var hour = LocalHourOfDay(b.Mills, tz);
+            bolus[hour] += b.Insulin;
+            counts[hour]++;
+            bolusDays.Add(LocalDay(b.Mills, tz));
+        }
+
+        // Algorithm micro-boluses are basal-replacement doses above schedule
+        foreach (var ab in algorithmBoluses)
+        {
+            if (ab.Insulin <= 0)
+                continue;
+            var hour = LocalHourOfDay(ab.Mills, tz);
+            tempBasal[hour] += ab.Insulin;
+            counts[hour]++;
+            basalDays.Add(LocalDay(ab.Mills, tz));
+        }
+
+        // Average each component over the days that actually have its data, not
+        // the requested window: a period extending before the first record must
+        // not dilute (or, combined with gap-fill, distort) the daily pattern.
+        var basalDayCount = Math.Max(1, basalDays.Count);
+        var bolusDayCount = Math.Max(1, bolusDays.Count);
+
+        var hours = new List<HourlyInsulinDeliveryPoint>(24);
+        for (int hour = 0; hour < 24; hour++)
+        {
+            var avgScheduled = Math.Round(scheduledBasal[hour] / basalDayCount * 100) / 100;
+            var avgTemp = Math.Round(tempBasal[hour] / basalDayCount * 100) / 100;
+            var avgBolus = Math.Round(bolus[hour] / bolusDayCount * 100) / 100;
+            hours.Add(new HourlyInsulinDeliveryPoint
+            {
+                Hour = hour,
+                ScheduledBasal = avgScheduled,
+                TempBasal = avgTemp,
+                Basal = Math.Round((avgScheduled + avgTemp) * 100) / 100,
+                Bolus = avgBolus,
+                Total = Math.Round((avgScheduled + avgTemp + avgBolus) * 100) / 100,
+                Count = counts[hour],
+            });
+        }
+
+        var allDays = new HashSet<DateOnly>(basalDays);
+        allDays.UnionWith(bolusDays);
+
+        return new HourlyInsulinDeliveryResponse
+        {
+            Hours = hours,
+            DayCount = allDays.Count,
+            StartDate = startDate.ToString("yyyy-MM-dd"),
+            EndDate = endDate.ToString("yyyy-MM-dd"),
+        };
+    }
+
+    /// <summary>
+    /// Adds a constant-rate delivery interval's insulin into per-local-hour-of-day
+    /// buckets, splitting on the timezone's local hour boundaries so each hour
+    /// receives exactly the insulin delivered during it. Also records the local
+    /// days the interval touches.
+    /// </summary>
+    private static void DistributeInsulinAcrossHourOfDay(
+        long startMills,
+        long endMills,
+        double rate,
+        TimeZoneInfo tz,
+        double[] insulinBuckets,
+        HashSet<DateOnly> localDays)
+    {
+        if (endMills <= startMills) return;
+        const long HourMs = 3_600_000L;
+        long cursor = startMills;
+        while (cursor < endMills)
+        {
+            var utcDt = DateTimeOffset.FromUnixTimeMilliseconds(cursor);
+            var offsetMs = (long)tz.GetUtcOffset(utcDt).TotalMilliseconds;
+            long nextLocalHourBoundary = ((cursor + offsetMs) / HourMs + 1) * HourMs - offsetMs;
+            long sliceEnd = Math.Min(nextLocalHourBoundary, endMills);
+            var localDt = TimeZoneInfo.ConvertTimeFromUtc(utcDt.UtcDateTime, tz);
+            insulinBuckets[localDt.Hour] += rate * (sliceEnd - cursor) / HourMs;
+            localDays.Add(DateOnly.FromDateTime(localDt));
+            cursor = sliceEnd;
+        }
+    }
+
+    private static int LocalHourOfDay(long mills, TimeZoneInfo tz) =>
+        TimeZoneInfo.ConvertTimeFromUtc(
+            DateTimeOffset.FromUnixTimeMilliseconds(mills).UtcDateTime, tz).Hour;
+
+    private static DateOnly LocalDay(long mills, TimeZoneInfo tz) =>
+        DateOnly.FromDateTime(TimeZoneInfo.ConvertTimeFromUtc(
+            DateTimeOffset.FromUnixTimeMilliseconds(mills).UtcDateTime, tz));
+
     /// <summary>
     /// Walks a [startMills, endMills) interval and adds (rate, overlapMs) entries to each
     /// <paramref name="tz"/>-local hour-of-day bucket the interval crosses. A 30-minute interval

--- a/src/Core/Nocturne.Core.Contracts/Analytics/IStatisticsService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Analytics/IStatisticsService.cs
@@ -397,4 +397,20 @@ public interface IStatisticsService
         DateTime startDate,
         DateTime endDate,
         TimeZoneInfo? userTimeZone = null);
+
+    /// <summary>
+    /// Calculate the average insulin delivered per hour of day, from pump-confirmed
+    /// delivery records only. Basal insulin is duration-weighted across the
+    /// <paramref name="userTimeZone"/>-local hours each TempBasal overlaps; averages
+    /// divide by the number of distinct local days that have delivery data, so a
+    /// period that extends beyond the available data does not distort the pattern.
+    /// Defaults to UTC hour-of-day when <paramref name="userTimeZone"/> is null.
+    /// </summary>
+    HourlyInsulinDeliveryResponse CalculateHourlyInsulinDelivery(
+        IEnumerable<TempBasal> tempBasals,
+        IEnumerable<Bolus> boluses,
+        IEnumerable<Bolus> algorithmBoluses,
+        DateTime startDate,
+        DateTime endDate,
+        TimeZoneInfo? userTimeZone = null);
 }

--- a/src/Core/Nocturne.Core.Models/StatisticsModels.cs
+++ b/src/Core/Nocturne.Core.Models/StatisticsModels.cs
@@ -2171,6 +2171,76 @@ public class BasalAnalysisResponse
 }
 
 /// <summary>
+/// Average insulin delivered during one hour of the day, split by delivery kind.
+/// Values are units per day, averaged over the days that have delivery data.
+/// </summary>
+public class HourlyInsulinDeliveryPoint
+{
+    /// <summary>
+    /// Hour of day (0-23) in the user's profile timezone
+    /// </summary>
+    public int Hour { get; set; }
+
+    /// <summary>
+    /// Average insulin from scheduled-rate basal delivery (Scheduled/Inferred origin)
+    /// </summary>
+    public double ScheduledBasal { get; set; }
+
+    /// <summary>
+    /// Average insulin from temp adjustments (Algorithm/Manual/Suspended origin)
+    /// and algorithm micro-boluses
+    /// </summary>
+    public double TempBasal { get; set; }
+
+    /// <summary>
+    /// Average total basal insulin (scheduled + temp)
+    /// </summary>
+    public double Basal { get; set; }
+
+    /// <summary>
+    /// Average insulin from user boluses
+    /// </summary>
+    public double Bolus { get; set; }
+
+    /// <summary>
+    /// Average total insulin delivered during this hour
+    /// </summary>
+    public double Total { get; set; }
+
+    /// <summary>
+    /// Number of delivery records contributing to this hour
+    /// </summary>
+    public int Count { get; set; }
+}
+
+/// <summary>
+/// Hourly insulin delivery pattern for a period, computed from pump-confirmed
+/// delivery records (TempBasals + boluses) only
+/// </summary>
+public class HourlyInsulinDeliveryResponse
+{
+    /// <summary>
+    /// One entry per hour of day (0-23)
+    /// </summary>
+    public List<HourlyInsulinDeliveryPoint> Hours { get; set; } = new();
+
+    /// <summary>
+    /// Number of distinct days with delivery data the averages are taken over
+    /// </summary>
+    public int DayCount { get; set; }
+
+    /// <summary>
+    /// Start date of the analysis period
+    /// </summary>
+    public string StartDate { get; set; } = string.Empty;
+
+    /// <summary>
+    /// End date of the analysis period
+    /// </summary>
+    public string EndDate { get; set; } = string.Empty;
+}
+
+/// <summary>
 /// Complete site change impact analysis result
 /// </summary>
 public class SiteChangeImpactAnalysis

--- a/src/Web/packages/app/src/lib/api/reports.remote.ts
+++ b/src/Web/packages/app/src/lib/api/reports.remote.ts
@@ -232,33 +232,6 @@ export const getReportsAnalysis = query(
 );
 
 /**
- * Boluses and basal series for a date range, for the basal-analysis and
- * insulin-delivery reports.
- */
-export const getBasalReportData = query(
-  DateRangeSchema.optional(),
-  async (input) => {
-    const { locals } = getRequestEvent();
-    const { apiClient } = locals;
-    const { startDate, endDate } = calculateDateRange(input);
-
-    const [bolusResult, basalSeries] = await Promise.all([
-      apiClient.bolus.getAll(startDate, endDate, 10000),
-      apiClient.chartData.getBasalSeries(startDate.getTime(), endDate.getTime()),
-    ]);
-
-    return {
-      boluses: bolusResult.data ?? [],
-      basalSeries: basalSeries ?? [],
-      dateRange: {
-        from: startDate.toISOString(),
-        to: endDate.toISOString(),
-      },
-    };
-  }
-);
-
-/**
  * Sensor data-quality / integrity report for a date range: the raw glucose trace plus the
  * server-computed sensor-integrity analysis (noise clusters + cluster-linked hypo events).
  * The frontend renders this verbatim — all detection and scoring happens backend-side.

--- a/src/Web/packages/app/src/lib/components/reports/InsulinDeliveryChart.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/InsulinDeliveryChart.svelte
@@ -1,28 +1,16 @@
 <script lang="ts">
   import { AreaChart } from "layerchart";
-  import type { Bolus, BasalPoint } from "$lib/api";
-  import { BasalDeliveryOrigin } from "$lib/api";
+  import type { HourlyInsulinDeliveryPoint } from "$lib/api";
   import { Syringe } from "lucide-svelte";
   import { categoryPatternClass } from "$lib/components/charts/print/chart-print-patterns";
 
-  interface HourlyInsulinData {
-    hour: number;
-    timeLabel: string;
-    scheduledBasal: number;
-    tempBasal: number;
-    basal: number; // Total basal (scheduled + temp adjustment)
-    bolus: number;
-    total: number;
-    count: number;
-  }
-
   interface Props {
-    boluses: Bolus[];
-    basalSeries?: BasalPoint[];
+    /** Backend-computed hourly delivery averages (24 entries, hour 0-23) */
+    data: HourlyInsulinDeliveryPoint[];
     showStacked?: boolean;
   }
 
-  let { boluses, basalSeries = [], showStacked = true }: Props = $props();
+  let { data, showStacked = true }: Props = $props();
 
   // Format hour for display
   function formatHour(hour: number): string {
@@ -32,132 +20,36 @@
     return `${hour - 12} PM`;
   }
 
-  // Process boluses and basal series to get hourly insulin delivery
-  function processInsulinData(boluses: Bolus[], basalPoints: BasalPoint[]): HourlyInsulinData[] {
-    // Initialize hourly buckets
-    const hourlyData: Map<
-      number,
-      {
-        scheduledBasal: number;
-        tempBasal: number;
-        bolus: number;
-        count: number;
-      }
-    > = new Map();
-    for (let h = 0; h < 24; h++) {
-      hourlyData.set(h, {
-        scheduledBasal: 0,
-        tempBasal: 0,
-        bolus: 0,
-        count: 0,
-      });
-    }
+  const chartData = $derived(data ?? []);
 
-    // Count number of days for averaging
-    const uniqueDays = new Set<string>();
-
-    // Process boluses
-    for (const bolus of boluses) {
-      const date = new Date(bolus.mills ?? Date.now());
-      if (isNaN(date.getTime())) continue;
-
-      uniqueDays.add(date.toISOString().split("T")[0]);
-
-      const hour = date.getHours();
-      const hourData = hourlyData.get(hour)!;
-      hourData.bolus += bolus.insulin ?? 0;
-      hourData.count++;
-    }
-
-    // Process basal series from chart data API
-    // Each BasalPoint represents a rate at a timestamp - we need to calculate insulin delivered
-    const sortedBasal = [...basalPoints].sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0));
-
-    for (let i = 0; i < sortedBasal.length; i++) {
-      const point = sortedBasal[i];
-      const timestamp = point.timestamp ?? 0;
-      const rate = point.rate ?? 0;
-      const origin = point.origin;
-
-      // Calculate duration until next point (or assume 5 min if last point)
-      const nextTimestamp = sortedBasal[i + 1]?.timestamp ?? (timestamp + 5 * 60 * 1000);
-      const durationMs = nextTimestamp - timestamp;
-      const durationHours = durationMs / (1000 * 60 * 60);
-
-      // Calculate insulin delivered during this period
-      const insulinDelivered = rate * durationHours;
-
-      if (insulinDelivered <= 0) continue;
-
-      const date = new Date(timestamp);
-      if (isNaN(date.getTime())) continue;
-
-      uniqueDays.add(date.toISOString().split("T")[0]);
-      const hour = date.getHours();
-      const hourData = hourlyData.get(hour)!;
-
-      // Categorize by origin
-      if (origin === BasalDeliveryOrigin.Scheduled || origin === BasalDeliveryOrigin.Inferred) {
-        hourData.scheduledBasal += insulinDelivered;
-      } else {
-        // Algorithm, Manual, Suspended all count as "temp" adjustments
-        hourData.tempBasal += insulinDelivered;
-      }
-      hourData.count++;
-    }
-
-    const numDays = Math.max(1, uniqueDays.size);
-
-    // Convert to array with averaged values
-    const data: HourlyInsulinData[] = [];
-    for (let hour = 0; hour < 24; hour++) {
-      const hourData = hourlyData.get(hour)!;
-      const avgScheduledBasal = hourData.scheduledBasal / numDays;
-      const avgTempBasal = hourData.tempBasal / numDays;
-      const avgBolus = hourData.bolus / numDays;
-      const avgBasal = avgScheduledBasal + avgTempBasal;
-      data.push({
-        hour,
-        timeLabel: formatHour(hour),
-        scheduledBasal: Math.round(avgScheduledBasal * 100) / 100,
-        tempBasal: Math.round(avgTempBasal * 100) / 100,
-        basal: Math.round(avgBasal * 100) / 100,
-        bolus: Math.round(avgBolus * 100) / 100,
-        total: Math.round((avgBasal + avgBolus) * 100) / 100,
-        count: hourData.count,
-      });
-    }
-
-    return data;
-  }
-
-  // Use derived values instead of effect to avoid infinite loops
-  const chartData = $derived(
-    (boluses && boluses.length > 0) || (basalSeries && basalSeries.length > 0)
-      ? processInsulinData(boluses, basalSeries)
-      : []
+  // The non-stacked variant plots basal only (used by the basal analysis
+  // report); the stacked variant plots the full delivery split.
+  const displayValue = $derived(
+    showStacked
+      ? (d: HourlyInsulinDeliveryPoint) => d.total ?? 0
+      : (d: HourlyInsulinDeliveryPoint) => d.basal ?? 0
   );
 
   const maxInsulin = $derived.by(() => {
     if (chartData.length === 0) return 5;
-    const maxTotal = Math.max(...chartData.map((d) => d.total));
-    return Math.max(2, Math.ceil(maxTotal * 1.2));
+    const maxValue = Math.max(...chartData.map(displayValue));
+    return Math.max(2, Math.ceil(maxValue * 1.2));
   });
 
   // Check if we have both scheduled and temp basal data
   const hasScheduledBasalData = $derived(
-    chartData.some((d) => d.scheduledBasal > 0)
+    chartData.some((d) => (d.scheduledBasal ?? 0) > 0)
   );
-  const hasTempBasalData = $derived(chartData.some((d) => d.tempBasal > 0));
+  const hasTempBasalData = $derived(chartData.some((d) => (d.tempBasal ?? 0) > 0));
 </script>
 
 <div class="w-full">
-  {#if chartData.length > 0 && chartData.some((d) => d.total > 0)}
+  {#if chartData.length > 0 && chartData.some((d) => displayValue(d) > 0)}
     <div class="h-[350px] w-full">
       <AreaChart
         data={chartData}
         x={(d) => d.hour}
-        y={(d) => d.total}
+        y={displayValue}
         series={showStacked
           ? [
               // Show scheduled basal, temp basal adjustments, and bolus as stacked
@@ -165,7 +57,7 @@
                 ? [
                     {
                       key: "scheduledBasal",
-                      value: (d: HourlyInsulinData) => d.scheduledBasal,
+                      value: (d: HourlyInsulinDeliveryPoint) => d.scheduledBasal ?? 0,
                       color: "var(--insulin-scheduled-basal)",
                       label: "Scheduled Basal",
                       props: { class: categoryPatternClass(1) },
@@ -176,7 +68,7 @@
                 ? [
                     {
                       key: "tempBasal",
-                      value: (d: HourlyInsulinData) => d.tempBasal,
+                      value: (d: HourlyInsulinDeliveryPoint) => d.tempBasal ?? 0,
                       color: "var(--insulin-additional-basal)",
                       label: "Temp Basal",
                       props: { class: categoryPatternClass(2) },
@@ -188,7 +80,7 @@
                 ? [
                     {
                       key: "basal",
-                      value: (d: HourlyInsulinData) => d.basal,
+                      value: (d: HourlyInsulinDeliveryPoint) => d.basal ?? 0,
                       color: "var(--insulin-scheduled-basal)",
                       label: "Basal",
                       props: { class: categoryPatternClass(1) },
@@ -197,7 +89,7 @@
                 : []),
               {
                 key: "bolus",
-                value: (d: HourlyInsulinData) => d.bolus,
+                value: (d: HourlyInsulinDeliveryPoint) => d.bolus ?? 0,
                 color: "var(--insulin-bolus)",
                 label: "Bolus",
                 props: { class: categoryPatternClass(3) },
@@ -205,10 +97,10 @@
             ]
           : [
               {
-                key: "total",
-                value: (d: HourlyInsulinData) => d.total,
+                key: "basal",
+                value: (d: HourlyInsulinDeliveryPoint) => d.basal ?? 0,
                 color: "var(--chart-1)",
-                label: "Total Insulin",
+                label: "Basal Insulin",
               },
             ]}
         xDomain={[0, 23]}
@@ -229,13 +121,13 @@
 
     <!-- Time period insights -->
     {#if chartData.length >= 24}
-      {@const morning = chartData.slice(6, 12).reduce((s, d) => s + d.total, 0)}
+      {@const morning = chartData.slice(6, 12).reduce((s, d) => s + displayValue(d), 0)}
       {@const afternoon = chartData
         .slice(12, 18)
-        .reduce((s, d) => s + d.total, 0)}
+        .reduce((s, d) => s + displayValue(d), 0)}
       {@const evening =
-        chartData.slice(18, 24).reduce((s, d) => s + d.total, 0) +
-        chartData.slice(0, 6).reduce((s, d) => s + d.total, 0)}
+        chartData.slice(18, 24).reduce((s, d) => s + displayValue(d), 0) +
+        chartData.slice(0, 6).reduce((s, d) => s + displayValue(d), 0)}
       {@const totalDaily = morning + afternoon + evening}
       <div class="mt-4 grid grid-cols-3 gap-3 text-center">
         <div class="rounded-lg border bg-card p-3">
@@ -267,8 +159,14 @@
     >
       <div class="text-center">
         <Syringe class="mx-auto h-10 w-10 opacity-30" />
-        <p class="mt-2 font-medium">No insulin delivery data</p>
-        <p class="text-sm">No treatments found in this period</p>
+        <p class="mt-2 font-medium">
+          {showStacked ? "No insulin delivery data" : "No basal delivery data"}
+        </p>
+        <p class="text-sm">
+          {showStacked
+            ? "No treatments found in this period"
+            : "No basal records found in this period"}
+        </p>
       </div>
     </div>
   {/if}

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/basal-analysis/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/basal-analysis/+page.svelte
@@ -39,9 +39,5 @@
 </svelte:head>
 
 {#key rangeKey}
-  <BasalAnalysisContent
-    rangeInput={reportsParams.dateRangeInput}
-    {analysisDates}
-    {dateInfo}
-  />
+  <BasalAnalysisContent {analysisDates} {dateInfo} />
 {/key}

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/basal-analysis/BasalAnalysisContent.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/basal-analysis/BasalAnalysisContent.svelte
@@ -23,28 +23,26 @@
   import BasalRatePercentileChart from "$lib/components/reports/BasalRatePercentileChart.svelte";
   import InsulinDeliveryChart from "$lib/components/reports/InsulinDeliveryChart.svelte";
   import ReportsSkeleton from "$lib/components/reports/ReportsSkeleton.svelte";
-  import { getBasalReportData } from "$api/reports.remote";
-  import { getBasalAnalysis } from "$api/generated/statistics.generated.remote";
-  import type { DateRangeInput } from "$lib/hooks/date-params.svelte";
+  import {
+    getBasalAnalysis,
+    getHourlyInsulinDelivery,
+  } from "$api/generated/statistics.generated.remote";
 
   interface Props {
-    rangeInput: DateRangeInput | undefined;
     analysisDates: { startDate: Date; endDate: Date };
     dateInfo: { from: Date; to: Date; dayCount: number };
   }
-  let { rangeInput, analysisDates, dateInfo }: Props = $props();
+  let { analysisDates, dateInfo }: Props = $props();
 
   // Query instances are created once per component instance (the parent remounts
   // this component via {#key} when the date range changes). Creating a query
   // inside $derived and polling .loading/.current can strand the resolved
-  // response on a superseded instance (sveltejs/kit#14915) — with this report's
-  // large getBasalReportData payload that reliably left .loading stuck at true
-  // and the page blank. Component-level instances avoid the race.
-  const reportsQuery = getBasalReportData(rangeInput);
+  // response on a superseded instance (sveltejs/kit#14915), leaving .loading
+  // stuck at true and the page blank. Component-level instances avoid the race.
+  const hourlyDeliveryQuery = getHourlyInsulinDelivery(analysisDates);
   const analysisQuery = getBasalAnalysis(analysisDates);
 
-  const boluses = $derived(reportsQuery.current?.boluses ?? []);
-  const basalSeries = $derived(reportsQuery.current?.basalSeries ?? []);
+  const hourlyDelivery = $derived(hourlyDeliveryQuery.current?.hours ?? []);
 
   const basalStats = $derived.by(() => {
     const s = analysisQuery.current?.stats;
@@ -71,7 +69,7 @@
   const hourlyPercentiles = $derived(analysisQuery.current?.hourlyPercentiles ?? []);
 </script>
 
-{#if reportsQuery.error || analysisQuery.error}
+{#if hourlyDeliveryQuery.error || analysisQuery.error}
   <div class="@container container mx-auto max-w-7xl p-3 @md:p-6">
     <Card
       class="border-2 border-red-200 bg-red-50/50 dark:border-red-800 dark:bg-red-950/30"
@@ -85,11 +83,11 @@
         </CardTitle>
       </CardHeader>
       <CardContent class="text-sm text-muted-foreground">
-        {String(reportsQuery.error ?? analysisQuery.error)}
+        {String(hourlyDeliveryQuery.error ?? analysisQuery.error)}
       </CardContent>
     </Card>
   </div>
-{:else if !reportsQuery.current}
+{:else if !hourlyDeliveryQuery.current}
   <ReportsSkeleton />
 {:else}
   <div class="@container container mx-auto max-w-7xl space-y-8 p-3 @md:p-6">
@@ -264,7 +262,7 @@
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <InsulinDeliveryChart {boluses} {basalSeries} showStacked={false} />
+        <InsulinDeliveryChart data={hourlyDelivery} showStacked={false} />
       </CardContent>
     </Card>
 
@@ -394,7 +392,7 @@
     <!-- Footer -->
     <div class="space-y-1 text-center text-xs text-muted-foreground">
       <p>
-        Report generated from {boluses.length.toLocaleString()} boluses between
+        Report generated from {basalStats.count.toLocaleString()} basal events between
         {dateInfo.from.toLocaleDateString()} and {dateInfo.to.toLocaleDateString()}
       </p>
       <p class="text-muted-foreground/60">

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/insulin-delivery/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/insulin-delivery/+page.svelte
@@ -25,8 +25,11 @@
   import InsulinDeliveryChart from "$lib/components/reports/InsulinDeliveryChart.svelte";
   import ReliabilityBadge from "$lib/components/reports/ReliabilityBadge.svelte";
   import type { InsulinDeliveryStatistics } from "$lib/api";
-  import { getBasalReportData } from "$api/reports.remote";
-  import { getMultiPeriodStatistics, getDailyBasalBolusRatios } from "$api/generated/statistics.generated.remote";
+  import {
+    getMultiPeriodStatistics,
+    getDailyBasalBolusRatios,
+    getHourlyInsulinDelivery,
+  } from "$api/generated/statistics.generated.remote";
   import { requireDateParamsContext } from "$lib/hooks/date-params.svelte";
   import { contextResource } from "$lib/hooks/resource-context.svelte";
 
@@ -34,23 +37,13 @@
   // Default: 30 days for insulin delivery analysis (TDD and ratios benefit from more data)
   const reportsParams = requireDateParamsContext(30);
 
-  // Create primary resource with automatic layout registration
-  const reportsResource = contextResource(
-    () => getBasalReportData(reportsParams.dateRangeInput),
-    { errorTitle: "Error Loading Insulin Delivery Data" }
-  );
+  const dateRange = $derived.by(() => {
+    const range = reportsParams.getDateRange();
+    return { from: range.start.toISOString(), to: range.end.toISOString() };
+  });
 
-  const boluses = $derived(reportsResource.current?.boluses ?? []);
-  const basalSeries = $derived(reportsResource.current?.basalSeries ?? []);
-  const dateRange = $derived(
-    reportsResource.current?.dateRange ?? {
-      from: new Date().toISOString(),
-      to: new Date().toISOString(),
-    }
-  );
-
-  // Daily basal/bolus breakdown for the chart
-  const dailyRatiosDates = $derived.by(() => {
+  // Date args shared by the statistics queries
+  const statisticsDates = $derived.by(() => {
     const input = reportsParams.dateRangeInput;
     const endDate = input?.to ? new Date(input.to) : new Date();
     endDate.setHours(23, 59, 59, 999);
@@ -73,7 +66,15 @@
       endDate: endDate.toISOString() as unknown as Date,
     };
   });
-  const dailyRatiosResource = $derived(getDailyBasalBolusRatios(dailyRatiosDates));
+  const dailyRatiosResource = $derived(getDailyBasalBolusRatios(statisticsDates));
+
+  // Hourly delivery pattern with automatic layout registration. Computed
+  // backend-side from pump-confirmed records, bucketed by the user's timezone.
+  const hourlyDeliveryResource = contextResource(
+    () => getHourlyInsulinDelivery(statisticsDates),
+    { errorTitle: "Error Loading Insulin Delivery Data" }
+  );
+  const hourlyDelivery = $derived(hourlyDeliveryResource.current?.hours ?? []);
 
   // Secondary resource for multi-period statistics
   const multiPeriodStatsResource = $derived(getMultiPeriodStatistics());
@@ -154,7 +155,7 @@
   />
 </svelte:head>
 
-{#if reportsResource.current || multiPeriodStatsResource.current}
+{#if hourlyDeliveryResource.current || multiPeriodStatsResource.current}
 <div class="@container container mx-auto max-w-7xl space-y-8 p-3 @md:p-6">
   <!-- Header -->
   <div class="space-y-4">
@@ -348,7 +349,7 @@
       </CardDescription>
     </CardHeader>
     <CardContent>
-      <InsulinDeliveryChart {boluses} {basalSeries} showStacked={true} />
+      <InsulinDeliveryChart data={hourlyDelivery} showStacked={true} />
     </CardContent>
   </Card>
 
@@ -518,7 +519,7 @@
   <!-- Footer -->
   <div class="space-y-1 text-center text-xs text-muted-foreground">
     <p>
-      Report generated from {boluses.length.toLocaleString()} boluses between
+      Report generated from {(insulinStats.bolusCount ?? 0).toLocaleString()} boluses between
       {startDate.toLocaleDateString()} and {endDate.toLocaleDateString()}
     </p>
     <p class="text-muted-foreground/60">

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceHourlyDeliveryTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceHourlyDeliveryTests.cs
@@ -196,7 +196,7 @@ public class StatisticsServiceHourlyDeliveryTests
 
         result.Hours.Should().HaveCount(24);
         result.DayCount.Should().Be(0);
-        result.Hours.Should().OnlyContain(h => h.Total == 0);
+        result.Hours.Should().OnlyContain(h => Math.Abs(h.Total) < 1e-9);
     }
 
     private static DateTime Utc(int year, int month, int day, int hour, int minute) =>

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceHourlyDeliveryTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceHourlyDeliveryTests.cs
@@ -1,0 +1,228 @@
+using FluentAssertions;
+using Nocturne.API.Services.Analytics;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.API.Tests.Services.Analytics;
+
+/// <summary>
+/// Tests for CalculateHourlyInsulinDelivery: duration-weighted hour-of-day
+/// bucketing of pump-confirmed delivery in the user's timezone, averaged over
+/// days that have data. Guards the nightscout/nocturne#509 regression where a
+/// report window extending before the first record produced a phantom
+/// multi-hundred-unit spike at the window-start hour.
+/// </summary>
+public class StatisticsServiceHourlyDeliveryTests
+{
+    private readonly StatisticsService _sut = new();
+
+    private static readonly DateTime StartDate = new(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime EndDate = new(2024, 1, 31, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void FlatBasal_DistributesAcrossOverlappedHours()
+    {
+        // 1.2 U/hr from 10:00 to 13:00 on a single day
+        var tempBasals = new[]
+        {
+            MakeTempBasal(rate: 1.2, startUtc: Utc(2024, 1, 1, 10, 0), endUtc: Utc(2024, 1, 1, 13, 0)),
+        };
+
+        var result = _sut.CalculateHourlyInsulinDelivery(
+            tempBasals, [], [], StartDate, EndDate);
+
+        result.DayCount.Should().Be(1);
+        result.Hours[10].Basal.Should().Be(1.2);
+        result.Hours[11].Basal.Should().Be(1.2);
+        result.Hours[12].Basal.Should().Be(1.2);
+        result.Hours[13].Basal.Should().Be(0);
+        result.Hours[9].Basal.Should().Be(0);
+    }
+
+    [Fact]
+    public void PartialHours_SplitOnHourBoundaries()
+    {
+        // 1.0 U/hr from 10:30 to 11:30 — half an hour in each bucket
+        var tempBasals = new[]
+        {
+            MakeTempBasal(rate: 1.0, startUtc: Utc(2024, 1, 1, 10, 30), endUtc: Utc(2024, 1, 1, 11, 30)),
+        };
+
+        var result = _sut.CalculateHourlyInsulinDelivery(
+            tempBasals, [], [], StartDate, EndDate);
+
+        result.Hours[10].Basal.Should().Be(0.5);
+        result.Hours[11].Basal.Should().Be(0.5);
+    }
+
+    [Fact]
+    public void UserTimezone_BucketsByLocalHour()
+    {
+        // 1.0 U/hr from 00:00 to 01:00 UTC; at UTC-8 that's 16:00-17:00 local
+        var tz = TimeZoneInfo.CreateCustomTimeZone("test-8", TimeSpan.FromHours(-8), "-8", "-8");
+        var tempBasals = new[]
+        {
+            MakeTempBasal(rate: 1.0, startUtc: Utc(2024, 1, 1, 0, 0), endUtc: Utc(2024, 1, 1, 1, 0)),
+        };
+
+        var result = _sut.CalculateHourlyInsulinDelivery(
+            tempBasals, [], [], StartDate, EndDate, tz);
+
+        result.Hours[16].Basal.Should().Be(1.0);
+        result.Hours[0].Basal.Should().Be(0);
+    }
+
+    [Fact]
+    public void HalfHourOffsetTimezone_SplitsOnLocalHourBoundaries()
+    {
+        // 1.0 U/hr from 00:00 to 01:00 UTC; at UTC+9:30 that's 09:30-10:30 local
+        var tz = TimeZoneInfo.CreateCustomTimeZone("test+930", TimeSpan.FromMinutes(9 * 60 + 30), "+9:30", "+9:30");
+        var tempBasals = new[]
+        {
+            MakeTempBasal(rate: 1.0, startUtc: Utc(2024, 1, 1, 0, 0), endUtc: Utc(2024, 1, 1, 1, 0)),
+        };
+
+        var result = _sut.CalculateHourlyInsulinDelivery(
+            tempBasals, [], [], StartDate, EndDate, tz);
+
+        result.Hours[9].Basal.Should().Be(0.5);
+        result.Hours[10].Basal.Should().Be(0.5);
+    }
+
+    [Fact]
+    public void WindowExtendingBeforeFirstRecord_AveragesOverDataDaysOnly()
+    {
+        // nightscout/nocturne#509: 30-day window, but delivery data exists only
+        // for the last two days (flat 0.3 U/hr). Every hour must average 0.3 —
+        // no hour may absorb the empty weeks as phantom insulin.
+        var tempBasals = new[]
+        {
+            MakeTempBasal(rate: 0.3, startUtc: Utc(2024, 1, 29, 0, 0), endUtc: Utc(2024, 1, 30, 0, 0), origin: TempBasalOrigin.Scheduled),
+            MakeTempBasal(rate: 0.3, startUtc: Utc(2024, 1, 30, 0, 0), endUtc: Utc(2024, 1, 31, 0, 0), origin: TempBasalOrigin.Scheduled),
+        };
+
+        var result = _sut.CalculateHourlyInsulinDelivery(
+            tempBasals, [], [], StartDate, EndDate);
+
+        result.DayCount.Should().Be(2, "only two days have delivery data");
+        foreach (var hour in result.Hours)
+        {
+            hour.Basal.Should().Be(0.3, $"hour {hour.Hour} must show the flat rate, not a gap artifact");
+        }
+    }
+
+    [Fact]
+    public void Origin_SplitsScheduledFromTempAdjustments()
+    {
+        var tempBasals = new[]
+        {
+            MakeTempBasal(rate: 0.5, startUtc: Utc(2024, 1, 1, 8, 0), endUtc: Utc(2024, 1, 1, 9, 0), origin: TempBasalOrigin.Scheduled),
+            MakeTempBasal(rate: 1.5, startUtc: Utc(2024, 1, 1, 9, 0), endUtc: Utc(2024, 1, 1, 10, 0), origin: TempBasalOrigin.Algorithm),
+        };
+
+        var result = _sut.CalculateHourlyInsulinDelivery(
+            tempBasals, [], [], StartDate, EndDate);
+
+        result.Hours[8].ScheduledBasal.Should().Be(0.5);
+        result.Hours[8].TempBasal.Should().Be(0);
+        result.Hours[9].ScheduledBasal.Should().Be(0);
+        result.Hours[9].TempBasal.Should().Be(1.5);
+    }
+
+    [Fact]
+    public void Boluses_BucketByHour_AlgorithmBolusesCountAsTempBasal()
+    {
+        var boluses = new[] { MakeBolus(5.0, Utc(2024, 1, 1, 8, 15)) };
+        var algorithmBoluses = new[] { MakeBolus(0.4, Utc(2024, 1, 1, 9, 5)) };
+
+        var result = _sut.CalculateHourlyInsulinDelivery(
+            [], boluses, algorithmBoluses, StartDate, EndDate);
+
+        result.Hours[8].Bolus.Should().Be(5.0);
+        result.Hours[9].Bolus.Should().Be(0);
+        result.Hours[9].TempBasal.Should().Be(0.4);
+        result.Hours[8].Total.Should().Be(5.0);
+    }
+
+    [Fact]
+    public void Averages_DivideByDistinctDataDays()
+    {
+        var boluses = new[]
+        {
+            MakeBolus(4.0, Utc(2024, 1, 1, 12, 0)),
+            MakeBolus(2.0, Utc(2024, 1, 2, 12, 30)),
+        };
+
+        var result = _sut.CalculateHourlyInsulinDelivery(
+            [], boluses, [], StartDate, EndDate);
+
+        result.DayCount.Should().Be(2);
+        result.Hours[12].Bolus.Should().Be(3.0);
+        result.Hours[12].Count.Should().Be(2);
+    }
+
+    [Fact]
+    public void BasalAndBolusAverages_UseSeparateDayDenominators()
+    {
+        // Profile-derived scheduled segments tiling a whole month (the
+        // no-TempBasal fallback) must not dilute boluses that exist on only
+        // two days: each component averages over its own data days.
+        var tempBasals = Enumerable.Range(0, 30)
+            .Select(day => MakeTempBasal(
+                rate: 0.5,
+                startUtc: StartDate.AddDays(day),
+                endUtc: StartDate.AddDays(day + 1),
+                origin: TempBasalOrigin.Scheduled))
+            .ToArray();
+        var boluses = new[]
+        {
+            MakeBolus(4.0, Utc(2024, 1, 29, 12, 0)),
+            MakeBolus(2.0, Utc(2024, 1, 30, 12, 0)),
+        };
+
+        var result = _sut.CalculateHourlyInsulinDelivery(
+            tempBasals, boluses, [], StartDate, EndDate);
+
+        result.Hours[12].ScheduledBasal.Should().Be(0.5, "basal averages over its 30 covered days");
+        result.Hours[12].Bolus.Should().Be(3.0, "boluses average over their own 2 data days");
+        result.DayCount.Should().Be(30);
+    }
+
+    [Fact]
+    public void NoData_ReturnsZeroedHours()
+    {
+        var result = _sut.CalculateHourlyInsulinDelivery(
+            [], [], [], StartDate, EndDate);
+
+        result.Hours.Should().HaveCount(24);
+        result.DayCount.Should().Be(0);
+        result.Hours.Should().OnlyContain(h => h.Total == 0);
+    }
+
+    private static DateTime Utc(int year, int month, int day, int hour, int minute) =>
+        new(year, month, day, hour, minute, 0, DateTimeKind.Utc);
+
+    private static TempBasal MakeTempBasal(
+        double rate,
+        DateTime startUtc,
+        DateTime endUtc,
+        TempBasalOrigin origin = TempBasalOrigin.Algorithm)
+    {
+        return new TempBasal
+        {
+            StartTimestamp = startUtc,
+            EndTimestamp = endUtc,
+            Rate = rate,
+            Origin = origin,
+        };
+    }
+
+    private static Bolus MakeBolus(double insulin, DateTime timestampUtc)
+    {
+        return new Bolus
+        {
+            Insulin = insulin,
+            Timestamp = timestampUtc,
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the wrong-values half of #509 (the bug-report-form half is #510). The reporter — TDD ~19u — saw **103.76u "at 5pm"** on the hourly insulin delivery chart and 40.7u on the basal report.

### Root cause (three compounding defects)

1. The chart computed hourly buckets **client-side** from the sparse basal-rate point series, attributing each point's `rate × time-until-next-point` entirely to the hour the point *starts* in.
2. `BasalSeriesBuilder` emits profile-derived points only on rate changes, so for a tenant whose window predates their first TempBasal record, the entire head gap collapses into **one point at the window start** — with a flat 0.3 U/hr profile, an 85-day gap is ~619u on a single point.
3. Report windows snap to **UTC midnight server-side** — 5pm Pacific for this tenant — which is where that point sits. Combined with dividing by days-with-data (6), that's 619 ÷ 6 ≈ 103.1u, matching her screenshot to within her real 5pm average.

### Fix

New `GET api/v4/statistics/hourly-insulin-delivery` (`[RemoteQuery]`), consumed verbatim by the chart per the repo's backend-is-source-of-truth rule:

- **Duration-weighted bucketing**: each TempBasal's insulin is split across the user-timezone-local hours it overlaps (`DistributeInsulinAcrossHourOfDay` splits on local hour boundaries, correct for :30/:45-offset timezones), using the existing `ClipOverlappingTempBasals` clipping. Manual boluses bucket by local hour; algorithm micro-boluses count as temp basal, consistent with `CalculateInsulinDeliveryStatistics`.
- **Honest averaging**: each component divides by the days that have *that component's* data — a window extending before the first record can't distort the pattern, and the profile-fallback (used only when zero TempBasals exist, mirroring `GetBasalAnalysis`) can't dilute sparse bolus days.
- **Truncation fix**: fetch limits raised 10000 → `int.MaxValue` here **and in `GetBasalAnalysis`** — ~5-minute AID records blow past 10k at ~35 days, silently limiting analyses to the oldest slice of a 90-day window.
- Frontend: `InsulinDeliveryChart` takes the response as a prop; the non-stacked variant (basal-analysis "Average Hourly Basal Delivery") now plots **basal only**, matching its title (it previously included boluses). The insulin-delivery page drops its 10k-row `getBasalReportData` fetch entirely (deleted — no remaining consumers).

### Tests

`StatisticsServiceHourlyDeliveryTests` (10 new): hour splitting, partial hours, timezone bucketing (incl. +9:30 offsets), origin split, bolus/SMB bucketing, per-component denominators, and the **#509 regression**: a 30-day window with data on only the last 2 days must show the flat 0.3 U/hr everywhere — no phantom spike, DayCount = 2. Full StatisticsService suite 170/170; `pnpm check` clean in touched files (repo baseline unchanged). Reviewed by a fresh-context agent; its two findings (10k truncation, fallback diluting bolus averages) are fixed in this diff.