### PR TITLE
fix(connectors): stop the Nightscout realtime listener rejecting its own reconnect options

### DIFF
--- a/src/API/Nocturne.API/Services/BackgroundServices/NightscoutConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/NightscoutConnectorBackgroundService.cs
@@ -21,6 +21,26 @@ public class NightscoutConnectorBackgroundService : ConnectorBackgroundService<N
 {
     private readonly ConcurrentDictionary<Guid, SocketIO> _socketClients = new();
 
+    /// <summary>
+    /// Reconnection budget for a tenant's Socket.IO client. SocketIOClient bounds the whole
+    /// connect-with-retries operation with <c>new CancellationTokenSource(ReconnectionAttempts *
+    /// ReconnectionDelayMax)</c>, evaluated in <see cref="int"/> arithmetic: a product above
+    /// <see cref="int.MaxValue"/> wraps negative and <c>ConnectAsync</c> throws
+    /// <see cref="ArgumentOutOfRangeException"/> before it attempts a single connection. Keep
+    /// <see cref="ReconnectionAttempts"/> * <see cref="ReconnectionDelayMaxMs"/> well inside int.
+    /// </summary>
+    internal const int ReconnectionAttempts = 3;
+
+    /// <inheritdoc cref="ReconnectionAttempts"/>
+    internal const int ReconnectionDelayMaxMs = 5_000;
+
+    /// <summary>
+    /// Per-tenant cap on establishing the initial Socket.IO connection. Tenants are connected
+    /// concurrently and a failure falls back to polling, so this only bounds how long service
+    /// startup waits on unreachable Nightscout instances.
+    /// </summary>
+    private static readonly TimeSpan ConnectTimeout = TimeSpan.FromSeconds(10);
+
     /// <param name="serviceProvider">Service provider used to create a DI scope per sync cycle.</param>
     /// <param name="logger">Logger instance for this background service.</param>
     public NightscoutConnectorBackgroundService(
@@ -49,75 +69,113 @@ public class NightscoutConnectorBackgroundService : ConnectorBackgroundService<N
             .Select(t => new { t.Id, t.Slug, t.DisplayName })
             .ToListAsync(cancellationToken);
 
-        foreach (var tenant in tenants)
-        {
-            try
+        // Connect tenants concurrently: each tenant waits up to ConnectTimeout, and the poll loop
+        // does not start until this returns, so connecting them in sequence would delay the first
+        // sync of every tenant by the sum of all unreachable instances' timeouts.
+        await Parallel.ForEachAsync(
+            tenants,
+            new ParallelOptions
             {
-                using var tenantScope = ServiceProvider.CreateScope();
-
-                var tenantAccessor = tenantScope.ServiceProvider.GetRequiredService<ITenantAccessor>();
-                tenantAccessor.SetTenant(new TenantContext(tenant.Id, tenant.Slug, tenant.DisplayName, true));
-
-                var loader = tenantScope.ServiceProvider
-                    .GetRequiredService<IConnectorConfigurationLoader<NightscoutConnectorConfiguration>>();
-
-                NightscoutConnectorConfiguration config;
+                MaxDegreeOfParallelism = MaxConcurrentTenantSyncs,
+                CancellationToken = cancellationToken
+            },
+            async (tenant, ct) =>
+            {
                 try
                 {
-                    config = await loader.LoadForTenantAsync(cancellationToken);
+                    await StartListenerForTenantAsync(tenant.Id, tenant.Slug, tenant.DisplayName, ct);
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     Logger.LogWarning(
                         ex,
-                        "Failed to load Nightscout config for tenant {TenantSlug}, skipping real-time listener",
+                        "Unexpected error starting real-time listener for tenant {TenantSlug}",
                         tenant.Slug);
-                    continue;
                 }
+            });
+    }
 
-                if (!config.Enabled || string.IsNullOrWhiteSpace(config.Url))
-                    continue;
+    private async Task StartListenerForTenantAsync(
+        Guid tenantId,
+        string tenantSlug,
+        string displayName,
+        CancellationToken cancellationToken)
+    {
+        using var tenantScope = ServiceProvider.CreateScope();
 
-                var client = new SocketIO(new Uri(config.Url), new SocketIOOptions
-                {
-                    Reconnection = true,
-                    ReconnectionAttempts = int.MaxValue,
-                    ReconnectionDelayMax = 30_000,
-                });
+        var tenantAccessor = tenantScope.ServiceProvider.GetRequiredService<ITenantAccessor>();
+        tenantAccessor.SetTenant(new TenantContext(tenantId, tenantSlug, displayName, true));
 
-                var tenantId = tenant.Id;
-                foreach (var evt in new[] { "dataUpdate", "create", "update" })
-                    client.On(evt, _ => { RequestImmediateSync(tenantId); return Task.CompletedTask; });
+        var loader = tenantScope.ServiceProvider
+            .GetRequiredService<IConnectorConfigurationLoader<NightscoutConnectorConfiguration>>();
 
-                try
-                {
-                    await client.ConnectAsync(cancellationToken);
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogWarning(
-                        ex,
-                        "Failed to connect Socket.IO for tenant {TenantSlug} at {Url}, will rely on polling",
-                        tenant.Slug, config.Url);
-
-                    client.Dispose();
-                    continue;
-                }
-
-                _socketClients.TryAdd(tenantId, client);
-
-                Logger.LogInformation(
-                    "Started real-time listener for Nightscout tenant {TenantSlug}",
-                    tenant.Slug);
-            }
-            catch (Exception ex)
-            {
-                Logger.LogWarning(
-                    ex,
-                    "Unexpected error starting real-time listener for tenant {TenantSlug}",
-                    tenant.Slug);
-            }
+        NightscoutConnectorConfiguration config;
+        try
+        {
+            config = await loader.LoadForTenantAsync(cancellationToken);
         }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(
+                ex,
+                "Failed to load Nightscout config for tenant {TenantSlug}, skipping real-time listener",
+                tenantSlug);
+            return;
+        }
+
+        if (!config.Enabled || string.IsNullOrWhiteSpace(config.Url))
+            return;
+
+        // Tenants may store a bare host with no scheme. Normalise through the same helper the sync
+        // path uses so a URL that polls fine does not fail here on Uri parsing.
+        var socketUrl = NightscoutConnectorService.ResolveBaseUrl(config.Url);
+
+        if (!Uri.TryCreate(socketUrl, UriKind.Absolute, out var socketUri))
+        {
+            Logger.LogWarning(
+                "Nightscout URL {Url} for tenant {TenantSlug} is not a valid absolute URI, will rely on polling",
+                socketUrl, tenantSlug);
+            return;
+        }
+
+        var client = new SocketIO(socketUri, new SocketIOOptions
+        {
+            Reconnection = true,
+            ReconnectionAttempts = ReconnectionAttempts,
+            ReconnectionDelayMax = ReconnectionDelayMaxMs,
+        });
+
+        foreach (var evt in new[] { "dataUpdate", "create", "update" })
+            client.On(evt, _ => { RequestImmediateSync(tenantId); return Task.CompletedTask; });
+
+        try
+        {
+            using var connectCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            connectCts.CancelAfter(ConnectTimeout);
+
+            await client.ConnectAsync(connectCts.Token);
+        }
+        catch (Exception ex)
+        {
+            client.Dispose();
+
+            // The service is shutting down — let the caller unwind rather than reporting a failure.
+            if (cancellationToken.IsCancellationRequested)
+                throw;
+
+            Logger.LogWarning(
+                ex,
+                "Failed to connect Socket.IO for tenant {TenantSlug} at {Url}, will rely on polling",
+                tenantSlug, socketUrl);
+
+            return;
+        }
+
+        _socketClients.TryAdd(tenantId, client);
+
+        Logger.LogInformation(
+            "Started real-time listener for Nightscout tenant {TenantSlug}",
+            tenantSlug);
     }
 
     /// <inheritdoc />

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
@@ -760,7 +760,13 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         return url;
     }
 
-    private static string ResolveBaseUrl(string configUrl)
+    /// <summary>
+    /// Normalises a tenant-configured Nightscout URL: supplies <c>https://</c> when the tenant
+    /// stored a bare host, and trims any trailing slash so callers can append paths directly.
+    /// </summary>
+    /// <param name="configUrl">The URL as stored in the tenant's connector configuration.</param>
+    /// <exception cref="InvalidOperationException">The configured URL is null or empty.</exception>
+    public static string ResolveBaseUrl(string configUrl)
     {
         if (string.IsNullOrEmpty(configUrl))
             throw new InvalidOperationException("Nightscout URL is not configured");

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/NightscoutRealtimeListenerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/NightscoutRealtimeListenerTests.cs
@@ -129,7 +129,113 @@ public class NightscoutRealtimeListenerTests
         await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
     }
 
+    /// <summary>
+    /// SocketIOClient bounds the whole connect-with-retries operation with
+    /// <c>new CancellationTokenSource(ReconnectionAttempts * ReconnectionDelayMax)</c>, evaluated in
+    /// int arithmetic. A product above <see cref="int.MaxValue"/> wraps negative and ConnectAsync
+    /// throws ArgumentOutOfRangeException before attempting a single connection, so every tenant
+    /// silently loses its real-time listener.
+    /// </summary>
+    [Fact]
+    public void ReconnectionBudget_FitsWithinInt()
+    {
+        var product = (long)NightscoutConnectorBackgroundService.ReconnectionAttempts
+            * NightscoutConnectorBackgroundService.ReconnectionDelayMaxMs;
+
+        Assert.InRange(product, 1, int.MaxValue);
+    }
+
+    /// <summary>
+    /// A tenant with an enabled connector pointing at an unreachable instance must fall back to
+    /// polling. Regression test for the reconnection-budget overflow: the resulting
+    /// ArgumentOutOfRangeException was swallowed by the per-tenant catch, so the only visible
+    /// symptom was a recurring warning and no listener ever starting.
+    /// </summary>
+    [Fact]
+    public async Task StartRealtimeListenersAsync_UnreachableInstance_DoesNotFailOnReconnectionBudget()
+    {
+        // Arrange — one tenant pointing at a closed port (discard service)
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: true);
+        using var _ = cleanup;
+
+        var config = new NightscoutConnectorConfiguration
+        {
+            Enabled = true,
+            Url = "http://127.0.0.1:9",
+        };
+
+        var logger = new CapturingLogger();
+        var serviceProvider = BuildServiceProvider(connectionString, config);
+        var sut = new NightscoutConnectorBackgroundService(serviceProvider, logger);
+
+        // Act
+        await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
+
+        // Assert — the connect failed (nothing is listening on port 9), but it must have failed by
+        // actually attempting to connect, not by rejecting our own options.
+        Assert.DoesNotContain(logger.Exceptions, ex => ex is ArgumentOutOfRangeException);
+    }
+
+    /// <summary>
+    /// Tenants may store a bare host with no scheme; the polling path normalises this via
+    /// ResolveBaseUrl. The listener path must not blow up on Uri parsing where polling succeeds.
+    /// </summary>
+    [Fact]
+    public async Task StartRealtimeListenersAsync_SchemelessUrl_DoesNotThrowUriFormatException()
+    {
+        // Arrange — a bare host, as three production tenants have stored
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: true);
+        using var _ = cleanup;
+
+        var config = new NightscoutConnectorConfiguration
+        {
+            Enabled = true,
+            Url = "127.0.0.1:9",
+        };
+
+        var logger = new CapturingLogger();
+        var serviceProvider = BuildServiceProvider(connectionString, config);
+        var sut = new NightscoutConnectorBackgroundService(serviceProvider, logger);
+
+        // Act
+        await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
+
+        // Assert
+        Assert.DoesNotContain(logger.Exceptions, ex => ex is UriFormatException);
+    }
+
     #region Helpers
+
+    /// <summary>
+    /// Captures exceptions passed to the logger so tests can assert on how a failure surfaced.
+    /// </summary>
+    private sealed class CapturingLogger : ILogger<NightscoutConnectorBackgroundService>
+    {
+        private readonly List<Exception> _exceptions = [];
+
+        public IReadOnlyList<Exception> Exceptions
+        {
+            get { lock (_exceptions) return _exceptions.ToList(); }
+        }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (exception is null)
+                return;
+
+            lock (_exceptions)
+                _exceptions.Add(exception);
+        }
+    }
 
     /// <summary>
     /// Invokes the protected StartRealtimeListenersAsync via reflection.


### PR DESCRIPTION
## Problem

`SocketIOClient` bounds the whole connect-with-retries operation with
`new CancellationTokenSource(ReconnectionAttempts * ReconnectionDelayMax)`, evaluated in
**`int` arithmetic**. We set `ReconnectionAttempts = int.MaxValue` and `ReconnectionDelayMax = 30_000`,
whose product overflows — so `ConnectAsync` threw
`ArgumentOutOfRangeException("millisecondsDelay")` *before attempting a single connection*.

The per-tenant `catch` swallowed it as a warning, so the only visible symptom was a recurring
exception at startup. The real impact is larger: **no Nightscout tenant has ever had a realtime
listener**. All of them silently fall back to the 5-minute poll. Production confirms this — there
are zero `Started real-time listener` lines in the API logs, across 27 tenants with the connector
enabled.

Bisected against the pinned SocketIOClient 4.0.4:

| ReconnectionAttempts | ReconnectionDelayMax | product | outcome |
|---|---|---:|---|
| 10 (library default) | 5 000 | 50 000 | `ConnectionException` after 51.4s, 10 retries |
| **int.MaxValue** | **30 000** | 6.4e13 | **AOORE at 0.0s, 0 retries** ← what we shipped |
| 100 000 | 30 000 | 3.0e9 | AOORE at 0.0s |
| 50 000 | 30 000 | 1.5e9 | retries normally (fits in int) |

A second bug was masked behind the first: tenants may store a bare host with no scheme, and
`new Uri(config.Url)` throws `UriFormatException` on those — even though the sync path handles them
fine via its own `ResolveBaseUrl` normalisation.

## Changes

1. **Cap the retry budget** to `3 × 5_000` as named `internal const`s, with the overflow constraint
   documented at the declaration so it can't silently regress.
2. **Bound and parallelise the per-tenant connect.** This part matters: `ConnectAsync` blocks for the
   *whole* budget before giving up, and `ConnectorBackgroundService` awaits listener startup *before*
   the poll loop begins. Fixing only the numbers would trade an instant failure for ~23 minutes of no
   polling at all across 27 sequential tenants — worse than the bug. Each tenant now gets a 10s
   connect cap and tenants connect concurrently.
3. **Share the URL normalisation** instead of duplicating it: `ResolveBaseUrl` becomes `public static`
   and the listener path routes through it.

## Tests

Three regression tests, verified red-then-green. Against the unfixed code they fail with exactly the
production symptoms — `ArgumentOutOfRangeException (Parameter 'millisecondsDelay')` and
`UriFormatException`. The existing tests all covered skip paths (no tenants / disabled / empty URL),
never a reachable enabled URL, which is why this shipped.

Full suite green locally: 4229 API tests + 375 connector tests.

## Follow-up, not in this PR

`ReconnectionAttempts` also governs post-drop reconnects, so a socket that drops now gives up after
3 tries and stays down until the API restarts. The old `int.MaxValue` was reaching for "never give
up", which this library cannot express through these options. Restoring that intent properly means
periodically re-running listener startup — worth doing, but a separate change.
