### PR TITLE
feat(bridge): let legacy Nightscout clients use the realtime socket (#354)

### DIFF
--- a/src/Web/packages/bridge/src/lib/socketio-server.test.ts
+++ b/src/Web/packages/bridge/src/lib/socketio-server.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { createServer } from 'http';
 import SocketIOServer, { pickHandshakeHost, resolveTenantSlug } from './socketio-server.js';
 import { signHandshakeTicket } from './handshake-ticket.js';
@@ -80,18 +80,24 @@ describe('SocketIOServer.authorizeHandshake', () => {
     expect(next.mock.calls[0][0].message).toBe('tenant_unresolved');
   });
 
-  it('rejects a connection that carries no ticket', async () => {
+  it('admits a connection with no ticket but leaves it unauthorized', async () => {
+    // Legacy clients send credentials only after connecting, so the socket is
+    // allowed in — but it must not be authorized, which is what joins it to the
+    // tenant room. Until `authorize` succeeds it receives nothing.
     const server = makeServer();
     const next = vi.fn();
     const socket = fakeSocket({ 'x-forwarded-host': 'rhys.nocturne.run' });
 
     await server.authorizeHandshake(socket as never, next);
 
-    expect(next.mock.calls[0][0].message).toBe('unauthorized');
+    expect(next).toHaveBeenCalledWith();
     expect(socket.data.tenantSlug).toBeUndefined();
+    expect(socket.data.pendingTenantSlug).toBe('rhys');
   });
 
   it('rejects a tampered ticket', async () => {
+    // A ticket that was offered but doesn't verify is still rejected outright —
+    // only a connection offering no ticket at all falls through to the legacy path.
     const server = makeServer();
     const next = vi.fn();
     const ticket = signHandshakeTicket(SECRET, 'rhys.nocturne.run');
@@ -104,6 +110,7 @@ describe('SocketIOServer.authorizeHandshake', () => {
 
     expect(next.mock.calls[0][0].message).toBe('unauthorized');
     expect(socket.data.tenantSlug).toBeUndefined();
+    expect(socket.data.pendingTenantSlug).toBeUndefined();
   });
 
   it('rejects a ticket minted for a different host (no cross-tenant replay)', async () => {
@@ -120,7 +127,7 @@ describe('SocketIOServer.authorizeHandshake', () => {
     expect(socket.data.tenantSlug).toBeUndefined();
   });
 
-  it('rejects an expired ticket', async () => {
+  it('rejects an expired ticket so the client refetches instead of going quiet', async () => {
     const server = makeServer();
     const next = vi.fn();
     // Sign a ticket that expired one minute ago.
@@ -131,6 +138,7 @@ describe('SocketIOServer.authorizeHandshake', () => {
 
     expect(next.mock.calls[0][0].message).toBe('unauthorized');
     expect(socket.data.tenantSlug).toBeUndefined();
+    expect(socket.data.pendingTenantSlug).toBeUndefined();
   });
 
   it('admits a valid ticket and tags the socket with its tenant', async () => {
@@ -173,5 +181,130 @@ describe('SocketIOServer.authorizeHandshake', () => {
 
     expect(next).toHaveBeenCalledWith();
     expect(socket.data.tenantSlug).toBe('only');
+  });
+});
+
+describe('SocketIOServer.handleAuthorize', () => {
+  function pendingSocket(pendingTenantSlug?: string) {
+    return {
+      id: 'sock1',
+      data: { pendingTenantSlug } as Record<string, unknown>,
+      join: vi.fn(),
+      disconnect: vi.fn(),
+    };
+  }
+
+  function makeApiServer(apiBaseUrl = 'http://api.internal') {
+    return new SocketIOServer(
+      createServer(),
+      {},
+      'nocturne.run',
+      [],
+      SECRET,
+      apiBaseUrl,
+    );
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('joins the tenant room when the API accepts the credential', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const server = makeApiServer();
+    const socket = pendingSocket('rhys');
+    const callback = vi.fn();
+
+    await server.handleAuthorize(socket as never, { secret: 'sha1hash' }, callback);
+
+    expect(socket.join).toHaveBeenCalledWith('tenant:rhys');
+    expect(socket.data.tenantSlug).toBe('rhys');
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({ read: true }),
+    );
+
+    // The probe must carry the client's credential scoped to its own tenant, and
+    // must NOT carry the bridge's instance key.
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain('/api/v1/entries');
+    expect(init.headers['api-secret']).toBe('sha1hash');
+    expect(init.headers['X-Forwarded-Host']).toBe('rhys.nocturne.run');
+    expect(init.headers['X-Instance-Key']).toBeUndefined();
+  });
+
+  it('passes a subject token through as a query parameter', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const server = makeApiServer();
+    const socket = pendingSocket('rhys');
+
+    await server.handleAuthorize(socket as never, { token: 'phone-a1b2c3d4e5f6g7h8' });
+
+    expect(String(fetchMock.mock.calls[0][0])).toContain('token=phone-a1b2c3d4e5f6g7h8');
+    expect(socket.data.tenantSlug).toBe('rhys');
+  });
+
+  it('disconnects without joining when the API rejects the credential', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 401 }));
+
+    const server = makeApiServer();
+    const socket = pendingSocket('rhys');
+    const callback = vi.fn();
+
+    await server.handleAuthorize(socket as never, { secret: 'wrong' }, callback);
+
+    expect(socket.join).not.toHaveBeenCalled();
+    expect(socket.data.tenantSlug).toBeUndefined();
+    expect(socket.disconnect).toHaveBeenCalled();
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({ read: false }),
+    );
+  });
+
+  it('refuses to authorize when no credentials are supplied', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const server = makeApiServer();
+    const socket = pendingSocket('rhys');
+
+    await server.handleAuthorize(socket as never, {});
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(socket.join).not.toHaveBeenCalled();
+    expect(socket.disconnect).toHaveBeenCalled();
+  });
+
+  it('refuses to authorize a socket whose host resolved to no tenant', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const server = makeApiServer();
+    const socket = pendingSocket(undefined);
+
+    await server.handleAuthorize(socket as never, { secret: 'sha1hash' });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(socket.join).not.toHaveBeenCalled();
+    expect(socket.disconnect).toHaveBeenCalled();
+  });
+
+  it('does not re-probe a socket already authorized by a ticket', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const server = makeApiServer();
+    const socket = pendingSocket();
+    socket.data.tenantSlug = 'rhys';
+    const callback = vi.fn();
+
+    await server.handleAuthorize(socket as never, { secret: 'sha1hash' }, callback);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(socket.disconnect).not.toHaveBeenCalled();
+    expect(callback).toHaveBeenCalledWith(expect.objectContaining({ read: true }));
   });
 });

--- a/src/Web/packages/bridge/src/lib/socketio-server.ts
+++ b/src/Web/packages/bridge/src/lib/socketio-server.ts
@@ -41,6 +41,12 @@ export function pickHandshakeHost(
  *  the API's tenant resolution so a single tenant served on the root domain works
  *  without a subdomain. Returns null when the host is foreign or the apex can't be
  *  resolved to a single tenant. */
+/** Socket.IO query values are `string | string[]`; take the first. */
+function queryValue(value: string | string[] | undefined): string | undefined {
+  const single = Array.isArray(value) ? value[0] : value;
+  return single || undefined;
+}
+
 export function resolveTenantSlug(
   host: string | undefined,
   baseDomain: string,
@@ -71,6 +77,7 @@ class SocketIOServer {
   private baseDomain: string;
   private tenantSlugs: string[];
   private signingSecret: string;
+  private apiBaseUrl: string;
 
   constructor(
     httpServer: HttpServer,
@@ -78,11 +85,13 @@ class SocketIOServer {
     baseDomain: string,
     tenantSlugs: string[] = [],
     signingSecret: string = '',
+    apiBaseUrl: string = '',
   ) {
     this.httpServer = httpServer;
     this.baseDomain = baseDomain;
     this.tenantSlugs = tenantSlugs;
     this.signingSecret = signingSecret;
+    this.apiBaseUrl = apiBaseUrl;
     this.config = {
       cors: config.cors ?? { origin: '*', methods: ['GET', 'POST'], credentials: true },
       transports: config.transports || ['websocket', 'polling'],
@@ -99,7 +108,11 @@ class SocketIOServer {
           cors: this.config.cors,
           transports: this.config.transports as any,
           pingTimeout: this.config.pingTimeout,
-          pingInterval: this.config.pingInterval
+          pingInterval: this.config.pingInterval,
+          // Legacy Nightscout clients (LoopFollow's socket.io-client-swift) speak
+          // Engine.IO v3 and are otherwise rejected with "Unsupported protocol
+          // version" before any handler runs.
+          allowEIO3: true
         });
 
         this.setupHandshakeAuth();
@@ -140,21 +153,39 @@ class SocketIOServer {
         return next(new Error('tenant_unresolved'));
       }
 
-      const token = (socket.handshake.auth as { token?: string } | undefined)?.token;
-      const ticket = verifyHandshakeTicket(this.signingSecret, token);
-      if (!ticket) {
-        logger.warn(`Rejecting connection ${socket.id}: missing or invalid handshake ticket for tenant ${tenantSlug}`);
-        return next(new Error('unauthorized'));
+      // Engine.IO v3 clients have no `auth` payload — that arrived with the v4
+      // protocol — so also accept the ticket from the handshake query.
+      const token =
+        (socket.handshake.auth as { token?: string } | undefined)?.token
+        ?? queryValue(socket.handshake.query?.token);
+      if (token) {
+        // A ticket was offered, so this is the browser path: reject it outright if
+        // it doesn't verify. Admitting it silently would leave a client whose
+        // ticket merely expired connected but receiving nothing, instead of
+        // getting connect_error and retrying with a fresh one.
+        const ticket = verifyHandshakeTicket(this.signingSecret, token);
+        if (!ticket) {
+          logger.warn(`Rejecting connection ${socket.id}: invalid handshake ticket for tenant ${tenantSlug}`);
+          return next(new Error('unauthorized'));
+        }
+
+        // Bind the ticket to the host the connection actually arrived on, so a
+        // ticket minted for one tenant can't be replayed on another tenant's socket.
+        if (ticket.h !== normalizeHandshakeHost(host!)) {
+          logger.warn(`Rejecting connection ${socket.id}: handshake ticket host mismatch for tenant ${tenantSlug}`);
+          return next(new Error('unauthorized'));
+        }
+
+        socket.data.tenantSlug = tenantSlug;
+        return next();
       }
 
-      // Bind the ticket to the host the connection actually arrived on, so a
-      // ticket minted for one tenant can't be replayed on another tenant's socket.
-      if (ticket.h !== normalizeHandshakeHost(host!)) {
-        logger.warn(`Rejecting connection ${socket.id}: handshake ticket host mismatch for tenant ${tenantSlug}`);
-        return next(new Error('unauthorized'));
-      }
-
-      socket.data.tenantSlug = tenantSlug;
+      // No ticket offered at all: admit the socket unauthorized so a legacy
+      // Nightscout client can complete the classic `authorize` exchange, which it
+      // sends only after connecting. The socket joins no room until that succeeds,
+      // so it receives nothing in the meantime.
+      logger.debug(`Connection ${socket.id} carries no ticket; awaiting classic authorize for tenant ${tenantSlug}`);
+      socket.data.pendingTenantSlug = tenantSlug;
       next();
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -187,6 +218,12 @@ class SocketIOServer {
         logger.info(`Client ${clientId} joined tenant room: ${tenantSlug}`);
       }
 
+      // Classic Nightscout authorization: legacy clients connect first and then
+      // send their credentials in an `authorize` message.
+      socket.on('authorize', (payload: unknown, callback?: (result: unknown) => void) => {
+        void this.handleAuthorize(socket, payload, callback);
+      });
+
       // Handle client disconnection
       socket.on('disconnect', (reason: string) => {
         this.clients.delete(clientId);
@@ -203,10 +240,94 @@ class SocketIOServer {
     });
   }
 
-  /** Return the Socket.IO emit target: tenant room if scoped, or all clients. */
+  /** Handle the classic Nightscout `authorize` message.
+   *
+   *  Legacy clients (LoopFollow, Nightscout watchfaces) don't have — and can't
+   *  obtain — a handshake ticket, because /realtime/ticket mints one only after
+   *  replaying the read against the API with the caller's browser session. They
+   *  authenticate the way they do against classic Nightscout instead: an API
+   *  secret (already SHA-1 hashed by the client) and/or a subject token.
+   *
+   *  Rather than interpret those credentials here, replay them against the same
+   *  read the ticket endpoint probes. The API applies its own per-tenant policy,
+   *  so this grants exactly what a REST read with the same credential would.
+   *  Only on success does the socket join its tenant room.
+   *
+   *  The probe carries the client's credential and nothing else — never the
+   *  bridge's instance key, which would authenticate any anonymous caller as a
+   *  service and hand them another tenant's data. */
+  async handleAuthorize(
+    socket: Socket,
+    payload: unknown,
+    callback?: (result: unknown) => void,
+  ): Promise<void> {
+    const deny = (reason: string) => {
+      logger.warn(`Authorize failed for ${socket.id}: ${reason}`);
+      callback?.({ read: false, write: false, write_treatment: false });
+      socket.disconnect(true);
+    };
+
+    // Already authorized by a valid handshake ticket — nothing more to do.
+    if (socket.data.tenantSlug) {
+      callback?.({ read: true, write: false, write_treatment: false });
+      return;
+    }
+
+    const tenantSlug = socket.data.pendingTenantSlug as string | undefined;
+    if (!tenantSlug) return deny('no resolvable tenant');
+
+    if (!this.apiBaseUrl) return deny('bridge has no API base URL configured');
+
+    const message = (payload ?? {}) as { secret?: unknown; token?: unknown };
+    const secret = typeof message.secret === 'string' ? message.secret : undefined;
+    const token = typeof message.token === 'string' ? message.token : undefined;
+    if (!secret && !token) return deny('no credentials supplied');
+
+    try {
+      const url = new URL(`${this.apiBaseUrl}/api/v1/entries`);
+      url.searchParams.set('count', '1');
+      if (token) url.searchParams.set('token', token);
+
+      const headers: Record<string, string> = {
+        'X-Forwarded-Host': `${tenantSlug}.${this.baseDomain}`,
+        // The API's response cache runs before auth and keys on the internal
+        // Host, so a cached authenticated 200 could otherwise authorize an
+        // unauthenticated probe.
+        'Cache-Control': 'no-cache, no-store',
+      };
+      if (secret) headers['api-secret'] = secret;
+
+      const probe = await fetch(url, {
+        method: 'GET',
+        headers,
+        signal: AbortSignal.timeout(5000),
+      });
+
+      if (!probe.ok) return deny(`API denied the credential (${probe.status})`);
+
+      socket.data.tenantSlug = tenantSlug;
+      socket.data.pendingTenantSlug = undefined;
+      socket.join(`tenant:${tenantSlug}`);
+      logger.info(`Client ${socket.id} authorized via legacy credentials for tenant: ${tenantSlug}`);
+      callback?.({ read: true, write: false, write_treatment: false });
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      return deny(`credential probe failed: ${reason}`);
+    }
+  }
+
+  /** Return the Socket.IO emit target for a tenant room.
+   *
+   *  Always scoped: an unscoped broadcast would also reach sockets that are
+   *  connected but not yet authorized (legacy clients mid-`authorize`), which
+   *  would leak one tenant's data to them. */
   private emitTarget(tenantSlug?: string) {
     if (!this.io) return null;
-    return tenantSlug ? this.io.to(`tenant:${tenantSlug}`) : this.io;
+    if (!tenantSlug) {
+      logger.warn('Refusing to broadcast without a tenant slug');
+      return null;
+    }
+    return this.io.to(`tenant:${tenantSlug}`);
   }
 
   // Methods to broadcast messages to clients

--- a/src/Web/packages/bridge/src/setup.ts
+++ b/src/Web/packages/bridge/src/setup.ts
@@ -106,6 +106,8 @@ export async function setupBridge(
     );
   }
 
+  const apiBaseUrl = apiBaseFromHubUrl(config.signalr.hubUrl);
+
   // Start the Socket.IO server eagerly — it doesn't need tenant info to accept
   // browser connections. Tenant room assignment uses the Host header; the slug
   // list is only needed for the apex-domain single-tenant case and is filled in
@@ -116,6 +118,7 @@ export async function setupBridge(
     baseDomain,
     [],
     config.instanceKey,
+    apiBaseUrl,
   );
 
   await socketIOServer.start();
@@ -131,7 +134,6 @@ export async function setupBridge(
     .digest('hex')
     .toLowerCase();
 
-  const apiBaseUrl = apiBaseFromHubUrl(config.signalr.hubUrl);
   const clients: SignalRClient[] = [];
   let cancelled = false;
 


### PR DESCRIPTION
## Problem

From #354:

> The Socket.IO bridge only speaks Engine.IO v4 — legacy clients on EIO=3 (LoopFollow's socket.io-client-swift, `?EIO=3&b64=1`) get `{"code":5,"message":"Unsupported protocol version"}` and fall back to polling; classic Nightscout accepts EIO=3

The protocol version is real, but it isn't the whole story — enabling `allowEIO3` on its own changes nothing for these clients. There are three stacked blockers:

1. **Engine.IO v3 is rejected** at the transport layer before any handler runs.
2. **The handshake demands a signed ticket**, which `/realtime/ticket` mints only after replaying the read against the API *using the caller's browser session*. A native client has no session, so it can never obtain one.
3. **There's no classic `authorize` handler.** Legacy clients authenticate the way they do against classic Nightscout: connect first, then send an api-secret and/or subject token in an `authorize` message.

## What this does

- Enables `allowEIO3`.
- Reads the handshake ticket from the query as well as `auth`, since the v3 protocol has no `auth` payload.
- Implements the classic `authorize` exchange. Rather than interpret credentials in the bridge, it replays them against the same read `/realtime/ticket` probes (`GET /api/v1/entries?count=1` with `X-Forwarded-Host` set to the tenant) and lets the API apply its own per-tenant policy. This grants exactly what a REST read with that credential would.

## Security notes for review

- **The probe carries the client's credential and nothing else.** Attaching the bridge's instance key would authenticate any anonymous caller as a service and hand them another tenant's data. Mirrors the same warning already in the web app's `/api` proxy.
- **A connection offering no ticket is admitted but unauthorized.** It has to be — a legacy client can't authorize before connecting. It joins no room until the probe succeeds, so it receives nothing in the meantime.
- **A connection that *does* offer a ticket is still rejected outright when the ticket doesn't verify.** This keeps the browser path unchanged: a client whose ticket merely expired keeps getting `connect_error` and refetching, rather than sitting connected and silently receiving nothing.
- **`emitTarget` no longer falls back to broadcasting to every socket** when given no tenant slug. No caller does that today, but with unauthorized sockets now able to linger, an unscoped broadcast would hand them another tenant's data.
- Authorized legacy clients get `read: true` only; the bridge is a one-way relay and doesn't implement write-back.

## Scope

This restores **live updates**. Clients still fetch history over REST, and there's no initial `dataUpdate` replay on authorize, so this doesn't make the bridge a complete classic-Nightscout socket implementation.

## Tests

6 new cases around `handleAuthorize`: room join on success, token passed as a query parameter, denial + disconnect on API rejection, refusal with no credentials, refusal when the host resolves to no tenant, and no re-probe for a socket already authorized by a ticket. The probe assertions check that the credential is forwarded and that the instance key is not. Existing handshake tests updated for the admitted-but-unauthorized path. 32/32 green, `tsc --noEmit` clean.

Ref: #354
