### PR TITLE
fix(v1): preserve automatic/SMB bolus distinction on treatment reads (#354)

### DIFF
--- a/src/API/Nocturne.API/Services/V4/V4ToLegacyProjectionService.cs
+++ b/src/API/Nocturne.API/Services/V4/V4ToLegacyProjectionService.cs
@@ -468,6 +468,7 @@ public class V4ToLegacyProjectionService : IV4ToLegacyProjectionService
             SyncIdentifier = bolus.SyncIdentifier,
             InsulinType = bolus.InsulinType,
             UtcOffset = bolus.UtcOffset,
+            Automatic = bolus.Automatic,
         };
 
     private static Treatment ProjectCorrectionBolus(Bolus bolus) =>
@@ -482,6 +483,11 @@ public class V4ToLegacyProjectionService : IV4ToLegacyProjectionService
             SyncIdentifier = bolus.SyncIdentifier,
             InsulinType = bolus.InsulinType,
             UtcOffset = bolus.UtcOffset,
+            // Preserve the algorithm/manual distinction (SMBs, auto-boluses): the v4 Bolus.Automatic
+            // flag (set alongside Kind=Algorithm during decomposition) maps onto the legacy Nightscout
+            // `automatic` field so v1/v3 clients (LoopFollow, Trio import) can tell an SMB from a
+            // user-initiated bolus.
+            Automatic = bolus.Automatic,
         };
 
     private static Treatment ProjectCarbCorrection(CarbIntake carb, List<TreatmentFood> foods) =>

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/BolusMarker.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/BolusMarker.svelte
@@ -6,12 +6,28 @@
     yPos: number;
     insulin: number;
     isOverride: boolean;
+    /** Backend-categorized bolus type (e.g. "AutomaticBolus", "Smb", "Bolus"). */
+    bolusType?: string;
     treatmentId: string;
     onMarkerClick: (treatmentId: string) => void;
   }
 
-  let { xPos, yPos, insulin, isOverride, treatmentId, onMarkerClick }: Props =
-    $props();
+  let {
+    xPos,
+    yPos,
+    insulin,
+    isOverride,
+    bolusType,
+    treatmentId,
+    onMarkerClick,
+  }: Props = $props();
+
+  // Algorithm-delivered doses (SMBs / auto-boluses) render as an outlined dome so
+  // they read distinctly from a user-initiated (filled) bolus. Category comes from
+  // the backend; the frontend only picks the shape.
+  const isAutomatic = $derived(
+    bolusType === "AutomaticBolus" || bolusType === "Smb",
+  );
 </script>
 
 <Group
@@ -29,6 +45,14 @@
         { x: 8, y: 0 },
       ]}
       class="opacity-90 fill-insulin-bolus hover:opacity-100 transition-opacity"
+    />
+  {:else if isAutomatic}
+    <!-- Outlined dome for algorithm-delivered doses (SMB / auto-bolus) -->
+    <path
+      d="M -8,0 A 8,8 0 0,1 8,0 Z"
+      fill="none"
+      class="stroke-insulin-bolus opacity-90 hover:opacity-100 transition-opacity"
+      stroke-width="1.5"
     />
   {:else}
     <!-- Hemisphere (dome shape - curves above baseline) -->

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/tracks/IobCobTrack.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/tracks/IobCobTrack.svelte
@@ -129,6 +129,7 @@
           {yPos}
           insulin={marker.insulin ?? 0}
           isOverride={marker.isOverride ?? false}
+          bolusType={marker.bolusType}
           treatmentId={marker.treatmentId ?? ""}
           onMarkerClick={effectiveOnMarkerClick}
         />

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/V4ToLegacyProjectionServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/V4ToLegacyProjectionServiceTests.cs
@@ -175,6 +175,47 @@ public class V4ToLegacyProjectionServiceTests
     }
 
     [Fact]
+    public async Task GetProjectedTreatments_AlgorithmBolus_ProjectsAutomaticFlag()
+    {
+        // An SMB / auto-bolus is stored with Kind=Algorithm + Automatic=true; a user-initiated
+        // bolus with Automatic=false. Both must surface on the legacy `automatic` field so v1/v3
+        // clients (LoopFollow, Trio import) can distinguish them. Each bolus is standalone
+        // (distinct CorrelationId, no carbs) so both project as Correction Bolus.
+        var timestamp = new DateTime(2025, 01, 01, 12, 0, 0, DateTimeKind.Utc);
+
+        var smb = new Bolus
+        {
+            Id = Guid.CreateVersion7(),
+            CorrelationId = Guid.CreateVersion7(),
+            Timestamp = timestamp,
+            Insulin = 0.3,
+            Kind = BolusKind.Algorithm,
+            Automatic = true,
+        };
+        var manual = new Bolus
+        {
+            Id = Guid.CreateVersion7(),
+            CorrelationId = Guid.CreateVersion7(),
+            Timestamp = timestamp.AddMinutes(5),
+            Insulin = 4.0,
+            Kind = BolusKind.Manual,
+            Automatic = false,
+        };
+
+        SetupBoluses(new[] { smb, manual });
+        SetupCarbs(Enumerable.Empty<CarbIntake>());
+
+        var result = (await _service.GetProjectedTreatmentsAsync(null, null, 100)).ToList();
+
+        var smbTreatment = result.Single(t => t.Id == smb.Id.ToString());
+        smbTreatment.EventType.Should().Be(TreatmentTypes.CorrectionBolus);
+        smbTreatment.Automatic.Should().Be(true);
+
+        var manualTreatment = result.Single(t => t.Id == manual.Id.ToString());
+        manualTreatment.Automatic.Should().Be(false);
+    }
+
+    [Fact]
     public async Task GetProjectedTreatments_MultipleCarbsInCorrelation_SelectsLargestAsMealBolus()
     {
         var correlationId = Guid.CreateVersion7();


### PR DESCRIPTION
## Problem

Part of #354 (Trio compatibility). Two reporters (ideaweb, mountrcg) flagged that algorithm-delivered boluses — SMBs from Trio/AAPS/OpenAPS and auto-boluses from Loop — are **indistinguishable from manual boluses** everywhere:

> the v1 treatment projection drops the SMB/manual distinction: algorithm boluses come back as `Correction Bolus` with `automatic:null`, indistinguishable from a manual bolus

The domain model (`Bolus.Kind` = Manual/Algorithm, `Bolus.Automatic`), the DB, and ingestion (`TreatmentDecomposer` sets `Kind=Algorithm` + `Automatic=true`) **already preserve** the distinction. The break was purely on the read side: `V4ToLegacyProjectionService` never copied the flag onto the legacy `Treatment.automatic` field.

## Fix

- **`V4ToLegacyProjectionService`** — project `bolus.Automatic` onto `Treatment.Automatic` in both the meal- and correction-bolus projections. This restores the discriminator for v1/v3 API consumers (LoopFollow, Trio's external-treatment import) and lights up the **existing** `Auto` label in the treatments table, which already reads `automatic`. The AAPS modified-since pull path routes through the same projection, so it's covered too.
- **Glucose chart** — render algorithm-delivered doses as an outlined dome so SMBs read distinctly from manual (filled) boluses. The marker consumes the backend-provided `bolusType` (`AutomaticBolus`/`Smb`) that `ChartDataService` already computes; the frontend only picks the shape.

`eventType` is deliberately left unchanged (`Correction Bolus`/`Meal Bolus`), so `find[eventType]` filtering and re-ingestion are unaffected — the discriminator is the canonical Nightscout `automatic` field.

## Test

New `V4ToLegacyProjectionServiceTests.GetProjectedTreatments_AlgorithmBolus_ProjectsAutomaticFlag` asserts an `Algorithm` bolus projects `automatic:true` and a manual one `automatic:false` (fails pre-fix, where both were null).

Ref: #354