### PR TITLE
fix(web): make the report date range mean one thing

### DIFF
--- a/src/Web/packages/app/src/lib/api/idp.remote.ts
+++ b/src/Web/packages/app/src/lib/api/idp.remote.ts
@@ -3,56 +3,11 @@
  * glucose, boluses, carb intakes, insulin delivery stats, profile summary,
  * extended glucose analytics, averaged stats, and basal analysis
  */
-import { z } from "zod";
 import { getRequestEvent, query } from "$app/server";
-import { error } from "@sveltejs/kit";
 import { fetchAllGlucose } from "./glucose-pagination";
+import { DateRangeSchema, resolveReportRange } from "./report-range";
 
-/**
- * Input schema for date range queries. Uses nullish() to accept both null and
- * undefined, matching the date-params hook.
- */
-const DateRangeSchema = z.object({
-  days: z.number().nullish(),
-  from: z.string().nullish(),
-  to: z.string().nullish(),
-});
-
-export type DateRangeInput = z.infer<typeof DateRangeSchema>;
-
-/** Calculate date range from input parameters */
-function calculateDateRange(input?: DateRangeInput): {
-  startDate: Date;
-  endDate: Date;
-} {
-  let startDate: Date;
-  let endDate: Date;
-
-  if (input?.from && input?.to) {
-    startDate = new Date(input.from);
-    endDate = new Date(input.to);
-  } else if (input?.days) {
-    endDate = new Date();
-    startDate = new Date(endDate);
-    startDate.setDate(endDate.getDate() - (input.days - 1));
-  } else {
-    // Default to last 7 days
-    endDate = new Date();
-    startDate = new Date(endDate);
-    startDate.setDate(endDate.getDate() - 6);
-  }
-
-  // Validate dates
-  if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
-    throw error(400, "Invalid date parameters provided");
-  }
-
-  // Set to full day boundaries
-  startDate.setHours(0, 0, 0, 0);
-  endDate.setHours(23, 59, 59, 999);
-
-  return { startDate, endDate };
-}
+export type { DateRangeInput } from "./report-range";
 
 /**
  * Combined query to get all data needed for the Insulin Dosing Profile report.
@@ -62,7 +17,7 @@ function calculateDateRange(input?: DateRangeInput): {
 export const getIdpData = query(DateRangeSchema.optional(), async (input) => {
   const { locals } = getRequestEvent();
   const { apiClient } = locals;
-  const { startDate, endDate } = calculateDateRange(input);
+  const { startDate, endDate } = await resolveReportRange(input, 14);
 
   // Raw readings (paginated) and boluses for the charts.
   const [entries, bolusResult] = await Promise.all([

--- a/src/Web/packages/app/src/lib/api/report-range.ts
+++ b/src/Web/packages/app/src/lib/api/report-range.ts
@@ -10,7 +10,7 @@ import { z } from "zod";
 import { error } from "@sveltejs/kit";
 import { getProfileSummary } from "$api/generated/profiles.generated.remote";
 import { getLocalDayBoundariesUtc } from "$lib/utils/timezone";
-import { dayCount, resolveDayRange } from "$lib/utils/date-range";
+import { dayCount, isTimeZone, resolveDayRange } from "$lib/utils/date-range";
 
 /**
  * Input schema for date range queries. Uses nullish() to accept both null and
@@ -36,10 +36,14 @@ export interface ReportRange {
   timeZone: string | null;
 }
 
-/** The patient's configured IANA timezone, or null when unset. */
+/**
+ * The patient's configured IANA timezone, or null when it is unset or is a value
+ * this runtime does not recognise. Null means the day boundaries fall back to UTC.
+ */
 export async function getPatientTimeZone(): Promise<string | null> {
   const profile = await getProfileSummary(undefined);
-  return profile?.therapySettings?.[0]?.timezone ?? null;
+  const timeZone = profile?.therapySettings?.[0]?.timezone;
+  return isTimeZone(timeZone) ? timeZone : null;
 }
 
 /** Resolve a report window against the patient's timezone. */
@@ -48,14 +52,7 @@ export async function resolveReportRange(
   defaultDays = 7
 ): Promise<ReportRange> {
   const timeZone = await getPatientTimeZone();
-
-  let from: string;
-  let to: string;
-  try {
-    ({ from, to } = resolveDayRange(input, defaultDays, timeZone ?? "UTC"));
-  } catch {
-    throw error(400, "Invalid date parameters provided");
-  }
+  const { from, to } = resolveDayRange(input, defaultDays, timeZone ?? "UTC");
 
   const { start: startDate } = getLocalDayBoundariesUtc(from, timeZone);
   const { end: endDate } = getLocalDayBoundariesUtc(to, timeZone);

--- a/src/Web/packages/app/src/lib/api/report-range.ts
+++ b/src/Web/packages/app/src/lib/api/report-range.ts
@@ -1,0 +1,68 @@
+/**
+ * Server-side resolution of a report's date range.
+ *
+ * A report's "day" is the patient's day, so the day boundaries are computed in
+ * the timezone on their therapy settings rather than the container's timezone.
+ * The window is inclusive: it runs from midnight opening `from` to the last
+ * millisecond of `to`, both read in that timezone.
+ */
+import { z } from "zod";
+import { error } from "@sveltejs/kit";
+import { getProfileSummary } from "$api/generated/profiles.generated.remote";
+import { getLocalDayBoundariesUtc } from "$lib/utils/timezone";
+import { dayCount, resolveDayRange } from "$lib/utils/date-range";
+
+/**
+ * Input schema for date range queries. Uses nullish() to accept both null and
+ * undefined, matching the date-params hook which uses nullable defaults for
+ * runed compatibility.
+ */
+export const DateRangeSchema = z.object({
+  days: z.number().nullish(),
+  from: z.string().nullish(),
+  to: z.string().nullish(),
+});
+
+export type DateRangeInput = z.infer<typeof DateRangeSchema>;
+
+export interface ReportRange {
+  /** UTC instant at which the patient's first day begins. */
+  startDate: Date;
+  /** UTC instant of the last millisecond of the patient's last day. */
+  endDate: Date;
+  /** Calendar days the window covers, counting both end days. */
+  dayCount: number;
+  /** The patient's IANA timezone, or null when their profile does not set one. */
+  timeZone: string | null;
+}
+
+/** The patient's configured IANA timezone, or null when unset. */
+export async function getPatientTimeZone(): Promise<string | null> {
+  const profile = await getProfileSummary(undefined);
+  return profile?.therapySettings?.[0]?.timezone ?? null;
+}
+
+/** Resolve a report window against the patient's timezone. */
+export async function resolveReportRange(
+  input?: DateRangeInput | null,
+  defaultDays = 7
+): Promise<ReportRange> {
+  const timeZone = await getPatientTimeZone();
+
+  let from: string;
+  let to: string;
+  try {
+    ({ from, to } = resolveDayRange(input, defaultDays, timeZone ?? "UTC"));
+  } catch {
+    throw error(400, "Invalid date parameters provided");
+  }
+
+  const { start: startDate } = getLocalDayBoundariesUtc(from, timeZone);
+  const { end: endDate } = getLocalDayBoundariesUtc(to, timeZone);
+
+  if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
+    throw error(400, "Invalid date parameters provided");
+  }
+
+  return { startDate, endDate, dayCount: dayCount(from, to), timeZone };
+}

--- a/src/Web/packages/app/src/lib/api/reports.remote.ts
+++ b/src/Web/packages/app/src/lib/api/reports.remote.ts
@@ -5,62 +5,17 @@
 import { z } from "zod";
 import { DiabetesPopulationSchema } from "$lib/api/generated/schemas";
 import { getRequestEvent, query } from "$app/server";
-import { error } from "@sveltejs/kit";
 import { DiabetesPopulation, ClusterConfidence } from "$lib/api";
 import { fetchAllGlucose } from "./glucose-pagination";
+import { DateRangeSchema, resolveReportRange } from "./report-range";
 
-/**
- * Input schema for date range queries. Uses nullish() to accept both null and
- * undefined, matching the date-params hook which uses nullable defaults for
- * runed compatibility.
- */
-const DateRangeSchema = z.object({
-  days: z.number().nullish(),
-  from: z.string().nullish(),
-  to: z.string().nullish(),
-});
-
-export type DateRangeInput = z.infer<typeof DateRangeSchema>;
-
-/** Calculate date range from input parameters */
-function calculateDateRange(input?: DateRangeInput): {
-  startDate: Date;
-  endDate: Date;
-} {
-  let startDate: Date;
-  let endDate: Date;
-
-  if (input?.from && input?.to) {
-    startDate = new Date(input.from);
-    endDate = new Date(input.to);
-  } else if (input?.days) {
-    endDate = new Date();
-    startDate = new Date(endDate);
-    startDate.setDate(endDate.getDate() - (input.days - 1));
-  } else {
-    // Default to last 7 days
-    endDate = new Date();
-    startDate = new Date(endDate);
-    startDate.setDate(endDate.getDate() - 6);
-  }
-
-  // Validate dates
-  if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
-    throw error(400, "Invalid date parameters provided");
-  }
-
-  // Set to full day boundaries
-  startDate.setHours(0, 0, 0, 0);
-  endDate.setHours(23, 59, 59, 999);
-
-  return { startDate, endDate };
-}
+export type { DateRangeInput } from "./report-range";
 
 /** Get sensor glucose readings for a date range */
 export const getEntries = query(DateRangeSchema.optional(), async (input) => {
   const { locals } = getRequestEvent();
   const { apiClient } = locals;
-  const { startDate, endDate } = calculateDateRange(input);
+  const { startDate, endDate } = await resolveReportRange(input);
 
   const entries = await fetchAllGlucose(apiClient, startDate, endDate);
 
@@ -79,7 +34,7 @@ export const getBolusesAndCarbs = query(
   async (input) => {
     const { locals } = getRequestEvent();
     const { apiClient } = locals;
-    const { startDate, endDate } = calculateDateRange(input);
+    const { startDate, endDate } = await resolveReportRange(input);
 
     const pageSize = 1000;
 
@@ -186,7 +141,7 @@ export const getReportsData = query(
   async (input) => {
     const { locals } = getRequestEvent();
     const { apiClient } = locals;
-    const { startDate, endDate } = calculateDateRange(input);
+    const { startDate, endDate } = await resolveReportRange(input);
 
     const [entries, { analysis, averagedStats, personalRange }] = await Promise.all([
       fetchAllGlucose(apiClient, startDate, endDate),
@@ -216,7 +171,7 @@ export const getReportsAnalysis = query(
   async (input) => {
     const { locals } = getRequestEvent();
     const { apiClient } = locals;
-    const { startDate, endDate } = calculateDateRange(input);
+    const { startDate, endDate } = await resolveReportRange(input);
 
     const { analysis, averagedStats, personalRange } =
       await apiClient.statistics.getRangeAnalytics(startDate, endDate);
@@ -243,7 +198,7 @@ export const getDataQualityReport = query(
   async (input) => {
     const { locals } = getRequestEvent();
     const { apiClient } = locals;
-    const { startDate, endDate } = calculateDateRange(input);
+    const { startDate, endDate } = await resolveReportRange(input);
 
     const [entries, integrity] = await Promise.all([
       fetchAllGlucose(apiClient, startDate, endDate),
@@ -275,10 +230,7 @@ export const getDataQualityReport = query(
  * Input schema for site change impact analysis. Uses nullish() for date fields
  * to match date-params hook.
  */
-const SiteChangeImpactSchema = z.object({
-  days: z.number().nullish(),
-  from: z.string().nullish(),
-  to: z.string().nullish(),
+const SiteChangeImpactSchema = DateRangeSchema.extend({
   hoursBeforeChange: z.number().optional().default(12),
   hoursAfterChange: z.number().optional().default(24),
   bucketSizeMinutes: z.number().optional().default(30),
@@ -295,7 +247,7 @@ export const getSiteChangeImpact = query(
   async (input) => {
     const { locals } = getRequestEvent();
     const { apiClient } = locals;
-    const { startDate, endDate } = calculateDateRange(input);
+    const { startDate, endDate } = await resolveReportRange(input);
 
     // Fetch all sensor glucose readings
     const entries = await fetchAllGlucose(apiClient, startDate, endDate);

--- a/src/Web/packages/app/src/lib/components/actogram/actogram.ts
+++ b/src/Web/packages/app/src/lib/components/actogram/actogram.ts
@@ -1,8 +1,15 @@
 import type { ScaleTime } from 'd3-scale';
 
 export const MS_PER_HOUR = 3_600_000;
+export const MS_PER_DAY = 86_400_000;
 export const HOURS_PER_DAY = 24;
 export const HOURS_PER_ROW = 48;
+
+/**
+ * Days either side of the selected range that actogram pages fetch, so each row's
+ * next-day double plot has data and scrolling back has context.
+ */
+export const ACTOGRAM_PADDING_DAYS = 14;
 
 export interface ActogramPoint {
 	mills: number;
@@ -61,6 +68,46 @@ export function findNearestPoint<T extends ActogramPoint>(
 	}
 
 	return minDist <= maxDistanceHours ? nearest : undefined;
+}
+
+/** Every local-midnight Date between `fromMs` and `toMs`, inclusive. */
+export function buildDayRange(fromMs: number, toMs: number): Date[] {
+	const start = new Date(fromMs);
+	const end = new Date(toMs);
+	const startMidnight = new Date(start.getFullYear(), start.getMonth(), start.getDate());
+	const endMidnight = new Date(end.getFullYear(), end.getMonth(), end.getDate());
+	const dayCount =
+		Math.round((endMidnight.getTime() - startMidnight.getTime()) / MS_PER_DAY) + 1;
+	return Array.from({ length: Math.max(1, dayCount) }, (_, i) => {
+		const day = new Date(startMidnight);
+		day.setDate(day.getDate() + i);
+		return day;
+	});
+}
+
+/** Points whose `mills` fall inside the inclusive window. */
+export function pointsInRange<T extends ActogramPoint>(points: T[], from: number, to: number): T[] {
+	return points.filter((point) => point.mills >= from && point.mills <= to);
+}
+
+/**
+ * Lowest and highest `read` value across `items`, or null when there are none.
+ * Reduces rather than spreading into `Math.min`/`Math.max`, which is passed one
+ * argument per reading and throws RangeError on a long window of per-minute data.
+ */
+export function extentOf<T>(
+	items: readonly T[],
+	read: (item: T) => number,
+): { min: number; max: number } | null {
+	if (items.length === 0) return null;
+	let min = Infinity;
+	let max = -Infinity;
+	for (const item of items) {
+		const value = read(item);
+		if (value < min) min = value;
+		if (value > max) max = value;
+	}
+	return { min, max };
 }
 
 function slicePoints<T extends ActogramPoint>(data: T[], days: Date[]): { day: Date; data: RowDataPoint<T>[] }[] {

--- a/src/Web/packages/app/src/lib/components/actogram/index.ts
+++ b/src/Web/packages/app/src/lib/components/actogram/index.ts
@@ -1,6 +1,12 @@
 export { default as Actogram } from './Actogram.svelte';
 export { default as ActogramRow } from './ActogramRow.svelte';
-export { findNearestPoint } from './actogram';
+export {
+	ACTOGRAM_PADDING_DAYS,
+	buildDayRange,
+	extentOf,
+	findNearestPoint,
+	pointsInRange,
+} from './actogram';
 export type {
 	ActogramPoint,
 	ActogramRowContext,

--- a/src/Web/packages/app/src/lib/components/layout/ReportsFilterSidebar.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/ReportsFilterSidebar.svelte
@@ -4,11 +4,11 @@
   import { Label } from "$lib/components/ui/label";
   import { Separator } from "$lib/components/ui/separator";
   import { ScrollArea } from "$lib/components/ui/scroll-area";
-  import { Switch } from "$lib/components/ui/switch";
   import { getLocalTimeZone, parseDate, today } from "@internationalized/date";
   import type { DateRange } from "bits-ui";
   import { requireDateParamsContext } from "$lib/hooks/date-params.svelte";
   import { RangeCalendar } from "$lib/components/ui/range-calendar";
+  import { dayCount } from "$lib/utils/date-range";
   import { Calendar, Filter, RotateCcw } from "lucide-svelte";
 
   interface Props {
@@ -30,8 +30,6 @@
     { label: "30 Days", days: 30 },
     { label: "90 Days", days: 90 },
   ];
-
-  const MS_PER_DAY = 86_400_000;
 
   // === DRAFT STATE ===
   // The pending date range selection before clicking "Apply Filters".
@@ -74,10 +72,7 @@
     const tz = getLocalTimeZone();
     if (end.compare(today(tz)) !== 0) return undefined;
 
-    const days =
-      Math.round(
-        (end.toDate(tz).getTime() - start.toDate(tz).getTime()) / MS_PER_DAY
-      ) + 1;
+    const days = dayCount(start.toString(), end.toString());
     return dayPresets.some((p) => p.days === days) ? days : undefined;
   });
 
@@ -95,8 +90,16 @@
     }
   }
 
+  /**
+   * Return to the on-screen report's own default window and hand the range back
+   * to default mode, so navigating to another report can adjust it again.
+   * Resetting to a fixed 7 days shortened 30-day reports and pinned the result
+   * as a user choice.
+   */
   function resetFilters() {
-    selectPreset(7);
+    params.reset();
+    open = false;
+    onOpenChange?.(false);
   }
 
   function applyFilters() {
@@ -139,7 +142,7 @@
         </Sheet.Title>
       </div>
       <Sheet.Description class="text-sm text-muted-foreground">
-        Adjust the date range and filters for your report.
+        Adjust the date range for your report.
       </Sheet.Description>
     </Sheet.Header>
 
@@ -180,30 +183,6 @@
               onValueChange={handleCalendarChange}
               class="p-0"
             />
-          </div>
-        </div>
-
-        <Separator />
-
-        <!-- Additional Filters (placeholders for future features) -->
-        <div class="space-y-3">
-          <Label class="text-sm font-medium">Display Options</Label>
-
-          <div class="flex items-center justify-between">
-            <Label class="text-sm text-muted-foreground">
-              Show target range
-            </Label>
-            <Switch checked={true} />
-          </div>
-
-          <div class="flex items-center justify-between">
-            <Label class="text-sm text-muted-foreground">Show treatments</Label>
-            <Switch checked={true} />
-          </div>
-
-          <div class="flex items-center justify-between">
-            <Label class="text-sm text-muted-foreground">Include notes</Label>
-            <Switch checked={false} />
           </div>
         </div>
       </div>

--- a/src/Web/packages/app/src/lib/components/reports/BasalBolusRatioChart.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/BasalBolusRatioChart.svelte
@@ -18,22 +18,13 @@
   }
 
   interface Props {
-    /** Start date for the report (ISO string or Date) - for future data fetching */
-    startDate?: string | Date;
-    /** End date for the report (ISO string or Date) - for future data fetching */
-    endDate?: string | Date;
     /** Optional pre-loaded ratio data */
     data?: DailyBasalBolusRatioResponse | null;
     /** Whether data is currently loading */
     loading?: boolean;
   }
 
-  let {
-    startDate: _startDate,
-    endDate: _endDate,
-    data = null,
-    loading = false,
-  }: Props = $props();
+  let { data = null, loading = false }: Props = $props();
 
   // Extract data from prop
   const ratioData = $derived(data as DailyBasalBolusRatioResponse | null);

--- a/src/Web/packages/app/src/lib/components/reports/ResourceGuard.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/ResourceGuard.svelte
@@ -17,6 +17,8 @@
     error: Error | string | null | undefined;
     /** Whether there is cached data to show (prevents skeleton flash) */
     hasData?: boolean;
+    /** Whether a new value is loading while the previous one is still shown */
+    refreshing?: boolean;
     /** Title for error card */
     errorTitle?: string;
     /** Function to call for retry */
@@ -35,6 +37,7 @@
     loading,
     error,
     hasData = false,
+    refreshing = false,
     errorTitle = "Error Loading Data",
     onRetry,
     compact = false,
@@ -64,7 +67,22 @@
   break hydration on the next render. When skeleton or error UI is shown,
   children remain mounted but are visually hidden via the `hidden` attribute.
 -->
-<div hidden={!showContent} aria-hidden={!showContent}>
+<!--
+  While a new range loads, the previous report stays on screen with a status line
+  above it rather than being replaced by a skeleton, so scroll position and any
+  panel already valid survive the change.
+-->
+{#if showContent && refreshing}
+  <div
+    class="flex items-center justify-center gap-2 border-b border-border bg-muted/40 px-4 py-1.5 text-xs text-muted-foreground print:hidden"
+    role="status"
+  >
+    <RefreshCw class="h-3 w-3 animate-spin" />
+    Loading the selected range
+  </div>
+{/if}
+
+<div hidden={!showContent} aria-hidden={!showContent} aria-busy={refreshing}>
   {@render children()}
 </div>
 

--- a/src/Web/packages/app/src/lib/components/treatments/TreatmentStatsCard.svelte
+++ b/src/Web/packages/app/src/lib/components/treatments/TreatmentStatsCard.svelte
@@ -28,19 +28,11 @@
   interface Props {
     treatmentSummary: TreatmentSummaryData;
     counts: Record<EntryCategoryId | "all", number>;
-    dateRange: { from: string; to: string };
+    /** Calendar days the selected range covers, counting both end days. */
+    dayCount: number;
   }
 
-  let { treatmentSummary, counts, dateRange }: Props = $props();
-
-  let daysInRange = $derived.by(() => {
-    const from = new Date(dateRange.from);
-    const to = new Date(dateRange.to);
-    return Math.max(
-      1,
-      Math.ceil((to.getTime() - from.getTime()) / (1000 * 60 * 60 * 24))
-    );
-  });
+  let { treatmentSummary, counts, dayCount }: Props = $props();
 
   const totalInsulin = $derived(
     (treatmentSummary.totals?.insulin?.bolus ?? 0) +
@@ -50,8 +42,8 @@
   const bolusCount = $derived(counts.bolus);
   const carbEntriesCount = $derived(counts.carbs);
 
-  let dailyAvgCarbs = $derived(totalCarbs / daysInRange);
-  let dailyAvgBoluses = $derived(bolusCount / daysInRange);
+  let dailyAvgCarbs = $derived(totalCarbs / dayCount);
+  let dailyAvgBoluses = $derived(bolusCount / dayCount);
 
   let avgInsulinPerBolus = $derived(
     bolusCount > 0 ? totalInsulin / bolusCount : 0

--- a/src/Web/packages/app/src/lib/hooks/date-params.svelte.ts
+++ b/src/Web/packages/app/src/lib/hooks/date-params.svelte.ts
@@ -70,6 +70,11 @@ export function useDateParams(defaultDays = 7) {
   // Track initialization to prevent infinite loops
   let initialized = $state(false);
 
+  // The default window of the report currently on screen, which differs from the
+  // layout's baseline (insulin-delivery wants 30 days, readings 7). Reset returns
+  // to this rather than to the layout's, so Reset on a 30-day report stays 30 days.
+  let reportDefaultDays = $state(defaultDays);
+
   // Compute initial defaults eagerly so memoizedInput is valid before effects run (SSR)
   const _initEnd = today(getLocalTimeZone());
   const _initStart = _initEnd.subtract({ days: defaultDays - 1 });
@@ -206,9 +211,9 @@ export function useDateParams(defaultDays = 7) {
    */
   function reset() {
     const endDate = today(getLocalTimeZone());
-    const startDate = endDate.subtract({ days: defaultDays - 1 });
+    const startDate = endDate.subtract({ days: reportDefaultDays - 1 });
 
-    params.days = defaultDays;
+    params.days = reportDefaultDays;
     params.from = startDate.toString();
     params.to = endDate.toString();
     params.isDefault = true;
@@ -295,11 +300,25 @@ export function useDateParams(defaultDays = 7) {
     reset,
     getDateRange,
 
+    /** The default window of the report currently on screen. */
+    get reportDefaultDays(): number {
+      return reportDefaultDays;
+    },
+
+    /**
+     * Internal method: record the on-screen report's default window, so Reset
+     * returns to it rather than to the layout's baseline.
+     */
+    _setReportDefaultDays(daysCount: number) {
+      reportDefaultDays = daysCount;
+    },
+
     /**
      * Internal method: Set day range while keeping isDefault=true.
      * Used when auto-adjusting to a report's preferred default.
      */
     _setDefaultDayRange(daysCount: number) {
+      reportDefaultDays = daysCount;
       const endDate = today(getLocalTimeZone());
       const startDate = endDate.subtract({ days: daysCount - 1 });
       params.days = daysCount;
@@ -387,11 +406,15 @@ export function requireDateParamsContext(reportDefaultDays?: number): ReportsPar
   // Use untrack to read values without creating reactive dependencies that could
   // cause effect_update_depth_exceeded when this is called during component init
   untrack(() => {
-    if (reportDefaultDays !== undefined && params.isDefault && params.days !== reportDefaultDays) {
+    if (reportDefaultDays === undefined) return;
+    if (params.isDefault && params.days !== reportDefaultDays) {
       // The user hasn't made a custom selection (isDefault=true), so we can adjust
       // to this report's preferred default range using direct property assignment
       // (which triggers runed's reactive proxy correctly)
       params._setDefaultDayRange(reportDefaultDays);
+    } else {
+      // No adjustment needed, but Reset still has to know this report's default.
+      params._setReportDefaultDays(reportDefaultDays);
     }
   });
 

--- a/src/Web/packages/app/src/lib/hooks/date-params.svelte.ts
+++ b/src/Web/packages/app/src/lib/hooks/date-params.svelte.ts
@@ -14,7 +14,8 @@
 import { useSearchParams } from "runed/kit";
 import { z } from "zod";
 import { getLocalTimeZone, today } from "@internationalized/date";
-import { getContext, setContext, untrack } from "svelte";
+import { getContext, onDestroy, setContext, untrack } from "svelte";
+import { SvelteSet } from "svelte/reactivity";
 import {
   dayCount as countDays,
   endOfDay,
@@ -381,6 +382,41 @@ export function getDateParamsContext(): ReportsParamsReturn | undefined {
 }
 
 /**
+ * Whether the report on screen reads the shared date range.
+ *
+ * The layout offers the range button and Filters sheet on every report route, but
+ * Comparison, Year Overview, Day in Review, Data Quality and Compression Lows
+ * carry their own period controls and ignore it — changing the range there did
+ * nothing. Reports declare their use by asking for the context with a default
+ * window; consumers are tracked by token so an outgoing page unregistering after
+ * an incoming page registers cannot hide a control that is in use.
+ */
+export class SharedRangeUse {
+  #consumers = new SvelteSet<symbol>();
+
+  get consumed(): boolean {
+    return this.#consumers.size > 0;
+  }
+
+  add(token: symbol): void {
+    this.#consumers.add(token);
+  }
+
+  remove(token: symbol): void {
+    this.#consumers.delete(token);
+  }
+}
+
+const SHARED_RANGE_USE_KEY = Symbol("shared-range-use");
+
+/** Create and provide the shared-range-use flag. Call this in the reports layout. */
+export function createSharedRangeUse(): SharedRangeUse {
+  const use = new SharedRangeUse();
+  setContext(SHARED_RANGE_USE_KEY, use);
+  return use;
+}
+
+/**
  * Get the shared date params from context, throwing if not available.
  * Use this when you're certain the context has been set (e.g., in report pages).
  *
@@ -405,6 +441,15 @@ export function requireDateParamsContext(reportDefaultDays?: number): ReportsPar
   // Auto-adjust if this report has a different default and we're in default mode
   // Use untrack to read values without creating reactive dependencies that could
   // cause effect_update_depth_exceeded when this is called during component init
+  if (reportDefaultDays !== undefined) {
+    const use = getContext<SharedRangeUse | undefined>(SHARED_RANGE_USE_KEY);
+    if (use) {
+      const token = Symbol("shared-range-consumer");
+      use.add(token);
+      onDestroy(() => use.remove(token));
+    }
+  }
+
   untrack(() => {
     if (reportDefaultDays === undefined) return;
     if (params.isDefault && params.days !== reportDefaultDays) {

--- a/src/Web/packages/app/src/lib/hooks/date-params.svelte.ts
+++ b/src/Web/packages/app/src/lib/hooks/date-params.svelte.ts
@@ -13,8 +13,15 @@
  */
 import { useSearchParams } from "runed/kit";
 import { z } from "zod";
-import { getLocalTimeZone, today, parseDate } from "@internationalized/date";
+import { getLocalTimeZone, today } from "@internationalized/date";
 import { getContext, setContext, untrack } from "svelte";
+import {
+  dayCount as countDays,
+  endOfDay,
+  resolveDayRange,
+  startOfDay,
+  type DayRangeStrings,
+} from "$lib/utils/date-range";
 
 /**
  * Zod schema for reports URL parameters.
@@ -208,34 +215,6 @@ export function useDateParams(defaultDays = 7) {
   }
 
   /**
-   * Get the current date range as Date objects.
-   */
-  function getDateRange(): { start: Date; end: Date } {
-    if (params.from && params.to) {
-      try {
-        const startParsed = parseDate(params.from);
-        const endParsed = parseDate(params.to);
-        return {
-          start: startParsed.toDate(getLocalTimeZone()),
-          end: endParsed.toDate(getLocalTimeZone()),
-        };
-      } catch {
-        // Fall through to default
-      }
-    }
-
-    // Calculate from days or use default
-    const daysCount = params.days ?? defaultDays;
-    const endDate = today(getLocalTimeZone());
-    const startDate = endDate.subtract({ days: daysCount - 1 });
-
-    return {
-      start: startDate.toDate(getLocalTimeZone()),
-      end: endDate.toDate(getLocalTimeZone()),
-    };
-  }
-
-  /**
    * Effective [from, to] as YYYY-MM-DD strings. Explicit from/to win; otherwise
    * the window is the last `days` (or defaultDays) ending today.
    *
@@ -244,16 +223,17 @@ export function useDateParams(defaultDays = 7) {
    * which the init effect copies through as from/to undefined) into a single
    * today→today range — reported as "N of 1" and anchoring the actograms on today.
    */
-  function resolveRangeStrings(
-    daysVal: number | null | undefined,
-    fromVal: string | null | undefined,
-    toVal: string | null | undefined,
-  ): { from: string; to: string } {
-    if (fromVal && toVal) return { from: fromVal, to: toVal };
-    const daysCount = daysVal ?? defaultDays;
-    const end = today(getLocalTimeZone());
-    const start = end.subtract({ days: daysCount - 1 });
-    return { from: start.toString(), to: end.toString() };
+  function resolvedRange(): DayRangeStrings {
+    return resolveDayRange(memoizedInput, defaultDays);
+  }
+
+  /**
+   * The current range as instants: local midnight opening the first day through
+   * the last millisecond of the last day, so the range is inclusive.
+   */
+  function getDateRange(): { start: Date; end: Date } {
+    const { from, to } = resolvedRange();
+    return { start: startOfDay(from), end: endOfDay(to) };
   }
 
   return {
@@ -277,20 +257,36 @@ export function useDateParams(defaultDays = 7) {
       return memoizedInput;
     },
 
-    /** Start of the date range as a Date object. Derived from memoizedInput for stability. */
+    /** First day of the range as YYYY-MM-DD. */
+    get fromDay(): string {
+      return resolvedRange().from;
+    },
+
+    /** Last day of the range as YYYY-MM-DD. */
+    get toDay(): string {
+      return resolvedRange().to;
+    },
+
+    /** Local midnight opening the range. */
     get startDate(): Date {
-      return new Date(resolveRangeStrings(memoizedInput.days, memoizedInput.from, memoizedInput.to).from);
+      return startOfDay(resolvedRange().from);
     },
 
-    /** End of the date range as a Date object. Derived from memoizedInput for stability. */
+    /** Last millisecond of the range's final day, local time. */
     get endDate(): Date {
-      return new Date(resolveRangeStrings(memoizedInput.days, memoizedInput.from, memoizedInput.to).to);
+      return endOfDay(resolvedRange().to);
     },
 
-    /** Date range as Unix milliseconds. Derived from memoizedInput for stability. */
+    /** The inclusive range as Unix milliseconds. */
     get dateRangeMillis(): { from: number; to: number } {
-      const { from, to } = resolveRangeStrings(memoizedInput.days, memoizedInput.from, memoizedInput.to);
-      return { from: new Date(from).getTime(), to: new Date(to).getTime() };
+      const { from, to } = resolvedRange();
+      return { from: startOfDay(from).getTime(), to: endOfDay(to).getTime() };
+    },
+
+    /** Calendar days the range covers, counting both end days. */
+    get dayCount(): number {
+      const { from, to } = resolvedRange();
+      return countDays(from, to);
     },
 
     // Helper methods

--- a/src/Web/packages/app/src/lib/hooks/resource-context.svelte.ts
+++ b/src/Web/packages/app/src/lib/hooks/resource-context.svelte.ts
@@ -14,6 +14,8 @@ interface ContextResourceBase<T> {
   readonly loading: boolean;
   readonly error: unknown;
   readonly current: T | undefined;
+  /** Whether `current` is a retained value from a superseded query. */
+  readonly stale: boolean;
   refresh(): void;
 }
 
@@ -36,6 +38,8 @@ export interface ResourceRegistration {
   loading: boolean;
   error: Error | string | null | undefined;
   hasData: boolean;
+  /** Loading a new value while a previous one is still on screen. */
+  refreshing: boolean;
   errorTitle: string;
   refetch: () => void;
 }
@@ -81,6 +85,11 @@ export class ResourceContext {
   /** Whether any resource has data (prevents skeleton flash). */
   get hasData(): boolean {
     return this.#all.some((r) => r.hasData);
+  }
+
+  /** Whether a new value is loading while a previous one is still on screen. */
+  get refreshing(): boolean {
+    return this.#all.some((r) => r.refreshing);
   }
 
   /** Title for the error card, taken from whichever resource failed. */
@@ -163,6 +172,7 @@ export function useResourceContext(config: {
       loading: config.loading(),
       error: config.error(),
       hasData: config.hasData(),
+      refreshing: config.loading() && config.hasData(),
       errorTitle: config.errorTitle ?? "Error Loading Data",
       refetch: config.refetch,
     })
@@ -214,12 +224,27 @@ export function contextResource<T>(
   // are never constructed inside an $effect (which would trigger a Svelte warning).
   const query = $derived(queryFn());
 
+  // Hold on to the last resolved value. Changing the range creates a new query
+  // whose `.current` is undefined, which failed both the page's own `{#if}` gate
+  // and the layout's hasData check at once: the report went blank, then swapped in
+  // a full-page skeleton, losing scroll position and every panel already valid.
+  let retained = $state<T | undefined>(undefined);
+  $effect.pre(() => {
+    if (query.current !== undefined && query.current !== null) {
+      retained = query.current;
+    }
+  });
+
+  const current = $derived(query.current ?? retained);
+  const stale = $derived(query.current === undefined && retained !== undefined);
+
   registerWith(
     getResourceContext(),
     () => ({
       loading: query.loading,
       error: query.error as Error | string | null | undefined,
-      hasData: query.current !== undefined && query.current !== null,
+      hasData: current !== undefined && current !== null,
+      refreshing: query.loading && current !== undefined && current !== null,
       errorTitle,
       refetch: () => query.refresh(),
     })
@@ -233,7 +258,10 @@ export function contextResource<T>(
       return query.error;
     },
     get current() {
-      return query.current;
+      return current;
+    },
+    get stale() {
+      return stale;
     },
     refresh() {
       query.refresh();

--- a/src/Web/packages/app/src/lib/hooks/resource-context.svelte.ts
+++ b/src/Web/packages/app/src/lib/hooks/resource-context.svelte.ts
@@ -1,4 +1,5 @@
-import { getContext, setContext } from "svelte";
+import { getContext, onDestroy, setContext } from "svelte";
+import { SvelteMap } from "svelte/reactivity";
 import type { ReportsParamsReturn } from "./date-params.svelte";
 
 export interface DateInfo {
@@ -30,37 +31,67 @@ interface ContextResourceOptionsWithDate extends ContextResourceOptions {
 
 const RESOURCE_CONTEXT_KEY = Symbol("resource-context");
 
-export interface ResourceState {
-  /** Whether any registered resource is loading */
+/** One panel's fetch state, as reported to the layout's ResourceGuard. */
+export interface ResourceRegistration {
   loading: boolean;
-  /** First error from any registered resource */
   error: Error | string | null | undefined;
-  /** Whether any resource has data (prevents skeleton flash) */
   hasData: boolean;
-  /** Title for the error card */
   errorTitle: string;
-  /** Function to retry all registered resources */
   refetch: () => void;
 }
 
 /**
- * Reactive resource context class using Svelte 5 runes.
- * Using a class with $state ensures getters are properly reactive.
+ * Aggregate fetch state for a report page.
+ *
+ * Resources register under their own key and the page-level state is derived
+ * across all of them. A page with two resources therefore surfaces either one's
+ * failure and retries both; previously each registration overwrote the fields
+ * unconditionally, so whichever wrote last decided what the page showed — on the
+ * Sleep page a successful trends fetch masked a failed actogram fetch entirely.
  */
 export class ResourceContext {
-  loading = $state(false);
-  error = $state<Error | string | null | undefined>(null);
-  hasData = $state(false);
-  errorTitle = $state("Error Loading Data");
-  refetch = $state<() => void>(() => {});
+  #registrations = new SvelteMap<symbol, ResourceRegistration>();
 
-  setResource(newState: Partial<ResourceState>) {
-    if (newState.loading !== undefined) this.loading = newState.loading;
-    if (newState.error !== undefined) this.error = newState.error;
-    if (newState.hasData !== undefined) this.hasData = newState.hasData;
-    if (newState.errorTitle !== undefined) this.errorTitle = newState.errorTitle;
-    if (newState.refetch !== undefined) this.refetch = newState.refetch;
+  register(key: symbol, registration: ResourceRegistration): void {
+    this.#registrations.set(key, registration);
   }
+
+  unregister(key: symbol): void {
+    this.#registrations.delete(key);
+  }
+
+  get #all(): ResourceRegistration[] {
+    return [...this.#registrations.values()];
+  }
+
+  get #failed(): ResourceRegistration | undefined {
+    return this.#all.find((r) => r.error != null);
+  }
+
+  /** Whether any registered resource is loading. */
+  get loading(): boolean {
+    return this.#all.some((r) => r.loading);
+  }
+
+  /** First error across registered resources. */
+  get error(): Error | string | null | undefined {
+    return this.#failed?.error ?? null;
+  }
+
+  /** Whether any resource has data (prevents skeleton flash). */
+  get hasData(): boolean {
+    return this.#all.some((r) => r.hasData);
+  }
+
+  /** Title for the error card, taken from whichever resource failed. */
+  get errorTitle(): string {
+    return this.#failed?.errorTitle ?? this.#all[0]?.errorTitle ?? "Error Loading Data";
+  }
+
+  /** Retry every registered resource. */
+  refetch = (): void => {
+    for (const registration of this.#all) registration.refetch();
+  };
 }
 
 /**
@@ -79,6 +110,21 @@ export function createResourceContext(): ResourceContext {
  */
 export function getResourceContext(): ResourceContext | undefined {
   return getContext<ResourceContext | undefined>(RESOURCE_CONTEXT_KEY);
+}
+
+/**
+ * Register `read` under a fresh key for the lifetime of the calling component.
+ * Syncs in `$effect.pre` — before render — because the layout's ResourceGuard
+ * conditionally renders children off this state.
+ */
+function registerWith(
+  ctx: ResourceContext | undefined,
+  read: () => ResourceRegistration
+): void {
+  if (!ctx) return;
+  const key = Symbol("resource-registration");
+  $effect.pre(() => ctx.register(key, read()));
+  onDestroy(() => ctx.unregister(key));
 }
 
 /**
@@ -111,19 +157,16 @@ export function useResourceContext(config: {
   errorTitle?: string;
   refetch: () => void;
 }): void {
-  const ctx = getResourceContext();
-  if (!ctx) return;
-
-  // Use an effect to keep context state synced with resource state
-  $effect(() => {
-    ctx.setResource({
+  registerWith(
+    getResourceContext(),
+    () => ({
       loading: config.loading(),
       error: config.error(),
       hasData: config.hasData(),
       errorTitle: config.errorTitle ?? "Error Loading Data",
       refetch: config.refetch,
-    });
-  });
+    })
+  );
 }
 
 /**
@@ -166,22 +209,21 @@ export function contextResource<T>(
   options: ContextResourceOptions & { dateParams?: ReportsParamsReturn } = {}
 ): ContextResourceBase<T> | ContextResourceWithDate<T> {
   const { errorTitle = "Error Loading Data", dateParams } = options;
-  const ctx = getResourceContext();
 
   // Create the query in a $derived tracking context so reactive queries
   // are never constructed inside an $effect (which would trigger a Svelte warning).
   const query = $derived(queryFn());
 
-  // Use $effect.pre to sync state BEFORE render
-  $effect.pre(() => {
-    if (ctx) {
-      ctx.loading = query.loading;
-      ctx.error = query.error as Error | string | null | undefined;
-      ctx.hasData = query.current !== undefined && query.current !== null;
-      ctx.errorTitle = errorTitle;
-      ctx.refetch = () => query.refresh();
-    }
-  });
+  registerWith(
+    getResourceContext(),
+    () => ({
+      loading: query.loading,
+      error: query.error as Error | string | null | undefined,
+      hasData: query.current !== undefined && query.current !== null,
+      errorTitle,
+      refetch: () => query.refresh(),
+    })
+  );
 
   const base = {
     get loading() {
@@ -203,12 +245,10 @@ export function contextResource<T>(
   return {
     ...base,
     get date(): DateInfo {
-      const range = dateParams.getDateRange();
-      const ms = range.end.getTime() - range.start.getTime();
       return {
-        from: range.start,
-        to: range.end,
-        dayCount: Math.max(1, Math.round(ms / (1000 * 60 * 60 * 24))),
+        from: dateParams.startDate,
+        to: dateParams.endDate,
+        dayCount: dateParams.dayCount,
       };
     },
   };

--- a/src/Web/packages/app/src/lib/hooks/resource-context.test.ts
+++ b/src/Web/packages/app/src/lib/hooks/resource-context.test.ts
@@ -6,6 +6,7 @@ function registration(overrides: Partial<ResourceRegistration> = {}): ResourceRe
     loading: false,
     error: null,
     hasData: true,
+    refreshing: false,
     errorTitle: "Error Loading Data",
     refetch: () => {},
     ...overrides,
@@ -71,6 +72,20 @@ describe("ResourceContext", () => {
     ctx.register(key, registration({ error: null }));
     expect(ctx.error).toBeNull();
     expect(ctx.loading).toBe(true);
+  });
+
+  it("is refreshing when a resource reloads with a previous value still shown", () => {
+    const ctx = new ResourceContext();
+    ctx.register(Symbol(), registration());
+    ctx.register(Symbol(), registration({ loading: true, refreshing: true }));
+    expect(ctx.refreshing).toBe(true);
+    expect(ctx.hasData).toBe(true);
+  });
+
+  it("is not refreshing when a loading resource has nothing to show yet", () => {
+    const ctx = new ResourceContext();
+    ctx.register(Symbol(), registration({ loading: true, hasData: false }));
+    expect(ctx.refreshing).toBe(false);
   });
 
   it("drops a resource's state when it unregisters", () => {

--- a/src/Web/packages/app/src/lib/hooks/resource-context.test.ts
+++ b/src/Web/packages/app/src/lib/hooks/resource-context.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from "vitest";
+import { ResourceContext, type ResourceRegistration } from "./resource-context.svelte";
+
+function registration(overrides: Partial<ResourceRegistration> = {}): ResourceRegistration {
+  return {
+    loading: false,
+    error: null,
+    hasData: true,
+    errorTitle: "Error Loading Data",
+    refetch: () => {},
+    ...overrides,
+  };
+}
+
+describe("ResourceContext", () => {
+  it("reports no error and no loading with nothing registered", () => {
+    const ctx = new ResourceContext();
+    expect(ctx.loading).toBe(false);
+    expect(ctx.error).toBeNull();
+    expect(ctx.hasData).toBe(false);
+    expect(ctx.errorTitle).toBe("Error Loading Data");
+  });
+
+  it("is loading while any one resource is loading", () => {
+    const ctx = new ResourceContext();
+    ctx.register(Symbol(), registration({ loading: true, hasData: false }));
+    ctx.register(Symbol(), registration());
+    expect(ctx.loading).toBe(true);
+  });
+
+  it("surfaces a failure even when a sibling registered later succeeded", () => {
+    const ctx = new ResourceContext();
+    const failing = Symbol();
+    const succeeding = Symbol();
+    ctx.register(failing, registration({ error: "actogram failed", errorTitle: "Error Loading Sleep Report", hasData: false }));
+    ctx.register(succeeding, registration());
+    expect(ctx.error).toBe("actogram failed");
+    expect(ctx.errorTitle).toBe("Error Loading Sleep Report");
+  });
+
+  it("surfaces a failure even when a sibling registered earlier succeeded", () => {
+    const ctx = new ResourceContext();
+    ctx.register(Symbol(), registration());
+    ctx.register(Symbol(), registration({ error: "trends failed", hasData: false }));
+    expect(ctx.error).toBe("trends failed");
+  });
+
+  it("fans refetch out to every registered resource", () => {
+    const ctx = new ResourceContext();
+    const first = vi.fn();
+    const second = vi.fn();
+    ctx.register(Symbol(), registration({ refetch: first }));
+    ctx.register(Symbol(), registration({ refetch: second }));
+    ctx.refetch();
+    expect(first).toHaveBeenCalledOnce();
+    expect(second).toHaveBeenCalledOnce();
+  });
+
+  it("has data when any resource has data", () => {
+    const ctx = new ResourceContext();
+    ctx.register(Symbol(), registration({ hasData: false, loading: true }));
+    ctx.register(Symbol(), registration({ hasData: true }));
+    expect(ctx.hasData).toBe(true);
+  });
+
+  it("re-registering the same key replaces that resource's state only", () => {
+    const ctx = new ResourceContext();
+    const key = Symbol();
+    ctx.register(Symbol(), registration({ loading: true, hasData: false }));
+    ctx.register(key, registration({ error: "transient" }));
+    ctx.register(key, registration({ error: null }));
+    expect(ctx.error).toBeNull();
+    expect(ctx.loading).toBe(true);
+  });
+
+  it("drops a resource's state when it unregisters", () => {
+    const ctx = new ResourceContext();
+    const key = Symbol();
+    ctx.register(key, registration({ error: "gone with the panel", hasData: false }));
+    ctx.unregister(key);
+    expect(ctx.error).toBeNull();
+    expect(ctx.hasData).toBe(false);
+  });
+});

--- a/src/Web/packages/app/src/lib/utils/date-range.test.ts
+++ b/src/Web/packages/app/src/lib/utils/date-range.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import {
+  dayCount,
+  endOfDay,
+  resolveDayRange,
+  startOfDay,
+  toDayString,
+} from "./date-range";
+
+// A zone well east of UTC and one well west, so a UTC-anchored implementation
+// lands on the wrong calendar day in one direction or the other.
+const SYDNEY = "Australia/Sydney";
+const DENVER = "America/Denver";
+
+describe("startOfDay / endOfDay", () => {
+  it("anchors the start on local midnight, not UTC midnight", () => {
+    // 2026-07-25 00:00 AEST (UTC+10) is 2026-07-24 14:00Z.
+    expect(startOfDay("2026-07-25", SYDNEY).toISOString()).toBe(
+      "2026-07-24T14:00:00.000Z"
+    );
+  });
+
+  it("ends the range on the last millisecond of the last day", () => {
+    expect(endOfDay("2026-07-25", SYDNEY).toISOString()).toBe(
+      "2026-07-25T13:59:59.999Z"
+    );
+  });
+
+  it("spans a whole day, so nothing on the final day is lost", () => {
+    const start = startOfDay("2026-07-25", DENVER).getTime();
+    const end = endOfDay("2026-07-25", DENVER).getTime();
+    expect(end - start).toBe(86_400_000 - 1);
+  });
+
+  it("covers 25 hours on the day a DST fall-back lengthens", () => {
+    // Denver leaves DST on 2026-11-01.
+    const start = startOfDay("2026-11-01", DENVER).getTime();
+    const end = endOfDay("2026-11-01", DENVER).getTime();
+    expect(end - start).toBe(25 * 60 * 60 * 1000 - 1);
+  });
+
+  it("covers 23 hours on the day a DST spring-forward shortens", () => {
+    // Denver enters DST on 2026-03-08.
+    const start = startOfDay("2026-03-08", DENVER).getTime();
+    const end = endOfDay("2026-03-08", DENVER).getTime();
+    expect(end - start).toBe(23 * 60 * 60 * 1000 - 1);
+  });
+
+  it("tolerates a full ISO instant by keeping its date part", () => {
+    expect(startOfDay("2026-07-25T09:31:00.000Z", SYDNEY).toISOString()).toBe(
+      startOfDay("2026-07-25", SYDNEY).toISOString()
+    );
+  });
+});
+
+describe("dayCount", () => {
+  it("counts both end days, so a full week is 7", () => {
+    expect(dayCount("2026-07-19", "2026-07-25")).toBe(7);
+  });
+
+  it("counts a fortnight as 14", () => {
+    expect(dayCount("2026-07-12", "2026-07-25")).toBe(14);
+  });
+
+  it("counts a single day as 1", () => {
+    expect(dayCount("2026-07-25", "2026-07-25")).toBe(1);
+  });
+
+  it("is unaffected by a DST spring-forward inside the range", () => {
+    expect(dayCount("2026-03-05", "2026-03-11")).toBe(7);
+  });
+
+  it("is unaffected by a DST fall-back inside the range", () => {
+    expect(dayCount("2026-10-29", "2026-11-04")).toBe(7);
+  });
+
+  it("counts across a month boundary", () => {
+    expect(dayCount("2026-01-28", "2026-02-03")).toBe(7);
+  });
+
+  it("counts across a leap-day February", () => {
+    expect(dayCount("2028-02-01", "2028-02-29")).toBe(29);
+  });
+
+  it("counts across a year boundary", () => {
+    expect(dayCount("2026-12-28", "2027-01-03")).toBe(7);
+  });
+
+  it("counts a full non-leap year", () => {
+    expect(dayCount("2026-01-01", "2026-12-31")).toBe(365);
+  });
+
+  it("accepts Date instants and reads their local day", () => {
+    const from = new Date(2026, 6, 19, 0, 0, 0);
+    const to = new Date(2026, 6, 25, 23, 59, 59, 999);
+    expect(dayCount(from, to)).toBe(7);
+  });
+
+  it("never reports fewer than one day", () => {
+    expect(dayCount("2026-07-25", "2026-07-19")).toBe(1);
+  });
+});
+
+describe("resolveDayRange", () => {
+  it("passes explicit from/to through", () => {
+    expect(resolveDayRange({ from: "2026-07-01", to: "2026-07-10" }, 14)).toEqual({
+      from: "2026-07-01",
+      to: "2026-07-10",
+    });
+  });
+
+  it("resolves a relative window to N inclusive days ending today", () => {
+    const range = resolveDayRange({ days: 7 }, 14, SYDNEY);
+    expect(dayCount(range.from, range.to)).toBe(7);
+  });
+
+  it("falls back to defaultDays when nothing is set", () => {
+    const range = resolveDayRange(undefined, 30, SYDNEY);
+    expect(dayCount(range.from, range.to)).toBe(30);
+  });
+
+  it("ends a relative window on today in the given timezone", () => {
+    // Both zones' "today" must be the calendar date each zone is actually on.
+    const sydney = resolveDayRange({ days: 1 }, 14, SYDNEY);
+    const denver = resolveDayRange({ days: 1 }, 14, DENVER);
+    const todayIn = (timeZone: string) =>
+      new Intl.DateTimeFormat("en-CA", {
+        timeZone,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      }).format(new Date());
+    expect(sydney.to).toBe(todayIn(SYDNEY));
+    expect(denver.to).toBe(todayIn(DENVER));
+  });
+
+  it("ignores a half-specified explicit range", () => {
+    const range = resolveDayRange({ days: 7, from: "2026-07-01" }, 14, SYDNEY);
+    expect(dayCount(range.from, range.to)).toBe(7);
+  });
+});
+
+describe("toDayString", () => {
+  it("reads the local calendar day, not the UTC one", () => {
+    // 23:30 local on the 25th is the 25th, whichever side of UTC midnight it is.
+    const late = new Date(2026, 6, 25, 23, 30);
+    expect(toDayString(late)).toBe("2026-07-25");
+  });
+
+  it("reads an early-morning local time as that same day", () => {
+    const early = new Date(2026, 6, 25, 0, 30);
+    expect(toDayString(early)).toBe("2026-07-25");
+  });
+
+  it("zero-pads month and day", () => {
+    expect(toDayString(new Date(2026, 0, 5))).toBe("2026-01-05");
+  });
+});

--- a/src/Web/packages/app/src/lib/utils/date-range.test.ts
+++ b/src/Web/packages/app/src/lib/utils/date-range.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   dayCount,
   endOfDay,
+  isDayString,
+  isTimeZone,
   resolveDayRange,
   startOfDay,
   toDayString,
@@ -137,6 +139,48 @@ describe("resolveDayRange", () => {
   it("ignores a half-specified explicit range", () => {
     const range = resolveDayRange({ days: 7, from: "2026-07-01" }, 14, SYDNEY);
     expect(dayCount(range.from, range.to)).toBe(7);
+  });
+
+  it("falls back to the relative window for an unresolvable day", () => {
+    const range = resolveDayRange({ days: 7, from: "not-a-day", to: "2026-07-25" }, 14, SYDNEY);
+    expect(dayCount(range.from, range.to)).toBe(7);
+    expect(isDayString(range.from)).toBe(true);
+  });
+
+  it("falls back to UTC for an unrecognised timezone", () => {
+    const range = resolveDayRange({ days: 3 }, 14, "Mars/Olympus_Mons");
+    expect(dayCount(range.from, range.to)).toBe(3);
+  });
+});
+
+describe("isDayString", () => {
+  it("accepts a plain day", () => {
+    expect(isDayString("2026-07-25")).toBe(true);
+  });
+
+  it("accepts a full ISO instant", () => {
+    expect(isDayString("2026-07-25T09:31:00.000Z")).toBe(true);
+  });
+
+  it("rejects nothing, empty strings and nonsense", () => {
+    expect(isDayString(null)).toBe(false);
+    expect(isDayString(undefined)).toBe(false);
+    expect(isDayString("")).toBe(false);
+    expect(isDayString("not-a-day")).toBe(false);
+    expect(isDayString("2026-13-45")).toBe(false);
+  });
+});
+
+describe("isTimeZone", () => {
+  it("accepts an IANA zone", () => {
+    expect(isTimeZone(SYDNEY)).toBe(true);
+    expect(isTimeZone("UTC")).toBe(true);
+  });
+
+  it("rejects nothing and unrecognised zones", () => {
+    expect(isTimeZone(null)).toBe(false);
+    expect(isTimeZone("")).toBe(false);
+    expect(isTimeZone("Mars/Olympus_Mons")).toBe(false);
   });
 });
 

--- a/src/Web/packages/app/src/lib/utils/date-range.ts
+++ b/src/Web/packages/app/src/lib/utils/date-range.ts
@@ -1,0 +1,82 @@
+/**
+ * Primitives for "the selected date range" — the single definition shared by the
+ * reports area, the filter sidebar and the report remote functions.
+ *
+ * A range is two `YYYY-MM-DD` day strings and is **inclusive of both days**.
+ * Resolving it to instants anchors on midnight in a calendar timezone (the
+ * viewer's local zone by default, the patient's configured zone on the server),
+ * never UTC midnight, and the end bound is the last millisecond of the last day.
+ */
+import { getLocalTimeZone, parseDate, today } from "@internationalized/date";
+
+const MS_PER_DAY = 86_400_000;
+
+export type DayRangeStrings = { from: string; to: string };
+
+/** The URL-shaped range: explicit `from`/`to`, or a relative `days` window. */
+export type DayRangeInput = {
+  days?: number | null;
+  from?: string | null;
+  to?: string | null;
+};
+
+/** `YYYY-MM-DD` for a Date read in the local calendar, not the UTC calendar. */
+export function toDayString(date: Date = new Date()): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/** Day part of a day string; a longer ISO string keeps only its date. */
+function dayPart(value: string): string {
+  return value.length > 10 ? value.slice(0, 10) : value;
+}
+
+function toDay(value: string | Date): string {
+  return typeof value === "string" ? dayPart(value) : toDayString(value);
+}
+
+/**
+ * The effective range: explicit `from`/`to` win, otherwise the last `days`
+ * (or `defaultDays`) calendar days ending today in `timeZone`.
+ */
+export function resolveDayRange(
+  input: DayRangeInput | null | undefined,
+  defaultDays: number,
+  timeZone: string = getLocalTimeZone()
+): DayRangeStrings {
+  if (input?.from && input?.to) {
+    return { from: dayPart(input.from), to: dayPart(input.to) };
+  }
+  const days = input?.days ?? defaultDays;
+  const end = today(timeZone);
+  const start = end.subtract({ days: Math.max(1, days) - 1 });
+  return { from: start.toString(), to: end.toString() };
+}
+
+/** Midnight opening `day` in `timeZone`. */
+export function startOfDay(day: string, timeZone: string = getLocalTimeZone()): Date {
+  return parseDate(dayPart(day)).toDate(timeZone);
+}
+
+/**
+ * Last millisecond of `day` in `timeZone`. Derived from the next day's midnight
+ * so a day shortened or lengthened by a DST transition still ends correctly.
+ */
+export function endOfDay(day: string, timeZone: string = getLocalTimeZone()): Date {
+  return new Date(
+    parseDate(dayPart(day)).add({ days: 1 }).toDate(timeZone).getTime() - 1
+  );
+}
+
+/**
+ * Calendar days covered by an inclusive range: a Monday-to-Sunday range is 7,
+ * and a single day is 1. Counted on the calendar, so DST transitions and
+ * month/year boundaries do not shift it.
+ */
+export function dayCount(from: string | Date, to: string | Date): number {
+  const start = parseDate(toDay(from)).toDate("UTC").getTime();
+  const end = parseDate(toDay(to)).toDate("UTC").getTime();
+  return Math.max(1, Math.round((end - start) / MS_PER_DAY) + 1);
+}

--- a/src/Web/packages/app/src/lib/utils/date-range.ts
+++ b/src/Web/packages/app/src/lib/utils/date-range.ts
@@ -37,22 +37,47 @@ function toDay(value: string | Date): string {
   return typeof value === "string" ? dayPart(value) : toDayString(value);
 }
 
+/** Whether `value` names a day this module can resolve to instants. */
+export function isDayString(value: string | null | undefined): value is string {
+  if (!value) return false;
+  try {
+    parseDate(dayPart(value));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * The effective range: explicit `from`/`to` win, otherwise the last `days`
- * (or `defaultDays`) calendar days ending today in `timeZone`.
+ * (or `defaultDays`) calendar days ending today in `timeZone`. A `from`/`to` pair
+ * that isn't a resolvable day — a hand-edited URL, say — falls through to the
+ * relative window rather than throwing.
  */
 export function resolveDayRange(
   input: DayRangeInput | null | undefined,
   defaultDays: number,
   timeZone: string = getLocalTimeZone()
 ): DayRangeStrings {
-  if (input?.from && input?.to) {
+  if (isDayString(input?.from) && isDayString(input?.to)) {
     return { from: dayPart(input.from), to: dayPart(input.to) };
   }
   const days = input?.days ?? defaultDays;
-  const end = today(timeZone);
+  const zone = isTimeZone(timeZone) ? timeZone : "UTC";
+  const end = today(zone);
   const start = end.subtract({ days: Math.max(1, days) - 1 });
   return { from: start.toString(), to: end.toString() };
+}
+
+/** Whether `timeZone` is an IANA zone this runtime knows. */
+export function isTimeZone(timeZone: string | null | undefined): timeZone is string {
+  if (!timeZone) return false;
+  try {
+    new Intl.DateTimeFormat("en-CA", { timeZone });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /** Midnight opening `day` in `timeZone`. */

--- a/src/Web/packages/app/src/routes/(authenticated)/calendar/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/calendar/+page.svelte
@@ -221,20 +221,28 @@
     );
     const summary = monthData?.summary;
     const days = monthData?.days ?? [];
-    const daysWithData = days.filter((d) => d.totalReadings || 0 > 0);
-    const totalCarbs = days.reduce((sum, d) => sum + (d.totalCarbs ?? 0), 0);
-    const totalInsulin = days.reduce(
-      (sum, d) => sum + (d.totalInsulin ?? 0),
-      0
-    );
-    const dayCount = daysWithData.length;
+
+    // Each per-day average divides by the days that carry that kind of data.
+    // Dividing both by the days with CGM readings overstated TDD and carbs by the
+    // whole sensor-outage share of the month — a month with 10 outage days but
+    // complete pump data read about 50% high.
+    const withCarbs = days.filter((d) => (d.totalCarbs ?? 0) > 0);
+    const withInsulin = days.filter((d) => (d.totalInsulin ?? 0) > 0);
+    const sum = (
+      entries: typeof days,
+      read: (day: (typeof days)[number]) => number | undefined
+    ) => entries.reduce((total, day) => total + (read(day) ?? 0), 0);
 
     return {
       totalReadings: summary?.totalReadings ?? 0,
       inRangePercent: summary?.inRangePercent ?? 0,
       avgGlucose: summary?.avgGlucose ?? 0,
-      avgDailyCarbs: dayCount > 0 ? totalCarbs / dayCount : 0,
-      tdd: dayCount > 0 ? totalInsulin / dayCount : 0,
+      avgDailyCarbs:
+        withCarbs.length > 0 ? sum(withCarbs, (d) => d.totalCarbs) / withCarbs.length : 0,
+      tdd:
+        withInsulin.length > 0
+          ? sum(withInsulin, (d) => d.totalInsulin) / withInsulin.length
+          : 0,
     };
   });
 

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/+layout.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/+layout.svelte
@@ -138,6 +138,7 @@
                 loading={resourceCtx.loading}
                 error={resourceCtx.error}
                 hasData={resourceCtx.hasData}
+                refreshing={resourceCtx.refreshing}
                 errorTitle={resourceCtx.errorTitle}
                 onRetry={resourceCtx.refetch}
             >

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/+layout.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/+layout.svelte
@@ -4,7 +4,7 @@
     import {ReportsFilterSidebar} from "$lib/components/layout";
     import ResourceGuard from "$lib/components/reports/ResourceGuard.svelte";
     import {Filter, Calendar, ChevronDown} from "lucide-svelte";
-    import {useDateParams, setDateParamsContext} from "$lib/hooks/date-params.svelte";
+    import {useDateParams, setDateParamsContext, createSharedRangeUse} from "$lib/hooks/date-params.svelte";
     import {createResourceContext} from "$lib/hooks/resource-context.svelte";
 
     let {children} = $props();
@@ -21,6 +21,12 @@
     // adjustment, so they no longer depend on the adjust-up path resolving.
     const params = useDateParams(14);
     setDateParamsContext(params);
+
+    // Reports declare whether they read the shared range; those that carry their
+    // own period controls (comparison, year overview, day in review, data quality)
+    // do not, and the range control is hidden for them rather than sitting there
+    // doing nothing.
+    const sharedRangeUse = createSharedRangeUse();
 
     // Create resource context for layout-level loading/error handling
     const resourceCtx = createResourceContext();
@@ -46,8 +52,10 @@
         );
     });
 
-    // Determine if we should show the filter button (not on main reports page)
-    const showFilters = $derived(page.url.pathname !== "/reports");
+    // Show the range control only where the report actually reads the range
+    const showFilters = $derived(
+        page.url.pathname !== "/reports" && sharedRangeUse.consumed
+    );
 
     // Format date range for display
     const dateRangeDisplay = $derived.by(() => {
@@ -78,7 +86,7 @@
         <div class="hidden print:block border-b border-border pb-3 mb-4 px-3">
             <h1 class="text-xl font-bold text-foreground">{reportName}</h1>
             <p class="text-sm text-muted-foreground">
-                {dateRangeDisplay} · Generated {new Date().toLocaleString()}
+                {#if showFilters}{dateRangeDisplay} · {/if}Generated {new Date().toLocaleString()}
             </p>
         </div>
 
@@ -141,8 +149,10 @@
     </main>
 
     <!-- Filter Sidebar -->
-    <ReportsFilterSidebar
-            bind:open={filterSidebarOpen}
-            onOpenChange={(open) => (filterSidebarOpen = open)}
-    />
+    {#if showFilters}
+        <ReportsFilterSidebar
+                bind:open={filterSidebarOpen}
+                onOpenChange={(open) => (filterSidebarOpen = open)}
+        />
+    {/if}
 </div>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/+page.svelte
@@ -85,7 +85,7 @@
 
   const reportsResource = contextResource(
     () => getReportsData(reportsParams.dateRangeInput),
-    { errorTitle: "Error Loading Reports" }
+    { errorTitle: "Error Loading Reports", dateParams: reportsParams }
   );
 
   const isLoading = $derived(reportsResource.loading);
@@ -93,13 +93,9 @@
   const entries = $derived(queryData?.entries ?? []);
   const analysis = $derived(queryData?.analysis);
   const averagedStats = $derived(queryData?.averagedStats);
-  const dateRange = $derived(
-    queryData?.dateRange ?? {
-      from: new Date().toISOString(),
-      to: new Date().toISOString(),
-      lastUpdated: new Date().toISOString(),
-    }
-  );
+  const startDate = $derived(reportsResource.date.from);
+  const endDate = $derived(reportsResource.date.to);
+  const lastUpdated = $derived(queryData?.dateRange?.lastUpdated);
 
   const units = $derived(glucoseUnits.current);
   const glucoseFormatting = $derived({
@@ -197,10 +193,10 @@
             class="mb-3 inline-flex items-center gap-2 rounded-full bg-primary/5 px-4 py-1.5 text-sm font-medium text-primary"
           >
             <Calendar class="h-4 w-4" />
-            {new Date(dateRange.from).toLocaleDateString("en-US", {
+            {startDate.toLocaleDateString("en-US", {
               month: "short",
               day: "numeric",
-            })} – {new Date(dateRange.to).toLocaleDateString("en-US", {
+            })} – {endDate.toLocaleDateString("en-US", {
               month: "short",
               day: "numeric",
               year: "numeric",
@@ -561,14 +557,14 @@
           <span class="font-medium">
             {entries.length.toLocaleString()} readings
           </span>
-          from {new Date(dateRange.from).toLocaleDateString()} to {new Date(
-            dateRange.to
-          ).toLocaleDateString()}
-          <span class="mx-2 opacity-50">•</span>
-          Last updated {new Date(dateRange.lastUpdated).toLocaleTimeString([], {
-            hour: "2-digit",
-            minute: "2-digit",
-          })}
+          from {startDate.toLocaleDateString()} to {endDate.toLocaleDateString()}
+          {#if lastUpdated}
+            <span class="mx-2 opacity-50">•</span>
+            Last updated {new Date(lastUpdated).toLocaleTimeString([], {
+              hour: "2-digit",
+              minute: "2-digit",
+            })}
+          {/if}
         </p>
         <p class="mt-1 text-xs text-muted-foreground/70">
           This report is for informational purposes. Always consult your

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/agp/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/agp/+page.svelte
@@ -29,38 +29,20 @@
   // Default: 14 days is the standard AGP report period
   const reportsParams = requireDateParamsContext(14);
 
-  // Create resource with automatic layout registration
+  // Create resource with automatic layout registration; `date` carries the
+  // selected range so the header and footer never disagree with the query.
   const reportsResource = contextResource(
     () => getReportsData(reportsParams.dateRangeInput),
-    { errorTitle: "Error Loading AGP Report" }
+    { errorTitle: "Error Loading AGP Report", dateParams: reportsParams }
   );
 
-  // Unwrap the data from the resource with null safety
-  const data = $derived({
-    entries: reportsResource.current?.entries ?? [],
-    analysis: reportsResource.current?.analysis,
-    averagedStats: reportsResource.current?.averagedStats,
-    dateRange: reportsResource.current?.dateRange ?? {
-      from: new Date().toISOString(),
-      to: new Date().toISOString(),
-      lastUpdated: new Date().toISOString(),
-    },
-  });
-
-  // Derived values from data
-  const entries = $derived(data.entries);
-  const analysis = $derived(data.analysis);
-  const dateRange = $derived(data.dateRange);
-  const startDate = $derived(new Date(dateRange.from));
-  const endDate = $derived(new Date(dateRange.to));
-  const dayCount = $derived(
-    Math.max(
-      1,
-      Math.round(
-        (endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)
-      )
-    )
-  );
+  const entries = $derived(reportsResource.current?.entries ?? []);
+  const analysis = $derived(reportsResource.current?.analysis);
+  const averagedStats = $derived(reportsResource.current?.averagedStats);
+  const lastUpdated = $derived(reportsResource.current?.dateRange?.lastUpdated);
+  const startDate = $derived(reportsResource.date.from);
+  const endDate = $derived(reportsResource.date.to);
+  const dayCount = $derived(reportsResource.date.dayCount);
 </script>
 
 <svelte:head>
@@ -230,7 +212,7 @@
         </CardDescription>
       </CardHeader>
       <CardContent class="h-80 @lg:h-96 w-full">
-        <AmbulatoryGlucoseProfile averagedStats={data.averagedStats} />
+        <AmbulatoryGlucoseProfile {averagedStats} />
       </CardContent>
     </Card>
 
@@ -348,7 +330,9 @@
 
   <div class="text-xs text-muted-foreground text-center">
     Data from {startDate.toLocaleDateString()} – {endDate.toLocaleDateString()}.
-    Last updated {new Date(dateRange.lastUpdated).toLocaleString()}.
+    {#if lastUpdated}
+      Last updated {new Date(lastUpdated).toLocaleString()}.
+    {/if}
   </div>
 </div>
 {/if}

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/basal-analysis/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/basal-analysis/+page.svelte
@@ -6,15 +6,11 @@
   // Default: 14 days for basal pattern analysis
   const reportsParams = requireDateParamsContext(14);
 
-  // Date info derived from the URL params (same shape contextResource.date exposed).
-  const dateInfo = $derived.by(() => {
-    const range = reportsParams.getDateRange();
-    const ms = range.end.getTime() - range.start.getTime();
-    return {
-      from: range.start,
-      to: range.end,
-      dayCount: Math.max(1, Math.round(ms / (1000 * 60 * 60 * 24))),
-    };
+  // Date info derived from the URL params (same shape contextResource.date exposes).
+  const dateInfo = $derived({
+    from: reportsParams.startDate,
+    to: reportsParams.endDate,
+    dayCount: reportsParams.dayCount,
   });
 
   // ISO strings rather than Date objects: remote-query arguments are devalue

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/battery/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/battery/+page.svelte
@@ -439,9 +439,7 @@
       <p>
         Data collected from {allDevices.length} device{allDevices.length !== 1
           ? "s"
-          : ""} over {Math.round(
-          (dateRange.to - dateRange.from) / (24 * 60 * 60 * 1000)
-        )} days
+          : ""} over {reportsParams.dayCount} days
       </p>
       <p class="text-muted-foreground/60">
         Battery statistics are calculated from device status reports sent by

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/comparison/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/comparison/+page.svelte
@@ -14,7 +14,7 @@
   import { untrack } from "svelte";
   import { useSearchParams } from "runed/kit";
   import { z } from "zod";
-  import { dayCount, startOfDay, toDayString } from "$lib/utils/date-range";
+  import { dayCount, isDayString, startOfDay, toDayString } from "$lib/utils/date-range";
 
   const PRESETS = [
     "last7-prior7",
@@ -111,20 +111,26 @@
     noScroll: true,
   });
 
-  /** The committed comparison, read out of the URL with the preset as fallback. */
+  /**
+   * The committed comparison, read out of the URL with the preset as fallback.
+   * A day that isn't resolvable falls back to the preset's rather than being fed
+   * to the queries.
+   */
   function readCommitted(): Periods {
     const preset = urlParams.preset ?? DEFAULT_PRESET;
     const fromPreset = computePreset(preset === "custom" ? DEFAULT_PRESET : preset);
+    const day = (value: string | null, fallback: string) =>
+      isDayString(value) ? value : fallback;
     return {
       a: {
         label: urlParams.aLabel ?? fromPreset.a.label,
-        from: urlParams.aFrom ?? fromPreset.a.from,
-        to: urlParams.aTo ?? fromPreset.a.to,
+        from: day(urlParams.aFrom, fromPreset.a.from),
+        to: day(urlParams.aTo, fromPreset.a.to),
       },
       b: {
         label: urlParams.bLabel ?? fromPreset.b.label,
-        from: urlParams.bFrom ?? fromPreset.b.from,
-        to: urlParams.bTo ?? fromPreset.b.to,
+        from: day(urlParams.bFrom, fromPreset.b.from),
+        to: day(urlParams.bTo, fromPreset.b.to),
       },
     };
   }

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/comparison/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/comparison/+page.svelte
@@ -9,7 +9,7 @@
   import TIRStackedChart from "$lib/components/reports/TIRStackedChart.svelte";
   import { getReportsAnalysis, type DateRangeInput } from "$api/reports.remote";
   import { bg, bgDelta, bgLabel } from "$lib/utils/formatting";
-  import { getResourceContext } from "$lib/hooks/resource-context.svelte";
+  import { contextResource } from "$lib/hooks/resource-context.svelte";
 
   type Preset =
     | "last7-prior7"
@@ -111,29 +111,13 @@
     periods.b.to !== committed.b.to
   );
 
-  // Call queries directly in reactive context — SvelteKit query() returns a
-  // reactive QueryResult, not a Promise. Using $derived ensures the queries
-  // re-run when inputs change.
-  const queryA = $derived(getReportsAnalysis(inputA));
-  const queryB = $derived(getReportsAnalysis(inputB));
-
-  // Sync to layout's ResourceContext using $effect.pre (matching contextResource's
-  // approach). $effect.pre runs before DOM updates, which is critical: the layout's
-  // ResourceGuard conditionally renders children, so the context must be updated
-  // before the render pass commits.
-  const ctx = getResourceContext();
-
-  $effect.pre(() => {
-    if (ctx) {
-      ctx.loading = queryA.loading || queryB.loading;
-      ctx.error = (queryA.error ?? queryB.error) as Error | string | null | undefined;
-      ctx.hasData = !!queryA.current && !!queryB.current;
-      ctx.errorTitle = "Error Loading Comparison";
-      ctx.refetch = () => {
-        queryA.refresh();
-        queryB.refresh();
-      };
-    }
+  // Both periods register with the layout's ResourceContext, which merges them:
+  // either side's failure surfaces and Retry refetches both.
+  const queryA = contextResource(() => getReportsAnalysis(inputA), {
+    errorTitle: "Error Loading Comparison",
+  });
+  const queryB = contextResource(() => getReportsAnalysis(inputB), {
+    errorTitle: "Error Loading Comparison",
   });
 
   type MetricKey =

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/comparison/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/comparison/+page.svelte
@@ -10,33 +10,49 @@
   import { getReportsAnalysis, type DateRangeInput } from "$api/reports.remote";
   import { bg, bgDelta, bgLabel } from "$lib/utils/formatting";
   import { contextResource } from "$lib/hooks/resource-context.svelte";
+  import { parseDate } from "@internationalized/date";
+  import { untrack } from "svelte";
+  import { useSearchParams } from "runed/kit";
+  import { z } from "zod";
+  import { dayCount, startOfDay, toDayString } from "$lib/utils/date-range";
 
-  type Preset =
-    | "last7-prior7"
-    | "last14-prior14"
-    | "last30-prior30"
-    | "thisMonth-lastMonth"
-    | "custom";
+  const PRESETS = [
+    "last7-prior7",
+    "last14-prior14",
+    "last30-prior30",
+    "thisMonth-lastMonth",
+    "custom",
+  ] as const;
+
+  type Preset = (typeof PRESETS)[number];
+  type Side = "a" | "b";
 
   type Periods = {
     a: { label: string; from: string; to: string };
     b: { label: string; from: string; to: string };
   };
 
-  function fmtIso(d: Date): string {
-    return d.toISOString().slice(0, 10);
-  }
+  const DEFAULT_PRESET: Preset = "last14-prior14";
 
-  function shiftDays(date: string, days: number): string {
-    const d = new Date(date);
-    d.setDate(d.getDate() + days);
-    return fmtIso(d);
-  }
+  /**
+   * The comparison lives in the URL, so refresh, share and Back all reproduce it,
+   * and the committed periods the queries read are the same values the labels and
+   * range lines render from — previously the header read a draft the numbers had
+   * never been loaded for, so after Swap period A's figures sat under period B's
+   * label until Load was pressed.
+   */
+  const ComparisonParamsSchema = z.object({
+    preset: z.enum(PRESETS).nullable().default(null),
+    aFrom: z.string().nullable().default(null),
+    aTo: z.string().nullable().default(null),
+    aLabel: z.string().nullable().default(null),
+    bFrom: z.string().nullable().default(null),
+    bTo: z.string().nullable().default(null),
+    bLabel: z.string().nullable().default(null),
+  });
 
-  function daysBetween(from: string, to: string): number {
-    const a = new Date(from);
-    const b = new Date(to);
-    return Math.round((b.getTime() - a.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+  function shiftDays(day: string, days: number): string {
+    return parseDate(day).add({ days }).toString();
   }
 
   function rangeDisplay(from: string, to: string): string {
@@ -45,33 +61,40 @@
       day: "numeric",
       year: "numeric",
     };
-    const fromStr = new Date(from).toLocaleDateString(undefined, opts);
-    const toStr = new Date(to).toLocaleDateString(undefined, opts);
-    return `${fromStr} – ${toStr}`;
+    return `${startOfDay(from).toLocaleDateString(undefined, opts)} – ${startOfDay(to).toLocaleDateString(undefined, opts)}`;
+  }
+
+  // Presets are built on the local calendar day. Deriving "today" from
+  // `toISOString()` named yesterday for anyone east of UTC, which also excluded
+  // today from the calendar picker's maxDate.
+  function todayDay(): string {
+    return toDayString();
   }
 
   function computePreset(preset: Preset): Periods {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    const todayIso = fmtIso(today);
+    const today = todayDay();
 
     if (preset === "thisMonth-lastMonth") {
-      const firstOfThis = new Date(today.getFullYear(), today.getMonth(), 1);
-      const firstOfLast = new Date(today.getFullYear(), today.getMonth() - 1, 1);
-      const lastOfLast = new Date(today.getFullYear(), today.getMonth(), 0);
+      const thisMonthStart = parseDate(today).set({ day: 1 });
+      const lastMonthStart = thisMonthStart.subtract({ months: 1 });
+      const lastMonthEnd = thisMonthStart.subtract({ days: 1 });
       return {
-        a: { label: "Last Month", from: fmtIso(firstOfLast), to: fmtIso(lastOfLast) },
-        b: { label: "This Month", from: fmtIso(firstOfThis), to: todayIso },
+        a: {
+          label: "Last Month",
+          from: lastMonthStart.toString(),
+          to: lastMonthEnd.toString(),
+        },
+        b: { label: "This Month", from: thisMonthStart.toString(), to: today },
       };
     }
 
     const span = preset === "last7-prior7" ? 7 : preset === "last14-prior14" ? 14 : 30;
-    const bFrom = shiftDays(todayIso, -(span - 1));
+    const bFrom = shiftDays(today, -(span - 1));
     const aTo = shiftDays(bFrom, -1);
     const aFrom = shiftDays(aTo, -(span - 1));
     return {
       a: { label: `Prior ${span} days`, from: aFrom, to: aTo },
-      b: { label: `Last ${span} days`, from: bFrom, to: todayIso },
+      b: { label: `Last ${span} days`, from: bFrom, to: today },
     };
   }
 
@@ -83,32 +106,82 @@
     { value: "custom", label: "Custom" },
   ];
 
-  let preset = $state<Preset>("last14-prior14");
-  let openPopover = $state<"a" | "b" | null>(null);
-  let periods = $state<Periods>(computePreset("last14-prior14"));
-  /** The period values that queries are actually reading from. */
-  let committed = $state<Periods>(computePreset("last14-prior14"));
+  const urlParams = useSearchParams(ComparisonParamsSchema, {
+    showDefaults: true,
+    noScroll: true,
+  });
 
-  function applyPreset(p: Preset) {
-    preset = p;
-    if (p !== "custom") {
-      periods = computePreset(p);
-      committed = periods;
-    }
+  /** The committed comparison, read out of the URL with the preset as fallback. */
+  function readCommitted(): Periods {
+    const preset = urlParams.preset ?? DEFAULT_PRESET;
+    const fromPreset = computePreset(preset === "custom" ? DEFAULT_PRESET : preset);
+    return {
+      a: {
+        label: urlParams.aLabel ?? fromPreset.a.label,
+        from: urlParams.aFrom ?? fromPreset.a.from,
+        to: urlParams.aTo ?? fromPreset.a.to,
+      },
+      b: {
+        label: urlParams.bLabel ?? fromPreset.b.label,
+        from: urlParams.bFrom ?? fromPreset.b.from,
+        to: urlParams.bTo ?? fromPreset.b.to,
+      },
+    };
   }
 
+  const committed = $derived.by(readCommitted);
+
+  let openPopover = $state<Side | null>(null);
+  let preset = $state<Preset>(untrack(() => urlParams.preset ?? DEFAULT_PRESET));
+  /** Pending edits to the compared ranges, applied to the URL by Load. */
+  let draft = $state<Periods>(untrack(readCommitted));
+
+  /** Write a comparison to the URL, which is what the queries read. */
+  function commit(next: Periods, nextPreset: Preset) {
+    draft = next;
+    preset = nextPreset;
+    urlParams.update({
+      preset: nextPreset,
+      aFrom: next.a.from,
+      aTo: next.a.to,
+      aLabel: next.a.label,
+      bFrom: next.b.from,
+      bTo: next.b.to,
+      bLabel: next.b.label,
+    });
+  }
+
+  function applyPreset(p: Preset) {
+    if (p === "custom") {
+      preset = p;
+      return;
+    }
+    commit(computePreset(p), p);
+  }
+
+  /**
+   * Swapping is a relabelling of two windows that are already loaded, so it
+   * applies straight away rather than waiting for Load.
+   */
   function swap() {
-    periods = { a: periods.b, b: periods.a };
+    commit({ a: committed.b, b: committed.a }, "custom");
+  }
+
+  /** A label is display-only, so it commits on its own without reloading. */
+  function setLabel(side: Side, label: string) {
+    draft = { ...draft, [side]: { ...draft[side], label } };
+    urlParams.update(side === "a" ? { aLabel: label } : { bLabel: label });
   }
 
   const inputA = $derived<DateRangeInput>({ from: committed.a.from, to: committed.a.to });
   const inputB = $derived<DateRangeInput>({ from: committed.b.from, to: committed.b.to });
 
+  // Only the compared windows need reloading; labels are excluded.
   const isDirty = $derived(
-    periods.a.from !== committed.a.from ||
-    periods.a.to !== committed.a.to ||
-    periods.b.from !== committed.b.from ||
-    periods.b.to !== committed.b.to
+    draft.a.from !== committed.a.from ||
+    draft.a.to !== committed.a.to ||
+    draft.b.from !== committed.b.from ||
+    draft.b.to !== committed.b.to
   );
 
   // Both periods register with the layout's ResourceContext, which merges them:
@@ -304,15 +377,15 @@
   const tirColumns = $derived([
     {
       tir: tirA,
-      periodLabel: periods.a.label,
-      range: rangeDisplay(periods.a.from, periods.a.to),
+      periodLabel: committed.a.label,
+      range: rangeDisplay(committed.a.from, committed.a.to),
       accent: "var(--muted-foreground)",
       key: "a",
     },
     {
       tir: tirB,
-      periodLabel: periods.b.label,
-      range: rangeDisplay(periods.b.from, periods.b.to),
+      periodLabel: committed.b.label,
+      range: rangeDisplay(committed.b.from, committed.b.to),
       accent: "var(--glucose-in-range)",
       key: "b",
     },
@@ -352,7 +425,7 @@
         <Button
           size="sm"
           disabled={!isDirty}
-          onclick={() => { committed = { ...periods }; }}
+          onclick={() => commit(draft, preset)}
           class="gap-2"
         >
           Load
@@ -361,7 +434,7 @@
 
       <div class="grid gap-4 @xl:grid-cols-2">
         {#each sideConfigs as cfg (cfg.side)}
-          {@const p = periods[cfg.side]}
+          {@const p = draft[cfg.side]}
           <div class="rounded-md border border-border bg-card p-3">
             <div class="mb-2 flex items-center gap-2">
               <span
@@ -371,14 +444,11 @@
               <Input
                 value={p.label}
                 oninput={(e: Event & { currentTarget: HTMLInputElement }) =>
-                  (periods = {
-                    ...periods,
-                    [cfg.side]: { ...p, label: e.currentTarget.value },
-                  })}
+                  setLabel(cfg.side, e.currentTarget.value)}
                 class="h-7 border-0 bg-transparent px-1 text-sm font-semibold focus-visible:ring-1"
               />
               <span class="ml-auto font-mono text-[11px] text-muted-foreground">
-                {daysBetween(p.from, p.to)}d
+                {dayCount(p.from, p.to)}d
               </span>
             </div>
             <Popover.Root
@@ -402,11 +472,11 @@
                 <GlucoseRangeCalendarPicker
                   startDate={p.from}
                   endDate={p.to}
-                  maxDate={fmtIso(new Date())}
+                  maxDate={todayDay()}
                   onRangeChange={(start, end) => {
                     preset = "custom";
-                    periods = {
-                      ...periods,
+                    draft = {
+                      ...draft,
                       [cfg.side]: { ...p, from: start, to: end },
                     };
                     openPopover = null;
@@ -429,7 +499,7 @@
             class="inline-block h-2 w-2 rounded-full"
             style="background: var(--muted-foreground);"
           ></span>
-          {periods.a.label}
+          {committed.a.label}
         </span>
         <span class="font-mono text-[11px] uppercase tracking-[0.15em] text-muted-foreground">
           vs
@@ -439,12 +509,12 @@
             class="inline-block h-2 w-2 rounded-full"
             style="background: var(--glucose-in-range);"
           ></span>
-          {periods.b.label}
+          {committed.b.label}
         </span>
         <span class="ml-auto font-mono text-[11px] text-muted-foreground">
-          {rangeDisplay(periods.a.from, periods.a.to)}
+          {rangeDisplay(committed.a.from, committed.a.to)}
           <ArrowRight class="mx-1 inline h-3 w-3" />
-          {rangeDisplay(periods.b.from, periods.b.to)}
+          {rangeDisplay(committed.b.from, committed.b.to)}
         </span>
       </div>
 
@@ -477,9 +547,9 @@
       </div>
 
       <div class="flex justify-between font-mono text-[10px] uppercase tracking-[0.06em] text-muted-foreground">
-        <span>← lower in {periods.b.label}</span>
+        <span>← lower in {committed.b.label}</span>
         <span>no change</span>
-        <span>higher in {periods.b.label} →</span>
+        <span>higher in {committed.b.label} →</span>
       </div>
     </Card.Content>
   </Card.Root>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/day-in-review/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/day-in-review/+page.svelte
@@ -38,9 +38,11 @@
   import { GlucoseChartCard } from "$lib/components/dashboard/glucose-chart";
   import { contextResource } from "$lib/hooks/resource-context.svelte";
   import { apsSnapshotToPrediction } from "$lib/utils/aps-snapshot-to-prediction";
+  import { startOfDay, toDayString } from "$lib/utils/date-range";
 
-  // Get date from URL search params
-  const today = new Date().toISOString().split("T")[0];
+  // Get date from URL search params. The default is the local calendar day —
+  // taking it from `toISOString()` names yesterday for anyone east of UTC.
+  const today = toDayString();
   const dateParam = $derived(
     page.url.searchParams.get("date") ?? today
   );
@@ -61,8 +63,9 @@
   const delivery = $derived(dayData?.insulinDelivery as any);
   const summary = $derived(dayData?.treatmentSummary as any);
 
-  // Parse current date from URL
-  const currentDate = $derived(new Date(dateParam));
+  // Parse current date from URL. Read as a local day, not as UTC midnight, which
+  // renders as the previous day for anyone west of UTC.
+  const currentDate = $derived(startOfDay(dateParam));
 
   // Treatments timeline filter/sort state
   let filterEventType = $state<string | null>(null);
@@ -70,22 +73,12 @@
   let sortDirection = $state<"asc" | "desc">("asc");
 
   // Date navigation
-  function goToPreviousDay() {
-    const prevDate = new Date(currentDate);
-    prevDate.setDate(prevDate.getDate() - 1);
-    goto(
-      `/reports/day-in-review?date=${prevDate.toISOString().split("T")[0]}`,
-      { invalidateAll: true }
-    );
-  }
-
-  function goToNextDay() {
-    const nextDate = new Date(currentDate);
-    nextDate.setDate(nextDate.getDate() + 1);
-    goto(
-      `/reports/day-in-review?date=${nextDate.toISOString().split("T")[0]}`,
-      { invalidateAll: true }
-    );
+  function goToDayOffset(days: number) {
+    const target = new Date(currentDate);
+    target.setDate(target.getDate() + days);
+    goto(`/reports/day-in-review?date=${toDayString(target)}`, {
+      invalidateAll: true,
+    });
   }
 
   function goBackToMonthView() {
@@ -297,7 +290,7 @@
             variant="outline"
             size="icon"
             class="shrink-0"
-            onclick={goToPreviousDay}
+            onclick={() => goToDayOffset(-1)}
           >
             <ChevronLeft class="h-4 w-4" />
           </Button>
@@ -313,7 +306,7 @@
             variant="outline"
             size="icon"
             class="shrink-0"
-            onclick={goToNextDay}
+            onclick={() => goToDayOffset(1)}
           >
             <ChevronRight class="h-4 w-4" />
           </Button>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/day-in-review/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/day-in-review/+page.svelte
@@ -38,14 +38,15 @@
   import { GlucoseChartCard } from "$lib/components/dashboard/glucose-chart";
   import { contextResource } from "$lib/hooks/resource-context.svelte";
   import { apsSnapshotToPrediction } from "$lib/utils/aps-snapshot-to-prediction";
-  import { startOfDay, toDayString } from "$lib/utils/date-range";
+  import { isDayString, startOfDay, toDayString } from "$lib/utils/date-range";
 
   // Get date from URL search params. The default is the local calendar day —
   // taking it from `toISOString()` names yesterday for anyone east of UTC.
   const today = toDayString();
-  const dateParam = $derived(
-    page.url.searchParams.get("date") ?? today
-  );
+  const dateParam = $derived.by(() => {
+    const fromUrl = page.url.searchParams.get("date");
+    return isDayString(fromUrl) ? fromUrl : today;
+  });
 
   // Create resource with automatic layout registration
   const dayDataResource = contextResource(

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/day-in-review/data.remote.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/day-in-review/data.remote.ts
@@ -7,7 +7,7 @@ import { getRequestEvent, query } from '$app/server';
 import { error } from '@sveltejs/kit';
 import { getAll as getApsSnapshots } from '$api/generated/apsSnapshots.generated.remote';
 import { getInsulinDeliveryStatistics } from '$api/generated/statistics.generated.remote';
-import { getProfileSummary } from '$api/generated/profiles.generated.remote';
+import { getPatientTimeZone } from '$api/report-range';
 import { getLocalDayBoundariesUtc } from '$lib/utils/timezone';
 
 /**
@@ -28,9 +28,8 @@ export const getDayInReviewData = query(
 		const { locals } = getRequestEvent();
 		const { apiClient } = locals;
 
-		// Resolve the user's timezone from their profile to compute correct day boundaries
-		const profile = await getProfileSummary(undefined);
-		const timezone = profile?.therapySettings?.[0]?.timezone;
+		// Resolve the patient's timezone so the day boundaries are their day, not the server's
+		const timezone = await getPatientTimeZone();
 		const { start: dayStart, end: dayEnd } = getLocalDayBoundariesUtc(dateParam, timezone);
 
 		// Fetch v4 data + APS snapshots for historical predictions

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/executive-summary/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/executive-summary/+page.svelte
@@ -36,30 +36,17 @@
   // Default: 14 days is standard for executive summary reports
   const reportsParams = requireDateParamsContext(14);
 
-  // Create resource with automatic layout registration
+  // Create resource with automatic layout registration; `date` carries the
+  // selected range so per-day figures divide by the days the user picked.
   const reportsResource = contextResource(
     () => getReportsData(reportsParams.dateRangeInput),
-    { errorTitle: "Error Loading Executive Summary" }
+    { errorTitle: "Error Loading Executive Summary", dateParams: reportsParams }
   );
 
-  const dateRange = $derived(
-    reportsResource.current?.dateRange ?? {
-      from: new Date().toISOString(),
-      to: new Date().toISOString(),
-      lastUpdated: new Date().toISOString(),
-    }
-  );
   const entries = $derived(reportsResource.current?.entries ?? []);
   const analysis = $derived(reportsResource.current?.analysis);
-
-  // Helper to get date values
-  const startDate = $derived(new Date(dateRange.from));
-  const endDate = $derived(new Date(dateRange.to));
-  const dayCount = $derived(
-    Math.round(
-      (endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)
-    )
-  );
+  const lastUpdated = $derived(reportsResource.current?.dateRange?.lastUpdated);
+  const dayCount = $derived(reportsResource.date.dayCount);
 
   function formatDuration(minutes: number): string {
     const hours = Math.floor(minutes / 60);
@@ -168,7 +155,7 @@
                   <span class="text-green-600 font-medium">In Range</span>
                   <span>
                     {formatDuration(
-                      (durations?.target ?? 0) / Math.max(1, dayCount)
+                      (durations?.target ?? 0) / dayCount
                     )}
                   </span>
                 </div>
@@ -177,7 +164,7 @@
                   <span>
                     {formatDuration(
                       ((durations?.low ?? 0) + (durations?.veryLow ?? 0)) /
-                        Math.max(1, dayCount)
+                        dayCount
                     )}
                   </span>
                 </div>
@@ -186,7 +173,7 @@
                   <span>
                     {formatDuration(
                       ((durations?.high ?? 0) + (durations?.veryHigh ?? 0)) /
-                        Math.max(1, dayCount)
+                        dayCount
                     )}
                   </span>
                 </div>
@@ -558,9 +545,9 @@
 
     <!-- Footer -->
     <div class="text-xs text-muted-foreground text-center space-y-1 print:mt-8">
-      <p>
-        Report generated: {new Date(dateRange.lastUpdated).toLocaleString()}
-      </p>
+      {#if lastUpdated}
+        <p>Report generated: {new Date(lastUpdated).toLocaleString()}</p>
+      {/if}
       <p class="text-muted-foreground/60">
         This report is for informational purposes. Always consult your
         healthcare provider for medical decisions.

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/glucose-distribution/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/glucose-distribution/+page.svelte
@@ -9,6 +9,8 @@
   import { requireDateParamsContext } from "$lib/hooks/date-params.svelte";
   import { contextResource } from "$lib/hooks/resource-context.svelte";
   import { bg, bgLabel } from "$lib/utils/formatting";
+  import { useSearchParams } from "runed/kit";
+  import { z } from "zod";
 
   const reportsParams = requireDateParamsContext(14);
 
@@ -17,7 +19,12 @@
     { errorTitle: "Error Loading Glucose Distribution" }
   );
 
-  let showTightRange = $state(true);
+  // In the URL so the chart the user is looking at can be refreshed and shared.
+  const viewParams = useSearchParams(
+    z.object({ tightRange: z.enum(["show", "hide"]).nullable().default(null) }),
+    { showDefaults: false, noScroll: true }
+  );
+  const showTightRange = $derived(viewParams.tightRange !== "hide");
 
   const rangeStats = $derived.by(() => {
     const tir =
@@ -117,7 +124,8 @@
                 variant="ghost"
                 size="sm"
                 class="print:hidden"
-                onclick={() => (showTightRange = !showTightRange)}
+                onclick={() =>
+                  (viewParams.tightRange = showTightRange ? "hide" : "show")}
               >
                 {showTightRange ? "Hide" : "Show"} Tight Range
               </Button>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/heart-rate/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/heart-rate/+page.svelte
@@ -7,59 +7,38 @@
   } from "$lib/components/ui/card";
   import { HeartPulse, TrendingDown, TrendingUp, Calendar } from "lucide-svelte";
   import {
+    ACTOGRAM_PADDING_DAYS,
     Actogram,
+    buildDayRange,
+    extentOf,
+    pointsInRange,
     type ActogramRowContext,
   } from "$lib/components/actogram";
-  import { MS_PER_HOUR } from "$lib/components/actogram/actogram";
+  import { MS_PER_DAY, MS_PER_HOUR } from "$lib/components/actogram/actogram";
   import { getActogramData } from "$api/actogram.remote";
   import { requireDateParamsContext } from "$lib/hooks/date-params.svelte";
   import { contextResource } from "$lib/hooks/resource-context.svelte";
 
   const VISIBLE_DAYS = 14;
-  const PADDING_DAYS = 14;
-  const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
   const reportsParams = requireDateParamsContext(14);
 
-  const dateRangeMillis = $derived({
-    from: reportsParams.dateRangeMillis.from - PADDING_DAYS * MS_PER_DAY,
-    to: reportsParams.dateRangeMillis.to + PADDING_DAYS * MS_PER_DAY,
+  /** Padded window the actogram loads, so its double-plot rows have context either side. */
+  const paddedRangeMillis = $derived({
+    from: reportsParams.dateRangeMillis.from - ACTOGRAM_PADDING_DAYS * MS_PER_DAY,
+    to: reportsParams.dateRangeMillis.to + ACTOGRAM_PADDING_DAYS * MS_PER_DAY,
   });
 
   const actogramResource = contextResource(
     () =>
       getActogramData({
-        from: dateRangeMillis.from,
-        to: dateRangeMillis.to,
+        from: paddedRangeMillis.from,
+        to: paddedRangeMillis.to,
       }),
     { errorTitle: "Error Loading Heart Rate Report" }
   );
 
-  // Build day array from date range
-  const days = $derived.by(() => {
-    const start = new Date(dateRangeMillis.from);
-    const end = new Date(dateRangeMillis.to);
-    const startMidnight = new Date(
-      start.getFullYear(),
-      start.getMonth(),
-      start.getDate()
-    );
-    const endMidnight = new Date(
-      end.getFullYear(),
-      end.getMonth(),
-      end.getDate()
-    );
-    const dayCount =
-      Math.round(
-        (endMidnight.getTime() - startMidnight.getTime()) /
-          (24 * 60 * 60 * 1000)
-      ) + 1;
-    return Array.from({ length: dayCount }, (_, i) => {
-      const d = new Date(startMidnight);
-      d.setDate(d.getDate() + i);
-      return d;
-    });
-  });
+  const days = $derived(buildDayRange(paddedRangeMillis.from, paddedRangeMillis.to));
 
   // HR data as ActogramPoints
   const hrPoints = $derived(
@@ -71,29 +50,31 @@
     (actogramResource.current?.glucoseData ?? []).map((g) => ({ mills: g.mills, sgv: g.sgv, color: g.color }))
   );
 
-  // Summary statistics
-  const avgBpm = $derived.by(() => {
-    const rates = actogramResource.current?.heartRates ?? [];
-    return rates.length > 0
-      ? Math.round(rates.reduce((sum, h) => sum + h.bpm, 0) / rates.length)
-      : 0;
-  });
-  const minBpm = $derived.by(() => {
-    const rates = actogramResource.current?.heartRates ?? [];
-    return rates.length > 0 ? Math.min(...rates.map((h) => h.bpm)) : 0;
-  });
-  const maxBpm = $derived.by(() => {
-    const rates = actogramResource.current?.heartRates ?? [];
-    return rates.length > 0 ? Math.max(...rates.map((h) => h.bpm)) : 0;
-  });
+  // Summary statistics cover the selected range only. The actogram fetches ±14
+  // days of context around it, so aggregating the whole response described a
+  // window up to 28 days wider than the one the picker showed.
+  const selectedRates = $derived(
+    pointsInRange(
+      actogramResource.current?.heartRates ?? [],
+      reportsParams.dateRangeMillis.from,
+      reportsParams.dateRangeMillis.to
+    )
+  );
 
-  // Resting HR estimate: 10th percentile of all readings
+  const avgBpm = $derived(
+    selectedRates.length > 0
+      ? Math.round(selectedRates.reduce((sum, h) => sum + h.bpm, 0) / selectedRates.length)
+      : 0
+  );
+  const bpmExtent = $derived(extentOf(selectedRates, (h) => h.bpm));
+  const minBpm = $derived(bpmExtent?.min ?? 0);
+  const maxBpm = $derived(bpmExtent?.max ?? 0);
+
+  // Resting HR estimate: 10th percentile of the range's readings
   const restingBpm = $derived.by(() => {
-    const rates = actogramResource.current?.heartRates ?? [];
-    if (rates.length === 0) return 0;
-    const sorted = [...rates].sort((a, b) => a.bpm - b.bpm);
-    const idx = Math.floor(sorted.length * 0.1);
-    return sorted[idx]?.bpm ?? 0;
+    if (selectedRates.length === 0) return 0;
+    const sorted = [...selectedRates].sort((a, b) => a.bpm - b.bpm);
+    return sorted[Math.floor(sorted.length * 0.1)]?.bpm ?? 0;
   });
 
   // Scale for dot Y position (map BPM to row height)
@@ -179,7 +160,7 @@
           <div class="flex items-center gap-2">
             <Calendar class="h-5 w-5 text-muted-foreground" />
             <span class="text-2xl font-bold tabular-nums">
-              {(actogramResource.current?.heartRates ?? []).length.toLocaleString()}
+              {selectedRates.length.toLocaleString()}
             </span>
           </div>
         </CardContent>
@@ -202,7 +183,7 @@
           thresholds={actogramResource.current?.thresholds}
           rowHeight={48}
           visibleCount={VISIBLE_DAYS}
-          initialOffset={PADDING_DAYS}
+          initialOffset={ACTOGRAM_PADDING_DAYS}
         >
           {#snippet tooltipValue({ point })}
             {@const bpm = (point as { mills: number; bpm: number }).bpm ?? 0}

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/idp/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/idp/+page.svelte
@@ -32,13 +32,13 @@
   // Default: 14 days is the standard IDP report period
   const reportsParams = requireDateParamsContext(14);
 
-  // Create resource with automatic layout registration
+  // Create resource with automatic layout registration; `date` carries the
+  // selected range, so the page has one day count rather than two.
   const reportsResource = contextResource(
     () => getIdpData(reportsParams.dateRangeInput),
-    { errorTitle: "Error Loading IDP Report" }
+    { errorTitle: "Error Loading IDP Report", dateParams: reportsParams }
   );
 
-  // Unwrap the data from the resource with null safety
   const data = $derived({
     entries: reportsResource.current?.entries ?? [],
     boluses: reportsResource.current?.boluses ?? [],
@@ -47,11 +47,6 @@
     analysis: reportsResource.current?.analysis,
     averagedStats: reportsResource.current?.averagedStats,
     aidSystemMetrics: reportsResource.current?.aidSystemMetrics,
-    dateRange: reportsResource.current?.dateRange ?? {
-      from: new Date().toISOString(),
-      to: new Date().toISOString(),
-      lastUpdated: new Date().toISOString(),
-    },
   });
 
   // Derived values from data
@@ -60,17 +55,10 @@
   const insulinStats = $derived(data.insulinDeliveryStats);
   const analysis = $derived(data.analysis);
   const aidMetrics = $derived(data.aidSystemMetrics);
-  const dateRange = $derived(data.dateRange);
-  const startDate = $derived(new Date(dateRange.from));
-  const endDate = $derived(new Date(dateRange.to));
-  const dayCount = $derived(
-    Math.max(
-      1,
-      Math.round(
-        (endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)
-      )
-    )
-  );
+  const lastUpdated = $derived(reportsResource.current?.dateRange?.lastUpdated);
+  const startDate = $derived(reportsResource.date.from);
+  const endDate = $derived(reportsResource.date.to);
+  const dayCount = $derived(reportsResource.date.dayCount);
 </script>
 
 <svelte:head>
@@ -135,10 +123,9 @@
         </CardDescription>
       </CardHeader>
       <CardContent class="space-y-4">
-        {@const days = Math.max(insulinStats?.dayCount ?? 1, 1)}
-        {@const avgBasal = insulinStats?.totalBasal != null ? insulinStats.totalBasal / days : null}
-        {@const avgBolus = insulinStats?.totalBolus != null ? insulinStats.totalBolus / days : null}
-        {@const avgScheduled = insulinStats?.scheduledBasal != null ? insulinStats.scheduledBasal / days : null}
+        {@const avgBasal = insulinStats?.totalBasal != null ? insulinStats.totalBasal / dayCount : null}
+        {@const avgBolus = insulinStats?.totalBolus != null ? insulinStats.totalBolus / dayCount : null}
+        {@const avgScheduled = insulinStats?.scheduledBasal != null ? insulinStats.scheduledBasal / dayCount : null}
 
         <!-- TDD -->
         <div class="flex items-baseline justify-between">
@@ -197,13 +184,13 @@
           <div>
             <div class="text-muted-foreground">Meal Boluses/Day</div>
             <div class="font-semibold">
-              {insulinStats?.mealBoluses != null ? (insulinStats.mealBoluses / days).toFixed(1) : "--"}
+              {insulinStats?.mealBoluses != null ? (insulinStats.mealBoluses / dayCount).toFixed(1) : "--"}
             </div>
           </div>
           <div>
             <div class="text-muted-foreground">Correction Boluses/Day</div>
             <div class="font-semibold">
-              {insulinStats?.correctionBoluses != null ? (insulinStats.correctionBoluses / days).toFixed(1) : "--"}
+              {insulinStats?.correctionBoluses != null ? (insulinStats.correctionBoluses / dayCount).toFixed(1) : "--"}
             </div>
           </div>
         </div>
@@ -374,7 +361,9 @@
 
   <div class="text-xs text-muted-foreground text-center">
     Data from {startDate.toLocaleDateString()} – {endDate.toLocaleDateString()}.
-    Last updated {new Date(dateRange.lastUpdated).toLocaleString()}.
+    {#if lastUpdated}
+      Last updated {new Date(lastUpdated).toLocaleString()}.
+    {/if}
   </div>
 </div>
 {/if}

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/insulin-delivery/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/insulin-delivery/+page.svelte
@@ -25,7 +25,7 @@
   import ReliabilityBadge from "$lib/components/reports/ReliabilityBadge.svelte";
   import type { InsulinDeliveryStatistics } from "$lib/api";
   import {
-    getMultiPeriodStatistics,
+    getInsulinDeliveryStatistics,
     getDailyBasalBolusRatios,
     getHourlyInsulinDelivery,
   } from "$api/generated/statistics.generated.remote";
@@ -36,36 +36,30 @@
   // Default: 30 days for insulin delivery analysis (TDD and ratios benefit from more data)
   const reportsParams = requireDateParamsContext(30);
 
-  const dateRange = $derived.by(() => {
-    const range = reportsParams.getDateRange();
-    return { from: range.start.toISOString(), to: range.end.toISOString() };
+  // Date args shared by every statistics query on this page.
+  // Send ISO strings, not Date objects. A Date can't be serialised as a
+  // remote-query argument ("Unknown date type"), so passing Dates left these
+  // queries erroring — empty on first load, hard error when the filter dates
+  // change. The server schema is z.coerce.date(), which parses the ISO strings
+  // back to dates; the cast satisfies the generated Date arg type.
+  // Same pattern as ReplayPanel's replay() call.
+  const statisticsDates = $derived({
+    startDate: reportsParams.startDate.toISOString() as unknown as Date,
+    endDate: reportsParams.endDate.toISOString() as unknown as Date,
   });
 
-  // Date args shared by the statistics queries
-  const statisticsDates = $derived.by(() => {
-    const input = reportsParams.dateRangeInput;
-    const endDate = input?.to ? new Date(input.to) : new Date();
-    endDate.setHours(23, 59, 59, 999);
-    const startDate = input?.from
-      ? new Date(input.from)
-      : (() => {
-          const d = new Date(endDate);
-          d.setDate(d.getDate() - ((input?.days ?? 30) - 1));
-          return d;
-        })();
-    startDate.setHours(0, 0, 0, 0);
-    // Send ISO strings, not Date objects. A Date can't be serialised as a
-    // remote-query argument ("Unknown date type"), so passing Dates left this
-    // query erroring — empty on first load, hard error when the filter dates
-    // change. The server schema is z.coerce.date(), which parses the ISO
-    // strings back to dates; the cast satisfies the generated Date arg type.
-    // Same pattern as ReplayPanel's replay() call.
-    return {
-      startDate: startDate.toISOString() as unknown as Date,
-      endDate: endDate.toISOString() as unknown as Date,
-    };
-  });
   const dailyRatiosResource = $derived(getDailyBasalBolusRatios(statisticsDates));
+
+  // Headline insulin figures for the selected range. The fixed-bucket
+  // multi-period endpoint was used here instead, so every number above the
+  // charts described the last 30 days no matter what the picker said.
+  const insulinResource = contextResource(
+    () => getInsulinDeliveryStatistics(statisticsDates),
+    {
+      errorTitle: "Error Loading Insulin Delivery Data",
+      dateParams: reportsParams,
+    }
+  );
 
   // Hourly delivery pattern with automatic layout registration. Computed
   // backend-side from pump-confirmed records, bucketed by the user's timezone.
@@ -75,11 +69,7 @@
   );
   const hourlyDelivery = $derived(hourlyDeliveryResource.current?.hours ?? []);
 
-  // Secondary resource for multi-period statistics
-  const multiPeriodStatsResource = $derived(getMultiPeriodStatistics());
-
-  // Default statistics when loading or no data
-  const defaultStats: InsulinDeliveryStatistics = {
+  const emptyStats: InsulinDeliveryStatistics = {
     totalBolus: 0,
     totalBasal: 0,
     totalInsulin: 0,
@@ -94,24 +84,15 @@
     correctionBoluses: 0,
     icRatio: 0,
     bolusesPerDay: 0,
-    dayCount: 1,
-    startDate: new Date().toISOString(),
-    endDate: new Date().toISOString(),
     carbCount: 0,
     carbBolusCount: 0,
   };
 
-  // Get insulin stats from the appropriate period based on date range
-  // Default to 30-day stats which is most commonly used for reports
-  const insulinStats = $derived(
-    multiPeriodStatsResource.current?.lastMonth?.insulinDelivery ?? defaultStats
-  );
+  const insulinStats = $derived(insulinResource.current ?? emptyStats);
 
-  // Helper dates derived from backend stats
-  const startDate = $derived(new Date(insulinStats.startDate || dateRange.from));
-  const endDate = $derived(new Date(insulinStats.endDate || dateRange.to));
-  const dayCount = $derived(insulinStats.dayCount || 1);
-
+  const startDate = $derived(insulinResource.date.from);
+  const endDate = $derived(insulinResource.date.to);
+  const dayCount = $derived(insulinResource.date.dayCount);
 </script>
 
 <svelte:head>
@@ -122,7 +103,7 @@
   />
 </svelte:head>
 
-{#if hourlyDeliveryResource.current || multiPeriodStatsResource.current}
+{#if insulinResource.current}
 <div class="@container container mx-auto max-w-7xl space-y-8 p-3 @md:p-6">
   <!-- Header -->
   <div class="space-y-4">
@@ -297,8 +278,6 @@
     </CardHeader>
     <CardContent>
       <BasalBolusRatioChart
-        startDate={dateRange.from}
-        endDate={dateRange.to}
         data={dailyRatiosResource.current}
         loading={dailyRatiosResource.loading}
       />

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/site-change-impact/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/site-change-impact/+page.svelte
@@ -31,33 +31,18 @@
   // Default: 30 days to capture multiple site changes for meaningful analysis
   const reportsParams = requireDateParamsContext(30);
 
-  // Create resource with automatic layout registration
+  // Create resource with automatic layout registration; `date` carries the
+  // selected range so the header matches the window that was queried.
   const siteChangeResource = contextResource(
     () => getSiteChangeImpact(reportsParams.dateRangeInput),
-    { errorTitle: "Error Loading Site Change Data" }
+    { errorTitle: "Error Loading Site Change Data", dateParams: reportsParams }
   );
 
   const isLoading = $derived(siteChangeResource.loading);
-  const queryData = $derived(siteChangeResource.current);
-  const analysis = $derived(queryData?.analysis ?? null);
-  const dateRange = $derived(
-    queryData?.dateRange ?? {
-      from: new Date().toISOString(),
-      to: new Date().toISOString(),
-    }
-  );
-
-  // Helper dates
-  const startDate = $derived(new Date(dateRange.from));
-  const endDate = $derived(new Date(dateRange.to));
-  const dayCount = $derived(
-    Math.max(
-      1,
-      Math.round(
-        (endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)
-      )
-    )
-  );
+  const analysis = $derived(siteChangeResource.current?.analysis ?? null);
+  const startDate = $derived(siteChangeResource.date.from);
+  const endDate = $derived(siteChangeResource.date.to);
+  const dayCount = $derived(siteChangeResource.date.dayCount);
 
   // Format date for display
   function formatDate(date: Date): string {

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/sleep/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/sleep/+page.svelte
@@ -19,10 +19,12 @@
     Activity,
   } from "lucide-svelte";
   import {
+    ACTOGRAM_PADDING_DAYS,
     Actogram,
+    buildDayRange,
     type ActogramRowContext,
   } from "$lib/components/actogram";
-  import { MS_PER_HOUR, HOURS_PER_ROW } from "$lib/components/actogram/actogram";
+  import { MS_PER_DAY, MS_PER_HOUR, HOURS_PER_ROW } from "$lib/components/actogram/actogram";
   import { getActogramData } from "$api/actogram.remote";
   import { getTrends } from "$api/generated/sleepReports.generated.remote";
   import { requireDateParamsContext } from "$lib/hooks/date-params.svelte";
@@ -38,15 +40,13 @@
   import { SleepSource } from "$api";
 
   const VISIBLE_DAYS = 14;
-  const PADDING_DAYS = 14;
-  const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
   const reportsParams = requireDateParamsContext(14);
 
-  /** Padded ±14-day window the actogram loads, so its double-plot rows have context on either side. */
+  /** Padded window the actogram loads, so its double-plot rows have context either side. */
   const paddedRangeMillis = $derived({
-    from: reportsParams.dateRangeMillis.from - PADDING_DAYS * MS_PER_DAY,
-    to: reportsParams.dateRangeMillis.to + PADDING_DAYS * MS_PER_DAY,
+    from: reportsParams.dateRangeMillis.from - ACTOGRAM_PADDING_DAYS * MS_PER_DAY,
+    to: reportsParams.dateRangeMillis.to + ACTOGRAM_PADDING_DAYS * MS_PER_DAY,
   });
 
   const actogramResource = contextResource(
@@ -90,29 +90,14 @@
     { errorTitle: "Error Loading Sleep Report" }
   );
 
-  /** Every local-midnight Date between `fromMs` and `toMs`, inclusive. */
-  function buildDayRange(fromMs: number, toMs: number): Date[] {
-    const start = new Date(fromMs);
-    const end = new Date(toMs);
-    const startMidnight = new Date(start.getFullYear(), start.getMonth(), start.getDate());
-    const endMidnight = new Date(end.getFullYear(), end.getMonth(), end.getDate());
-    const dayCount =
-      Math.round((endMidnight.getTime() - startMidnight.getTime()) / MS_PER_DAY) + 1;
-    return Array.from({ length: dayCount }, (_, i) => {
-      const d = new Date(startMidnight);
-      d.setDate(d.getDate() + i);
-      return d;
-    });
-  }
-
   // Actogram rows run newest-first (most recent night on top), descending into
   // the past. Anchored at the selected range end — never the future — so padding
   // days after `to` are not shown as rows; the padded fetch window above still
-  // feeds each row's next-day double-plot. Extends PADDING_DAYS before the range
-  // start for scroll-back context.
+  // feeds each row's next-day double-plot. Extends ACTOGRAM_PADDING_DAYS before
+  // the range start for scroll-back context.
   const days = $derived(
     buildDayRange(
-      reportsParams.dateRangeMillis.from - PADDING_DAYS * MS_PER_DAY,
+      reportsParams.dateRangeMillis.from - ACTOGRAM_PADDING_DAYS * MS_PER_DAY,
       reportsParams.dateRangeMillis.to
     ).reverse()
   );

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/sleep/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/sleep/+page.svelte
@@ -38,6 +38,8 @@
   import SleepCompositionChart from "$lib/components/reports/sleep/SleepCompositionChart.svelte";
   import SleepWeeklyBreakdown from "$lib/components/reports/sleep/SleepWeeklyBreakdown.svelte";
   import { SleepSource } from "$api";
+  import { useSearchParams } from "runed/kit";
+  import { z } from "zod";
 
   const VISIBLE_DAYS = 14;
 
@@ -58,8 +60,15 @@
     { errorTitle: "Error Loading Sleep Report" }
   );
 
-  /** "All sources" is a frontend-only sentinel; omitted from the request when selected. */
-  let sourceFilter = $state<SleepSource | "all">("all");
+  /**
+   * "All sources" is a frontend-only sentinel; omitted from the request when
+   * selected. Held in the URL so a filtered report can be refreshed and shared.
+   */
+  const viewParams = useSearchParams(
+    z.object({ source: z.enum(SleepSource).nullable().default(null) }),
+    { showDefaults: false, noScroll: true }
+  );
+  const sourceFilter = $derived<SleepSource | "all">(viewParams.source ?? "all");
 
   const sourceOptions: { value: SleepSource | "all"; label: string }[] = [
     { value: "all", label: "All sources" },
@@ -367,7 +376,8 @@
               <Select.Root
                 type="single"
                 value={sourceFilter}
-                onValueChange={(v) => (sourceFilter = (v || "all") as SleepSource | "all")}
+                onValueChange={(v) =>
+                  (viewParams.source = v && v !== "all" ? (v as SleepSource) : null)}
               >
                 <Select.Trigger class="w-44">
                   {sourceLabel}

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/steps/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/steps/+page.svelte
@@ -7,79 +7,54 @@
   } from "$lib/components/ui/card";
   import { Footprints, TrendingUp, Calendar } from "lucide-svelte";
   import {
+    ACTOGRAM_PADDING_DAYS,
     Actogram,
+    buildDayRange,
+    extentOf,
+    pointsInRange,
     type ActogramRowContext,
   } from "$lib/components/actogram";
-  import { MS_PER_HOUR } from "$lib/components/actogram/actogram";
+  import { MS_PER_DAY, MS_PER_HOUR } from "$lib/components/actogram/actogram";
   import { getActogramData } from "$api/actogram.remote";
   import { requireDateParamsContext } from "$lib/hooks/date-params.svelte";
   import { contextResource } from "$lib/hooks/resource-context.svelte";
-  import { computeDayTotals, computeInitialOffset } from './steps.utils';
-  import { untrack } from 'svelte';
+  import { computeDayTotals } from './steps.utils';
 
   const VISIBLE_DAYS = 14;
-  const PADDING_DAYS = 14;
-  const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
   const reportsParams = requireDateParamsContext(14);
 
-  // Frozen at mount — does NOT react to reportsParams changes caused by actogram navigation.
-  // This prevents a re-fetch every time the user scrolls the actogram.
-  const fetchRange = {
-    from: reportsParams.dateRangeMillis.from - PADDING_DAYS * MS_PER_DAY,
-    to: reportsParams.dateRangeMillis.to + PADDING_DAYS * MS_PER_DAY,
-  };
+  /** Padded window the actogram loads, so its double-plot rows have context either side. */
+  const paddedRangeMillis = $derived({
+    from: reportsParams.dateRangeMillis.from - ACTOGRAM_PADDING_DAYS * MS_PER_DAY,
+    to: reportsParams.dateRangeMillis.to + ACTOGRAM_PADDING_DAYS * MS_PER_DAY,
+  });
 
   const actogramResource = contextResource(
     () =>
       getActogramData({
-        from: fetchRange.from,
-        to: fetchRange.to,
+        from: paddedRangeMillis.from,
+        to: paddedRangeMillis.to,
       }),
     { errorTitle: "Error Loading Step Count Report" }
   );
 
-  // Build day array from date range
-  const days = $derived.by(() => {
-    const start = new Date(fetchRange.from);
-    const end = new Date(fetchRange.to);
-    const startMidnight = new Date(
-      start.getFullYear(),
-      start.getMonth(),
-      start.getDate()
-    );
-    const endMidnight = new Date(
-      end.getFullYear(),
-      end.getMonth(),
-      end.getDate()
-    );
-    const dayCount =
-      Math.round(
-        (endMidnight.getTime() - startMidnight.getTime()) /
-          (24 * 60 * 60 * 1000)
-      ) + 1;
-    return Array.from({ length: dayCount }, (_, i) => {
-      const d = new Date(startMidnight);
-      d.setDate(d.getDate() + i);
-      return d;
-    });
-  });
+  // Rows run newest-first, anchored at the selected range end — never the future —
+  // so padding days after `to` are not shown as rows; the padded fetch window above
+  // still feeds each row's next-day double plot. Extends ACTOGRAM_PADDING_DAYS
+  // before the range start for scroll-back context.
+  const days = $derived(
+    buildDayRange(
+      reportsParams.dateRangeMillis.from - ACTOGRAM_PADDING_DAYS * MS_PER_DAY,
+      reportsParams.dateRangeMillis.to
+    ).reverse()
+  );
 
   const dayTotals = $derived(computeDayTotals(actogramResource.current?.stepCounts ?? [], days));
 
   function formatDate(date: Date): string {
     return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
   }
-
-  // Read once at mount — not reactive. Sets the starting scroll position from URL params.
-  // Uses local midnight from the days array to avoid UTC/local timezone mismatch.
-  const initialOffset = untrack(() => {
-    const targetDate = reportsParams.from;
-    const targetMs = targetDate
-      ? new Date(targetDate).setHours(0, 0, 0, 0)
-      : fetchRange.from;
-    return computeInitialOffset(days, targetMs, VISIBLE_DAYS);
-  });
 
   // Step data as ActogramPoints
   const stepPoints = $derived(
@@ -91,32 +66,21 @@
     (actogramResource.current?.glucoseData ?? []).map((g) => ({ mills: g.mills, sgv: g.sgv, color: g.color }))
   );
 
-  // Summary statistics scoped to the currently visible period (not the padded fetch window)
-  const visibleStepCounts = $derived(
-    (actogramResource.current?.stepCounts ?? []).filter(
-      (s) =>
-        s.mills >= reportsParams.dateRangeMillis.from &&
-        s.mills <= reportsParams.dateRangeMillis.to
+  // Summary statistics scoped to the selected range, not the padded fetch window
+  const selectedStepCounts = $derived(
+    pointsInRange(
+      actogramResource.current?.stepCounts ?? [],
+      reportsParams.dateRangeMillis.from,
+      reportsParams.dateRangeMillis.to
     )
   );
-  const totalSteps = $derived(visibleStepCounts.reduce((sum, s) => sum + s.metric, 0));
-  const dayCount = $derived(
-    reportsParams.from && reportsParams.to
-      ? Math.round(
-          (new Date(reportsParams.to).getTime() - new Date(reportsParams.from).getTime()) /
-            MS_PER_DAY
-        ) + 1
-      : VISIBLE_DAYS
-  );
-  const dailyAverage = $derived(
-    dayCount > 0 ? Math.round(totalSteps / dayCount) : 0
-  );
-  const maxStepsInHour = $derived.by(() => {
-    const counts = actogramResource.current?.stepCounts ?? [];
-    return counts.length > 0 ? Math.max(...counts.map((s) => s.metric)) : 1000;
-  });
+  const totalSteps = $derived(selectedStepCounts.reduce((sum, s) => sum + s.metric, 0));
+  const dayCount = $derived(reportsParams.dayCount);
+  const dailyAverage = $derived(Math.round(totalSteps / dayCount));
   // Cap bar scale at a reasonable max
-  const barScale = $derived(Math.max(maxStepsInHour, 1000));
+  const barScale = $derived(
+    Math.max(extentOf(selectedStepCounts, (s) => s.metric)?.max ?? 0, 1000)
+  );
 </script>
 
 <svelte:head>
@@ -205,13 +169,6 @@
           thresholds={actogramResource.current?.thresholds}
           rowHeight={64}
           visibleCount={VISIBLE_DAYS}
-          {initialOffset}
-          onVisibleRangeChange={(from, to) => {
-            reportsParams.setCustomRange(
-              `${from.getFullYear()}-${String(from.getMonth() + 1).padStart(2, '0')}-${String(from.getDate()).padStart(2, '0')}`,
-              `${to.getFullYear()}-${String(to.getMonth() + 1).padStart(2, '0')}-${String(to.getDate()).padStart(2, '0')}`,
-            );
-          }}
         >
           {#snippet rowLabel({ day })}
             <div class="text-right pr-2">

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/steps/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/steps/+page.svelte
@@ -96,7 +96,7 @@
     (actogramResource.current?.stepCounts ?? []).filter(
       (s) =>
         s.mills >= reportsParams.dateRangeMillis.from &&
-        s.mills <= reportsParams.dateRangeMillis.to + MS_PER_DAY - 1
+        s.mills <= reportsParams.dateRangeMillis.to
     )
   );
   const totalSteps = $derived(visibleStepCounts.reduce((sum, s) => sum + s.metric, 0));

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/steps/steps.utils.test.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/steps/steps.utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeDayTotals, computeInitialOffset } from './steps.utils';
+import { computeDayTotals } from './steps.utils';
 
 describe('computeDayTotals', () => {
   const apr20 = new Date('2026-04-20T00:00:00');
@@ -45,29 +45,5 @@ describe('computeDayTotals', () => {
     const totals = computeDayTotals(stepCounts, days);
     expect(totals.get(apr20.getTime())).toBe(100);
     expect(totals.get(apr21.getTime())).toBe(200);
-  });
-});
-
-describe('computeInitialOffset', () => {
-  const days = Array.from({ length: 42 }, (_, i) => {
-    const d = new Date('2026-04-06T00:00:00');
-    d.setDate(d.getDate() + i);
-    return d;
-  });
-  const VISIBLE = 14;
-
-  it('returns the index of the matching day', () => {
-    const target = new Date('2026-04-20T00:00:00').getTime();
-    expect(computeInitialOffset(days, target, VISIBLE)).toBe(14);
-  });
-
-  it('clamps to 0 when target is before the first day', () => {
-    const target = new Date('2026-01-01T00:00:00').getTime();
-    expect(computeInitialOffset(days, target, VISIBLE)).toBe(0);
-  });
-
-  it('clamps so the last page is fully visible', () => {
-    const target = new Date('2026-05-20T00:00:00').getTime();
-    expect(computeInitialOffset(days, target, VISIBLE)).toBe(days.length - VISIBLE);
   });
 });

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/steps/steps.utils.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/steps/steps.utils.ts
@@ -19,23 +19,3 @@ export function computeDayTotals(
   }
   return totals;
 }
-
-/**
- * Converts a target timestamp into an actogram row offset.
- *
- * Finds the first day >= targetMs and returns its index, clamped so that
- * `visibleCount` rows always fit.
- *
- * @param targetMs - Must be a local midnight timestamp (e.g. `new Date(y, m, d).getTime()`).
- *   Passing a UTC midnight value (`new Date('YYYY-MM-DD').getTime()`) may give off-by-one
- *   results in UTC+ timezones.
- */
-export function computeInitialOffset(
-  days: Date[],
-  targetMs: number,
-  visibleCount: number,
-): number {
-  const idx = days.findIndex((d) => d.getTime() >= targetMs);
-  if (idx === -1) return Math.max(0, days.length - visibleCount);
-  return Math.max(0, Math.min(idx, days.length - visibleCount));
-}

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/treatments/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/treatments/+page.svelte
@@ -66,7 +66,7 @@
 
   const reportsResource = contextResource(
     () => getTreatmentsData(reportsParams.dateRangeInput),
-    { errorTitle: "Error Loading Treatments" }
+    { errorTitle: "Error Loading Treatments", dateParams: reportsParams }
   );
 
   const allRows = $derived(
@@ -79,12 +79,7 @@
       basalInjections: reportsResource.current?.basalInjections,
     })
   );
-  const dateRange = $derived(
-    reportsResource.current?.dateRange ?? {
-      from: new Date().toISOString(),
-      to: new Date().toISOString(),
-    }
-  );
+  const dateInfo = $derived(reportsResource.date);
 
   const treatmentSummary = $derived(
     reportsResource.current?.treatmentSummary ??
@@ -373,9 +368,7 @@
     >
       <Calendar class="h-4 w-4" />
       <span>
-        {new Date(dateRange.from).toLocaleDateString()} – {new Date(
-          dateRange.to
-        ).toLocaleDateString()}
+        {dateInfo.from.toLocaleDateString()} – {dateInfo.to.toLocaleDateString()}
       </span>
       <span class="text-muted-foreground/50">•</span>
       <span>{allRows.length.toLocaleString()} records</span>
@@ -389,7 +382,7 @@
   </div>
 
   <!-- Summary Stats -->
-  <TreatmentStatsCard {treatmentSummary} counts={filteredCounts} {dateRange} />
+  <TreatmentStatsCard {treatmentSummary} counts={filteredCounts} dayCount={dateInfo.dayCount} />
 
   <!-- Category Tabs — view toggle, print chaff -->
   <div class="print:hidden">
@@ -505,9 +498,7 @@
   <div class="text-center text-xs text-muted-foreground">
     <p>
       Report generated from {allRows.length.toLocaleString()} records between
-      {new Date(dateRange.from).toLocaleDateString()} and {new Date(
-        dateRange.to
-      ).toLocaleDateString()}
+      {dateInfo.from.toLocaleDateString()} and {dateInfo.to.toLocaleDateString()}
     </p>
   </div>
 </div>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/treatments/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/treatments/+page.svelte
@@ -211,27 +211,29 @@
   let filteredCounts = $derived(countEntryRecords(filteredRows));
 
   // Handlers
-  function handleCategoryChange(category: EntryCategoryId | "all") {
-    activeCategory = category;
+  // Filters are reflected in the URL via SvelteKit shallow routing, so a filtered
+  // log can be refreshed and shared and `page.url` stays authoritative (the edit
+  // dialog reads it to keep its `?edit=` param in sync).
+  function setFilterParam(name: string, value: string) {
     const url = new URL(page.url);
-    if (category === "all") {
-      url.searchParams.delete("category");
-    } else {
-      url.searchParams.set("category", category);
-    }
-    // Use SvelteKit shallow routing so `page.url` stays authoritative (the edit
-    // dialog reads it to keep its `?edit=` param in sync).
+    if (value) url.searchParams.set(name, value);
+    else url.searchParams.delete(name);
     replaceState(url, page.state);
   }
 
-  function handleSearch(e: Event) {
-    const target = e.target as HTMLInputElement;
-    searchQuery = target.value;
+  function setCategory(category: EntryCategoryId | "all") {
+    activeCategory = category;
+    setFilterParam("category", category === "all" ? "" : category);
+  }
+
+  function setSearch(value: string) {
+    searchQuery = value;
+    setFilterParam("search", value.trim());
   }
 
   function clearFilters() {
-    searchQuery = "";
-    activeCategory = "all";
+    setSearch("");
+    setCategory("all");
   }
 
   function confirmDelete(row: EntryRecord) {
@@ -389,7 +391,7 @@
     <TreatmentCategoryTabs
       {activeCategory}
       categoryCounts={counts}
-      onChange={handleCategoryChange}
+      onChange={setCategory}
     />
   </div>
 
@@ -407,7 +409,8 @@
               type="text"
               placeholder="Search records..."
               value={searchQuery}
-              oninput={handleSearch}
+              oninput={(e: Event & { currentTarget: HTMLInputElement }) =>
+                setSearch(e.currentTarget.value)}
             />
           </div>
         </div>
@@ -456,7 +459,7 @@
             <Badge variant="secondary" class="gap-1">
               {ENTRY_CATEGORIES[activeCategory].name}
               <button
-                onclick={() => (activeCategory = "all")}
+                onclick={() => setCategory("all")}
                 class="ml-1 hover:text-foreground"
               >
                 <X class="h-3 w-3" />
@@ -468,7 +471,7 @@
             <Badge variant="outline" class="gap-1">
               "{searchQuery}"
               <button
-                onclick={() => (searchQuery = "")}
+                onclick={() => setSearch("")}
                 class="ml-1 hover:text-foreground"
               >
                 <X class="h-3 w-3" />

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/treatments/data.remote.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/treatments/data.remote.ts
@@ -27,44 +27,7 @@ import {
 	CreateBasalInjectionRequestSchema,
 	UpdateBasalInjectionRequestSchema,
 } from '$lib/api/generated/schemas';
-import { getProfileSummary } from '$api/generated/profiles.generated.remote';
-import { getLocalDayBoundariesUtc } from '$lib/utils/timezone';
-
-/**
- * Input schema for date range queries (matches reports layout pattern)
- */
-const DateRangeSchema = z.object({
-	days: z.number().nullish(),
-	from: z.string().nullish(),
-	to: z.string().nullish(),
-});
-
-function calculateDateRange(input: z.infer<typeof DateRangeSchema> | undefined, timezone?: string | null) {
-	let startDateStr: string;
-	let endDateStr: string;
-
-	if (input?.from && input?.to) {
-		startDateStr = input.from.split('T')[0];
-		endDateStr = input.to.split('T')[0];
-	} else if (input?.days) {
-		const end = new Date();
-		const start = new Date(end);
-		start.setDate(end.getDate() - (input.days - 1));
-		startDateStr = start.toISOString().split('T')[0];
-		endDateStr = end.toISOString().split('T')[0];
-	} else {
-		const end = new Date();
-		const start = new Date(end);
-		start.setDate(end.getDate() - 7);
-		startDateStr = start.toISOString().split('T')[0];
-		endDateStr = end.toISOString().split('T')[0];
-	}
-
-	const { start: startDate } = getLocalDayBoundariesUtc(startDateStr, timezone);
-	const { end: endDate } = getLocalDayBoundariesUtc(endDateStr, timezone);
-
-	return { startDate, endDate };
-}
+import { DateRangeSchema, resolveReportRange } from '$api/report-range';
 
 /**
  * Get all v4 entry types for the treatments page.
@@ -76,9 +39,7 @@ export const getTreatmentsData = query(
 	async (input) => {
 		const { locals } = getRequestEvent();
 		const { apiClient } = locals;
-		const profile = await getProfileSummary(undefined);
-		const timezone = profile?.therapySettings?.[0]?.timezone;
-		const { startDate, endDate } = calculateDateRange(input, timezone);
+		const { startDate, endDate } = await resolveReportRange(input);
 		const [
 			bolusResponse,
 			carbResponse,

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/week-to-week/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/week-to-week/+page.svelte
@@ -8,17 +8,24 @@
   import { contextResource } from "$lib/hooks/resource-context.svelte";
   import { toDayString } from "$lib/utils/date-range";
   import { bg } from "$lib/utils/formatting";
+  import { DAY_KEYS, buildWeekdayBuckets } from "./week-to-week.utils";
 
-  // Day of week series config
-  const DAY_SERIES = [
-    { key: "sun", label: "Sun", color: "#808080" },
-    { key: "mon", label: "Mon", color: "#1e90ff" },
-    { key: "tue", label: "Tue", color: "#009e73" },
-    { key: "wed", label: "Wed", color: "#ff9a00" },
-    { key: "thu", label: "Thu", color: "#f0e442" },
-    { key: "fri", label: "Fri", color: "#ec7892" },
-    { key: "sat", label: "Sat", color: "#d55e00" },
-  ] as const;
+  const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const DAY_COLORS = [
+    "#808080",
+    "#1e90ff",
+    "#009e73",
+    "#ff9a00",
+    "#f0e442",
+    "#ec7892",
+    "#d55e00",
+  ];
+
+  const DAY_SERIES = DAY_KEYS.map((key, i) => ({
+    key,
+    label: DAY_LABELS[i],
+    color: DAY_COLORS[i],
+  }));
 
   // Get shared date params from context (set by reports layout)
   // Default: 7 days (today + last 6 days = 1 full week)
@@ -39,46 +46,10 @@
     return `${reportsParams.startDate.toLocaleDateString(undefined, opts)} – ${reportsParams.endDate.toLocaleDateString(undefined, opts)}`;
   });
 
-  // Transform entries into chart data: each row = { time, sun?, mon?, tue?, ... }
-  const chartData = $derived.by(() => {
-    const entries = reportsResource.current?.entries ?? [];
-
-    // Group by normalized time across all days in the range
-    const timeMap = new Map<number, Record<string, number | Date>>();
-
-    for (const entry of entries) {
-      const mills = entry.mills ?? 0;
-
-      const entryDate = new Date(mills);
-      const dayOfWeek = entryDate.getDay();
-      const dayKey = DAY_SERIES[dayOfWeek].key;
-
-      // Normalize to time-of-day only (minutes since midnight)
-      const minutesInDay = entryDate.getHours() * 60 + entryDate.getMinutes();
-      // Round to 5-minute buckets for grouping
-      const bucket = Math.round(minutesInDay / 5) * 5;
-
-      if (!timeMap.has(bucket)) {
-        // Create a date for x-axis (today's date + time-of-day)
-        const now = new Date();
-        const time = new Date(now.getFullYear(), now.getMonth(), now.getDate(), Math.floor(bucket / 60), bucket % 60);
-        timeMap.set(bucket, { time });
-      }
-
-      const row = timeMap.get(bucket)!;
-      // Average values if we already have data for this day/time slot
-      if (row[dayKey] !== undefined) {
-        row[dayKey] = ((row[dayKey] as number) + bg(entry.mgdl ?? 0)) / 2;
-      } else {
-        row[dayKey] = bg(entry.mgdl ?? 0);
-      }
-    }
-
-    // Sort by time
-    return Array.from(timeMap.values()).sort(
-      (a, b) => (a.time as Date).getTime() - (b.time as Date).getTime()
-    );
-  });
+  // Each cell is the mean of every reading in that weekday's 5-minute bucket.
+  const chartData = $derived(
+    buildWeekdayBuckets(reportsResource.current?.entries ?? [], (mgdl) => bg(mgdl))
+  );
 
   // Navigation helpers
   function previousWeek() {
@@ -135,11 +106,7 @@
         data={chartData}
         x="time"
         legend
-        series={DAY_SERIES.map((d) => ({
-          key: d.key,
-          label: d.label,
-          color: d.color,
-        }))}
+        series={DAY_SERIES}
       />
     {:else}
       <div

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/week-to-week/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/week-to-week/+page.svelte
@@ -6,6 +6,7 @@
   import { getReportsData } from "$api/reports.remote";
   import { requireDateParamsContext } from "$lib/hooks/date-params.svelte";
   import { contextResource } from "$lib/hooks/resource-context.svelte";
+  import { toDayString } from "$lib/utils/date-range";
   import { bg } from "$lib/utils/formatting";
 
   // Day of week series config
@@ -85,10 +86,7 @@
     newEnd.setDate(newEnd.getDate() - 1);
     const newStart = new Date(newEnd);
     newStart.setDate(newStart.getDate() - 6);
-    reportsParams.setCustomRange(
-      newStart.toISOString().split("T")[0],
-      newEnd.toISOString().split("T")[0]
-    );
+    reportsParams.setCustomRange(toDayString(newStart), toDayString(newEnd));
   }
 
   function nextWeek() {
@@ -96,10 +94,7 @@
     newStart.setDate(newStart.getDate() + 1);
     const newEnd = new Date(newStart);
     newEnd.setDate(newEnd.getDate() + 6);
-    reportsParams.setCustomRange(
-      newStart.toISOString().split("T")[0],
-      newEnd.toISOString().split("T")[0]
-    );
+    reportsParams.setCustomRange(toDayString(newStart), toDayString(newEnd));
   }
 
   function goToCurrentWeek() {

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/week-to-week/week-to-week.utils.test.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/week-to-week/week-to-week.utils.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { buildWeekdayBuckets } from "./week-to-week.utils";
+
+const identity = (mgdl: number) => mgdl;
+const ANCHOR = new Date(2026, 6, 25);
+
+/** 2026-07-20 is a Monday. */
+function monday(hour: number, minute: number, mgdl: number) {
+  return { mills: new Date(2026, 6, 20, hour, minute).getTime(), mgdl };
+}
+
+describe("buildWeekdayBuckets", () => {
+  it("keys a reading by its weekday", () => {
+    const rows = buildWeekdayBuckets([monday(8, 0, 120)], identity, ANCHOR);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].mon).toBe(120);
+  });
+
+  it("means two readings in the same cell", () => {
+    const rows = buildWeekdayBuckets(
+      [monday(8, 0, 100), monday(8, 1, 200)],
+      identity,
+      ANCHOR
+    );
+    expect(rows[0].mon).toBe(150);
+  });
+
+  it("means three readings in the same cell rather than halving the earlier ones", () => {
+    // The running-half formula gave 60/4 + 120/4 + 240/2 = 165 for these.
+    const rows = buildWeekdayBuckets(
+      [monday(8, 0, 60), monday(8, 1, 120), monday(8, 2, 240)],
+      identity,
+      ANCHOR
+    );
+    expect(rows[0].mon).toBe(140);
+  });
+
+  it("means four readings in the same cell", () => {
+    const rows = buildWeekdayBuckets(
+      [monday(8, 0, 100), monday(8, 0, 100), monday(8, 1, 100), monday(8, 1, 300)],
+      identity,
+      ANCHOR
+    );
+    expect(rows[0].mon).toBe(150);
+  });
+
+  it("means same-weekday readings from different weeks into one cell", () => {
+    const mondayA = { mills: new Date(2026, 6, 13, 8, 0).getTime(), mgdl: 100 };
+    const mondayB = { mills: new Date(2026, 6, 20, 8, 0).getTime(), mgdl: 200 };
+    const rows = buildWeekdayBuckets([mondayA, mondayB], identity, ANCHOR);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].mon).toBe(150);
+  });
+
+  it("keeps weekdays in separate series within one cell", () => {
+    const tuesday = { mills: new Date(2026, 6, 21, 8, 0).getTime(), mgdl: 200 };
+    const rows = buildWeekdayBuckets([monday(8, 0, 100), tuesday], identity, ANCHOR);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].mon).toBe(100);
+    expect(rows[0].tue).toBe(200);
+  });
+
+  it("rounds times into 5-minute cells", () => {
+    const rows = buildWeekdayBuckets(
+      [monday(8, 1, 100), monday(8, 2, 200), monday(8, 8, 300)],
+      identity,
+      ANCHOR
+    );
+    // 8:01 and 8:02 both round to 8:00; 8:08 rounds to 8:10.
+    expect(rows).toHaveLength(2);
+    expect(rows[0].mon).toBe(150);
+    expect(rows[1].mon).toBe(300);
+    expect(rows.map((r) => r.time.getMinutes())).toEqual([0, 10]);
+  });
+
+  it("sorts cells by time of day", () => {
+    const rows = buildWeekdayBuckets(
+      [monday(20, 0, 100), monday(6, 0, 100)],
+      identity,
+      ANCHOR
+    );
+    expect(rows.map((r) => r.time.getHours())).toEqual([6, 20]);
+  });
+
+  it("anchors every cell on the anchor's calendar day", () => {
+    const rows = buildWeekdayBuckets([monday(8, 0, 100)], identity, ANCHOR);
+    expect(rows[0].time.getFullYear()).toBe(2026);
+    expect(rows[0].time.getMonth()).toBe(6);
+    expect(rows[0].time.getDate()).toBe(25);
+    expect(rows[0].time.getHours()).toBe(8);
+  });
+
+  it("applies the unit conversion before averaging", () => {
+    const toMmol = (mgdl: number) => mgdl / 18;
+    const rows = buildWeekdayBuckets(
+      [monday(8, 0, 90), monday(8, 0, 180)],
+      toMmol,
+      ANCHOR
+    );
+    expect(rows[0].mon).toBeCloseTo(7.5, 5);
+  });
+
+  it("returns no rows for no readings", () => {
+    expect(buildWeekdayBuckets([], identity, ANCHOR)).toEqual([]);
+  });
+});

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/week-to-week/week-to-week.utils.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/week-to-week/week-to-week.utils.ts
@@ -1,0 +1,64 @@
+/** Series keys in `Date.getDay()` order, so a reading's weekday indexes straight in. */
+export const DAY_KEYS = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"] as const;
+
+export type DayKey = (typeof DAY_KEYS)[number];
+
+/** A chart row: the time-of-day plus one mean per weekday that has readings. */
+export type WeekdayBucketRow = { time: Date } & Partial<Record<DayKey, number>>;
+
+const BUCKET_MINUTES = 5;
+
+/**
+ * Group readings into 5-minute time-of-day buckets per weekday and average each
+ * cell. Readings accumulate as a sum and a count and are divided once — folding
+ * each new reading in as `(previous + next) / 2` weights the last reading at half
+ * the cell and halves every earlier one again, so any cell with more than two
+ * readings is not the mean.
+ *
+ * @param convert - Maps a mg/dL reading into the displayed unit.
+ * @param anchor - Date supplying the calendar day for the x-axis, which reads
+ *   only the time-of-day part.
+ */
+export function buildWeekdayBuckets(
+  entries: readonly { mills?: number; mgdl?: number }[],
+  convert: (mgdl: number) => number,
+  anchor: Date = new Date()
+): WeekdayBucketRow[] {
+  type Bucket = { time: Date; means: Map<DayKey, { sum: number; count: number }> };
+  const buckets = new Map<number, Bucket>();
+
+  for (const entry of entries) {
+    const at = new Date(entry.mills ?? 0);
+    const dayKey = DAY_KEYS[at.getDay()];
+    const minutesInDay = at.getHours() * 60 + at.getMinutes();
+    const bucket = Math.round(minutesInDay / BUCKET_MINUTES) * BUCKET_MINUTES;
+
+    let slot = buckets.get(bucket);
+    if (!slot) {
+      slot = {
+        time: new Date(
+          anchor.getFullYear(),
+          anchor.getMonth(),
+          anchor.getDate(),
+          Math.floor(bucket / 60),
+          bucket % 60
+        ),
+        means: new Map(),
+      };
+      buckets.set(bucket, slot);
+    }
+
+    const running = slot.means.get(dayKey) ?? { sum: 0, count: 0 };
+    running.sum += convert(entry.mgdl ?? 0);
+    running.count += 1;
+    slot.means.set(dayKey, running);
+  }
+
+  return Array.from(buckets.values())
+    .sort((a, b) => a.time.getTime() - b.time.getTime())
+    .map(({ time, means }) => {
+      const row: WeekdayBucketRow = { time };
+      for (const [dayKey, { sum, count }] of means) row[dayKey] = sum / count;
+      return row;
+    });
+}

--- a/src/Web/packages/app/src/routes/(authenticated)/time-spans/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/time-spans/+page.svelte
@@ -8,7 +8,13 @@
   import { ChevronLeft, ChevronRight, ArrowLeft } from "lucide-svelte";
   import { StateSpansTimeline } from "$lib/components/dashboard/state-spans-timeline";
   import { getTimeSpansData } from "./data.remote";
-  import { dayCount as countDays, resolveDayRange, startOfDay, toDayString } from "$lib/utils/date-range";
+  import {
+    dayCount as countDays,
+    isDayString,
+    resolveDayRange,
+    startOfDay,
+    toDayString,
+  } from "$lib/utils/date-range";
   import { useSearchParams } from "runed/kit";
   import { z } from "zod";
 
@@ -16,12 +22,14 @@
   // `toISOString()` named yesterday for anyone east of UTC.
   const defaults = resolveDayRange({ days: 7 }, 7);
 
-  const fromParam = $derived(
-    page.url.searchParams.get("from") ?? defaults.from
-  );
-  const toParam = $derived(
-    page.url.searchParams.get("to") ?? defaults.to
-  );
+  const fromParam = $derived.by(() => {
+    const fromUrl = page.url.searchParams.get("from");
+    return isDayString(fromUrl) ? fromUrl : defaults.from;
+  });
+  const toParam = $derived.by(() => {
+    const fromUrl = page.url.searchParams.get("to");
+    return isDayString(fromUrl) ? fromUrl : defaults.to;
+  });
 
   // Fetch data using remote function with date range
   const dataQuery = $derived(

--- a/src/Web/packages/app/src/routes/(authenticated)/time-spans/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/time-spans/+page.svelte
@@ -8,16 +8,17 @@
   import { ChevronLeft, ChevronRight, ArrowLeft } from "lucide-svelte";
   import { StateSpansTimeline } from "$lib/components/dashboard/state-spans-timeline";
   import { getTimeSpansData } from "./data.remote";
+  import { dayCount as countDays, resolveDayRange, startOfDay, toDayString } from "$lib/utils/date-range";
 
-  // Get date range from URL search params
-  const defaultFrom = new Date(Date.now() - 6 * 24 * 60 * 60 * 1000).toISOString().split("T")[0];
-  const defaultTo = new Date().toISOString().split("T")[0];
+  // Default range: the last 7 local calendar days. Deriving these from
+  // `toISOString()` named yesterday for anyone east of UTC.
+  const defaults = resolveDayRange({ days: 7 }, 7);
 
   const fromParam = $derived(
-    page.url.searchParams.get("from") ?? defaultFrom
+    page.url.searchParams.get("from") ?? defaults.from
   );
   const toParam = $derived(
-    page.url.searchParams.get("to") ?? defaultTo
+    page.url.searchParams.get("to") ?? defaults.to
   );
 
   // Fetch data using remote function with date range
@@ -26,19 +27,11 @@
   );
   const data = $derived(dataQuery.current);
 
-  // Parse dates for display and navigation
-  const fromDate = $derived(new Date(fromParam));
-  const toDate = $derived(new Date(toParam));
+  // Parse dates for display and navigation, as local days rather than UTC midnight
+  const fromDate = $derived(startOfDay(fromParam));
+  const toDate = $derived(startOfDay(toParam));
 
-  // Calculate number of days in range for display
-  const dayCount = $derived(
-    Math.max(
-      1,
-      Math.ceil(
-        (toDate.getTime() - fromDate.getTime()) / (24 * 60 * 60 * 1000)
-      ) + 1
-    )
-  );
+  const dayCount = $derived(countDays(fromParam, toParam));
 
   // Date range for the chart component
   const dateRange = $derived({
@@ -53,23 +46,15 @@
   let showOverrides = $state(true);
   let showActivities = $state(true);
 
-  // Date navigation - shift by the current range duration
-  function goToPreviousPeriod() {
-    const durationMs = toDate.getTime() - fromDate.getTime();
-    const newTo = new Date(fromDate.getTime() - 24 * 60 * 60 * 1000);
-    const newFrom = new Date(newTo.getTime() - durationMs);
+  /** Shift the window by whole days, keeping its length. */
+  function shiftPeriod(direction: -1 | 1) {
+    const anchor = direction === -1 ? fromDate : toDate;
+    const newFirst = new Date(anchor);
+    newFirst.setDate(newFirst.getDate() + direction * (direction === -1 ? dayCount : 1));
+    const newLast = new Date(newFirst);
+    newLast.setDate(newLast.getDate() + dayCount - 1);
     goto(
-      `/time-spans?from=${newFrom.toISOString().split("T")[0]}&to=${newTo.toISOString().split("T")[0]}`,
-      { invalidateAll: true }
-    );
-  }
-
-  function goToNextPeriod() {
-    const durationMs = toDate.getTime() - fromDate.getTime();
-    const newFrom = new Date(toDate.getTime() + 24 * 60 * 60 * 1000);
-    const newTo = new Date(newFrom.getTime() + durationMs);
-    goto(
-      `/time-spans?from=${newFrom.toISOString().split("T")[0]}&to=${newTo.toISOString().split("T")[0]}`,
+      `/time-spans?from=${toDayString(newFirst)}&to=${toDayString(newLast)}`,
       { invalidateAll: true }
     );
   }
@@ -112,7 +97,7 @@
 
         <!-- Date Navigation -->
         <div class="flex items-center gap-2">
-          <Button variant="outline" size="icon" onclick={goToPreviousPeriod}>
+          <Button variant="outline" size="icon" onclick={() => shiftPeriod(-1)}>
             <ChevronLeft class="h-4 w-4" />
           </Button>
           <div
@@ -120,7 +105,7 @@
           >
             <span class="text-lg font-medium">{dateRangeDisplay}</span>
           </div>
-          <Button variant="outline" size="icon" onclick={goToNextPeriod}>
+          <Button variant="outline" size="icon" onclick={() => shiftPeriod(1)}>
             <ChevronRight class="h-4 w-4" />
           </Button>
         </div>

--- a/src/Web/packages/app/src/routes/(authenticated)/time-spans/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/time-spans/+page.svelte
@@ -9,6 +9,8 @@
   import { StateSpansTimeline } from "$lib/components/dashboard/state-spans-timeline";
   import { getTimeSpansData } from "./data.remote";
   import { dayCount as countDays, resolveDayRange, startOfDay, toDayString } from "$lib/utils/date-range";
+  import { useSearchParams } from "runed/kit";
+  import { z } from "zod";
 
   // Default range: the last 7 local calendar days. Deriving these from
   // `toISOString()` named yesterday for anyone east of UTC.
@@ -39,12 +41,40 @@
     to: data?.dateRange.to ?? toDate,
   });
 
-  // Toggle states for each category (all enabled by default)
-  let showPumpModes = $state(true);
-  let showProfiles = $state(true);
-  let showTempBasals = $state(true);
-  let showOverrides = $state(true);
-  let showActivities = $state(true);
+  const CATEGORIES = [
+    { key: "pumpModes", label: "Pump Modes", color: "var(--pump-mode-automatic)" },
+    { key: "profiles", label: "Profiles", color: "var(--chart-1)" },
+    { key: "basal", label: "Basal", color: "var(--insulin-basal)" },
+    { key: "overrides", label: "Overrides", color: "var(--chart-2)" },
+    { key: "activities", label: "Activities", color: "var(--pump-mode-sleep)" },
+  ] as const;
+
+  type CategoryKey = (typeof CATEGORIES)[number]["key"];
+
+  // Every category shows by default; the hidden ones are named in the URL, so a
+  // timeline narrowed to one or two categories can be refreshed and shared.
+  const viewParams = useSearchParams(
+    z.object({ hide: z.string().nullable().default(null) }),
+    { showDefaults: false, noScroll: true }
+  );
+
+  const hidden = $derived(
+    new Set((viewParams.hide ?? "").split(",").filter(Boolean) as CategoryKey[])
+  );
+
+  const isShown = (key: CategoryKey) => !hidden.has(key);
+
+  function setShown(key: CategoryKey, shown: boolean) {
+    const next = new Set(hidden);
+    if (shown) next.delete(key);
+    else next.add(key);
+    viewParams.hide =
+      next.size > 0
+        ? CATEGORIES.filter((c) => next.has(c.key))
+            .map((c) => c.key)
+            .join(",")
+        : null;
+  }
 
   /** Shift the window by whole days, keeping its length. */
   function shiftPeriod(direction: -1 | 1) {
@@ -129,66 +159,21 @@
     <Card.Content>
       <!-- Category toggles -->
       <div class="flex flex-wrap gap-2 mb-4">
-        <Toggle
-          variant="outline"
-          size="sm"
-          bind:pressed={showPumpModes}
-          aria-label="Toggle pump modes"
-        >
-          <span
-            class="w-2 h-2 rounded-full mr-2"
-            style="background-color: var(--pump-mode-automatic);"
-          ></span>
-          Pump Modes
-        </Toggle>
-        <Toggle
-          variant="outline"
-          size="sm"
-          bind:pressed={showProfiles}
-          aria-label="Toggle profiles"
-        >
-          <span
-            class="w-2 h-2 rounded-full mr-2"
-            style="background-color: var(--chart-1);"
-          ></span>
-          Profiles
-        </Toggle>
-        <Toggle
-          variant="outline"
-          size="sm"
-          bind:pressed={showTempBasals}
-          aria-label="Toggle basal delivery"
-        >
-          <span
-            class="w-2 h-2 rounded-full mr-2"
-            style="background-color: var(--insulin-basal);"
-          ></span>
-          Basal
-        </Toggle>
-        <Toggle
-          variant="outline"
-          size="sm"
-          bind:pressed={showOverrides}
-          aria-label="Toggle overrides"
-        >
-          <span
-            class="w-2 h-2 rounded-full mr-2"
-            style="background-color: var(--chart-2);"
-          ></span>
-          Overrides
-        </Toggle>
-        <Toggle
-          variant="outline"
-          size="sm"
-          bind:pressed={showActivities}
-          aria-label="Toggle activities"
-        >
-          <span
-            class="w-2 h-2 rounded-full mr-2"
-            style="background-color: var(--pump-mode-sleep);"
-          ></span>
-          Activities
-        </Toggle>
+        {#each CATEGORIES as category (category.key)}
+          <Toggle
+            variant="outline"
+            size="sm"
+            pressed={isShown(category.key)}
+            onPressedChange={(pressed: boolean) => setShown(category.key, pressed)}
+            aria-label="Toggle {category.label.toLowerCase()}"
+          >
+            <span
+              class="w-2 h-2 rounded-full mr-2"
+              style="background-color: {category.color};"
+            ></span>
+            {category.label}
+          </Toggle>
+        {/each}
       </div>
 
       <!-- Timeline visualization -->
@@ -199,11 +184,11 @@
         overrideSpans={data?.overrideSpans ?? []}
         activitySpans={data?.activitySpans ?? []}
         {dateRange}
-        {showPumpModes}
-        {showProfiles}
-        {showTempBasals}
-        {showOverrides}
-        {showActivities}
+        showPumpModes={isShown("pumpModes")}
+        showProfiles={isShown("profiles")}
+        showTempBasals={isShown("basal")}
+        showOverrides={isShown("overrides")}
+        showActivities={isShown("activities")}
       />
     </Card.Content>
   </Card.Root>


### PR DESCRIPTION
> **Stacked on #555** — review that first; this PR's diff is against `refactor/reports-copy-and-theme`.

Two reports could disagree about what "last 14 days" meant, and Insulin Delivery showed 30-day statistics beside 7-day charts regardless of what was picked. There was no single source of truth for the selected range.

## The primitives

**The range end was exclusive and UTC-anchored.** `dateRangeMillis`/`startDate`/`endDate` did `new Date("2026-07-25").getTime()`, which parses a date-only string as **UTC midnight** — so every consumer silently lost the final day, and a UTC+10 user's window shifted 10 hours. Meanwhile `getDateRange()` on the *same hook* used `parseDate(...).toDate(getLocalTimeZone())` — local midnight. Two getters, ten hours apart, from one URL. All now route through one `$lib/utils/date-range.ts` with an inclusive local end-of-day.

**Day boundaries were computed in the server's timezone.** `calculateDateRange` parsed as UTC then mutated with `setHours()` inside a `query()`, i.e. server-local. On a UTC container a UTC+10 user asking for the 25th got 10:00 on the 25th → 09:59 on the 26th, and the response echoed the wrong bounds back so the mismatch was invisible. The helper was copy-pasted in three places while a correct primitive (`getLocalDayBoundariesUtc`) sat with two consumers. All three copies deleted for one `resolveReportRange` using the patient's therapy-settings timezone — **no backend change needed**.

**Three day-count formulas, one off by one.** `Math.round(ms / 86400000)` over local-midnight-to-local-midnight returns 6 for an inclusive 7-day window. Basal Analysis had its own copy and divided by it. Now one `dayCount` helper; five duplicate formulas deleted.

**`contextResource(…, { dateParams })` existed to supply exactly this and no page used it** — seven hand-rolled the block instead, with a `new Date()` fallback that rendered "today – today" on a failed fetch. Adopted everywhere; fallbacks removed.

**`contextResource` was last-write-wins.** Each registration wrote `ctx.loading/error/refetch` unconditionally, so two resources on one page overwrote each other — on Sleep, an actogram failure was masked by a successful trends fetch. The tell was that Comparison had hand-rolled the correct merge. Now a keyed map: loading = any, error = first, refetch = fan-out.

## Pages

- **Insulin Delivery** used `getMultiPeriodStatistics()`, which takes no arguments and returns fixed 1/3/7/30/90-day buckets, for every headline figure while its charts honoured the picker. Now uses the range-scoped endpoint that already existed.
- **Steps** froze its fetch window at mount but recomputed tiles reactively — changing the range gave "Total Steps 0" over a window nothing was fetched for.
- **Heart Rate** aggregated over the ±14-day padding, up to 28 days wider than the selection. `Math.min(...arr)` spreads replaced with a reducer (~60k arguments was a real `RangeError` risk).
- **Week-to-week** averaged with `(existing + new) / 2`, yielding `a/4 + b/4 + c/2` for three values.
- **Calendar** divided monthly TDD and carbs by days-with-CGM-readings. Also fixed a latent precedence bug, `d.totalReadings || 0 > 0`.
- **UTC-date defaults** made Day in Review, Time Spans and Comparison select and label the wrong day for non-UTC users.
- **URL state:** comparison (7 params), plus glucose-distribution, sleep, treatments and time-spans filters. Comparison's labels came from the draft while its numbers came from the committed range, so after Swap you saw A's numbers under B's label — fixed by making committed state *be* the URL.
- **Filter sidebar:** Reset went to 7 days regardless of the report's default and pinned it; three "Display Options" switches were hardcoded with no binding and no consumer, and are deleted.
- The shared range control is now hidden on the seven reports that ignore it.

## User-visible figures that change

These were overstated and are now correct — worth a release note:

| | change |
|---|---|
| Basal analysis units/day | **−14%** on a 7-day window (−7.1% on 14) — was dividing by 6 |
| Treatment log carbs/day, boluses/day | **−14%** on 7 days |
| Calendar month TDD, avg carbs | up to **−50%** in a month with 10 sensor-outage days |
| Insulin Delivery headline block | switches from fixed-30-day to the selected range |
| Heart Rate tiles | all change — described up to 28 days more than the selection |
| Week-to-week cells | every bucket with >2 readings moves |
| Battery footer | "over 6 days" → "over 7 days"; the last day's readings appear at all |
| All reports, UTC+ users | spans shift by the offset and gain the final day |

## Behaviour removal needing sign-off

**Scrolling the Steps actogram no longer moves the date picker.** Keeping `onVisibleRangeChange` makes a reactive fetch window impossible without a two-way offset binding on `Actogram`; Sleep, the reference implementation, has no writeback. Say if this should come back.

## Note

`parseDate` **throws** where `new Date()` returned Invalid Date, so this migration would have turned a hand-edited `?from=` or an unknown profile timezone into a render throw. `isDayString`/`isTimeZone` guards were added to prevent that.

Filter state uses `useSearchParams` rather than `<form method="GET">`: every control is a shadcn `Toggle`/`Select`/`Button`, not a native input, so a GET form would need a shadow set of hidden inputs for no JS-free benefit.

## Verification

`pnpm test:unit` 424 → **474 passed** (+50 tests covering inclusive bounds, DST-lengthened/shortened days, month/leap-year/year-boundary day counts, local-vs-UTC day strings, the week-to-week mean, and the multi-registration merge). `pnpm check` unchanged at 64 errors / 9 warnings before and after. Everything reactive was verified by reading only — `$effect.pre` registration ordering under real navigation, and comparison's 7-key `useSearchParams` round-trip, are not exercised in a browser.

## Follow-ups

Calendar TDD and avg carbs are still frontend-computed clinical aggregates (the backend month summary carries no insulin or carb totals). `getMultiPeriodStatistics` now has no caller in the reports area. Per-card loading during a range change is unfinished, and `basal-analysis` still blanks because its `{#key}` remount works around sveltejs/kit#14915. All filed separately.
