### PR TITLE
fix(ci): pin openapi-generator-cli to v7.21.0 across all SDK targets

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -98,7 +98,7 @@ jobs:
           path: sdk/
 
       - name: Generate C# SDK
-        uses: docker://openapitools/openapi-generator-cli:latest
+        uses: docker://openapitools/openapi-generator-cli:v7.21.0
         with:
           args: >-
             generate
@@ -149,7 +149,7 @@ jobs:
           path: sdk/
 
       - name: Generate TypeScript SDK
-        uses: docker://openapitools/openapi-generator-cli:latest
+        uses: docker://openapitools/openapi-generator-cli:v7.21.0
         with:
           args: >-
             generate
@@ -196,7 +196,7 @@ jobs:
           path: sdk/
 
       - name: Generate Kotlin SDK
-        uses: docker://openapitools/openapi-generator-cli:latest
+        uses: docker://openapitools/openapi-generator-cli:v7.21.0
         with:
           args: >-
             generate
@@ -267,12 +267,23 @@ jobs:
           name: openapi-v4-spec
           path: sdk/
 
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      # brew's openapi-generator formula always installs latest, unlike the
+      # pinned :v7.21.0 Docker image the other SDK targets use (Docker isn't
+      # available on GitHub-hosted macOS runners). Pin the same version here
+      # via the jar directly, so all seven targets generate from one
+      # reproducible generator version.
       - name: Install OpenAPI Generator
-        run: brew install openapi-generator
+        run: curl -L -o openapi-generator-cli.jar https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.21.0/openapi-generator-cli-7.21.0.jar
 
       - name: Generate Swift SDK
         run: |
-          openapi-generator generate \
+          java -jar openapi-generator-cli.jar generate \
             -i sdk/openapi-v4.json \
             -c sdk/swift/config.yaml \
             -o sdk/swift/out \
@@ -339,7 +350,7 @@ jobs:
           path: sdk/
 
       - name: Generate Python SDK
-        uses: docker://openapitools/openapi-generator-cli:latest
+        uses: docker://openapitools/openapi-generator-cli:v7.21.0
         with:
           args: >-
             generate
@@ -388,7 +399,7 @@ jobs:
           path: sdk/
 
       - name: Generate Java SDK
-        uses: docker://openapitools/openapi-generator-cli:latest
+        uses: docker://openapitools/openapi-generator-cli:v7.21.0
         with:
           args: >-
             generate
@@ -464,7 +475,7 @@ jobs:
           path: sdk/
 
       - name: Generate Rust SDK
-        uses: docker://openapitools/openapi-generator-cli:latest
+        uses: docker://openapitools/openapi-generator-cli:v7.21.0
         with:
           args: >-
             generate


### PR DESCRIPTION
## Summary
- The v0.2.1 `publish-swift` job failed with `type 'Any' does not conform to the 'Sendable' protocol` across ~30 generated files, despite #514 already fixing the `asParameter` codegen bug in the same run — a genuinely different failure than every prior release.
- Root cause: all seven SDK-publish jobs generate from an **unpinned** generator install. Six jobs (csharp/typescript/kotlin/python/java/rust) use `docker://openapitools/openapi-generator-cli:latest`, which is a rolling SNAPSHOT tag, not a stable release — I confirmed the image was rebuilt within a couple hours between my local repro (no Sendable bug) and the actual v0.2.1 CI run (bug present). `publish-swift` doesn't even use Docker (unavailable on GitHub-hosted macOS runners) — it does `brew install openapi-generator`, which always installs whatever's currently latest in Homebrew core, with no way to pin a version through brew.
- There's no way to get a reproducible SDK build while every job floats to "whatever commit of openapi-generator happens to be tagged/brewed right now."

## Fix
- Pin all six Docker-based jobs to `openapitools/openapi-generator-cli:v7.21.0`.
- Replace `publish-swift`'s `brew install openapi-generator` with downloading the matching `v7.21.0` jar from Maven Central and running it via `java -jar` (Java is already available on the macOS runner via `actions/setup-java`), so all seven targets share one reproducible generator version.

## Test plan
- [ ] Next tagged release's `publish-swift` job should build cleanly (the flaky Sendable errors specifically should not recur)
- [x] Verified locally: generating the Swift SDK from the real spec against `v7.21.0` (both via the jar directly and via the equivalent Docker image) produces zero `[String: Any]` Sendable errors, on top of the already-fixed `asParameter` issue from #514