### PR TITLE
test(alerts): cover the smart-snooze scope in the parity corpus

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,6 +109,13 @@ jobs:
           cargo test --workspace
           cargo clippy --workspace --all-targets -- -D warnings
           cargo fmt --check
+      # `uniffi` is off by default, so `--workspace` above never compiles the
+      # UniFFI surface or its tests — including the corpus round-trip that is the
+      # in-repo proxy for prelude's Kotlin CorpusHarness. Without this step a
+      # change to that surface can break with every other job green.
+      - name: Rust tests (uniffi surface)
+        working-directory: crates
+        run: cargo test -p nocturne-alerts-ffi --features uniffi
       - name: Build nocturne_alerts cdylib
         working-directory: crates
         run: cargo build --release -p nocturne-alerts-ffi

--- a/crates/nocturne-alerts-core/README.md
+++ b/crates/nocturne-alerts-core/README.md
@@ -41,13 +41,13 @@ The crate is **pure evaluation**: no I/O, no clock, no persistence.
 | `eval` | one module per leaf family plus container evaluation (composite short-circuit, `not`, dispatch) |
 | `sustained` | timer state in/out and the `sustained` container |
 | `excursion` | excursion tracker state machine incl. force-close |
-| `engine` | `evaluate_tick` / `evaluate_rule` driver mirroring the orchestrator contract (root eval → leaf force-eval → tracker → unconditional auto-resolve) |
+| `engine` | `evaluate_rule` driver mirroring the orchestrator contract (root eval → leaf force-eval → tracker → unconditional auto-resolve), plus `evaluate_snooze_conditions` for the sweep's smart-snooze predicate under the `snooze` path root |
 
 ## Verification
 
 ```bash
 cd crates
-cargo test --workspace                          # parity corpus (103 scenarios) + unit tests
+cargo test --workspace                          # parity corpus (107 scenarios) + unit tests
 cargo clippy --workspace --all-targets -- -D warnings
 cargo fmt --check
 ```

--- a/crates/nocturne-alerts-core/src/engine.rs
+++ b/crates/nocturne-alerts-core/src/engine.rs
@@ -5,7 +5,7 @@
 //! every leaf for the leaf log.
 
 use chrono::{DateTime, Utc};
-use serde_json::Value;
+use serde_json::{Value, json};
 use uuid::Uuid;
 
 use crate::context::SensorContext;
@@ -15,7 +15,7 @@ use crate::excursion::{
 };
 use crate::leaf_identity::collect_leaves;
 use crate::model::{ConditionKind, Node, parse_payload};
-use crate::paths::AUTO_RESOLVE_ROOT;
+use crate::paths::{AUTO_RESOLVE_ROOT, SNOOZE_ROOT};
 use crate::sustained::{TimerOp, TimerStore};
 
 /// An alert rule as stored: `(condition_type, condition_params)` plus tracker
@@ -75,20 +75,12 @@ pub struct RuleOutcome {
     pub timer_ops: Vec<TimerOp>,
 }
 
-/// Evaluates every rule (in order) against one tick.
-pub fn evaluate_tick(
-    rules: &[Rule],
-    ctx: &SensorContext,
-    now: DateTime<Utc>,
-    state: &mut EngineState,
-) -> Vec<RuleOutcome> {
-    rules
-        .iter()
-        .map(|rule| evaluate_rule(rule, ctx, now, state))
-        .collect()
-}
-
 /// Evaluates a single rule for one tick, mirroring the orchestrator contract.
+///
+/// Callers drive their own per-tick loop over rules: a host that also runs
+/// smart snooze has to interleave [`evaluate_snooze_conditions`] between this
+/// call and its timer drain, so a batching wrapper here would only ever fit the
+/// rule-body-only case.
 pub fn evaluate_rule(
     rule: &Rule,
     ctx: &SensorContext,
@@ -179,6 +171,44 @@ pub fn evaluate_rule(
         auto_resolved,
         timer_ops: state.timers.drain_ops(),
     }
+}
+
+/// Mirrors `AlertSweepService.EvaluateSnoozeConditionsAsync`: a rule's
+/// configured smart-snooze conditions are wrapped as
+/// `composite{and, conditions}` and evaluated under the reserved `snooze` path
+/// root, so a `sustained` inside them keys its timer separately from the rule
+/// body's and auto-resolve's.
+///
+/// Deliberately not part of [`evaluate_rule`]: snooze evaluation belongs to the
+/// sweep, driven by a snooze expiring rather than by a reading. Hosts compose
+/// the two calls (the FFI exposes this scope as `evaluate_node` with
+/// `root: "snooze"`); the corpus harness composes them per tick.
+///
+/// The host-side extend/clear policy around this predicate (max counts, extend
+/// minutes, the trend-favourable fallback when no conditions are configured)
+/// stays with the caller — see `docs/alerts/engine-semantics.md` §9.
+pub fn evaluate_snooze_conditions(
+    rule_id: Uuid,
+    conditions: &[Value],
+    ctx: &SensorContext,
+    now: DateTime<Utc>,
+    timers: &mut TimerStore,
+) -> bool {
+    let wrapped = json!({
+        "type": "composite",
+        "composite": { "operator": "and", "conditions": conditions },
+    });
+    let Ok(node) = Node::parse(&wrapped) else {
+        return false;
+    };
+
+    let mut env = Env {
+        now,
+        rule_id,
+        ctx,
+        timers,
+    };
+    eval_node(Some(&node), SNOOZE_ROOT, &mut env)
 }
 
 /// Mirrors `AlertOrchestrator.TryAutoResolveAsync`: only while an excursion is

--- a/crates/nocturne-alerts-core/tests/parity.rs
+++ b/crates/nocturne-alerts-core/tests/parity.rs
@@ -12,7 +12,9 @@ use serde_json::{Map, Value, json};
 use uuid::Uuid;
 
 use nocturne_alerts_core::context::SensorContext;
-use nocturne_alerts_core::engine::{EngineState, Rule, RuleOutcome, evaluate_tick};
+use nocturne_alerts_core::engine::{
+    EngineState, Rule, RuleOutcome, evaluate_rule, evaluate_snooze_conditions,
+};
 use nocturne_alerts_core::excursion::{CloseReason, TransitionType};
 use nocturne_alerts_core::model::ConditionKind;
 use nocturne_alerts_core::sustained::{TimerOp, TimerOpKind};
@@ -45,6 +47,11 @@ struct ScenarioRule {
     auto_resolve_enabled: bool,
     #[serde(default)]
     auto_resolve_params: Option<Value>,
+    /// The rule's smart-snooze conditions as stored (a flat array of full
+    /// ConditionNode objects). Absent or empty means the harness runs no
+    /// snooze step for this rule.
+    #[serde(default)]
+    snooze_conditions: Option<Vec<Value>>,
 }
 
 #[derive(Deserialize)]
@@ -87,7 +94,7 @@ fn timer_op_json(op: &TimerOp) -> Value {
     Value::Object(o)
 }
 
-fn outcome_json(outcome: &RuleOutcome) -> Value {
+fn outcome_json(outcome: &RuleOutcome, snooze_extend: Option<bool>) -> Value {
     let mut o = Map::new();
     o.insert("rule_id".into(), Value::String(outcome.rule_id.to_string()));
     if outcome.skipped {
@@ -148,6 +155,9 @@ fn outcome_json(outcome: &RuleOutcome) -> Value {
     if outcome.auto_resolved {
         o.insert("auto_resolved".into(), Value::Bool(true));
     }
+    if let Some(extend) = snooze_extend {
+        o.insert("snooze_extend".into(), Value::Bool(extend));
+    }
     if !outcome.timer_ops.is_empty() {
         o.insert(
             "timer_ops".into(),
@@ -182,10 +192,40 @@ fn run_scenario(scenario: &ScenarioFile) -> Value {
         .ticks
         .iter()
         .map(|tick| {
-            let outcomes = evaluate_tick(&rules, &tick.context, tick.at, &mut state);
+            // Per rule: the orchestrator's driver, then the sweep's snooze predicate —
+            // the same two-step composition the backend performs across its two
+            // schedules, and the order the C# corpus runner records timer ops in.
+            let outcomes: Vec<Value> = rules
+                .iter()
+                .zip(&scenario.rules)
+                .map(|(rule, source)| {
+                    let mut outcome = evaluate_rule(rule, &tick.context, tick.at, &mut state);
+                    let snooze_extend = match source.snooze_conditions.as_deref() {
+                        // A skipped rule (signal_loss) records nothing else, so there is
+                        // nowhere to put a snooze result. Production does not skip it —
+                        // the generator rejects the combination at authoring time so no
+                        // scenario can reach this arm with conditions configured.
+                        _ if outcome.skipped => None,
+                        Some(conditions) if !conditions.is_empty() => {
+                            let extend = evaluate_snooze_conditions(
+                                rule.id,
+                                conditions,
+                                &tick.context,
+                                tick.at,
+                                &mut state.timers,
+                            );
+                            outcome.timer_ops.extend(state.timers.drain_ops());
+                            Some(extend)
+                        }
+                        _ => None,
+                    };
+                    outcome_json(&outcome, snooze_extend)
+                })
+                .collect();
+
             json!({
                 "at": fmt_at(tick.at),
-                "rules": outcomes.iter().map(outcome_json).collect::<Vec<_>>(),
+                "rules": outcomes,
             })
         })
         .collect();

--- a/crates/nocturne-alerts-ffi/src/tests.rs
+++ b/crates/nocturne-alerts-ffi/src/tests.rs
@@ -114,10 +114,18 @@ fn load_scenario(path: &PathBuf) -> (ScenarioFile, Value) {
     (scenario, expected)
 }
 
-/// Drives one scenario through an evaluate-envelope function (C ABI or
+/// Drives one scenario through the evaluate-envelope functions (C ABI or
 /// UniFFI), threading the timers/tracker state envelopes between ticks exactly
 /// as a host would, and returns the assembled expected-file Value.
-fn run_scenario(scenario: &ScenarioFile, evaluate: impl Fn(&Value) -> Value) -> Value {
+///
+/// Two envelopes, because a host runs two: `evaluate` for the rule body on each
+/// reading, and `evaluate_node` under `root: "snooze"` for the sweep's
+/// smart-snooze predicate whenever the scenario configures snooze conditions.
+fn run_scenario(
+    scenario: &ScenarioFile,
+    evaluate: impl Fn(&Value) -> Value,
+    evaluate_node: impl Fn(&Value) -> Value,
+) -> Value {
     // Per-rule persisted state, plus the shared next-excursion ordinal.
     let mut timers: Map<String, Value> = Map::new(); // rule id -> timers object
     let mut trackers: Map<String, Value> = Map::new(); // rule id -> tracker object
@@ -164,7 +172,16 @@ fn run_scenario(scenario: &ScenarioFile, evaluate: impl Fn(&Value) -> Value) -> 
                         .as_u64()
                         .expect("next_excursion_ordinal present");
 
-                    response["result"].clone()
+                    let mut result = response["result"].clone();
+                    apply_snooze_step(
+                        rule,
+                        tick,
+                        &rule_id,
+                        &mut timers,
+                        &mut result,
+                        &evaluate_node,
+                    );
+                    result
                 })
                 .collect();
             json!({ "at": tick.at, "rules": rules })
@@ -178,9 +195,76 @@ fn run_scenario(scenario: &ScenarioFile, evaluate: impl Fn(&Value) -> Value) -> 
     })
 }
 
-/// Runs the full corpus through an evaluate-envelope function and pins every
-/// scenario against its committed `.expected.json` snapshot.
-fn assert_corpus_round_trips(evaluate: impl Fn(&Value) -> Value) {
+/// Folds the rule's smart-snooze predicate into its result object: wraps the
+/// configured conditions as `composite{and, conditions}`, evaluates them under
+/// `root: "snooze"` against the same threaded timer state, and records
+/// `snooze_extend` plus any timer ops after the rule body's.
+///
+/// A skipped rule (`signal_loss`) records nothing else, so there is nowhere to
+/// put a snooze result. Production does *not* skip it; the generator rejects
+/// that combination at authoring time, so no scenario reaches this branch with
+/// conditions configured.
+fn apply_snooze_step(
+    rule: &Value,
+    tick: &ScenarioTick,
+    rule_id: &str,
+    timers: &mut Map<String, Value>,
+    result: &mut Value,
+    evaluate_node: impl Fn(&Value) -> Value,
+) {
+    if result.get("skipped").is_some() {
+        return;
+    }
+    let Some(conditions) = rule
+        .get("snooze_conditions")
+        .and_then(Value::as_array)
+        .filter(|c| !c.is_empty())
+    else {
+        return;
+    };
+
+    let response = evaluate_node(&json!({
+        "schema_version": 1,
+        "rule_id": rule_id,
+        "node": {
+            "type": "composite",
+            "composite": { "operator": "and", "conditions": conditions },
+        },
+        "root": "snooze",
+        "context": tick.context,
+        "now": tick.at,
+        "timers": timers.get(rule_id).cloned().unwrap_or_else(|| json!({})),
+    }));
+    assert_eq!(
+        response["ok"],
+        Value::Bool(true),
+        "snooze step for rule {rule_id} at {}: {}",
+        tick.at,
+        response["error"]
+    );
+
+    timers.insert(rule_id.to_string(), response["timers"].clone());
+
+    let result = result.as_object_mut().expect("rule result is an object");
+    result.insert("snooze_extend".into(), response["value"].clone());
+
+    let ops = response["timer_ops"].as_array().expect("timer_ops array");
+    if !ops.is_empty() {
+        result
+            .entry("timer_ops")
+            .or_insert_with(|| json!([]))
+            .as_array_mut()
+            .expect("timer_ops is an array")
+            .extend(ops.iter().cloned());
+    }
+}
+
+/// Runs the full corpus through the evaluate envelopes and pins every scenario
+/// against its committed `.expected.json` snapshot.
+fn assert_corpus_round_trips(
+    evaluate: impl Fn(&Value) -> Value,
+    evaluate_node: impl Fn(&Value) -> Value,
+) {
     let scenario_paths = scenario_paths();
     assert!(
         scenario_paths.len() >= 100,
@@ -191,7 +275,7 @@ fn assert_corpus_round_trips(evaluate: impl Fn(&Value) -> Value) {
     let mut failed: Vec<String> = Vec::new();
     for path in &scenario_paths {
         let (scenario, expected) = load_scenario(path);
-        let actual = run_scenario(&scenario, &evaluate);
+        let actual = run_scenario(&scenario, &evaluate, &evaluate_node);
         if actual != expected {
             failed.push(format!(
                 "scenario {}: FFI output differs from expected snapshot",
@@ -210,7 +294,7 @@ fn assert_corpus_round_trips(evaluate: impl Fn(&Value) -> Value) {
 
 #[test]
 fn corpus_round_trips_through_c_abi() {
-    assert_corpus_round_trips(evaluate);
+    assert_corpus_round_trips(evaluate, evaluate_node);
 }
 
 #[test]
@@ -1149,6 +1233,11 @@ mod uniffi_surface {
             .expect("uniffi evaluate returned valid JSON")
     }
 
+    fn evaluate_node(request: &Value) -> Value {
+        serde_json::from_str(&uniffi_api::evaluate_node(request.to_string()))
+            .expect("uniffi evaluate_node returned valid JSON")
+    }
+
     #[test]
     fn version_matches_crate_version() {
         assert_eq!(uniffi_api::version(), env!("CARGO_PKG_VERSION"));
@@ -1156,18 +1245,34 @@ mod uniffi_surface {
 
     #[test]
     fn corpus_scenario_round_trips_through_uniffi_surface() {
-        // One full scenario threaded tick-by-tick through the uniffi-exported
-        // `evaluate`, pinned against the committed snapshot — same driver as
+        // Two scenarios threaded tick-by-tick through the uniffi-exported
+        // envelopes, pinned against the committed snapshots — same driver as
         // the C ABI corpus test. (The full corpus already runs through the C
         // ABI in this build; both paths share one envelope implementation.)
+        //
+        // A snooze scenario is included explicitly: it is the only shape that
+        // reaches `evaluate_node`, and this test is the in-repo proxy for
+        // prelude's Kotlin CorpusHarness, which drives exactly this surface.
         let paths = scenario_paths();
-        let (scenario, expected) = load_scenario(paths.first().expect("corpus is non-empty"));
-        let actual = run_scenario(&scenario, evaluate);
-        assert_eq!(
-            actual, expected,
-            "scenario {}: uniffi output differs from expected snapshot",
-            scenario.name
-        );
+        let first = paths.first().expect("corpus is non-empty").clone();
+        let snooze = paths
+            .iter()
+            .find(|p| {
+                p.file_stem()
+                    .is_some_and(|s| s.to_string_lossy().starts_with("snooze-"))
+            })
+            .expect("corpus has a snooze scenario")
+            .clone();
+
+        for path in [first, snooze] {
+            let (scenario, expected) = load_scenario(&path);
+            let actual = run_scenario(&scenario, evaluate, evaluate_node);
+            assert_eq!(
+                actual, expected,
+                "scenario {}: uniffi output differs from expected snapshot",
+                scenario.name
+            );
+        }
     }
 
     #[test]

--- a/docs/alerts/engine-semantics.md
+++ b/docs/alerts/engine-semantics.md
@@ -347,7 +347,13 @@ contexts; window resolution, reading fetch, and fact-timeline capture stay host-
 - Smart snooze policy (extend/clear, max counts, trend-favorable heuristic) — but note
   snooze *conditions* are evaluated through the normal node dispatch with
   `CurrentPath = "snooze"`, wrapped as `composite{and, [conditions]}`; that evaluation
-  goes through the crate
+  goes through the crate.
+
+  The predicate is corpus-covered: a scenario rule may carry `snooze_conditions`, and the
+  runners record its truth as `snooze_extend` plus any timer ops the tree produced, after
+  the rule body's. Note the corpus is the *only* cross-engine check on this scope —
+  `ShadowAlertEngine` shadows `EvaluateRuleAsync` alone, so `EvaluateNodeAsync` (and its
+  `root` override) never diverge-logs against production traffic.
 - Rule CRUD, validation, `RuleReferenceResolver.FilterEvaluable`, topo-sort inputs
 
 ## 10. Known anomalies index

--- a/src/API/Nocturne.API/Services/Alerts/AlertSweepService.cs
+++ b/src/API/Nocturne.API/Services/Alerts/AlertSweepService.cs
@@ -338,8 +338,8 @@ public class AlertSweepService : BackgroundService
             var conditions = configsByInstance[instance.InstanceId].Conditions;
             if (conditions is null || conditions.Count == 0) continue;
 
-            var composite = new CompositeCondition("and", conditions);
-            var json = JsonSerializer.Serialize(composite, EvaluatorJson.Options);
+            var json = JsonSerializer.Serialize(
+                SnoozeConditionTree.Payload(conditions), EvaluatorJson.Options);
             syntheticRules.Add(new AlertRuleSnapshot(
                 instance.AlertRuleId,
                 tenantId,
@@ -381,9 +381,7 @@ public class AlertSweepService : BackgroundService
         using var scope = _serviceProvider.CreateScope();
         var engine = scope.ServiceProvider.GetRequiredService<IAlertEvaluationEngine>();
 
-        var node = new ConditionNode(
-            "composite",
-            Composite: new CompositeCondition("and", conditions));
+        var node = SnoozeConditionTree.Wrap(conditions);
 
         try
         {

--- a/src/API/Nocturne.API/Services/Alerts/Evaluators/SnoozeConditionTree.cs
+++ b/src/API/Nocturne.API/Services/Alerts/Evaluators/SnoozeConditionTree.cs
@@ -1,0 +1,34 @@
+using Nocturne.Core.Models;
+
+namespace Nocturne.API.Services.Alerts.Evaluators;
+
+/// <summary>
+/// Shape of the smart-snooze evaluation scope. A rule's configured snooze conditions
+/// (<c>client_configuration.snooze.conditions</c>) are a flat array; the engine sees them
+/// as a single tree, so they are wrapped in <c>composite{and, conditions}</c> and evaluated
+/// under <see cref="AlertConditionTypeNames.SnoozePathRoot"/>.
+/// </summary>
+/// <remarks>
+/// The wrap lives here rather than inline in <c>AlertSweepService</c> because the parity
+/// corpus has to build the byte-identical tree — a corpus that pinned a differently shaped
+/// wrapper would pin condition paths the sweep never produces.
+/// </remarks>
+internal static class SnoozeConditionTree
+{
+    /// <summary>
+    /// The composite payload alone, for callers that need the rule's
+    /// <c>condition_params</c> shape rather than a full node — the sweep builds a synthetic
+    /// rule in this shape so <c>RuleDataNeeds.Walk</c> enriches exactly the facts the
+    /// conditions will read.
+    /// </summary>
+    public static CompositeCondition Payload(List<ConditionNode> conditions) =>
+        new("and", conditions);
+
+    /// <summary>
+    /// Wraps <paramref name="conditions"/> as the root node of the snooze scope. Callers
+    /// gate on a non-empty list (an empty <c>composite</c> evaluates false, which as a
+    /// snooze predicate means "clear the snooze and re-fire").
+    /// </summary>
+    public static ConditionNode Wrap(List<ConditionNode> conditions) =>
+        new("composite", Composite: Payload(conditions));
+}

--- a/tests/Parity/AlertEngineCorpus/snooze-composite-and-short-circuit.expected.json
+++ b/tests/Parity/AlertEngineCorpus/snooze-composite-and-short-circuit.expected.json
@@ -1,0 +1,144 @@
+{
+  "schema_version": 1,
+  "scenario": "snooze-composite-and-short-circuit",
+  "ticks": [
+    {
+      "at": "2026-01-05T12:00:00Z",
+      "rules": [
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000001",
+          "root": true,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": true
+            }
+          ],
+          "transition": "opened",
+          "tracker": {
+            "state": "active",
+            "confirmation_count": 0,
+            "excursion": 1
+          },
+          "snooze_extend": false
+        }
+      ]
+    },
+    {
+      "at": "2026-01-05T12:05:00Z",
+      "rules": [
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000001",
+          "root": false,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": false
+            }
+          ],
+          "transition": "hysteresis_started",
+          "tracker": {
+            "state": "hysteresis",
+            "confirmation_count": 0,
+            "excursion": 1
+          },
+          "snooze_extend": false
+        }
+      ]
+    },
+    {
+      "at": "2026-01-05T12:10:00Z",
+      "rules": [
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000001",
+          "root": false,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": false
+            }
+          ],
+          "transition": "closed",
+          "close_reason": "hysteresis",
+          "tracker": {
+            "state": "idle",
+            "confirmation_count": 0
+          },
+          "snooze_extend": false,
+          "timer_ops": [
+            {
+              "op": "set",
+              "path": "snooze[1].sustained",
+              "at": "2026-01-05T12:10:00Z"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "at": "2026-01-05T12:15:00Z",
+      "rules": [
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000001",
+          "root": false,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": false
+            }
+          ],
+          "transition": "none",
+          "tracker": {
+            "state": "idle",
+            "confirmation_count": 0
+          },
+          "snooze_extend": true
+        }
+      ]
+    },
+    {
+      "at": "2026-01-05T12:20:00Z",
+      "rules": [
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000001",
+          "root": true,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": true
+            }
+          ],
+          "transition": "opened",
+          "tracker": {
+            "state": "active",
+            "confirmation_count": 0,
+            "excursion": 2
+          },
+          "snooze_extend": false
+        }
+      ]
+    },
+    {
+      "at": "2026-01-05T12:25:00Z",
+      "rules": [
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000001",
+          "root": false,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": false
+            }
+          ],
+          "transition": "hysteresis_started",
+          "tracker": {
+            "state": "hysteresis",
+            "confirmation_count": 0,
+            "excursion": 2
+          },
+          "snooze_extend": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/Parity/AlertEngineCorpus/snooze-composite-and-short-circuit.json
+++ b/tests/Parity/AlertEngineCorpus/snooze-composite-and-short-circuit.json
@@ -1,0 +1,121 @@
+{
+  "schema_version": 1,
+  "name": "snooze-composite-and-short-circuit",
+  "description": "the conditions array is wrapped in composite{and}, so a false leading condition short-circuits the rest \u2014 a skipped sustained neither sets nor clears its timer",
+  "rules": [
+    {
+      "id": "00000000-0000-0000-0000-000000000001",
+      "name": "rule-1",
+      "condition_type": "threshold",
+      "condition_params": {
+        "direction": "below",
+        "value": 70
+      },
+      "confirmation_readings": 1,
+      "hysteresis_minutes": 0,
+      "auto_resolve_enabled": false,
+      "snooze_conditions": [
+        {
+          "type": "threshold",
+          "threshold": {
+            "direction": "above",
+            "value": 100
+          }
+        },
+        {
+          "type": "sustained",
+          "sustained": {
+            "minutes": 5,
+            "child": {
+              "type": "threshold",
+              "threshold": {
+                "direction": "above",
+                "value": 200
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "ticks": [
+    {
+      "at": "2026-01-05T12:00:00Z",
+      "context": {
+        "latest_value": 65,
+        "latest_timestamp": "2026-01-05T12:00:00Z",
+        "trend_rate": 0,
+        "last_reading_at": "2026-01-05T12:00:00Z",
+        "has_ever_aps_cycled": false,
+        "has_ever_pump_snapshot": false,
+        "has_ever_uploader_snapshot": false,
+        "has_ever_aps_sensitivity": false
+      }
+    },
+    {
+      "at": "2026-01-05T12:05:00Z",
+      "context": {
+        "latest_value": 150,
+        "latest_timestamp": "2026-01-05T12:05:00Z",
+        "trend_rate": 0,
+        "last_reading_at": "2026-01-05T12:05:00Z",
+        "has_ever_aps_cycled": false,
+        "has_ever_pump_snapshot": false,
+        "has_ever_uploader_snapshot": false,
+        "has_ever_aps_sensitivity": false
+      }
+    },
+    {
+      "at": "2026-01-05T12:10:00Z",
+      "context": {
+        "latest_value": 250,
+        "latest_timestamp": "2026-01-05T12:10:00Z",
+        "trend_rate": 0,
+        "last_reading_at": "2026-01-05T12:10:00Z",
+        "has_ever_aps_cycled": false,
+        "has_ever_pump_snapshot": false,
+        "has_ever_uploader_snapshot": false,
+        "has_ever_aps_sensitivity": false
+      }
+    },
+    {
+      "at": "2026-01-05T12:15:00Z",
+      "context": {
+        "latest_value": 250,
+        "latest_timestamp": "2026-01-05T12:15:00Z",
+        "trend_rate": 0,
+        "last_reading_at": "2026-01-05T12:15:00Z",
+        "has_ever_aps_cycled": false,
+        "has_ever_pump_snapshot": false,
+        "has_ever_uploader_snapshot": false,
+        "has_ever_aps_sensitivity": false
+      }
+    },
+    {
+      "at": "2026-01-05T12:20:00Z",
+      "context": {
+        "latest_value": 50,
+        "latest_timestamp": "2026-01-05T12:20:00Z",
+        "trend_rate": 0,
+        "last_reading_at": "2026-01-05T12:20:00Z",
+        "has_ever_aps_cycled": false,
+        "has_ever_pump_snapshot": false,
+        "has_ever_uploader_snapshot": false,
+        "has_ever_aps_sensitivity": false
+      }
+    },
+    {
+      "at": "2026-01-05T12:25:00Z",
+      "context": {
+        "latest_value": 250,
+        "latest_timestamp": "2026-01-05T12:25:00Z",
+        "trend_rate": 0,
+        "last_reading_at": "2026-01-05T12:25:00Z",
+        "has_ever_aps_cycled": false,
+        "has_ever_pump_snapshot": false,
+        "has_ever_uploader_snapshot": false,
+        "has_ever_aps_sensitivity": false
+      }
+    }
+  ]
+}

--- a/tests/Parity/AlertEngineCorpus/snooze-sustained-separate-timer.expected.json
+++ b/tests/Parity/AlertEngineCorpus/snooze-sustained-separate-timer.expected.json
@@ -1,0 +1,114 @@
+{
+  "schema_version": 1,
+  "scenario": "snooze-sustained-separate-timer",
+  "ticks": [
+    {
+      "at": "2026-01-05T12:00:00Z",
+      "rules": [
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000001",
+          "root": false,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": true
+            }
+          ],
+          "transition": "none",
+          "tracker": {
+            "state": "idle",
+            "confirmation_count": 0
+          },
+          "snooze_extend": false,
+          "timer_ops": [
+            {
+              "op": "set",
+              "path": "sustained",
+              "at": "2026-01-05T12:00:00Z"
+            },
+            {
+              "op": "set",
+              "path": "snooze[0].sustained",
+              "at": "2026-01-05T12:00:00Z"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "at": "2026-01-05T12:05:00Z",
+      "rules": [
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000001",
+          "root": false,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": true
+            }
+          ],
+          "transition": "none",
+          "tracker": {
+            "state": "idle",
+            "confirmation_count": 0
+          },
+          "snooze_extend": false
+        }
+      ]
+    },
+    {
+      "at": "2026-01-05T12:10:00Z",
+      "rules": [
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000001",
+          "root": true,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": true
+            }
+          ],
+          "transition": "opened",
+          "tracker": {
+            "state": "active",
+            "confirmation_count": 0,
+            "excursion": 1
+          },
+          "snooze_extend": true
+        }
+      ]
+    },
+    {
+      "at": "2026-01-05T12:15:00Z",
+      "rules": [
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000001",
+          "root": false,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": false
+            }
+          ],
+          "transition": "hysteresis_started",
+          "tracker": {
+            "state": "hysteresis",
+            "confirmation_count": 0,
+            "excursion": 1
+          },
+          "snooze_extend": false,
+          "timer_ops": [
+            {
+              "op": "clear",
+              "path": "sustained"
+            },
+            {
+              "op": "clear",
+              "path": "snooze[0].sustained"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/Parity/AlertEngineCorpus/snooze-sustained-separate-timer.json
+++ b/tests/Parity/AlertEngineCorpus/snooze-sustained-separate-timer.json
@@ -1,0 +1,94 @@
+{
+  "schema_version": 1,
+  "name": "snooze-sustained-separate-timer",
+  "description": "a sustained in the snooze conditions keys its timer under the snooze path root, so an identically shaped sustained in the rule body cannot share its row",
+  "rules": [
+    {
+      "id": "00000000-0000-0000-0000-000000000001",
+      "name": "rule-1",
+      "condition_type": "sustained",
+      "condition_params": {
+        "minutes": 10,
+        "child": {
+          "type": "threshold",
+          "threshold": {
+            "direction": "below",
+            "value": 70
+          }
+        }
+      },
+      "confirmation_readings": 1,
+      "hysteresis_minutes": 0,
+      "auto_resolve_enabled": false,
+      "snooze_conditions": [
+        {
+          "type": "sustained",
+          "sustained": {
+            "minutes": 10,
+            "child": {
+              "type": "threshold",
+              "threshold": {
+                "direction": "below",
+                "value": 70
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "ticks": [
+    {
+      "at": "2026-01-05T12:00:00Z",
+      "context": {
+        "latest_value": 65,
+        "latest_timestamp": "2026-01-05T12:00:00Z",
+        "trend_rate": 0,
+        "last_reading_at": "2026-01-05T12:00:00Z",
+        "has_ever_aps_cycled": false,
+        "has_ever_pump_snapshot": false,
+        "has_ever_uploader_snapshot": false,
+        "has_ever_aps_sensitivity": false
+      }
+    },
+    {
+      "at": "2026-01-05T12:05:00Z",
+      "context": {
+        "latest_value": 65,
+        "latest_timestamp": "2026-01-05T12:05:00Z",
+        "trend_rate": 0,
+        "last_reading_at": "2026-01-05T12:05:00Z",
+        "has_ever_aps_cycled": false,
+        "has_ever_pump_snapshot": false,
+        "has_ever_uploader_snapshot": false,
+        "has_ever_aps_sensitivity": false
+      }
+    },
+    {
+      "at": "2026-01-05T12:10:00Z",
+      "context": {
+        "latest_value": 65,
+        "latest_timestamp": "2026-01-05T12:10:00Z",
+        "trend_rate": 0,
+        "last_reading_at": "2026-01-05T12:10:00Z",
+        "has_ever_aps_cycled": false,
+        "has_ever_pump_snapshot": false,
+        "has_ever_uploader_snapshot": false,
+        "has_ever_aps_sensitivity": false
+      }
+    },
+    {
+      "at": "2026-01-05T12:15:00Z",
+      "context": {
+        "latest_value": 100,
+        "latest_timestamp": "2026-01-05T12:15:00Z",
+        "trend_rate": 0,
+        "last_reading_at": "2026-01-05T12:15:00Z",
+        "has_ever_aps_cycled": false,
+        "has_ever_pump_snapshot": false,
+        "has_ever_uploader_snapshot": false,
+        "has_ever_aps_sensitivity": false
+      }
+    }
+  ]
+}

--- a/tests/Parity/AlertEngineCorpus/snooze-trend-recovering-predicate.expected.json
+++ b/tests/Parity/AlertEngineCorpus/snooze-trend-recovering-predicate.expected.json
@@ -1,0 +1,94 @@
+{
+  "schema_version": 1,
+  "scenario": "snooze-trend-recovering-predicate",
+  "ticks": [
+    {
+      "at": "2026-01-05T12:00:00Z",
+      "rules": [
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000001",
+          "root": true,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": true
+            }
+          ],
+          "transition": "opened",
+          "tracker": {
+            "state": "active",
+            "confirmation_count": 0,
+            "excursion": 1
+          },
+          "snooze_extend": false
+        }
+      ]
+    },
+    {
+      "at": "2026-01-05T12:05:00Z",
+      "rules": [
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000001",
+          "root": true,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": true
+            }
+          ],
+          "transition": "continues",
+          "tracker": {
+            "state": "active",
+            "confirmation_count": 0,
+            "excursion": 1
+          },
+          "snooze_extend": false
+        }
+      ]
+    },
+    {
+      "at": "2026-01-05T12:10:00Z",
+      "rules": [
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000001",
+          "root": true,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": true
+            }
+          ],
+          "transition": "continues",
+          "tracker": {
+            "state": "active",
+            "confirmation_count": 0,
+            "excursion": 1
+          },
+          "snooze_extend": true
+        }
+      ]
+    },
+    {
+      "at": "2026-01-05T12:15:00Z",
+      "rules": [
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000001",
+          "root": true,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": true
+            }
+          ],
+          "transition": "continues",
+          "tracker": {
+            "state": "active",
+            "confirmation_count": 0,
+            "excursion": 1
+          },
+          "snooze_extend": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/Parity/AlertEngineCorpus/snooze-trend-recovering-predicate.json
+++ b/tests/Parity/AlertEngineCorpus/snooze-trend-recovering-predicate.json
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "name": "snooze-trend-recovering-predicate",
+  "description": "a multi-leaf snooze predicate over trend and glucose: extend only while glucose is climbing AND has cleared a floor, so a low that is rising but still deep re-fires",
+  "rules": [
+    {
+      "id": "00000000-0000-0000-0000-000000000001",
+      "name": "rule-1",
+      "condition_type": "threshold",
+      "condition_params": {
+        "direction": "below",
+        "value": 70
+      },
+      "confirmation_readings": 1,
+      "hysteresis_minutes": 0,
+      "auto_resolve_enabled": false,
+      "snooze_conditions": [
+        {
+          "type": "rate_of_change",
+          "rate_of_change": {
+            "direction": "rising",
+            "rate": 0.5
+          }
+        },
+        {
+          "type": "threshold",
+          "threshold": {
+            "direction": "above",
+            "value": 60
+          }
+        }
+      ]
+    }
+  ],
+  "ticks": [
+    {
+      "at": "2026-01-05T12:00:00Z",
+      "context": {
+        "latest_value": 65,
+        "latest_timestamp": "2026-01-05T12:00:00Z",
+        "trend_rate": 0,
+        "last_reading_at": "2026-01-05T12:00:00Z",
+        "has_ever_aps_cycled": false,
+        "has_ever_pump_snapshot": false,
+        "has_ever_uploader_snapshot": false,
+        "has_ever_aps_sensitivity": false
+      }
+    },
+    {
+      "at": "2026-01-05T12:05:00Z",
+      "context": {
+        "latest_value": 62,
+        "latest_timestamp": "2026-01-05T12:05:00Z",
+        "trend_rate": -1,
+        "last_reading_at": "2026-01-05T12:05:00Z",
+        "has_ever_aps_cycled": false,
+        "has_ever_pump_snapshot": false,
+        "has_ever_uploader_snapshot": false,
+        "has_ever_aps_sensitivity": false
+      }
+    },
+    {
+      "at": "2026-01-05T12:10:00Z",
+      "context": {
+        "latest_value": 64,
+        "latest_timestamp": "2026-01-05T12:10:00Z",
+        "trend_rate": 0.8,
+        "last_reading_at": "2026-01-05T12:10:00Z",
+        "has_ever_aps_cycled": false,
+        "has_ever_pump_snapshot": false,
+        "has_ever_uploader_snapshot": false,
+        "has_ever_aps_sensitivity": false
+      }
+    },
+    {
+      "at": "2026-01-05T12:15:00Z",
+      "context": {
+        "latest_value": 58,
+        "latest_timestamp": "2026-01-05T12:15:00Z",
+        "trend_rate": 1,
+        "last_reading_at": "2026-01-05T12:15:00Z",
+        "has_ever_aps_cycled": false,
+        "has_ever_pump_snapshot": false,
+        "has_ever_uploader_snapshot": false,
+        "has_ever_aps_sensitivity": false
+      }
+    }
+  ]
+}

--- a/tests/Parity/AlertEngineCorpus/snooze-unknown-kinds.expected.json
+++ b/tests/Parity/AlertEngineCorpus/snooze-unknown-kinds.expected.json
@@ -1,0 +1,84 @@
+{
+  "schema_version": 1,
+  "scenario": "snooze-unknown-kinds",
+  "ticks": [
+    {
+      "at": "2026-01-05T12:00:00Z",
+      "rules": [
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000001",
+          "root": true,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": true
+            }
+          ],
+          "transition": "opened",
+          "tracker": {
+            "state": "active",
+            "confirmation_count": 0,
+            "excursion": 1
+          },
+          "snooze_extend": false
+        },
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000002",
+          "root": true,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": true
+            }
+          ],
+          "transition": "opened",
+          "tracker": {
+            "state": "active",
+            "confirmation_count": 0,
+            "excursion": 2
+          },
+          "snooze_extend": true
+        }
+      ]
+    },
+    {
+      "at": "2026-01-05T12:05:00Z",
+      "rules": [
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000001",
+          "root": true,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": true
+            }
+          ],
+          "transition": "continues",
+          "tracker": {
+            "state": "active",
+            "confirmation_count": 0,
+            "excursion": 1
+          },
+          "snooze_extend": false
+        },
+        {
+          "rule_id": "00000000-0000-0000-0000-000000000002",
+          "root": true,
+          "leaves": [
+            {
+              "leaf_id": 0,
+              "value": true
+            }
+          ],
+          "transition": "continues",
+          "tracker": {
+            "state": "active",
+            "confirmation_count": 0,
+            "excursion": 2
+          },
+          "snooze_extend": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/Parity/AlertEngineCorpus/snooze-unknown-kinds.json
+++ b/tests/Parity/AlertEngineCorpus/snooze-unknown-kinds.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "name": "snooze-unknown-kinds",
+  "description": "silent-false and the not-over-unknown inversion hold under the snooze root exactly as they do in a rule body",
+  "rules": [
+    {
+      "id": "00000000-0000-0000-0000-000000000001",
+      "name": "unknown-child",
+      "condition_type": "threshold",
+      "condition_params": {
+        "direction": "below",
+        "value": 70
+      },
+      "confirmation_readings": 1,
+      "hysteresis_minutes": 0,
+      "auto_resolve_enabled": false,
+      "snooze_conditions": [
+        {
+          "type": "nope"
+        }
+      ]
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000002",
+      "name": "not-over-unknown",
+      "condition_type": "threshold",
+      "condition_params": {
+        "direction": "below",
+        "value": 70
+      },
+      "confirmation_readings": 1,
+      "hysteresis_minutes": 0,
+      "auto_resolve_enabled": false,
+      "snooze_conditions": [
+        {
+          "type": "not",
+          "not": {
+            "child": {
+              "type": "nope"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "ticks": [
+    {
+      "at": "2026-01-05T12:00:00Z",
+      "context": {
+        "latest_value": 65,
+        "latest_timestamp": "2026-01-05T12:00:00Z",
+        "trend_rate": 0,
+        "last_reading_at": "2026-01-05T12:00:00Z",
+        "has_ever_aps_cycled": false,
+        "has_ever_pump_snapshot": false,
+        "has_ever_uploader_snapshot": false,
+        "has_ever_aps_sensitivity": false
+      }
+    },
+    {
+      "at": "2026-01-05T12:05:00Z",
+      "context": {
+        "latest_value": 65,
+        "latest_timestamp": "2026-01-05T12:05:00Z",
+        "trend_rate": 0,
+        "last_reading_at": "2026-01-05T12:05:00Z",
+        "has_ever_aps_cycled": false,
+        "has_ever_pump_snapshot": false,
+        "has_ever_uploader_snapshot": false,
+        "has_ever_aps_sensitivity": false
+      }
+    }
+  ]
+}

--- a/tests/Parity/Nocturne.Alerts.ParityCorpus.Generator/Harness/ScenarioModels.cs
+++ b/tests/Parity/Nocturne.Alerts.ParityCorpus.Generator/Harness/ScenarioModels.cs
@@ -1,7 +1,19 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Nocturne.API.Services.Alerts.Evaluators;
 
 namespace Nocturne.Alerts.ParityCorpus.Generator.Harness;
+
+/// <summary>
+/// Reserved <c>ConditionPath</c> roots for the auxiliary evaluation scopes, re-exported from
+/// the engine's internal <c>AlertConditionTypeNames</c> so corpus consumers that cannot see
+/// Nocturne.API internals — the native FFI suite drives the library directly — still bind to
+/// the one definition rather than restating the literal.
+/// </summary>
+public static class CorpusPathRoots
+{
+    public static readonly string Snooze = AlertConditionTypeNames.SnoozePathRoot;
+}
 
 /// <summary>
 /// Serialization contract for corpus scenario files (<c>*.json</c>) and expected
@@ -100,6 +112,20 @@ public sealed record ScenarioRule
     /// <summary>A full ConditionNode object (<c>{"type": …, …}</c>), or null.</summary>
     [JsonPropertyName("auto_resolve_params")]
     public JsonElement? AutoResolveParams { get; init; }
+
+    /// <summary>
+    /// The rule's smart-snooze conditions exactly as stored in
+    /// <c>client_configuration.snooze.conditions</c>: a flat array of full ConditionNode
+    /// objects, or null when the rule configures none.
+    /// </summary>
+    /// <remarks>
+    /// Drives the harness's snooze step (see <see cref="ExpectedRuleResult.SnoozeExtend"/>).
+    /// Null or empty means no step at all — mirroring the sweep, which only evaluates
+    /// conditions when at least one is configured and otherwise falls back to its host-side
+    /// trend heuristic.
+    /// </remarks>
+    [JsonPropertyName("snooze_conditions")]
+    public List<JsonElement>? SnoozeConditions { get; init; }
 }
 
 public sealed record ScenarioTick
@@ -241,8 +267,17 @@ public sealed record ExpectedRuleResult
     public bool? AutoResolved { get; init; }
 
     /// <summary>
-    /// Sustained-timer store mutations performed during this rule's evaluation (root eval
-    /// then auto-resolve eval), in execution order.
+    /// Truth of the rule's smart-snooze condition tree under the <c>snooze</c> path root,
+    /// or null when the rule configures no snooze conditions. This is the predicate the
+    /// sweep reads as "extend the snooze"; the extend/clear policy around it is host-side
+    /// and deliberately not snapshotted.
+    /// </summary>
+    [JsonPropertyName("snooze_extend")]
+    public bool? SnoozeExtend { get; init; }
+
+    /// <summary>
+    /// Sustained-timer store mutations performed during this rule's evaluation (root eval,
+    /// then auto-resolve eval, then snooze eval), in execution order.
     /// </summary>
     [JsonPropertyName("timer_ops")]
     public List<ExpectedTimerOp>? TimerOps { get; init; }

--- a/tests/Parity/Nocturne.Alerts.ParityCorpus.Generator/Harness/ScenarioRunner.cs
+++ b/tests/Parity/Nocturne.Alerts.ParityCorpus.Generator/Harness/ScenarioRunner.cs
@@ -96,6 +96,21 @@ public sealed class ScenarioRunner
         {
             // Orchestrator parity: no evaluator (e.g. signal_loss as a root type) means the
             // rule is skipped entirely — no tracker call, no auto-resolve.
+            //
+            // The snapshot records nothing else for a skipped rule, so there is nowhere to
+            // put a snooze result either. Production does NOT skip it: signal-loss rules open
+            // excursions via AlertSweepService.EvaluateSignalLossAsync, and
+            // CheckSnoozedInstancesAsync iterates instances with no filter on condition type.
+            // Rather than silently pin nothing, reject the combination at authoring time.
+            if (scenarioRule.SnoozeConditions is { Count: > 0 })
+            {
+                throw new InvalidOperationException(
+                    $"Scenario rule '{scenarioRule.Name}' has snooze_conditions on condition_type "
+                    + $"'{scenarioRule.ConditionType}', which the orchestrator skips. The snooze scope "
+                    + "cannot be snapshotted for a skipped rule even though the sweep does evaluate it "
+                    + "in production; cover it on an evaluable rule instead.");
+            }
+
             return new ExpectedRuleResult { RuleId = rule.Id, Skipped = true };
         }
 
@@ -122,6 +137,8 @@ public sealed class ScenarioRunner
             autoResolved = await TryAutoResolveAsync(rule, context, registry, tracker, ct);
         }
 
+        var snoozeExtend = await TryEvaluateSnoozeAsync(scenarioRule, context, registry, ct);
+
         var state = await trackerRepo.GetTrackerStateAsync(rule.Id, ct);
 
         return new ExpectedRuleResult
@@ -143,8 +160,39 @@ public sealed class ScenarioRunner
                     Excursion = trackerRepo.OrdinalOf(state.ActiveExcursionId),
                 },
             AutoResolved = autoResolved ? true : null,
+            SnoozeExtend = snoozeExtend,
             TimerOps = timerStore.DrainOps() is { Count: > 0 } ops ? ops : null,
         };
+    }
+
+    /// <summary>
+    /// Mirrors <c>AlertSweepService.EvaluateSnoozeConditionsAsync</c>. The sweep runs this
+    /// on its own cadence (when a snooze expires), not per reading; folding it into the tick
+    /// keeps the corpus one file per scenario while still pinning what the crate owns — the
+    /// <c>snooze</c> path root and the timer keys a <c>sustained</c> inside it produces.
+    /// </summary>
+    private static async Task<bool?> TryEvaluateSnoozeAsync(
+        ScenarioRule scenarioRule,
+        SensorContext context,
+        ConditionEvaluatorRegistry registry,
+        CancellationToken ct)
+    {
+        if (scenarioRule.SnoozeConditions is not { Count: > 0 } rawConditions)
+            return null;
+
+        var conditions = rawConditions
+            .Select(c => JsonSerializer.Deserialize<ConditionNode>(c.GetRawText(), EvaluatorJson.Options)
+                ?? throw new InvalidOperationException(
+                    $"Scenario rule '{scenarioRule.Name}' has a null snooze condition"))
+            .ToList();
+
+        var snoozeContext = context with
+        {
+            CurrentRuleId = scenarioRule.Id,
+            CurrentPath = AlertConditionTypeNames.SnoozePathRoot,
+        };
+
+        return await registry.EvaluateNodeAsync(SnoozeConditionTree.Wrap(conditions), snoozeContext, ct);
     }
 
     /// <summary>Mirrors <c>AlertOrchestrator.TryAutoResolveAsync</c>.</summary>

--- a/tests/Parity/Nocturne.Alerts.ParityCorpus.Generator/Program.cs
+++ b/tests/Parity/Nocturne.Alerts.ParityCorpus.Generator/Program.cs
@@ -28,6 +28,7 @@ scenarios.AddRange(ContainerScenarios.All());
 scenarios.AddRange(SustainedScenarios.All());
 scenarios.AddRange(TrackerScenarios.All());
 scenarios.AddRange(AutoResolveScenarios.All());
+scenarios.AddRange(SnoozeScenarios.All());
 
 var duplicate = scenarios.GroupBy(s => s.Name).FirstOrDefault(g => g.Count() > 1);
 if (duplicate is not null)

--- a/tests/Parity/Nocturne.Alerts.ParityCorpus.Generator/Scenarios/B.cs
+++ b/tests/Parity/Nocturne.Alerts.ParityCorpus.Generator/Scenarios/B.cs
@@ -34,7 +34,8 @@ public static class B
         int confirm = 1,
         int hysteresis = 0,
         string? autoResolveParams = null,
-        string? name = null) =>
+        string? name = null,
+        params string[] snoozeConditions) =>
         new()
         {
             Id = RId(id),
@@ -45,6 +46,9 @@ public static class B
             HysteresisMinutes = hysteresis,
             AutoResolveEnabled = autoResolveParams is not null,
             AutoResolveParams = autoResolveParams is null ? null : J(autoResolveParams),
+            SnoozeConditions = snoozeConditions.Length == 0
+                ? null
+                : snoozeConditions.Select(J).ToList(),
         };
 
     public static ScenarioTick Tick(DateTime at, ScenarioContext ctx) =>

--- a/tests/Parity/Nocturne.Alerts.ParityCorpus.Generator/Scenarios/SnoozeScenarios.cs
+++ b/tests/Parity/Nocturne.Alerts.ParityCorpus.Generator/Scenarios/SnoozeScenarios.cs
@@ -1,0 +1,96 @@
+using Nocturne.Alerts.ParityCorpus.Generator.Harness;
+using static Nocturne.Alerts.ParityCorpus.Generator.Scenarios.B;
+
+namespace Nocturne.Alerts.ParityCorpus.Generator.Scenarios;
+
+/// <summary>
+/// Smart-snooze conditions: the auxiliary evaluation scope the sweep runs under the
+/// reserved <c>snooze</c> path root, with the configured conditions wrapped as
+/// <c>composite{and, conditions}</c>. Only the predicate is pinned here — the extend/clear
+/// policy around it (max counts, extend minutes, the trend heuristic used when no
+/// conditions are configured) is host-side.
+/// </summary>
+public static class SnoozeScenarios
+{
+    private const string Low70 = """{"direction": "below", "value": 70}""";
+
+    public static IEnumerable<ScenarioFile> All()
+    {
+        yield return Scenario(
+            "snooze-sustained-separate-timer",
+            "a sustained in the snooze conditions keys its timer under the snooze path root, so an identically shaped sustained in the rule body cannot share its row",
+            [Rule(1, "sustained", """
+                    {"minutes": 10, "child": {"type": "threshold", "threshold": {"direction": "below", "value": 70}}}
+                    """,
+                snoozeConditions: [
+                    """
+                    {"type": "sustained", "sustained": {"minutes": 10, "child":
+                        {"type": "threshold", "threshold": {"direction": "below", "value": 70}}}}
+                    """,
+                ])],
+            [
+                // Both trees see the same true child and both set a timer: two set ops, at
+                // 'sustained' (the body's root) and 'snooze[0].sustained'. One op here would
+                // mean the roots collided.
+                Tick(T(0), Ctx(T(0), glucose: 65m)),
+                Tick(T(5), Ctx(T(5), glucose: 65m)),   // 5m of 10m on both: still false
+                Tick(T(10), Ctx(T(10), glucose: 65m)), // 10m elapsed: body opens, snooze extends
+                Tick(T(15), Ctx(T(15), glucose: 100m)), // child false: both timers cleared
+            ]);
+
+        yield return Scenario(
+            "snooze-composite-and-short-circuit",
+            "the conditions array is wrapped in composite{and}, so a false leading condition short-circuits the rest — a skipped sustained neither sets nor clears its timer",
+            [Rule(1, "threshold", Low70, snoozeConditions: [
+                """{"type": "threshold", "threshold": {"direction": "above", "value": 100}}""",
+                """
+                {"type": "sustained", "sustained": {"minutes": 5, "child":
+                    {"type": "threshold", "threshold": {"direction": "above", "value": 200}}}}
+                """,
+            ])],
+            [
+                Tick(T(0), Ctx(T(0), glucose: 65m)),    // first condition false -> sustained never evaluated
+                Tick(T(5), Ctx(T(5), glucose: 150m)),   // first true; sustained child false -> clear (no timer, no op)
+                Tick(T(10), Ctx(T(10), glucose: 250m)), // sustained child true -> sets 'snooze[1].sustained'
+                Tick(T(15), Ctx(T(15), glucose: 250m)), // 5m elapsed -> both conditions true -> extend
+                Tick(T(20), Ctx(T(20), glucose: 50m)),  // short-circuit: the sustained timer survives untouched
+                Tick(T(25), Ctx(T(25), glucose: 250m)), // still timing from T10, not T25 -> extend again
+            ]);
+
+        yield return Scenario(
+            "snooze-unknown-kinds",
+            "silent-false and the not-over-unknown inversion hold under the snooze root exactly as they do in a rule body",
+            [
+                Rule(1, "threshold", Low70, name: "unknown-child", snoozeConditions: [
+                    """{"type": "nope"}""",
+                ]),
+                Rule(2, "threshold", Low70, name: "not-over-unknown", snoozeConditions: [
+                    """{"type": "not", "not": {"child": {"type": "nope"}}}""",
+                ]),
+            ],
+            [
+                Tick(T(0), Ctx(T(0), glucose: 65m)),
+                Tick(T(5), Ctx(T(5), glucose: 65m)),
+            ]);
+
+        // Caveat for anyone reading this as a worked example rather than an engine pin:
+        // AlertSweepService.BuildSnoozeContextAsync sets LatestValue = null and the enricher
+        // never fills it in, so the threshold half of a predicate like this is always false
+        // in production today. The rate_of_change half is the only part that can fire. The
+        // scenario still pins what the engines must do with a populated context, which is
+        // what the corpus is for — and it is the regression test if that gap is closed.
+        yield return Scenario(
+            "snooze-trend-recovering-predicate",
+            "a multi-leaf snooze predicate over trend and glucose: extend only while glucose is climbing AND has cleared a floor, so a low that is rising but still deep re-fires",
+            [Rule(1, "threshold", Low70, snoozeConditions: [
+                """{"type": "rate_of_change", "rate_of_change": {"direction": "rising", "rate": 0.5}}""",
+                """{"type": "threshold", "threshold": {"direction": "above", "value": 60}}""",
+            ])],
+            [
+                Tick(T(0), Ctx(T(0), glucose: 65m, trendRate: 0m)),    // flat: not recovering
+                Tick(T(5), Ctx(T(5), glucose: 62m, trendRate: -1m)),   // still falling
+                Tick(T(10), Ctx(T(10), glucose: 64m, trendRate: 0.8m)), // rising and above the floor: extend
+                Tick(T(15), Ctx(T(15), glucose: 58m, trendRate: 1m)),  // rising but below the floor: re-fire
+            ]);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/Engines/AlertEngineCorpusTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/Engines/AlertEngineCorpusTests.cs
@@ -95,8 +95,11 @@ public class AlertEngineCorpusTests
             foreach (var (scenarioRule, snapshot) in scenario.Rules.Zip(snapshots))
             {
                 var evaluation = await engine.EvaluateRuleAsync(snapshot, context, options, ct);
+                var snoozeExtend = evaluation.Skipped
+                    ? null
+                    : await EngineTestHarness.EvaluateSnoozeAsync(engine, scenarioRule, context, ct);
                 ruleResults.Add(await EngineTestHarness.ToExpectedResultAsync(
-                    scenarioRule, evaluation, trackerRepo, timerStore, ct));
+                    scenarioRule, evaluation, trackerRepo, timerStore, snoozeExtend, ct));
             }
 
             expectedTicks.Add(new ExpectedTick { At = at, Rules = ruleResults });

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/Engines/EngineTestHarness.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/Engines/EngineTestHarness.cs
@@ -282,6 +282,35 @@ internal static class EngineTestHarness
     }
 
     /// <summary>
+    /// Drives the rule's smart-snooze conditions through the seam's auxiliary scope
+    /// (<c>EvaluateNodeAsync</c> under the <c>snooze</c> path root) — the call the sweep
+    /// makes, and the only corpus step that exercises a root-path override on either
+    /// adapter. Returns null when the rule configures no conditions.
+    /// </summary>
+    public static async Task<bool?> EvaluateSnoozeAsync(
+        IAlertEvaluationEngine engine,
+        ScenarioRule rule,
+        SensorContext context,
+        CancellationToken ct)
+    {
+        if (rule.SnoozeConditions is not { Count: > 0 } rawConditions)
+            return null;
+
+        var conditions = rawConditions
+            .Select(c => JsonSerializer.Deserialize<ConditionNode>(c.GetRawText(), EvaluatorJson.Options)
+                ?? throw new InvalidOperationException(
+                    $"Scenario rule '{rule.Name}' has a null snooze condition"))
+            .ToList();
+
+        return await engine.EvaluateNodeAsync(
+            rule.Id,
+            SnoozeConditionTree.Wrap(conditions),
+            context,
+            AlertConditionTypeNames.SnoozePathRoot,
+            ct);
+    }
+
+    /// <summary>
     /// Assembles an <see cref="ExpectedRuleResult"/> from a seam evaluation plus the
     /// observable state in the fakes — the same projection the corpus generator records.
     /// </summary>
@@ -290,6 +319,7 @@ internal static class EngineTestHarness
         AlertEngineEvaluation evaluation,
         InMemoryTrackerRepository trackerRepo,
         RecordingTimerStore timerStore,
+        bool? snoozeExtend,
         CancellationToken ct)
     {
         if (evaluation.Skipped)
@@ -318,6 +348,7 @@ internal static class EngineTestHarness
                     Excursion = trackerRepo.OrdinalOf(state.ActiveExcursionId),
                 },
             AutoResolved = evaluation.AutoResolved ? true : null,
+            SnoozeExtend = snoozeExtend,
             TimerOps = timerStore.DrainOps() is { Count: > 0 } ops ? ops : null,
         };
     }

--- a/tests/Unit/Nocturne.Alerts.Native.Tests/ThreeWayParityTests.cs
+++ b/tests/Unit/Nocturne.Alerts.Native.Tests/ThreeWayParityTests.cs
@@ -98,7 +98,9 @@ public class ThreeWayParityTests
                     nextExcursionOrdinal = response.Tracker.NextExcursionOrdinal;
                 }
 
-                rules.Add(JsonNode.Parse(response.Result!.Value.GetRawText()));
+                var result = (JsonObject)JsonNode.Parse(response.Result!.Value.GetRawText())!;
+                ApplySnoozeStep(rule, context, at, timers, result);
+                rules.Add(result);
             }
 
             ticks.Add(new JsonObject
@@ -114,6 +116,68 @@ public class ThreeWayParityTests
             ["scenario"] = scenario.Name,
             ["ticks"] = ticks,
         };
+    }
+
+    /// <summary>
+    /// Runs the rule's smart-snooze conditions through <c>nocturne_alerts_evaluate_node</c>
+    /// with <c>root: "snooze"</c> and folds the outcome into the rule's result object —
+    /// the same two-call composition the backend performs (orchestrator per reading, sweep
+    /// per expiring snooze) and the only place the FFI's root-path override is exercised
+    /// against the corpus.
+    /// </summary>
+    private static void ApplySnoozeStep(
+        ScenarioRule rule,
+        JsonElement context,
+        DateTime at,
+        Dictionary<Guid, Dictionary<string, DateTime>> timers,
+        JsonObject result)
+    {
+        // A skipped rule (signal_loss) records nothing else, so there is nowhere to put a
+        // snooze result. Production does not skip it; the generator rejects that combination
+        // at authoring time, so no scenario reaches here with conditions configured.
+        if (result["skipped"] is not null) return;
+        if (rule.SnoozeConditions is not { Count: > 0 } conditions) return;
+
+        var wrapped = new JsonObject
+        {
+            ["type"] = "composite",
+            ["composite"] = new JsonObject
+            {
+                ["operator"] = "and",
+                ["conditions"] = new JsonArray(
+                    conditions.Select(c => (JsonNode?)JsonNode.Parse(c.GetRawText())).ToArray()),
+            },
+        };
+
+        var response = RustAlertEngine.EvaluateNode(new RustEvaluateNodeRequest
+        {
+            RuleId = rule.Id,
+            Node = JsonSerializer.Deserialize<JsonElement>(wrapped.ToJsonString()),
+            Root = CorpusPathRoots.Snooze,
+            Context = context,
+            Now = at,
+            Timers = timers.GetValueOrDefault(rule.Id),
+        });
+
+        timers[rule.Id] = response.Timers ?? new Dictionary<string, DateTime>();
+        result["snooze_extend"] = response.Value;
+
+        if (response.TimerOps is not { Count: > 0 } ops) return;
+
+        // Ops from the rule-body call come first; the snapshot records both in execution
+        // order under the rule's single timer_ops list.
+        if (result["timer_ops"] is not JsonArray merged)
+        {
+            merged = new JsonArray();
+            result["timer_ops"] = merged;
+        }
+        foreach (var op in ops)
+        {
+            var node = new JsonObject { ["op"] = op.Op, ["path"] = op.Path };
+            if (op.At is { } opAt)
+                node["at"] = opAt.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'");
+            merged.Add(node);
+        }
     }
 
     private static RustAlertRule ToRustRule(ScenarioRule rule) => new()


### PR DESCRIPTION
Stacked on `rust-alerts`.

## Why

The golden corpus pinned only the per-reading rule driver. The **smart-snooze scope** — a rule's `client_configuration.snooze.conditions` wrapped as `composite{and, conditions}` and evaluated under the reserved `snooze` path root — had no cross-engine coverage at all.

It gets no production signal either: `ShadowAlertEngine` shadows `EvaluateRuleAsync` only, and `EvaluateNodeAsync` passes straight through to the managed engine. So flipping `Alerts:Engine=rust` would have taken that scope live having never been compared against C# on anything.

The failure direction is at least benign — `EvaluateSnoozeConditionsAsync` catches everything and returns false, so a divergence makes an alarm sound when it needn't rather than go silent. That's an argument for closing this with tests rather than blocking cutover on it, not for leaving it uncovered.

## What

Scenario files gain an optional `snooze_conditions` array; expected snapshots gain `snooze_extend` plus the tree's timer ops, appended after the rule body's. Additive — **all 103 pre-existing snapshots are byte-identical**.

Four scenarios, chosen to discriminate rather than merely exercise:

| scenario | pins |
|---|---|
| `snooze-sustained-separate-timer` | body and snooze trees are structurally identical, so two set ops at `sustained` and `snooze[0].sustained` prove the roots don't collide — one op would mean they did |
| `snooze-composite-and-short-circuit` | it's an `and`; a short-circuited `sustained` neither sets nor clears, and its timer survives the skipped tick (shown at T+20/T+25) |
| `snooze-unknown-kinds` | silent-false, and the `not`-over-unknown inversion, under this root |
| `snooze-trend-recovering-predicate` | a multi-leaf predicate over trend and glucose |

All six runners perform the identical step: the generator, the `IAlertEvaluationEngine` seam (the one that actually exercises the root-path override on **both** adapters), both C ABI drivers, the crate-level parity test, and prelude's Kotlin harness — ryceg/prelude#14.

## Supporting changes

- **`SnoozeConditionTree`** gives the sweep and the corpus one definition of the wrap. `AlertSweepService` built it twice — once to evaluate, once to synthesise the enrichment rule — so the two halves could silently disagree about what gets enriched vs evaluated.
- **The generator now rejects `snooze_conditions` on a condition type the orchestrator skips.** Such a scenario would pin nothing, while production *does* evaluate that scope: `CheckSnoozedInstancesAsync` iterates instances with no condition-type filter. Verified the guard fires.
- **CI gains `cargo test -p nocturne-alerts-ffi --features uniffi`.** That feature is off by default, so `--workspace` never compiled the UniFFI surface or its tests — the in-repo proxy for prelude's harness. It could break with every other job green. It did, during this change; that's how the gap was found.
- **`evaluate_tick` is removed.** Its only caller was the parity runner, which now interleaves the snooze step per rule, so a rule-body-only batching wrapper no longer fits any caller.

## Verification

- `cargo test` (default) — 122 green; `cargo test -p nocturne-alerts-ffi --features uniffi` — 57
- `Nocturne.API.Tests --filter ~Alerts` — 737; `Nocturne.Alerts.Native.Tests` — 138
- generator `--check` — 107 scenarios up to date
- prelude `:core:alerts:compileDebugAndroidTestKotlin` — succeeds (instrumented run needs a device + a pin bump, so untested here)

Note `cargo fmt --check` and `cargo clippy -D warnings` are already failing on `rust-alerts` in `classify.rs` and the `classify_*` tests — pre-existing, untouched here, but they'll show red.

## Follow-ups filed

`engine-semantics.md` now records that this corpus is the **only** cross-engine check on the scope. Separately filed while working on this:

- #581 — timezone resolution is exact-match in Rust where C# is lenient (**cutover blocker**, hits known production data)
- #582 — C# throws where Rust returns false, diverging the excursion tracker; shadow mode is blind to it (**cutover blocker**)
- #583 — remaining corpus coverage holes
- #584 — smart snooze: conditions can never fire, alarm-profile settings wired to nothing
- #585 — smart snooze: trend fallback has no magnitude gate
