### PR TITLE
fix(auth): anonymous passkey binding to any subject, and an unauthenticated demo admin API

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
@@ -108,15 +108,96 @@ public class PasskeyController : ControllerBase
             return Problem(detail: "Username is required", statusCode: 400, title: "Bad Request");
         }
 
+        var subjectId = await ResolveRegistrationSubjectAsync(request.Username);
+        if (subjectId == null)
+        {
+            // Deliberately not distinguishing "no such username" from "that account already
+            // has a credential", matching RecoveryVerify's non-disclosure.
+            return Problem(
+                detail: "Cannot register a passkey for this account",
+                statusCode: 400, title: "Bad Request");
+        }
+
         var tenantId = _tenantAccessor.TenantId;
         var result = await _passkeyService.GenerateRegistrationOptionsAsync(
-            request.SubjectId, request.Username, tenantId);
+            subjectId.Value, request.Username, tenantId);
 
         return Ok(new PasskeyOptionsResponse
         {
             Options = result.OptionsJson,
             ChallengeToken = result.ChallengeToken,
         });
+    }
+
+    /// <summary>
+    /// Resolves which subject a registration ceremony is allowed to bind a credential to.
+    /// </summary>
+    /// <param name="username">The account named on the request.</param>
+    /// <returns>The subject to register against, or <see langword="null"/> when none qualifies.</returns>
+    /// <remarks>
+    /// <para>
+    /// The request deliberately gets no say in this. The subject id is sealed into the challenge
+    /// token here and nothing downstream re-checks it, so honouring a caller-supplied one let an
+    /// anonymous caller bind their own authenticator to any subject whose id they knew and then
+    /// log in as them.
+    /// </para>
+    /// <para>
+    /// Three flows legitimately reach this endpoint, in precedence order: adding a passkey to
+    /// your own account, re-registering after spending a recovery code, and claiming an account
+    /// that holds no credential at all (first owner on a fresh install, or an orphaned subject
+    /// while the instance is in recovery mode).
+    /// </para>
+    /// </remarks>
+    private async Task<Guid?> ResolveRegistrationSubjectAsync(string username)
+    {
+        var auth = HttpContext.GetAuthContext();
+        if (auth is { IsAuthenticated: true, SubjectId: not null })
+            return auth.SubjectId;
+
+        if (TryReadRecoverySessionSubject() is { } recoverySubjectId)
+            return recoverySubjectId;
+
+        return await FindCredentiallessSubjectAsync(username);
+    }
+
+    /// <summary>
+    /// Reads the subject out of the short-lived recovery session minted by
+    /// <see cref="RecoveryVerify"/>, which is the proof that a recovery code was spent.
+    /// </summary>
+    private Guid? TryReadRecoverySessionSubject()
+    {
+        var token = Request.Cookies[RecoveryCookieName];
+        if (string.IsNullOrEmpty(token))
+            return null;
+
+        var validation = _jwtService.ValidateAccessToken(token);
+        if (!validation.IsValid || validation.Claims is null)
+            return null;
+
+        return validation.Claims.Permissions.Contains("passkey:manage")
+            ? validation.Claims.SubjectId
+            : null;
+    }
+
+    /// <summary>
+    /// Finds the named subject in the current tenant only if it holds no passkey and no OIDC
+    /// identity. Such a subject cannot currently be logged into by anyone, so binding the first
+    /// credential to it takes nothing over — this is the same condition
+    /// <see cref="GetAuthStatus"/> reports as setup-required or recovery mode.
+    /// </summary>
+    private async Task<Guid?> FindCredentiallessSubjectAsync(string username)
+    {
+        var tenantId = _tenantAccessor.TenantId;
+
+        return await _dbContext.TenantMembers
+            .Where(tm => tm.TenantId == tenantId)
+            .Select(tm => tm.Subject!)
+            .Where(s => s.Username == username && s.IsActive && !s.IsSystemSubject)
+            .Where(s =>
+                !_dbContext.PasskeyCredentials.Any(c => c.SubjectId == s.Id) &&
+                !_dbContext.SubjectOidcIdentities.Any(o => o.SubjectId == s.Id))
+            .Select(s => (Guid?)s.Id)
+            .FirstOrDefaultAsync();
     }
 
     /// <summary>
@@ -803,7 +884,11 @@ public class PasskeyOptionsResponse
 /// </summary>
 public class PasskeyRegisterOptionsRequest
 {
-    public Guid SubjectId { get; set; }
+    /// <remarks>
+    /// Names the account only for the credentialless-claim flow. There is deliberately no
+    /// subject id here — the server resolves the subject, because a caller-supplied one is an
+    /// anonymous account-takeover.
+    /// </remarks>
     public string Username { get; set; } = string.Empty;
 }
 

--- a/src/API/Nocturne.API/Controllers/V4/Admin/DemoAdminController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Admin/DemoAdminController.cs
@@ -13,11 +13,17 @@ namespace Nocturne.API.Controllers.V4.Admin;
 
 /// <summary>
 /// Internal admin controller for demo tenant lifecycle management.
-/// Called only by the demo background service (service-to-service); not exposed through the gateway.
 /// </summary>
+/// <remarks>
+/// Called by the demo background service, which authenticates with the instance key — that
+/// yields the <c>platform_admin</c> role, so no caller change was needed to gate this. It was
+/// previously <c>[AllowAnonymous]</c> on the assumption it was unreachable from outside; it is
+/// in fact tenantless-allowed and reachable through the web app's <c>/api</c> proxy, which made
+/// demo-tenant provisioning and deletion anonymous operations.
+/// </remarks>
 [ApiController]
 [Route("api/v4/admin/demo")]
-[AllowAnonymous]
+[Authorize(Roles = "platform_admin")]
 [ApiExplorerSettings(IgnoreApi = true)]
 public class DemoAdminController : ControllerBase
 {

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/account/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/account/+page.svelte
@@ -133,7 +133,7 @@
     errorMessage = null;
 
     try {
-      const response = await registerOptions({ subjectId: user.subjectId, username: user.name });
+      const response = await registerOptions({ username: user.name });
       const options = JSON.parse(response.options ?? "");
       const challengeToken = response.challengeToken ?? "";
 

--- a/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyControllerTests.cs
@@ -10,6 +10,8 @@ using Moq;
 using Nocturne.API.Controllers.Authentication;
 using Nocturne.API.Services.Auth;
 using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.Configuration;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
@@ -98,14 +100,112 @@ public class PasskeyControllerTests : IDisposable
         _connection.Dispose();
     }
 
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    /// <summary>Seeds an active subject that is a member of the given tenant (this one by default).</summary>
+    private async Task<Guid> SeedMemberAsync(string username, Guid? tenantId = null)
+    {
+        var resolvedTenantId = tenantId ?? _tenantId;
+        await EnsureTenantAsync(resolvedTenantId);
+
+        var subjectId = Guid.CreateVersion7();
+        _dbContext.Subjects.Add(new SubjectEntity
+        {
+            Id = subjectId,
+            Name = username,
+            Username = username,
+            IsActive = true,
+            IsSystemSubject = false,
+        });
+        _dbContext.TenantMembers.Add(new TenantMemberEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = resolvedTenantId,
+            SubjectId = subjectId,
+        });
+        await _dbContext.SaveChangesAsync();
+        return subjectId;
+    }
+
+    private async Task EnsureTenantAsync(Guid tenantId)
+    {
+        if (await _dbContext.Set<TenantEntity>().AnyAsync(t => t.Id == tenantId))
+            return;
+
+        _dbContext.Set<TenantEntity>().Add(new TenantEntity
+        {
+            Id = tenantId,
+            Slug = "t" + tenantId.ToString("N")[..8],
+            DisplayName = "Tenant",
+        });
+        await _dbContext.SaveChangesAsync();
+    }
+
+    private async Task SeedPasskeyCredentialAsync(Guid subjectId)
+    {
+        _dbContext.PasskeyCredentials.Add(new PasskeyCredentialEntity
+        {
+            Id = Guid.CreateVersion7(),
+            SubjectId = subjectId,
+            CredentialId = Guid.CreateVersion7().ToByteArray(),
+            PublicKey = [1, 2, 3],
+        });
+        await _dbContext.SaveChangesAsync();
+    }
+
+    private async Task SeedOidcIdentityAsync(Guid subjectId)
+    {
+        var providerId = Guid.CreateVersion7();
+        _dbContext.Set<OidcProviderEntity>().Add(new OidcProviderEntity
+        {
+            Id = providerId,
+            Name = "Keycloak",
+            IssuerUrl = "https://issuer.example",
+            ClientId = "nocturne",
+        });
+        _dbContext.SubjectOidcIdentities.Add(new SubjectOidcIdentityEntity
+        {
+            Id = Guid.CreateVersion7(),
+            SubjectId = subjectId,
+            ProviderId = providerId,
+            OidcSubjectId = "ext-" + subjectId,
+            Issuer = "https://issuer.example",
+        });
+        await _dbContext.SaveChangesAsync();
+    }
+
+    private void Authenticate(Guid subjectId) =>
+        _controller.ControllerContext.HttpContext.Items["AuthContext"] = new AuthContext
+        {
+            IsAuthenticated = true,
+            SubjectId = subjectId,
+            TenantId = _tenantId,
+        };
+
+    /// <summary>Presents a recovery-session cookie that the JWT service accepts for this subject.</summary>
+    private void GiveRecoverySession(Guid subjectId, params string[] permissions)
+    {
+        const string token = "recovery-token";
+        _controller.ControllerContext.HttpContext.Request.Headers.Cookie =
+            $".Nocturne.RecoverySession={token}";
+        _jwtService
+            .Setup(s => s.ValidateAccessToken(token))
+            .Returns(JwtValidationResult.Success(new JwtClaims
+            {
+                SubjectId = subjectId,
+                Permissions = [.. permissions],
+            }));
+    }
+
+    private void StubRegistrationOptions(Guid subjectId, string username) =>
+        _passkeyService
+            .Setup(s => s.GenerateRegistrationOptionsAsync(subjectId, username, _tenantId))
+            .ReturnsAsync(new PasskeyRegistrationOptions("{\"challenge\":\"abc\"}", "token-data"));
+
     [Fact]
     public async Task RegisterOptions_EmptyUsername_ReturnsBadRequest()
     {
-        var request = new PasskeyRegisterOptionsRequest
-        {
-            SubjectId = Guid.CreateVersion7(),
-            Username = "",
-        };
+        var request = new PasskeyRegisterOptionsRequest { Username = "" };
 
         var result = await _controller.RegisterOptions(request);
 
@@ -116,24 +216,121 @@ public class PasskeyControllerTests : IDisposable
     [Fact]
     public async Task RegisterOptions_ValidRequest_CallsServiceAndReturnsOptionsWithToken()
     {
-        var subjectId = Guid.CreateVersion7();
-        _passkeyService
-            .Setup(s => s.GenerateRegistrationOptionsAsync(subjectId, "testuser", _tenantId))
-            .ReturnsAsync(new PasskeyRegistrationOptions("{\"challenge\":\"abc\"}", "token-data"));
+        var subjectId = await SeedMemberAsync("testuser");
+        StubRegistrationOptions(subjectId, "testuser");
 
-        var request = new PasskeyRegisterOptionsRequest
-        {
-            SubjectId = subjectId,
-            Username = "testuser",
-        };
-
-        var result = await _controller.RegisterOptions(request);
+        var result = await _controller.RegisterOptions(
+            new PasskeyRegisterOptionsRequest { Username = "testuser" });
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var response = Assert.IsType<PasskeyOptionsResponse>(okResult.Value);
         Assert.Contains("challenge", response.Options);
         Assert.Equal("token-data", response.ChallengeToken);
         _passkeyService.Verify(s => s.GenerateRegistrationOptionsAsync(subjectId, "testuser", _tenantId), Times.Once);
+    }
+
+    // ── Registration subject binding ─────────────────────────────────────
+
+    [Fact]
+    public async Task RegisterOptions_WhenAnonymousAndTheAccountHasACredential_IsRefused()
+    {
+        // The takeover: an anonymous caller naming an established account used to have its
+        // subject id honoured, binding their own authenticator to that account.
+        var victimId = await SeedMemberAsync("victim");
+        await SeedPasskeyCredentialAsync(victimId);
+
+        var result = await _controller.RegisterOptions(
+            new PasskeyRegisterOptionsRequest { Username = "victim" });
+
+        var objectResult = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(400, objectResult.StatusCode);
+        _passkeyService.Verify(
+            s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task RegisterOptions_WhenAnonymousAndTheAccountHasAnOidcIdentity_IsRefused()
+    {
+        var victimId = await SeedMemberAsync("victim");
+        await SeedOidcIdentityAsync(victimId);
+
+        var result = await _controller.RegisterOptions(
+            new PasskeyRegisterOptionsRequest { Username = "victim" });
+
+        Assert.Equal(400, Assert.IsType<ObjectResult>(result.Result).StatusCode);
+        _passkeyService.Verify(
+            s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task RegisterOptions_WhenAuthenticated_BindsToTheAuthenticatedSubject()
+    {
+        // Adding a passkey to your own account. The username on the request is not the
+        // authority — the session is — so naming someone else changes nothing.
+        var callerId = await SeedMemberAsync("caller");
+        await SeedPasskeyCredentialAsync(callerId);
+        var victimId = await SeedMemberAsync("victim");
+        await SeedPasskeyCredentialAsync(victimId);
+        Authenticate(callerId);
+        StubRegistrationOptions(callerId, "victim");
+
+        var result = await _controller.RegisterOptions(
+            new PasskeyRegisterOptionsRequest { Username = "victim" });
+
+        Assert.IsType<OkObjectResult>(result.Result);
+        _passkeyService.Verify(
+            s => s.GenerateRegistrationOptionsAsync(callerId, "victim", _tenantId), Times.Once);
+        _passkeyService.Verify(
+            s => s.GenerateRegistrationOptionsAsync(victimId, It.IsAny<string>(), It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RegisterOptions_WithARecoverySession_BindsToTheCookieSubject()
+    {
+        // Re-registering after spending a recovery code: the account still holds its old
+        // credential, so only the recovery session makes this allowed.
+        var subjectId = await SeedMemberAsync("owner");
+        await SeedPasskeyCredentialAsync(subjectId);
+        GiveRecoverySession(subjectId, "passkey:manage");
+        StubRegistrationOptions(subjectId, "owner");
+
+        var result = await _controller.RegisterOptions(
+            new PasskeyRegisterOptionsRequest { Username = "owner" });
+
+        Assert.IsType<OkObjectResult>(result.Result);
+        _passkeyService.Verify(
+            s => s.GenerateRegistrationOptionsAsync(subjectId, "owner", _tenantId), Times.Once);
+    }
+
+    [Fact]
+    public async Task RegisterOptions_WithARecoverySessionLackingPasskeyManage_IsRefused()
+    {
+        var subjectId = await SeedMemberAsync("owner");
+        await SeedPasskeyCredentialAsync(subjectId);
+        GiveRecoverySession(subjectId, "glucose.read");
+
+        var result = await _controller.RegisterOptions(
+            new PasskeyRegisterOptionsRequest { Username = "owner" });
+
+        Assert.Equal(400, Assert.IsType<ObjectResult>(result.Result).StatusCode);
+    }
+
+    [Fact]
+    public async Task RegisterOptions_ForAnotherTenantsMember_IsRefused()
+    {
+        // Subjects are global; membership is what scopes them. A credentialless subject in
+        // another tenant must not be claimable from this one.
+        var otherTenantSubjectId = await SeedMemberAsync("elsewhere", tenantId: Guid.CreateVersion7());
+
+        var result = await _controller.RegisterOptions(
+            new PasskeyRegisterOptionsRequest { Username = "elsewhere" });
+
+        Assert.Equal(400, Assert.IsType<ObjectResult>(result.Result).StatusCode);
+        _passkeyService.Verify(
+            s => s.GenerateRegistrationOptionsAsync(otherTenantSubjectId, It.IsAny<string>(), It.IsAny<Guid>()),
+            Times.Never);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Validators/Auth/PasskeyRegisterOptionsRequestValidatorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Validators/Auth/PasskeyRegisterOptionsRequestValidatorTests.cs
@@ -11,7 +11,6 @@ public class PasskeyRegisterOptionsRequestValidatorTests
 
     private static PasskeyRegisterOptionsRequest ValidRequest() => new()
     {
-        SubjectId = Guid.NewGuid(),
         Username = "testuser",
     };
 


### PR DESCRIPTION
Two anonymously-reachable privileged endpoints, found while auditing the class of bug behind #577 and #578: a bootstrap endpoint that never checks the instance still needs bootstrapping.

---

## 1. Anonymous passkey binding to any subject

`POST /api/auth/passkey/register/options` is `[AllowAnonymous]` and took the subject from the request body:

```csharp
if (string.IsNullOrEmpty(request.Username))
    return Problem(detail: "Username is required", statusCode: 400, title: "Bad Request");

var tenantId = _tenantAccessor.TenantId;
var result = await _passkeyService.GenerateRegistrationOptionsAsync(
    request.SubjectId, request.Username, tenantId);   // ← unvalidated body field
```

`GenerateRegistrationOptionsAsync` seals that GUID into the challenge token and **discards `tenantId`**. `CompleteRegistrationAsync` then persists a credential for `cookie.SubjectId` with no membership check, no ownership check, and no setup-state check — the only limit is a 20-credential cap. `CompleteAssertionAsync` requires only that a credential's subject be a member of the tenant, which the victim is.

**Attack.** Preconditions: network reach to the tenant, and one target subject GUID.

1. `POST register/options` → `{"subjectId":"<victim-guid>","username":"anything"}`
2. Run the WebAuthn ceremony against your own authenticator
3. `POST register/complete` → your authenticator is now a credential on the victim's account
4. `POST login/options` + `login/complete` → session cookies as the victim

If the victim is the first owner they carry `is_platform_admin`, so this chains to platform admin and `PlatformAccessController`'s any-tenant-by-slug grant. Subject ids are UUIDv7 and not brute-forceable, but they aren't secrets either — `POST /api/oauth/introspect` is unauthenticated and returns `sub` for any token, and `GET /api/v4/member-invites/{token}/info` returns `UsedBy` subject ids anonymously.

Data Protection on the challenge token made it *unforgeable*, not *authorized*. The attacker minted it themselves through the front door.

### The fix

The request no longer gets a say. `ResolveRegistrationSubjectAsync` picks the subject, in precedence order:

| Flow | Source of truth |
|---|---|
| Adding a passkey to your own account | the authenticated session |
| Re-registering after spending a recovery code | the `.Nocturne.RecoverySession` cookie's `passkey:manage` claim |
| First owner on a fresh install, or an orphaned subject in recovery mode | username lookup restricted to this tenant's subjects that hold **no** passkey and **no** OIDC identity |

Only the third is anonymous, and a subject with no credential is one nobody can currently log into — binding the first one takes nothing over. It's the same condition `GetAuthStatus` already reports as `setupRequired` / `recoveryMode`.

`SubjectId` is **removed** from the DTO rather than ignored, so it can't drift back. The regenerated schema is `additionalProperties: false`, so it's rejected on the wire too. Only one caller ever sent it (`settings/account`, sending its own id).

Worth flagging: the recovery page's comment said *"registerOptions finds the account by username"* and it sent username only — the server never did that lookup, so `SubjectId` defaulted to `Guid.Empty`. That flow was already broken; it now works as its comment claimed.

### Known residual, deliberately unchanged

Recovery mode is anonymous *by design* — an orphaned subject can be claimed by whoever reaches the instance first. That's how a locked-out owner recovers, and the instance 503s until it's resolved, so it isn't silent. Requiring a recovery code there is a product decision, not a bug fix; say the word and I'll do it separately.

---

## 2. Unauthenticated demo tenant admin API

`DemoAdminController` was `[AllowAnonymous]`, justified by:

> Called only by the demo background service (service-to-service); not exposed through the gateway.

Both halves are wrong. `/api/v4/admin/demo/` is in `TenantResolutionMiddleware`'s tenantless allowlist, and the web app proxies every `/api` path straight through, so the controller is internet-reachable. That made `POST provision`, `PATCH status`, `DELETE entries|treatments|data` and the seeding endpoints anonymous operations — `provision` creates a tenant and grants the anonymous Public subject tenant Admin with `LimitTo24Hours = false`; `DELETE data` destroys the demo tenant's data including every tracker instance, alert instance and excursion.

The real caller already authenticates: the demo service sends `X-Instance-Key` + `X-Instance-Service`, which `InstanceKeyHandler` turns into `IsPlatformAdmin` and `AuthenticationMiddleware` stamps as the `platform_admin` role. So `[Authorize(Roles = "platform_admin")]` — matching `PlatformAdmin/TenantController` — closes it with **no client change**.

---

## Testing

Full API unit suite green: **4176 passed, 0 failed**. Frontend `pnpm check` clean for the touched files.

Six new tests in `PasskeyControllerTests`:

| Test | Asserts |
|---|---|
| `RegisterOptions_WhenAnonymousAndTheAccountHasACredential_IsRefused` | the takeover, closed |
| `RegisterOptions_WhenAnonymousAndTheAccountHasAnOidcIdentity_IsRefused` | OIDC-only accounts are equally protected |
| `RegisterOptions_WhenAuthenticated_BindsToTheAuthenticatedSubject` | the username on the request is not the authority |
| `RegisterOptions_WithARecoverySession_BindsToTheCookieSubject` | recovery-code re-registration still works |
| `RegisterOptions_WithARecoverySessionLackingPasskeyManage_IsRefused` | the claim is actually checked |
| `RegisterOptions_ForAnotherTenantsMember_IsRefused` | subjects are global; membership scopes them |

I verified three of the six genuinely fail with the credentialless check removed.

## Related

- #578 — OIDC state parameter authentication (the root cause of the original report)
- #577 — setup-state gate on the OIDC callback, and re-deriving the platform-admin grant

Same class in all three: a bootstrap path that stays live and trusts a caller-supplied identity. Four lower-severity findings from the same sweep (connector username disclosure on an anonymous endpoint, trackers defaulting to `Public` visibility, unauthenticated OAuth introspection, invite info leaking on expired tokens) plus the unauthenticated SignalR hubs are not in this PR — happy to file them as issues.
