### PR TITLE
feat(preferences): per-user display preferences store (#520)

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/OidcController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/OidcController.cs
@@ -644,6 +644,7 @@ public class OidcController : ControllerBase
                 Permissions = authContext.Permissions,
                 ExpiresAt = authContext.ExpiresAt,
                 PreferredLanguage = userInfo?.PreferredLanguage,
+                Preferences = userInfo?.Preferences,
                 IsPlatformAdmin = authContext.IsPlatformAdmin,
                 IsPlatformAccessGrant = authContext.AuthType == AuthType.PlatformAccess,
                 AvatarUrl = userInfo?.AvatarUrl,
@@ -954,6 +955,12 @@ public class SessionInfo
     /// User's preferred language code (e.g., "en", "fr", "de")
     /// </summary>
     public string? PreferredLanguage { get; set; }
+
+    /// <summary>
+    /// Per-user display preferences (units, time format, theme, chart style, etc.).
+    /// Used for server-side hydration so first paint matches the user's saved choices.
+    /// </summary>
+    public UserDisplayPreferences? Preferences { get; set; }
 
     /// <summary>
     /// Whether this subject has platform-level admin access

--- a/src/API/Nocturne.API/Controllers/V4/Profiles/UserPreferencesController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Profiles/UserPreferencesController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
 using Nocturne.API.Extensions;
+using Nocturne.Core.Models.Configuration;
 using Nocturne.Infrastructure.Data;
 
 namespace Nocturne.API.Controllers.V4.Profiles;
@@ -66,7 +67,8 @@ public class UserPreferencesController : ControllerBase
 
         return Ok(new UserPreferencesResponse
         {
-            PreferredLanguage = subject.PreferredLanguage
+            PreferredLanguage = subject.PreferredLanguage,
+            Preferences = UserDisplayPreferences.Deserialize(subject.Preferences)
         });
     }
 
@@ -99,6 +101,12 @@ public class UserPreferencesController : ControllerBase
             });
         }
 
+        // Validate the constrained display-preference values if provided.
+        if (request.Preferences?.Validate() is { } validationError)
+        {
+            return BadRequest(new { error = "invalid_preference", message = validationError });
+        }
+
         var subject = await _dbContext.Subjects
             .FirstOrDefaultAsync(s => s.Id == authContext.SubjectId.Value);
 
@@ -113,6 +121,14 @@ public class UserPreferencesController : ControllerBase
             subject.PreferredLanguage = request.PreferredLanguage;
         }
 
+        // Merge the partial display preferences over the stored blob so unset fields are preserved.
+        if (request.Preferences != null)
+        {
+            var merged = UserDisplayPreferences.Deserialize(subject.Preferences);
+            merged.MergeWith(request.Preferences);
+            subject.Preferences = merged.Serialize();
+        }
+
         subject.UpdatedAt = DateTime.UtcNow;
         await _dbContext.SaveChangesAsync();
 
@@ -123,7 +139,8 @@ public class UserPreferencesController : ControllerBase
 
         return Ok(new UserPreferencesResponse
         {
-            PreferredLanguage = subject.PreferredLanguage
+            PreferredLanguage = subject.PreferredLanguage,
+            Preferences = UserDisplayPreferences.Deserialize(subject.Preferences)
         });
     }
 }
@@ -137,6 +154,12 @@ public class UserPreferencesResponse
     /// User's preferred language code (e.g., "en", "fr", "de")
     /// </summary>
     public string? PreferredLanguage { get; set; }
+
+    /// <summary>
+    /// Per-user display preferences (units, time format, theme, chart style, etc.).
+    /// Always present; unset fields are null.
+    /// </summary>
+    public UserDisplayPreferences Preferences { get; set; } = new();
 }
 
 /// <summary>
@@ -148,4 +171,9 @@ public class UpdateUserPreferencesRequest
     /// User's preferred language code (e.g., "en", "fr", "de")
     /// </summary>
     public string? PreferredLanguage { get; set; }
+
+    /// <summary>
+    /// Partial display preferences to merge over the stored value. Only non-null fields are applied.
+    /// </summary>
+    public UserDisplayPreferences? Preferences { get; set; }
 }

--- a/src/API/Nocturne.API/Services/Auth/OidcAuthService.cs
+++ b/src/API/Nocturne.API/Services/Auth/OidcAuthService.cs
@@ -512,6 +512,7 @@ public class OidcAuthService : IOidcAuthService
             ProviderName = providerName,
             LastLoginAt = subject.LastLoginAt,
             PreferredLanguage = subject.PreferredLanguage,
+            Preferences = UserDisplayPreferences.Deserialize(subject.Preferences),
             AvatarUrl = subject.AvatarUrl,
         };
     }

--- a/src/API/Nocturne.API/Services/Auth/SubjectService.cs
+++ b/src/API/Nocturne.API/Services/Auth/SubjectService.cs
@@ -818,6 +818,7 @@ public class SubjectService : ISubjectService
             LastLoginAt = entity.LastLoginAt,
             Notes = entity.Notes,
             PreferredLanguage = entity.PreferredLanguage,
+            Preferences = entity.Preferences,
             AvatarUrl = entity.AvatarUrl,
             Roles = new List<Role>(),
             Permissions = new List<string>(),

--- a/src/Core/Nocturne.Core.Contracts/Auth/IOidcAuthService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Auth/IOidcAuthService.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Models.Authorization;
+using Nocturne.Core.Models.Configuration;
 
 namespace Nocturne.Core.Contracts.Auth;
 
@@ -365,6 +366,11 @@ public class OidcUserInfo
     /// User's preferred language code (e.g., "en", "fr", "de")
     /// </summary>
     public string? PreferredLanguage { get; set; }
+
+    /// <summary>
+    /// Per-user display preferences (units, time format, theme, chart style, etc.).
+    /// </summary>
+    public UserDisplayPreferences? Preferences { get; set; }
 
     /// <summary>
     /// URL to the subject's uploaded avatar image

--- a/src/Core/Nocturne.Core.Models/Authorization/Subject.cs
+++ b/src/Core/Nocturne.Core.Models/Authorization/Subject.cs
@@ -78,6 +78,12 @@ public class Subject
     /// User's preferred language code (e.g., "en", "fr", "de")
     /// </summary>
     public string? PreferredLanguage { get; set; }
+
+    /// <summary>
+    /// Per-user display preferences serialized as a JSON blob (see
+    /// <see cref="Configuration.UserDisplayPreferences"/>). Null until first saved.
+    /// </summary>
+    public string? Preferences { get; set; }
 }
 
 /// <summary>

--- a/src/Core/Nocturne.Core.Models/Configuration/UserDisplayPreferences.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/UserDisplayPreferences.cs
@@ -1,0 +1,224 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Nocturne.Core.Models.Configuration;
+
+/// <summary>
+/// Per-user display preferences that follow the user across devices and tenants.
+/// Stored as a JSONB blob on the subject and served via the user preferences endpoint.
+/// Every property is nullable so a PATCH carries only the fields being changed and the
+/// server merges them over the stored value. String values mirror the frontend's literal
+/// unions (e.g. units "mg/dl"/"mmol") so the generated client stays a single shared shape.
+/// Language is intentionally excluded: it lives in its own subject column because the
+/// session and server-side locale resolution depend on it.
+/// </summary>
+public class UserDisplayPreferences
+{
+    /// <summary>Shared JSON options for (de)serializing the preferences blob (camelCase / web defaults).</summary>
+    public static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    /// <summary>
+    /// Deserializes a stored preferences blob, returning an empty (all-null) instance when the
+    /// input is null/blank or cannot be parsed. Never throws — a corrupt blob degrades to defaults.
+    /// </summary>
+    public static UserDisplayPreferences Deserialize(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return new UserDisplayPreferences();
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<UserDisplayPreferences>(json, JsonOptions)
+                ?? new UserDisplayPreferences();
+        }
+        catch (JsonException)
+        {
+            return new UserDisplayPreferences();
+        }
+    }
+
+    /// <summary>Serializes this instance to the JSONB storage representation.</summary>
+    public string Serialize() => JsonSerializer.Serialize(this, JsonOptions);
+
+    // Allowed values for the constrained string preferences (mirror the frontend literal unions).
+    private static readonly HashSet<string> AllowedGlucoseUnits = new(StringComparer.Ordinal) { "mg/dl", "mmol" };
+    private static readonly HashSet<string> AllowedTimeFormats = new(StringComparer.Ordinal) { "12", "24" };
+    private static readonly HashSet<string> AllowedColorThemes = new(StringComparer.Ordinal) { "nocturne", "trio", "aaps", "classic" };
+    private static readonly HashSet<string> AllowedSidebarWidgets = new(StringComparer.Ordinal) { "graph", "halo-dial" };
+    private static readonly HashSet<string> AllowedPredictionModes = new(StringComparer.Ordinal) { "cone", "lines", "main", "iob", "zt", "uam", "cob" };
+    private static readonly HashSet<string> AllowedColorModes = new(StringComparer.Ordinal) { "single", "threshold", "continuous" };
+    private static readonly HashSet<string> AllowedAreaModes = new(StringComparer.Ordinal) { "off", "baseline", "deviation" };
+
+    /// <summary>
+    /// Validates the constrained string values and numeric ranges. Returns a "field: message"
+    /// description of the first invalid value, or null when every present value is acceptable.
+    /// Null fields are skipped (a partial payload only validates what it carries).
+    /// </summary>
+    public string? Validate()
+    {
+        var stringError =
+            Check("glucoseUnits", GlucoseUnits, AllowedGlucoseUnits)
+            ?? Check("timeFormat", TimeFormat, AllowedTimeFormats)
+            ?? Check("colorTheme", ColorTheme, AllowedColorThemes)
+            ?? Check("sidebarWidget", SidebarWidget, AllowedSidebarWidgets)
+            ?? Check("prediction.displayMode", Prediction?.DisplayMode, AllowedPredictionModes)
+            ?? Check("chart.lineColorMode", Chart?.LineColorMode, AllowedColorModes)
+            ?? Check("chart.pointColorMode", Chart?.PointColorMode, AllowedColorModes)
+            ?? Check("chart.areaMode", Chart?.AreaMode, AllowedAreaModes);
+        if (stringError != null)
+        {
+            return stringError;
+        }
+
+        if (Chart?.AreaOpacity is { } opacity && (opacity < 0 || opacity > 1))
+        {
+            return "chart.areaOpacity: must be between 0 and 1";
+        }
+        if (Prediction?.Minutes is { } minutes && minutes < 0)
+        {
+            return "prediction.minutes: must be non-negative";
+        }
+        if (Chart?.Lookback is { } lookback && lookback <= 0)
+        {
+            return "chart.lookback: must be greater than 0";
+        }
+
+        return null;
+
+        static string? Check(string field, string? value, HashSet<string> allowed) =>
+            value != null && !allowed.Contains(value)
+                ? $"{field}: '{value}' is not allowed. Valid values: {string.Join(", ", allowed)}"
+                : null;
+    }
+
+    /// <summary>
+    /// Merges the non-null fields of <paramref name="incoming"/> into this instance so unset
+    /// fields are preserved. Nested prediction/chart objects merge field-by-field; scalar and
+    /// list values replace wholesale when present.
+    /// </summary>
+    public void MergeWith(UserDisplayPreferences incoming)
+    {
+        GlucoseUnits = incoming.GlucoseUnits ?? GlucoseUnits;
+        TimeFormat = incoming.TimeFormat ?? TimeFormat;
+        ColorTheme = incoming.ColorTheme ?? ColorTheme;
+        NightModeSchedule = incoming.NightModeSchedule ?? NightModeSchedule;
+        DashboardTopWidgets = incoming.DashboardTopWidgets ?? DashboardTopWidgets;
+        SidebarWidget = incoming.SidebarWidget ?? SidebarWidget;
+
+        if (incoming.Prediction is { } prediction)
+        {
+            Prediction ??= new PredictionPreferences();
+            Prediction.Enabled = prediction.Enabled ?? Prediction.Enabled;
+            Prediction.Minutes = prediction.Minutes ?? Prediction.Minutes;
+            Prediction.DisplayMode = prediction.DisplayMode ?? Prediction.DisplayMode;
+        }
+
+        if (incoming.Chart is { } chart)
+        {
+            Chart ??= new ChartPreferences();
+            Chart.LineColorMode = chart.LineColorMode ?? Chart.LineColorMode;
+            Chart.LineColor = chart.LineColor ?? Chart.LineColor;
+            Chart.PointColorMode = chart.PointColorMode ?? Chart.PointColorMode;
+            Chart.PointColor = chart.PointColor ?? Chart.PointColor;
+            Chart.ShowPoints = chart.ShowPoints ?? Chart.ShowPoints;
+            Chart.AreaMode = chart.AreaMode ?? Chart.AreaMode;
+            Chart.AreaOpacity = chart.AreaOpacity ?? Chart.AreaOpacity;
+            Chart.AlwaysShowPatterns = chart.AlwaysShowPatterns ?? Chart.AlwaysShowPatterns;
+            Chart.Lookback = chart.Lookback ?? Chart.Lookback;
+        }
+    }
+
+    /// <summary>Glucose units: "mg/dl" or "mmol".</summary>
+    [JsonPropertyName("glucoseUnits")]
+    public string? GlucoseUnits { get; set; }
+
+    /// <summary>Time format: "12" or "24".</summary>
+    [JsonPropertyName("timeFormat")]
+    public string? TimeFormat { get; set; }
+
+    /// <summary>Color theme: "nocturne", "trio", "aaps", or "classic".</summary>
+    [JsonPropertyName("colorTheme")]
+    public string? ColorTheme { get; set; }
+
+    /// <summary>Whether the automatic night-mode schedule is enabled.</summary>
+    [JsonPropertyName("nightModeSchedule")]
+    public bool? NightModeSchedule { get; set; }
+
+    /// <summary>Prediction display preferences.</summary>
+    [JsonPropertyName("prediction")]
+    public PredictionPreferences? Prediction { get; set; }
+
+    /// <summary>Glucose-chart visual style preferences.</summary>
+    [JsonPropertyName("chart")]
+    public ChartPreferences? Chart { get; set; }
+
+    /// <summary>Ordered widget IDs shown in the dashboard top-widget grid.</summary>
+    [JsonPropertyName("dashboardTopWidgets")]
+    public List<WidgetId>? DashboardTopWidgets { get; set; }
+
+    /// <summary>Sidebar widget preference: "graph" or "halo-dial".</summary>
+    [JsonPropertyName("sidebarWidget")]
+    public string? SidebarWidget { get; set; }
+}
+
+/// <summary>
+/// Prediction display preferences (mirrors the frontend prediction settings).
+/// </summary>
+public class PredictionPreferences
+{
+    /// <summary>Whether prediction lines are shown on charts.</summary>
+    [JsonPropertyName("enabled")]
+    public bool? Enabled { get; set; }
+
+    /// <summary>Prediction time horizon in minutes.</summary>
+    [JsonPropertyName("minutes")]
+    public int? Minutes { get; set; }
+
+    /// <summary>Prediction display mode: "cone", "lines", "main", "iob", "zt", "uam", or "cob".</summary>
+    [JsonPropertyName("displayMode")]
+    public string? DisplayMode { get; set; }
+}
+
+/// <summary>
+/// Glucose-chart visual style preferences (mirrors the frontend chart settings).
+/// </summary>
+public class ChartPreferences
+{
+    /// <summary>Line color mode: "single", "threshold", or "continuous".</summary>
+    [JsonPropertyName("lineColorMode")]
+    public string? LineColorMode { get; set; }
+
+    /// <summary>Line color as a hex string (used when line color mode is "single").</summary>
+    [JsonPropertyName("lineColor")]
+    public string? LineColor { get; set; }
+
+    /// <summary>Point color mode: "single", "threshold", or "continuous".</summary>
+    [JsonPropertyName("pointColorMode")]
+    public string? PointColorMode { get; set; }
+
+    /// <summary>Point color as a hex string (used when point color mode is "single").</summary>
+    [JsonPropertyName("pointColor")]
+    public string? PointColor { get; set; }
+
+    /// <summary>Whether individual glucose points are rendered.</summary>
+    [JsonPropertyName("showPoints")]
+    public bool? ShowPoints { get; set; }
+
+    /// <summary>Area fill mode: "off", "baseline", or "deviation".</summary>
+    [JsonPropertyName("areaMode")]
+    public string? AreaMode { get; set; }
+
+    /// <summary>Area fill opacity (0..1).</summary>
+    [JsonPropertyName("areaOpacity")]
+    public double? AreaOpacity { get; set; }
+
+    /// <summary>Always render range/category patterns on screen (accessibility aid).</summary>
+    [JsonPropertyName("alwaysShowPatterns")]
+    public bool? AlwaysShowPatterns { get; set; }
+
+    /// <summary>Glucose-chart lookback window width in hours (may be a custom fractional value).</summary>
+    [JsonPropertyName("lookback")]
+    public double? Lookback { get; set; }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/SubjectEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/SubjectEntity.cs
@@ -103,6 +103,15 @@ public class SubjectEntity : IEntityTimestamped
     public string? PreferredLanguage { get; set; }
 
     /// <summary>
+    /// Per-user display preferences (glucose units, time format, theme, chart style, etc.)
+    /// serialized as a JSONB blob (<see cref="Core.Models.Configuration.UserDisplayPreferences"/>).
+    /// Stored on the subject so preferences follow the user across devices and tenants.
+    /// Null until the user first saves a preference.
+    /// </summary>
+    [Column("preferences")]
+    public string? Preferences { get; set; }
+
+    /// <summary>
     /// Approval status for access requests (e.g., "Approved", "Pending", "Denied")
     /// Defaults to "Approved" for existing subjects
     /// </summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260719015845_AddSubjectPreferences.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260719015845_AddSubjectPreferences.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260719015845_AddSubjectPreferences")]
+    partial class AddSubjectPreferences
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260719015845_AddSubjectPreferences.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260719015845_AddSubjectPreferences.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSubjectPreferences : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "preferences",
+                table: "subjects",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "preferences",
+                table: "subjects");
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -2646,6 +2646,9 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
                 .HasDefaultValueSql("CURRENT_TIMESTAMP")
                 .ValueGeneratedOnAddOrUpdate();
 
+            // Per-user display preferences stored as a JSONB blob (semantic comparison is
+            // applied by the relational jsonb-string value-comparer configured above).
+            entity.Property(e => e.Preferences).HasColumnType("jsonb");
         });
 
         modelBuilder.Entity<SubjectAvatarEntity>(entity =>

--- a/src/Web/packages/app/src/app.d.ts
+++ b/src/Web/packages/app/src/app.d.ts
@@ -1,6 +1,6 @@
 // See https://svelte.dev/docs/kit/types#app
 // for information about these interfaces
-import { ApiClient } from "$lib/api";
+import { ApiClient, UserDisplayPreferences } from "$lib/api";
 
 
 export interface ServerSettings {
@@ -25,6 +25,8 @@ export interface AuthUser {
 	expiresAt?: Date;
 	/** User's preferred language code (e.g., "en", "fr", "de") */
 	preferredLanguage?: string;
+	/** Per-user display preferences (units, time format, theme, chart style, etc.) */
+	preferences?: UserDisplayPreferences;
 	/** URL to the subject's avatar image */
 	avatarUrl?: string;
 }

--- a/src/Web/packages/app/src/hooks.server.ts
+++ b/src/Web/packages/app/src/hooks.server.ts
@@ -136,6 +136,7 @@ const authHandle: Handle = async ({ event, resolve }) => {
         permissions: session.permissions ?? [],
         expiresAt: session.expiresAt,
         preferredLanguage: session.preferredLanguage ?? undefined,
+        preferences: session.preferences ?? undefined,
         avatarUrl: session.avatarUrl ?? undefined,
       };
 

--- a/src/Web/packages/app/src/lib/api/user-preferences.remote.ts
+++ b/src/Web/packages/app/src/lib/api/user-preferences.remote.ts
@@ -1,6 +1,8 @@
 /** Remote functions for user preferences management */
 import { getRequestEvent, command } from "$app/server";
 import { z } from "zod";
+import type { UserDisplayPreferences } from "$lib/api";
+import { UserDisplayPreferencesSchema } from "$lib/api/generated/schemas";
 
 const updateLanguageSchema = z.object({
   preferredLanguage: z.string(),
@@ -30,6 +32,33 @@ export const updateLanguagePreference = command(
       });
     } catch (err) {
       console.error("Error updating language preference:", err);
+      // Don't throw - failing to save preference shouldn't break the UI
+      return null;
+    }
+  }
+);
+
+/**
+ * Update the current user's display preferences (units, time format, theme, chart
+ * style, widgets). Merged server-side over the stored blob, so a partial payload is fine.
+ */
+export const updateDisplayPreferences = command(
+  UserDisplayPreferencesSchema,
+  async (preferences) => {
+    const { locals } = getRequestEvent();
+
+    // Only persist for authenticated users; guests/anonymous keep client-only prefs.
+    if (!locals.isAuthenticated || !locals.user) {
+      return null;
+    }
+
+    try {
+      return await locals.apiClient.userPreferences.updatePreferences({
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- z.fromJSONSchema infers unknown; UserDisplayPreferencesSchema validates the shape at runtime
+        preferences: preferences as UserDisplayPreferences,
+      });
+    } catch (err) {
+      console.error("Error updating display preferences:", err);
       // Don't throw - failing to save preference shouldn't break the UI
       return null;
     }

--- a/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
@@ -1,14 +1,24 @@
 /**
  * Appearance Store - Unified store for all appearance settings
  *
- * Uses runed's PersistedState for automatic localStorage persistence with
- * instant reactivity and cross-tab sync. Consolidates:
- * - Color theme (Nocturne vs Trio)
- * - Color scheme (light/dark/system mode via mode-watcher)
- * - Glucose units (mg/dL vs mmol/L)
- * - Time format (12h vs 24h)
- * - Night mode schedule
- * - Language preference
+ * Per-user display preferences (units, time format, theme, prediction, chart
+ * style, widgets) are backed by a `SyncedPref`: it keeps the reactive `.current`
+ * API of runed's PersistedState, but additionally
+ *  - hydrates from the `nocturne-prefs` cookie / legacy per-key localStorage,
+ *  - mirrors every change into one `nocturne-prefs` cookie so a returning device
+ *    hydrates synchronously at module load (before first paint), avoiding a wait
+ *    on the session/API round-trip, and
+ *  - writes through to the backend user-preferences endpoint (injected callback)
+ *    so a user's choices follow them across devices and tenants.
+ *
+ * SSR note: this module's `$state` is shared across requests on the server, so it
+ * is NEVER mutated server-side — the cookie is read and applied only in the browser
+ * (`if (browser)` at module load). SSR therefore renders defaults and the client
+ * corrects on hydration; server-side rendering of preference-dependent text is a
+ * known limitation of the synchronous `bg()`-style accessors.
+ *
+ * Language keeps its own dedicated cookie + backend path (used by SSR locale
+ * resolution). The halo-dial config stays device-local.
  */
 
 import { browser } from "$app/environment";
@@ -16,6 +26,7 @@ import { PersistedState } from "runed";
 import { setMode, mode, userPrefersMode } from "mode-watcher";
 import supportedLocales from "../../../../../supportedLocales.json";
 import { WidgetId } from "../api/generated/nocturne-api-client";
+import type { UserDisplayPreferences } from "$lib/api";
 import { type HaloDialConfig, defaultHaloDialConfig } from "../components/dashboard/halo-dial/config";
 
 // ==========================================
@@ -41,6 +52,102 @@ export type SidebarWidget = "graph" | "halo-dial";
 export type SupportedLocale = (typeof supportedLocales)[number];
 
 // ==========================================
+// Synced preference infrastructure
+// ==========================================
+
+/** Cookie mirroring the per-user synced preferences, written and read client-side for synchronous hydration. */
+export const PREFS_COOKIE_NAME = "nocturne-prefs";
+const PREFS_COOKIE_MAX_AGE = 31536000; // 1 year
+
+/** Registry of synced prefs by their localStorage key — powers cross-tab sync. */
+const syncedRegistry = new Map<string, SyncedPref<unknown>>();
+
+/**
+ * Backend write-through callback, injected by the app (kept out of this module so
+ * the store never imports a server remote directly — mirrors setLanguage's design).
+ */
+let writeThrough: ((prefs: UserDisplayPreferences) => unknown) | null = null;
+
+/** Register the backend write-through used to persist synced preferences per-user. */
+export function registerPreferencesWriteThrough(
+  fn: (prefs: UserDisplayPreferences) => unknown
+): void {
+  writeThrough = fn;
+}
+
+let persistTimer: ReturnType<typeof setTimeout> | null = null;
+
+/** Mirror to cookie immediately and debounce the backend write-through. */
+function schedulePersist(): void {
+  if (!browser) return;
+  const prefs = collectPreferences();
+  writePrefsCookie(prefs);
+  if (persistTimer) clearTimeout(persistTimer);
+  persistTimer = setTimeout(() => {
+    persistTimer = null;
+    writeThrough?.(prefs);
+  }, 400);
+}
+
+function readInitial<T>(key: string, fallback: T): T {
+  if (!browser) return fallback;
+  const raw = localStorage.getItem(key);
+  if (raw === null) return fallback;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function persistLocal<T>(key: string, value: T): void {
+  if (!browser) return;
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // Ignore quota / disabled-storage errors — the cookie + backend remain sources of truth.
+  }
+}
+
+/**
+ * A per-user preference with the same reactive `.current` surface as runed's
+ * PersistedState, so no consumer changes. Writes propagate to localStorage (cache),
+ * the shared cookie, and the backend. `hydrate` sets the value without a
+ * backend/cookie echo (used when applying server- or cross-tab-sourced values).
+ */
+class SyncedPref<T> {
+  private _value = $state<T>(undefined as T);
+  private _key: string;
+
+  constructor(key: string, initial: T) {
+    this._key = key;
+    this._value = readInitial(key, initial);
+    syncedRegistry.set(key, this as SyncedPref<unknown>);
+  }
+
+  get current(): T {
+    return this._value;
+  }
+
+  set current(value: T) {
+    this._value = value;
+    persistLocal(this._key, value);
+    schedulePersist();
+  }
+
+  /**
+   * Apply an externally-sourced value (server/cross-tab) without re-persisting outward.
+   * INVARIANT: browser-only. Callers (reconcilePreferences, module-load cookie hydration,
+   * the storage listener) are all `if (browser)`-gated; never call this during SSR — the
+   * `$state` is shared across requests and would leak one user's value into another's render.
+   */
+  hydrate(value: T): void {
+    this._value = value;
+    persistLocal(this._key, value);
+  }
+}
+
+// ==========================================
 // Persisted State Instances
 // ==========================================
 
@@ -48,59 +155,42 @@ export type SupportedLocale = (typeof supportedLocales)[number];
  * Color theme preference (Nocturne vs Trio)
  * Controls the CSS class applied to the document root
  */
-export const colorTheme = new PersistedState<ColorTheme>(
-  "nocturne-color-theme",
-  "nocturne"
-);
+export const colorTheme = new SyncedPref<ColorTheme>("nocturne-color-theme", "nocturne");
 
 /**
- * Blood glucose units preference
- * Automatically persists to localStorage and syncs across tabs
+ * Blood glucose units preference. Per-user: syncs across devices/tenants.
  */
-export const glucoseUnits = new PersistedState<GlucoseUnits>(
-  "nocturne-glucose-units",
-  "mg/dl"
-);
+export const glucoseUnits = new SyncedPref<GlucoseUnits>("nocturne-glucose-units", "mg/dl");
 
 /**
  * Time format preference (12-hour or 24-hour)
  */
-export const timeFormat = new PersistedState<TimeFormat>(
-  "nocturne-time-format",
-  "12"
-);
+export const timeFormat = new SyncedPref<TimeFormat>("nocturne-time-format", "12");
 
 /**
  * Night mode schedule toggle
  * When enabled, automatically switches to dark mode at night
  */
-export const nightModeSchedule = new PersistedState<boolean>(
-  "nocturne-night-mode-schedule",
-  false
-);
+export const nightModeSchedule = new SyncedPref<boolean>("nocturne-night-mode-schedule", false);
 
 /**
  * Dashboard top widgets configuration
  * Stores the ordered list of widget IDs displayed in the top widget grid
- * Default: BgDelta (includes connection + last updated), TirChart, Tdd
  */
-export const dashboardTopWidgets = new PersistedState<WidgetId[]>(
-  "nocturne-dashboard-top-widgets",
-  [WidgetId.BgDelta, WidgetId.TirChart, WidgetId.Tdd]
-);
+export const dashboardTopWidgets = new SyncedPref<WidgetId[]>("nocturne-dashboard-top-widgets", [
+  WidgetId.BgDelta,
+  WidgetId.TirChart,
+  WidgetId.Tdd,
+]);
 
 /**
  * Sidebar widget preference — graph or halo dial
  * Default: graph (compact glucose chart)
  */
-export const sidebarWidget = new PersistedState<SidebarWidget>(
-  "nocturne-sidebar-widget",
-  "graph"
-);
+export const sidebarWidget = new SyncedPref<SidebarWidget>("nocturne-sidebar-widget", "graph");
 
 /**
- * Halo dial configuration
- * Full config for the halo dial sidebar widget
+ * Halo dial configuration — device-local (not part of the per-user synced set).
  */
 export const haloDialConfig = new PersistedState<HaloDialConfig>(
   "nocturne-halo-dial-config",
@@ -220,19 +310,13 @@ export function setGlucoseUnits(units: GlucoseUnits): void {
  * Prediction time horizon in minutes
  * Controls how far into the future predictions are shown
  */
-export const predictionMinutes = new PersistedState<number>(
-  "nocturne-prediction-minutes",
-  30
-);
+export const predictionMinutes = new SyncedPref<number>("nocturne-prediction-minutes", 30);
 
 /**
  * Prediction enabled state
  * Controls whether prediction lines are shown on charts
  */
-export const predictionEnabled = new PersistedState<boolean>(
-  "nocturne-prediction-enabled",
-  true
-);
+export const predictionEnabled = new SyncedPref<boolean>("nocturne-prediction-enabled", true);
 
 /**
  * Get current prediction minutes
@@ -254,10 +338,6 @@ export function getPredictionEnabled(): boolean {
 export function setPredictionMinutes(minutes: number): void {
   predictionMinutes.current = minutes;
 }
-
-/**
- * Set prediction enabled state
- */
 
 /**
  * Set prediction enabled state
@@ -285,7 +365,7 @@ export type AreaMode = "off" | "baseline" | "deviation";
 /**
  * Prediction display mode preference
  */
-export const predictionDisplayMode = new PersistedState<PredictionDisplayMode>(
+export const predictionDisplayMode = new SyncedPref<PredictionDisplayMode>(
   "nocturne-prediction-display-mode",
   "cone"
 );
@@ -301,10 +381,7 @@ export type TimeRangeOption = "2" | "4" | "6" | "12" | "24" | "48";
  * This controls the span of time shown, always ending at "now"
  * Can be a preset value or a custom number from brush selection
  */
-export const glucoseChartLookback = new PersistedState<number>(
-  "nocturne-glucose-chart-lookback",
-  12
-);
+export const glucoseChartLookback = new SyncedPref<number>("nocturne-glucose-chart-lookback", 12);
 
 /**
  * Default fetch range in hours for glucose chart data
@@ -316,50 +393,205 @@ export const GLUCOSE_CHART_FETCH_HOURS = 48;
 // Glucose Chart Visual Style
 // ==========================================
 
-export const chartLineColorMode = new PersistedState<LineColorMode>(
+export const chartLineColorMode = new SyncedPref<LineColorMode>(
   "nocturne-chart-line-color-mode",
   "threshold"
 );
 
-export const chartLineColor = new PersistedState<string>(
-  "nocturne-chart-line-color",
-  "#22c55e"
-);
+export const chartLineColor = new SyncedPref<string>("nocturne-chart-line-color", "#22c55e");
 
-export const chartPointColorMode = new PersistedState<LineColorMode>(
+export const chartPointColorMode = new SyncedPref<LineColorMode>(
   "nocturne-chart-point-color-mode",
   "threshold"
 );
 
-export const chartPointColor = new PersistedState<string>(
-  "nocturne-chart-point-color",
-  "#22c55e"
-);
+export const chartPointColor = new SyncedPref<string>("nocturne-chart-point-color", "#22c55e");
 
-export const chartShowPoints = new PersistedState<boolean>(
-  "nocturne-chart-show-points",
-  true
-);
+export const chartShowPoints = new SyncedPref<boolean>("nocturne-chart-show-points", true);
 
-export const chartAreaMode = new PersistedState<AreaMode>(
-  "nocturne-chart-area-mode",
-  "off"
-);
+export const chartAreaMode = new SyncedPref<AreaMode>("nocturne-chart-area-mode", "off");
 
-export const chartAreaOpacity = new PersistedState<number>(
-  "nocturne-chart-area-opacity",
-  0.5
-);
+export const chartAreaOpacity = new SyncedPref<number>("nocturne-chart-area-opacity", 0.5);
 
 /**
  * Always render chart range/category patterns on screen, not just in print.
  * An accessibility aid for colour-blind and low-vision users — textures
  * distinguish series that otherwise rely on colour alone.
  */
-export const chartAlwaysShowPatterns = new PersistedState<boolean>(
+export const chartAlwaysShowPatterns = new SyncedPref<boolean>(
   "nocturne-chart-always-show-patterns",
   false
 );
+
+// ==========================================
+// Collect / apply the synced preference set
+// ==========================================
+
+/**
+ * Assemble the full per-user preference payload from the current store values.
+ * Shape mirrors the backend `UserDisplayPreferences` (nested prediction/chart).
+ */
+export function collectPreferences(): UserDisplayPreferences {
+  return {
+    glucoseUnits: glucoseUnits.current,
+    timeFormat: timeFormat.current,
+    colorTheme: colorTheme.current,
+    nightModeSchedule: nightModeSchedule.current,
+    dashboardTopWidgets: dashboardTopWidgets.current,
+    sidebarWidget: sidebarWidget.current,
+    prediction: {
+      enabled: predictionEnabled.current,
+      minutes: predictionMinutes.current,
+      displayMode: predictionDisplayMode.current,
+    },
+    chart: {
+      lineColorMode: chartLineColorMode.current,
+      lineColor: chartLineColor.current,
+      pointColorMode: chartPointColorMode.current,
+      pointColor: chartPointColor.current,
+      showPoints: chartShowPoints.current,
+      areaMode: chartAreaMode.current,
+      areaOpacity: chartAreaOpacity.current,
+      alwaysShowPatterns: chartAlwaysShowPatterns.current,
+      lookback: glucoseChartLookback.current,
+    },
+  } as UserDisplayPreferences;
+}
+
+/**
+ * Apply a server- (or cookie-) sourced preference payload to the store without
+ * echoing back to the backend. Only fields present in `prefs` are applied.
+ * Optionally refreshes the cookie mirror so it matches the applied state.
+ */
+export function applyPreferences(
+  prefs: UserDisplayPreferences | null | undefined,
+  options: { refreshCookie?: boolean } = {}
+): void {
+  if (!prefs) return;
+
+  hydrateIfPresent(glucoseUnits, prefs.glucoseUnits as GlucoseUnits | undefined);
+  hydrateIfPresent(timeFormat, prefs.timeFormat as TimeFormat | undefined);
+  hydrateIfPresent(colorTheme, prefs.colorTheme as ColorTheme | undefined);
+  hydrateIfPresent(nightModeSchedule, prefs.nightModeSchedule ?? undefined);
+  hydrateIfPresent(dashboardTopWidgets, prefs.dashboardTopWidgets ?? undefined);
+  hydrateIfPresent(sidebarWidget, prefs.sidebarWidget as SidebarWidget | undefined);
+
+  if (prefs.prediction) {
+    hydrateIfPresent(predictionEnabled, prefs.prediction.enabled ?? undefined);
+    hydrateIfPresent(predictionMinutes, prefs.prediction.minutes ?? undefined);
+    hydrateIfPresent(
+      predictionDisplayMode,
+      prefs.prediction.displayMode as PredictionDisplayMode | undefined
+    );
+  }
+
+  if (prefs.chart) {
+    hydrateIfPresent(chartLineColorMode, prefs.chart.lineColorMode as LineColorMode | undefined);
+    hydrateIfPresent(chartLineColor, prefs.chart.lineColor ?? undefined);
+    hydrateIfPresent(chartPointColorMode, prefs.chart.pointColorMode as LineColorMode | undefined);
+    hydrateIfPresent(chartPointColor, prefs.chart.pointColor ?? undefined);
+    hydrateIfPresent(chartShowPoints, prefs.chart.showPoints ?? undefined);
+    hydrateIfPresent(chartAreaMode, prefs.chart.areaMode as AreaMode | undefined);
+    hydrateIfPresent(chartAreaOpacity, prefs.chart.areaOpacity ?? undefined);
+    hydrateIfPresent(chartAlwaysShowPatterns, prefs.chart.alwaysShowPatterns ?? undefined);
+    hydrateIfPresent(glucoseChartLookback, prefs.chart.lookback ?? undefined);
+  }
+
+  if (browser) applyColorTheme(colorTheme.current);
+  if (options.refreshCookie) writePrefsCookie(collectPreferences());
+}
+
+function hydrateIfPresent<T>(pref: SyncedPref<T>, value: T | undefined): void {
+  if (value !== undefined && value !== null) pref.hydrate(value);
+}
+
+/** True when a server preference payload carries at least one saved value. */
+export function hasStoredPreferences(prefs: UserDisplayPreferences | null | undefined): boolean {
+  if (!prefs) return false;
+  return Object.values(prefs).some((v) => v !== undefined && v !== null);
+}
+
+/** Ensures reconciliation happens once per document load, not on every client navigation. */
+let preferencesReconciled = false;
+
+/**
+ * Reconcile the store against the authenticated user's server preferences on load.
+ * - server has values -> apply them (server wins across devices)
+ * - server empty AND this device has customizations -> seed the backend from them once
+ * Generalizes the language reconciliation previously inlined in +layout.ts.
+ *
+ * Runs at most once per document load: `+layout.ts`'s universal `load` re-runs on every
+ * client navigation, but `data.user` is derived only from `locals` (no url/params dependency),
+ * so it stays frozen at the initial snapshot. Re-applying it on each navigation would revert a
+ * preference the user just changed in-session, so we guard with `preferencesReconciled`.
+ */
+export function reconcilePreferences(serverPrefs: UserDisplayPreferences | null | undefined): void {
+  if (!browser || preferencesReconciled) return;
+  preferencesReconciled = true;
+
+  if (hasStoredPreferences(serverPrefs)) {
+    applyPreferences(serverPrefs, { refreshCookie: true });
+  } else if (hasAnyLocalPreference()) {
+    // No server blob yet, but this device carries customizations (existing user or a device
+    // that already synced): seed the backend from them once. Gated on local customization so an
+    // uncustomized device never seeds all-defaults over another device's real preferences.
+    const prefs = collectPreferences();
+    writePrefsCookie(prefs);
+    writeThrough?.(prefs);
+  }
+}
+
+/** True if any synced preference has a stored value on this device (legacy localStorage / prior sync). */
+function hasAnyLocalPreference(): boolean {
+  if (!browser) return false;
+  for (const key of syncedRegistry.keys()) {
+    if (localStorage.getItem(key) !== null) return true;
+  }
+  return false;
+}
+
+// ==========================================
+// Preference cookie helpers
+// ==========================================
+
+function writePrefsCookie(prefs: UserDisplayPreferences): void {
+  if (!browser) return;
+  const value = encodeURIComponent(JSON.stringify(prefs));
+  document.cookie = `${PREFS_COOKIE_NAME}=${value};path=/;max-age=${PREFS_COOKIE_MAX_AGE};SameSite=Lax`;
+}
+
+function readPrefsCookie(): UserDisplayPreferences | null {
+  if (!browser) return null;
+  const match = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith(`${PREFS_COOKIE_NAME}=`));
+  if (!match) return null;
+  try {
+    return JSON.parse(decodeURIComponent(match.slice(PREFS_COOKIE_NAME.length + 1)));
+  } catch {
+    return null;
+  }
+}
+
+// Hydrate synchronously from the cookie on load (before first paint) so a known
+// device renders the user's units/theme immediately; server reconciliation
+// (via reconcilePreferences in +layout) then confirms/corrects.
+if (browser) {
+  applyPreferences(readPrefsCookie());
+
+  // Cross-tab sync: mirror another tab's change into this tab's store.
+  window.addEventListener("storage", (event) => {
+    if (!event.key || event.newValue === null) return;
+    const pref = syncedRegistry.get(event.key);
+    if (!pref) return;
+    try {
+      pref.hydrate(JSON.parse(event.newValue));
+    } catch {
+      // Ignore malformed cross-tab payloads.
+    }
+    if (event.key === "nocturne-color-theme") applyColorTheme(colorTheme.current);
+  });
+}
 
 // ==========================================
 // Language Preference
@@ -369,7 +601,9 @@ export const chartAlwaysShowPatterns = new PersistedState<boolean>(
 export { supportedLocales };
 
 /**
- * Language preference - stored in localStorage and synced to cookie for SSR
+ * Language preference - stored in localStorage and synced to cookie for SSR.
+ * Kept as a dedicated PersistedState (not part of the display-preferences blob)
+ * because server-side locale resolution reads its own cookie + subject column.
  */
 export const preferredLanguage = new PersistedState<SupportedLocale>(
   "nocturne-language",

--- a/src/Web/packages/app/src/lib/stores/appearance-store.test.ts
+++ b/src/Web/packages/app/src/lib/stores/appearance-store.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { UserDisplayPreferences } from "$lib/api";
+
+// Node env (browser=false): DOM/cookie I/O is skipped, so we exercise the pure
+// hydration mapping — the crux of the cross-device fix (server prefs -> store).
+vi.mock("$app/environment", () => ({ browser: false, dev: false }));
+vi.mock("$app/navigation", () => ({}));
+vi.mock("$app/state", () => ({}));
+vi.mock("mode-watcher", () => ({
+  setMode: vi.fn(),
+  mode: { current: "light" },
+  userPrefersMode: { current: "system" },
+}));
+
+const {
+  glucoseUnits,
+  timeFormat,
+  colorTheme,
+  predictionMinutes,
+  predictionEnabled,
+  chartLineColor,
+  glucoseChartLookback,
+  applyPreferences,
+  collectPreferences,
+  hasStoredPreferences,
+} = await import("./appearance-store.svelte");
+
+describe("appearance-store preference sync", () => {
+  beforeEach(() => {
+    // Reset to defaults between tests (module-level singletons).
+    applyPreferences({
+      glucoseUnits: "mg/dl",
+      timeFormat: "12",
+      colorTheme: "nocturne",
+      prediction: { enabled: true, minutes: 30 },
+      chart: { lineColor: "#22c55e", lookback: 12 },
+    });
+  });
+
+  it("collectPreferences reflects the current store values", () => {
+    const prefs = collectPreferences();
+    expect(prefs.glucoseUnits).toBe("mg/dl");
+    expect(prefs.timeFormat).toBe("12");
+    expect(prefs.colorTheme).toBe("nocturne");
+    expect(prefs.prediction?.minutes).toBe(30);
+    expect(prefs.chart?.lineColor).toBe("#22c55e");
+    expect(prefs.chart?.lookback).toBe(12);
+  });
+
+  it("applyPreferences hydrates the store from a server payload (new-device case)", () => {
+    applyPreferences({
+      glucoseUnits: "mmol",
+      timeFormat: "24",
+      colorTheme: "trio",
+      prediction: { minutes: 45 },
+      chart: { lineColor: "#abcdef", lookback: 6 },
+    });
+
+    expect(glucoseUnits.current).toBe("mmol");
+    expect(timeFormat.current).toBe("24");
+    expect(colorTheme.current).toBe("trio");
+    expect(predictionMinutes.current).toBe(45);
+    expect(chartLineColor.current).toBe("#abcdef");
+    expect(glucoseChartLookback.current).toBe(6);
+  });
+
+  it("applyPreferences leaves unset fields untouched (partial payload)", () => {
+    applyPreferences({ glucoseUnits: "mmol" });
+
+    expect(glucoseUnits.current).toBe("mmol"); // applied
+    expect(timeFormat.current).toBe("12"); // untouched
+    expect(predictionEnabled.current).toBe(true); // untouched
+  });
+
+  it("applyPreferences ignores null/undefined input", () => {
+    applyPreferences(null);
+    applyPreferences(undefined);
+    expect(glucoseUnits.current).toBe("mg/dl");
+  });
+
+  it("collectPreferences round-trips through applyPreferences", () => {
+    const source: UserDisplayPreferences = {
+      glucoseUnits: "mmol",
+      timeFormat: "24",
+      colorTheme: "aaps",
+      nightModeSchedule: true,
+      sidebarWidget: "graph",
+      prediction: { enabled: false, minutes: 60, displayMode: "lines" },
+      chart: { lineColor: "#000000", pointColor: "#ffffff", showPoints: false, lookback: 4 },
+    };
+
+    applyPreferences(source);
+    const collected = collectPreferences();
+
+    expect(collected.glucoseUnits).toBe("mmol");
+    expect(collected.colorTheme).toBe("aaps");
+    expect(collected.nightModeSchedule).toBe(true);
+    expect(collected.prediction?.displayMode).toBe("lines");
+    expect(collected.chart?.showPoints).toBe(false);
+  });
+
+  describe("hasStoredPreferences", () => {
+    it("is false for null/empty payloads", () => {
+      expect(hasStoredPreferences(null)).toBe(false);
+      expect(hasStoredPreferences(undefined)).toBe(false);
+      expect(hasStoredPreferences({})).toBe(false);
+    });
+
+    it("is true when any value is present", () => {
+      expect(hasStoredPreferences({ glucoseUnits: "mmol" })).toBe(true);
+      expect(hasStoredPreferences({ prediction: { minutes: 30 } })).toBe(true);
+    });
+  });
+});

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
@@ -492,7 +492,8 @@
           Units & Formats
         </CardTitle>
         <CardDescription>
-          Configure measurement units and display formats
+          Configure measurement units and display formats. These preferences sync
+          across your devices.
         </CardDescription>
       </CardHeader>
       <CardContent class="space-y-4">

--- a/src/Web/packages/app/src/routes/+layout.ts
+++ b/src/Web/packages/app/src/routes/+layout.ts
@@ -5,8 +5,11 @@ import { browser } from '$app/environment'
 import {
     preferredLanguage,
     isSupportedLocale,
+    registerPreferencesWriteThrough,
+    reconcilePreferences,
     type SupportedLocale,
 } from '$lib/stores/appearance-store.svelte'
+import { updateDisplayPreferences } from '$lib/api/user-preferences.remote'
 // so that the loaders are registered, only here, not required in nested ones (below)
 // import '../../../../locales/main.loader.svelte.js'
 // import '../../../../locales/js.loader.js'
@@ -35,6 +38,16 @@ export const load: LayoutLoad = async ({ url, data }) => {
             locale = userPreference
             // Also update the cookie
             document.cookie = `nocturne-language=${userPreference};path=/;max-age=31536000;SameSite=Lax`
+        }
+    }
+
+    // Wire up per-user display-preference sync (units, time format, theme, chart style).
+    // Registering the backend write-through here keeps the store free of server-remote imports.
+    if (browser) {
+        registerPreferencesWriteThrough((prefs) => updateDisplayPreferences(prefs))
+        if (data?.isAuthenticated) {
+            // Server preferences win across devices; an empty server blob seeds from local once.
+            reconcilePreferences(data?.user?.preferences)
         }
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/UserPreferencesControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/UserPreferencesControllerTests.cs
@@ -1,0 +1,143 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.API.Controllers.V4.Profiles;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Core.Models.Configuration;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4;
+
+/// <summary>
+/// Unit coverage for <see cref="UserPreferencesController"/> — the per-user display-preferences
+/// store that fixes cross-device drift (nocturne#520). Focuses on the request wiring: partial
+/// merge over the stored blob, validation, defaults when unset, and the unauthenticated gate.
+/// </summary>
+[Trait("Category", "Unit")]
+public class UserPreferencesControllerTests
+{
+    private static readonly Guid SubjectId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    [Fact]
+    public async Task GetPreferences_returnsEmptyDefaults_whenNothingStored()
+    {
+        var (controller, _) = NewController();
+
+        var result = await controller.GetPreferences();
+
+        var value = OkValue(result);
+        value.Preferences.Should().NotBeNull();
+        value.Preferences.GlucoseUnits.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UpdatePreferences_persists_andGetReturnsIt()
+    {
+        var (controller, options) = NewController();
+
+        await controller.UpdatePreferences(new UpdateUserPreferencesRequest
+        {
+            Preferences = new UserDisplayPreferences { GlucoseUnits = "mmol" },
+        });
+
+        var value = OkValue(await controller.GetPreferences());
+        value.Preferences.GlucoseUnits.Should().Be("mmol");
+
+        // And it is actually written to the subject row as a jsonb blob.
+        await using var db = new NocturneDbContext(options);
+        (await db.Subjects.FirstAsync(s => s.Id == SubjectId)).Preferences.Should().Contain("mmol");
+    }
+
+    [Fact]
+    public async Task UpdatePreferences_mergesPartial_withoutClobberingUnsetFields()
+    {
+        var (controller, _) = NewController();
+
+        await controller.UpdatePreferences(new UpdateUserPreferencesRequest
+        {
+            Preferences = new UserDisplayPreferences { GlucoseUnits = "mmol", TimeFormat = "24" },
+        });
+
+        // Second PATCH only touches the theme — units and time format must survive.
+        await controller.UpdatePreferences(new UpdateUserPreferencesRequest
+        {
+            Preferences = new UserDisplayPreferences { ColorTheme = "trio" },
+        });
+
+        var value = OkValue(await controller.GetPreferences());
+        value.Preferences.GlucoseUnits.Should().Be("mmol");
+        value.Preferences.TimeFormat.Should().Be("24");
+        value.Preferences.ColorTheme.Should().Be("trio");
+    }
+
+    [Fact]
+    public async Task UpdatePreferences_rejectsInvalidUnits()
+    {
+        var (controller, _) = NewController();
+
+        var result = await controller.UpdatePreferences(new UpdateUserPreferencesRequest
+        {
+            Preferences = new UserDisplayPreferences { GlucoseUnits = "mgdl" },
+        });
+
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetPreferences_unauthenticated_returns401()
+    {
+        var (controller, _) = NewController(authenticated: false);
+
+        var result = await controller.GetPreferences();
+
+        result.Result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    // ----- helpers -----
+
+    private static (UserPreferencesController Controller, DbContextOptions<NocturneDbContext> Options) NewController(
+        bool authenticated = true)
+    {
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        using (var seed = new NocturneDbContext(options))
+        {
+            seed.Subjects.Add(new SubjectEntity { Id = SubjectId, Name = "Test" });
+            seed.SaveChanges();
+        }
+
+        var dbContext = new NocturneDbContext(options);
+        var controller = new UserPreferencesController(dbContext, NullLogger<UserPreferencesController>.Instance)
+        {
+            ControllerContext = new ControllerContext { HttpContext = HttpContextWith(authenticated) },
+        };
+        return (controller, options);
+    }
+
+    private static DefaultHttpContext HttpContextWith(bool authenticated)
+    {
+        var context = new DefaultHttpContext();
+        if (authenticated)
+        {
+            context.Items["AuthContext"] = new AuthContext
+            {
+                IsAuthenticated = true,
+                SubjectId = SubjectId,
+            };
+        }
+        return context;
+    }
+
+    private static UserPreferencesResponse OkValue(ActionResult<UserPreferencesResponse> result)
+    {
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        return ok.Value.Should().BeAssignableTo<UserPreferencesResponse>().Subject;
+    }
+}

--- a/tests/Unit/Nocturne.Core.Models.Tests/Configuration/UserDisplayPreferencesTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/Configuration/UserDisplayPreferencesTests.cs
@@ -1,0 +1,237 @@
+using FluentAssertions;
+using Nocturne.Core.Models.Configuration;
+using Xunit;
+
+namespace Nocturne.Core.Models.Tests.Configuration;
+
+[Trait("Category", "Unit")]
+public class UserDisplayPreferencesTests
+{
+    // ----- Deserialize -----
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Deserialize_returns_empty_for_null_or_blank(string? json)
+    {
+        var prefs = UserDisplayPreferences.Deserialize(json);
+
+        prefs.Should().NotBeNull();
+        prefs.GlucoseUnits.Should().BeNull();
+        prefs.Prediction.Should().BeNull();
+        prefs.Chart.Should().BeNull();
+    }
+
+    [Fact]
+    public void Deserialize_returns_empty_for_malformed_json()
+    {
+        UserDisplayPreferences.Deserialize("{not valid json").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Serialize_then_Deserialize_round_trips_values()
+    {
+        var original = new UserDisplayPreferences
+        {
+            GlucoseUnits = "mmol",
+            TimeFormat = "24",
+            ColorTheme = "trio",
+            NightModeSchedule = true,
+            SidebarWidget = "graph",
+            Prediction = new PredictionPreferences { Enabled = true, Minutes = 45, DisplayMode = "cone" },
+            Chart = new ChartPreferences { LineColor = "#123456", AreaOpacity = 0.25, Lookback = 6 },
+        };
+
+        var restored = UserDisplayPreferences.Deserialize(original.Serialize());
+
+        restored.GlucoseUnits.Should().Be("mmol");
+        restored.TimeFormat.Should().Be("24");
+        restored.ColorTheme.Should().Be("trio");
+        restored.NightModeSchedule.Should().BeTrue();
+        restored.Prediction!.Minutes.Should().Be(45);
+        restored.Chart!.LineColor.Should().Be("#123456");
+        restored.Chart.AreaOpacity.Should().Be(0.25);
+        restored.Chart.Lookback.Should().Be(6);
+    }
+
+    // ----- MergeWith -----
+
+    [Fact]
+    public void MergeWith_preserves_unset_fields()
+    {
+        var existing = new UserDisplayPreferences { GlucoseUnits = "mmol", TimeFormat = "24" };
+        var incoming = new UserDisplayPreferences { GlucoseUnits = "mg/dl" };
+
+        existing.MergeWith(incoming);
+
+        existing.GlucoseUnits.Should().Be("mg/dl"); // overwritten
+        existing.TimeFormat.Should().Be("24"); // preserved (incoming was null)
+    }
+
+    [Fact]
+    public void MergeWith_merges_nested_prediction_field_by_field()
+    {
+        var existing = new UserDisplayPreferences
+        {
+            Prediction = new PredictionPreferences { Enabled = true, Minutes = 30, DisplayMode = "cone" },
+        };
+        var incoming = new UserDisplayPreferences
+        {
+            Prediction = new PredictionPreferences { Minutes = 60 },
+        };
+
+        existing.MergeWith(incoming);
+
+        existing.Prediction!.Minutes.Should().Be(60); // overwritten
+        existing.Prediction.Enabled.Should().BeTrue(); // preserved
+        existing.Prediction.DisplayMode.Should().Be("cone"); // preserved
+    }
+
+    [Fact]
+    public void MergeWith_creates_nested_object_when_absent_on_existing()
+    {
+        var existing = new UserDisplayPreferences();
+        var incoming = new UserDisplayPreferences
+        {
+            Chart = new ChartPreferences { LineColor = "#abcdef" },
+        };
+
+        existing.MergeWith(incoming);
+
+        existing.Chart!.LineColor.Should().Be("#abcdef");
+    }
+
+    [Fact]
+    public void MergeWith_merges_nested_chart_field_by_field()
+    {
+        var existing = new UserDisplayPreferences
+        {
+            Chart = new ChartPreferences { LineColor = "#111111", ShowPoints = true, Lookback = 12 },
+        };
+        var incoming = new UserDisplayPreferences
+        {
+            Chart = new ChartPreferences { Lookback = 6 },
+        };
+
+        existing.MergeWith(incoming);
+
+        existing.Chart!.Lookback.Should().Be(6); // overwritten
+        existing.Chart.LineColor.Should().Be("#111111"); // preserved
+        existing.Chart.ShowPoints.Should().BeTrue(); // preserved
+    }
+
+    [Fact]
+    public void MergeWith_replaces_widget_list_wholesale()
+    {
+        var existing = new UserDisplayPreferences
+        {
+            DashboardTopWidgets = new List<WidgetId> { WidgetId.BgDelta, WidgetId.Tdd },
+        };
+        var incoming = new UserDisplayPreferences
+        {
+            DashboardTopWidgets = new List<WidgetId> { WidgetId.TirChart },
+        };
+
+        existing.MergeWith(incoming);
+
+        existing.DashboardTopWidgets.Should().ContainSingle().Which.Should().Be(WidgetId.TirChart);
+    }
+
+    // ----- Validate -----
+
+    [Fact]
+    public void Validate_accepts_all_null_fields()
+    {
+        new UserDisplayPreferences().Validate().Should().BeNull();
+    }
+
+    [Fact]
+    public void Validate_accepts_valid_values()
+    {
+        var prefs = new UserDisplayPreferences
+        {
+            GlucoseUnits = "mmol",
+            TimeFormat = "12",
+            ColorTheme = "aaps",
+            SidebarWidget = "halo-dial",
+        };
+
+        prefs.Validate().Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("mgdl", null, null, null, "glucoseUnits")]
+    [InlineData(null, "48", null, null, "timeFormat")]
+    [InlineData(null, null, "midnight", null, "colorTheme")]
+    [InlineData(null, null, null, "spinner", "sidebarWidget")]
+    public void Validate_rejects_invalid_value(
+        string? units, string? timeFormat, string? theme, string? sidebar, string expectedField)
+    {
+        var prefs = new UserDisplayPreferences
+        {
+            GlucoseUnits = units,
+            TimeFormat = timeFormat,
+            ColorTheme = theme,
+            SidebarWidget = sidebar,
+        };
+
+        prefs.Validate().Should().NotBeNull().And.Contain(expectedField);
+    }
+
+    [Fact]
+    public void Validate_accepts_valid_nested_values()
+    {
+        var prefs = new UserDisplayPreferences
+        {
+            Prediction = new PredictionPreferences { DisplayMode = "uam", Minutes = 30 },
+            Chart = new ChartPreferences
+            {
+                LineColorMode = "continuous",
+                PointColorMode = "single",
+                AreaMode = "baseline",
+                AreaOpacity = 0.5,
+                Lookback = 12,
+            },
+        };
+
+        prefs.Validate().Should().BeNull();
+    }
+
+    [Fact]
+    public void Validate_rejects_invalid_prediction_display_mode()
+    {
+        new UserDisplayPreferences { Prediction = new PredictionPreferences { DisplayMode = "hologram" } }
+            .Validate().Should().NotBeNull().And.Contain("prediction.displayMode");
+    }
+
+    [Fact]
+    public void Validate_rejects_invalid_chart_color_mode()
+    {
+        new UserDisplayPreferences { Chart = new ChartPreferences { LineColorMode = "rainbow" } }
+            .Validate().Should().NotBeNull().And.Contain("chart.lineColorMode");
+    }
+
+    [Theory]
+    [InlineData(-0.1)]
+    [InlineData(1.5)]
+    public void Validate_rejects_area_opacity_out_of_range(double opacity)
+    {
+        new UserDisplayPreferences { Chart = new ChartPreferences { AreaOpacity = opacity } }
+            .Validate().Should().NotBeNull().And.Contain("areaOpacity");
+    }
+
+    [Fact]
+    public void Validate_rejects_negative_prediction_minutes()
+    {
+        new UserDisplayPreferences { Prediction = new PredictionPreferences { Minutes = -5 } }
+            .Validate().Should().NotBeNull().And.Contain("prediction.minutes");
+    }
+
+    [Fact]
+    public void Validate_rejects_non_positive_lookback()
+    {
+        new UserDisplayPreferences { Chart = new ChartPreferences { Lookback = 0 } }
+            .Validate().Should().NotBeNull().And.Contain("chart.lookback");
+    }
+}


### PR DESCRIPTION
## Why

Issue #520: a user set **mmol/L** — it stuck on their Mac but showed **mixed units on their iPhone**. Glucose units (and ~20 other display preferences) lived in per-**device** `localStorage`, so a user's choices never followed them to another device. This moves them into a **per-user** store.

## What

**Backend**
- New typed `UserDisplayPreferences` model (units, time format, theme, night-mode, prediction, chart style, dashboard/sidebar widgets) with `Deserialize`/`Serialize`/`Validate`/`MergeWith`.
- Persisted as a JSONB `preferences` column on the **global** `subjects` table (per-user, spans tenants) via a new EF migration.
- Served by the existing `UserPreferencesController` (`GET`/`PATCH /api/v4/user/preferences`) with partial-merge + strict validation.
- Preferences surfaced on the session (`OidcUserInfo` → `SessionInfo`) for hydration.

**Frontend**
- The `appearance-store` accessors (`glucoseUnits.current`, …) are **preserved unchanged** — re-backed by a `SyncedPref` that hydrates from a `nocturne-prefs` cookie / legacy localStorage, mirrors changes to the cookie for synchronous first-paint hydration, and writes through to the backend via an injected callback.
- Reconciled against server prefs **once per document load** (server wins across devices; an empty server blob seeds from local only when the device is actually customized, so an uncustomized device can't clobber another's prefs).

Language keeps its own cookie + backend path (SSR locale resolution); halo-dial config stays device-local.

## Tests

- Model: merge (partial preserves unset fields; nested prediction/chart), validation (string enums + numeric ranges), serialize round-trip.
- Controller: partial merge, validation, defaults-when-unset, unauthenticated 401, DB persistence.
- Store: server→store hydration mapping + precedence + `hasStoredPreferences`.

## Notes / limitations

- SSR renders defaults and the client corrects on hydration; fully eliminating a first-paint flash for `bg()`-rendered text would require threading units through context across many call sites (out of scope). The cookie makes a returning device hydrate synchronously.
- Last-writer-wins on the JSONB blob (acceptable for preferences).