### PR TITLE
feat(web): make the clocks obey display preferences, and add a regional format

### DIFF
--- a/src/Core/Nocturne.Core.Models/ClockFaceModels.cs
+++ b/src/Core/Nocturne.Core.Models/ClockFaceModels.cs
@@ -116,7 +116,7 @@ public class ClockElement
     public int? MinutesAhead { get; set; }
 
     /// <summary>
-    /// Time format for time element (12h or 24h)
+    /// Time format for time element: "auto" (follow the viewer's preference), "12h", or "24h"
     /// </summary>
     [JsonPropertyName("format")]
     public string? Format { get; set; }

--- a/src/Core/Nocturne.Core.Models/Configuration/UserDisplayPreferences.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/UserDisplayPreferences.cs
@@ -45,6 +45,20 @@ public class UserDisplayPreferences
     // Allowed values for the constrained string preferences (mirror the frontend literal unions).
     private static readonly HashSet<string> AllowedGlucoseUnits = new(StringComparer.Ordinal) { "mg/dl", "mmol" };
     private static readonly HashSet<string> AllowedTimeFormats = new(StringComparer.Ordinal) { "12", "24" };
+
+    /// <summary>
+    /// Regional formats offered to the user. Empty string means "follow the display language".
+    /// Each tag drives date ordering, month/weekday names and the first day of the week through
+    /// Intl on the frontend, so adding one here is all that a new region needs.
+    /// </summary>
+    private static readonly HashSet<string> AllowedRegionFormats = new(StringComparer.Ordinal)
+    {
+        "",
+        "en-US", "en-GB", "en-AU", "en-CA", "en-IE", "en-NZ", "en-ZA",
+        "de-DE", "fr-FR", "es-ES", "it-IT", "nl-NL", "pl-PL", "pt-PT", "pt-BR",
+        "sv-SE", "nb-NO", "da-DK", "fi-FI", "cs-CZ", "ru-RU", "ja-JP",
+    };
+
     private static readonly HashSet<string> AllowedColorThemes = new(StringComparer.Ordinal) { "nocturne", "trio", "aaps", "classic" };
     private static readonly HashSet<string> AllowedSidebarWidgets = new(StringComparer.Ordinal) { "graph", "halo-dial" };
     private static readonly HashSet<string> AllowedPredictionModes = new(StringComparer.Ordinal) { "cone", "lines", "main", "iob", "zt", "uam", "cob" };
@@ -61,6 +75,7 @@ public class UserDisplayPreferences
         var stringError =
             Check("glucoseUnits", GlucoseUnits, AllowedGlucoseUnits)
             ?? Check("timeFormat", TimeFormat, AllowedTimeFormats)
+            ?? Check("regionFormat", RegionFormat, AllowedRegionFormats)
             ?? Check("colorTheme", ColorTheme, AllowedColorThemes)
             ?? Check("sidebarWidget", SidebarWidget, AllowedSidebarWidgets)
             ?? Check("prediction.displayMode", Prediction?.DisplayMode, AllowedPredictionModes)
@@ -102,6 +117,7 @@ public class UserDisplayPreferences
     {
         GlucoseUnits = incoming.GlucoseUnits ?? GlucoseUnits;
         TimeFormat = incoming.TimeFormat ?? TimeFormat;
+        RegionFormat = incoming.RegionFormat ?? RegionFormat;
         ColorTheme = incoming.ColorTheme ?? ColorTheme;
         NightModeSchedule = incoming.NightModeSchedule ?? NightModeSchedule;
         DashboardTopWidgets = incoming.DashboardTopWidgets ?? DashboardTopWidgets;
@@ -137,6 +153,14 @@ public class UserDisplayPreferences
     /// <summary>Time format: "12" or "24".</summary>
     [JsonPropertyName("timeFormat")]
     public string? TimeFormat { get; set; }
+
+    /// <summary>
+    /// Regional format as a BCP-47 tag (e.g. "en-GB"), driving date ordering, month and weekday
+    /// names, and the first day of the week. Empty string follows the display language.
+    /// Separate from language so a user can read the UI in English on a European calendar.
+    /// </summary>
+    [JsonPropertyName("regionFormat")]
+    public string? RegionFormat { get; set; }
 
     /// <summary>Color theme: "nocturne", "trio", "aaps", or "classic".</summary>
     [JsonPropertyName("colorTheme")]

--- a/src/Web/packages/app/src/lib/clock-builder/factories.ts
+++ b/src/Web/packages/app/src/lib/clock-builder/factories.ts
@@ -7,6 +7,7 @@
 
 import { randomUUID } from "$lib/utils";
 import type { ClockElement, ClockFaceConfig } from "$lib/api";
+import { DEFAULT_CLOCK_TIME_FORMAT } from "$lib/components/clock/clock-time";
 import {
   ELEMENT_INFO,
   DEFAULT_SETTINGS,
@@ -32,7 +33,7 @@ export function createDefaultElement(type: ClockElementType): ClockElement {
     },
   };
   if (info.hasHoursOption) element.hours = 3;
-  if (info.hasFormatOption) element.format = "12h";
+  if (info.hasFormatOption) element.format = DEFAULT_CLOCK_TIME_FORMAT;
   if (info.hasMinutesAheadOption) element.minutesAhead = 30;
   if (type === "tracker") {
     element.show = ["name", "remaining"];

--- a/src/Web/packages/app/src/lib/clock-builder/utils.ts
+++ b/src/Web/packages/app/src/lib/clock-builder/utils.ts
@@ -8,6 +8,8 @@
 import type { ClockElement, TrackerDefinitionDto } from "$lib/api";
 import { ELEMENT_INFO, type ClockElementType, type InternalElement } from "./types";
 import { browser } from "$app/environment";
+import { formatClockTime } from "$lib/components/clock/clock-time";
+import { bg, bgDelta as formatBgDelta, bgLabel } from "$lib/utils/formatting";
 
 /**
  * Resolve CSS variable to its computed value
@@ -158,18 +160,6 @@ export function buildStyleString(element: ClockElement, currentBG: number): stri
 }
 
 /**
- * Format time based on 12h/24h preference
- */
-export function formatTime(format: string | undefined, currentTime: Date): string {
-  const is24h = format === "24h";
-  return currentTime.toLocaleTimeString([], {
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: !is24h,
-  });
-}
-
-/**
  * Check if element is a text-based element (uses unified text rendering)
  */
 export function isTextElement(type: string): boolean {
@@ -232,6 +222,10 @@ export function isCategoryChecked(
 
 /**
  * Render element value (for text-based elements, not arrow/tracker)
+ *
+ * @param currentBG Sample glucose in mg/dL; converted here to the user's units so the
+ *   builder preview matches what the saved face will actually show.
+ * @param bgDelta Sample delta in mg/dL.
  */
 export function renderElementValue(
   element: ClockElement,
@@ -241,15 +235,17 @@ export function renderElementValue(
 ): string {
   switch (element.type) {
     case "sg":
-      return currentBG.toString();
+      return String(bg(currentBG));
     case "delta":
-      return `${bgDelta > 0 ? "+" : ""}${bgDelta}${element.showUnits !== false ? " mg/dL" : ""}`;
+      return element.showUnits !== false
+        ? `${formatBgDelta(bgDelta)} ${bgLabel()}`
+        : formatBgDelta(bgDelta);
     case "arrow":
       return ""; // Handled separately with Lucide icon
     case "age":
       return "3m ago";
     case "time":
-      return formatTime(element.format, currentTime);
+      return formatClockTime(currentTime, element.format);
     case "iob":
       return "--U";
     case "cob":
@@ -257,7 +253,7 @@ export function renderElementValue(
     case "basal":
       return "0.8U/h";
     case "forecast":
-      return `${currentBG + 10}`;
+      return String(bg(currentBG + 10));
     case "summary":
       return "92% in range";
     case "tracker":

--- a/src/Web/packages/app/src/lib/components/alerts/GlucoseCalendarPicker.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/GlucoseCalendarPicker.svelte
@@ -22,6 +22,7 @@
   import { Button } from "$lib/components/ui/button";
   import { getPunchCardData } from "$api/generated/statistics.generated.remote";
   import GlucosePickerCell from "$lib/components/alerts/GlucosePickerCell.svelte";
+  import { formatLocale } from "$lib/utils/formatting";
 
   interface Props {
     /** Currently-selected date, or undefined for the "Last 24 hours" sentinel. */
@@ -31,13 +32,15 @@
     /** Disables days strictly later than this (typically `today()`). */
     maxValue?: DateValue;
     /**
-     * Locale tag used for week-start and weekday labels. Defaults to en-US
-     * (Sunday-first).
+     * Locale tag used for week-start and weekday labels. Defaults to the user's
+     * regional format, so a European format gives Monday-first weeks.
      */
     locale?: string;
   }
 
-  let { value, onValueChange, maxValue, locale = "en-US" }: Props = $props();
+  let { value, onValueChange, maxValue, locale: localeProp }: Props = $props();
+
+  const locale = $derived(localeProp ?? formatLocale());
 
   const tz = getLocalTimeZone();
   const todayValue = today(tz);

--- a/src/Web/packages/app/src/lib/components/alerts/GlucosePickerCell.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/GlucosePickerCell.svelte
@@ -3,6 +3,7 @@
   import { getLocalTimeZone } from "@internationalized/date";
   import { cn } from "$lib/utils";
   import GlucoseSparkline from "$lib/components/calendar/GlucoseSparkline.svelte";
+  import { formatLocale } from "$lib/utils/formatting";
 
   interface Props {
     date: DateValue;
@@ -31,9 +32,11 @@
     inRange = false,
     isStart = false,
     isEnd = false,
-    locale = "en-US",
+    locale: localeProp,
     onclick,
   }: Props = $props();
+
+  const locale = $derived(localeProp ?? formatLocale());
 
   const tz = getLocalTimeZone();
 

--- a/src/Web/packages/app/src/lib/components/alerts/GlucoseRangeCalendarPicker.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/GlucoseRangeCalendarPicker.svelte
@@ -26,6 +26,7 @@
   import { Button } from "$lib/components/ui/button";
   import GlucosePickerCell from "$lib/components/alerts/GlucosePickerCell.svelte";
   import { getPunchCardData } from "$api/generated/statistics.generated.remote";
+  import { formatLocale } from "$lib/utils/formatting";
 
   interface Props {
     /** ISO start of the confirmed range, or undefined. */
@@ -36,6 +37,10 @@
     onRangeChange?: (start: string, end: string) => void;
     /** Days strictly after this value are disabled. Defaults to today. */
     maxDate?: string;
+    /**
+     * Locale tag used for week-start and weekday labels. Defaults to the user's
+     * regional format, so a European format gives Monday-first weeks.
+     */
     locale?: string;
   }
 
@@ -44,8 +49,10 @@
     endDate,
     onRangeChange,
     maxDate,
-    locale = "en-US",
+    locale: localeProp,
   }: Props = $props();
+
+  const locale = $derived(localeProp ?? formatLocale());
 
   const tz = getLocalTimeZone();
   const todayValue = today(tz);

--- a/src/Web/packages/app/src/lib/components/calendar/CalendarDayCell.svelte
+++ b/src/Web/packages/app/src/lib/components/calendar/CalendarDayCell.svelte
@@ -8,7 +8,7 @@
   import TrackerPopoverContent from "$lib/components/calendar/TrackerPopoverContent.svelte";
   import { TrackerCategory } from "$api";
   import type { TrackerInstanceDto, TrackerDefinitionDto } from "$api";
-  import { formatGlucoseValue } from "$lib/utils/formatting";
+  import { formatGlucoseValue, formatLocale } from "$lib/utils/formatting";
   import type { GlucoseUnits } from "$lib/utils/formatting";
   import { formatCalendarDate, getCalendarDayNumber } from "$lib/components/calendar/calendar-date";
 
@@ -163,7 +163,7 @@
       >
         <div class="space-y-1.5">
           <div class="font-medium text-sm">
-            {formatCalendarDate(day.date, undefined, {
+            {formatCalendarDate(day.date, formatLocale(), {
               weekday: "long",
               month: "short",
               day: "numeric",

--- a/src/Web/packages/app/src/lib/components/calendar/calendar-date.test.ts
+++ b/src/Web/packages/app/src/lib/components/calendar/calendar-date.test.ts
@@ -5,6 +5,7 @@ import {
   getCalendarDayNumber,
   leadingBlankDays,
   weekdayLabels,
+  weekStartName,
 } from "./calendar-date";
 
 describe("calendar date helpers", () => {
@@ -44,6 +45,31 @@ describe("calendar date helpers", () => {
     expect(weekdayLabels("en-US")[0]).toBe("Sun");
     expect(weekdayLabels("en-GB")[0]).toBe("Mon");
     expect(weekdayLabels("en-GB")[6]).toBe("Sun");
+  });
+
+  it("clips weekday labels for locales whose short form is the full word", () => {
+    // pt-PT's abbreviated weekday names are "domingo", "segunda", ... — unclipped
+    // they would blow out a fixed seven-column header.
+    expect(weekdayLabels("pt-PT", "short")[0]).toBe("domingo");
+    expect(weekdayLabels("pt-PT", "short", 3)).toEqual([
+      "dom",
+      "seg",
+      "ter",
+      "qua",
+      "qui",
+      "sex",
+      "sáb",
+    ]);
+    // English already abbreviates to three, so clipping leaves it untouched.
+    expect(weekdayLabels("en-US", "short", 3)[0]).toBe("Sun");
+  });
+
+  it("names the week start in the reader's language, not the region's", () => {
+    expect(weekStartName("de-DE", "en")).toBe("Monday");
+    expect(weekStartName("de-DE", "de")).toBe("Montag");
+    // Portugal writes day-before-month yet still starts weeks on Sunday.
+    expect(weekStartName("pt-PT", "en")).toBe("Sunday");
+    expect(weekStartName("en-US", "en")).toBe("Sunday");
   });
 
   it("offsets the first of the month by the locale's week start", () => {

--- a/src/Web/packages/app/src/lib/components/calendar/calendar-date.test.ts
+++ b/src/Web/packages/app/src/lib/components/calendar/calendar-date.test.ts
@@ -1,5 +1,11 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { formatCalendarDate, getCalendarDayNumber } from "./calendar-date";
+import {
+  firstDayOfWeek,
+  formatCalendarDate,
+  getCalendarDayNumber,
+  leadingBlankDays,
+  weekdayLabels,
+} from "./calendar-date";
 
 describe("calendar date helpers", () => {
   const originalTimezone = process.env.TZ;
@@ -25,5 +31,27 @@ describe("calendar date helpers", () => {
     expect(formatCalendarDate("2026-06-14", "en-US", { weekday: "long" })).toBe(
       "Sunday"
     );
+  });
+
+  it("starts the week on Sunday for US formats and Monday for European ones", () => {
+    expect(firstDayOfWeek("en-US")).toBe(0);
+    expect(firstDayOfWeek("en-GB")).toBe(1);
+    expect(firstDayOfWeek("de-DE")).toBe(1);
+    expect(firstDayOfWeek("sv-SE")).toBe(1);
+  });
+
+  it("orders weekday labels from the locale's first day of the week", () => {
+    expect(weekdayLabels("en-US")[0]).toBe("Sun");
+    expect(weekdayLabels("en-GB")[0]).toBe("Mon");
+    expect(weekdayLabels("en-GB")[6]).toBe("Sun");
+  });
+
+  it("offsets the first of the month by the locale's week start", () => {
+    // 1 June 2026 is a Monday.
+    expect(leadingBlankDays(2026, 5, "en-US")).toBe(1);
+    expect(leadingBlankDays(2026, 5, "en-GB")).toBe(0);
+    // 1 November 2026 is a Sunday.
+    expect(leadingBlankDays(2026, 10, "en-US")).toBe(0);
+    expect(leadingBlankDays(2026, 10, "en-GB")).toBe(6);
   });
 });

--- a/src/Web/packages/app/src/lib/components/calendar/calendar-date.ts
+++ b/src/Web/packages/app/src/lib/components/calendar/calendar-date.ts
@@ -22,8 +22,13 @@ export function formatCalendarDate(
   return parseCalendarDate(date).toLocaleDateString(locales, options);
 }
 
-/** 2026-01-04 is a Sunday — the anchor both helpers below walk a week from. */
+/** 2026-01-04 is a Sunday — the anchor the helpers below walk a week from. */
 const A_SUNDAY = new CalendarDate(2026, 1, 4);
+
+/** `offset` days after the anchor Sunday, as a plain Date for Intl formatting. */
+function daysAfterAnchorSunday(offset: number): Date {
+  return new Date(2026, 0, 4 + offset);
+}
 
 /**
  * The day a week starts on for a locale, as a JS day number (0 = Sunday).
@@ -34,15 +39,34 @@ export function firstDayOfWeek(locale: string): number {
   return startOfWeek(A_SUNDAY, locale).toDate(getLocalTimeZone()).getDay();
 }
 
-/** Weekday names for a locale, ordered from its first day of the week. */
+/**
+ * Weekday names for a locale, ordered from its first day of the week.
+ *
+ * `maxLength` clips each name. Some locales have no genuinely abbreviated
+ * weekday form — pt-PT's "short" names are the full words ("domingo") — which
+ * would blow out a fixed seven-column header. Omit it where width is free.
+ */
 export function weekdayLabels(
   locale: string,
-  weekday: Intl.DateTimeFormatOptions["weekday"] = "short"
+  weekday: Intl.DateTimeFormatOptions["weekday"] = "short",
+  maxLength?: number
 ): string[] {
   const start = firstDayOfWeek(locale);
   const format = new Intl.DateTimeFormat(locale, { weekday });
-  return Array.from({ length: 7 }, (_, i) =>
-    format.format(new Date(2026, 0, 4 + start + i))
+  return Array.from({ length: 7 }, (_, i) => {
+    const label = format.format(daysAfterAnchorSunday(start + i));
+    return maxLength === undefined ? label : label.slice(0, maxLength);
+  });
+}
+
+/**
+ * Name of the day `locale`'s weeks start on, spelled in `nameLocale`. The two differ
+ * where a setting describes one region to a reader of another language — "Germany …
+ * weeks start Monday" rather than "… Montag".
+ */
+export function weekStartName(locale: string, nameLocale: string): string {
+  return new Intl.DateTimeFormat(nameLocale, { weekday: "long" }).format(
+    daysAfterAnchorSunday(firstDayOfWeek(locale))
   );
 }
 

--- a/src/Web/packages/app/src/lib/components/calendar/calendar-date.ts
+++ b/src/Web/packages/app/src/lib/components/calendar/calendar-date.ts
@@ -1,3 +1,9 @@
+import {
+  CalendarDate,
+  getLocalTimeZone,
+  startOfWeek,
+} from "@internationalized/date";
+
 export function parseCalendarDate(date: string): Date {
   const [year, month, day] = date.split("-").map(Number);
 
@@ -14,4 +20,41 @@ export function formatCalendarDate(
   options: Intl.DateTimeFormatOptions
 ): string {
   return parseCalendarDate(date).toLocaleDateString(locales, options);
+}
+
+/** 2026-01-04 is a Sunday — the anchor both helpers below walk a week from. */
+const A_SUNDAY = new CalendarDate(2026, 1, 4);
+
+/**
+ * The day a week starts on for a locale, as a JS day number (0 = Sunday).
+ * Read from the same table the date pickers use, so the month grid and the
+ * pickers can never disagree about where a week begins.
+ */
+export function firstDayOfWeek(locale: string): number {
+  return startOfWeek(A_SUNDAY, locale).toDate(getLocalTimeZone()).getDay();
+}
+
+/** Weekday names for a locale, ordered from its first day of the week. */
+export function weekdayLabels(
+  locale: string,
+  weekday: Intl.DateTimeFormatOptions["weekday"] = "short"
+): string[] {
+  const start = firstDayOfWeek(locale);
+  const format = new Intl.DateTimeFormat(locale, { weekday });
+  return Array.from({ length: 7 }, (_, i) =>
+    format.format(new Date(2026, 0, 4 + start + i))
+  );
+}
+
+/**
+ * How many blank cells precede the 1st of a month in a grid whose columns start
+ * at the locale's first day of the week.
+ */
+export function leadingBlankDays(
+  year: number,
+  month: number,
+  locale: string
+): number {
+  const firstOfMonth = new Date(year, month, 1).getDay();
+  return (firstOfMonth - firstDayOfWeek(locale) + 7) % 7;
 }

--- a/src/Web/packages/app/src/lib/components/clock-builder/ElementInspector.svelte
+++ b/src/Web/packages/app/src/lib/components/clock-builder/ElementInspector.svelte
@@ -23,6 +23,13 @@
     getTrackerName,
   } from "$lib/clock-builder";
   import TextStyleControls from "./TextStyleControls.svelte";
+  import { DEFAULT_CLOCK_TIME_FORMAT } from "$lib/components/clock/clock-time";
+
+  const FORMAT_LABELS: Record<string, string> = {
+    auto: "Match my preference",
+    "12h": "12-hour",
+    "24h": "24-hour",
+  };
 
   interface Props {
     element: InternalElement;
@@ -126,13 +133,15 @@
         <Label>Format</Label>
         <Select.Root
           type="single"
-          value={element.format || "12h"}
+          value={element.format || DEFAULT_CLOCK_TIME_FORMAT}
           onValueChange={(v) => onUpdateElement({ format: v })}
         >
           <Select.Trigger>
-            {element.format === "24h" ? "24h" : "12h"}
+            {FORMAT_LABELS[element.format ?? ""] ??
+              FORMAT_LABELS[DEFAULT_CLOCK_TIME_FORMAT]}
           </Select.Trigger>
           <Select.Content>
+            <Select.Item value="auto">Match my preference</Select.Item>
             <Select.Item value="12h">12-hour</Select.Item>
             <Select.Item value="24h">24-hour</Select.Item>
           </Select.Content>

--- a/src/Web/packages/app/src/lib/components/clock/ClockFaceRenderer.svelte
+++ b/src/Web/packages/app/src/lib/components/clock/ClockFaceRenderer.svelte
@@ -9,6 +9,7 @@
   } from "$lib/utils/formatting";
   import { isUnwiredElementType } from "$lib/clock-builder/types";
   import { renderClockElementValue } from "$lib/components/clock/element-value";
+  import { formatClockTime } from "$lib/components/clock/clock-time";
   import { ArrowUp } from "lucide-svelte";
   import { createChartDataEngine } from "$lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte";
   import GlucoseChartShell from "$lib/components/dashboard/glucose-chart/GlucoseChartShell.svelte";
@@ -103,16 +104,6 @@
   const timeSince = $derived(
     readingAgeLabel(lastUpdated, currentTime.getTime())
   );
-
-  // Format time based on 12h/24h preference
-  function formatTime(format: string | undefined): string {
-    const is24h = format === "24h";
-    return currentTime.toLocaleTimeString([], {
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: !is24h,
-    });
-  }
 
   // Resolve CSS variable to its computed value
   function resolveCssVar(name: string): string {
@@ -227,7 +218,7 @@
       displayDelta,
       unitLabel: bgLabel(),
       age: timeSince,
-      time: formatTime(element.format),
+      time: formatClockTime(currentTime, element.format),
     });
   }
 

--- a/src/Web/packages/app/src/lib/components/clock/clock-time.test.ts
+++ b/src/Web/packages/app/src/lib/components/clock/clock-time.test.ts
@@ -1,0 +1,70 @@
+/**
+ * The clock surfaces used to each resolve 12h/24h their own way — one hardcoded
+ * 12-hour, one reading only the element's format. These cover the shared rule.
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { TimeFormat } from "$lib/stores/appearance-store.svelte";
+
+// formatting.ts pulls in appearance-store, which pulls in mode-watcher (no node
+// export). Stub the chain, same as formatting.test.ts.
+vi.mock("$app/environment", () => ({ browser: false }));
+vi.mock("mode-watcher", () => ({}));
+vi.mock("runed", () => ({
+  PersistedState: class {
+    current: unknown;
+    constructor(v: unknown) {
+      this.current = v;
+    }
+  },
+}));
+vi.mock("$lib/stores/appearance-store.svelte", () => ({
+  glucoseUnits: { current: "mg/dl" },
+  timeFormat: { current: "12" },
+  regionFormat: { current: "" },
+  preferredLanguage: { current: "en" },
+}));
+
+const { formatClockTime, DEFAULT_CLOCK_TIME_FORMAT } = await import("./clock-time");
+const store = await import("$lib/stores/appearance-store.svelte");
+
+describe("formatClockTime", () => {
+  const afternoon = new Date(2026, 11, 31, 14, 5);
+
+  function withTimeFormat(value: TimeFormat, run: () => void) {
+    const previous = store.timeFormat.current;
+    store.timeFormat.current = value;
+    try {
+      run();
+    } finally {
+      store.timeFormat.current = previous;
+    }
+  }
+
+  it("defaults new elements to following the preference", () => {
+    expect(DEFAULT_CLOCK_TIME_FORMAT).toBe("auto");
+  });
+
+  it("follows the time-format preference when set to auto", () => {
+    withTimeFormat("24", () =>
+      expect(formatClockTime(afternoon, "auto")).toBe("14:05"),
+    );
+    withTimeFormat("12", () =>
+      expect(formatClockTime(afternoon, "auto")).toMatch(/^02:05\s?[Pp]/),
+    );
+  });
+
+  it("follows the preference for a face saved before auto existed", () => {
+    withTimeFormat("24", () =>
+      expect(formatClockTime(afternoon, undefined)).toBe("14:05"),
+    );
+  });
+
+  it("honours an explicit pin regardless of the preference", () => {
+    withTimeFormat("24", () =>
+      expect(formatClockTime(afternoon, "12h")).toMatch(/^02:05\s?[Pp]/),
+    );
+    withTimeFormat("12", () =>
+      expect(formatClockTime(afternoon, "24h")).toBe("14:05"),
+    );
+  });
+});

--- a/src/Web/packages/app/src/lib/components/clock/clock-time.ts
+++ b/src/Web/packages/app/src/lib/components/clock/clock-time.ts
@@ -1,0 +1,41 @@
+/**
+ * Time rendering for clock faces — the single place the 12h/24h decision is made
+ * for the builder preview, the live renderer and the public clock link, so a face
+ * reads the same on all three.
+ */
+
+import { formatLocale, prefersHour12 } from "$lib/utils/formatting";
+
+/**
+ * A time element's format. "auto" follows the viewer's time-format preference;
+ * "12h"/"24h" pin the element to one format regardless of it.
+ */
+export type ClockTimeFormat = "auto" | "12h" | "24h";
+
+/** Default for a newly added time element, and for a face saved before "auto" existed. */
+export const DEFAULT_CLOCK_TIME_FORMAT: ClockTimeFormat = "auto";
+
+/**
+ * Resolve a stored `format` value to the 12-hour flag to render with.
+ * Anything other than an explicit "12h"/"24h" pin defers to the preference.
+ */
+function hour12For(format: string | undefined | null): boolean {
+  if (format === "12h") return true;
+  if (format === "24h") return false;
+  return prefersHour12();
+}
+
+/**
+ * Render the time for a clock element. Zero-padded hours because a clock face is
+ * read at a glance from across a room and a jumping digit is harder to track.
+ */
+export function formatClockTime(
+  date: Date,
+  format: string | undefined | null
+): string {
+  return date.toLocaleTimeString(formatLocale(), {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: hour12For(format),
+  });
+}

--- a/src/Web/packages/app/src/lib/components/clock/element-value.ts
+++ b/src/Web/packages/app/src/lib/components/clock/element-value.ts
@@ -18,7 +18,7 @@ export interface ClockElementValueContext {
   unitLabel: string;
   /** Compact age of the last reading, e.g. "now" or "7m". */
   age: string;
-  /** Current time formatted per the element's 12h/24h setting. */
+  /** Current time, already formatted per the element's format and the viewer's locale. */
   time: string;
 }
 

--- a/src/Web/packages/app/src/lib/components/dashboard/CurrentBGDisplay.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/CurrentBGDisplay.svelte
@@ -103,9 +103,14 @@
     () => `Last reading: ${formatTimeSinceLastReading()}`
   );
 
-  // Format current time in local timezone
+  // Format current time in local timezone. Renders beside the profile-timezone
+  // clock below, so both must resolve the format the same way.
   const formattedLocalTime = $derived(
-    currentTime.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+    currentTime.toLocaleTimeString(formatLocale(), {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: prefersHour12(),
+    })
   );
 
   // Format time in profile timezone if provided and different

--- a/src/Web/packages/app/src/lib/components/dashboard/CurrentBGDisplay.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/CurrentBGDisplay.svelte
@@ -20,7 +20,9 @@
   import {
     formatGlucoseValue,
     formatGlucoseDelta,
+    formatLocale,
     minutesAgo,
+    prefersHour12,
   } from "$lib/utils/formatting";
   import { Clock } from "lucide-svelte";
 
@@ -114,9 +116,10 @@
       const localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
       if (localTz === profileTimezone) return null;
 
-      const profileTime = currentTime.toLocaleTimeString([], {
+      const profileTime = currentTime.toLocaleTimeString(formatLocale(), {
         hour: "2-digit",
         minute: "2-digit",
+        hour12: prefersHour12(),
         timeZone: profileTimezone,
       });
 

--- a/src/Web/packages/app/src/lib/components/dashboard/widgets/ClockWidget.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/widgets/ClockWidget.svelte
@@ -1,39 +1,12 @@
 <script lang="ts">
   import WidgetCard from "./WidgetCard.svelte";
   import { getRealtimeStore } from "$lib/stores/realtime-store.svelte";
-  import { timeFormat } from "$lib/stores/appearance-store.svelte";
+  import { time, formatWeekdayDate } from "$lib/utils/formatting";
 
   const realtimeStore = getRealtimeStore();
 
-  // Current time formatted based on user preference
-  const currentTime = $derived.by(() => {
-    const date = new Date(realtimeStore.now);
-    const format = timeFormat.current;
-
-    if (format === "24") {
-      return date.toLocaleTimeString(undefined, {
-        hour: "2-digit",
-        minute: "2-digit",
-        hour12: false,
-      });
-    }
-
-    return date.toLocaleTimeString(undefined, {
-      hour: "numeric",
-      minute: "2-digit",
-      hour12: true,
-    });
-  });
-
-  // Current date
-  const currentDate = $derived.by(() => {
-    const date = new Date(realtimeStore.now);
-    return date.toLocaleDateString(undefined, {
-      weekday: "short",
-      month: "short",
-      day: "numeric",
-    });
-  });
+  const currentTime = $derived(time(realtimeStore.now));
+  const currentDate = $derived(formatWeekdayDate(realtimeStore.now));
 
   // Seconds for optional display
   const seconds = $derived.by(() => {

--- a/src/Web/packages/app/src/lib/components/layout/ReportsFilterSidebar.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/ReportsFilterSidebar.svelte
@@ -127,7 +127,7 @@
     if (draftCalendarValue?.start && draftCalendarValue?.end) {
       const start = draftCalendarValue.start.toDate(getLocalTimeZone());
       const end = draftCalendarValue.end.toDate(getLocalTimeZone());
-      return `${start.toLocaleDateString()} - ${end.toLocaleDateString()}`;
+      return `${start.toLocaleDateString(formatLocale())} - ${end.toLocaleDateString(formatLocale())}`;
     }
     return "Select dates";
   });

--- a/src/Web/packages/app/src/lib/components/layout/ReportsFilterSidebar.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/ReportsFilterSidebar.svelte
@@ -9,6 +9,7 @@
   import { requireDateParamsContext } from "$lib/hooks/date-params.svelte";
   import { RangeCalendar } from "$lib/components/ui/range-calendar";
   import { dayCount } from "$lib/utils/date-range";
+  import { formatLocale } from "$lib/utils/formatting";
   import { Calendar, Filter, RotateCcw } from "lucide-svelte";
 
   interface Props {
@@ -180,6 +181,7 @@
             <RangeCalendar
               bind:value={draftCalendarValue}
               captionLayout="dropdown"
+              locale={formatLocale()}
               onValueChange={handleCalendarChange}
               class="p-0"
             />

--- a/src/Web/packages/app/src/lib/components/trackers/TrackerStartDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/trackers/TrackerStartDialog.svelte
@@ -6,6 +6,7 @@
   import { TextareaAutosize } from "$lib/components/ui/textarea";
   import { Play } from "lucide-svelte";
   import { cn } from "$lib/utils";
+  import { formatShortDate, time } from "$lib/utils/formatting";
 
   import { tick } from "svelte";
   import {
@@ -107,22 +108,14 @@
     const yesterday = new Date(now);
     yesterday.setDate(yesterday.getDate() - 1);
 
-    const timeStr = d.toLocaleTimeString("en-US", {
-      hour: "numeric",
-      minute: "2-digit",
-      hour12: true,
-    });
+    const timeStr = time(d);
 
     if (isSameDay(d, now)) {
       return `today at ${timeStr}`;
     } else if (isSameDay(d, yesterday)) {
       return `yesterday at ${timeStr}`;
     } else {
-      const dateStr = d.toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-      });
-      return `on ${dateStr} at ${timeStr}`;
+      return `on ${formatShortDate(d)} at ${timeStr}`;
     }
   }
 

--- a/src/Web/packages/app/src/lib/components/ui/date-range-picker.svelte
+++ b/src/Web/packages/app/src/lib/components/ui/date-range-picker.svelte
@@ -170,7 +170,7 @@
           class="w-56 justify-between font-normal"
         >
           {value?.start && value?.end
-            ? `${value.start.toDate(getLocalTimeZone()).toLocaleDateString()} - ${value.end.toDate(getLocalTimeZone()).toLocaleDateString()}`
+            ? `${value.start.toDate(getLocalTimeZone()).toLocaleDateString(formatLocale())} - ${value.end.toDate(getLocalTimeZone()).toLocaleDateString(formatLocale())}`
             : "Select date"}
           <ChevronDownIcon />
         </Button>

--- a/src/Web/packages/app/src/lib/components/ui/date-range-picker.svelte
+++ b/src/Web/packages/app/src/lib/components/ui/date-range-picker.svelte
@@ -5,6 +5,7 @@
   import { queryParam } from "sveltekit-search-params";
 
   import { RangeCalendar } from "$lib/components/ui/range-calendar";
+  import { formatLocale } from "$lib/utils/formatting";
   import * as Popover from "$lib/components/ui/popover/index.js";
   import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
 
@@ -179,6 +180,7 @@
       <RangeCalendar
         bind:value
         captionLayout="dropdown"
+        locale={formatLocale()}
         onValueChange={handleCalendarChange}
       />
     </Popover.Content>

--- a/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
@@ -45,6 +45,24 @@ export type GlucoseUnits = "mg/dl" | "mmol";
 /** Time format preference */
 export type TimeFormat = "12" | "24";
 
+/**
+ * Regional format: a BCP-47 tag driving date ordering, month/weekday names and the
+ * first day of the week. Empty string follows the display language.
+ */
+export type RegionFormat = (typeof REGION_FORMATS)[number];
+
+/**
+ * Regional formats offered in settings, mirroring the backend allow-list. Labels are
+ * derived at render time from `Intl.DisplayNames` plus a sample date, so a new region
+ * only needs its tag added here (and to `AllowedRegionFormats` server-side).
+ */
+export const REGION_FORMATS = [
+  "",
+  "en-US", "en-GB", "en-AU", "en-CA", "en-IE", "en-NZ", "en-ZA",
+  "de-DE", "fr-FR", "es-ES", "it-IT", "nl-NL", "pl-PL", "pt-PT", "pt-BR",
+  "sv-SE", "nb-NO", "da-DK", "fi-FI", "cs-CZ", "ru-RU", "ja-JP",
+] as const;
+
 /** Sidebar widget preference */
 export type SidebarWidget = "graph" | "halo-dial";
 
@@ -166,6 +184,14 @@ export const glucoseUnits = new SyncedPref<GlucoseUnits>("nocturne-glucose-units
  * Time format preference (12-hour or 24-hour)
  */
 export const timeFormat = new SyncedPref<TimeFormat>("nocturne-time-format", "12");
+
+/**
+ * Regional format preference. Empty (the default) means "follow the display language",
+ * which is what a user who never opens this setting gets. Set it to e.g. "en-GB" or
+ * "de-DE" for European date ordering and Monday-first calendars while keeping the
+ * interface in another language.
+ */
+export const regionFormat = new SyncedPref<RegionFormat>("nocturne-region-format", "");
 
 /**
  * Night mode schedule toggle
@@ -440,6 +466,7 @@ export function collectPreferences(): UserDisplayPreferences {
   return {
     glucoseUnits: glucoseUnits.current,
     timeFormat: timeFormat.current,
+    regionFormat: regionFormat.current,
     colorTheme: colorTheme.current,
     nightModeSchedule: nightModeSchedule.current,
     dashboardTopWidgets: dashboardTopWidgets.current,
@@ -476,6 +503,7 @@ export function applyPreferences(
 
   hydrateIfPresent(glucoseUnits, prefs.glucoseUnits as GlucoseUnits | undefined);
   hydrateIfPresent(timeFormat, prefs.timeFormat as TimeFormat | undefined);
+  hydrateIfPresent(regionFormat, prefs.regionFormat as RegionFormat | undefined);
   hydrateIfPresent(colorTheme, prefs.colorTheme as ColorTheme | undefined);
   hydrateIfPresent(nightModeSchedule, prefs.nightModeSchedule ?? undefined);
   hydrateIfPresent(dashboardTopWidgets, prefs.dashboardTopWidgets ?? undefined);
@@ -651,6 +679,29 @@ export function getLanguageLabel(
   } catch {
     return code;
   }
+}
+
+/** A date whose day, month and year are all unambiguous, so a sample shows the real ordering. */
+const REGION_SAMPLE_DATE = new Date(2026, 11, 31);
+
+/**
+ * Label for a regional format: the region's name in the user's own language, plus the
+ * date it produces. The sample is what makes the choice legible — nobody picks a
+ * calendar style by its BCP-47 tag.
+ */
+export function regionFormatLabel(tag: RegionFormat): string {
+  if (!tag) return "Match my language";
+  const region = tag.split("-")[1];
+  let name: string = tag;
+  try {
+    name =
+      new Intl.DisplayNames([preferredLanguage.current], { type: "region" }).of(
+        region
+      ) ?? tag;
+  } catch {
+    // Unknown region subtag: the tag itself is still a usable label.
+  }
+  return `${name} — ${REGION_SAMPLE_DATE.toLocaleDateString(tag)}`;
 }
 
 /**

--- a/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
@@ -28,6 +28,7 @@ import supportedLocales from "../../../../../supportedLocales.json";
 import { WidgetId } from "../api/generated/nocturne-api-client";
 import type { UserDisplayPreferences } from "$lib/api";
 import { type HaloDialConfig, defaultHaloDialConfig } from "../components/dashboard/halo-dial/config";
+import { weekStartName } from "../components/calendar/calendar-date";
 
 // ==========================================
 // Type Definitions
@@ -685,12 +686,14 @@ export function getLanguageLabel(
 const REGION_SAMPLE_DATE = new Date(2026, 11, 31);
 
 /**
- * Label for a regional format: the region's name in the user's own language, plus the
- * date it produces. The sample is what makes the choice legible — nobody picks a
- * calendar style by its BCP-47 tag.
+ * Label for a regional format: the region's name in the user's own language, then the
+ * date it produces and the day its weeks start on. Both samples are spelled out because
+ * neither is guessable from a country name — Portugal writes 31/12/2026 but still starts
+ * its weeks on Sunday — and nobody picks a calendar style by its BCP-47 tag.
  */
 export function regionFormatLabel(tag: RegionFormat): string {
   if (!tag) return "Match my language";
+
   const region = tag.split("-")[1];
   let name: string = tag;
   try {
@@ -701,7 +704,10 @@ export function regionFormatLabel(tag: RegionFormat): string {
   } catch {
     // Unknown region subtag: the tag itself is still a usable label.
   }
-  return `${name} — ${REGION_SAMPLE_DATE.toLocaleDateString(tag)}`;
+
+  const sample = REGION_SAMPLE_DATE.toLocaleDateString(tag);
+  const weekStart = weekStartName(tag, preferredLanguage.current);
+  return `${name} — ${sample}, weeks start ${weekStart}`;
 }
 
 /**

--- a/src/Web/packages/app/src/lib/utils/formatting.test.ts
+++ b/src/Web/packages/app/src/lib/utils/formatting.test.ts
@@ -7,6 +7,7 @@
  * in browser tests instead.
  */
 import { describe, it, expect, vi } from "vitest";
+import type { RegionFormat } from "$lib/stores/appearance-store.svelte";
 
 // `formatting.ts` imports from appearance-store which imports mode-watcher.
 // mode-watcher has no node export. We stub the entire chain so Vite never
@@ -19,6 +20,7 @@ vi.mock("runed", () => ({
 vi.mock("$lib/stores/appearance-store.svelte", () => ({
 	glucoseUnits: { current: "mg/dl" },
 	timeFormat: { current: "12" },
+	regionFormat: { current: "" },
 	preferredLanguage: { current: "en" },
 }));
 
@@ -30,6 +32,10 @@ const {
 	formatGlucoseDelta,
 	getUnitLabel,
 	formatGlucoseRange,
+	formatLocale,
+	prefersHour12,
+	formatShortDate,
+	formatWeekdayDate,
 	formatDateTime,
 	formatDate,
 	formatDateDetailed,
@@ -43,6 +49,10 @@ const {
 	formatEventType,
 	formatNotes,
 } = await import("./formatting");
+
+// The mocked store holds plain objects, so a test can move a preference and read
+// the effect the same way the app does.
+const store = await import("$lib/stores/appearance-store.svelte");
 
 describe("Glucose conversion", () => {
 	describe("convertToDisplayUnits", () => {
@@ -309,5 +319,52 @@ describe("Treatment formatting", () => {
 				formatNotes({ notes: "Test note", enteredBy: "admin" } as any),
 			).toBe("Test note by admin");
 		});
+	});
+});
+
+describe("Regional format", () => {
+	function withRegion(tag: RegionFormat, run: () => void) {
+		const previous = store.regionFormat.current;
+		store.regionFormat.current = tag;
+		try {
+			run();
+		} finally {
+			store.regionFormat.current = previous;
+		}
+	}
+
+	it("falls back to the display language when no region is chosen", () => {
+		expect(formatLocale()).toBe("en");
+	});
+
+	it("prefers the regional format over the display language", () => {
+		withRegion("en-GB", () => expect(formatLocale()).toBe("en-GB"));
+	});
+
+	it("writes the day before the month for a European region", () => {
+		const date = new Date(2026, 11, 31, 9, 5);
+		withRegion("en-GB", () =>
+			expect(formatShortDate(date, true)).toBe("31 Dec 2026"),
+		);
+		withRegion("en-US", () =>
+			expect(formatShortDate(date, true)).toBe("Dec 31, 2026"),
+		);
+	});
+
+	it("names the weekday in the regional format", () => {
+		const date = new Date(2026, 11, 31);
+		withRegion("de-DE", () => expect(formatWeekdayDate(date)).toContain("Do"));
+		withRegion("en-US", () => expect(formatWeekdayDate(date)).toContain("Thu"));
+	});
+});
+
+describe("prefersHour12", () => {
+	it("follows the time-format preference when not overridden", () => {
+		expect(prefersHour12()).toBe(true);
+	});
+
+	it("lets a caller pin the format", () => {
+		expect(prefersHour12(false)).toBe(false);
+		expect(prefersHour12(true)).toBe(true);
 	});
 });

--- a/src/Web/packages/app/src/lib/utils/formatting.ts
+++ b/src/Web/packages/app/src/lib/utils/formatting.ts
@@ -8,7 +8,13 @@
  * - Insulin/carb/percentage display formatting
  */
 
-import { glucoseUnits, timeFormat, preferredLanguage, type GlucoseUnits } from "$lib/stores/appearance-store.svelte";
+import {
+  glucoseUnits,
+  timeFormat,
+  regionFormat,
+  preferredLanguage,
+  type GlucoseUnits,
+} from "$lib/stores/appearance-store.svelte";
 import type { Treatment } from "$lib/api";
 
 // Re-export for backward compatibility
@@ -150,14 +156,24 @@ export function timeStringToSeconds(time: string | undefined): number {
   return h * 3600 + m * 60 + s;
 }
 
-/** The user's preferred locale for Intl formatting */
-function locale(): string {
-  return preferredLanguage.current;
+/**
+ * The locale every Intl call in the app should format with: the regional-format
+ * preference when the user has picked one, otherwise their display language.
+ *
+ * Keeping these separate is what lets someone read an English interface on a
+ * European calendar — "en-GB" gives DD/MM/YYYY and Monday-first weeks without
+ * translating the UI.
+ */
+export function formatLocale(): string {
+  return regionFormat.current || preferredLanguage.current;
 }
 
-/** Whether the user prefers 12-hour time */
-function hour12(): boolean {
-  return timeFormat.current !== "24";
+/**
+ * Whether times render in 12-hour form. `override` pins the answer for a surface
+ * that carries its own format (a clock face element), ignoring the preference.
+ */
+export function prefersHour12(override?: boolean): boolean {
+  return override ?? timeFormat.current !== "24";
 }
 
 /**
@@ -170,10 +186,10 @@ export function time(date: Date | number, compact?: boolean): string {
   const d = typeof date === "number" ? new Date(date) : date;
   const options: Intl.DateTimeFormatOptions = {
     hour: "numeric",
-    minute: compact && hour12() ? "numeric" : "2-digit",
-    hour12: hour12(),
+    minute: compact && prefersHour12() ? "numeric" : "2-digit",
+    hour12: prefersHour12(),
   };
-  return d.toLocaleTimeString(locale(), options);
+  return d.toLocaleTimeString(formatLocale(), options);
 }
 
 /**
@@ -202,13 +218,13 @@ export function lastSeen(
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   if (days < 7) return `${days}d ago`;
-  return d.toLocaleDateString(locale());
+  return d.toLocaleDateString(formatLocale());
 }
 
-/** Format elapsed time as minutes ago using the user's language preference. */
+/** Format elapsed time as minutes ago in the user's regional format. */
 export function minutesAgo(from: number, to: number = Date.now()): string {
   const minutes = Math.max(0, Math.floor((to - from) / 60000));
-  return new Intl.RelativeTimeFormat(locale(), {
+  return new Intl.RelativeTimeFormat(formatLocale(), {
     numeric: "always",
     style: "short",
   }).format(-minutes, "minute");
@@ -226,10 +242,10 @@ export function minutesAgo(from: number, to: number = Date.now()): string {
 export function formatDateTime(dateStr: string | undefined): string {
   if (!dateStr) return "—";
   const date = new Date(dateStr);
-  return date.toLocaleDateString(locale()) + " " + date.toLocaleTimeString(locale(), {
+  return date.toLocaleDateString(formatLocale()) + " " + date.toLocaleTimeString(formatLocale(), {
     hour: "numeric",
     minute: "2-digit",
-    hour12: hour12(),
+    hour12: prefersHour12(),
   });
 }
 
@@ -240,7 +256,7 @@ export function formatDateTime(dateStr: string | undefined): string {
  */
 export function formatDate(date: Date | string | undefined): string {
   if (!date) return "N/A";
-  return new Date(date).toLocaleString(locale());
+  return new Date(date).toLocaleString(formatLocale());
 }
 
 /**
@@ -251,17 +267,45 @@ export function formatDate(date: Date | string | undefined): string {
 export function formatDateDetailed(dateString: string | undefined): string {
   if (!dateString) return "Unknown";
   try {
-    return new Date(dateString).toLocaleDateString(locale(), {
+    return new Date(dateString).toLocaleDateString(formatLocale(), {
       year: "numeric",
       month: "long",
       day: "numeric",
       hour: "2-digit",
       minute: "2-digit",
-      hour12: hour12(),
+      hour12: prefersHour12(),
     });
   } catch {
     return dateString;
   }
+}
+
+/**
+ * Date with its weekday and no time, e.g. "Tue, 28 Jul" — ordering and names
+ * follow the regional format.
+ */
+export function formatWeekdayDate(date: Date | string | number): string {
+  const d = date instanceof Date ? date : new Date(date);
+  return d.toLocaleDateString(formatLocale(), {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/**
+ * Short date with no time, e.g. "28 Jul" or "28 Jul 2026" with `withYear`.
+ */
+export function formatShortDate(
+  date: Date | string | number,
+  withYear = false
+): string {
+  const d = date instanceof Date ? date : new Date(date);
+  return d.toLocaleDateString(formatLocale(), {
+    month: "short",
+    day: "numeric",
+    ...(withYear ? { year: "numeric" as const } : {}),
+  });
 }
 
 /**
@@ -288,12 +332,12 @@ export function formatDateForInput(dateStr: string | undefined): string {
 export function formatDateTimeCompact(date: Date | string | number | undefined): string {
   if (date == null) return "—";
   const d = date instanceof Date ? date : new Date(date);
-  return d.toLocaleDateString(locale(), {
+  return d.toLocaleDateString(formatLocale(), {
     month: "short",
     day: "numeric",
     hour: "2-digit",
     minute: "2-digit",
-    hour12: hour12(),
+    hour12: prefersHour12(),
   });
 }
 

--- a/src/Web/packages/app/src/routes/(authenticated)/calendar/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/calendar/+page.svelte
@@ -8,7 +8,11 @@
   import { NotificationUrgency as NotificationUrgencyEnum } from "$api";
   import { Button } from "$lib/components/ui/button";
   import { glucoseUnits } from "$lib/stores/appearance-store.svelte";
-  import { getUnitLabel } from "$lib/utils/formatting";
+  import { getUnitLabel, formatLocale } from "$lib/utils/formatting";
+  import {
+    leadingBlankDays,
+    weekdayLabels,
+  } from "$lib/components/calendar/calendar-date";
   import CalendarSkeleton from "$lib/components/calendar/CalendarSkeleton.svelte";
   import { TrackerCompletionDialog } from "$lib/components/trackers";
   import CalendarHeader from "$lib/components/calendar/CalendarHeader.svelte";
@@ -123,21 +127,13 @@
   const units = $derived(glucoseUnits.current);
   const unitLabel = $derived(getUnitLabel(units));
 
-  const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-  const MONTH_NAMES = [
-    "January",
-    "February",
-    "March",
-    "April",
-    "May",
-    "June",
-    "July",
-    "August",
-    "September",
-    "October",
-    "November",
-    "December",
-  ];
+  // Column headings and month names follow the regional format, so a European
+  // format renders Monday-first weeks with its own weekday and month names.
+  const DAY_NAMES = $derived(weekdayLabels(formatLocale()));
+  const MONTH_NAMES = $derived.by(() => {
+    const format = new Intl.DateTimeFormat(formatLocale(), { month: "long" });
+    return Array.from({ length: 12 }, (_, m) => format.format(new Date(2026, m, 1)));
+  });
 
   // Reactive loading/error states for query results
   const punchCardLoading = $derived(punchCardQuery.loading);
@@ -173,10 +169,9 @@
   });
 
   const calendarGrid = $derived.by(() => {
-    const firstDay = new Date(currentYear, currentMonth, 1);
     const lastDay = new Date(currentYear, currentMonth + 1, 0);
     const daysInMonth = lastDay.getDate();
-    const startDayOfWeek = firstDay.getDay();
+    const startDayOfWeek = leadingBlankDays(currentYear, currentMonth, formatLocale());
 
     const grid: (DayStats | null | { empty: true; dayNumber?: number })[][] =
       [];

--- a/src/Web/packages/app/src/routes/(authenticated)/calendar/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/calendar/+page.svelte
@@ -8,7 +8,7 @@
   import { NotificationUrgency as NotificationUrgencyEnum } from "$api";
   import { Button } from "$lib/components/ui/button";
   import { glucoseUnits } from "$lib/stores/appearance-store.svelte";
-  import { getUnitLabel, formatLocale } from "$lib/utils/formatting";
+  import { getUnitLabel, formatLocale, formatDate, time } from "$lib/utils/formatting";
   import {
     leadingBlankDays,
     weekdayLabels,
@@ -129,7 +129,8 @@
 
   // Column headings and month names follow the regional format, so a European
   // format renders Monday-first weeks with its own weekday and month names.
-  const DAY_NAMES = $derived(weekdayLabels(formatLocale()));
+  // 3 chars keeps the seven columns even; English already abbreviates to that.
+  const DAY_NAMES = $derived(weekdayLabels(formatLocale(), "short", 3));
   const MONTH_NAMES = $derived.by(() => {
     const format = new Intl.DateTimeFormat(formatLocale(), { month: "long" });
     return Array.from({ length: 12 }, (_, m) => format.format(new Date(2026, m, 1)));
@@ -326,10 +327,7 @@
     if (!startedAt) return null;
     const date = new Date(startedAt);
     if (Number.isNaN(date.getTime())) return null;
-    return date.toLocaleTimeString(undefined, {
-      hour: "2-digit",
-      minute: "2-digit",
-    });
+    return time(date);
   }
 
   let isCompletionDialogOpen = $state(false);
@@ -398,7 +396,7 @@
         {currentYear}
       </h1>
       <p class="text-sm text-muted-foreground">
-        Generated {new Date().toLocaleString()}
+        Generated {formatDate(new Date())}
       </p>
     </div>
 

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/+page.svelte
@@ -71,6 +71,7 @@
   import {
     formatGlucoseValue,
     formatGlucoseRange,
+    formatShortDate,
     getUnitLabel,
   } from "$lib/utils/formatting";
   import ReportsSkeleton from "$lib/components/reports/ReportsSkeleton.svelte";
@@ -193,14 +194,7 @@
             class="mb-3 inline-flex items-center gap-2 rounded-full bg-primary/5 px-4 py-1.5 text-sm font-medium text-primary"
           >
             <Calendar class="h-4 w-4" />
-            {startDate.toLocaleDateString("en-US", {
-              month: "short",
-              day: "numeric",
-            })} – {endDate.toLocaleDateString("en-US", {
-              month: "short",
-              day: "numeric",
-              year: "numeric",
-            })}
+            {formatShortDate(startDate)} – {formatShortDate(endDate, true)}
           </div>
           <h1
             class="bg-linear-to-r from-slate-900 via-slate-700 to-slate-800 bg-clip-text text-4xl font-bold tracking-tight text-transparent dark:from-white dark:via-slate-200 dark:to-slate-300 @lg:text-5xl"

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/site-change-impact/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/site-change-impact/+page.svelte
@@ -8,6 +8,7 @@
   } from "$lib/components/ui/card";
   import { Button } from "$lib/components/ui/button";
   import { Separator } from "$lib/components/ui/separator";
+  import { formatShortDate } from "$lib/utils/formatting";
   import {
     Calendar,
     Info,
@@ -46,11 +47,7 @@
 
   // Format date for display
   function formatDate(date: Date): string {
-    return date.toLocaleDateString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    });
+    return formatShortDate(date, true);
   }
 </script>
 

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
@@ -597,8 +597,9 @@
           </Select>
           <p class="text-xs text-muted-foreground">
             Sets date order, month and weekday names, and the day your calendars
-            start on. Pick a European region for day-before-month dates and weeks
-            that start on Monday. Your interface stays in the language above.
+            start on. Each option shows the date it writes and the day its weeks
+            begin, so pick whichever matches how you read a calendar. Your
+            interface stays in the language above.
           </p>
         </div>
       </CardContent>

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
@@ -22,7 +22,11 @@
     chartAreaMode,
     chartAreaOpacity,
     chartAlwaysShowPatterns,
+    regionFormat,
+    regionFormatLabel,
+    REGION_FORMATS,
     type ColorScheme,
+    type RegionFormat,
   } from "$lib/stores/appearance-store.svelte";
   import HaloDialConfigurator from "$lib/components/settings/HaloDialConfigurator.svelte";
   import { getRealtimeStore } from "$lib/stores/realtime-store.svelte";
@@ -570,6 +574,32 @@
               </SelectContent>
             </Select>
           </div>
+        </div>
+
+        <div class="space-y-2">
+          <Label>Regional format</Label>
+          <Select
+            type="single"
+            value={regionFormat.current}
+            onValueChange={(value) => {
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- value is constrained to REGION_FORMATS by the sibling SelectItems
+              regionFormat.current = value as RegionFormat;
+            }}
+          >
+            <SelectTrigger>
+              <span>{regionFormatLabel(regionFormat.current)}</span>
+            </SelectTrigger>
+            <SelectContent>
+              {#each REGION_FORMATS as region (region)}
+                <SelectItem value={region}>{regionFormatLabel(region)}</SelectItem>
+              {/each}
+            </SelectContent>
+          </Select>
+          <p class="text-xs text-muted-foreground">
+            Sets date order, month and weekday names, and the day your calendars
+            start on. Pick a European region for day-before-month dates and weeks
+            that start on Monday. Your interface stays in the language above.
+          </p>
         </div>
       </CardContent>
     </Card>

--- a/src/Web/packages/app/src/routes/(unauthenticated)/clock/[id]/+page@.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/clock/[id]/+page@.svelte
@@ -14,6 +14,7 @@
     Loader2,
   } from "lucide-svelte";
   import ClockFaceRenderer from "$lib/components/clock/ClockFaceRenderer.svelte";
+  import { formatClockTime } from "$lib/components/clock/clock-time";
   import {
     isClockReadingStale,
     readingAgeLabel,
@@ -92,14 +93,9 @@
     readingAgeLabel(lastUpdated, currentTime.getTime())
   );
 
-  // Format time based on 12h/24h preference
-  function formatTime(): string {
-    return currentTime.toLocaleTimeString([], {
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: true,
-    });
-  }
+  // The fallback readout is not a configured element, so it follows the viewer's
+  // own time-format preference rather than any format stored on the face.
+  const clockTime = $derived(formatClockTime(currentTime, "auto"));
 
   // Show time based on configuration
   const showTime = $derived(clockConfig?.settings?.alwaysShowTime || isStale);
@@ -177,7 +173,7 @@
       <div class="fixed bottom-20 left-1/2 z-20 -translate-x-1/2">
         <div class="flex items-center gap-2 text-2xl text-white/80">
           <ClockIcon class="size-6" />
-          {formatTime()}
+          {clockTime}
         </div>
       </div>
     {/if}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/UserPreferencesControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/UserPreferencesControllerTests.cs
@@ -88,6 +88,52 @@ public class UserPreferencesControllerTests
     }
 
     [Fact]
+    public async Task UpdatePreferences_persistsRegionFormat()
+    {
+        var (controller, _) = NewController();
+
+        await controller.UpdatePreferences(new UpdateUserPreferencesRequest
+        {
+            Preferences = new UserDisplayPreferences { RegionFormat = "en-GB" },
+        });
+
+        OkValue(await controller.GetPreferences()).Preferences.RegionFormat.Should().Be("en-GB");
+    }
+
+    [Fact]
+    public async Task UpdatePreferences_clearsRegionFormat_backToFollowingTheLanguage()
+    {
+        var (controller, _) = NewController();
+
+        await controller.UpdatePreferences(new UpdateUserPreferencesRequest
+        {
+            Preferences = new UserDisplayPreferences { RegionFormat = "de-DE" },
+        });
+
+        // Empty string is the "match my language" choice, and unlike null it must
+        // survive the merge — otherwise the setting could never be undone.
+        await controller.UpdatePreferences(new UpdateUserPreferencesRequest
+        {
+            Preferences = new UserDisplayPreferences { RegionFormat = "" },
+        });
+
+        OkValue(await controller.GetPreferences()).Preferences.RegionFormat.Should().Be("");
+    }
+
+    [Fact]
+    public async Task UpdatePreferences_rejectsUnknownRegionFormat()
+    {
+        var (controller, _) = NewController();
+
+        var result = await controller.UpdatePreferences(new UpdateUserPreferencesRequest
+        {
+            Preferences = new UserDisplayPreferences { RegionFormat = "en-XX" },
+        });
+
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
     public async Task GetPreferences_unauthenticated_returns401()
     {
         var (controller, _) = NewController(authenticated: false);


### PR DESCRIPTION
## The clocks didn't respect the display preferences

Four clock surfaces each resolved formatting their own way:

- The **public clock link** was hardcoded to 12-hour, ignoring both the stored face format and the viewer.
- The **clock-face renderer** and the **builder preview** read only the element's own `12h`/`24h` field — there was no way to say "follow my preference".
- The **builder preview** printed raw `mg/dL` whatever the units preference said, so the preview didn't match the face you'd get.
- The **dashboard clock widget** honoured the time format but passed no locale at all.

`lib/components/clock/clock-time.ts` is now the single place that decision is made, and a time element defaults to a new `auto` format that follows the viewer's preference.

## There was no way to get a European calendar

Dates were ordered by the display language, and every month grid started on Sunday — `/calendar` hardcoded English weekday and month names and derived its leading blanks straight from `getDay()`.

This adds a `regionFormat` preference: a BCP-47 tag, empty meaning "follow the language", carried in the existing `UserDisplayPreferences` JSONB blob (**no migration**). It drives date ordering, month and weekday names, and the first day of the week, so picking `en-GB` or `de-DE` gives day-before-month dates and Monday-first weeks while the interface stays in the chosen language.

`formatLocale()` in `lib/utils/formatting.ts` is the single accessor — the date pickers, the two `RangeCalendar` consumers and the month grid all read their week start from the same CLDR-backed table (`firstDayOfWeek` / `weekdayLabels` / `leadingBlankDays` / `weekStartName` in `lib/components/calendar/calendar-date.ts`).

Also routes the remaining hardcoded `"en-US"` and bare-`toLocaleDateString()` display formatting in reports, trackers, the calendar page and the timezone readout through the shared helpers.

## Two CLDR facts worth knowing

Both verified against Node's Intl rather than assumed:

- **"European" does not mean Monday-first.** Portugal, Canada and South Africa are Sunday-first (`new Intl.Locale("pt-PT").getWeekInfo().firstDay` → 7) even though Portugal writes `31/12/2026`. The first draft of the settings copy told users to pick a European region for Monday weeks, which would have been wrong for them. Each option now states the date it writes *and* the day its weeks begin, so the setting describes itself rather than relying on a rule with exceptions:

  ```
  Match my language
  United States — 12/31/2026, weeks start Sunday
  United Kingdom — 31/12/2026, weeks start Monday
  Germany — 31.12.2026, weeks start Monday
  Portugal — 31/12/2026, weeks start Sunday
  ```

  `weekStartName` spells that day in the reader's own language, so an English reader sees "weeks start Monday", not "Montag".

- **`weekday: "short"` isn't short in `pt-PT`** — CLDR returns the full words (`domingo`, `segunda`, …, 7 chars vs 3 for `en`), which would wrap or overflow the fixed seven-column header. `weekdayLabels` takes a `maxLength` and the grid clips to 3; English already abbreviates to that so it's unchanged.

## Known limitation

Faces saved before this store `"12h"` explicitly, so **existing time elements stay pinned to 12-hour** until re-edited — only newly created ones pick up `auto`. Converting them would need a data migration; happy to add one if wanted.

## Testing

- **614 frontend unit tests pass**, 16 of them new: clock format resolution (auto / legacy-undefined / explicit pin), region vs language locale resolution, the `weekday: "short"` clipping, week-start naming, and the grid offset math.
- **8 `UserPreferencesControllerTests` pass**, including that `""` round-trips through `MergeWith`'s null-coalescing and `hydrateIfPresent` — otherwise the setting could never be undone.
- `pnpm check` sits at the pre-existing 64-error baseline (generated client + unbuilt `@nocturne/bot`/`@nocturne/bridge`) with **none in touched files**; ESLint clean on the new modules.
- A review pass swept `leadingBlankDays`/`weekdayLabels` across all 22 offered locales × every month 2020–2035 asserting the 1st lands under its correct column — 0 mismatches — and confirmed max cells is 37 ≤ 42, so the 6-week loop can't truncate a month. It also confirmed the new `$derived` values are reactive and that nothing mutates the appearance store's shared `$state` server-side.

**Not verified:** never run in a browser, so the settings select and month grid have no visual confirmation.
