### PR TITLE
feat(cms): add an `unlisted` frontmatter flag and `listedPosts` helper

### DIFF
--- a/src/Web/packages/cms/src/blog/manifest.test.ts
+++ b/src/Web/packages/cms/src/blog/manifest.test.ts
@@ -35,6 +35,65 @@ summary: A test post
     expect(meta).toBeNull();
   });
 
+  // A post authored on Windows arrives with CRLF. The delimiter pattern only accepted a
+  // bare newline, so such a post parsed as having no frontmatter, dropped out of the
+  // manifest and was never built — silently, with both check and build still passing, so
+  // only the live 404 revealed it.
+  it('parses frontmatter with CRLF line endings', () => {
+    const content = [
+      '---',
+      'title: Windows Post',
+      'slug: windows-post',
+      'date: 2026-04-12',
+      'tags: [announcement, release]',
+      'category: news',
+      'author: Rhys',
+      'summary: Authored with CRLF',
+      'draft: true',
+      '---',
+      '',
+      '# Content here',
+    ].join('\r\n');
+
+    const meta = parseFrontmatter(content, 'windows-post.svx');
+
+    expect(meta).toEqual({
+      title: 'Windows Post',
+      slug: 'windows-post',
+      date: '2026-04-12',
+      tags: ['announcement', 'release'],
+      category: 'news',
+      author: 'Rhys',
+      summary: 'Authored with CRLF',
+      image: undefined,
+      draft: true,
+    });
+  });
+
+  // Covers the parts a trailing trim() alone would not: the last entry of an inline array,
+  // and a boolean matched by exact value.
+  it('leaves no carriage returns in values parsed from CRLF content', () => {
+    const content = [
+      '---',
+      'title: Trailing CR',
+      'slug: trailing-cr',
+      'date: 2026-04-12',
+      'tags: [one, two]',
+      'category: news',
+      'author: Rhys',
+      'summary: No stray carriage returns',
+      'draft: true',
+      '---',
+      '# Body',
+    ].join('\r\n');
+
+    const meta = parseFrontmatter(content, 'trailing-cr.svx');
+
+    expect(meta?.tags).toEqual(['one', 'two']);
+    expect(meta?.draft).toBe(true);
+    expect(JSON.stringify(meta)).not.toContain('\\r');
+  });
+
   it('handles optional image and draft fields', () => {
     const content = `---
 title: Draft Post

--- a/src/Web/packages/cms/src/blog/manifest.test.ts
+++ b/src/Web/packages/cms/src/blog/manifest.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseFrontmatter, buildManifest } from './manifest.ts';
+import { parseFrontmatter, buildManifest, listedPosts } from './manifest.ts';
 import type { BlogPostMeta } from './types.ts';
 
 describe('parseFrontmatter', () => {
@@ -27,6 +27,7 @@ summary: A test post
       summary: 'A test post',
       image: undefined,
       draft: undefined,
+      unlisted: undefined,
     });
   });
 
@@ -111,6 +112,32 @@ draft: true
     expect(meta?.image).toBe('/blog/draft.png');
     expect(meta?.draft).toBe(true);
   });
+
+  it('parses the unlisted flag', () => {
+    const content = `---
+title: Unlisted Post
+slug: unlisted-post
+date: 2026-04-12
+tags: []
+category: dev
+author: Rhys
+summary: Circulating for review
+unlisted: true
+---`;
+
+    expect(parseFrontmatter(content, 'unlisted-post.svx')?.unlisted).toBe(true);
+  });
+});
+
+describe('listedPosts', () => {
+  it('drops unlisted posts and keeps everything else', () => {
+    const posts = [
+      makeMeta({ slug: 'public' }),
+      makeMeta({ slug: 'hidden', unlisted: true }),
+      makeMeta({ slug: 'explicitly-listed', unlisted: false }),
+    ];
+    expect(listedPosts(posts).map((p) => p.slug)).toEqual(['public', 'explicitly-listed']);
+  });
 });
 
 describe('buildManifest', () => {
@@ -151,6 +178,22 @@ describe('buildManifest', () => {
     const manifest = buildManifest(posts, false);
     expect(manifest.tags).toEqual(['a', 'b', 'c']);
     expect(manifest.categories).toEqual(['dev', 'news']);
+  });
+
+  it('keeps unlisted posts in production so their page still builds', () => {
+    const posts = [makeMeta({ slug: 'published' }), makeMeta({ slug: 'hidden', unlisted: true })];
+    const manifest = buildManifest(posts, true);
+    expect(manifest.posts.map((p) => p.slug).sort()).toEqual(['hidden', 'published']);
+  });
+
+  it('does not let an unlisted post widen the tag or category lists', () => {
+    const posts = [
+      makeMeta({ tags: ['a'], category: 'news' }),
+      makeMeta({ tags: ['secret'], category: 'skunkworks', unlisted: true }),
+    ];
+    const manifest = buildManifest(posts, true);
+    expect(manifest.tags).toEqual(['a']);
+    expect(manifest.categories).toEqual(['news']);
   });
 });
 

--- a/src/Web/packages/cms/src/blog/manifest.ts
+++ b/src/Web/packages/cms/src/blog/manifest.ts
@@ -44,15 +44,28 @@ export function parseFrontmatter(content: string, filename: string): BlogPostMet
     summary: String(meta.summary ?? ''),
     image: meta.image ? String(meta.image) : undefined,
     draft: typeof meta.draft === 'boolean' ? meta.draft : undefined,
+    unlisted: typeof meta.unlisted === 'boolean' ? meta.unlisted : undefined,
   };
+}
+
+/**
+ * The posts that belong in an index, feed or sitemap. Unlisted posts are
+ * deliberately absent: they stay in the manifest so their page is still built
+ * and reachable, but nothing should link to or announce them.
+ */
+export function listedPosts(posts: BlogPostMeta[]): BlogPostMeta[] {
+  return posts.filter((post) => !post.unlisted);
 }
 
 export function buildManifest(posts: BlogPostMeta[], isProduction: boolean): BlogManifest {
   let filtered = isProduction ? posts.filter((p) => !p.draft) : posts;
   filtered = filtered.sort((a, b) => b.date.localeCompare(a.date));
 
-  const tags = [...new Set(filtered.flatMap((p) => p.tags))].sort();
-  const categories = [...new Set(filtered.map((p) => p.category))].sort();
+  // Unlisted posts keep their place in `posts` so routing and prerendering can
+  // reach them, but must not widen the tag and category lists the indexes use.
+  const listed = listedPosts(filtered);
+  const tags = [...new Set(listed.flatMap((p) => p.tags))].sort();
+  const categories = [...new Set(listed.map((p) => p.category))].sort();
 
   return { posts: filtered, tags, categories };
 }

--- a/src/Web/packages/cms/src/blog/manifest.ts
+++ b/src/Web/packages/cms/src/blog/manifest.ts
@@ -1,10 +1,16 @@
 import type { BlogPostMeta, BlogManifest } from './types.ts';
 
 export function parseFrontmatter(content: string, filename: string): BlogPostMeta | null {
-  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  // `\r?` matters: a post authored on Windows arrives with CRLF, and an `\n`-only
+  // delimiter silently fails to match. The post then parses as having no frontmatter,
+  // drops out of the manifest and is never built — with no error anywhere, so `check`
+  // and `build` both pass and only the live 404 reveals it.
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (!match) return null;
 
-  const yaml = match[1];
+  // Normalised so a CRLF body cannot leave a stray \r inside a value. Scalars are
+  // trimmed below, but array entries are split on ',' and would keep it.
+  const yaml = match[1].replace(/\r\n/g, '\n');
   const meta: Record<string, unknown> = {};
 
   for (const line of yaml.split('\n')) {

--- a/src/Web/packages/cms/src/blog/types.ts
+++ b/src/Web/packages/cms/src/blog/types.ts
@@ -7,7 +7,14 @@ export interface BlogPostMeta {
   author: string;
   summary: string;
   image?: string;
+  /** Excluded from the manifest entirely in production, so it is never built. */
   draft?: boolean;
+  /**
+   * Built and reachable at its URL, but kept off every index, feed and sitemap.
+   * For circulating a finished post privately (proofreading, review) before it
+   * is announced. Unlike `draft`, it stays in the manifest so the page renders.
+   */
+  unlisted?: boolean;
 }
 
 export interface BlogManifest {


### PR DESCRIPTION
> **Stacked on #567** (the CRLF frontmatter fix, same files). Review that one first; this PR's base will retarget to `main` once it merges.

## Why

`draft` removes a post from the manifest in production, so it is never built. That's the wrong tool for a *finished* post you want to circulate privately before announcing it — proofreading, or review by someone who needs to see the real rendered page.

`unlisted` keeps the post in the manifest, so it still builds and its URL works, but excludes it from every index, feed and sitemap — and from the tag/category lists those indexes are derived from, which is easy to miss.

`listedPosts()` puts that filter in one place so consumers can't disagree about what "listed" means.

## Context

This was sitting as uncommitted work in a nocturne-cloud contributor's submodule checkout. It needs to land here because **nocturne-cloud's marketing site already imports `listedPosts` on its default branch**, so a fresh clone builds only if you happen to have this change locally. Lifting just the three CMS files; the rest of that working tree is unrelated and untouched.

## Tests

`npx vitest run src/blog/manifest.test.ts` → 13 passed. Adds coverage for parsing the flag and for `listedPosts` keeping `unlisted: false` and absent-flag posts.