### PR TITLE
fix(api): declare the missing query invalidations on remote commands

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/OidcController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/OidcController.cs
@@ -426,7 +426,7 @@ public class OidcController : ControllerBase
     /// <response code="404">Identity not found.</response>
     /// <response code="409">Cannot remove the last primary sign-in method.</response>
     [HttpDelete("link/identities/{identityId:guid}")]
-    [RemoteCommand]
+    [RemoteCommand(Invalidates = ["GetLinkedIdentities"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/src/API/Nocturne.API/Controllers/V4/Connectors/ConfigurationController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Connectors/ConfigurationController.cs
@@ -326,7 +326,7 @@ public class ConfigurationController : ControllerBase
     /// <param name="request">Request containing the active state</param>
     /// <param name="ct">Cancellation token</param>
     [HttpPatch("{connectorName}/active")]
-    [RemoteCommand(Invalidates = ["GetAllConnectorStatus"])]
+    [RemoteCommand(Invalidates = ["GetConfiguration", "GetAllConnectorStatus"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<IActionResult> SetActive(
         string connectorName,

--- a/src/API/Nocturne.API/Controllers/V4/Identity/GuestLinkController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/GuestLinkController.cs
@@ -37,7 +37,7 @@ public class GuestLinkController : ControllerBase
     /// </summary>
     [HttpPost]
     [Authorize]
-    [RemoteCommand]
+    [RemoteCommand(Invalidates = ["GetGuestLinks"])]
     [ProducesResponseType(typeof(GuestLinkCreationResult), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/src/API/Nocturne.API/Controllers/V4/Identity/MembershipRequestController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/MembershipRequestController.cs
@@ -25,7 +25,7 @@ public class MembershipRequestController(
     /// </summary>
     [HttpPost]
     [Authorize]
-    [RemoteCommand]
+    [RemoteCommand(Invalidates = ["GetMyRequest"])]
     [ProducesResponseType(typeof(CreateMembershipRequestResult), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> CreateRequest(
@@ -90,7 +90,7 @@ public class MembershipRequestController(
     /// </summary>
     [HttpPost("{id:guid}/approve")]
     [Authorize]
-    [RemoteCommand]
+    [RemoteCommand(Invalidates = ["GetPendingRequests"])]
     [ProducesResponseType(typeof(DecideMembershipRequestResult), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
@@ -121,7 +121,7 @@ public class MembershipRequestController(
     /// </summary>
     [HttpPost("{id:guid}/deny")]
     [Authorize]
-    [RemoteCommand]
+    [RemoteCommand(Invalidates = ["GetPendingRequests"])]
     [ProducesResponseType(typeof(DecideMembershipRequestResult), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]

--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertCustomSoundsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertCustomSoundsController.cs
@@ -38,7 +38,7 @@ public class AlertCustomSoundsController : ControllerBase
     /// Upload a custom alert sound file.
     /// </summary>
     [HttpPost]
-    [RemoteCommand]
+    [RemoteCommand(Invalidates = ["GetSounds"])]
     [RequestSizeLimit(512_000)]
     [ProducesResponseType(typeof(AlertCustomSoundResponse), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/src/API/Nocturne.API/Controllers/V4/Platform/ServicesController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/ServicesController.cs
@@ -435,7 +435,14 @@ public class ServicesController : ControllerBase
     /// <returns>Sync result with success status and details</returns>
     [HttpPost("connectors/{id}/sync")]
     [RequireAdmin]
-    [RemoteCommand]
+    [RemoteCommand(
+        Invalidates = [
+            "GetServicesOverview",
+            "GetActiveDataSources",
+            "GetConnectorDataSummary",
+            "GetConnectorSyncStatus",
+        ]
+    )]
     [ProducesResponseType(typeof(Nocturne.Connectors.Core.Models.SyncResult), 200)]
     [ProducesResponseType(400)]
     public async Task<
@@ -478,7 +485,14 @@ public class ServicesController : ControllerBase
     /// <returns>Sync result with success status and details.</returns>
     [HttpPost("connectors/{id}/reset-cursor")]
     [RequireAdmin]
-    [RemoteCommand]
+    [RemoteCommand(
+        Invalidates = [
+            "GetServicesOverview",
+            "GetActiveDataSources",
+            "GetConnectorDataSummary",
+            "GetConnectorSyncStatus",
+        ]
+    )]
     [ProducesResponseType(typeof(Nocturne.Connectors.Core.Models.SyncResult), 200)]
     [ProducesResponseType(400)]
     public async Task<

--- a/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/AccessRequestController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/AccessRequestController.cs
@@ -58,7 +58,7 @@ public class AccessRequestController(
 
     /// <inheritdoc cref="ITenantService.AddMemberAsync"/>
     [HttpPost("{subjectId:guid}/approve")]
-    [RemoteCommand]
+    [RemoteCommand(Invalidates = ["GetPendingRequests"])]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> Approve(
@@ -123,7 +123,7 @@ public class AccessRequestController(
 
     /// <inheritdoc cref="ISubjectService.DeleteSubjectAsync"/>
     [HttpPost("{subjectId:guid}/deny")]
-    [RemoteCommand]
+    [RemoteCommand(Invalidates = ["GetPendingRequests"])]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> Deny(Guid subjectId, CancellationToken ct)

--- a/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/TenantController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/TenantController.cs
@@ -148,7 +148,7 @@ public class TenantController : ControllerBase
 
     /// <inheritdoc cref="IMemberInviteService.CreateInviteAsync"/>
     [HttpPost("{id:guid}/invites")]
-    [RemoteCommand(Invalidates = ["GetById"])]
+    [RemoteCommand(Invalidates = ["GetById", "ListInvites"])]
     [ProducesResponseType(typeof(MemberInviteResult), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> CreateInvite(

--- a/src/API/Nocturne.API/Controllers/V4/Profiles/UserPreferencesController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Profiles/UserPreferencesController.cs
@@ -78,7 +78,7 @@ public class UserPreferencesController : ControllerBase
     /// <param name="request">The preferences to update</param>
     /// <returns>Updated preferences</returns>
     [HttpPatch]
-    [RemoteCommand]
+    [RemoteCommand(Invalidates = ["GetPreferences"])]
     [ProducesResponseType(typeof(UserPreferencesResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]

--- a/src/API/Nocturne.API/Controllers/V4/TenantAdmin/DeduplicationController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/TenantAdmin/DeduplicationController.cs
@@ -95,7 +95,7 @@ public class DeduplicationController : ControllerBase
 
     /// <inheritdoc cref="IDeduplicationService.CancelJobAsync"/>
     [HttpPost("cancel/{jobId:guid}")]
-    [RemoteCommand]
+    [RemoteCommand(Invalidates = ["GetJobStatus"])]
     [ProducesResponseType(typeof(CancelJobResponse), 200)]
     [ProducesResponseType(404)]
     [ProducesResponseType(500)]

--- a/src/API/Nocturne.API/Controllers/V4/TenantAdmin/MigrationController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/TenantAdmin/MigrationController.cs
@@ -92,7 +92,7 @@ public class MigrationController : ControllerBase
     /// Start a migration using saved connector credentials (e.g., after Nightscout connector setup).
     /// </summary>
     [HttpPost("start-from-connector/{connectorName}")]
-    [RemoteCommand]
+    [RemoteCommand(Invalidates = ["GetHistory"])]
     [ProducesResponseType(typeof(MigrationJobInfo), StatusCodes.Status202Accepted)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<MigrationJobInfo>> StartFromConnector(
@@ -146,7 +146,7 @@ public class MigrationController : ControllerBase
 
     /// <inheritdoc cref="IMigrationJobService.CancelAsync"/>
     [HttpPost("{jobId:guid}/cancel")]
-    [RemoteCommand]
+    [RemoteCommand(Invalidates = ["GetStatus", "GetHistory"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> CancelMigration(Guid jobId)

--- a/src/Web/packages/app/src/lib/components/connectors/ConnectorSetup.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/ConnectorSetup.svelte
@@ -190,12 +190,18 @@
   );
   const hasData = $derived(dataSummary && (dataSummary.total ?? 0) > 0);
 
-  // --- Initialize configuration when server data loads or changes ---
-  $effect(() => {
-    const config = existingConfig;
-    const s = schema;
-    if (!s) return;
+  /** The connector whose stored config has already been loaded into the form. */
+  let seededConnectorId = $state<string | undefined>(undefined);
 
+  // --- Seed the form from the stored config, once per connector ---
+  // setActive invalidates GetConfiguration, so this runs again after the enable/disable
+  // toggle; re-seeding then would discard edits the user hasn't saved yet.
+  $effect(() => {
+    const s = schema;
+    const id = activeId;
+    if (!s || !id || configQuery?.loading || seededConnectorId === id) return;
+
+    const config = existingConfig;
     const configData = config?.configuration?.rootElement ?? config?.configuration;
     if (configData && typeof configData === "object" && Object.keys(configData).length > 0) {
       configuration = { ...configData };
@@ -203,6 +209,7 @@
       configuration = getDefaultsFromSchema(s);
     }
     secrets = {};
+    seededConnectorId = id;
   });
 
   function getDefaultsFromSchema(s: JsonSchema): Record<string, unknown> {
@@ -249,6 +256,8 @@
         });
       }
 
+      // Secrets are write-only — drop the entered values once they're stored.
+      secrets = {};
       saveMessage = { type: "success", text: "Configuration saved" };
     } catch (e) {
       saveMessage = {
@@ -298,6 +307,7 @@
     step = "selection";
     manuallySelectedId = undefined;
     // Reactive queries auto-clean when activeId becomes undefined
+    seededConnectorId = undefined;
     configuration = {};
     secrets = {};
     syncResult = null;

--- a/src/Web/packages/app/src/lib/components/members/GuestLinksSection.svelte
+++ b/src/Web/packages/app/src/lib/components/members/GuestLinksSection.svelte
@@ -38,7 +38,7 @@
 
   // UI state
   let showDismissed = $state(false);
-  let removingIds = $state(new Set<string>());
+  let pendingIds = $state(new Set<string>());
 
   // Query
   const guestLinksQuery = $derived(
@@ -46,9 +46,7 @@
   );
   const allLinks = $derived(guestLinksQuery?.current ?? []);
   const guestLinks = $derived(
-    (showDismissed ? allLinks : allLinks.filter((l) => !l.dismissedAt)).filter(
-      (l) => !removingIds.has(l.id!)
-    )
+    showDismissed ? allLinks : allLinks.filter((l) => !l.dismissedAt)
   );
   const dismissedCount = $derived(allLinks.filter((l) => l.dismissedAt).length);
   let showCreateForm = $state(false);
@@ -188,24 +186,28 @@
     }
   }
 
-  async function handleDismiss(id: string) {
-    removingIds = new Set([...removingIds, id]);
+  /**
+   * Run a guest-link mutation and pull the updated list. The commands' declared
+   * GetGuestLinks invalidation refreshes `getGuestLinks(undefined)`, which is a
+   * different cache key from the `{ includeDismissed: true }` this component
+   * subscribes with, so the refresh has to be issued here.
+   */
+  async function mutateLink(id: string, run: (id: string) => Promise<unknown>) {
+    pendingIds = new Set([...pendingIds, id]);
     try {
-      await dismissGuestLink(id);
-    } catch {
-      // Restore on failure
-      removingIds = new Set([...removingIds].filter((x) => x !== id));
+      await run(id);
+      await guestLinksQuery?.refresh();
+    } finally {
+      pendingIds = new Set([...pendingIds].filter((x) => x !== id));
     }
   }
 
+  async function handleDismiss(id: string) {
+    await mutateLink(id, dismissGuestLink);
+  }
+
   async function handleRevoke(id: string) {
-    removingIds = new Set([...removingIds, id]);
-    try {
-      await revokeGuestLink(id);
-    } catch {
-      // Restore on failure
-      removingIds = new Set([...removingIds].filter((x) => x !== id));
-    }
+    await mutateLink(id, revokeGuestLink);
   }
 
   let reissuingId = $state<string | null>(null);
@@ -481,6 +483,7 @@
                     variant="ghost"
                     size="sm"
                     class="text-destructive hover:text-destructive shrink-0"
+                    disabled={pendingIds.has(link.id!)}
                     onclick={() => handleRevoke(link.id!)}
                   >
                     <X class="mr-1 h-3.5 w-3.5" />
@@ -491,6 +494,7 @@
                     variant="ghost"
                     size="sm"
                     class="text-muted-foreground hover:text-foreground shrink-0"
+                    disabled={pendingIds.has(link.id!)}
                     onclick={() => handleDismiss(link.id!)}
                   >
                     <EyeOff class="mr-1 h-3.5 w-3.5" />

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/members/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/members/+page.svelte
@@ -115,7 +115,6 @@
   let showCreateInvite = $state(false);
   let errorMessage = $state<string | null>(null);
   let successMessage = $state<string | null>(null);
-  let removingMemberIds = $state(new Set<string>());
 
   // --- Member edit state ---
   let expandedMember = $state<string | null>(null);
@@ -130,9 +129,7 @@
   // Visible members — system subjects (e.g. Public) are managed via the
   // public access card above, not as removable/editable cards.
   const visibleMembers = $derived(
-    allMembers.filter(
-      (m) => !m.isSystemSubject && !removingMemberIds.has(m.subjectId!),
-    ),
+    allMembers.filter((m) => !m.isSystemSubject),
   );
 
   function clearMessages() {
@@ -176,6 +173,9 @@
     errorMessage = null;
     try {
       await approveRequest({ id: requestId, request: { roleIds } });
+      // The approved requester becomes a member; GetMembers is on another
+      // controller so ApproveRequest's Invalidates cannot name it.
+      await membersQuery.refresh();
       successMessage = "Membership request approved.";
       clearMessages();
     } catch {
@@ -275,7 +275,7 @@
         />
       {/if}
 
-      {#if visibleMembers.length === 0 && removingMemberIds.size === 0}
+      {#if visibleMembers.length === 0}
         <Card.Root>
           <Card.Content class="flex flex-col items-center justify-center py-12 text-center">
             <div class="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
@@ -313,15 +313,16 @@
               }}
               onRemove={async () => {
                 if (!tenantId || !member.subjectId) return;
-                removingMemberIds = new Set([...removingMemberIds, member.subjectId]);
                 errorMessage = null;
                 try {
                   await removeMember({ id: tenantId, subjectId: member.subjectId });
+                  // GetMembers lives on MemberInviteController, so RemoveMember's
+                  // Invalidates cannot name it — refresh from here.
+                  await membersQuery.refresh();
                   successMessage = "Member removed successfully.";
                   clearMessages();
                 } catch (e) {
                   errorMessage = messageFrom(e, "Failed to remove member. Please try again.");
-                  removingMemberIds = new Set([...removingMemberIds].filter(x => x !== member.subjectId));
                   clearMessages();
                 }
               }}

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/weight/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/weight/+page.svelte
@@ -8,6 +8,9 @@
   import * as bw from "$api/generated/bodyWeights.generated.remote";
   import type { BodyWeight } from "$api";
 
+  // create/deleteBodyWeight declare a GetBodyWeights invalidation, but it refreshes
+  // getBodyWeights(undefined) — a different cache key from this subscription — so each
+  // mutation below refreshes this query itself.
   const weightsQuery = bw.getBodyWeights({ count: 100, skip: 0 });
   const entries = $derived<BodyWeight[]>(weightsQuery.current ?? []);
 
@@ -39,6 +42,7 @@
         weightKg: kg,
         mills: newDate ? new Date(newDate).getTime() : Date.now(),
       });
+      await weightsQuery.refresh();
       newWeightKg = "";
       newDate = "";
     } catch (e) {
@@ -54,6 +58,7 @@
     if (!entry?.id) return;
     try {
       await bw.deleteBodyWeight(entry.id);
+      await weightsQuery.refresh();
     } catch (e) {
       errorMessage = (e as { message?: string })?.message ?? "Failed to delete entry";
     }


### PR DESCRIPTION
Mutations were leaving the UI showing state that no longer existed. Query invalidation is declared in C# via `[RemoteCommand(Invalidates = [...])]`, which the codegen turns into `.refresh()` calls in the generated TS — and 53 of 186 actions carried no `Invalidates` at all.

Audited all 53. Added `Invalidates` to 14 and amended 2; the remaining 39 are deliberately left bare, each for a stated reason (no same-controller query reflects the mutation; the mutation provably doesn't change the query; the refresh would fail after the mutation, e.g. `ValidateInvite` returns 410 Gone once redeemed; or the job is enqueued asynchronously so nothing has changed at response time).

## Bugs fixed

- Approving/denying a membership request left the card on screen with live buttons — clicking again re-hit the server
- Same on the platform-admin passkey access-request queue
- A created invite never appeared in Pending Invites (`RevokeInvite` already invalidated `ListInvites`, which proved the omission)
- Removing the last member left a blank area instead of the empty state
- The connector Enable/Disable switch visibly snapped back while the banner said "Connector enabled", and the Active/Inactive badge lied after save-and-activate
- Weight history stayed stale after add/delete
- Guest links vanished permanently on revoke instead of showing their intended Revoked badge
- Removing an OIDC sign-in method left its row on screen (found during the audit)

Three of these needed call-site refreshes rather than the attribute: `Invalidates` cannot express query *arguments* (the weight endpoint defaults to `count = 10`, so `getBodyWeights(undefined)` is not equivalent to `{count: 100}`) and cannot name a query on another controller (`GetMembers` lives on `MemberInviteController`, not `TenantController`).

## Hacks removed

The optimistic-hide workarounds these gaps forced into existence, which caused bugs of their own:
- `removingMemberIds` — never cleared on success, so the empty state never rendered
- `removingIds` in `GuestLinksSection` — cleared only on failure, so a revoked row was hidden permanently

## Regression found and fixed in-branch

Making `setActive` invalidate `GetConfiguration` caused `ConnectorSetup`'s seeding `$effect` to re-run on toggle and reset unsaved config/secrets — flipping Enable would have discarded edits. Now seeded once per connector.

## Verification

- `dotnet build src/API/Nocturne.API` — 0 errors
- Full codegen pipeline run; regenerated output diffed against a pre-change snapshot: exactly 11 modules changed with exactly the intended `.refresh()` calls and nothing else
- `pnpm check` — 64 errors before and after, identical baseline, none in touched files
- Symptom-to-cause mappings and query-key matches verified by reading, not by browser click-through

## Follow-ups

Two upstream changes to `openapi-remote-codegen` would close the remaining gaps structurally — emitting `requested(query, Infinity).refreshAll()` alongside the fixed-key refresh, and an `InvalidatesAcross` attribute for cross-controller naming. Filed separately.

Note: `.updates()` cannot be emitted by the generator — it is a client-side-only method and the server wrapper throws if called there. The generated `.refresh()` already rides back in the same response, so it is not an extra round-trip.
