### PR TITLE
fix(cms): parse frontmatter in posts saved with CRLF line endings

### DIFF
--- a/src/Web/packages/cms/src/blog/manifest.test.ts
+++ b/src/Web/packages/cms/src/blog/manifest.test.ts
@@ -35,6 +35,65 @@ summary: A test post
     expect(meta).toBeNull();
   });
 
+  // A post authored on Windows arrives with CRLF. The delimiter pattern only accepted a
+  // bare newline, so such a post parsed as having no frontmatter, dropped out of the
+  // manifest and was never built — silently, with both check and build still passing, so
+  // only the live 404 revealed it.
+  it('parses frontmatter with CRLF line endings', () => {
+    const content = [
+      '---',
+      'title: Windows Post',
+      'slug: windows-post',
+      'date: 2026-04-12',
+      'tags: [announcement, release]',
+      'category: news',
+      'author: Rhys',
+      'summary: Authored with CRLF',
+      'draft: true',
+      '---',
+      '',
+      '# Content here',
+    ].join('\r\n');
+
+    const meta = parseFrontmatter(content, 'windows-post.svx');
+
+    expect(meta).toEqual({
+      title: 'Windows Post',
+      slug: 'windows-post',
+      date: '2026-04-12',
+      tags: ['announcement', 'release'],
+      category: 'news',
+      author: 'Rhys',
+      summary: 'Authored with CRLF',
+      image: undefined,
+      draft: true,
+    });
+  });
+
+  // Covers the parts a trailing trim() alone would not: the last entry of an inline array,
+  // and a boolean matched by exact value.
+  it('leaves no carriage returns in values parsed from CRLF content', () => {
+    const content = [
+      '---',
+      'title: Trailing CR',
+      'slug: trailing-cr',
+      'date: 2026-04-12',
+      'tags: [one, two]',
+      'category: news',
+      'author: Rhys',
+      'summary: No stray carriage returns',
+      'draft: true',
+      '---',
+      '# Body',
+    ].join('\r\n');
+
+    const meta = parseFrontmatter(content, 'trailing-cr.svx');
+
+    expect(meta?.tags).toEqual(['one', 'two']);
+    expect(meta?.draft).toBe(true);
+    expect(JSON.stringify(meta)).not.toContain('\\r');
+  });
+
   it('handles optional image and draft fields', () => {
     const content = `---
 title: Draft Post

--- a/src/Web/packages/cms/src/blog/manifest.ts
+++ b/src/Web/packages/cms/src/blog/manifest.ts
@@ -1,10 +1,16 @@
 import type { BlogPostMeta, BlogManifest } from './types.ts';
 
 export function parseFrontmatter(content: string, filename: string): BlogPostMeta | null {
-  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  // `\r?` matters: a post authored on Windows arrives with CRLF, and an `\n`-only
+  // delimiter silently fails to match. The post then parses as having no frontmatter,
+  // drops out of the manifest and is never built — with no error anywhere, so `check`
+  // and `build` both pass and only the live 404 reveals it.
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (!match) return null;
 
-  const yaml = match[1];
+  // Normalised so a CRLF body cannot leave a stray \r inside a value. Scalars are
+  // trimmed below, but array entries are split on ',' and would keep it.
+  const yaml = match[1].replace(/\r\n/g, '\n');
   const meta: Record<string, unknown> = {};
 
   for (const line of yaml.split('\n')) {


### PR DESCRIPTION
## The bug

`parseFrontmatter` matched its delimiters with a bare `\n`:

```ts
content.match(/^---\n([\s\S]*?)\n---/)
```

A post authored on Windows arrives with CRLF, so `^---\r\n` fails that match. `parseFrontmatter` returns `null`, the vite plugin skips the file, and the post never enters the blog manifest — so it is never built and its URL 404s.

**Nothing surfaces this.** `pnpm check` and `pnpm build` both pass, because a post that isn't in the manifest simply isn't a page. It was found downstream in nocturne-cloud only after a live 404 on a post that had been actively edited for hours.

## The fix

- Accept an optional `\r` on both delimiters.
- Normalise the captured block before splitting, so a CRLF body can't leave a stray `\r` inside an inline array entry. Scalar values were already `.trim()`ed, but array entries are split on `,` before trimming, so `tags: [a, b]` would have yielded `'b\r'`.

## Tests

Two regression tests, both of which **fail against the old pattern** (verified by reverting the regex):

- `parses frontmatter with CRLF line endings` — the whole-object assertion.
- `leaves no carriage returns in values parsed from CRLF content` — covers the inline-array tail and a boolean matched by exact value.

`npx vitest run src/blog/manifest.test.ts` → 9 passed.

## Note for reviewers

A `.gitattributes` entry normalising `*.svx` to LF would be a reasonable belt-and-braces addition, but it wouldn't help a file already committed with CRLF, or an author with a differently-configured editor — hence fixing the parser rather than only the inputs.