### PR TITLE
feat(v2): fill in missing legacy /properties fields (#354)

### DIFF
--- a/src/API/Nocturne.API/Services/Profiles/PropertiesService.cs
+++ b/src/API/Nocturne.API/Services/Profiles/PropertiesService.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using System.Text.Json;
+using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.Legacy;
 using Nocturne.Core.Contracts.Profiles;
 using Nocturne.Core.Contracts.Profiles.Resolvers;
@@ -27,6 +29,7 @@ public class PropertiesService : IPropertiesService
     private readonly ICarbIntakeRepository _carbIntakeRepository;
     private readonly ITempBasalRepository _tempBasalRepository;
     private readonly IAr2Service _ar2Service;
+    private readonly IDeviceAgeService _deviceAgeService;
 
     // Properties that should be filtered out for security
     private static readonly string[] SecureProperties =
@@ -48,7 +51,8 @@ public class PropertiesService : IPropertiesService
         IBolusRepository bolusRepository,
         ICarbIntakeRepository carbIntakeRepository,
         ITempBasalRepository tempBasalRepository,
-        IAr2Service ar2Service
+        IAr2Service ar2Service,
+        IDeviceAgeService deviceAgeService
     )
     {
         _ddataService = ddataService;
@@ -59,6 +63,7 @@ public class PropertiesService : IPropertiesService
         _carbIntakeRepository = carbIntakeRepository;
         _tempBasalRepository = tempBasalRepository;
         _ar2Service = ar2Service;
+        _deviceAgeService = deviceAgeService;
     }
 
     /// <inheritdoc />
@@ -187,6 +192,9 @@ public class PropertiesService : IPropertiesService
             // Battery properties
             SetBatteryProperties(properties, ddata);
 
+            // Device age properties (cannula / sensor / insulin / battery age)
+            await SetDeviceAgePropertiesAsync(properties, cancellationToken);
+
             // Profile properties
             SetProfileProperties(properties, ddata);
 
@@ -299,28 +307,26 @@ public class PropertiesService : IPropertiesService
                 limit: 1000, offset: 0, descending: false
             )).ToList();
 
-            if (!boluses.Any() && !tempBasals.Any())
-                return;
+            // Emit the property even with no insulin on board: legacy clients treat a
+            // missing `iob` as "server doesn't support it" rather than "zero".
+            var iobResult = boluses.Any() || tempBasals.Any()
+                ? await _iobCalculator.CalculateTotalAsync(boluses, tempBasals, now)
+                : null;
 
-            var iobResult = await _iobCalculator.CalculateTotalAsync(
-                boluses,
-                tempBasals,
-                now
-            );
-
-            if (iobResult == null)
-                return;
+            var iob = Math.Round(iobResult?.Iob ?? 0, 2);
+            var display = iobResult?.Display ?? iob.ToString(CultureInfo.InvariantCulture);
 
             properties["iob"] = new Dictionary<string, object?>
             {
-                ["iob"] = Math.Round(iobResult.Iob, 2),
-                ["displayLine"] = iobResult.DisplayLine ?? $"IOB: {Math.Round(iobResult.Iob, 2)}U",
+                ["iob"] = iob,
+                ["display"] = display,
+                ["displayLine"] = iobResult?.DisplayLine ?? $"IOB: {display}U",
                 ["timestamp"] = now,
-                ["source"] = iobResult.Source ?? "Care Portal",
-                ["activity"] = iobResult.Activity,
-                ["lastBolus"] = iobResult.LastBolus?.Mills,
-                ["basalIob"] = iobResult.BasalIob,
-                ["treatmentIob"] = iobResult.TreatmentIob,
+                ["source"] = iobResult?.Source ?? "Care Portal",
+                ["activity"] = iobResult?.Activity,
+                ["lastBolus"] = iobResult?.LastBolus?.Mills,
+                ["basalIob"] = iobResult?.BasalIob,
+                ["treatmentIob"] = iobResult?.TreatmentIob,
             };
         }
         catch (Exception ex)
@@ -355,31 +361,24 @@ public class PropertiesService : IPropertiesService
                 limit: 1000, offset: 0, descending: false
             )).ToList();
 
-            if (!carbIntakes.Any())
-            {
-                _logger.LogDebug("SetCobProperties: No carb intakes, returning");
-                return;
-            }
+            // Emit the property even with no carbs on board: legacy clients treat a
+            // missing `cob` as "server doesn't support it" rather than "zero".
+            var cobResult = carbIntakes.Any()
+                ? await _cobCalculator.CalculateTotalAsync(carbIntakes, boluses, tempBasals, now)
+                : null;
 
-            _logger.LogDebug("SetCobProperties: Calling COB calculator");
-            var cobResult = await _cobCalculator.CalculateTotalAsync(carbIntakes, boluses, tempBasals, now);
-            _logger.LogDebug("SetCobProperties: COB calculator returned result, is null: {IsNull}", cobResult == null);
-
-            if (cobResult == null)
-            {
-                _logger.LogDebug("SetCobProperties: COB result is null, returning");
-                return;
-            }
+            var cob = Math.Round(cobResult?.Cob ?? 0);
+            var display = cobResult?.Display ?? cob.ToString(CultureInfo.InvariantCulture);
 
             properties["cob"] = new Dictionary<string, object?>
             {
-                ["cob"] = Math.Round(cobResult.Cob),
-                ["displayLine"] = cobResult.DisplayLine ?? $"COB: {Math.Round(cobResult.Cob)}g",
+                ["cob"] = cob,
+                ["display"] = display,
+                ["displayLine"] = cobResult?.DisplayLine ?? $"COB: {display}g",
                 ["timestamp"] = now,
-                ["source"] = cobResult.Source ?? "Care Portal",
-                ["activity"] = cobResult.Activity,
+                ["source"] = cobResult?.Source ?? "Care Portal",
+                ["activity"] = cobResult?.Activity,
             };
-            _logger.LogDebug("SetCobProperties: COB property set successfully");
         }
         catch (Exception ex)
         {
@@ -515,11 +514,59 @@ public class PropertiesService : IPropertiesService
         if (!batteryLevel.HasValue)
             return;
 
+        // Per-device uploader batteries: the most recent report from each uploader,
+        // weakest first. Legacy clients read this list to show more than one phone.
+        var devices = (ddata.DeviceStatus ?? [])
+            .Where(d => d.Uploader?.Battery != null)
+            .GroupBy(d => d.Device ?? "unknown")
+            .Select(g => g.OrderByDescending(d => d.Mills).First())
+            .Select(d => new Dictionary<string, object?>
+            {
+                ["name"] = d.Uploader!.Name ?? d.Device ?? "unknown",
+                ["device"] = d.Device,
+                ["value"] = d.Uploader.Battery,
+                ["voltage"] = d.Uploader.BatteryVoltage,
+                ["isCharging"] = d.Uploader.IsCharging,
+                ["temperature"] = d.Uploader.Temperature,
+                ["mills"] = d.Mills,
+            })
+            .OrderBy(d => (int?)d["value"])
+            .ToList();
+
         properties["upbat"] = new Dictionary<string, object>
         {
             ["level"] = batteryLevel.Value,
+            ["display"] = $"{batteryLevel}%",
             ["displayLine"] = $"Battery: {batteryLevel}%",
+            ["devices"] = devices,
         };
+    }
+
+    /// <summary>
+    /// Set the legacy device-age plugin properties: cannula (cage), sensor (sage),
+    /// insulin (iage) and pump battery (bage) age.
+    /// </summary>
+    private async Task SetDeviceAgePropertiesAsync(
+        Dictionary<string, object> properties,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            // Thresholds/display are per-plugin settings in legacy Nightscout; the
+            // properties endpoint reports the service defaults.
+            var prefs = new DeviceAgePreferences();
+
+            properties["cage"] = await _deviceAgeService.GetCannulaAgeAsync(prefs, cancellationToken);
+            properties["sage"] = await _deviceAgeService.GetSensorAgeAsync(prefs, cancellationToken);
+            properties["iage"] = await _deviceAgeService.GetInsulinAgeAsync(prefs, cancellationToken);
+            properties["bage"] = await _deviceAgeService.GetBatteryAgeAsync(prefs, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error setting device age properties");
+            // Don't throw, just skip setting device age properties
+        }
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Services/Profiles/PropertiesService.cs
+++ b/src/API/Nocturne.API/Services/Profiles/PropertiesService.cs
@@ -31,6 +31,10 @@ public class PropertiesService : IPropertiesService
     private readonly IAr2Service _ar2Service;
     private readonly IDeviceAgeService _deviceAgeService;
 
+    // Properties served by IDeviceAgeService, each costing its own query.
+    private static readonly HashSet<string> DeviceAgeProperties =
+        new(StringComparer.OrdinalIgnoreCase) { "cage", "sage", "iage", "bage" };
+
     // Properties that should be filtered out for security
     private static readonly string[] SecureProperties =
     {
@@ -91,10 +95,11 @@ public class PropertiesService : IPropertiesService
     {
         try
         {
-            var allProperties = await BuildSandboxPropertiesAsync(cancellationToken);
+            var requested = propertyNames as IReadOnlyCollection<string> ?? propertyNames.ToList();
+            var allProperties = await BuildSandboxPropertiesAsync(cancellationToken, requested);
             var filteredProperties = new Dictionary<string, object>();
 
-            foreach (var propertyName in propertyNames)
+            foreach (var propertyName in requested)
             {
                 if (allProperties.TryGetValue(propertyName, out var value))
                 {
@@ -151,8 +156,13 @@ public class PropertiesService : IPropertiesService
     /// Build sandbox properties similar to the legacy JavaScript implementation
     /// This simulates the plugin system that sets properties on the sandbox
     /// </summary>
+    /// <param name="requested">
+    /// When set, only these property names were asked for. Used to skip building the
+    /// properties whose sources cost extra queries; null builds everything.
+    /// </param>
     private async Task<Dictionary<string, object>> BuildSandboxPropertiesAsync(
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        IReadOnlyCollection<string>? requested = null
     )
     {
         var properties = new Dictionary<string, object>();
@@ -192,8 +202,13 @@ public class PropertiesService : IPropertiesService
             // Battery properties
             SetBatteryProperties(properties, ddata);
 
-            // Device age properties (cannula / sensor / insulin / battery age)
-            await SetDeviceAgePropertiesAsync(properties, cancellationToken);
+            // Device age properties (cannula / sensor / insulin / battery age). Each is a
+            // separate query, so skip them when the caller asked for other properties —
+            // clients poll single properties like /api/v2/properties/iob frequently.
+            if (requested == null || requested.Any(DeviceAgeProperties.Contains))
+            {
+                await SetDeviceAgePropertiesAsync(properties, cancellationToken);
+            }
 
             // Profile properties
             SetProfileProperties(properties, ddata);
@@ -323,10 +338,11 @@ public class PropertiesService : IPropertiesService
                 ["displayLine"] = iobResult?.DisplayLine ?? $"IOB: {display}U",
                 ["timestamp"] = now,
                 ["source"] = iobResult?.Source ?? "Care Portal",
-                ["activity"] = iobResult?.Activity,
+                // Legacy calcTotal reports zeros rather than nulls for the numeric parts.
+                ["activity"] = iobResult?.Activity ?? 0,
                 ["lastBolus"] = iobResult?.LastBolus?.Mills,
-                ["basalIob"] = iobResult?.BasalIob,
-                ["treatmentIob"] = iobResult?.TreatmentIob,
+                ["basalIob"] = iobResult?.BasalIob ?? 0,
+                ["treatmentIob"] = iobResult?.TreatmentIob ?? 0,
             };
         }
         catch (Exception ex)
@@ -377,7 +393,7 @@ public class PropertiesService : IPropertiesService
                 ["displayLine"] = cobResult?.DisplayLine ?? $"COB: {display}g",
                 ["timestamp"] = now,
                 ["source"] = cobResult?.Source ?? "Care Portal",
-                ["activity"] = cobResult?.Activity,
+                ["activity"] = cobResult?.Activity ?? 0,
             };
         }
         catch (Exception ex)
@@ -508,34 +524,47 @@ public class PropertiesService : IPropertiesService
     /// </summary>
     private void SetBatteryProperties(Dictionary<string, object> properties, DData ddata)
     {
-        var deviceStatus = ddata.DeviceStatus?.OrderByDescending(d => d.Mills).FirstOrDefault();
-        var batteryLevel = deviceStatus?.Uploader?.Battery;
+        // Only statuses that actually carry an uploader battery: AID systems interleave
+        // pump-only device statuses, and the newest record is often one of those.
+        var batteryReports = (ddata.DeviceStatus ?? [])
+            .Where(d => d.Uploader?.Battery != null)
+            .ToList();
 
-        if (!batteryLevel.HasValue)
+        if (batteryReports.Count == 0)
             return;
 
-        // Per-device uploader batteries: the most recent report from each uploader,
-        // weakest first. Legacy clients read this list to show more than one phone.
-        var devices = (ddata.DeviceStatus ?? [])
-            .Where(d => d.Uploader?.Battery != null)
-            .GroupBy(d => d.Device ?? "unknown")
+        // The most recent report from each uploader, weakest battery first. Legacy
+        // clients read this list to show more than one phone.
+        var latestPerDevice = batteryReports
+            .GroupBy(d => string.IsNullOrEmpty(d.Device) ? "unknown" : d.Device)
             .Select(g => g.OrderByDescending(d => d.Mills).First())
+            .OrderBy(d => d.Uploader!.Battery)
+            .ToList();
+
+        var devices = latestPerDevice
             .Select(d => new Dictionary<string, object?>
             {
-                ["name"] = d.Uploader!.Name ?? d.Device ?? "unknown",
-                ["device"] = d.Device,
+                ["name"] = d.Uploader!.Name
+                    ?? (string.IsNullOrEmpty(d.Device) ? "unknown" : d.Device),
+                ["device"] = string.IsNullOrEmpty(d.Device) ? "unknown" : d.Device,
                 ["value"] = d.Uploader.Battery,
                 ["voltage"] = d.Uploader.BatteryVoltage,
                 ["isCharging"] = d.Uploader.IsCharging,
                 ["temperature"] = d.Uploader.Temperature,
                 ["mills"] = d.Mills,
             })
-            .OrderBy(d => (int?)d["value"])
             .ToList();
+
+        // `level` stays the newest reported battery, as before — not the weakest — so
+        // single-uploader setups keep their existing reading.
+        var batteryLevel = batteryReports
+            .OrderByDescending(d => d.Mills)
+            .First()
+            .Uploader!.Battery!.Value;
 
         properties["upbat"] = new Dictionary<string, object>
         {
-            ["level"] = batteryLevel.Value,
+            ["level"] = batteryLevel,
             ["display"] = $"{batteryLevel}%",
             ["displayLine"] = $"Battery: {batteryLevel}%",
             ["devices"] = devices,
@@ -557,10 +586,20 @@ public class PropertiesService : IPropertiesService
             // properties endpoint reports the service defaults.
             var prefs = new DeviceAgePreferences();
 
-            properties["cage"] = await _deviceAgeService.GetCannulaAgeAsync(prefs, cancellationToken);
-            properties["sage"] = await _deviceAgeService.GetSensorAgeAsync(prefs, cancellationToken);
-            properties["iage"] = await _deviceAgeService.GetInsulinAgeAsync(prefs, cancellationToken);
-            properties["bage"] = await _deviceAgeService.GetBatteryAgeAsync(prefs, cancellationToken);
+            var sensor = await _deviceAgeService.GetSensorAgeAsync(prefs, cancellationToken);
+
+            properties["cage"] = ToAgeDictionary(
+                await _deviceAgeService.GetCannulaAgeAsync(prefs, cancellationToken));
+            properties["sage"] = new Dictionary<string, object?>
+            {
+                ["Sensor Start"] = ToAgeDictionary(sensor.SensorStart),
+                ["Sensor Change"] = ToAgeDictionary(sensor.SensorChange),
+                ["min"] = sensor.Min,
+            };
+            properties["iage"] = ToAgeDictionary(
+                await _deviceAgeService.GetInsulinAgeAsync(prefs, cancellationToken));
+            properties["bage"] = ToAgeDictionary(
+                await _deviceAgeService.GetBatteryAgeAsync(prefs, cancellationToken));
         }
         catch (Exception ex)
         {
@@ -568,6 +607,29 @@ public class PropertiesService : IPropertiesService
             // Don't throw, just skip setting device age properties
         }
     }
+
+    /// <summary>
+    /// Projects a <see cref="DeviceAgeInfo"/> into a dictionary so every field reaches the
+    /// wire. The Nightscout response filter serializes with
+    /// <see cref="System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault"/>,
+    /// which drops zero/false properties off typed objects — that would hide
+    /// <c>age</c>/<c>days</c>/<c>level</c> exactly when a site was just changed, and never
+    /// emit <c>found: false</c>. Dictionary values are exempt from that condition.
+    /// </summary>
+    private static Dictionary<string, object?> ToAgeDictionary(DeviceAgeInfo age) =>
+        new()
+        {
+            ["found"] = age.Found,
+            ["age"] = age.Age,
+            ["days"] = age.Days,
+            ["hours"] = age.Hours,
+            ["treatmentDate"] = age.TreatmentDate,
+            ["notes"] = age.Notes,
+            ["minFractions"] = age.MinFractions,
+            ["level"] = age.Level,
+            ["display"] = age.Display,
+            ["notification"] = age.Notification,
+        };
 
     /// <summary>
     /// Set profile properties

--- a/src/API/Nocturne.API/Services/Treatments/CobCalculator.cs
+++ b/src/API/Nocturne.API/Services/Treatments/CobCalculator.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Contracts.Treatments;
@@ -438,8 +439,10 @@ public class CobCalculator(
         if (cob.Cob <= 0)
             return cob;
 
-        var display = Math.Round(cob.Cob * 10) / 10;
-        cob.Display = display.ToString();
+        // Invariant: these strings go out over the API, so they must not pick up the
+        // server's decimal separator.
+        var display = (Math.Round(cob.Cob * 10) / 10).ToString(CultureInfo.InvariantCulture);
+        cob.Display = display;
         cob.DisplayLine = $"COB: {display}g";
 
         return cob;

--- a/src/API/Nocturne.API/Services/Treatments/IobCalculator.cs
+++ b/src/API/Nocturne.API/Services/Treatments/IobCalculator.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.V4.Repositories;
@@ -427,7 +428,9 @@ public class IobCalculator(
             return iob;
         }
 
-        var display = iob.Iob.ToString("F2");
+        // Invariant: these strings go out over the API, so they must not pick up the
+        // server's decimal separator.
+        var display = iob.Iob.ToString("F2", CultureInfo.InvariantCulture);
         iob.Display = display;
         iob.DisplayLine = $"IOB: {display}U";
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Profiles/PropertiesServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Profiles/PropertiesServiceTests.cs
@@ -1,5 +1,7 @@
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Nocturne.API.Configuration;
 using Nocturne.API.Services.Profiles;
 using Nocturne.API.Services.Treatments;
 using Nocturne.Core.Contracts.Devices;
@@ -142,9 +144,61 @@ public class PropertiesServiceTests
         Assert.True(result.ContainsKey("iage"));
         Assert.True(result.ContainsKey("bage"));
 
-        var cage = Assert.IsType<DeviceAgeInfo>(result["cage"]);
-        Assert.True(cage.Found);
-        Assert.Equal(10, cage.Age);
+        var cage = Assert.IsType<Dictionary<string, object?>>(result["cage"]);
+        Assert.Equal(true, cage["found"]);
+        Assert.Equal(10, cage["age"]);
+
+        var sage = Assert.IsType<Dictionary<string, object?>>(result["sage"]);
+        Assert.True(sage.ContainsKey("Sensor Start"));
+        Assert.True(sage.ContainsKey("Sensor Change"));
+        Assert.Equal("Sensor Start", sage["min"]);
+    }
+
+    [Fact]
+    public async Task GetAllPropertiesAsync_DeviceAgeFields_SurviveNightscoutSerialization()
+    {
+        // The Nightscout response filter serializes with WhenWritingDefault, which strips
+        // zero/false members from typed objects. Age fields are legitimately zero right
+        // after a site change, so they must be projected as dictionaries to reach clients.
+        _mockDeviceAgeService
+            .Setup(x => x.GetCannulaAgeAsync(It.IsAny<DeviceAgePreferences>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeviceAgeInfo { Found = false, Age = 0, Days = 0, Hours = 0, Level = 0 });
+        _mockDDataService
+            .Setup(x => x.GetDDataAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateTestDData());
+
+        var result = await _service.GetAllPropertiesAsync(CancellationToken.None);
+
+        var json = JsonSerializer.Serialize(result, NightscoutJsonOptions.Create());
+        using var doc = JsonDocument.Parse(json);
+        var cage = doc.RootElement.GetProperty("cage");
+
+        Assert.False(cage.GetProperty("found").GetBoolean());
+        Assert.Equal(0, cage.GetProperty("age").GetInt32());
+        Assert.Equal(0, cage.GetProperty("days").GetInt32());
+        Assert.Equal(0, cage.GetProperty("level").GetInt32());
+    }
+
+    [Fact]
+    public async Task GetPropertiesAsync_WithoutAgeNames_SkipsDeviceAgeLookups()
+    {
+        // Clients poll single properties (e.g. /api/v2/properties/iob); those requests
+        // shouldn't pay for the device-age queries.
+        _mockDDataService
+            .Setup(x => x.GetDDataAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateTestDData());
+
+        await _service.GetPropertiesAsync(new[] { "iob" }, CancellationToken.None);
+
+        _mockDeviceAgeService.Verify(
+            x => x.GetCannulaAgeAsync(It.IsAny<DeviceAgePreferences>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        await _service.GetPropertiesAsync(new[] { "cage" }, CancellationToken.None);
+
+        _mockDeviceAgeService.Verify(
+            x => x.GetCannulaAgeAsync(It.IsAny<DeviceAgePreferences>(), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]
@@ -194,6 +248,43 @@ public class PropertiesServiceTests
         Assert.Equal(85, devices[1]["value"]);
         Assert.Equal(true, devices[1]["isCharging"]);
         Assert.Equal(4.1, devices[1]["voltage"]);
+    }
+
+    [Fact]
+    public async Task GetAllPropertiesAsync_EmitsUpbat_WhenNewestStatusHasNoUploaderBattery()
+    {
+        // AID systems interleave pump-only device statuses; the newest record often has
+        // no uploader battery, which must not suppress the whole property.
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var ddata = CreateTestDData();
+        ddata.DeviceStatus = new List<DeviceStatus>
+        {
+            new DeviceStatus
+            {
+                Device = "phone-a",
+                Mills = now - 60_000,
+                Uploader = new UploaderStatus { Battery = 72 },
+            },
+            new DeviceStatus
+            {
+                Device = "pump",
+                Mills = now,
+                Pump = new PumpStatus { Reservoir = 120 },
+            },
+        };
+
+        _mockDDataService
+            .Setup(x => x.GetDDataAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ddata);
+
+        var result = await _service.GetAllPropertiesAsync(CancellationToken.None);
+
+        var upbat = Assert.IsType<Dictionary<string, object>>(result["upbat"]);
+        Assert.Equal(72, upbat["level"]);
+
+        var devices = Assert.IsType<List<Dictionary<string, object?>>>(upbat["devices"]);
+        Assert.Single(devices);
+        Assert.Equal("phone-a", devices[0]["device"]);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/Profiles/PropertiesServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Profiles/PropertiesServiceTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Nocturne.API.Services.Profiles;
 using Nocturne.API.Services.Treatments;
+using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.Legacy;
 using Nocturne.Core.Contracts.Profiles;
 using Nocturne.Core.Contracts.Glucose;
@@ -20,6 +21,7 @@ public class PropertiesServiceTests
 {
     private readonly Mock<IDDataService> _mockDDataService;
     private readonly Mock<ILogger<PropertiesService>> _mockLogger;
+    private readonly Mock<IDeviceAgeService> _mockDeviceAgeService;
     private readonly PropertiesService _service;
 
     public PropertiesServiceTests()
@@ -33,6 +35,20 @@ public class PropertiesServiceTests
         var mockTempBasalRepo = new Mock<ITempBasalRepository>();
         var mockAr2Service = new Mock<IAr2Service>();
 
+        _mockDeviceAgeService = new Mock<IDeviceAgeService>();
+        _mockDeviceAgeService
+            .Setup(x => x.GetCannulaAgeAsync(It.IsAny<DeviceAgePreferences>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeviceAgeInfo { Found = true, Age = 10, Days = 0, Hours = 10 });
+        _mockDeviceAgeService
+            .Setup(x => x.GetSensorAgeAsync(It.IsAny<DeviceAgePreferences>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SensorAgeInfo());
+        _mockDeviceAgeService
+            .Setup(x => x.GetInsulinAgeAsync(It.IsAny<DeviceAgePreferences>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeviceAgeInfo { Found = true, Age = 30, Days = 1, Hours = 6 });
+        _mockDeviceAgeService
+            .Setup(x => x.GetBatteryAgeAsync(It.IsAny<DeviceAgePreferences>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeviceAgeInfo());
+
         _service = new PropertiesService(
             _mockDDataService.Object,
             _mockLogger.Object,
@@ -41,7 +57,8 @@ public class PropertiesServiceTests
             mockBolusRepo.Object,
             mockCarbIntakeRepo.Object,
             mockTempBasalRepo.Object,
-            mockAr2Service.Object
+            mockAr2Service.Object,
+            _mockDeviceAgeService.Object
         );
     }
 
@@ -87,6 +104,96 @@ public class PropertiesServiceTests
         Assert.True(result.ContainsKey("bgnow"));
         Assert.True(result.ContainsKey("delta"));
         Assert.False(result.ContainsKey("direction"));
+    }
+
+    [Fact]
+    public async Task GetAllPropertiesAsync_EmitsIobAndCobAtZero_WithDisplayFields()
+    {
+        // Legacy clients (LoopFollow, Trio) treat a missing `iob`/`cob` as "unsupported"
+        // rather than "zero", so both must be present even with no insulin/carbs on board.
+        _mockDDataService
+            .Setup(x => x.GetDDataAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateTestDData());
+
+        var result = await _service.GetAllPropertiesAsync(CancellationToken.None);
+
+        var iob = Assert.IsType<Dictionary<string, object?>>(result["iob"]);
+        Assert.Equal(0d, iob["iob"]);
+        Assert.Equal("0", iob["display"]);
+        Assert.Equal("IOB: 0U", iob["displayLine"]);
+
+        var cob = Assert.IsType<Dictionary<string, object?>>(result["cob"]);
+        Assert.Equal(0d, cob["cob"]);
+        Assert.Equal("0", cob["display"]);
+        Assert.Equal("COB: 0g", cob["displayLine"]);
+    }
+
+    [Fact]
+    public async Task GetAllPropertiesAsync_EmitsDeviceAgeProperties()
+    {
+        _mockDDataService
+            .Setup(x => x.GetDDataAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateTestDData());
+
+        var result = await _service.GetAllPropertiesAsync(CancellationToken.None);
+
+        Assert.True(result.ContainsKey("cage"));
+        Assert.True(result.ContainsKey("sage"));
+        Assert.True(result.ContainsKey("iage"));
+        Assert.True(result.ContainsKey("bage"));
+
+        var cage = Assert.IsType<DeviceAgeInfo>(result["cage"]);
+        Assert.True(cage.Found);
+        Assert.Equal(10, cage.Age);
+    }
+
+    [Fact]
+    public async Task GetAllPropertiesAsync_EmitsPerDeviceUploaderBatteries()
+    {
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var ddata = CreateTestDData();
+        ddata.DeviceStatus = new List<DeviceStatus>
+        {
+            // Two reports from the same phone: only the newest should be listed.
+            new DeviceStatus
+            {
+                Device = "phone-a",
+                Mills = now - 60_000,
+                Uploader = new UploaderStatus { Battery = 90, IsCharging = false },
+            },
+            new DeviceStatus
+            {
+                Device = "phone-a",
+                Mills = now,
+                Uploader = new UploaderStatus { Battery = 85, IsCharging = true, BatteryVoltage = 4.1 },
+            },
+            new DeviceStatus
+            {
+                Device = "phone-b",
+                Mills = now - 30_000,
+                Uploader = new UploaderStatus { Battery = 40, IsCharging = false },
+            },
+        };
+
+        _mockDDataService
+            .Setup(x => x.GetDDataAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ddata);
+
+        var result = await _service.GetAllPropertiesAsync(CancellationToken.None);
+
+        var upbat = Assert.IsType<Dictionary<string, object>>(result["upbat"]);
+        var devices = Assert.IsType<List<Dictionary<string, object?>>>(upbat["devices"]);
+
+        Assert.Equal(2, devices.Count);
+
+        // Weakest battery first.
+        Assert.Equal("phone-b", devices[0]["device"]);
+        Assert.Equal(40, devices[0]["value"]);
+
+        Assert.Equal("phone-a", devices[1]["device"]);
+        Assert.Equal(85, devices[1]["value"]);
+        Assert.Equal(true, devices[1]["isCharging"]);
+        Assert.Equal(4.1, devices[1]["voltage"]);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

Part of #354 (Trio/LoopFollow compatibility). A reporter listed four legacy plugin fields missing from `/api/v2/properties`:

> - `cob` is missing entirely
> - `iob.display` is missing (only `iob.iob`/`displayLine` are present)
> - `sage` / `cage` / `iage` (sensor / cannula / insulin age) are missing
> - `upbat.devices` is missing (per-device uploader battery incl. `isCharging`) — only `level`/`displayLine` are present

Worth noting `/api/v1/status` already advertises cage/sage/iage as enabled features, which is likely why they were expected here.

## What this does

- **`iob`/`cob` are always emitted.** They were skipped entirely when there was no insulin or no carbs in the window. Legacy clients read a missing key as "server doesn't support this" rather than "zero" — that's the root of "`cob` is missing entirely". Both now report a zero value, with `activity`/`basalIob`/`treatmentIob` as `0` to match legacy `calcTotal`.
- **Added `iob.display` / `cob.display`** — the bare rounded string the Nightscout plugins publish alongside `displayLine`. The calculators already produced it; only the property projection dropped it.
- **Added `cage` / `sage` / `iage`** (plus `bage`), sourced from the existing `IDeviceAgeService` — the same shapes the v4 device-age endpoint already serves.
- **Added `upbat.devices`** — newest report per uploader, weakest battery first, carrying `isCharging`, voltage and temperature. `level`/`displayLine` keep their existing meaning; `display` added for parity.

## Notes for review

Two things a review pass caught that are worth calling out:

- **Device-age fields are projected as dictionaries, not typed models.** The global `NightscoutJsonFilter` serializes `/api/v1|v2|v3` responses with `DefaultIgnoreCondition = WhenWritingDefault`, which strips zero/false members from typed objects but *not* from dictionary values. Left typed, `cage.age` would disappear precisely when a site had just been changed, and `found: false` would never ship. There's a serialization-level test asserting this against `NightscoutJsonOptions`.
- **`upbat` no longer keys off the single newest device status.** AID systems interleave pump-only statuses; one arriving last used to suppress the entire property, which would have taken the new `devices` list with it.

Also: the device-age lookups are skipped when a caller requested only other properties, since clients poll single properties like `/api/v2/properties/iob`; and the IOB/COB display strings are now formatted with `InvariantCulture` so a comma-decimal server locale can't emit `"IOB: 1,23U"`.

## Follow-up (not in this PR)

`device_events` has no index supporting `WHERE tenant_id = … AND event_type IN (…) ORDER BY timestamp DESC LIMIT 1`. For a tenant that has never logged a given event type — common for `bage` — that degenerates into a full backward index scan. The v4 device-age endpoint already issues these same queries today, so this isn't new, but a `(tenant_id, event_type, timestamp DESC)` index would help both call sites.

## Tests

New unit tests cover the zero-state `iob`/`cob` payloads with `display`, the device-age properties surviving Nightscout serialization, per-device uploader batteries, `upbat` surviving a pump-only newest status, and the age-lookup skip. Full unit suite green locally.

Ref: #354