### PR TITLE
feat(auth): match legacy Nightscout access tokens 1:1 for migrated subjects (#538)

### DIFF
--- a/src/API/Nocturne.API/Middleware/Handlers/AccessTokenHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/AccessTokenHandler.cs
@@ -71,7 +71,11 @@ public class AccessTokenHandler : IAuthHandler
 
         try
         {
-            var subject = await subjectService.GetSubjectByAccessTokenHashAsync(tokenHash);
+            // Native lookup: SHA-256 of the presented token. Migrated legacy Nightscout subjects
+            // fall back to prefix-matching the stored 40-char digest (Nightscout's findSubject
+            // rule) so existing AAPS / legacy client tokens keep authenticating unchanged.
+            var subject = await subjectService.GetSubjectByAccessTokenHashAsync(tokenHash)
+                ?? await subjectService.FindSubjectByLegacyTokenAsync(accessToken);
 
             if (subject == null)
             {

--- a/src/API/Nocturne.API/Services/Auth/LegacyNightscoutToken.cs
+++ b/src/API/Nocturne.API/Services/Auth/LegacyNightscoutToken.cs
@@ -1,0 +1,106 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Nocturne.API.Services.Auth;
+
+/// <summary>
+/// Reproduces legacy Nightscout's access-token matching so migrated tokens keep working 1:1.
+/// </summary>
+/// <remarks>
+/// Legacy Nightscout (<c>cgm-remote-monitor</c>, <c>lib/authorization/storage.js</c>) derives a
+/// subject's <c>digest = sha1(sha1(api_secret) + mongo _id)</c> (40 hex chars) and its human-facing
+/// access token as <c>{name-abbrev}-{first 16 chars of digest}</c>. Its <c>findSubject</c> then
+/// matches an incoming token by taking the substring after the <em>last</em> dash and checking that
+/// it is a prefix (length ≥ 16) of the stored digest. Because only that suffix is compared, the
+/// name-abbrev is cosmetic and any prefix of the digest between 16 and 40 chars authenticates.
+/// <para>
+/// This helper implements that suffix-prefix rule (Nightscout's dominant path). It deliberately does
+/// not implement the secondary <c>sha1(accessToken)</c> path — no known client emits it and matching
+/// it would require persisting a second bearer-equivalent hash at rest.
+/// </para>
+/// </remarks>
+public static class LegacyNightscoutToken
+{
+    /// <summary>Minimum length Nightscout requires for the digest-prefix suffix.</summary>
+    private const int MinPrefixLength = 16;
+
+    /// <summary>Length of the full SHA-1 digest in hex characters.</summary>
+    private const int DigestLength = 40;
+
+    /// <summary>
+    /// Extracts the normalized digest-prefix (the part after the last dash) from an incoming legacy
+    /// token, or null if the token cannot match any digest. The prefix must be 16–40 hex characters;
+    /// requiring hex also makes the value safe to use as a SQL <c>LIKE</c> pattern and mirrors the
+    /// fact that a non-hex suffix can never be a prefix of a hex digest.
+    /// </summary>
+    public static string? ExtractDigestPrefix(string? token)
+    {
+        if (string.IsNullOrEmpty(token))
+        {
+            return null;
+        }
+
+        var dashIndex = token.LastIndexOf('-');
+        var suffix = dashIndex >= 0 ? token[(dashIndex + 1)..] : token;
+
+        if (suffix.Length < MinPrefixLength || suffix.Length > DigestLength)
+        {
+            return null;
+        }
+
+        foreach (var c in suffix)
+        {
+            if (!Uri.IsHexDigit(c))
+            {
+                return null;
+            }
+        }
+
+        return suffix.ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Returns true if <paramref name="token"/> resolves to a subject with the given
+    /// <paramref name="legacyTokenDigest"/> under Nightscout's suffix-prefix matching rule.
+    /// </summary>
+    public static bool Matches(string? legacyTokenDigest, string? token)
+    {
+        if (string.IsNullOrEmpty(legacyTokenDigest))
+        {
+            return false;
+        }
+
+        var prefix = ExtractDigestPrefix(token);
+        return prefix != null && legacyTokenDigest.StartsWith(prefix, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Reconstructs a subject's legacy Nightscout digest (<c>sha1(hashedSecret + mongoId)</c>) at
+    /// migration time. <paramref name="hashedSecret"/> is the source instance's
+    /// <c>sha1(api_secret)</c> (what Nightscout stores and what the migration sends as the
+    /// <c>api-secret</c> header). Returns null when any input is missing, or when the reconstructed
+    /// digest does not match the token Nightscout actually issued (<c>{abbrev}-{first 16 of
+    /// digest}</c>) — the self-check guards against a rotated or mismatched source secret producing
+    /// a digest that would never authenticate the client's real token.
+    /// </summary>
+    /// <param name="hashedSecret">The source instance's <c>sha1(api_secret)</c> (40 hex chars).</param>
+    /// <param name="mongoId">The subject's Mongo <c>_id</c> string.</param>
+    /// <param name="issuedAccessToken">The plaintext access token the source instance issued.</param>
+    public static string? DeriveDigest(string? hashedSecret, string? mongoId, string? issuedAccessToken)
+    {
+        if (string.IsNullOrEmpty(hashedSecret) || string.IsNullOrEmpty(mongoId))
+        {
+            return null;
+        }
+
+        var digest = Convert.ToHexStringLower(SHA1.HashData(Encoding.UTF8.GetBytes(hashedSecret + mongoId)));
+
+        var prefix = ExtractDigestPrefix(issuedAccessToken);
+        if (prefix == null || !digest.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return digest;
+    }
+}

--- a/src/API/Nocturne.API/Services/Auth/SubjectService.cs
+++ b/src/API/Nocturne.API/Services/Auth/SubjectService.cs
@@ -69,20 +69,19 @@ public class SubjectService : ISubjectService
             return null;
         }
 
-        // Only migrated subjects carry a legacy digest, so this candidate set is tiny (a handful
-        // of imported devices/roles per tenant). Match in memory to mirror Nightscout's own
-        // in-memory findSubject and stay independent of provider LIKE support (InMemory in tests).
-        var candidates = await _dbContext
+        // Push Nightscout's digest-prefix rule to the database. The prefix is validated hex, so it
+        // is safe as a LIKE pattern; StartsWith translates to an index-friendly LIKE on PostgreSQL
+        // (against the filtered ix_subjects_legacy_token_digest) and still evaluates on the InMemory
+        // provider used in tests. Both stored digest and prefix are lowercase, so a case-sensitive
+        // match is correct. Returns at most one row rather than materialising every migrated subject.
+        var entity = await _dbContext
             .Subjects.AsNoTracking()
             .Include(s => s.SubjectRoles)
             .ThenInclude(sr => sr.Role)
-            .Where(s => s.LegacyTokenDigest != null && s.IsActive)
-            .ToListAsync();
+            .Where(s => s.LegacyTokenDigest != null && s.IsActive && s.LegacyTokenDigest!.StartsWith(prefix))
+            .FirstOrDefaultAsync();
 
-        var match = candidates.FirstOrDefault(s =>
-            s.LegacyTokenDigest!.StartsWith(prefix, StringComparison.Ordinal));
-
-        return match == null ? null : MapToModel(match);
+        return entity == null ? null : MapToModel(entity);
     }
 
     /// <inheritdoc />
@@ -335,6 +334,9 @@ public class SubjectService : ISubjectService
         var plainAccessToken = GenerateAccessToken();
         entity.AccessTokenHash = HashAccessToken(plainAccessToken);
         entity.AccessTokenPrefix = $"{entity.Name.ToLowerInvariant()}-{plainAccessToken[..8]}";
+        // Rotation must revoke the legacy Nightscout token too, otherwise the old (possibly
+        // leaked) migrated token would keep authenticating through the legacy digest fallback.
+        entity.LegacyTokenDigest = null;
         entity.UpdatedAt = DateTime.UtcNow;
 
         await _dbContext.SaveChangesAsync();

--- a/src/API/Nocturne.API/Services/Auth/SubjectService.cs
+++ b/src/API/Nocturne.API/Services/Auth/SubjectService.cs
@@ -61,6 +61,31 @@ public class SubjectService : ISubjectService
     }
 
     /// <inheritdoc />
+    public async Task<Subject?> FindSubjectByLegacyTokenAsync(string legacyAccessToken)
+    {
+        var prefix = LegacyNightscoutToken.ExtractDigestPrefix(legacyAccessToken);
+        if (prefix == null)
+        {
+            return null;
+        }
+
+        // Only migrated subjects carry a legacy digest, so this candidate set is tiny (a handful
+        // of imported devices/roles per tenant). Match in memory to mirror Nightscout's own
+        // in-memory findSubject and stay independent of provider LIKE support (InMemory in tests).
+        var candidates = await _dbContext
+            .Subjects.AsNoTracking()
+            .Include(s => s.SubjectRoles)
+            .ThenInclude(sr => sr.Role)
+            .Where(s => s.LegacyTokenDigest != null && s.IsActive)
+            .ToListAsync();
+
+        var match = candidates.FirstOrDefault(s =>
+            s.LegacyTokenDigest!.StartsWith(prefix, StringComparison.Ordinal));
+
+        return match == null ? null : MapToModel(match);
+    }
+
+    /// <inheritdoc />
     public async Task<Subject> FindOrCreateFromOidcAsync(
         Guid providerId,
         string oidcSubjectId,

--- a/src/API/Nocturne.API/Services/Identity/AuthorizationService.cs
+++ b/src/API/Nocturne.API/Services/Identity/AuthorizationService.cs
@@ -83,8 +83,11 @@ public class AuthorizationService : IAuthorizationService, IDisposable
             // Hash the access token to look it up
             var tokenHash = ComputeSha256Hash(accessToken);
 
-            // Find subject by access token hash
-            var subject = await _subjectService.GetSubjectByAccessTokenHashAsync(tokenHash);
+            // Find subject by access token hash, falling back to legacy Nightscout digest matching
+            // for tokens migrated from a classic instance (AAPS V3 exchanges its plaintext token
+            // here via /api/v2/authorization/request/{token}).
+            var subject = await _subjectService.GetSubjectByAccessTokenHashAsync(tokenHash)
+                ?? await _subjectService.FindSubjectByLegacyTokenAsync(accessToken);
 
             if (subject == null)
             {

--- a/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
+++ b/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
@@ -1402,6 +1402,13 @@ internal class MigrationJob
             var nocturneRoles = await dbContext.Roles
                 .ToDictionaryAsync(r => r.Name, r => r.Id, ct);
 
+            // Nightscout derives each subject's token from digest = sha1(sha1(api_secret) + _id).
+            // HashApiSecret yields exactly that inner sha1(api_secret), so with the mongo _id we
+            // can reconstruct the full 40-char digest and store it for 1:1 legacy token matching.
+            var hashedSecret = string.IsNullOrEmpty(_request.NightscoutApiSecret)
+                ? null
+                : HashApiSecret(_request.NightscoutApiSecret);
+
             foreach (var subject in subjects)
             {
                 ct.ThrowIfCancellationRequested();
@@ -1425,15 +1432,19 @@ internal class MigrationJob
                     // Determine if subject should be inactive ("denied" is only role)
                     var isDenied = subject.Roles is ["denied"];
 
+                    var mongoId = subject.MongoId ?? subject.Id;
+                    var legacyDigest = Auth.LegacyNightscoutToken.DeriveDigest(hashedSecret, mongoId, subject.AccessToken);
+
                     var entity = new SubjectEntity
                     {
                         Id = Guid.CreateVersion7(),
                         Name = subject.Name ?? "Unnamed",
                         AccessTokenHash = tokenHash,
                         AccessTokenPrefix = $"{(subject.Name ?? "unknown").ToLowerInvariant()}-{subject.AccessToken[..Math.Min(8, subject.AccessToken.Length)]}",
+                        LegacyTokenDigest = legacyDigest,
                         IsActive = !isDenied,
                         Notes = "Migrated from Nightscout. Consider rotating to a Nocturne token.",
-                        OriginalId = subject.MongoId ?? subject.Id,
+                        OriginalId = mongoId,
                         CreatedAt = DateTime.UtcNow,
                         UpdatedAt = DateTime.UtcNow,
                         ApprovalStatus = "Approved",

--- a/src/Core/Nocturne.Core.Contracts/Auth/ISubjectService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Auth/ISubjectService.cs
@@ -26,6 +26,16 @@ public interface ISubjectService
     Task<Subject?> GetSubjectByAccessTokenHashAsync(string accessTokenHash);
 
     /// <summary>
+    /// Finds an active subject by matching a legacy Nightscout access token against the stored
+    /// legacy token digest, reproducing Nightscout's prefix-based matching (the substring after
+    /// the last dash, 16–40 hex chars, matched as a prefix of the 40-char digest). Only subjects
+    /// migrated from a legacy Nightscout instance carry a digest; returns null otherwise.
+    /// </summary>
+    /// <param name="legacyAccessToken">The raw legacy access token as presented by the client.</param>
+    /// <returns>Subject if a migrated digest matches and the subject is active, null otherwise.</returns>
+    Task<Subject?> FindSubjectByLegacyTokenAsync(string legacyAccessToken);
+
+    /// <summary>
     /// Find or create a subject from OIDC claims
     /// </summary>
     /// <param name="oidcSubjectId">OIDC subject identifier (sub claim)</param>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/SubjectEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/SubjectEntity.cs
@@ -46,6 +46,23 @@ public class SubjectEntity : IEntityTimestamped
     public string? AccessTokenPrefix { get; set; }
 
     /// <summary>
+    /// Legacy Nightscout subject digest (40-char SHA-1 hex of <c>sha1(api_secret) + mongo _id</c>),
+    /// captured at migration time. Only ever populated for subjects imported from a legacy
+    /// Nightscout instance — natively-created subjects use the strong random token + SHA-256
+    /// <see cref="AccessTokenHash"/> scheme and leave this null.
+    /// <para>
+    /// Legacy Nightscout derives a subject's access token as <c>{name-abbrev}-{first 16 chars of
+    /// this digest}</c> and authenticates by prefix-matching the part after the last dash against
+    /// the digest. Storing the digest lets Nocturne reproduce that matching 1:1 for migrated
+    /// tokens (see the legacy fallback in the auth handlers) so existing AAPS / legacy client
+    /// setups keep working without re-issuing tokens.
+    /// </para>
+    /// </summary>
+    [MaxLength(40)]
+    [Column("legacy_token_digest")]
+    public string? LegacyTokenDigest { get; set; }
+
+    /// <summary>
     /// Email address (from OIDC claims or manually set)
     /// </summary>
     [MaxLength(255)]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260725025314_AddSubjectLegacyTokenDigest.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260725025314_AddSubjectLegacyTokenDigest.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260725025314_AddSubjectLegacyTokenDigest")]
+    partial class AddSubjectLegacyTokenDigest
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260725025314_AddSubjectLegacyTokenDigest.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260725025314_AddSubjectLegacyTokenDigest.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSubjectLegacyTokenDigest : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "legacy_token_digest",
+                table: "subjects",
+                type: "character varying(40)",
+                maxLength: 40,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_subjects_legacy_token_digest",
+                table: "subjects",
+                column: "legacy_token_digest",
+                filter: "legacy_token_digest IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_subjects_legacy_token_digest",
+                table: "subjects");
+
+            migrationBuilder.DropColumn(
+                name: "legacy_token_digest",
+                table: "subjects");
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -942,6 +942,14 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             .HasDatabaseName("ix_subjects_access_token_hash")
             .IsUnique();
 
+        // Legacy Nightscout digest is prefix-matched (not equality), so this index only
+        // narrows the candidate set; it is filtered to the small migrated-subject population.
+        modelBuilder
+            .Entity<SubjectEntity>()
+            .HasIndex(s => s.LegacyTokenDigest)
+            .HasDatabaseName("ix_subjects_legacy_token_digest")
+            .HasFilter("legacy_token_digest IS NOT NULL");
+
         modelBuilder
             .Entity<SubjectEntity>()
             .HasIndex(s => s.Email)

--- a/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/AccessTokenHandlerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/AccessTokenHandlerTests.cs
@@ -66,4 +66,25 @@ public class AccessTokenHandlerTests
             s => s.GetSubjectByAccessTokenHashAsync(It.IsAny<string>()),
             Times.Never);
     }
+
+    [Fact]
+    public async Task AuthenticateAsync_LegacyMigratedToken_FallsBackToDigestMatch()
+    {
+        // The SHA-256 lookup misses (subject was migrated from a classic Nightscout and stores
+        // only the legacy digest), so the handler must fall back to digest matching and succeed.
+        var subjectId = Guid.NewGuid();
+        _subjectService
+            .Setup(s => s.GetSubjectByAccessTokenHashAsync(It.IsAny<string>()))
+            .ReturnsAsync((Subject?)null);
+        _subjectService
+            .Setup(s => s.FindSubjectByLegacyTokenAsync("phone-318030bcdc470b9d"))
+            .ReturnsAsync(new Subject { Id = subjectId, Name = "Phone", IsActive = true });
+
+        var result = await _handler.AuthenticateAsync(CreateContext("phone-318030bcdc470b9d"));
+
+        Assert.True(result.Succeeded);
+        _subjectService.Verify(
+            s => s.FindSubjectByLegacyTokenAsync("phone-318030bcdc470b9d"),
+            Times.Once);
+    }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/LegacyNightscoutTokenTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/LegacyNightscoutTokenTests.cs
@@ -1,0 +1,87 @@
+using Nocturne.API.Services.Auth;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Auth;
+
+/// <summary>
+/// Verifies Nocturne reproduces legacy Nightscout's access-token matching. The vector below is a
+/// real Nightscout derivation:
+///   hashedSecret = sha1("my-test-secret-123") = 0d4e7110fb6d9c37b624fbed8b6249826d00a4d2
+///   mongoId      = 5f9b3faa1c9d440000a1b2c3
+///   digest       = sha1(hashedSecret + mongoId) = 318030bcdc470b9d05518755491a80239a640400
+///   accessToken  = "phone-" + digest[..16]      = phone-318030bcdc470b9d
+/// </summary>
+public class LegacyNightscoutTokenTests
+{
+    private const string HashedSecret = "0d4e7110fb6d9c37b624fbed8b6249826d00a4d2";
+    private const string MongoId = "5f9b3faa1c9d440000a1b2c3";
+    private const string Digest = "318030bcdc470b9d05518755491a80239a640400";
+    private const string CanonicalToken = "phone-318030bcdc470b9d";
+
+    [Theory]
+    // Canonical token AAPS is configured with.
+    [InlineData(CanonicalToken, true)]
+    // Nightscout ignores the name-abbrev; only the suffix after the last dash matters.
+    [InlineData("differentname-318030bcdc470b9d", true)]
+    // Uppercase hex still resolves (clients may emit either case).
+    [InlineData("PHONE-318030BCDC470B9D", true)]
+    // Nightscout also accepts any digest prefix of length 16..40, including the full digest.
+    [InlineData("phone-318030bcdc470b9d05518755491a80239a640400", true)]
+    // A bare full digest (no dash) is a valid prefix of itself.
+    [InlineData(Digest, true)]
+    // Suffix shorter than 16 chars is rejected (Nightscout's minimum).
+    [InlineData("phone-318030bcdc470b9", false)]
+    // Correct length, wrong value.
+    [InlineData("phone-aaaaaaaaaaaaaaaa", false)]
+    // Non-hex suffix can never prefix a hex digest.
+    [InlineData("phone-zzzzzzzzzzzzzzzz", false)]
+    // JWT-shaped input is not a legacy token.
+    [InlineData("header.payload.signature", false)]
+    public void Matches_follows_nightscout_prefix_rule(string token, bool expected)
+    {
+        LegacyNightscoutToken.Matches(Digest, token).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Matches_returns_false_when_no_digest_stored()
+    {
+        LegacyNightscoutToken.Matches(null, CanonicalToken).Should().BeFalse();
+        LegacyNightscoutToken.Matches("", CanonicalToken).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ExtractDigestPrefix_normalizes_to_lowercase_hex()
+    {
+        LegacyNightscoutToken.ExtractDigestPrefix("PHONE-318030BCDC470B9D")
+            .Should().Be("318030bcdc470b9d");
+    }
+
+    [Fact]
+    public void DeriveDigest_reconstructs_the_nightscout_digest()
+    {
+        var digest = LegacyNightscoutToken.DeriveDigest(HashedSecret, MongoId, CanonicalToken);
+
+        digest.Should().Be(Digest);
+    }
+
+    [Fact]
+    public void DeriveDigest_selfcheck_rejects_mismatched_secret()
+    {
+        // A digest reconstructed from the wrong secret would never match the client's real token,
+        // so it must not be stored.
+        var wrongSecret = "ffffffffffffffffffffffffffffffffffffffff";
+
+        LegacyNightscoutToken.DeriveDigest(wrongSecret, MongoId, CanonicalToken)
+            .Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(null, MongoId)]
+    [InlineData(HashedSecret, null)]
+    [InlineData("", "")]
+    public void DeriveDigest_returns_null_on_missing_inputs(string? hashedSecret, string? mongoId)
+    {
+        LegacyNightscoutToken.DeriveDigest(hashedSecret, mongoId, CanonicalToken)
+            .Should().BeNull();
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/SubjectServiceLegacyTokenTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/SubjectServiceLegacyTokenTests.cs
@@ -1,0 +1,94 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Auth;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Auth;
+
+/// <summary>
+/// Exercises legacy Nightscout token resolution on <see cref="SubjectService"/> against a real EF
+/// InMemory DbContext. Vector: digest = 318030bcdc470b9d05518755491a80239a640400, canonical token
+/// phone-318030bcdc470b9d (see <see cref="LegacyNightscoutTokenTests"/>).
+/// </summary>
+public class SubjectServiceLegacyTokenTests : IDisposable
+{
+    private const string Digest = "318030bcdc470b9d05518755491a80239a640400";
+    private const string CanonicalToken = "phone-318030bcdc470b9d";
+
+    private readonly NocturneDbContext _db;
+    private readonly SubjectService _service;
+    private readonly Mock<IAuthAuditService> _audit = new();
+
+    public SubjectServiceLegacyTokenTests()
+    {
+        _db = TestDbContextFactory.CreateInMemoryContext();
+        _service = new SubjectService(_db, _audit.Object, NullLogger<SubjectService>.Instance);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private async Task<Guid> SeedMigratedSubjectAsync(bool isActive = true)
+    {
+        var id = Guid.CreateVersion7();
+        _db.Subjects.Add(new SubjectEntity
+        {
+            Id = id,
+            Name = "Phone",
+            AccessTokenHash = "unused-sha256",
+            LegacyTokenDigest = Digest,
+            IsActive = isActive,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+        return id;
+    }
+
+    [Fact]
+    public async Task FindSubjectByLegacyTokenAsync_resolves_migrated_token()
+    {
+        var id = await SeedMigratedSubjectAsync();
+
+        var subject = await _service.FindSubjectByLegacyTokenAsync(CanonicalToken);
+
+        subject.Should().NotBeNull();
+        subject!.Id.Should().Be(id);
+    }
+
+    [Fact]
+    public async Task FindSubjectByLegacyTokenAsync_ignores_inactive_subjects()
+    {
+        await SeedMigratedSubjectAsync(isActive: false);
+
+        var subject = await _service.FindSubjectByLegacyTokenAsync(CanonicalToken);
+
+        subject.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task FindSubjectByLegacyTokenAsync_returns_null_for_non_matching_token()
+    {
+        await SeedMigratedSubjectAsync();
+
+        var subject = await _service.FindSubjectByLegacyTokenAsync("phone-aaaaaaaaaaaaaaaa");
+
+        subject.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RegenerateAccessTokenAsync_revokes_the_legacy_token()
+    {
+        var id = await SeedMigratedSubjectAsync();
+
+        var newToken = await _service.RegenerateAccessTokenAsync(id);
+
+        newToken.Should().NotBeNull();
+        // The digest must be cleared so the old (possibly leaked) legacy token stops authenticating.
+        (await _service.FindSubjectByLegacyTokenAsync(CanonicalToken)).Should().BeNull();
+        (await _db.Subjects.AsNoTracking().FirstAsync(s => s.Id == id)).LegacyTokenDigest.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Closes #538. Makes migrated legacy Nightscout access tokens authenticate 1:1, so existing AAPS / legacy client setups keep working without re-issuing tokens.

Stock Nightscout (`cgm-remote-monitor`, `lib/authorization/storage.js`) derives, per subject, `digest = sha1(sha1(api_secret) + mongo _id)` (40 hex chars) and the human token as `{name-abbrev}-{first 16 chars of digest}`. Its `findSubject` authenticates by taking the substring **after the last dash**, requiring length ≥ 16, and checking it is a **prefix of the stored digest** — so the name-abbrev is cosmetic and any 16–40 char digest prefix authenticates.

Nocturne stored only `SHA-256(exact token)` and matched by exact equality — narrower than Nightscout. Migrated AAPS tokens therefore failed the digest-suffix, mismatched-abbrev and full-digest forms that stock Nightscout accepts.

## What changed

- **`subjects.legacy_token_digest`** (`varchar(40)`, nullable) — populated **only** at migration from `sha1(sha1(sourceSecret) + mongoId)`, with a self-check against the token the source actually issued (guards a rotated/mismatched source secret). Natively-created subjects keep the strong random-token + SHA-256 scheme and leave it null, so the weaker SHA-1/prefix matching is quarantined to explicitly-imported legacy tokens.
- **`LegacyNightscoutToken`** — centralises all NS token knowledge: the suffix-prefix `Matches` rule + `DeriveDigest`, covered by a real NS-derived test vector.
- **Fallback after the SHA-256 miss** in the two subject-token surfaces: `AccessTokenHandler` (`?token=`/Bearer) and the `/api/v2/authorization/request/{token}` exchange (AAPS V3's path).
- Rotation (`RegenerateAccessTokenAsync`) now clears the digest, so a leaked migrated token is revoked; the lookup is an index-backed DB `StartsWith` returning ≤1 row.

## Deliberately not replicated

- NS's secondary `sha1(accessToken)` path — no known client emits it, and matching it would mean persisting a second bearer-equivalent hash at rest.
- Subject tokens carried in the `api-secret` header (a pre-existing gap for the SHA-256 path too; `ApiKeyHandler`'s grant/scope shape doesn't fit subjects).

## Testing

- `LegacyNightscoutTokenTests` — real NS-derived vector drives the matcher truth table (canonical / any-abbrev / full-digest / uppercase / <16 reject / non-hex reject) + `DeriveDigest` self-check.
- `SubjectServiceLegacyTokenTests` — InMemory lookup, inactive-subject exclusion, and rotation-revokes-legacy-token.
- `AccessTokenHandlerTests` — SHA-256 miss falls back to digest match.

Reviewed for auth-bypass / over-match / tenancy / brute-force posture; matcher is strictly narrower than stock Nightscout.
