### PR TITLE
fix: route /pebble to the API and keep auth going past an unknown token (#354)

### DIFF
--- a/src/API/Nocturne.API/Middleware/Handlers/AccessTokenHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/AccessTokenHandler.cs
@@ -75,8 +75,13 @@ public class AccessTokenHandler : IAuthHandler
 
             if (subject == null)
             {
-                _logger.LogDebug("Access token not found in database");
-                return AuthResult.Failure("Invalid access token");
+                // Skip rather than fail so the chain keeps trying later credentials: a
+                // request may carry an unknown ?token= alongside a valid api-secret, and
+                // classic Nightscout authenticates it on the api-secret. Mirrors
+                // DirectGrantTokenHandler, which skips its own miss for the same reason.
+                // With no other credential the request still ends up unauthenticated.
+                _logger.LogDebug("Access token not found in database, skipping");
+                return AuthResult.Skip();
             }
 
             if (!subject.IsActive)

--- a/src/Aspire/Nocturne.Aspire.Host/Program.cs
+++ b/src/Aspire/Nocturne.Aspire.Host/Program.cs
@@ -673,6 +673,11 @@ class Program
                 // OAuth/OIDC discovery endpoints → API
                 ApplyEdgeTransforms(yarp.AddRoute("/.well-known/{**catch-all}", api.GetEndpoint("http")));
 
+                // Legacy Nightscout /pebble (watchfaces, Loop, LoopFollow) → API. It sits
+                // outside /api, so without this route the web fallback answers with the SPA
+                // 404 page instead. Authorization is the API's default-deny fallback policy.
+                ApplyEdgeTransforms(yarp.AddRoute("/pebble", api.GetEndpoint("http")));
+
                 // Fallback → web (includes Socket.IO websockets, HMR, all frontend routes)
                 ApplyEdgeTransforms(yarp.AddRoute(webEndpoints.GetEndpoint("http")));
             });

--- a/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/AccessTokenHandlerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/AccessTokenHandlerTests.cs
@@ -1,0 +1,69 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Middleware.Handlers;
+using Nocturne.Core.Contracts.Auth;
+using Xunit;
+using Subject = Nocturne.Core.Models.Authorization.Subject;
+
+namespace Nocturne.API.Tests.Middleware.Handlers;
+
+public class AccessTokenHandlerTests
+{
+    private readonly Mock<ISubjectService> _subjectService = new();
+    private readonly AccessTokenHandler _handler;
+
+    public AccessTokenHandlerTests()
+    {
+        var serviceProvider = new Mock<IServiceProvider>();
+        serviceProvider
+            .Setup(p => p.GetService(typeof(ISubjectService)))
+            .Returns(_subjectService.Object);
+
+        var scope = new Mock<IServiceScope>();
+        scope.Setup(s => s.ServiceProvider).Returns(serviceProvider.Object);
+
+        var scopeFactory = new Mock<IServiceScopeFactory>();
+        scopeFactory.Setup(f => f.CreateScope()).Returns(scope.Object);
+
+        _handler = new AccessTokenHandler(
+            scopeFactory.Object,
+            NullLogger<AccessTokenHandler>.Instance);
+    }
+
+    private static HttpContext CreateContext(string token)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString($"?token={token}");
+        return context;
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_UnknownToken_ReturnsSkip()
+    {
+        // A request can carry an unrecognized ?token= alongside a valid api-secret; the
+        // chain must keep going so ApiKeyHandler (priority 400) still gets to authenticate
+        // it, as classic Nightscout does. Failing here would stop the chain.
+        _subjectService
+            .Setup(s => s.GetSubjectByAccessTokenHashAsync(It.IsAny<string>()))
+            .ReturnsAsync((Subject?)null);
+
+        var result = await _handler.AuthenticateAsync(CreateContext("someone-a1b2c3d4e5f6g7h8"));
+
+        Assert.True(result.ShouldSkip);
+        Assert.False(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_MalformedToken_ReturnsSkip()
+    {
+        // No dash: not the legacy name-hash shape, so this handler doesn't own it.
+        var result = await _handler.AuthenticateAsync(CreateContext("notanaccesstoken"));
+
+        Assert.True(result.ShouldSkip);
+        _subjectService.Verify(
+            s => s.GetSubjectByAccessTokenHashAsync(It.IsAny<string>()),
+            Times.Never);
+    }
+}


### PR DESCRIPTION
Fixes two legacy-client items from #354: the missing /pebble gateway route, and an unknown ?token= aborting the auth chain before a valid api-secret is tried. See the commit message for the full rationale, including two claims from the report that turned out not to hold.