### PR TITLE
fix(auth): authenticate the OIDC state parameter

### DIFF
--- a/src/API/Nocturne.API/Middleware/OidcCallbackRedirectMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/OidcCallbackRedirectMiddleware.cs
@@ -1,8 +1,6 @@
-using System.Text;
-using System.Text.Json;
 using Microsoft.Extensions.Options;
-using Nocturne.API.Helpers;
 using Nocturne.API.Multitenancy;
+using Nocturne.Core.Contracts.Auth;
 
 namespace Nocturne.API.Middleware;
 
@@ -21,8 +19,10 @@ namespace Nocturne.API.Middleware;
 /// <see cref="MemberScopeMiddleware"/>, <see cref="SiteSecurityMiddleware"/>.
 /// </para>
 /// <para>
-/// Extracts the tenant slug from the base64-encoded OIDC <c>state</c> query parameter
-/// and issues a 302 redirect to the correct <c>{slug}.{baseDomain}</c> URL.
+/// Reads the tenant slug out of the protected OIDC <c>state</c> query parameter via
+/// <see cref="IOidcAuthService.TryReadTenantSlug"/> and issues a 302 redirect to the correct
+/// <c>{slug}.{baseDomain}</c> URL. The slug comes from the authenticated state rather than
+/// from a caller-supplied parameter, so the redirect target is one this instance issued.
 /// </para>
 /// </remarks>
 /// <seealso cref="Multitenancy.TenantResolutionMiddleware"/>
@@ -88,7 +88,8 @@ public partial class OidcCallbackRedirectMiddleware
             return;
         }
 
-        var tenantSlug = ExtractTenantSlug(stateParam);
+        var oidcAuthService = context.RequestServices.GetRequiredService<IOidcAuthService>();
+        var tenantSlug = oidcAuthService.TryReadTenantSlug(stateParam);
         if (string.IsNullOrEmpty(tenantSlug))
         {
             await _next(context);
@@ -116,25 +117,6 @@ public partial class OidcCallbackRedirectMiddleware
     {
         var value = path.Value ?? "";
         return CallbackPaths.Any(p => value.Equals(p, StringComparison.OrdinalIgnoreCase));
-    }
-
-    private static string? ExtractTenantSlug(string encoded)
-    {
-        try
-        {
-            var bytes = Base64Url.Decode(encoded);
-            var json = Encoding.UTF8.GetString(bytes);
-
-            using var doc = JsonDocument.Parse(json);
-            if (doc.RootElement.TryGetProperty("TenantSlug", out var prop))
-                return prop.GetString();
-
-            return null;
-        }
-        catch
-        {
-            return null;
-        }
     }
 
     [System.Text.RegularExpressions.GeneratedRegex(@"^[a-z0-9][a-z0-9\-]{0,61}[a-z0-9]$")]

--- a/src/API/Nocturne.API/Services/Auth/OidcAuthService.cs
+++ b/src/API/Nocturne.API/Services/Auth/OidcAuthService.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Options;
 using Nocturne.API.Helpers;
 using Nocturne.Core.Constants;
@@ -29,6 +30,7 @@ public class OidcAuthService : IOidcAuthService
     private readonly IRefreshTokenService _refreshTokenService;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ITenantMemberService _tenantMemberService;
+    private readonly IDataProtector _stateProtector;
     private readonly OidcOptions _options;
     private readonly IConfiguration _configuration;
     private readonly ILogger<OidcAuthService> _logger;
@@ -43,6 +45,7 @@ public class OidcAuthService : IOidcAuthService
     /// <param name="refreshTokenService">Service for validating refresh tokens (non-rotation refresh path only).</param>
     /// <param name="httpClientFactory">Factory for the <c>OidcProvider</c> named HTTP client.</param>
     /// <param name="tenantMemberService">Service for verifying tenant membership before issuing a login session.</param>
+    /// <param name="dataProtectionProvider">Provider for the protector that authenticates the state parameter.</param>
     /// <param name="options">OIDC session and state configuration options.</param>
     /// <param name="configuration">Application configuration for reading the base URL.</param>
     /// <param name="logger">Logger instance.</param>
@@ -54,6 +57,7 @@ public class OidcAuthService : IOidcAuthService
         IRefreshTokenService refreshTokenService,
         IHttpClientFactory httpClientFactory,
         ITenantMemberService tenantMemberService,
+        IDataProtectionProvider dataProtectionProvider,
         IOptions<OidcOptions> options,
         IConfiguration configuration,
         ILogger<OidcAuthService> logger
@@ -66,6 +70,7 @@ public class OidcAuthService : IOidcAuthService
         _refreshTokenService = refreshTokenService;
         _httpClientFactory = httpClientFactory;
         _tenantMemberService = tenantMemberService;
+        _stateProtector = dataProtectionProvider.CreateProtector("Nocturne.Oidc.State");
         _options = options.Value;
         _configuration = configuration;
         _logger = logger;
@@ -75,7 +80,6 @@ public class OidcAuthService : IOidcAuthService
     public async Task<OidcAuthorizationRequest> GenerateAuthorizationUrlAsync(
         Guid? providerId,
         string? returnUrl = null,
-        string? state = null,
         string? tenantSlug = null
     )
     {
@@ -119,14 +123,13 @@ public class OidcAuthService : IOidcAuthService
             TenantSlug = tenantSlug,
         };
 
-        return await BuildAuthorizationUrlAsync(provider, stateData, returnUrl, state);
+        return await BuildAuthorizationUrlAsync(provider, stateData, returnUrl);
     }
 
     private async Task<OidcAuthorizationRequest> BuildAuthorizationUrlAsync(
         OidcProvider provider,
         OidcStateData stateData,
         string? returnUrl,
-        string? state = null,
         string callbackPath = LoginCallbackPath
     )
     {
@@ -136,7 +139,7 @@ public class OidcAuthService : IOidcAuthService
                 $"Could not fetch OIDC discovery document for {provider.Name}"
             );
 
-        state ??= EncodeState(stateData);
+        var state = EncodeState(stateData);
 
         var redirectUri = GetRedirectUri(callbackPath);
         var authUrl = BuildAuthorizationUrl(
@@ -191,7 +194,8 @@ public class OidcAuthService : IOidcAuthService
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to decode OIDC state");
+            // Also the forgery path: an unprotectable state was not issued by this instance.
+            _logger.LogWarning(ex, "Rejected an OIDC state that failed to decode");
             return CallbackParseResult.Fail("invalid_state", "Invalid state format");
         }
 
@@ -241,7 +245,9 @@ public class OidcAuthService : IOidcAuthService
             {
                 idTokenClaims = ParseIdToken(providerTokens.IdToken);
 
-                if (!string.IsNullOrEmpty(stateData.Nonce) && idTokenClaims.Nonce != stateData.Nonce)
+                // Required, not conditional: every state this service issues carries a nonce, so
+                // an absent one means the ID token cannot be bound to this authorization request.
+                if (string.IsNullOrEmpty(stateData.Nonce) || idTokenClaims.Nonce != stateData.Nonce)
                 {
                     return CallbackParseResult.Fail("invalid_nonce", "ID token nonce mismatch");
                 }
@@ -307,14 +313,38 @@ public class OidcAuthService : IOidcAuthService
         // identity is not a member of the tenant being logged into. The per-request
         // membership gate in AuthenticationMiddleware would block this subject's data
         // access anyway, but only after a session (and a "logged in" UI) already existed.
-        if (currentTenantId is { } tenantId
-            && !await _tenantMemberService.IsMemberAsync(subject.Id, tenantId))
+        //
+        // Two conditions, because either one alone leaves a gap.
+        //
+        // A resolved tenant always requires membership. A callback delivered to a tenant
+        // subdomain resolves that tenant wherever the login started, so an apex-minted state
+        // (no slug) replayed at {tenant}.{basedomain} arrives here with a tenant resolved;
+        // keying only off the slug would skip the check for exactly that case.
+        //
+        // A state that names a tenant also requires one to have resolved. Such a state was
+        // minted by a tenant login and must have been bounced to that subdomain, so an
+        // unresolved tenant means something upstream failed — and treating that as "nothing to
+        // check" is how the gate silently disappeared when the state encoding changed.
+        if (currentTenantId is { } tenantId)
         {
-            _logger.LogWarning(
-                "OIDC login denied: subject {SubjectId} is not a member of tenant {TenantId}",
-                subject.Id,
-                tenantId);
-            return OidcCallbackResult.NotAMember(subject.Id, stateData.ReturnUrl);
+            if (!await _tenantMemberService.IsMemberAsync(subject.Id, tenantId))
+            {
+                _logger.LogWarning(
+                    "OIDC login denied: subject {SubjectId} is not a member of tenant {TenantId}",
+                    subject.Id,
+                    tenantId);
+                return OidcCallbackResult.NotAMember(subject.Id, stateData.ReturnUrl);
+            }
+        }
+        else if (!string.IsNullOrEmpty(stateData.TenantSlug))
+        {
+            _logger.LogError(
+                "OIDC login denied: state was minted for tenant '{TenantSlug}' but no tenant "
+                    + "resolved on the callback, so membership could not be verified",
+                stateData.TenantSlug);
+            return OidcCallbackResult.Failed(
+                "invalid_state",
+                "The login could not be completed against the tenant it was started from.");
         }
 
         // Update last login
@@ -1032,30 +1062,53 @@ public class OidcAuthService : IOidcAuthService
     }
 
     /// <summary>
-    /// Serialises an <see cref="OidcStateData"/> object to a URL-safe Base64 string.
+    /// Serialises an <see cref="OidcStateData"/> object to an authenticated, URL-safe state string.
     /// </summary>
     /// <param name="data">The state data to encode.</param>
-    /// <returns>URL-safe Base64-encoded JSON state string.</returns>
-    private static string EncodeState(OidcStateData data)
-    {
-        var json = JsonSerializer.Serialize(data);
-        var bytes = Encoding.UTF8.GetBytes(json);
-        return Base64Url.Encode(bytes);
-    }
+    /// <returns>A data-protected state string.</returns>
+    /// <remarks>
+    /// The payload is protected rather than plain-encoded because the callback trusts what it
+    /// carries. <c>Intent</c> selects which flow runs and <c>SubjectId</c> names the account an
+    /// identity is bound to, so an unauthenticated blob lets a caller mint state for any subject.
+    /// The state cookie is a CSRF defence, not an integrity one — a caller acting as its own HTTP
+    /// client supplies both halves of the double-submit.
+    /// </remarks>
+    private string EncodeState(OidcStateData data) =>
+        _stateProtector.Protect(JsonSerializer.Serialize(data));
 
     /// <summary>
-    /// Deserialises an <see cref="OidcStateData"/> object from a URL-safe Base64 string.
+    /// Deserialises an <see cref="OidcStateData"/> object from a protected state string.
     /// </summary>
-    /// <param name="encoded">URL-safe Base64-encoded state string produced by <see cref="EncodeState"/>.</param>
+    /// <param name="encoded">State string produced by <see cref="EncodeState"/>.</param>
     /// <returns>The decoded <see cref="OidcStateData"/>.</returns>
     /// <exception cref="InvalidOperationException">Thrown when the state cannot be deserialised.</exception>
-    private static OidcStateData DecodeState(string encoded)
+    /// <exception cref="System.Security.Cryptography.CryptographicException">
+    /// Thrown when the state was not produced by this instance's key ring, including any attempt
+    /// to forge or tamper with it.
+    /// </exception>
+    private OidcStateData DecodeState(string encoded)
     {
-        var bytes = Base64Url.Decode(encoded);
-        var json = Encoding.UTF8.GetString(bytes);
+        var json = _stateProtector.Unprotect(encoded);
 
         return JsonSerializer.Deserialize<OidcStateData>(json)
             ?? throw new InvalidOperationException("Invalid state data");
+    }
+
+    /// <inheritdoc />
+    public string? TryReadTenantSlug(string state)
+    {
+        if (string.IsNullOrEmpty(state))
+            return null;
+
+        try
+        {
+            return DecodeState(state).TenantSlug;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Could not read a tenant slug from the OIDC state");
+            return null;
+        }
     }
 
     /// <summary>

--- a/src/Core/Nocturne.Core.Contracts/Auth/IOidcAuthService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Auth/IOidcAuthService.cs
@@ -17,15 +17,36 @@ public interface IOidcAuthService
     /// </summary>
     /// <param name="providerId">OIDC provider ID (null = use default)</param>
     /// <param name="returnUrl">URL to return to after login</param>
-    /// <param name="state">State parameter for CSRF protection (generated if null)</param>
+    /// <param name="tenantSlug">Tenant the login is being performed against</param>
     /// <returns>Authorization request containing URL and state</returns>
+    /// <remarks>
+    /// The state is always generated and cryptographically protected here. There is deliberately
+    /// no caller-supplied override: the callback trusts the intent and subject the state carries.
+    /// </remarks>
     /// <exception cref="InvalidOperationException">Thrown when the provider is not found, not configured, or not enabled.</exception>
     Task<OidcAuthorizationRequest> GenerateAuthorizationUrlAsync(
         Guid? providerId,
         string? returnUrl = null,
-        string? state = null,
         string? tenantSlug = null
     );
+
+    /// <summary>
+    /// Reads the tenant slug out of a protected state parameter, for routing a callback that
+    /// landed on the apex to the subdomain the login was initiated from.
+    /// </summary>
+    /// <param name="state">The state parameter as received on the callback.</param>
+    /// <returns>
+    /// The tenant slug the login was initiated against, or <c>null</c> when the state was not
+    /// issued by this instance, has been tampered with, or carries no slug (an apex login).
+    /// </returns>
+    /// <remarks>
+    /// This is the only part of the state readable before the callback is handled, and it goes
+    /// through the same protector as the rest of the payload — the redirect target is therefore
+    /// derived from data this instance signed, not from a caller-supplied value. Deliberately
+    /// exposes only the slug: nothing else in the state is safe to act on before the full
+    /// callback validation in <see cref="HandleCallbackAsync"/> has run.
+    /// </remarks>
+    string? TryReadTenantSlug(string state);
 
     /// <summary>
     /// Handle the OIDC callback - exchange code for tokens and create session

--- a/tests/Unit/Nocturne.API.Tests/Middleware/OidcCallbackRedirectMiddlewareTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/OidcCallbackRedirectMiddlewareTests.cs
@@ -1,11 +1,12 @@
-using System.Text;
-using System.Text.Json;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Moq;
 using Nocturne.API.Middleware;
 using Nocturne.API.Multitenancy;
+using Nocturne.Core.Contracts.Auth;
 using Xunit;
 
 namespace Nocturne.API.Tests.Middleware;
@@ -13,6 +14,7 @@ namespace Nocturne.API.Tests.Middleware;
 public class OidcCallbackRedirectMiddlewareTests
 {
     private readonly BaseDomainOptions _config = new() { BaseDomain = "nocturne.run" };
+    private readonly Mock<IOidcAuthService> _oidcAuthService = new();
 
     private OidcCallbackRedirectMiddleware CreateMiddleware(RequestDelegate? next = null)
     {
@@ -23,19 +25,32 @@ public class OidcCallbackRedirectMiddlewareTests
             Options.Create(_config));
     }
 
-    private static string EncodeState(object data)
+    /// <summary>
+    /// Returns an opaque state token that the auth service resolves to <paramref name="tenantSlug"/>.
+    /// The real state is data-protected, so the middleware cannot read it directly — it asks the
+    /// service, and these tests stub that. A token with no mapping resolves to <c>null</c>, which
+    /// is what the service returns for a state this instance did not issue.
+    /// </summary>
+    private string StateFor(string? tenantSlug)
     {
-        var json = JsonSerializer.Serialize(data);
-        return Convert.ToBase64String(Encoding.UTF8.GetBytes(json))
-            .Replace("+", "-").Replace("/", "_").TrimEnd('=');
+        var token = Guid.NewGuid().ToString("N");
+        _oidcAuthService.Setup(s => s.TryReadTenantSlug(token)).Returns(tenantSlug);
+        return token;
+    }
+
+    private DefaultHttpContext NewContext()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(_oidcAuthService.Object);
+        return new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
     }
 
     [Fact]
     public async Task Redirects_apex_oidc_callback_to_tenant_subdomain()
     {
         var middleware = CreateMiddleware();
-        var state = EncodeState(new { TenantSlug = "ryceg" });
-        var context = new DefaultHttpContext();
+        var state = StateFor("ryceg");
+        var context = NewContext();
         context.Request.Scheme = "https";
         context.Request.Host = new HostString("nocturne.run");
         context.Request.Path = "/api/auth/oidc/link/callback";
@@ -55,8 +70,8 @@ public class OidcCallbackRedirectMiddlewareTests
     public async Task Redirects_apex_login_callback_to_tenant_subdomain()
     {
         var middleware = CreateMiddleware();
-        var state = EncodeState(new { TenantSlug = "alice" });
-        var context = new DefaultHttpContext();
+        var state = StateFor("alice");
+        var context = NewContext();
         context.Request.Scheme = "https";
         context.Request.Host = new HostString("nocturne.run");
         context.Request.Path = "/api/auth/oidc/callback";
@@ -75,8 +90,8 @@ public class OidcCallbackRedirectMiddlewareTests
     {
         var called = false;
         var middleware = CreateMiddleware(_ => { called = true; return Task.CompletedTask; });
-        var state = EncodeState(new { TenantSlug = "ryceg" });
-        var context = new DefaultHttpContext();
+        var state = StateFor("ryceg");
+        var context = NewContext();
         context.Request.Host = new HostString("ryceg.nocturne.run");
         context.Request.Path = "/api/auth/oidc/link/callback";
         context.Request.QueryString = new QueryString($"?code=abc&state={state}");
@@ -91,7 +106,7 @@ public class OidcCallbackRedirectMiddlewareTests
     {
         var called = false;
         var middleware = CreateMiddleware(_ => { called = true; return Task.CompletedTask; });
-        var context = new DefaultHttpContext();
+        var context = NewContext();
         context.Request.Host = new HostString("nocturne.run");
         context.Request.Path = "/api/v4/entries";
 
@@ -105,11 +120,28 @@ public class OidcCallbackRedirectMiddlewareTests
     {
         var called = false;
         var middleware = CreateMiddleware(_ => { called = true; return Task.CompletedTask; });
-        var state = EncodeState(new { Intent = "login" });
-        var context = new DefaultHttpContext();
+        var state = StateFor(null);
+        var context = NewContext();
         context.Request.Host = new HostString("nocturne.run");
         context.Request.Path = "/api/auth/oidc/callback";
         context.Request.QueryString = new QueryString($"?code=abc&state={state}");
+
+        await middleware.InvokeAsync(context);
+
+        called.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Passes_through_when_state_was_not_issued_by_this_instance()
+    {
+        // No mapping registered: the service refuses to unprotect it and returns null, so the
+        // middleware must not derive a redirect target from it.
+        var called = false;
+        var middleware = CreateMiddleware(_ => { called = true; return Task.CompletedTask; });
+        var context = NewContext();
+        context.Request.Host = new HostString("nocturne.run");
+        context.Request.Path = "/api/auth/oidc/callback";
+        context.Request.QueryString = new QueryString("?code=abc&state=eyJUZW5hbnRTbHVnIjoiZXZpbCJ9");
 
         await middleware.InvokeAsync(context);
 
@@ -125,7 +157,7 @@ public class OidcCallbackRedirectMiddlewareTests
             _ => { called = true; return Task.CompletedTask; },
             NullLogger<OidcCallbackRedirectMiddleware>.Instance,
             Options.Create(config));
-        var context = new DefaultHttpContext();
+        var context = NewContext();
         context.Request.Host = new HostString("nocturne.run");
         context.Request.Path = "/api/auth/oidc/callback";
 
@@ -139,7 +171,7 @@ public class OidcCallbackRedirectMiddlewareTests
     {
         var called = false;
         var middleware = CreateMiddleware(_ => { called = true; return Task.CompletedTask; });
-        var context = new DefaultHttpContext();
+        var context = NewContext();
         context.Request.Host = new HostString("nocturne.run");
         context.Request.Path = "/api/auth/oidc/callback";
         context.Request.QueryString = new QueryString("?code=abc");
@@ -154,8 +186,8 @@ public class OidcCallbackRedirectMiddlewareTests
     {
         var called = false;
         var middleware = CreateMiddleware(_ => { called = true; return Task.CompletedTask; });
-        var state = EncodeState(new { TenantSlug = "ryceg" });
-        var context = new DefaultHttpContext();
+        var state = StateFor("ryceg");
+        var context = NewContext();
         context.Request.Host = new HostString("nocturne-api");
         context.Request.Headers["X-Forwarded-Host"] = "ryceg.nocturne.run";
         context.Request.Path = "/api/auth/oidc/link/callback";
@@ -171,8 +203,8 @@ public class OidcCallbackRedirectMiddlewareTests
     {
         var called = false;
         var middleware = CreateMiddleware(_ => { called = true; return Task.CompletedTask; });
-        var state = EncodeState(new { TenantSlug = "evil.attacker.com" });
-        var context = new DefaultHttpContext();
+        var state = StateFor("evil.attacker.com");
+        var context = NewContext();
         context.Request.Host = new HostString("nocturne.run");
         context.Request.Path = "/api/auth/oidc/callback";
         context.Request.QueryString = new QueryString($"?code=abc&state={state}");

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcAuthServiceLinkTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcAuthServiceLinkTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -39,6 +40,7 @@ public class OidcAuthServiceLinkTests
             _refreshTokenService.Object,
             _httpFactory.Object,
             _tenantMemberService.Object,
+            new EphemeralDataProtectionProvider(),
             options,
             _configuration.Object,
             NullLogger<OidcAuthService>.Instance);

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcAuthServiceLoginGateTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcAuthServiceLoginGateTests.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using FluentAssertions;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -44,6 +45,7 @@ public class OidcAuthServiceLoginGateTests
             _refreshTokenService.Object,
             _httpFactory.Object,
             _tenantMemberService.Object,
+            new EphemeralDataProtectionProvider(),
             options,
             _configuration.Object,
             NullLogger<OidcAuthService>.Instance);
@@ -140,6 +142,50 @@ public class OidcAuthServiceLoginGateTests
         _sessionService.Verify(
             s => s.IssueSessionAsync(subject.Id, It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CompleteLoginAsync_WhenStateHasNoSlugButATenantResolved_StillChecksMembership()
+    {
+        // The crossed pair, and the reachable one: a login started on the apex mints a state
+        // with no slug, but the redirect URI is fixed, so the callback can be delivered to
+        // {tenant}.{basedomain} where that tenant resolves. Gating the check on the slug rather
+        // than on the resolved tenant would let a non-member take a session on that subdomain.
+        var subject = SetupResolvedSubject();
+        var tenantId = Guid.NewGuid();
+        _tenantMemberService
+            .Setup(t => t.IsMemberAsync(subject.Id, tenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await _service.CompleteLoginAsync(
+            LoginState(tenantSlug: null!), Provider(), Claims(), tenantId, ipAddress: null, userAgent: null);
+
+        result.Success.Should().BeFalse();
+        result.IsAccessDenied.Should().BeTrue();
+
+        _sessionService.Verify(
+            s => s.IssueSessionAsync(It.IsAny<Guid>(), It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "an apex-minted state replayed at a tenant subdomain must not mint a session for a non-member");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CompleteLoginAsync_WhenStateNamesATenantButNoneResolved_IsDenied()
+    {
+        // Nothing to check membership against, so the login is unverifiable rather than tenantless.
+        var subject = SetupResolvedSubject();
+
+        var result = await _service.CompleteLoginAsync(
+            LoginState(tenantSlug: "erik"), Provider(), Claims(), currentTenantId: null, ipAddress: null, userAgent: null);
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Be("invalid_state");
+
+        _sessionService.Verify(
+            s => s.IssueSessionAsync(It.IsAny<Guid>(), It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcAuthServiceOAuth2ClaimsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcAuthServiceOAuth2ClaimsTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text;
 using FluentAssertions;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -41,6 +42,7 @@ public class OidcAuthServiceOAuth2ClaimsTests
             new Mock<IRefreshTokenService>().Object,
             _httpFactory.Object,
             new Mock<ITenantMemberService>().Object,
+            new EphemeralDataProtectionProvider(),
             Options.Create(new OidcOptions()),
             new Mock<IConfiguration>().Object,
             NullLogger<OidcAuthService>.Instance);

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcAuthServiceStateProtectionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcAuthServiceStateProtectionTests.cs
@@ -68,8 +68,13 @@ public class OidcAuthServiceStateProtectionTests
 
     /// <summary>
     /// Builds the state an attacker can construct unaided: plain base64url JSON, naming any
-    /// subject it likes. This is exactly what the pre-fix <c>EncodeState</c> produced.
+    /// subject and tenant it likes. This is exactly what the pre-fix <c>EncodeState</c> produced.
     /// </summary>
+    /// <remarks>
+    /// The slug is populated so <see cref="TryReadTenantSlug_ForAStateThisInstanceDidNotIssue_ReturnsNull"/>
+    /// has something to find if the protector is ever bypassed. Without it that test passes
+    /// against a plain decoder too, because there is no slug in the payload either way.
+    /// </remarks>
     private static string ForgeState(string intent, Guid subjectId) =>
         Base64Url.Encode(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new
         {
@@ -80,6 +85,7 @@ public class OidcAuthServiceStateProtectionTests
             ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
             Intent = intent,
             SubjectId = subjectId,
+            TenantSlug = "forged-tenant",
         })));
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcAuthServiceStateProtectionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcAuthServiceStateProtectionTests.cs
@@ -1,0 +1,202 @@
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Nocturne.API.Helpers;
+using Nocturne.API.Services.Auth;
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Core.Models.Configuration;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Auth;
+
+/// <summary>
+/// The callback trusts what the state carries: <c>Intent</c> selects the flow and
+/// <c>SubjectId</c> names the account an external identity is bound to. The state cookie is
+/// only a CSRF defence — a caller acting as its own HTTP client supplies both halves of the
+/// double-submit — so integrity has to come from the state itself.
+/// </summary>
+public class OidcAuthServiceStateProtectionTests
+{
+    private readonly Mock<IOidcProviderService> _providerService = new();
+    private readonly OidcAuthService _service;
+
+    private static readonly Guid ProviderId = Guid.NewGuid();
+
+    public OidcAuthServiceStateProtectionTests()
+    {
+        var configuration = new Mock<IConfiguration>();
+        _service = new OidcAuthService(
+            _providerService.Object,
+            new Mock<ISubjectService>().Object,
+            new Mock<ISessionService>().Object,
+            new Mock<IJwtService>().Object,
+            new Mock<IRefreshTokenService>().Object,
+            new Mock<IHttpClientFactory>().Object,
+            new Mock<ITenantMemberService>().Object,
+            new EphemeralDataProtectionProvider(),
+            Options.Create(new OidcOptions()),
+            configuration.Object,
+            NullLogger<OidcAuthService>.Instance);
+
+        _providerService
+            .Setup(p => p.GetProviderByIdAsync(ProviderId))
+            .ReturnsAsync(new OidcProvider
+            {
+                Id = ProviderId,
+                Name = "Keycloak",
+                IssuerUrl = "https://issuer.example",
+                ClientId = "nocturne",
+                IsEnabled = true,
+            });
+
+        _providerService
+            .Setup(p => p.GetDiscoveryDocumentAsync(ProviderId))
+            .ReturnsAsync(new OidcDiscoveryDocument
+            {
+                Issuer = "https://issuer.example",
+                AuthorizationEndpoint = "https://issuer.example/authorize",
+                TokenEndpoint = "https://issuer.example/token",
+            });
+    }
+
+    /// <summary>
+    /// Builds the state an attacker can construct unaided: plain base64url JSON, naming any
+    /// subject it likes. This is exactly what the pre-fix <c>EncodeState</c> produced.
+    /// </summary>
+    private static string ForgeState(string intent, Guid subjectId) =>
+        Base64Url.Encode(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new
+        {
+            ProviderId,
+            ReturnUrl = "/",
+            Nonce = (string?)null,
+            CreatedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+            Intent = intent,
+            SubjectId = subjectId,
+        })));
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleSetupCallback_WithForgedState_IsRejected()
+    {
+        var victimSubjectId = Guid.NewGuid();
+        var forged = ForgeState("setup", victimSubjectId);
+
+        // The attacker controls the cookie too, so the double-submit check passes.
+        var result = await _service.HandleSetupCallbackAsync("any-code", forged, forged);
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Be("invalid_state");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleCallback_WithForgedState_IsRejected()
+    {
+        var forged = ForgeState("login", Guid.NewGuid());
+
+        var result = await _service.HandleCallbackAsync("any-code", forged, forged);
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Be("invalid_state");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleLinkCallback_WithForgedState_IsRejected()
+    {
+        var authenticatedSubjectId = Guid.NewGuid();
+        var forged = ForgeState("link", authenticatedSubjectId);
+
+        var result = await _service.HandleLinkCallbackAsync(
+            "any-code", forged, forged, authenticatedSubjectId);
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Be("invalid_state");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GeneratedSetupState_DoesNotExposeItsPayload()
+    {
+        var subjectId = Guid.NewGuid();
+
+        var request = await _service.GenerateSetupAuthorizationUrlAsync(ProviderId, subjectId);
+
+        // A reader who can decode the state can also rewrite it, so the subject must not be
+        // legible in the first place.
+        request.State.Should().NotContain(subjectId.ToString());
+        DecodeAsPlainJson(request.State).Should().BeNull(
+            "the state must not be readable as plain base64url JSON");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task TryReadTenantSlug_RoundTripsTheSlugItWasIssuedWith()
+    {
+        // The seam OidcCallbackRedirectMiddleware depends on. It stubs TryReadTenantSlug, so
+        // without this nothing asserts that a real generated state actually yields its slug —
+        // which is how protecting the payload silently broke the apex-to-subdomain redirect.
+        var request = await _service.GenerateAuthorizationUrlAsync(ProviderId, "/", tenantSlug: "erik");
+
+        _service.TryReadTenantSlug(request.State).Should().Be("erik");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void TryReadTenantSlug_ForAStateThisInstanceDidNotIssue_ReturnsNull()
+    {
+        _service.TryReadTenantSlug(ForgeState("login", Guid.NewGuid())).Should().BeNull();
+        _service.TryReadTenantSlug("not-a-state").Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task StateFromAnotherKeyRing_IsRejected()
+    {
+        // Stands in for any state this instance did not issue. A well-formed state minted
+        // elsewhere must not be honoured here, which is only true while the payload is
+        // authenticated rather than merely encoded.
+        var foreign = await BuildServiceWithOwnKeyRing()
+            .GenerateSetupAuthorizationUrlAsync(ProviderId, Guid.NewGuid());
+
+        var result = await _service.HandleSetupCallbackAsync(
+            "any-code", foreign.State, foreign.State);
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Be("invalid_state");
+    }
+
+    private OidcAuthService BuildServiceWithOwnKeyRing() =>
+        new(
+            _providerService.Object,
+            new Mock<ISubjectService>().Object,
+            new Mock<ISessionService>().Object,
+            new Mock<IJwtService>().Object,
+            new Mock<IRefreshTokenService>().Object,
+            new Mock<IHttpClientFactory>().Object,
+            new Mock<ITenantMemberService>().Object,
+            new EphemeralDataProtectionProvider(),
+            Options.Create(new OidcOptions()),
+            new Mock<IConfiguration>().Object,
+            NullLogger<OidcAuthService>.Instance);
+
+    private static JsonDocument? DecodeAsPlainJson(string state)
+    {
+        try
+        {
+            return JsonDocument.Parse(Encoding.UTF8.GetString(Base64Url.Decode(state)));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Supersedes #578, which carried some commits I could not vouch for. Same content, re-authored in three reviewed commits. The analysis and live-test results on #578 remain valid and are summarised below.

## The bug

The `state` parameter is plain base64url JSON. No signature, no encryption, no server-side record:

```csharp
private static string EncodeState(OidcStateData data)
{
    var json = JsonSerializer.Serialize(data);
    var bytes = Encoding.UTF8.GetBytes(json);
    return Base64Url.Encode(bytes);
}
```

The only integrity check is `state != expectedState`, where `expectedState` comes from the `.Nocturne.OidcState` cookie. That is a double-submit CSRF defence — it stops a *victim's browser* being walked through a flow it did not start. It does nothing against a caller acting as its own HTTP client, which sets both halves. So every field in the state is caller-chosen.

The callback trusts two of them. `Intent` selects which flow runs; `SubjectId` names the account an external identity gets bound to. `HandleSetupCallbackAsync` reads both:

```csharp
if (stateData.Intent != "setup") return Failed("invalid_intent", ...);
if (!stateData.SubjectId.HasValue) return Failed("invalid_state", ...);
var subjectId = stateData.SubjectId.Value;

var (outcome, _) = await _subjectService.AttachOidcIdentityAsync(subjectId, provider.Id, claims.Sub, ...);
```

Given `{"Intent":"setup","SubjectId":"<any guid>","Nonce":null}`, that links the caller's own provider account to the named subject and issues a session for it. `AttachOidcIdentityAsync` returns `Created` for a fresh provider account — only `AlreadyLinkedToOther` fails — so the bind succeeds against a subject the caller has never had access to. Setting `Nonce` to null also skipped the ID-token nonce check, which was conditional on the state carrying one.

It lands on `/api/v4/setup/oidc/callback`, which is `[AllowAnonymous] [AllowDuringSetup]` and stays reachable for the life of the instance. Naming the platform admin's subject yields a session as the platform admin, and `PlatformAccessController` then mints `permissions: ["*"]` into any tenant by slug — cross-tenant CGM and therapy data.

Preconditions: an enabled provider whose registered redirect URIs include the setup callback, and knowledge of a target subject GUID. Subject ids are UUIDv7 and not brute-forceable, but they are not secrets — `POST /api/oauth/introspect` is unauthenticated and returns `sub` for any token.

## The change

**1 — Protect the payload** (`fedc1d893`). `EncodeState`/`DecodeState` now go through `IDataProtector`, matching `PasskeyService`, `TotpService`, `OidcProviderService` and `GuestSessionHandler`. Keys already persist to the database (`AddDataProtection().PersistKeysToNocturneDb()`), so this survives restarts and works across instances. It is a single chokepoint, so login, link and setup are all covered by one change — no per-flow patching. Also makes the nonce check unconditional for OIDC providers, and drops the unused caller-supplied `state` override that was a route to putting an unprotected state back on the wire.

**2 — One decoder** (`5325a6553`). `OidcCallbackRedirectMiddleware` kept its *own* copy of the state decoder to extract `TenantSlug` for the apex-to-subdomain bounce. Protecting the payload leaves that copy reading a blob it cannot parse — it swallows the failure, returns null, and apex callbacks silently stop redirecting to the tenant subdomain, while still compiling. `TryReadTenantSlug` routes it through the same protector. It exposes only the slug, and the existing regex still guards the redirect URL.

**3 — Tighten the cross-tenant guard** (`a21dfa715`). The guard denied non-members of a resolved tenant but did nothing when the state named a tenant and none resolved — the exact signature of the bounce in (2) failing. Both conditions now stand, because either alone leaves a gap: a resolved tenant always requires membership (the redirect URI is built from the configured base URL, not the request host, so an apex-minted state replayed at `{tenant}.{basedomain}` arrives with a tenant resolved), and a state naming a tenant requires one to have resolved.

### Why not a server-side state store

The other standard answer, and strictly more moving parts: a table, a write per authorization start, expiry pruning. Protecting the payload gets the same property — the callback can only act on state this instance issued — with no new storage. If single-use states are wanted later (replay inside the 15-minute lifetime), that is the point to add one.

## Deploy note

OIDC logins already in flight when this rolls out fail with `invalid_state` and succeed on retry. Nothing persisted is affected; no migration.

## Live verification

Run against a real stack with a provider pointed at Google's actual discovery document:

| Check | Result |
|---|---|
| Authorization URL built from Google's real discovery doc | 302 issued |
| State URL-safe — appears **verbatim** in `Location` while `redirect_uri` beside it *is* percent-encoded | `^[A-Za-z0-9_-]+$` |
| State length / full authorize URL | 475 / 729 chars |
| Cookie value == URL state value | identical |
| Payload decodable as plain JSON | no, opaque |
| Genuine state round-trips and drives a real HTTPS token exchange | `token_exchange_failed` (fake code rejected by Google) |
| Tampered state | `invalid_state` |
| **Forged plain-JSON setup state naming a victim subject**, attacker supplying both cookie and query param | `invalid_state`, **no session cookies issued** |

The apex-to-subdomain bounce was verified too: a login started on `livetest.nocturne.localhost` mints a 496-char slug-carrying state, and the apex callback correctly 302s to `http://livetest.nocturne.localhost/api/auth/oidc/callback?code=…&state=…` with both preserved — while a slug-less apex state correctly does not redirect to a subdomain.

## Testing

Full API unit suite: **4180 passed, 0 failed**.

| Test | Asserts |
|---|---|
| `HandleSetupCallback_WithForgedState_IsRejected` | the account-takeover primitive, closed |
| `HandleCallback_WithForgedState_IsRejected` | login callback |
| `HandleLinkCallback_WithForgedState_IsRejected` | link callback |
| `GeneratedSetupState_DoesNotExposeItsPayload` | the subject is not legible in the state |
| `StateFromAnotherKeyRing_IsRejected` | a well-formed state this instance did not issue is refused |
| `TryReadTenantSlug_RoundTripsTheSlugItWasIssuedWith` | closes the seam the middleware tests stub out |
| `TryReadTenantSlug_ForAStateThisInstanceDidNotIssue_ReturnsNull` | forged and malformed input |
| `CompleteLoginAsync_WhenStateHasNoSlugButATenantResolved_StillChecksMembership` | membership keyed on the resolved tenant, not the state |
| `CompleteLoginAsync_WhenStateNamesATenantButNoneResolved_IsDenied` | a failed bounce is unverifiable, not tenantless |

The forged-state helper builds exactly what the old `EncodeState` produced, so the tests encode the real attack rather than a proxy for it. Each new guard was verified by removing it and confirming the corresponding tests fail.

One caveat worth recording: a vacuity check run while an Aspire stack was live against the same worktree reported false passes, because `dotnet watch` held the API assembly and the test run used a stale build. The verifications above were re-run against a clean build.

## Prior review coverage

A security review of this content swept exhaustively for a second state producer or consumer — the failure mode that caused (2) — and found none: `DecodeState` has exactly two call sites and `EncodeState` one, all three URL generators funnel through `BuildAuthorizationUrlAsync`, controllers treat state as an opaque string, the generated clients and `sdk/openapi-v4.json` type it as a bare `string`, the bot/bridge and billing use entirely separate state schemes, and no consumer exists in nocturne-cloud. Also confirmed: distinct protector purposes, fail-closed on every decode path, a nonce at all three construction sites with OAuth2 correctly excluded, and DB-persisted keys so rotation and multi-instance work.

## Related

- #577 — setup-state gate on the OIDC callback, and re-deriving the platform-admin grant
- #579 — anonymous passkey binding to any subject, and an unauthenticated demo admin API

Same class in all three: a bootstrap path that stays live and trusts a caller-supplied identity.
