### PR TITLE
fix: prefer device-reported IOB/COB across display paths, default predictions to DeviceStatus

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Analytics/PredictionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/PredictionController.cs
@@ -77,8 +77,10 @@ public class PredictionController : ControllerBase
         }
         catch (InvalidOperationException ex)
         {
-            _logger.LogWarning(ex, "Invalid operation for predictions");
-            return Problem(detail: ex.Message, statusCode: 400, title: "Bad Request");
+            // No recent device-status prediction data — the normal state for care-portal-only
+            // tenants now that DeviceStatus is the default source, so not a client fault.
+            _logger.LogWarning(ex, "No prediction data available");
+            return Problem(detail: ex.Message, statusCode: 404, title: "Not Found");
         }
         catch (Exception ex)
         {

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/PredictionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/PredictionController.cs
@@ -41,7 +41,7 @@ public class PredictionController : ControllerBase
     {
         _predictionService = predictionService;
         _profileSnapshotService = profileSnapshotService;
-        _source = configuration.GetValue<PredictionSource>("Predictions:Source", PredictionSource.None);
+        _source = PredictionOptions.ResolveSource(configuration);
         _logger = logger;
     }
 

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -103,10 +103,7 @@ public static class ServiceRegistrationExtensions
         services.AddScoped<IPropertiesService, PropertiesService>();
         services.AddScoped<ISummaryService, SummaryService>();
         // Prediction service — configurable via Predictions:Source (None, DeviceStatus, OrefWasm)
-        var predictionSource = configuration.GetValue<PredictionSource>(
-            "Predictions:Source",
-            PredictionSource.None
-        );
+        var predictionSource = PredictionOptions.ResolveSource(configuration);
         switch (predictionSource)
         {
             case PredictionSource.DeviceStatus:

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -295,6 +295,7 @@ builder.Services.AddNocturneAuthorization();
 // Normalize the configured base domain once (strip scheme/path/port/stray dots) so
 // misformatted values like "https://nocturne.run" or "nocturne.run/" still resolve to
 // a matchable host instead of silently disabling cross-origin CORS. See CorsOriginPolicy.
+const string PublicDocsCorsPolicy = "PublicDocs";
 var rawCorsBaseDomain = builder.Configuration[BaseDomainOptions.ConfigKey] ?? "";
 var corsBaseDomain = CorsOriginPolicy.NormalizeBaseHost(rawCorsBaseDomain);
 var corsAllowLocalhost = builder.Environment.IsDevelopment();
@@ -311,6 +312,19 @@ builder.Services.AddCors(options =>
             .AllowAnyMethod()
             .AllowAnyHeader()
             .AllowCredentials(); // Required for cookies/auth to work cross-origin
+    });
+
+    // The OpenAPI specs and Scalar assets are tenantless, unauthenticated, and already
+    // readable by anyone, so they're served to any origin — this is what lets docs sites
+    // hosted off the base domain (getnocturne.dev) embed the reference. Kept as a separate
+    // policy because the default one allows credentials, which the CORS spec forbids
+    // combining with AllowAnyOrigin. No credentials here, so no tenant data is reachable.
+    options.AddPolicy(PublicDocsCorsPolicy, policy =>
+    {
+        policy
+            .AllowAnyOrigin()
+            .AllowAnyMethod()
+            .AllowAnyHeader();
     });
 });
 
@@ -352,7 +366,13 @@ else
 // Configure middleware pipeline
 app.UseExceptionHandler();
 app.UseStatusCodePages();
-app.UseCors();
+// Documentation paths get the any-origin policy, everything else the credentialed default.
+// The two branches are complementary so exactly one CORS middleware ever runs per request —
+// chaining both would emit conflicting Access-Control-Allow-Origin headers. Both sit ahead of
+// UseStaticFiles so the Scalar assets under wwwroot/scalar are covered, and ahead of
+// UseRouting so preflights short-circuit.
+app.UseWhen(IsPublicDocsPath, branch => branch.UseCors(PublicDocsCorsPolicy));
+app.UseWhen(context => !IsPublicDocsPath(context), branch => branch.UseCors());
 app.UseStaticFiles();
 app.UseForwardedHeaders();
 
@@ -376,9 +396,7 @@ app.UseRouting();
 // middleware stack — they're tenantless and publicly accessible.
 app.Use(async (context, next) =>
 {
-    var path = context.Request.Path.Value ?? "";
-    if (path.StartsWith("/scalar", StringComparison.OrdinalIgnoreCase)
-        || path.StartsWith("/openapi", StringComparison.OrdinalIgnoreCase))
+    if (IsPublicDocsPath(context))
     {
         // Jump straight to the endpoint (MapOpenApi / MapScalarApiReference)
         var endpoint = context.GetEndpoint();
@@ -586,6 +604,16 @@ if (app.Environment.IsDevelopment() && !isNSwagGeneration)
 }
 
 await app.RunAsync();
+
+// Documentation paths: the OpenAPI specs and the Scalar UI plus its wwwroot assets.
+// These are tenantless and publicly accessible, so they both bypass the tenant/auth
+// middleware stack and get the any-origin CORS policy.
+static bool IsPublicDocsPath(HttpContext context)
+{
+    var path = context.Request.Path.Value ?? "";
+    return path.StartsWith("/scalar", StringComparison.OrdinalIgnoreCase)
+        || path.StartsWith("/openapi", StringComparison.OrdinalIgnoreCase);
+}
 
 // Detects if the application is being run by NSwag for OpenAPI document generation.
 // NSwag uses its AspNetCore.Launcher to load and introspect the app without actually running it.

--- a/src/API/Nocturne.API/Services/ChartData/ChartDataContext.cs
+++ b/src/API/Nocturne.API/Services/ChartData/ChartDataContext.cs
@@ -62,6 +62,12 @@ public sealed record ChartDataContext
     public IReadOnlyList<BGCheck> BgCheckList { get; init; } = [];
     public IReadOnlyList<DeviceEvent> DeviceEventList { get; init; } = [];
     public IReadOnlyList<TempBasal> TempBasalList { get; init; } = [];
+
+    /// <summary>
+    /// APS snapshots covering the buffer window, ascending by timestamp. Carries the IOB/COB the
+    /// AID system reported, which the IOB/COB series prefers over its own recomputation.
+    /// </summary>
+    public IReadOnlyList<ApsSnapshot> ApsSnapshotList { get; init; } = [];
     public IReadOnlyList<BasalInjection> BasalInjectionList { get; init; } = [];
     /// <summary>State spans keyed by category, populated from a batched repository query.</summary>
     public IReadOnlyDictionary<StateSpanCategory, IEnumerable<StateSpan>> StateSpans { get; init; }

--- a/src/API/Nocturne.API/Services/ChartData/ChartDataContext.cs
+++ b/src/API/Nocturne.API/Services/ChartData/ChartDataContext.cs
@@ -64,10 +64,10 @@ public sealed record ChartDataContext
     public IReadOnlyList<TempBasal> TempBasalList { get; init; } = [];
 
     /// <summary>
-    /// APS snapshots covering the buffer window, ascending by timestamp. Carries the IOB/COB the
-    /// AID system reported, which the IOB/COB series prefers over its own recomputation.
+    /// APS snapshot IOB/COB points covering the buffer window, ascending by timestamp. Carries the
+    /// IOB/COB the AID system reported, which the IOB/COB series prefers over its own recomputation.
     /// </summary>
-    public IReadOnlyList<ApsSnapshot> ApsSnapshotList { get; init; } = [];
+    public IReadOnlyList<ApsIobCobPoint> ApsSnapshotList { get; init; } = [];
     public IReadOnlyList<BasalInjection> BasalInjectionList { get; init; } = [];
     /// <summary>State spans keyed by category, populated from a batched repository query.</summary>
     public IReadOnlyDictionary<StateSpanCategory, IEnumerable<StateSpan>> StateSpans { get; init; }

--- a/src/API/Nocturne.API/Services/ChartData/Stages/DataFetchStage.cs
+++ b/src/API/Nocturne.API/Services/ChartData/Stages/DataFetchStage.cs
@@ -178,19 +178,16 @@ internal sealed class DataFetchStage(
             ct: cancellationToken
         )).ToList();
 
-        // Fetch APS snapshots (ascending) so the IOB/COB series can prefer the values the AID
-        // system actually acted on. The buffer start is used so a tick at the very left edge of
-        // the window can still resolve a snapshot uploaded just before it.
-        var apsSnapshotList = (await apsSnapshotRepository.GetAsync(
-            from: MillsToDateTime(bufferStartTime),
-            to: MillsToDateTime(endTime),
-            device: null,
-            source: null,
-            limit: treatmentLimit,
-            offset: 0,
-            descending: false,
+        // Fetch APS snapshot IOB/COB points (ascending) so the IOB/COB series can prefer the
+        // values the AID system actually acted on. The buffer start is used so a tick at the very
+        // left edge of the window can still resolve a snapshot uploaded just before it. The slim
+        // projection is deliberate: full snapshots carry multi-KB JSON blob columns, and a limit
+        // heuristic would truncate the newest rows for high-cadence uploaders.
+        var apsSnapshotList = await apsSnapshotRepository.GetIobCobPointsAsync(
+            from: MillsToDateTime(bufferStartTime)!.Value,
+            to: MillsToDateTime(endTime)!.Value,
             ct: cancellationToken
-        )).ToList();
+        );
 
         // Fetch all state spans in a single batched query
         var stateSpanCategories = new[]

--- a/src/API/Nocturne.API/Services/ChartData/Stages/DataFetchStage.cs
+++ b/src/API/Nocturne.API/Services/ChartData/Stages/DataFetchStage.cs
@@ -47,6 +47,7 @@ internal sealed class DataFetchStage(
     IBGCheckRepository bgCheckRepository,
     IDeviceEventRepository deviceEventRepository,
     ITempBasalRepository tempBasalRepository,
+    IApsSnapshotRepository apsSnapshotRepository,
     IStateSpanRepository stateSpanRepository,
     ISystemEventRepository systemEventRepository,
     ITrackerRepository trackerRepository,
@@ -177,6 +178,20 @@ internal sealed class DataFetchStage(
             ct: cancellationToken
         )).ToList();
 
+        // Fetch APS snapshots (ascending) so the IOB/COB series can prefer the values the AID
+        // system actually acted on. The buffer start is used so a tick at the very left edge of
+        // the window can still resolve a snapshot uploaded just before it.
+        var apsSnapshotList = (await apsSnapshotRepository.GetAsync(
+            from: MillsToDateTime(bufferStartTime),
+            to: MillsToDateTime(endTime),
+            device: null,
+            source: null,
+            limit: treatmentLimit,
+            offset: 0,
+            descending: false,
+            ct: cancellationToken
+        )).ToList();
+
         // Fetch all state spans in a single batched query
         var stateSpanCategories = new[]
         {
@@ -274,6 +289,7 @@ internal sealed class DataFetchStage(
             BgCheckList = bgCheckList,
             DeviceEventList = deviceEventList,
             TempBasalList = tempBasalList,
+            ApsSnapshotList = apsSnapshotList,
             BasalInjectionList = basalInjectionList,
             StateSpans = stateSpansReadOnly,
             SystemEvents = systemEventsResult?.ToList() ?? [],

--- a/src/API/Nocturne.API/Services/ChartData/Stages/IobCobComputeStage.cs
+++ b/src/API/Nocturne.API/Services/ChartData/Stages/IobCobComputeStage.cs
@@ -116,7 +116,7 @@ internal sealed class IobCobComputeStage(
         int intervalMinutes,
         List<TempBasal>? tempBasals,
         TherapyTimeline timeline,
-        IReadOnlyList<ApsSnapshot>? apsSnapshots = null,
+        IReadOnlyList<ApsIobCobPoint>? apsSnapshots = null,
         CancellationToken ct = default
     )
     {
@@ -177,7 +177,7 @@ internal sealed class IobCobComputeStage(
         // at-or-before t with a single advancing pointer.
         var sortedSnapshots = (apsSnapshots ?? [])
             .Select(s => (
-                Mills: new DateTimeOffset(s.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
+                Mills: new DateTimeOffset(DateTime.SpecifyKind(s.Timestamp, DateTimeKind.Utc), TimeSpan.Zero).ToUnixTimeMilliseconds(),
                 s.Iob,
                 s.Cob
             ))
@@ -308,7 +308,7 @@ internal sealed class IobCobComputeStage(
         long endTime,
         int intervalMinutes,
         List<TempBasal>? tempBasals = null,
-        IReadOnlyList<ApsSnapshot>? apsSnapshots = null
+        IReadOnlyList<ApsIobCobPoint>? apsSnapshots = null
     )
     {
         // Round start/end times to interval boundaries for better cache hits
@@ -341,16 +341,18 @@ internal sealed class IobCobComputeStage(
             }
         }
 
-        // Include APS snapshot data in cache key — a new snapshot changes the series
+        // Include APS snapshot data in cache key — a new snapshot changes the series. Null and 0
+        // fingerprint differently ("~" vs "0"): null falls back to computed while 0 is a device
+        // value, and sync-id upserts can flip one to the other without changing the timestamp.
         if (apsSnapshots != null)
         {
             foreach (var s in apsSnapshots)
             {
                 sb.Append(s.Timestamp.Ticks)
                     .Append(':')
-                    .Append(s.Iob ?? 0)
+                    .Append(s.Iob?.ToString() ?? "~")
                     .Append(':')
-                    .Append(s.Cob ?? 0)
+                    .Append(s.Cob?.ToString() ?? "~")
                     .Append('|');
             }
         }

--- a/src/API/Nocturne.API/Services/ChartData/Stages/IobCobComputeStage.cs
+++ b/src/API/Nocturne.API/Services/ChartData/Stages/IobCobComputeStage.cs
@@ -7,6 +7,7 @@ using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.API.Services.Treatments;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
 
@@ -16,6 +17,12 @@ namespace Nocturne.API.Services.ChartData.Stages;
 /// Chart data pipeline stage that computes IOB/COB time series and the basal delivery series.
 /// </summary>
 /// <remarks>
+/// <para>
+/// At each interval step, ticks covered by a recent APS snapshot take the device-reported IOB/COB
+/// verbatim — the AID system's own numbers are the values it acted on, and matching them keeps the
+/// chart consistent with the uploader and with the status pill. Ticks with no recent snapshot
+/// (pre-AID history, upload gaps, care-portal-only tenants) fall back to local recomputation.
+/// </para>
 /// <para>
 /// IOB and COB are computed at each interval step across the requested time window.
 /// Treatments are kept in time-sorted arrays and the active window is tracked with two-pointer
@@ -74,7 +81,8 @@ internal sealed class IobCobComputeStage(
         var timeline = await therapyTimelineResolver.BuildAsync(startTime, endTime + 1, ct: cancellationToken);
 
         var (iobSeries, cobSeries, maxIob, maxCob) = BuildIobCobSeries(
-            bolusList, carbIntakeList, startTime, endTime, intervalMinutes, tempBasalList, timeline, cancellationToken
+            bolusList, carbIntakeList, startTime, endTime, intervalMinutes, tempBasalList, timeline,
+            context.ApsSnapshotList, cancellationToken
         );
 
         var basalSeries = await basalSeriesBuilder.BuildAsync(tempBasalList, startTime, endTime, defaultBasalRate, timeline, cancellationToken);
@@ -108,12 +116,13 @@ internal sealed class IobCobComputeStage(
         int intervalMinutes,
         List<TempBasal>? tempBasals,
         TherapyTimeline timeline,
+        IReadOnlyList<ApsSnapshot>? apsSnapshots = null,
         CancellationToken ct = default
     )
     {
 
         // Generate cache key based on data hash and time range
-        var cacheKey = GenerateIobCobCacheKey(boluses, carbIntakes, startTime, endTime, intervalMinutes, tempBasals);
+        var cacheKey = GenerateIobCobCacheKey(boluses, carbIntakes, startTime, endTime, intervalMinutes, tempBasals, apsSnapshots);
 
         // Try to get from cache
         if (
@@ -163,12 +172,25 @@ internal sealed class IobCobComputeStage(
             .ToList();
         var sortedTempBasals = tempBasals?.OrderBy(tb => tb.StartMills).ToList();
 
+        // Device-reported IOB/COB, preferred over local recomputation at any tick with a recent
+        // snapshot. Sorted with precomputed mills so the tick loop can track the newest snapshot
+        // at-or-before t with a single advancing pointer.
+        var sortedSnapshots = (apsSnapshots ?? [])
+            .Select(s => (
+                Mills: new DateTimeOffset(s.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
+                s.Iob,
+                s.Cob
+            ))
+            .OrderBy(s => s.Mills)
+            .ToList();
+
         int insulinHi = 0,
             insulinLo = 0;
         int carbHi = 0,
             carbLo = 0;
         int basalHi = 0,
             basalLo = 0;
+        int snapshotHi = 0;
 
         for (long t = startTime; t <= endTime; t += intervalMs)
         {
@@ -200,42 +222,68 @@ internal sealed class IobCobComputeStage(
                     basalLo++;
             }
 
-            var insulinCount = insulinHi - insulinLo;
-            var iobResult = insulinCount > 0
-                ? iobCalculator.FromBoluses(sortedBoluses.GetRange(insulinLo, insulinCount), snapshot, t)
-                : new IobResult { Iob = 0 };
+            // Newest snapshot at-or-before t; usable while it is within the recency window.
+            while (snapshotHi < sortedSnapshots.Count && sortedSnapshots[snapshotHi].Mills <= t)
+                snapshotHi++;
+            var deviceValues = snapshotHi > 0
+                && t - sortedSnapshots[snapshotHi - 1].Mills <= DeviceReportedValues.RecencyThresholdMs
+                    ? sortedSnapshots[snapshotHi - 1]
+                    : default((long Mills, double? Iob, double? Cob)?);
 
-            var basalIob = 0.0;
+            var insulinCount = insulinHi - insulinLo;
             var basalCount = basalHi - basalLo;
-            if (sortedTempBasals is not null && basalCount > 0)
+
+            double iob;
+            if (deviceValues?.Iob is { } deviceIob)
             {
-                var basalResult = iobCalculator.FromTempBasals(
-                    sortedTempBasals.GetRange(basalLo, basalCount),
-                    snapshot,
-                    t
-                );
-                basalIob = basalResult.BasalIob ?? 0;
+                // Device IOB is the total the AID system acted on (bolus + temp-basal delta).
+                iob = deviceIob;
+            }
+            else
+            {
+                var iobResult = insulinCount > 0
+                    ? iobCalculator.FromBoluses(sortedBoluses.GetRange(insulinLo, insulinCount), snapshot, t)
+                    : new IobResult { Iob = 0 };
+
+                var basalIob = 0.0;
+                if (sortedTempBasals is not null && basalCount > 0)
+                {
+                    var basalResult = iobCalculator.FromTempBasals(
+                        sortedTempBasals.GetRange(basalLo, basalCount),
+                        snapshot,
+                        t
+                    );
+                    basalIob = basalResult.BasalIob ?? 0;
+                }
+
+                iob = iobResult.Iob + basalIob;
             }
 
-            var iob = iobResult.Iob + basalIob;
             iobSeries.Add(new TimeSeriesPoint { Timestamp = t, Value = iob });
             if (iob > maxIob)
                 maxIob = iob;
 
-            var carbCount = carbHi - carbLo;
-            var cobResult = carbCount > 0
-                ? cobCalculator.FromCarbIntakes(
-                    sortedCarbs.GetRange(carbLo, carbCount),
-                    sortedBoluses.GetRange(insulinLo, insulinCount),
-                    sortedTempBasals is not null && basalCount > 0
-                        ? sortedTempBasals.GetRange(basalLo, basalCount)
-                        : null,
-                    snapshot,
-                    t
-                )
-                : new CobResult { Cob = 0 };
-
-            var cob = cobResult.Cob;
+            double cob;
+            if (deviceValues?.Cob is { } deviceCob)
+            {
+                cob = deviceCob;
+            }
+            else
+            {
+                var carbCount = carbHi - carbLo;
+                var cobResult = carbCount > 0
+                    ? cobCalculator.FromCarbIntakes(
+                        sortedCarbs.GetRange(carbLo, carbCount),
+                        sortedBoluses.GetRange(insulinLo, insulinCount),
+                        sortedTempBasals is not null && basalCount > 0
+                            ? sortedTempBasals.GetRange(basalLo, basalCount)
+                            : null,
+                        snapshot,
+                        t
+                    )
+                    : new CobResult { Cob = 0 };
+                cob = cobResult.Cob;
+            }
             cobSeries.Add(new TimeSeriesPoint { Timestamp = t, Value = cob });
             if (cob > maxCob)
                 maxCob = cob;
@@ -259,7 +307,8 @@ internal sealed class IobCobComputeStage(
         long startTime,
         long endTime,
         int intervalMinutes,
-        List<TempBasal>? tempBasals = null
+        List<TempBasal>? tempBasals = null,
+        IReadOnlyList<ApsSnapshot>? apsSnapshots = null
     )
     {
         // Round start/end times to interval boundaries for better cache hits
@@ -288,6 +337,20 @@ internal sealed class IobCobComputeStage(
                     .Append(tb.Rate)
                     .Append(':')
                     .Append(tb.EndMills ?? 0)
+                    .Append('|');
+            }
+        }
+
+        // Include APS snapshot data in cache key — a new snapshot changes the series
+        if (apsSnapshots != null)
+        {
+            foreach (var s in apsSnapshots)
+            {
+                sb.Append(s.Timestamp.Ticks)
+                    .Append(':')
+                    .Append(s.Iob ?? 0)
+                    .Append(':')
+                    .Append(s.Cob ?? 0)
                     .Append('|');
             }
         }

--- a/src/API/Nocturne.API/Services/Devices/DeviceStatusPredictionService.cs
+++ b/src/API/Nocturne.API/Services/Devices/DeviceStatusPredictionService.cs
@@ -4,6 +4,7 @@ using Nocturne.API.Controllers.V4.Analytics;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.API.Services.Glucose;
+using Nocturne.API.Services.Treatments;
 
 namespace Nocturne.API.Services.Devices;
 
@@ -34,9 +35,13 @@ public class DeviceStatusPredictionService : IPredictionService
     {
         // For replay we want the snapshot active at-or-before the anchor — the AID system
         // already wrote forward predictions historically, so picking the most recent snapshot
-        // before `asOf` gives us the forecast the user actually had at that tick.
+        // before `asOf` gives us the forecast the user actually had at that tick. The lower
+        // bound rejects stale snapshots: consumers anchor the curve at the anchor instant
+        // (alert evaluation measures offsets from "now"), so a forecast from an uploader that
+        // stopped hours ago must read as "no predictions", not as a current one.
+        var anchor = asOf ?? DateTimeOffset.UtcNow;
         var snapshots = await _apsSnapshots.GetAsync(
-            from: null,
+            from: anchor.UtcDateTime.AddMilliseconds(-DeviceReportedValues.RecencyThresholdMs),
             to: asOf?.UtcDateTime,
             device: null,
             source: null,

--- a/src/API/Nocturne.API/Services/Glucose/PredictionConfiguration.cs
+++ b/src/API/Nocturne.API/Services/Glucose/PredictionConfiguration.cs
@@ -12,8 +12,9 @@ public class PredictionOptions
 
     /// <summary>
     /// The source for glucose predictions. Defaults to <see cref="PredictionSource.DeviceStatus"/>
-    /// so prediction curves uploaded by an AID system render without per-deployment configuration;
-    /// tenants with no uploaded curves get an empty forecast rather than an error.
+    /// so prediction curves uploaded by an AID system render without per-deployment configuration.
+    /// Tenants with no recent uploaded curves get a 404 from the predictions endpoint (which the
+    /// web client renders as no curve) and an empty forecast in alert evaluation.
     /// </summary>
     public PredictionSource Source { get; set; } = DefaultSource;
 

--- a/src/API/Nocturne.API/Services/Glucose/PredictionConfiguration.cs
+++ b/src/API/Nocturne.API/Services/Glucose/PredictionConfiguration.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Configuration;
+
 namespace Nocturne.API.Services.Glucose;
 
 /// <summary>
@@ -9,9 +11,27 @@ public class PredictionOptions
     public const string SectionName = "Predictions";
 
     /// <summary>
-    /// The source for glucose predictions.
+    /// The source for glucose predictions. Defaults to <see cref="PredictionSource.DeviceStatus"/>
+    /// so prediction curves uploaded by an AID system render without per-deployment configuration;
+    /// tenants with no uploaded curves get an empty forecast rather than an error.
     /// </summary>
-    public PredictionSource Source { get; set; } = PredictionSource.None;
+    public PredictionSource Source { get; set; } = DefaultSource;
+
+    /// <summary>
+    /// The source used when <c>Predictions:Source</c> is absent from configuration.
+    /// </summary>
+    public const PredictionSource DefaultSource = PredictionSource.DeviceStatus;
+
+    /// <summary>
+    /// Reads <c>Predictions:Source</c>, falling back to <see cref="DefaultSource"/>.
+    /// </summary>
+    /// <remarks>
+    /// Service registration and <c>PredictionController</c> both need the resolved source and must
+    /// agree: registration decides whether an <see cref="IPredictionService"/> exists at all, and a
+    /// disagreement would leave the controller returning 404 with a service registered, or vice versa.
+    /// </remarks>
+    public static PredictionSource ResolveSource(IConfiguration configuration) =>
+        configuration.GetValue($"{SectionName}:{nameof(Source)}", DefaultSource);
 }
 
 /// <summary>

--- a/src/API/Nocturne.API/Services/Treatments/CobCalculator.cs
+++ b/src/API/Nocturne.API/Services/Treatments/CobCalculator.cs
@@ -22,7 +22,6 @@ public class CobCalculator(
 ) : ICobCalculator
 {
     // Constants from legacy implementation - exact values required
-    public const long RECENCY_THRESHOLD = 30 * 60 * 1000; // 30 minutes in milliseconds
     private const double LIVER_SENS_RATIO = 8.0; // Legacy: var liverSensRatio = 8;
     private const int DELAY_MINUTES = 20; // Legacy: const delay = 20;
 
@@ -69,12 +68,14 @@ public class CobCalculator(
         // Get COB from APS snapshot (prioritized source)
         var deviceCob = await GetLatestDeviceCobAsync(currentTime, ct);
 
-        // Legacy logic: if device COB exists and is recent (within 10 minutes), use it
-        if (deviceCob != null && deviceCob.Cob > 0 && deviceCob.Mills.HasValue)
+        // Prefer the device's own COB when it is recent. A reported COB of exactly zero is a
+        // real value ("no carbs on board"), not a missing one, so it is accepted like any other.
+        // Age is measured against currentTime so historical queries resolve against the requested
+        // instant rather than the wall clock.
+        if (deviceCob != null && deviceCob.Mills.HasValue)
         {
-            var deviceAge =
-                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - deviceCob.Mills.Value;
-            if (deviceAge <= 10 * 60 * 1000)
+            var deviceAge = currentTime - deviceCob.Mills.Value;
+            if (deviceAge <= DeviceReportedValues.RecencyThresholdMs)
             {
                 return AddDisplay(deviceCob);
             }
@@ -393,8 +394,8 @@ public class CobCalculator(
     /// </summary>
     internal async Task<CobResult?> GetLatestDeviceCobAsync(long time, CancellationToken ct = default)
     {
-        var futureMills = time + 5 * 60 * 1000; // Allow for clocks to be a little off
-        var recentMills = time - RECENCY_THRESHOLD;
+        var futureMills = time + DeviceReportedValues.FutureSkewToleranceMs;
+        var recentMills = time - DeviceReportedValues.RecencyThresholdMs;
 
         var recentTime = DateTimeOffset.FromUnixTimeMilliseconds(recentMills).UtcDateTime;
         var futureTime = DateTimeOffset.FromUnixTimeMilliseconds(futureMills).UtcDateTime;
@@ -411,7 +412,8 @@ public class CobCalculator(
         );
 
         var apsSnapshot = apsSnapshots.FirstOrDefault();
-        if (apsSnapshot?.Cob is > 0)
+        // A reported COB of exactly zero is a real value ("no carbs on board"), not a missing one.
+        if (apsSnapshot?.Cob is not null)
         {
             var source = apsSnapshot.AidAlgorithm switch
             {

--- a/src/API/Nocturne.API/Services/Treatments/DeviceReportedValues.cs
+++ b/src/API/Nocturne.API/Services/Treatments/DeviceReportedValues.cs
@@ -1,0 +1,26 @@
+namespace Nocturne.API.Services.Treatments;
+
+/// <summary>
+/// Shared rules for preferring device-reported IOB/COB over locally-computed values.
+/// </summary>
+/// <remarks>
+/// An AID system (Loop, OpenAPS, AAPS, Trio) uploads the IOB and COB it acted on. Nocturne's own
+/// curve is an approximation of that, so where a recent device value exists it is the better answer
+/// and every display path should agree on which one that is. <see cref="IobCalculator"/>,
+/// <see cref="CobCalculator"/> and the chart pipeline all resolve recency through this constant so
+/// the status pill, the chart and <c>/api/v4/summary</c> cannot disagree about whether a given
+/// snapshot is still current.
+/// </remarks>
+public static class DeviceReportedValues
+{
+    /// <summary>
+    /// How old a device snapshot may be and still be preferred over a locally-computed value.
+    /// </summary>
+    public const long RecencyThresholdMs = 30 * 60 * 1000;
+
+    /// <summary>
+    /// How far past the requested instant a snapshot may be timestamped and still be accepted,
+    /// absorbing clock skew between the uploading device and the server.
+    /// </summary>
+    public const long FutureSkewToleranceMs = 5 * 60 * 1000;
+}

--- a/src/API/Nocturne.API/Services/Treatments/IobCalculator.cs
+++ b/src/API/Nocturne.API/Services/Treatments/IobCalculator.cs
@@ -24,7 +24,6 @@ public class IobCalculator(
 ) : IIobCalculator
 {
     // Constants from legacy implementation (identical to IobService)
-    private const long RECENCY_THRESHOLD = 30 * 60 * 1000; // 30 minutes in milliseconds
     private const double DEFAULT_DIA = 3.0;
     private const double SCALE_FACTOR_BASE = 3.0;
     private const double PEAK_MINUTES = 75.0;
@@ -74,11 +73,12 @@ public class IobCalculator(
                 result.TreatmentIob = RoundToThreeDecimals(bolusResult.Iob);
             }
 
-            // Add bolus basal IOB to device status basal IOB if available
-            if (bolusResult.BasalIob.HasValue)
+            // A device that reports basal IOB has already accounted for its own temp basals;
+            // adding the locally-computed value on top would count that insulin twice. Only
+            // substitute the local estimate when the device reported no basal IOB of its own.
+            if (!result.BasalIob.HasValue && bolusResult.BasalIob.HasValue)
             {
-                result.BasalIob = (result.BasalIob ?? 0) + bolusResult.BasalIob.Value;
-                result.BasalIob = RoundToThreeDecimals(result.BasalIob.Value);
+                result.BasalIob = RoundToThreeDecimals(bolusResult.BasalIob.Value);
             }
         }
 
@@ -348,8 +348,8 @@ public class IobCalculator(
     /// </summary>
     internal async Task<IobResult> GetLatestDeviceIobAsync(long time, CancellationToken ct = default)
     {
-        var futureMills = time + 5 * 60 * 1000;
-        var recentMills = time - RECENCY_THRESHOLD;
+        var futureMills = time + DeviceReportedValues.FutureSkewToleranceMs;
+        var recentMills = time - DeviceReportedValues.RecencyThresholdMs;
 
         var recentTime = DateTimeOffset.FromUnixTimeMilliseconds(recentMills).UtcDateTime;
         var futureTime = DateTimeOffset.FromUnixTimeMilliseconds(futureMills).UtcDateTime;

--- a/src/API/Nocturne.API/Services/Treatments/IobCalculator.cs
+++ b/src/API/Nocturne.API/Services/Treatments/IobCalculator.cs
@@ -39,8 +39,10 @@ public class IobCalculator(
     {
         var currentTime = time ?? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
-        // Get IOB from device snapshots (APS, pump) - prioritized source
-        var result = await GetLatestDeviceIobAsync(currentTime, ct);
+        // Get IOB from device snapshots (APS, pump) - prioritized source. Null means no recent
+        // snapshot carried an IOB at all; a reported IOB of zero (or negative, after a long
+        // low-temp) is a real device value and is kept.
+        var deviceResult = await GetLatestDeviceIobAsync(currentTime, ct);
 
         // Calculate IOB from boluses
         var bolusResult =
@@ -61,12 +63,14 @@ public class IobCalculator(
             bolusResult.Activity = (bolusResult.Activity ?? 0) + (tempBasalResult.Activity ?? 0);
         }
 
-        if (IsEmpty(result))
+        IobResult result;
+        if (deviceResult is null)
         {
             result = bolusResult;
         }
         else
         {
+            result = deviceResult;
             // Add bolus IOB as separate property for device status sources
             if (bolusResult.Iob > 0)
             {
@@ -344,9 +348,11 @@ public class IobCalculator(
 
     /// <summary>
     /// Query <see cref="IApsSnapshotRepository"/> and <see cref="IPumpSnapshotRepository"/>
-    /// for the most recent device-reported IOB within the staleness window.
+    /// for the most recent device-reported IOB within the staleness window. Returns <c>null</c>
+    /// when no recent snapshot carries an IOB value — a reported zero is a real value, not an
+    /// absence, so "device said 0" and "device said nothing" are distinct results.
     /// </summary>
-    internal async Task<IobResult> GetLatestDeviceIobAsync(long time, CancellationToken ct = default)
+    internal async Task<IobResult?> GetLatestDeviceIobAsync(long time, CancellationToken ct = default)
     {
         var futureMills = time + DeviceReportedValues.FutureSkewToleranceMs;
         var recentMills = time - DeviceReportedValues.RecencyThresholdMs;
@@ -367,9 +373,9 @@ public class IobCalculator(
         );
 
         var apsSnapshot = apsSnapshots.FirstOrDefault();
-        if (apsSnapshot != null)
+        if (apsSnapshot is { Iob: not null } or { BasalIob: not null })
         {
-            var source = apsSnapshot.AidAlgorithm switch
+            var source = apsSnapshot!.AidAlgorithm switch
             {
                 AidAlgorithm.Loop => "Loop",
                 _ => "OpenAPS",
@@ -398,27 +404,25 @@ public class IobCalculator(
         );
 
         var pumpSnapshot = pumpSnapshots.FirstOrDefault();
-        if (pumpSnapshot != null)
+        if (pumpSnapshot is { Iob: not null } or { BolusIob: not null })
         {
-            var iobValue = pumpSnapshot.Iob ?? pumpSnapshot.BolusIob ?? 0.0;
-
             return new IobResult
             {
-                Iob = iobValue,
+                Iob = pumpSnapshot!.Iob ?? pumpSnapshot.BolusIob ?? 0.0,
                 Source = "Pump",
                 Device = pumpSnapshot.Device,
                 Mills = new DateTimeOffset(pumpSnapshot.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
             };
         }
 
-        return new IobResult();
+        return null;
     }
 
     #region Helper Methods
 
     private static IobResult AddDisplay(IobResult iob)
     {
-        if (IsEmpty(iob) || iob.Iob <= 0)
+        if (iob.Iob <= 0)
         {
             return iob;
         }
@@ -428,11 +432,6 @@ public class IobCalculator(
         iob.DisplayLine = $"IOB: {display}U";
 
         return iob;
-    }
-
-    private static bool IsEmpty(IobResult? iob)
-    {
-        return iob == null || (iob.Iob <= 0 && !iob.BasalIob.HasValue && !iob.Activity.HasValue);
     }
 
     private static double RoundToThreeDecimals(double num)

--- a/src/API/Nocturne.API/appsettings.example.json
+++ b/src/API/Nocturne.API/appsettings.example.json
@@ -48,9 +48,10 @@
   // Base domain for subdomain tenant routing, WebAuthn, and URL construction
   "BASE_DOMAIN": "localhost:1612",
 
-  // Predictions: None | DeviceStatus | OrefWasm
+  // Predictions: None | DeviceStatus | OrefWasm (default: DeviceStatus — renders
+  // prediction curves uploaded by AID systems such as Loop, AAPS, and Trio)
   "Predictions": {
-    "Source": "None"
+    "Source": "DeviceStatus"
   },
 
   // Operator branding and self-service controls for managed/SaaS deployments

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IApsSnapshotRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IApsSnapshotRepository.cs
@@ -28,6 +28,19 @@ public interface IApsSnapshotRepository : IV4Repository<ApsSnapshot>
     /// <returns>Matching <see cref="ApsSnapshot"/> records.</returns>
     new Task<IEnumerable<ApsSnapshot>> GetAsync(DateTime? from, DateTime? to, string? device, string? source, int limit = 100, int offset = 0, bool descending = true, CancellationToken ct = default);
 
+    /// <summary>
+    /// Retrieve <see cref="ApsIobCobPoint"/> projections within a time window, ordered oldest-first.
+    /// </summary>
+    /// <remarks>
+    /// Unlimited within the window and projected server-side: the chart pipeline needs every
+    /// snapshot's IOB/COB (uploaders post every 1-5 minutes, so any per-hour limit heuristic
+    /// eventually truncates the newest rows) but none of the JSON blob columns.
+    /// </remarks>
+    /// <param name="from">Inclusive start of the time window.</param>
+    /// <param name="to">Inclusive end of the time window.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<IReadOnlyList<ApsIobCobPoint>> GetIobCobPointsAsync(DateTime from, DateTime to, CancellationToken ct = default);
+
     /// <summary>Returns a single <see cref="ApsSnapshot"/> by its UUID v7, or <c>null</c> if not found.</summary>
     /// <param name="id">UUID v7 record identifier.</param>
     /// <param name="ct">Cancellation token.</param>

--- a/src/Core/Nocturne.Core.Models/V4/ApsIobCobPoint.cs
+++ b/src/Core/Nocturne.Core.Models/V4/ApsIobCobPoint.cs
@@ -1,0 +1,11 @@
+namespace Nocturne.Core.Models.V4;
+
+/// <summary>
+/// Slim projection of an <see cref="ApsSnapshot"/> carrying only the device-reported IOB/COB
+/// needed by the chart pipeline. Fetching full snapshots there would round-trip every prediction
+/// and decision JSON blob (several KB per row) on each chart-data request.
+/// </summary>
+/// <param name="Timestamp">Snapshot timestamp (UTC).</param>
+/// <param name="Iob">Device-reported total IOB, or <c>null</c> when the snapshot carried none.</param>
+/// <param name="Cob">Device-reported COB, or <c>null</c> when the snapshot carried none.</param>
+public readonly record struct ApsIobCobPoint(DateTime Timestamp, double? Iob, double? Cob);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
@@ -75,6 +75,18 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
         return entities.Select(ApsSnapshotMapper.ToDomainModel);
     }
 
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<ApsIobCobPoint>> GetIobCobPointsAsync(
+        DateTime from, DateTime to, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        return await ctx.ApsSnapshots.AsNoTracking()
+            .Where(e => e.Timestamp >= from && e.Timestamp <= to)
+            .OrderBy(e => e.Timestamp)
+            .Select(e => new ApsIobCobPoint(e.Timestamp, e.Iob, e.Cob))
+            .ToListAsync(ct);
+    }
+
     /// <summary>
     /// Gets an APS snapshot by its unique identifier.
     /// </summary>

--- a/tests/Unit/Nocturne.API.Tests/Services/ChartData/Stages/DataFetchStageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ChartData/Stages/DataFetchStageTests.cs
@@ -29,6 +29,7 @@ public class DataFetchStageTests
     private readonly Mock<IBGCheckRepository> _mockBgCheckRepo = new();
     private readonly Mock<IDeviceEventRepository> _mockDeviceEventRepo = new();
     private readonly Mock<ITempBasalRepository> _mockTempBasalRepo = new();
+    private readonly Mock<IApsSnapshotRepository> _mockApsSnapshotRepo = new();
     private readonly Mock<IStateSpanRepository> _mockStateSpanRepo;
     private readonly Mock<ISystemEventRepository> _mockSystemEventRepo;
     private readonly Mock<ITrackerRepository> _mockTrackerRepo;
@@ -54,6 +55,7 @@ public class DataFetchStageTests
             _mockBgCheckRepo.Object,
             _mockDeviceEventRepo.Object,
             _mockTempBasalRepo.Object,
+            _mockApsSnapshotRepo.Object,
             _mockStateSpanRepo.Object,
             _mockSystemEventRepo.Object,
             _mockTrackerRepo.Object,
@@ -120,6 +122,15 @@ public class DataFetchStageTests
                 It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<TempBasal>());
+
+        // IApsSnapshotRepository.GetAsync
+        _mockApsSnapshotRepo
+            .Setup(r => r.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ApsSnapshot>());
 
         // IBasalInjectionRepository.GetAsync
         _mockBasalInjectionRepo

--- a/tests/Unit/Nocturne.API.Tests/Services/ChartData/Stages/DataFetchStageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ChartData/Stages/DataFetchStageTests.cs
@@ -123,14 +123,12 @@ public class DataFetchStageTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<TempBasal>());
 
-        // IApsSnapshotRepository.GetAsync
+        // IApsSnapshotRepository.GetIobCobPointsAsync
         _mockApsSnapshotRepo
-            .Setup(r => r.GetAsync(
-                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
-                It.IsAny<string?>(), It.IsAny<string?>(),
-                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(),
+            .Setup(r => r.GetIobCobPointsAsync(
+                It.IsAny<DateTime>(), It.IsAny<DateTime>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<ApsSnapshot>());
+            .ReturnsAsync(Array.Empty<ApsIobCobPoint>());
 
         // IBasalInjectionRepository.GetAsync
         _mockBasalInjectionRepo

--- a/tests/Unit/Nocturne.API.Tests/Services/ChartData/Stages/IobCobComputeStageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ChartData/Stages/IobCobComputeStageTests.cs
@@ -293,4 +293,188 @@ public class IobCobComputeStageTests
         result.IobSeries.Should().Contain(p => p.Value > 0, "boluses + temp basals should yield IOB");
         result.CobSeries.Should().Contain(p => p.Value > 0, "carbs should yield COB");
     }
+
+    [Fact]
+    public async Task ExecuteAsync_WithRecentApsSnapshots_PrefersDeviceReportedValues()
+    {
+        // 30-minute window, one snapshot every 5 minutes covering every tick — the whole series
+        // must be the device-reported values, and the local calculators must never run.
+        var startTime = TestMills;
+        var endTime = TestMills + 30 * 60 * 1000;
+        const int intervalMinutes = 5;
+
+        var snapshots = new List<ApsSnapshot>();
+        for (var t = startTime; t <= endTime; t += 5 * 60 * 1000)
+        {
+            snapshots.Add(new ApsSnapshot
+            {
+                Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(t).UtcDateTime,
+                Iob = 1.25,
+                Cob = 18.0,
+            });
+        }
+
+        var context = new ChartDataContext
+        {
+            StartTime = startTime,
+            EndTime = endTime,
+            IntervalMinutes = intervalMinutes,
+            DefaultBasalRate = 1.0,
+            BolusList = [new Bolus
+            {
+                Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(startTime).UtcDateTime,
+                Insulin = 3.0,
+            }],
+            CarbIntakeList = [new CarbIntake
+            {
+                Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(startTime).UtcDateTime,
+                Carbs = 45.0,
+            }],
+            TempBasalList = [],
+            ApsSnapshotList = snapshots,
+        };
+
+        var result = await _stage.ExecuteAsync(context, CancellationToken.None);
+
+        result.IobSeries.Should().AllSatisfy(p => p.Value.Should().Be(1.25));
+        result.CobSeries.Should().AllSatisfy(p => p.Value.Should().Be(18.0));
+        _mockIobCalculator.Verify(
+            s => s.FromBoluses(It.IsAny<List<Bolus>>(), It.IsAny<TherapySnapshot>(), It.IsAny<long>()),
+            Times.Never
+        );
+        _mockCobCalculator.Verify(
+            s => s.FromCarbIntakes(It.IsAny<List<CarbIntake>>(), It.IsAny<List<Bolus>?>(), It.IsAny<List<TempBasal>?>(), It.IsAny<TherapySnapshot>(), It.IsAny<long>()),
+            Times.Never
+        );
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SnapshotOlderThanRecencyWindow_FallsBackToComputed()
+    {
+        // A single snapshot 45 minutes before the window start is stale for every tick, so the
+        // series must come from the local calculators.
+        var startTime = TestMills;
+        var endTime = TestMills + 10 * 60 * 1000;
+        const int intervalMinutes = 5;
+
+        _mockIobCalculator
+            .Setup(s => s.FromBoluses(It.IsAny<List<Bolus>>(), It.IsAny<TherapySnapshot>(), It.IsAny<long>()))
+            .Returns(new IobResult { Iob = 2.0 });
+        _mockCobCalculator
+            .Setup(s => s.FromCarbIntakes(It.IsAny<List<CarbIntake>>(), It.IsAny<List<Bolus>?>(), It.IsAny<List<TempBasal>?>(), It.IsAny<TherapySnapshot>(), It.IsAny<long>()))
+            .Returns(new CobResult { Cob = 20.0 });
+
+        var context = new ChartDataContext
+        {
+            StartTime = startTime,
+            EndTime = endTime,
+            IntervalMinutes = intervalMinutes,
+            DefaultBasalRate = 1.0,
+            BolusList = [new Bolus
+            {
+                Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(startTime - 5 * 60 * 1000).UtcDateTime,
+                Insulin = 3.0,
+            }],
+            CarbIntakeList = [new CarbIntake
+            {
+                Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(startTime - 5 * 60 * 1000).UtcDateTime,
+                Carbs = 45.0,
+            }],
+            TempBasalList = [],
+            ApsSnapshotList = [new ApsSnapshot
+            {
+                Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(startTime - 45 * 60 * 1000).UtcDateTime,
+                Iob = 9.99,
+                Cob = 99.0,
+            }],
+        };
+
+        var result = await _stage.ExecuteAsync(context, CancellationToken.None);
+
+        result.IobSeries.Should().AllSatisfy(p => p.Value.Should().Be(2.0));
+        result.CobSeries.Should().AllSatisfy(p => p.Value.Should().Be(20.0));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SnapshotWithNullValues_FallsBackPerComponent()
+    {
+        // A recent snapshot carrying only IOB: the IOB series takes the device value while the
+        // COB series still comes from the local calculator.
+        var startTime = TestMills;
+        var endTime = TestMills;
+        const int intervalMinutes = 5;
+
+        _mockCobCalculator
+            .Setup(s => s.FromCarbIntakes(It.IsAny<List<CarbIntake>>(), It.IsAny<List<Bolus>?>(), It.IsAny<List<TempBasal>?>(), It.IsAny<TherapySnapshot>(), It.IsAny<long>()))
+            .Returns(new CobResult { Cob = 20.0 });
+
+        var context = new ChartDataContext
+        {
+            StartTime = startTime,
+            EndTime = endTime,
+            IntervalMinutes = intervalMinutes,
+            DefaultBasalRate = 1.0,
+            BolusList = [],
+            CarbIntakeList = [new CarbIntake
+            {
+                Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(startTime - 5 * 60 * 1000).UtcDateTime,
+                Carbs = 45.0,
+            }],
+            TempBasalList = [],
+            ApsSnapshotList = [new ApsSnapshot
+            {
+                Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(startTime - 60 * 1000).UtcDateTime,
+                Iob = 1.5,
+                Cob = null,
+            }],
+        };
+
+        var result = await _stage.ExecuteAsync(context, CancellationToken.None);
+
+        result.IobSeries.Should().ContainSingle().Which.Value.Should().Be(1.5);
+        result.CobSeries.Should().ContainSingle().Which.Value.Should().Be(20.0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NewSnapshot_InvalidatesCachedSeries()
+    {
+        // Same treatments, same window — a snapshot arriving between two requests must change
+        // the result rather than replaying the cached series.
+        var startTime = TestMills;
+        var endTime = TestMills;
+        const int intervalMinutes = 5;
+
+        _mockIobCalculator
+            .Setup(s => s.FromBoluses(It.IsAny<List<Bolus>>(), It.IsAny<TherapySnapshot>(), It.IsAny<long>()))
+            .Returns(new IobResult { Iob = 2.0 });
+
+        var baseContext = new ChartDataContext
+        {
+            StartTime = startTime,
+            EndTime = endTime,
+            IntervalMinutes = intervalMinutes,
+            DefaultBasalRate = 1.0,
+            BolusList = [new Bolus
+            {
+                Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(startTime - 5 * 60 * 1000).UtcDateTime,
+                Insulin = 3.0,
+            }],
+            CarbIntakeList = [],
+            TempBasalList = [],
+        };
+
+        var first = await _stage.ExecuteAsync(baseContext, CancellationToken.None);
+        first.IobSeries.Should().ContainSingle().Which.Value.Should().Be(2.0);
+
+        var second = await _stage.ExecuteAsync(baseContext with
+        {
+            ApsSnapshotList = [new ApsSnapshot
+            {
+                Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(startTime - 60 * 1000).UtcDateTime,
+                Iob = 1.5,
+            }],
+        }, CancellationToken.None);
+
+        second.IobSeries.Should().ContainSingle().Which.Value.Should().Be(1.5);
+    }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/ChartData/Stages/IobCobComputeStageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ChartData/Stages/IobCobComputeStageTests.cs
@@ -303,15 +303,11 @@ public class IobCobComputeStageTests
         var endTime = TestMills + 30 * 60 * 1000;
         const int intervalMinutes = 5;
 
-        var snapshots = new List<ApsSnapshot>();
+        var snapshots = new List<ApsIobCobPoint>();
         for (var t = startTime; t <= endTime; t += 5 * 60 * 1000)
         {
-            snapshots.Add(new ApsSnapshot
-            {
-                Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(t).UtcDateTime,
-                Iob = 1.25,
-                Cob = 18.0,
-            });
+            snapshots.Add(new ApsIobCobPoint(
+                DateTimeOffset.FromUnixTimeMilliseconds(t).UtcDateTime, 1.25, 18.0));
         }
 
         var context = new ChartDataContext
@@ -381,12 +377,8 @@ public class IobCobComputeStageTests
                 Carbs = 45.0,
             }],
             TempBasalList = [],
-            ApsSnapshotList = [new ApsSnapshot
-            {
-                Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(startTime - 45 * 60 * 1000).UtcDateTime,
-                Iob = 9.99,
-                Cob = 99.0,
-            }],
+            ApsSnapshotList = [new ApsIobCobPoint(
+                DateTimeOffset.FromUnixTimeMilliseconds(startTime - 45 * 60 * 1000).UtcDateTime, 9.99, 99.0)],
         };
 
         var result = await _stage.ExecuteAsync(context, CancellationToken.None);
@@ -421,12 +413,8 @@ public class IobCobComputeStageTests
                 Carbs = 45.0,
             }],
             TempBasalList = [],
-            ApsSnapshotList = [new ApsSnapshot
-            {
-                Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(startTime - 60 * 1000).UtcDateTime,
-                Iob = 1.5,
-                Cob = null,
-            }],
+            ApsSnapshotList = [new ApsIobCobPoint(
+                DateTimeOffset.FromUnixTimeMilliseconds(startTime - 60 * 1000).UtcDateTime, 1.5, null)],
         };
 
         var result = await _stage.ExecuteAsync(context, CancellationToken.None);
@@ -468,11 +456,8 @@ public class IobCobComputeStageTests
 
         var second = await _stage.ExecuteAsync(baseContext with
         {
-            ApsSnapshotList = [new ApsSnapshot
-            {
-                Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(startTime - 60 * 1000).UtcDateTime,
-                Iob = 1.5,
-            }],
+            ApsSnapshotList = [new ApsIobCobPoint(
+                DateTimeOffset.FromUnixTimeMilliseconds(startTime - 60 * 1000).UtcDateTime, 1.5, null)],
         }, CancellationToken.None);
 
         second.IobSeries.Should().ContainSingle().Which.Value.Should().Be(1.5);

--- a/tests/Unit/Nocturne.API.Tests/Services/Glucose/PredictionConfigurationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Glucose/PredictionConfigurationTests.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.Configuration;
+using Nocturne.API.Services.Glucose;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Glucose;
+
+public class PredictionConfigurationTests
+{
+    [Fact]
+    public void ResolveSource_NoConfiguration_DefaultsToDeviceStatus()
+    {
+        // Predictions must work out of the box: an AID uploader's curves should render without
+        // any per-deployment Predictions__Source configuration.
+        var configuration = new ConfigurationBuilder().Build();
+
+        Assert.Equal(PredictionSource.DeviceStatus, PredictionOptions.ResolveSource(configuration));
+    }
+
+    [Theory]
+    [InlineData("None", PredictionSource.None)]
+    [InlineData("DeviceStatus", PredictionSource.DeviceStatus)]
+    [InlineData("OrefWasm", PredictionSource.OrefWasm)]
+    public void ResolveSource_ExplicitConfiguration_Wins(string configured, PredictionSource expected)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Predictions:Source"] = configured })
+            .Build();
+
+        Assert.Equal(expected, PredictionOptions.ResolveSource(configuration));
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Treatments/CobCalculatorParityTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Treatments/CobCalculatorParityTests.cs
@@ -307,8 +307,14 @@ public class CobCalculatorParityTests
         Assert.Equal("Care Portal", result.Source);
     }
 
+    /// <summary>
+    /// Deliberate divergence from legacy: the JS cob plugin's <c>if (devicestatusCOB)</c> treats a
+    /// reported COB of 0 as missing and falls back to treatment-derived COB. A device reporting 0
+    /// means "no carbs on board" — the value the AID system acted on — so it is accepted like any
+    /// other reading instead of being overridden by a local recomputation.
+    /// </summary>
     [Fact]
-    public async Task CobTotal_FallsBackToCarbIntakes_WhenApsSnapshotHasZeroCob()
+    public async Task CobTotal_AcceptsApsSnapshotWithZeroCob()
     {
         var time = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         var carbIntakes = new List<CarbIntake> { MakeCarbIntake(time - 1, 20) };
@@ -327,8 +333,8 @@ public class CobCalculatorParityTests
 
         var result = await _calculator.CalculateTotalAsync(carbIntakes, time: time);
 
-        Assert.Equal("Care Portal", result.Source);
-        Assert.True(result.Cob > 0);
+        Assert.Equal("OpenAPS", result.Source);
+        Assert.Equal(0.0, result.Cob);
     }
 
     #endregion

--- a/tests/Unit/Nocturne.API.Tests/Services/Treatments/CobCalculatorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Treatments/CobCalculatorTests.cs
@@ -261,4 +261,64 @@ public class CobCalculatorTests
     }
 
     #endregion
+
+    #region CalculateTotalAsync device-value preference
+
+    [Fact]
+    public async Task CalculateTotalAsync_DeviceReportsZeroCob_ZeroIsAccepted()
+    {
+        // COB of exactly zero from the device means "no carbs on board" and must win over a
+        // local recomputation that still sees recent carb treatments decaying.
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        _apsSnapshotRepo
+            .Setup(r => r.GetAsync(It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new ApsSnapshot
+                {
+                    Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(now - 2 * 60 * 1000).UtcDateTime,
+                    Cob = 0.0,
+                },
+            });
+
+        var carbIntakes = new List<CarbIntake>
+        {
+            new()
+            {
+                Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(now - 30 * 60 * 1000).UtcDateTime,
+                Carbs = 60.0,
+            },
+        };
+
+        var result = await _calculator.CalculateTotalAsync(carbIntakes, time: now);
+
+        Assert.Equal(0.0, result.Cob);
+        Assert.NotEqual("Care Portal", result.Source);
+    }
+
+    [Fact]
+    public async Task CalculateTotalAsync_HistoricalTime_DeviceAgeMeasuredAgainstRequestedInstant()
+    {
+        // A query for a past instant must judge snapshot freshness against that instant, not the
+        // wall clock — otherwise every historical snapshot looks stale and is silently discarded.
+        var historical = DateTimeOffset.UtcNow.AddDays(-30).ToUnixTimeMilliseconds();
+
+        _apsSnapshotRepo
+            .Setup(r => r.GetAsync(It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new ApsSnapshot
+                {
+                    Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(historical - 5 * 60 * 1000).UtcDateTime,
+                    Cob = 25.0,
+                },
+            });
+
+        var result = await _calculator.CalculateTotalAsync(new List<CarbIntake>(), time: historical);
+
+        Assert.Equal(25.0, result.Cob);
+    }
+
+    #endregion
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Treatments/IobCalculatorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Treatments/IobCalculatorTests.cs
@@ -354,6 +354,40 @@ public class IobCalculatorTests
     #region CalculateTotalAsync device-value merge
 
     [Fact]
+    public async Task CalculateTotalAsync_DeviceReportsZeroIob_ZeroIsAccepted()
+    {
+        // IOB of exactly zero from the device is a real value (e.g. after a long suspend) and
+        // must win over a local recomputation that still sees recent boluses decaying.
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        _apsSnapshotRepo
+            .Setup(r => r.GetAsync(It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new ApsSnapshot
+                {
+                    Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(now - 2 * 60 * 1000).UtcDateTime,
+                    Iob = 0.0,
+                },
+            });
+
+        var boluses = new List<Bolus>
+        {
+            new()
+            {
+                Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(now - 30 * 60 * 1000).UtcDateTime,
+                Insulin = 2.0,
+            },
+        };
+
+        var result = await _calculator.CalculateTotalAsync(boluses, time: now);
+
+        Assert.Equal(0.0, result.Iob);
+        Assert.Equal("OpenAPS", result.Source);
+        Assert.NotNull(result.TreatmentIob);
+    }
+
+    [Fact]
     public async Task CalculateTotalAsync_DeviceReportsBasalIob_LocalBasalIobNotAdded()
     {
         // The device's basal IOB already covers its own temp basals; the locally-computed value

--- a/tests/Unit/Nocturne.API.Tests/Services/Treatments/IobCalculatorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Treatments/IobCalculatorTests.cs
@@ -350,4 +350,82 @@ public class IobCalculatorTests
     }
 
     #endregion
+
+    #region CalculateTotalAsync device-value merge
+
+    [Fact]
+    public async Task CalculateTotalAsync_DeviceReportsBasalIob_LocalBasalIobNotAdded()
+    {
+        // The device's basal IOB already covers its own temp basals; the locally-computed value
+        // must not be added on top of it.
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        _apsSnapshotRepo
+            .Setup(r => r.GetAsync(It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new ApsSnapshot
+                {
+                    Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(now - 2 * 60 * 1000).UtcDateTime,
+                    Iob = 2.0,
+                    BasalIob = 0.3,
+                },
+            });
+
+        // An active high temp basal that yields a non-zero local basal IOB.
+        var tempBasals = new List<TempBasal>
+        {
+            new()
+            {
+                StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(now - 60 * 60 * 1000).UtcDateTime,
+                EndTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(now).UtcDateTime,
+                Rate = 3.0,
+                ScheduledRate = DefaultBasalRate,
+                Origin = TempBasalOrigin.Algorithm,
+            },
+        };
+
+        var result = await _calculator.CalculateTotalAsync(new List<Bolus>(), tempBasals, now);
+
+        Assert.Equal(2.0, result.Iob);
+        Assert.Equal(0.3, result.BasalIob);
+    }
+
+    [Fact]
+    public async Task CalculateTotalAsync_DeviceReportsNoBasalIob_LocalBasalIobSubstituted()
+    {
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        _apsSnapshotRepo
+            .Setup(r => r.GetAsync(It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new ApsSnapshot
+                {
+                    Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(now - 2 * 60 * 1000).UtcDateTime,
+                    Iob = 2.0,
+                    BasalIob = null,
+                },
+            });
+
+        var tempBasals = new List<TempBasal>
+        {
+            new()
+            {
+                StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(now - 60 * 60 * 1000).UtcDateTime,
+                EndTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(now).UtcDateTime,
+                Rate = 3.0,
+                ScheduledRate = DefaultBasalRate,
+                Origin = TempBasalOrigin.Algorithm,
+            },
+        };
+
+        var result = await _calculator.CalculateTotalAsync(new List<Bolus>(), tempBasals, now);
+
+        Assert.Equal(2.0, result.Iob);
+        Assert.NotNull(result.BasalIob);
+        Assert.True(result.BasalIob > 0, "local basal IOB should fill in when the device reports none");
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Addresses the IOB/COB/prediction display findings in #354 (jdtoppin's report and follow-up verification).

## Problem

AID systems (Trio, AAPS, Loop) upload the IOB, COB, and prediction curves they acted on, and devicestatus ingestion stores them correctly in `aps_snapshots` — but three independent display paths disagreed about using them:

- The **chart** (`IobCobComputeStage`) recomputed IOB/COB locally from treatments and never consulted APS snapshots, so its curve never matched Trio or the status pill above it.
- The **status pill** took snapshot values verbatim (30-min window).
- **`/api/v4/summary`** preferred device values but added locally-computed basal IOB on top of the device's own `BasalIob` (double-counting temp-basal insulin), and used a different COB recency window (10 min vs 30).
- **Predictions** defaulted to `Predictions:Source=None` with no deployment setting it, so `/api/v4/predictions` returned 404 for every tenant and uploaded curves sat unrendered.

## Changes

- Chart ticks covered by an APS snapshot ≤30 min old take the device-reported IOB/COB verbatim; ticks without one (pre-AID history, upload gaps, care-portal-only tenants) fall back to local recomputation. Snapshots are fetched via a new slim `(Timestamp, Iob, Cob)` projection — no JSON blob columns, no row limit that would truncate high-cadence uploaders.
- All device-preference rules (30-min recency, 5-min future clock skew) unified in one `DeviceReportedValues` constants class shared by the chart, `IobCalculator`, and `CobCalculator`.
- Device-reported IOB/COB of exactly **0** is accepted as a real value ("nothing on board"). Previously both calculators treated 0 as missing (legacy JS falsiness) and substituted local recomputation — deliberate legacy divergence, documented in the parity test.
- Basal IOB no longer double-counted in `CalculateTotalAsync`: the local estimate only substitutes when the device reported none.
- COB snapshot age measured against the requested instant, not the wall clock, so historical queries resolve device values.
- `Predictions:Source` defaults to `DeviceStatus`, resolved through a single `PredictionOptions.ResolveSource` helper so DI registration and `PredictionController` cannot disagree. `DeviceStatusPredictionService` gained a 30-min staleness bound (alert evaluation anchors curve offsets at "now", so a days-old forecast must read as no data, not a current one), and the no-data error is now 404 rather than 400.

## Not addressed here (separate follow-ups from #354)

- v1 `find[...]` filter support (ideaweb's list) — the full `QueryParser` exists but is unwired; separate PR.
- SMB/manual bolus visual distinction in the web UI.
- `pump.reservoir` and `uploader.isCharging` were verified already fixed on main (#450); the reporter's v0.1.5 predates both.

## Testing

- New unit tests: device-preferred chart series (verbatim values, per-component null fallback, stale-snapshot fallback, cache invalidation on new snapshots), zero-IOB/zero-COB acceptance, basal no-double-count, historical-instant COB age, prediction default resolution.
- Full `Nocturne.API.Tests` suite: 4095 passed; 2 pre-existing failures unrelated to this change (`CacheIntegrationTests.CreateEntriesAsync_DecomposesToV4AndFiresEvents` — stale mock from the batch-decomposition change, fails on a clean checkout — and an environment-sensitive memory benchmark).
