### PR TITLE
feat(dashboard): surface pump reservoir + battery (#354)

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Analytics/CurrentTherapyStateController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/CurrentTherapyStateController.cs
@@ -3,14 +3,16 @@ using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
 using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Contracts.Profiles.Resolvers;
+using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 
 namespace Nocturne.API.Controllers.V4.Analytics;
 
 /// <summary>
 /// Returns small "right now" therapy values consumed by the dashboard Halo Dial:
-/// the active pump operational mode and the current insulin sensitivity expressed
-/// as a percentage of the profile baseline.
+/// the active pump operational mode, the current insulin sensitivity expressed
+/// as a percentage of the profile baseline, and the pump's latest reservoir and
+/// battery reading.
 /// </summary>
 [ApiController]
 [Tags("Current Therapy State")]
@@ -20,17 +22,21 @@ public class CurrentTherapyStateController : ControllerBase
 {
     private readonly IStateSpanService _stateSpanService;
     private readonly ISensitivityResolver _sensitivityResolver;
+    private readonly IPumpSnapshotRepository _pumpSnapshotRepository;
 
     public CurrentTherapyStateController(
         IStateSpanService stateSpanService,
-        ISensitivityResolver sensitivityResolver)
+        ISensitivityResolver sensitivityResolver,
+        IPumpSnapshotRepository pumpSnapshotRepository)
     {
         _stateSpanService = stateSpanService;
         _sensitivityResolver = sensitivityResolver;
+        _pumpSnapshotRepository = pumpSnapshotRepository;
     }
 
     /// <summary>
-    /// Get the current pump mode and sensitivity adjustment for the active tenant.
+    /// Get the current pump mode, sensitivity adjustment, and latest pump
+    /// reservoir/battery reading for the active tenant.
     /// </summary>
     [HttpGet]
     [RemoteQuery]
@@ -40,10 +46,14 @@ public class CurrentTherapyStateController : ControllerBase
     {
         var pumpMode = await _stateSpanService.GetCurrentPumpModeAsync(cancellationToken);
         var sensitivityPercent = await _sensitivityResolver.GetCurrentSensitivityPercentAsync(cancellationToken);
+        var latestPump = await _pumpSnapshotRepository.GetLatestAsync(asOf: null, cancellationToken);
         return Ok(new CurrentTherapyStateResponse
         {
             CurrentPumpMode = pumpMode,
             SensitivityPercent = sensitivityPercent,
+            Reservoir = latestPump?.Reservoir,
+            PumpBatteryPercent = latestPump?.BatteryPercent,
+            PumpBatteryVoltage = latestPump?.BatteryVoltage,
         });
     }
 }
@@ -66,4 +76,23 @@ public class CurrentTherapyStateResponse
     /// Null when no CircadianPercentageProfile adjustment is active.
     /// </summary>
     public double? SensitivityPercent { get; set; }
+
+    /// <summary>
+    /// Insulin remaining in the pump reservoir (units), from the most recent pump
+    /// snapshot. Null when no pump has reported a reservoir value — e.g. Omnipod
+    /// pods report no numeric reservoir until they drop below 50 U.
+    /// </summary>
+    public double? Reservoir { get; set; }
+
+    /// <summary>
+    /// Pump battery level as a percentage (0–100) from the most recent pump
+    /// snapshot, or null when the pump reports no battery percentage.
+    /// </summary>
+    public int? PumpBatteryPercent { get; set; }
+
+    /// <summary>
+    /// Pump battery voltage from the most recent pump snapshot, or null when the
+    /// pump reports no battery voltage.
+    /// </summary>
+    public double? PumpBatteryVoltage { get; set; }
 }

--- a/src/Core/Nocturne.Core.Models/Configuration/HaloDialConfig.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/HaloDialConfig.cs
@@ -64,12 +64,17 @@ public class HaloDialConfig
 /// <summary>
 /// The four corner-slot stacks on the Halo Dial. Each holds up to three
 /// elements rendered top-to-bottom. Defaults reproduce the source design's
-/// "loop dot top-right; direction + eventual + loop label bottom-right".
+/// "loop dot top-right; direction + eventual + loop label bottom-right", with
+/// pump reservoir and battery in the top-left.
 /// </summary>
 public class HaloDialCorners
 {
     [JsonPropertyName("tl")]
-    public List<HaloDialCornerElement> Tl { get; set; } = new();
+    public List<HaloDialCornerElement> Tl { get; set; } = new()
+    {
+        HaloDialCornerElement.Reservoir,
+        HaloDialCornerElement.Battery,
+    };
 
     [JsonPropertyName("tr")]
     public List<HaloDialCornerElement> Tr { get; set; } = new() { HaloDialCornerElement.LoopDot };

--- a/src/Web/packages/app/src/lib/components/dashboard/CurrentBGDisplay.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/CurrentBGDisplay.svelte
@@ -7,6 +7,7 @@
     BasalPill,
     IOBPill,
     LoopPill,
+    ReservoirPill,
     TrackerPillBar,
   } from "$lib/components/status-pills";
   import { GlucoseValueIndicator } from "$lib/components/shared";
@@ -197,6 +198,11 @@
         <BasalPill data={realtimeStore.pillsData.basal} />
         <IOBPill data={realtimeStore.pillsData.iob} />
         <LoopPill data={realtimeStore.pillsData.loop} />
+        <!-- Reservoir is optional: many pumps/pods report no numeric value
+             (e.g. Omnipod above 50 U), so only show the pill when present. -->
+        {#if realtimeStore.currentReservoir !== null}
+          <ReservoirPill reservoir={realtimeStore.currentReservoir} />
+        {/if}
       {/if}
       <!-- Tracker Pills -->
       {#if trackerPillsEnabled && realtimeStore.trackerInstances.length > 0}

--- a/src/Web/packages/app/src/lib/components/dashboard/halo-dial/HaloDial.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/halo-dial/HaloDial.svelte
@@ -68,6 +68,9 @@
   );
   const pills = $derived(realtime?.pillsData ?? null);
   const direction = $derived(realtime?.direction ?? "Flat");
+  const reservoir = $derived(realtime?.currentReservoir ?? null);
+  const pumpBatteryPercent = $derived(realtime?.currentPumpBatteryPercent ?? null);
+  const pumpBatteryVoltage = $derived(realtime?.currentPumpBatteryVoltage ?? null);
 
   // Cutoff rounded to one-minute buckets so the per-second `now` tick doesn't
   // invalidate `historyValues` (and the whole HistoryRing) 60 times a minute.
@@ -235,10 +238,17 @@
           percent: pills.basal.tempBasal?.percent ?? 100,
         }
       : null,
-    reservoir: null, // Not yet surfaced via pillsData; Phase 5/6 will hook reservoir DTO.
+    // Reservoir units come straight from the latest pump snapshot; percent and
+    // time-remaining aren't derivable without reservoir capacity / delivery rate,
+    // so they stay undefined (the "units" format is the default and only one the
+    // data supports).
+    reservoir: reservoir !== null ? { units: reservoir } : null,
     sensorAge: null,
     pumpSiteAge: null,
-    battery: null,
+    battery:
+      pumpBatteryPercent !== null
+        ? { percent: pumpBatteryPercent, voltage: pumpBatteryVoltage ?? undefined }
+        : null,
     loop: pills?.loop ? { status: pills.loop.status } : null,
     direction: { direction },
     eventual: predictions

--- a/src/Web/packages/app/src/lib/components/dashboard/halo-dial/HaloDial.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/halo-dial/HaloDial.svelte.test.ts
@@ -42,6 +42,9 @@ function makeStub(overrides: Record<string, unknown> = {}) {
 		now: baseNow,
 		currentPumpMode: null,
 		currentSensitivityPercent: null,
+		currentReservoir: null,
+		currentPumpBatteryPercent: null,
+		currentPumpBatteryVoltage: null,
 		pillsData: { iob: null, cob: null, cage: null, sage: null, basal: null, loop: null },
 		direction: "Flat",
 		entries: [
@@ -83,6 +86,36 @@ describe("HaloDial", () => {
 		// and a non-empty SVG exists.
 		const svg = container.querySelector("[data-testid='halo-dial-svg']");
 		expect(svg).not.toBeNull();
+	});
+
+	it("renders pump reservoir and battery in the default top-left corner from the store", () => {
+		const { container } = render(HaloDial, {
+			realtimeOverride: makeStub({
+				currentReservoir: 87.5,
+				currentPumpBatteryPercent: 64,
+			}),
+			configOverride: defaultHaloDialConfig(),
+		});
+
+		const reservoir = container.querySelector("[data-testid='reservoir']");
+		expect(reservoir!.textContent).toContain("87.5 U");
+
+		const battery = container.querySelector("[data-testid='battery']");
+		expect(battery!.textContent).toContain("64%");
+	});
+
+	it("shows placeholders when the pump reports no reservoir or battery", () => {
+		const { container } = render(HaloDial, {
+			realtimeOverride: makeStub(),
+			configOverride: defaultHaloDialConfig(),
+		});
+
+		expect(
+			container.querySelector("[data-testid='reservoir']")!.textContent
+		).toContain("--");
+		expect(
+			container.querySelector("[data-testid='battery']")!.textContent
+		).toContain("--");
 	});
 
 	it("applies the stale class and hides the chevron when the latest entry is older than the threshold", () => {

--- a/src/Web/packages/app/src/lib/components/dashboard/halo-dial/config.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/halo-dial/config.test.ts
@@ -36,7 +36,10 @@ describe("defaultHaloDialConfig", () => {
     expect(config.iobMaxUnits).toBe(8.0);
     expect(config.cobMaxGrams).toBe(80.0);
 
-    expect(config.corners!.tl).toEqual([]);
+    expect(config.corners!.tl).toEqual([
+      HaloDialCornerElement.Reservoir,
+      HaloDialCornerElement.Battery,
+    ]);
     expect(config.corners!.tr).toEqual([HaloDialCornerElement.LoopDot]);
     expect(config.corners!.bl).toEqual([]);
     expect(config.corners!.br).toEqual([

--- a/src/Web/packages/app/src/lib/components/dashboard/halo-dial/config.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/halo-dial/config.ts
@@ -42,7 +42,7 @@ export function defaultHaloDialConfig(): HaloDialConfig {
     iobMaxUnits: 8.0,
     cobMaxGrams: 80.0,
     corners: {
-      tl: [],
+      tl: [HaloDialCornerElement.Reservoir, HaloDialCornerElement.Battery],
       tr: [HaloDialCornerElement.LoopDot],
       bl: [],
       br: [

--- a/src/Web/packages/app/src/lib/components/dashboard/halo-dial/corners/CornerSlot.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/halo-dial/corners/CornerSlot.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" module>
 	export interface CornerData {
 		basalRate?: { rate: number; percent: number } | null;
-		reservoir?: { units: number; percent: number; minutesRemaining: number } | null;
+		reservoir?: { units: number; percent?: number; minutesRemaining?: number } | null;
 		sensorAge?: { startedAtMs: number; expiryMs?: number } | null;
 		pumpSiteAge?: { startedAtMs: number; expiryMs?: number } | null;
 		battery?: { percent: number; voltage?: number; minutesRemaining?: number } | null;

--- a/src/Web/packages/app/src/lib/components/dashboard/halo-dial/corners/elements/Reservoir.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/halo-dial/corners/elements/Reservoir.svelte
@@ -3,7 +3,7 @@
 
 	interface Props {
 		value:
-			| { units: number; percent: number; minutesRemaining: number }
+			| { units: number; percent?: number; minutesRemaining?: number }
 			| null;
 		options: { format: "units" | "percent" | "time-left" };
 	}
@@ -23,9 +23,15 @@
 			case "units":
 				return `${value.units.toFixed(1)} U`;
 			case "percent":
-				return `${Math.round(value.percent)}%`;
+				// percent/time-left need reservoir capacity / delivery rate, which
+				// a pump snapshot doesn't carry — show placeholder when absent.
+				return value.percent === undefined
+					? "--"
+					: `${Math.round(value.percent)}%`;
 			case "time-left":
-				return formatMinutes(value.minutesRemaining);
+				return value.minutesRemaining === undefined
+					? "--"
+					: formatMinutes(value.minutesRemaining);
 		}
 	});
 </script>

--- a/src/Web/packages/app/src/lib/components/status-pills/ReservoirPill.svelte
+++ b/src/Web/packages/app/src/lib/components/status-pills/ReservoirPill.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import StatusPill from "./StatusPill.svelte";
+
+  interface ReservoirPillProps {
+    /** Insulin remaining in the pump reservoir, in units. */
+    reservoir: number;
+  }
+
+  let { reservoir }: ReservoirPillProps = $props();
+
+  const display = $derived(`${reservoir.toFixed(1)} U`);
+</script>
+
+<StatusPill value={display} label="Reservoir" level="none" />

--- a/src/Web/packages/app/src/lib/components/status-pills/ReservoirPill.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/status-pills/ReservoirPill.svelte.test.ts
@@ -1,0 +1,11 @@
+import { render } from "vitest-browser-svelte";
+import { describe, it, expect } from "vitest";
+import ReservoirPill from "./ReservoirPill.svelte";
+
+describe("ReservoirPill", () => {
+  it("renders reservoir units to one decimal with a U suffix", () => {
+    const { container } = render(ReservoirPill, { reservoir: 42.34 });
+    expect(container.textContent).toContain("Reservoir");
+    expect(container.textContent).toContain("42.3 U");
+  });
+});

--- a/src/Web/packages/app/src/lib/components/status-pills/index.ts
+++ b/src/Web/packages/app/src/lib/components/status-pills/index.ts
@@ -4,6 +4,7 @@ export { default as IOBPill } from './IOBPill.svelte';
 export { default as COBPill } from './COBPill.svelte';
 export { default as BasalPill } from './BasalPill.svelte';
 export { default as LoopPill } from './LoopPill.svelte';
+export { default as ReservoirPill } from './ReservoirPill.svelte';
 export { default as StatusPillBar } from './StatusPillBar.svelte';
 export { default as TrackerPill } from './TrackerPill.svelte';
 export { default as TrackerPillBar } from './TrackerPillBar.svelte';

--- a/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
@@ -191,9 +191,14 @@ export const sidebarWidget = new SyncedPref<SidebarWidget>("nocturne-sidebar-wid
 
 /**
  * Halo dial configuration — device-local (not part of the per-user synced set).
+ *
+ * The storage key carries a version suffix: bumping it discards a stale persisted
+ * blob so a changed default (e.g. new default corner elements) reaches existing
+ * devices. Safe while the dial has no user-facing editor — no real customization
+ * exists to lose. Bump the suffix whenever `defaultHaloDialConfig()` changes.
  */
 export const haloDialConfig = new PersistedState<HaloDialConfig>(
-  "nocturne-halo-dial-config",
+  "nocturne-halo-dial-config-v2",
   defaultHaloDialConfig()
 );
 

--- a/src/Web/packages/app/src/lib/stores/realtime-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/realtime-store.svelte.ts
@@ -127,6 +127,11 @@ export class RealtimeStore {
   /** Current ISF as % of profile baseline (null when no CCP adjustment is active). Fetched once at init. */
   currentSensitivityPercent = $state<number | null>(null);
 
+  /** Latest pump reservoir (units) and battery. Fetched once at init; not yet pushed via the realtime channel. */
+  currentReservoir = $state<number | null>(null);
+  currentPumpBatteryPercent = $state<number | null>(null);
+  currentPumpBatteryVoltage = $state<number | null>(null);
+
   /** Connection state (with safe initialization) */
   connectionStatus = $derived(
     this.websocketClient?.connectionStatus || "disconnected"
@@ -418,6 +423,9 @@ export class RealtimeStore {
         if (currentTherapyState) {
           this.currentPumpMode = currentTherapyState.currentPumpMode ?? null;
           this.currentSensitivityPercent = currentTherapyState.sensitivityPercent ?? null;
+          this.currentReservoir = currentTherapyState.reservoir ?? null;
+          this.currentPumpBatteryPercent = currentTherapyState.pumpBatteryPercent ?? null;
+          this.currentPumpBatteryVoltage = currentTherapyState.pumpBatteryVoltage ?? null;
         }
 
         this.isReady = true;

--- a/tests/Unit/Nocturne.API.Tests/Controllers/CurrentTherapyStateControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/CurrentTherapyStateControllerTests.cs
@@ -1,0 +1,64 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Nocturne.API.Controllers.V4.Analytics;
+using Nocturne.Core.Contracts.Glucose;
+using Nocturne.Core.Contracts.Profiles.Resolvers;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.V4;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers;
+
+public class CurrentTherapyStateControllerTests
+{
+    private readonly Mock<IStateSpanService> _stateSpanService = new();
+    private readonly Mock<ISensitivityResolver> _sensitivityResolver = new();
+    private readonly Mock<IPumpSnapshotRepository> _pumpSnapshotRepository = new();
+    private readonly CurrentTherapyStateController _controller;
+
+    public CurrentTherapyStateControllerTests()
+    {
+        _controller = new CurrentTherapyStateController(
+            _stateSpanService.Object,
+            _sensitivityResolver.Object,
+            _pumpSnapshotRepository.Object);
+    }
+
+    [Fact]
+    public async Task GetCurrentTherapyState_SurfacesLatestReservoirAndBattery()
+    {
+        _pumpSnapshotRepository
+            .Setup(r => r.GetLatestAsync(null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PumpSnapshot
+            {
+                Reservoir = 87.5,
+                BatteryPercent = 64,
+                BatteryVoltage = 1.45,
+            });
+
+        var result = await _controller.GetCurrentTherapyState();
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<CurrentTherapyStateResponse>(ok.Value);
+        response.Reservoir.Should().Be(87.5);
+        response.PumpBatteryPercent.Should().Be(64);
+        response.PumpBatteryVoltage.Should().Be(1.45);
+    }
+
+    [Fact]
+    public async Task GetCurrentTherapyState_NoPumpSnapshot_LeavesPumpFieldsNull()
+    {
+        _pumpSnapshotRepository
+            .Setup(r => r.GetLatestAsync(null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PumpSnapshot?)null);
+
+        var result = await _controller.GetCurrentTherapyState();
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<CurrentTherapyStateResponse>(ok.Value);
+        response.Reservoir.Should().BeNull();
+        response.PumpBatteryPercent.Should().BeNull();
+        response.PumpBatteryVoltage.Should().BeNull();
+    }
+}

--- a/tests/Unit/Nocturne.Core.Models.Tests/Configuration/HaloDialConfigTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/Configuration/HaloDialConfigTests.cs
@@ -24,7 +24,9 @@ public class HaloDialConfigTests
         config.IobMaxUnits.Should().Be(8.0);
         config.CobMaxGrams.Should().Be(80.0);
 
-        config.Corners.Tl.Should().BeEmpty();
+        config.Corners.Tl.Should().Equal(
+            HaloDialCornerElement.Reservoir,
+            HaloDialCornerElement.Battery);
         config.Corners.Tr.Should().Equal(HaloDialCornerElement.LoopDot);
         config.Corners.Bl.Should().BeEmpty();
         config.Corners.Br.Should().Equal(
@@ -62,11 +64,13 @@ public class HaloDialConfigTests
     public void RoundTrip_PreservesCornerStacks()
     {
         var original = new HaloDialConfig();
-        original.Corners.Tl.AddRange(new[]
+        // Replace (not append to) the default stack so the assertion is independent
+        // of whatever the default Tl corner ships with.
+        original.Corners.Tl = new()
         {
             HaloDialCornerElement.SensorAge,
             HaloDialCornerElement.PumpSiteAge,
-        });
+        };
 
         var json = JsonSerializer.Serialize(original);
         var roundTripped = JsonSerializer.Deserialize<HaloDialConfig>(json)!;


### PR DESCRIPTION
## Problem

Part of #354 (Trio compatibility). Pumps upload reservoir and pump battery via `/api/v1/devicestatus`; ingestion stores them in `pump_snapshots`, but **nothing on the dashboard displayed insulin-remaining**. The reporter asked directly: *"where should insulin remaining appear? … none show remaining insulin."* The Halo Dial's reservoir/battery corner slots existed but were hardcoded to `null` (a deferred phase-5/6 stub), and no frontend code fetched pump snapshots.

## What this does

**Backend**
- `CurrentTherapyStateController` (the dial's "right now" endpoint) now also returns the latest pump snapshot's `reservoir` + battery (`percent`/`voltage`) via `IPumpSnapshotRepository.GetLatestAsync`.

**Frontend — two surfaces**
- **Reservoir status pill** on `CurrentBGDisplay` — the always-visible dashboard header alongside COB/Basal/IOB/Loop. This is where the reporter expected it ("across the top"), and it shows regardless of sidebar-widget choice. Rendered only when a numeric reservoir is present (many pods report none, e.g. Omnipod above 50 U — no permanent placeholder).
- **Halo Dial** reservoir + battery corner data is wired from the store (was `null`), and Reservoir/Battery now sit in the default top-left corner. Reservoir `percent`/`time-left` formats need capacity/rate the pump doesn't report, so they show a placeholder; the default `units` format is backed by data. Reservoir's optional fields now mirror Battery's.

**Plumbing**
- The realtime store captures reservoir/battery at init, mirroring the existing `currentPumpMode` pattern.
- Bumped the device-local halo-dial-config storage key so the new default corner reaches devices that already persisted the old default (safe — the dial has no user-facing editor yet).

## Tests
- Backend `CurrentTherapyStateControllerTests` (populated + null snapshot).
- Frontend: HaloDial reservoir/battery render + placeholder tests, `ReservoirPill` render test, updated `config.test.ts` default-corner assertion.

## Notes
- reservoir/battery refresh at init (like pump mode); a follow-up could re-fetch `current-therapy-state` when a devicestatus arrives to refresh all four fields live.

Ref: #354