### PR TITLE
fix(compat): round all AAPS integer-typed treatment fields at serialization (#522)

### DIFF
--- a/src/Core/Nocturne.Core.Models/Treatment.cs
+++ b/src/Core/Nocturne.Core.Models/Treatment.cs
@@ -131,12 +131,16 @@ public class Treatment : ProcessableDocumentBase
     /// Gets or sets the protein content in grams
     /// </summary>
     [JsonPropertyName("protein")]
+    // AAPS parses protein as an Int; a fractional value crashes its sync loop
+    [JsonConverter(typeof(RoundedNullableDoubleConverter))]
     public double? Protein { get; set; }
 
     /// <summary>
     /// Gets or sets the fat content in grams
     /// </summary>
     [JsonPropertyName("fat")]
+    // AAPS parses fat as an Int; a fractional value crashes its sync loop
+    [JsonConverter(typeof(RoundedNullableDoubleConverter))]
     public double? Fat { get; set; }
 
     /// <summary>
@@ -413,6 +417,8 @@ public class Treatment : ProcessableDocumentBase
     /// Gets or sets the pre-bolus time in minutes (used by Glooko connector)
     /// </summary>
     [JsonPropertyName("preBolus")]
+    // AAPS parses preBolus as an Int; a fractional value crashes its sync loop
+    [JsonConverter(typeof(RoundedNullableDoubleConverter))]
     public double? PreBolus { get; set; }
 
     /// <summary>
@@ -512,12 +518,16 @@ public class Treatment : ProcessableDocumentBase
     /// Gets or sets the percentage of combo bolus delivered immediately
     /// </summary>
     [JsonPropertyName("splitNow")]
+    // AAPS parses splitNow as an Int; a fractional value crashes its sync loop
+    [JsonConverter(typeof(RoundedNullableDoubleConverter))]
     public double? SplitNow { get; set; }
 
     /// <summary>
     /// Gets or sets the percentage of combo bolus delivered extended
     /// </summary>
     [JsonPropertyName("splitExt")]
+    // AAPS parses splitExt as an Int; a fractional value crashes its sync loop
+    [JsonConverter(typeof(RoundedNullableDoubleConverter))]
     public double? SplitExt { get; set; }
 
     /// <summary>
@@ -578,12 +588,16 @@ public class Treatment : ProcessableDocumentBase
     /// Gets or sets the percentage for CircadianPercentageProfile
     /// </summary>
     [JsonPropertyName("percentage")]
+    // AAPS parses percentage as an Int; a fractional value crashes its sync loop
+    [JsonConverter(typeof(RoundedNullableDoubleConverter))]
     public double? Percentage { get; set; }
 
     /// <summary>
     /// Gets or sets the timeshift for CircadianPercentageProfile (in hours)
     /// </summary>
     [JsonPropertyName("timeshift")]
+    // AAPS parses timeshift as a Long; a fractional value crashes its sync loop
+    [JsonConverter(typeof(RoundedNullableDoubleConverter))]
     public double? Timeshift { get; set; }
 
     /// <summary>

--- a/tests/Unit/Nocturne.Core.Models.Tests/TreatmentAapsIntegerFieldTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/TreatmentAapsIntegerFieldTests.cs
@@ -1,0 +1,50 @@
+using System.Text.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace Nocturne.Core.Models.Tests;
+
+/// <summary>
+/// AAPS's Gson models type these treatment fields as <c>Int</c>/<c>Long</c> and throw
+/// <c>NumberFormatException</c> on a fractional value, crashing the sync loop (#522, #516).
+/// Like <c>duration</c> (see <see cref="TreatmentDurationTests"/>), each must serialize as
+/// a whole number while the in-memory value keeps its exact precision.
+/// </summary>
+[Trait("Category", "Unit")]
+public class TreatmentAapsIntegerFieldTests
+{
+    public static TheoryData<string, Treatment> FractionalFieldCases =>
+        new()
+        {
+            { "protein", new Treatment { Protein = 12.5 } },
+            { "fat", new Treatment { Fat = 7.4 } },
+            { "preBolus", new Treatment { PreBolus = 14.9666 } },
+            { "splitNow", new Treatment { SplitNow = 33.3 } },
+            { "splitExt", new Treatment { SplitExt = 66.7 } },
+            { "percentage", new Treatment { Percentage = 109.5 } },
+            { "timeshift", new Treatment { Timeshift = 1.5 } },
+        };
+
+    [Theory]
+    [MemberData(nameof(FractionalFieldCases))]
+    public void AapsIntegerField_Fractional_SerializesAsWholeNumber(
+        string propertyName,
+        Treatment treatment
+    )
+    {
+        var json = JsonSerializer.Serialize(treatment);
+        var property = JsonSerializer.Deserialize<JsonElement>(json).GetProperty(propertyName);
+
+        property.TryGetInt64(out _).Should()
+            .BeTrue($"AAPS parses {propertyName} as an integer type");
+    }
+
+    [Fact]
+    public void AapsIntegerFields_InMemoryValues_KeepExactPrecision()
+    {
+        var treatment = new Treatment { Protein = 12.5, Timeshift = 1.5 };
+
+        treatment.Protein.Should().Be(12.5);
+        treatment.Timeshift.Should().Be(1.5);
+    }
+}


### PR DESCRIPTION
Follow-up to #535, prompted by the #522 reporter noting the remaining error "seems to also be a remnant of the float rounding bug."

## Problem

AAPS's Gson models (`RemoteTreatment`) type these fields as `Int`/`Long`:

| field | AAPS type | Nocturne type |
|---|---|---|
| `protein` | Int | double? |
| `fat` | Int | double? |
| `preBolus` | Int | double? |
| `splitNow` | Int | double? |
| `splitExt` | Int | double? |
| `percentage` | Int | double? |
| `timeshift` | Long | double? |

A fractional value in any of them makes Gson throw `NumberFormatException` and crashes the AAPS sync loop — the same failure mode as the `duration` bug fixed in #523, which only covered `duration`. Fractional values can be sitting in stored data (entered via the web UI, synthesized by pre-#523 builds, or written by other uploaders/connectors), so a "remnant" keeps crashing sync even on a current build.

## Fix

Apply the existing `RoundedNullableDoubleConverter` to the remaining seven fields. It rounds at JSON write only — in-memory values keep exact precision for internal math, matching the `duration` precedent and its regression guard (`TreatmentDurationTests`).

`devicestatus` integer fields (`uploaderBattery`, pump battery `percent`) were audited and are already `int?` server-side.

## Tests

- New `TreatmentAapsIntegerFieldTests`: each field serializes fractional input as a whole JSON number; in-memory precision preserved.
- `Nocturne.Core.Models.Tests`: 367 passed / 0 failed; `Nocturne.API.Tests`: 4094 passed / 0 failed.

Refs #522, #516
