### PR TITLE
fix(connectors): file connector notifications under the tenant owner

### DIFF
--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -235,6 +235,7 @@ public static class ServiceRegistrationExtensions
             }, "Operator:Support:AccountBilling:Url is required when AccountBilling is configured");
 
         services.AddScoped<ITenantAccessor, HttpContextTenantAccessor>();
+        services.AddScoped<ITenantOwnerResolver, TenantOwnerResolver>();
         services.AddScoped<ITenantMemberService, TenantMemberService>();
         services.AddScoped<ITenantRoleService, TenantRoleService>();
         services.AddScoped<ITenantService, TenantService>();

--- a/src/API/Nocturne.API/Services/BackgroundServices/CompressionLowDetectionService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/CompressionLowDetectionService.cs
@@ -7,6 +7,7 @@ using Nocturne.Core.Contracts.Notifications;
 using Nocturne.Core.Contracts.Profiles;
 using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Contracts.Glucose;
+using Nocturne.Core.Contracts.Identity;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models;
@@ -724,20 +725,10 @@ public class CompressionLowDetectionService : BackgroundService, ICompressionLow
     /// <param name="scopedProvider">Scoped service provider for database access.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The owner's subject ID as a string, or <see langword="null"/>.</returns>
-    private async Task<string?> GetTenantOwnerSubjectIdAsync(
+    private static Task<string?> GetTenantOwnerSubjectIdAsync(
         Guid tenantId,
         IServiceProvider scopedProvider,
-        CancellationToken cancellationToken)
-    {
-        var factory = scopedProvider.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
-        await using var context = await factory.CreateDbContextAsync(cancellationToken);
-
-        var ownerSubjectId = await context.TenantMembers.AsNoTracking()
-            .Where(tm => tm.TenantId == tenantId
-                && tm.MemberRoles.Any(mr => mr.TenantRole.Slug == TenantPermissions.SeedRoles.Owner))
-            .Select(tm => tm.SubjectId)
-            .FirstOrDefaultAsync(cancellationToken);
-
-        return ownerSubjectId == Guid.Empty ? null : ownerSubjectId.ToString();
-    }
+        CancellationToken cancellationToken) =>
+        scopedProvider.GetRequiredService<ITenantOwnerResolver>()
+            .GetOwnerSubjectIdAsync(tenantId, cancellationToken);
 }

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/MetadataPublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/MetadataPublisher.cs
@@ -1,6 +1,8 @@
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Core.Contracts.Health;
 using Nocturne.Core.Contracts.Connectors;
+using Nocturne.Core.Contracts.Identity;
+using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Contracts.Profiles;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.Glucose;
@@ -19,8 +21,6 @@ namespace Nocturne.API.Services.ConnectorPublishing;
 /// <seealso cref="IMetadataPublisher"/>
 internal sealed class MetadataPublisher : IMetadataPublisher
 {
-    private const string DefaultUserId = "default";
-
     private readonly IProfileWriteService _profileWriteService;
     private readonly IFoodService _foodService;
     private readonly IConnectorFoodEntryService _connectorFoodEntryService;
@@ -28,6 +28,8 @@ internal sealed class MetadataPublisher : IMetadataPublisher
     private readonly IStateSpanService _stateSpanService;
     private readonly ISystemEventRepository _systemEventRepository;
     private readonly INoteRepository _noteRepository;
+    private readonly ITenantOwnerResolver _tenantOwnerResolver;
+    private readonly ITenantAccessor _tenantAccessor;
     private readonly ILogger<MetadataPublisher> _logger;
 
     public MetadataPublisher(
@@ -38,6 +40,8 @@ internal sealed class MetadataPublisher : IMetadataPublisher
         IStateSpanService stateSpanService,
         ISystemEventRepository systemEventRepository,
         INoteRepository noteRepository,
+        ITenantOwnerResolver tenantOwnerResolver,
+        ITenantAccessor tenantAccessor,
         ILogger<MetadataPublisher> logger)
     {
         _profileWriteService = profileWriteService ?? throw new ArgumentNullException(nameof(profileWriteService));
@@ -47,7 +51,40 @@ internal sealed class MetadataPublisher : IMetadataPublisher
         _stateSpanService = stateSpanService ?? throw new ArgumentNullException(nameof(stateSpanService));
         _systemEventRepository = systemEventRepository ?? throw new ArgumentNullException(nameof(systemEventRepository));
         _noteRepository = noteRepository ?? throw new ArgumentNullException(nameof(noteRepository));
+        _tenantOwnerResolver = tenantOwnerResolver ?? throw new ArgumentNullException(nameof(tenantOwnerResolver));
+        _tenantAccessor = tenantAccessor ?? throw new ArgumentNullException(nameof(tenantAccessor));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// The subject a connector's food entries are attributed to, so the match suggestions they raise
+    /// reach a real person. A sync has no user of its own, and the UI lists notifications for the
+    /// signed-in subject, so anything else is filed where nobody will ever see it.
+    /// </summary>
+    private async Task<string?> ResolveNotificationSubjectAsync(
+        string source,
+        CancellationToken cancellationToken)
+    {
+        if (!_tenantAccessor.IsResolved)
+        {
+            _logger.LogWarning(
+                "No tenant resolved while publishing for {Source}; cannot attribute its notifications",
+                source);
+            return null;
+        }
+
+        var subjectId = await _tenantOwnerResolver.GetOwnerSubjectIdAsync(
+            _tenantAccessor.TenantId, cancellationToken);
+
+        if (subjectId == null)
+        {
+            _logger.LogWarning(
+                "Tenant {TenantId} has no owner; {Source} food entries will import without match suggestions",
+                _tenantAccessor.TenantId,
+                source);
+        }
+
+        return subjectId;
     }
 
     public async Task<bool> PublishProfilesAsync(
@@ -94,7 +131,7 @@ internal sealed class MetadataPublisher : IMetadataPublisher
         try
         {
             return await _connectorFoodEntryService.ImportAsync(
-                DefaultUserId,
+                await ResolveNotificationSubjectAsync(source, cancellationToken),
                 entries,
                 cancellationToken);
         }

--- a/src/API/Nocturne.API/Services/Connectors/ConnectorFoodEntryService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/ConnectorFoodEntryService.cs
@@ -32,7 +32,7 @@ public class ConnectorFoodEntryService : IConnectorFoodEntryService
     }
 
     public async Task<IReadOnlyList<ConnectorFoodEntry>> ImportAsync(
-        string userId,
+        string? userId,
         IEnumerable<ConnectorFoodEntryImport> imports,
         CancellationToken cancellationToken = default
     )
@@ -181,7 +181,9 @@ public class ConnectorFoodEntryService : IConnectorFoodEntryService
             .Select(r => r.Id)
             .ToList();
 
-        if (newEntryIds.Count > 0)
+        // Importing does not depend on having someone to notify, so a tenant without a resolvable
+        // owner still gets its entries and its suggestion list; only the notifications are skipped.
+        if (newEntryIds.Count > 0 && !string.IsNullOrEmpty(userId))
         {
             try
             {

--- a/src/API/Nocturne.API/Services/Identity/TenantOwnerResolver.cs
+++ b/src/API/Nocturne.API/Services/Identity/TenantOwnerResolver.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using Nocturne.Core.Contracts.Identity;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Infrastructure.Data;
+
+namespace Nocturne.API.Services.Identity;
+
+/// <inheritdoc cref="ITenantOwnerResolver"/>
+public class TenantOwnerResolver : ITenantOwnerResolver
+{
+    private readonly IDbContextFactory<NocturneDbContext> _contextFactory;
+
+    public TenantOwnerResolver(IDbContextFactory<NocturneDbContext> contextFactory)
+    {
+        _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> GetOwnerSubjectIdAsync(
+        Guid tenantId,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var ownerSubjectId = await context.TenantMembers.AsNoTracking()
+            .Where(tm => tm.TenantId == tenantId
+                && tm.MemberRoles.Any(mr => mr.TenantRole.Slug == TenantPermissions.SeedRoles.Owner))
+            .Select(tm => tm.SubjectId)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return ownerSubjectId == Guid.Empty ? null : ownerSubjectId.ToString();
+    }
+}

--- a/src/Core/Nocturne.Core.Contracts/Connectors/IConnectorFoodEntryService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Connectors/IConnectorFoodEntryService.cs
@@ -12,11 +12,14 @@ public interface IConnectorFoodEntryService
     /// <summary>
     /// Import connector food entries, deduplicating foods and entries as needed.
     /// </summary>
-    /// <param name="userId">The user ID for meal matching notifications</param>
+    /// <param name="userId">
+    /// Subject the match suggestions are raised for. Null when the caller has no subject to
+    /// attribute them to; the entries still import, without suggestions.
+    /// </param>
     /// <param name="imports">The food entry imports to process</param>
     /// <param name="cancellationToken">Cancellation token</param>
     Task<IReadOnlyList<ConnectorFoodEntry>> ImportAsync(
-        string userId,
+        string? userId,
         IEnumerable<ConnectorFoodEntryImport> imports,
         CancellationToken cancellationToken = default
     );

--- a/src/Core/Nocturne.Core.Contracts/Identity/ITenantOwnerResolver.cs
+++ b/src/Core/Nocturne.Core.Contracts/Identity/ITenantOwnerResolver.cs
@@ -1,0 +1,20 @@
+namespace Nocturne.Core.Contracts.Identity;
+
+/// <summary>
+/// Resolves the subject a tenant's background work should be attributed to.
+/// </summary>
+/// <remarks>
+/// In-app notifications are keyed by subject id, not tenant id, so anything raised outside a request
+/// — a connector sync, a detection pass — has no user of its own and must borrow one. A placeholder
+/// is not viable: the UI lists notifications for the signed-in subject, so a notification filed under
+/// anything else is created, counted against rate limits, and never seen.
+/// </remarks>
+public interface ITenantOwnerResolver
+{
+    /// <summary>
+    /// Returns the subject id of the tenant's owner, or <c>null</c> when the tenant has none.
+    /// </summary>
+    /// <param name="tenantId">The tenant whose owner is wanted.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<string?> GetOwnerSubjectIdAsync(Guid tenantId, CancellationToken cancellationToken = default);
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/MetadataPublisherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/MetadataPublisherTests.cs
@@ -8,6 +8,8 @@ using Nocturne.Core.Contracts.Connectors;
 using Nocturne.Core.Contracts.Profiles;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.Glucose;
+using Nocturne.Core.Contracts.Identity;
+using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Contracts.Repositories;
 using Nocturne.Core.Models;
@@ -26,6 +28,11 @@ public class MetadataPublisherTests
     private readonly Mock<IStateSpanService> _mockStateSpanService;
     private readonly Mock<INoteRepository> _mockNoteRepository;
     private readonly Mock<ISystemEventRepository> _mockSystemEventRepository;
+    private readonly Mock<ITenantOwnerResolver> _mockTenantOwnerResolver;
+    private readonly Mock<ITenantAccessor> _mockTenantAccessor;
+
+    private static readonly Guid TenantId = Guid.NewGuid();
+    private const string OwnerSubjectId = "0199aaaa-bbbb-cccc-dddd-eeeeffff0000";
 
     public MetadataPublisherTests()
     {
@@ -36,6 +43,15 @@ public class MetadataPublisherTests
         _mockStateSpanService = new Mock<IStateSpanService>();
         _mockNoteRepository = new Mock<INoteRepository>();
         _mockSystemEventRepository = new Mock<ISystemEventRepository>();
+
+        _mockTenantAccessor = new Mock<ITenantAccessor>();
+        _mockTenantAccessor.Setup(t => t.IsResolved).Returns(true);
+        _mockTenantAccessor.Setup(t => t.TenantId).Returns(TenantId);
+
+        _mockTenantOwnerResolver = new Mock<ITenantOwnerResolver>();
+        _mockTenantOwnerResolver
+            .Setup(r => r.GetOwnerSubjectIdAsync(TenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OwnerSubjectId);
     }
 
     private MetadataPublisher CreatePublisher()
@@ -48,8 +64,45 @@ public class MetadataPublisherTests
             _mockStateSpanService.Object,
             _mockSystemEventRepository.Object,
             _mockNoteRepository.Object,
+            _mockTenantOwnerResolver.Object,
+            _mockTenantAccessor.Object,
             NullLogger<MetadataPublisher>.Instance
         );
+    }
+
+    [Fact]
+    public async Task PublishConnectorFoodEntriesAsync_AttributesEntriesToTheTenantOwner()
+    {
+        // Notifications are keyed by subject id and the UI lists them for the signed-in subject, so
+        // a connector filing them under anything else raises suggestions nobody can see.
+        await CreatePublisher().PublishConnectorFoodEntriesAsync(
+            [new ConnectorFoodEntryImport()], "myfitnesspal-connector", WriteOrigin.Live);
+
+        _mockConnectorFoodEntryService.Verify(
+            s => s.ImportAsync(
+                OwnerSubjectId,
+                It.IsAny<IEnumerable<ConnectorFoodEntryImport>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task PublishConnectorFoodEntriesAsync_StillImportsWhenTheTenantHasNoOwner()
+    {
+        _mockTenantOwnerResolver
+            .Setup(r => r.GetOwnerSubjectIdAsync(TenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        await CreatePublisher().PublishConnectorFoodEntriesAsync(
+            [new ConnectorFoodEntryImport()], "myfitnesspal-connector", WriteOrigin.Live);
+
+        // The data still lands; only the suggestions it would have raised are skipped.
+        _mockConnectorFoodEntryService.Verify(
+            s => s.ImportAsync(
+                null,
+                It.IsAny<IEnumerable<ConnectorFoodEntryImport>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]
@@ -87,7 +140,7 @@ public class MetadataPublisherTests
     {
         var entries = new List<ConnectorFoodEntryImport> { new() };
         _mockConnectorFoodEntryService
-            .Setup(s => s.ImportAsync("default", It.IsAny<IEnumerable<ConnectorFoodEntryImport>>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.ImportAsync(OwnerSubjectId, It.IsAny<IEnumerable<ConnectorFoodEntryImport>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<ConnectorFoodEntry> { new() });
 
         var publisher = CreatePublisher();
@@ -96,7 +149,7 @@ public class MetadataPublisherTests
         result.Should().NotBeNull();
         result.Should().HaveCount(1);
         _mockConnectorFoodEntryService.Verify(
-            s => s.ImportAsync("default", It.IsAny<IEnumerable<ConnectorFoodEntryImport>>(), It.IsAny<CancellationToken>()),
+            s => s.ImportAsync(OwnerSubjectId, It.IsAny<IEnumerable<ConnectorFoodEntryImport>>(), It.IsAny<CancellationToken>()),
             Times.Once
         );
     }


### PR DESCRIPTION
## Why

In-app notifications are keyed by **subject id**, and the UI lists them for the signed-in subject (`NotificationsController` → `HttpContext.GetSubjectIdString()`). Connector-published ones were filed under the literal string `"default"`:

```csharp
private const string DefaultUserId = "default";
...
await _connectorFoodEntryService.ImportAsync(DefaultUserId, entries, cancellationToken);
```

Nothing reads that user. So every meal-match suggestion a connector raised was created, counted against the per-source active-notification cap, and **never shown to anyone**. Accept and dismiss (`MealMatchingController`) archive under the real subject id, so they never matched those rows either — they stayed active forever, quietly consuming the cap of 10 per source.

The notification half of meal matching has never worked for a real user.

## What

A sync has no user of its own, so it borrows the tenant's owner. That is not a new idea here — `CompressionLowDetectionService` already did exactly this, and its comment names the problem outright:

> Notifications are keyed by subject ID (not tenant ID). Look up the tenant owner so the notification is attributed to an actual user.

That lookup is now `ITenantOwnerResolver`, and both callers share it rather than the second copying the first.

A tenant with **no** resolvable owner still imports its entries and still builds its suggestion list — that is read on demand by `GetSuggestionsAsync` and needs no subject. Only the notifications are skipped, and the reason is logged. That is why `userId` on `IConnectorFoodEntryService.ImportAsync` is now nullable: ingesting data must not depend on there being somebody to notify.

## Testing

Verified end-to-end on a local stack against a real connector account, not only unit tests:

- an imported food entry matching a treatment raises a suggestion whose `user_id` is the owner's subject id
- `GET /api/v4/notifications` returns it to that signed-in subject, with its `accept` / `review` / `dismiss` actions
- `POST /api/v4/meal-matching/dismiss` archives it and the list empties

Every one of those steps was previously invisible.

One existing test asserted `ImportAsync("default", …)` — it was pinning the bug in place, so it is updated rather than worked around.

API suite 4172 passed / 1 failed (`CacheIntegrationTests.CreateEntriesAsync_DecomposesToV4AndFiresEvents`, pre-existing and failing identically on `main`).

## Notes

- Pre-existing `"default"` rows are left alone: they are unreachable, tenant-scoped, and rate-limit only the pseudo-user they were filed under. Deleting them would be a data migration to remove records nobody can see.
- The active-notification cap is per **source** rather than per entry, so a user with 11+ simultaneously-matching pending entries still loses the last ones. Pre-existing and out of scope here — it affects every notification source, not just connectors.

Split out of #550, which found this while testing the MyFitnessPal connector end-to-end but does not depend on it.
