### PR TITLE
fix(alerts): make severity real, and stop a toast disabling a safety rule

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertsController.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -144,6 +145,7 @@ public class AlertsController : ControllerBase
                 e.AlertRuleId,
                 RuleName = e.AlertRule != null ? e.AlertRule.Name : string.Empty,
                 ConditionType = e.AlertRule != null ? e.AlertRule.ConditionType : AlertConditionType.Threshold,
+                Severity = e.AlertRule != null ? e.AlertRule.Severity : AlertRuleSeverity.Warning,
                 e.StartedAt,
                 EndedAt = e.EndedAt!.Value,
                 e.AcknowledgedAt,
@@ -164,6 +166,7 @@ public class AlertsController : ControllerBase
                 AlertRuleId = e.AlertRuleId,
                 RuleName = e.RuleName,
                 ConditionType = e.ConditionType,
+                Severity = e.Severity,
                 StartedAt = e.StartedAt,
                 EndedAt = e.EndedAt,
                 AcknowledgedAt = e.AcknowledgedAt,
@@ -173,6 +176,33 @@ public class AlertsController : ControllerBase
         };
 
         return Ok(result);
+    }
+
+    /// <summary>
+    /// Who to record as having acknowledged an alert.
+    /// </summary>
+    /// <remarks>
+    /// Taken from the authenticated principal, not from the request. The web app
+    /// used to send a fixed "web_user", which made "who silenced the 3am low?"
+    /// unanswerable on a tenant with more than one caregiver — and any caller
+    /// could have claimed to be anyone. The request field is honoured only for
+    /// callers with no name claim at all (a machine token), where it is the only
+    /// information available.
+    /// </remarks>
+    private string ResolveAcknowledger(AcknowledgeRequest request)
+    {
+        var name = User.FindFirstValue(ClaimTypes.Name);
+        if (!string.IsNullOrWhiteSpace(name))
+            return name;
+
+        var subjectId = User.FindFirstValue(ClaimTypes.NameIdentifier)
+            ?? User.FindFirstValue("sub");
+        if (!string.IsNullOrWhiteSpace(subjectId))
+            return subjectId;
+
+        return string.IsNullOrWhiteSpace(request.AcknowledgedBy)
+            ? "unknown"
+            : request.AcknowledgedBy;
     }
 
     /// <inheritdoc cref="IAlertAcknowledgementService.AcknowledgeAllAsync"/>
@@ -186,7 +216,7 @@ public class AlertsController : ControllerBase
 
         await _acknowledgementService.AcknowledgeAllAsync(
             tenantId,
-            request.AcknowledgedBy ?? "unknown",
+            ResolveAcknowledger(request),
             ct);
 
         return NoContent();
@@ -222,7 +252,7 @@ public class AlertsController : ControllerBase
         await _acknowledgementService.AcknowledgeExcursionAsync(
             tenantId,
             excursionId,
-            request.AcknowledgedBy ?? "unknown",
+            ResolveAcknowledger(request),
             broadcast: true,
             ct);
 
@@ -372,6 +402,13 @@ public class HistoryExcursionResponse
     public Guid AlertRuleId { get; set; }
     public string RuleName { get; set; } = string.Empty;
     public AlertConditionType ConditionType { get; set; } = AlertConditionType.Threshold;
+
+    /// <summary>
+    /// The rule's severity, so a history row can be read the same way as a live
+    /// one rather than showing every past fire identically.
+    /// </summary>
+    public AlertRuleSeverity Severity { get; set; } = AlertRuleSeverity.Warning;
+
     public DateTime StartedAt { get; set; }
     public DateTime EndedAt { get; set; }
     public DateTime? AcknowledgedAt { get; set; }

--- a/src/Web/packages/app/src/lib/components/alerts/AlertBanner.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/AlertBanner.svelte
@@ -4,21 +4,22 @@
     acknowledgeExcursion,
   } from "$api/generated/alerts.generated.remote";
   import { Button } from "$lib/components/ui/button";
-  import { AlertTriangle, X, Check } from "lucide-svelte";
+  import { AlertTriangle, Check } from "lucide-svelte";
   import { formatTimeSince } from "./alertTime";
+  import { severity, severityLabel } from "./severity";
 
   // Reactive query: reading `.current` subscribes this component, so an
   // optimistic withOverride from any acknowledge (here or the fresh-fire
   // toast) shows immediately and is reconciled by the single-flight refresh.
   const activeAlerts = getActiveAlerts();
 
-  let dismissedIds = $state<Set<string>>(new Set());
   let acknowledgingId = $state<string | null>(null);
 
+  // Acknowledging is the only way off this surface. The X that used to sit here
+  // hid a live, unacknowledged alert for the rest of the session while recording
+  // nothing server-side and halting no escalation.
   const visibleAlerts = $derived(
-    (activeAlerts.current ?? []).filter(
-      (a) => !a.acknowledgedAt && !dismissedIds.has(a.id ?? "")
-    )
+    (activeAlerts.current ?? []).filter((a) => !a.acknowledgedAt)
   );
 
   function getConditionLabel(conditionType: string | undefined): string {
@@ -45,7 +46,9 @@
       // visibleAlerts at once; the single-flight refresh confirms server-side.
       await acknowledgeExcursion({
         excursionId: id,
-        request: { acknowledgedBy: "web_user" },
+        // Who acknowledged is taken from the session server-side; sending a
+        // fixed "web_user" made this unanswerable on a multi-caregiver tenant.
+        request: {},
       }).updates(
         activeAlerts.withOverride((current) =>
           (current ?? []).map((a) =>
@@ -58,21 +61,27 @@
     }
   }
 
-  function handleDismiss(id: string) {
-    dismissedIds = new Set([...dismissedIds, id]);
-  }
-
 </script>
 
 {#if visibleAlerts.length > 0}
-  <div class="border-b border-destructive/20 bg-destructive/5">
+  <div class="border-b">
     {#each visibleAlerts as alert (alert.id)}
+      <!-- Coloured by the rule's own severity: styling every banner as
+           destructive made an info rule indistinguishable from a critical low. -->
       <div
-        class="container mx-auto flex items-center gap-3 px-4 py-2 max-w-7xl"
+        class="container mx-auto flex items-center gap-3 border-b px-4 py-2 max-w-7xl last:border-b-0 {severity(
+          alert.severity,
+          'strip'
+        )}"
       >
-        <AlertTriangle class="h-4 w-4 shrink-0 text-destructive" />
+        <AlertTriangle class="h-4 w-4 shrink-0" />
         <div class="flex-1 min-w-0">
-          <span class="text-sm font-medium text-destructive">
+          <!-- Named as well as coloured: colour alone is unavailable to a
+               screen reader and to anyone who can't distinguish these hues. -->
+          <span class="text-[10px] font-semibold uppercase tracking-wider">
+            {severityLabel(alert.severity)}
+          </span>
+          <span class="text-sm font-medium">
             {alert.ruleName ?? "Alert"}
           </span>
           <span class="text-sm text-muted-foreground mx-2">
@@ -95,14 +104,7 @@
               Acknowledge
             </Button>
           {/if}
-          <Button
-            variant="ghost"
-            size="sm"
-            class="h-7 w-7 p-0"
-            onclick={() => handleDismiss(alert.id ?? "")}
-          >
-            <X class="h-3 w-3" />
-          </Button>
+
         </div>
       </div>
     {/each}

--- a/src/Web/packages/app/src/lib/components/alerts/FiringToast.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/FiringToast.svelte
@@ -4,7 +4,6 @@
     snoozeInstance,
     acknowledgeExcursion,
   } from "$api/generated/alerts.generated.remote";
-  import { toggleRule } from "$api/generated/alertRules.generated.remote";
   import type { ActiveExcursionResponse } from "$api-clients";
   import { Button } from "$lib/components/ui/button";
   import { Bell, BellOff, X } from "lucide-svelte";
@@ -92,7 +91,7 @@
     return optimistic(id, () =>
       acknowledgeExcursion({
         excursionId: id,
-        request: { acknowledgedBy: "web_user" },
+        request: {},
       }).updates(
         activeAlerts.withOverride((current) =>
           (current ?? []).map((a) =>
@@ -103,13 +102,11 @@
     );
   }
 
-  function muteRule(id: string, ruleId: string | undefined): Promise<void> {
-    if (!ruleId) {
-      dismiss(id);
-      return Promise.resolve();
-    }
-    return optimistic(id, () => toggleRule(ruleId));
-  }
+  // "Mute the rule" used to call toggleRule, which disables the rule outright,
+  // tenant-wide, with no confirmation — a one-tap way to switch off a safety rule
+  // at 3am, and one that silently re-enabled a rule already disabled. Snoozing is
+  // the transient action; changing a rule now happens on the rule's own page,
+  // where the effect is labelled.
 </script>
 
 {#if queue.length > 0}
@@ -126,7 +123,7 @@
         <div class="flex items-start gap-2">
           <span
             class="mt-0.5 grid h-7 w-7 shrink-0 place-items-center rounded-full {severity(
-              'critical',
+              a.severity,
               'chip'
             )}"
           >
@@ -180,33 +177,38 @@
               >
                 1h
               </Button>
+              <!-- This one records the acknowledgement; the X beside it only
+                   closes the card. They used to read "Dismiss" and an unlabelled
+                   cross, which is the wrong pair of words for that difference. -->
               <Button
                 type="button"
                 variant="ghost"
                 size="sm"
                 class="h-7 px-2 text-xs ml-auto"
                 onclick={() => ack(a.id ?? "")}
-                title="Acknowledge"
               >
-                Dismiss
+                Acknowledge
               </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                class="h-7 px-2 text-xs"
-                onclick={() => muteRule(a.id ?? "", a.alertRuleId)}
-                title="Mute the rule"
-              >
-                <BellOff class="h-3.5 w-3.5" />
-              </Button>
+              {#if a.alertRuleId}
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  class="h-7 px-2 text-xs"
+                  href="/alerts/{a.alertRuleId}"
+                  title="Open this rule's settings"
+                  aria-label="Open settings for {a.ruleName ?? 'this rule'}"
+                >
+                  <BellOff class="h-3.5 w-3.5" />
+                </Button>
+              {/if}
               <Button
                 type="button"
                 variant="ghost"
                 size="icon"
                 class="h-7 w-7"
                 onclick={() => dismiss(a.id ?? "")}
-                aria-label="Close"
+                aria-label="Close this notification without acknowledging"
               >
                 <X class="h-3.5 w-3.5" />
               </Button>

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/+page.svelte
@@ -34,6 +34,7 @@
   import AlertRuleRow from "$lib/components/alerts/AlertRuleRow.svelte";
   import DndNoticeStrip from "$lib/components/alerts/DndNoticeStrip.svelte";
   import { isDndActiveNow } from "$lib/components/alerts/dnd";
+  import { severity, severityLabel } from "$lib/components/alerts/severity";
 
   // ---- Queries ----
   const rulesQuery = getRules();
@@ -104,7 +105,7 @@
       // Optimistically badge every unacknowledged excursion so the card updates
       // at once; the command's GetActiveAlerts invalidation reconciles it in the
       // same round-trip (same pattern as AlertBanner/FiringToast).
-      await acknowledge({ acknowledgedBy: "web_user" }).updates(
+      await acknowledge({}).updates(
         activeAlertsQuery.withOverride((current) =>
           (current ?? []).map((a) =>
             a.acknowledgedAt ? a : { ...a, acknowledgedAt: new Date() },
@@ -257,9 +258,17 @@
         <CardContent class="space-y-2">
           {#each activeAlerts as a (a.id)}
             <div class="flex items-center gap-3 rounded-md border bg-background p-3">
-              <span class="h-2 w-2 rounded-full bg-status-critical" aria-hidden="true"></span>
+              <span
+                class="h-2 w-2 shrink-0 rounded-full {severity(a.severity, 'dot')}"
+                aria-hidden="true"
+              ></span>
               <div class="flex-1 min-w-0">
-                <p class="text-sm font-medium truncate">{a.ruleName ?? "Alert"}</p>
+                <p class="text-sm font-medium truncate">
+                  <span class="text-muted-foreground text-xs uppercase tracking-wider">
+                    {severityLabel(a.severity)}
+                  </span>
+                  {a.ruleName ?? "Alert"}
+                </p>
                 <p class="text-xs text-muted-foreground">
                   Since {a.startedAt ? new Date(a.startedAt).toLocaleTimeString() : "—"}
                 </p>

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/[id]/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/[id]/+page.svelte
@@ -46,7 +46,7 @@
   import AutoResolveSection from "$lib/components/alerts/AutoResolveSection.svelte";
   import ChannelsSection from "$lib/components/alerts/ChannelsSection.svelte";
   import ReplayPanel from "$lib/components/alerts/ReplayPanel.svelte";
-  import { severityLabel } from "$lib/components/alerts/severity";
+  import { severity, severityLabel } from "$lib/components/alerts/severity";
   import {
     parseRule,
     flattenSingleChildRoot,
@@ -602,7 +602,10 @@
                       title="Replay this day in the simulator"
                     >
                       <span
-                        class="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500"
+                        class="h-1.5 w-1.5 shrink-0 rounded-full {severity(
+                          h.severity,
+                          'dot'
+                        )}"
                         aria-hidden="true"
                       ></span>
                       <span class="min-w-0 flex-1 truncate tabular-nums">

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/history/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/history/+page.svelte
@@ -13,6 +13,7 @@
   import { ArrowLeft, History as HistoryIcon, Loader2 } from "lucide-svelte";
   import { formatDuration } from "$lib/components/alerts/alertTime";
   import { formatDateTimeCompact } from "$lib/utils/formatting";
+  import { severity, severityLabel } from "$lib/components/alerts/severity";
 
   let page = $state(1);
   const historyQuery = $derived(getAlertHistory({ page, pageSize: 25 }));
@@ -120,7 +121,16 @@
   <div class="flex items-center gap-3 rounded-md border bg-background px-3 py-2">
     <div class="min-w-0 flex-1">
       <div class="flex items-center gap-2">
+        <span
+          class="h-2 w-2 shrink-0 rounded-full {severity(h.severity, 'dot')}"
+          aria-hidden="true"
+        ></span>
         <span class="text-sm font-semibold truncate">{h.ruleName ?? "Alert"}</span>
+        <!-- Named as well as coloured, so history reads the same to a screen
+             reader as it does on screen. -->
+        <Badge variant="outline" class="text-[10px] shrink-0">
+          {severityLabel(h.severity)}
+        </Badge>
         {#if h.acknowledgedAt}
           <Badge variant="secondary" class="text-[10px]">Acknowledged</Badge>
         {/if}

--- a/src/Web/packages/ui/src/styles/aaps-theme.css
+++ b/src/Web/packages/ui/src/styles/aaps-theme.css
@@ -57,6 +57,7 @@
   --status-warning: oklch(0.8 0.2 100);     /* Yellow */
   --status-critical: oklch(0.55 0.25 29);   /* Red */
   --status-normal: oklch(0.75 0.3 142);     /* Green */
+  --status-info: oklch(0.7 0.16 250);       /* Blue */
 
   /* IOB (Insulin on Board) */
   --iob-basal: rgba(51, 120, 197, 0.5);

--- a/src/Web/packages/ui/src/styles/classic-theme.css
+++ b/src/Web/packages/ui/src/styles/classic-theme.css
@@ -57,6 +57,7 @@
   --status-warning: oklch(0.9 0.18 105);    /* Yellow */
   --status-critical: oklch(0.55 0.25 29);   /* Red */
   --status-normal: oklch(0.8 0.35 142);     /* Neon green */
+  --status-info: oklch(0.75 0.2 250);       /* Blue */
 
   /* IOB */
   --iob-basal: rgba(0, 153, 255, 0.5);

--- a/src/Web/packages/ui/src/styles/nocturne-theme.css
+++ b/src/Web/packages/ui/src/styles/nocturne-theme.css
@@ -65,6 +65,7 @@
   --status-warning: oklch(0.646 0.222 41.116);
   --status-critical: oklch(0.577 0.245 27.325);
   --status-normal: oklch(0.6 0.118 184.704);
+  --status-info: oklch(0.62 0.16 250);
 
   /* IOB (Insulin on Board) - for charts - should be more prominent than basal */
   --iob-basal: rgba(30, 150, 252, 0.7);
@@ -166,6 +167,7 @@
   --color-status-warning: var(--status-warning);
   --color-status-critical: var(--status-critical);
   --color-status-normal: var(--status-normal);
+  --color-status-info: var(--status-info);
 
   /* IOB */
   --color-iob-basal: var(--iob-basal);

--- a/src/Web/packages/ui/src/styles/trio-theme.css
+++ b/src/Web/packages/ui/src/styles/trio-theme.css
@@ -72,6 +72,7 @@
   --status-warning: rgb(255, 193, 69);
   --status-critical: rgb(235, 87, 87);
   --status-normal: rgb(111, 207, 151);
+  --status-info: rgb(30, 150, 252);
   --status-aging: rgb(255, 193, 69);
   --status-stale: rgb(235, 87, 87);
 


### PR DESCRIPTION
The safety-relevant alert findings from #569.

> No longer stacked: #574 and #575 have merged, so this is rebased onto `main` as a
> single commit and CI runs on it normally.

## Severity was decorative

`severity()` already existed, the payload already carried the value, and
`AlertRuleRow` already used it correctly. Five surfaces didn't, so an `info` rule
and a critical low looked identical:

| Surface | Was |
|---|---|
| `FiringToast` | passed the literal `'critical'` for every alert |
| `AlertBanner` | `text-destructive` regardless |
| alerts index | hardcoded `bg-status-critical` dot |
| rule detail | raw `bg-amber-500` per past fire |
| history | nothing at all |

History *couldn't* show it: the endpoint never projected severity.
`HistoryExcursionResponse` now carries it, mirroring the active-excursion
projection two methods above.

**A latent bug this exposed:** `severity()`'s `info` branch emits
`bg-status-info` / `text-status-info`, and **no theme defined `--status-info`** —
those classes resolved to nothing. Only `AlertRuleRow` could reach that branch
before, so it went unnoticed; with five more surfaces reaching it, the token is
now defined in all four themes and registered as a Tailwind colour alongside
`--status-warning` and `--status-critical`. Verified the utility is emitted in the
built CSS:

```
text-status-info{color:var(--status-info)}
```

Severity is also **named** on the banner, index and history, not just coloured.
Colour alone reaches neither a screen reader nor anyone who can't separate these
hues, on a surface whose entire purpose is conveying urgency.

## "Mute the rule" disabled a safety rule

The bell-off button on a firing toast called `toggleRule`. One unconfirmed tap at
3am disabled the rule outright and tenant-wide — and on a rule already disabled it
silently **re-enabled** it, which is arguably worse.

The toast keeps its 5m/15m/30m/1h snooze buttons, which are the right transient
action for a toast. The bell-off button now opens the rule's own page, where the
effect is labelled and deliberate. I chose a link over adding a confirm dialog
because "are you sure you want to turn off low alerts?" is not a question a toast
should be asking someone who has just been woken by one.

## Who acknowledged

`acknowledgedBy: "web_user"` was hardcoded at three call sites, so "who silenced
the 3am low?" was unanswerable on any tenant with more than one caregiver. It was
also **client-supplied** — any caller could claim to be anyone, in a field that
exists to attribute a safety action.

The server now takes it from the authenticated principal (`ClaimTypes.Name`, then
the subject id), falling back to the request body only for a caller with no name
claim at all, where it's the only information available. The field stays on the
wire for compatibility; the web clients stop sending it.

## Dismiss

`AlertBanner`'s X hid a **live, unacknowledged** alert for the rest of the session
while recording nothing server-side and halting no escalation. It's removed:
acknowledging is the only way off that surface, and acknowledging already clears
the row (the list filters on `!acknowledgedAt`). Note this means the banner can no
longer be silenced without a server-side record — deliberate, but flag it if you
disagree.

On `FiringToast`, "Dismiss" acknowledged on the server while the adjacent
unlabelled cross was a local hide — the wrong pair of words for that difference.
Now "Acknowledge", and a cross that says it closes without acknowledging.

## Verification

- `dotnet build src/API/Nocturne.API` — 0 errors.
- `pnpm test:unit`: 540 passed, 1 skipped. `pnpm test:browser src/lib/components/alerts`: 30 passed.
- `pnpm check`: unchanged from base — 24 in the gitignored generated client, 2
  pre-existing in untouched files.
- `pnpm build`: green, and the built CSS was grepped to confirm the new token
  resolves.

The rebase's only conflict was the four theme CSS files: #555 consolidated the
duplicated `packages/app/src/styles/*-theme.css` into `packages/ui`, and this commit
had edited both copies identically, so the `app/` side was dropped and the `ui/` side
kept. Re-verified after the rebase: API build 0 errors; `pnpm test:unit` 599 passed,
1 skipped; alerts browser tests 30 passed; `pnpm build` green, with
`text-status-info{color:var(--status-info)}` and all four theme values present in the
output CSS.

The generated TS client was patched locally to typecheck against the new
`Severity` field; it's gitignored and CI regenerates it from the OpenAPI doc.

Refs #569


