### PR TITLE
fix(v3): resolve AAPS V3 client sync compatibility (#516)

### DIFF
--- a/src/API/Nocturne.API/Controllers/V3/BaseV3Controller.cs
+++ b/src/API/Nocturne.API/Controllers/V3/BaseV3Controller.cs
@@ -369,6 +369,19 @@ public abstract class BaseV3Controller<T> : ControllerBase
     }
 
     /// <summary>
+    /// Set <c>Last-Modified</c> and <c>ETag</c> on a V3 <c>history/{lastModified}</c> response.
+    /// AAPS advances its incremental-sync cursor from these headers; without them the cursor
+    /// stays put and the same page is requested repeatedly.
+    /// </summary>
+    /// <param name="maxMills">Highest record timestamp in the response, in Unix milliseconds.</param>
+    protected void SetHistoryCursorHeaders(long maxMills)
+    {
+        var lastModified = DateTimeOffset.FromUnixTimeMilliseconds(maxMills).UtcDateTime;
+        Response.Headers["Last-Modified"] = lastModified.ToString("R");
+        Response.Headers["ETag"] = $"W/\"{maxMills}\"";
+    }
+
+    /// <summary>
     /// Create a standardized V3 success response with metadata including pagination headers.
     /// Returns the Nightscout V3-compatible envelope: <c>{"status": 200, "result": [...]}</c>.
     /// </summary>

--- a/src/API/Nocturne.API/Controllers/V3/DeviceStatusController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/DeviceStatusController.cs
@@ -507,11 +507,17 @@ public class DeviceStatusController : BaseV3Controller<DeviceStatus>
         {
             limit = Math.Min(Math.Max(limit, 1), 1000);
 
-            var deviceStatuses = await _projection.GetModifiedSinceAsync(
+            var deviceStatuses = (await _projection.GetModifiedSinceAsync(
                 lastModified,
                 limit,
                 cancellationToken
-            );
+            )).ToList();
+
+            if (deviceStatuses.Count > 0)
+            {
+                SetHistoryCursorHeaders(deviceStatuses.Max(d => d.Mills));
+            }
+
             var mappedData = deviceStatuses.Select(MapToV3Dto);
             return CreateV3SuccessResponse(mappedData);
         }

--- a/src/API/Nocturne.API/Controllers/V3/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/EntriesController.cs
@@ -509,17 +509,28 @@ public class EntriesController : BaseV3Controller<Entry>
         {
             limit = Math.Min(Math.Max(limit, 1), 1000);
 
-            // Build a find query for entries since the given timestamp
-            var findQuery = $"{{\"date\":{{\"$gte\":{lastModified}}}}}";
-            var entries = await _entryService.GetEntriesWithAdvancedFilterAsync(
+            // Build a find query for entries strictly newer than the cursor. Strictly-greater
+            // (not $gte) so the cursor record AAPS already holds is not re-returned, which
+            // would otherwise loop the incremental sync.
+            var findQuery = $"{{\"date\":{{\"$gt\":{lastModified}}}}}";
+            // Page oldest-first (reverseResults: true -> ascending) so a backlog larger than one
+            // page advances the cursor forward record by record. Newest-first would set the
+            // cursor to the newest of the first page and skip every older unsynced entry.
+            var entries = (await _entryService.GetEntriesWithAdvancedFilterAsync(
                 type: null,
                 count: limit,
                 skip: 0,
                 findQuery: findQuery,
                 dateString: null,
-                reverseResults: false,
+                reverseResults: true,
                 cancellationToken: cancellationToken
-            );
+            )).ToList();
+
+            if (entries.Count > 0)
+            {
+                SetHistoryCursorHeaders(entries.Max(e => e.Mills));
+            }
+
             var v3Entries = entries.ToV3Responses().ToList();
             return CreateV3SuccessResponse(v3Entries);
         }

--- a/src/API/Nocturne.API/Controllers/V3/LastModifiedController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/LastModifiedController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
 using Nocturne.Core.Contracts.Platform;
 using Nocturne.Core.Models;
+using System.Linq;
 
 namespace Nocturne.API.Controllers.V3;
 
@@ -93,11 +94,10 @@ public class LastModifiedController : ControllerBase
         Add("settings", lastModified.Settings);
         Add("activity", lastModified.Activity);
 
-        foreach (var kvp in lastModified.Additional)
+        foreach (var kvp in lastModified.Additional.Where(kvp => kvp.Key != "auth"))
         {
             // Exclude internal keys (e.g. auth) that are not sync collections.
-            if (kvp.Key != "auth")
-                Add(kvp.Key, kvp.Value);
+            Add(kvp.Key, kvp.Value);
         }
 
         return new

--- a/src/API/Nocturne.API/Controllers/V3/LastModifiedController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/LastModifiedController.cs
@@ -41,8 +41,8 @@ public class LastModifiedController : ControllerBase
     /// <response code="200">Last modified timestamps for each collection.</response>
     [HttpGet]
     [NightscoutEndpoint("/api/v3/lastModified")]
-    [ProducesResponseType(typeof(LastModifiedResponse), 200)]
-    public async Task<ActionResult<LastModifiedResponse>> GetLastModified()
+    [ProducesResponseType(typeof(object), 200)]
+    public async Task<ActionResult> GetLastModified()
     {
         _logger.LogDebug(
             "LastModified endpoint requested from {RemoteIpAddress}",
@@ -55,28 +55,59 @@ public class LastModifiedController : ControllerBase
 
             _logger.LogDebug("Successfully generated last modified response");
 
-            return Ok(lastModified);
+            return Ok(ToV3Envelope(lastModified));
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error generating last modified response");
 
-            // Return minimal response even on error to maintain compatibility
-            var serverTime = DateTime.UtcNow;
-            return Ok(
-                new LastModifiedResponse
-                {
-                    ServerTime = serverTime,
-                    Entries = null,
-                    Treatments = null,
-                    Profile = null,
-                    DeviceStatus = null,
-                    Food = null,
-                    Settings = null,
-                    Activity = null,
-                    Additional = new Dictionary<string, DateTime>(),
-                }
-            );
+            // Return the envelope even on error to maintain compatibility with clients
+            // (e.g. AAPS) that depend on this endpoint always returning the V3 shape.
+            return Ok(ToV3Envelope(new LastModifiedResponse { ServerTime = DateTime.UtcNow }));
         }
+    }
+
+    /// <summary>
+    /// Convert a <see cref="LastModifiedResponse"/> to the Nightscout V3 envelope AAPS expects:
+    /// <c>{ status, result: { srvDate, collections } }</c> with Unix-millisecond timestamps and
+    /// lowercase collection keys (singular <c>profile</c>, lowercase <c>devicestatus</c>).
+    /// </summary>
+    private static object ToV3Envelope(LastModifiedResponse lastModified)
+    {
+        var collections = new Dictionary<string, long>();
+
+        static long ToUnixMillis(DateTime value) =>
+            new DateTimeOffset(DateTime.SpecifyKind(value, DateTimeKind.Utc)).ToUnixTimeMilliseconds();
+
+        void Add(string key, DateTime? value)
+        {
+            if (value.HasValue)
+                collections[key] = ToUnixMillis(value.Value);
+        }
+
+        Add("entries", lastModified.Entries);
+        Add("treatments", lastModified.Treatments);
+        Add("profile", lastModified.Profile);
+        Add("devicestatus", lastModified.DeviceStatus);
+        Add("food", lastModified.Food);
+        Add("settings", lastModified.Settings);
+        Add("activity", lastModified.Activity);
+
+        foreach (var kvp in lastModified.Additional)
+        {
+            // Exclude internal keys (e.g. auth) that are not sync collections.
+            if (kvp.Key != "auth")
+                Add(kvp.Key, kvp.Value);
+        }
+
+        return new
+        {
+            status = 200,
+            result = new
+            {
+                srvDate = ToUnixMillis(lastModified.ServerTime),
+                collections,
+            },
+        };
     }
 }

--- a/src/API/Nocturne.API/Controllers/V3/TreatmentsController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/TreatmentsController.cs
@@ -501,7 +501,14 @@ public class TreatmentsController : BaseV3Controller<Treatment>
                 limit,
                 cancellationToken
             );
-            return CreateV3SuccessResponse(treatments);
+
+            var treatmentsList = treatments.ToList();
+            if (treatmentsList.Count > 0)
+            {
+                SetHistoryCursorHeaders(treatmentsList.Max(t => t.SrvModified ?? t.Mills));
+            }
+
+            return CreateV3SuccessResponse(treatmentsList);
         }
         catch (Exception ex)
         {

--- a/src/API/Nocturne.API/Services/V4/V4ToLegacyProjectionService.cs
+++ b/src/API/Nocturne.API/Services/V4/V4ToLegacyProjectionService.cs
@@ -379,10 +379,13 @@ public class V4ToLegacyProjectionService : IV4ToLegacyProjectionService
         var threshold = DateTimeOffset.FromUnixTimeMilliseconds(lastModifiedMills).UtcDateTime;
         var treatments = new List<Treatment>();
 
+        // Strictly-greater (not >=) so the cursor record AAPS already holds is not
+        // re-returned; an inclusive bound makes AAPS re-request the same page in a loop.
+
         // Query each V4 entity table by ModifiedAt, map to domain, then project to Treatment.
         // Sequential to avoid DbContext thread-safety issues.
         var boluses = await _dbContext.Boluses.AsNoTracking()
-            .Where(e => e.SysUpdatedAt >= threshold)
+            .Where(e => e.SysUpdatedAt > threshold)
             .OrderBy(static e => e.SysUpdatedAt)
             .Take(limit)
             .ToListAsync(ct);
@@ -390,7 +393,7 @@ public class V4ToLegacyProjectionService : IV4ToLegacyProjectionService
             treatments.Add(WithSrvModified(ProjectCorrectionBolus(BolusMapper.ToDomainModel(entity)), entity.SysUpdatedAt));
 
         var carbIntakes = await _dbContext.CarbIntakes.AsNoTracking()
-            .Where(e => e.SysUpdatedAt >= threshold)
+            .Where(e => e.SysUpdatedAt > threshold)
             .OrderBy(static e => e.SysUpdatedAt)
             .Take(limit)
             .ToListAsync(ct);
@@ -398,7 +401,7 @@ public class V4ToLegacyProjectionService : IV4ToLegacyProjectionService
             treatments.Add(WithSrvModified(ProjectCarbCorrection(CarbIntakeMapper.ToDomainModel(entity), []), entity.SysUpdatedAt));
 
         var bgChecks = await _dbContext.BGChecks.AsNoTracking()
-            .Where(e => e.SysUpdatedAt >= threshold)
+            .Where(e => e.SysUpdatedAt > threshold)
             .OrderBy(static e => e.SysUpdatedAt)
             .Take(limit)
             .ToListAsync(ct);
@@ -406,7 +409,7 @@ public class V4ToLegacyProjectionService : IV4ToLegacyProjectionService
             treatments.Add(WithSrvModified(ProjectBgCheck(BGCheckMapper.ToDomainModel(entity)), entity.SysUpdatedAt));
 
         var notes = await _dbContext.Notes.AsNoTracking()
-            .Where(e => e.SysUpdatedAt >= threshold)
+            .Where(e => e.SysUpdatedAt > threshold)
             .OrderBy(static e => e.SysUpdatedAt)
             .Take(limit)
             .ToListAsync(ct);
@@ -414,7 +417,7 @@ public class V4ToLegacyProjectionService : IV4ToLegacyProjectionService
             treatments.Add(WithSrvModified(ProjectNote(NoteMapper.ToDomainModel(entity)), entity.SysUpdatedAt));
 
         var deviceEvents = await _dbContext.DeviceEvents.AsNoTracking()
-            .Where(e => e.SysUpdatedAt >= threshold)
+            .Where(e => e.SysUpdatedAt > threshold)
             .OrderBy(static e => e.SysUpdatedAt)
             .Take(limit)
             .ToListAsync(ct);
@@ -422,7 +425,7 @@ public class V4ToLegacyProjectionService : IV4ToLegacyProjectionService
             treatments.Add(WithSrvModified(ProjectDeviceEvent(DeviceEventMapper.ToDomainModel(entity)), entity.SysUpdatedAt));
 
         var tempBasals = await _dbContext.TempBasals.AsNoTracking()
-            .Where(e => e.SysUpdatedAt >= threshold)
+            .Where(e => e.SysUpdatedAt > threshold)
             .OrderBy(static e => e.SysUpdatedAt)
             .Take(limit)
             .ToListAsync(ct);
@@ -430,7 +433,7 @@ public class V4ToLegacyProjectionService : IV4ToLegacyProjectionService
             treatments.Add(WithSrvModified(TempBasalToTreatmentMapper.ToTreatment(TempBasalMapper.ToDomainModel(entity)), entity.SysUpdatedAt));
 
         var bolusCalcs = await _dbContext.BolusCalculations.AsNoTracking()
-            .Where(e => e.SysUpdatedAt >= threshold)
+            .Where(e => e.SysUpdatedAt > threshold)
             .OrderBy(static e => e.SysUpdatedAt)
             .Take(limit)
             .ToListAsync(ct);

--- a/src/Core/Nocturne.Core.Models/Serializers/FlexibleNumberConverters.cs
+++ b/src/Core/Nocturne.Core.Models/Serializers/FlexibleNumberConverters.cs
@@ -194,6 +194,58 @@ public class FlexibleNullableDoubleConverter : JsonConverter<double?>
 }
 
 /// <summary>
+/// Reads a nullable double flexibly (number or string, like <see cref="FlexibleNullableDoubleConverter"/>)
+/// but writes it rounded to a whole number. Nightscout's <c>duration</c> is integer minutes on the wire;
+/// AAPS parses it as a Long and throws <c>NumberFormatException</c> on a fractional value. Rounding lives
+/// here — at serialization — rather than in the model getter, so in-memory calculations that rely on
+/// sub-minute precision (e.g. temp-basal duration cutting) keep the exact value.
+/// </summary>
+/// <seealso cref="FlexibleNullableDoubleConverter"/>
+public class RoundedNullableDoubleConverter : JsonConverter<double?>
+{
+    public override double? Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options
+    )
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.Number:
+                return reader.GetDouble();
+
+            case JsonTokenType.String:
+                var stringValue = reader.GetString();
+                if (string.IsNullOrWhiteSpace(stringValue))
+                    return null;
+
+                if (double.TryParse(stringValue, out var result))
+                    return result;
+
+                return null;
+
+            case JsonTokenType.Null:
+                return null;
+
+            default:
+                return null;
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, double? value, JsonSerializerOptions options)
+    {
+        if (value.HasValue)
+        {
+            writer.WriteNumberValue(Math.Round(value.Value));
+        }
+        else
+        {
+            writer.WriteNullValue();
+        }
+    }
+}
+
+/// <summary>
 /// JSON converter that handles flexible decimal serialization for Nightscout compatibility.
 /// Nightscout may send numeric values as either numbers or strings depending on the context.
 /// </summary>

--- a/src/Core/Nocturne.Core.Models/Treatment.cs
+++ b/src/Core/Nocturne.Core.Models/Treatment.cs
@@ -243,8 +243,10 @@ public class Treatment : ProcessableDocumentBase
     {
         get
         {
+            // AAPS parses duration as a Long and throws NumberFormatException on a
+            // fractional value, so round to whole minutes in every branch.
             if (_duration.HasValue)
-                return _duration;
+                return Math.Round(_duration.Value);
 
             // Try to calculate from Insulin / Rate
             // resolving synonyms
@@ -253,7 +255,7 @@ public class Treatment : ProcessableDocumentBase
 
             if (i.HasValue && r.HasValue && r.Value > 0)
             {
-                return (i.Value / r.Value) * 60.0;
+                return Math.Round((i.Value / r.Value) * 60.0);
             }
             // Nightscout returns 0 for duration when not set
             return 0;

--- a/src/Core/Nocturne.Core.Models/Treatment.cs
+++ b/src/Core/Nocturne.Core.Models/Treatment.cs
@@ -239,14 +239,15 @@ public class Treatment : ProcessableDocumentBase
     /// </summary>
     [JsonPropertyName("duration")]
     [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+    // Serializes rounded to whole minutes (AAPS parses duration as a Long); the getter keeps the
+    // exact value so in-memory duration math (e.g. temp-basal cutting) is not corrupted.
+    [JsonConverter(typeof(RoundedNullableDoubleConverter))]
     public double? Duration
     {
         get
         {
-            // AAPS parses duration as a Long and throws NumberFormatException on a
-            // fractional value, so round to whole minutes in every branch.
             if (_duration.HasValue)
-                return Math.Round(_duration.Value);
+                return _duration;
 
             // Try to calculate from Insulin / Rate
             // resolving synonyms
@@ -255,7 +256,7 @@ public class Treatment : ProcessableDocumentBase
 
             if (i.HasValue && r.HasValue && r.Value > 0)
             {
-                return Math.Round((i.Value / r.Value) * 60.0);
+                return (i.Value / r.Value) * 60.0;
             }
             // Nightscout returns 0 for duration when not set
             return 0;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
@@ -231,10 +231,17 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var since = DateTimeOffset.FromUnixTimeMilliseconds(lastModifiedMills).UtcDateTime;
+        // Filter and order on the event Timestamp: it is the clock the V3 devicestatus DTO
+        // reports as srvModified and the AAPS history cursor advances on, and it is the
+        // indexed column. Filtering on the write clock (SysUpdatedAt) instead sets the cursor
+        // below the returned rows' write time, so every poll re-matches them (an incremental-
+        // sync loop). Strictly-greater (not >=) so the cursor record AAPS already holds is not
+        // re-returned; the boundary record's sub-millisecond remainder is deduplicated by AAPS
+        // rather than dropped (a >= cursor+1ms bound would silently skip sub-ms page splits).
         var entities = await ctx.ApsSnapshots
             .AsNoTracking()
-            .Where(e => e.SysUpdatedAt >= since)
-            .OrderBy(e => e.SysUpdatedAt)
+            .Where(e => e.Timestamp > since)
+            .OrderBy(e => e.Timestamp)
             .Take(limit)
             .ToListAsync(ct);
 

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V3/EntriesHistoryOrderTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V3/EntriesHistoryOrderTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Controllers.V3;
+using Nocturne.Core.Contracts.Alerts;
+using Nocturne.Core.Contracts.Glucose;
+using Nocturne.Core.Contracts.Legacy;
+using Nocturne.Core.Models;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V3;
+
+/// <summary>
+/// The entries <c>history/{lastModified}</c> endpoint must page oldest-first so a backlog
+/// larger than one page advances the AAPS cursor forward record by record. Newest-first paging
+/// (reverseResults: false) sets the cursor to the newest of the first page and silently skips
+/// every older unsynced entry.
+/// </summary>
+[Trait("Category", "Unit")]
+public class EntriesHistoryOrderTests
+{
+    [Fact]
+    public async Task GetEntryHistory_PagesAscending()
+    {
+        var entryService = new Mock<IEntryService>();
+        entryService
+            .Setup(s => s.GetEntriesWithAdvancedFilterAsync(
+                It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Entry>());
+
+        var controller = new EntriesController(
+            Mock.Of<IDocumentProcessingService>(),
+            entryService.Object,
+            Mock.Of<ICanonicalAlertEvaluator>(),
+            NullLogger<EntriesController>.Instance)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+        };
+
+        await controller.GetEntryHistory(0);
+
+        entryService.Verify(s => s.GetEntriesWithAdvancedFilterAsync(
+            It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>(),
+            It.IsAny<string?>(), It.IsAny<string?>(),
+            true, // reverseResults -> ascending
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V3/LastModifiedControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V3/LastModifiedControllerTests.cs
@@ -1,0 +1,94 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Controllers.V3;
+using Nocturne.Core.Contracts.Platform;
+using Nocturne.Core.Models;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V3;
+
+/// <summary>
+/// The <c>/api/v3/lastModified</c> response must use the Nightscout V3 envelope AAPS
+/// expects: <c>{ status, result: { srvDate, collections } }</c> with Unix-millisecond
+/// timestamps and lowercase collection keys. A raw serialization of the C# model
+/// (ISO strings, camelCase <c>deviceStatus</c>/<c>serverTime</c>) makes AAPS report a
+/// failed sync.
+/// </summary>
+[Trait("Category", "Unit")]
+public class LastModifiedControllerTests
+{
+    private static LastModifiedController CreateController(Mock<IStatusService> statusService)
+    {
+        return new LastModifiedController(statusService.Object, NullLogger<LastModifiedController>.Instance)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            },
+        };
+    }
+
+    private static JsonElement CaptureBody(IActionResult result)
+    {
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        return JsonSerializer.SerializeToElement(ok.Value);
+    }
+
+    [Fact]
+    public async Task GetLastModified_WrapsInV3Envelope_WithMillisAndLowercaseKeys()
+    {
+        var entries = new DateTime(2024, 3, 26, 12, 0, 0, DateTimeKind.Utc);
+        var deviceStatus = new DateTime(2024, 3, 26, 12, 5, 0, DateTimeKind.Utc);
+        var profile = new DateTime(2024, 3, 20, 8, 0, 0, DateTimeKind.Utc);
+
+        var statusService = new Mock<IStatusService>();
+        statusService.Setup(s => s.GetLastModifiedAsync()).ReturnsAsync(new LastModifiedResponse
+        {
+            ServerTime = new DateTime(2024, 3, 26, 12, 6, 0, DateTimeKind.Utc),
+            Entries = entries,
+            DeviceStatus = deviceStatus,
+            Profile = profile,
+            Additional = new Dictionary<string, DateTime>
+            {
+                ["auth"] = new DateTime(2024, 3, 26, 12, 0, 0, DateTimeKind.Utc),
+            },
+        });
+
+        var body = CaptureBody(await CreateController(statusService).GetLastModified());
+
+        body.GetProperty("status").GetInt32().Should().Be(200);
+
+        var result = body.GetProperty("result");
+        result.GetProperty("srvDate").GetInt64()
+            .Should().Be(new DateTimeOffset(2024, 3, 26, 12, 6, 0, TimeSpan.Zero).ToUnixTimeMilliseconds());
+
+        var collections = result.GetProperty("collections");
+        collections.GetProperty("entries").GetInt64()
+            .Should().Be(new DateTimeOffset(entries).ToUnixTimeMilliseconds());
+        // Lowercase, singular Nightscout collection names.
+        collections.GetProperty("devicestatus").GetInt64()
+            .Should().Be(new DateTimeOffset(deviceStatus).ToUnixTimeMilliseconds());
+        collections.GetProperty("profile").GetInt64()
+            .Should().Be(new DateTimeOffset(profile).ToUnixTimeMilliseconds());
+        // Internal keys are not sync collections.
+        collections.TryGetProperty("auth", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetLastModified_OnServiceError_StillReturnsEnvelope()
+    {
+        var statusService = new Mock<IStatusService>();
+        statusService.Setup(s => s.GetLastModifiedAsync()).ThrowsAsync(new InvalidOperationException("boom"));
+
+        var body = CaptureBody(await CreateController(statusService).GetLastModified());
+
+        body.GetProperty("status").GetInt32().Should().Be(200);
+        var result = body.GetProperty("result");
+        result.GetProperty("srvDate").GetInt64().Should().BeGreaterThan(0);
+        result.GetProperty("collections").EnumerateObject().Should().BeEmpty();
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V3/TreatmentsHistoryHeaderTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V3/TreatmentsHistoryHeaderTests.cs
@@ -1,0 +1,74 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Controllers.V3;
+using Nocturne.Core.Contracts.Legacy;
+using Nocturne.Core.Contracts.Treatments;
+using Nocturne.Core.Models;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V3;
+
+/// <summary>
+/// AAPS advances its incremental-sync cursor from the <c>Last-Modified</c> and <c>ETag</c>
+/// headers on <c>history/{lastModified}</c> responses. Without them the cursor never moves
+/// and AAPS re-requests the same page indefinitely.
+/// </summary>
+[Trait("Category", "Unit")]
+public class TreatmentsHistoryHeaderTests
+{
+    private static TreatmentsController CreateController(Mock<ITreatmentService> treatmentService)
+    {
+        return new TreatmentsController(
+            Mock.Of<ITreatmentStore>(),
+            Mock.Of<IDocumentProcessingService>(),
+            treatmentService.Object,
+            NullLogger<TreatmentsController>.Instance)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            },
+        };
+    }
+
+    [Fact]
+    public async Task GetTreatmentHistory_SetsCursorHeadersFromNewestRecord()
+    {
+        var newest = new DateTimeOffset(2024, 3, 26, 12, 5, 0, TimeSpan.Zero).ToUnixTimeMilliseconds();
+        var older = new DateTimeOffset(2024, 3, 26, 12, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds();
+
+        var treatmentService = new Mock<ITreatmentService>();
+        treatmentService
+            .Setup(s => s.GetTreatmentsModifiedSinceAsync(It.IsAny<long>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new Treatment { EventType = "Note", SrvModified = older },
+                new Treatment { EventType = "Note", SrvModified = newest },
+            });
+
+        var controller = CreateController(treatmentService);
+        await controller.GetTreatmentHistory(0);
+
+        var expected = DateTimeOffset.FromUnixTimeMilliseconds(newest).UtcDateTime.ToString("R");
+        controller.Response.Headers["Last-Modified"].ToString().Should().Be(expected);
+        controller.Response.Headers["ETag"].ToString().Should().Be($"W/\"{newest}\"");
+    }
+
+    [Fact]
+    public async Task GetTreatmentHistory_EmptyResult_SetsNoCursorHeaders()
+    {
+        var treatmentService = new Mock<ITreatmentService>();
+        treatmentService
+            .Setup(s => s.GetTreatmentsModifiedSinceAsync(It.IsAny<long>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Treatment>());
+
+        var controller = CreateController(treatmentService);
+        await controller.GetTreatmentHistory(0);
+
+        controller.Response.Headers.Should().NotContainKey("Last-Modified");
+        controller.Response.Headers.Should().NotContainKey("ETag");
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/GoldenFiles/V3/LastModifiedGoldenTests.GetLastModified_WithEmptyDb_ReturnsNullCollectionTimestamps.verified.txt
+++ b/tests/Unit/Nocturne.API.Tests/GoldenFiles/V3/LastModifiedGoldenTests.GetLastModified_WithEmptyDb_ReturnsNullCollectionTimestamps.verified.txt
@@ -2,6 +2,9 @@
   StatusCode: 200,
   ContentType: application/json; charset=utf-8,
   Body: {
-    serverTime: {Scrubbed}
+    status: 200,
+    result: {
+      srvDate: {Scrubbed}
+    }
   }
 }

--- a/tests/Unit/Nocturne.API.Tests/GoldenFiles/V3/LastModifiedGoldenTests.GetLastModified_WithSeededEntries_ReturnsEntryTimestamp.verified.txt
+++ b/tests/Unit/Nocturne.API.Tests/GoldenFiles/V3/LastModifiedGoldenTests.GetLastModified_WithSeededEntries_ReturnsEntryTimestamp.verified.txt
@@ -2,6 +2,9 @@
   StatusCode: 200,
   ContentType: application/json; charset=utf-8,
   Body: {
-    serverTime: {Scrubbed}
+    status: 200,
+    result: {
+      srvDate: {Scrubbed}
+    }
   }
 }

--- a/tests/Unit/Nocturne.API.Tests/GoldenFiles/V3/LastModifiedGoldenTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/GoldenFiles/V3/LastModifiedGoldenTests.cs
@@ -18,7 +18,7 @@ public class LastModifiedGoldenTests : GoldenFileTestBase
         var captured = await CaptureResponse(response);
 
         await Verify(captured)
-            .ScrubMembers("serverTime");
+            .ScrubMembers("srvDate");
     }
 
     [Fact]
@@ -40,7 +40,7 @@ public class LastModifiedGoldenTests : GoldenFileTestBase
         var captured = await CaptureResponse(response);
 
         await Verify(captured)
-            .ScrubMembers("serverTime");
+            .ScrubMembers("srvDate");
     }
 
     #endregion

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/V4ToLegacyProjectionServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/V4ToLegacyProjectionServiceTests.cs
@@ -8,6 +8,8 @@ using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
 
@@ -33,6 +35,7 @@ public class V4ToLegacyProjectionServiceTests
     private readonly Mock<ITempBasalRepository> _tempBasalRepo = new();
     private readonly Mock<IBolusCalculationRepository> _bolusCalcRepo = new();
     private readonly Mock<ITreatmentFoodService> _treatmentFoodService = new();
+    private readonly NocturneDbContext _dbContext;
     private readonly V4ToLegacyProjectionService _service;
 
     public V4ToLegacyProjectionServiceTests()
@@ -87,7 +90,7 @@ public class V4ToLegacyProjectionServiceTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(Enumerable.Empty<BolusCalculation>());
 
-        var dbContext = TestDbContextFactory.CreateInMemoryContext();
+        _dbContext = TestDbContextFactory.CreateInMemoryContext();
 
         _service = new V4ToLegacyProjectionService(
             _sensorGlucoseRepo.Object,
@@ -99,7 +102,7 @@ public class V4ToLegacyProjectionServiceTests
             _tempBasalRepo.Object,
             _bolusCalcRepo.Object,
             _treatmentFoodService.Object,
-            dbContext,
+            _dbContext,
             NullLogger<V4ToLegacyProjectionService>.Instance
         );
     }
@@ -306,5 +309,47 @@ public class V4ToLegacyProjectionServiceTests
         var leftover1 = result1.Single(t => t.EventType == TreatmentTypes.CarbCorrection);
         var leftover2 = result2.Single(t => t.EventType == TreatmentTypes.CarbCorrection);
         leftover1.Id.Should().Be(leftover2.Id).And.Be(highId.ToString());
+    }
+
+    [Fact]
+    public async Task GetProjectedTreatmentsModifiedSince_ExcludesRecordAtCursor()
+    {
+        // AAPS passes the timestamp of the newest record it already holds as the cursor.
+        // The history query must be strictly-greater (>), so the record AT the cursor is
+        // not re-returned; an inclusive bound loops AAPS re-requesting the same page.
+        var cursor = new DateTime(2025, 01, 01, 12, 0, 0, DateTimeKind.Utc);
+        var tenantId = Guid.CreateVersion7();
+        _dbContext.TenantId = tenantId; // satisfy the tenant query filter
+
+        var atCursor = new BolusEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = tenantId,
+            Timestamp = cursor,
+            Insulin = 1.0,
+        };
+        var newer = Guid.CreateVersion7();
+        var afterCursor = new BolusEntity
+        {
+            Id = newer,
+            TenantId = tenantId,
+            Timestamp = cursor.AddMinutes(1),
+            Insulin = 2.0,
+        };
+        _dbContext.Boluses.Add(atCursor);
+        _dbContext.Boluses.Add(afterCursor);
+        await _dbContext.SaveChangesAsync();
+
+        // SaveChanges stamps SysUpdatedAt = UtcNow on insert; a second save that touches only
+        // SysUpdatedAt keeps the assigned value, letting us pin the two rows either side of the cursor.
+        atCursor.SysUpdatedAt = cursor; // exactly at the cursor -> must be excluded
+        afterCursor.SysUpdatedAt = cursor.AddMilliseconds(1); // strictly newer -> must be returned
+        await _dbContext.SaveChangesAsync();
+
+        var cursorMills = new DateTimeOffset(cursor).ToUnixTimeMilliseconds();
+        var result = (await _service.GetProjectedTreatmentsModifiedSinceAsync(cursorMills, 100)).ToList();
+
+        result.Should().ContainSingle();
+        result[0].Id.Should().Be(newer.ToString());
     }
 }

--- a/tests/Unit/Nocturne.Core.Models.Tests/TreatmentDurationTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/TreatmentDurationTests.cs
@@ -8,44 +8,48 @@ namespace Nocturne.Core.Models.Tests;
 /// <summary>
 /// AAPS parses treatment <c>duration</c> as a Long and throws
 /// <c>NumberFormatException: Expected a long</c> on a fractional value, so the
-/// getter must always resolve to a whole number of minutes.
+/// serialized value must be a whole number of minutes. Rounding happens at
+/// serialization, not in the getter — internal duration math (e.g. temp-basal
+/// cutting in DDataService) relies on the exact sub-minute value.
 /// </summary>
 [Trait("Category", "Unit")]
 public class TreatmentDurationTests
 {
     [Fact]
-    public void Duration_ComputedFromInsulinAndRate_IsRoundedToWholeMinutes()
+    public void Duration_Getter_KeepsExactValue_ForInternalCalculations()
     {
-        // (0.75 / 1.0) * 60 = 45; but e.g. 0.7492 / 1.0 * 60 = 44.952 -> must round.
-        var treatment = new Treatment { Insulin = 0.7492, Rate = 1.0 };
-
-        treatment.Duration!.Value.Should().Be(45);
+        // Regression guard: DDataService.ProcessDurations cuts a temp basal to a fractional
+        // sub-minute duration that is legitimately > 0 and filters on Duration > 0. Rounding
+        // in the getter would collapse it to 0 and silently drop the treatment.
+        new Treatment { Duration = 0.4833 }.Duration!.Value.Should().BeApproximately(0.4833, 1e-9);
+        new Treatment { Insulin = 0.7492, Rate = 1.0 }.Duration!.Value.Should().BeApproximately(44.952, 1e-9);
     }
 
     [Fact]
-    public void Duration_ExplicitFractionalValue_IsRounded()
+    public void Duration_SerializesRoundedToWholeMinutes()
     {
-        var treatment = new Treatment { Duration = 44.9666 };
-
-        treatment.Duration!.Value.Should().Be(45);
+        DurationInJson(new Treatment { Duration = 44.9666 }).Should().Be("45");
+        DurationInJson(new Treatment { Insulin = 0.7492, Rate = 1.0 }).Should().Be("45");
     }
 
     [Fact]
-    public void Duration_ComputedFractional_SerializesWithoutDecimalPoint()
+    public void Duration_ComputedFractional_SerializesAsIntegerNotDouble()
     {
-        var treatment = new Treatment { Insulin = 0.7492, Rate = 1.0 };
+        var json = JsonSerializer.Serialize(new Treatment { Insulin = 0.7492, Rate = 1.0 });
+        var duration = JsonSerializer.Deserialize<JsonElement>(json).GetProperty("duration");
 
-        var json = JsonSerializer.Serialize(treatment);
-        var doc = JsonSerializer.Deserialize<JsonElement>(json);
-
-        var duration = doc.GetProperty("duration");
         duration.GetRawText().Should().Be("45");
         duration.TryGetInt64(out _).Should().BeTrue();
     }
 
     [Fact]
-    public void Duration_Unset_DefaultsToZero()
+    public void Duration_Unset_SerializesAsZero()
     {
-        new Treatment().Duration!.Value.Should().Be(0);
+        DurationInJson(new Treatment()).Should().Be("0");
     }
+
+    private static string DurationInJson(Treatment treatment) =>
+        JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(treatment))
+            .GetProperty("duration")
+            .GetRawText();
 }

--- a/tests/Unit/Nocturne.Core.Models.Tests/TreatmentDurationTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/TreatmentDurationTests.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using FluentAssertions;
+using Nocturne.Core.Models;
+using Xunit;
+
+namespace Nocturne.Core.Models.Tests;
+
+/// <summary>
+/// AAPS parses treatment <c>duration</c> as a Long and throws
+/// <c>NumberFormatException: Expected a long</c> on a fractional value, so the
+/// getter must always resolve to a whole number of minutes.
+/// </summary>
+[Trait("Category", "Unit")]
+public class TreatmentDurationTests
+{
+    [Fact]
+    public void Duration_ComputedFromInsulinAndRate_IsRoundedToWholeMinutes()
+    {
+        // (0.75 / 1.0) * 60 = 45; but e.g. 0.7492 / 1.0 * 60 = 44.952 -> must round.
+        var treatment = new Treatment { Insulin = 0.7492, Rate = 1.0 };
+
+        treatment.Duration!.Value.Should().Be(45);
+    }
+
+    [Fact]
+    public void Duration_ExplicitFractionalValue_IsRounded()
+    {
+        var treatment = new Treatment { Duration = 44.9666 };
+
+        treatment.Duration!.Value.Should().Be(45);
+    }
+
+    [Fact]
+    public void Duration_ComputedFractional_SerializesWithoutDecimalPoint()
+    {
+        var treatment = new Treatment { Insulin = 0.7492, Rate = 1.0 };
+
+        var json = JsonSerializer.Serialize(treatment);
+        var doc = JsonSerializer.Deserialize<JsonElement>(json);
+
+        var duration = doc.GetProperty("duration");
+        duration.GetRawText().Should().Be("45");
+        duration.TryGetInt64(out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Duration_Unset_DefaultsToZero()
+    {
+        new Treatment().Duration!.Value.Should().Be(0);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/ApsSnapshotRepositoryTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/ApsSnapshotRepositoryTests.cs
@@ -273,4 +273,23 @@ public class ApsSnapshotRepositoryTests : IDisposable
 
         result.Should().BeNull();
     }
+
+    [Fact]
+    public async Task GetModifiedSinceAsync_FiltersOnEventTimestampNotWriteClock()
+    {
+        // AAPS advances its devicestatus history cursor on the event Timestamp (the V3 DTO's
+        // srvModified), so the query must filter on Timestamp, not the write clock SysUpdatedAt.
+        // SeedAsync stamps SysUpdatedAt = UtcNow (now), so filtering on SysUpdatedAt would return
+        // both rows for any past cursor and re-loop the sync.
+        var cursor = new DateTime(2026, 4, 30, 12, 0, 0, DateTimeKind.Utc);
+        await SeedAsync(TenantA,
+            (cursor, false, null),                 // exactly at the cursor -> excluded
+            (cursor.AddMinutes(1), false, null));  // strictly newer -> returned
+
+        var cursorMills = new DateTimeOffset(cursor).ToUnixTimeMilliseconds();
+        var result = (await _repository.GetModifiedSinceAsync(cursorMills)).ToList();
+
+        result.Should().ContainSingle()
+            .Which.Timestamp.Should().Be(cursor.AddMinutes(1));
+    }
 }


### PR DESCRIPTION
Closes #516.

AndroidAPS's V3 client sync fails against Nocturne on four independent discrepancies, diagnosed with local fixes by @old-square-eyes in #516. This implements all four, plus two consistency fixes surfaced while making the history endpoints uniform, each covered by a test.

## Fixes

### 1. `/api/v3/lastModified` envelope
Returned the raw C# model (camelCase keys, ISO timestamps, no envelope). Now wrapped in the Nightscout V3 envelope `{ status, result: { srvDate, collections } }` with Unix-millisecond values and lowercase/singular collection keys (`profile`, `devicestatus`). `DateTime.Kind` is normalised to UTC before conversion.

### 2. Incremental-sync infinite loop (`>=` → `>`)
`/history/{lastModified}` returned records `>=` the cursor, so the record AAPS already holds is re-returned and AAPS re-requests immediately (>10 req/s). Changed to strictly-greater in the treatment projection (all 7 tables) and the APS-snapshot repository; the entries find-query goes `$gte` → `$gt`.

### 3. Missing `Last-Modified` / `ETag` on history responses
Without these the client cursor never advances. Added `SetHistoryCursorHeaders` on `BaseV3Controller` (computes both from the max returned timestamp) and call it from the treatments, devicestatus and entries history endpoints.

### 4. Treatment `duration` rounding
Computed `(insulin / rate) * 60` can be fractional; AAPS parses `duration` as a `Long` and throws `NumberFormatException`. Rounded in the `Duration` getter (both the explicit and computed branches).

## Consistency fixes (found while unifying the history endpoints)

- **Entries history paged newest-first.** Advancing the cursor to the newest returned record silently skipped the middle of any backlog larger than one page (a fresh install or a few hours offline exceeds a 1000-row page). Now pages oldest-first (`reverseResults: true`) like the treatments projection.
- **Devicestatus history filtered on the wrong clock.** The query filtered on the write clock `SysUpdatedAt`, but the V3 DTO's `srvModified` and the AAPS cursor use the event `Timestamp` — so the cursor sat below the returned rows' write time and re-matched them every poll (the loop #2 is meant to kill). Now filters and orders on `Timestamp`, which is also the indexed column.

## On `>` vs a `>= cursor+1ms` bound
The ms-granularity cursor vs µs-precision `SysUpdatedAt` means the boundary record can re-qualify once per poll. Keeping `>` is deliberate: the boundary record is deduplicated by AAPS, whereas a `>= cursor+1ms` bound would silently drop records that share a millisecond across a page split. Favouring a benign re-fetch over silent data loss.

## Tests
- `lastModified` envelope — unit (`LastModifiedControllerTests`) + golden re-accept
- `Duration` rounding, incl. integer JSON serialization (`TreatmentDurationTests`)
- Treatment history `>` boundary + header (`V4ToLegacyProjectionServiceTests`, `TreatmentsHistoryHeaderTests`)
- Devicestatus event-clock filter (`ApsSnapshotRepositoryTests.GetModifiedSinceAsync_FiltersOnEventTimestampNotWriteClock`)
- Entries ascending paging (`EntriesHistoryOrderTests`)

Credit to @old-square-eyes for the diagnosis and initial patches in #516.