### PR TITLE
fix(auth): resolve a member's scopes from one place, and make tenant roles enforceable

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Identity/MyTenantsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/MyTenantsController.cs
@@ -64,18 +64,18 @@ public class MyTenantsController : ControllerBase
         if (authContext?.SubjectId == null)
             return Unauthorized();
 
-        // Per-tenant data is gated on membership permissions intersected with the auth token's
-        // granted scopes (as resolved by AuthenticationMiddleware). This endpoint is tenantless,
-        // so MemberScopeMiddleware has not applied the membership restriction here — the service
-        // mirrors it per tenant. InstanceKey/PlatformAccess are superuser auth types, matching
-        // MemberScopeMiddleware's handling.
+        // This endpoint is tenantless, so MemberScopeMiddleware has not applied the membership
+        // restriction — the service resolves it per tenant through MemberScopeResolver, which needs
+        // the credential type to know whether the token's scopes are a ceiling at all.
+        // InstanceKey/PlatformAccess are superuser auth types, matching MemberScopeMiddleware's
+        // handling: they never reach membership resolution there, so stand in a full-access grant.
         IReadOnlySet<string> tokenScopes =
             authContext.AuthType is AuthType.InstanceKey or AuthType.PlatformAccess
                 ? new HashSet<string> { OAuthScopes.FullAccess }
                 : HttpContext.GetGrantedScopes();
 
         var overview = await _overviewService.GetOverviewAsync(
-            authContext.SubjectId.Value, tokenScopes, ct);
+            authContext.SubjectId.Value, tokenScopes, authContext.AuthType, ct);
         return Ok(overview);
     }
 

--- a/src/API/Nocturne.API/Middleware/MemberScopeMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/MemberScopeMiddleware.cs
@@ -11,9 +11,9 @@ namespace Nocturne.API.Middleware;
 /// <summary>
 /// Middleware that resolves the authenticated user's tenant membership and applies
 /// RBAC-based permission restrictions. Effective permissions are the union of all
-/// role permissions + direct permissions, intersected with the credential's granted scopes
-/// via <see cref="OAuthScopes"/>. Widening to superuser happens only for a <c>"*"</c> membership
-/// presented on an unscoped credential (see <see cref="UnscopedCredentialTypes"/>).
+/// role permissions + direct permissions; <see cref="MemberScopeResolver"/> turns them into the
+/// granted scope set, intersecting with the credential's own scopes unless the credential carries
+/// none (<see cref="MemberScopeResolver.UnscopedCredentialTypes"/>).
 /// Must run after <see cref="AuthenticationMiddleware"/>.
 /// </summary>
 /// <remarks>
@@ -38,25 +38,6 @@ public class MemberScopeMiddleware
 {
     private readonly RequestDelegate _next;
     private readonly ILogger<MemberScopeMiddleware> _logger;
-
-    /// <summary>
-    /// Credential types that carry no scope grant of their own — the authenticated human's own
-    /// interactive login. Tenant membership is the only authority for these, so a <c>"*"</c>
-    /// membership widens to superuser. Every other credential presents scopes that bound what it
-    /// may do (an OAuth access token's consented scopes, a direct grant's scopes, an API key's
-    /// grant scopes, a guest link's scopes) and is intersected with membership instead. Membership
-    /// resolution must never widen a scoped credential, or the consent decision is erased. Keyed on
-    /// the credential type rather than on "the scope list is empty" because an interactive OIDC
-    /// login carries the identity provider's own scopes (<c>openid</c>, <c>profile</c>), which are
-    /// not Nocturne data scopes. Types absent from this set are treated as scoped (fail closed).
-    /// </summary>
-    private static readonly IReadOnlySet<AuthType> UnscopedCredentialTypes = new HashSet<AuthType>
-    {
-        AuthType.SessionCookie,
-        AuthType.OidcToken,
-        AuthType.LegacyJwt,
-        AuthType.LegacyAccessToken,
-    };
 
     /// <summary>
     /// Creates a new instance of <see cref="MemberScopeMiddleware"/>.
@@ -160,67 +141,19 @@ public class MemberScopeMiddleware
         var directPermissions = membership.DirectPermissions ?? [];
         var effectivePermissions = rolePermissions.Union(directPermissions).ToHashSet();
 
-        if (effectivePermissions.Contains("*")
-            && UnscopedCredentialTypes.Contains(authContext.AuthType))
-        {
-            // Superuser — grant all scopes AND a wildcard permission trie. Both must be set:
-            // GrantedScopes drives RequireScope checks, while the PermissionTrie drives the
-            // HasPermissions policy (the legacy v1 endpoints). Session tokens carry only the
-            // subject's global role permissions — empty for a normal tenant owner/admin whose
-            // permissions come from membership — so the trie built by AuthenticationMiddleware
-            // is empty. Without rebuilding it here, HasPermissions-gated endpoints would 403
-            // for a tenant superuser on their own tenant (matching the InstanceKey/PlatformAccess
-            // branch above, which sets both).
-            //
-            // Restricted to <see cref="UnscopedCredentialTypes"/>: a scoped credential carries a
-            // consent boundary, and an owner's "*" membership must not widen past it. An owner who
-            // authorized a third-party app for glucose.read falls through to the intersection below
-            // and gets glucose.read, matching what the same credential resolves to when the token
-            // is presented in the api-secret header (AuthType.ApiKey, handled above).
-            context.Items["GrantedScopes"] = (IReadOnlySet<string>)effectivePermissions;
+        var resolvedScopes = MemberScopeResolver.Resolve(
+            effectivePermissions, authContext.AuthType, context.GetGrantedScopes());
+        context.Items["GrantedScopes"] = resolvedScopes;
 
-            var superuserTrie = new PermissionTrie();
-            superuserTrie.Add(["*"]);
-            context.Items["PermissionTrie"] = superuserTrie;
-        }
-        else
-        {
-            // Intersect with auth token scopes. OAuthScopes.Normalize expands a "*" membership to
-            // the full scope list, so a superuser on a scoped credential lands on exactly the
-            // credential's scopes; the "*" scope itself survives only when the credential carries
-            // full access.
-            var normalizedMemberScopes = OAuthScopes.Normalize(effectivePermissions.ToList());
-            var currentScopes = context.GetGrantedScopes();
-            var restrictedScopes = normalizedMemberScopes
-                .Where(memberScope => OAuthScopes.SatisfiesScope(currentScopes, memberScope))
-                .ToHashSet();
-
-            // Member-personal device scopes bypass the role intersection. device.notify /
-            // device.actuate authorize the alert engine to drive the member's OWN registered
-            // client devices (rows RLS-scoped to the member's subject), not patient data. Role
-            // rows are persisted per tenant at seed time and never reconciled
-            // (TenantRoleService.SeedRolesForTenantAsync skips existing slugs), so roles seeded
-            // before these atoms existed would strip the scopes for every pre-existing tenant —
-            // no relink or re-consent can fix that. Grant them from the auth token alone for any
-            // member who holds at least one permission; zero-permission members (the Denied seed
-            // role) stay fully stripped because alert actuations reveal patient state.
-            if (effectivePermissions.Count > 0)
-            {
-                foreach (var personalScope in TenantPermissions.MemberPersonalScopes)
-                {
-                    if (OAuthScopes.SatisfiesScope(currentScopes, personalScope))
-                        restrictedScopes.Add(personalScope);
-                }
-            }
-
-            context.Items["GrantedScopes"] = (IReadOnlySet<string>)restrictedScopes;
-
-            // Rebuild permission trie from restricted scopes
-            var restrictedPermissions = ScopeTranslator.ToPermissions(restrictedScopes);
-            var permissionTrie = new PermissionTrie();
-            permissionTrie.Add(restrictedPermissions);
-            context.Items["PermissionTrie"] = permissionTrie;
-        }
+        // Rebuild the permission trie from the resolved scopes. Both must be set: GrantedScopes
+        // drives RequireScope checks, while the trie drives the HasPermissions policy (the legacy
+        // v1/v2/v3 endpoints). The trie AuthenticationMiddleware built holds only the subject's
+        // global role permissions — empty for a member whose access comes from tenant membership —
+        // so without rebuilding it here every HasPermissions-gated endpoint 403s. ScopeTranslator
+        // collapses a resolved set containing "*" to a wildcard trie.
+        var memberTrie = new PermissionTrie();
+        memberTrie.Add(ScopeTranslator.ToPermissions(resolvedScopes));
+        context.Items["PermissionTrie"] = memberTrie;
 
         authContext.LimitTo24Hours = membership.LimitTo24Hours;
 

--- a/src/API/Nocturne.API/Services/Identity/ITenantOverviewService.cs
+++ b/src/API/Nocturne.API/Services/Identity/ITenantOverviewService.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.API.Services.Identity;
 
@@ -12,10 +13,11 @@ public interface ITenantOverviewService
     /// <summary>
     /// Returns the latest canonical reading, resolved thresholds, status classification,
     /// and active alert summary for every qualifying tenant of <paramref name="subjectId"/>.
-    /// Per-tenant access is each membership's effective permissions intersected with
-    /// <paramref name="tokenScopes"/> (the auth token's granted scopes), mirroring
-    /// <c>MemberScopeMiddleware</c>: a superuser membership bypasses the intersection.
+    /// Per-tenant access is resolved by <see cref="MemberScopeResolver"/> from each membership's
+    /// effective permissions, <paramref name="authType"/> and <paramref name="tokenScopes"/> — the
+    /// same resolution <c>MemberScopeMiddleware</c> applies per request.
     /// </summary>
     Task<TenantOverviewResponse> GetOverviewAsync(
-        Guid subjectId, IReadOnlySet<string> tokenScopes, CancellationToken ct = default);
+        Guid subjectId, IReadOnlySet<string> tokenScopes, AuthType authType,
+        CancellationToken ct = default);
 }

--- a/src/API/Nocturne.API/Services/Identity/TenantOverviewService.cs
+++ b/src/API/Nocturne.API/Services/Identity/TenantOverviewService.cs
@@ -41,7 +41,8 @@ public class TenantOverviewService : ITenantOverviewService
     }
 
     public async Task<TenantOverviewResponse> GetOverviewAsync(
-        Guid subjectId, IReadOnlySet<string> tokenScopes, CancellationToken ct = default)
+        Guid subjectId, IReadOnlySet<string> tokenScopes, AuthType authType,
+        CancellationToken ct = default)
     {
         // tenant_members has a global RevokedAt == null query filter, so revoked
         // memberships are already excluded here.
@@ -65,7 +66,7 @@ public class TenantOverviewService : ITenantOverviewService
             var tenant = membership.Tenant;
             if (tenant is null || !tenant.IsActive) continue;
 
-            var allowed = ResolveAllowedScopes(membership, tokenScopes);
+            var allowed = ResolveAllowedScopes(membership, tokenScopes, authType);
             if (!TenantPermissions.HasPermission(allowed, TenantPermissions.GlucoseRead)) continue;
             var includeAlerts = TenantPermissions.HasPermission(allowed, TenantPermissions.AlertsRead);
 
@@ -87,27 +88,20 @@ public class TenantOverviewService : ITenantOverviewService
     }
 
     /// <summary>
-    /// Resolves what the caller may see on this tenant, mirroring <c>MemberScopeMiddleware</c>:
-    /// effective permissions are the union of role permissions and direct permissions; a
-    /// superuser membership ("*") bypasses the token-scope intersection (MemberScopeMiddleware's
-    /// superuser branch grants all effective scopes without consulting the token); otherwise the
-    /// member's normalized scopes are restricted to those the auth token's granted scopes satisfy.
+    /// Resolves what the caller may see on this tenant. Delegates to
+    /// <see cref="MemberScopeResolver"/>, the same resolution <c>MemberScopeMiddleware</c> applies
+    /// per request, so the tenant picker cannot list a tenant the endpoints behind it refuse (or
+    /// hide one they would serve).
     /// </summary>
     internal static IReadOnlySet<string> ResolveAllowedScopes(
-        TenantMemberEntity membership, IReadOnlySet<string> tokenScopes)
+        TenantMemberEntity membership, IReadOnlySet<string> tokenScopes, AuthType authType)
     {
         var effective = membership.MemberRoles
             .SelectMany(mr => mr.TenantRole.Permissions)
             .Union(membership.DirectPermissions ?? [])
             .ToHashSet();
 
-        if (effective.Contains(TenantPermissions.Superuser))
-            return new HashSet<string> { TenantPermissions.Superuser };
-
-        var normalizedMemberScopes = OAuthScopes.Normalize(effective.ToList());
-        return normalizedMemberScopes
-            .Where(memberScope => OAuthScopes.SatisfiesScope(tokenScopes, memberScope))
-            .ToHashSet();
+        return MemberScopeResolver.Resolve(effective, authType, tokenScopes);
     }
 
     private async Task<TenantOverviewItem> BuildItemAsync(

--- a/src/Core/Nocturne.Core.Models/Authorization/MemberScopeResolver.cs
+++ b/src/Core/Nocturne.Core.Models/Authorization/MemberScopeResolver.cs
@@ -1,0 +1,143 @@
+namespace Nocturne.Core.Models.Authorization;
+
+/// <summary>
+/// Resolves what a tenant membership grants on a given credential: the single place that turns a
+/// member's effective permissions (role permissions ∪ direct permissions) into the granted scope
+/// set. <c>MemberScopeMiddleware</c> applies it per request; <c>TenantOverviewService</c> applies it
+/// per membership to decide which tenants the caller may see. Both must agree, or the tenant picker
+/// and the endpoints it links to disagree about access.
+/// </summary>
+/// <seealso cref="OAuthScopes"/>
+/// <seealso cref="TenantPermissions"/>
+/// <seealso cref="ScopeTranslator"/>
+public static class MemberScopeResolver
+{
+    /// <summary>
+    /// Credential types that carry no scope grant of their own — the authenticated human's own
+    /// interactive login. Tenant membership is the only authority for these, so a <c>"*"</c>
+    /// membership widens to superuser. Every other credential presents scopes that bound what it
+    /// may do (an OAuth access token's consented scopes, a direct grant's scopes, an API key's
+    /// grant scopes, a guest link's scopes) and is intersected with membership instead. Membership
+    /// resolution must never widen a scoped credential, or the consent decision is erased. Keyed on
+    /// the credential type rather than on "the scope list is empty" because an interactive OIDC
+    /// login carries the identity provider's own scopes (<c>openid</c>, <c>profile</c>), which are
+    /// not Nocturne data scopes. Types absent from this set are treated as scoped (fail closed).
+    /// </summary>
+    /// <remarks>
+    /// Per-type basis for membership:
+    /// <list type="bullet">
+    /// <item><see cref="AuthType.SessionCookie"/> — <c>SessionCookieHandler</c> never sets
+    /// <c>Scopes</c>; the session JWT's permission claims are the subject's global
+    /// <c>SubjectRoles</c>, which are unrelated to this tenant.</item>
+    /// <item><see cref="AuthType.OidcToken"/> — <c>OidcTokenHandler</c> sets <c>Scopes</c> to the
+    /// provider's configured scopes (<c>openid</c>, <c>profile</c>, <c>email</c>), an outbound
+    /// protocol list identical for every user of that provider, not a per-user Nocturne grant.</item>
+    /// <item><see cref="AuthType.LegacyJwt"/> — structurally unscoped:
+    /// <c>OAuthAccessTokenHandler</c> runs first and claims every JWT bearing a <c>scope</c> or
+    /// <c>client_id</c> claim, so a JWT that reaches <c>LegacyJwtHandler</c> has neither.
+    /// <c>SessionService</c> mints session tokens through the same <c>IJwtService</c>, so this is
+    /// the same credential as a session cookie presented on a different transport.</item>
+    /// <item><see cref="AuthType.LegacyAccessToken"/> — <c>AccessTokenHandler</c> never sets
+    /// <c>Scopes</c>. The token identifies a subject; every path that gives a subject a tenant
+    /// membership (invite acceptance, membership-request approval, platform admin, tenant setup)
+    /// assigns tenant roles deliberately, and none of them writes global <c>SubjectRoles</c>. The
+    /// membership is the grant.</item>
+    /// </list>
+    /// <see cref="AuthType.ApiKey"/>, <see cref="AuthType.Guest"/>, <see cref="AuthType.InstanceKey"/>
+    /// and <see cref="AuthType.PlatformAccess"/> are absent because <c>MemberScopeMiddleware</c>
+    /// resolves them before reaching membership at all; <see cref="AuthType.OAuthAccessToken"/> and
+    /// <see cref="AuthType.DirectGrant"/> are absent because their scopes are a consent boundary.
+    /// </remarks>
+    public static readonly IReadOnlySet<AuthType> UnscopedCredentialTypes = new HashSet<AuthType>
+    {
+        AuthType.SessionCookie,
+        AuthType.OidcToken,
+        AuthType.LegacyJwt,
+        AuthType.LegacyAccessToken,
+    };
+
+    /// <summary>
+    /// Resolves the scopes a membership grants on a credential.
+    /// </summary>
+    /// <param name="effectivePermissions">
+    /// The membership's effective permissions: role permissions unioned with direct permissions.
+    /// These come from the tenant RBAC vocabulary, so they are normalized through
+    /// <see cref="OAuthScopes.NormalizeMemberPermissions"/> rather than
+    /// <see cref="OAuthScopes.Normalize"/>.
+    /// </param>
+    /// <param name="authType">The credential type, matched against <see cref="UnscopedCredentialTypes"/>.</param>
+    /// <param name="credentialScopes">
+    /// The scopes the credential presents. Ignored for an unscoped credential, which has none.
+    /// </param>
+    /// <returns>The granted scope set. Empty when the membership grants nothing.</returns>
+    public static IReadOnlySet<string> Resolve(
+        IReadOnlySet<string> effectivePermissions,
+        AuthType authType,
+        IReadOnlySet<string> credentialScopes)
+    {
+        var isUnscoped = UnscopedCredentialTypes.Contains(authType);
+
+        // Superuser on an unscoped credential: membership is the whole authority. The raw
+        // permissions are published (rather than the normalized expansion) so "*" itself reaches
+        // RequireScope checks and ScopeTranslator collapses the trie to a wildcard.
+        if (isUnscoped && effectivePermissions.Contains(TenantPermissions.Superuser))
+            return effectivePermissions;
+
+        var memberScopes = OAuthScopes.NormalizeMemberPermissions(effectivePermissions).ToHashSet();
+
+        // Member-personal device scopes are not part of the role intersection. device.notify /
+        // device.actuate authorize the alert engine to drive the member's OWN registered client
+        // devices (rows RLS-scoped to the member's subject), not patient data. Role rows are
+        // persisted per tenant at seed time and never reconciled
+        // (TenantRoleService.SeedRolesForTenantAsync skips existing slugs), so roles seeded before
+        // these atoms existed would strip the scopes for every pre-existing tenant — no relink or
+        // re-consent can fix that. Treat them as held by any member with at least one permission;
+        // zero-permission members (the Denied seed role) stay fully stripped because alert
+        // actuations reveal patient state. Added before the intersection below, so a scoped
+        // credential still has to carry them.
+        if (effectivePermissions.Count > 0)
+            memberScopes.UnionWith(TenantPermissions.MemberPersonalScopes);
+
+        // No grant to intersect against, so membership is the whole ceiling. An empty scope list on
+        // an unscoped credential is the absence of a ceiling, not a ceiling of nothing: intersecting
+        // against it resolved every non-owner member — Admin, Clinician, Caretaker, Viewer — to zero
+        // scopes, because only an Owner escaped through the superuser branch above.
+        if (isUnscoped)
+            return memberScopes;
+
+        // Scoped credential: the grant is a consent boundary that membership must not widen past.
+        //
+        // The credential's scopes are re-normalized through the REQUEST vocabulary, which drops
+        // anything a client could not have asked for — in particular the tenant-administration
+        // atoms, which are absent from ValidRequestScopes precisely because no client may request
+        // them and no user may consent to them. Without this the intersection would honour an
+        // administration atom that reached a credential's scope list by any route (a hand-written
+        // grant row, a future endpoint), because an exact match satisfies the intersection. Making
+        // it structural here means the property does not rest on every issuing path staying correct.
+        var boundedCredentialScopes = OAuthScopes.Normalize(credentialScopes);
+
+        var resolved = new HashSet<string>();
+        foreach (var memberScope in memberScopes)
+        {
+            if (OAuthScopes.SatisfiesScope(boundedCredentialScopes, memberScope))
+            {
+                resolved.Add(memberScope);
+                continue;
+            }
+
+            // A readwrite membership on a read-only credential downgrades to read instead of
+            // dropping. SatisfiesScope answers false for a readwrite requirement met only by read,
+            // and NormalizeMemberPermissions does not add the read counterpart, so a member holding
+            // glucose.readwrite against a glucose.read token previously resolved to neither scope.
+            // Both sides permit the read counterpart: the membership because readwrite includes
+            // read, the credential because it granted read outright.
+            if (OAuthScopes.TryGetImpliedReadScope(memberScope, out var readScope)
+                && OAuthScopes.SatisfiesScope(boundedCredentialScopes, readScope))
+            {
+                resolved.Add(readScope);
+            }
+        }
+
+        return resolved;
+    }
+}

--- a/src/Core/Nocturne.Core.Models/Authorization/OAuthScopes.cs
+++ b/src/Core/Nocturne.Core.Models/Authorization/OAuthScopes.cs
@@ -136,6 +136,19 @@ public static class OAuthScopes
     };
 
     /// <summary>
+    /// Every scope a tenant membership can grant: <see cref="ValidRequestScopes"/> plus every
+    /// <see cref="TenantPermissions.All">tenant permission atom</see>. The two sets differ over the
+    /// tenant-administration atoms (<c>members.manage</c>, <c>roles.manage</c>, <c>tenant.settings</c>,
+    /// <c>audit.read</c>, …): a tenant role may grant them, but a client may not request them at
+    /// <c>/authorize</c> and a user cannot consent to them, because there is no per-client scope
+    /// ceiling to bound such a request. Derived from <see cref="TenantPermissions.All"/> so a new
+    /// permission atom is grantable without a second edit here.
+    /// </summary>
+    /// <seealso cref="NormalizeMemberPermissions"/>
+    public static readonly IReadOnlySet<string> MemberGrantableScopes =
+        new HashSet<string>(ValidRequestScopes.Concat(TenantPermissions.All));
+
+    /// <summary>
     /// Expansion of the health.read convenience alias.
     /// </summary>
     public static readonly IReadOnlyList<string> HealthReadExpansion = new[]
@@ -191,12 +204,46 @@ public static class OAuthScopes
     }
 
     /// <summary>
+    /// Look up the read scope a readwrite scope implies. Lets a caller narrow a readwrite grant to
+    /// its read counterpart, which <see cref="SatisfiesScope"/> cannot express: it answers whether
+    /// a granted set covers a required scope, not what the closest covered scope is.
+    /// </summary>
+    /// <param name="readWriteScope">The readwrite scope to narrow.</param>
+    /// <param name="readScope">The implied read scope, when one exists.</param>
+    /// <returns><c>true</c> when <paramref name="readWriteScope"/> has a read counterpart.</returns>
+    public static bool TryGetImpliedReadScope(string readWriteScope, out string readScope)
+    {
+        return ReadWriteImpliesRead.TryGetValue(readWriteScope, out readScope!);
+    }
+
+    /// <summary>
     /// Expand aliases and normalize a set of requested scopes into concrete scopes.
     /// - Expands health.read into its component scopes
     /// - readwrite scopes implicitly include their read counterpart (no need to list both)
     /// - * (full access) expands to all scopes
+    /// Anything outside <see cref="ValidRequestScopes"/> is dropped, so this is safe to call on
+    /// caller-supplied input.
     /// </summary>
     public static IReadOnlySet<string> Normalize(IEnumerable<string> requestedScopes)
+    {
+        return Normalize(requestedScopes, ValidRequestScopes);
+    }
+
+    /// <summary>
+    /// Expand and normalize a tenant member's effective permissions into granted scopes.
+    /// Behaves like <see cref="Normalize"/> but recognizes <see cref="MemberGrantableScopes"/>, so
+    /// the tenant-administration atoms survive instead of being dropped. Call this only for
+    /// permissions that came from a tenant membership (role rows and direct permissions), never
+    /// for scopes supplied by a client.
+    /// </summary>
+    /// <seealso cref="MemberScopeResolver"/>
+    public static IReadOnlySet<string> NormalizeMemberPermissions(IEnumerable<string> permissions)
+    {
+        return Normalize(permissions, MemberGrantableScopes);
+    }
+
+    private static IReadOnlySet<string> Normalize(
+        IEnumerable<string> requestedScopes, IReadOnlySet<string> recognizedScopes)
     {
         var result = new HashSet<string>();
 
@@ -222,7 +269,7 @@ public static class OAuthScopes
                 continue;
             }
 
-            if (ValidRequestScopes.Contains(scope))
+            if (recognizedScopes.Contains(scope))
             {
                 result.Add(scope);
             }

--- a/tests/Unit/Nocturne.API.Tests/Middleware/AuthenticationMiddlewareShareAccessTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/AuthenticationMiddlewareShareAccessTests.cs
@@ -134,6 +134,35 @@ public sealed class AuthenticationMiddlewareShareAccessTests
     }
 
     [Fact]
+    public async Task Share_access_never_admits_a_tenant_administration_atom()
+    {
+        // The member-permissions API can write any atom onto the Public membership, and the
+        // administration atoms are now part of the grantable scope vocabulary. The share host
+        // must still resolve to at most the shareable read scopes.
+        SetPublicDirectPermissions([
+            OAuthScopes.GlucoseRead,
+            TenantPermissions.MembersManage,
+            TenantPermissions.RolesManage,
+            TenantPermissions.TenantSettings,
+            TenantPermissions.AuditRead,
+            TenantPermissions.SharingManage,
+        ]);
+
+        var ctx = ContextFor(shareAccess: true);
+
+        await Build().InvokeAsync(ctx);
+
+        var scopes = ctx.Items["GrantedScopes"] as IReadOnlySet<string>;
+        scopes.Should().NotBeNull();
+        scopes.Should().BeSubsetOf(TenantPermissions.PublicShareScopes);
+        scopes.Should().BeEquivalentTo([OAuthScopes.GlucoseRead]);
+
+        var trie = ctx.Items["PermissionTrie"] as PermissionTrie;
+        trie!.Check(TenantPermissions.MembersManage).Should().BeFalse();
+        trie.Check(TenantPermissions.AuditRead).Should().BeFalse();
+    }
+
+    [Fact]
     public async Task Share_with_only_heartrate_and_stepcount_still_carries_a_nonempty_trie()
     {
         // heartrate.read/stepcount.read have no legacy api:* equivalent, so a trie derived

--- a/tests/Unit/Nocturne.API.Tests/Middleware/MemberScopeFilterPipelineTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/MemberScopeFilterPipelineTests.cs
@@ -1,0 +1,327 @@
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.API.Attributes;
+using Nocturne.API.Middleware;
+using Nocturne.API.Tests.Infrastructure;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Infrastructure.Data;
+using Xunit;
+
+namespace Nocturne.API.Tests.Middleware;
+
+/// <summary>
+/// End-to-end authorization proof: the real <see cref="MemberScopeMiddleware"/> feeding the real
+/// <see cref="RequireScopeAttribute"/> authorization filter, over every scope-gated action the API
+/// assembly declares. Unit-testing the middleware's output set proves what it resolves; this proves
+/// the gates downstream of it actually open, which is the property that regressed — every
+/// <c>[RequireScope]</c> action returned 403 for every non-owner member of every tenant.
+/// </summary>
+/// <remarks>
+/// The gated actions are discovered by reflection rather than listed, so a newly gated controller is
+/// covered without editing this file and cannot silently fall outside the proof.
+/// </remarks>
+[Trait("Category", "Unit")]
+public class MemberScopeFilterPipelineTests
+{
+    /// <summary>
+    /// A scope-gated action: the declaring controller, the method, and the filter instances that
+    /// guard it (method-level attributes plus any class-level attribute).
+    /// </summary>
+    private sealed record GatedAction(
+        string Controller, string Action, RequireScopeAttribute[] Filters, bool RequiresFullAccess);
+
+    private static IEnumerable<GatedAction> DiscoverGatedActions()
+    {
+        var controllers = typeof(RequireScopeAttribute).Assembly
+            .GetTypes()
+            .Where(type => typeof(ControllerBase).IsAssignableFrom(type)
+                           && type is { IsAbstract: false, IsPublic: true });
+
+        foreach (var controller in controllers)
+        {
+            var classFilters = controller
+                .GetCustomAttributes<RequireScopeAttribute>(inherit: true)
+                .ToArray();
+
+            var actions = controller.GetMethods(BindingFlags.Public | BindingFlags.Instance
+                                                | BindingFlags.DeclaredOnly);
+
+            foreach (var action in actions)
+            {
+                if (action.IsSpecialName) continue;
+
+                var methodFilters = action.GetCustomAttributes<RequireScopeAttribute>(inherit: true)
+                    .ToArray();
+                var filters = methodFilters.Concat(classFilters).ToArray();
+                if (filters.Length == 0) continue;
+
+                // Delete endpoints are gated on "*" by design: an Administrator is deliberately not
+                // a superuser, so these must stay closed and act as the negative control.
+                var requiresFullAccess = RequiredScopesOf(filters).Contains(OAuthScopes.FullAccess);
+
+                yield return new GatedAction(
+                    controller.Name, action.Name, filters, requiresFullAccess);
+            }
+        }
+    }
+
+    private static IReadOnlySet<string> RequiredScopesOf(IEnumerable<RequireScopeAttribute> filters)
+    {
+        // The required scopes are private state on the attribute; read them the same way the
+        // framework would not have to, so the negative control keys off the real values.
+        var scopes = new HashSet<string>();
+        foreach (var filter in filters)
+        {
+            var field = typeof(RequireScopeAttribute)
+                .GetField("_requiredScopes", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (field?.GetValue(filter) is string[] required)
+                scopes.UnionWith(required);
+        }
+        return scopes;
+    }
+
+    [Fact]
+    public void DiscoversTheGatedSurface()
+    {
+        // Guards the proof itself: a reflection change that silently found nothing would make every
+        // assertion below vacuous.
+        var gated = DiscoverGatedActions().ToList();
+
+        gated.Should().HaveCountGreaterThan(50);
+        gated.Select(g => g.Controller).Should().Contain(
+        [
+            "ClientDevicesController", "HeartRateController", "StepCountController",
+            "SleepReportController", "ApsSnapshotController", "PumpSnapshotController",
+            "UploaderSnapshotController",
+        ]);
+        gated.Should().Contain(g => g.RequiresFullAccess);
+    }
+
+    [Fact]
+    public async Task AdministratorOnABrowserSession_ReachesEveryScopeGatedAction()
+    {
+        // The live regression: an Administrator (or Clinician, Caretaker, Viewer) logged into the web
+        // app resolved to an empty scope set, so every one of these actions returned 403 — heart
+        // rate, step count, sleep reports and client devices were unreachable for every non-owner.
+        var grantedScopes = await ResolveScopesForRoleAsync(
+            TenantPermissions.SeedRoles.Admin, AuthType.SessionCookie);
+
+        grantedScopes.Should().NotBeEmpty();
+
+        var reached = new List<string>();
+        var forbidden = new List<string>();
+
+        foreach (var gated in DiscoverGatedActions())
+        {
+            var result = RunAuthorizationFilters(gated, grantedScopes);
+            (result is null ? reached : forbidden).Add($"{gated.Controller}.{gated.Action}");
+
+            if (gated.RequiresFullAccess)
+                result.Should().BeOfType<ForbidResult>(
+                    $"{gated.Controller}.{gated.Action} requires '*', which an Administrator does not hold");
+            else
+                result.Should().BeNull(
+                    $"{gated.Controller}.{gated.Action} is gated on a scope the Administrator role grants");
+        }
+
+        reached.Should().NotBeEmpty();
+
+        // Nothing is refused except the "*"-gated actions — the Administrator role covers the whole
+        // rest of the gated surface.
+        forbidden.Should().BeEquivalentTo(DiscoverGatedActions()
+            .Where(g => g.RequiresFullAccess)
+            .Select(g => $"{g.Controller}.{g.Action}"));
+    }
+
+    [Fact]
+    public async Task ClinicianOnABrowserSession_ReachesReadGatesAndIsRefusedWriteGates()
+    {
+        // The fix must not flatten the roles: a read-only member reaches the read gates and is still
+        // refused the write gates on the same controller.
+        var grantedScopes = await ResolveScopesForRoleAsync(
+            TenantPermissions.SeedRoles.Clinician, AuthType.SessionCookie);
+
+        RunAuthorizationFilters(GatedActionFor("SleepController", OAuthScopes.SleepRead), grantedScopes)
+            .Should().BeNull("a Clinician holds sleep.read");
+        RunAuthorizationFilters(GatedActionFor("SleepController", OAuthScopes.SleepReadWrite), grantedScopes)
+            .Should().BeOfType<ForbidResult>("a Clinician does not hold sleep.readwrite");
+
+        RunAuthorizationFilters(GatedActionFor("HeartRateController", OAuthScopes.HeartRateRead), grantedScopes)
+            .Should().BeNull("a Clinician holds heartrate.read");
+        RunAuthorizationFilters(GatedActionFor("HeartRateController", OAuthScopes.HeartRateReadWrite), grantedScopes)
+            .Should().BeOfType<ForbidResult>("a Clinician does not hold heartrate.readwrite");
+    }
+
+    [Fact]
+    public async Task ViewerOnABrowserSession_IsRefusedTheGatesItsRoleDoesNotCover()
+    {
+        // The narrowest authenticated role: glucose.read and reports.read only.
+        var grantedScopes = await ResolveScopesForRoleAsync(
+            TenantPermissions.SeedRoles.Viewer, AuthType.SessionCookie);
+
+        RunAuthorizationFilters(GatedActionFor("SleepController", OAuthScopes.SleepRead), grantedScopes)
+            .Should().BeOfType<ForbidResult>("a Viewer does not hold sleep.read");
+        RunAuthorizationFilters(GatedActionFor("HeartRateController", OAuthScopes.HeartRateRead), grantedScopes)
+            .Should().BeOfType<ForbidResult>("a Viewer does not hold heartrate.read");
+
+        // device.notify / device.actuate are member-personal capabilities every role holds.
+        RunAuthorizationFilters(
+            GatedActionFor("ClientDevicesController", OAuthScopes.DeviceNotify), grantedScopes)
+            .Should().BeNull("client devices are the member's own, granted to every role");
+    }
+
+    [Fact]
+    public async Task DeniedMemberOnABrowserSession_IsRefusedEveryScopeGatedAction()
+    {
+        // Fail closed: removing the credential ceiling must not remove the membership check.
+        var grantedScopes = await ResolveScopesForRoleAsync(
+            TenantPermissions.SeedRoles.Denied, AuthType.SessionCookie);
+
+        grantedScopes.Should().BeEmpty();
+
+        foreach (var gated in DiscoverGatedActions())
+        {
+            RunAuthorizationFilters(gated, grantedScopes)
+                .Should().BeOfType<ForbidResult>($"{gated.Controller}.{gated.Action} must stay closed");
+        }
+    }
+
+    [Fact]
+    public async Task AdministratorOnADelegatedToken_IsRefusedWhatTheTokenDidNotConsentTo()
+    {
+        // The consent boundary survives the fix: the same Administrator over a third-party token
+        // scoped to glucose.read reaches nothing gated on heart rate, step count or sleep.
+        var grantedScopes = await ResolveScopesForRoleAsync(
+            TenantPermissions.SeedRoles.Admin, AuthType.OAuthAccessToken, OAuthScopes.GlucoseRead);
+
+        grantedScopes.Should().BeEquivalentTo([OAuthScopes.GlucoseRead]);
+
+        foreach (var gated in DiscoverGatedActions()
+                     .Where(g => g.Controller is "HeartRateController" or "StepCountController"
+                         or "ClientDevicesController" or "SleepReportController"))
+        {
+            RunAuthorizationFilters(gated, grantedScopes)
+                .Should().BeOfType<ForbidResult>(
+                    $"{gated.Controller}.{gated.Action} was never consented to");
+        }
+    }
+
+    private static GatedAction GatedActionFor(string controller, string requiredScope)
+    {
+        return DiscoverGatedActions().First(g =>
+            g.Controller == controller && RequiredScopesOf(g.Filters).Contains(requiredScope));
+    }
+
+    /// <summary>
+    /// Runs the real <see cref="RequireScopeAttribute"/> filters over a context carrying the given
+    /// resolved scopes, and returns the short-circuit result (<c>null</c> when the action is reached).
+    /// </summary>
+    private static IActionResult? RunAuthorizationFilters(
+        GatedAction gated, IReadOnlySet<string> grantedScopes)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["AuthContext"] = new AuthContext
+        {
+            IsAuthenticated = true,
+            AuthType = AuthType.SessionCookie,
+            SubjectId = Guid.CreateVersion7(),
+            TenantId = TestDatabaseSeeder.TenantId,
+        };
+        httpContext.Items["GrantedScopes"] = grantedScopes;
+
+        var actionContext = new ActionContext(
+            httpContext, new RouteData(), new ActionDescriptor());
+        var filterContext = new AuthorizationFilterContext(actionContext, []);
+
+        foreach (var filter in gated.Filters)
+        {
+            filter.OnAuthorization(filterContext);
+            if (filterContext.Result is not null) break;
+        }
+
+        return filterContext.Result;
+    }
+
+    /// <summary>
+    /// Runs the real <see cref="MemberScopeMiddleware"/> for a member holding the given seed role on
+    /// the given credential type, and returns the scopes it publishes.
+    /// </summary>
+    private static async Task<IReadOnlySet<string>> ResolveScopesForRoleAsync(
+        string roleSlug, AuthType authType, params string[] credentialScopes)
+    {
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
+
+        var subjectId = Guid.CreateVersion7();
+        using (var seed = new NocturneDbContext(options))
+        {
+            seed.Database.EnsureCreated();
+            TestDatabaseSeeder.Seed(seed);
+
+            seed.Subjects.Add(new Nocturne.Infrastructure.Data.Entities.SubjectEntity
+            {
+                Id = subjectId, Name = "Member", IsActive = true, IsSystemSubject = false,
+            });
+            var memberId = Guid.CreateVersion7();
+            seed.TenantMembers.Add(new Nocturne.Infrastructure.Data.Entities.TenantMemberEntity
+            {
+                Id = memberId, TenantId = TestDatabaseSeeder.TenantId, SubjectId = subjectId,
+            });
+            var roleId = Guid.CreateVersion7();
+            seed.TenantRoles.Add(new Nocturne.Infrastructure.Data.Entities.TenantRoleEntity
+            {
+                Id = roleId,
+                TenantId = TestDatabaseSeeder.TenantId,
+                Name = roleSlug,
+                // TestDatabaseSeeder already seeds the canonical slugs for this tenant, and
+                // (tenant_id, slug) is unique. The permission atoms are what this asserts on.
+                Slug = $"{roleSlug}-under-test",
+                Permissions = TenantPermissions.SeedRolePermissions[roleSlug],
+                IsSystem = true,
+                SysCreatedAt = DateTime.UtcNow,
+                SysUpdatedAt = DateTime.UtcNow,
+            });
+            seed.TenantMemberRoles.Add(new Nocturne.Infrastructure.Data.Entities.TenantMemberRoleEntity
+            {
+                Id = Guid.CreateVersion7(),
+                TenantMemberId = memberId,
+                TenantRoleId = roleId,
+                SysCreatedAt = DateTime.UtcNow,
+            });
+            seed.SaveChanges();
+        }
+
+        var services = new ServiceCollection();
+        services.AddScoped(_ => new NocturneDbContext(options));
+        using var provider = services.BuildServiceProvider();
+
+        var httpContext = new DefaultHttpContext { RequestServices = provider };
+        httpContext.Items["AuthContext"] = new AuthContext
+        {
+            IsAuthenticated = true,
+            AuthType = authType,
+            SubjectId = subjectId,
+            TenantId = TestDatabaseSeeder.TenantId,
+            Scopes = [.. credentialScopes],
+        };
+        // As AuthenticationMiddleware leaves it.
+        httpContext.Items["GrantedScopes"] = OAuthScopes.Normalize(credentialScopes);
+        httpContext.Items["PermissionTrie"] = new PermissionTrie();
+
+        var middleware = new MemberScopeMiddleware(
+            _ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
+        await middleware.InvokeAsync(httpContext);
+
+        return (IReadOnlySet<string>)httpContext.Items["GrantedScopes"]!;
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Middleware/MemberScopeMiddlewareTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/MemberScopeMiddlewareTests.cs
@@ -385,6 +385,243 @@ public class MemberScopeMiddlewareTests
         grantedScopes.Should().BeEmpty();
     }
 
+    [Theory]
+    [InlineData(AuthType.SessionCookie)]
+    [InlineData(AuthType.LegacyJwt)]
+    [InlineData(AuthType.LegacyAccessToken)]
+    public async Task UnscopedCredential_ForAdminMember_ResolvesTheRoleIncludingAdministration(
+        AuthType authType)
+    {
+        // The real web-app credential shape: no scopes at all, because SessionCookieHandler and
+        // AccessTokenHandler never set them and a JWT reaching LegacyJwtHandler has no scope claim
+        // (OAuthAccessTokenHandler claims those first). Intersecting membership against that empty
+        // set 403ed the whole scope-gated surface for every non-owner. Every administration gate
+        // (MemberInviteController, RoleController, ShareLinkController, GuestLinkController,
+        // AuditController) reads GrantedScopes through TenantPermissions.HasPermission.
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
+
+        var subjectId = SeedMemberWithRole(
+            options, TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Admin]);
+
+        var (context, provider) = BuildMemberContext(options, subjectId, [], authType);
+        using (provider)
+        {
+            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
+            await middleware.InvokeAsync(context);
+        }
+
+        var grantedScopes = context.Items["GrantedScopes"] as IReadOnlySet<string>;
+        grantedScopes.Should().NotBeNull();
+        grantedScopes.Should().NotBeEmpty();
+
+        foreach (var atom in new[]
+                 {
+                     TenantPermissions.MembersManage, TenantPermissions.MembersInvite,
+                     TenantPermissions.RolesManage, TenantPermissions.TenantSettings,
+                     TenantPermissions.SharingManage, TenantPermissions.SharingGuest,
+                     TenantPermissions.AuditRead, TenantPermissions.GlucoseReadWrite,
+                 })
+        {
+            TenantPermissions.HasPermission(grantedScopes!, atom).Should().BeTrue($"'{atom}' is granted");
+        }
+
+        // An Administrator is not a superuser, and audit.manage is Owner-only by design.
+        grantedScopes.Should().NotContain(OAuthScopes.FullAccess);
+        TenantPermissions.HasPermission(grantedScopes!, TenantPermissions.AuditManage)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task InteractiveOidcLogin_IsNotBoundedByTheProvidersProtocolScopes()
+    {
+        // OidcTokenHandler sets Scopes to the provider's configured scopes — openid/profile/email,
+        // an outbound protocol list identical for every user of that provider, not a Nocturne data
+        // grant. Normalize drops all three, so treating them as a ceiling resolved the member to
+        // nothing.
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
+
+        var subjectId = SeedMemberWithRole(
+            options, TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Caretaker]);
+
+        var (context, provider) = BuildMemberContext(
+            options, subjectId, ["openid", "profile", "email"], AuthType.OidcToken);
+        using (provider)
+        {
+            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
+            await middleware.InvokeAsync(context);
+        }
+
+        var grantedScopes = context.Items["GrantedScopes"] as IReadOnlySet<string>;
+        grantedScopes.Should().NotBeNull();
+        grantedScopes.Should().Contain(OAuthScopes.GlucoseRead);
+        grantedScopes.Should().Contain(OAuthScopes.TreatmentsReadWrite);
+        // The IdP's protocol scopes are not Nocturne scopes and must not be published.
+        grantedScopes.Should().NotContain("openid");
+        grantedScopes.Should().NotContain("profile");
+    }
+
+    [Fact]
+    public async Task UnscopedCredential_RebuildsThePermissionTrieForLegacyEndpoints()
+    {
+        // The trie drives the HasPermissions policy on v1/v2/v3. An empty resolved scope set left it
+        // empty for every non-owner web-app user.
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
+
+        var subjectId = SeedMemberWithRole(
+            options, TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Caretaker]);
+
+        var (context, provider) = BuildMemberContext(options, subjectId, [], AuthType.SessionCookie);
+        using (provider)
+        {
+            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
+            await middleware.InvokeAsync(context);
+        }
+
+        var permissionTrie = context.Items["PermissionTrie"] as PermissionTrie;
+        permissionTrie.Should().NotBeNull();
+        permissionTrie!.Check("api:entries:read").Should().BeTrue();
+        permissionTrie.Check("api:treatments:create").Should().BeTrue();
+        // Caretaker holds glucose.read, not glucose.readwrite.
+        permissionTrie.Check("api:entries:create").Should().BeFalse();
+        permissionTrie.Check("*").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UnscopedCredential_WithDeniedRole_ResolvesToNothing()
+    {
+        // An unscoped credential removes the ceiling, not the membership check.
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
+
+        var subjectId = SeedMemberWithRole(
+            options, TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Denied]);
+
+        var (context, provider) = BuildMemberContext(options, subjectId, [], AuthType.SessionCookie);
+        using (provider)
+        {
+            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
+            await middleware.InvokeAsync(context);
+        }
+
+        (context.Items["GrantedScopes"] as IReadOnlySet<string>).Should().BeEmpty();
+        (context.Items["PermissionTrie"] as PermissionTrie)!.IsEmpty.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(AuthType.OAuthAccessToken)]
+    [InlineData(AuthType.DirectGrant)]
+    public async Task ScopedCredential_ForAdminMember_StaysBoundedByTheGrant(AuthType authType)
+    {
+        // An OAuth access token and a direct grant both carry a consent boundary, so an Admin
+        // membership must not widen past the scopes the credential presents — administration
+        // included, since no client can request an administration atom.
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
+
+        var subjectId = SeedMemberWithRole(
+            options, TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Admin]);
+
+        var (context, provider) = BuildMemberContext(
+            options, subjectId, [OAuthScopes.GlucoseReadWrite], authType);
+        using (provider)
+        {
+            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
+            await middleware.InvokeAsync(context);
+        }
+
+        var grantedScopes = context.Items["GrantedScopes"] as IReadOnlySet<string>;
+        grantedScopes.Should().BeEquivalentTo([OAuthScopes.GlucoseReadWrite]);
+        TenantPermissions.HasPermission(grantedScopes!, TenantPermissions.MembersManage)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ScopedCredential_ForReadWriteMember_DowngradesToTheGrantedReadScope()
+    {
+        // A read-only app authorized by a Caretaker: the member holds treatments.readwrite and the
+        // token grants treatments.read. SatisfiesScope answers false for the readwrite requirement
+        // and normalization adds no read counterpart, so this resolved to NEITHER scope.
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
+
+        var subjectId = SeedMemberWithRole(
+            options, TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Caretaker]);
+
+        var (context, provider) = BuildMemberContext(
+            options, subjectId, [OAuthScopes.TreatmentsRead], AuthType.OAuthAccessToken);
+        using (provider)
+        {
+            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
+            await middleware.InvokeAsync(context);
+        }
+
+        var grantedScopes = context.Items["GrantedScopes"] as IReadOnlySet<string>;
+        grantedScopes.Should().BeEquivalentTo([OAuthScopes.TreatmentsRead]);
+        grantedScopes.Should().NotContain(OAuthScopes.TreatmentsReadWrite);
+
+        var permissionTrie = context.Items["PermissionTrie"] as PermissionTrie;
+        permissionTrie!.Check("api:treatments:read").Should().BeTrue();
+        permissionTrie.Check("api:treatments:create").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GuestCredential_ForAdminMember_KeepsOnlyTheGuestLinkScopes()
+    {
+        // A guest link carries its own read-only scopes and never reaches the membership lookup.
+        // Membership must not widen it even when the guest code was activated by a subject who is
+        // also an Admin member of the tenant.
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
+
+        var subjectId = SeedMemberWithRole(
+            options, TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Admin]);
+
+        var (context, provider) = BuildMemberContext(
+            options, subjectId, [OAuthScopes.GlucoseRead], AuthType.Guest);
+        using (provider)
+        {
+            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
+            await middleware.InvokeAsync(context);
+        }
+
+        (context.Items["GrantedScopes"] as IReadOnlySet<string>)
+            .Should().BeEquivalentTo([OAuthScopes.GlucoseRead]);
+    }
+
+    [Fact]
+    public async Task UnauthenticatedShareRequest_IsLeftUntouched()
+    {
+        // The public share path resolves its scopes in AuthenticationMiddleware with
+        // IsAuthenticated false, so the Public membership never reaches this middleware. A share can
+        // therefore never be widened by membership resolution, whatever atoms the Public subject
+        // carries.
+        var publicScopes = (IReadOnlySet<string>)new HashSet<string> { OAuthScopes.GlucoseRead };
+
+        var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
+        var context = new DefaultHttpContext();
+        context.Items["AuthContext"] = new AuthContext
+        {
+            IsAuthenticated = false,
+            AuthType = AuthType.None,
+            TenantId = TestDatabaseSeeder.TenantId,
+        };
+        context.Items["GrantedScopes"] = publicScopes;
+
+        await middleware.InvokeAsync(context);
+
+        context.Items["GrantedScopes"].Should().BeSameAs(publicScopes);
+    }
+
     /// <summary>The desktop Companion's device-flow token scopes.</summary>
     private static readonly List<string> CompanionTokenScopes =
     [

--- a/tests/Unit/Nocturne.API.Tests/Services/GuestLinkServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/GuestLinkServiceTests.cs
@@ -82,6 +82,24 @@ public class GuestLinkServiceTests : IDisposable
             .WithMessage("*not allowed*");
     }
 
+    [Theory]
+    [InlineData(TenantPermissions.MembersManage)]
+    [InlineData(TenantPermissions.MembersInvite)]
+    [InlineData(TenantPermissions.RolesManage)]
+    [InlineData(TenantPermissions.TenantSettings)]
+    [InlineData(TenantPermissions.SharingManage)]
+    [InlineData(TenantPermissions.SharingGuest)]
+    [InlineData(TenantPermissions.AuditRead)]
+    [InlineData(TenantPermissions.AuditManage)]
+    public async Task CreateGuestLink_RejectsTenantAdministrationScopes(string scope)
+    {
+        var act = () => _service.CreateGuestLinkAsync(
+            _dataOwnerId, _creatorId, "Admin Scopes", "https://example.com", [scope]);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*not allowed*");
+    }
+
     [Fact]
     public async Task CreateGuestLink_EnforcesMaxActiveLimit()
     {

--- a/tests/Unit/Nocturne.API.Tests/Services/Identity/TenantOverviewServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Identity/TenantOverviewServiceTests.cs
@@ -193,7 +193,7 @@ public class TenantOverviewServiceTests
         SeedMembership(options, Guid.NewGuid(), "other-subject", [TenantPermissions.GlucoseRead]);
 
         var service = NewService(options);
-        var response = await service.GetOverviewAsync(subjectId, FullTokenScopes);
+        var response = await service.GetOverviewAsync(subjectId, FullTokenScopes, AuthType.OAuthAccessToken);
 
         response.Tenants.Select(t => t.Slug).Should().BeEquivalentTo(
             ["included", "superuser", "readwrite", "direct-only"]);
@@ -204,7 +204,7 @@ public class TenantOverviewServiceTests
     // ---- token scope gating ----
 
     [Fact]
-    public async Task GetOverview_tokenWithoutGlucoseScope_excludesNonSuperuserTenants()
+    public async Task GetOverview_delegatedTokenWithoutGlucoseScope_excludesEveryTenant()
     {
         var subjectId = Guid.NewGuid();
         var options = NewOptions();
@@ -214,19 +214,52 @@ public class TenantOverviewServiceTests
 
         var service = NewService(options);
 
-        // A narrowly-scoped token (no glucose scope) drops member tenants; the superuser
-        // membership bypasses the intersection, matching MemberScopeMiddleware.
+        // A delegated token bounds every membership, the owner's included: an app authorized for
+        // treatments.read must not be handed glucose through a "*" membership. The superuser
+        // membership used to bypass the intersection here, so an owner's narrowly-scoped
+        // third-party token still saw every tenant in the picker.
         var narrow = await service.GetOverviewAsync(
-            subjectId, new HashSet<string> { OAuthScopes.TreatmentsRead });
-        narrow.Tenants.Select(t => t.Slug).Should().BeEquivalentTo(["owner-tenant"]);
+            subjectId, new HashSet<string> { OAuthScopes.TreatmentsRead }, AuthType.OAuthAccessToken);
+        narrow.Tenants.Should().BeEmpty();
 
-        // An empty token scope set (no grants at all) still keeps the superuser tenant.
-        var empty = await service.GetOverviewAsync(subjectId, new HashSet<string>());
-        empty.Tenants.Select(t => t.Slug).Should().BeEquivalentTo(["owner-tenant"]);
+        // An empty scope set on a delegated credential grants nothing.
+        var empty = await service.GetOverviewAsync(
+            subjectId, new HashSet<string>(), AuthType.OAuthAccessToken);
+        empty.Tenants.Should().BeEmpty();
 
-        // A full-access token (what a session with the admin global role resolves to) sees both.
-        var full = await service.GetOverviewAsync(subjectId, FullTokenScopes);
+        // A full-access token consents to everything, so both memberships resolve in full.
+        var full = await service.GetOverviewAsync(subjectId, FullTokenScopes, AuthType.OAuthAccessToken);
         full.Tenants.Select(t => t.Slug).Should().BeEquivalentTo(["member-tenant", "owner-tenant"]);
+    }
+
+    [Fact]
+    public async Task GetOverview_unscopedSessionCredential_seesTenantsFromTheMembershipAlone()
+    {
+        // A browser session carries no scope grant: its JWT permission claims come from the
+        // subject's GLOBAL roles, which are empty for a member who joined by invite. Intersecting
+        // against them emptied the tenant picker for every non-owner membership.
+        var subjectId = Guid.NewGuid();
+        var options = NewOptions();
+
+        SeedMembership(options, subjectId, "member-tenant", [TenantPermissions.GlucoseRead]);
+        SeedMembership(options, subjectId, "admin-tenant",
+            TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Admin]);
+        SeedMembership(options, subjectId, "owner-tenant", [TenantPermissions.Superuser]);
+        SeedMembership(options, subjectId, "no-glucose", [TenantPermissions.TreatmentsRead]);
+        SeedMembership(options, subjectId, "denied",
+            TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Denied]);
+
+        var service = NewService(options);
+
+        var session = await service.GetOverviewAsync(
+            subjectId, new HashSet<string>(), AuthType.SessionCookie);
+        session.Tenants.Select(t => t.Slug).Should().BeEquivalentTo(
+            ["member-tenant", "admin-tenant", "owner-tenant"]);
+
+        // The same subject over a delegated credential with no scopes still sees nothing.
+        var delegated = await service.GetOverviewAsync(
+            subjectId, new HashSet<string>(), AuthType.OAuthAccessToken);
+        delegated.Tenants.Should().BeEmpty();
     }
 
     [Fact]
@@ -239,7 +272,7 @@ public class TenantOverviewServiceTests
 
         var service = NewService(options);
         var response = await service.GetOverviewAsync(
-            subjectId, new HashSet<string> { OAuthScopes.GlucoseRead });
+            subjectId, new HashSet<string> { OAuthScopes.GlucoseRead }, AuthType.OAuthAccessToken);
 
         var item = response.Tenants.Should().ContainSingle().Subject;
         item.ActiveAlertCount.Should().BeNull();
@@ -257,7 +290,7 @@ public class TenantOverviewServiceTests
         SeedActiveExcursion(options, tenantId, AlertRuleSeverity.Warning);
 
         var service = NewService(options);
-        var response = await service.GetOverviewAsync(subjectId, FullTokenScopes);
+        var response = await service.GetOverviewAsync(subjectId, FullTokenScopes, AuthType.OAuthAccessToken);
 
         var item = response.Tenants.Should().ContainSingle().Subject;
         item.ActiveAlertCount.Should().BeNull();
@@ -323,7 +356,7 @@ public class TenantOverviewServiceTests
         };
         var service = NewService(options, latest);
 
-        var response = await service.GetOverviewAsync(subjectId, FullTokenScopes);
+        var response = await service.GetOverviewAsync(subjectId, FullTokenScopes, AuthType.OAuthAccessToken);
 
         var item = response.Tenants.Should().ContainSingle().Subject;
         item.Latest.Should().NotBeNull();
@@ -353,7 +386,7 @@ public class TenantOverviewServiceTests
 
         var latest = new SensorGlucose { Mgdl = 120, Timestamp = DateTime.UtcNow.AddMinutes(-2) };
         var service = NewService(options, latest);
-        var response = await service.GetOverviewAsync(subjectId, FullTokenScopes);
+        var response = await service.GetOverviewAsync(subjectId, FullTokenScopes, AuthType.OAuthAccessToken);
 
         var item = response.Tenants.Should().ContainSingle().Subject;
         item.TenantId.Should().Be(tenantA);
@@ -374,7 +407,7 @@ public class TenantOverviewServiceTests
         var latest = new SensorGlucose { Mgdl = 120, Timestamp = DateTime.UtcNow.AddMinutes(-2) };
         var service = NewService(options, latest, failingTenantId: badTenant);
 
-        var response = await service.GetOverviewAsync(subjectId, FullTokenScopes);
+        var response = await service.GetOverviewAsync(subjectId, FullTokenScopes, AuthType.OAuthAccessToken);
 
         response.Tenants.Should().HaveCount(2);
 
@@ -421,7 +454,7 @@ public class TenantOverviewServiceTests
 
         var latest = new SensorGlucose { Mgdl = 120, Timestamp = DateTime.UtcNow.AddMinutes(-2) };
         var service = NewService(options, latest);
-        var response = await service.GetOverviewAsync(subjectId, FullTokenScopes);
+        var response = await service.GetOverviewAsync(subjectId, FullTokenScopes, AuthType.OAuthAccessToken);
 
         var item = response.Tenants.Should().ContainSingle().Subject;
         // The bad rule is skipped, the good rule still applies, and the reading survives.

--- a/tests/Unit/Nocturne.Core.Models.Tests/Authorization/MemberScopeResolverTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/Authorization/MemberScopeResolverTests.cs
@@ -1,0 +1,390 @@
+using FluentAssertions;
+using Nocturne.Core.Models.Authorization;
+using Xunit;
+
+namespace Nocturne.Core.Models.Tests.Authorization;
+
+/// <summary>
+/// Pins <see cref="MemberScopeResolver"/>, the single place a tenant membership is turned into a
+/// granted scope set. Both <c>MemberScopeMiddleware</c> (per request) and
+/// <c>TenantOverviewService</c> (per membership, for the tenant picker) route through it, so these
+/// cases bind the access decision for the whole tenant surface.
+/// </summary>
+[Trait("Category", "Unit")]
+public class MemberScopeResolverTests
+{
+    private static readonly IReadOnlySet<string> NoScopes = new HashSet<string>();
+
+    /// <summary>The credential types that carry no scope grant, as the resolver must classify them.</summary>
+    private static readonly AuthType[] ExpectedUnscopedTypes =
+    [
+        AuthType.SessionCookie,
+        AuthType.OidcToken,
+        AuthType.LegacyJwt,
+        AuthType.LegacyAccessToken,
+    ];
+
+    private static IReadOnlySet<string> Resolve(
+        IEnumerable<string> permissions, AuthType authType, params string[] credentialScopes)
+    {
+        return MemberScopeResolver.Resolve(
+            new HashSet<string>(permissions), authType, new HashSet<string>(credentialScopes));
+    }
+
+    // ---- the discriminator ----
+
+    [Fact]
+    public void UnscopedCredentialTypes_IsExactlyTheCredentialsThatCarryNoGrant()
+    {
+        // A mutation here is the whole security boundary: adding a delegated type erases consent,
+        // removing an unscoped type resolves that credential to nothing.
+        MemberScopeResolver.UnscopedCredentialTypes.Should().BeEquivalentTo(ExpectedUnscopedTypes);
+    }
+
+    [Fact]
+    public void EveryOtherAuthType_IsTreatedAsScoped()
+    {
+        // Fail closed: a newly declared AuthType is capped by the credential's scopes until someone
+        // deliberately classifies it.
+        var scoped = Enum.GetValues<AuthType>().Except(ExpectedUnscopedTypes);
+
+        scoped.Should().OnlyContain(
+            authType => !MemberScopeResolver.UnscopedCredentialTypes.Contains(authType));
+    }
+
+    [Theory]
+    [InlineData(AuthType.OAuthAccessToken)]
+    [InlineData(AuthType.DirectGrant)]
+    [InlineData(AuthType.ApiKey)]
+    [InlineData(AuthType.Guest)]
+    [InlineData(AuthType.InstanceKey)]
+    [InlineData(AuthType.PlatformAccess)]
+    [InlineData(AuthType.None)]
+    public void ScopedCredential_WithNoScopes_ResolvesToNothing(AuthType authType)
+    {
+        // A credential that presents no scopes and is not classified as unscoped grants nothing,
+        // however broad the membership.
+        Resolve([TenantPermissions.Superuser], authType).Should().BeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(UnscopedTypes))]
+    public void UnscopedCredential_WithNoScopes_ResolvesFromMembership(AuthType authType)
+    {
+        Resolve([TenantPermissions.GlucoseRead], authType)
+            .Should().Contain(OAuthScopes.GlucoseRead);
+    }
+
+    public static TheoryData<AuthType> UnscopedTypes()
+    {
+        var data = new TheoryData<AuthType>();
+        foreach (var authType in ExpectedUnscopedTypes)
+            data.Add(authType);
+        return data;
+    }
+
+    // ---- per-seed-role resolution on an unscoped credential ----
+
+    [Theory]
+    [MemberData(nameof(SeedRoleExpectations))]
+    public void SeedRole_OnUnscopedCredential_ResolvesRoleScopesWithoutWidening(
+        string roleSlug, AuthType authType, string[] expected, string[] notExpected)
+    {
+        // The real web-app credential shape: no scopes at all, because a session JWT's permission
+        // claims are the subject's GLOBAL roles (empty for a member who joined by invite).
+        // Intersecting against that resolved every non-owner role to zero scopes.
+        var resolved = Resolve(
+            TenantPermissions.SeedRolePermissions[roleSlug], authType);
+
+        foreach (var scope in expected)
+            TenantPermissions.HasPermission(resolved, scope).Should().BeTrue($"'{scope}' is granted");
+        foreach (var scope in notExpected)
+            TenantPermissions.HasPermission(resolved, scope).Should().BeFalse($"'{scope}' is not granted");
+    }
+
+    /// <summary>
+    /// Every seed role crossed with every unscoped credential type: the permissions the role must
+    /// resolve to, and the permissions it must not reach. Asserted through
+    /// <see cref="TenantPermissions.HasPermission"/> because that is the gate the administration and
+    /// data controllers actually apply to <c>GrantedScopes</c>.
+    /// </summary>
+    public static TheoryData<string, AuthType, string[], string[]> SeedRoleExpectations()
+    {
+        (string Role, string[] Expected, string[] NotExpected)[] roles =
+        [
+            (
+                TenantPermissions.SeedRoles.Owner,
+                // "*" satisfies every atom through TenantPermissions.Satisfies.
+                [TenantPermissions.Superuser, TenantPermissions.GlucoseReadWrite, TenantPermissions.AuditManage],
+                []
+            ),
+            (
+                TenantPermissions.SeedRoles.Admin,
+                [
+                    TenantPermissions.GlucoseReadWrite, TenantPermissions.TreatmentsReadWrite,
+                    TenantPermissions.TherapyReadWrite, TenantPermissions.FoodReadWrite,
+                    TenantPermissions.AlertsReadWrite, TenantPermissions.DevicesReadWrite,
+                    TenantPermissions.SleepReadWrite, TenantPermissions.ReportsRead,
+                    TenantPermissions.MembersManage, TenantPermissions.MembersInvite,
+                    TenantPermissions.TenantSettings, TenantPermissions.RolesManage,
+                    TenantPermissions.SharingManage, TenantPermissions.SharingGuest,
+                    TenantPermissions.AuditRead,
+                    TenantPermissions.DeviceNotify, TenantPermissions.DeviceActuate,
+                ],
+                // audit.manage is Owner-only by design, and an Administrator is not a superuser.
+                [TenantPermissions.Superuser, TenantPermissions.AuditManage]
+            ),
+            (
+                TenantPermissions.SeedRoles.Clinician,
+                [
+                    TenantPermissions.GlucoseRead, TenantPermissions.TreatmentsRead,
+                    TenantPermissions.TherapyRead, TenantPermissions.AlertsRead,
+                    TenantPermissions.ReportsRead, TenantPermissions.SleepRead,
+                ],
+                [
+                    TenantPermissions.Superuser, TenantPermissions.GlucoseReadWrite,
+                    TenantPermissions.TreatmentsReadWrite, TenantPermissions.TherapyReadWrite,
+                    TenantPermissions.AlertsReadWrite,
+                    TenantPermissions.MembersManage, TenantPermissions.TenantSettings,
+                    TenantPermissions.AuditRead,
+                ]
+            ),
+            (
+                TenantPermissions.SeedRoles.Caretaker,
+                [
+                    TenantPermissions.GlucoseRead, TenantPermissions.TreatmentsReadWrite,
+                    TenantPermissions.TherapyRead, TenantPermissions.AlertsReadWrite,
+                    TenantPermissions.FoodRead,
+                ],
+                [
+                    TenantPermissions.Superuser, TenantPermissions.GlucoseReadWrite,
+                    TenantPermissions.TherapyReadWrite, TenantPermissions.FoodReadWrite,
+                    TenantPermissions.MembersManage, TenantPermissions.TenantSettings,
+                    TenantPermissions.AuditRead,
+                ]
+            ),
+            (
+                TenantPermissions.SeedRoles.Viewer,
+                [TenantPermissions.GlucoseRead, TenantPermissions.ReportsRead],
+                [
+                    TenantPermissions.Superuser, TenantPermissions.GlucoseReadWrite,
+                    TenantPermissions.TreatmentsRead, TenantPermissions.TherapyRead,
+                    TenantPermissions.TenantSettings, TenantPermissions.MembersManage,
+                ]
+            ),
+            (
+                TenantPermissions.SeedRoles.Denied,
+                [],
+                [
+                    TenantPermissions.Superuser, TenantPermissions.GlucoseRead,
+                    TenantPermissions.ReportsRead, TenantPermissions.DeviceNotify,
+                    TenantPermissions.DeviceActuate, TenantPermissions.MembersManage,
+                ]
+            ),
+        ];
+
+        var data = new TheoryData<string, AuthType, string[], string[]>();
+        foreach (var (role, expected, notExpected) in roles)
+        {
+            foreach (var authType in ExpectedUnscopedTypes)
+                data.Add(role, authType, expected, notExpected);
+        }
+        return data;
+    }
+
+    [Fact]
+    public void DeniedRole_OnUnscopedCredential_ResolvesToNothing()
+    {
+        // An unscoped credential removes the ceiling, not the membership check. Zero permissions
+        // means zero scopes, including the member-personal device capabilities — alert actuations
+        // reveal patient state.
+        Resolve(TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Denied],
+            AuthType.SessionCookie).Should().BeEmpty();
+    }
+
+    // ---- superuser ----
+
+    [Fact]
+    public void Superuser_OnUnscopedCredential_KeepsTheWildcard()
+    {
+        Resolve([TenantPermissions.Superuser], AuthType.SessionCookie)
+            .Should().Contain(TenantPermissions.Superuser);
+    }
+
+    [Theory]
+    [InlineData(AuthType.OAuthAccessToken)]
+    [InlineData(AuthType.DirectGrant)]
+    public void Superuser_OnScopedCredential_KeepsOnlyTheCredentialScopes(AuthType authType)
+    {
+        // An owner who authorized a third-party app for glucose.read must not hand it superuser.
+        var resolved = Resolve([TenantPermissions.Superuser], authType, OAuthScopes.GlucoseRead);
+
+        resolved.Should().BeEquivalentTo([OAuthScopes.GlucoseRead]);
+        resolved.Should().NotContain(TenantPermissions.Superuser);
+    }
+
+    [Theory]
+    [InlineData(AuthType.OAuthAccessToken)]
+    [InlineData(AuthType.DirectGrant)]
+    public void Superuser_OnFullAccessCredential_KeepsTheWildcard(AuthType authType)
+    {
+        // "*" on the credential bounds nothing, so the owner keeps superuser.
+        Resolve([TenantPermissions.Superuser], authType, OAuthScopes.FullAccess)
+            .Should().Contain(OAuthScopes.FullAccess);
+    }
+
+    // ---- the readwrite/read downgrade ----
+
+    [Fact]
+    public void ReadWriteMembership_OnReadOnlyCredential_DowngradesToRead()
+    {
+        // SatisfiesScope answers false for a readwrite requirement met only by read, and
+        // NormalizeMemberPermissions adds no read counterpart, so this member previously resolved
+        // to NEITHER scope. Both sides permit the read counterpart.
+        var resolved = Resolve(
+            [TenantPermissions.GlucoseReadWrite], AuthType.OAuthAccessToken, OAuthScopes.GlucoseRead);
+
+        resolved.Should().BeEquivalentTo([OAuthScopes.GlucoseRead]);
+        resolved.Should().NotContain(OAuthScopes.GlucoseReadWrite);
+    }
+
+    [Fact]
+    public void ReadWriteMembership_OnReadOnlyCredential_DowngradesEveryTieredScope()
+    {
+        var readWriteRole = TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Admin];
+        var readOnlyCredential = new[]
+        {
+            OAuthScopes.GlucoseRead, OAuthScopes.TreatmentsRead, OAuthScopes.TherapyRead,
+            OAuthScopes.AlertsRead, OAuthScopes.FoodRead, OAuthScopes.DevicesRead,
+        };
+
+        var resolved = Resolve(readWriteRole, AuthType.OAuthAccessToken, readOnlyCredential);
+
+        resolved.Should().BeEquivalentTo(readOnlyCredential);
+    }
+
+    [Fact]
+    public void ReadOnlyMembership_OnReadWriteCredential_StaysRead()
+    {
+        // The downgrade never runs backwards: membership is still the other bound.
+        Resolve([TenantPermissions.GlucoseRead], AuthType.OAuthAccessToken, OAuthScopes.GlucoseReadWrite)
+            .Should().BeEquivalentTo([OAuthScopes.GlucoseRead]);
+    }
+
+    // ---- administration atoms ----
+
+    [Fact]
+    public void AdministrationAtoms_SurviveOnAnUnscopedCredential()
+    {
+        var resolved = Resolve(
+            [TenantPermissions.MembersManage, TenantPermissions.AuditRead], AuthType.SessionCookie);
+
+        resolved.Should().Contain(TenantPermissions.MembersManage);
+        resolved.Should().Contain(TenantPermissions.AuditRead);
+    }
+
+    [Theory]
+    [InlineData(AuthType.OAuthAccessToken)]
+    [InlineData(AuthType.DirectGrant)]
+    public void AdministrationAtoms_NeverSurviveOnAScopedCredential(AuthType authType)
+    {
+        // A delegated credential never administers the tenant, even when it presents an
+        // administration atom outright. Non-requestability at /authorize means no legitimate
+        // credential holds one; the resolver bounds the credential's scopes by the request
+        // vocabulary so an atom that arrived by any other route is dropped here too.
+        var resolved = Resolve(
+            TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Admin],
+            authType,
+            OAuthScopes.GlucoseRead,
+            TenantPermissions.MembersManage, TenantPermissions.RolesManage,
+            TenantPermissions.TenantSettings, TenantPermissions.AuditRead,
+            TenantPermissions.SharingManage, TenantPermissions.SharingGuest);
+
+        resolved.Should().BeEquivalentTo([OAuthScopes.GlucoseRead]);
+
+        foreach (var atom in new[]
+                 {
+                     TenantPermissions.MembersManage, TenantPermissions.RolesManage,
+                     TenantPermissions.TenantSettings, TenantPermissions.AuditRead,
+                     TenantPermissions.SharingManage, TenantPermissions.SharingGuest,
+                 })
+        {
+            TenantPermissions.HasPermission(resolved, atom).Should().BeFalse(
+                $"a delegated credential must not administer the tenant via '{atom}'");
+        }
+    }
+
+    [Theory]
+    [InlineData(AuthType.OAuthAccessToken)]
+    [InlineData(AuthType.DirectGrant)]
+    public void ScopedCredential_CannotWidenItselfWithANonRequestableScope(AuthType authType)
+    {
+        // The credential presents only administration atoms. It resolves to nothing rather than to
+        // tenant administration, so a forged or hand-written grant row cannot escalate.
+        Resolve(
+            TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Admin],
+            authType,
+            TenantPermissions.MembersManage, TenantPermissions.RolesManage)
+            .Should().BeEmpty();
+    }
+
+    // ---- member-personal device capabilities ----
+
+    [Fact]
+    public void StaleRoleWithoutDeviceAtoms_StillResolvesDeviceScopes_OnUnscopedCredential()
+    {
+        // Seed role rows are never reconciled, so a tenant seeded before these atoms existed has
+        // role rows without them. They authorize the member's OWN client devices, not patient data.
+        var resolved = Resolve([TenantPermissions.GlucoseRead], AuthType.SessionCookie);
+
+        resolved.Should().Contain(OAuthScopes.DeviceNotify);
+        resolved.Should().Contain(OAuthScopes.DeviceActuate);
+    }
+
+    [Fact]
+    public void StaleRoleWithoutDeviceAtoms_StillResolvesDeviceScopes_FromAScopedCredential()
+    {
+        var resolved = Resolve(
+            [TenantPermissions.GlucoseRead], AuthType.OAuthAccessToken,
+            OAuthScopes.GlucoseRead, OAuthScopes.DeviceNotify);
+
+        resolved.Should().Contain(OAuthScopes.DeviceNotify);
+        // The credential did not carry device.actuate, so membership must not add it.
+        resolved.Should().NotContain(OAuthScopes.DeviceActuate);
+    }
+
+    [Fact]
+    public void ZeroPermissionMember_GetsNoDeviceScopes_FromAScopedCredential()
+    {
+        Resolve([], AuthType.OAuthAccessToken, OAuthScopes.DeviceNotify, OAuthScopes.DeviceActuate)
+            .Should().BeEmpty();
+    }
+
+    // ---- unknown atoms ----
+
+    [Fact]
+    public void UnknownPermissionAtoms_AreDropped()
+    {
+        // Role rows written before the 2026-05-12 atom rename hold strings the vocabulary no longer
+        // recognizes (entries.* -> glucose.*, profile.* -> therapy.*). They resolve to nothing
+        // rather than leaking through as opaque scope strings.
+        var resolved = Resolve(
+            ["entries.read", "profile.read", "members.destroy", TenantPermissions.GlucoseRead],
+            AuthType.SessionCookie);
+
+        resolved.Should().NotContain("entries.read");
+        resolved.Should().NotContain("profile.read");
+        resolved.Should().NotContain("members.destroy");
+        resolved.Should().Contain(OAuthScopes.GlucoseRead);
+    }
+
+    [Fact]
+    public void Resolve_DoesNotMutateTheCallersPermissionSet()
+    {
+        var permissions = new HashSet<string> { TenantPermissions.GlucoseRead };
+
+        MemberScopeResolver.Resolve(permissions, AuthType.SessionCookie, NoScopes);
+
+        permissions.Should().BeEquivalentTo([TenantPermissions.GlucoseRead]);
+    }
+}

--- a/tests/Unit/Nocturne.Core.Models.Tests/Authorization/OAuthScopeVocabularyTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/Authorization/OAuthScopeVocabularyTests.cs
@@ -1,0 +1,185 @@
+using FluentAssertions;
+using Nocturne.Core.Models.Authorization;
+using Xunit;
+
+namespace Nocturne.Core.Models.Tests.Authorization;
+
+/// <summary>
+/// Pins the relationship between the tenant RBAC permission vocabulary
+/// (<see cref="TenantPermissions"/>) and the OAuth scope vocabulary
+/// (<see cref="OAuthScopes"/>). <c>MemberScopeMiddleware</c> converts a member's effective
+/// permissions into granted scopes, so an atom the scope vocabulary does not recognize is
+/// silently deleted and the permission becomes unenforceable.
+/// </summary>
+[Trait("Category", "Unit")]
+public class OAuthScopeVocabularyTests
+{
+    /// <summary>The tenant-administration atoms: grantable through a tenant role, never requestable.</summary>
+    private static readonly string[] AdministrationAtoms =
+    [
+        TenantPermissions.MembersInvite,
+        TenantPermissions.MembersManage,
+        TenantPermissions.RolesManage,
+        TenantPermissions.TenantSettings,
+        TenantPermissions.SharingManage,
+        TenantPermissions.SharingGuest,
+        TenantPermissions.AuditRead,
+        TenantPermissions.AuditManage,
+    ];
+
+    [Fact]
+    public void EveryTenantPermissionAtom_IsGrantableAsAScope()
+    {
+        OAuthScopes.MemberGrantableScopes.Should().Contain(TenantPermissions.All);
+    }
+
+    [Fact]
+    public void NormalizeMemberPermissions_PreservesEveryTenantPermissionAtom()
+    {
+        OAuthScopes.NormalizeMemberPermissions(TenantPermissions.All)
+            .Should().Contain(TenantPermissions.All);
+    }
+
+    [Fact]
+    public void NormalizeMemberPermissions_PreservesAdministrationAtoms()
+    {
+        OAuthScopes.NormalizeMemberPermissions(AdministrationAtoms)
+            .Should().BeEquivalentTo(AdministrationAtoms);
+    }
+
+    [Fact]
+    public void NormalizeMemberPermissions_StillDropsUnknownAtoms()
+    {
+        OAuthScopes.NormalizeMemberPermissions(new[] { "glucose.read", "members.destroy", "entries.readwrite" })
+            .Should().BeEquivalentTo([OAuthScopes.GlucoseRead]);
+    }
+
+    [Fact]
+    public void AdministrationAtoms_AreNotRequestableByAClient()
+    {
+        // /authorize, the direct-grant validator and dynamic client registration all gate on
+        // ValidRequestScopes. There is no per-client scope ceiling, so a requestable
+        // administration atom would let any client ask a user to consent to tenant administration.
+        foreach (var atom in AdministrationAtoms)
+        {
+            OAuthScopes.IsValid(atom).Should().BeFalse($"'{atom}' must not be requestable");
+            OAuthScopes.ValidRequestScopes.Should().NotContain(atom);
+        }
+    }
+
+    [Fact]
+    public void Normalize_DropsAdministrationAtoms()
+    {
+        OAuthScopes.Normalize(AdministrationAtoms).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FullAccessExpansion_DoesNotEnumerateAdministrationAtoms()
+    {
+        // A "*" grant keeps satisfying every permission through the FullAccess shortcut in
+        // SatisfiesScope/TenantPermissions.Satisfies; what must not change is the literal
+        // expansion, which is what share narrowing and the scope-display surfaces enumerate.
+        var expanded = OAuthScopes.Normalize([OAuthScopes.FullAccess]);
+
+        expanded.Should().Contain(OAuthScopes.FullAccess);
+        expanded.Should().NotIntersectWith(AdministrationAtoms);
+        OAuthScopes.AllScopes.Should().NotIntersectWith(AdministrationAtoms);
+
+        foreach (var atom in AdministrationAtoms)
+        {
+            OAuthScopes.SatisfiesScope(expanded, atom).Should().BeTrue();
+            TenantPermissions.HasPermission(expanded, atom).Should().BeTrue();
+        }
+    }
+
+    [Fact]
+    public void PublicShareScopes_ContainNoAdministrationAtom()
+    {
+        TenantPermissions.PublicShareScopes.Should().NotIntersectWith(AdministrationAtoms);
+        TenantPermissions.PublicShareScopes.Should().OnlyContain(scope => scope.EndsWith(".read"));
+    }
+
+    [Fact]
+    public void ScopeTranslator_MapsNoLegacyPermissionToAnAdministrationAtom()
+    {
+        // The legacy Shiro trie has no tenant-administration equivalent. A mapping would let a
+        // migrated Nightscout api-secret carrying api:*:update administer the tenant.
+        string[] legacyPermissions =
+        [
+            "api:*:read", "api:*:create", "api:*:update", "api:*:delete",
+            "api:entries:read", "api:entries:create", "api:treatments:update",
+            "api:devicestatus:create", "api:food:update", "api:profile:create",
+            "readable",
+        ];
+
+        ScopeTranslator.FromPermissions(legacyPermissions).Should().NotIntersectWith(AdministrationAtoms);
+    }
+
+    [Fact]
+    public void ScopeTranslator_TranslatesNoAdministrationAtomToATriePermission()
+    {
+        // The rebuilt PermissionTrie drives the legacy HasPermissions policy. Administration atoms
+        // are enforced against GrantedScopes only, so they must not reach the trie.
+        ScopeTranslator.ToPermissions(AdministrationAtoms).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MemberGrantableScopes_IsDerivedFromTheTenantPermissionVocabulary()
+    {
+        // Derived, not hand-listed: a new atom in TenantPermissions.All is grantable with no second
+        // edit, so the two vocabularies cannot drift.
+        OAuthScopes.MemberGrantableScopes.Should().BeEquivalentTo(
+            OAuthScopes.ValidRequestScopes.Concat(TenantPermissions.All).ToHashSet());
+    }
+
+    [Theory]
+    [InlineData(OAuthScopes.GlucoseReadWrite, OAuthScopes.GlucoseRead)]
+    [InlineData(OAuthScopes.TreatmentsReadWrite, OAuthScopes.TreatmentsRead)]
+    [InlineData(OAuthScopes.DevicesReadWrite, OAuthScopes.DevicesRead)]
+    [InlineData(OAuthScopes.TherapyReadWrite, OAuthScopes.TherapyRead)]
+    [InlineData(OAuthScopes.AlertsReadWrite, OAuthScopes.AlertsRead)]
+    [InlineData(OAuthScopes.HeartRateReadWrite, OAuthScopes.HeartRateRead)]
+    [InlineData(OAuthScopes.StepCountReadWrite, OAuthScopes.StepCountRead)]
+    [InlineData(OAuthScopes.SleepReadWrite, OAuthScopes.SleepRead)]
+    [InlineData(OAuthScopes.FoodReadWrite, OAuthScopes.FoodRead)]
+    public void TryGetImpliedReadScope_NarrowsEveryTieredScope(string readWrite, string expectedRead)
+    {
+        OAuthScopes.TryGetImpliedReadScope(readWrite, out var readScope).Should().BeTrue();
+        readScope.Should().Be(expectedRead);
+    }
+
+    [Theory]
+    [InlineData(OAuthScopes.GlucoseRead)]
+    [InlineData(OAuthScopes.ReportsRead)]
+    [InlineData(OAuthScopes.IdentityRead)]
+    [InlineData(OAuthScopes.DeviceNotify)]
+    [InlineData(OAuthScopes.DeviceActuate)]
+    [InlineData(OAuthScopes.FullAccess)]
+    [InlineData(TenantPermissions.MembersManage)]
+    public void TryGetImpliedReadScope_HasNoCounterpartForAnUntieredScope(string scope)
+    {
+        // Notably "*": a superuser membership on a read-only credential must not downgrade the
+        // wildcard to some read scope, it must simply not survive.
+        OAuthScopes.TryGetImpliedReadScope(scope, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void SatisfiesScope_DoesNotTreatReadAsSatisfyingReadWrite()
+    {
+        // The asymmetry the downgrade in MemberScopeResolver exists to handle. Pinned here so the
+        // downgrade is not silently made redundant (or contradicted) by a change to SatisfiesScope.
+        OAuthScopes.SatisfiesScope([OAuthScopes.GlucoseRead], OAuthScopes.GlucoseReadWrite)
+            .Should().BeFalse();
+        OAuthScopes.SatisfiesScope([OAuthScopes.GlucoseReadWrite], OAuthScopes.GlucoseRead)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void NormalizeMemberPermissions_DoesNotAddTheReadCounterpartOfAReadWriteScope()
+    {
+        // The other half of the asymmetry: normalization leaves readwrite alone, so an intersection
+        // against a read-only credential had nothing to match.
+        OAuthScopes.NormalizeMemberPermissions([TenantPermissions.GlucoseReadWrite])
+            .Should().BeEquivalentTo([OAuthScopes.GlucoseReadWrite]);
+    }
+}


### PR DESCRIPTION
A first-party session carries no scope grant, so intersecting membership against it resolved every non-owner member to an empty scope set. Any endpoint with a scope gate therefore refused Admin, Clinician and Caretaker through the web UI — already the case today for heart rate, step count, sleep reports and client devices.

Tenant-administration atoms were also dropped by scope normalisation, so the seeded Administrator role could not manage members, roles, sharing or the audit log.

`MemberScopeMiddleware` and `TenantOverviewService.ResolveAllowedScopes` were two copies of the same resolution algorithm; both now call one resolver. Unifying them surfaced three further issues, each fixed here: the tenant picker still let a superuser membership bypass the scope intersection; an administration atom presented by a credential was honoured rather than bounded by the request vocabulary; and a `readwrite` role paired with a `read` token resolved to neither scope instead of downgrading.

The administration atoms stay out of `ValidRequestScopes`, so they remain non-requestable by third-party clients.

Verified: unit and Core.Models suites green, five mutation checks, and a filter-pipeline test that chains the real middleware into the real scope filter across all 80 gated actions, with a negative control at the pre-fix commit.