### PR TITLE
test(cors): cover the public-docs any-origin policy

### DIFF
--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/PublicDocsCorsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/PublicDocsCorsTests.cs
@@ -1,0 +1,64 @@
+using FluentAssertions;
+using Nocturne.API.Tests.Infrastructure;
+using Xunit;
+
+namespace Nocturne.API.Tests.Multitenancy;
+
+/// <summary>
+/// Covers the CORS split in the request pipeline: the documentation paths (<c>/openapi</c>,
+/// <c>/scalar</c>) are served to any origin, while everything else stays on the credentialed
+/// base-domain policy. Docs sites are hosted off the base domain (getnocturne.dev embeds the
+/// Scalar reference), so without the any-origin policy the browser blocks the spec fetch and
+/// the reference renders empty. Which origins the credentialed default policy itself admits
+/// is covered by <see cref="CorsOriginPolicyTests"/>.
+/// </summary>
+public sealed class PublicDocsCorsTests : IClassFixture<AuthenticationTestFactory>
+{
+    private const string ForeignOrigin = "https://getnocturne.dev";
+
+    private readonly AuthenticationTestFactory _factory;
+
+    public PublicDocsCorsTests(AuthenticationTestFactory factory)
+    {
+        _factory = factory;
+    }
+
+    private HttpClient CreateClient() => _factory.CreateClient();
+
+    [Theory]
+    [InlineData("/openapi/nocturne.json")]      // spec fetched by the embedded reference
+    [InlineData("/scalar/mermaid-loader.js")]   // wwwroot asset, loaded as a crossorigin module
+    public async Task Documentation_paths_are_readable_from_any_origin(string path)
+    {
+        var client = CreateClient();
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Origin", ForeignOrigin);
+
+        var response = await client.SendAsync(request, CancellationToken.None);
+
+        response.Headers.GetValues("Access-Control-Allow-Origin").Should().ContainSingle()
+            .Which.Should().Be("*");
+        // AllowAnyOrigin and credentials are mutually exclusive per the CORS spec; the
+        // any-origin policy must never grant credentials.
+        response.Headers.Contains("Access-Control-Allow-Credentials").Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("/api/v1/status")]
+    [InlineData("/api/v1/entries")]
+    public async Task Api_paths_never_get_the_any_origin_policy(string path)
+    {
+        var client = CreateClient();
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Origin", ForeignOrigin);
+
+        var response = await client.SendAsync(request, CancellationToken.None);
+
+        // Tenant data stays on the credentialed base-domain policy. A wildcard here would
+        // hand every origin read access to the API, so the any-origin policy must not leak
+        // past the documentation paths.
+        response.Headers.Contains("Access-Control-Allow-Origin")
+            .Should().BeFalse(
+                "the any-origin documentation policy must not apply to {0}", path);
+    }
+}


### PR DESCRIPTION
Follow-up test for the CORS split that landed in #527 (the `Program.cs` change in that PR was an unrelated scalar-docs fix that got swept in; this adds the coverage it should have shipped with).

## Why

`https://getnocturne.dev/scalar` rendered an empty page. The portal's Scalar reference fetches its specs from `https://nocturne.run`, and the API's CORS policy only admits the base domain and its subdomains, so the browser blocked both the spec fetch and the `crossorigin` mermaid-loader module:

```
Access to fetch at 'https://nocturne.run/openapi/nocturne.json' from origin
'https://getnocturne.dev' has been blocked by CORS policy: No
'Access-Control-Allow-Origin' header is present on the requested resource.
```

#527 fixed it by serving the documentation paths (`/openapi`, `/scalar`) under a separate any-origin policy, leaving everything else on the credentialed base-domain policy.

## What this adds

- Documentation paths return `Access-Control-Allow-Origin: *` and **no** `Access-Control-Allow-Credentials` (the two are mutually exclusive per the CORS spec). Covers both the spec endpoint and the `wwwroot/scalar` asset, since the latter is served by static files rather than an endpoint.
- API paths never receive the wildcard — the regression that would matter, since a wildcard there would hand every origin read access to the API.

Which origins the credentialed default policy itself admits is already covered by `CorsOriginPolicyTests`; this exercises the pipeline wiring around it.
