### PR TITLE
fix(v3): emit AAPS-parseable cursor ETags on all V3 endpoints (#522)

### DIFF
--- a/src/API/Nocturne.API/Controllers/V3/BaseV3Controller.cs
+++ b/src/API/Nocturne.API/Controllers/V3/BaseV3Controller.cs
@@ -256,16 +256,24 @@ public abstract class BaseV3Controller<T> : ControllerBase
     /// <param name="data">Response data</param>
     /// <param name="parameters">Query parameters</param>
     /// <param name="totalCount">Total count of items (for pagination)</param>
+    /// <param name="lastModified">
+    /// Newest record timestamp when the caller already knows it (e.g. computed from domain
+    /// models before mapping to DTOs the timestamp reflection can't read).
+    /// </param>
     protected void SetV3ResponseHeaders<TItem>(
         IEnumerable<TItem> data,
         V3QueryParameters parameters,
-        long totalCount
+        long totalCount,
+        DateTimeOffset? lastModified = null
     )
     {
         // Cursor-style ETag from the newest record; falls back to the current time for
         // collections whose items carry no recognizable timestamp.
-        var lastModified = GetLastModified(data.Cast<object>()) ?? DateTimeOffset.UtcNow;
-        Response.Headers["ETag"] = FormatCursorETag(lastModified.ToUnixTimeMilliseconds());
+        var effectiveLastModified =
+            lastModified ?? GetLastModified(data.Cast<object>()) ?? DateTimeOffset.UtcNow;
+        Response.Headers["ETag"] = FormatCursorETag(
+            effectiveLastModified.ToUnixTimeMilliseconds()
+        );
 
         // Set pagination headers
         Response.Headers["X-Total-Count"] = totalCount.ToString();
@@ -295,7 +303,7 @@ public abstract class BaseV3Controller<T> : ControllerBase
 
         // Set cache control headers
         Response.Headers["Cache-Control"] = "public, max-age=60";
-        Response.Headers["Last-Modified"] = lastModified.UtcDateTime.ToString("R");
+        Response.Headers["Last-Modified"] = effectiveLastModified.UtcDateTime.ToString("R");
         Response.Headers["Vary"] = "Accept, If-Modified-Since, If-None-Match";
     }
 
@@ -332,6 +340,24 @@ public abstract class BaseV3Controller<T> : ControllerBase
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Parse a legacy <c>created_at</c> string into Unix milliseconds.
+    /// </summary>
+    protected static long? ParseCreatedAtMills(string? createdAt)
+    {
+        if (string.IsNullOrEmpty(createdAt))
+            return null;
+
+        return DateTimeOffset.TryParse(
+            createdAt,
+            System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.AssumeUniversal,
+            out var parsed
+        )
+            ? parsed.ToUnixTimeMilliseconds()
+            : null;
     }
 
     private static string NormalizeETag(string etag)
@@ -400,7 +426,8 @@ public abstract class BaseV3Controller<T> : ControllerBase
     protected IActionResult CreateV3CollectionResponse<TItem>(
         IEnumerable<TItem> data,
         V3QueryParameters parameters,
-        long totalCount
+        long totalCount,
+        DateTimeOffset? lastModified = null
     )
     {
         // Apply field selection
@@ -423,7 +450,7 @@ public abstract class BaseV3Controller<T> : ControllerBase
         };
 
         // Set response headers
-        SetV3ResponseHeaders(data, parameters, totalCount);
+        SetV3ResponseHeaders(data, parameters, totalCount, lastModified);
 
         // Nightscout V3 API returns {"status": 200, "result": [...]}
         return Ok(
@@ -623,15 +650,18 @@ public abstract class BaseV3Controller<T> : ControllerBase
                     itemModified = srvModified;
                 }
 
-                // Check for CreatedAt property
+                // Check for CreatedAt property (DateTimeOffset or ISO-8601 string)
                 var createdAtProperty = itemType.GetProperty("CreatedAt");
-                if (
-                    createdAtProperty != null
-                    && createdAtProperty.GetValue(item) is DateTimeOffset createdAt
-                )
+                var createdAt = createdAtProperty?.GetValue(item) switch
                 {
-                    if (itemModified == null || createdAt > itemModified)
-                        itemModified = createdAt;
+                    DateTimeOffset dto => dto,
+                    string s when ParseCreatedAtMills(s) is long createdAtMills =>
+                        DateTimeOffset.FromUnixTimeMilliseconds(createdAtMills),
+                    _ => (DateTimeOffset?)null,
+                };
+                if (createdAt != null && (itemModified == null || createdAt > itemModified))
+                {
+                    itemModified = createdAt;
                 }
 
                 if (itemModified != null && (lastModified == null || itemModified > lastModified))

--- a/src/API/Nocturne.API/Controllers/V3/BaseV3Controller.cs
+++ b/src/API/Nocturne.API/Controllers/V3/BaseV3Controller.cs
@@ -241,18 +241,14 @@ public abstract class BaseV3Controller<T> : ControllerBase
     }
 
     /// <summary>
-    /// Generate ETag for a collection of data
+    /// Format a V3 ETag from a record timestamp. AAPS parses every V3 ETag by stripping the
+    /// first three characters (<c>W/"</c>) and the trailing quote, then calling
+    /// <c>toLong()</c> — so the value between the quotes MUST be a bare Unix-milliseconds
+    /// number. Any other shape (e.g. a content hash) crashes the AAPS sync loop with
+    /// <c>NumberFormatException</c> (#522).
     /// </summary>
-    /// <param name="data">Data to generate ETag for</param>
-    /// <returns>ETag value</returns>
-    protected string GenerateETag<TItem>(IEnumerable<TItem> data)
-    {
-        var json = JsonSerializer.Serialize(data);
-        var hash = System.Security.Cryptography.SHA256.HashData(
-            System.Text.Encoding.UTF8.GetBytes(json)
-        );
-        return Convert.ToHexString(hash)[..16]; // Use first 16 characters
-    }
+    /// <param name="maxMills">Highest record timestamp in the response, in Unix milliseconds.</param>
+    protected static string FormatCursorETag(long maxMills) => $"W/\"{maxMills}\"";
 
     /// <summary>
     /// Set V3 response headers including pagination, ETag, and caching
@@ -266,9 +262,10 @@ public abstract class BaseV3Controller<T> : ControllerBase
         long totalCount
     )
     {
-        // Set ETag header
-        var etag = GenerateETag(data);
-        Response.Headers["ETag"] = $"\"{etag}\"";
+        // Cursor-style ETag from the newest record; falls back to the current time for
+        // collections whose items carry no recognizable timestamp.
+        var lastModified = GetLastModified(data.Cast<object>()) ?? DateTimeOffset.UtcNow;
+        Response.Headers["ETag"] = FormatCursorETag(lastModified.ToUnixTimeMilliseconds());
 
         // Set pagination headers
         Response.Headers["X-Total-Count"] = totalCount.ToString();
@@ -298,28 +295,28 @@ public abstract class BaseV3Controller<T> : ControllerBase
 
         // Set cache control headers
         Response.Headers["Cache-Control"] = "public, max-age=60";
-        Response.Headers["Last-Modified"] = DateTimeOffset.UtcNow.ToString("R");
+        Response.Headers["Last-Modified"] = lastModified.UtcDateTime.ToString("R");
         Response.Headers["Vary"] = "Accept, If-Modified-Since, If-None-Match";
     }
 
     /// <summary>
-    /// Check if the request can return a 304 Not Modified response
+    /// Check if the request can return a 304 Not Modified response.
+    /// The current ETag is derived from <paramref name="lastModified"/> with
+    /// <see cref="FormatCursorETag"/>, matching what the response headers carry.
     /// </summary>
-    /// <param name="etag">Current ETag</param>
-    /// <param name="lastModified">Last modified timestamp</param>
+    /// <param name="lastModified">Last modified timestamp of the response data</param>
     /// <param name="parameters">Query parameters</param>
     /// <returns>True if 304 should be returned</returns>
-    protected bool ShouldReturn304(
-        string etag,
-        DateTimeOffset lastModified,
-        V3QueryParameters parameters
-    )
+    protected bool ShouldReturn304(DateTimeOffset lastModified, V3QueryParameters parameters)
     {
-        // Check If-None-Match header
+        // Check If-None-Match header (tolerate weak markers and quoting variations)
         if (!string.IsNullOrEmpty(parameters.IfNoneMatch))
         {
-            var clientETag = parameters.IfNoneMatch.Trim('"');
-            if (clientETag == etag)
+            var clientETag = NormalizeETag(parameters.IfNoneMatch);
+            var currentETag = NormalizeETag(
+                FormatCursorETag(lastModified.ToUnixTimeMilliseconds())
+            );
+            if (clientETag == currentETag)
             {
                 return true;
             }
@@ -335,6 +332,16 @@ public abstract class BaseV3Controller<T> : ControllerBase
         }
 
         return false;
+    }
+
+    private static string NormalizeETag(string etag)
+    {
+        var value = etag.Trim();
+        if (value.StartsWith("W/", StringComparison.OrdinalIgnoreCase))
+        {
+            value = value[2..];
+        }
+        return value.Trim('"');
     }
 
     /// <summary>
@@ -378,7 +385,7 @@ public abstract class BaseV3Controller<T> : ControllerBase
     {
         var lastModified = DateTimeOffset.FromUnixTimeMilliseconds(maxMills).UtcDateTime;
         Response.Headers["Last-Modified"] = lastModified.ToString("R");
-        Response.Headers["ETag"] = $"W/\"{maxMills}\"";
+        Response.Headers["ETag"] = FormatCursorETag(maxMills);
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Controllers/V3/DeviceStatusController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/DeviceStatusController.cs
@@ -115,8 +115,15 @@ public class DeviceStatusController : BaseV3Controller<DeviceStatus>
                 return StatusCode(304);
             }
 
-            // Create V3 response
-            var response = CreateV3CollectionResponse(mappedData, parameters, totalCount);
+            // Create V3 response. Pass the model-derived timestamp explicitly: the mapped
+            // DTOs are dictionaries the timestamp reflection can't read, and the emitted
+            // ETag must match the one the 304 check above compares against.
+            var response = CreateV3CollectionResponse(
+                mappedData,
+                parameters,
+                totalCount,
+                lastModified
+            );
 
             _logger.LogDebug(
                 "Successfully returned {Count} device status records with V3 format",

--- a/src/API/Nocturne.API/Controllers/V3/DeviceStatusController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/DeviceStatusController.cs
@@ -109,9 +109,8 @@ public class DeviceStatusController : BaseV3Controller<DeviceStatus>
 
             // Check for conditional requests (304 Not Modified)
             var lastModified = GetLastModified(deviceStatusList.Cast<object>());
-            var etag = GenerateETag(deviceStatusList);
 
-            if (lastModified.HasValue && ShouldReturn304(etag, lastModified.Value, parameters))
+            if (lastModified.HasValue && ShouldReturn304(lastModified.Value, parameters))
             {
                 return StatusCode(304);
             }

--- a/src/API/Nocturne.API/Controllers/V3/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/EntriesController.cs
@@ -105,9 +105,8 @@ public class EntriesController : BaseV3Controller<Entry>
 
             // Check for conditional requests (304 Not Modified)
             var lastModified = GetLastModified(entriesList);
-            var etag = GenerateETag(entriesList);
 
-            if (ShouldReturn304(etag, lastModified, parameters))
+            if (ShouldReturn304(lastModified, parameters))
             {
                 return StatusCode(304);
             }
@@ -167,8 +166,7 @@ public class EntriesController : BaseV3Controller<Entry>
             }
 
             // Set appropriate headers
-            var etag = GenerateETag(new[] { entry });
-            Response.Headers["ETag"] = $"\"{etag}\"";
+            Response.Headers["ETag"] = FormatCursorETag(entry.Mills);
             Response.Headers["Cache-Control"] = "public, max-age=60";
 
             return Ok(entry.ToV3Response());

--- a/src/API/Nocturne.API/Controllers/V3/FoodController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/FoodController.cs
@@ -185,16 +185,6 @@ public class FoodController : BaseV3Controller<Food>
         }
     }
 
-    private static long? ParseCreatedAtMills(string? createdAt)
-    {
-        if (string.IsNullOrEmpty(createdAt))
-            return null;
-
-        return DateTimeOffset.TryParse(createdAt, out var parsed)
-            ? parsed.ToUnixTimeMilliseconds()
-            : null;
-    }
-
     /// <summary>
     /// Apply V3 filter criteria to a list of food records
     /// </summary>

--- a/src/API/Nocturne.API/Controllers/V3/FoodController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/FoodController.cs
@@ -91,9 +91,8 @@ public class FoodController : BaseV3Controller<Food>
 
             // Check for conditional requests (304 Not Modified)
             var lastModified = GetLastModified(foodList.Cast<object>());
-            var etag = GenerateETag(foodList);
 
-            if (lastModified.HasValue && ShouldReturn304(etag, lastModified.Value, parameters))
+            if (lastModified.HasValue && ShouldReturn304(lastModified.Value, parameters))
             {
                 return StatusCode(304);
             }
@@ -121,6 +120,79 @@ public class FoodController : BaseV3Controller<Food>
             _logger.LogError(ex, "Error retrieving V3 food");
             return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
         }
+    }
+
+    /// <summary>
+    /// Get food records modified since a given timestamp (for AAPS incremental sync).
+    /// </summary>
+    /// <param name="lastModified">Unix timestamp in milliseconds. Only foods newer than this time are returned.</param>
+    /// <param name="limit">Maximum number of foods to return (1-1000, default 1000).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>V3 collection of <see cref="Food"/> records newer than the given timestamp.</returns>
+    /// <remarks>
+    /// AAPS requires a parseable cursor ETag on this response even when it is empty (its food
+    /// loader throws on a missing ETag), so the request cursor is echoed back when no newer
+    /// records exist.
+    /// </remarks>
+    /// <response code="200">Foods newer than the given timestamp.</response>
+    /// <response code="500">Internal server error.</response>
+    [HttpGet("history/{lastModified:long}")]
+    [NightscoutEndpoint("/api/v3/food/history/{lastModified}")]
+    [ProducesResponseType(typeof(object), 200)]
+    [ProducesResponseType(500)]
+    public async Task<ActionResult> GetFoodHistory(
+        long lastModified,
+        [FromQuery] int limit = 1000,
+        CancellationToken cancellationToken = default
+    )
+    {
+        _logger.LogDebug(
+            "V3 food history requested since {LastModified} with limit {Limit}",
+            lastModified,
+            limit
+        );
+
+        try
+        {
+            limit = Math.Min(Math.Max(limit, 1), 1000);
+
+            var foodRecords = await _foods.GetFoodWithAdvancedFilterAsync(
+                count: int.MaxValue,
+                skip: 0,
+                findQuery: null,
+                type: null,
+                reverseResults: false,
+                cancellationToken: cancellationToken
+            );
+
+            var newerFoods = foodRecords
+                .Select(f => (Food: f, Mills: ParseCreatedAtMills(f.CreatedAt)))
+                .Where(x => x.Mills.HasValue && x.Mills.Value > lastModified)
+                .OrderBy(x => x.Mills)
+                .Take(limit)
+                .ToList();
+
+            SetHistoryCursorHeaders(
+                newerFoods.Count > 0 ? newerFoods.Max(x => x.Mills!.Value) : lastModified
+            );
+
+            return CreateV3SuccessResponse(newerFoods.Select(x => x.Food).ToList());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error retrieving V3 food history");
+            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
+        }
+    }
+
+    private static long? ParseCreatedAtMills(string? createdAt)
+    {
+        if (string.IsNullOrEmpty(createdAt))
+            return null;
+
+        return DateTimeOffset.TryParse(createdAt, out var parsed)
+            ? parsed.ToUnixTimeMilliseconds()
+            : null;
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Controllers/V3/ProfileController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/ProfileController.cs
@@ -74,22 +74,20 @@ public class ProfileController : BaseV3Controller<Profile>
                 ct: cancellationToken
             ); // Check for conditional requests (304 Not Modified)
             var lastModified = GetLastModified(profilesList.Cast<object>());
-            var etag = GenerateETag(profilesList);
 
-            if (lastModified.HasValue && ShouldReturn304(etag, lastModified.Value, parameters))
+            if (lastModified.HasValue && ShouldReturn304(lastModified.Value, parameters))
             {
                 return StatusCode(304);
             }
-
-            // Create V3 response
-            var response = CreateV3CollectionResponse(profilesList, parameters, totalCount);
 
             _logger.LogDebug(
                 "Successfully returned {Count} profiles with V3 format",
                 profilesList.Count
             );
 
-            return Ok(response);
+            // CreateV3CollectionResponse returns the {status, result} envelope IActionResult;
+            // wrapping it in Ok(...) again would serialize the ActionResult object itself.
+            return (ActionResult)CreateV3CollectionResponse(profilesList, parameters, totalCount);
         }
         catch (ArgumentException ex)
         {
@@ -99,6 +97,61 @@ public class ProfileController : BaseV3Controller<Profile>
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error retrieving V3 profiles");
+            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Get profiles modified since a given timestamp (for AAPS incremental sync).
+    /// </summary>
+    /// <param name="lastModified">Unix timestamp in milliseconds. Only profiles newer than this time are returned.</param>
+    /// <param name="limit">Maximum number of profiles to return (1-100, default 10).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>V3 collection of <see cref="Profile"/> records newer than the given timestamp.</returns>
+    /// <remarks>
+    /// AAPS calls this on every incremental profile sync after the first load; without this
+    /// route its profile cursor never advances and it re-requests (and errors) every cycle.
+    /// </remarks>
+    /// <response code="200">Profiles newer than the given timestamp.</response>
+    /// <response code="500">Internal server error.</response>
+    [HttpGet("history/{lastModified:long}")]
+    [NightscoutEndpoint("/api/v3/profile/history/{lastModified}")]
+    [ProducesResponseType(typeof(object), 200)]
+    [ProducesResponseType(500)]
+    public async Task<ActionResult> GetProfileHistory(
+        long lastModified,
+        [FromQuery] int limit = 10,
+        CancellationToken cancellationToken = default
+    )
+    {
+        _logger.LogDebug(
+            "V3 profile history requested since {LastModified} with limit {Limit}",
+            lastModified,
+            limit
+        );
+
+        try
+        {
+            limit = Math.Min(Math.Max(limit, 1), 100);
+
+            var profiles = await _projectionService.GetProfilesAsync(
+                count: limit,
+                skip: 0,
+                ct: cancellationToken
+            );
+
+            var newerProfiles = profiles.Where(p => p.Mills > lastModified).ToList();
+
+            if (newerProfiles.Count > 0)
+            {
+                SetHistoryCursorHeaders(newerProfiles.Max(p => p.Mills));
+            }
+
+            return CreateV3SuccessResponse(newerProfiles);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error retrieving V3 profile history");
             return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
         }
     }

--- a/src/API/Nocturne.API/Controllers/V3/ProfileController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/ProfileController.cs
@@ -134,18 +134,26 @@ public class ProfileController : BaseV3Controller<Profile>
         {
             limit = Math.Min(Math.Max(limit, 1), 100);
 
+            // The projection returns the newest `limit` profiles. A record newer than the
+            // cursor but older than this window is a superseded profile version; AAPS only
+            // activates the newest store in the page, so skipping it loses nothing.
             var profiles = await _projectionService.GetProfilesAsync(
                 count: limit,
                 skip: 0,
                 ct: cancellationToken
             );
 
-            var newerProfiles = profiles.Where(p => p.Mills > lastModified).ToList();
+            // Ascending order: AAPS activates the LAST element of the page.
+            var newerProfiles = profiles
+                .Where(p => p.Mills > lastModified)
+                .OrderBy(p => p.Mills)
+                .ToList();
 
-            if (newerProfiles.Count > 0)
-            {
-                SetHistoryCursorHeaders(newerProfiles.Max(p => p.Mills));
-            }
+            // Echo the request cursor on an empty page so conditional clients always see
+            // a parseable cursor ETag.
+            SetHistoryCursorHeaders(
+                newerProfiles.Count > 0 ? newerProfiles.Max(p => p.Mills) : lastModified
+            );
 
             return CreateV3SuccessResponse(newerProfiles);
         }

--- a/src/API/Nocturne.API/Controllers/V3/SettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/SettingsController.cs
@@ -86,22 +86,20 @@ public class SettingsController : BaseV3Controller<Settings>
                 "settings"
             ); // Check for conditional requests (304 Not Modified)
             var lastModified = GetLastModified(settingsList.Cast<object>());
-            var etag = GenerateETag(settingsList);
 
-            if (lastModified.HasValue && ShouldReturn304(etag, lastModified.Value, parameters))
+            if (lastModified.HasValue && ShouldReturn304(lastModified.Value, parameters))
             {
                 return StatusCode(304);
             }
-
-            // Create V3 response
-            var response = CreateV3CollectionResponse(settingsList, parameters, totalCount);
 
             _logger.LogDebug(
                 "Successfully returned {Count} settings with V3 format",
                 settingsList.Count
             );
 
-            return Ok(response);
+            // CreateV3CollectionResponse returns the {status, result} envelope IActionResult;
+            // wrapping it in Ok(...) again would serialize the ActionResult object itself.
+            return (ActionResult)CreateV3CollectionResponse(settingsList, parameters, totalCount);
         }
         catch (ArgumentException ex)
         {

--- a/src/API/Nocturne.API/Controllers/V3/TreatmentsController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/TreatmentsController.cs
@@ -99,9 +99,8 @@ public class TreatmentsController : BaseV3Controller<Treatment>
 
             // Check for conditional requests (304 Not Modified)
             var lastModified = GetLastModified(treatmentsList);
-            var etag = GenerateETag(treatmentsList);
 
-            if (ShouldReturn304(etag, lastModified, parameters))
+            if (ShouldReturn304(lastModified, parameters))
             {
                 return StatusCode(304);
             }
@@ -158,8 +157,7 @@ public class TreatmentsController : BaseV3Controller<Treatment>
             }
 
             // Set appropriate headers
-            var etag = GenerateETag(new[] { treatment });
-            Response.Headers["ETag"] = $"\"{etag}\"";
+            Response.Headers["ETag"] = FormatCursorETag(treatment.SrvModified ?? treatment.Mills);
             Response.Headers["Cache-Control"] = "public, max-age=60";
 
             return Ok(treatment);

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V3/V3CursorETagTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V3/V3CursorETagTests.cs
@@ -122,8 +122,9 @@ public class V3CursorETagTests
     }
 
     [Fact]
-    public async Task GetProfileHistory_ReturnsOnlyNewerProfiles_AndSetsCursorHeaders()
+    public async Task GetProfileHistory_ReturnsNewerProfilesAscending_AndSetsCursorHeaders()
     {
+        var cursor = new DateTimeOffset(2024, 3, 26, 11, 55, 0, TimeSpan.Zero).ToUnixTimeMilliseconds();
         var older = new DateTimeOffset(2024, 3, 26, 12, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds();
         var newer = new DateTimeOffset(2024, 3, 26, 12, 5, 0, TimeSpan.Zero).ToUnixTimeMilliseconds();
 
@@ -132,12 +133,13 @@ public class V3CursorETagTests
             .Setup(s => s.GetProfilesAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[]
             {
-                new Profile { Mills = older },
+                // Projection returns newest-first
                 new Profile { Mills = newer },
+                new Profile { Mills = older },
             });
 
         var controller = CreateProfileController(projectionService);
-        var result = await controller.GetProfileHistory(older);
+        var result = await controller.GetProfileHistory(cursor);
 
         controller.Response.Headers["ETag"].ToString().Should().Be($"W/\"{newer}\"");
 
@@ -146,7 +148,25 @@ public class V3CursorETagTests
         var resultProperty = envelope.GetType().GetProperty("result");
         var profiles = resultProperty!.GetValue(envelope)
             .Should().BeAssignableTo<IEnumerable<Profile>>().Subject.ToList();
-        profiles.Should().ContainSingle().Which.Mills.Should().Be(newer);
+
+        // Ascending order matters: AAPS activates the LAST element of the page.
+        profiles.Select(p => p.Mills).Should().Equal(older, newer);
+    }
+
+    [Fact]
+    public async Task GetProfileHistory_EmptyResult_EchoesRequestCursorInETag()
+    {
+        var cursor = new DateTimeOffset(2024, 3, 26, 12, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds();
+
+        var projectionService = new Mock<IProfileProjectionService>();
+        projectionService
+            .Setup(s => s.GetProfilesAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Profile>());
+
+        var controller = CreateProfileController(projectionService);
+        await controller.GetProfileHistory(cursor);
+
+        controller.Response.Headers["ETag"].ToString().Should().Be($"W/\"{cursor}\"");
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V3/V3CursorETagTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V3/V3CursorETagTests.cs
@@ -1,0 +1,228 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Controllers.V3;
+using Nocturne.Core.Contracts.Legacy;
+using Nocturne.Core.Contracts.Profiles;
+using Nocturne.Core.Contracts.Repositories;
+using Nocturne.Core.Contracts.Treatments;
+using Nocturne.Core.Models;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V3;
+
+/// <summary>
+/// AAPS parses every V3 ETag it reads by stripping the first three characters (<c>W/"</c>)
+/// and the trailing quote, then calling <c>toLong()</c>. A non-numeric ETag payload (such as
+/// the content-hash ETags V3 collection endpoints used to emit) crashes the AAPS sync loop
+/// with <c>NumberFormatException</c> on every cycle (#522).
+/// </summary>
+[Trait("Category", "Unit")]
+public class V3CursorETagTests
+{
+    private static ProfileController CreateProfileController(
+        Mock<IProfileProjectionService> projectionService
+    )
+    {
+        return new ProfileController(
+            projectionService.Object,
+            Mock.Of<IProfileWriteService>(),
+            Mock.Of<IDocumentProcessingService>(),
+            NullLogger<ProfileController>.Instance)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            },
+        };
+    }
+
+    private static FoodController CreateFoodController(Mock<IFoodRepository> foods)
+    {
+        return new FoodController(
+            foods.Object,
+            Mock.Of<IDocumentProcessingService>(),
+            NullLogger<FoodController>.Instance)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            },
+        };
+    }
+
+    [Fact]
+    public async Task GetProfiles_SetsAapsParseableCursorETag()
+    {
+        var mills = new DateTimeOffset(2024, 3, 26, 12, 5, 0, TimeSpan.Zero).ToUnixTimeMilliseconds();
+
+        var projectionService = new Mock<IProfileProjectionService>();
+        projectionService
+            .Setup(s => s.GetProfilesAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new Profile { Mills = mills } });
+        projectionService
+            .Setup(s => s.CountProfilesAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var controller = CreateProfileController(projectionService);
+        await controller.GetProfiles();
+
+        controller.Response.Headers["ETag"].ToString().Should().Be($"W/\"{mills}\"");
+    }
+
+    [Fact]
+    public async Task GetProfiles_ReturnsEnvelopeDirectly_NotDoubleWrapped()
+    {
+        var projectionService = new Mock<IProfileProjectionService>();
+        projectionService
+            .Setup(s => s.GetProfilesAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new Profile { Mills = 1 } });
+        projectionService
+            .Setup(s => s.CountProfilesAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var controller = CreateProfileController(projectionService);
+        var result = await controller.GetProfiles();
+
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        var envelope = okResult.Value.Should()
+            .BeAssignableTo<IDictionary<string, object>>()
+            .Subject;
+        envelope["status"].Should().Be(200);
+        envelope.Should().ContainKey("result");
+    }
+
+    [Fact]
+    public async Task GetProfiles_IfNoneMatchWithCursorETag_Returns304()
+    {
+        var mills = new DateTimeOffset(2024, 3, 26, 12, 5, 0, TimeSpan.Zero).ToUnixTimeMilliseconds();
+
+        var projectionService = new Mock<IProfileProjectionService>();
+        projectionService
+            .Setup(s => s.GetProfilesAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new Profile { Mills = mills } });
+        projectionService
+            .Setup(s => s.CountProfilesAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var controller = CreateProfileController(projectionService);
+        controller.HttpContext.Request.Query = new QueryCollection(
+            new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
+            {
+                ["if-none-match"] = $"W/\"{mills}\"",
+            }
+        );
+
+        var result = await controller.GetProfiles();
+
+        result.Should().BeOfType<StatusCodeResult>()
+            .Which.StatusCode.Should().Be(304);
+    }
+
+    [Fact]
+    public async Task GetProfileHistory_ReturnsOnlyNewerProfiles_AndSetsCursorHeaders()
+    {
+        var older = new DateTimeOffset(2024, 3, 26, 12, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds();
+        var newer = new DateTimeOffset(2024, 3, 26, 12, 5, 0, TimeSpan.Zero).ToUnixTimeMilliseconds();
+
+        var projectionService = new Mock<IProfileProjectionService>();
+        projectionService
+            .Setup(s => s.GetProfilesAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new Profile { Mills = older },
+                new Profile { Mills = newer },
+            });
+
+        var controller = CreateProfileController(projectionService);
+        var result = await controller.GetProfileHistory(older);
+
+        controller.Response.Headers["ETag"].ToString().Should().Be($"W/\"{newer}\"");
+
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        var envelope = okResult.Value!;
+        var resultProperty = envelope.GetType().GetProperty("result");
+        var profiles = resultProperty!.GetValue(envelope)
+            .Should().BeAssignableTo<IEnumerable<Profile>>().Subject.ToList();
+        profiles.Should().ContainSingle().Which.Mills.Should().Be(newer);
+    }
+
+    [Fact]
+    public async Task GetFoodHistory_EmptyResult_EchoesRequestCursorInETag()
+    {
+        var cursor = new DateTimeOffset(2024, 3, 26, 12, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds();
+
+        var foods = new Mock<IFoodRepository>();
+        foods
+            .Setup(f => f.GetFoodWithAdvancedFilterAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Food>());
+
+        var controller = CreateFoodController(foods);
+        await controller.GetFoodHistory(cursor);
+
+        // AAPS's food loader throws when the ETag is missing, so an empty page must
+        // still carry a parseable cursor.
+        controller.Response.Headers["ETag"].ToString().Should().Be($"W/\"{cursor}\"");
+    }
+
+    [Fact]
+    public async Task GetFoodHistory_ReturnsOnlyNewerFoods_AndAdvancesCursor()
+    {
+        var cursor = new DateTimeOffset(2024, 3, 26, 12, 0, 0, TimeSpan.Zero);
+        var newer = cursor.AddMinutes(5);
+
+        var foods = new Mock<IFoodRepository>();
+        foods
+            .Setup(f => f.GetFoodWithAdvancedFilterAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new Food { Name = "old", CreatedAt = cursor.AddMinutes(-5).ToString("O") },
+                new Food { Name = "new", CreatedAt = newer.ToString("O") },
+            });
+
+        var controller = CreateFoodController(foods);
+        var result = await controller.GetFoodHistory(cursor.ToUnixTimeMilliseconds());
+
+        controller.Response.Headers["ETag"].ToString()
+            .Should().Be($"W/\"{newer.ToUnixTimeMilliseconds()}\"");
+
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        var resultProperty = okResult.Value!.GetType().GetProperty("result");
+        var returned = resultProperty!.GetValue(okResult.Value)
+            .Should().BeAssignableTo<IEnumerable<Food>>().Subject.ToList();
+        returned.Should().ContainSingle().Which.Name.Should().Be("new");
+    }
+
+    [Fact]
+    public async Task GetTreatment_SingleRecord_SetsAapsParseableCursorETag()
+    {
+        var mills = new DateTimeOffset(2024, 3, 26, 12, 5, 0, TimeSpan.Zero).ToUnixTimeMilliseconds();
+
+        var treatmentService = new Mock<ITreatmentService>();
+        treatmentService
+            .Setup(s => s.GetTreatmentByIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Treatment { EventType = "Note", SrvModified = mills });
+
+        var controller = new TreatmentsController(
+            Mock.Of<ITreatmentStore>(),
+            Mock.Of<IDocumentProcessingService>(),
+            treatmentService.Object,
+            NullLogger<TreatmentsController>.Instance)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            },
+        };
+
+        await controller.GetTreatment("abc");
+
+        controller.Response.Headers["ETag"].ToString().Should().Be($"W/\"{mills}\"");
+    }
+}


### PR DESCRIPTION
## Why #522 kept reproducing after #523/#525

AAPS parses **every** V3 ETag it reads with

```kotlin
val eTag = eTagString?.substring(3, eTagString.length - 1)?.toLong()
```

— it hard-assumes the `W/"<unix-ms>"` shape. Outside the three history routes fixed in #523, our V3 collection endpoints emitted a SHA-256 content-hash ETag (`"FA85FE0572408F63"`, via `BaseV3Controller.GenerateETag`). AAPS strips the first three chars and the trailing quote, leaving a 14-char hex string, and `toLong()` throws — which is exactly the error in the #522 screenshot: `ERROR For input string: "FA85FE0572408F"`.

`getLastProfile` (`GET /api/v3/profile?sort$desc=date&limit=1`) runs on **every AAPS sync cycle**, so the crash persisted after the record-ID fixes (#525) and survives any database cleanup — the poison was in a response header, not the data.

## Changes

- **All V3 ETags are now cursor ETags** (`W/"<newest record mills>"`, falling back to server time for collections with no recognizable timestamp): `SetV3ResponseHeaders` (profile/food/settings/devicestatus collection GETs), single-record treatment/entry GETs. `Last-Modified` derives from the same timestamp.
- **`ShouldReturn304`** now derives the current ETag from the data timestamp and normalizes weak markers/quotes on the client value, so `If-None-Match` matches what we actually serve. DeviceStatus passes its model-derived timestamp explicitly so the emitted ETag and the 304 comparison can't disagree (the mapped DTO dictionaries carry no readable timestamp).
- **Fix `GetProfiles`/`GetSettings` double-wrapping** the collection envelope in `Ok(...)` — they serialized the `OkObjectResult` itself, so the v3 profile response body was unreadable to clients (`result` was never present).
- **Add `GET /api/v3/profile/history/{lastModified}`**: AAPS switches to this route for every profile sync after the first load; without it the 404 means its profile cursor never advances and it errors every cycle after any profile change. Returns ascending order — AAPS activates the **last** element of the page.
- **Add `GET /api/v3/food/history/{lastModified}`**, always carrying a cursor ETag (AAPS's food loader throws on a missing ETag) and echoing the request cursor on an empty page.
- `GetLastModified` also reads string `created_at` values (invariant culture, assume-UTC) so food/created_at-shaped collections get a stable ETag instead of a per-request server-time value.

## Tests

- New `V3CursorETagTests`: ETag format on profile collection + single-record treatment GETs, envelope no longer double-wrapped, 304 round-trip with a `W/"<ms>"` `If-None-Match`, profile history ascending order + cursor headers + empty-page cursor echo, food history filtering + empty-page cursor echo.
- Full `Nocturne.API.Tests` suite: 4094 passed / 0 failed.

## Known pre-existing gaps (not this PR)

- `If-None-Match`/`If-Modified-Since` are only read from the query string, never the HTTP request headers (`ParseV3QueryParameters`).
- `[ProducesResponseType(typeof(V3CollectionResponse<object>))]` doesn't match the actual `{status, result}` envelope, and the `V3CollectionResponse` built inside `CreateV3CollectionResponse` is constructed then discarded.

Fixes #522
