### PR TITLE
fix(sdk): match openapi-generator's Sendable-safe query-item dict type

### DIFF
--- a/sdk/swift/fix-generated.py
+++ b/sdk/swift/fix-generated.py
@@ -32,7 +32,7 @@ def fix_file(path: str) -> None:
             return m.group(0)
         counter[0] += 1
         varname = f"_qp{counter[0]}"
-        typed = f"let {varname}: [String: (wrappedValue: Any?, isExplode: Bool)] = {entries}"
+        typed = f"let {varname}: [String: (wrappedValue: (any Sendable)?, isExplode: Bool)] = {entries}"
         assign = f"localVariableUrlComponents?.queryItems = APIHelper.mapValuesToQueryItems({varname})"
         return f"{typed}\n        {assign}"
 


### PR DESCRIPTION
## Summary
- `v0.2.1` and `v0.2.2` both still failed `publish-swift` with `type 'Any' does not conform to the 'Sendable' protocol`, even after #517 pinned the generator to a stable `v7.21.0` — so it wasn't generator-version drift after all.
- Actual root cause: `sdk/swift/fix-generated.py` extracts large `mapValuesToQueryItems` dict literals into an explicitly-typed local variable (to dodge a Swift type-checking timeout on big dicts), and hardcodes that type as `[String: (wrappedValue: Any?, isExplode: Bool)]`. But `APIHelper.mapValuesToQueryItems` itself (as generated by `v7.21.0`) takes `[String: (wrappedValue: (any Sendable)?, isExplode: Bool)]` — bare `Any` isn't `Sendable`, so every endpoint this patch touches (19 files: Bolus, Calibration, Sleep, StateSpans, etc.) fails under Swift 6 strict concurrency.
- This script's type annotation was simply stale relative to the generator's current signature — nothing to do with which generator version or snapshot got pulled.

## Fix
- One-line change: `Any?` → `(any Sendable)?` in the patch template, matching `APIHelper.mapValuesToQueryItems`'s actual parameter type.

## Test plan
- [ ] Next tagged release's `publish-swift` job should compile cleanly
- [x] Verified end-to-end locally: generated the real V4 spec through the pinned `v7.21.0` jar, ran this patched `fix-generated.py`, confirmed zero `Any`/`Sendable` errors remain in any generated API file (previously 19 files were patched with the bad type)