### PR TITLE
fix(setup): grant the first owner platform admin so a fresh install can reach the admin UI

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/SetupController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/SetupController.cs
@@ -356,6 +356,16 @@ public partial class SetupController : ControllerBase
             return Redirect("/setup?error=missing_parameters");
         }
 
+        // The sibling setup endpoints all gate on this; without it the callback is the one
+        // setup route that stays live on an established instance, and it both links an
+        // identity and issues a session for whatever subject the state names.
+        var (_, setupClosed) = await GetSoleTenantWithoutOwnerAsync(ct);
+        if (setupClosed != null)
+        {
+            ClearOidcStateCookie();
+            return Redirect("/setup?error=setup_already_complete");
+        }
+
         var expectedState = Request.Cookies[_oidcOptions.Cookie.StateCookieName];
         ClearOidcStateCookie();
 

--- a/src/API/Nocturne.API/Controllers/V4/SetupController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/SetupController.cs
@@ -45,6 +45,7 @@ public partial class SetupController : ControllerBase
     private readonly IOidcAuthService _oidcAuthService;
     private readonly OperatorConfiguration _operatorConfig;
     private readonly IHttpClientFactory _httpClientFactory;
+    private readonly PlatformAdminBootstrapService _platformAdminBootstrap;
     private readonly ILogger<SetupController> _logger;
 
     public SetupController(
@@ -58,6 +59,7 @@ public partial class SetupController : ControllerBase
         IOidcAuthService oidcAuthService,
         IOptions<OperatorConfiguration> operatorConfig,
         IHttpClientFactory httpClientFactory,
+        PlatformAdminBootstrapService platformAdminBootstrap,
         ILogger<SetupController> logger)
     {
         _tenantService = tenantService;
@@ -70,6 +72,7 @@ public partial class SetupController : ControllerBase
         _oidcAuthService = oidcAuthService;
         _operatorConfig = operatorConfig.Value;
         _httpClientFactory = httpClientFactory;
+        _platformAdminBootstrap = platformAdminBootstrap;
         _logger = logger;
     }
 
@@ -239,6 +242,8 @@ public partial class SetupController : ControllerBase
                 request.AttestationResponseJson, request.ChallengeToken, tenant!.Id,
                 expectedSubjectId: ownerSubjectId.Value);
 
+            await GrantFirstOwnerPlatformAdminAsync(credResult.SubjectId);
+
             // Generate recovery codes
             var recoveryCodes = await _recoveryCodeService.GenerateCodesAsync(credResult.SubjectId);
 
@@ -369,6 +374,9 @@ public partial class SetupController : ControllerBase
                 result.Error, result.ErrorDescription);
             return Redirect($"/setup?error={Uri.EscapeDataString(result.Error ?? "unknown")}");
         }
+
+        if (result.SubjectId is { } oidcOwnerSubjectId)
+            await GrantFirstOwnerPlatformAdminAsync(oidcOwnerSubjectId);
 
         // Temporary bridge: construct SessionTokenPair from OidcTokenResponse until
         // OidcAuthService is migrated to ISessionService.
@@ -551,6 +559,25 @@ public partial class SetupController : ControllerBase
         await _subjectService.AssignRoleAsync(subjectId, "admin");
 
         return subjectId;
+    }
+
+    /// <summary>
+    /// Grants the new owner platform admin now that it holds a credential. The startup
+    /// bootstrap pass ran against an empty database on a fresh install, so without this
+    /// the owner cannot reach /settings/admin until the API restarts.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately called from the completion paths rather than
+    /// <see cref="EnsureOwnerSubjectAsync"/>: an abandoned WebAuthn ceremony would
+    /// otherwise leave a credential-less subject holding the flag, which then suppresses
+    /// every later grant — including the startup pass — and locks the instance out for good.
+    /// </remarks>
+    private async Task GrantFirstOwnerPlatformAdminAsync(Guid subjectId)
+    {
+        // Not the request token: a client that disconnects mid-response would otherwise
+        // abort the grant and leave the owner locked out of the admin UI.
+        await _platformAdminBootstrap.EnsureFirstOwnerIsPlatformAdminAsync(
+            subjectId, CancellationToken.None);
     }
 
     private void SetOidcStateCookie(string state, DateTimeOffset expiresAt)

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -192,6 +192,7 @@ public static class ServiceRegistrationExtensions
         services.AddScoped<IRoleService, RoleService>();
         services.AddScoped<IOidcProviderService, OidcProviderService>();
         services.AddScoped<IOidcAuthService, OidcAuthService>();
+        services.AddScoped<PlatformAdminBootstrapService>();
 
         // OAuth services
         services.AddScoped<IOAuthClientService, OAuthClientService>();

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
-using Microsoft.Extensions.Options;
 using Nocturne.API.Authorization;
 using Nocturne.API.Configuration;
 using Nocturne.API.Services.Audit;
@@ -617,9 +616,7 @@ if (!isNSwagGeneration && !app.Environment.IsEnvironment("Testing"))
 {
     using (var scope = app.Services.CreateScope())
     {
-        var db = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
-        var platformOptions = scope.ServiceProvider.GetRequiredService<IOptions<PlatformOptions>>();
-        var bootstrap = new PlatformAdminBootstrapService(db, platformOptions);
+        var bootstrap = scope.ServiceProvider.GetRequiredService<PlatformAdminBootstrapService>();
         await bootstrap.BootstrapAsync(CancellationToken.None);
     }
 }

--- a/src/API/Nocturne.API/Services/Auth/PlatformAdminBootstrapService.cs
+++ b/src/API/Nocturne.API/Services/Auth/PlatformAdminBootstrapService.cs
@@ -133,10 +133,18 @@ public class PlatformAdminBootstrapService
     /// so a fresh install is administrable without restarting the API.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Declines when the operator pinned the choice through <c>Platform:AdminSubjectIds</c>,
     /// and when the instance already has a platform admin — an established instance must not
-    /// hand the flag to whoever runs setup. Takes the subject explicitly rather than
-    /// re-deriving the oldest tenant's owner, so the grant cannot land on a different subject.
+    /// hand the flag to whoever runs setup.
+    /// </para>
+    /// <para>
+    /// The caller names the subject, but this method re-derives whether that subject is
+    /// eligible rather than taking its word: the instance must still be a single-tenant
+    /// install and the subject must hold that tenant's <c>owner</c> role. A privilege grant
+    /// shouldn't depend on every present and future call site having checked setup state
+    /// first, and the setup OIDC callback in particular is reachable anonymously.
+    /// </para>
     /// </remarks>
     /// <param name="subjectId">The owner subject that just bound a credential.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -151,6 +159,24 @@ public class PlatformAdminBootstrapService
 
         if (await db.Subjects.AnyAsync(s => s.IsPlatformAdmin, cancellationToken))
             return false;
+
+        // More than one tenant means this is not a fresh install, whatever the caller thinks.
+        if (await db.Tenants.Take(2).CountAsync(cancellationToken) != 1)
+            return false;
+
+        var isTenantOwner = await db.TenantMembers
+            .AnyAsync(
+                tm => tm.SubjectId == subjectId
+                    && tm.MemberRoles.Any(mr => mr.TenantRole!.Slug == "owner"),
+                cancellationToken);
+
+        if (!isTenantOwner)
+        {
+            _logger.LogWarning(
+                "Declined to grant platform admin to subject {SubjectId}: it does not hold the " +
+                "owner role on the sole tenant", subjectId);
+            return false;
+        }
 
         var granted = await GrantAsync(db, subjectId, cancellationToken) > 0;
 

--- a/src/API/Nocturne.API/Services/Auth/PlatformAdminBootstrapService.cs
+++ b/src/API/Nocturne.API/Services/Auth/PlatformAdminBootstrapService.cs
@@ -8,29 +8,44 @@ using Nocturne.Infrastructure.Data.Extensions;
 namespace Nocturne.API.Services.Auth;
 
 /// <summary>
-/// Ensures at least one platform admin exists on startup.
+/// Ensures at least one platform admin exists.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Priority order:
 /// <list type="number">
 ///   <item>If <c>Platform:AdminSubjectIds</c> is configured, those subjects are granted platform admin status.</item>
 ///   <item>Otherwise, if no platform admin exists, the owner of the oldest tenant is granted it.</item>
 /// </list>
+/// </para>
+/// <para>
+/// <see cref="BootstrapAsync"/> runs at startup. On a fresh install it sees an empty
+/// database and grants nothing, so the setup flow calls
+/// <see cref="EnsureFirstOwnerIsPlatformAdminAsync"/> once the first owner has bound a
+/// credential — otherwise that owner could not reach the admin UI until the API restarted.
+/// </para>
 /// </remarks>
 public class PlatformAdminBootstrapService
 {
-    private readonly NocturneDbContext _db;
+    private readonly IDbContextFactory<NocturneDbContext> _dbFactory;
     private readonly PlatformOptions _options;
+    private readonly ILogger<PlatformAdminBootstrapService> _logger;
 
     /// <summary>
     /// Initialises a new <see cref="PlatformAdminBootstrapService"/>.
     /// </summary>
-    /// <param name="db">Database context for subject and tenant member queries.</param>
+    /// <param name="dbFactory">Factory for subject and tenant member queries. A dedicated
+    /// context keeps the bootstrap independent of any tenant pinned on a request-scoped one.</param>
     /// <param name="options">Platform configuration options, including <c>AdminSubjectIds</c>.</param>
-    public PlatformAdminBootstrapService(NocturneDbContext db, IOptions<PlatformOptions> options)
+    /// <param name="logger">Logger for the resulting grant.</param>
+    public PlatformAdminBootstrapService(
+        IDbContextFactory<NocturneDbContext> dbFactory,
+        IOptions<PlatformOptions> options,
+        ILogger<PlatformAdminBootstrapService> logger)
     {
-        _db = db;
+        _dbFactory = dbFactory;
         _options = options.Value;
+        _logger = logger;
     }
 
     /// <summary>
@@ -39,28 +54,48 @@ public class PlatformAdminBootstrapService
     /// <param name="cancellationToken">Cancellation token.</param>
     public async Task BootstrapAsync(CancellationToken cancellationToken)
     {
+        await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
+
         // Option 1: explicit config takes precedence
         if (_options.AdminSubjectIds.Count > 0)
         {
-            await _db.Subjects
+            var configGrants = await db.Subjects
                 .Where(s => _options.AdminSubjectIds.Contains(s.Id))
                 .ExecuteUpdateAsync(s => s.SetProperty(x => x.IsPlatformAdmin, true), cancellationToken);
+
+            // Config wins outright, so a set of IDs that matches nothing leaves the
+            // instance with no platform admin and no way into the admin UI.
+            if (configGrants == 0)
+                _logger.LogWarning(
+                    "Platform:AdminSubjectIds lists {ConfiguredCount} subject ID(s), none of which " +
+                    "matched an existing subject. No platform admin was granted.",
+                    _options.AdminSubjectIds.Count);
+
             return;
         }
 
         // No-op if a platform admin already exists
-        if (await _db.Subjects.AnyAsync(s => s.IsPlatformAdmin, cancellationToken))
+        if (await db.Subjects.AnyAsync(s => s.IsPlatformAdmin, cancellationToken))
             return;
 
         // Option 2: grant to the owner of the oldest tenant that has one. Resolved by walking
         // tenants oldest-first and looking the owner up under each tenant's own pin, because a
         // single query over every tenant's memberships has no tenant to be pinned to.
-        var firstOwnerSubjectId = await FindOldestTenantOwnerAsync(cancellationToken);
-        if (firstOwnerSubjectId is null) return;
+        var firstOwnerSubjectId = await FindOldestTenantOwnerAsync(db, cancellationToken);
 
-        await _db.Subjects
-            .Where(s => s.Id == firstOwnerSubjectId)
-            .ExecuteUpdateAsync(s => s.SetProperty(x => x.IsPlatformAdmin, true), cancellationToken);
+        if (firstOwnerSubjectId is null)
+        {
+            // Expected on a fresh install, where setup has not created an owner yet.
+            _logger.LogInformation(
+                "No platform admin exists and no tenant owner was found, so none was granted");
+            return;
+        }
+
+        await GrantAsync(db, firstOwnerSubjectId.Value, cancellationToken);
+
+        _logger.LogInformation(
+            "Granted platform admin to subject {SubjectId}, the owner of the oldest tenant",
+            firstOwnerSubjectId);
     }
 
     /// <summary>
@@ -68,19 +103,20 @@ public class PlatformAdminBootstrapService
     /// <see langword="null"/> when no tenant does. Tenants without an owner are skipped, matching
     /// the ordered membership scan this replaces.
     /// </summary>
-    private async Task<Guid?> FindOldestTenantOwnerAsync(CancellationToken cancellationToken)
+    private static async Task<Guid?> FindOldestTenantOwnerAsync(
+        NocturneDbContext db, CancellationToken cancellationToken)
     {
         // tenants is not tenant-scoped, so the ordering can be resolved unpinned.
-        var tenantIds = await _db.Tenants
+        var tenantIds = await db.Tenants
             .OrderBy(t => t.SysCreatedAt)
             .Select(t => t.Id)
             .ToListAsync(cancellationToken);
 
         foreach (var tenantId in tenantIds)
         {
-            await _db.PinTenantAsync(tenantId, cancellationToken);
+            await db.PinTenantAsync(tenantId, cancellationToken);
 
-            var ownerSubjectId = await _db.TenantMembers
+            var ownerSubjectId = await db.TenantMembers
                 .Where(tm => tm.TenantId == tenantId
                     && tm.MemberRoles.Any(mr => mr.TenantRole!.Slug == TenantPermissions.SeedRoles.Owner))
                 .Select(tm => tm.SubjectId)
@@ -91,4 +127,43 @@ public class PlatformAdminBootstrapService
 
         return null;
     }
+
+    /// <summary>
+    /// Grants platform admin to the subject that has just completed first-owner setup,
+    /// so a fresh install is administrable without restarting the API.
+    /// </summary>
+    /// <remarks>
+    /// Declines when the operator pinned the choice through <c>Platform:AdminSubjectIds</c>,
+    /// and when the instance already has a platform admin — an established instance must not
+    /// hand the flag to whoever runs setup. Takes the subject explicitly rather than
+    /// re-deriving the oldest tenant's owner, so the grant cannot land on a different subject.
+    /// </remarks>
+    /// <param name="subjectId">The owner subject that just bound a credential.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns><c>true</c> if the flag was granted.</returns>
+    public async Task<bool> EnsureFirstOwnerIsPlatformAdminAsync(
+        Guid subjectId, CancellationToken cancellationToken)
+    {
+        if (_options.AdminSubjectIds.Count > 0)
+            return false;
+
+        await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
+
+        if (await db.Subjects.AnyAsync(s => s.IsPlatformAdmin, cancellationToken))
+            return false;
+
+        var granted = await GrantAsync(db, subjectId, cancellationToken) > 0;
+
+        if (granted)
+            _logger.LogInformation(
+                "Granted platform admin to first owner {SubjectId} on setup completion", subjectId);
+
+        return granted;
+    }
+
+    private static Task<int> GrantAsync(
+        NocturneDbContext db, Guid subjectId, CancellationToken cancellationToken) =>
+        db.Subjects
+            .Where(s => s.Id == subjectId)
+            .ExecuteUpdateAsync(s => s.SetProperty(x => x.IsPlatformAdmin, true), cancellationToken);
 }

--- a/src/API/Nocturne.API/Services/Auth/PlatformAdminBootstrapService.cs
+++ b/src/API/Nocturne.API/Services/Auth/PlatformAdminBootstrapService.cs
@@ -161,13 +161,20 @@ public class PlatformAdminBootstrapService
             return false;
 
         // More than one tenant means this is not a fresh install, whatever the caller thinks.
-        if (await db.Tenants.Take(2).CountAsync(cancellationToken) != 1)
+        var tenantIds = await db.Tenants.Select(t => t.Id).Take(2).ToListAsync(cancellationToken);
+        if (tenantIds.Count != 1)
             return false;
+
+        // The membership read runs under the sole tenant's pin: tenant_members is slated for
+        // RLS policies keyed on the tenant GUC, and an unpinned read would then see no rows
+        // and silently decline the grant — reintroducing the fresh-install lockout.
+        await db.PinTenantAsync(tenantIds[0], cancellationToken);
 
         var isTenantOwner = await db.TenantMembers
             .AnyAsync(
-                tm => tm.SubjectId == subjectId
-                    && tm.MemberRoles.Any(mr => mr.TenantRole!.Slug == "owner"),
+                tm => tm.TenantId == tenantIds[0]
+                    && tm.SubjectId == subjectId
+                    && tm.MemberRoles.Any(mr => mr.TenantRole!.Slug == TenantPermissions.SeedRoles.Owner),
                 cancellationToken);
 
         if (!isTenantOwner)

--- a/src/Web/packages/portal/src/content/docs/authentication/github.svx
+++ b/src/Web/packages/portal/src/content/docs/authentication/github.svx
@@ -4,6 +4,7 @@ title: Sign in with GitHub
 
 <script>
   import Callout from '@nocturne/cms/components/Callout.svelte';
+  import PlatformAdminNote from '$lib/components/docs/PlatformAdminNote.svelte';
 </script>
 
 # Sign in with GitHub
@@ -40,8 +41,10 @@ Replace `your-instance.com` with your actual Nocturne domain.
 
 ## 3. Add the provider in Nocturne
 
-1. Sign in to your Nocturne instance as an admin
-2. Go to **Settings > Admin > OIDC Providers**
+<PlatformAdminNote />
+
+1. Sign in to your Nocturne instance as a platform admin
+2. Go to **Settings > Administration** (`/settings/admin`) and open the **Identity Providers** tab
 3. Click **Add Provider** and fill in:
 
 | Field | Value |

--- a/src/Web/packages/portal/src/content/docs/authentication/google.svx
+++ b/src/Web/packages/portal/src/content/docs/authentication/google.svx
@@ -4,6 +4,7 @@ title: Sign in with Google
 
 <script>
   import Callout from '@nocturne/cms/components/Callout.svelte';
+  import PlatformAdminNote from '$lib/components/docs/PlatformAdminNote.svelte';
 </script>
 
 # Sign in with Google
@@ -56,8 +57,10 @@ Replace `your-instance.com` with your actual Nocturne domain (e.g. `rhys.nocturn
 
 ## 4. Add the provider in Nocturne
 
-1. Sign in to your Nocturne instance as an admin
-2. Go to **Settings > Admin > OIDC Providers**
+<PlatformAdminNote />
+
+1. Sign in to your Nocturne instance as a platform admin
+2. Go to **Settings > Administration** (`/settings/admin`) and open the **Identity Providers** tab
 3. Click **Add Provider** and fill in:
 
 | Field | Value |

--- a/src/Web/packages/portal/src/content/docs/authentication/oidc.svx
+++ b/src/Web/packages/portal/src/content/docs/authentication/oidc.svx
@@ -4,6 +4,7 @@ title: Sign in with any OIDC provider
 
 <script>
   import Callout from '@nocturne/cms/components/Callout.svelte';
+  import PlatformAdminNote from '$lib/components/docs/PlatformAdminNote.svelte';
 </script>
 
 # Sign in with any OIDC provider
@@ -31,7 +32,7 @@ every provider — only the credentials differ.
 Nocturne reads providers from one of two places:
 
 1. **Admin UI (database-backed)** — add and edit providers at runtime from
-   **Settings > Admin > OIDC Providers**. No restart needed. This is the default.
+   **Settings > Administration > Identity Providers**. No restart needed. This is the default.
 2. **Operator config (`appsettings` / environment)** — declare providers in configuration.
    When one or more providers are configured this way, Nocturne **bypasses the database
    entirely and hides the management UI**. Use this for declarative, infrastructure-as-code
@@ -45,10 +46,13 @@ Nocturne reads providers from one of two places:
 
 ### Option A: the admin UI
 
+<PlatformAdminNote />
+
 1. Register the callback URL (above) with your provider and obtain a **client ID** and
    **client secret**.
-2. Sign in to your Nocturne instance as an admin.
-3. Go to **Settings > Admin > OIDC Providers** and click **Add Provider**.
+2. Sign in to your Nocturne instance as a platform admin.
+3. Go to **Settings > Administration** (`/settings/admin`), open the **Identity Providers**
+   tab, and click **Add Provider**.
 4. Fill in the fields (see the field reference below) and **Save**.
 
 The new sign-in button appears on your login page immediately.

--- a/src/Web/packages/portal/src/lib/components/docs/PlatformAdminNote.svelte
+++ b/src/Web/packages/portal/src/lib/components/docs/PlatformAdminNote.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+    // Shared by every page that sends the reader to Settings > Administration. That
+    // section is gated on the platform admin flag, which is easy to mistake for the
+    // tenant owner role, so the explanation lives here rather than on one page.
+    import Callout from "@nocturne/cms/components/Callout.svelte";
+</script>
+
+<Callout type="info" title="Can't see the Administration section?">
+    Administration is only visible to a <strong>platform admin</strong>. That is a
+    separate permission from a tenant's <strong>owner</strong> role, so being the owner
+    of your instance is not enough on its own — opening
+    <code>/settings/admin</code> without it sends you back to <strong>Settings</strong>.
+    On a new install the permission goes to the owner of the first tenant, granted when
+    that owner finishes setting up their passkey or sign-in provider.
+    <br /><br />
+    If you set your instance up on an earlier version, the grant only ran while the API
+    was starting, so the owner never received it. Restart the Nocturne API container
+    once and sign in again. That works as long as nobody currently holds the
+    permission; if someone does, have them grant it to you from
+    <strong>Settings &gt; Administration</strong>.
+</Callout>

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/SetupControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/SetupControllerTests.cs
@@ -746,6 +746,58 @@ public class SetupControllerTests : IDisposable
         subject.IsPlatformAdmin.Should().BeFalse();
     }
 
+    [Fact]
+    public async Task OidcCallback_WhenSetupAlreadyComplete_DoesNotProcessTheCallback()
+    {
+        // Every sibling setup endpoint dead-ends once an owner holds credentials. Without the
+        // same guard here this callback stays live for the life of the instance, and it links
+        // an identity and issues a session for whatever subject the state names.
+        await SeedConfiguredTenantAsync("established", "Established");
+        SetOidcStateCookieOnRequest("expected-state");
+
+        var result = await _controller.OidcCallback(
+            code: "auth-code", state: "expected-state", error: null, error_description: null,
+            ct: CancellationToken.None);
+
+        result.Should().BeOfType<RedirectResult>()
+            .Which.Url.Should().Contain("setup_already_complete");
+        _oidcAuthService.Verify(
+            s => s.HandleSetupCallbackAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<string?>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task OidcCallback_WhenTheCallbackNamesANonOwnerSubject_DoesNotGrantPlatformAdmin()
+    {
+        // The grant re-derives eligibility instead of trusting the subject it is handed, so a
+        // subject that does not hold the tenant's owner role gets nothing.
+        await SeedSoleTenantWithOwnerRoleAsync();
+        var bystanderId = Guid.CreateVersion7();
+        _dbContext.Subjects.Add(new SubjectEntity
+        {
+            Id = bystanderId, Name = "Bystander", Username = "bystander",
+            IsActive = true, IsSystemSubject = false,
+        });
+        await _dbContext.SaveChangesAsync();
+
+        SetOidcStateCookieOnRequest("expected-state");
+        _oidcAuthService
+            .Setup(s => s.HandleSetupCallbackAsync(
+                "auth-code", "expected-state", "expected-state",
+                It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(OidcSetupCallbackResult.Succeeded(
+                bystanderId, new OidcTokenResponse { AccessToken = "at", RefreshToken = "rt", ExpiresIn = 3600 }));
+
+        await _controller.OidcCallback(
+            code: "auth-code", state: "expected-state", error: null, error_description: null,
+            ct: CancellationToken.None);
+
+        var bystander = await FreshContext().Subjects.SingleAsync(s => s.Id == bystanderId);
+        bystander.IsPlatformAdmin.Should().BeFalse();
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────
 
     private NocturneDbContext FreshContext() => new(_dbOptions);

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/SetupControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/SetupControllerTests.cs
@@ -5,10 +5,12 @@ using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Nocturne.API.Configuration;
 using Nocturne.API.Controllers.V4;
+using Nocturne.API.Services.Auth;
 using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Configuration;
@@ -37,6 +39,7 @@ public class SetupControllerTests : IDisposable
     private readonly Mock<ISessionService> _sessionService;
     private readonly Mock<ISubjectService> _subjectService;
     private readonly Mock<IOidcAuthService> _oidcAuthService;
+    private readonly PlatformOptions _platformOptions;
     private readonly SetupController _controller;
 
     public SetupControllerTests()
@@ -77,6 +80,14 @@ public class SetupControllerTests : IDisposable
                 return ctx;
             });
 
+        // A real instance, not a mock: the platform-admin grant is part of the
+        // behaviour under test, and BootstrapAsync is not virtual.
+        _platformOptions = new PlatformOptions();
+        var platformAdminBootstrap = new PlatformAdminBootstrapService(
+            dbFactory.Object,
+            Options.Create(_platformOptions),
+            NullLogger<PlatformAdminBootstrapService>.Instance);
+
         _controller = new SetupController(
             _tenantService.Object,
             _passkeyService.Object,
@@ -88,6 +99,7 @@ public class SetupControllerTests : IDisposable
             _oidcAuthService.Object,
             Options.Create(new OperatorConfiguration()),
             new Mock<IHttpClientFactory>().Object,
+            platformAdminBootstrap,
             new Mock<ILogger<SetupController>>().Object);
 
         _controller.ControllerContext = new ControllerContext
@@ -311,8 +323,9 @@ public class SetupControllerTests : IDisposable
         result.Should().BeOfType<ConflictObjectResult>();
     }
 
-    // OwnerOptions scenarios whose outcome depends on RLS rather than on the guard logic live
-    // in the integration suite: SQLite has no policies for the pinned reads to be gated by.
+    // Sole-tenant paths run here via the set_config() stand-in registered in the
+    // constructor. What SQLite cannot reproduce is RLS, so tests that depend on rows
+    // being filtered by tenant belong in the integration suite.
 
     // ── Soft-lock scenario: the full sequence ─────────────────────────────
 
@@ -623,10 +636,206 @@ public class SetupControllerTests : IDisposable
         result.Should().BeOfType<ConflictObjectResult>();
     }
 
-    // OwnerOidc scenarios that require a sole tenant (e.g. validation of empty
-    // username/ProviderId) are covered by the integration suite.
+    // OwnerOidc field-validation cases (empty username, empty ProviderId) are left to
+    // the integration suite; the sole-tenant guard itself is exercised above.
+
+    // ── Platform admin bootstrap ─────────────────────────────────────────
+
+    [Fact]
+    public async Task OwnerComplete_WhenFirstOwnerRegistersPasskey_GrantsPlatformAdmin()
+    {
+        // The fresh-install lockout: the startup bootstrap pass ran against an empty
+        // database, so the owner created by setup kept is_platform_admin = false and
+        // /settings/admin redirected to /settings until the API was restarted.
+        var (_, subjectId) = await SeedSoleTenantWithOwnerRoleAsync();
+        StubPasskeyCompletion(subjectId);
+
+        var result = await CompleteOwnerSetupAsync();
+
+        result.Should().BeOfType<OkObjectResult>();
+        var subject = await FreshContext().Subjects.SingleAsync(s => s.Id == subjectId);
+        subject.IsPlatformAdmin.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task OwnerOptions_BeforeCeremonyCompletes_DoesNotGrantPlatformAdmin()
+    {
+        // An abandoned WebAuthn ceremony must not leave a credential-less subject holding
+        // the flag: that would suppress every later grant, including the startup pass,
+        // and lock the instance out permanently.
+        var (_, subjectId) = await SeedSoleTenantWithOwnerRoleAsync();
+        _passkeyService
+            .Setup(s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>()))
+            .ReturnsAsync(new PasskeyRegistrationOptions("{}", "challenge-token"));
+
+        await _controller.OwnerOptions(
+            new SetupOwnerOptionsRequest { Username = "owner", DisplayName = "Owner" },
+            CancellationToken.None);
+
+        var subject = await FreshContext().Subjects.SingleAsync(s => s.Id == subjectId);
+        subject.IsPlatformAdmin.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task OwnerComplete_WhenPlatformAdminAlreadyExists_DoesNotGrantToOwner()
+    {
+        // An existing platform admin means this is not a fresh install, so setup must
+        // not hand the flag to whoever completes it.
+        var (_, subjectId) = await SeedSoleTenantWithOwnerRoleAsync();
+        await SeedPlatformAdminAsync();
+        StubPasskeyCompletion(subjectId);
+
+        await CompleteOwnerSetupAsync();
+
+        var subject = await FreshContext().Subjects.SingleAsync(s => s.Id == subjectId);
+        subject.IsPlatformAdmin.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task OwnerComplete_WhenAdminSubjectIdsConfigured_LeavesOwnerWithoutPlatformAdmin()
+    {
+        // Operators who pin Platform:AdminSubjectIds own the decision outright.
+        var (_, subjectId) = await SeedSoleTenantWithOwnerRoleAsync();
+        _platformOptions.AdminSubjectIds.Add(Guid.CreateVersion7());
+        StubPasskeyCompletion(subjectId);
+
+        await CompleteOwnerSetupAsync();
+
+        var subject = await FreshContext().Subjects.SingleAsync(s => s.Id == subjectId);
+        subject.IsPlatformAdmin.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task OidcCallback_WhenFirstOwnerLinksIdentity_GrantsPlatformAdmin()
+    {
+        // The OIDC setup path completes in the callback, not OwnerOidc, so it needs the
+        // same grant — this is the path a self-hoster using Google login takes.
+        var (_, subjectId) = await SeedSoleTenantWithOwnerRoleAsync();
+        SetOidcStateCookieOnRequest("expected-state");
+        _oidcAuthService
+            .Setup(s => s.HandleSetupCallbackAsync(
+                "auth-code", "expected-state", "expected-state",
+                It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(OidcSetupCallbackResult.Succeeded(
+                subjectId, new OidcTokenResponse { AccessToken = "at", RefreshToken = "rt", ExpiresIn = 3600 }));
+
+        await _controller.OidcCallback(
+            code: "auth-code", state: "expected-state", error: null, error_description: null,
+            ct: CancellationToken.None);
+
+        var subject = await FreshContext().Subjects.SingleAsync(s => s.Id == subjectId);
+        subject.IsPlatformAdmin.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task OidcCallback_WhenCallbackFails_DoesNotGrantPlatformAdmin()
+    {
+        var (_, subjectId) = await SeedSoleTenantWithOwnerRoleAsync();
+        SetOidcStateCookieOnRequest("expected-state");
+        _oidcAuthService
+            .Setup(s => s.HandleSetupCallbackAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(OidcSetupCallbackResult.Failed("invalid_grant"));
+
+        await _controller.OidcCallback(
+            code: "auth-code", state: "expected-state", error: null, error_description: null,
+            ct: CancellationToken.None);
+
+        var subject = await FreshContext().Subjects.SingleAsync(s => s.Id == subjectId);
+        subject.IsPlatformAdmin.Should().BeFalse();
+    }
 
     // ── Helpers ──────────────────────────────────────────────────────────
+
+    private NocturneDbContext FreshContext() => new(_dbOptions);
+
+    /// <summary>
+    /// Drives the passkey completion step with the mocks it needs to reach the grant.
+    /// </summary>
+    private Task<IActionResult> CompleteOwnerSetupAsync() =>
+        _controller.OwnerComplete(
+            new SetupOwnerCompleteRequest
+            {
+                AttestationResponseJson = "{}",
+                ChallengeToken = "challenge-token",
+            },
+            CancellationToken.None);
+
+    private void StubPasskeyCompletion(Guid subjectId)
+    {
+        _passkeyService
+            .Setup(s => s.CompleteRegistrationAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), subjectId, It.IsAny<string?>()))
+            .ReturnsAsync(new PasskeyCredentialResult(Guid.CreateVersion7(), subjectId));
+        _recoveryCodeService
+            .Setup(s => s.GenerateCodesAsync(subjectId))
+            .ReturnsAsync(["code-1", "code-2"]);
+        _sessionService
+            .Setup(s => s.IssueSessionAsync(subjectId, It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SessionTokenPair("access", "refresh", 3600));
+    }
+
+    private void SetOidcStateCookieOnRequest(string state) =>
+        _controller.ControllerContext.HttpContext.Request.Headers.Cookie =
+            $".Nocturne.OidcState={state}";
+
+    /// <summary>
+    /// Seeds a subject that already holds platform admin, making the instance an
+    /// established one rather than a fresh install.
+    /// </summary>
+    private async Task SeedPlatformAdminAsync()
+    {
+        _dbContext.Subjects.Add(new SubjectEntity
+        {
+            Id = Guid.CreateVersion7(),
+            Name = "Existing Admin",
+            Username = "existing-admin",
+            IsActive = true,
+            IsSystemSubject = true,
+            IsPlatformAdmin = true,
+        });
+        await _dbContext.SaveChangesAsync();
+    }
+
+    /// <summary>
+    /// Seeds the state a fresh install reaches after tenant creation and a first pass
+    /// through owner setup: a sole tenant whose credential-less member holds the owner
+    /// role. <see cref="ITenantService.AddMemberAsync"/> is mocked, so the membership
+    /// and its role link are written directly.
+    /// </summary>
+    private async Task<(Guid TenantId, Guid SubjectId)> SeedSoleTenantWithOwnerRoleAsync()
+    {
+        var tenantId = Guid.CreateVersion7();
+        var subjectId = Guid.CreateVersion7();
+        var memberId = Guid.CreateVersion7();
+        var ownerRoleId = Guid.CreateVersion7();
+
+        _dbContext.Set<TenantEntity>().Add(new TenantEntity
+        {
+            Id = tenantId, Slug = "my-instance", DisplayName = "My Instance",
+        });
+        _dbContext.Subjects.Add(new SubjectEntity
+        {
+            Id = subjectId, Name = "Owner", Username = "owner",
+            IsActive = true, IsSystemSubject = false,
+        });
+        _dbContext.TenantMembers.Add(new TenantMemberEntity
+        {
+            Id = memberId, TenantId = tenantId, SubjectId = subjectId,
+        });
+        _dbContext.Set<TenantRoleEntity>().Add(new TenantRoleEntity
+        {
+            Id = ownerRoleId, TenantId = tenantId, Name = "Owner", Slug = "owner", IsSystem = true,
+        });
+        _dbContext.Set<TenantMemberRoleEntity>().Add(new TenantMemberRoleEntity
+        {
+            Id = Guid.CreateVersion7(), TenantMemberId = memberId, TenantRoleId = ownerRoleId,
+        });
+        await _dbContext.SaveChangesAsync();
+
+        return (tenantId, subjectId);
+    }
 
     /// <summary>
     /// Seeds the sole tenant plus the credential-less owner subject and membership that

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/SetupControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/SetupControllerTests.cs
@@ -323,9 +323,9 @@ public class SetupControllerTests : IDisposable
         result.Should().BeOfType<ConflictObjectResult>();
     }
 
-    // Sole-tenant paths run here via the set_config() stand-in registered in the
-    // constructor. What SQLite cannot reproduce is RLS, so tests that depend on rows
-    // being filtered by tenant belong in the integration suite.
+    // Sole-tenant paths run here because PinTenantAsync no-ops off Postgres. What SQLite
+    // cannot reproduce is RLS, so tests that depend on rows being filtered by tenant
+    // belong in the integration suite.
 
     // ── Soft-lock scenario: the full sequence ─────────────────────────────
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/PlatformAdminBootstrapServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/PlatformAdminBootstrapServiceTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Nocturne.API.Services.Auth;
 using Nocturne.Core.Models.Authorization;
@@ -23,6 +24,7 @@ namespace Nocturne.API.Tests.Services.Auth;
 public class PlatformAdminBootstrapServiceTests : IDisposable
 {
     private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<NocturneDbContext> _dbOptions;
     private readonly NocturneDbContext _db;
 
     public PlatformAdminBootstrapServiceTests()
@@ -30,12 +32,12 @@ public class PlatformAdminBootstrapServiceTests : IDisposable
         _connection = new SqliteConnection("DataSource=:memory:");
         _connection.Open();
 
-        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+        _dbOptions = new DbContextOptionsBuilder<NocturneDbContext>()
             .UseSqlite(_connection)
             .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
             .Options;
 
-        _db = new NocturneDbContext(options);
+        _db = new NocturneDbContext(_dbOptions);
         _db.Database.EnsureCreated();
     }
 
@@ -106,9 +108,16 @@ public class PlatformAdminBootstrapServiceTests : IDisposable
 
     private Task BootstrapAsync(List<Guid>? adminSubjectIds = null) =>
         new PlatformAdminBootstrapService(
-            _db,
-            Options.Create(new PlatformOptions { AdminSubjectIds = adminSubjectIds ?? [] }))
+            new TestDbContextFactory(_dbOptions),
+            Options.Create(new PlatformOptions { AdminSubjectIds = adminSubjectIds ?? [] }),
+            NullLogger<PlatformAdminBootstrapService>.Instance)
             .BootstrapAsync(CancellationToken.None);
+
+    private sealed class TestDbContextFactory(DbContextOptions<NocturneDbContext> options)
+        : IDbContextFactory<NocturneDbContext>
+    {
+        public NocturneDbContext CreateDbContext() => new(options);
+    }
 
     private async Task<bool> IsPlatformAdminAsync(Guid subjectId) =>
         await _db.Subjects.AsNoTracking()


### PR DESCRIPTION
## The bug

A new self-hoster reported that they couldn't find the Admin Panel the docs describe — `/settings/admin` just redirected them back to `/settings`, despite being the owner of their instance.

They were right, and it wasn't a permissions misunderstanding. The admin UI is gated on `subjects.is_platform_admin`, which is a separate per-subject column, **not** the tenant `owner` role. That flag was only ever granted by `PlatformAdminBootstrapService`, which runs once at API startup. On a fresh install the ordering is fatal:

1. Container starts → migrations run → bootstrap runs against an **empty** database → grants nothing (returns early when no owner exists).
2. The setup wizard creates the owner. Nothing in `SetupController` ever touched `is_platform_admin`.
3. Bootstrap is never re-invoked in the process lifetime.

Result: the owner is redirected away from `/settings/admin` indefinitely, and the sidebar entry is hidden by the same flag, so there's no visible hint the section exists. Nothing is cached — the middleware reads the column fresh per request — so the `false` they saw was the genuine DB value. The only recovery was restarting the API container, which is undocumented.

## The fix

Grant the flag at the two points where first-owner setup actually completes: after the passkey attestation verifies (`OwnerComplete`), and after the setup OIDC callback succeeds (`OidcCallback`). Both call `EnsureFirstOwnerIsPlatformAdminAsync`, which preserves the existing precedence rules:

- `Platform:AdminSubjectIds` wins outright — operators who pin the choice keep it.
- An instance that already has a platform admin is left alone, so an established instance never hands the flag to whoever runs setup.

**Why completion and not `EnsureOwnerSubjectAsync`:** that helper is the shared chokepoint and was my first instinct, but it runs *before* the WebAuthn ceremony. An abandoned ceremony would leave a credential-less subject holding the flag, and since the bootstrap no-ops when *any* platform admin exists, that would suppress every later grant **including the startup pass** — converting a restart-recoverable lockout into a permanent one. Granting on completion avoids that entirely.

The new method also takes the subject explicitly rather than re-deriving "owner of the oldest tenant", so the grant can't land on a different subject when more than one non-system subject exists (the reuse pick in `EnsureOwnerSubjectAsync` has no `OrderBy`).

### Diagnosability

Two silent lockout paths now log:

- `Platform:AdminSubjectIds` matching no existing subject. Config wins, so one typo'd GUID leaves the instance with no platform admin at all and no way in — previously silent.
- No tenant owner found during the startup pass (expected on a fresh install, but it's the exact state an operator debugging this needs to see).

### Docs

The docs said **Settings > Admin > OIDC Providers**. The real heading is **Administration** and the tab is **Identity Providers** — so the reporter was looking for something that doesn't exist under that name, with no URL given. Corrected across `google.svx`, `github.svx` and `oidc.svx`, plus a shared `PlatformAdminNote` component explaining the owner-vs-platform-admin distinction and the restart workaround for instances already in this state.

## Testing

Full API unit suite green: **4164 passed, 0 failed**.

Six new tests in `SetupControllerTests`, covering both grant paths and the guards:

| Test | Asserts |
|---|---|
| `OwnerComplete_WhenFirstOwnerRegistersPasskey_GrantsPlatformAdmin` | the reported bug is fixed |
| `OidcCallback_WhenFirstOwnerLinksIdentity_GrantsPlatformAdmin` | the OIDC path (what this reporter was setting up) |
| `OwnerOptions_BeforeCeremonyCompletes_DoesNotGrantPlatformAdmin` | no credential-less subject holds the flag |
| `OwnerComplete_WhenPlatformAdminAlreadyExists_DoesNotGrantToOwner` | established instances unaffected |
| `OwnerComplete_WhenAdminSubjectIdsConfigured_LeavesOwnerWithoutPlatformAdmin` | operator config still wins |
| `OidcCallback_WhenCallbackFails_DoesNotGrantPlatformAdmin` | failed auth grants nothing |

I verified the two grant tests genuinely fail with the calls removed, so they aren't passing vacuously. Portal builds and the shared note renders on all three prerendered pages.

## Note for reviewers

`PlatformAdminBootstrapService` now takes `IDbContextFactory<NocturneDbContext>` instead of an injected `NocturneDbContext`, so it works identically at startup and mid-request without depending on a tenant pinned to a request-scoped context. It's registered in DI rather than hand-constructed in `Program.cs`. The four tables it touches (`subjects`, `tenant_members`, `tenant_roles`, `tenant_member_roles`) carry no RLS policies and don't implement `ITenantScoped`, so the tenantless context reads them correctly — I checked this against the migrations rather than assuming.

One pre-existing behaviour left alone: `ExecuteUpdateAsync` bypasses `SaveChanges`, so the privilege grant writes no audit row. Worth a follow-up, but out of scope here.
