### PR TITLE
fix(sdk): OkHttp 3.12-compatible Java SDK with OAuth endpoints

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -71,7 +71,7 @@ jobs:
             echo "version=0.0.0-dev.${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Filter spec to V4 endpoints
+      - name: Filter spec to SDK endpoints (V4 + OAuth)
         run: node sdk/filter-v4-spec.js src/Web/packages/app/src/lib/api/generated/openapi.json sdk/openapi-v4.json
 
       - name: Upload V4 OpenAPI spec
@@ -406,6 +406,7 @@ jobs:
             -i sdk/openapi-v4.json
             -c sdk/java/config.yaml
             -o sdk/java/out
+            --ignore-file-override sdk/java/.openapi-generator-ignore
             --additional-properties=artifactVersion=${{ needs.generate-spec.outputs.sdk_version }}
 
       - name: Fix file permissions
@@ -413,18 +414,35 @@ jobs:
           sudo chown -R $USER:$USER sdk/java/out
           chmod +x sdk/java/out/gradlew
 
-      - name: Apply publish overlay
-        run: |
-          cat sdk/java/publish.gradle >> sdk/java/out/build.gradle
-          # Remove API files with multipart upload bugs (OpenAPI Generator native library issue)
-          rm -f sdk/java/out/src/main/java/org/nightscoutfoundation/nocturne/api/AlertCustomSoundsApi.java
-          rm -f sdk/java/out/src/test/java/org/nightscoutfoundation/nocturne/api/AlertCustomSoundsApiTest.java
-
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: "17"
+
+      - name: Verify OkHttp 3.12 floor compatibility
+        working-directory: sdk/java/out
+        run: |
+          # Android consumers (xDrip) exclude this SDK's OkHttp 4.x/gson transitives and
+          # supply OkHttp 3.12.x / gson 2.8.x. The ApiClient template override in
+          # sdk/java/templates keeps the generated code compatible with both OkHttp majors;
+          # this compile gate stops a generator upgrade from silently regressing that.
+          mkdir -p /tmp/floor
+          for dep in \
+            com/squareup/okhttp3/okhttp/3.12.13/okhttp-3.12.13.jar \
+            com/squareup/okhttp3/logging-interceptor/3.12.13/logging-interceptor-3.12.13.jar \
+            com/squareup/okio/okio/1.15.0/okio-1.15.0.jar \
+            com/google/code/gson/gson/2.8.6/gson-2.8.6.jar \
+            io/gsonfire/gson-fire/1.9.0/gson-fire-1.9.0.jar \
+            com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar \
+            org/openapitools/jackson-databind-nullable/0.2.9/jackson-databind-nullable-0.2.9.jar \
+            jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5.jar; do
+            curl -sfL -o "/tmp/floor/$(basename "$dep")" "https://repo1.maven.org/maven2/$dep"
+          done
+          find src/main/java -name '*.java' > /tmp/floor-files.txt
+          javac -nowarn -proc:none -d /tmp/floor-classes \
+            -cp "$(ls /tmp/floor/*.jar | paste -sd:)" @/tmp/floor-files.txt
+          echo "Generated sources compile against the OkHttp 3.12.13 / gson 2.8.6 floor"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/sdk/filter-v4-spec.js
+++ b/sdk/filter-v4-spec.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 /**
- * Filters the full Nocturne OpenAPI spec down to V4 endpoints only.
+ * Filters the full Nocturne OpenAPI spec down to the SDK surface:
+ * the V4 endpoints plus the OAuth endpoints (/api/oauth/**) that native
+ * clients need for Dynamic Client Registration and the device flow.
  * Usage: node filter-v4-spec.js <input-openapi.json> <output-openapi-v4.json>
  */
 import { readFileSync, writeFileSync } from 'fs';
@@ -13,10 +15,12 @@ if (!inputPath || !outputPath) {
 
 const spec = JSON.parse(readFileSync(inputPath, 'utf8'));
 
-// Filter paths to only /api/v4/**
+// Filter paths to /api/v4/** plus the OAuth endpoints (RFC 7591 dynamic
+// client registration, RFC 8628 device flow, token/revoke) so generated
+// SDKs can drive the full connect flow, not just the data API
 const filteredPaths = {};
 for (const [path, operations] of Object.entries(spec.paths)) {
-  if (path.startsWith('/api/v4/')) {
+  if (path.startsWith('/api/v4/') || path.startsWith('/api/oauth/')) {
     filteredPaths[path] = operations;
   }
 }

--- a/sdk/java/.openapi-generator-ignore
+++ b/sdk/java/.openapi-generator-ignore
@@ -1,0 +1,5 @@
+# Passed to the generator via --ignore-file-override (the output dir is
+# created fresh in CI, so the file can't live there).
+# API files with multipart upload bugs (OpenAPI Generator native library issue)
+**/AlertCustomSoundsApi.java
+**/AlertCustomSoundsApiTest.java

--- a/sdk/java/config.yaml
+++ b/sdk/java/config.yaml
@@ -1,5 +1,10 @@
 generatorName: java
 outputDir: ./out
+# Overrides ApiClient.mustache so RequestBody.create uses the MediaType-first
+# argument order, which exists in both OkHttp 3.12.x and 4.x. Android consumers
+# (xDrip) pin OkHttp 3.12.x; the stock template's content-first order is 4.x-only.
+# Path is relative to the CI working directory (repo root).
+templateDir: sdk/java/templates
 globalProperties:
   skipFormModel: true
 additionalProperties:
@@ -16,4 +21,3 @@ additionalProperties:
   java8: false
   dateLibrary: java8
   openApiNullable: true
-  okHttpVersion: "3.12.13"

--- a/sdk/java/templates/README.md
+++ b/sdk/java/templates/README.md
@@ -1,0 +1,52 @@
+# Java SDK template overrides
+
+Both files are the stock templates from openapi-generator **v7.21.0**
+(`modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/`)
+with minimal, documented changes. Together with `../.openapi-generator-ignore`
+they replace all post-generation shell edits — the generated project under
+`sdk/java/out` needs no mutation before building.
+
+## `libraries/okhttp-gson/ApiClient.mustache`
+
+Every `RequestBody.create(content, mediaType)` call site (9 of them) is
+swapped to the `RequestBody.create(mediaType, content)` argument order.
+
+The MediaType-first order exists in OkHttp 3.x and is retained (deprecated
+but functional) in 4.x, so the generated client is bytecode-compatible with
+both majors. The content-first order the stock template uses only exists in
+OkHttp 4.x. Android consumers — xDrip pins OkHttp 3.12.13 — exclude this
+SDK's OkHttp 4.x transitive and supply their own 3.12.x at runtime, which
+only works if the generated code sticks to the shared API surface.
+
+The "Verify OkHttp 3.12 floor compatibility" step in
+`.github/workflows/sdk-publish.yml` compiles the generated sources against
+OkHttp 3.12.13 / gson 2.8.6 and fails the publish if this guarantee breaks.
+
+Note: `okHttpVersion` in `config.yaml` is **not** a supported
+openapi-generator option — it was silently ignored (versions ≤ 0.2.3
+shipped requiring OkHttp 4.12.0 despite it). The template override plus the
+CI gate is what actually provides 3.x compatibility.
+
+## `libraries/okhttp-gson/build.gradle.mustache`
+
+Two changes:
+
+1. Removes the `jakarta.ws.rs-api` and `commons-lang3` dependencies —
+   declared by the stock template but referenced by zero generated sources.
+2. Appends a guarded `apply from: '../publish.gradle'` so the Maven Central
+   publishing/signing overlay is picked up whenever the project is generated
+   into its repo location (`sdk/java/out`), with no build-file editing in CI.
+
+A stale fork of this template fails loudly: missing dependencies break the
+gradle build, and the publish overlay guard only affects publishing config.
+
+## Refreshing after a generator upgrade
+
+When bumping the pinned `openapitools/openapi-generator-cli` version:
+
+1. Fetch the new tag's stock templates from
+   `https://raw.githubusercontent.com/OpenAPITools/openapi-generator/<tag>/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/`
+2. Re-apply the changes above (diff against the previous stock version to
+   see exactly what was changed).
+3. The floor-compatibility CI step catches a missed `RequestBody.create`
+   swap; a missed build.gradle change surfaces as a gradle build failure.

--- a/sdk/java/templates/libraries/okhttp-gson/ApiClient.mustache
+++ b/sdk/java/templates/libraries/okhttp-gson/ApiClient.mustache
@@ -1,0 +1,1983 @@
+{{>licenseInfo}}
+
+package {{invokerPackage}};
+
+{{#dynamicOperations}}
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.parameters.Parameter.StyleEnum;
+import io.swagger.v3.parser.OpenAPIV3Parser;
+{{/dynamicOperations}}
+import okhttp3.*;
+import okhttp3.internal.http.HttpMethod;
+import okhttp3.internal.tls.OkHostnameVerifier;
+import okhttp3.logging.HttpLoggingInterceptor;
+import okhttp3.logging.HttpLoggingInterceptor.Level;
+import okio.Buffer;
+import okio.BufferedSink;
+import okio.Okio;
+{{#joda}}
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.joda.time.format.DateTimeFormatter;
+{{/joda}}
+{{#hasOAuthMethods}}
+import org.apache.oltu.oauth2.client.request.OAuthClientRequest.TokenRequestBuilder;
+import org.apache.oltu.oauth2.common.message.types.GrantType;
+{{/hasOAuthMethods}}
+
+import javax.net.ssl.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Type;
+import java.net.URI;
+import java.net.URLConnection;
+import java.net.URLEncoder;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.SecureRandom;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.text.DateFormat;
+{{#jsr310}}
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+{{/jsr310}}
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import {{invokerPackage}}.auth.Authentication;
+import {{invokerPackage}}.auth.HttpBasicAuth;
+import {{invokerPackage}}.auth.HttpBearerAuth;
+import {{invokerPackage}}.auth.ApiKeyAuth;
+{{#hasOAuthMethods}}
+import {{invokerPackage}}.auth.OAuth;
+import {{invokerPackage}}.auth.RetryingOAuth;
+import {{invokerPackage}}.auth.OAuthFlow;
+{{/hasOAuthMethods}}
+{{#withAWSV4Signature}}
+import {{invokerPackage}}.auth.AWS4Auth;
+{{/withAWSV4Signature}}
+
+/**
+ * <p>ApiClient class.</p>
+ */
+public class ApiClient {
+
+    protected String basePath = "{{{basePath}}}";
+    protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>({{#servers}}{{#-first}}Arrays.asList(
+{{/-first}}    new ServerConfiguration(
+      "{{{url}}}",
+      "{{{description}}}{{^description}}No description provided{{/description}}",
+      new HashMap<String, ServerVariable>(){{#variables}}{{#-first}} {{
+{{/-first}}        put("{{{name}}}", new ServerVariable(
+          "{{{description}}}{{^description}}No description provided{{/description}}",
+          "{{{defaultValue}}}",
+          new HashSet<String>(
+          {{#enumValues}}
+          {{#-first}}
+            Arrays.asList(
+          {{/-first}}
+              "{{{.}}}"{{^-last}},{{/-last}}
+          {{#-last}}
+            )
+          {{/-last}}
+          {{/enumValues}}
+          )
+        ));
+      {{#-last}}
+      }}{{/-last}}{{/variables}}
+    ){{^-last}},{{/-last}}
+  {{#-last}}
+  ){{/-last}}{{/servers}});
+    protected Integer serverIndex = 0;
+    protected Map<String, String> serverVariables = null;
+    protected boolean debugging = false;
+    protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+    protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+    protected String tempFolderPath = null;
+
+    protected Map<String, Authentication> authentications;
+
+    protected DateFormat dateFormat;
+    protected DateFormat datetimeFormat;
+    protected boolean lenientDatetimeFormat;
+    protected int dateLength;
+
+    protected InputStream sslCaCert;
+    protected boolean verifyingSsl;
+    protected KeyManager[] keyManagers;
+    protected String tlsServerName;
+    
+    protected OkHttpClient httpClient;
+    protected JSON json;
+
+    protected HttpLoggingInterceptor loggingInterceptor;
+
+    {{#dynamicOperations}}
+    protected Map<String, ApiOperation> operationLookupMap = new HashMap<>();
+
+    {{/dynamicOperations}}
+    /**
+     * Basic constructor for ApiClient
+     */
+    public ApiClient() {
+        init();
+        initHttpClient();
+
+        // Setup authentications (key: authentication name, value: authentication).{{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
+        authentications.put("{{name}}", new HttpBasicAuth());{{/isBasicBasic}}{{#isBasicBearer}}
+        authentications.put("{{name}}", new HttpBearerAuth("{{scheme}}"));{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
+        authentications.put("{{name}}", new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{#isKeyInQuery}}"query"{{/isKeyInQuery}}{{#isKeyInCookie}}"cookie"{{/isKeyInCookie}}, "{{keyParamName}}"));{{/isApiKey}}{{#isOAuth}}
+        authentications.put("{{name}}", new OAuth());{{/isOAuth}}{{/authMethods}}{{#withAWSV4Signature}}
+        authentications.put("AWS4Auth", new AWS4Auth());{{/withAWSV4Signature}}
+        // Prevent the authentications from being modified.
+        authentications = Collections.unmodifiableMap(authentications);
+    }
+
+    /**
+     * Basic constructor with custom OkHttpClient
+     *
+     * @param client a {@link okhttp3.OkHttpClient} object
+     */
+    public ApiClient(OkHttpClient client) {
+        init();
+
+        httpClient = client;
+
+        // Setup authentications (key: authentication name, value: authentication).{{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
+        authentications.put("{{name}}", new HttpBasicAuth());{{/isBasicBasic}}{{#isBasicBearer}}
+        authentications.put("{{name}}", new HttpBearerAuth("{{scheme}}"));{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
+        authentications.put("{{name}}", new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{#isKeyInQuery}}"query"{{/isKeyInQuery}}{{#isKeyInCookie}}"cookie"{{/isKeyInCookie}}, "{{keyParamName}}"));{{/isApiKey}}{{#isOAuth}}
+        authentications.put("{{name}}", new OAuth());{{/isOAuth}}{{/authMethods}}{{#withAWSV4Signature}}
+        authentications.put("AWS4Auth", new AWS4Auth());{{/withAWSV4Signature}}
+        // Prevent the authentications from being modified.
+        authentications = Collections.unmodifiableMap(authentications);
+    }
+
+    {{#hasOAuthMethods}}
+    {{#oauthMethods}}
+    {{#-first}}
+    /**
+     * Constructor for ApiClient to support access token retry on 401/403 configured with client ID
+     *
+     * @param clientId client ID
+     */
+    public ApiClient(String clientId) {
+        this(clientId, null, null);
+    }
+
+    /**
+     * Constructor for ApiClient to support access token retry on 401/403 configured with client ID and additional parameters
+     *
+     * @param clientId client ID
+     * @param parameters a {@link java.util.Map} of parameters
+     */
+    public ApiClient(String clientId, Map<String, String> parameters) {
+        this(clientId, null, parameters);
+    }
+
+    /**
+     * Constructor for ApiClient to support access token retry on 401/403 configured with client ID, secret, and additional parameters
+     *
+     * @param clientId client ID
+     * @param clientSecret client secret
+     * @param parameters a {@link java.util.Map} of parameters
+     */
+    public ApiClient(String clientId, String clientSecret, Map<String, String> parameters) {
+        this(null, clientId, clientSecret, parameters);
+    }
+
+    /**
+     * Constructor for ApiClient to support access token retry on 401/403 configured with base path, client ID, secret, and additional parameters
+     *
+     * @param basePath base path
+     * @param clientId client ID
+     * @param clientSecret client secret
+     * @param parameters a {@link java.util.Map} of parameters
+     */
+    public ApiClient(String basePath, String clientId, String clientSecret, Map<String, String> parameters) {
+        init();
+        if (basePath != null) {
+            this.basePath = basePath;
+        }
+
+        String tokenUrl = "{{{tokenUrl}}}";
+        if (!"".equals(tokenUrl) && !URI.create(tokenUrl).isAbsolute()) {
+            URI uri = URI.create(getBasePath());
+            tokenUrl = uri.getScheme() + ":" +
+                (uri.getAuthority() != null ? "//" + uri.getAuthority() : "") +
+                tokenUrl;
+            if (!URI.create(tokenUrl).isAbsolute()) {
+                throw new IllegalArgumentException("OAuth2 token URL must be an absolute URL");
+            }
+        }
+        RetryingOAuth retryingOAuth = new RetryingOAuth(tokenUrl, clientId, OAuthFlow.{{#lambda.uppercase}}{{#lambda.snakecase}}{{flow}}{{/lambda.snakecase}}{{/lambda.uppercase}}, clientSecret, parameters);
+        authentications.put(
+                "{{name}}",
+                retryingOAuth
+        );
+        initHttpClient(Collections.<Interceptor>singletonList(retryingOAuth));
+        // Setup authentications (key: authentication name, value: authentication).{{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
+        authentications.put("{{name}}", new HttpBasicAuth());{{/isBasicBasic}}{{#isBasicBearer}}
+        authentications.put("{{name}}", new HttpBearerAuth("{{scheme}}"));{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
+        authentications.put("{{name}}", new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{#isKeyInQuery}}"query"{{/isKeyInQuery}}{{#isKeyInCookie}}"cookie"{{/isKeyInCookie}}, "{{keyParamName}}"));{{/isApiKey}}{{/authMethods}}{{#withAWSV4Signature}}
+        authentications.put("AWS4Auth", new AWS4Auth());{{/withAWSV4Signature}}
+
+        // Prevent the authentications from being modified.
+        authentications = Collections.unmodifiableMap(authentications);
+    }
+
+    {{/-first}}
+    {{/oauthMethods}}
+    {{/hasOAuthMethods}}
+    protected void initHttpClient() {
+        initHttpClient(Collections.<Interceptor>emptyList());
+    }
+
+    protected void initHttpClient(List<Interceptor> interceptors) {
+        OkHttpClient.Builder builder = new OkHttpClient.Builder();
+        builder.addNetworkInterceptor(getProgressInterceptor());
+        for (Interceptor interceptor: interceptors) {
+            builder.addInterceptor(interceptor);
+        }
+        {{#useGzipFeature}}
+        // Enable gzip request compression
+        builder.addInterceptor(new GzipRequestInterceptor());
+        {{/useGzipFeature}}
+
+        httpClient = builder.build();
+    }
+
+    protected void init() {
+        verifyingSsl = true;
+
+        json = new JSON();
+
+        // Set default User-Agent.
+        setUserAgent("{{{httpUserAgent}}}{{^httpUserAgent}}OpenAPI-Generator/{{{artifactVersion}}}/java{{/httpUserAgent}}");
+
+        authentications = new HashMap<String, Authentication>();
+        {{#dynamicOperations}}
+
+        OpenAPI openAPI = new OpenAPIV3Parser().read("openapi/openapi.yaml");
+        createOperationLookupMap(openAPI);
+        {{/dynamicOperations}}
+    }
+
+    /**
+     * Get base path
+     *
+     * @return Base path
+     */
+    public String getBasePath() {
+        return basePath;
+    }
+
+    /**
+     * Set base path
+     *
+     * @param basePath Base path of the URL (e.g {{{basePath}}})
+     * @return An instance of ApiClient
+     */
+    public ApiClient setBasePath(String basePath) {
+        this.basePath = basePath;
+        this.serverIndex = null;
+        return this;
+    }
+
+    public List<ServerConfiguration> getServers() {
+        return servers;
+    }
+
+    public ApiClient setServers(List<ServerConfiguration> servers) {
+        this.servers = servers;
+        return this;
+    }
+
+    public Integer getServerIndex() {
+        return serverIndex;
+    }
+
+    public ApiClient setServerIndex(Integer serverIndex) {
+        this.serverIndex = serverIndex;
+        return this;
+    }
+
+    public Map<String, String> getServerVariables() {
+        return serverVariables;
+    }
+
+    public ApiClient setServerVariables(Map<String, String> serverVariables) {
+        this.serverVariables = serverVariables;
+        return this;
+    }
+
+    /**
+     * Get HTTP client
+     *
+     * @return An instance of OkHttpClient
+     */
+    public OkHttpClient getHttpClient() {
+        return httpClient;
+    }
+
+    /**
+     * Set HTTP client, which must never be null.
+     *
+     * @param newHttpClient An instance of OkHttpClient
+     * @return ApiClient
+     * @throws java.lang.NullPointerException when newHttpClient is null
+     */
+    public ApiClient setHttpClient(OkHttpClient newHttpClient) {
+        this.httpClient = Objects.requireNonNull(newHttpClient, "HttpClient must not be null!");
+        return this;
+    }
+
+    /**
+     * Get JSON
+     *
+     * @return JSON object
+     */
+    public JSON getJSON() {
+        return json;
+    }
+
+    /**
+     * Set JSON
+     *
+     * @param json JSON object
+     * @return Api client
+     */
+    public ApiClient setJSON(JSON json) {
+        this.json = json;
+        return this;
+    }
+
+    /**
+     * True if isVerifyingSsl flag is on
+     *
+     * @return True if isVerifySsl flag is on
+     */
+    public boolean isVerifyingSsl() {
+        return verifyingSsl;
+    }
+
+    /**
+     * Configure whether to verify certificate and hostname when making https requests.
+     * Default to true.
+     * NOTE: Do NOT set to false in production code, otherwise you would face multiple types of cryptographic attacks.
+     *
+     * @param verifyingSsl True to verify TLS/SSL connection
+     * @return ApiClient
+     */
+    public ApiClient setVerifyingSsl(boolean verifyingSsl) {
+        this.verifyingSsl = verifyingSsl;
+        applySslSettings();
+        return this;
+    }
+
+    /**
+     * Get SSL CA cert.
+     *
+     * @return Input stream to the SSL CA cert
+     */
+    public InputStream getSslCaCert() {
+        return sslCaCert;
+    }
+
+    /**
+     * Configure the CA certificate to be trusted when making https requests.
+     * Use null to reset to default.
+     *
+     * @param sslCaCert input stream for SSL CA cert
+     * @return ApiClient
+     */
+    public ApiClient setSslCaCert(InputStream sslCaCert) {
+        this.sslCaCert = sslCaCert;
+        applySslSettings();
+        return this;
+    }
+
+    /**
+     * <p>Getter for the field <code>keyManagers</code>.</p>
+     *
+     * @return an array of {@link javax.net.ssl.KeyManager} objects
+     */
+    public KeyManager[] getKeyManagers() {
+        return keyManagers;
+    }
+
+    /**
+     * Configure client keys to use for authorization in an SSL session.
+     * Use null to reset to default.
+     *
+     * @param managers The KeyManagers to use
+     * @return ApiClient
+     */
+    public ApiClient setKeyManagers(KeyManager[] managers) {
+        this.keyManagers = managers;
+        applySslSettings();
+        return this;
+    }
+
+    /**
+     * Get TLS server name for SNI (Server Name Indication).
+     *
+     * @return The TLS server name
+     */
+    public String getTlsServerName() {
+        return tlsServerName;
+    }
+
+    /**
+     * Set TLS server name for SNI (Server Name Indication).
+     * This is used to verify the server certificate against a specific hostname
+     * instead of the hostname in the URL.
+     *
+     * @param tlsServerName The TLS server name to use for certificate verification
+     * @return ApiClient
+     */
+    public ApiClient setTlsServerName(String tlsServerName) {
+        this.tlsServerName = tlsServerName;
+        applySslSettings();
+        return this;
+    }
+
+    /**
+     * <p>Getter for the field <code>dateFormat</code>.</p>
+     *
+     * @return a {@link java.text.DateFormat} object
+     */
+    public DateFormat getDateFormat() {
+        return dateFormat;
+    }
+
+    /**
+     * <p>Setter for the field <code>dateFormat</code>.</p>
+     *
+     * @param dateFormat a {@link java.text.DateFormat} object
+     * @return a {@link {{invokerPackage}}.ApiClient} object
+     */
+    public ApiClient setDateFormat(DateFormat dateFormat) {
+        JSON.setDateFormat(dateFormat);
+        return this;
+    }
+
+    /**
+     * <p>Set SqlDateFormat.</p>
+     *
+     * @param dateFormat a {@link java.text.DateFormat} object
+     * @return a {@link {{invokerPackage}}.ApiClient} object
+     */
+    public ApiClient setSqlDateFormat(DateFormat dateFormat) {
+        JSON.setSqlDateFormat(dateFormat);
+        return this;
+    }
+
+    {{#joda}}
+    public ApiClient setDateTimeFormat(DateTimeFormatter dateFormat) {
+        JSON.setDateTimeFormat(dateFormat);
+        return this;
+    }
+
+    public ApiClient setLocalDateFormat(DateTimeFormatter dateFormat) {
+        JSON.setLocalDateFormat(dateFormat);
+        return this;
+    }
+
+    {{/joda}}
+    {{#jsr310}}
+    /**
+     * <p>Set OffsetDateTimeFormat.</p>
+     *
+     * @param dateFormat a {@link java.time.format.DateTimeFormatter} object
+     * @return a {@link {{invokerPackage}}.ApiClient} object
+     */
+    public ApiClient setOffsetDateTimeFormat(DateTimeFormatter dateFormat) {
+        JSON.setOffsetDateTimeFormat(dateFormat);
+        return this;
+    }
+
+    /**
+     * <p>Set LocalDateFormat.</p>
+     *
+     * @param dateFormat a {@link java.time.format.DateTimeFormatter} object
+     * @return a {@link {{invokerPackage}}.ApiClient} object
+     */
+    public ApiClient setLocalDateFormat(DateTimeFormatter dateFormat) {
+        JSON.setLocalDateFormat(dateFormat);
+        return this;
+    }
+
+    {{/jsr310}}
+    /**
+     * <p>Set LenientOnJson.</p>
+     *
+     * @param lenientOnJson a boolean
+     * @return a {@link {{invokerPackage}}.ApiClient} object
+     */
+    public ApiClient setLenientOnJson(boolean lenientOnJson) {
+        JSON.setLenientOnJson(lenientOnJson);
+        return this;
+    }
+
+    /**
+     * Get authentications (key: authentication name, value: authentication).
+     *
+     * @return Map of authentication objects
+     */
+    public Map<String, Authentication> getAuthentications() {
+        return authentications;
+    }
+
+    /**
+     * Get authentication for the given name.
+     *
+     * @param authName The authentication name
+     * @return The authentication, null if not found
+     */
+    public Authentication getAuthentication(String authName) {
+        return authentications.get(authName);
+    }
+
+    {{#hasHttpBearerMethods}}
+    /**
+     * Helper method to set access token for the first Bearer authentication.
+     * @param bearerToken Bearer token
+     */
+    public void setBearerToken(String bearerToken) {
+        setBearerToken(() -> bearerToken);
+    }
+
+    /**
+     * Helper method to set the supplier of access tokens for Bearer authentication.
+     *
+     * @param tokenSupplier The supplier of bearer tokens
+     */
+    public void setBearerToken(Supplier<String> tokenSupplier) {
+        for (Authentication auth : authentications.values()) {
+            if (auth instanceof HttpBearerAuth) {
+                ((HttpBearerAuth) auth).setBearerToken(tokenSupplier);
+                return;
+            }
+        }
+        throw new RuntimeException("No Bearer authentication configured!");
+    }
+    {{/hasHttpBearerMethods}}
+
+    /**
+     * Helper method to set username for the first HTTP basic authentication.
+     *
+     * @param username Username
+     */
+    public void setUsername(String username) {
+        for (Authentication auth : authentications.values()) {
+            if (auth instanceof HttpBasicAuth) {
+                ((HttpBasicAuth) auth).setUsername(username);
+                return;
+            }
+        }
+        throw new RuntimeException("No HTTP basic authentication configured!");
+    }
+
+    /**
+     * Helper method to set password for the first HTTP basic authentication.
+     *
+     * @param password Password
+     */
+    public void setPassword(String password) {
+        for (Authentication auth : authentications.values()) {
+            if (auth instanceof HttpBasicAuth) {
+                ((HttpBasicAuth) auth).setPassword(password);
+                return;
+            }
+        }
+        throw new RuntimeException("No HTTP basic authentication configured!");
+    }
+
+    /**
+     * Helper method to set API key value for the first API key authentication.
+     *
+     * @param apiKey API key
+     */
+    public void setApiKey(String apiKey) {
+        for (Authentication auth : authentications.values()) {
+            if (auth instanceof ApiKeyAuth) {
+                ((ApiKeyAuth) auth).setApiKey(apiKey);
+                return;
+            }
+        }
+        throw new RuntimeException("No API key authentication configured!");
+    }
+
+    /**
+     * Helper method to set API key prefix for the first API key authentication.
+     *
+     * @param apiKeyPrefix API key prefix
+     */
+    public void setApiKeyPrefix(String apiKeyPrefix) {
+        for (Authentication auth : authentications.values()) {
+            if (auth instanceof ApiKeyAuth) {
+                ((ApiKeyAuth) auth).setApiKeyPrefix(apiKeyPrefix);
+                return;
+            }
+        }
+        throw new RuntimeException("No API key authentication configured!");
+    }
+
+    /**
+     * Helper method to set access token for the first OAuth2 authentication.
+     *
+     * @param accessToken Access token
+     */
+    public void setAccessToken(String accessToken) {
+        {{#hasOAuthMethods}}
+        for (Authentication auth : authentications.values()) {
+            if (auth instanceof OAuth) {
+                ((OAuth) auth).setAccessToken(accessToken);
+                return;
+            }
+        }
+        {{/hasOAuthMethods}}
+        throw new RuntimeException("No OAuth2 authentication configured!");
+    }
+
+    /**
+     * Helper method to set credentials for AWSV4 Signature
+     *
+     * @param accessKey Access Key
+     * @param secretKey Secret Key
+     * @param region Region
+     * @param service Service to access to
+     */
+    public void setAWS4Configuration(String accessKey, String secretKey, String region, String service) {
+        {{#withAWSV4Signature}}
+        for (Authentication auth : authentications.values()) {
+            if (auth instanceof AWS4Auth) {
+                ((AWS4Auth) auth).setCredentials(accessKey, secretKey);
+                ((AWS4Auth) auth).setRegion(region);
+                ((AWS4Auth) auth).setService(service);
+                return;
+            }
+        }
+        {{/withAWSV4Signature}}
+        throw new RuntimeException("No AWS4 authentication configured!");
+    }
+
+    /**
+     * Helper method to set credentials for AWSV4 Signature
+     *
+     * @param accessKey Access Key
+     * @param secretKey Secret Key
+     * @param sessionToken Session Token
+     * @param region Region
+     * @param service Service to access to
+     */
+    public void setAWS4Configuration(String accessKey, String secretKey, String sessionToken, String region, String service) {
+        {{#withAWSV4Signature}}
+        for (Authentication auth : authentications.values()) {
+            if (auth instanceof AWS4Auth) {
+                ((AWS4Auth) auth).setCredentials(accessKey, secretKey, sessionToken);
+                ((AWS4Auth) auth).setRegion(region);
+                ((AWS4Auth) auth).setService(service);
+                return;
+            }
+        }
+        {{/withAWSV4Signature}}
+        throw new RuntimeException("No AWS4 authentication configured!");
+    }
+
+    /**
+     * Set the User-Agent header's value (by adding to the default header map).
+     *
+     * @param userAgent HTTP request's user agent
+     * @return ApiClient
+     */
+    public ApiClient setUserAgent(String userAgent) {
+        addDefaultHeader("User-Agent", userAgent);
+        return this;
+    }
+
+    /**
+     * Add a default header.
+     *
+     * @param key The header's key
+     * @param value The header's value
+     * @return ApiClient
+     */
+    public ApiClient addDefaultHeader(String key, String value) {
+        defaultHeaderMap.put(key, value);
+        return this;
+    }
+
+    /**
+     * Add a default cookie.
+     *
+     * @param key The cookie's key
+     * @param value The cookie's value
+     * @return ApiClient
+     */
+    public ApiClient addDefaultCookie(String key, String value) {
+        defaultCookieMap.put(key, value);
+        return this;
+    }
+
+    /**
+     * Check that whether debugging is enabled for this API client.
+     *
+     * @return True if debugging is enabled, false otherwise.
+     */
+    public boolean isDebugging() {
+        return debugging;
+    }
+
+    /**
+     * Enable/disable debugging for this API client.
+     *
+     * @param debugging To enable (true) or disable (false) debugging
+     * @return ApiClient
+     */
+    public ApiClient setDebugging(boolean debugging) {
+        if (debugging != this.debugging) {
+            if (debugging) {
+                loggingInterceptor = new HttpLoggingInterceptor();
+                loggingInterceptor.setLevel(Level.BODY);
+                httpClient = httpClient.newBuilder().addInterceptor(loggingInterceptor).build();
+            } else {
+                final OkHttpClient.Builder builder = httpClient.newBuilder();
+                builder.interceptors().remove(loggingInterceptor);
+                httpClient = builder.build();
+                loggingInterceptor = null;
+            }
+        }
+        this.debugging = debugging;
+        return this;
+    }
+
+    /**
+     * The path of temporary folder used to store downloaded files from endpoints
+     * with file response. The default value is <code>null</code>, i.e. using
+     * the system's default temporary folder.
+     *
+     * @see <a href="https://docs.oracle.com/javase/7/docs/api/java/nio/file/Files.html#createTempFile(java.lang.String,%20java.lang.String,%20java.nio.file.attribute.FileAttribute...)">createTempFile</a>
+     * @return Temporary folder path
+     */
+    public String getTempFolderPath() {
+        return tempFolderPath;
+    }
+
+    /**
+     * Set the temporary folder path (for downloading files)
+     *
+     * @param tempFolderPath Temporary folder path
+     * @return ApiClient
+     */
+    public ApiClient setTempFolderPath(String tempFolderPath) {
+        this.tempFolderPath = tempFolderPath;
+        return this;
+    }
+
+    /**
+     * Get connection timeout (in milliseconds).
+     *
+     * @return Timeout in milliseconds
+     */
+    public int getConnectTimeout() {
+        return httpClient.connectTimeoutMillis();
+    }
+
+    /**
+     * Sets the connect timeout (in milliseconds).
+     * A value of 0 means no timeout, otherwise values must be between 1 and
+     * {@link java.lang.Integer#MAX_VALUE}.
+     *
+     * @param connectionTimeout connection timeout in milliseconds
+     * @return Api client
+     */
+    public ApiClient setConnectTimeout(int connectionTimeout) {
+        httpClient = httpClient.newBuilder().connectTimeout(connectionTimeout, TimeUnit.MILLISECONDS).build();
+        return this;
+    }
+
+    /**
+     * Get read timeout (in milliseconds).
+     *
+     * @return Timeout in milliseconds
+     */
+    public int getReadTimeout() {
+        return httpClient.readTimeoutMillis();
+    }
+
+    /**
+     * Sets the read timeout (in milliseconds).
+     * A value of 0 means no timeout, otherwise values must be between 1 and
+     * {@link java.lang.Integer#MAX_VALUE}.
+     *
+     * @param readTimeout read timeout in milliseconds
+     * @return Api client
+     */
+    public ApiClient setReadTimeout(int readTimeout) {
+        httpClient = httpClient.newBuilder().readTimeout(readTimeout, TimeUnit.MILLISECONDS).build();
+        return this;
+    }
+
+    /**
+     * Get write timeout (in milliseconds).
+     *
+     * @return Timeout in milliseconds
+     */
+    public int getWriteTimeout() {
+        return httpClient.writeTimeoutMillis();
+    }
+
+    /**
+     * Sets the write timeout (in milliseconds).
+     * A value of 0 means no timeout, otherwise values must be between 1 and
+     * {@link java.lang.Integer#MAX_VALUE}.
+     *
+     * @param writeTimeout connection timeout in milliseconds
+     * @return Api client
+     */
+    public ApiClient setWriteTimeout(int writeTimeout) {
+        httpClient = httpClient.newBuilder().writeTimeout(writeTimeout, TimeUnit.MILLISECONDS).build();
+        return this;
+    }
+
+    {{#hasOAuthMethods}}
+    /**
+     * Helper method to configure the token endpoint of the first oauth found in the apiAuthorizations (there should be only one)
+     *
+     * @return Token request builder
+     */
+    public TokenRequestBuilder getTokenEndPoint() {
+        for (Authentication apiAuth : authentications.values()) {
+            if (apiAuth instanceof RetryingOAuth) {
+                RetryingOAuth retryingOAuth = (RetryingOAuth) apiAuth;
+                return retryingOAuth.getTokenRequestBuilder();
+            }
+        }
+        return null;
+    }
+    {{/hasOAuthMethods}}
+
+    /**
+     * Format the given parameter object into string.
+     *
+     * @param param Parameter
+     * @return String representation of the parameter
+     */
+    public String parameterToString(Object param) {
+        if (param == null) {
+            return "";
+        } else if (param instanceof Date {{#joda}}|| param instanceof DateTime || param instanceof LocalDate{{/joda}}{{#jsr310}}|| param instanceof OffsetDateTime || param instanceof LocalDate{{/jsr310}}) {
+            //Serialize to json string and remove the " enclosing characters
+            String jsonStr = JSON.serialize(param);
+            return jsonStr.substring(1, jsonStr.length() - 1);
+        } else if (param instanceof Collection) {
+            StringBuilder b = new StringBuilder();
+            for (Object o : (Collection) param) {
+                if (b.length() > 0) {
+                    b.append(",");
+                }
+                b.append(o);
+            }
+            return b.toString();
+        } else {
+            return String.valueOf(param);
+        }
+    }
+
+    /**
+     * Formats the specified query parameter to a list containing a single {@code Pair} object.
+     *
+     * Note that {@code value} must not be a collection.
+     *
+     * @param name The name of the parameter.
+     * @param value The value of the parameter.
+     * @return A list containing a single {@code Pair} object.
+     */
+    public List<Pair> parameterToPair(String name, Object value) {
+        List<Pair> params = new ArrayList<Pair>();
+
+        // preconditions
+        if (name == null || name.isEmpty() || value == null || value instanceof Collection) {
+            return params;
+        }
+
+        params.add(new Pair(name, parameterToString(value)));
+        return params;
+    }
+
+    {{^dynamicOperations}}
+    /**
+     * Formats the specified collection query parameters to a list of {@code Pair} objects.
+     *
+     * Note that the values of each of the returned Pair objects are percent-encoded.
+     *
+     * @param collectionFormat The collection format of the parameter.
+     * @param name The name of the parameter.
+     * @param value The value of the parameter.
+     * @return A list of {@code Pair} objects.
+     */
+    public List<Pair> parameterToPairs(String collectionFormat, String name, Collection<?> value) {
+        List<Pair> params = new ArrayList<Pair>();
+
+        // preconditions
+        if (name == null || name.isEmpty() || value == null || value.isEmpty()) {
+            return params;
+        }
+
+        // create the params based on the collection format
+        if ("multi".equals(collectionFormat)) {
+            for (Object item : value) {
+                params.add(new Pair(name, escapeString(parameterToString(item))));
+            }
+            return params;
+        }
+
+        // collectionFormat is assumed to be "csv" by default
+        String delimiter = ",";
+
+        // escape all delimiters except commas, which are URI reserved
+        // characters
+        if ("ssv".equals(collectionFormat)) {
+            delimiter = escapeString(" ");
+        } else if ("tsv".equals(collectionFormat)) {
+            delimiter = escapeString("\t");
+        } else if ("pipes".equals(collectionFormat)) {
+            delimiter = escapeString("|");
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (Object item : value) {
+            sb.append(delimiter);
+            sb.append(escapeString(parameterToString(item)));
+        }
+
+        params.add(new Pair(name, sb.substring(delimiter.length())));
+
+        return params;
+    }
+    {{/dynamicOperations}}
+    {{#dynamicOperations}}
+    public List<Pair> parameterToPairs(Parameter param, Collection value) {
+        List<Pair> params = new ArrayList<Pair>();
+
+        // preconditions
+        if (param == null || param.getName() == null || param.getName().isEmpty() || value == null || value.isEmpty()) {
+            return params;
+        }
+
+        // create the params based on the collection format
+        if (StyleEnum.FORM.equals(param.getStyle()) && Boolean.TRUE.equals(param.getExplode())) {
+            for (Object item : value) {
+                params.add(new Pair(param.getName(), escapeString(parameterToString(item))));
+            }
+            return params;
+        }
+
+        // collectionFormat is assumed to be "csv" by default
+        String delimiter = ",";
+
+        // escape all delimiters except commas, which are URI reserved
+        // characters
+        if (StyleEnum.SPACEDELIMITED.equals(param.getStyle())) {
+            delimiter = escapeString(" ");
+        } else if (StyleEnum.PIPEDELIMITED.equals(param.getStyle())) {
+            delimiter = escapeString("|");
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (Object item : value) {
+            sb.append(delimiter);
+            sb.append(escapeString(parameterToString(item)));
+        }
+
+        params.add(new Pair(param.getName(), sb.substring(delimiter.length())));
+
+        return params;
+    }
+    {{/dynamicOperations}}
+
+   /**
+    * Formats the specified free-form query parameters to a list of {@code Pair} objects.
+    *
+    * @param value The free-form query parameters.
+    * @return A list of {@code Pair} objects.
+    */
+    public List<Pair> freeFormParameterToPairs(Object value) {
+        List<Pair> params = new ArrayList<>();
+
+        // preconditions
+        if (value == null || !(value instanceof Map )) {
+            return params;
+        }
+
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> valuesMap = (Map<String, Object>) value;
+
+        for (Map.Entry<String, Object> entry : valuesMap.entrySet()) {
+            params.add(new Pair(entry.getKey(), parameterToString(entry.getValue())));
+        }
+
+        return params;
+    }
+
+
+    /**
+     * Formats the specified collection path parameter to a string value.
+     *
+     * @param collectionFormat The collection format of the parameter.
+     * @param value The value of the parameter.
+     * @return String representation of the parameter
+     */
+    public String collectionPathParameterToString(String collectionFormat, Collection value) {
+        // create the value based on the collection format
+        if ("multi".equals(collectionFormat)) {
+            // not valid for path params
+            return parameterToString(value);
+        }
+
+        // collectionFormat is assumed to be "csv" by default
+        String delimiter = ",";
+
+        if ("ssv".equals(collectionFormat)) {
+            delimiter = " ";
+        } else if ("tsv".equals(collectionFormat)) {
+            delimiter = "\t";
+        } else if ("pipes".equals(collectionFormat)) {
+            delimiter = "|";
+        }
+
+        StringBuilder sb = new StringBuilder() ;
+        for (Object item : value) {
+            sb.append(delimiter);
+            sb.append(parameterToString(item));
+        }
+
+        return sb.substring(delimiter.length());
+    }
+
+    /**
+     * Sanitize filename by removing path.
+     * e.g. ../../sun.gif becomes sun.gif
+     *
+     * @param filename The filename to be sanitized
+     * @return The sanitized filename
+     */
+    public String sanitizeFilename(String filename) {
+        return filename.replaceFirst("^.*[/\\\\]", "");
+    }
+
+    /**
+     * Check if the given MIME is a JSON MIME.
+     * JSON MIME examples:
+     *   application/json
+     *   application/json; charset=UTF8
+     *   APPLICATION/JSON
+     *   application/vnd.company+json
+     * "* / *" is also default to JSON
+     * @param mime MIME (Multipurpose Internet Mail Extensions)
+     * @return True if the given MIME is JSON, false otherwise.
+     */
+    public boolean isJsonMime(String mime) {
+        String jsonMime = "(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
+        return mime != null && (mime.matches(jsonMime) || mime.equals("*/*"));
+    }
+
+    /**
+     * Select the Accept header's value from the given accepts array:
+     *   if JSON exists in the given array, use it;
+     *   otherwise use all of them (joining into a string)
+     *
+     * @param accepts The accepts array to select from
+     * @return The Accept header to use. If the given array is empty,
+     *   null will be returned (not to set the Accept header explicitly).
+     */
+    public String selectHeaderAccept(String[] accepts) {
+        if (accepts.length == 0) {
+            return null;
+        }
+        for (String accept : accepts) {
+            if (isJsonMime(accept)) {
+                return accept;
+            }
+        }
+        return StringUtil.join(accepts, ",");
+    }
+
+    /**
+     * Select the Content-Type header's value from the given array:
+     *   if JSON exists in the given array, use it;
+     *   otherwise use the first one of the array.
+     *
+     * @param contentTypes The Content-Type array to select from
+     * @return The Content-Type header to use. If the given array is empty,
+     *   returns null. If it matches "any", JSON will be used.
+     */
+    public String selectHeaderContentType(String[] contentTypes) {
+        if (contentTypes.length == 0) {
+            return null;
+        }
+
+        if (contentTypes[0].equals("*/*")) {
+            return "application/json";
+        }
+
+        for (String contentType : contentTypes) {
+            if (isJsonMime(contentType)) {
+                return contentType;
+            }
+        }
+
+        return contentTypes[0];
+    }
+
+    /**
+     * Escape the given string to be used as URL query value.
+     *
+     * @param str String to be escaped
+     * @return Escaped string
+     */
+    public String escapeString(String str) {
+        try {
+            return URLEncoder.encode(str, "utf8").replaceAll("\\+", "%20");
+        } catch (UnsupportedEncodingException e) {
+            return str;
+        }
+    }
+
+    /**
+     * Deserialize response body to Java object, according to the return type and
+     * the Content-Type response header.
+     *
+     * @param <T> Type
+     * @param response HTTP response
+     * @param returnType The type of the Java object
+     * @return The deserialized Java object
+     * @throws {{invokerPackage}}.ApiException If fail to deserialize response body, i.e. cannot read response body
+     *   or the Content-Type of the response is not supported.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T deserialize(Response response, Type returnType) throws ApiException {
+        if (response == null || returnType == null) {
+            return null;
+        }
+
+        if ("byte[]".equals(returnType.toString())) {
+            // Handle binary response (byte array).
+            try {
+                return (T) response.body().bytes();
+            } catch (IOException e) {
+                throw new ApiException(e);
+            }
+        } else if (returnType.equals(File.class)) {
+            // Handle file downloading.
+            return (T) downloadFileFromResponse(response);
+        }
+
+        ResponseBody respBody = response.body();
+        if (respBody == null) {
+            return null;
+        }
+
+        String contentType = response.headers().get("Content-Type");
+        if (contentType == null) {
+            // ensuring a default content type
+            contentType = "application/json";
+        }
+        try {
+            if (isJsonMime(contentType)) {
+                if (returnType.equals(String.class)) {
+                    String respBodyString = respBody.string();
+                    if (respBodyString.isEmpty()) {
+                        return null;
+                    }
+                    // Use String-based deserialize for String return type with fallback
+                    return JSON.deserialize(respBodyString, returnType);
+                } else {
+                    // Use InputStream-based deserialize which supports responses > 2GB
+                    return JSON.deserialize(respBody.byteStream(), returnType);
+                }
+            } else if (returnType.equals(String.class)) {
+                String respBodyString = respBody.string();
+                if (respBodyString.isEmpty()) {
+                    return null;
+                }
+                // Expecting string, return the raw response body.
+                return (T) respBodyString;
+            } else {
+                throw new ApiException(
+                    "Content type \"" + contentType + "\" is not supported for type: " + returnType,
+                    response.code(),
+                    response.headers().toMultimap(),
+                    response.body().string());
+            }
+        } catch (IOException e) {
+            throw new ApiException(e);
+        }
+    }
+
+    /**
+     * Serialize the given Java object into request body according to the object's
+     * class and the request Content-Type.
+     *
+     * @param obj The Java object
+     * @param contentType The request Content-Type
+     * @return The serialized request body
+     * @throws {{invokerPackage}}.ApiException If fail to serialize the given object
+     */
+    public RequestBody serialize(Object obj, String contentType) throws ApiException {
+        if (obj instanceof byte[]) {
+            // Binary (byte array) body parameter support.
+            return RequestBody.create(MediaType.parse(contentType), (byte[]) obj);
+        } else if (obj instanceof File) {
+            // File body parameter support.
+            return RequestBody.create(MediaType.parse(contentType), (File) obj);
+        } else if ("text/plain".equals(contentType) && obj instanceof String) {
+            return RequestBody.create(MediaType.parse(contentType), (String) obj);
+        } else if (isJsonMime(contentType)) {
+            String content;
+            if (obj != null) {
+                content = JSON.serialize(obj);
+            } else {
+                content = null;
+            }
+            return RequestBody.create(MediaType.parse(contentType), content);
+        } else if (obj instanceof String) {
+            return RequestBody.create(MediaType.parse(contentType), (String) obj);
+        } else {
+            throw new ApiException("Content type \"" + contentType + "\" is not supported");
+        }
+    }
+
+    /**
+     * Download file from the given response.
+     *
+     * @param response An instance of the Response object
+     * @throws {{invokerPackage}}.ApiException If fail to read file content from response and write to disk
+     * @return Downloaded file
+     */
+    public File downloadFileFromResponse(Response response) throws ApiException {
+        try {
+            File file = prepareDownloadFile(response);
+            BufferedSink sink = Okio.buffer(Okio.sink(file));
+            sink.writeAll(response.body().source());
+            sink.close();
+            return file;
+        } catch (IOException e) {
+            throw new ApiException(e);
+        }
+    }
+
+    /**
+     * Prepare file for download
+     *
+     * @param response An instance of the Response object
+     * @return Prepared file for the download
+     * @throws java.io.IOException If fail to prepare file for download
+     */
+    public File prepareDownloadFile(Response response) throws IOException {
+        String filename = null;
+        String contentDisposition = response.header("Content-Disposition");
+        if (contentDisposition != null && !"".equals(contentDisposition)) {
+            // Get filename from the Content-Disposition header.
+            Pattern pattern = Pattern.compile("filename=['\"]?([^'\"\\s]+)['\"]?");
+            Matcher matcher = pattern.matcher(contentDisposition);
+            if (matcher.find()) {
+                filename = sanitizeFilename(matcher.group(1));
+            }
+        }
+
+        String prefix = null;
+        String suffix = null;
+        if (filename == null) {
+            prefix = "download-";
+            suffix = "";
+        } else {
+            int pos = filename.lastIndexOf(".");
+            if (pos == -1) {
+                prefix = filename + "-";
+            } else {
+                prefix = filename.substring(0, pos) + "-";
+                suffix = filename.substring(pos);
+            }
+            // Files.createTempFile requires the prefix to be at least three characters long
+            if (prefix.length() < 3)
+                prefix = "download-";
+        }
+
+        if (tempFolderPath == null)
+            return Files.createTempFile(prefix, suffix).toFile();
+        else
+            return Files.createTempFile(Paths.get(tempFolderPath), prefix, suffix).toFile();
+    }
+
+    /**
+     * {@link #execute(Call, Type)}
+     *
+     * @param <T> Type
+     * @param call An instance of the Call object
+     * @return ApiResponse&lt;T&gt;
+     * @throws {{invokerPackage}}.ApiException If fail to execute the call
+     */
+    public <T> ApiResponse<T> execute(Call call) throws ApiException {
+        return execute(call, null);
+    }
+
+    /**
+     * Execute HTTP call and deserialize the HTTP response body into the given return type.
+     *
+     * @param returnType The return type used to deserialize HTTP response body
+     * @param <T> The return type corresponding to (same with) returnType
+     * @param call Call
+     * @return ApiResponse object containing response status, headers and
+     *   data, which is a Java object deserialized from response body and would be null
+     *   when returnType is null.
+     * @throws {{invokerPackage}}.ApiException If fail to execute the call
+     */
+    public <T> ApiResponse<T> execute(Call call, Type returnType) throws ApiException {
+        try {
+            Response response = call.execute();
+            T data = handleResponse(response, returnType);
+            return new ApiResponse<T>(response.code(), response.headers().toMultimap(), data);
+        } catch (IOException e) {
+            throw new ApiException(e);
+        }
+    }
+
+    {{#supportStreaming}}
+    /**
+     * <p>Execute stream.</p>
+     *
+     * @param call a {@link okhttp3.Call} object
+     * @param returnType a {@link java.lang.reflect.Type} object
+     * @return a {@link java.io.InputStream} object
+     * @throws {{invokerPackage}}.ApiException if any.
+     */
+    public InputStream executeStream(Call call, Type returnType) throws ApiException {
+        try {
+             Response response = call.execute();
+             if (!response.isSuccessful()) {
+                 throw new ApiException(response.code(), response.message(), response.headers().toMultimap(), null);
+             }
+             if (response.body() == null) {
+                 return null;
+             }
+             return response.body().byteStream();
+        } catch (IOException e) {
+            throw new ApiException(e);
+        }
+    }
+
+    {{/supportStreaming}}
+    /**
+     * {@link #executeAsync(Call, Type, ApiCallback)}
+     *
+     * @param <T> Type
+     * @param call An instance of the Call object
+     * @param callback ApiCallback&lt;T&gt;
+     */
+    public <T> void executeAsync(Call call, ApiCallback<T> callback) {
+        executeAsync(call, null, callback);
+    }
+
+    /**
+     * Execute HTTP call asynchronously.
+     *
+     * @param <T> Type
+     * @param call The callback to be executed when the API call finishes
+     * @param returnType Return type
+     * @param callback ApiCallback
+     * @see #execute(Call, Type)
+     */
+    @SuppressWarnings("unchecked")
+    public <T> void executeAsync(Call call, final Type returnType, final ApiCallback<T> callback) {
+        call.enqueue(new Callback() {
+            @Override
+            public void onFailure(Call call, IOException e) {
+                callback.onFailure(new ApiException(e), 0, null);
+            }
+
+            @Override
+            public void onResponse(Call call, Response response) throws IOException {
+                T result;
+                try {
+                    result = (T) handleResponse(response, returnType);
+                } catch (ApiException e) {
+                    callback.onFailure(e, response.code(), response.headers().toMultimap());
+                    return;
+                } catch (Exception e) {
+                    callback.onFailure(new ApiException(e), response.code(), response.headers().toMultimap());
+                    return;
+                }
+                callback.onSuccess(result, response.code(), response.headers().toMultimap());
+            }
+        });
+    }
+
+    /**
+     * Handle the given response, return the deserialized object when the response is successful.
+     *
+     * @param <T> Type
+     * @param response Response
+     * @param returnType Return type
+     * @return Type
+     * @throws {{invokerPackage}}.ApiException If the response has an unsuccessful status code or
+     *                      fail to deserialize the response body
+     */
+    public <T> T handleResponse(Response response, Type returnType) throws ApiException {
+        if (response.isSuccessful()) {
+            if (returnType == null || response.code() == 204) {
+                // returning null if the returnType is not defined,
+                // or the status code is 204 (No Content)
+                if (response.body() != null) {
+                    try {
+                        response.body().close();
+                    } catch (Exception e) {
+                        throw new ApiException(response.message(), e, response.code(), response.headers().toMultimap());
+                    }
+                }
+                return null;
+            } else {
+                return deserialize(response, returnType);
+            }
+        } else {
+            String respBody = null;
+            if (response.body() != null) {
+                try {
+                    respBody = response.body().string();
+                } catch (IOException e) {
+                    throw new ApiException(response.message(), e, response.code(), response.headers().toMultimap());
+                }
+            }
+            throw new ApiException(response.message(), response.code(), response.headers().toMultimap(), respBody);
+        }
+    }
+
+    /**
+     * Build HTTP call with the given options.
+     *
+     * @param baseUrl The base URL
+     * @param path The sub-path of the HTTP URL
+     * @param method The request method, one of "GET", "HEAD", "OPTIONS", "POST", "PUT", "PATCH" and "DELETE"
+     * @param queryParams The query parameters
+     * @param collectionQueryParams The collection query parameters
+     * @param body The request body object
+     * @param headerParams The header parameters
+     * @param cookieParams The cookie parameters
+     * @param formParams The form parameters
+     * @param authNames The authentications to apply
+     * @param callback Callback for upload/download progress
+     * @return The HTTP call
+     * @throws {{invokerPackage}}.ApiException If fail to serialize the request body object
+     */
+    public Call buildCall(String baseUrl, String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String[] authNames, ApiCallback callback) throws ApiException {
+        Request request = buildRequest(baseUrl, path, method, queryParams, collectionQueryParams, body, headerParams, cookieParams, formParams, authNames, callback);
+
+        return httpClient.newCall(request);
+    }
+
+    /**
+     * Build an HTTP request with the given options.
+     *
+     * @param baseUrl The base URL
+     * @param path The sub-path of the HTTP URL
+     * @param method The request method, one of "GET", "HEAD", "OPTIONS", "POST", "PUT", "PATCH" and "DELETE"
+     * @param queryParams The query parameters
+     * @param collectionQueryParams The collection query parameters
+     * @param body The request body object
+     * @param headerParams The header parameters
+     * @param cookieParams The cookie parameters
+     * @param formParams The form parameters
+     * @param authNames The authentications to apply
+     * @param callback Callback for upload/download progress
+     * @return The HTTP request
+     * @throws {{invokerPackage}}.ApiException If fail to serialize the request body object
+     */
+    public Request buildRequest(String baseUrl, String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String[] authNames, ApiCallback callback) throws ApiException {
+        final String url = buildUrl(baseUrl, path, queryParams, collectionQueryParams);
+
+        // prepare HTTP request body
+        RequestBody reqBody;
+        String contentType = headerParams.get("Content-Type");
+        String contentTypePure = contentType;
+        if (contentTypePure != null && contentTypePure.contains(";")) {
+            contentTypePure = contentType.substring(0, contentType.indexOf(";"));
+        }
+        if (!HttpMethod.permitsRequestBody(method)) {
+            reqBody = null;
+        } else if ("application/x-www-form-urlencoded".equals(contentTypePure)) {
+            reqBody = buildRequestBodyFormEncoding(formParams);
+        } else if ("multipart/form-data".equals(contentTypePure)) {
+            reqBody = buildRequestBodyMultipart(formParams);
+        } else if (body == null) {
+            if ("DELETE".equals(method)) {
+                // allow calling DELETE without sending a request body
+                reqBody = null;
+            } else {
+                // use an empty request body (for POST, PUT and PATCH)
+                reqBody = RequestBody.create(contentType == null ? null : MediaType.parse(contentType), "");
+            }
+        } else {
+            reqBody = serialize(body, contentType);
+        }
+
+        List<Pair> updatedQueryParams = new ArrayList<>(queryParams);
+
+        // update parameters with authentication settings
+        updateParamsForAuth(authNames, updatedQueryParams, headerParams, cookieParams, requestBodyToString(reqBody), method, URI.create(url));
+
+        final Request.Builder reqBuilder = new Request.Builder().url(buildUrl(baseUrl, path, updatedQueryParams, collectionQueryParams));
+        processHeaderParams(headerParams, reqBuilder);
+        processCookieParams(cookieParams, reqBuilder);
+
+        // Associate callback with request (if not null) so interceptor can
+        // access it when creating ProgressResponseBody
+        reqBuilder.tag(callback);
+
+        Request request = null;
+
+        if (callback != null && reqBody != null) {
+            ProgressRequestBody progressRequestBody = new ProgressRequestBody(reqBody, callback);
+            request = reqBuilder.method(method, progressRequestBody).build();
+        } else {
+            request = reqBuilder.method(method, reqBody).build();
+        }
+
+        return request;
+    }
+
+    /**
+     * Build full URL by concatenating base path, the given sub path and query parameters.
+     *
+     * @param baseUrl The base URL
+     * @param path The sub path
+     * @param queryParams The query parameters
+     * @param collectionQueryParams The collection query parameters
+     * @return The full URL
+     */
+    public String buildUrl(String baseUrl, String path, List<Pair> queryParams, List<Pair> collectionQueryParams) {
+        final StringBuilder url = new StringBuilder();
+        if (baseUrl != null) {
+            url.append(baseUrl).append(path);
+        } else {
+            String baseURL;
+            if (serverIndex != null) {
+                if (serverIndex < 0 || serverIndex >= servers.size()) {
+                    throw new ArrayIndexOutOfBoundsException(String.format(
+                        java.util.Locale.ROOT,
+                        "Invalid index %d when selecting the host settings. Must be less than %d", serverIndex, servers.size()
+                    ));
+                }
+                baseURL = servers.get(serverIndex).URL(serverVariables);
+            } else {
+                baseURL = basePath;
+            }
+            url.append(baseURL).append(path);
+        }
+
+        if (queryParams != null && !queryParams.isEmpty()) {
+            // support (constant) query string in `path`, e.g. "/posts?draft=1"
+            String prefix = path.contains("?") ? "&" : "?";
+            for (Pair param : queryParams) {
+                if (param.getValue() != null) {
+                    if (prefix != null) {
+                        url.append(prefix);
+                        prefix = null;
+                    } else {
+                        url.append("&");
+                    }
+                    String value = parameterToString(param.getValue());
+                    url.append(escapeString(param.getName())).append("=").append(escapeString(value));
+                }
+            }
+        }
+
+        if (collectionQueryParams != null && !collectionQueryParams.isEmpty()) {
+            String prefix = url.toString().contains("?") ? "&" : "?";
+            for (Pair param : collectionQueryParams) {
+                if (param.getValue() != null) {
+                    if (prefix != null) {
+                        url.append(prefix);
+                        prefix = null;
+                    } else {
+                        url.append("&");
+                    }
+                    String value = parameterToString(param.getValue());
+                    // collection query parameter value already escaped as part of parameterToPairs
+                    url.append(escapeString(param.getName())).append("=").append(value);
+                }
+            }
+        }
+
+        return url.toString();
+    }
+
+    /**
+     * Set header parameters to the request builder, including default headers.
+     *
+     * @param headerParams Header parameters in the form of Map
+     * @param reqBuilder Request.Builder
+     */
+    public void processHeaderParams(Map<String, String> headerParams, Request.Builder reqBuilder) {
+        for (Entry<String, String> param : headerParams.entrySet()) {
+            reqBuilder.header(param.getKey(), parameterToString(param.getValue()));
+        }
+        for (Entry<String, String> header : defaultHeaderMap.entrySet()) {
+            if (!headerParams.containsKey(header.getKey())) {
+                reqBuilder.header(header.getKey(), parameterToString(header.getValue()));
+            }
+        }
+    }
+
+    /**
+     * Set cookie parameters to the request builder, including default cookies.
+     *
+     * @param cookieParams Cookie parameters in the form of Map
+     * @param reqBuilder Request.Builder
+     */
+    public void processCookieParams(Map<String, String> cookieParams, Request.Builder reqBuilder) {
+        for (Entry<String, String> param : cookieParams.entrySet()) {
+            reqBuilder.addHeader("Cookie", String.format(java.util.Locale.ROOT, "%s=%s", param.getKey(), param.getValue()));
+        }
+        for (Entry<String, String> param : defaultCookieMap.entrySet()) {
+            if (!cookieParams.containsKey(param.getKey())) {
+                reqBuilder.addHeader("Cookie", String.format(java.util.Locale.ROOT, "%s=%s", param.getKey(), param.getValue()));
+            }
+        }
+    }
+
+    /**
+     * Update query and header parameters based on authentication settings.
+     *
+     * @param authNames The authentications to apply
+     * @param queryParams List of query parameters
+     * @param headerParams Map of header parameters
+     * @param cookieParams Map of cookie parameters
+     * @param payload HTTP request body
+     * @param method HTTP method
+     * @param uri URI
+     * @throws {{invokerPackage}}.ApiException If fails to update the parameters
+     */
+    public void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams,
+                                    Map<String, String> cookieParams, String payload, String method, URI uri) throws ApiException {
+        for (String authName : authNames) {
+            Authentication auth = authentications.get(authName);
+            if (auth == null) {
+                throw new RuntimeException("Authentication undefined: " + authName);
+            }
+            auth.applyToParams(queryParams, headerParams, cookieParams, payload, method, uri);
+        }
+    }
+
+    /**
+     * Build a form-encoding request body with the given form parameters.
+     *
+     * @param formParams Form parameters in the form of Map
+     * @return RequestBody
+     */
+    public RequestBody buildRequestBodyFormEncoding(Map<String, Object> formParams) {
+        okhttp3.FormBody.Builder formBuilder = new okhttp3.FormBody.Builder();
+        for (Entry<String, Object> param : formParams.entrySet()) {
+            formBuilder.add(param.getKey(), parameterToString(param.getValue()));
+        }
+        return formBuilder.build();
+    }
+
+    /**
+     * Build a multipart (file uploading) request body with the given form parameters,
+     * which could contain text fields and file fields.
+     *
+     * @param formParams Form parameters in the form of Map
+     * @return RequestBody
+     */
+    public RequestBody buildRequestBodyMultipart(Map<String, Object> formParams) {
+        MultipartBody.Builder mpBuilder = new MultipartBody.Builder().setType(MultipartBody.FORM);
+        for (Entry<String, Object> param : formParams.entrySet()) {
+            if (param.getValue() instanceof File) {
+                File file = (File) param.getValue();
+                addPartToMultiPartBuilder(mpBuilder, param.getKey(), file);
+            } else if (param.getValue() instanceof List) {
+                List list = (List) param.getValue();
+                for (Object item: list) {
+                    if (item instanceof File) {
+                        addPartToMultiPartBuilder(mpBuilder, param.getKey(), (File) item);
+                    } else {
+                        addPartToMultiPartBuilder(mpBuilder, param.getKey(), param.getValue());
+                    }
+                }
+            } else {
+                addPartToMultiPartBuilder(mpBuilder, param.getKey(), param.getValue());
+            }
+        }
+        return mpBuilder.build();
+    }
+
+    /**
+     * Guess Content-Type header from the given file (defaults to "application/octet-stream").
+     *
+     * @param file The given file
+     * @return The guessed Content-Type
+     */
+    public String guessContentTypeFromFile(File file) {
+        String contentType = URLConnection.guessContentTypeFromName(file.getName());
+        if (contentType == null) {
+            return "application/octet-stream";
+        } else {
+            return contentType;
+        }
+    }
+
+    /**
+     * Add a Content-Disposition Header for the given key and file to the MultipartBody Builder.
+     *
+     * @param mpBuilder MultipartBody.Builder 
+     * @param key The key of the Header element
+     * @param file The file to add to the Header
+     */ 
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
+        Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
+        MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));
+        mpBuilder.addPart(partHeaders, RequestBody.create(mediaType, file));
+    }
+
+    /**
+     * Add a Content-Disposition Header for the given key and complex object to the MultipartBody Builder.
+     *
+     * @param mpBuilder MultipartBody.Builder
+     * @param key The key of the Header element
+     * @param obj The complex object to add to the Header
+     */
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
+        RequestBody requestBody;
+        if (obj instanceof String) {
+            requestBody = RequestBody.create(MediaType.parse("text/plain"), (String) obj);
+        } else {
+            String content;
+            if (obj != null) {
+                content = JSON.serialize(obj);
+            } else {
+                content = null;
+            }
+            requestBody = RequestBody.create(MediaType.parse("application/json"), content);
+        }
+
+        Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"");
+        mpBuilder.addPart(partHeaders, requestBody);
+    }
+
+    /**
+     * Get network interceptor to add it to the httpClient to track download progress for
+     * async requests.
+     */
+    protected Interceptor getProgressInterceptor() {
+        return new Interceptor() {
+            @Override
+            public Response intercept(Interceptor.Chain chain) throws IOException {
+                final Request request = chain.request();
+                final Response originalResponse = chain.proceed(request);
+                if (request.tag() instanceof ApiCallback) {
+                    final ApiCallback callback = (ApiCallback) request.tag();
+                    return originalResponse.newBuilder()
+                        .body(new ProgressResponseBody(originalResponse.body(), callback))
+                        .build();
+                }
+                return originalResponse;
+            }
+        };
+    }
+
+    /**
+     * Apply SSL related settings to httpClient according to the current values of
+     * verifyingSsl and sslCaCert.
+     */
+    protected void applySslSettings() {
+        try {
+            TrustManager[] trustManagers;
+            HostnameVerifier hostnameVerifier;
+            if (!verifyingSsl) {
+                trustManagers = new TrustManager[]{
+                        new X509TrustManager() {
+                            @Override
+                            public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
+                            }
+
+                            @Override
+                            public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
+                            }
+
+                            @Override
+                            public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                                return new java.security.cert.X509Certificate[]{};
+                            }
+                        }
+                };
+                hostnameVerifier = new HostnameVerifier() {
+                    @Override
+                    public boolean verify(String hostname, SSLSession session) {
+                        return true;
+                    }
+                };
+            } else {
+                TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+
+                if (sslCaCert == null) {
+                    trustManagerFactory.init((KeyStore) null);
+                } else {
+                    char[] password = null; // Any password will work.
+                    CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+                    Collection<? extends Certificate> certificates = certificateFactory.generateCertificates(sslCaCert);
+                    if (certificates.isEmpty()) {
+                        throw new IllegalArgumentException("expected non-empty set of trusted certificates");
+                    }
+                    KeyStore caKeyStore = newEmptyKeyStore(password);
+                    int index = 0;
+                    for (Certificate certificate : certificates) {
+                        String certificateAlias = "ca" + (index++);
+                        caKeyStore.setCertificateEntry(certificateAlias, certificate);
+                    }
+                    trustManagerFactory.init(caKeyStore);
+                }
+                trustManagers = trustManagerFactory.getTrustManagers();
+                if (tlsServerName != null && !tlsServerName.isEmpty()) {
+                    hostnameVerifier = new HostnameVerifier() {
+                        @Override
+                        public boolean verify(String hostname, SSLSession session) {
+                            // Verify the certificate against tlsServerName instead of the actual hostname
+                            return OkHostnameVerifier.INSTANCE.verify(tlsServerName, session);
+                        }
+                    };
+                } else {
+                    hostnameVerifier = OkHostnameVerifier.INSTANCE;
+                }
+            }
+
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(keyManagers, trustManagers, new SecureRandom());
+            httpClient = httpClient.newBuilder()
+                            .sslSocketFactory(sslContext.getSocketFactory(), (X509TrustManager) trustManagers[0])
+                            .hostnameVerifier(hostnameVerifier)
+                            .build();
+        } catch (GeneralSecurityException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
+        try {
+            KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            keyStore.load(null, password);
+            return keyStore;
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+    }
+    {{#dynamicOperations}}
+
+    public ApiClient createOperationLookupMap(OpenAPI openAPI) {
+        operationLookupMap = new HashMap<>();
+        for (Map.Entry<String, PathItem> pathItemEntry : openAPI.getPaths().entrySet()) {
+            String path = pathItemEntry.getKey();
+            PathItem pathItem = pathItemEntry.getValue();
+            addOperationLookupEntry(path, "GET", pathItem.getGet());
+            addOperationLookupEntry(path, "PUT", pathItem.getPut());
+            addOperationLookupEntry(path, "POST", pathItem.getPost());
+            addOperationLookupEntry(path, "DELETE", pathItem.getDelete());
+            addOperationLookupEntry(path, "OPTIONS", pathItem.getOptions());
+            addOperationLookupEntry(path, "HEAD", pathItem.getHead());
+            addOperationLookupEntry(path, "PATCH", pathItem.getPatch());
+            addOperationLookupEntry(path, "TRACE", pathItem.getTrace());
+        }
+        return this;
+    }
+
+    protected void addOperationLookupEntry(String path, String method, Operation operation) {
+        if ( operation != null && operation.getOperationId() != null) {
+            operationLookupMap.put(
+                    operation.getOperationId(),
+                    new ApiOperation(path, method, operation));
+        }
+    }
+
+    public Map<String, ApiOperation> getOperationLookupMap() {
+        return operationLookupMap;
+    }
+
+    public String fillParametersFromOperation(
+            Operation operation,
+            Map<String, Object> paramMap,
+            String path,
+            List<Pair> queryParams,
+            List<Pair> collectionQueryParams,
+            Map<String, String> headerParams,
+            Map<String, String> cookieParams
+    ) {
+        for (Map.Entry<String, Object> entry : paramMap.entrySet()) {
+            Object value = entry.getValue();
+            for (Parameter param : operation.getParameters()) {
+                if (entry.getKey().equals(param.getName())) {
+                    switch (param.getIn()) {
+                        case "path":
+                            path = path.replace("{" + param.getName() + "}", escapeString(value.toString()));
+                            break;
+                        case "query":
+                            if (value instanceof Collection<?>) {
+                                collectionQueryParams.addAll(parameterToPairs(param, (Collection) value));
+                            } else {
+                                queryParams.addAll(parameterToPair(param.getName(), value));
+                            }
+                            break;
+                        case "header":
+                            headerParams.put(param.getName(), parameterToString(value));
+                            break;
+                        case "cookie":
+                            cookieParams.put(param.getName(), parameterToString(value));
+                            break;
+                        default:
+                            throw new IllegalStateException("Unexpected param in: " + param.getIn());
+                    }
+
+                }
+            }
+        }
+        return path;
+    }
+    {{/dynamicOperations}}
+
+    /**
+     * Convert the HTTP request body to a string.
+     *
+     * @param requestBody The HTTP request object
+     * @return The string representation of the HTTP request body
+     * @throws {{invokerPackage}}.ApiException If fail to serialize the request body object into a string
+     */
+    protected String requestBodyToString(RequestBody requestBody) throws ApiException {
+        if (requestBody != null) {
+            try {
+                final Buffer buffer = new Buffer();
+                requestBody.writeTo(buffer);
+                return buffer.readUtf8();
+            } catch (final IOException e) {
+                throw new ApiException(e);
+            }
+        }
+
+        // empty http request body
+        return "";
+    }
+}

--- a/sdk/java/templates/libraries/okhttp-gson/build.gradle.mustache
+++ b/sdk/java/templates/libraries/okhttp-gson/build.gradle.mustache
@@ -1,0 +1,209 @@
+apply plugin: 'idea'
+apply plugin: 'eclipse'
+{{#sourceFolder}}
+apply plugin: 'java'
+{{/sourceFolder}}
+apply plugin: 'com.diffplug.spotless'
+
+group = '{{groupId}}'
+version = '{{artifactVersion}}'
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:2.3.+'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
+        classpath 'com.diffplug.spotless:spotless-plugin-gradle:6.11.0'
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+{{#sourceFolder}}
+sourceSets {
+    main.java.srcDirs = ['{{sourceFolder}}']
+}
+
+{{/sourceFolder}}
+if(hasProperty('target') && target == 'android') {
+
+    apply plugin: 'com.android.library'
+    apply plugin: 'com.github.dcendents.android-maven'
+
+    android {
+        compileSdkVersion 25
+        buildToolsVersion '25.0.2'
+        defaultConfig {
+            minSdkVersion 14
+            targetSdkVersion 25
+        }
+        compileOptions {
+            sourceCompatibility JavaVersion.VERSION_1_8
+            targetCompatibility JavaVersion.VERSION_1_8
+        }
+
+        // Rename the aar correctly
+        libraryVariants.all { variant ->
+            variant.outputs.each { output ->
+                def outputFile = output.outputFile
+                if (outputFile != null && outputFile.name.endsWith('.aar')) {
+                    def fileName = "${project.name}-${variant.baseName}-${version}.aar"
+                    output.outputFile = new File(outputFile.parent, fileName)
+                }
+            }
+        }
+
+        dependencies {
+            provided "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"
+        }
+    }
+
+    afterEvaluate {
+        android.libraryVariants.all { variant ->
+            def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
+            task.description = "Create jar artifact for ${variant.name}"
+            task.dependsOn variant.javaCompile
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
+            artifacts.add('archives', task)
+        }
+    }
+
+    task sourcesJar(type: Jar) {
+        from android.sourceSets.main.java.srcDirs
+        classifier = 'sources'
+    }
+
+    artifacts {
+        archives sourcesJar
+    }
+
+} else {
+
+    apply plugin: 'java'
+    apply plugin: 'maven-publish'
+
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+
+    publishing {
+        publications {
+            maven(MavenPublication) {
+               artifactId = '{{artifactId}}'
+               from components.java
+            }
+        }
+    }
+
+    task execute(type:JavaExec) {
+       main = System.getProperty('mainClass')
+       classpath = sourceSets.main.runtimeClasspath
+    }
+}
+
+ext {
+    {{#swagger1AnnotationLibrary}}
+    swagger_annotations_version = "1.6.9"
+    {{/swagger1AnnotationLibrary}}
+    {{#swagger2AnnotationLibrary}}
+    swagger_annotations_version = "2.2.9"
+    {{/swagger2AnnotationLibrary}}
+    jakarta_annotation_version = "1.3.5"
+    {{#useBeanValidation}}
+    bean_validation_version = "2.0.2"
+    {{/useBeanValidation}}
+}
+
+dependencies {
+    {{#swagger1AnnotationLibrary}}
+    implementation "io.swagger:swagger-annotations:$swagger_annotations_version"
+    {{/swagger1AnnotationLibrary}}
+    {{#swagger2AnnotationLibrary}}
+    implementation "io.swagger.core.v3:swagger-annotations:$swagger_annotations_version"
+    {{/swagger2AnnotationLibrary}}
+    implementation "com.google.code.findbugs:jsr305:3.0.2"
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.12.0'
+    implementation 'com.google.code.gson:gson:2.9.1'
+    implementation 'io.gsonfire:gson-fire:1.9.0'
+    {{#openApiNullable}}
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.9'
+    {{/openApiNullable}}
+    {{#withAWSV4Signature}}
+    implementation 'software.amazon.awssdk:auth:2.20.157'
+    {{/withAWSV4Signature}}
+    {{#hasOAuthMethods}}
+    implementation group: 'org.apache.oltu.oauth2', name: 'org.apache.oltu.oauth2.client', version: '1.0.2'
+    {{/hasOAuthMethods}}
+    {{#joda}}
+    implementation 'joda-time:joda-time:2.9.9'
+    {{/joda}}
+    {{#dynamicOperations}}
+    implementation 'io.swagger.parser.v3:swagger-parser-v3:2.0.30'
+    {{/dynamicOperations}}
+    implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"
+    {{#useBeanValidation}}
+    implementation "jakarta.validation:jakarta.validation-api:$bean_validation_version"
+    {{/useBeanValidation}}
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.3'
+    testImplementation 'org.mockito:mockito-core:3.12.4'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.3'
+}
+
+javadoc {
+    options.tags = [ "http.response.details:a:Http Response Details" ]
+}
+
+// Use spotless plugin to automatically format code, remove unused import, etc
+// To apply changes directly to the file, run `gradlew spotlessApply`
+// Ref: https://github.com/diffplug/spotless/tree/main/plugin-gradle
+spotless {
+    // comment out below to run spotless as part of the `check` task
+    enforceCheck false
+
+    format 'misc', {
+        // define the files (e.g. '*.gradle', '*.md') to apply `misc` to
+        target '.gitignore'
+
+        // define the steps to apply to those files
+        trimTrailingWhitespace()
+        indentWithSpaces() // Takes an integer argument if you don't like 4
+        endWithNewline()
+    }
+    java {
+        // don't need to set target, it is inferred from java
+
+        // apply a specific flavor of google-java-format
+        googleJavaFormat('1.8').aosp().reflowLongStrings()
+
+        removeUnusedImports()
+        importOrder()
+    }
+}
+
+test {
+    // Enable JUnit 5 (Gradle 4.6+).
+    useJUnitPlatform()
+
+    // Always run tests, even when nothing changed.
+    dependsOn 'cleanTest'
+
+    // Show test results.
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
+
+}
+
+// Nocturne: apply the Maven Central publishing/signing overlay when the
+// generated project sits in its repo location (sdk/java/out, next to
+// sdk/java/publish.gradle). Guarded so the project still evaluates when
+// generated to a standalone directory.
+def publishOverlay = file("${projectDir}/../publish.gradle")
+if (publishOverlay.exists()) {
+    apply from: publishOverlay
+}


### PR DESCRIPTION
## Problem

The published `nocturne-java` artifact is unusable from xDrip (and any Android app pinned to OkHttp 3.x), which blocks rebuilding [xDrip PR #4529](https://github.com/NightscoutFoundation/xDrip/pull/4529) on the SDK instead of hand-rolled HTTP:

1. `okHttpVersion: "3.12.13"` in `sdk/java/config.yaml` is **not a real openapi-generator option** — it was silently ignored, and every release ≤ 0.2.3 ships requiring OkHttp 4.12.0.
2. The SDK spec filter keeps only `/api/v4/**`, so the OAuth endpoints native clients need to connect at all (RFC 7591 dynamic client registration, RFC 8628 device flow, token refresh, revocation) are missing from every generated SDK.
3. The generated models use `java.time` (fine — consumers gate on API 26+) but the POM also drags in `jakarta.ws.rs-api` and `commons-lang3`, which zero generated sources reference.

## Changes

- **Template override** (`sdk/java/templates/libraries/okhttp-gson/ApiClient.mustache`): swaps all 9 `RequestBody.create(content, mediaType)` call sites to the MediaType-first order, which exists in OkHttp 3.x and is retained (deprecated) in 4.x — one artifact, bytecode-compatible with both majors. The POM still declares 4.12.0; Android consumers exclude it and supply their own 3.12.x.
- **Publish gate**: new workflow step compiles the generated sources against OkHttp 3.12.13 / okio 1.15.0 / gson 2.8.6 so a future generator bump can't silently regress 3.x compatibility.
- **Filter**: `filter-v4-spec.js` now also keeps `/api/oauth/**`, generating an `OAuthApi` with typed DTOs. **Note: this widens every SDK target, not just Java.**
- **Declarative post-processing**: the shell overlay (`cat`/`rm`/`sed`) is gone — broken-file removal moved to `.openapi-generator-ignore`, the publish.gradle overlay is picked up via a guarded `apply from:` in a forked `build.gradle.mustache` (which also drops the two unused deps), and CI no longer mutates generated output. `sdk/java/templates/README.md` documents both forks and the refresh procedure for generator bumps.

## Verification (local, generator v7.21.0)

- Filtered spec: 420 paths incl. all 11 OAuth endpoints; `OAuthApi` generated with `oAuthRegister`/`oAuthDeviceAuthorization`/`oAuthToken`/`oAuthRevoke`.
- All generated main sources compile with **zero errors** against OkHttp 3.12.13 + okio 1.15.0 + gson 2.8.6 (xDrip's exact pins).
- Gradle evaluation of the generated project produces a POM with the overlay metadata (name, AGPL-3.0-only) and the trimmed dependency set.

## Caveats

- The OAuth filter change affects all SDK targets on the next tag; TypeScript and Rust publish jobs were already failing before this PR for unrelated reasons.
- `securitySchemes` in the filtered spec is currently empty (nothing matches the http/bearer keep-filter), though the generated `ApiClient` still exposes `setAccessToken()`. Worth a follow-up look server-side.