### PR TITLE
feat(api): v4 device-status writes, temp-basal endpoint, bulk creates + carb macros

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Devices/ApsSnapshotController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/ApsSnapshotController.cs
@@ -1,26 +1,103 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
 using Nocturne.API.Controllers.V4.Base;
+using Nocturne.API.Models.Requests.V4;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
 
 namespace Nocturne.API.Controllers.V4.Devices;
 
 /// <summary>
-/// Controller for read-only access to APS (Artificial Pancreas System) loop algorithm snapshot data.
-/// Exposes standard V4 read operations via <see cref="V4ReadOnlyControllerBase{TModel,TRepository}"/>.
+/// Controller for APS (Artificial Pancreas System) loop algorithm snapshot data.
+/// Exposes standard V4 read operations via <see cref="V4ReadOnlyControllerBase{TModel,TRepository}"/>
+/// plus a bulk create-or-update endpoint for native uploaders (e.g. Trio).
 /// </summary>
 /// <remarks>
 /// APS snapshots capture the real-time output of loop algorithm calculations (e.g., AAPS oref0/oref1
 /// output) recorded at the time of each closed-loop decision. Records are written by connector
-/// ingest pipelines and are not editable via the API.
+/// ingest pipelines or uploaded directly via the bulk endpoint.
 /// </remarks>
 /// <seealso cref="IApsSnapshotRepository"/>
 /// <seealso cref="ApsSnapshot"/>
+/// <seealso cref="UpsertApsSnapshotRequest"/>
 [ApiController]
 [Tags("Devices")]
 [Route("api/v4/device-status/aps")]
 [Authorize]
 [Produces("application/json")]
 public class ApsSnapshotController(IApsSnapshotRepository repo)
-    : V4ReadOnlyControllerBase<ApsSnapshot, IApsSnapshotRepository>(repo);
+    : V4ReadOnlyControllerBase<ApsSnapshot, IApsSnapshotRepository>(repo)
+{
+    /// <summary>
+    /// Create or update APS snapshots in bulk (max 1000).
+    /// </summary>
+    /// <remarks>
+    /// Array semantics are per-item upsert, not all-or-nothing: each snapshot carrying both
+    /// `dataSource` and `syncIdentifier` updates the row already matched by that pair; all others
+    /// insert. Validation failures reject the whole request with `400 Bad Request` before anything
+    /// is persisted.
+    /// </remarks>
+    [HttpPost]
+    [RequireScope(OAuthScopes.DevicesReadWrite)]
+    [ProducesResponseType(typeof(ApsSnapshot[]), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<ApsSnapshot[]>> CreateApsSnapshots(
+        [FromBody] UpsertApsSnapshotRequest[] requests,
+        CancellationToken ct = default)
+    {
+        if (requests is not { Length: > 0 })
+            return Problem(detail: "APS snapshot data is required", statusCode: 400, title: "Bad Request");
+
+        if (requests.Length > 1000)
+            return Problem(detail: "Bulk operations are limited to 1000 snapshots per request", statusCode: 400, title: "Bad Request");
+
+        if (requests.Any(r => r.Timestamp == default))
+            return Problem(detail: "Timestamp must be set on every snapshot", statusCode: 400, title: "Bad Request");
+
+        if (requests.Any(r => !string.IsNullOrEmpty(r.SyncIdentifier) && string.IsNullOrEmpty(r.DataSource)))
+            return Problem(detail: "DataSource is required when SyncIdentifier is supplied", statusCode: 400, title: "Bad Request");
+
+        var models = requests.Select(MapToModel).ToList();
+        var persisted = await Repository.BulkUpsertAsync(models, WriteOrigin.Live, ct);
+        return StatusCode(201, persisted.ToArray());
+    }
+
+    private static ApsSnapshot MapToModel(UpsertApsSnapshotRequest request) => new()
+    {
+        Timestamp = request.Timestamp.UtcDateTime,
+        UtcOffset = request.UtcOffset,
+        Device = request.Device,
+        App = request.App,
+        DataSource = request.DataSource,
+        SyncIdentifier = request.SyncIdentifier,
+        CorrelationId = request.CorrelationId,
+        AidAlgorithm = request.AidAlgorithm,
+        AidVersion = request.AidVersion,
+        Iob = request.Iob,
+        BasalIob = request.BasalIob,
+        BolusIob = request.BolusIob,
+        Cob = request.Cob,
+        CurrentBg = request.CurrentBg,
+        EventualBg = request.EventualBg,
+        TargetBg = request.TargetBg,
+        RecommendedBolus = request.RecommendedBolus,
+        SensitivityRatio = request.SensitivityRatio,
+        Enacted = request.Enacted,
+        EnactedRate = request.EnactedRate,
+        EnactedDuration = request.EnactedDuration,
+        EnactedBolusVolume = request.EnactedBolusVolume,
+        SuggestedJson = request.SuggestedJson,
+        EnactedJson = request.EnactedJson,
+        PredictedDefaultJson = request.PredictedDefaultJson,
+        PredictedIobJson = request.PredictedIobJson,
+        PredictedZtJson = request.PredictedZtJson,
+        PredictedCobJson = request.PredictedCobJson,
+        PredictedUamJson = request.PredictedUamJson,
+        PredictedStartTimestamp = request.PredictedStartTimestamp?.UtcDateTime,
+        LoopJson = request.LoopJson,
+        AdditionalProperties = request.AdditionalProperties,
+    };
+}

--- a/src/API/Nocturne.API/Controllers/V4/Devices/ApsSnapshotController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/ApsSnapshotController.cs
@@ -39,6 +39,10 @@ public class ApsSnapshotController(IApsSnapshotRepository repo)
     /// `dataSource` and `syncIdentifier` updates the row already matched by that pair; all others
     /// insert. Validation failures reject the whole request with `400 Bad Request` before anything
     /// is persisted.
+    ///
+    /// Device attribution is a deliberate scope cut: unlike the legacy decomposer path, records
+    /// written here carry no Device/PatientDevice link (snapshots are not <c>IDeviceAttributed</c>,
+    /// so the stamper can't take them). Reads that join by <c>correlationId</c> are unaffected.
     /// </remarks>
     [HttpPost]
     [RequireScope(OAuthScopes.DevicesReadWrite)]

--- a/src/API/Nocturne.API/Controllers/V4/Devices/PumpSnapshotController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/PumpSnapshotController.cs
@@ -39,6 +39,10 @@ public class PumpSnapshotController(IPumpSnapshotRepository repo)
     /// `dataSource` and `syncIdentifier` updates the row already matched by that pair; all others
     /// insert. Validation failures reject the whole request with `400 Bad Request` before anything
     /// is persisted. Omit `reservoir` when the level is unknown rather than sending a sentinel.
+    ///
+    /// Device attribution is a deliberate scope cut: unlike the legacy decomposer path, records
+    /// written here carry no Device/PatientDevice link (snapshots are not <c>IDeviceAttributed</c>,
+    /// so the stamper can't take them). Reads that join by <c>correlationId</c> are unaffected.
     /// </remarks>
     [HttpPost]
     [RequireScope(OAuthScopes.DevicesReadWrite)]

--- a/src/API/Nocturne.API/Controllers/V4/Devices/PumpSnapshotController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/PumpSnapshotController.cs
@@ -1,26 +1,92 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
 using Nocturne.API.Controllers.V4.Base;
+using Nocturne.API.Models.Requests.V4;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
 
 namespace Nocturne.API.Controllers.V4.Devices;
 
 /// <summary>
-/// Controller for read-only access to insulin pump snapshot data.
-/// Exposes standard V4 read operations via <see cref="V4ReadOnlyControllerBase{TModel,TRepository}"/>.
+/// Controller for insulin pump snapshot data.
+/// Exposes standard V4 read operations via <see cref="V4ReadOnlyControllerBase{TModel,TRepository}"/>
+/// plus a bulk create-or-update endpoint for native uploaders (e.g. Trio).
 /// </summary>
 /// <remarks>
 /// Pump snapshots capture the reported state of the insulin pump at a point in time
 /// (reservoir level, active basal rate, delivery status, etc.). Records are written
-/// by connector ingest pipelines and are not editable via the API.
+/// by connector ingest pipelines or uploaded directly via the bulk endpoint.
 /// </remarks>
 /// <seealso cref="IPumpSnapshotRepository"/>
 /// <seealso cref="PumpSnapshot"/>
+/// <seealso cref="UpsertPumpSnapshotRequest"/>
 [ApiController]
 [Tags("Devices")]
 [Route("api/v4/device-status/pump")]
 [Authorize]
 [Produces("application/json")]
 public class PumpSnapshotController(IPumpSnapshotRepository repo)
-    : V4ReadOnlyControllerBase<PumpSnapshot, IPumpSnapshotRepository>(repo);
+    : V4ReadOnlyControllerBase<PumpSnapshot, IPumpSnapshotRepository>(repo)
+{
+    /// <summary>
+    /// Create or update pump snapshots in bulk (max 1000).
+    /// </summary>
+    /// <remarks>
+    /// Array semantics are per-item upsert, not all-or-nothing: each snapshot carrying both
+    /// `dataSource` and `syncIdentifier` updates the row already matched by that pair; all others
+    /// insert. Validation failures reject the whole request with `400 Bad Request` before anything
+    /// is persisted. Omit `reservoir` when the level is unknown rather than sending a sentinel.
+    /// </remarks>
+    [HttpPost]
+    [RequireScope(OAuthScopes.DevicesReadWrite)]
+    [ProducesResponseType(typeof(PumpSnapshot[]), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<PumpSnapshot[]>> CreatePumpSnapshots(
+        [FromBody] UpsertPumpSnapshotRequest[] requests,
+        CancellationToken ct = default)
+    {
+        if (requests is not { Length: > 0 })
+            return Problem(detail: "Pump snapshot data is required", statusCode: 400, title: "Bad Request");
+
+        if (requests.Length > 1000)
+            return Problem(detail: "Bulk operations are limited to 1000 snapshots per request", statusCode: 400, title: "Bad Request");
+
+        if (requests.Any(r => r.Timestamp == default))
+            return Problem(detail: "Timestamp must be set on every snapshot", statusCode: 400, title: "Bad Request");
+
+        if (requests.Any(r => !string.IsNullOrEmpty(r.SyncIdentifier) && string.IsNullOrEmpty(r.DataSource)))
+            return Problem(detail: "DataSource is required when SyncIdentifier is supplied", statusCode: 400, title: "Bad Request");
+
+        var models = requests.Select(MapToModel).ToList();
+        var persisted = await Repository.BulkUpsertAsync(models, WriteOrigin.Live, ct);
+        return StatusCode(201, persisted.ToArray());
+    }
+
+    private static PumpSnapshot MapToModel(UpsertPumpSnapshotRequest request) => new()
+    {
+        Timestamp = request.Timestamp.UtcDateTime,
+        UtcOffset = request.UtcOffset,
+        Device = request.Device,
+        App = request.App,
+        DataSource = request.DataSource,
+        SyncIdentifier = request.SyncIdentifier,
+        CorrelationId = request.CorrelationId,
+        Manufacturer = request.Manufacturer,
+        Model = request.Model,
+        Reservoir = request.Reservoir,
+        ReservoirDisplay = request.ReservoirDisplay,
+        BatteryPercent = request.BatteryPercent,
+        BatteryVoltage = request.BatteryVoltage,
+        Bolusing = request.Bolusing,
+        Suspended = request.Suspended,
+        PumpStatus = request.PumpStatus,
+        PumpMode = request.PumpMode,
+        Clock = request.Clock,
+        Iob = request.Iob,
+        BolusIob = request.BolusIob,
+        AdditionalProperties = request.AdditionalProperties,
+    };
+}

--- a/src/API/Nocturne.API/Controllers/V4/Devices/UploaderSnapshotController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/UploaderSnapshotController.cs
@@ -39,6 +39,10 @@ public class UploaderSnapshotController(IUploaderSnapshotRepository repo)
     /// `dataSource` and `syncIdentifier` updates the row already matched by that pair; all others
     /// insert. Validation failures reject the whole request with `400 Bad Request` before anything
     /// is persisted.
+    ///
+    /// Device attribution is a deliberate scope cut: unlike the legacy decomposer path, records
+    /// written here carry no Device/PatientDevice link (snapshots are not <c>IDeviceAttributed</c>,
+    /// so the stamper can't take them). Reads that join by <c>correlationId</c> are unaffected.
     /// </remarks>
     [HttpPost]
     [RequireScope(OAuthScopes.DevicesReadWrite)]

--- a/src/API/Nocturne.API/Controllers/V4/Devices/UploaderSnapshotController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/UploaderSnapshotController.cs
@@ -1,26 +1,85 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
 using Nocturne.API.Controllers.V4.Base;
+using Nocturne.API.Models.Requests.V4;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
 
 namespace Nocturne.API.Controllers.V4.Devices;
 
 /// <summary>
-/// Controller for read-only access to uploader/bridge device snapshot data.
-/// Exposes standard V4 read operations via <see cref="V4ReadOnlyControllerBase{TModel,TRepository}"/>.
+/// Controller for uploader/bridge device snapshot data.
+/// Exposes standard V4 read operations via <see cref="V4ReadOnlyControllerBase{TModel,TRepository}"/>
+/// plus a bulk create-or-update endpoint for native uploaders (e.g. Trio).
 /// </summary>
 /// <remarks>
 /// Uploader snapshots capture the state of the device running the upload software
 /// (e.g. phone battery, connectivity status, app version). Records are written by
-/// connector ingest pipelines and are not editable via the API.
+/// connector ingest pipelines or uploaded directly via the bulk endpoint.
 /// </remarks>
 /// <seealso cref="IUploaderSnapshotRepository"/>
 /// <seealso cref="UploaderSnapshot"/>
+/// <seealso cref="UpsertUploaderSnapshotRequest"/>
 [ApiController]
 [Tags("Devices")]
 [Route("api/v4/device-status/uploader")]
 [Authorize]
 [Produces("application/json")]
 public class UploaderSnapshotController(IUploaderSnapshotRepository repo)
-    : V4ReadOnlyControllerBase<UploaderSnapshot, IUploaderSnapshotRepository>(repo);
+    : V4ReadOnlyControllerBase<UploaderSnapshot, IUploaderSnapshotRepository>(repo)
+{
+    /// <summary>
+    /// Create or update uploader snapshots in bulk (max 1000).
+    /// </summary>
+    /// <remarks>
+    /// Array semantics are per-item upsert, not all-or-nothing: each snapshot carrying both
+    /// `dataSource` and `syncIdentifier` updates the row already matched by that pair; all others
+    /// insert. Validation failures reject the whole request with `400 Bad Request` before anything
+    /// is persisted.
+    /// </remarks>
+    [HttpPost]
+    [RequireScope(OAuthScopes.DevicesReadWrite)]
+    [ProducesResponseType(typeof(UploaderSnapshot[]), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<UploaderSnapshot[]>> CreateUploaderSnapshots(
+        [FromBody] UpsertUploaderSnapshotRequest[] requests,
+        CancellationToken ct = default)
+    {
+        if (requests is not { Length: > 0 })
+            return Problem(detail: "Uploader snapshot data is required", statusCode: 400, title: "Bad Request");
+
+        if (requests.Length > 1000)
+            return Problem(detail: "Bulk operations are limited to 1000 snapshots per request", statusCode: 400, title: "Bad Request");
+
+        if (requests.Any(r => r.Timestamp == default))
+            return Problem(detail: "Timestamp must be set on every snapshot", statusCode: 400, title: "Bad Request");
+
+        if (requests.Any(r => !string.IsNullOrEmpty(r.SyncIdentifier) && string.IsNullOrEmpty(r.DataSource)))
+            return Problem(detail: "DataSource is required when SyncIdentifier is supplied", statusCode: 400, title: "Bad Request");
+
+        var models = requests.Select(MapToModel).ToList();
+        var persisted = await Repository.BulkUpsertAsync(models, WriteOrigin.Live, ct);
+        return StatusCode(201, persisted.ToArray());
+    }
+
+    private static UploaderSnapshot MapToModel(UpsertUploaderSnapshotRequest request) => new()
+    {
+        Timestamp = request.Timestamp.UtcDateTime,
+        UtcOffset = request.UtcOffset,
+        Device = request.Device,
+        App = request.App,
+        DataSource = request.DataSource,
+        SyncIdentifier = request.SyncIdentifier,
+        CorrelationId = request.CorrelationId,
+        Name = request.Name,
+        Battery = request.Battery,
+        BatteryVoltage = request.BatteryVoltage,
+        IsCharging = request.IsCharging,
+        Temperature = request.Temperature,
+        Type = request.Type,
+        AdditionalProperties = request.AdditionalProperties,
+    };
+}

--- a/src/API/Nocturne.API/Controllers/V4/SleepController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/SleepController.cs
@@ -98,6 +98,48 @@ public class SleepController : ControllerBase
     }
 
     /// <summary>
+    /// Create or upsert sleep sessions in bulk (max 100)
+    /// </summary>
+    /// <remarks>
+    /// Sessions are upserted one by one with the same dedup semantics as the single create, so a
+    /// retried batch is idempotent. On a concurrent-insert conflict the request stops with `409
+    /// Conflict`; sessions upserted before the conflict remain persisted, and retrying the whole
+    /// batch is safe.
+    /// </remarks>
+    [HttpPost("bulk")]
+    [RequireScope(OAuthScopes.SleepReadWrite)]
+    [ProducesResponseType(typeof(SleepSession[]), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<ActionResult<SleepSession[]>> CreateSessionsBulk(
+        [FromBody] SleepSession[] sessions,
+        CancellationToken cancellationToken = default)
+    {
+        if (sessions is not { Length: > 0 })
+            return Problem(detail: "Sleep session data is required", statusCode: 400, title: "Bad Request");
+
+        // Sessions embed stage intervals and biometric samples, so the cap is lower than the
+        // 1000-item flat-record bulks.
+        if (sessions.Length > 100)
+            return Problem(detail: "Bulk operations are limited to 100 sessions per request", statusCode: 400, title: "Bad Request");
+
+        var results = new List<SleepSession>(sessions.Length);
+        try
+        {
+            foreach (var session in sessions)
+                results.Add(await _sleepService.UpsertSessionAsync(session, cancellationToken));
+        }
+        catch (DbUpdateException)
+        {
+            // A concurrent request inserted a session with the same key between
+            // the upsert's dedup lookup and its insert.
+            return Problem(detail: "A sleep session with the same identifier was created concurrently.", statusCode: 409, title: "Conflict");
+        }
+
+        return StatusCode(201, results.ToArray());
+    }
+
+    /// <summary>
     /// Update an existing sleep session
     /// </summary>
     [HttpPut("{id:guid}")]

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/BasalInjectionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/BasalInjectionController.cs
@@ -134,6 +134,52 @@ public class BasalInjectionController(
         CreatedAt = existing.CreatedAt,
     };
 
+    /// <summary>
+    /// Create or update basal injections in bulk (max 1000).
+    /// </summary>
+    /// <remarks>
+    /// Array semantics are per-item upsert, not all-or-nothing: each injection carrying both
+    /// `dataSource` and `syncIdentifier` updates the row already matched by that pair; all others
+    /// insert. Every item is validated with the same rules as the single create; validation
+    /// failures reject the whole request with `400 Bad Request` before anything is persisted.
+    /// </remarks>
+    [HttpPost("bulk")]
+    [ProducesResponseType(typeof(BasalInjection[]), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<BasalInjection[]>> CreateBasalInjectionsBulk(
+        [FromBody] CreateBasalInjectionRequest[] requests,
+        CancellationToken ct = default)
+    {
+        if (requests is not { Length: > 0 })
+            return Problem(detail: "Basal injection data is required", statusCode: 400, title: "Bad Request");
+
+        if (requests.Length > 1000)
+            return Problem(detail: "Bulk operations are limited to 1000 injections per request", statusCode: 400, title: "Bad Request");
+
+        if (requests.Any(r => !string.IsNullOrEmpty(r.SyncIdentifier) && string.IsNullOrEmpty(r.DataSource)))
+            return Problem(detail: "DataSource is required when SyncIdentifier is supplied", statusCode: 400, title: "Bad Request");
+
+        var models = new List<BasalInjection>(requests.Length);
+        foreach (var request in requests)
+        {
+            if (ValidateUnitsAndTimestamp(request.Units, request.Timestamp) is { } unitsOrTsProblem)
+                return unitsOrTsProblem;
+
+            // Resolved per item: the active-at-injection-time window check depends on each
+            // item's timestamp, so a per-insulin cache would skip it.
+            var (insulin, insulinProblem) = await ResolveInsulinAsync(request.PatientInsulinId, request.Timestamp, ct);
+            if (insulinProblem is not null)
+                return insulinProblem;
+
+            var model = MapCreateToModel(request);
+            model.InsulinContext = BuildContext(insulin!);
+            models.Add(model);
+        }
+
+        var persisted = await Repository.BulkCreateAsync(models, WriteOrigin.Live, ct);
+        return StatusCode(201, persisted.ToArray());
+    }
+
     private ObjectResult? ValidateUnitsAndTimestamp(double units, DateTimeOffset timestamp)
     {
         if (units <= 0 || units > UnitsHardCeiling)

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/BolusController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/BolusController.cs
@@ -143,6 +143,46 @@ public class BolusController(IBolusRepository repo, IPatientInsulinRepository in
     };
 
     /// <summary>
+    /// Create or update boluses in bulk (max 1000).
+    /// </summary>
+    /// <remarks>
+    /// Array semantics are per-item upsert, not all-or-nothing: each bolus carrying both
+    /// `dataSource` and `syncIdentifier` updates the row already matched by that pair; all others
+    /// insert. Validation failures reject the whole request with `400 Bad Request` before anything
+    /// is persisted.
+    /// </remarks>
+    [HttpPost("bulk")]
+    [ProducesResponseType(typeof(Bolus[]), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<Bolus[]>> CreateBolusesBulk(
+        [FromBody] CreateBolusRequest[] requests,
+        CancellationToken ct = default)
+    {
+        if (requests is not { Length: > 0 })
+            return Problem(detail: "Bolus data is required", statusCode: 400, title: "Bad Request");
+
+        if (requests.Length > 1000)
+            return Problem(detail: "Bulk operations are limited to 1000 boluses per request", statusCode: 400, title: "Bad Request");
+
+        if (requests.Any(r => r.Timestamp == default))
+            return Problem(detail: "Timestamp must be set on every bolus", statusCode: 400, title: "Bad Request");
+
+        if (requests.Any(r => !string.IsNullOrEmpty(r.SyncIdentifier) && string.IsNullOrEmpty(r.DataSource)))
+            return Problem(detail: "DataSource is required when SyncIdentifier is supplied", statusCode: 400, title: "Bad Request");
+
+        var models = new List<Bolus>(requests.Length);
+        foreach (var request in requests)
+        {
+            var model = MapCreateToModel(request);
+            await EnrichInsulinContextAsync(model, request.PatientInsulinId, ct);
+            models.Add(model);
+        }
+
+        var persisted = await Repository.BulkCreateAsync(models, WriteOrigin.Live, ct);
+        return StatusCode(201, persisted.ToArray());
+    }
+
+    /// <summary>
     /// Delete a bolus by its external sync identifier (dataSource + syncIdentifier pair).
     /// </summary>
     [HttpDelete("by-sync-id")]

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/NutritionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/NutritionController.cs
@@ -115,27 +115,62 @@ public class NutritionController : ControllerBase
         if (request.Timestamp == default)
             return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
 
-        // Records split from one source share a correlation_id; it is a free-standing
-        // grouping value (no batch row to persist), so honour a client-supplied id or mint one.
-        var correlationId = request.CorrelationId ?? Guid.CreateVersion7();
-
-        var model = new CarbIntake
-        {
-            Timestamp = request.Timestamp.UtcDateTime,
-            UtcOffset = request.UtcOffset,
-            Device = request.Device,
-            App = request.App,
-            DataSource = request.DataSource,
-            Carbs = request.Carbs,
-            SyncIdentifier = request.SyncIdentifier,
-            CarbTime = request.CarbTime,
-            AbsorptionTime = request.AbsorptionTime,
-            CorrelationId = correlationId,
-        };
+        var model = MapCreateToModel(request);
 
         var created = await _carbIntakeRepo.CreateAsync(model, WriteOrigin.Live, ct);
         return CreatedAtAction(nameof(GetCarbIntakeById), new { id = created.Id }, created);
     }
+
+    /// <summary>
+    /// Create or update carb intakes in bulk (max 1000).
+    /// </summary>
+    /// <remarks>
+    /// Array semantics are per-item upsert, not all-or-nothing: each intake carrying both
+    /// `dataSource` and `syncIdentifier` updates the row already matched by that pair; all others
+    /// insert. Validation failures reject the whole request with `400 Bad Request` before anything
+    /// is persisted.
+    /// </remarks>
+    [HttpPost("carbs/bulk")]
+    [ProducesResponseType(typeof(CarbIntake[]), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<CarbIntake[]>> CreateCarbIntakesBulk(
+        [FromBody] CreateCarbIntakeRequest[] requests,
+        CancellationToken ct = default)
+    {
+        if (requests is not { Length: > 0 })
+            return Problem(detail: "Carb intake data is required", statusCode: 400, title: "Bad Request");
+
+        if (requests.Length > 1000)
+            return Problem(detail: "Bulk operations are limited to 1000 intakes per request", statusCode: 400, title: "Bad Request");
+
+        if (requests.Any(r => r.Timestamp == default))
+            return Problem(detail: "Timestamp must be set on every intake", statusCode: 400, title: "Bad Request");
+
+        if (requests.Any(r => !string.IsNullOrEmpty(r.SyncIdentifier) && string.IsNullOrEmpty(r.DataSource)))
+            return Problem(detail: "DataSource is required when SyncIdentifier is supplied", statusCode: 400, title: "Bad Request");
+
+        var models = requests.Select(MapCreateToModel).ToList();
+        var persisted = await _carbIntakeRepo.BulkCreateAsync(models, WriteOrigin.Live, ct);
+        return StatusCode(201, persisted.ToArray());
+    }
+
+    private static CarbIntake MapCreateToModel(CreateCarbIntakeRequest request) => new()
+    {
+        Timestamp = request.Timestamp.UtcDateTime,
+        UtcOffset = request.UtcOffset,
+        Device = request.Device,
+        App = request.App,
+        DataSource = request.DataSource,
+        Carbs = request.Carbs,
+        SyncIdentifier = request.SyncIdentifier,
+        CarbTime = request.CarbTime,
+        AbsorptionTime = request.AbsorptionTime,
+        FatGrams = request.FatGrams,
+        ProteinGrams = request.ProteinGrams,
+        // Records split from one source share a correlation_id; it is a free-standing
+        // grouping value (no batch row to persist), so honour a client-supplied id or mint one.
+        CorrelationId = request.CorrelationId ?? Guid.CreateVersion7(),
+    };
 
     /// <summary>
     /// Update an existing carb intake
@@ -166,6 +201,8 @@ public class NutritionController : ControllerBase
             SyncIdentifier = request.SyncIdentifier,
             CarbTime = request.CarbTime,
             AbsorptionTime = request.AbsorptionTime,
+            FatGrams = request.FatGrams,
+            ProteinGrams = request.ProteinGrams,
             CorrelationId = request.CorrelationId ?? existing.CorrelationId,
             LegacyId = existing.LegacyId,
             CreatedAt = existing.CreatedAt,

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/TempBasalController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/TempBasalController.cs
@@ -1,0 +1,165 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
+using Nocturne.API.Models.Requests.V4;
+using Nocturne.Core.Contracts.Devices;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.API.Controllers.V4.Treatments;
+
+/// <summary>
+/// Controller for temporary basal rate spans.
+/// Provides read access plus a bulk write endpoint for native uploaders (e.g. Trio) —
+/// previously temp basals were only written by the legacy v1 treatment decomposer and connectors.
+/// </summary>
+/// <remarks>
+/// Temp basals are span records (<see cref="TempBasal.StartTimestamp"/>/<see cref="TempBasal.EndTimestamp"/>),
+/// not point events. The write endpoint accepts both new spans and cancels: a cancel truncates the
+/// span active at its timestamp. Overlapping spans are not auto-truncated on create — the basal
+/// timeline resolves overlaps at read time, matching the decomposer-written data.
+/// </remarks>
+/// <seealso cref="ITempBasalRepository"/>
+/// <seealso cref="TempBasal"/>
+/// <seealso cref="CreateTempBasalRequest"/>
+[ApiController]
+[Tags("Treatments")]
+[Route("api/v4/insulin/temp-basals")]
+[Authorize]
+[Produces("application/json")]
+public class TempBasalController(
+    ITempBasalRepository repo,
+    IPatientDeviceStamper deviceStamper) : ControllerBase
+{
+    /// <summary>
+    /// Lists temp basal spans, newest-first by default.
+    /// </summary>
+    [HttpGet]
+    [RequireScope(OAuthScopes.TreatmentsRead)]
+    [ResponseCache(Duration = 90, VaryByQueryKeys = new[] { "*" })]
+    [ProducesResponseType(typeof(PaginatedResponse<TempBasal>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<PaginatedResponse<TempBasal>>> GetAll(
+        [FromQuery] DateTime? from, [FromQuery] DateTime? to,
+        [FromQuery] int limit = 100, [FromQuery] int offset = 0,
+        [FromQuery] string sort = "timestamp_desc",
+        [FromQuery] string? device = null, [FromQuery] string? source = null,
+        CancellationToken ct = default)
+    {
+        if (sort is not "timestamp_desc" and not "timestamp_asc")
+            return Problem(detail: $"Invalid sort value '{sort}'. Must be 'timestamp_asc' or 'timestamp_desc'.", statusCode: 400, title: "Bad Request");
+
+        var descending = sort == "timestamp_desc";
+        var data = await repo.GetAsync(from, to, device, source, limit, offset, descending, ct);
+        var total = await repo.CountAsync(from, to, ct);
+        return Ok(new PaginatedResponse<TempBasal> { Data = data, Pagination = new PaginationInfo(limit, offset, total) });
+    }
+
+    /// <summary>
+    /// Returns a single temp basal span by ID.
+    /// </summary>
+    [HttpGet("{id:guid}")]
+    [RequireScope(OAuthScopes.TreatmentsRead)]
+    [ProducesResponseType(typeof(TempBasal), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<TempBasal>> GetById(Guid id, CancellationToken ct = default)
+    {
+        var result = await repo.GetByIdAsync(id, ct);
+        return result is null ? NotFound() : Ok(result);
+    }
+
+    /// <summary>
+    /// Write temp basal spans and cancels in bulk (max 1000).
+    /// </summary>
+    /// <remarks>
+    /// Items are processed in timestamp order, one at a time, so a batch may start a temp basal
+    /// and cancel it later in the same request. Semantics are per-item, not all-or-nothing:
+    ///
+    /// - A regular item carrying both `dataSource` and `syncIdentifier` updates the row already
+    ///   matched by that pair; all others insert.
+    /// - A cancel (`isCancel: true`) truncates the temp basal active at its timestamp by setting
+    ///   the span end to that instant; with no active temp basal it is a no-op.
+    ///
+    /// Validation failures reject the whole request with `400 Bad Request` before anything is
+    /// persisted. The response contains every record written or truncated, in processing order.
+    /// </remarks>
+    [HttpPost]
+    [RequireScope(OAuthScopes.TreatmentsReadWrite)]
+    [ProducesResponseType(typeof(TempBasal[]), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<TempBasal[]>> CreateTempBasals(
+        [FromBody] CreateTempBasalRequest[] requests,
+        CancellationToken ct = default)
+    {
+        if (requests is not { Length: > 0 })
+            return Problem(detail: "Temp basal data is required", statusCode: 400, title: "Bad Request");
+
+        if (requests.Length > 1000)
+            return Problem(detail: "Bulk operations are limited to 1000 temp basals per request", statusCode: 400, title: "Bad Request");
+
+        if (requests.Any(r => r.Timestamp == default))
+            return Problem(detail: "Timestamp must be set on every temp basal", statusCode: 400, title: "Bad Request");
+
+        if (requests.Any(r => !string.IsNullOrEmpty(r.SyncIdentifier) && string.IsNullOrEmpty(r.DataSource)))
+            return Problem(detail: "DataSource is required when SyncIdentifier is supplied", statusCode: 400, title: "Bad Request");
+
+        if (requests.Any(r => !r.IsCancel && (r.Rate < 0 || r.DurationMinutes < 0)))
+            return Problem(detail: "Rate and duration must not be negative", statusCode: 400, title: "Bad Request");
+
+        var results = new List<TempBasal>(requests.Length);
+        foreach (var request in requests.OrderBy(r => r.Timestamp))
+        {
+            if (request.IsCancel)
+            {
+                var truncated = await CancelActiveAtAsync(request.Timestamp.UtcDateTime, ct);
+                if (truncated is not null)
+                    results.Add(truncated);
+                continue;
+            }
+
+            var model = MapToModel(request);
+            // Attribute like the sensor-glucose native path — otherwise direct API records stay
+            // unstamped and only ever surface as pseudo-devices.
+            await deviceStamper.StampAsync([model], [DeviceCategory.InsulinPump], model.DataSource, ct);
+            results.Add(await repo.CreateAsync(model, WriteOrigin.Live, ct));
+        }
+
+        return StatusCode(201, results.ToArray());
+    }
+
+    /// <summary>
+    /// Truncates the temp basal active at <paramref name="at"/>, or returns null when none is
+    /// active (a cancel with nothing running is a no-op, matching pump behaviour).
+    /// </summary>
+    private async Task<TempBasal?> CancelActiveAtAsync(DateTime at, CancellationToken ct)
+    {
+        var active = await repo.GetActiveAtAsync(at, ct);
+        if (active is null)
+            return null;
+
+        active.EndTimestamp = at;
+        return await repo.UpdateAsync(active.Id, active, WriteOrigin.Live, ct);
+    }
+
+    private static TempBasal MapToModel(CreateTempBasalRequest request) => new()
+    {
+        StartTimestamp = request.Timestamp.UtcDateTime,
+        EndTimestamp = request.DurationMinutes is { } duration
+            ? request.Timestamp.UtcDateTime.AddMinutes(duration)
+            : null,
+        UtcOffset = request.UtcOffset,
+        Device = request.Device,
+        App = request.App,
+        DataSource = request.DataSource,
+        SyncIdentifier = request.SyncIdentifier,
+        CorrelationId = request.CorrelationId,
+        Rate = request.Rate,
+        ScheduledRate = request.ScheduledRate,
+        Origin = request.Origin ?? TempBasalOrigin.Manual,
+        PumpRecordId = request.PumpRecordId,
+        ApsSnapshotId = request.ApsSnapshotId,
+    };
+}

--- a/src/API/Nocturne.API/Models/Requests/V4/CreateCarbIntakeRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/CreateCarbIntakeRequest.cs
@@ -53,6 +53,17 @@ public class CreateCarbIntakeRequest
     public int? AbsorptionTime { get; set; }
 
     /// <summary>
+    /// Fat consumed in grams, when the source reports macros. Native fields replace the
+    /// synthesized FPU fake-carb series legacy uploaders emit for Nightscout.
+    /// </summary>
+    public double? FatGrams { get; set; }
+
+    /// <summary>
+    /// Protein consumed in grams, when the source reports macros.
+    /// </summary>
+    public double? ProteinGrams { get; set; }
+
+    /// <summary>
     /// Correlation identifier for grouping related events (e.g. a meal bolus and carb intake).
     /// </summary>
     public Guid? CorrelationId { get; set; }

--- a/src/API/Nocturne.API/Models/Requests/V4/CreateTempBasalRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/CreateTempBasalRequest.cs
@@ -1,0 +1,93 @@
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.API.Models.Requests.V4;
+
+/// <summary>
+/// Request body for writing a temporary basal rate span via the V4 API.
+/// </summary>
+/// <remarks>
+/// Records carrying both <see cref="DataSource"/> and <see cref="SyncIdentifier"/> are upserted:
+/// a row already matched by that pair is updated in place, so uploader retries stay idempotent.
+///
+/// A cancel (<see cref="IsCancel"/> = <see langword="true"/>) does not create a record: it
+/// truncates the temp basal active at <see cref="Timestamp"/> by setting its end to that instant.
+/// <see cref="Rate"/> and <see cref="DurationMinutes"/> are ignored for cancels.
+/// </remarks>
+/// <seealso cref="Nocturne.API.Controllers.V4.Treatments.TempBasalController"/>
+/// <seealso cref="TempBasal"/>
+public class CreateTempBasalRequest
+{
+    /// <summary>
+    /// When the temp basal started (or, for cancels, when the active temp basal ends).
+    /// </summary>
+    public DateTimeOffset Timestamp { get; set; }
+
+    /// <summary>
+    /// UTC offset in minutes at the time of the event, for local-time display.
+    /// </summary>
+    public int? UtcOffset { get; set; }
+
+    /// <summary>
+    /// Identifier of the pump that ran the temp basal.
+    /// </summary>
+    public string? Device { get; set; }
+
+    /// <summary>
+    /// Name of the application that submitted this record.
+    /// </summary>
+    public string? App { get; set; }
+
+    /// <summary>
+    /// Upstream data source identifier; required when SyncIdentifier is supplied.
+    /// </summary>
+    public string? DataSource { get; set; }
+
+    /// <summary>
+    /// Stable per-source identifier. When paired with DataSource, re-uploading the same
+    /// temp basal updates the existing record in place rather than creating a duplicate.
+    /// </summary>
+    public string? SyncIdentifier { get; set; }
+
+    /// <summary>
+    /// Correlation identifier for grouping related events (e.g. the APS snapshot that enacted it).
+    /// </summary>
+    public Guid? CorrelationId { get; set; }
+
+    /// <summary>
+    /// Temporary basal rate in units per hour. Zero is valid (zero-temp).
+    /// </summary>
+    public double Rate { get; set; }
+
+    /// <summary>
+    /// Planned duration in minutes; the span end is computed as timestamp + duration.
+    /// Omit for an open-ended span (ended later by a cancel or a superseding temp basal).
+    /// </summary>
+    public double? DurationMinutes { get; set; }
+
+    /// <summary>
+    /// Scheduled basal rate that this temp basal overrides, when known.
+    /// </summary>
+    public double? ScheduledRate { get; set; }
+
+    /// <summary>
+    /// Origin of this temp basal. Defaults to <see cref="TempBasalOrigin.Manual"/> when omitted;
+    /// AID uploaders should send <see cref="TempBasalOrigin.Algorithm"/>.
+    /// </summary>
+    public TempBasalOrigin? Origin { get; set; }
+
+    /// <summary>
+    /// Pump-specific record identifier, when the pump reports one.
+    /// </summary>
+    public string? PumpRecordId { get; set; }
+
+    /// <summary>
+    /// Links this temp basal to the APS decision snapshot that enacted it.
+    /// </summary>
+    public Guid? ApsSnapshotId { get; set; }
+
+    /// <summary>
+    /// When true, truncates the temp basal active at <see cref="Timestamp"/> instead of
+    /// creating a record. A cancel with no active temp basal is a no-op.
+    /// </summary>
+    public bool IsCancel { get; set; }
+}

--- a/src/API/Nocturne.API/Models/Requests/V4/UpdateCarbIntakeRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/UpdateCarbIntakeRequest.cs
@@ -54,6 +54,16 @@ public class UpdateCarbIntakeRequest
     public int? AbsorptionTime { get; set; }
 
     /// <summary>
+    /// Fat consumed in grams, when the source reports macros.
+    /// </summary>
+    public double? FatGrams { get; set; }
+
+    /// <summary>
+    /// Protein consumed in grams, when the source reports macros.
+    /// </summary>
+    public double? ProteinGrams { get; set; }
+
+    /// <summary>
     /// Correlation identifier for grouping related events.
     /// </summary>
     public Guid? CorrelationId { get; set; }

--- a/src/API/Nocturne.API/Models/Requests/V4/UpsertApsSnapshotRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/UpsertApsSnapshotRequest.cs
@@ -1,0 +1,133 @@
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.API.Models.Requests.V4;
+
+/// <summary>
+/// Request body for upserting an APS loop algorithm snapshot via the V4 API.
+/// Mirrors <see cref="ApsSnapshot"/> minus the server-assigned fields
+/// (Id, CreatedAt, ModifiedAt, LegacyId, Mills, device FKs).
+/// </summary>
+/// <remarks>
+/// Records carrying both <see cref="DataSource"/> and <see cref="SyncIdentifier"/> are upserted:
+/// a row already matched by that pair is updated in place, so uploader retries of the same loop
+/// cycle stay idempotent. <see cref="CorrelationId"/> ties one loop cycle's APS, pump, and
+/// uploader snapshots together.
+/// </remarks>
+/// <seealso cref="Nocturne.API.Controllers.V4.Devices.ApsSnapshotController"/>
+public class UpsertApsSnapshotRequest
+{
+    /// <summary>
+    /// When the loop decision was made (e.g. the determination's deliverAt).
+    /// </summary>
+    public DateTimeOffset Timestamp { get; set; }
+
+    /// <summary>
+    /// UTC offset in minutes at the time of the event, for local-time display.
+    /// </summary>
+    public int? UtcOffset { get; set; }
+
+    /// <summary>
+    /// Identifier of the device that produced this snapshot.
+    /// </summary>
+    public string? Device { get; set; }
+
+    /// <summary>
+    /// Name of the application that submitted this record.
+    /// </summary>
+    public string? App { get; set; }
+
+    /// <summary>
+    /// Upstream data source identifier; required when SyncIdentifier is supplied.
+    /// </summary>
+    public string? DataSource { get; set; }
+
+    /// <summary>
+    /// Stable per-source identifier. When paired with DataSource, re-uploading the same
+    /// snapshot updates the existing record in place rather than creating a duplicate.
+    /// </summary>
+    public string? SyncIdentifier { get; set; }
+
+    /// <summary>
+    /// Correlation identifier shared by the APS, pump, and uploader snapshots of one loop cycle.
+    /// </summary>
+    public Guid? CorrelationId { get; set; }
+
+    /// <summary>
+    /// Which AID algorithm produced this snapshot.
+    /// </summary>
+    public AidAlgorithm AidAlgorithm { get; set; }
+
+    /// <summary>
+    /// Algorithm version string (e.g. Trio app version).
+    /// </summary>
+    public string? AidVersion { get; set; }
+
+    /// <summary>Total insulin on board</summary>
+    public double? Iob { get; set; }
+
+    /// <summary>Basal component of IOB</summary>
+    public double? BasalIob { get; set; }
+
+    /// <summary>Bolus component of IOB</summary>
+    public double? BolusIob { get; set; }
+
+    /// <summary>Carbs on board</summary>
+    public double? Cob { get; set; }
+
+    /// <summary>Current blood glucose as seen by the algorithm (mg/dL)</summary>
+    public double? CurrentBg { get; set; }
+
+    /// <summary>Predicted eventual BG if no further action (mg/dL)</summary>
+    public double? EventualBg { get; set; }
+
+    /// <summary>Algorithm target BG (mg/dL)</summary>
+    public double? TargetBg { get; set; }
+
+    /// <summary>Recommended bolus (insulinReq for OpenAPS, recommendedBolus for Loop)</summary>
+    public double? RecommendedBolus { get; set; }
+
+    /// <summary>Autosens/dynamic ISF sensitivity ratio</summary>
+    public double? SensitivityRatio { get; set; }
+
+    /// <summary>Whether the algorithm's suggestion was enacted (confirmed by pump)</summary>
+    public bool Enacted { get; set; }
+
+    /// <summary>Enacted temp basal rate in U/hr</summary>
+    public double? EnactedRate { get; set; }
+
+    /// <summary>Enacted temp basal duration in minutes</summary>
+    public int? EnactedDuration { get; set; }
+
+    /// <summary>Enacted auto-bolus volume (SMB for OpenAPS, bolusVolume for Loop)</summary>
+    public double? EnactedBolusVolume { get; set; }
+
+    /// <summary>Full suggested/recommended JSON blob from the APS system</summary>
+    public string? SuggestedJson { get; set; }
+
+    /// <summary>Full enacted JSON blob from the APS system</summary>
+    public string? EnactedJson { get; set; }
+
+    /// <summary>Default prediction curve (IOB for OpenAPS, values for Loop) as JSON array</summary>
+    public string? PredictedDefaultJson { get; set; }
+
+    /// <summary>IOB-only prediction curve (OpenAPS only) as JSON array</summary>
+    public string? PredictedIobJson { get; set; }
+
+    /// <summary>Zero-temp prediction curve (OpenAPS only) as JSON array</summary>
+    public string? PredictedZtJson { get; set; }
+
+    /// <summary>COB prediction curve (OpenAPS only) as JSON array</summary>
+    public string? PredictedCobJson { get; set; }
+
+    /// <summary>UAM prediction curve (OpenAPS only) as JSON array</summary>
+    public string? PredictedUamJson { get; set; }
+
+    /// <summary>Timestamp the prediction curves start from</summary>
+    public DateTimeOffset? PredictedStartTimestamp { get; set; }
+
+    /// <summary>Full serialized Loop status object for round-trip fidelity</summary>
+    public string? LoopJson { get; set; }
+
+    /// <summary>Catch-all for fields not mapped to dedicated columns</summary>
+    public Dictionary<string, object?>? AdditionalProperties { get; set; }
+}

--- a/src/API/Nocturne.API/Models/Requests/V4/UpsertPumpSnapshotRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/UpsertPumpSnapshotRequest.cs
@@ -1,0 +1,118 @@
+namespace Nocturne.API.Models.Requests.V4;
+
+/// <summary>
+/// Request body for upserting a pump status snapshot via the V4 API.
+/// Mirrors <see cref="Nocturne.Core.Models.V4.PumpSnapshot"/> minus the server-assigned fields
+/// (Id, CreatedAt, ModifiedAt, LegacyId, Mills, device FKs).
+/// </summary>
+/// <remarks>
+/// Records carrying both <see cref="DataSource"/> and <see cref="SyncIdentifier"/> are upserted:
+/// a row already matched by that pair is updated in place, so uploader retries of the same loop
+/// cycle stay idempotent. <see cref="CorrelationId"/> ties one loop cycle's APS, pump, and
+/// uploader snapshots together. Omit <see cref="Reservoir"/> when the level is unknown rather
+/// than sending a sentinel value.
+/// </remarks>
+/// <seealso cref="Nocturne.API.Controllers.V4.Devices.PumpSnapshotController"/>
+public class UpsertPumpSnapshotRequest
+{
+    /// <summary>
+    /// When the pump status was read.
+    /// </summary>
+    public DateTimeOffset Timestamp { get; set; }
+
+    /// <summary>
+    /// UTC offset in minutes at the time of the event, for local-time display.
+    /// </summary>
+    public int? UtcOffset { get; set; }
+
+    /// <summary>
+    /// Identifier of the device that produced this snapshot (e.g. pump serial number).
+    /// </summary>
+    public string? Device { get; set; }
+
+    /// <summary>
+    /// Name of the application that submitted this record.
+    /// </summary>
+    public string? App { get; set; }
+
+    /// <summary>
+    /// Upstream data source identifier; required when SyncIdentifier is supplied.
+    /// </summary>
+    public string? DataSource { get; set; }
+
+    /// <summary>
+    /// Stable per-source identifier. When paired with DataSource, re-uploading the same
+    /// snapshot updates the existing record in place rather than creating a duplicate.
+    /// </summary>
+    public string? SyncIdentifier { get; set; }
+
+    /// <summary>
+    /// Correlation identifier shared by the APS, pump, and uploader snapshots of one loop cycle.
+    /// </summary>
+    public Guid? CorrelationId { get; set; }
+
+    /// <summary>
+    /// Pump manufacturer name (e.g., "Insulet", "Medtronic", "Tandem").
+    /// </summary>
+    public string? Manufacturer { get; set; }
+
+    /// <summary>
+    /// Pump model name (e.g., "Omnipod DASH", "MiniMed 780G").
+    /// </summary>
+    public string? Model { get; set; }
+
+    /// <summary>
+    /// Insulin remaining in the reservoir (units). Omit when unknown.
+    /// </summary>
+    public double? Reservoir { get; set; }
+
+    /// <summary>
+    /// Human-readable reservoir display string (e.g., "50+ U", "Low").
+    /// </summary>
+    public string? ReservoirDisplay { get; set; }
+
+    /// <summary>
+    /// Pump battery level as a percentage (0-100).
+    /// </summary>
+    public int? BatteryPercent { get; set; }
+
+    /// <summary>
+    /// Pump battery voltage (for devices that report voltage instead of percentage).
+    /// </summary>
+    public double? BatteryVoltage { get; set; }
+
+    /// <summary>
+    /// Whether the pump is currently delivering a bolus.
+    /// </summary>
+    public bool? Bolusing { get; set; }
+
+    /// <summary>
+    /// Whether the pump is currently in a suspended state.
+    /// </summary>
+    public bool? Suspended { get; set; }
+
+    /// <summary>
+    /// Pump status string as reported by the device (e.g., "normal", "suspended", "bolusing").
+    /// </summary>
+    public string? PumpStatus { get; set; }
+
+    /// <summary>
+    /// Canonical closed-loop operating mode (a PumpModeState name such as "Automatic" or
+    /// "Manual"), when the source reports it.
+    /// </summary>
+    public string? PumpMode { get; set; }
+
+    /// <summary>
+    /// Pump internal clock time as a string (device-local time).
+    /// </summary>
+    public string? Clock { get; set; }
+
+    /// <summary>Pump-reported total IOB (when no APS algorithm is running)</summary>
+    public double? Iob { get; set; }
+
+    /// <summary>Pump-reported bolus IOB</summary>
+    public double? BolusIob { get; set; }
+
+    /// <summary>Catch-all for fields not mapped to dedicated columns (e.g. bolus increment)</summary>
+    public Dictionary<string, object?>? AdditionalProperties { get; set; }
+}

--- a/src/API/Nocturne.API/Models/Requests/V4/UpsertUploaderSnapshotRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/UpsertUploaderSnapshotRequest.cs
@@ -1,0 +1,85 @@
+namespace Nocturne.API.Models.Requests.V4;
+
+/// <summary>
+/// Request body for upserting an uploader/phone status snapshot via the V4 API.
+/// Mirrors <see cref="Nocturne.Core.Models.V4.UploaderSnapshot"/> minus the server-assigned
+/// fields (Id, CreatedAt, ModifiedAt, LegacyId, Mills, device FK).
+/// </summary>
+/// <remarks>
+/// Records carrying both <see cref="DataSource"/> and <see cref="SyncIdentifier"/> are upserted:
+/// a row already matched by that pair is updated in place, so uploader retries of the same loop
+/// cycle stay idempotent. <see cref="CorrelationId"/> ties one loop cycle's APS, pump, and
+/// uploader snapshots together.
+/// </remarks>
+/// <seealso cref="Nocturne.API.Controllers.V4.Devices.UploaderSnapshotController"/>
+public class UpsertUploaderSnapshotRequest
+{
+    /// <summary>
+    /// When the uploader status was read.
+    /// </summary>
+    public DateTimeOffset Timestamp { get; set; }
+
+    /// <summary>
+    /// UTC offset in minutes at the time of the event, for local-time display.
+    /// </summary>
+    public int? UtcOffset { get; set; }
+
+    /// <summary>
+    /// Identifier of the uploader device.
+    /// </summary>
+    public string? Device { get; set; }
+
+    /// <summary>
+    /// Name of the application that submitted this record.
+    /// </summary>
+    public string? App { get; set; }
+
+    /// <summary>
+    /// Upstream data source identifier; required when SyncIdentifier is supplied.
+    /// </summary>
+    public string? DataSource { get; set; }
+
+    /// <summary>
+    /// Stable per-source identifier. When paired with DataSource, re-uploading the same
+    /// snapshot updates the existing record in place rather than creating a duplicate.
+    /// </summary>
+    public string? SyncIdentifier { get; set; }
+
+    /// <summary>
+    /// Correlation identifier shared by the APS, pump, and uploader snapshots of one loop cycle.
+    /// </summary>
+    public Guid? CorrelationId { get; set; }
+
+    /// <summary>
+    /// Uploader device name (e.g., phone model or bridge device name).
+    /// </summary>
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Uploader battery level as a percentage (0-100).
+    /// </summary>
+    public int? Battery { get; set; }
+
+    /// <summary>
+    /// Uploader battery voltage (for devices that report voltage).
+    /// </summary>
+    public double? BatteryVoltage { get; set; }
+
+    /// <summary>
+    /// Whether the uploader device is currently charging.
+    /// </summary>
+    public bool? IsCharging { get; set; }
+
+    /// <summary>
+    /// Uploader device temperature in degrees Celsius.
+    /// </summary>
+    public double? Temperature { get; set; }
+
+    /// <summary>
+    /// Uploader device type identifier (e.g., "phone", "bridge").
+    /// </summary>
+    public string? Type { get; set; }
+
+    /// <summary>Catch-all for fields not mapped to dedicated columns</summary>
+    public Dictionary<string, object?>? AdditionalProperties { get; set; }
+}

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IApsSnapshotRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IApsSnapshotRepository.cs
@@ -135,4 +135,16 @@ public interface IApsSnapshotRepository : IV4Repository<ApsSnapshot>
     Task<IEnumerable<ApsSnapshot>> BulkCreateAsync(
         IEnumerable<ApsSnapshot> records,
         WriteOrigin origin, CancellationToken ct = default);
+
+    /// <summary>
+    /// Bulk create-or-update by (DataSource, SyncIdentifier): rows matched by that key are updated
+    /// in place, so uploader retries of the same loop cycle stay idempotent. Everything else inserts
+    /// through the LegacyId-dedup path of <see cref="BulkCreateAsync"/>.
+    /// </summary>
+    /// <param name="records">Records to upsert.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>All persisted records: updated rows first, then inserted rows.</returns>
+    Task<IEnumerable<ApsSnapshot>> BulkUpsertAsync(
+        IEnumerable<ApsSnapshot> records,
+        WriteOrigin origin, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IPumpSnapshotRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IPumpSnapshotRepository.cs
@@ -117,4 +117,16 @@ public interface IPumpSnapshotRepository : IV4Repository<PumpSnapshot>
     Task<IEnumerable<PumpSnapshot>> BulkCreateAsync(
         IEnumerable<PumpSnapshot> records,
         WriteOrigin origin, CancellationToken ct = default);
+
+    /// <summary>
+    /// Bulk create-or-update by (DataSource, SyncIdentifier): rows matched by that key are updated
+    /// in place, so uploader retries of the same loop cycle stay idempotent. Everything else inserts
+    /// through the LegacyId-dedup path of <see cref="BulkCreateAsync"/>.
+    /// </summary>
+    /// <param name="records">Records to upsert.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>All persisted records: updated rows first, then inserted rows.</returns>
+    Task<IEnumerable<PumpSnapshot>> BulkUpsertAsync(
+        IEnumerable<PumpSnapshot> records,
+        WriteOrigin origin, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IUploaderSnapshotRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IUploaderSnapshotRepository.cs
@@ -106,4 +106,16 @@ public interface IUploaderSnapshotRepository : IV4Repository<UploaderSnapshot>
     Task<IEnumerable<UploaderSnapshot>> BulkCreateAsync(
         IEnumerable<UploaderSnapshot> records,
         WriteOrigin origin, CancellationToken ct = default);
+
+    /// <summary>
+    /// Bulk create-or-update by (DataSource, SyncIdentifier): rows matched by that key are updated
+    /// in place, so uploader retries of the same loop cycle stay idempotent. Everything else inserts
+    /// through the LegacyId-dedup path of <see cref="BulkCreateAsync"/>.
+    /// </summary>
+    /// <param name="records">Records to upsert.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>All persisted records: updated rows first, then inserted rows.</returns>
+    Task<IEnumerable<UploaderSnapshot>> BulkUpsertAsync(
+        IEnumerable<UploaderSnapshot> records,
+        WriteOrigin origin, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Models/V4/ApsSnapshot.cs
+++ b/src/Core/Nocturne.Core.Models/V4/ApsSnapshot.cs
@@ -58,6 +58,12 @@ public class ApsSnapshot : IV4Record
     /// <inheritdoc />
     public string? DataSource { get; set; }
 
+    /// <summary>
+    /// Stable per-source identifier. Records matched on (DataSource, SyncIdentifier) are updated in
+    /// place on re-upload instead of duplicated, so uploader retries are idempotent.
+    /// </summary>
+    public string? SyncIdentifier { get; set; }
+
     /// <inheritdoc />
     public Guid? CorrelationId { get; set; }
 

--- a/src/Core/Nocturne.Core.Models/V4/CarbIntake.cs
+++ b/src/Core/Nocturne.Core.Models/V4/CarbIntake.cs
@@ -97,6 +97,17 @@ public class CarbIntake : IV4Record
     public int? AbsorptionTime { get; set; }
 
     /// <summary>
+    /// Fat consumed in grams, when the source reports macros. Native fields replace the
+    /// synthesized FPU fake-carb series legacy uploaders emit for Nightscout.
+    /// </summary>
+    public double? FatGrams { get; set; }
+
+    /// <summary>
+    /// Protein consumed in grams, when the source reports macros.
+    /// </summary>
+    public double? ProteinGrams { get; set; }
+
+    /// <summary>
     /// Catch-all for fields not mapped to dedicated columns
     /// </summary>
     public Dictionary<string, object?>? AdditionalProperties { get; set; }

--- a/src/Core/Nocturne.Core.Models/V4/PumpSnapshot.cs
+++ b/src/Core/Nocturne.Core.Models/V4/PumpSnapshot.cs
@@ -37,6 +37,12 @@ public class PumpSnapshot : IV4Record
     /// <inheritdoc />
     public string? DataSource { get; set; }
 
+    /// <summary>
+    /// Stable per-source identifier. Records matched on (DataSource, SyncIdentifier) are updated in
+    /// place on re-upload instead of duplicated, so uploader retries are idempotent.
+    /// </summary>
+    public string? SyncIdentifier { get; set; }
+
     /// <inheritdoc />
     public Guid? CorrelationId { get; set; }
 

--- a/src/Core/Nocturne.Core.Models/V4/TempBasal.cs
+++ b/src/Core/Nocturne.Core.Models/V4/TempBasal.cs
@@ -128,6 +128,12 @@ public class TempBasal : IDeviceAttributed
     public string? PumpRecordId { get; set; }
 
     /// <summary>
+    /// Stable per-source identifier. Records matched on (DataSource, SyncIdentifier) are updated in
+    /// place on re-upload instead of duplicated, so uploader retries are idempotent.
+    /// </summary>
+    public string? SyncIdentifier { get; set; }
+
+    /// <summary>
     /// FK to the <see cref="ApsSnapshot"/> whose algorithm decision set this temp basal.
     /// </summary>
     public Guid? ApsSnapshotId { get; set; }

--- a/src/Core/Nocturne.Core.Models/V4/UploaderSnapshot.cs
+++ b/src/Core/Nocturne.Core.Models/V4/UploaderSnapshot.cs
@@ -37,6 +37,12 @@ public class UploaderSnapshot : IV4Record
     /// <inheritdoc />
     public string? DataSource { get; set; }
 
+    /// <summary>
+    /// Stable per-source identifier. Records matched on (DataSource, SyncIdentifier) are updated in
+    /// place on re-upload instead of duplicated, so uploader retries are idempotent.
+    /// </summary>
+    public string? SyncIdentifier { get; set; }
+
     /// <inheritdoc />
     public Guid? CorrelationId { get; set; }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/ApsSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/ApsSnapshotEntity.cs
@@ -64,6 +64,22 @@ public class ApsSnapshotEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISyst
     public string? DataSource { get; set; }
 
     /// <summary>
+    /// Application that uploaded this snapshot
+    /// </summary>
+    [Column("app")]
+    [MaxLength(256)]
+    public string? App { get; set; }
+
+    /// <summary>
+    /// Stable per-source identifier for synchronization. Unlike <see cref="LegacyId"/> (insert-only),
+    /// a record matched by (DataSource, SyncIdentifier) is updated in place on re-upload — required so
+    /// uploader retries of the same loop cycle don't duplicate the snapshot.
+    /// </summary>
+    [Column("sync_identifier")]
+    [MaxLength(256)]
+    public string? SyncIdentifier { get; set; }
+
+    /// <summary>
     /// System tracking: when record was inserted
     /// </summary>
     [AuditIgnored]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbIntakeEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbIntakeEntity.cs
@@ -111,6 +111,18 @@ public class CarbIntakeEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Ti
     public int? AbsorptionTime { get; set; }
 
     /// <summary>
+    /// Fat consumed in grams, when the source reports macros
+    /// </summary>
+    [Column("fat_grams")]
+    public double? FatGrams { get; set; }
+
+    /// <summary>
+    /// Protein consumed in grams, when the source reports macros
+    /// </summary>
+    [Column("protein_grams")]
+    public double? ProteinGrams { get; set; }
+
+    /// <summary>
     /// Catch-all JSONB column for fields not mapped to dedicated columns
     /// </summary>
     [Column("additional_properties", TypeName = "jsonb")]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PumpSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PumpSnapshotEntity.cs
@@ -64,6 +64,22 @@ public class PumpSnapshotEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISys
     public string? DataSource { get; set; }
 
     /// <summary>
+    /// Application that uploaded this snapshot
+    /// </summary>
+    [Column("app")]
+    [MaxLength(256)]
+    public string? App { get; set; }
+
+    /// <summary>
+    /// Stable per-source identifier for synchronization. Unlike <see cref="LegacyId"/> (insert-only),
+    /// a record matched by (DataSource, SyncIdentifier) is updated in place on re-upload — required so
+    /// uploader retries of the same loop cycle don't duplicate the snapshot.
+    /// </summary>
+    [Column("sync_identifier")]
+    [MaxLength(256)]
+    public string? SyncIdentifier { get; set; }
+
+    /// <summary>
     /// System tracking: when record was inserted
     /// </summary>
     [AuditIgnored]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TempBasalEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TempBasalEntity.cs
@@ -123,6 +123,15 @@ public class TempBasalEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Ent
     public Guid? PatientDeviceId { get; set; }
 
     /// <summary>
+    /// Stable per-source identifier for synchronization. Unlike <see cref="LegacyId"/> (insert-only),
+    /// a record matched by (DataSource, SyncIdentifier) is updated in place on re-upload — required so
+    /// uploader retries of the same pump event don't duplicate the span.
+    /// </summary>
+    [Column("sync_identifier")]
+    [MaxLength(256)]
+    public string? SyncIdentifier { get; set; }
+
+    /// <summary>
     /// Pump-specific record identifier for deduplication
     /// </summary>
     [Column("pump_record_id")]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/UploaderSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/UploaderSnapshotEntity.cs
@@ -64,6 +64,22 @@ public class UploaderSnapshotEntity : ITenantScoped, ISoftDeletable, IV4Entity, 
     public string? DataSource { get; set; }
 
     /// <summary>
+    /// Application that uploaded this snapshot
+    /// </summary>
+    [Column("app")]
+    [MaxLength(256)]
+    public string? App { get; set; }
+
+    /// <summary>
+    /// Stable per-source identifier for synchronization. Unlike <see cref="LegacyId"/> (insert-only),
+    /// a record matched by (DataSource, SyncIdentifier) is updated in place on re-upload — required so
+    /// uploader retries of the same loop cycle don't duplicate the snapshot.
+    /// </summary>
+    [Column("sync_identifier")]
+    [MaxLength(256)]
+    public string? SyncIdentifier { get; set; }
+
+    /// <summary>
     /// System tracking: when record was inserted
     /// </summary>
     [AuditIgnored]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/ApsSnapshotMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/ApsSnapshotMapper.cs
@@ -27,6 +27,8 @@ public static class ApsSnapshotMapper
             CorrelationId = model.CorrelationId,
             LegacyId = model.LegacyId,
             DataSource = model.DataSource,
+            App = model.App,
+            SyncIdentifier = model.SyncIdentifier,
             SysCreatedAt = DateTime.UtcNow,
             SysUpdatedAt = DateTime.UtcNow,
             AidAlgorithm = model.AidAlgorithm.ToString(),
@@ -77,6 +79,8 @@ public static class ApsSnapshotMapper
             CorrelationId = entity.CorrelationId,
             LegacyId = entity.LegacyId,
             DataSource = entity.DataSource,
+            App = entity.App,
+            SyncIdentifier = entity.SyncIdentifier,
             CreatedAt = entity.SysCreatedAt,
             ModifiedAt = entity.SysUpdatedAt,
             AidAlgorithm = Enum.TryParse<AidAlgorithm>(entity.AidAlgorithm, out var sys) ? sys : AidAlgorithm.Unknown,
@@ -124,6 +128,8 @@ public static class ApsSnapshotMapper
         entity.CorrelationId = model.CorrelationId;
         entity.LegacyId = model.LegacyId;
         entity.DataSource = model.DataSource;
+        entity.App = model.App;
+        entity.SyncIdentifier = model.SyncIdentifier;
         entity.AidAlgorithm = model.AidAlgorithm.ToString();
         entity.Iob = model.Iob;
         entity.BasalIob = model.BasalIob;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/CarbIntakeMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/CarbIntakeMapper.cs
@@ -32,6 +32,8 @@ public static class CarbIntakeMapper
             SyncIdentifier = model.SyncIdentifier,
             CarbTime = model.CarbTime,
             AbsorptionTime = model.AbsorptionTime,
+            FatGrams = model.FatGrams,
+            ProteinGrams = model.ProteinGrams,
             AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
                 ? JsonSerializer.Serialize(model.AdditionalProperties)
                 : null,
@@ -61,6 +63,8 @@ public static class CarbIntakeMapper
             SyncIdentifier = entity.SyncIdentifier,
             CarbTime = entity.CarbTime,
             AbsorptionTime = entity.AbsorptionTime,
+            FatGrams = entity.FatGrams,
+            ProteinGrams = entity.ProteinGrams,
             AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
                 ? JsonSerializer.Deserialize<Dictionary<string, object?>>(entity.AdditionalPropertiesJson)
                 : null,
@@ -85,6 +89,8 @@ public static class CarbIntakeMapper
         entity.SyncIdentifier = model.SyncIdentifier;
         entity.CarbTime = model.CarbTime;
         entity.AbsorptionTime = model.AbsorptionTime;
+        entity.FatGrams = model.FatGrams;
+        entity.ProteinGrams = model.ProteinGrams;
         entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
             ? JsonSerializer.Serialize(model.AdditionalProperties)
             : null;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/PumpSnapshotMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/PumpSnapshotMapper.cs
@@ -25,6 +25,8 @@ public static class PumpSnapshotMapper
             CorrelationId = model.CorrelationId,
             LegacyId = model.LegacyId,
             DataSource = model.DataSource,
+            App = model.App,
+            SyncIdentifier = model.SyncIdentifier,
             SysCreatedAt = DateTime.UtcNow,
             SysUpdatedAt = DateTime.UtcNow,
             Manufacturer = model.Manufacturer,
@@ -64,6 +66,8 @@ public static class PumpSnapshotMapper
             CorrelationId = entity.CorrelationId,
             LegacyId = entity.LegacyId,
             DataSource = entity.DataSource,
+            App = entity.App,
+            SyncIdentifier = entity.SyncIdentifier,
             CreatedAt = entity.SysCreatedAt,
             ModifiedAt = entity.SysUpdatedAt,
             Manufacturer = entity.Manufacturer,
@@ -100,6 +104,8 @@ public static class PumpSnapshotMapper
         entity.CorrelationId = model.CorrelationId;
         entity.LegacyId = model.LegacyId;
         entity.DataSource = model.DataSource;
+        entity.App = model.App;
+        entity.SyncIdentifier = model.SyncIdentifier;
         entity.Manufacturer = model.Manufacturer;
         entity.Model = model.Model;
         entity.Reservoir = model.Reservoir;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/TempBasalMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/TempBasalMapper.cs
@@ -35,6 +35,7 @@ public static class TempBasalMapper
             DeviceId = model.DeviceId,
             PatientDeviceId = model.PatientDeviceId,
             PumpRecordId = model.PumpRecordId,
+            SyncIdentifier = model.SyncIdentifier,
             ApsSnapshotId = model.ApsSnapshotId,
             InsulinContextJson = model.InsulinContext is not null
                 ? JsonSerializer.Serialize(model.InsulinContext)
@@ -73,6 +74,7 @@ public static class TempBasalMapper
             DeviceId = entity.DeviceId,
             PatientDeviceId = entity.PatientDeviceId,
             PumpRecordId = entity.PumpRecordId,
+            SyncIdentifier = entity.SyncIdentifier,
             ApsSnapshotId = entity.ApsSnapshotId,
             InsulinContext = !string.IsNullOrEmpty(entity.InsulinContextJson)
                 ? JsonSerializer.Deserialize<TreatmentInsulinContext>(entity.InsulinContextJson)
@@ -104,6 +106,7 @@ public static class TempBasalMapper
         entity.DeviceId = model.DeviceId;
         entity.PatientDeviceId = model.PatientDeviceId;
         entity.PumpRecordId = model.PumpRecordId;
+        entity.SyncIdentifier = model.SyncIdentifier;
         entity.ApsSnapshotId = model.ApsSnapshotId;
         entity.InsulinContextJson = model.InsulinContext is not null
             ? JsonSerializer.Serialize(model.InsulinContext)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/UploaderSnapshotMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/UploaderSnapshotMapper.cs
@@ -25,6 +25,8 @@ public static class UploaderSnapshotMapper
             CorrelationId = model.CorrelationId,
             LegacyId = model.LegacyId,
             DataSource = model.DataSource,
+            App = model.App,
+            SyncIdentifier = model.SyncIdentifier,
             SysCreatedAt = DateTime.UtcNow,
             SysUpdatedAt = DateTime.UtcNow,
             Name = model.Name,
@@ -56,6 +58,8 @@ public static class UploaderSnapshotMapper
             CorrelationId = entity.CorrelationId,
             LegacyId = entity.LegacyId,
             DataSource = entity.DataSource,
+            App = entity.App,
+            SyncIdentifier = entity.SyncIdentifier,
             CreatedAt = entity.SysCreatedAt,
             ModifiedAt = entity.SysUpdatedAt,
             Name = entity.Name,
@@ -84,6 +88,8 @@ public static class UploaderSnapshotMapper
         entity.CorrelationId = model.CorrelationId;
         entity.LegacyId = model.LegacyId;
         entity.DataSource = model.DataSource;
+        entity.App = model.App;
+        entity.SyncIdentifier = model.SyncIdentifier;
         entity.Name = model.Name;
         entity.Battery = model.Battery;
         entity.BatteryVoltage = model.BatteryVoltage;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260717133302_AddDeviceStatusSnapshotSyncIdentifiers.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260717133302_AddDeviceStatusSnapshotSyncIdentifiers.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260717133302_AddDeviceStatusSnapshotSyncIdentifiers")]
+    partial class AddDeviceStatusSnapshotSyncIdentifiers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260717133302_AddDeviceStatusSnapshotSyncIdentifiers.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260717133302_AddDeviceStatusSnapshotSyncIdentifiers.cs
@@ -1,0 +1,117 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDeviceStatusSnapshotSyncIdentifiers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "app",
+                table: "uploader_snapshots",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "sync_identifier",
+                table: "uploader_snapshots",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "app",
+                table: "pump_snapshots",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "sync_identifier",
+                table: "pump_snapshots",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "app",
+                table: "aps_snapshots",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "sync_identifier",
+                table: "aps_snapshots",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_uploader_snapshots_tenant_source_sync_id",
+                table: "uploader_snapshots",
+                columns: new[] { "tenant_id", "data_source", "sync_identifier" },
+                unique: true,
+                filter: "sync_identifier IS NOT NULL AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_pump_snapshots_tenant_source_sync_id",
+                table: "pump_snapshots",
+                columns: new[] { "tenant_id", "data_source", "sync_identifier" },
+                unique: true,
+                filter: "sync_identifier IS NOT NULL AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_aps_snapshots_tenant_source_sync_id",
+                table: "aps_snapshots",
+                columns: new[] { "tenant_id", "data_source", "sync_identifier" },
+                unique: true,
+                filter: "sync_identifier IS NOT NULL AND deleted_at IS NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_uploader_snapshots_tenant_source_sync_id",
+                table: "uploader_snapshots");
+
+            migrationBuilder.DropIndex(
+                name: "ix_pump_snapshots_tenant_source_sync_id",
+                table: "pump_snapshots");
+
+            migrationBuilder.DropIndex(
+                name: "ix_aps_snapshots_tenant_source_sync_id",
+                table: "aps_snapshots");
+
+            migrationBuilder.DropColumn(
+                name: "app",
+                table: "uploader_snapshots");
+
+            migrationBuilder.DropColumn(
+                name: "sync_identifier",
+                table: "uploader_snapshots");
+
+            migrationBuilder.DropColumn(
+                name: "app",
+                table: "pump_snapshots");
+
+            migrationBuilder.DropColumn(
+                name: "sync_identifier",
+                table: "pump_snapshots");
+
+            migrationBuilder.DropColumn(
+                name: "app",
+                table: "aps_snapshots");
+
+            migrationBuilder.DropColumn(
+                name: "sync_identifier",
+                table: "aps_snapshots");
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260717141728_AddTempBasalSyncIdentifierAndCarbMacros.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260717141728_AddTempBasalSyncIdentifierAndCarbMacros.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260717141728_AddTempBasalSyncIdentifierAndCarbMacros")]
+    partial class AddTempBasalSyncIdentifierAndCarbMacros
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260717141728_AddTempBasalSyncIdentifierAndCarbMacros.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260717141728_AddTempBasalSyncIdentifierAndCarbMacros.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTempBasalSyncIdentifierAndCarbMacros : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "sync_identifier",
+                table: "temp_basals",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "fat_grams",
+                table: "carb_intakes",
+                type: "double precision",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "protein_grams",
+                table: "carb_intakes",
+                type: "double precision",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_temp_basals_tenant_source_sync_id",
+                table: "temp_basals",
+                columns: new[] { "tenant_id", "data_source", "sync_identifier" },
+                unique: true,
+                filter: "sync_identifier IS NOT NULL AND deleted_at IS NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_temp_basals_tenant_source_sync_id",
+                table: "temp_basals");
+
+            migrationBuilder.DropColumn(
+                name: "sync_identifier",
+                table: "temp_basals");
+
+            migrationBuilder.DropColumn(
+                name: "fat_grams",
+                table: "carb_intakes");
+
+            migrationBuilder.DropColumn(
+                name: "protein_grams",
+                table: "carb_intakes");
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -1760,6 +1760,24 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             .HasIndex(e => e.LegacyId)
             .HasDatabaseName("ix_aps_snapshots_legacy_id");
 
+        // ApsSnapshot gains a SyncIdentifier upsert key (mirrors boluses) so uploader
+        // retries of the same loop cycle update in place instead of duplicating.
+        modelBuilder
+            .Entity<ApsSnapshotEntity>()
+            .HasIndex(e => new { e.TenantId, e.DataSource, e.SyncIdentifier })
+            .HasDatabaseName("ix_aps_snapshots_tenant_source_sync_id")
+            .IsUnique()
+            .HasFilter("sync_identifier IS NOT NULL AND deleted_at IS NULL");
+
+        // Keep the conventional TenantId index: the partial sync-id index above starts with
+        // tenant_id, which makes EF drop the auto-created one as redundant, but a filtered
+        // index can't serve general tenant-scoped scans (all pre-existing rows have NULL
+        // sync_identifier).
+        modelBuilder
+            .Entity<ApsSnapshotEntity>()
+            .HasIndex(e => e.TenantId)
+            .HasDatabaseName("IX_aps_snapshots_tenant_id");
+
         // PumpSnapshot indexes
         modelBuilder
             .Entity<PumpSnapshotEntity>()
@@ -1772,6 +1790,20 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             .HasIndex(e => e.LegacyId)
             .HasDatabaseName("ix_pump_snapshots_legacy_id");
 
+        // PumpSnapshot gains a SyncIdentifier upsert key (mirrors boluses).
+        modelBuilder
+            .Entity<PumpSnapshotEntity>()
+            .HasIndex(e => new { e.TenantId, e.DataSource, e.SyncIdentifier })
+            .HasDatabaseName("ix_pump_snapshots_tenant_source_sync_id")
+            .IsUnique()
+            .HasFilter("sync_identifier IS NOT NULL AND deleted_at IS NULL");
+
+        // Keep the conventional TenantId index (see ApsSnapshot note above).
+        modelBuilder
+            .Entity<PumpSnapshotEntity>()
+            .HasIndex(e => e.TenantId)
+            .HasDatabaseName("IX_pump_snapshots_tenant_id");
+
         // UploaderSnapshot indexes
         modelBuilder
             .Entity<UploaderSnapshotEntity>()
@@ -1783,6 +1815,20 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             .Entity<UploaderSnapshotEntity>()
             .HasIndex(e => e.LegacyId)
             .HasDatabaseName("ix_uploader_snapshots_legacy_id");
+
+        // UploaderSnapshot gains a SyncIdentifier upsert key (mirrors boluses).
+        modelBuilder
+            .Entity<UploaderSnapshotEntity>()
+            .HasIndex(e => new { e.TenantId, e.DataSource, e.SyncIdentifier })
+            .HasDatabaseName("ix_uploader_snapshots_tenant_source_sync_id")
+            .IsUnique()
+            .HasFilter("sync_identifier IS NOT NULL AND deleted_at IS NULL");
+
+        // Keep the conventional TenantId index (see ApsSnapshot note above).
+        modelBuilder
+            .Entity<UploaderSnapshotEntity>()
+            .HasIndex(e => e.TenantId)
+            .HasDatabaseName("IX_uploader_snapshots_tenant_id");
 
 
         // DeviceStatusExtras indexes

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -1867,6 +1867,15 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             .HasDatabaseName("ix_temp_basals_tenant_start_timestamp")
             .IsDescending(false, true);
 
+        // TempBasal gains a SyncIdentifier upsert key (mirrors boluses) so uploader
+        // retries of the same pump event update in place instead of duplicating.
+        modelBuilder
+            .Entity<TempBasalEntity>()
+            .HasIndex(e => new { e.TenantId, e.DataSource, e.SyncIdentifier })
+            .HasDatabaseName("ix_temp_basals_tenant_source_sync_id")
+            .IsUnique()
+            .HasFilter("sync_identifier IS NOT NULL AND deleted_at IS NULL");
+
         // Devices unique index (scoped to live records, per tenant).
         // TenantId must be part of the key: devices are tenant-owned (FindByCategoryTypeAndSerialAsync
         // is RLS-scoped to the current tenant) and the type/serial often carry shared, non-unique

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
@@ -377,4 +377,107 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
             return created;
         });
     }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Mirrors the (DataSource, SyncIdentifier) upsert split in <c>SensorGlucoseRepository</c> /
+    /// <c>BolusRepository</c>: intra-batch keep-last per key, DB-matched rows update in place,
+    /// the rest insert through the LegacyId-dedup path.
+    /// </remarks>
+    public async Task<IEnumerable<ApsSnapshot>> BulkUpsertAsync(
+        IEnumerable<ApsSnapshot> records,
+        WriteOrigin origin, CancellationToken ct = default)
+    {
+        var entities = records.Select(ApsSnapshotMapper.ToEntity).ToList();
+        if (entities.Count == 0)
+            return [];
+
+        // Intra-batch dedup: keep the last occurrence per (DataSource, SyncIdentifier).
+        // Records without both keys keep a unique grouping key so they're not collapsed.
+        entities = entities
+            .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
+                ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
+                : $"id|{e.Id}")
+            .Select(g => g.Last())
+            .ToList();
+
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var strategy = ctx.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
+        {
+            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
+
+            // DB-level upsert: rows matched by (DataSource, SyncIdentifier) are updated in place.
+            // Soft-deleted rows are excluded: the partial unique index ignores them, so a
+            // re-upload after a delete inserts a fresh row instead of writing into the deleted one.
+            var updatedEntities = new List<ApsSnapshotEntity>();
+            var toInsert = entities;
+            var syncKeyed = entities
+                .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
+                .ToList();
+
+            if (syncKeyed.Count > 0)
+            {
+                var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
+                var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
+
+                var existingRows = await ctx.ApsSnapshots.IgnoreQueryFilters()
+                    .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt == null)
+                    .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
+                    .ToListAsync(ct);
+
+                var existingByKey = existingRows
+                    .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
+                    .ToDictionary(g => g.Key, g => g.First());
+
+                toInsert = [];
+                foreach (var entity in entities)
+                {
+                    var hasKey = !string.IsNullOrEmpty(entity.DataSource)
+                        && !string.IsNullOrEmpty(entity.SyncIdentifier);
+                    if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
+                    {
+                        ApsSnapshotMapper.UpdateEntity(existing, ApsSnapshotMapper.ToDomainModel(entity));
+                        updatedEntities.Add(existing);
+                    }
+                    else
+                    {
+                        toInsert.Add(entity);
+                    }
+                }
+
+                if (updatedEntities.Count > 0)
+                    await ctx.SaveChangesAsync(ct);
+            }
+
+            // Insert path: LegacyId dedup as in BulkCreateAsync.
+            var legacyIds = toInsert
+                .Where(e => !string.IsNullOrEmpty(e.LegacyId))
+                .Select(e => e.LegacyId!)
+                .ToHashSet();
+
+            if (legacyIds.Count > 0)
+            {
+                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<ApsSnapshotEntity>(legacyIds, ct);
+                toInsert = toInsert
+                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
+                    .ToList();
+            }
+
+            const int batchSize = 500;
+            foreach (var batch in toInsert.Chunk(batchSize))
+            {
+                ctx.ApsSnapshots.AddRange(batch);
+                await ctx.SaveChangesAsync(ct);
+                ctx.ChangeTracker.Clear();
+            }
+
+            await tx.CommitAsync(ct);
+
+            var updated = updatedEntities.Select(ApsSnapshotMapper.ToDomainModel).ToList();
+            var created = toInsert.Select(ApsSnapshotMapper.ToDomainModel).ToList();
+            await RaiseBroadcastAsync(created, updated, [], origin, ct);
+            return updated.Concat(created).ToList();
+        });
+    }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
@@ -411,6 +411,7 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
             // Soft-deleted rows are excluded: the partial unique index ignores them, so a
             // re-upload after a delete inserts a fresh row instead of writing into the deleted one.
             var updatedEntities = new List<ApsSnapshotEntity>();
+            var materiallyChanged = new List<ApsSnapshotEntity>();
             var toInsert = entities;
             var syncKeyed = entities
                 .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
@@ -439,6 +440,9 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
                     {
                         ApsSnapshotMapper.UpdateEntity(existing, ApsSnapshotMapper.ToDomainModel(entity));
                         updatedEntities.Add(existing);
+                        // Capture material changes now, before SaveChanges clears the modified flags.
+                        if (V4MaterialChange.HasMaterialChange(ctx.Entry(existing)))
+                            materiallyChanged.Add(existing);
                     }
                     else
                     {
@@ -476,7 +480,9 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
 
             var updated = updatedEntities.Select(ApsSnapshotMapper.ToDomainModel).ToList();
             var created = toInsert.Select(ApsSnapshotMapper.ToDomainModel).ToList();
-            await RaiseBroadcastAsync(created, updated, [], origin, ct);
+            // Broadcast only materially changed updates: a byte-identical retry of the same
+            // batch must not push update events to every client (the #513 broadcast-storm shape).
+            await RaiseBroadcastAsync(created, materiallyChanged.Select(ApsSnapshotMapper.ToDomainModel).ToList(), [], origin, ct);
             return updated.Concat(created).ToList();
         });
     }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
@@ -339,4 +339,107 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
             return created;
         });
     }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Mirrors the (DataSource, SyncIdentifier) upsert split in <c>SensorGlucoseRepository</c> /
+    /// <c>BolusRepository</c>: intra-batch keep-last per key, DB-matched rows update in place,
+    /// the rest insert through the LegacyId-dedup path.
+    /// </remarks>
+    public async Task<IEnumerable<PumpSnapshot>> BulkUpsertAsync(
+        IEnumerable<PumpSnapshot> records,
+        WriteOrigin origin, CancellationToken ct = default)
+    {
+        var entities = records.Select(PumpSnapshotMapper.ToEntity).ToList();
+        if (entities.Count == 0)
+            return [];
+
+        // Intra-batch dedup: keep the last occurrence per (DataSource, SyncIdentifier).
+        // Records without both keys keep a unique grouping key so they're not collapsed.
+        entities = entities
+            .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
+                ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
+                : $"id|{e.Id}")
+            .Select(g => g.Last())
+            .ToList();
+
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var strategy = ctx.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
+        {
+            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
+
+            // DB-level upsert: rows matched by (DataSource, SyncIdentifier) are updated in place.
+            // Soft-deleted rows are excluded: the partial unique index ignores them, so a
+            // re-upload after a delete inserts a fresh row instead of writing into the deleted one.
+            var updatedEntities = new List<PumpSnapshotEntity>();
+            var toInsert = entities;
+            var syncKeyed = entities
+                .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
+                .ToList();
+
+            if (syncKeyed.Count > 0)
+            {
+                var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
+                var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
+
+                var existingRows = await ctx.PumpSnapshots.IgnoreQueryFilters()
+                    .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt == null)
+                    .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
+                    .ToListAsync(ct);
+
+                var existingByKey = existingRows
+                    .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
+                    .ToDictionary(g => g.Key, g => g.First());
+
+                toInsert = [];
+                foreach (var entity in entities)
+                {
+                    var hasKey = !string.IsNullOrEmpty(entity.DataSource)
+                        && !string.IsNullOrEmpty(entity.SyncIdentifier);
+                    if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
+                    {
+                        PumpSnapshotMapper.UpdateEntity(existing, PumpSnapshotMapper.ToDomainModel(entity));
+                        updatedEntities.Add(existing);
+                    }
+                    else
+                    {
+                        toInsert.Add(entity);
+                    }
+                }
+
+                if (updatedEntities.Count > 0)
+                    await ctx.SaveChangesAsync(ct);
+            }
+
+            // Insert path: LegacyId dedup as in BulkCreateAsync.
+            var legacyIds = toInsert
+                .Where(e => !string.IsNullOrEmpty(e.LegacyId))
+                .Select(e => e.LegacyId!)
+                .ToHashSet();
+
+            if (legacyIds.Count > 0)
+            {
+                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<PumpSnapshotEntity>(legacyIds, ct);
+                toInsert = toInsert
+                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
+                    .ToList();
+            }
+
+            const int batchSize = 500;
+            foreach (var batch in toInsert.Chunk(batchSize))
+            {
+                ctx.PumpSnapshots.AddRange(batch);
+                await ctx.SaveChangesAsync(ct);
+                ctx.ChangeTracker.Clear();
+            }
+
+            await tx.CommitAsync(ct);
+
+            var updated = updatedEntities.Select(PumpSnapshotMapper.ToDomainModel).ToList();
+            var created = toInsert.Select(PumpSnapshotMapper.ToDomainModel).ToList();
+            await RaiseBroadcastAsync(created, updated, [], origin, ct);
+            return updated.Concat(created).ToList();
+        });
+    }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
@@ -373,6 +373,7 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
             // Soft-deleted rows are excluded: the partial unique index ignores them, so a
             // re-upload after a delete inserts a fresh row instead of writing into the deleted one.
             var updatedEntities = new List<PumpSnapshotEntity>();
+            var materiallyChanged = new List<PumpSnapshotEntity>();
             var toInsert = entities;
             var syncKeyed = entities
                 .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
@@ -401,6 +402,9 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
                     {
                         PumpSnapshotMapper.UpdateEntity(existing, PumpSnapshotMapper.ToDomainModel(entity));
                         updatedEntities.Add(existing);
+                        // Capture material changes now, before SaveChanges clears the modified flags.
+                        if (V4MaterialChange.HasMaterialChange(ctx.Entry(existing)))
+                            materiallyChanged.Add(existing);
                     }
                     else
                     {
@@ -438,7 +442,9 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
 
             var updated = updatedEntities.Select(PumpSnapshotMapper.ToDomainModel).ToList();
             var created = toInsert.Select(PumpSnapshotMapper.ToDomainModel).ToList();
-            await RaiseBroadcastAsync(created, updated, [], origin, ct);
+            // Broadcast only materially changed updates: a byte-identical retry of the same
+            // batch must not push update events to every client (the #513 broadcast-storm shape).
+            await RaiseBroadcastAsync(created, materiallyChanged.Select(PumpSnapshotMapper.ToDomainModel).ToList(), [], origin, ct);
             return updated.Concat(created).ToList();
         });
     }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
@@ -133,14 +133,34 @@ public class TempBasalRepository : ITempBasalRepository
     }
 
     /// <summary>
-    /// Creates a new temporary basal record.
+    /// Creates a new temporary basal record. When <c>DataSource</c> and <c>SyncIdentifier</c>
+    /// match an existing live row for this tenant, the record is updated in place rather than
+    /// inserted — making the operation idempotent for uploader retries. Tenant scoping is
+    /// implicit via the DbContext's RLS-equivalent query filter. Mirrors SensorGlucoseRepository.
     /// </summary>
     /// <param name="model">The temporary basal record to create.</param>
     /// <param name="ct">The cancellation token.</param>
-    /// <returns>The created temporary basal record.</returns>
+    /// <returns>The created or updated temporary basal record.</returns>
     public async Task<TempBasal> CreateAsync(TempBasal model, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
+        if (!string.IsNullOrEmpty(model.DataSource) && !string.IsNullOrEmpty(model.SyncIdentifier))
+        {
+            var existing = await ctx.TempBasals
+                .FirstOrDefaultAsync(
+                    e => e.DataSource == model.DataSource && e.SyncIdentifier == model.SyncIdentifier,
+                    ct);
+            if (existing != null)
+            {
+                TempBasalMapper.UpdateEntity(existing, model);
+                await ctx.SaveChangesAsync(ct);
+                var upserted = TempBasalMapper.ToDomainModel(existing);
+                // A single explicit upsert always broadcasts (no material-change gate on the single path).
+                await RaiseBroadcastAsync([], [upserted], [], origin, ct);
+                return upserted;
+            }
+        }
+
         var entity = TempBasalMapper.ToEntity(model);
         ctx.TempBasals.Add(entity);
         await ctx.SaveChangesAsync(ct);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
@@ -329,4 +329,107 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
             return created;
         });
     }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Mirrors the (DataSource, SyncIdentifier) upsert split in <c>SensorGlucoseRepository</c> /
+    /// <c>BolusRepository</c>: intra-batch keep-last per key, DB-matched rows update in place,
+    /// the rest insert through the LegacyId-dedup path.
+    /// </remarks>
+    public async Task<IEnumerable<UploaderSnapshot>> BulkUpsertAsync(
+        IEnumerable<UploaderSnapshot> records,
+        WriteOrigin origin, CancellationToken ct = default)
+    {
+        var entities = records.Select(UploaderSnapshotMapper.ToEntity).ToList();
+        if (entities.Count == 0)
+            return [];
+
+        // Intra-batch dedup: keep the last occurrence per (DataSource, SyncIdentifier).
+        // Records without both keys keep a unique grouping key so they're not collapsed.
+        entities = entities
+            .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
+                ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
+                : $"id|{e.Id}")
+            .Select(g => g.Last())
+            .ToList();
+
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var strategy = ctx.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
+        {
+            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
+
+            // DB-level upsert: rows matched by (DataSource, SyncIdentifier) are updated in place.
+            // Soft-deleted rows are excluded: the partial unique index ignores them, so a
+            // re-upload after a delete inserts a fresh row instead of writing into the deleted one.
+            var updatedEntities = new List<UploaderSnapshotEntity>();
+            var toInsert = entities;
+            var syncKeyed = entities
+                .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
+                .ToList();
+
+            if (syncKeyed.Count > 0)
+            {
+                var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
+                var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
+
+                var existingRows = await ctx.UploaderSnapshots.IgnoreQueryFilters()
+                    .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt == null)
+                    .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
+                    .ToListAsync(ct);
+
+                var existingByKey = existingRows
+                    .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
+                    .ToDictionary(g => g.Key, g => g.First());
+
+                toInsert = [];
+                foreach (var entity in entities)
+                {
+                    var hasKey = !string.IsNullOrEmpty(entity.DataSource)
+                        && !string.IsNullOrEmpty(entity.SyncIdentifier);
+                    if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
+                    {
+                        UploaderSnapshotMapper.UpdateEntity(existing, UploaderSnapshotMapper.ToDomainModel(entity));
+                        updatedEntities.Add(existing);
+                    }
+                    else
+                    {
+                        toInsert.Add(entity);
+                    }
+                }
+
+                if (updatedEntities.Count > 0)
+                    await ctx.SaveChangesAsync(ct);
+            }
+
+            // Insert path: LegacyId dedup as in BulkCreateAsync.
+            var legacyIds = toInsert
+                .Where(e => !string.IsNullOrEmpty(e.LegacyId))
+                .Select(e => e.LegacyId!)
+                .ToHashSet();
+
+            if (legacyIds.Count > 0)
+            {
+                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<UploaderSnapshotEntity>(legacyIds, ct);
+                toInsert = toInsert
+                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
+                    .ToList();
+            }
+
+            const int batchSize = 500;
+            foreach (var batch in toInsert.Chunk(batchSize))
+            {
+                ctx.UploaderSnapshots.AddRange(batch);
+                await ctx.SaveChangesAsync(ct);
+                ctx.ChangeTracker.Clear();
+            }
+
+            await tx.CommitAsync(ct);
+
+            var updated = updatedEntities.Select(UploaderSnapshotMapper.ToDomainModel).ToList();
+            var created = toInsert.Select(UploaderSnapshotMapper.ToDomainModel).ToList();
+            await RaiseBroadcastAsync(created, updated, [], origin, ct);
+            return updated.Concat(created).ToList();
+        });
+    }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
@@ -363,6 +363,7 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
             // Soft-deleted rows are excluded: the partial unique index ignores them, so a
             // re-upload after a delete inserts a fresh row instead of writing into the deleted one.
             var updatedEntities = new List<UploaderSnapshotEntity>();
+            var materiallyChanged = new List<UploaderSnapshotEntity>();
             var toInsert = entities;
             var syncKeyed = entities
                 .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
@@ -391,6 +392,9 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
                     {
                         UploaderSnapshotMapper.UpdateEntity(existing, UploaderSnapshotMapper.ToDomainModel(entity));
                         updatedEntities.Add(existing);
+                        // Capture material changes now, before SaveChanges clears the modified flags.
+                        if (V4MaterialChange.HasMaterialChange(ctx.Entry(existing)))
+                            materiallyChanged.Add(existing);
                     }
                     else
                     {
@@ -428,7 +432,9 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
 
             var updated = updatedEntities.Select(UploaderSnapshotMapper.ToDomainModel).ToList();
             var created = toInsert.Select(UploaderSnapshotMapper.ToDomainModel).ToList();
-            await RaiseBroadcastAsync(created, updated, [], origin, ct);
+            // Broadcast only materially changed updates: a byte-identical retry of the same
+            // batch must not push update events to every client (the #513 broadcast-storm shape).
+            await RaiseBroadcastAsync(created, materiallyChanged.Select(UploaderSnapshotMapper.ToDomainModel).ToList(), [], origin, ct);
             return updated.Concat(created).ToList();
         });
     }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/TempBasalControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/TempBasalControllerTests.cs
@@ -1,0 +1,154 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Nocturne.API.Controllers.V4.Treatments;
+using Nocturne.API.Models.Requests.V4;
+using Nocturne.Core.Contracts.Devices;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.V4;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers;
+
+/// <summary>
+/// Unit tests for the temp basal write endpoint: per-item upsert dispatch,
+/// cancel truncation, and pre-persist validation.
+/// </summary>
+[Trait("Category", "Unit")]
+public class TempBasalControllerTests
+{
+    private readonly Mock<ITempBasalRepository> _repo = new();
+    private readonly Mock<IPatientDeviceStamper> _stamper = new();
+    private readonly TempBasalController _controller;
+
+    private static readonly DateTimeOffset T0 = new(2026, 7, 1, 12, 0, 0, TimeSpan.Zero);
+
+    public TempBasalControllerTests()
+    {
+        _controller = new TempBasalController(_repo.Object, _stamper.Object)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+        };
+
+        _repo.Setup(r => r.CreateAsync(It.IsAny<TempBasal>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TempBasal m, WriteOrigin _, CancellationToken _) => m);
+        _repo.Setup(r => r.UpdateAsync(It.IsAny<Guid>(), It.IsAny<TempBasal>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid _, TempBasal m, WriteOrigin _, CancellationToken _) => m);
+    }
+
+    private static CreateTempBasalRequest Request(
+        double rate = 1.5, double? durationMinutes = 30, bool isCancel = false, DateTimeOffset? timestamp = null)
+        => new()
+        {
+            Timestamp = timestamp ?? T0,
+            Rate = rate,
+            DurationMinutes = durationMinutes,
+            IsCancel = isCancel,
+            DataSource = "trio",
+            SyncIdentifier = Guid.NewGuid().ToString(),
+            Origin = TempBasalOrigin.Algorithm,
+        };
+
+    [Fact]
+    public async Task CreateTempBasals_MapsDurationToEndTimestamp()
+    {
+        var result = await _controller.CreateTempBasals([Request(rate: 2.0, durationMinutes: 30)], CancellationToken.None);
+
+        var created = ((ObjectResult)result.Result!).Value.Should().BeOfType<TempBasal[]>().Subject;
+        created.Should().HaveCount(1);
+        created[0].Rate.Should().Be(2.0);
+        created[0].StartTimestamp.Should().Be(T0.UtcDateTime);
+        created[0].EndTimestamp.Should().Be(T0.UtcDateTime.AddMinutes(30));
+        created[0].Origin.Should().Be(TempBasalOrigin.Algorithm);
+    }
+
+    [Fact]
+    public async Task CreateTempBasals_Cancel_TruncatesActiveSpan()
+    {
+        var active = new TempBasal
+        {
+            Id = Guid.NewGuid(),
+            StartTimestamp = T0.UtcDateTime.AddMinutes(-10),
+            EndTimestamp = null,
+            Rate = 1.0,
+        };
+        _repo.Setup(r => r.GetActiveAtAsync(T0.UtcDateTime, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(active);
+
+        var result = await _controller.CreateTempBasals([Request(isCancel: true)], CancellationToken.None);
+
+        var returned = ((ObjectResult)result.Result!).Value.Should().BeOfType<TempBasal[]>().Subject;
+        returned.Should().HaveCount(1);
+        returned[0].EndTimestamp.Should().Be(T0.UtcDateTime);
+        _repo.Verify(
+            r => r.UpdateAsync(active.Id, It.Is<TempBasal>(m => m.EndTimestamp == T0.UtcDateTime), WriteOrigin.Live, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _repo.Verify(r => r.CreateAsync(It.IsAny<TempBasal>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateTempBasals_CancelWithNothingActive_IsNoOp()
+    {
+        _repo.Setup(r => r.GetActiveAtAsync(It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TempBasal?)null);
+
+        var result = await _controller.CreateTempBasals([Request(isCancel: true)], CancellationToken.None);
+
+        var returned = ((ObjectResult)result.Result!).Value.Should().BeOfType<TempBasal[]>().Subject;
+        returned.Should().BeEmpty();
+        _repo.Verify(r => r.UpdateAsync(It.IsAny<Guid>(), It.IsAny<TempBasal>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateTempBasals_ProcessesItemsInTimestampOrder()
+    {
+        // A batch that starts a temp basal and cancels it later must apply the start first,
+        // even when the array arrives out of order.
+        var processed = new List<string>();
+        _repo.Setup(r => r.CreateAsync(It.IsAny<TempBasal>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback(() => processed.Add("create"))
+            .ReturnsAsync((TempBasal m, WriteOrigin _, CancellationToken _) => m);
+        _repo.Setup(r => r.GetActiveAtAsync(It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Callback(() => processed.Add("cancel"))
+            .ReturnsAsync((TempBasal?)null);
+
+        var cancelLater = Request(isCancel: true, timestamp: T0.AddMinutes(15));
+        var startFirst = Request(timestamp: T0);
+
+        await _controller.CreateTempBasals([cancelLater, startFirst], CancellationToken.None);
+
+        processed.Should().Equal("create", "cancel");
+    }
+
+    [Fact]
+    public async Task CreateTempBasals_RejectsSyncIdentifierWithoutDataSource()
+    {
+        var request = Request();
+        request.DataSource = null;
+
+        var result = await _controller.CreateTempBasals([request], CancellationToken.None);
+
+        ((ObjectResult)result.Result!).StatusCode.Should().Be(400);
+        _repo.Verify(r => r.CreateAsync(It.IsAny<TempBasal>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateTempBasals_RejectsNegativeRate()
+    {
+        var result = await _controller.CreateTempBasals([Request(rate: -0.5)], CancellationToken.None);
+
+        ((ObjectResult)result.Result!).StatusCode.Should().Be(400);
+    }
+
+    [Fact]
+    public async Task CreateTempBasals_RejectsOversizedBatch()
+    {
+        var requests = Enumerable.Range(0, 1001).Select(_ => Request()).ToArray();
+
+        var result = await _controller.CreateTempBasals(requests, CancellationToken.None);
+
+        ((ObjectResult)result.Result!).StatusCode.Should().Be(400);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/ApsSnapshotRepositoryBulkUpsertTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/ApsSnapshotRepositoryBulkUpsertTests.cs
@@ -149,4 +149,41 @@ public class ApsSnapshotRepositoryBulkUpsertTests : IDisposable
         result.Should().BeEmpty();
         _context.ApsSnapshots.Count().Should().Be(0);
     }
+
+    private sealed class RecordingBroadcaster : Core.Contracts.Events.IV4RecordBroadcaster<ApsSnapshot>
+    {
+        public List<ApsSnapshot> Created { get; } = [];
+        public List<ApsSnapshot> Updated { get; } = [];
+
+        public Task BroadcastCreatedAsync(IReadOnlyList<ApsSnapshot> items, CancellationToken ct = default)
+        {
+            Created.AddRange(items);
+            return Task.CompletedTask;
+        }
+
+        public Task BroadcastUpdatedAsync(IReadOnlyList<ApsSnapshot> items, CancellationToken ct = default)
+        {
+            Updated.AddRange(items);
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task BulkUpsertAsync_ByteIdenticalRetry_DoesNotBroadcastUpdates()
+    {
+        var broadcaster = new RecordingBroadcaster();
+        var repository = new ApsSnapshotRepository(
+            new TestTenantDbContextFactory(_context), NullLogger<ApsSnapshotRepository>.Instance, broadcaster);
+
+        await repository.BulkUpsertAsync([CreateSnapshot("sync-1", iob: 1.0)], WriteOrigin.Live);
+        broadcaster.Created.Should().HaveCount(1);
+
+        // Byte-identical retry: matched in place, but nothing materially changed.
+        await repository.BulkUpsertAsync([CreateSnapshot("sync-1", iob: 1.0)], WriteOrigin.Live);
+        broadcaster.Updated.Should().BeEmpty();
+
+        // A real change does broadcast as an update.
+        await repository.BulkUpsertAsync([CreateSnapshot("sync-1", iob: 2.0)], WriteOrigin.Live);
+        broadcaster.Updated.Should().HaveCount(1);
+    }
 }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/ApsSnapshotRepositoryBulkUpsertTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/ApsSnapshotRepositoryBulkUpsertTests.cs
@@ -1,0 +1,152 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+using Nocturne.Core.Contracts.V4;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class ApsSnapshotRepositoryBulkUpsertTests : IDisposable
+{
+    private static readonly Guid TenantA = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    private readonly NocturneDbContext _context;
+    private readonly ApsSnapshotRepository _repository;
+
+    public ApsSnapshotRepositoryBulkUpsertTests()
+    {
+        var dbName = $"aps_snapshot_upsert_tests_{Guid.NewGuid()}";
+        _context = TestDbContextFactory.CreateInMemoryContext(dbName);
+        _context.TenantId = TenantA;
+        _repository = new ApsSnapshotRepository(new TestTenantDbContextFactory(_context), NullLogger<ApsSnapshotRepository>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static ApsSnapshot CreateSnapshot(
+        string? syncIdentifier = null,
+        string? dataSource = "trio",
+        DateTime? timestamp = null,
+        double? iob = null)
+    {
+        return new ApsSnapshot
+        {
+            Timestamp = timestamp ?? new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc),
+            UtcOffset = 0,
+            DataSource = dataSource,
+            SyncIdentifier = syncIdentifier,
+            AidAlgorithm = AidAlgorithm.Trio,
+            Enacted = false,
+            Iob = iob,
+        };
+    }
+
+    [Fact]
+    public async Task BulkUpsertAsync_InsertsNewRecords()
+    {
+        var snapshots = new[]
+        {
+            CreateSnapshot("sync-1", timestamp: new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)),
+            CreateSnapshot("sync-2", timestamp: new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
+        };
+
+        var result = (await _repository.BulkUpsertAsync(snapshots, WriteOrigin.Live)).ToList();
+
+        result.Should().HaveCount(2);
+        _context.ApsSnapshots.Count().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task BulkUpsertAsync_UpdatesExistingRecordInPlace()
+    {
+        await _repository.BulkUpsertAsync([CreateSnapshot("sync-1", iob: 1.0)], WriteOrigin.Live);
+
+        var retry = CreateSnapshot("sync-1", iob: 2.5);
+        var result = (await _repository.BulkUpsertAsync([retry], WriteOrigin.Live)).ToList();
+
+        result.Should().HaveCount(1);
+        _context.ApsSnapshots.Count().Should().Be(1);
+        _context.ApsSnapshots.Single().Iob.Should().Be(2.5);
+    }
+
+    [Fact]
+    public async Task BulkUpsertAsync_KeepsLastOccurrenceWithinBatch()
+    {
+        var snapshots = new[]
+        {
+            CreateSnapshot("sync-dup", iob: 1.0),
+            CreateSnapshot("sync-dup", iob: 3.0),
+        };
+
+        var result = (await _repository.BulkUpsertAsync(snapshots, WriteOrigin.Live)).ToList();
+
+        result.Should().HaveCount(1);
+        _context.ApsSnapshots.Count().Should().Be(1);
+        _context.ApsSnapshots.Single().Iob.Should().Be(3.0);
+    }
+
+    [Fact]
+    public async Task BulkUpsertAsync_MixedBatch_UpdatesMatchedAndInsertsRest()
+    {
+        await _repository.BulkUpsertAsync([CreateSnapshot("sync-existing", iob: 1.0)], WriteOrigin.Live);
+
+        var snapshots = new[]
+        {
+            CreateSnapshot("sync-existing", iob: 4.0),
+            CreateSnapshot("sync-new"),
+        };
+
+        var result = (await _repository.BulkUpsertAsync(snapshots, WriteOrigin.Live)).ToList();
+
+        result.Should().HaveCount(2);
+        _context.ApsSnapshots.Count().Should().Be(2);
+        _context.ApsSnapshots.Single(e => e.SyncIdentifier == "sync-existing").Iob.Should().Be(4.0);
+    }
+
+    [Fact]
+    public async Task BulkUpsertAsync_RecordsWithoutSyncKeyAlwaysInsert()
+    {
+        var unkeyed = new[]
+        {
+            CreateSnapshot(syncIdentifier: null, timestamp: new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)),
+            CreateSnapshot(syncIdentifier: null, timestamp: new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)),
+        };
+
+        await _repository.BulkUpsertAsync(unkeyed, WriteOrigin.Live);
+        await _repository.BulkUpsertAsync(unkeyed, WriteOrigin.Live);
+
+        _context.ApsSnapshots.Count().Should().Be(4);
+    }
+
+    [Fact]
+    public async Task BulkUpsertAsync_SameSyncIdDifferentSource_DoesNotCollide()
+    {
+        var snapshots = new[]
+        {
+            CreateSnapshot("sync-1", dataSource: "trio"),
+            CreateSnapshot("sync-1", dataSource: "loop"),
+        };
+
+        var result = (await _repository.BulkUpsertAsync(snapshots, WriteOrigin.Live)).ToList();
+
+        result.Should().HaveCount(2);
+        _context.ApsSnapshots.Count().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task BulkUpsertAsync_EmptyInput_ReturnsEmpty()
+    {
+        var result = (await _repository.BulkUpsertAsync([], WriteOrigin.Live)).ToList();
+
+        result.Should().BeEmpty();
+        _context.ApsSnapshots.Count().Should().Be(0);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/PumpSnapshotRepositoryBulkUpsertTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/PumpSnapshotRepositoryBulkUpsertTests.cs
@@ -1,0 +1,68 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+using Nocturne.Core.Contracts.V4;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class PumpSnapshotRepositoryBulkUpsertTests : IDisposable
+{
+    private static readonly Guid TenantA = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    private readonly NocturneDbContext _context;
+    private readonly PumpSnapshotRepository _repository;
+
+    public PumpSnapshotRepositoryBulkUpsertTests()
+    {
+        var dbName = $"pump_snapshot_upsert_tests_{Guid.NewGuid()}";
+        _context = TestDbContextFactory.CreateInMemoryContext(dbName);
+        _context.TenantId = TenantA;
+        _repository = new PumpSnapshotRepository(new TestTenantDbContextFactory(_context), NullLogger<PumpSnapshotRepository>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static PumpSnapshot CreateSnapshot(string? syncIdentifier = null, double? reservoir = null)
+    {
+        return new PumpSnapshot
+        {
+            Timestamp = new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc),
+            UtcOffset = 0,
+            DataSource = "trio",
+            SyncIdentifier = syncIdentifier,
+            Reservoir = reservoir,
+        };
+    }
+
+    [Fact]
+    public async Task BulkUpsertAsync_UpdatesExistingRecordInPlace()
+    {
+        await _repository.BulkUpsertAsync([CreateSnapshot("sync-1", reservoir: 100)], WriteOrigin.Live);
+
+        var result = (await _repository.BulkUpsertAsync([CreateSnapshot("sync-1", reservoir: 80)], WriteOrigin.Live)).ToList();
+
+        result.Should().HaveCount(1);
+        _context.PumpSnapshots.Count().Should().Be(1);
+        _context.PumpSnapshots.Single().Reservoir.Should().Be(80);
+    }
+
+    [Fact]
+    public async Task BulkUpsertAsync_InsertsWhenNoKeyMatch()
+    {
+        await _repository.BulkUpsertAsync([CreateSnapshot("sync-1")], WriteOrigin.Live);
+
+        var result = (await _repository.BulkUpsertAsync([CreateSnapshot("sync-2")], WriteOrigin.Live)).ToList();
+
+        result.Should().HaveCount(1);
+        _context.PumpSnapshots.Count().Should().Be(2);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/TempBasalRepositorySyncUpsertTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/TempBasalRepositorySyncUpsertTests.cs
@@ -1,0 +1,83 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Infrastructure;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+using Nocturne.Core.Contracts.V4;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class TempBasalRepositorySyncUpsertTests : IDisposable
+{
+    private static readonly Guid TenantA = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    private readonly NocturneDbContext _context;
+    private readonly TempBasalRepository _repository;
+
+    public TempBasalRepositorySyncUpsertTests()
+    {
+        var dbName = $"tempbasal_sync_upsert_tests_{Guid.NewGuid()}";
+        _context = TestDbContextFactory.CreateInMemoryContext(dbName);
+        _context.TenantId = TenantA;
+        _repository = new TempBasalRepository(
+            new TestTenantDbContextFactory(_context),
+            new Mock<IDeduplicationService>().Object,
+            new Mock<IAuditContext>().Object,
+            NullLogger<TempBasalRepository>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static TempBasal CreateRecord(string? syncIdentifier = null, double rate = 1.0, DateTime? end = null) =>
+        new()
+        {
+            StartTimestamp = new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc),
+            EndTimestamp = end,
+            UtcOffset = 0,
+            Rate = rate,
+            Origin = TempBasalOrigin.Algorithm,
+            DataSource = "trio",
+            SyncIdentifier = syncIdentifier,
+        };
+
+    [Fact]
+    public async Task CreateAsync_WithMatchingSyncKey_UpdatesInPlace()
+    {
+        await _repository.CreateAsync(CreateRecord("sync-1", rate: 1.0), WriteOrigin.Live);
+
+        var retry = CreateRecord("sync-1", rate: 2.5);
+        var result = await _repository.CreateAsync(retry, WriteOrigin.Live);
+
+        _context.TempBasals.Count().Should().Be(1);
+        _context.TempBasals.Single().Rate.Should().Be(2.5);
+        result.Rate.Should().Be(2.5);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithDifferentSyncKey_Inserts()
+    {
+        await _repository.CreateAsync(CreateRecord("sync-1"), WriteOrigin.Live);
+        await _repository.CreateAsync(CreateRecord("sync-2"), WriteOrigin.Live);
+
+        _context.TempBasals.Count().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithoutSyncKey_AlwaysInserts()
+    {
+        await _repository.CreateAsync(CreateRecord(syncIdentifier: null), WriteOrigin.Live);
+        await _repository.CreateAsync(CreateRecord(syncIdentifier: null), WriteOrigin.Live);
+
+        _context.TempBasals.Count().Should().Be(2);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/UploaderSnapshotRepositoryBulkUpsertTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/UploaderSnapshotRepositoryBulkUpsertTests.cs
@@ -1,0 +1,68 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+using Nocturne.Core.Contracts.V4;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class UploaderSnapshotRepositoryBulkUpsertTests : IDisposable
+{
+    private static readonly Guid TenantA = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    private readonly NocturneDbContext _context;
+    private readonly UploaderSnapshotRepository _repository;
+
+    public UploaderSnapshotRepositoryBulkUpsertTests()
+    {
+        var dbName = $"uploader_snapshot_upsert_tests_{Guid.NewGuid()}";
+        _context = TestDbContextFactory.CreateInMemoryContext(dbName);
+        _context.TenantId = TenantA;
+        _repository = new UploaderSnapshotRepository(new TestTenantDbContextFactory(_context), NullLogger<UploaderSnapshotRepository>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static UploaderSnapshot CreateSnapshot(string? syncIdentifier = null, int? battery = null)
+    {
+        return new UploaderSnapshot
+        {
+            Timestamp = new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc),
+            UtcOffset = 0,
+            DataSource = "trio",
+            SyncIdentifier = syncIdentifier,
+            Battery = battery,
+        };
+    }
+
+    [Fact]
+    public async Task BulkUpsertAsync_UpdatesExistingRecordInPlace()
+    {
+        await _repository.BulkUpsertAsync([CreateSnapshot("sync-1", battery: 90)], WriteOrigin.Live);
+
+        var result = (await _repository.BulkUpsertAsync([CreateSnapshot("sync-1", battery: 85)], WriteOrigin.Live)).ToList();
+
+        result.Should().HaveCount(1);
+        _context.UploaderSnapshots.Count().Should().Be(1);
+        _context.UploaderSnapshots.Single().Battery.Should().Be(85);
+    }
+
+    [Fact]
+    public async Task BulkUpsertAsync_InsertsWhenNoKeyMatch()
+    {
+        await _repository.BulkUpsertAsync([CreateSnapshot("sync-1")], WriteOrigin.Live);
+
+        var result = (await _repository.BulkUpsertAsync([CreateSnapshot("sync-2")], WriteOrigin.Live)).ToList();
+
+        result.Should().HaveCount(1);
+        _context.UploaderSnapshots.Count().Should().Be(2);
+    }
+}


### PR DESCRIPTION
Implements the full Trio "Nocturne Uploader" server surface (P0 device-status writes + the P1 follow-ups). Native uploaders previously could only write glucose/single treatments; this adds device-status snapshots, temp basals, bulk treatment creates, and native carb macros.

## Commit 1 — device-status snapshot writes (P0)

- `POST /api/v4/device-status/{aps,pump,uploader}` — array body, ≤1000, `devices.readwrite`, per-item upsert on `(dataSource, syncIdentifier)`, `correlationId` ties one loop cycle's three snapshots.
- Snapshots gained `sync_identifier` + partial unique indexes, and the previously-dropped `app` column.
- Review fix: gate upsert update-broadcasts on `V4MaterialChange` so byte-identical retries don't re-broadcast (the #513 storm shape). Kept conventional `IX_*_tenant_id` indexes that EF wanted to drop as prefix-redundant.

## Commit 2 — temp basals, bulk creates, carb macros (P1)

**Temp basal write endpoint** (the spec's main open question — answered by building it):
- `POST /api/v4/insulin/temp-basals` (+ `GET` list/by-id, `treatments.read`). Bulk write of spans **and** cancels, `treatments.readwrite`, ≤1000, processed in timestamp order so one batch can start a temp basal and later cancel it.
- A `isCancel: true` item truncates the span active at its timestamp via `GetActiveAtAsync` (no-op if none active); regular items upsert by `(dataSource, syncIdentifier)`.
- `TempBasal` gains `SyncIdentifier` (+ partial unique index); `CreateAsync` now upserts on it, mirroring SensorGlucose/Bolus.
- Overlapping spans are **not** auto-truncated on insert — the basal timeline resolves overlaps at read time, matching decomposer-written data. Trio can now include non-bolus pump events in the Nocturne predicate.

**Bulk create endpoints** (remove the client's single-POST catch-up loops):
- `POST` bulk on `insulin/boluses`, `insulin/basal-injections`, `nutrition/carbs`, `sleep/sessions`. ≤1000 (≤100 for sleep, since sessions embed stage/biometric arrays).
- Each reuses the type's existing `(dataSource, syncIdentifier)` upsert in `BulkCreateAsync`, so retries are idempotent; per-item validation mirrors each single-create (bolus insulin-context enrichment, basal-injection units/active-window checks).

**Native carb macros**: `CarbIntake` gains `fatGrams`/`proteinGrams` — the native fields for what legacy Nightscout modelled as a synthesized FPU fake-carb series. Wired through model/entity/mapper and the create/update/bulk carb DTOs.

## Answers to the other spec questions (unchanged)

- **OIDC `trio`**: no server work — dynamic client registration, PKCE S256 already mandatory, 90-day rotating refresh tokens, standard discovery. One client note: custom redirect schemes must contain a dot (RFC 8252), so use `org.nightscout.trio://...` not `trio://...`.
- **P1 remaining**: manual-BG create already existed (MeterGlucose/BGCheck full CRUD). Everything else the spec listed is now in this PR.

## Migrations & tests

- Two EF migrations (`AddDeviceStatusSnapshotSyncIdentifiers`, `AddTempBasalSyncIdentifierAndCarbMacros`), both `dotnet ef`-generated, Up/Down symmetric.
- New tests: snapshot bulk-upsert (12), temp-basal repo sync-upsert (3), `TempBasalControllerTests` (7 — timestamp ordering, cancel truncation, no-op cancel, validation). Full suites green: **Infrastructure.Data 505**, **API 377**.

SDK regen (next sdk-publish) picks up `apsSnapshotCreateApsSnapshots`, `tempBasalCreateTempBasals`, the treatment `*Bulk` operations, and the carb-macro fields.
