### PR TITLE
fix(sdk): collapse NSwag's nullable-enum-ref query param idiom for codegen

### DIFF
--- a/sdk/filter-v4-spec.js
+++ b/sdk/filter-v4-spec.js
@@ -97,6 +97,34 @@ for (const schema of Object.values(filteredSchemas)) {
   }
 }
 
+// Collapse NSwag's nullable-enum-ref query parameter idiom down to a plain
+// $ref. NSwag emits optional enum query params as a doubly-nested oneOf
+// ({ oneOf: [{ nullable: true, oneOf: [{ $ref }] }] }) instead of a plain
+// $ref. openapi-generator's swift6 target treats that shape as a oneOf
+// composition and generates a wrapper enum with no `asParameter`
+// conformance, so every such parameter fails to compile. The wrapper is
+// unnecessary here: the param is already optional (no `required: true`), so
+// nullability adds nothing and the $ref can stand alone.
+function unwrapNullableEnumParam(schema) {
+  if (schema?.oneOf?.length === 1) {
+    const inner = schema.oneOf[0];
+    if (inner?.nullable === true && inner.oneOf?.length === 1 && inner.oneOf[0]['$ref']) {
+      return { '$ref': inner.oneOf[0]['$ref'] };
+    }
+  }
+  return schema;
+}
+
+for (const operations of Object.values(filteredPaths)) {
+  for (const operation of Object.values(operations)) {
+    for (const param of operation.parameters ?? []) {
+      if (param.schema) {
+        param.schema = unwrapNullableEnumParam(param.schema);
+      }
+    }
+  }
+}
+
 const output = {
   openapi: spec.openapi,
   info: {


### PR DESCRIPTION
## Summary
- The `publish-swift` job in `Publish SDKs` has failed on **every** tagged release since v0.1.0, always with the same errors: `value of type 'XxxParameter' has no member 'asParameter'` for every optional-enum query parameter (`category`, `status`, `type`, `overallMatch`, sleep session `type`/`source`, etc.)
- Root cause: NSwag emits optional enum query params as a doubly-nested `oneOf` (`{ oneOf: [{ nullable: true, oneOf: [{ $ref }] }] }`) instead of a plain `$ref`. openapi-generator's swift6 target treats that shape as a real `oneOf` composition and generates a wrapper enum that never gets the `asParameter` conformance plain enums get.
- Fix: `sdk/filter-v4-spec.js` (the script that already normalizes NSwag spec quirks ahead of SDK codegen, e.g. the existing `allOf` field-collision dedup) now collapses this pattern to a plain `$ref` for every query parameter. The param is already optional (no `required: true` in any of the affected params), so the nullable wrapper was redundant.
- Verified locally by regenerating the Swift SDK via the `openapitools/openapi-generator-cli` Docker image against the real spec, before and after: 6 wrapper types (`StateSpansGetStateSpansCategoryParameter`, `CompatibilityGetAnalysesOverallMatchParameter`, `CompressionLowGetSuggestionsStatusParameter`, `SystemEventsGetSystemEventsCategoryParameter`, `SystemEventsGetSystemEventsTypeParameter`, `TrackersGetDefinitionsCategoryParameter`) disappear entirely, and the affected params now type directly as the referenced enum (e.g. `category: StateSpanCategory?`), which does get `asParameter` via the standard `CaseIterable`/`RawRepresentable` extension.
- The fix is pattern-based (not hardcoded to these 6 names), so it also covers the sleep-session `type`/`source` params that appear in the current spec but weren't in the locally-tested (stale, committed) `sdk/openapi-v4.json` fixture.

## Test plan
- [ ] CI's `publish-swift` job (part of `Publish SDKs`, tag-triggered) should now get past the compile step it's failed at on every release to date
- [x] Locally regenerated the Swift SDK from the real spec via Docker before/after the fix and confirmed the wrapper types and their compile errors are gone