### PR TITLE
fix(v1/v3): present record ids as 24-hex Mongo ObjectIds for AAPS (#522)

### DIFF
--- a/src/API/Nocturne.API/Controllers/V3/DeviceStatusController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/DeviceStatusController.cs
@@ -700,7 +700,8 @@ public class DeviceStatusController : BaseV3Controller<DeviceStatus>
             ["created_at"] = status.CreatedAt,
             ["uploaderBattery"] = status.Uploader?.Battery,
             ["utcOffset"] = status.UtcOffset,
-            ["identifier"] = status.Id,
+            // 24-hex ObjectId so AAPS's isObjectId() passes; resolved back via GetByIdAsync.
+            ["identifier"] = MongoObjectId.Coerce(status.Id),
             ["srvModified"] = status.Mills,
             ["srvCreated"] = status.Mills,
         };

--- a/src/API/Nocturne.API/Controllers/V3/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/EntriesController.cs
@@ -234,13 +234,14 @@ public class EntriesController : BaseV3Controller<Entry>
                 );
                 if (existingEntry != null)
                 {
+                    var existingIdentifier = MongoObjectId.Coerce(existingEntry.Id);
                     return Ok(
                         new
                         {
                             status = 200,
-                            identifier = existingEntry.Id,
+                            identifier = existingIdentifier,
                             isDeduplication = true,
-                            deduplicatedIdentifier = existingEntry.Id,
+                            deduplicatedIdentifier = existingIdentifier,
                         }
                     );
                 }
@@ -267,12 +268,10 @@ public class EntriesController : BaseV3Controller<Entry>
 
             await EvaluateAlertsAsync(new[] { createdEntry }, cancellationToken);
 
-            // Set location header for created resource
-            Response.Headers["Location"] = $"/api/v3/entries/{createdEntry.Id}";
-
+            // Location resolves to the 24-hex ObjectId that matches the response body identifier.
             return CreatedAtAction(
                 nameof(GetEntry),
-                new { id = createdEntry.Id },
+                new { id = MongoObjectId.Coerce(createdEntry.Id) },
                 createdEntry.ToV3Response()
             );
         }

--- a/src/API/Nocturne.API/Controllers/V3/TreatmentsController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/TreatmentsController.cs
@@ -222,13 +222,14 @@ public class TreatmentsController : BaseV3Controller<Treatment>
                 );
                 if (existingTreatment != null)
                 {
+                    var existingIdentifier = MongoObjectId.Coerce(existingTreatment.Id);
                     return Ok(
                         new
                         {
                             status = 200,
-                            identifier = existingTreatment.Id,
+                            identifier = existingIdentifier,
                             isDeduplication = true,
-                            deduplicatedIdentifier = existingTreatment.Id,
+                            deduplicatedIdentifier = existingIdentifier,
                         }
                     );
                 }
@@ -255,12 +256,10 @@ public class TreatmentsController : BaseV3Controller<Treatment>
 
             _logger.LogDebug("Successfully created V3 treatment {Id}", createdTreatment.Id);
 
-            // Set location header for created resource
-            Response.Headers["Location"] = $"/api/v3/treatments/{Uri.EscapeDataString(createdTreatment.Id ?? string.Empty)}";
-
+            // Location resolves to the 24-hex ObjectId that matches the response body identifier.
             return CreatedAtAction(
                 nameof(GetTreatment),
-                new { id = createdTreatment.Id },
+                new { id = MongoObjectId.Coerce(createdTreatment.Id) },
                 createdTreatment
             );
         }
@@ -564,7 +563,7 @@ public class TreatmentsController : BaseV3Controller<Treatment>
                 {
                     status = 200,
                     result,
-                    identifier = result.Id,
+                    identifier = MongoObjectId.Coerce(result.Id),
                 }
             );
         }

--- a/src/API/Nocturne.API/Services/Devices/DeviceStatusProjectionService.cs
+++ b/src/API/Nocturne.API/Services/Devices/DeviceStatusProjectionService.cs
@@ -179,6 +179,17 @@ public class DeviceStatusProjectionService
                 uploader = await _uploaderRepo.GetByLegacyIdAsync(id, ct);
         }
 
+        // Fallback to a 24-hex ObjectId derived from the record's UUID (resolved via prefix range).
+        if (aps == null && pump == null && uploader == null
+            && MongoObjectId.TryGetGuidPrefixRange(id, out var low, out var high))
+        {
+            aps = await _apsRepo.GetByGuidRangeAsync(low, high, ct);
+            if (aps == null)
+                pump = await _pumpRepo.GetByGuidRangeAsync(low, high, ct);
+            if (aps == null && pump == null)
+                uploader = await _uploaderRepo.GetByGuidRangeAsync(low, high, ct);
+        }
+
         if (aps == null && pump == null && uploader == null)
             return null;
 

--- a/src/API/Nocturne.API/Services/Entries/EntryReadService.cs
+++ b/src/API/Nocturne.API/Services/Entries/EntryReadService.cs
@@ -90,7 +90,16 @@ public class EntryReadService : IEntryStore
         if (Guid.TryParse(id, out var guid))
             return await GetByGuidAsync(guid, ct);
 
-        return await GetByLegacyIdAsync(id, ct);
+        // A non-UUID id is either a legacy/AAPS-supplied ObjectId (stored as LegacyId) or a 24-hex
+        // ObjectId we derived from the record's UUID; resolve the latter via its uuid prefix range.
+        var byLegacy = await GetByLegacyIdAsync(id, ct);
+        if (byLegacy != null)
+            return byLegacy;
+
+        if (MongoObjectId.TryGetGuidPrefixRange(id, out var low, out var high))
+            return await GetByGuidRangeAsync(low, high, ct);
+
+        return null;
     }
 
     /// <inheritdoc />
@@ -247,6 +256,23 @@ public class EntryReadService : IEntryStore
             return EntryProjection.FromMeterGlucose(mg);
 
         var cal = await _calRepo.GetByLegacyIdAsync(legacyId, ct);
+        if (cal is not null)
+            return EntryProjection.FromCalibration(cal);
+
+        return null;
+    }
+
+    private async Task<Entry?> GetByGuidRangeAsync(Guid low, Guid high, CancellationToken ct)
+    {
+        var sg = await _sgRepo.GetByGuidRangeAsync(low, high, ct);
+        if (sg is not null)
+            return EntryProjection.FromSensorGlucose(sg);
+
+        var mg = await _mgRepo.GetByGuidRangeAsync(low, high, ct);
+        if (mg is not null)
+            return EntryProjection.FromMeterGlucose(mg);
+
+        var cal = await _calRepo.GetByGuidRangeAsync(low, high, ct);
         if (cal is not null)
             return EntryProjection.FromCalibration(cal);
 

--- a/src/API/Nocturne.API/Services/Treatments/TreatmentReadService.cs
+++ b/src/API/Nocturne.API/Services/Treatments/TreatmentReadService.cs
@@ -4,6 +4,7 @@ using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Entries;
+using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Mappers;
 
 namespace Nocturne.API.Services.Treatments;
@@ -202,9 +203,20 @@ public class TreatmentReadService : ITreatmentStore
         }
 
         // A 24-hex ObjectId AAPS derived from the record's UUID: resolve it via the uuid prefix
-        // range and delete the underlying record by its real UUID.
+        // range. Prefer deleting by the resolved record's LegacyId so correlated siblings (e.g. a
+        // meal bolus's carb, a bolus wizard's calculation) are removed together — DeleteByGuidRange
+        // only deletes the single matched row, which would orphan the sibling into a phantom.
         if (deleted == 0 && MongoObjectId.TryGetGuidPrefixRange(id, out var low, out var high))
         {
+            var legacyId = await FindLegacyIdByGuidRangeAsync(low, high, ct);
+            if (!string.IsNullOrEmpty(legacyId))
+            {
+                deleted = await _pipeline.DeleteByLegacyIdAsync<Treatment>(legacyId, WriteOrigin.Live, ct);
+                if (deleted > 0)
+                    return true;
+            }
+
+            // Native row with no LegacyId (no correlated sibling to worry about): delete by UUID.
             if (await DeleteByGuidRangeAsync(low, high, ct))
                 return true;
         }
@@ -330,10 +342,45 @@ public class TreatmentReadService : ITreatmentStore
         if (Guid.TryParse(id, out _))
             return null;
 
-        if (MongoObjectId.TryGetGuidPrefixRange(id, out var low, out var high))
-            return await FindLegacyIdByGuidRangeAsync(low, high, ct);
+        if (!MongoObjectId.TryGetGuidPrefixRange(id, out var low, out var high))
+            return null;
 
-        return null;
+        // Return the decomposer's upsert key (LegacyId). A native V4 row has no LegacyId, so the
+        // decomposer can't match it and would insert a duplicate; backfill it with the derived
+        // ObjectId (which is what the wire already shows for this record) so the update lands in
+        // place. Short-circuits on the first repo that owns the record.
+        return await ResolveOrBackfillLegacyIdAsync(_bolusRepo, low, high, ct)
+            ?? await ResolveOrBackfillLegacyIdAsync(_carbIntakeRepo, low, high, ct)
+            ?? await ResolveOrBackfillLegacyIdAsync(_bgCheckRepo, low, high, ct)
+            ?? await ResolveOrBackfillLegacyIdAsync(_noteRepo, low, high, ct)
+            ?? await ResolveOrBackfillLegacyIdAsync(_deviceEventRepo, low, high, ct)
+            ?? await ResolveOrBackfillLegacyIdAsync(_bolusCalcRepo, low, high, ct)
+            ?? await ResolveOrBackfillTempBasalLegacyIdAsync(low, high, ct);
+    }
+
+    private static async Task<string?> ResolveOrBackfillLegacyIdAsync<T>(
+        IV4Repository<T> repo, Guid low, Guid high, CancellationToken ct) where T : class, IV4Record
+    {
+        var entity = await repo.GetByGuidRangeAsync(low, high, ct);
+        if (entity is null) return null;
+        if (!string.IsNullOrEmpty(entity.LegacyId)) return entity.LegacyId;
+
+        var objectId = MongoObjectId.FromGuid(entity.Id);
+        entity.LegacyId = objectId;
+        await repo.UpdateAsync(entity.Id, entity, WriteOrigin.Live, ct);
+        return objectId;
+    }
+
+    private async Task<string?> ResolveOrBackfillTempBasalLegacyIdAsync(Guid low, Guid high, CancellationToken ct)
+    {
+        var tempBasal = await _tempBasalRepo.GetByGuidRangeAsync(low, high, ct);
+        if (tempBasal is null) return null;
+        if (!string.IsNullOrEmpty(tempBasal.LegacyId)) return tempBasal.LegacyId;
+
+        var objectId = MongoObjectId.FromGuid(tempBasal.Id);
+        tempBasal.LegacyId = objectId;
+        await _tempBasalRepo.UpdateAsync(tempBasal.Id, tempBasal, WriteOrigin.Live, ct);
+        return objectId;
     }
 
     private async Task<string?> FindLegacyIdByGuidRangeAsync(Guid low, Guid high, CancellationToken ct)

--- a/src/API/Nocturne.API/Services/Treatments/TreatmentReadService.cs
+++ b/src/API/Nocturne.API/Services/Treatments/TreatmentReadService.cs
@@ -78,7 +78,17 @@ public class TreatmentReadService : ITreatmentStore
         if (Guid.TryParse(id, out var guid))
             return await GetByGuidAsync(guid, ct);
 
-        return await GetByLegacyIdAsync(id, ct);
+        // A non-UUID id is either a legacy/AAPS-supplied ObjectId (stored as LegacyId) or a 24-hex
+        // ObjectId we derived from the record's UUID for the wire. Try the exact LegacyId match
+        // first, then resolve a derived ObjectId via its uuid prefix range.
+        var byLegacy = await GetByLegacyIdAsync(id, ct);
+        if (byLegacy != null)
+            return byLegacy;
+
+        if (MongoObjectId.TryGetGuidPrefixRange(id, out var low, out var high))
+            return await ResolveByGuidRangeAsync(low, high, ct);
+
+        return null;
     }
 
     /// <inheritdoc />
@@ -147,7 +157,9 @@ public class TreatmentReadService : ITreatmentStore
         var existing = await GetByIdAsync(id, ct);
         if (existing == null) return null;
 
-        treatment.Id = id;
+        // Re-key to the stored LegacyId so the decomposer upserts the existing record in place
+        // rather than creating a duplicate when the client sends a derived ObjectId.
+        treatment.Id = await ResolveCanonicalIdAsync(id, ct) ?? id;
         try
         {
             await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live, ct);
@@ -187,6 +199,14 @@ public class TreatmentReadService : ITreatmentStore
                 _logger.LogError(ex, "Failed to delete TempBasal record {Id}", tempBasal.Id);
                 return false;
             }
+        }
+
+        // A 24-hex ObjectId AAPS derived from the record's UUID: resolve it via the uuid prefix
+        // range and delete the underlying record by its real UUID.
+        if (deleted == 0 && MongoObjectId.TryGetGuidPrefixRange(id, out var low, out var high))
+        {
+            if (await DeleteByGuidRangeAsync(low, high, ct))
+                return true;
         }
 
         return deleted > 0;
@@ -259,6 +279,114 @@ public class TreatmentReadService : ITreatmentStore
             return TempBasalToTreatmentMapper.ToTreatment(tempBasal);
 
         return null;
+    }
+
+    /// <summary>
+    /// Resolves a UUID prefix range (from a derived 24-hex ObjectId) to a projected treatment by
+    /// finding which V4 table holds the record, then reusing the by-UUID projection logic so meal
+    /// pairing and temp-basal mapping are handled identically to a normal lookup.
+    /// </summary>
+    private async Task<Treatment?> ResolveByGuidRangeAsync(Guid low, Guid high, CancellationToken ct)
+    {
+        var bolus = await _bolusRepo.GetByGuidRangeAsync(low, high, ct);
+        if (bolus != null)
+            return await GetByGuidAsync(bolus.Id, ct);
+
+        var carbIntake = await _carbIntakeRepo.GetByGuidRangeAsync(low, high, ct);
+        if (carbIntake != null)
+            return await GetByGuidAsync(carbIntake.Id, ct);
+
+        var bgCheck = await _bgCheckRepo.GetByGuidRangeAsync(low, high, ct);
+        if (bgCheck != null)
+            return await GetByGuidAsync(bgCheck.Id, ct);
+
+        var note = await _noteRepo.GetByGuidRangeAsync(low, high, ct);
+        if (note != null)
+            return await GetByGuidAsync(note.Id, ct);
+
+        var deviceEvent = await _deviceEventRepo.GetByGuidRangeAsync(low, high, ct);
+        if (deviceEvent != null)
+            return await GetByGuidAsync(deviceEvent.Id, ct);
+
+        var bolusCalc = await _bolusCalcRepo.GetByGuidRangeAsync(low, high, ct);
+        if (bolusCalc != null)
+            return await GetByGuidAsync(bolusCalc.Id, ct);
+
+        var tempBasal = await _tempBasalRepo.GetByGuidRangeAsync(low, high, ct);
+        if (tempBasal != null)
+            return TempBasalToTreatmentMapper.ToTreatment(tempBasal);
+
+        return null;
+    }
+
+    /// <summary>
+    /// Maps a wire id (a 24-hex ObjectId derived from a record's UUID) to the <c>LegacyId</c> the
+    /// decomposer upserts on, so an update re-decomposes the existing record in place instead of
+    /// creating a duplicate. Returns null for a raw UUID or an id that is already the stored key
+    /// (the caller falls back to the existing id in that case).
+    /// </summary>
+    public async Task<string?> ResolveCanonicalIdAsync(string id, CancellationToken ct = default)
+    {
+        if (Guid.TryParse(id, out _))
+            return null;
+
+        if (MongoObjectId.TryGetGuidPrefixRange(id, out var low, out var high))
+            return await FindLegacyIdByGuidRangeAsync(low, high, ct);
+
+        return null;
+    }
+
+    private async Task<string?> FindLegacyIdByGuidRangeAsync(Guid low, Guid high, CancellationToken ct)
+    {
+        var bolus = await _bolusRepo.GetByGuidRangeAsync(low, high, ct);
+        if (bolus != null) return bolus.LegacyId;
+
+        var carbIntake = await _carbIntakeRepo.GetByGuidRangeAsync(low, high, ct);
+        if (carbIntake != null) return carbIntake.LegacyId;
+
+        var bgCheck = await _bgCheckRepo.GetByGuidRangeAsync(low, high, ct);
+        if (bgCheck != null) return bgCheck.LegacyId;
+
+        var note = await _noteRepo.GetByGuidRangeAsync(low, high, ct);
+        if (note != null) return note.LegacyId;
+
+        var deviceEvent = await _deviceEventRepo.GetByGuidRangeAsync(low, high, ct);
+        if (deviceEvent != null) return deviceEvent.LegacyId;
+
+        var bolusCalc = await _bolusCalcRepo.GetByGuidRangeAsync(low, high, ct);
+        if (bolusCalc != null) return bolusCalc.LegacyId;
+
+        var tempBasal = await _tempBasalRepo.GetByGuidRangeAsync(low, high, ct);
+        if (tempBasal != null) return tempBasal.LegacyId;
+
+        return null;
+    }
+
+    /// <summary>Deletes the record inside a UUID prefix range (derived ObjectId) by its real UUID.</summary>
+    private async Task<bool> DeleteByGuidRangeAsync(Guid low, Guid high, CancellationToken ct)
+    {
+        var bolus = await _bolusRepo.GetByGuidRangeAsync(low, high, ct);
+        if (bolus != null) { await _bolusRepo.DeleteAsync(bolus.Id, WriteOrigin.Live, ct); return true; }
+
+        var carbIntake = await _carbIntakeRepo.GetByGuidRangeAsync(low, high, ct);
+        if (carbIntake != null) { await _carbIntakeRepo.DeleteAsync(carbIntake.Id, WriteOrigin.Live, ct); return true; }
+
+        var bgCheck = await _bgCheckRepo.GetByGuidRangeAsync(low, high, ct);
+        if (bgCheck != null) { await _bgCheckRepo.DeleteAsync(bgCheck.Id, WriteOrigin.Live, ct); return true; }
+
+        var note = await _noteRepo.GetByGuidRangeAsync(low, high, ct);
+        if (note != null) { await _noteRepo.DeleteAsync(note.Id, WriteOrigin.Live, ct); return true; }
+
+        var deviceEvent = await _deviceEventRepo.GetByGuidRangeAsync(low, high, ct);
+        if (deviceEvent != null) { await _deviceEventRepo.DeleteAsync(deviceEvent.Id, WriteOrigin.Live, ct); return true; }
+
+        var bolusCalc = await _bolusCalcRepo.GetByGuidRangeAsync(low, high, ct);
+        if (bolusCalc != null) { await _bolusCalcRepo.DeleteAsync(bolusCalc.Id, WriteOrigin.Live, ct); return true; }
+
+        var tempBasal = await _tempBasalRepo.GetByGuidRangeAsync(low, high, ct);
+        if (tempBasal != null) { await _tempBasalRepo.DeleteAsync(tempBasal.Id, WriteOrigin.Live, ct); return true; }
+
+        return false;
     }
 
     private async Task<Treatment?> GetByLegacyIdAsync(string legacyId, CancellationToken ct)

--- a/src/API/Nocturne.API/Services/Treatments/TreatmentService.cs
+++ b/src/API/Nocturne.API/Services/Treatments/TreatmentService.cs
@@ -187,6 +187,10 @@ public class TreatmentService : ITreatmentService
         var existing = await _store.GetByIdAsync(id, cancellationToken);
         if (existing is null) return null;
 
+        // Re-key to the stored LegacyId so re-decomposition upserts this record in place instead
+        // of creating a duplicate when AAPS patches by a derived ObjectId.
+        existing.Id = await _store.ResolveCanonicalIdAsync(id, cancellationToken) ?? existing.Id;
+
         // Apply patch fields to existing treatment
         ApplyJsonPatch(existing, patchData);
 
@@ -201,6 +205,11 @@ public class TreatmentService : ITreatmentService
 
     private static void ApplyJsonPatch(Treatment treatment, JsonElement patchData)
     {
+        // The identity used to upsert (LegacyId matching) must survive the round-trip. Serializing
+        // rewrites _id to its 24-hex ObjectId form, so capture the real Id and restore it after the
+        // merge unless the patch explicitly changes _id.
+        var originalId = treatment.Id;
+
         // JSON merge-patch: serialize existing, overlay patch properties, deserialize back
         var existingJson = JsonSerializer.Serialize(treatment);
         using var existingDoc = JsonDocument.Parse(existingJson);
@@ -226,6 +235,11 @@ public class TreatmentService : ITreatmentService
             }
             catch { /* skip computed properties that throw on set */ }
         }
+
+        // A PATCH updates the record identified by the URL; it never changes identity. Restore the
+        // upsert key even if the client echoed an _id in the body (AAPS sends the derived ObjectId,
+        // which would otherwise defeat the re-key and duplicate the record).
+        treatment.Id = originalId;
     }
 
     /// <inheritdoc />

--- a/src/Core/Nocturne.Core.Contracts/Treatments/ITreatmentStore.cs
+++ b/src/Core/Nocturne.Core.Contracts/Treatments/ITreatmentStore.cs
@@ -29,6 +29,15 @@ public interface ITreatmentStore
     Task<Treatment?> GetByIdAsync(string id, CancellationToken ct = default);
 
     /// <summary>
+    /// Maps a wire identifier (a 24-hex ObjectId derived from a record's UUID) to the stored
+    /// <c>LegacyId</c> the decomposer upserts on. Returns null when the id is a raw UUID or already
+    /// the stored key. Used by update paths to re-decompose the existing record in place.
+    /// </summary>
+    /// <param name="id">The identifier as received from the client.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<string?> ResolveCanonicalIdAsync(string id, CancellationToken ct = default);
+
+    /// <summary>
     /// Returns treatments whose <see cref="Treatment.Mills"/> falls within
     /// <c>[fromMills, toMills]</c>, for the current tenant. Stable window read used by
     /// replay/point-in-time evaluation; not bounded by an arbitrary "newest N" page size.

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ITempBasalRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ITempBasalRepository.cs
@@ -50,6 +50,16 @@ public interface ITempBasalRepository
     /// <returns>The matching record, or <c>null</c> if not found.</returns>
     Task<TempBasal?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default);
 
+    /// <summary>
+    /// Retrieve the first <see cref="TempBasal"/> whose UUID falls within <c>[low, high]</c>,
+    /// resolving a 24-hex ObjectId (the first 24 hex of a UUID) back to its record via a uuid
+    /// prefix range.
+    /// </summary>
+    /// <param name="low">Inclusive lower bound.</param>
+    /// <param name="high">Inclusive upper bound.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<TempBasal?> GetByGuidRangeAsync(Guid low, Guid high, CancellationToken ct = default);
+
     /// <summary>Persist a new <see cref="TempBasal"/> and return the saved entity.</summary>
     /// <param name="model">Record to create.</param>
     /// <param name="ct">Cancellation token.</param>

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IV4Repository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IV4Repository.cs
@@ -41,6 +41,18 @@ public interface IV4Repository<T> where T : class, IV4Record
     Task<T?> GetByIdAsync(Guid id, CancellationToken ct = default);
 
     /// <summary>
+    /// Retrieve the first record whose UUID falls within <c>[low, high]</c>. Used to resolve a
+    /// 24-hex Mongo ObjectId (the first 24 hex of a UUID, emitted on the legacy API) back to its
+    /// record via a uuid prefix range. Postgres orders <c>uuid</c> byte-wise, so the range selects
+    /// exactly the UUIDs sharing that hex prefix.
+    /// </summary>
+    /// <param name="low">Inclusive lower bound (objectId + <c>00000000</c>).</param>
+    /// <param name="high">Inclusive upper bound (objectId + <c>ffffffff</c>).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The matching record, or <c>null</c>.</returns>
+    Task<T?> GetByGuidRangeAsync(Guid low, Guid high, CancellationToken ct = default);
+
+    /// <summary>
     /// Persist a new record and return the saved entity with any server-assigned fields populated.
     /// </summary>
     /// <param name="model">Record to create.</param>

--- a/src/Core/Nocturne.Core.Models/Extensions/EntryResponseExtensions.cs
+++ b/src/Core/Nocturne.Core.Models/Extensions/EntryResponseExtensions.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Nocturne.Core.Models.Serializers;
 
 namespace Nocturne.Core.Models.Extensions;
 
@@ -88,6 +89,7 @@ public class EntryV1Response
     }
 
     [JsonPropertyName("_id")]
+    [JsonConverter(typeof(ObjectIdJsonConverter))]
     public string? Id => _entry.Id;
 
     [JsonPropertyName("date")]
@@ -230,6 +232,7 @@ public class EntryV3Response
 
     // V3-specific computed fields
     [JsonPropertyName("identifier")]
+    [JsonConverter(typeof(ObjectIdJsonConverter))]
     public string? Identifier => _entry.Identifier;
 
     [JsonPropertyName("srvModified")]
@@ -246,6 +249,7 @@ public class EntryV3Response
 
     // Core fields (same as V1)
     [JsonPropertyName("_id")]
+    [JsonConverter(typeof(ObjectIdJsonConverter))]
     public string? Id => _entry.Id;
 
     [JsonPropertyName("date")]

--- a/src/Core/Nocturne.Core.Models/MongoObjectId.cs
+++ b/src/Core/Nocturne.Core.Models/MongoObjectId.cs
@@ -1,0 +1,80 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Nocturne.Core.Models;
+
+/// <summary>
+/// Helpers for presenting record identifiers as 24-character hex MongoDB ObjectIds on the
+/// legacy V1/V3 API surface. AAPS validates every record id with a strict <c>[0-9a-f]{24}</c>
+/// check and, on failure, falls back to parsing the id as a <c>Long</c> — a Nocturne UUID
+/// (36 chars) satisfies neither and crashes the sync with <c>NumberFormatException</c>.
+///
+/// <para>The conversion is deterministic and reversible enough to round-trip: a UUID maps to
+/// the first 24 hex chars of its canonical form, which <see cref="TryGetGuidPrefixRange"/>
+/// turns back into a uuid range for lookup. A real incoming ObjectId is preserved verbatim.</para>
+/// </summary>
+public static class MongoObjectId
+{
+    /// <summary>The 24-character lowercase-hex shape AAPS's <c>isObjectId()</c> accepts.</summary>
+    public static bool IsObjectId(string? value)
+    {
+        if (value is null || value.Length != 24)
+            return false;
+
+        foreach (var c in value)
+        {
+            var isHex = c is >= '0' and <= '9' or >= 'a' and <= 'f';
+            if (!isHex)
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// The first 24 hex chars of a UUID's canonical (dashless) form. Reversible to a uuid range
+    /// via <see cref="TryGetGuidPrefixRange"/>.
+    /// </summary>
+    public static string FromGuid(Guid id) => id.ToString("N").Substring(0, 24);
+
+    /// <summary>
+    /// Coerces any identifier into a 24-hex ObjectId for the wire:
+    /// an existing ObjectId passes through, a UUID becomes its 24-hex prefix, and anything else
+    /// (e.g. a synthetic or non-UUID legacy id) is hashed deterministically to 24 hex.
+    /// Null/empty is returned unchanged so callers can keep their own null handling.
+    /// </summary>
+    public static string? Coerce(string? id)
+    {
+        if (string.IsNullOrEmpty(id))
+            return id;
+
+        if (IsObjectId(id))
+            return id;
+
+        if (Guid.TryParse(id, out var guid))
+            return FromGuid(guid);
+
+        // Non-UUID, non-ObjectId legacy strings: hash to a stable 24-hex value so the wire is
+        // always AAPS-safe. These do not round-trip to a record (see the LegacyId lookup path).
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(id));
+        return Convert.ToHexStringLower(hash.AsSpan(0, 12));
+    }
+
+    /// <summary>
+    /// Turns a 24-hex ObjectId derived from a UUID back into the uuid range that contains the
+    /// source record: <c>[objectId + "00000000", objectId + "ffffffff"]</c>. Postgres orders
+    /// <c>uuid</c> byte-wise (= hex-prefix order), so a range query selects the source UUID.
+    /// Returns false when the input is not a valid ObjectId.
+    /// </summary>
+    public static bool TryGetGuidPrefixRange(string? objectId, out Guid low, out Guid high)
+    {
+        low = default;
+        high = default;
+        if (!IsObjectId(objectId))
+            return false;
+
+        low = Guid.ParseExact(objectId + "00000000", "N");
+        high = Guid.ParseExact(objectId + "ffffffff", "N");
+        return true;
+    }
+}

--- a/src/Core/Nocturne.Core.Models/Serializers/ObjectIdJsonConverter.cs
+++ b/src/Core/Nocturne.Core.Models/Serializers/ObjectIdJsonConverter.cs
@@ -1,0 +1,28 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Nocturne.Core.Models.Serializers;
+
+/// <summary>
+/// Serializes a record identifier as a 24-char hex Mongo ObjectId (<see cref="MongoObjectId.Coerce"/>)
+/// so AAPS's <c>isObjectId()</c> check passes. Reading is a passthrough — the incoming id (e.g. an
+/// AAPS-supplied ObjectId, or one echoed back for a PATCH/DELETE) is preserved verbatim and resolved
+/// server-side. Only the wire representation changes; the in-memory value is untouched.
+/// </summary>
+public class ObjectIdJsonConverter : JsonConverter<string?>
+{
+    public override string? Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options
+    ) => reader.TokenType == JsonTokenType.Null ? null : reader.GetString();
+
+    public override void Write(Utf8JsonWriter writer, string? value, JsonSerializerOptions options)
+    {
+        var coerced = MongoObjectId.Coerce(value);
+        if (coerced is null)
+            writer.WriteNullValue();
+        else
+            writer.WriteStringValue(coerced);
+    }
+}

--- a/src/Core/Nocturne.Core.Models/Treatment.cs
+++ b/src/Core/Nocturne.Core.Models/Treatment.cs
@@ -28,6 +28,7 @@ public class Treatment : ProcessableDocumentBase
     /// Gets or sets the MongoDB ObjectId
     /// </summary>
     [JsonPropertyName("_id")]
+    [JsonConverter(typeof(ObjectIdJsonConverter))]
     public override string? Id { get; set; }
 
     /// <summary>
@@ -35,6 +36,7 @@ public class Treatment : ProcessableDocumentBase
     /// Nightscout V3 API returns both _id and identifier fields with the same value.
     /// </summary>
     [JsonPropertyName("identifier")]
+    [JsonConverter(typeof(ObjectIdJsonConverter))]
     public string? Identifier => Id;
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/TempBasalToTreatmentMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/TempBasalToTreatmentMapper.cs
@@ -23,7 +23,12 @@ public static class TempBasalToTreatmentMapper
 
         var treatment = new Treatment
         {
-            Id = tempBasal.LegacyId ?? tempBasal.Id.ToString(),
+            // Emit a resolvable id: a caller-supplied ObjectId round-trips via LegacyId; otherwise
+            // the UUID, which serializes to a range-resolvable ObjectId. Update paths re-key to the
+            // stored LegacyId before re-decomposing, so PATCH updates in place.
+            Id = MongoObjectId.IsObjectId(tempBasal.LegacyId)
+                ? tempBasal.LegacyId
+                : tempBasal.Id.ToString(),
             Mills = tempBasal.StartMills,
             EventType = "Temp Basal",
             Duration = durationMinutes,

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
@@ -88,6 +88,16 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
         return entity is null ? null : ApsSnapshotMapper.ToDomainModel(entity);
     }
 
+    /// <inheritdoc />
+    public async Task<ApsSnapshot?> GetByGuidRangeAsync(Guid low, Guid high, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entity = await ctx.ApsSnapshots
+            .Where(e => e.Id >= low && e.Id <= high)
+            .FirstOrDefaultAsync(ct);
+        return entity is null ? null : ApsSnapshotMapper.ToDomainModel(entity);
+    }
+
     /// <summary>
     /// Gets an APS snapshot by its legacy identifier.
     /// </summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
@@ -94,6 +94,7 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.ApsSnapshots
             .Where(e => e.Id >= low && e.Id <= high)
+            .OrderBy(e => e.Id)
             .FirstOrDefaultAsync(ct);
         return entity is null ? null : ApsSnapshotMapper.ToDomainModel(entity);
     }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
@@ -113,6 +113,7 @@ public class BasalInjectionRepository : IBasalInjectionRepository
     {
         var entity = await _context.BasalInjections
             .Where(e => e.Id >= low && e.Id <= high)
+            .OrderBy(e => e.Id)
             .FirstOrDefaultAsync(ct);
         return entity is null ? null : BasalInjectionMapper.ToDomainModel(entity);
     }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
@@ -108,6 +108,15 @@ public class BasalInjectionRepository : IBasalInjectionRepository
         return entity is null ? null : BasalInjectionMapper.ToDomainModel(entity);
     }
 
+    /// <inheritdoc />
+    public async Task<BasalInjection?> GetByGuidRangeAsync(Guid low, Guid high, CancellationToken ct = default)
+    {
+        var entity = await _context.BasalInjections
+            .Where(e => e.Id >= low && e.Id <= high)
+            .FirstOrDefaultAsync(ct);
+        return entity is null ? null : BasalInjectionMapper.ToDomainModel(entity);
+    }
+
     /// <summary>
     /// Creates a new basal injection record. When <c>DataSource</c> and <c>SyncIdentifier</c>
     /// match an existing row for this tenant, the record is updated in place (upsert) rather

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
@@ -94,6 +94,7 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.PumpSnapshots
             .Where(e => e.Id >= low && e.Id <= high)
+            .OrderBy(e => e.Id)
             .FirstOrDefaultAsync(ct);
         return entity is null ? null : PumpSnapshotMapper.ToDomainModel(entity);
     }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
@@ -88,6 +88,16 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
         return entity is null ? null : PumpSnapshotMapper.ToDomainModel(entity);
     }
 
+    /// <inheritdoc />
+    public async Task<PumpSnapshot?> GetByGuidRangeAsync(Guid low, Guid high, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entity = await ctx.PumpSnapshots
+            .Where(e => e.Id >= low && e.Id <= high)
+            .FirstOrDefaultAsync(ct);
+        return entity is null ? null : PumpSnapshotMapper.ToDomainModel(entity);
+    }
+
     /// <summary>
     /// Gets a pump snapshot record by its legacy identifier.
     /// </summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
@@ -119,6 +119,16 @@ public class TempBasalRepository : ITempBasalRepository
         return entity is null ? null : TempBasalMapper.ToDomainModel(entity);
     }
 
+    /// <inheritdoc />
+    public async Task<TempBasal?> GetByGuidRangeAsync(Guid low, Guid high, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entity = await ctx.TempBasals
+            .Where(e => e.Id >= low && e.Id <= high)
+            .FirstOrDefaultAsync(ct);
+        return entity is null ? null : TempBasalMapper.ToDomainModel(entity);
+    }
+
     /// <summary>
     /// Gets a temporary basal record by its legacy (MongoDB) identifier.
     /// </summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
@@ -125,6 +125,7 @@ public class TempBasalRepository : ITempBasalRepository
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.TempBasals
             .Where(e => e.Id >= low && e.Id <= high)
+            .OrderBy(e => e.Id)
             .FirstOrDefaultAsync(ct);
         return entity is null ? null : TempBasalMapper.ToDomainModel(entity);
     }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
@@ -88,6 +88,16 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
         return entity is null ? null : UploaderSnapshotMapper.ToDomainModel(entity);
     }
 
+    /// <inheritdoc />
+    public async Task<UploaderSnapshot?> GetByGuidRangeAsync(Guid low, Guid high, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var entity = await ctx.UploaderSnapshots
+            .Where(e => e.Id >= low && e.Id <= high)
+            .FirstOrDefaultAsync(ct);
+        return entity is null ? null : UploaderSnapshotMapper.ToDomainModel(entity);
+    }
+
     /// <summary>
     /// Gets an uploader snapshot record by its legacy identifier.
     /// </summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
@@ -94,6 +94,7 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
         await using var ctx = await _contextFactory.CreateAsync(ct);
         var entity = await ctx.UploaderSnapshots
             .Where(e => e.Id >= low && e.Id <= high)
+            .OrderBy(e => e.Id)
             .FirstOrDefaultAsync(ct);
         return entity is null ? null : UploaderSnapshotMapper.ToDomainModel(entity);
     }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
@@ -187,6 +187,16 @@ public abstract class V4RepositoryBase<TModel, TEntity>
         return entity is null ? null : ToDomain(entity);
     }
 
+    /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.GetByGuidRangeAsync" />
+    public async Task<TModel?> GetByGuidRangeAsync(Guid low, Guid high, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var entity = await ctx.Set<TEntity>()
+            .Where(e => e.Id >= low && e.Id <= high)
+            .FirstOrDefaultAsync(ct);
+        return entity is null ? null : ToDomain(entity);
+    }
+
     /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.CreateAsync" />
     /// <remarks>Virtual: SyncId-upsert types (Bolus, CarbIntake) override to upsert in place.</remarks>
     public virtual async Task<TModel> CreateAsync(TModel model, WriteOrigin origin, CancellationToken ct = default)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
@@ -193,6 +193,7 @@ public abstract class V4RepositoryBase<TModel, TEntity>
         await using var ctx = await ContextFactory.CreateAsync(ct);
         var entity = await ctx.Set<TEntity>()
             .Where(e => e.Id >= low && e.Id <= high)
+            .OrderBy(e => e.Id)
             .FirstOrDefaultAsync(ct);
         return entity is null ? null : ToDomain(entity);
     }

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/ObjectIdRangeResolutionGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/ObjectIdRangeResolutionGoldenTests.cs
@@ -1,0 +1,65 @@
+using Microsoft.Extensions.DependencyInjection;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
+
+/// <summary>
+/// The AAPS ObjectId round-trip (issue #522) rests on one Postgres-specific fact: a record's UUID
+/// can be resolved from the first 24 hex chars of its canonical form via a uuid prefix range,
+/// because Postgres orders <c>uuid</c> byte-wise (= hex-string order). .NET's own Guid ordering is
+/// different, so this can only be verified against a real Postgres container, not the InMemory
+/// provider. These goldens pin that equivalence for the on-base <c>GetByGuidRangeAsync</c>.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("V4 goldens")]
+public class ObjectIdRangeResolutionGoldenTests
+{
+    private readonly V4GoldenFixture _fx;
+
+    public ObjectIdRangeResolutionGoldenTests(V4GoldenFixture fx) => _fx = fx;
+
+    private static readonly DateTime T0 = new(2026, 5, 1, 9, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task GetByGuidRange_ResolvesObjectIdDerivedFromUuid()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IBolusRepository>();
+
+        var created = await repo.CreateAsync(
+            new Bolus { Timestamp = T0, Insulin = 2.5, DataSource = "aaps", LegacyId = "b-range-1" },
+            WriteOrigin.Live, CancellationToken.None);
+
+        // The 24-hex ObjectId AAPS sees on the wire, derived from the record's UUID.
+        var objectId = MongoObjectId.FromGuid(created.Id);
+        MongoObjectId.TryGetGuidPrefixRange(objectId, out var low, out var high).Should().BeTrue();
+
+        var resolved = await repo.GetByGuidRangeAsync(low, high, CancellationToken.None);
+
+        resolved.Should().NotBeNull();
+        resolved!.Id.Should().Be(created.Id, "Postgres uuid ordering must select the source record by its hex prefix");
+    }
+
+    [Fact]
+    public async Task GetByGuidRange_DoesNotResolveUnrelatedPrefix()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IBolusRepository>();
+
+        await repo.CreateAsync(
+            new Bolus { Timestamp = T0, Insulin = 1.0, DataSource = "aaps", LegacyId = "b-range-2" },
+            WriteOrigin.Live, CancellationToken.None);
+
+        // A far-future prefix a UUID v7 (2026-era timestamp) can never share.
+        MongoObjectId.TryGetGuidPrefixRange("ffffffffffffffffffffffff", out var low, out var high).Should().BeTrue();
+
+        var resolved = await repo.GetByGuidRangeAsync(low, high, CancellationToken.None);
+
+        resolved.Should().BeNull();
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Treatments/TreatmentReadServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Treatments/TreatmentReadServiceTests.cs
@@ -230,4 +230,55 @@ public class TreatmentReadServiceTests
         result.Should().BeTrue();
         _pipeline.Verify(p => p.DeleteByLegacyIdAsync<Treatment>("t1", It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Once);
     }
+
+    [Fact]
+    public async Task DeleteAsync_ByDerivedObjectId_DeletesViaLegacyIdToRemoveSiblings()
+    {
+        // A meal bolus + its carb share one LegacyId; deleting by the derived wire ObjectId must
+        // route through DeleteByLegacyId (removes both) rather than the single-row range delete
+        // (which would orphan the carb into a phantom correction).
+        var uuid = Guid.CreateVersion7();
+        var wireId = MongoObjectId.FromGuid(uuid);
+        var bolus = new Bolus { Id = uuid, LegacyId = "syn-meal-1" };
+
+        _pipeline
+            .Setup(p => p.DeleteByLegacyIdAsync<Treatment>(wireId, It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0); // the ObjectId is not a stored LegacyId
+        _bolusRepo
+            .Setup(r => r.GetByGuidRangeAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(bolus);
+        _pipeline
+            .Setup(p => p.DeleteByLegacyIdAsync<Treatment>("syn-meal-1", It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2); // both siblings
+
+        var result = await _service.DeleteAsync(wireId);
+
+        result.Should().BeTrue();
+        _pipeline.Verify(
+            p => p.DeleteByLegacyIdAsync<Treatment>("syn-meal-1", It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ResolveCanonicalIdAsync_BackfillsNullLegacyId_SoUpdateUpsertsInPlace()
+    {
+        // A native V4 row (LegacyId == null) resolved by a derived ObjectId must be backfilled with
+        // that ObjectId so the decomposer upserts it in place instead of inserting a duplicate.
+        var uuid = Guid.CreateVersion7();
+        var wireId = MongoObjectId.FromGuid(uuid);
+        var note = new Note { Id = uuid, LegacyId = null };
+
+        _noteRepo
+            .Setup(r => r.GetByGuidRangeAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(note);
+
+        var canonical = await _service.ResolveCanonicalIdAsync(wireId);
+
+        canonical.Should().Be(wireId);
+        // The backfill goes through IV4Repository<Note>.UpdateAsync (the base slot the generic
+        // helper is typed against), which INoteRepository new-shadows — verify the base slot.
+        _noteRepo.As<IV4Repository<Note>>().Verify(
+            r => r.UpdateAsync(uuid, It.Is<Note>(n => n.LegacyId == wireId), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
 }

--- a/tests/Unit/Nocturne.Core.Models.Tests/MongoObjectIdTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/MongoObjectIdTests.cs
@@ -1,0 +1,132 @@
+using System.Text.Json;
+using FluentAssertions;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Extensions;
+using Xunit;
+
+namespace Nocturne.Core.Models.Tests;
+
+/// <summary>
+/// V1/V3 record identifiers must be 24-char hex Mongo ObjectIds — AAPS validates every id with
+/// <c>isObjectId()</c> and crashes (NumberFormatException) on a UUID. The conversion must be
+/// deterministic (stable across syncs) and reversible to a uuid range for lookup.
+/// </summary>
+[Trait("Category", "Unit")]
+public class MongoObjectIdTests
+{
+    [Fact]
+    public void FromGuid_IsFirst24HexOfCanonicalForm_AndIsObjectId()
+    {
+        var id = Guid.Parse("0192abcd-ef01-7123-8456-789abcdef012");
+
+        var oid = MongoObjectId.FromGuid(id);
+
+        oid.Length.Should().Be(24);
+        MongoObjectId.IsObjectId(oid).Should().BeTrue();
+        id.ToString("N").Should().StartWith(oid);
+    }
+
+    [Fact]
+    public void FromGuid_IsDeterministic()
+    {
+        var id = Guid.NewGuid();
+        MongoObjectId.FromGuid(id).Should().Be(MongoObjectId.FromGuid(id));
+    }
+
+    [Theory]
+    [InlineData("0192abcdef01712384560000", true)]
+    [InlineData("507f1f77bcf86cd799439011", true)]
+    [InlineData("0192ABCDEF01712384560000", false)] // uppercase rejected
+    [InlineData("0192abcd-ef01-7123-8456-789abcdef012", false)] // full UUID
+    [InlineData("507f1f77bcf86cd79943901", false)] // 23 chars
+    [InlineData("syn-abc", false)]
+    public void IsObjectId_MatchesStrict24Hex(string value, bool expected)
+    {
+        MongoObjectId.IsObjectId(value).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Coerce_PassesThroughRealObjectId()
+    {
+        MongoObjectId.Coerce("507f1f77bcf86cd799439011").Should().Be("507f1f77bcf86cd799439011");
+    }
+
+    [Fact]
+    public void Coerce_ConvertsGuidToObjectId()
+    {
+        var id = Guid.Parse("0192abcd-ef01-7123-8456-789abcdef012");
+        MongoObjectId.Coerce(id.ToString()).Should().Be(MongoObjectId.FromGuid(id));
+    }
+
+    [Fact]
+    public void Coerce_HashesArbitraryLegacyStringToObjectId()
+    {
+        var result = MongoObjectId.Coerce("syn-not-a-uuid");
+        MongoObjectId.IsObjectId(result).Should().BeTrue();
+        // deterministic
+        MongoObjectId.Coerce("syn-not-a-uuid").Should().Be(result);
+    }
+
+    [Fact]
+    public void Coerce_LeavesNullAndEmptyUnchanged()
+    {
+        MongoObjectId.Coerce(null).Should().BeNull();
+        MongoObjectId.Coerce("").Should().Be("");
+    }
+
+    [Fact]
+    public void TryGetGuidPrefixRange_BracketsTheSourceGuid()
+    {
+        var id = Guid.Parse("0192abcd-ef01-7123-8456-789abcdef012");
+        var oid = MongoObjectId.FromGuid(id);
+
+        MongoObjectId.TryGetGuidPrefixRange(oid, out var low, out var high).Should().BeTrue();
+
+        // The source UUID's canonical form starts with the objectId, so it sits within
+        // [oid+00000000, oid+ffffffff] under hex-string (Postgres uuid) ordering.
+        id.ToString("N").Should().StartWith(oid);
+        low.ToString("N").Should().Be(oid + "00000000");
+        high.ToString("N").Should().Be(oid + "ffffffff");
+    }
+
+    [Fact]
+    public void TryGetGuidPrefixRange_RejectsNonObjectId()
+    {
+        MongoObjectId.TryGetGuidPrefixRange("not-an-oid", out _, out _).Should().BeFalse();
+        MongoObjectId.TryGetGuidPrefixRange(Guid.NewGuid().ToString(), out _, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Treatment_SerializesIdAndIdentifierAsObjectId()
+    {
+        var id = Guid.Parse("0192abcd-ef01-7123-8456-789abcdef012");
+        var treatment = new Treatment { Id = id.ToString(), EventType = "Note" };
+
+        var json = JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(treatment));
+
+        var expected = MongoObjectId.FromGuid(id);
+        json.GetProperty("_id").GetString().Should().Be(expected);
+        json.GetProperty("identifier").GetString().Should().Be(expected);
+    }
+
+    [Fact]
+    public void Treatment_PreservesRealObjectIdOnWire()
+    {
+        var treatment = new Treatment { Id = "507f1f77bcf86cd799439011", EventType = "Note" };
+        var json = JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(treatment));
+        json.GetProperty("_id").GetString().Should().Be("507f1f77bcf86cd799439011");
+    }
+
+    [Fact]
+    public void EntryV3Response_SerializesIdentifierAsObjectId()
+    {
+        var id = Guid.Parse("0192abcd-ef01-7123-8456-789abcdef012");
+        var entry = new Entry { Id = id.ToString(), Mills = 1711454400000, Sgv = 120 };
+
+        var json = JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(entry.ToV3Response()));
+
+        var expected = MongoObjectId.FromGuid(id);
+        json.GetProperty("_id").GetString().Should().Be(expected);
+        json.GetProperty("identifier").GetString().Should().Be(expected);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/TempBasalToTreatmentMapperTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/TempBasalToTreatmentMapperTests.cs
@@ -161,17 +161,32 @@ public class TempBasalToTreatmentMapperTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public void ToTreatment_UsesLegacyIdWhenPresent()
+    public void ToTreatment_UsesLegacyIdWhenItIsAnObjectId()
     {
-        // Arrange
+        // A caller-supplied 24-hex ObjectId round-trips via an exact LegacyId lookup, so it is
+        // emitted verbatim.
         var tempBasal = CreateTempBasal(TempBasalOrigin.Algorithm, 1.0);
-        tempBasal.LegacyId = "legacy-treatment-abc";
+        tempBasal.LegacyId = "507f1f77bcf86cd799439011";
 
-        // Act
         var result = TempBasalToTreatmentMapper.ToTreatment(tempBasal);
 
-        // Assert
-        result.Id.Should().Be("legacy-treatment-abc");
+        result.Id.Should().Be("507f1f77bcf86cd799439011");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ToTreatment_FallsBackToGuidForNonObjectIdLegacyId()
+    {
+        // A non-ObjectId legacy string (e.g. a synthetic id) would serialize to an unresolvable
+        // hash; emit the UUID instead so the wire ObjectId resolves via a uuid prefix range.
+        var id = Guid.Parse("01234567-89ab-cdef-0123-456789abcdef");
+        var tempBasal = CreateTempBasal(TempBasalOrigin.Algorithm, 1.0);
+        tempBasal.Id = id;
+        tempBasal.LegacyId = "legacy-treatment-abc";
+
+        var result = TempBasalToTreatmentMapper.ToTreatment(tempBasal);
+
+        result.Id.Should().Be(id.ToString());
     }
 
     [Fact]


### PR DESCRIPTION
Closes #522.

AAPS validates every record id with a strict `isObjectId()` check (`[0-9a-f]{24}`) and, on failure, parses the id as a `Long`. A Nocturne UUID (36 chars) satisfies neither, so **every AAPS-uploaded treatment/entry crashed the next downward sync** with `NumberFormatException`.

## Emit side — 24-hex ObjectId on the wire
`MongoObjectId.Coerce(id)` maps a UUID to the first 24 hex of its canonical form (a real ObjectId passes through; any other string hashes deterministically to 24 hex). Applied via a `JsonConverter` on `Treatment._id`/`identifier`, the `Entry` V1/V3 response wrappers, and inline in the V3 devicestatus dto, plus the V3 create/dedup/patch `identifier` fields and the `Location` route. **Only the wire representation changes — the in-memory value is untouched**, so internal logic and the `LegacyId` dedup path are unaffected (`Read` is a passthrough).

## Reverse resolution — full round-trip
A 24-hex ObjectId derived from a UUID resolves back via a uuid **prefix range** `[oid+"00000000", oid+"ffffffff"]`. Postgres orders `uuid` byte-wise (= hex-prefix order), so the range selects exactly the source record. New `GetByGuidRangeAsync` on `IV4Repository`/`V4RepositoryBase` (+ the four non-base repos: TempBasal, Aps/Pump/Uploader snapshot, BasalInjection), wired into `GetByIdAsync` and `DELETE` for treatments, entries, and devicestatus, and into dedup-on-create.

## Update in place — no duplicates
`DecomposeAsync` upserts by `LegacyId`, but the wire id is a derived ObjectId, so a naive re-decompose would insert a duplicate. `ResolveCanonicalIdAsync` maps the wire ObjectId back to the stored `LegacyId`; `UpdateAsync`/`PatchTreatmentAsync` re-key to it before re-decomposing, and `ApplyJsonPatch` now preserves the id across its serialize round-trip (a PATCH never changes identity). Temp basals emit their UUID when the `LegacyId` isn't already an ObjectId, so temp-basal PATCH resolves via range.

## Why a range query (and why it's tested against real Postgres)
The reverse mapping is lossy (24 hex from a 128-bit UUID), so it can't be inverted arithmetically — it relies on Postgres `uuid` ordering matching hex-prefix ordering. **.NET's own `Guid` ordering differs**, so the InMemory provider can't validate it; the equivalence is pinned by an integration test against a real Postgres container (V4 goldens).

## Tests
- `MongoObjectIdTests` — helper + `Treatment`/`Entry` serialization (unit).
- `ObjectIdRangeResolutionGoldenTests` — uuid-prefix-range resolution on **real Postgres** (integration).
- Full unit suite green (4070 API + 332 Core.Models + 505 Infra), no regressions.

## Known limitation (pre-existing, tracked separately)
A native, UI-authored treatment that never received a `LegacyId` still can't be updated in place by AAPS (it duplicates) — the decomposer has no key to match. This predates the fix (all treatment PATCHes duplicated before, since the projected id was the UUID, not the `LegacyId`); the re-key here fixes the common case where AAPS edits its own (`LegacyId`-bearing) records. Fully closing it needs the decomposer to accept a UUID/ObjectId match key.

Credit to @old-square-eyes for the diagnosis in #522.