### PR TITLE
Gate single-record V4 UpdateAsync broadcast on material change

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
@@ -201,16 +201,26 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     }
 
     /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.UpdateAsync" />
+    /// <remarks>
+    /// Broadcasts only when the update is materially changed (same <see cref="HasMaterialChange"/>
+    /// predicate <see cref="BulkCreateAsync"/> applies to its upsert split), captured before
+    /// <see cref="Microsoft.EntityFrameworkCore.DbContext.SaveChangesAsync(CancellationToken)"/>
+    /// clears the change tracker's modified flags. This is the single-record twin of the bulk path's
+    /// gate: decomposers idempotently re-upsert by LegacyId on every re-poll of a connector's catch-up
+    /// overlap window, and without this gate a byte-identical re-send broadcasts as if it were a real
+    /// change.
+    /// </remarks>
     public async Task<TModel> UpdateAsync(Guid id, TModel model, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         var entity = await ctx.Set<TEntity>().FindAsync([id], ct)
             ?? throw new KeyNotFoundException($"{typeof(TModel).Name} {id} not found");
         ApplyUpdate(entity, model);
+        var materiallyChanged = HasMaterialChange(ctx, entity);
         await ctx.SaveChangesAsync(ct);
         var updated = ToDomain(entity);
-        // A single explicit update is always a material change worth broadcasting.
-        await RaiseBroadcastAsync([], [updated], [], origin, ct);
+        if (materiallyChanged)
+            await RaiseBroadcastAsync([], [updated], [], origin, ct);
         return updated;
     }
 

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/BroadcastGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/BroadcastGoldenTests.cs
@@ -214,4 +214,41 @@ public class BroadcastGoldenTests
             .Should().ContainSingle(e => e.Kind == "created" && e.ModelType == typeof(SensorGlucose))
             .Which.Count.Should().Be(1);
     }
+
+    /// <summary>
+    /// Regression for nocturne#500: decomposers (EntryDecomposer, TreatmentDecomposer,
+    /// DeviceStatusDecomposer) match an incoming record by LegacyId and route the "already exists"
+    /// branch through the single-record <see cref="Core.Contracts.V4.Repositories.IV4Repository{T}.UpdateAsync"/>,
+    /// not <c>BulkCreateAsync</c>'s upsert split. A connector's catch-up overlap window re-decomposes
+    /// the same already-stored records every poll cycle, so this path — not the bulk path — is what
+    /// chronically re-broadcasts byte-identical rows if it isn't gated on material change too.
+    /// </summary>
+    [Fact]
+    public async Task IdenticalReupload_ViaSingleUpdateAsync_DoesNotBroadcast()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<ISensorGlucoseRepository>();
+
+        var created = await repo.CreateAsync(
+            new SensorGlucose { Timestamp = T0, Mgdl = 150, DataSource = "dexcom", LegacyId = "upd-1" },
+            WriteOrigin.Live, CancellationToken.None);
+
+        // Decomposer-style idempotent upsert: re-match by LegacyId, then UpdateAsync with a CHANGED value.
+        _fx.Capture.Clear();
+        var changed = new SensorGlucose { Id = created.Id, Timestamp = T0, Mgdl = 155, DataSource = "dexcom", LegacyId = "upd-1" };
+        await repo.UpdateAsync(created.Id, changed, WriteOrigin.Live, CancellationToken.None);
+
+        _fx.Capture.Snapshot()
+            .Should().ContainSingle(e => e.Kind == "updated" && e.ModelType == typeof(SensorGlucose))
+            .Which.Count.Should().Be(1);
+
+        // Re-decomposing the SAME already-stored row (a connector's overlap-window re-poll) must not
+        // re-broadcast: nothing material changed.
+        _fx.Capture.Clear();
+        var identical = new SensorGlucose { Id = created.Id, Timestamp = T0, Mgdl = 155, DataSource = "dexcom", LegacyId = "upd-1" };
+        await repo.UpdateAsync(created.Id, identical, WriteOrigin.Live, CancellationToken.None);
+
+        _fx.Capture.Snapshot().Should().BeEmpty("an identical re-decomposed row changes nothing");
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the phantom re-broadcast loop in #500. Every re-decomposition of an already-stored record — which happens on every connector catch-up-overlap re-poll — was re-broadcasting a `dataUpdate` as if it were a real change.

## Root cause

The decomposers (`EntryDecomposer`, `TreatmentDecomposer`, `DeviceStatusDecomposer`) idempotently upsert by `LegacyId`: when a record already exists, they call the single-record `V4RepositoryBase<T,E>.UpdateAsync`, not `BulkCreateAsync`'s upsert split.

`BulkCreateAsync`/`SplitUpsertsAsync` already gates its `update` broadcast on `V4MaterialChange.HasMaterialChange` — a connector re-poll that resends a byte-identical row broadcasts nothing. But `UpdateAsync` never got the same gate; its comment explicitly assumed "a single explicit update is always a material change worth broadcasting."

That assumption holds for a genuine user-driven PUT/PATCH, but not for a decomposer's idempotent upsert-by-LegacyId, which is invoked from `PublishDeviceStatusAsync`/`PublishTreatmentsAsync`/`EntryDecomposer` in a loop, once per record, on every connector sync — including the deliberate 5-minute catch-up overlap window (`BaseConnectorService.TryCalculateCatchUpSince`) that intentionally re-fetches already-ingested records on every poll cycle to absorb clock drift. Each such re-poll re-decomposes the same rows, hits the `existing != null` branch, and unconditionally re-broadcasts via `UpdateAsync` — even when nothing changed. This matches the issue's measured ~48x amplification across `sensor_glucose`, `boluses`, `aps_snapshots`, `pump_snapshots`, and `uploader_snapshots` — exactly the tables the affected decomposers write to.

## Fix

Apply the same `HasMaterialChange` gate `BulkCreateAsync`'s upsert split already uses to the single-record `UpdateAsync` path, captured before `SaveChangesAsync` clears the change tracker's modified flags (same technique `SplitUpsertsAsync` uses). An identical re-decomposed record now broadcasts nothing; a record with an actual field change still broadcasts `updated` as before.

## Test plan

- [x] Added `IdenticalReupload_ViaSingleUpdateAsync_DoesNotBroadcast` golden test (real Postgres via Testcontainers) exercising the exact decomposer-style call pattern this bug lived in: create → `UpdateAsync` with a changed value (broadcasts) → `UpdateAsync` with an identical value (silent).
- [x] `dotnet test tests/Integration/Nocturne.Infrastructure.Data.Tests --filter FullyQualifiedName~BroadcastGoldenTests` — 9/9 pass
- [x] `dotnet test nocturne.sln` (unit suites) — 4024+2 passed, 0 failed