### PR TITLE
feat(portal): sponsorship tiers in docs, fix get-involved links

### DIFF
--- a/src/Web/packages/portal/src/lib/components/docs/SupportNocturne.svelte
+++ b/src/Web/packages/portal/src/lib/components/docs/SupportNocturne.svelte
@@ -1,52 +1,48 @@
 <script lang="ts">
     import { Heart, ArrowUpRight } from "@lucide/svelte";
+    import { LINKS } from "$lib/data/links";
 
-    type Props = {
-        /** Heading above the tiers. Pass null to render the tiers on their own. */
-        title?: string | null;
-        blurb?: string;
-        class?: string;
-    };
+    // Matches the portal accent used on the get-involved page. Not the
+    // --glucose-in-range token, which theme packs swap to green.
+    const ACCENT = "oklch(0.6 0.118 184.704)";
 
-    let {
-        title = "Support Nocturne",
-        blurb = "Nocturne is free, open source, and run by volunteers under the Nightscout Foundation, a registered non-profit. A monthly subscription covers servers, test devices, and the maintenance that keeps self-hosting working.",
-        class: className = "",
-    }: Props = $props();
+    let { class: className = "" }: { class?: string } = $props();
 
     const TIERS = [
         {
-            amount: "$10",
+            amount: "US$10",
             name: "Supporter",
             desc: "Covers the hosting behind the docs, the container registry, and the release pipeline.",
-            href: "https://buy.stripe.com/14A9AV4Gm9Dh1ribpXgIo02",
+            href: LINKS.subscribe10,
             featured: false,
         },
         {
-            amount: "$20",
+            amount: "US$20",
             name: "Sustainer",
             desc: "Adds test hardware — pumps, CGM transmitters, and phones the connectors are verified against.",
-            href: "https://buy.stripe.com/cNifZj4Gm3eT3zqeC9gIo01",
+            href: LINKS.subscribe20,
             featured: true,
         },
         {
-            amount: "$50",
+            amount: "US$50",
             name: "Patron",
             desc: "Funds sustained maintainer time on connectors, security updates, and support.",
-            href: "https://buy.stripe.com/4gMcN78WC8zdda01PngIo00",
+            href: LINKS.subscribe50,
             featured: false,
         },
     ];
 </script>
 
-<section class="not-prose {className}">
-    {#if title}
-        <h2 class="text-2xl font-bold mb-3 flex items-center gap-2.5">
-            <Heart class="w-5 h-5 text-primary shrink-0" />
-            {title}
-        </h2>
-    {/if}
-    <p class="text-muted-foreground mb-5">{blurb}</p>
+<section class="not-prose mt-12 pt-8 border-t border-border/60 {className}">
+    <h2 class="text-2xl font-bold mb-3 flex items-center gap-2.5">
+        <Heart class="w-5 h-5 shrink-0" color={ACCENT} aria-hidden="true" />
+        Support Nocturne
+    </h2>
+    <p class="text-muted-foreground mb-5">
+        Nocturne is free and always will be. A monthly subscription to the
+        Nightscout Foundation covers servers, test devices, and the maintenance
+        that keeps self-hosting working.
+    </p>
 
     <div class="grid gap-4 sm:grid-cols-3">
         {#each TIERS as tier (tier.name)}
@@ -55,8 +51,9 @@
                 target="_blank"
                 rel="noopener noreferrer"
                 class="group flex flex-col p-5 rounded-xl border transition-colors {tier.featured
-                    ? 'border-primary/40 bg-primary/5 hover:border-primary/60'
-                    : 'border-border/60 bg-card/50 hover:bg-card hover:border-primary/30'}"
+                    ? 'sn-featured'
+                    : 'border-border/60 bg-card/50 hover:bg-card'}"
+                style="--sn-accent: {ACCENT}"
             >
                 <div class="flex items-baseline gap-1.5">
                     <span class="text-3xl font-bold tracking-tight tabular-nums"
@@ -65,9 +62,10 @@
                     <span class="text-sm text-muted-foreground">/ month</span>
                 </div>
                 <div
-                    class="mt-1 text-xs font-semibold tracking-[0.08em] uppercase {tier.featured
-                        ? 'text-primary'
-                        : 'text-muted-foreground'}"
+                    class="mt-1 text-xs font-semibold tracking-[0.08em] uppercase"
+                    style={tier.featured
+                        ? `color: ${ACCENT}`
+                        : "color: var(--muted-foreground)"}
                 >
                     {tier.name}
                 </div>
@@ -75,25 +73,44 @@
                     {tier.desc}
                 </p>
                 <span
-                    class="mt-4 inline-flex items-center gap-1.5 text-sm font-semibold text-primary"
+                    class="sn-cta mt-4 inline-flex items-center gap-1.5 text-sm font-semibold"
+                    style="color: {ACCENT}"
                 >
                     Subscribe
-                    <ArrowUpRight
-                        class="w-4 h-4 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
-                    />
+                    <ArrowUpRight class="w-4 h-4" aria-hidden="true" />
                 </span>
             </a>
         {/each}
     </div>
 
     <p class="mt-4 text-xs text-muted-foreground">
-        Secure checkout via Stripe &middot; Cancel any time &middot; One-off donations go
-        through the
+        Secure checkout via Stripe &middot; Cancel any time &middot; One-off
+        donations go through the
         <a
-            href="https://www.nightscoutfoundation.org/donate"
+            href={LINKS.donate}
             target="_blank"
             rel="noopener noreferrer"
-            class="text-primary hover:underline">Nightscout Foundation</a
+            class="font-semibold hover:underline"
+            style="color: {ACCENT}">Nightscout Foundation</a
         >.
     </p>
 </section>
+
+<style>
+    .sn-featured {
+        border-color: color-mix(in oklch, var(--sn-accent), transparent 45%);
+        background: color-mix(in oklch, var(--sn-accent), var(--card) 88%);
+    }
+
+    a:hover:not(.sn-featured) {
+        border-color: color-mix(in oklch, var(--sn-accent), transparent 55%);
+    }
+
+    .sn-cta :global(svg) {
+        transition: transform 0.15s;
+    }
+
+    a:hover .sn-cta :global(svg) {
+        transform: translate(2px, -2px);
+    }
+</style>

--- a/src/Web/packages/portal/src/lib/components/docs/SupportNocturne.svelte
+++ b/src/Web/packages/portal/src/lib/components/docs/SupportNocturne.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+    import { Heart, ArrowUpRight } from "@lucide/svelte";
+
+    type Props = {
+        /** Heading above the tiers. Pass null to render the tiers on their own. */
+        title?: string | null;
+        blurb?: string;
+        class?: string;
+    };
+
+    let {
+        title = "Support Nocturne",
+        blurb = "Nocturne is free, open source, and run by volunteers under the Nightscout Foundation, a registered non-profit. A monthly subscription covers servers, test devices, and the maintenance that keeps self-hosting working.",
+        class: className = "",
+    }: Props = $props();
+
+    const TIERS = [
+        {
+            amount: "$10",
+            name: "Supporter",
+            desc: "Covers the hosting behind the docs, the container registry, and the release pipeline.",
+            href: "https://buy.stripe.com/14A9AV4Gm9Dh1ribpXgIo02",
+            featured: false,
+        },
+        {
+            amount: "$20",
+            name: "Sustainer",
+            desc: "Adds test hardware — pumps, CGM transmitters, and phones the connectors are verified against.",
+            href: "https://buy.stripe.com/cNifZj4Gm3eT3zqeC9gIo01",
+            featured: true,
+        },
+        {
+            amount: "$50",
+            name: "Patron",
+            desc: "Funds sustained maintainer time on connectors, security updates, and support.",
+            href: "https://buy.stripe.com/4gMcN78WC8zdda01PngIo00",
+            featured: false,
+        },
+    ];
+</script>
+
+<section class="not-prose {className}">
+    {#if title}
+        <h2 class="text-2xl font-bold mb-3 flex items-center gap-2.5">
+            <Heart class="w-5 h-5 text-primary shrink-0" />
+            {title}
+        </h2>
+    {/if}
+    <p class="text-muted-foreground mb-5">{blurb}</p>
+
+    <div class="grid gap-4 sm:grid-cols-3">
+        {#each TIERS as tier (tier.name)}
+            <a
+                href={tier.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="group flex flex-col p-5 rounded-xl border transition-colors {tier.featured
+                    ? 'border-primary/40 bg-primary/5 hover:border-primary/60'
+                    : 'border-border/60 bg-card/50 hover:bg-card hover:border-primary/30'}"
+            >
+                <div class="flex items-baseline gap-1.5">
+                    <span class="text-3xl font-bold tracking-tight tabular-nums"
+                        >{tier.amount}</span
+                    >
+                    <span class="text-sm text-muted-foreground">/ month</span>
+                </div>
+                <div
+                    class="mt-1 text-xs font-semibold tracking-[0.08em] uppercase {tier.featured
+                        ? 'text-primary'
+                        : 'text-muted-foreground'}"
+                >
+                    {tier.name}
+                </div>
+                <p class="mt-3 text-sm text-muted-foreground leading-relaxed flex-1">
+                    {tier.desc}
+                </p>
+                <span
+                    class="mt-4 inline-flex items-center gap-1.5 text-sm font-semibold text-primary"
+                >
+                    Subscribe
+                    <ArrowUpRight
+                        class="w-4 h-4 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+                    />
+                </span>
+            </a>
+        {/each}
+    </div>
+
+    <p class="mt-4 text-xs text-muted-foreground">
+        Secure checkout via Stripe &middot; Cancel any time &middot; One-off donations go
+        through the
+        <a
+            href="https://www.nightscoutfoundation.org/donate"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-primary hover:underline">Nightscout Foundation</a
+        >.
+    </p>
+</section>

--- a/src/Web/packages/portal/src/lib/data/links.ts
+++ b/src/Web/packages/portal/src/lib/data/links.ts
@@ -1,0 +1,16 @@
+/** Outbound links shared across portal pages. */
+export const LINKS = {
+  discord: "https://discord.gg/sKEhtHeb2z",
+  donate: "https://www.nightscoutfoundation.org/donate",
+  githubLabel: "https://github.com/nightscout/nocturne/labels/get-involved",
+  github: "https://github.com/nightscout/nocturne",
+  facebook: "https://www.facebook.com/groups/cgminthecloud",
+  hackDiabetes: "https://hackdiabetes.io",
+  testimonials: "mailto:testimonials@nocturne.run",
+  researchData: "mailto:research-data@nocturne.run",
+
+  // Stripe payment links for the monthly support tiers.
+  subscribe10: "https://buy.stripe.com/14A9AV4Gm9Dh1ribpXgIo02",
+  subscribe20: "https://buy.stripe.com/cNifZj4Gm3eT3zqeC9gIo01",
+  subscribe50: "https://buy.stripe.com/4gMcN78WC8zdda01PngIo00",
+} as const;

--- a/src/Web/packages/portal/src/routes/docs/+page.svelte
+++ b/src/Web/packages/portal/src/routes/docs/+page.svelte
@@ -123,7 +123,7 @@
         </a>
     </div>
 
-    <SupportNocturne class="mt-12" />
+    <SupportNocturne />
 
     <div class="mt-12 p-6 rounded-xl border border-amber-500/30 bg-amber-500/5">
         <div class="flex items-start gap-3">

--- a/src/Web/packages/portal/src/routes/docs/+page.svelte
+++ b/src/Web/packages/portal/src/routes/docs/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import Content from "../../content/docs/index.svx";
+    import SupportNocturne from "$lib/components/docs/SupportNocturne.svelte";
     import {
         ArrowRight,
         Book,
@@ -121,6 +122,8 @@
             </div>
         </a>
     </div>
+
+    <SupportNocturne class="mt-12" />
 
     <div class="mt-12 p-6 rounded-xl border border-amber-500/30 bg-amber-500/5">
         <div class="flex items-start gap-3">

--- a/src/Web/packages/portal/src/routes/docs/installation/byo-postgres/+page.svelte
+++ b/src/Web/packages/portal/src/routes/docs/installation/byo-postgres/+page.svelte
@@ -108,5 +108,5 @@
         </li>
     </ul>
 
-    <SupportNocturne class="mt-12 pt-8 border-t border-border/60" />
+    <SupportNocturne />
 </div>

--- a/src/Web/packages/portal/src/routes/docs/installation/byo-postgres/+page.svelte
+++ b/src/Web/packages/portal/src/routes/docs/installation/byo-postgres/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { Database } from "@lucide/svelte";
     import CodeBlock from "$lib/components/docs/CodeBlock.svelte";
+    import SupportNocturne from "$lib/components/docs/SupportNocturne.svelte";
     import bootstrapSql from "$lib/release/bootstrap-roles.sql?raw";
 </script>
 
@@ -106,4 +107,6 @@
             <code class="text-xs bg-muted/50 px-1 py-0.5 rounded">postgres</code> user.
         </li>
     </ul>
+
+    <SupportNocturne class="mt-12 pt-8 border-t border-border/60" />
 </div>

--- a/src/Web/packages/portal/src/routes/docs/installation/docker-compose/+page.svelte
+++ b/src/Web/packages/portal/src/routes/docs/installation/docker-compose/+page.svelte
@@ -110,5 +110,5 @@
     <h2 class="text-2xl font-bold mt-8 mb-4">Next Steps</h2>
     <NextSteps />
 
-    <SupportNocturne class="mt-12 pt-8 border-t border-border/60" />
+    <SupportNocturne />
 </div>

--- a/src/Web/packages/portal/src/routes/docs/installation/docker-compose/+page.svelte
+++ b/src/Web/packages/portal/src/routes/docs/installation/docker-compose/+page.svelte
@@ -2,6 +2,7 @@
     import SystemRequirements from "$lib/components/docs/SystemRequirements.svelte";
     import VerificationSteps from "$lib/components/docs/VerificationSteps.svelte";
     import NextSteps from "$lib/components/docs/NextSteps.svelte";
+    import SupportNocturne from "$lib/components/docs/SupportNocturne.svelte";
     import PasswordGenerator from "$lib/components/docs/PasswordGenerator.svelte";
     import CodeBlock from "$lib/components/docs/CodeBlock.svelte";
     import envExample from "$lib/release/docker-compose/.env.example?raw";
@@ -108,4 +109,6 @@
 
     <h2 class="text-2xl font-bold mt-8 mb-4">Next Steps</h2>
     <NextSteps />
+
+    <SupportNocturne class="mt-12 pt-8 border-t border-border/60" />
 </div>

--- a/src/Web/packages/portal/src/routes/docs/installation/portainer/+page.svelte
+++ b/src/Web/packages/portal/src/routes/docs/installation/portainer/+page.svelte
@@ -148,5 +148,5 @@
     <h2 class="text-2xl font-bold mt-8 mb-4">Next Steps</h2>
     <NextSteps />
 
-    <SupportNocturne class="mt-12 pt-8 border-t border-border/60" />
+    <SupportNocturne />
 </div>

--- a/src/Web/packages/portal/src/routes/docs/installation/portainer/+page.svelte
+++ b/src/Web/packages/portal/src/routes/docs/installation/portainer/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import NextSteps from "$lib/components/docs/NextSteps.svelte";
+    import SupportNocturne from "$lib/components/docs/SupportNocturne.svelte";
     import PasswordGenerator from "$lib/components/docs/PasswordGenerator.svelte";
     import CodeBlock from "$lib/components/docs/CodeBlock.svelte";
     import { Info } from "@lucide/svelte";
@@ -146,4 +147,6 @@
 
     <h2 class="text-2xl font-bold mt-8 mb-4">Next Steps</h2>
     <NextSteps />
+
+    <SupportNocturne class="mt-12 pt-8 border-t border-border/60" />
 </div>

--- a/src/Web/packages/portal/src/routes/features/+page.svelte
+++ b/src/Web/packages/portal/src/routes/features/+page.svelte
@@ -236,7 +236,7 @@
                     "A handful of reports, all built in 2014",
                     "Each device needs a separate uploader app",
                     "Alarms = an on/off threshold, nothing more",
-                    "Username & password — for life",
+                    "API secrets that you can't remember",
                     "Slows down after a year of readings",
                 ] as line (line)}
                     <div class="flex items-center gap-3 text-[1rem] text-muted-foreground/70">

--- a/src/Web/packages/portal/src/routes/get-involved/+page.svelte
+++ b/src/Web/packages/portal/src/routes/get-involved/+page.svelte
@@ -23,6 +23,10 @@
     donate: "https://www.nightscoutfoundation.org/donate",
     githubLabel: "https://github.com/nightscout/nocturne/labels/get-involved",
     github: "https://github.com/nightscout/nocturne",
+    facebook: "https://www.facebook.com/groups/cgminthecloud",
+    hackDiabetes: "https://hackdiabetes.io",
+    testimonials: "mailto:testimonials@nocturne.run",
+    researchData: "mailto:research-data@nocturne.run",
   };
 
   const STATS = [
@@ -82,7 +86,7 @@
       title: "Improve the docs",
       desc: "Spotted a gap, a stale screenshot, or a typo? Clear docs save everyone hours. Fix a page or write a guide for the setup you wish you'd had.",
       cta: "Browse the docs",
-      href: "#tasks",
+      href: "/docs",
     },
     {
       id: "peer",
@@ -90,17 +94,29 @@
       accent: "oklch(0.66 0.15 70)",
       title: "Peer support",
       desc: 'Plenty of people start in the "CGM in the Cloud" Facebook group and community forums. Share what you\'ve learned where newcomers actually ask.',
-      cta: "Visit the forums",
-      href: "#tasks",
+      cta: "Open CGM in the Cloud",
+      href: LINKS.facebook,
+      external: true,
     },
     {
       id: "spread",
       icon: Megaphone,
       accent: "oklch(0.68 0.16 40)",
       title: "Spread the word",
-      desc: "Write up your setup, post your time-in-range win, give a talk at your clinic. Word of mouth is how most people find Nightscout in the first place.",
-      cta: "Share your story",
-      href: "#tasks",
+      desc: "Write up your setup, post your time-in-range win, give a talk at your clinic. Word of mouth is how most people find Nightscout in the first place. Send us your story and we'll help share it.",
+      cta: "Email testimonials@nocturne.run",
+      href: LINKS.testimonials,
+      external: true,
+    },
+    {
+      id: "sponsor",
+      icon: HeartHandshake,
+      accent: "oklch(0.64 0.19 330)",
+      title: "Sponsor Hack Diabetes",
+      desc: "Hack Diabetes brings the open-source diabetes community together to build and test tools like Nocturne. Sponsors fund the events and get their name in front of the people who build this software.",
+      cta: "Sponsor an event",
+      href: LINKS.hackDiabetes,
+      external: true,
     },
     {
       id: "data",
@@ -108,8 +124,9 @@
       accent: "oklch(0.6 0.13 200)",
       title: "Donate anonymized data",
       desc: "Opt in to share de-identified glucose data so connectors and reports can be tested against real-world patterns — not just synthetic samples.",
-      cta: "Learn how it works",
-      href: "#tasks",
+      cta: "Email research-data@nocturne.run",
+      href: LINKS.researchData,
+      external: true,
     },
   ];
 
@@ -292,7 +309,7 @@
         Ways to help
       </p>
       <h2 class="text-[28px] font-bold tracking-tight">
-        Seven ways to contribute
+        {LANES.length} ways to contribute
       </h2>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 gap-3">

--- a/src/Web/packages/portal/src/routes/get-involved/+page.svelte
+++ b/src/Web/packages/portal/src/routes/get-involved/+page.svelte
@@ -15,19 +15,9 @@
     HeartHandshake,
   } from "@lucide/svelte";
   import { onMount } from "svelte";
+  import { LINKS } from "$lib/data/links";
 
   const ACCENT = "oklch(0.6 0.118 184.704)";
-
-  const LINKS = {
-    discord: "https://discord.gg/sKEhtHeb2z",
-    donate: "https://www.nightscoutfoundation.org/donate",
-    githubLabel: "https://github.com/nightscout/nocturne/labels/get-involved",
-    github: "https://github.com/nightscout/nocturne",
-    facebook: "https://www.facebook.com/groups/cgminthecloud",
-    hackDiabetes: "https://hackdiabetes.io",
-    testimonials: "mailto:testimonials@nocturne.run",
-    researchData: "mailto:research-data@nocturne.run",
-  };
 
   const STATS = [
     { value: "100%", label: "Built by volunteers" },
@@ -230,8 +220,9 @@
     return `${Math.floor(days / 30)}mo`;
   }
 
-  function resolveHref(href: string): string {
-    return (LINKS as Record<string, string>)[href] || href;
+  // mailto: hands off to the mail client, so a new tab would just be left orphaned.
+  function opensNewTab(lane: Lane): boolean {
+    return Boolean(lane.external) && !lane.href.startsWith("mailto:");
   }
 </script>
 
@@ -309,15 +300,15 @@
         Ways to help
       </p>
       <h2 class="text-[28px] font-bold tracking-tight">
-        {LANES.length} ways to contribute
+        Ways to contribute
       </h2>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
       {#each LANES as lane}
         <a
-          href={resolveHref(lane.href)}
-          target={lane.external ? "_blank" : undefined}
-          rel={lane.external ? "noopener noreferrer" : undefined}
+          href={lane.href}
+          target={opensNewTab(lane) ? "_blank" : undefined}
+          rel={opensNewTab(lane) ? "noopener noreferrer" : undefined}
           class="gi-lane-card flex flex-row items-start gap-4 bg-card border border-border rounded-xl p-5 transition-[border-color,transform] duration-200 no-underline text-inherit"
           class:gi-lane-highlight={lane.highlight}
           style="--lane-accent: {lane.accent}"


### PR DESCRIPTION
## What

Adds monthly Nightscout Foundation subscription tiers to the portal docs, and fixes the broken links on the Get Involved page.

### Sponsorship tiers
- New `SupportNocturne.svelte` renders three tiers — **US$10 Supporter / US$20 Sustainer / US$50 Patron** — as portal-styled cards linking to Stripe payment links. No `<stripe-buy-button>` embed, so the cards follow the site's theme tokens and dark mode and no third-party script loads on every docs page.
- Rendered at the end of the three installation guides (Docker Compose, Portainer, BYO Postgres) and on the `/docs` landing page.

### Get Involved
- Fix broken links: peer support → the [CGM in the Cloud](https://www.facebook.com/groups/cgminthecloud) Facebook group; "Spread the word" → `testimonials@nocturne.run`; "Donate anonymized data" → `research-data@nocturne.run`; "Improve the docs" → `/docs`.
- Add a **Sponsor Hack Diabetes** lane.
- Extract outbound links to `$lib/data/links.ts`, shared with `SupportNocturne`.

### Features
- The Nightscout comparison row now reads "API secrets that you can't remember" instead of "Username & password — for life".

## Notes for reviewers
- **Tier names and descriptions are placeholders** — please confirm they match what the Foundation actually funds before merge.
- The **"Translate Nocturne"** lane still points at the `#tasks` anchor; left as-is pending a destination.
- The two funding funnels (Get Involved's Donate lane → Foundation; the subscription tiers → `/docs`) are not cross-linked yet.
- Accent uses a local brand-teal constant, **not** `--glucose-in-range` (theme packs swap that to green) or `--primary` (the neutral shadcn token).

## Test
- `pnpm --filter @nocturne/portal check` — 0 errors, 0 warnings.
- All affected routes render 200 and were visually verified.