### PR TITLE
fix(web): make Acknowledge all update the alerts surface in one round-trip

### DIFF
--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/+page.svelte
@@ -114,8 +114,16 @@
   async function handleAcknowledge(): Promise<void> {
     acknowledging = true;
     try {
-      await acknowledge({ acknowledgedBy: "web_user" });
-      await activeAlertsQuery.refresh();
+      // Optimistically badge every unacknowledged excursion so the card updates
+      // at once; the command's GetActiveAlerts invalidation reconciles it in the
+      // same round-trip (same pattern as AlertBanner/FiringToast).
+      await acknowledge({ acknowledgedBy: "web_user" }).updates(
+        activeAlertsQuery.withOverride((current) =>
+          (current ?? []).map((a) =>
+            a.acknowledgedAt ? a : { ...a, acknowledgedAt: new Date() },
+          ),
+        ),
+      );
     } finally {
       acknowledging = false;
     }
@@ -236,7 +244,13 @@
               <AlertTriangle class="h-5 w-5 shrink-0" />
               <span class="truncate">Active alerts ({activeAlerts.length})</span>
             </CardTitle>
-            <Button class="@sm:shrink-0" variant="outline" size="sm" onclick={handleAcknowledge} disabled={acknowledging}>
+            <Button
+              class="@sm:shrink-0"
+              variant="outline"
+              size="sm"
+              onclick={handleAcknowledge}
+              disabled={acknowledging || activeAlerts.every((a) => a.acknowledgedAt)}
+            >
               {#if acknowledging}
                 <Loader2 class="h-4 w-4 mr-2 animate-spin" />
               {:else}


### PR DESCRIPTION
## What

`Acknowledge all` on `/alerts` acknowledged every active excursion and then issued a *separate* `getActiveAlerts` refresh, so nothing on screen moved until that second round-trip landed — despite the command already carrying `[RemoteCommand(Invalidates = ["GetActiveAlerts"])]`.

It now pushes a single-flight override, the same pattern `AlertBanner` and `FiringToast` already use:

```js
await acknowledge({ acknowledgedBy: "web_user" }).updates(
  activeAlertsQuery.withOverride((current) =>
    (current ?? []).map((a) => (a.acknowledgedAt ? a : { ...a, acknowledgedAt: new Date() })),
  ),
);
```

Every unacknowledged excursion gets its `Acknowledged` badge immediately and the command's invalidation reconciles the query in the same response, so the page, the banner and the toast settle on server truth together.

Acknowledged excursions stay in the active list until hysteresis closes them (`AlertsController.GetActiveAlerts` filters on `EndedAt == null` only), so the button is also disabled once nothing is left to acknowledge — previously it stayed live with no work to do.

## Testing

`pnpm run check` — no errors in the touched file. (The 26 errors it reports are pre-existing, in the gitignored generated client plus `RuleBuilderLeafEditor.svelte` / `SwimLaneTrack.svelte`.)