### PR TITLE
fix(oauth): enforce consented scopes, atomic code redemption, and reachable revocation

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/OAuthController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/OAuthController.cs
@@ -249,6 +249,29 @@ public class OAuthController : ControllerBase
             });
         }
 
+        // Find the client. Resolved before the approval decision is read: every exit from this
+        // action that redirects to request.RedirectUri needs the URI proven to belong to the client
+        // first, or the endpoint is an open redirect off a first-party origin.
+        var client = await _clientService.GetClientAsync(request.ClientId);
+        if (client == null)
+        {
+            return BadRequest(new OAuthError
+            {
+                Error = "invalid_client",
+                ErrorDescription = "Unknown client_id.",
+            });
+        }
+
+        // Re-validate redirect URI to prevent manipulation between GET and POST
+        if (!await _clientService.ValidateRedirectUriAsync(request.ClientId, request.RedirectUri))
+        {
+            return BadRequest(new OAuthError
+            {
+                Error = "invalid_request",
+                ErrorDescription = "Invalid redirect_uri for this client.",
+            });
+        }
+
         // If user denied
         if (!request.Approved)
         {
@@ -270,27 +293,6 @@ public class OAuthController : ControllerBase
             {
                 Error = "invalid_scope",
                 ErrorDescription = "No valid scopes were approved.",
-            });
-        }
-
-        // Find the client
-        var client = await _clientService.GetClientAsync(request.ClientId);
-        if (client == null)
-        {
-            return BadRequest(new OAuthError
-            {
-                Error = "invalid_client",
-                ErrorDescription = "Unknown client_id.",
-            });
-        }
-
-        // Re-validate redirect URI to prevent manipulation between GET and POST
-        if (!await _clientService.ValidateRedirectUriAsync(request.ClientId, request.RedirectUri))
-        {
-            return BadRequest(new OAuthError
-            {
-                Error = "invalid_request",
-                ErrorDescription = "Invalid redirect_uri for this client.",
             });
         }
 
@@ -677,6 +679,12 @@ public class OAuthController : ControllerBase
         return Redirect(redirectUrl);
     }
 
+    /// <summary>
+    /// Redirects to the client's registered <paramref name="redirectUri"/> with an OAuth error.
+    /// Performs no validation of its own: callers must have already proven the URI is registered to
+    /// the client (<see cref="IOAuthClientService.ValidateRedirectUriAsync"/>), otherwise this
+    /// redirects wherever the request asked.
+    /// </summary>
     private ActionResult RedirectWithError(
         string redirectUri,
         string error,

--- a/src/API/Nocturne.API/Controllers/Authentication/OAuthController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/OAuthController.cs
@@ -900,6 +900,13 @@ public class OAuthController : ControllerBase
                     return Ok(new TokenIntrospectionResponse { Active = false });
                 }
 
+                // A revoked grant takes its outstanding access tokens with it
+                if (claims is { GrantId: not null, TenantId: not null } &&
+                    await _grantService.IsGrantRevokedAsync(claims.GrantId.Value, claims.TenantId.Value))
+                {
+                    return Ok(new TokenIntrospectionResponse { Active = false });
+                }
+
                 return Ok(new TokenIntrospectionResponse
                 {
                     Active = true,

--- a/src/API/Nocturne.API/Controllers/V4/Identity/ConnectedAppsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/ConnectedAppsController.cs
@@ -77,9 +77,10 @@ public class ConnectedAppsController : ControllerBase
     }
 
     /// <summary>
-    /// Revoke a connected app. Soft-deletes the grant and invalidates all
-    /// associated refresh tokens; previously-issued access tokens become
-    /// unusable on next request via the revocation cache.
+    /// Revoke a connected app. Soft-deletes the grant and invalidates all associated refresh
+    /// tokens. Previously-issued access tokens carry the grant id and are rejected on their next
+    /// request, so no residual access survives the revocation. Access tokens minted before the
+    /// grant id was added to them are not covered and remain usable until they expire.
     /// </summary>
     /// <inheritdoc cref="IOAuthGrantService.RevokeGrantAsync"/>
     [HttpDelete("{grantId}")]

--- a/src/API/Nocturne.API/Middleware/Handlers/OAuthAccessTokenHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/OAuthAccessTokenHandler.cs
@@ -113,6 +113,28 @@ public class OAuthAccessTokenHandler : IAuthHandler
             }
         }
 
+        // Reject tokens whose grant has been revoked. Access tokens are stateless, so a
+        // "Disconnect" on a connected app can only reach them through the grant id they carry.
+        if (claims.GrantId.HasValue)
+        {
+            if (!claims.TenantId.HasValue)
+            {
+                // Grant-bound tokens are always minted with their grant's tenant pin; one without
+                // a pin cannot have its grant checked, so it is not accepted.
+                _logger.LogWarning(
+                    "OAuth access token carries grant {GrantId} without a tenant pin", claims.GrantId);
+                return AuthResult.Failure("Token has been revoked");
+            }
+
+            var grantService = scope.ServiceProvider.GetRequiredService<IOAuthGrantService>();
+            if (await grantService.IsGrantRevokedAsync(claims.GrantId.Value, claims.TenantId.Value))
+            {
+                _logger.LogDebug(
+                    "OAuth access token's grant has been revoked (grant: {GrantId})", claims.GrantId);
+                return AuthResult.Failure("Token has been revoked");
+            }
+        }
+
         // Check revocation cache
         if (!string.IsNullOrEmpty(claims.JwtId))
         {

--- a/src/API/Nocturne.API/Middleware/MemberScopeMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/MemberScopeMiddleware.cs
@@ -11,8 +11,9 @@ namespace Nocturne.API.Middleware;
 /// <summary>
 /// Middleware that resolves the authenticated user's tenant membership and applies
 /// RBAC-based permission restrictions. Effective permissions are the union of all
-/// role permissions + direct permissions. For non-superusers, effective permissions
-/// are intersected with the auth token's granted scopes via <see cref="OAuthScopes"/>.
+/// role permissions + direct permissions, intersected with the credential's granted scopes
+/// via <see cref="OAuthScopes"/>. Widening to superuser happens only for a <c>"*"</c> membership
+/// presented on an unscoped credential (see <see cref="UnscopedCredentialTypes"/>).
 /// Must run after <see cref="AuthenticationMiddleware"/>.
 /// </summary>
 /// <remarks>
@@ -37,6 +38,25 @@ public class MemberScopeMiddleware
 {
     private readonly RequestDelegate _next;
     private readonly ILogger<MemberScopeMiddleware> _logger;
+
+    /// <summary>
+    /// Credential types that carry no scope grant of their own — the authenticated human's own
+    /// interactive login. Tenant membership is the only authority for these, so a <c>"*"</c>
+    /// membership widens to superuser. Every other credential presents scopes that bound what it
+    /// may do (an OAuth access token's consented scopes, a direct grant's scopes, an API key's
+    /// grant scopes, a guest link's scopes) and is intersected with membership instead. Membership
+    /// resolution must never widen a scoped credential, or the consent decision is erased. Keyed on
+    /// the credential type rather than on "the scope list is empty" because an interactive OIDC
+    /// login carries the identity provider's own scopes (<c>openid</c>, <c>profile</c>), which are
+    /// not Nocturne data scopes. Types absent from this set are treated as scoped (fail closed).
+    /// </summary>
+    private static readonly IReadOnlySet<AuthType> UnscopedCredentialTypes = new HashSet<AuthType>
+    {
+        AuthType.SessionCookie,
+        AuthType.OidcToken,
+        AuthType.LegacyJwt,
+        AuthType.LegacyAccessToken,
+    };
 
     /// <summary>
     /// Creates a new instance of <see cref="MemberScopeMiddleware"/>.
@@ -140,7 +160,8 @@ public class MemberScopeMiddleware
         var directPermissions = membership.DirectPermissions ?? [];
         var effectivePermissions = rolePermissions.Union(directPermissions).ToHashSet();
 
-        if (effectivePermissions.Contains("*"))
+        if (effectivePermissions.Contains("*")
+            && UnscopedCredentialTypes.Contains(authContext.AuthType))
         {
             // Superuser — grant all scopes AND a wildcard permission trie. Both must be set:
             // GrantedScopes drives RequireScope checks, while the PermissionTrie drives the
@@ -150,6 +171,12 @@ public class MemberScopeMiddleware
             // is empty. Without rebuilding it here, HasPermissions-gated endpoints would 403
             // for a tenant superuser on their own tenant (matching the InstanceKey/PlatformAccess
             // branch above, which sets both).
+            //
+            // Restricted to <see cref="UnscopedCredentialTypes"/>: a scoped credential carries a
+            // consent boundary, and an owner's "*" membership must not widen past it. An owner who
+            // authorized a third-party app for glucose.read falls through to the intersection below
+            // and gets glucose.read, matching what the same credential resolves to when the token
+            // is presented in the api-secret header (AuthType.ApiKey, handled above).
             context.Items["GrantedScopes"] = (IReadOnlySet<string>)effectivePermissions;
 
             var superuserTrie = new PermissionTrie();
@@ -158,7 +185,10 @@ public class MemberScopeMiddleware
         }
         else
         {
-            // Intersect with auth token scopes
+            // Intersect with auth token scopes. OAuthScopes.Normalize expands a "*" membership to
+            // the full scope list, so a superuser on a scoped credential lands on exactly the
+            // credential's scopes; the "*" scope itself survives only when the credential carries
+            // full access.
             var normalizedMemberScopes = OAuthScopes.Normalize(effectivePermissions.ToList());
             var currentScopes = context.GetGrantedScopes();
             var restrictedScopes = normalizedMemberScopes

--- a/src/API/Nocturne.API/Services/Auth/JwtService.cs
+++ b/src/API/Nocturne.API/Services/Auth/JwtService.cs
@@ -134,7 +134,8 @@ public class JwtService : IJwtService
         bool limitTo24Hours = false,
         Guid? tenantId = null,
         TimeSpan? lifetime = null,
-        bool platformAccess = false
+        bool platformAccess = false,
+        Guid? grantId = null
     )
     {
         var now = DateTimeOffset.UtcNow;
@@ -189,6 +190,13 @@ public class JwtService : IJwtService
         if (platformAccess)
         {
             claims.Add(new Claim("platform_access", "true", ClaimValueTypes.Boolean));
+        }
+
+        // Bind the token to the grant it was minted from. Revoking the grant invalidates every
+        // access token carrying its id, without the server tracking individual jti values.
+        if (grantId.HasValue)
+        {
+            claims.Add(new Claim("grant_id", grantId.Value.ToString()));
         }
 
         // Add OAuth scopes as space-delimited string (RFC 6749 Section 3.3)
@@ -283,6 +291,10 @@ public class JwtService : IJwtService
             // Parse platform-access marker (platform-admin tenant-access grants)
             var platformAccess = principal.FindFirst("platform_access")?.Value == "true";
 
+            // Parse the originating grant so callers can check its revocation state
+            var grantIdClaim = principal.FindFirst("grant_id")?.Value;
+            Guid? grantId = Guid.TryParse(grantIdClaim, out var gid) ? gid : null;
+
             var claims = new JwtClaims
             {
                 SubjectId = subjectId,
@@ -294,6 +306,7 @@ public class JwtService : IJwtService
                 ClientId = principal.FindFirst("client_id")?.Value,
                 TenantId = tenantId,
                 PlatformAccess = platformAccess,
+                GrantId = grantId,
                 LimitTo24Hours = limitTo24Hours,
                 JwtId = jwtToken.Id,
                 IssuedAt = new DateTimeOffset(jwtToken.IssuedAt, TimeSpan.Zero),

--- a/src/API/Nocturne.API/Services/Auth/OAuthGrantService.cs
+++ b/src/API/Nocturne.API/Services/Auth/OAuthGrantService.cs
@@ -14,6 +14,7 @@ namespace Nocturne.API.Services.Auth;
 public class OAuthGrantService : IOAuthGrantService
 {
     private readonly NocturneDbContext _dbContext;
+    private readonly IDbContextFactory<NocturneDbContext> _dbContextFactory;
     private readonly IOAuthClientService _clientService;
     private readonly ILogger<OAuthGrantService> _logger;
 
@@ -21,14 +22,18 @@ public class OAuthGrantService : IOAuthGrantService
     /// Initialises a new <see cref="OAuthGrantService"/>.
     /// </summary>
     /// <param name="dbContext">Database context for grant persistence.</param>
+    /// <param name="dbContextFactory">Factory used by <see cref="IsGrantRevokedAsync"/>, which runs
+    /// during authentication and so cannot rely on the scoped context being tenant-pinned yet.</param>
     /// <param name="clientService">Used to resolve client metadata (currently unused in this implementation).</param>
     /// <param name="logger">Logger instance.</param>
     public OAuthGrantService(
         NocturneDbContext dbContext,
+        IDbContextFactory<NocturneDbContext> dbContextFactory,
         IOAuthClientService clientService,
         ILogger<OAuthGrantService> logger)
     {
         _dbContext = dbContext;
+        _dbContextFactory = dbContextFactory;
         _clientService = clientService;
         _logger = logger;
     }
@@ -171,6 +176,28 @@ public class OAuthGrantService : IOAuthGrantService
         _logger.LogInformation(
             "OAuthAudit: {Event} grant_id={GrantId} subject_id={SubjectId} revoked_tokens={TokenCount}",
             "grant_revoked", grantId, grant.SubjectId, refreshTokens.Count);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> IsGrantRevokedAsync(
+        Guid grantId,
+        Guid tenantId,
+        CancellationToken ct = default)
+    {
+        // A dedicated context pinned to the token's tenant: this runs inside the authentication
+        // handlers, which may hold a child scope whose context carries no tenant (and therefore no
+        // RLS tenant GUC), and an unpinned read would return nothing for every grant.
+        await using var db = await _dbContextFactory.CreateDbContextAsync(ct);
+        db.TenantId = tenantId;
+
+        var state = await db.OAuthGrants
+            .AsNoTracking()
+            .Where(g => g.Id == grantId && g.TenantId == tenantId)
+            .Select(g => new { g.RevokedAt })
+            .FirstOrDefaultAsync(ct);
+
+        // No row means the grant was deleted, belongs to another tenant, or never existed.
+        return state is null || state.RevokedAt != null;
     }
 
     /// <inheritdoc />

--- a/src/API/Nocturne.API/Services/Auth/OAuthTokenService.cs
+++ b/src/API/Nocturne.API/Services/Auth/OAuthTokenService.cs
@@ -19,6 +19,7 @@ public class OAuthTokenService : IOAuthTokenService
     private readonly IJwtService _jwtService;
     private readonly ISubjectService _subjectService;
     private readonly IOAuthGrantService _grantService;
+    private readonly IOAuthTokenRevocationCache _revocationCache;
     private readonly ILogger<OAuthTokenService> _logger;
 
     private static readonly TimeSpan AuthorizationCodeLifetime = TimeSpan.FromMinutes(10);
@@ -30,12 +31,14 @@ public class OAuthTokenService : IOAuthTokenService
     /// <param name="jwtService">Service for generating and validating JWT access tokens and refresh tokens.</param>
     /// <param name="subjectService">Service for resolving subject permissions and roles for token claims.</param>
     /// <param name="grantService">Service for persisting and querying OAuth consent grants.</param>
+    /// <param name="revocationCache">Blocklist of revoked access tokens, keyed by <c>jti</c>.</param>
     /// <param name="logger">The logger instance.</param>
     public OAuthTokenService(
         NocturneDbContext db,
         IJwtService jwtService,
         ISubjectService subjectService,
         IOAuthGrantService grantService,
+        IOAuthTokenRevocationCache revocationCache,
         ILogger<OAuthTokenService> logger
     )
     {
@@ -43,6 +46,7 @@ public class OAuthTokenService : IOAuthTokenService
         _jwtService = jwtService;
         _subjectService = subjectService;
         _grantService = grantService;
+        _revocationCache = revocationCache;
         _logger = logger;
     }
 
@@ -260,7 +264,8 @@ public class OAuthTokenService : IOAuthTokenService
             roles,
             grant.Scopes,
             grant.Client?.ClientId,
-            tenantId: grant.TenantId
+            tenantId: grant.TenantId,
+            grantId: grant.Id
         );
 
         var expiresIn = (int)_jwtService.GetAccessTokenLifetime().TotalSeconds;
@@ -276,27 +281,76 @@ public class OAuthTokenService : IOAuthTokenService
         CancellationToken ct = default
     )
     {
-        var tokenHash = _jwtService.HashRefreshToken(token);
-
-        // Try as refresh token first (or if hinted)
-        if (tokenTypeHint is null or "refresh_token")
+        // Per RFC 7009 Section 2.1 the hint is advisory: if it doesn't resolve the token, the
+        // server extends the search to the other types. Both types are therefore always tried.
+        if (await RevokeAsRefreshTokenAsync(token, ct))
         {
-            var refreshToken = await _db.OAuthRefreshTokens
-                .FirstOrDefaultAsync(t => t.TokenHash == tokenHash && t.RevokedAt == null, ct);
+            return;
+        }
 
-            if (refreshToken != null)
-            {
-                refreshToken.RevokedAt = DateTime.UtcNow;
-                await _db.SaveChangesAsync(ct);
-                _logger.LogInformation(
-                    "OAuthAudit: {Event} token_id={TokenId} grant_id={GrantId}",
-                    "refresh_token_revoked", refreshToken.Id, refreshToken.GrantId);
-                return;
-            }
+        if (await RevokeAsAccessTokenAsync(token, ct))
+        {
+            return;
         }
 
         // Per RFC 7009: always return success even if token not found
         _logger.LogDebug("Token revocation: token not found (this is normal per RFC 7009)");
+    }
+
+    /// <summary>
+    /// Revokes <paramref name="token"/> if it is a stored refresh token. Returns whether it was.
+    /// </summary>
+    private async Task<bool> RevokeAsRefreshTokenAsync(string token, CancellationToken ct)
+    {
+        var tokenHash = _jwtService.HashRefreshToken(token);
+
+        var refreshToken = await _db.OAuthRefreshTokens
+            .FirstOrDefaultAsync(t => t.TokenHash == tokenHash && t.RevokedAt == null, ct);
+
+        if (refreshToken == null)
+        {
+            return false;
+        }
+
+        refreshToken.RevokedAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync(ct);
+        _logger.LogInformation(
+            "OAuthAudit: {Event} token_id={TokenId} grant_id={GrantId}",
+            "refresh_token_revoked", refreshToken.Id, refreshToken.GrantId);
+        return true;
+    }
+
+    /// <summary>
+    /// Blocklists <paramref name="token"/> by its <c>jti</c> if it is a valid access-token JWT.
+    /// Returns whether it was. The blocklist entry lives only as long as the token would have,
+    /// which is all a stateless token needs.
+    /// </summary>
+    private async Task<bool> RevokeAsAccessTokenAsync(string token, CancellationToken ct)
+    {
+        if (token.Count(c => c == '.') != 2)
+        {
+            return false;
+        }
+
+        var validation = _jwtService.ValidateAccessToken(token);
+        if (!validation.IsValid || validation.Claims is null)
+        {
+            return false;
+        }
+
+        var claims = validation.Claims;
+        if (string.IsNullOrEmpty(claims.JwtId))
+        {
+            return false;
+        }
+
+        var remainingLifetime = claims.ExpiresAt - DateTimeOffset.UtcNow;
+        await _revocationCache.RevokeAsync(claims.JwtId, remainingLifetime, ct);
+
+        _logger.LogInformation(
+            "OAuthAudit: {Event} jti={Jti} grant_id={GrantId}",
+            "access_token_revoked", claims.JwtId, claims.GrantId);
+        return true;
     }
 
     /// <inheritdoc />
@@ -437,7 +491,8 @@ public class OAuthTokenService : IOAuthTokenService
             roles,
             grant.Scopes,
             grant.ClientId,
-            tenantId: grant.TenantId
+            tenantId: grant.TenantId,
+            grantId: grant.Id
         );
 
         // Generate and store refresh token

--- a/src/API/Nocturne.API/Services/Auth/OAuthTokenService.cs
+++ b/src/API/Nocturne.API/Services/Auth/OAuthTokenService.cs
@@ -99,32 +99,36 @@ public class OAuthTokenService : IOAuthTokenService
     )
     {
         var codeHash = _jwtService.HashRefreshToken(code);
+        var now = DateTime.UtcNow;
+
+        // Claim the code before anything else. Redemption state is not a concurrency token and the
+        // unique index is on the hash, so a read-then-write check let two simultaneous exchanges
+        // both see redeemed_at IS NULL and both mint a token pair. This single statement is the
+        // atomic claim: exactly one caller can move redeemed_at away from NULL.
+        var claimed = await _db.OAuthAuthorizationCodes
+            .Where(c => c.CodeHash == codeHash && c.RedeemedAt == null && c.ExpiresAt > now)
+            .ExecuteUpdateAsync(s => s.SetProperty(c => c.RedeemedAt, now), ct);
+
+        if (claimed == 0)
+        {
+            // Unknown, expired and already-redeemed are one error: RFC 6749 Section 5.2 maps all
+            // three to invalid_grant, and a single message tells a caller nothing about which code
+            // hashes exist. On a genuine replay the tokens already issued from the code are revoked
+            // (RFC 6749 Section 4.1.2, OAuth 2.0 Security BCP Section 4.1.2).
+            await RevokeGrantOnCodeReplayAsync(codeHash, ct);
+            return OAuthTokenResult.Fail("invalid_grant", "Authorization code is invalid.");
+        }
 
         var authCode = await _db.OAuthAuthorizationCodes
+            .AsNoTracking()
             .Include(c => c.Client)
             .FirstOrDefaultAsync(c => c.CodeHash == codeHash, ct);
 
         if (authCode == null)
         {
-            _logger.LogWarning("Authorization code exchange failed: code not found");
+            // The row was claimed a moment ago, so this only happens if it was deleted meanwhile.
+            _logger.LogWarning("Authorization code exchange failed: claimed code no longer readable");
             return OAuthTokenResult.Fail("invalid_grant", "Authorization code is invalid.");
-        }
-
-        // Check not expired
-        if (authCode.IsExpired)
-        {
-            _logger.LogWarning("Authorization code exchange failed: code expired");
-            return OAuthTokenResult.Fail("invalid_grant", "Authorization code has expired.");
-        }
-
-        // Check not already redeemed (prevents replay)
-        if (authCode.IsRedeemed)
-        {
-            _logger.LogWarning(
-                "Authorization code replay detected for subject {SubjectId}",
-                authCode.SubjectId
-            );
-            return OAuthTokenResult.Fail("invalid_grant", "Authorization code has already been used.");
         }
 
         // Verify client_id matches
@@ -148,9 +152,6 @@ public class OAuthTokenService : IOAuthTokenService
             return OAuthTokenResult.Fail("invalid_grant", "PKCE code_verifier validation failed.");
         }
 
-        // Mark as redeemed
-        authCode.RedeemedAt = DateTime.UtcNow;
-
         // Create or update grant
         var grant = await _grantService.CreateOrUpdateGrantAsync(
             authCode.ClientEntityId,
@@ -161,6 +162,39 @@ public class OAuthTokenService : IOAuthTokenService
 
         // Mint tokens
         return await MintTokenPairAsync(grant, ct);
+    }
+
+    /// <summary>
+    /// Handles a failed claim on an authorization code. When the code exists and was already
+    /// redeemed, the exchange is a replay: whoever holds the code is racing the legitimate client or
+    /// replaying a stolen one, and the tokens issued from the first redemption can no longer be
+    /// trusted, so the grant behind them is revoked. An unknown or merely expired code is nothing to
+    /// act on.
+    /// </summary>
+    private async Task RevokeGrantOnCodeReplayAsync(string codeHash, CancellationToken ct)
+    {
+        var replayed = await _db.OAuthAuthorizationCodes
+            .AsNoTracking()
+            .Where(c => c.CodeHash == codeHash && c.RedeemedAt != null)
+            .Select(c => new { c.ClientEntityId, c.SubjectId })
+            .FirstOrDefaultAsync(ct);
+
+        if (replayed == null)
+        {
+            _logger.LogWarning("Authorization code exchange failed: code unknown or expired");
+            return;
+        }
+
+        _logger.LogWarning(
+            "Authorization code replay detected for subject {SubjectId}", replayed.SubjectId);
+
+        var grant = await _grantService.GetActiveGrantAsync(
+            replayed.ClientEntityId, replayed.SubjectId, ct);
+
+        if (grant != null)
+        {
+            await _grantService.RevokeGrantAsync(grant.Id, ct);
+        }
     }
 
     /// <inheritdoc />

--- a/src/API/Nocturne.API/Services/Identity/AuthorizationService.cs
+++ b/src/API/Nocturne.API/Services/Identity/AuthorizationService.cs
@@ -185,7 +185,8 @@ public class AuthorizationService : IAuthorizationService, IDisposable
             roles: [],
             scopes: grant.Scopes,
             tenantId: grant.TenantId,
-            lifetime: ExchangedJwtLifetime
+            lifetime: ExchangedJwtLifetime,
+            grantId: grant.Id
         );
 
         // Stamp last-used so grants exchanged for JWTs don't show as never used.

--- a/src/API/Nocturne.API/Services/Identity/HubTokenAuthorizer.cs
+++ b/src/API/Nocturne.API/Services/Identity/HubTokenAuthorizer.cs
@@ -30,17 +30,20 @@ public class HubTokenAuthorizer : IHubTokenAuthorizer
 {
     private readonly IJwtService _jwtService;
     private readonly IOAuthTokenRevocationCache _revocationCache;
+    private readonly IOAuthGrantService _grantService;
     private readonly IAuthorizationService _authorizationService;
     private readonly ILogger<HubTokenAuthorizer> _logger;
 
     public HubTokenAuthorizer(
         IJwtService jwtService,
         IOAuthTokenRevocationCache revocationCache,
+        IOAuthGrantService grantService,
         IAuthorizationService authorizationService,
         ILogger<HubTokenAuthorizer> logger)
     {
         _jwtService = jwtService;
         _revocationCache = revocationCache;
+        _grantService = grantService;
         _authorizationService = authorizationService;
         _logger = logger;
     }
@@ -85,6 +88,14 @@ public class HubTokenAuthorizer : IHubTokenAuthorizer
             && await _revocationCache.IsRevokedAsync(claims.JwtId))
         {
             _logger.LogDebug("Hub JWT has been revoked (jti: {Jti})", claims.JwtId);
+            return false;
+        }
+
+        // A grant revocation reaches outstanding access tokens through the grant id they carry.
+        if (claims.GrantId.HasValue
+            && await _grantService.IsGrantRevokedAsync(claims.GrantId.Value, connectionTenantId.Value))
+        {
+            _logger.LogDebug("Hub JWT's grant has been revoked (grant: {GrantId})", claims.GrantId);
             return false;
         }
 

--- a/src/Core/Nocturne.Core.Contracts/Auth/IJwtService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Auth/IJwtService.cs
@@ -39,6 +39,10 @@ public interface IJwtService
     /// <param name="platformAccess">When true, marks this token as a platform-admin tenant-access
     /// grant. Combined with <paramref name="tenantId"/>, this is what authorizes out-of-tenant
     /// superuser access — a marker that no ordinary tenant-pinned token carries.</param>
+    /// <param name="grantId">The OAuth grant this token was minted from. Access tokens are
+    /// stateless, so this is what lets a grant revocation invalidate them: the authenticating
+    /// handler rejects a token whose grant is revoked. Omit only for tokens that have no grant
+    /// behind them (platform access, recovery, connector link tokens).</param>
     /// <returns>JWT access token string</returns>
     string GenerateAccessToken(
         SubjectInfo subject,
@@ -49,7 +53,8 @@ public interface IJwtService
         bool limitTo24Hours = false,
         Guid? tenantId = null,
         TimeSpan? lifetime = null,
-        bool platformAccess = false
+        bool platformAccess = false,
+        Guid? grantId = null
     );
 
     /// <summary>
@@ -209,6 +214,12 @@ public class JwtClaims
     /// last 24 hours (rolling window from current request time).
     /// </summary>
     public bool LimitTo24Hours { get; set; }
+
+    /// <summary>
+    /// The OAuth grant this token was minted from, if any. Null for tokens with no grant behind
+    /// them. When set, the grant's revocation state decides whether the token is still usable.
+    /// </summary>
+    public Guid? GrantId { get; set; }
 
     /// <summary>
     /// JWT ID (jti claim)

--- a/src/Core/Nocturne.Core.Contracts/Auth/IOAuthGrantService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Auth/IOAuthGrantService.cs
@@ -46,9 +46,20 @@ public interface IOAuthGrantService
     );
 
     /// <summary>
-    /// Revoke a grant (soft delete). Invalidates all associated refresh tokens.
+    /// Revoke a grant (soft delete). Invalidates all associated refresh tokens, and — because
+    /// access tokens carry their grant id — every outstanding access token minted from the grant.
     /// </summary>
     Task RevokeGrantAsync(Guid grantId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Whether the grant is revoked, for authenticating an access token that carries a grant id.
+    /// A grant that cannot be found is reported as revoked.
+    /// </summary>
+    /// <param name="grantId">The grant id carried by the access token.</param>
+    /// <param name="tenantId">The tenant the presented token is pinned to, already verified against
+    /// the request's tenant by the caller. Used to scope the lookup.</param>
+    /// <param name="ct">Cancellation token</param>
+    Task<bool> IsGrantRevokedAsync(Guid grantId, Guid tenantId, CancellationToken ct = default);
 
     /// <summary>
     /// Update last-used tracking on a grant.

--- a/src/Core/Nocturne.Core.Contracts/Auth/IOAuthTokenService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Auth/IOAuthTokenService.cs
@@ -12,8 +12,11 @@ namespace Nocturne.Core.Contracts.Auth;
 public interface IOAuthTokenService
 {
     /// <summary>
-    /// Exchange an authorization code for access + refresh tokens.
-    /// Validates PKCE, redirect URI, and code expiry.
+    /// Exchange an authorization code for access + refresh tokens. The code is claimed atomically
+    /// before anything else is validated, so concurrent exchanges of one code yield exactly one
+    /// token pair; PKCE, redirect URI and client id are then checked against the claimed code. A
+    /// code that is unknown, expired or already redeemed returns a single indistinguishable
+    /// <c>invalid_grant</c>, and a replay additionally revokes the grant the code issued.
     /// </summary>
     Task<OAuthTokenResult> ExchangeAuthorizationCodeAsync(
         string code,

--- a/src/Core/Nocturne.Core.Contracts/Auth/IOAuthTokenService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Auth/IOAuthTokenService.cs
@@ -34,7 +34,9 @@ public interface IOAuthTokenService
     );
 
     /// <summary>
-    /// Revoke a token (access or refresh). Per RFC 7009, always succeeds.
+    /// Revoke a token. A refresh token is marked revoked in the database; an access token is
+    /// blocklisted by its <c>jti</c> for the remainder of its lifetime. The type hint is advisory —
+    /// both types are tried. Per RFC 7009, always succeeds, including when nothing matched.
     /// </summary>
     Task RevokeTokenAsync(
         string token,

--- a/tests/Unit/Nocturne.API.Tests/Authorization/OAuthControllerConsentTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/OAuthControllerConsentTests.cs
@@ -1,0 +1,133 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Controllers.Authentication;
+using Nocturne.API.Models.OAuth;
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Models.Authorization;
+using Xunit;
+
+namespace Nocturne.API.Tests.Authorization;
+
+/// <summary>
+/// Unit tests for the consent-approval endpoint (<c>POST /api/oauth/authorize</c>), covering the
+/// order in which the client and its redirect URI are validated. Both the approve and the deny path
+/// end in a redirect to <c>redirect_uri</c>, so both need the URI proven to belong to the client
+/// before anything is emitted.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Category", "OAuth")]
+public class OAuthControllerConsentTests
+{
+    private const string ClientId = "test-client-id";
+    private const string RegisteredRedirectUri = "org.nightscout.trio://oauth/callback";
+    private const string UnregisteredRedirectUri = "https://not-the-client.example/collect";
+
+    private readonly Guid _clientEntityId = Guid.CreateVersion7();
+    private readonly Guid _subjectId = Guid.CreateVersion7();
+
+    private readonly Mock<IOAuthClientService> _clientService = new();
+    private readonly Mock<IOAuthTokenService> _tokenService = new();
+
+    public OAuthControllerConsentTests()
+    {
+        _clientService
+            .Setup(s => s.GetClientAsync(ClientId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OAuthClientInfo
+            {
+                Id = _clientEntityId,
+                ClientId = ClientId,
+                DisplayName = "Trio",
+            });
+        _clientService
+            .Setup(s => s.ValidateRedirectUriAsync(
+                ClientId, RegisteredRedirectUri, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _clientService
+            .Setup(s => s.ValidateRedirectUriAsync(
+                ClientId, UnregisteredRedirectUri, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _tokenService
+            .Setup(s => s.GenerateAuthorizationCodeAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<IEnumerable<string>>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync("the-code");
+    }
+
+    private OAuthController CreateController()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["AuthContext"] = new AuthContext
+        {
+            IsAuthenticated = true,
+            AuthType = AuthType.SessionCookie,
+            SubjectId = _subjectId,
+        };
+
+        return new OAuthController(
+            _clientService.Object,
+            Mock.Of<IOAuthGrantService>(),
+            _tokenService.Object,
+            Mock.Of<IOAuthDeviceCodeService>(),
+            Mock.Of<ISubjectService>(),
+            Mock.Of<IJwtService>(),
+            Mock.Of<IOAuthTokenRevocationCache>(),
+            NullLogger<OAuthController>.Instance
+        )
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext },
+        };
+    }
+
+    private static ConsentApprovalRequest Consent(bool approved, string redirectUri) => new()
+    {
+        ClientId = ClientId,
+        RedirectUri = redirectUri,
+        Scope = OAuthScopes.GlucoseRead,
+        CodeChallenge = "a-code-challenge",
+        State = "opaque-state",
+        Approved = approved,
+    };
+
+    [Fact]
+    public async Task Denial_with_an_unregistered_redirect_uri_is_rejected_not_redirected()
+    {
+        var result = await CreateController().ApproveConsent(Consent(false, UnregisteredRedirectUri));
+
+        var badRequest = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        badRequest.Value.Should().BeOfType<OAuthError>()
+            .Which.Error.Should().Be("invalid_request");
+    }
+
+    [Fact]
+    public async Task Approval_with_an_unregistered_redirect_uri_is_rejected()
+    {
+        var result = await CreateController().ApproveConsent(Consent(true, UnregisteredRedirectUri));
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task Denial_with_the_registered_redirect_uri_redirects_with_access_denied()
+    {
+        var result = await CreateController().ApproveConsent(Consent(false, RegisteredRedirectUri));
+
+        var redirect = result.Should().BeOfType<RedirectResult>().Subject;
+        redirect.Url.Should().StartWith(RegisteredRedirectUri);
+        redirect.Url.Should().Contain("error=access_denied");
+        redirect.Url.Should().Contain("state=opaque-state");
+    }
+
+    [Fact]
+    public async Task Approval_with_the_registered_redirect_uri_issues_a_code()
+    {
+        var result = await CreateController().ApproveConsent(Consent(true, RegisteredRedirectUri));
+
+        var redirect = result.Should().BeOfType<RedirectResult>().Subject;
+        redirect.Url.Should().StartWith(RegisteredRedirectUri);
+        redirect.Url.Should().Contain("code=the-code");
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Authorization/OAuthDeviceCodeServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/OAuthDeviceCodeServiceTests.cs
@@ -512,7 +512,9 @@ public class OAuthDeviceCodeExchangeTests : IDisposable
                 It.IsAny<string?>(),
                 It.IsAny<bool>(),
                 It.IsAny<Guid?>(),
-                It.IsAny<TimeSpan?>()))
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<bool>(),
+                It.IsAny<Guid?>()))
             .Returns(TestAccessToken);
         _mockJwtService.Setup(j => j.GetAccessTokenLifetime())
             .Returns(TimeSpan.FromHours(1));
@@ -535,6 +537,7 @@ public class OAuthDeviceCodeExchangeTests : IDisposable
             _mockJwtService.Object,
             _mockSubjectService.Object,
             _mockGrantService.Object,
+            Mock.Of<IOAuthTokenRevocationCache>(),
             _mockLogger.Object
         );
     }

--- a/tests/Unit/Nocturne.API.Tests/Authorization/OAuthGrantServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/OAuthGrantServiceTests.cs
@@ -70,7 +70,23 @@ public class OAuthGrantServiceTests : IDisposable
 
     private OAuthGrantService CreateService(NocturneDbContext dbContext)
     {
-        return new OAuthGrantService(dbContext, _mockClientService.Object, _mockLogger.Object);
+        return new OAuthGrantService(
+            dbContext,
+            new TestDbContextFactory(_contextOptions, _testTenantId),
+            _mockClientService.Object,
+            _mockLogger.Object);
+    }
+
+    /// <summary>
+    /// Hands out tenant-pinned contexts over the shared in-memory connection, standing in for the
+    /// registered <see cref="IDbContextFactory{TContext}"/>.
+    /// </summary>
+    private sealed class TestDbContextFactory(
+        DbContextOptions<NocturneDbContext> options, Guid tenantId)
+        : IDbContextFactory<NocturneDbContext>
+    {
+        public NocturneDbContext CreateDbContext() =>
+            new(options) { TenantId = tenantId };
     }
 
     private NocturneDbContext CreateDbContext()

--- a/tests/Unit/Nocturne.API.Tests/Authorization/OAuthTokenServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/OAuthTokenServiceTests.cs
@@ -24,6 +24,7 @@ public class OAuthTokenServiceTests : IDisposable
     private readonly Mock<IJwtService> _mockJwtService;
     private readonly Mock<ISubjectService> _mockSubjectService;
     private readonly Mock<IOAuthGrantService> _mockGrantService;
+    private readonly Mock<IOAuthTokenRevocationCache> _mockRevocationCache;
     private readonly Mock<ILogger<OAuthTokenService>> _mockLogger;
 
     // Deterministic test values
@@ -61,6 +62,7 @@ public class OAuthTokenServiceTests : IDisposable
         _mockJwtService = new Mock<IJwtService>();
         _mockSubjectService = new Mock<ISubjectService>();
         _mockGrantService = new Mock<IOAuthGrantService>();
+        _mockRevocationCache = new Mock<IOAuthTokenRevocationCache>();
         _mockLogger = new Mock<ILogger<OAuthTokenService>>();
 
         SetupDefaultMocks();
@@ -85,7 +87,9 @@ public class OAuthTokenServiceTests : IDisposable
                 It.IsAny<string?>(),
                 It.IsAny<bool>(),
                 It.IsAny<Guid?>(),
-                It.IsAny<TimeSpan?>()))
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<bool>(),
+                It.IsAny<Guid?>()))
             .Returns(TestAccessToken);
         _mockJwtService.Setup(j => j.GetAccessTokenLifetime())
             .Returns(TimeSpan.FromHours(1));
@@ -125,6 +129,7 @@ public class OAuthTokenServiceTests : IDisposable
             _mockJwtService.Object,
             _mockSubjectService.Object,
             _mockGrantService.Object,
+            _mockRevocationCache.Object,
             _mockLogger.Object
         );
     }
@@ -577,6 +582,65 @@ public class OAuthTokenServiceTests : IDisposable
         _mockGrantService.Verify(g => g.RevokeGrantAsync(
             It.IsAny<Guid>(),
             It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ---------------------------------------------------------------
+    // RevokeTokenAsync tests
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public async Task RevokeTokenAsync_AccessToken_BlocklistsTheJti()
+    {
+        // RFC 7009 allows revoking an access token. It is a stateless JWT, so the only way to stop
+        // it before expiry is the jti blocklist.
+        const string accessToken = "header.payload.signature";
+        var expiresAt = DateTimeOffset.UtcNow.AddMinutes(12);
+
+        _mockJwtService.Setup(j => j.HashRefreshToken(accessToken))
+            .Returns("no-such-refresh-token-hash");
+        _mockJwtService.Setup(j => j.ValidateAccessToken(accessToken))
+            .Returns(JwtValidationResult.Success(new JwtClaims
+            {
+                SubjectId = _testSubjectId,
+                JwtId = "jti-to-revoke",
+                IssuedAt = DateTimeOffset.UtcNow,
+                ExpiresAt = expiresAt,
+            }));
+
+        using var db = CreateDbContext();
+        var service = CreateService(db);
+
+        await service.RevokeTokenAsync(accessToken, "access_token");
+
+        _mockRevocationCache.Verify(c => c.RevokeAsync(
+            "jti-to-revoke",
+            It.Is<TimeSpan>(t => t > TimeSpan.Zero),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RevokeTokenAsync_RefreshTokenWithAccessTokenHint_StillRevokesIt()
+    {
+        // The hint is advisory per RFC 7009 Section 2.1: a wrong hint must not make revocation a
+        // no-op.
+        const string refreshToken = "opaque-refresh-token";
+        const string refreshTokenHash = "opaque-refresh-token-hash";
+
+        _mockJwtService.Setup(j => j.HashRefreshToken(refreshToken))
+            .Returns(refreshTokenHash);
+
+        using var db = CreateDbContext();
+        await SeedClientAsync(db);
+        await SeedSubjectAsync(db);
+        var grantId = await SeedGrantAsync(db);
+        await SeedRefreshTokenAsync(db, refreshTokenHash, grantId: grantId);
+
+        var service = CreateService(db);
+
+        await service.RevokeTokenAsync(refreshToken, "access_token");
+
+        var stored = await db.OAuthRefreshTokens.FirstAsync(t => t.TokenHash == refreshTokenHash);
+        Assert.NotNull(stored.RevokedAt);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Authorization/OAuthTokenServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/OAuthTokenServiceTests.cs
@@ -297,8 +297,12 @@ public class OAuthTokenServiceTests : IDisposable
         Assert.Null(result.Error);
         Assert.Null(result.ErrorDescription);
 
-        // Verify the auth code was marked as redeemed
-        var redeemed = await db.OAuthAuthorizationCodes.FirstAsync(c => c.CodeHash == testCodeHash);
+        // Verify the auth code was marked as redeemed. Read fresh: the claim is an ExecuteUpdate,
+        // which bypasses the change tracker, so the instance seeded on this context is stale.
+        using var verifyDb = CreateDbContext();
+        var redeemed = await verifyDb.OAuthAuthorizationCodes
+            .AsNoTracking()
+            .FirstAsync(c => c.CodeHash == testCodeHash);
         Assert.NotNull(redeemed.RedeemedAt);
 
         // Verify grant creation was called
@@ -336,14 +340,19 @@ public class OAuthTokenServiceTests : IDisposable
             TestRedirectUri,
             TestClientId);
 
-        // Assert
+        // Assert — unknown, expired and already-used share one invalid_grant message per
+        // RFC 6749 Section 5.2, so the response reveals nothing about which codes exist.
         Assert.False(result.Success);
         Assert.Equal("invalid_grant", result.Error);
-        Assert.Contains("expired", result.ErrorDescription, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("Authorization code is invalid.", result.ErrorDescription);
+
+        // An expired code was never redeemed, so there is nothing to revoke.
+        _mockGrantService.Verify(g => g.RevokeGrantAsync(
+            It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
-    public async Task ExchangeAuthorizationCodeAsync_AlreadyRedeemed_ReturnsError()
+    public async Task ExchangeAuthorizationCodeAsync_AlreadyRedeemed_RevokesTheGrantItIssued()
     {
         // Arrange
         const string testCode = "redeemed-auth-code";
@@ -358,6 +367,10 @@ public class OAuthTokenServiceTests : IDisposable
         await SeedAuthorizationCodeAsync(db, testCodeHash,
             redeemedAt: DateTime.UtcNow.AddMinutes(-1));
 
+        _mockGrantService.Setup(g => g.GetActiveGrantAsync(
+                _testClientEntityId, _testSubjectId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OAuthGrantInfo { Id = _testGrantId, SubjectId = _testSubjectId });
+
         var service = CreateService(db);
 
         // Act
@@ -370,7 +383,71 @@ public class OAuthTokenServiceTests : IDisposable
         // Assert
         Assert.False(result.Success);
         Assert.Equal("invalid_grant", result.Error);
-        Assert.Contains("already been used", result.ErrorDescription, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("Authorization code is invalid.", result.ErrorDescription);
+
+        // A replayed code means the tokens from the first redemption are suspect
+        // (RFC 6749 Section 4.1.2).
+        _mockGrantService.Verify(g => g.RevokeGrantAsync(
+            _testGrantId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExchangeAuthorizationCodeAsync_ConcurrentRedemptions_OnlyOneSucceeds()
+    {
+        // Two exchanges of the same code at the same time. The claim is a single conditional UPDATE,
+        // so only one can move redeemed_at away from NULL; a read-then-write check let both through.
+        // Separate connections to a shared-cache database so the two calls really contend.
+        const string testCode = "raced-auth-code";
+        const string testCodeHash = "raced-auth-code-hash";
+        var dataSource = $"file:{Guid.NewGuid():N}?mode=memory&cache=shared";
+
+        _mockJwtService.Setup(j => j.HashRefreshToken(testCode))
+            .Returns(testCodeHash);
+
+        // Keeps the shared-cache database alive for the duration of the test.
+        using var keepAlive = new SqliteConnection($"DataSource={dataSource}");
+        keepAlive.Open();
+
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite($"DataSource={dataSource};Default Timeout=30")
+            .Options;
+
+        using (var seed = new NocturneDbContext(options) { TenantId = _testTenantId })
+        {
+            await seed.Database.EnsureCreatedAsync();
+            seed.Tenants.Add(new TenantEntity { Id = _testTenantId, Slug = "test" });
+            await seed.SaveChangesAsync();
+            await SeedClientAsync(seed);
+            await SeedSubjectAsync(seed);
+            await SeedGrantAsync(seed);
+            await SeedAuthorizationCodeAsync(seed, testCodeHash);
+        }
+
+        using var dbA = new NocturneDbContext(options) { TenantId = _testTenantId };
+        using var dbB = new NocturneDbContext(options) { TenantId = _testTenantId };
+
+        // Act
+        var attempts = await Task.WhenAll(
+            Redeem(CreateService(dbA)),
+            Redeem(CreateService(dbB)));
+
+        // Assert
+        Assert.Equal(1, attempts.Count(r => r));
+
+        async Task<bool> Redeem(OAuthTokenService service)
+        {
+            try
+            {
+                var result = await service.ExchangeAuthorizationCodeAsync(
+                    testCode, TestCodeVerifier, TestRedirectUri, TestClientId);
+                return result.Success;
+            }
+            catch (SqliteException)
+            {
+                // Losing the write lock is a failed redemption, not a second success.
+                return false;
+            }
+        }
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Connectors/CareLinkConnectControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Connectors/CareLinkConnectControllerTests.cs
@@ -79,9 +79,10 @@ public sealed class CareLinkConnectControllerTests
                 It.IsAny<bool>(),
                 It.IsAny<Guid?>(),
                 It.IsAny<TimeSpan?>(),
-                It.IsAny<bool>()))
+                It.IsAny<bool>(),
+                It.IsAny<Guid?>()))
             .Callback((SubjectInfo s, IEnumerable<string> p, IEnumerable<string> _, IEnumerable<string> sc,
-                string? _, bool _, Guid? t, TimeSpan? l, bool _) =>
+                string? _, bool _, Guid? t, TimeSpan? l, bool _, Guid? _) =>
             {
                 subject = s;
                 permissions = p;
@@ -115,7 +116,7 @@ public sealed class CareLinkConnectControllerTests
             .Setup(j => j.GenerateAccessToken(
                 It.IsAny<SubjectInfo>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(),
                 It.IsAny<IEnumerable<string>>(), It.IsAny<string?>(), It.IsAny<bool>(),
-                It.IsAny<Guid?>(), It.IsAny<TimeSpan?>(), It.IsAny<bool>()))
+                It.IsAny<Guid?>(), It.IsAny<TimeSpan?>(), It.IsAny<bool>(), It.IsAny<Guid?>()))
             .Returns("t");
 
         var controller = Build(Tenant(), Auth());

--- a/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/OAuthAccessTokenHandlerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/OAuthAccessTokenHandlerTests.cs
@@ -32,6 +32,7 @@ public class OAuthAccessTokenHandlerTests
     private readonly Guid _subjectId = Guid.CreateVersion7();
 
     private readonly IJwtService _jwt;
+    private readonly Mock<IOAuthGrantService> _grantService = new();
     private readonly OAuthAccessTokenHandler _handler;
 
     public OAuthAccessTokenHandlerTests()
@@ -54,6 +55,7 @@ public class OAuthAccessTokenHandlerTests
         var services = new ServiceCollection();
         services.AddSingleton(_jwt);
         services.AddSingleton(revocationCache.Object);
+        services.AddSingleton(_grantService.Object);
         var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
 
         _handler = new OAuthAccessTokenHandler(scopeFactory, NullLogger<OAuthAccessTokenHandler>.Instance);
@@ -67,6 +69,16 @@ public class OAuthAccessTokenHandlerTests
             scopes: ["connectors:carelink:connect"],
             tenantId: _tenantId,
             lifetime: TimeSpan.FromMinutes(10));
+
+    /// <summary>An app token as the OAuth token endpoint mints it: scoped, pinned, grant-bound.</summary>
+    private string MintGrantBoundToken(Guid grantId) =>
+        _jwt.GenerateAccessToken(
+            new SubjectInfo { Id = _subjectId, Name = "Acme User" },
+            permissions: [],
+            roles: [],
+            scopes: [OAuthScopes.GlucoseRead],
+            tenantId: _tenantId,
+            grantId: grantId);
 
     /// <summary>JwtService refuses to mint already-expired tokens, so build one by hand.</summary>
     private string MintExpiredToken()
@@ -140,6 +152,39 @@ public class OAuthAccessTokenHandlerTests
     public async Task Rejects_an_expired_token()
     {
         var context = Request(MintExpiredToken(), Tenant());
+
+        var result = await _handler.AuthenticateAsync(context);
+
+        result.Succeeded.Should().BeFalse();
+        result.ShouldSkip.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Accepts_a_grant_bound_token_while_its_grant_is_active()
+    {
+        var grantId = Guid.CreateVersion7();
+        _grantService
+            .Setup(g => g.IsGrantRevokedAsync(grantId, _tenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var context = Request(MintGrantBoundToken(grantId), Tenant());
+
+        var result = await _handler.AuthenticateAsync(context);
+
+        result.Succeeded.Should().BeTrue(result.Error);
+    }
+
+    [Fact]
+    public async Task Rejects_a_grant_bound_token_once_its_grant_is_revoked()
+    {
+        // Disconnecting a connected app revokes the grant; the app's still-valid access token must
+        // stop working on its next request rather than at natural expiry.
+        var grantId = Guid.CreateVersion7();
+        _grantService
+            .Setup(g => g.IsGrantRevokedAsync(grantId, _tenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var context = Request(MintGrantBoundToken(grantId), Tenant());
 
         var result = await _handler.AuthenticateAsync(context);
 

--- a/tests/Unit/Nocturne.API.Tests/Middleware/MemberScopeMiddlewareTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/MemberScopeMiddlewareTests.cs
@@ -209,6 +209,94 @@ public class MemberScopeMiddlewareTests
     }
 
     [Fact]
+    public async Task OwnerMember_WithNarrowlyScopedOAuthToken_KeepsOnlyTheTokenScopes()
+    {
+        // A tenant owner who authorized a third-party app for glucose.read only. The owner's
+        // membership grants "*", but the access token is the consent boundary: widening to
+        // superuser here would hand the app write/delete on every resource.
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
+
+        var subjectId = SeedMemberWithRole(
+            options, TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Owner]);
+
+        var (context, provider) = BuildMemberContext(options, subjectId, [OAuthScopes.GlucoseRead]);
+        using (provider)
+        {
+            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
+            await middleware.InvokeAsync(context);
+        }
+
+        var grantedScopes = context.Items["GrantedScopes"] as IReadOnlySet<string>;
+        grantedScopes.Should().NotBeNull();
+        grantedScopes.Should().Contain(OAuthScopes.GlucoseRead);
+        grantedScopes.Should().NotContain("*");
+        grantedScopes.Should().NotContain(OAuthScopes.TreatmentsReadWrite);
+        grantedScopes.Should().NotContain(OAuthScopes.TherapyReadWrite);
+
+        var permissionTrie = context.Items["PermissionTrie"] as PermissionTrie;
+        permissionTrie.Should().NotBeNull();
+        permissionTrie!.Check("api:entries:read").Should().BeTrue();
+        permissionTrie.Check("api:entries:create").Should().BeFalse();
+        permissionTrie.Check("api:profile:update").Should().BeFalse();
+        permissionTrie.Check("*").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task OwnerMember_WithFullAccessOAuthToken_StillGetsSuperuser()
+    {
+        // The same owner consenting to full access keeps superuser: the credential's own scope
+        // list is what bounds it, and "*" bounds nothing.
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
+
+        var subjectId = SeedMemberWithRole(
+            options, TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Owner]);
+
+        var (context, provider) = BuildMemberContext(options, subjectId, [OAuthScopes.FullAccess]);
+        using (provider)
+        {
+            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
+            await middleware.InvokeAsync(context);
+        }
+
+        var grantedScopes = context.Items["GrantedScopes"] as IReadOnlySet<string>;
+        grantedScopes.Should().NotBeNull();
+        grantedScopes.Should().Contain("*");
+
+        var permissionTrie = context.Items["PermissionTrie"] as PermissionTrie;
+        permissionTrie.Should().NotBeNull();
+        permissionTrie!.Check("*").Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task OwnerMember_WithNarrowlyScopedDirectGrant_KeepsOnlyTheTokenScopes()
+    {
+        // Same token, presented as a bearer/?token= direct grant instead of an OAuth JWT. It must
+        // resolve to the same narrow scopes it does in the api-secret header (AuthType.ApiKey).
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
+
+        var subjectId = SeedMemberWithRole(
+            options, TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Owner]);
+
+        var (context, provider) = BuildMemberContext(
+            options, subjectId, [OAuthScopes.GlucoseRead], AuthType.DirectGrant);
+        using (provider)
+        {
+            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
+            await middleware.InvokeAsync(context);
+        }
+
+        var grantedScopes = context.Items["GrantedScopes"] as IReadOnlySet<string>;
+        grantedScopes.Should().NotBeNull();
+        grantedScopes.Should().BeEquivalentTo([OAuthScopes.GlucoseRead]);
+    }
+
+    [Fact]
     public async Task NonOwnerMember_WithDeviceScopedToken_RetainsDeviceScopes()
     {
         // A caretaker running the desktop Companion: the OAuth token carries the device
@@ -358,7 +446,10 @@ public class MemberScopeMiddlewareTests
     /// scopes, as AuthenticationMiddleware would leave it. The caller disposes the provider.
     /// </summary>
     private static (DefaultHttpContext context, ServiceProvider provider) BuildMemberContext(
-        DbContextOptions<NocturneDbContext> options, Guid subjectId, List<string> tokenScopes)
+        DbContextOptions<NocturneDbContext> options,
+        Guid subjectId,
+        List<string> tokenScopes,
+        AuthType authType = AuthType.OAuthAccessToken)
     {
         var services = new ServiceCollection();
         services.AddScoped(_ => new NocturneDbContext(options));
@@ -368,7 +459,7 @@ public class MemberScopeMiddlewareTests
         context.Items["AuthContext"] = new AuthContext
         {
             IsAuthenticated = true,
-            AuthType = AuthType.OAuthAccessToken,
+            AuthType = authType,
             SubjectId = subjectId,
             TenantId = TestDatabaseSeeder.TenantId,
             Scopes = tokenScopes,

--- a/tests/Unit/Nocturne.API.Tests/Services/Identity/AuthorizationServiceTokenExchangeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Identity/AuthorizationServiceTokenExchangeTests.cs
@@ -117,7 +117,8 @@ public class AuthorizationServiceTokenExchangeTests : IDisposable
                 It.IsAny<bool>(),
                 It.IsAny<Guid?>(),
                 It.IsAny<TimeSpan?>(),
-                It.IsAny<bool>()))
+                It.IsAny<bool>(),
+                It.IsAny<Guid?>()))
             .Returns(jwt);
     }
 
@@ -145,7 +146,8 @@ public class AuthorizationServiceTokenExchangeTests : IDisposable
             It.IsAny<bool>(),
             _testTenantId,
             It.IsAny<TimeSpan?>(),
-            It.IsAny<bool>()), Times.Once);
+            It.IsAny<bool>(),
+            It.IsAny<Guid?>()), Times.Once);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/Identity/HubTokenAuthorizerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Identity/HubTokenAuthorizerTests.cs
@@ -27,15 +27,20 @@ public class HubTokenAuthorizerTests
 
     private readonly Mock<IJwtService> _jwtService = new();
     private readonly Mock<IOAuthTokenRevocationCache> _revocationCache = new();
+    private readonly Mock<IOAuthGrantService> _grantService = new();
     private readonly Mock<IAuthorizationService> _authorizationService = new();
 
     private HubTokenAuthorizer CreateAuthorizer() => new(
         _jwtService.Object,
         _revocationCache.Object,
+        _grantService.Object,
         _authorizationService.Object,
         NullLogger<HubTokenAuthorizer>.Instance);
 
-    private void SetupValidJwt(Guid? tenantId, params string[] scopes)
+    private void SetupValidJwt(Guid? tenantId, params string[] scopes) =>
+        SetupValidJwt(tenantId, grantId: null, scopes);
+
+    private void SetupValidJwt(Guid? tenantId, Guid? grantId, params string[] scopes)
     {
         _jwtService
             .Setup(s => s.ValidateAccessToken(JwtShapedToken))
@@ -43,6 +48,7 @@ public class HubTokenAuthorizerTests
             {
                 SubjectId = Guid.NewGuid(),
                 TenantId = tenantId,
+                GrantId = grantId,
                 Scopes = [.. scopes],
                 JwtId = "jti-1",
                 IssuedAt = DateTimeOffset.UtcNow,
@@ -96,6 +102,22 @@ public class HubTokenAuthorizerTests
     public async Task Jwt_without_required_scope_is_rejected()
     {
         SetupValidJwt(Tenant, OAuthScopes.TherapyRead);
+        var authorizer = CreateAuthorizer();
+
+        var result = await authorizer.IsTokenAuthorizedAsync(
+            JwtShapedToken, Tenant, OAuthScopes.GlucoseRead);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Jwt_whose_grant_is_revoked_is_rejected()
+    {
+        var grantId = Guid.CreateVersion7();
+        SetupValidJwt(Tenant, grantId, OAuthScopes.GlucoseRead);
+        _grantService
+            .Setup(g => g.IsGrantRevokedAsync(grantId, Tenant, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
         var authorizer = CreateAuthorizer();
 
         var result = await authorizer.IsTokenAuthorizedAsync(


### PR DESCRIPTION
Four related fixes in the OAuth 2.0 authorization server. Details are in the individual commit messages.

- Consented scopes were discarded for a tenant superuser, so a third-party grant resolved to full access regardless of what was consented.
- Access-token revocation did not reach outstanding tokens; the revocation cache was never written.
- Authorization-code single-use was a read-then-write race, so concurrent redemptions could both mint.
- The consent-denial path issued a redirect before validating `redirect_uri`.

Verified: full API unit suite green, two of the four fixes mutation-checked (reverting each fails exactly the intended tests). No schema change — the grant id is a JWT claim, and `ef migrations has-pending-model-changes` reports none.