### PR TITLE
feat(v4): first-class PatientDevice link on device events

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Devices/DeviceEventController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/DeviceEventController.cs
@@ -2,7 +2,9 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Models.Requests.V4;
+using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
 using Nocturne.Core.Contracts.V4;
 
@@ -21,7 +23,9 @@ namespace Nocturne.API.Controllers.V4.Devices;
 /// Create and update use the same <see cref="UpsertDeviceEventRequest"/> shape. On update,
 /// the immutable fields <see cref="DeviceEvent.CorrelationId"/>, <see cref="DeviceEvent.LegacyId"/>,
 /// <see cref="DeviceEvent.CreatedAt"/>, <see cref="DeviceEvent.SyncIdentifier"/>, and
-/// <see cref="DeviceEvent.AdditionalProperties"/> are preserved from the existing record.
+/// <see cref="DeviceEvent.AdditionalProperties"/> are preserved from the existing record,
+/// as are <see cref="DeviceEvent.DeviceId"/> and <see cref="DeviceEvent.PatientDeviceId"/>
+/// when the request carries no explicit <c>patientDeviceId</c>.
 /// </remarks>
 /// <seealso cref="IDeviceEventRepository"/>
 /// <seealso cref="DeviceEvent"/>
@@ -31,14 +35,96 @@ namespace Nocturne.API.Controllers.V4.Devices;
 [Route("api/v4/observations/device-events")]
 [Authorize]
 [Produces("application/json")]
-public class DeviceEventController(IDeviceEventRepository repo)
+public class DeviceEventController(
+    IDeviceEventRepository repo,
+    IPatientDeviceRepository patientDevices,
+    IPatientDeviceStamper deviceStamper)
     : V4CrudControllerBase<DeviceEvent, UpsertDeviceEventRequest, UpsertDeviceEventRequest, IDeviceEventRepository>(repo)
 {
+    /// <summary>
+    /// Lists device events. Adds an optional <c>patientDeviceId</c> query filter on top of the base list
+    /// surface: when set, only events linked to that registered device are returned. Pagination totals
+    /// match the base device/source behaviour (the count is unscoped by the device filters).
+    /// </summary>
+    /// <remarks>
+    /// The <c>patientDeviceId</c> query parameter is read directly from the request because the base list
+    /// signature (shared by every V4 read controller) has no device-attribution concept — binding it here
+    /// keeps a single <c>GET</c> action while adding the device-event-only filter.
+    /// </remarks>
+    public override async Task<ActionResult<PaginatedResponse<DeviceEvent>>> GetAll(
+        [FromQuery] DateTime? from, [FromQuery] DateTime? to,
+        [FromQuery] int limit = 100, [FromQuery] int offset = 0,
+        [FromQuery] string sort = "timestamp_desc",
+        [FromQuery] string? device = null, [FromQuery] string? source = null,
+        CancellationToken ct = default)
+    {
+        if (sort is not "timestamp_desc" and not "timestamp_asc")
+            return Problem(detail: $"Invalid sort value '{sort}'. Must be 'timestamp_asc' or 'timestamp_desc'.", statusCode: 400, title: "Bad Request");
+
+        Guid? patientDeviceId = null;
+        if (Request.Query.TryGetValue("patientDeviceId", out var raw) && Guid.TryParse(raw, out var parsed))
+            patientDeviceId = parsed;
+
+        var descending = sort == "timestamp_desc";
+        var data = await Repository.GetAsync(from, to, device, source, limit, offset, descending,
+            nativeOnly: false, patientDeviceId: patientDeviceId, ct: ct);
+        var total = await Repository.CountAsync(from, to, ct);
+        return Ok(new PaginatedResponse<DeviceEvent> { Data = data, Pagination = new PaginationInfo(limit, offset, total) });
+    }
+
+    public override async Task<ActionResult<DeviceEvent>> Create([FromBody] UpsertDeviceEventRequest request, CancellationToken ct = default)
+    {
+        var model = MapCreateToModel(request);
+
+        if (model.Timestamp == default)
+            return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
+
+        if (await ResolveExplicitPatientDeviceAsync(request, ct) is { } error)
+            return error;
+
+        // V4 REST writes bypass the connector/decomposer ingest paths, so attribute here — otherwise
+        // direct API records stay unstamped. No-op when the request carried an explicit patientDeviceId.
+        await deviceStamper.StampAsync([model], CategoriesFor(model.EventType), model.DataSource, ct);
+
+        var created = await Repository.CreateAsync(model, WriteOrigin.Live, ct);
+        created = await OnAfterCreateAsync(created, ct);
+        return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+    }
+
+    public override async Task<ActionResult<DeviceEvent>> Update(Guid id, [FromBody] UpsertDeviceEventRequest request, CancellationToken ct = default)
+    {
+        var existing = await Repository.GetByIdAsync(id, ct);
+        if (existing is null)
+            return NotFound();
+
+        var model = MapUpdateToModel(id, request, existing);
+
+        if (model.Timestamp == default)
+            return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
+
+        if (await ResolveExplicitPatientDeviceAsync(request, ct) is { } error)
+            return error;
+
+        // No-op when attribution was preserved or explicitly set above; re-attributes only records still unstamped.
+        await deviceStamper.StampAsync([model], CategoriesFor(model.EventType), model.DataSource, ct);
+
+        try
+        {
+            var updated = await Repository.UpdateAsync(id, model, WriteOrigin.Live, ct);
+            return Ok(updated);
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound();
+        }
+    }
+
     protected override DeviceEvent MapCreateToModel(UpsertDeviceEventRequest request) => new()
     {
         Timestamp = request.Timestamp.UtcDateTime,
         UtcOffset = request.UtcOffset,
         Device = request.Device,
+        PatientDeviceId = request.PatientDeviceId,
         App = request.App,
         DataSource = request.DataSource,
         EventType = request.EventType,
@@ -52,6 +138,10 @@ public class DeviceEventController(IDeviceEventRepository repo)
         Timestamp = request.Timestamp.UtcDateTime,
         UtcOffset = request.UtcOffset,
         Device = request.Device,
+        // Preserve attribution across edits unless the request explicitly re-links the event; rebuilding
+        // the model without this would silently drop the stamped device link.
+        DeviceId = existing.DeviceId,
+        PatientDeviceId = request.PatientDeviceId ?? existing.PatientDeviceId,
         App = request.App,
         DataSource = request.DataSource,
         EventType = request.EventType,
@@ -61,6 +151,34 @@ public class DeviceEventController(IDeviceEventRepository repo)
         CreatedAt = existing.CreatedAt,
         SyncIdentifier = existing.SyncIdentifier,
         AdditionalProperties = existing.AdditionalProperties,
+    };
+
+    /// <summary>
+    /// Validates an explicit <see cref="UpsertDeviceEventRequest.PatientDeviceId"/> against the caller's
+    /// registered devices. Returns a 400 result when the id doesn't resolve (tenant scoping makes a
+    /// cross-tenant id indistinguishable from a nonexistent one), or <c>null</c> when valid or absent.
+    /// </summary>
+    private async Task<ObjectResult?> ResolveExplicitPatientDeviceAsync(UpsertDeviceEventRequest request, CancellationToken ct)
+    {
+        if (request.PatientDeviceId is not { } patientDeviceId)
+            return null;
+
+        var device = await patientDevices.GetByIdAsync(patientDeviceId, ct);
+        return device is null
+            ? Problem(detail: $"patientDeviceId '{patientDeviceId}' does not resolve to a registered patient device", statusCode: 400, title: "Bad Request")
+            : null;
+    }
+
+    /// <summary>
+    /// Device categories eligible to receive an event of the given type: sensor lifecycle events belong
+    /// to CGMs, every other lifecycle event (site, cannula, reservoir, battery, pod, priming, settings)
+    /// to insulin pumps.
+    /// </summary>
+    private static DeviceCategory[] CategoriesFor(DeviceEventType eventType) => eventType switch
+    {
+        DeviceEventType.SensorStart or DeviceEventType.SensorChange or DeviceEventType.SensorStop
+            or DeviceEventType.TransmitterSensorInsert => [DeviceCategory.CGM],
+        _ => [DeviceCategory.InsulinPump],
     };
 
     /// <summary>

--- a/src/API/Nocturne.API/Models/Requests/V4/UpsertDeviceEventRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/UpsertDeviceEventRequest.cs
@@ -25,6 +25,14 @@ public class UpsertDeviceEventRequest
     public string? Device { get; set; }
 
     /// <summary>
+    /// Optional reference to the registered <see cref="Nocturne.Core.Models.V4.PatientDevice"/> the event
+    /// occurred on. Must resolve to one of the caller's registered devices. When omitted on create, the
+    /// server attempts attribution from <see cref="Device"/> and <see cref="DataSource"/>; when omitted on
+    /// update, the existing link is preserved.
+    /// </summary>
+    public Guid? PatientDeviceId { get; set; }
+
+    /// <summary>
     /// Name of the application that submitted this record.
     /// </summary>
     public string? App { get; set; }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IDeviceEventRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IDeviceEventRepository.cs
@@ -29,6 +29,8 @@ public interface IDeviceEventRepository : IV4Repository<DeviceEvent>
     /// <param name="offset">Number of records to skip for pagination (default 0).</param>
     /// <param name="descending">When <c>true</c>, results are ordered newest-first (default).</param>
     /// <param name="nativeOnly">When <c>true</c>, excludes records projected from legacy V1/V2/V3 treatments.</param>
+    /// <param name="patientDeviceId">Optional filter restricting results to events linked to a single
+    /// registered <see cref="PatientDevice"/>.</param>
     /// <param name="ct">Cancellation token.</param>
     Task<IEnumerable<DeviceEvent>> GetAsync(
         DateTime? from,
@@ -39,6 +41,7 @@ public interface IDeviceEventRepository : IV4Repository<DeviceEvent>
         int offset = 0,
         bool descending = true,
         bool nativeOnly = false,
+        Guid? patientDeviceId = null,
         CancellationToken ct = default
     );
 
@@ -46,7 +49,7 @@ public interface IDeviceEventRepository : IV4Repository<DeviceEvent>
     Task<IEnumerable<DeviceEvent>> IV4Repository<DeviceEvent>.GetAsync(
         DateTime? from, DateTime? to, string? device, string? source,
         int limit, int offset, bool descending, CancellationToken ct)
-        => GetAsync(from, to, device, source, limit, offset, descending, false, ct);
+        => GetAsync(from, to, device, source, limit, offset, descending, nativeOnly: false, patientDeviceId: null, ct: ct);
 
     /// <summary>Returns a single <see cref="DeviceEvent"/> by its UUID v7, or <c>null</c> if not found.</summary>
     /// <param name="id">UUID v7 record identifier.</param>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
@@ -69,7 +69,7 @@ public class DeviceEventRepository : V4RepositoryBase<DeviceEvent, DeviceEventEn
         DateTime? from, DateTime? to, string? device, string? source,
         int limit = 100, int offset = 0, bool descending = true,
         CancellationToken ct = default)
-        => GetAsync(from, to, device, source, limit, offset, descending, nativeOnly: false, ct);
+        => GetAsync(from, to, device, source, limit, offset, descending, nativeOnly: false, patientDeviceId: null, ct: ct);
 
     /// <summary>
     /// Gets device event records based on filter criteria.
@@ -83,6 +83,7 @@ public class DeviceEventRepository : V4RepositoryBase<DeviceEvent, DeviceEventEn
     /// <param name="offset">The number of records to skip.</param>
     /// <param name="descending">Whether to sort by timestamp in descending order.</param>
     /// <param name="nativeOnly">Whether to return only native records.</param>
+    /// <param name="patientDeviceId">Optional filter restricting results to events linked to a single registered patient device.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>A collection of device events.</returns>
     public async Task<IEnumerable<DeviceEvent>> GetAsync(
@@ -94,6 +95,7 @@ public class DeviceEventRepository : V4RepositoryBase<DeviceEvent, DeviceEventEn
         int offset = 0,
         bool descending = true,
         bool nativeOnly = false,
+        Guid? patientDeviceId = null,
         CancellationToken ct = default
     )
     {
@@ -109,6 +111,8 @@ public class DeviceEventRepository : V4RepositoryBase<DeviceEvent, DeviceEventEn
             query = query.Where(e => e.DataSource == source);
         if (nativeOnly)
             query = query.Where(e => e.LegacyId == null);
+        if (patientDeviceId.HasValue)
+            query = query.Where(e => e.PatientDeviceId == patientDeviceId.Value);
 
         // Exclude non-primary duplicates from cross-connector deduplication
         query = query.Where(b => !ctx.LinkedRecords

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/DeviceEventControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/DeviceEventControllerTests.cs
@@ -1,0 +1,223 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Nocturne.API.Controllers.V4.Devices;
+using Nocturne.API.Models.Requests.V4;
+using Nocturne.Core.Contracts.Devices;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+using Xunit;
+using Nocturne.Core.Contracts.V4;
+
+namespace Nocturne.API.Tests.Controllers.V4;
+
+[Trait("Category", "Unit")]
+public class DeviceEventControllerTests
+{
+    private readonly Mock<IDeviceEventRepository> _repoMock = new();
+    private readonly Mock<IPatientDeviceRepository> _patientDevicesMock = new();
+    private readonly Mock<IPatientDeviceStamper> _deviceStamperMock = new();
+
+    private DeviceEventController CreateController(IQueryCollection? query = null)
+    {
+        var controller = new DeviceEventController(
+            _repoMock.Object,
+            _patientDevicesMock.Object,
+            _deviceStamperMock.Object);
+
+        var httpContext = new DefaultHttpContext();
+        if (query is not null)
+            httpContext.Request.Query = query;
+
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        return controller;
+    }
+
+    private static UpsertDeviceEventRequest ValidRequest(Guid? patientDeviceId = null, DeviceEventType eventType = DeviceEventType.SiteChange) => new()
+    {
+        Timestamp = DateTimeOffset.UtcNow,
+        EventType = eventType,
+        PatientDeviceId = patientDeviceId,
+    };
+
+    private void SetupCreatePassthrough(Action<DeviceEvent>? capture = null) =>
+        _repoMock
+            .Setup(r => r.CreateAsync(It.IsAny<DeviceEvent>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback<DeviceEvent, WriteOrigin, CancellationToken>((m, _, _) => capture?.Invoke(m))
+            .ReturnsAsync((DeviceEvent m, WriteOrigin _, CancellationToken _) => m);
+
+    private void SetupRegisteredDevice(Guid patientDeviceId) =>
+        _patientDevicesMock
+            .Setup(p => p.GetByIdAsync(patientDeviceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PatientDevice { Id = patientDeviceId, DeviceCategory = DeviceCategory.InsulinPump });
+
+    [Fact]
+    public async Task Create_PersistsExplicitPatientDeviceId()
+    {
+        var patientDeviceId = Guid.NewGuid();
+        SetupRegisteredDevice(patientDeviceId);
+        DeviceEvent? persisted = null;
+        SetupCreatePassthrough(m => persisted = m);
+
+        var result = await CreateController().Create(ValidRequest(patientDeviceId));
+
+        result.Result.Should().BeOfType<CreatedAtActionResult>();
+        persisted.Should().NotBeNull();
+        persisted!.PatientDeviceId.Should().Be(patientDeviceId);
+    }
+
+    [Fact]
+    public async Task Create_Returns400_WhenPatientDeviceIdDoesNotResolve()
+    {
+        _patientDevicesMock
+            .Setup(p => p.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PatientDevice?)null);
+
+        var result = await CreateController().Create(ValidRequest(Guid.NewGuid()));
+
+        var problem = result.Result.Should().BeOfType<ObjectResult>().Subject;
+        problem.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        _repoMock.Verify(r => r.CreateAsync(It.IsAny<DeviceEvent>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(DeviceEventType.SensorChange, DeviceCategory.CGM)]
+    [InlineData(DeviceEventType.SensorStart, DeviceCategory.CGM)]
+    [InlineData(DeviceEventType.SiteChange, DeviceCategory.InsulinPump)]
+    [InlineData(DeviceEventType.ReservoirChange, DeviceCategory.InsulinPump)]
+    public async Task Create_StampsUnattributedEvents_WithEventTypeCategory(DeviceEventType eventType, DeviceCategory expectedCategory)
+    {
+        SetupCreatePassthrough();
+
+        await CreateController().Create(ValidRequest(eventType: eventType));
+
+        _deviceStamperMock.Verify(s => s.StampAsync(
+            It.IsAny<IReadOnlyList<IDeviceAttributed>>(),
+            It.Is<IReadOnlyList<DeviceCategory>>(c => c.Single() == expectedCategory),
+            It.IsAny<string?>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Create_PersistsStampedAttribution()
+    {
+        var patientDeviceId = Guid.NewGuid();
+        _deviceStamperMock
+            .Setup(s => s.StampAsync(
+                It.IsAny<IReadOnlyList<IDeviceAttributed>>(),
+                It.IsAny<IReadOnlyList<DeviceCategory>>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<IDeviceAttributed>, IReadOnlyList<DeviceCategory>, string?, CancellationToken>(
+                (records, _, _, _) => records[0].PatientDeviceId = patientDeviceId)
+            .Returns(Task.CompletedTask);
+        DeviceEvent? persisted = null;
+        SetupCreatePassthrough(m => persisted = m);
+
+        await CreateController().Create(ValidRequest());
+
+        persisted.Should().NotBeNull();
+        persisted!.PatientDeviceId.Should().Be(patientDeviceId);
+    }
+
+    [Fact]
+    public async Task Update_PreservesAttribution_WhenRequestOmitsPatientDeviceId()
+    {
+        var id = Guid.NewGuid();
+        var existing = new DeviceEvent
+        {
+            Id = id,
+            Timestamp = DateTime.UtcNow,
+            EventType = DeviceEventType.SiteChange,
+            DeviceId = Guid.NewGuid(),
+            PatientDeviceId = Guid.NewGuid(),
+        };
+        _repoMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+        DeviceEvent? updated = null;
+        _repoMock
+            .Setup(r => r.UpdateAsync(id, It.IsAny<DeviceEvent>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, DeviceEvent, WriteOrigin, CancellationToken>((_, m, _, _) => updated = m)
+            .ReturnsAsync((Guid _, DeviceEvent m, WriteOrigin _, CancellationToken _) => m);
+
+        var result = await CreateController().Update(id, ValidRequest());
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        updated.Should().NotBeNull();
+        updated!.DeviceId.Should().Be(existing.DeviceId);
+        updated.PatientDeviceId.Should().Be(existing.PatientDeviceId);
+    }
+
+    [Fact]
+    public async Task Update_RelinksAttribution_WhenRequestCarriesPatientDeviceId()
+    {
+        var id = Guid.NewGuid();
+        var newPatientDeviceId = Guid.NewGuid();
+        SetupRegisteredDevice(newPatientDeviceId);
+        var existing = new DeviceEvent
+        {
+            Id = id,
+            Timestamp = DateTime.UtcNow,
+            EventType = DeviceEventType.SiteChange,
+            PatientDeviceId = Guid.NewGuid(),
+        };
+        _repoMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+        DeviceEvent? updated = null;
+        _repoMock
+            .Setup(r => r.UpdateAsync(id, It.IsAny<DeviceEvent>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, DeviceEvent, WriteOrigin, CancellationToken>((_, m, _, _) => updated = m)
+            .ReturnsAsync((Guid _, DeviceEvent m, WriteOrigin _, CancellationToken _) => m);
+
+        await CreateController().Update(id, ValidRequest(newPatientDeviceId));
+
+        updated.Should().NotBeNull();
+        updated!.PatientDeviceId.Should().Be(newPatientDeviceId);
+    }
+
+    [Fact]
+    public async Task Update_Returns400_WhenPatientDeviceIdDoesNotResolve()
+    {
+        var id = Guid.NewGuid();
+        _repoMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeviceEvent { Id = id, Timestamp = DateTime.UtcNow, EventType = DeviceEventType.SiteChange });
+        _patientDevicesMock
+            .Setup(p => p.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PatientDevice?)null);
+
+        var result = await CreateController().Update(id, ValidRequest(Guid.NewGuid()));
+
+        var problem = result.Result.Should().BeOfType<ObjectResult>().Subject;
+        problem.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        _repoMock.Verify(r => r.UpdateAsync(It.IsAny<Guid>(), It.IsAny<DeviceEvent>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetAll_PassesPatientDeviceIdFilter_ToRepository()
+    {
+        var patientDeviceId = Guid.NewGuid();
+        _repoMock
+            .Setup(r => r.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<int>(),
+                It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Guid?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var query = new QueryCollection(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
+        {
+            ["patientDeviceId"] = patientDeviceId.ToString(),
+        });
+
+        var result = await CreateController(query).GetAll(from: null, to: null);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        _repoMock.Verify(r => r.GetAsync(
+            It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+            It.IsAny<string?>(), It.IsAny<string?>(),
+            It.IsAny<int>(), It.IsAny<int>(),
+            It.IsAny<bool>(), It.IsAny<bool>(), patientDeviceId,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/ChartData/Stages/DataFetchStageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ChartData/Stages/DataFetchStageTests.cs
@@ -105,13 +105,13 @@ public class DataFetchStageTests
                 It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<BGCheck>());
 
-        // IDeviceEventRepository.GetAsync: (DateTime?, DateTime?, string?, string?, int, int, bool, bool, CancellationToken)
+        // IDeviceEventRepository.GetAsync: (DateTime?, DateTime?, string?, string?, int, int, bool, bool, Guid?, CancellationToken)
         _mockDeviceEventRepo
             .Setup(r => r.GetAsync(
                 It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
                 It.IsAny<string?>(), It.IsAny<string?>(),
                 It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(),
-                It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<DeviceEvent>());
 
         // ITempBasalRepository.GetAsync: (DateTime?, DateTime?, string?, string?, int, int, bool, CancellationToken) — no nativeOnly

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/V4ToLegacyProjectionServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/V4ToLegacyProjectionServiceTests.cs
@@ -64,7 +64,7 @@ public class V4ToLegacyProjectionServiceTests
                 It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
                 It.IsAny<string?>(), It.IsAny<string?>(),
                 It.IsAny<int>(), It.IsAny<int>(),
-                It.IsAny<bool>(), It.IsAny<bool>(),
+                It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Guid?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(Enumerable.Empty<DeviceEvent>());
 


### PR DESCRIPTION
## Summary

A `DeviceEvent` could only be tied to hardware through the free-form `device` string. The persistence layer already had everything (`patient_device_id` column + FK + index, mapper round-trip, `PatientDeviceId` on the read model since #142) — but the V4 API surface never caught up:

1. **`UpsertDeviceEventRequest` had no `patientDeviceId`** — a client that knows which registered device an event belongs to (e.g. a mobile client's device-care picker) couldn't record it.
2. **`PUT` silently wiped attribution** — `MapUpdateToModel` preserved `CorrelationId`/`LegacyId`/`CreatedAt`/`SyncIdentifier`/`AdditionalProperties` but rebuilt the model without `DeviceId`/`PatientDeviceId`, so any edit dropped a previously stamped link.
3. **V4 REST creates were never stamped** — `SensorGlucoseController` runs `IPatientDeviceStamper` on direct writes; `DeviceEventController` didn't, so V4-written events stayed unattributed even when the `device` string matched a registered device.
4. **The list endpoint couldn't filter by device id** — only the `device` string and `source`.

## Changes

- `UpsertDeviceEventRequest.PatientDeviceId` (optional). An explicit id is validated against the caller's registered devices and rejected with 400 when it doesn't resolve (RLS scopes the lookup, so a cross-tenant id is indistinguishable from a nonexistent one). Explicit id wins; the `device` string stays a free-form label.
- Update preserves `DeviceId` and `PatientDeviceId` unless the request explicitly re-links.
- Create/update run the stamper for still-unattributed records, mirroring the sensor-glucose pattern. Sensor lifecycle events (`SensorStart`/`SensorChange`/`SensorStop`/`TransmitterSensorInsert`) match CGM candidates; every other event type matches insulin pumps.
- `GET /api/v4/observations/device-events?patientDeviceId=…` filters by the FK (same `Request.Query` binding pattern as sensor glucose, extended repository overload + `patient_device_id` predicate).

## Non-goals

- `deviceage` endpoints still derive age from event types only; per-device scoping is now possible as a follow-up.
- No way to *clear* a link via PUT (omitted = preserved), matching sensor-glucose semantics.
- No backfill of historical `device` strings into FKs.

## Tests

- New `DeviceEventControllerTests` (10 tests): explicit-id persistence, 400 on unresolvable id (create + update), category selection per event type, stamped-attribution persistence, preserve-on-update, re-link-on-update, list filter passthrough.
- Two existing mock setups updated for the extended `GetAsync` signature.
- Full `Nocturne.API.Tests` unit suite green (4124 passed).
