### PR TITLE
fix(web): authenticate the bot dispatch route, and address nocturne-web internally

### DIFF
--- a/src/API/Nocturne.API/Authorization/InstanceKeyDigest.cs
+++ b/src/API/Nocturne.API/Authorization/InstanceKeyDigest.cs
@@ -1,0 +1,31 @@
+using Nocturne.Connectors.Core.Utilities;
+using Nocturne.Core.Constants;
+
+namespace Nocturne.API.Authorization;
+
+/// <summary>
+/// Resolves the SHA-256 hex digest of the configured instance key.
+/// </summary>
+/// <remarks>
+/// Single source of truth for how the instance key is located in configuration and
+/// hashed, shared by <see cref="InstanceKeyValidator"/> (which checks inbound
+/// credentials) and by services that present the digest on outbound calls to other
+/// Nocturne services (see
+/// <see cref="Services.Alerts.Providers.ChatBotProvider"/>).
+/// </remarks>
+public static class InstanceKeyDigest
+{
+    /// <summary>
+    /// Returns the digest of the configured instance key, or an empty string when no
+    /// instance key is configured.
+    /// </summary>
+    public static string Resolve(IConfiguration configuration)
+    {
+        var instanceKey =
+            configuration[$"Parameters:{ServiceNames.Parameters.InstanceKey}"]
+            ?? configuration[ServiceNames.ConfigKeys.InstanceKey]
+            ?? "";
+
+        return !string.IsNullOrEmpty(instanceKey) ? HashUtils.Sha256Hex(instanceKey) : "";
+    }
+}

--- a/src/API/Nocturne.API/Authorization/InstanceKeyValidator.cs
+++ b/src/API/Nocturne.API/Authorization/InstanceKeyValidator.cs
@@ -1,4 +1,3 @@
-using Nocturne.Connectors.Core.Utilities;
 using Nocturne.Core.Constants;
 
 namespace Nocturne.API.Authorization;
@@ -48,11 +47,7 @@ public class InstanceKeyValidator : IInstanceKeyValidator
 
     public InstanceKeyValidator(IConfiguration configuration)
     {
-        var instanceKey =
-            configuration[$"Parameters:{ServiceNames.Parameters.InstanceKey}"]
-            ?? configuration[ServiceNames.ConfigKeys.InstanceKey]
-            ?? "";
-        _instanceKeyHash = !string.IsNullOrEmpty(instanceKey) ? HashUtils.Sha256Hex(instanceKey) : "";
+        _instanceKeyHash = InstanceKeyDigest.Resolve(configuration);
     }
 
     /// <inheritdoc />

--- a/src/API/Nocturne.API/Services/Alerts/Providers/ChatBotProvider.cs
+++ b/src/API/Nocturne.API/Services/Alerts/Providers/ChatBotProvider.cs
@@ -14,11 +14,14 @@ namespace Nocturne.API.Services.Alerts.Providers;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The bot endpoint is derived from <c>WEB_URL</c> when set (the internal web
-/// endpoint wired by the AppHost), otherwise from the deployment's public base
-/// URL (<see cref="ServiceNames.ConfigKeys.BaseUrl"/>) — which reaches the same
-/// SvelteKit dispatch route through the gateway. Delivery is skipped with a
-/// warning when neither is configured.
+/// The bot endpoint is derived from <c>WEB_URL</c>, which names the web app's
+/// deployment-internal address (the AppHost wires it from the web resource's
+/// endpoint; the Compose bundles set <c>http://nocturne-web:&lt;port&gt;</c>).
+/// Delivery is skipped with a warning when it is unset. The deployment's public
+/// base URL (<see cref="ServiceNames.ConfigKeys.BaseUrl"/>) is deliberately not
+/// used as a fallback: an edge proxy fronting that URL strips the instance-key
+/// service headers below, because the same <c>/api/**</c> prefix is reachable from
+/// the internet, and the dispatch would arrive unauthenticated and be rejected.
 /// </para>
 /// <para>
 /// The dispatch route is reachable from the internet through the gateway, so the
@@ -66,15 +69,13 @@ internal sealed class ChatBotProvider(
     /// <param name="ct">Cancellation token.</param>
     public async Task SendAsync(Guid deliveryId, ChannelType channelType, string destination, AlertPayload payload, CancellationToken ct)
     {
+        // Internal address only — see the remarks on this type for why the public
+        // base URL is not an acceptable substitute.
         var webUrl = configuration["WEB_URL"];
         if (string.IsNullOrEmpty(webUrl))
         {
-            webUrl = configuration[ServiceNames.ConfigKeys.BaseUrl];
-        }
-
-        if (string.IsNullOrEmpty(webUrl))
-        {
-            logger.LogWarning("Neither WEB_URL nor BaseUrl configured, cannot dispatch to chat bot");
+            logger.LogWarning(
+                "WEB_URL is not configured with the web app's internal address, cannot dispatch to chat bot");
             return;
         }
 

--- a/src/API/Nocturne.API/Services/Alerts/Providers/ChatBotProvider.cs
+++ b/src/API/Nocturne.API/Services/Alerts/Providers/ChatBotProvider.cs
@@ -1,5 +1,8 @@
 using System.Net.Http.Json;
+using System.Text.Json;
+using Nocturne.API.Authorization;
 using Nocturne.Core.Constants;
+using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Alerts;
 
@@ -10,17 +13,34 @@ namespace Nocturne.API.Services.Alerts.Providers;
 /// to the Nocturne bot service over HTTP.
 /// </summary>
 /// <remarks>
+/// <para>
 /// The bot endpoint is derived from <c>WEB_URL</c> when set (the internal web
 /// endpoint wired by the AppHost), otherwise from the deployment's public base
 /// URL (<see cref="ServiceNames.ConfigKeys.BaseUrl"/>) — which reaches the same
 /// SvelteKit dispatch route through the gateway. Delivery is skipped with a
 /// warning when neither is configured.
+/// </para>
+/// <para>
+/// The dispatch route is reachable from the internet through the gateway, so the
+/// request carries the instance-key service credential
+/// (<see cref="ServiceNames.Headers.InstanceKey"/> +
+/// <see cref="ServiceNames.Headers.InstanceService"/>) and names the target tenant
+/// in the body. Delivery is skipped when either is unavailable.
+/// </para>
 /// </remarks>
 internal sealed class ChatBotProvider(
     IHttpClientFactory httpClientFactory,
     IConfiguration configuration,
+    ITenantAccessor tenantAccessor,
     ILogger<ChatBotProvider> logger)
 {
+    /// <summary>
+    /// Matches the camelCase body the SvelteKit dispatch route parses. <c>PostAsJsonAsync</c>
+    /// applies these defaults implicitly; they are explicit here because the request is
+    /// built by hand to carry the service-auth headers.
+    /// </summary>
+    private static readonly JsonSerializerOptions DispatchJsonOptions = new(JsonSerializerDefaults.Web);
+
     /// <summary>
     /// The set of <see cref="ChannelType"/> values that this provider can deliver to.
     /// </summary>
@@ -58,18 +78,47 @@ internal sealed class ChatBotProvider(
             return;
         }
 
+        var instanceKeyDigest = InstanceKeyDigest.Resolve(configuration);
+        if (string.IsNullOrEmpty(instanceKeyDigest))
+        {
+            logger.LogError(
+                "No instance key configured, cannot authenticate the chat bot dispatch for delivery {DeliveryId}",
+                deliveryId);
+            return;
+        }
+
+        // The dispatch route resolves the tenant from this slug instead of a forwarded
+        // host header, so a missing slug means the request cannot be scoped and is dropped.
+        var tenantSlug = tenantAccessor.Context?.Slug;
+        if (string.IsNullOrEmpty(tenantSlug))
+        {
+            logger.LogError(
+                "No tenant resolved, cannot dispatch chat bot alert for delivery {DeliveryId}",
+                deliveryId);
+            return;
+        }
+
         try
         {
             var client = httpClientFactory.CreateClient("ChatBot");
             var dispatchUrl = $"{webUrl.TrimEnd('/')}/api/v4/bot/dispatch";
 
-            var response = await client.PostAsJsonAsync(dispatchUrl, new
+            using var request = new HttpRequestMessage(HttpMethod.Post, dispatchUrl)
             {
-                DeliveryId = deliveryId,
-                ChannelType = channelType,
-                Destination = destination,
-                Payload = payload,
-            }, ct);
+                Content = JsonContent.Create(new
+                {
+                    DeliveryId = deliveryId,
+                    ChannelType = channelType,
+                    Destination = destination,
+                    Payload = payload,
+                    TenantSlug = tenantSlug,
+                }, options: DispatchJsonOptions),
+            };
+
+            request.Headers.Add(ServiceNames.Headers.InstanceKey, instanceKeyDigest);
+            request.Headers.Add(ServiceNames.Headers.InstanceService, ServiceNames.NocturneApi);
+
+            var response = await client.SendAsync(request, ct);
 
             response.EnsureSuccessStatusCode();
 

--- a/src/API/Nocturne.API/Services/Alerts/Providers/ChatBotProvider.cs
+++ b/src/API/Nocturne.API/Services/Alerts/Providers/ChatBotProvider.cs
@@ -17,18 +17,28 @@ namespace Nocturne.API.Services.Alerts.Providers;
 /// The bot endpoint is derived from <c>WEB_URL</c>, which names the web app's
 /// deployment-internal address (the AppHost wires it from the web resource's
 /// endpoint; the Compose bundles set <c>http://nocturne-web:&lt;port&gt;</c>).
-/// Delivery is skipped with a warning when it is unset. The deployment's public
-/// base URL (<see cref="ServiceNames.ConfigKeys.BaseUrl"/>) is deliberately not
-/// used as a fallback: an edge proxy fronting that URL strips the instance-key
-/// service headers below, because the same <c>/api/**</c> prefix is reachable from
-/// the internet, and the dispatch would arrive unauthenticated and be rejected.
+/// The deployment's public base URL (<see cref="ServiceNames.ConfigKeys.BaseUrl"/>)
+/// is deliberately not used as a fallback. It is a hairpin: an intra-cluster call
+/// between two containers on the same network would leave the deployment, traverse
+/// the CDN and the edge proxy, and come back in — carrying the instance-key service
+/// credential across the public internet on every alert. It also makes delivery
+/// depend on the edge forwarding those headers unchanged, which is not a property
+/// the edge guarantees; header sanitisation there would silently 401 every dispatch.
 /// </para>
 /// <para>
 /// The dispatch route is reachable from the internet through the gateway, so the
 /// request carries the instance-key service credential
 /// (<see cref="ServiceNames.Headers.InstanceKey"/> +
 /// <see cref="ServiceNames.Headers.InstanceService"/>) and names the target tenant
-/// in the body. Delivery is skipped when either is unavailable.
+/// in the body.
+/// </para>
+/// <para>
+/// A missing address, instance key, or tenant slug throws rather than returning.
+/// <see cref="AlertDeliveryService"/> creates the <c>alert_deliveries</c> row before
+/// calling this provider and marks neither delivered nor failed for chat-bot
+/// channels, so a silent return leaves that row <c>pending</c> forever with no error
+/// text and no retry accounting. Throwing lands the reason in the row's error field
+/// via the caller's <c>MarkFailedAsync</c>, matching how an HTTP failure is recorded.
 /// </para>
 /// </remarks>
 internal sealed class ChatBotProvider(
@@ -67,6 +77,10 @@ internal sealed class ChatBotProvider(
     /// <param name="destination">Platform-specific destination identifier (user/channel ID).</param>
     /// <param name="payload">The <see cref="AlertPayload"/> to deliver.</param>
     /// <param name="ct">Cancellation token.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <c>WEB_URL</c>, the instance key, or the tenant slug is unavailable. See the
+    /// remarks on this type for why these are thrown rather than logged and skipped.
+    /// </exception>
     public async Task SendAsync(Guid deliveryId, ChannelType channelType, string destination, AlertPayload payload, CancellationToken ct)
     {
         // Internal address only — see the remarks on this type for why the public
@@ -74,29 +88,24 @@ internal sealed class ChatBotProvider(
         var webUrl = configuration["WEB_URL"];
         if (string.IsNullOrEmpty(webUrl))
         {
-            logger.LogWarning(
+            throw new InvalidOperationException(
                 "WEB_URL is not configured with the web app's internal address, cannot dispatch to chat bot");
-            return;
         }
 
         var instanceKeyDigest = InstanceKeyDigest.Resolve(configuration);
         if (string.IsNullOrEmpty(instanceKeyDigest))
         {
-            logger.LogError(
-                "No instance key configured, cannot authenticate the chat bot dispatch for delivery {DeliveryId}",
-                deliveryId);
-            return;
+            throw new InvalidOperationException(
+                "No instance key configured, cannot authenticate the chat bot dispatch");
         }
 
         // The dispatch route resolves the tenant from this slug instead of a forwarded
-        // host header, so a missing slug means the request cannot be scoped and is dropped.
+        // host header, so a missing slug means the request cannot be scoped.
         var tenantSlug = tenantAccessor.Context?.Slug;
         if (string.IsNullOrEmpty(tenantSlug))
         {
-            logger.LogError(
-                "No tenant resolved, cannot dispatch chat bot alert for delivery {DeliveryId}",
-                deliveryId);
-            return;
+            throw new InvalidOperationException(
+                "No tenant resolved, cannot dispatch chat bot alert");
         }
 
         try

--- a/src/Web/packages/app/src/hooks.server.ts
+++ b/src/Web/packages/app/src/hooks.server.ts
@@ -6,9 +6,14 @@ import { env as publicEnv } from "$env/dynamic/public";
 import { dev } from "$app/environment";
 import {
   getApiBaseUrl,
-  getHashedInstanceKey,
   createServerApiClient,
 } from "$lib/server/api-client-factory";
+import {
+  getHashedInstanceKey,
+  INSTANCE_KEY_HEADER,
+  INSTANCE_SERVICE_HEADER,
+  INSTANCE_SERVICE_NAME,
+} from "$lib/server/instance-key";
 import { sequence } from "@sveltejs/kit/hooks";
 import type { AuthUser } from "./app.d";
 import { AUTH_COOKIE_NAMES } from "$lib/config/auth-cookies";
@@ -67,10 +72,10 @@ const authHandle: Handle = async ({ event, resolve }) => {
 
         const hashedKey = getHashedInstanceKey();
         if (hashedKey) {
-          headers["X-Instance-Key"] = hashedKey;
+          headers[INSTANCE_KEY_HEADER] = hashedKey;
           // Genuine SSR service call — declare the service so the API honors
           // the instance key (a bare key is ignored).
-          headers["X-Instance-Service"] = "nocturne-web";
+          headers[INSTANCE_SERVICE_HEADER] = INSTANCE_SERVICE_NAME;
         }
 
         const sessionRes = await fetch(`${apiBaseUrl}/api/auth/oidc/session`, { headers });

--- a/src/Web/packages/app/src/lib/server/api-client-factory.ts
+++ b/src/Web/packages/app/src/lib/server/api-client-factory.ts
@@ -1,8 +1,12 @@
-import { createHash } from "crypto";
 import { env } from "$env/dynamic/private";
 import { env as publicEnv } from "$env/dynamic/public";
 import { ApiClient } from "$lib/api/api-client.generated";
 import { AUTH_COOKIE_NAMES } from "$lib/config/auth-cookies";
+import {
+  INSTANCE_KEY_HEADER,
+  INSTANCE_SERVICE_HEADER,
+  INSTANCE_SERVICE_NAME,
+} from "./instance-key";
 import {
   propagateAuthCookies,
   type CookieSetter,
@@ -14,26 +18,6 @@ import {
 export function getApiBaseUrl(): string | null {
   return env.NOCTURNE_API_URL || publicEnv.PUBLIC_API_URL || null;
 }
-
-/**
- * Helper to get the hashed instance key for service authentication.
- */
-export function getHashedInstanceKey(): string | null {
-  const instanceKey = env.INSTANCE_KEY;
-  return instanceKey
-    ? createHash("sha256").update(instanceKey).digest("hex").toLowerCase()
-    : null;
-}
-
-/**
- * Header naming the trusted service presenting the instance key. The API's
- * InstanceKeyHandler only authenticates the instance key as admin when this
- * marker is present, so a bare key accidentally forwarded onto an end-user
- * request cannot elevate that request and bypass per-tenant public access.
- * Must stay in sync with `ServiceNames.Headers.InstanceService` on the API.
- */
-const INSTANCE_SERVICE_HEADER = "X-Instance-Service";
-const INSTANCE_SERVICE_NAME = "nocturne-web";
 
 export interface ServerHttpClientOptions {
   accessToken?: string;
@@ -70,7 +54,7 @@ export function createServerHttpClient(
       const headers = new Headers(init?.headers);
 
       if (options?.hashedInstanceKey) {
-        headers.set("X-Instance-Key", options.hashedInstanceKey);
+        headers.set(INSTANCE_KEY_HEADER, options.hashedInstanceKey);
         // Declare this as a genuine service call so the API honors the key.
         headers.set(INSTANCE_SERVICE_HEADER, INSTANCE_SERVICE_NAME);
       }

--- a/src/Web/packages/app/src/lib/server/bot/api-client.ts
+++ b/src/Web/packages/app/src/lib/server/bot/api-client.ts
@@ -3,8 +3,8 @@ import type { ApiClient } from "$lib/api";
 import {
   createServerApiClient,
   getApiBaseUrl,
-  getHashedInstanceKey,
 } from "$lib/server/api-client-factory";
+import { getHashedInstanceKey } from "$lib/server/instance-key";
 
 /**
  * Adapts a NocturneApiClient to the BotApiClient interface used by @nocturne/bot.
@@ -99,8 +99,13 @@ export function buildBotApiClient(api: ApiClient): BotApiClient {
  * Builds the **unscoped** (apex / cross-tenant) BotApiClient using an explicit
  * instance-key client. Pass the forwarded host/proto headers from the incoming
  * request so tenant resolution and HTTPS enforcement on the API match what the
- * caller intended (the bot dispatch route relies on X-Forwarded-Host to target
- * the correct tenant).
+ * caller intended.
+ *
+ * Only for callers whose target tenant is genuinely unknown (webhook command
+ * routing, which resolves a chat identity to a tenant first). A caller that
+ * already knows the tenant must use {@link buildScopedBotApiClient} instead —
+ * a forwarded host from an inbound request is client-controlled and would let
+ * the caller pick the tenant these admin-privileged calls act on.
  */
 export function buildUnscopedBotApiClient(
   fetchFn: typeof globalThis.fetch,

--- a/src/Web/packages/app/src/lib/server/bot/index.ts
+++ b/src/Web/packages/app/src/lib/server/bot/index.ts
@@ -1,7 +1,8 @@
 import { createBot, registerAllCommands, AlertDeliveryHandler, type BotOptions, type PlatformCredentials } from "@nocturne/bot";
 import type { BotApiClient, AlertDispatchEvent } from "@nocturne/bot";
 import { env } from "$env/dynamic/private";
-import { createServerApiClient, getApiBaseUrl, getHashedInstanceKey } from "$lib/server/api-client-factory";
+import { createServerApiClient, getApiBaseUrl } from "$lib/server/api-client-factory";
+import { getHashedInstanceKey } from "$lib/server/instance-key";
 import { fetchDecryptedPlatformCredentials } from "./platform-credentials";
 import type { PlatformCredentials as ApiPlatformCredentials } from "$api";
 

--- a/src/Web/packages/app/src/lib/server/bot/platform-credentials.ts
+++ b/src/Web/packages/app/src/lib/server/bot/platform-credentials.ts
@@ -3,8 +3,8 @@ import type { PlatformCredentials } from "$api";
 import {
 	createServerApiClient,
 	getApiBaseUrl,
-	getHashedInstanceKey,
 } from "$lib/server/api-client-factory";
+import { getHashedInstanceKey } from "$lib/server/instance-key";
 
 /**
  * Fetches all decrypted platform credentials over the instance-key

--- a/src/Web/packages/app/src/lib/server/instance-key.test.ts
+++ b/src/Web/packages/app/src/lib/server/instance-key.test.ts
@@ -1,0 +1,121 @@
+import { createHash } from "crypto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  INSTANCE_KEY_HEADER,
+  INSTANCE_SERVICE_HEADER,
+  getHashedInstanceKey,
+  isTrustedInstanceRequest,
+} from "./instance-key";
+
+const INSTANCE_KEY = "s3cret-instance-key";
+const DIGEST = createHash("sha256").update(INSTANCE_KEY).digest("hex");
+
+function makeRequest(headers: Record<string, string>): Request {
+  return new Request("http://web.internal/api/v4/bot/dispatch", {
+    method: "POST",
+    headers,
+  });
+}
+
+describe("isTrustedInstanceRequest", () => {
+  const previous = process.env.INSTANCE_KEY;
+
+  beforeEach(() => {
+    process.env.INSTANCE_KEY = INSTANCE_KEY;
+  });
+
+  afterEach(() => {
+    if (previous === undefined) delete process.env.INSTANCE_KEY;
+    else process.env.INSTANCE_KEY = previous;
+  });
+
+  it("hashes the configured instance key as lowercase sha256 hex", () => {
+    expect(getHashedInstanceKey()).toBe(DIGEST);
+  });
+
+  it("accepts the digest plus a service marker", () => {
+    const request = makeRequest({
+      [INSTANCE_KEY_HEADER]: DIGEST,
+      [INSTANCE_SERVICE_HEADER]: "nocturne-api",
+    });
+
+    expect(isTrustedInstanceRequest(request)).toBe(true);
+  });
+
+  it("accepts an uppercase digest", () => {
+    const request = makeRequest({
+      [INSTANCE_KEY_HEADER]: DIGEST.toUpperCase(),
+      [INSTANCE_SERVICE_HEADER]: "nocturne-api",
+    });
+
+    expect(isTrustedInstanceRequest(request)).toBe(true);
+  });
+
+  it("rejects a request with no instance key header", () => {
+    expect(
+      isTrustedInstanceRequest(
+        makeRequest({ [INSTANCE_SERVICE_HEADER]: "nocturne-api" }),
+      ),
+    ).toBe(false);
+    expect(isTrustedInstanceRequest(makeRequest({}))).toBe(false);
+  });
+
+  it("rejects a wrong digest, including one of a different length", () => {
+    const wrong = createHash("sha256").update("not-the-key").digest("hex");
+
+    expect(
+      isTrustedInstanceRequest(
+        makeRequest({
+          [INSTANCE_KEY_HEADER]: wrong,
+          [INSTANCE_SERVICE_HEADER]: "nocturne-api",
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isTrustedInstanceRequest(
+        makeRequest({
+          [INSTANCE_KEY_HEADER]: DIGEST.slice(0, 32),
+          [INSTANCE_SERVICE_HEADER]: "nocturne-api",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects the raw instance key presented instead of its digest", () => {
+    expect(
+      isTrustedInstanceRequest(
+        makeRequest({
+          [INSTANCE_KEY_HEADER]: INSTANCE_KEY,
+          [INSTANCE_SERVICE_HEADER]: "nocturne-api",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a valid digest with no service marker", () => {
+    expect(
+      isTrustedInstanceRequest(makeRequest({ [INSTANCE_KEY_HEADER]: DIGEST })),
+    ).toBe(false);
+  });
+
+  it("rejects everything when no instance key is configured", () => {
+    delete process.env.INSTANCE_KEY;
+
+    expect(
+      isTrustedInstanceRequest(
+        makeRequest({
+          [INSTANCE_KEY_HEADER]: DIGEST,
+          [INSTANCE_SERVICE_HEADER]: "nocturne-api",
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isTrustedInstanceRequest(
+        makeRequest({
+          [INSTANCE_KEY_HEADER]: "",
+          [INSTANCE_SERVICE_HEADER]: "nocturne-api",
+        }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/Web/packages/app/src/lib/server/instance-key.ts
+++ b/src/Web/packages/app/src/lib/server/instance-key.ts
@@ -1,0 +1,71 @@
+import { createHash, timingSafeEqual } from "crypto";
+import { env } from "$env/dynamic/private";
+
+/**
+ * The shared instance key and the headers that carry it. Owns both directions:
+ * the digest this app presents on outbound service calls, and the check applied
+ * to inbound service calls. Kept apart from the API-client factory so routes can
+ * verify a caller without pulling in the generated client.
+ */
+
+/**
+ * Header carrying the SHA-256 hex digest of the shared instance key.
+ * Must stay in sync with `ServiceNames.Headers.InstanceKey` on the API.
+ */
+export const INSTANCE_KEY_HEADER = "X-Instance-Key";
+
+/**
+ * Header naming the trusted service presenting the instance key. The API's
+ * InstanceKeyHandler only authenticates the instance key as admin when this
+ * marker is present, so a bare key accidentally forwarded onto an end-user
+ * request cannot elevate that request and bypass per-tenant public access.
+ * Must stay in sync with `ServiceNames.Headers.InstanceService` on the API.
+ */
+export const INSTANCE_SERVICE_HEADER = "X-Instance-Service";
+
+/** This app's value for {@link INSTANCE_SERVICE_HEADER}. */
+export const INSTANCE_SERVICE_NAME = "nocturne-web";
+
+/**
+ * The digest of the configured instance key, used for service authentication.
+ * Null when no instance key is configured.
+ */
+export function getHashedInstanceKey(): string | null {
+  const instanceKey = env.INSTANCE_KEY;
+  return instanceKey
+    ? createHash("sha256").update(instanceKey).digest("hex").toLowerCase()
+    : null;
+}
+
+/**
+ * Verifies that an inbound request carries the internal service credential:
+ * {@link INSTANCE_KEY_HEADER} holding the digest of `INSTANCE_KEY`, plus an
+ * {@link INSTANCE_SERVICE_HEADER} marker naming the calling service. This is the
+ * same credential shape the API's `InstanceKeyValidator` accepts, so both
+ * directions of service-to-service traffic use one convention.
+ *
+ * Use on any SvelteKit route that acts with instance-key (admin) privilege and
+ * is exempted from the handles in `hooks.server.ts` — such routes are reachable
+ * from the internet through the gateway's `/api/**` route.
+ *
+ * Fails closed: rejects when no instance key is configured, when either header
+ * is missing, and when the presented digest does not match.
+ */
+export function isTrustedInstanceRequest(request: Request): boolean {
+  const expected = getHashedInstanceKey();
+  if (!expected) return false;
+
+  const presented = request.headers.get(INSTANCE_KEY_HEADER);
+  if (!presented) return false;
+
+  // The service marker distinguishes a deliberate service call from a key that
+  // leaked onto an end-user request, matching the API's rule.
+  if (!request.headers.get(INSTANCE_SERVICE_HEADER)) return false;
+
+  const presentedBytes = Buffer.from(presented.trim().toLowerCase(), "utf8");
+  const expectedBytes = Buffer.from(expected, "utf8");
+  // timingSafeEqual throws on differing lengths, so the length check comes first.
+  if (presentedBytes.length !== expectedBytes.length) return false;
+
+  return timingSafeEqual(presentedBytes, expectedBytes);
+}

--- a/src/Web/packages/app/src/lib/test-stubs/env-dynamic-private.ts
+++ b/src/Web/packages/app/src/lib/test-stubs/env-dynamic-private.ts
@@ -1,0 +1,6 @@
+/**
+ * Stub for $env/dynamic/private in the node test environment. SvelteKit reads
+ * private env vars at call time from the process environment, so tests set
+ * `process.env.*` and the module under test observes it.
+ */
+export const env: Record<string, string | undefined> = process.env;

--- a/src/Web/packages/app/src/routes/(unauthenticated)/auth/bot/discord/callback/+server.ts
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/auth/bot/discord/callback/+server.ts
@@ -3,8 +3,8 @@ import { error, redirect } from "@sveltejs/kit";
 import {
 	createServerApiClient,
 	getApiBaseUrl,
-	getHashedInstanceKey,
 } from "$lib/server/api-client-factory";
+import { getHashedInstanceKey } from "$lib/server/instance-key";
 import { verifyOAuthLinkState } from "$lib/server/bot/oauth-state";
 import { getDiscordOAuthConfig } from "$lib/server/bot/platform-credentials";
 

--- a/src/Web/packages/app/src/routes/api/otel/errors/+server.ts
+++ b/src/Web/packages/app/src/routes/api/otel/errors/+server.ts
@@ -9,9 +9,14 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 const MAX_FIELD_LENGTH = 4096;
 const MAX_BODY_BYTES = 16_384;
 
-/** Clamps a reported field to a fixed length before it reaches a span attribute. */
-const clampField = (value: string | undefined): string =>
-  (value ?? "").slice(0, MAX_FIELD_LENGTH);
+/**
+ * Clamps a reported field to a fixed length before it reaches a span attribute.
+ * Non-string input reads as absent: the body is caller-supplied JSON, so a number
+ * or object here would otherwise throw inside the handler and turn an anonymous
+ * report into a 500 plus a logged stack.
+ */
+const clampField = (value: unknown): string =>
+  typeof value === "string" ? value.slice(0, MAX_FIELD_LENGTH) : "";
 
 /**
  * Reads the request body with a hard byte ceiling, returning null once the
@@ -54,18 +59,10 @@ async function readBounded(
 // session, so this endpoint cannot require the instance key. Volume is bounded
 // per request by MAX_BODY_BYTES and by the fixed span-attribute clamps.
 export const POST: RequestHandler = async ({ request }) => {
-  // A missing or unparseable Content-Length is rejected rather than treated as
-  // zero. The byte ceiling below is what actually bounds the read; this only
-  // rejects callers that decline to declare a size.
-  const contentLength = request.headers.get("content-length")?.trim();
-  const declaredLength = contentLength ? Number(contentLength) : NaN;
-  if (!Number.isSafeInteger(declaredLength) || declaredLength < 0) {
-    return new Response(null, { status: 411 });
-  }
-  if (declaredLength > MAX_BODY_BYTES) {
-    return new Response(null, { status: 413 });
-  }
-
+  // Content-Length is deliberately not consulted. readBounded enforces the cap on
+  // bytes actually read, so a declared length adds no protection, and requiring one
+  // would reject any report whose body a hop re-framed as chunked — silently, since
+  // the reporter in hooks.client.ts swallows failures.
   const raw = await readBounded(request, MAX_BODY_BYTES);
   if (raw === null) {
     return new Response(null, { status: 413 });

--- a/src/Web/packages/app/src/routes/api/otel/errors/+server.ts
+++ b/src/Web/packages/app/src/routes/api/otel/errors/+server.ts
@@ -7,10 +7,67 @@ const tracer = trace.getTracer("nocturne-web-client", "1.0.0");
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const MAX_FIELD_LENGTH = 4096;
+const MAX_BODY_BYTES = 16_384;
 
+/** Clamps a reported field to a fixed length before it reaches a span attribute. */
+const clampField = (value: string | undefined): string =>
+  (value ?? "").slice(0, MAX_FIELD_LENGTH);
+
+/**
+ * Reads the request body with a hard byte ceiling, returning null once the
+ * ceiling is passed. Enforcing the limit on bytes actually read means a chunked
+ * request (no Content-Length) or a request that understates its length cannot
+ * exceed the cap.
+ */
+async function readBounded(
+  request: Request,
+  maxBytes: number,
+): Promise<string | null> {
+  // No body stream at all reads as empty, which the JSON parse below rejects.
+  const reader = request.body?.getReader();
+  if (!reader) return "";
+
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      return null;
+    }
+    chunks.push(value);
+  }
+
+  const buffer = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    buffer.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(buffer);
+}
+
+// Anonymous by design: browser error reports arrive before (or instead of) any
+// session, so this endpoint cannot require the instance key. Volume is bounded
+// per request by MAX_BODY_BYTES and by the fixed span-attribute clamps.
 export const POST: RequestHandler = async ({ request }) => {
-  const contentLength = parseInt(request.headers.get("content-length") ?? "0", 10);
-  if (contentLength > 16_384) {
+  // A missing or unparseable Content-Length is rejected rather than treated as
+  // zero. The byte ceiling below is what actually bounds the read; this only
+  // rejects callers that decline to declare a size.
+  const contentLength = request.headers.get("content-length")?.trim();
+  const declaredLength = contentLength ? Number(contentLength) : NaN;
+  if (!Number.isSafeInteger(declaredLength) || declaredLength < 0) {
+    return new Response(null, { status: 411 });
+  }
+  if (declaredLength > MAX_BODY_BYTES) {
+    return new Response(null, { status: 413 });
+  }
+
+  const raw = await readBounded(request, MAX_BODY_BYTES);
+  if (raw === null) {
     return new Response(null, { status: 413 });
   }
 
@@ -23,23 +80,27 @@ export const POST: RequestHandler = async ({ request }) => {
   };
 
   try {
-    body = await request.json();
+    body = JSON.parse(raw);
   } catch {
     return json({ error: "Invalid JSON" }, { status: 400 });
   }
 
+  if (typeof body !== "object" || body === null) {
+    return json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
   const errorId = UUID_RE.test(body.errorId) ? body.errorId : randomUUID();
-  const message = (body.message ?? "").slice(0, MAX_FIELD_LENGTH);
-  const stack = (body.stack ?? "").slice(0, MAX_FIELD_LENGTH);
+  const message = clampField(body.message);
 
   const span = tracer.startSpan("client-error", {
     attributes: {
       "error.id": errorId,
       "error.message": message,
-      "error.stack": stack,
-      "error.url": body.url,
-      "http.user_agent":
-        body.userAgent ?? request.headers.get("user-agent") ?? "",
+      "error.stack": clampField(body.stack),
+      "error.url": clampField(body.url),
+      "http.user_agent": clampField(
+        body.userAgent ?? request.headers.get("user-agent") ?? undefined,
+      ),
     },
   });
 

--- a/src/Web/packages/app/src/routes/api/otel/errors/errors.test.ts
+++ b/src/Web/packages/app/src/routes/api/otel/errors/errors.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type SpanOptions = { attributes: Record<string, string> };
+
+const startSpan = vi.fn((_name: string, _options: SpanOptions) => ({
+  setStatus: vi.fn(),
+  end: vi.fn(),
+}));
+
+vi.mock("@opentelemetry/api", () => ({
+  trace: { getTracer: () => ({ startSpan }) },
+  SpanStatusCode: { ERROR: 2 },
+}));
+
+const { POST } = await import("./+server");
+
+function post(request: Request) {
+  return (POST as unknown as (event: { request: Request }) => Promise<Response>)(
+    { request },
+  );
+}
+
+const URL_UNDER_TEST = "https://acme.nocturne.run/api/otel/errors";
+
+/**
+ * A request the way a runtime hands it to the handler: Content-Length set from
+ * the body. `declaredLength` overrides it to model a caller that lies.
+ */
+function request(body: string, declaredLength?: string): Request {
+  return new Request(URL_UNDER_TEST, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "content-length":
+        declaredLength ?? String(new TextEncoder().encode(body).byteLength),
+    },
+    body,
+  });
+}
+
+/** A body sent as a stream, so the request carries no Content-Length. */
+function chunkedRequest(payload: string): Request {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(payload));
+      controller.close();
+    },
+  });
+
+  return new Request(URL_UNDER_TEST, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+    // @ts-expect-error duplex is required by undici for a stream body
+    duplex: "half",
+  });
+}
+
+const REPORT = {
+  message: "boom",
+  stack: "at foo",
+  url: "https://acme.nocturne.run/dashboard",
+  errorId: "8ba6dd4d-5f0d-4a0d-9a58-6a4e4bd2c111",
+};
+
+const OVERSIZED = JSON.stringify({ ...REPORT, stack: "x".repeat(32_768) });
+
+describe("POST /api/otel/errors", () => {
+  beforeEach(() => {
+    startSpan.mockClear();
+  });
+
+  it("accepts a normal report", async () => {
+    const response = await post(request(JSON.stringify(REPORT)));
+
+    expect(response.status).toBe(204);
+    expect(startSpan).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an oversized body that understates its Content-Length", async () => {
+    const response = await post(request(OVERSIZED, "42"));
+
+    expect(response.status).toBe(413);
+    expect(startSpan).not.toHaveBeenCalled();
+  });
+
+  it("rejects an oversized body that declares its real length", async () => {
+    const response = await post(request(OVERSIZED));
+
+    expect(response.status).toBe(413);
+    expect(startSpan).not.toHaveBeenCalled();
+  });
+
+  it("rejects a chunked body, which declares no length at all", async () => {
+    const response = await post(chunkedRequest(OVERSIZED));
+
+    expect(response.status).toBe(411);
+    expect(startSpan).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unparseable Content-Length", async () => {
+    const response = await post(request(JSON.stringify(REPORT), "not-a-number"));
+
+    expect(response.status).toBe(411);
+    expect(startSpan).not.toHaveBeenCalled();
+  });
+
+  it("clamps url the same way message and stack are clamped", async () => {
+    // Each field is over the 4096 clamp while the whole body stays under the
+    // 16 KB cap.
+    const long = "y".repeat(5000);
+    const response = await post(
+      request(
+        JSON.stringify({
+          ...REPORT,
+          message: long,
+          stack: long,
+          url: `https://acme.nocturne.run/?q=${long}`,
+        }),
+      ),
+    );
+
+    expect(response.status).toBe(204);
+    const attributes = startSpan.mock.calls[0][1].attributes;
+    expect(attributes["error.message"]).toHaveLength(4096);
+    expect(attributes["error.stack"]).toHaveLength(4096);
+    expect(attributes["error.url"]).toHaveLength(4096);
+  });
+
+  it("rejects invalid JSON", async () => {
+    const response = await post(request("{not json"));
+
+    expect(response.status).toBe(400);
+    expect(startSpan).not.toHaveBeenCalled();
+  });
+
+  it("rejects a JSON body that is not an object", async () => {
+    const response = await post(request("null"));
+
+    expect(response.status).toBe(400);
+    expect(startSpan).not.toHaveBeenCalled();
+  });
+});

--- a/src/Web/packages/app/src/routes/api/otel/errors/errors.test.ts
+++ b/src/Web/packages/app/src/routes/api/otel/errors/errors.test.ts
@@ -91,18 +91,41 @@ describe("POST /api/otel/errors", () => {
     expect(startSpan).not.toHaveBeenCalled();
   });
 
-  it("rejects a chunked body, which declares no length at all", async () => {
+  it("caps an oversized chunked body, which declares no length at all", async () => {
+    // The cap is enforced on bytes read, so this is rejected for its size rather
+    // than for the absent Content-Length.
     const response = await post(chunkedRequest(OVERSIZED));
 
-    expect(response.status).toBe(411);
+    expect(response.status).toBe(413);
     expect(startSpan).not.toHaveBeenCalled();
   });
 
-  it("rejects an unparseable Content-Length", async () => {
+  it("accepts a chunked report within the cap", async () => {
+    // Content-Length is never consulted: a hop that re-frames the body as chunked
+    // must not turn a legitimate browser error report into a rejection. The client
+    // reporter swallows failures, so this would go dark silently.
+    const response = await post(chunkedRequest(JSON.stringify(REPORT)));
+
+    expect(response.status).toBe(204);
+    expect(startSpan).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts a report whose Content-Length is unparseable", async () => {
     const response = await post(request(JSON.stringify(REPORT), "not-a-number"));
 
-    expect(response.status).toBe(411);
-    expect(startSpan).not.toHaveBeenCalled();
+    expect(response.status).toBe(204);
+    expect(startSpan).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not 500 on a non-string field", async () => {
+    // Anonymous and internet-reachable: a caller-supplied number where a string is
+    // declared must not throw inside the handler.
+    const response = await post(
+      request(JSON.stringify({ ...REPORT, message: 1, stack: { a: 1 }, url: [] })),
+    );
+
+    expect(response.status).toBe(204);
+    expect(startSpan).toHaveBeenCalledTimes(1);
   });
 
   it("clamps url the same way message and stack are clamped", async () => {

--- a/src/Web/packages/app/src/routes/api/v4/bot/dispatch/+server.ts
+++ b/src/Web/packages/app/src/routes/api/v4/bot/dispatch/+server.ts
@@ -1,23 +1,35 @@
 import type { RequestHandler } from "./$types";
 import { handleBotDispatch } from "$lib/server/bot";
-import { buildUnscopedBotApiClient } from "$lib/server/bot/api-client";
-import { getEffectiveHost, getOriginalProto } from "$lib/server/request-host";
+import { buildScopedBotApiClient } from "$lib/server/bot/api-client";
+import { isTrustedInstanceRequest } from "$lib/server/instance-key";
 import type { AlertDispatchEvent } from "@nocturne/bot";
 
-export const POST: RequestHandler = async ({ request, cookies, fetch }) => {
+export const POST: RequestHandler = async ({ request, fetch }) => {
+	// This is a public HTTP endpoint: the gateway routes /api/** here and
+	// hooks.server.ts exempts /api/v4/bot from the site-security handle and the
+	// credential-scoping proxy. Dispatching posts an alert to a chat platform and
+	// writes delivery state with instance-key (admin) privilege, so the caller
+	// must present the instance key before anything else happens.
+	if (!isTrustedInstanceRequest(request)) {
+		return new Response(null, { status: 401 });
+	}
+
 	try {
 		const event: AlertDispatchEvent = await request.json();
 
-		// The bot is a trusted service: build an explicit instance-key client,
-		// forwarding the incoming host/proto so tenant resolution targets the
-		// right tenant. (locals.apiClient carries only the end user's creds.)
-		const extraHeaders: Record<string, string> = {
-			"X-Forwarded-Proto": getOriginalProto(request),
-		};
-		const host = getEffectiveHost(request, cookies);
-		if (host) extraHeaders["X-Forwarded-Host"] = host;
+		// The target tenant comes from the authenticated body, not from
+		// X-Forwarded-Host: the edge gateway does not sanitize that header, so a
+		// forwarded host lets the caller choose which tenant the admin-privileged
+		// API calls land on. buildScopedBotApiClient derives the host from the
+		// server's BASE_DOMAIN and this slug.
+		if (!event?.tenantSlug) {
+			return new Response(JSON.stringify({ error: "tenantSlug is required" }), {
+				status: 400,
+				headers: { "Content-Type": "application/json" },
+			});
+		}
 
-		const botApiClient = buildUnscopedBotApiClient(fetch, extraHeaders);
+		const botApiClient = buildScopedBotApiClient(fetch, event.tenantSlug);
 		await handleBotDispatch(event, botApiClient);
 		return new Response(null, { status: 204 });
 	} catch (err) {

--- a/src/Web/packages/app/src/routes/api/v4/bot/dispatch/+server.ts
+++ b/src/Web/packages/app/src/routes/api/v4/bot/dispatch/+server.ts
@@ -22,7 +22,12 @@ export const POST: RequestHandler = async ({ request, fetch }) => {
 		// forwarded host lets the caller choose which tenant the admin-privileged
 		// API calls land on. buildScopedBotApiClient derives the host from the
 		// server's BASE_DOMAIN and this slug.
-		if (!event?.tenantSlug) {
+		// Shape-checked, not just present. The slug becomes a label in the Host header
+		// buildScopedBotApiClient constructs, so a value containing a dot resolves as a
+		// different host than intended — `<token>.share` would put the API into
+		// share-resolution mode. Anything else non-conforming would reach undici and
+		// throw, surfacing as a 500 rather than a bad request.
+		if (typeof event?.tenantSlug !== "string" || !/^[a-z0-9][a-z0-9-]*$/.test(event.tenantSlug)) {
 			return new Response(JSON.stringify({ error: "tenantSlug is required" }), {
 				status: 400,
 				headers: { "Content-Type": "application/json" },

--- a/src/Web/packages/app/src/routes/api/v4/bot/dispatch/dispatch.test.ts
+++ b/src/Web/packages/app/src/routes/api/v4/bot/dispatch/dispatch.test.ts
@@ -1,0 +1,134 @@
+import { createHash } from "crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  INSTANCE_KEY_HEADER,
+  INSTANCE_SERVICE_HEADER,
+} from "$lib/server/instance-key";
+
+const handleBotDispatch = vi.fn(
+  (_event: { deliveryId: string }, _api: unknown) => Promise.resolve(),
+);
+const buildScopedBotApiClient = vi.fn(
+  (_fetchFn: typeof fetch, _tenantSlug: string) => ({ scoped: true }),
+);
+
+vi.mock("$lib/server/bot", () => ({
+  handleBotDispatch: (event: { deliveryId: string }, api: unknown) =>
+    handleBotDispatch(event, api),
+}));
+
+vi.mock("$lib/server/bot/api-client", () => ({
+  buildScopedBotApiClient: (fetchFn: typeof fetch, tenantSlug: string) =>
+    buildScopedBotApiClient(fetchFn, tenantSlug),
+}));
+
+const { POST } = await import("./+server");
+
+const INSTANCE_KEY = "s3cret-instance-key";
+const DIGEST = createHash("sha256").update(INSTANCE_KEY).digest("hex");
+
+const EVENT = {
+  deliveryId: "8ba6dd4d-5f0d-4a0d-9a58-6a4e4bd2c111",
+  channelType: "discord_dm",
+  destination: "channel-1",
+  tenantSlug: "acme",
+  payload: { ruleName: "Low glucose" },
+};
+
+/** Invokes the handler the way SvelteKit would, with only what the route reads. */
+function post(body: unknown, headers: Record<string, string>) {
+  const request = new Request("https://acme.nocturne.run/api/v4/bot/dispatch", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+
+  return (POST as unknown as (event: {
+    request: Request;
+    fetch: typeof fetch;
+  }) => Promise<Response>)({ request, fetch });
+}
+
+const serviceHeaders = {
+  [INSTANCE_KEY_HEADER]: DIGEST,
+  [INSTANCE_SERVICE_HEADER]: "nocturne-api",
+};
+
+describe("POST /api/v4/bot/dispatch", () => {
+  const previousKey = process.env.INSTANCE_KEY;
+  const previousDomain = process.env.BASE_DOMAIN;
+
+  beforeEach(() => {
+    process.env.INSTANCE_KEY = INSTANCE_KEY;
+    process.env.BASE_DOMAIN = "nocturne.run";
+    handleBotDispatch.mockReset();
+    buildScopedBotApiClient.mockClear();
+  });
+
+  afterEach(() => {
+    if (previousKey === undefined) delete process.env.INSTANCE_KEY;
+    else process.env.INSTANCE_KEY = previousKey;
+    if (previousDomain === undefined) delete process.env.BASE_DOMAIN;
+    else process.env.BASE_DOMAIN = previousDomain;
+  });
+
+  it("rejects a request with no instance key", async () => {
+    const response = await post(EVENT, {});
+
+    expect(response.status).toBe(401);
+    expect(handleBotDispatch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a request with a wrong instance key", async () => {
+    const response = await post(EVENT, {
+      [INSTANCE_KEY_HEADER]: createHash("sha256")
+        .update("wrong-key")
+        .digest("hex"),
+      [INSTANCE_SERVICE_HEADER]: "nocturne-api",
+    });
+
+    expect(response.status).toBe(401);
+    expect(handleBotDispatch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a valid key with no service marker", async () => {
+    const response = await post(EVENT, { [INSTANCE_KEY_HEADER]: DIGEST });
+
+    expect(response.status).toBe(401);
+    expect(handleBotDispatch).not.toHaveBeenCalled();
+  });
+
+  it("accepts a request carrying the instance key and dispatches it", async () => {
+    const response = await post(EVENT, serviceHeaders);
+
+    expect(response.status).toBe(204);
+    expect(handleBotDispatch).toHaveBeenCalledTimes(1);
+    expect(handleBotDispatch.mock.calls[0][0]).toMatchObject({
+      deliveryId: EVENT.deliveryId,
+    });
+  });
+
+  it("scopes the API client to the tenant named in the body", async () => {
+    await post(EVENT, serviceHeaders);
+
+    expect(buildScopedBotApiClient).toHaveBeenCalledTimes(1);
+    expect(buildScopedBotApiClient.mock.calls[0][1]).toBe("acme");
+  });
+
+  it("ignores a forwarded host that disagrees with the body", async () => {
+    await post(EVENT, {
+      ...serviceHeaders,
+      "X-Forwarded-Host": "victim.nocturne.run",
+    });
+
+    expect(buildScopedBotApiClient.mock.calls[0][1]).toBe("acme");
+  });
+
+  it("rejects an event with no tenant slug", async () => {
+    const { tenantSlug: _omitted, ...noSlug } = EVENT;
+    const response = await post(noSlug, serviceHeaders);
+
+    expect(response.status).toBe(400);
+    expect(handleBotDispatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/Web/packages/app/src/routes/api/v4/bot/dispatch/dispatch.test.ts
+++ b/src/Web/packages/app/src/routes/api/v4/bot/dispatch/dispatch.test.ts
@@ -131,4 +131,20 @@ describe("POST /api/v4/bot/dispatch", () => {
     expect(response.status).toBe(400);
     expect(handleBotDispatch).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ["a dotted slug that would reach a different host", "sometoken.share"],
+    ["an uppercase slug", "Acme"],
+    ["a slug with a leading hyphen", "-acme"],
+    ["a slug with CR/LF", "acme\r\nX-Evil: 1"],
+    ["an empty slug", ""],
+    ["a non-string slug", 1 as unknown as string],
+  ])("rejects %s", async (_label, tenantSlug) => {
+    // The slug becomes a Host label, so shape matters: "<token>.share" would put
+    // the API into share-resolution mode rather than resolving the tenant.
+    const response = await post({ ...EVENT, tenantSlug }, serviceHeaders);
+
+    expect(response.status).toBe(400);
+    expect(handleBotDispatch).not.toHaveBeenCalled();
+  });
 });

--- a/src/Web/packages/app/src/routes/realtime/ticket/+server.ts
+++ b/src/Web/packages/app/src/routes/realtime/ticket/+server.ts
@@ -4,9 +4,9 @@ import { env } from "$env/dynamic/private";
 import { signHandshakeTicket } from "@nocturne/bridge/ticket";
 import {
   getApiBaseUrl,
-  getHashedInstanceKey,
   createServerHttpClient,
 } from "$lib/server/api-client-factory";
+import { getHashedInstanceKey } from "$lib/server/instance-key";
 import { getEffectiveHost, getOriginalProto } from "$lib/server/request-host";
 import { AUTH_COOKIE_NAMES } from "$lib/config/auth-cookies";
 

--- a/src/Web/packages/app/vitest.config.ts
+++ b/src/Web/packages/app/vitest.config.ts
@@ -23,6 +23,9 @@ export default defineConfig({
       // mode-watcher only exports under "svelte" condition — stub for node tests
       "mode-watcher": new URL("./src/lib/test-stubs/mode-watcher.ts", import.meta.url).pathname,
       "$app/environment": new URL("./src/lib/test-stubs/app-environment-node.ts", import.meta.url).pathname,
+      // SvelteKit's env modules are virtual (provided by its vite plugin, which
+      // isn't loaded here) — stub so server modules can be unit tested
+      "$env/dynamic/private": new URL("./src/lib/test-stubs/env-dynamic-private.ts", import.meta.url).pathname,
     },
   },
 });

--- a/src/Web/packages/bot/src/types.ts
+++ b/src/Web/packages/bot/src/types.ts
@@ -124,4 +124,10 @@ export interface AlertDispatchEvent {
   channelType: string;
   destination: string;
   payload: AlertPayload;
+  /**
+   * Slug of the tenant the alert belongs to. Sent by the API so the dispatch
+   * route resolves the tenant from the request body rather than a forwarded
+   * host header.
+   */
+  tenantSlug: string;
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/Providers/ChatBotProviderTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/Providers/ChatBotProviderTests.cs
@@ -152,30 +152,38 @@ public class ChatBotProviderTests
     }
 
     [Fact]
-    public async Task SendAsync_SkipsDispatch_WhenInstanceKeyNotConfigured()
+    public async Task SendAsync_ThrowsWithoutDispatching_WhenInstanceKeyNotConfigured()
     {
         // Arrange
         var handler = new MockHttpMessageHandler(HttpStatusCode.OK);
         var provider = CreateProvider(handler, instanceKey: null);
 
         // Act
-        await provider.SendAsync(Guid.NewGuid(), ChannelType.DiscordDm, "u1", CreateTestPayload(), CancellationToken.None);
+        var act = () => provider.SendAsync(
+            Guid.NewGuid(), ChannelType.DiscordDm, "u1", CreateTestPayload(), CancellationToken.None);
 
-        // Assert -- an unauthenticated dispatch would be rejected, so none is sent
+        // Assert -- an unauthenticated dispatch would be rejected, so none is sent. The throw
+        // reaches AlertDeliveryService's MarkFailedAsync; a silent return would leave the
+        // alert_deliveries row pending forever.
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*instance key*");
         handler.CapturedRequest.Should().BeNull();
     }
 
     [Fact]
-    public async Task SendAsync_SkipsDispatch_WhenNoTenantResolved()
+    public async Task SendAsync_ThrowsWithoutDispatching_WhenNoTenantResolved()
     {
         // Arrange
         var handler = new MockHttpMessageHandler(HttpStatusCode.OK);
         var provider = CreateProvider(handler, tenantSlug: null);
 
         // Act
-        await provider.SendAsync(Guid.NewGuid(), ChannelType.DiscordDm, "u1", CreateTestPayload(), CancellationToken.None);
+        var act = () => provider.SendAsync(
+            Guid.NewGuid(), ChannelType.DiscordDm, "u1", CreateTestPayload(), CancellationToken.None);
 
         // Assert
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*tenant*");
         handler.CapturedRequest.Should().BeNull();
     }
 
@@ -198,30 +206,35 @@ public class ChatBotProviderTests
     [Fact]
     public async Task SendAsync_DoesNotFallBackToThePublicBaseUrl()
     {
-        // Arrange -- only the public base URL is configured. An edge proxy in front of
-        // it strips X-Instance-Key/X-Instance-Service (the /api/** prefix is
-        // internet-reachable), so dispatching there would 401 and drop the alert.
+        // Arrange -- only the public base URL is configured. Dispatching there would hairpin an
+        // intra-cluster call out through the CDN and edge and back in, carrying the instance-key
+        // service credential across the public internet.
         var handler = new MockHttpMessageHandler(HttpStatusCode.OK);
         var provider = CreateProvider(handler, webUrl: "", baseUrl: "https://nocturne.run");
 
         // Act
-        await provider.SendAsync(Guid.NewGuid(), ChannelType.DiscordDm, "u1", CreateTestPayload(), CancellationToken.None);
+        var act = () => provider.SendAsync(
+            Guid.NewGuid(), ChannelType.DiscordDm, "u1", CreateTestPayload(), CancellationToken.None);
 
         // Assert -- no request at all, rather than one to the public URL
+        await act.Should().ThrowAsync<InvalidOperationException>();
         handler.CapturedRequest.Should().BeNull();
     }
 
     [Fact]
-    public async Task SendAsync_LogsWarning_WhenWebUrlNotConfigured()
+    public async Task SendAsync_ThrowsWithoutDispatching_WhenWebUrlNotConfigured()
     {
         // Arrange
         var handler = new MockHttpMessageHandler(HttpStatusCode.OK);
         var provider = CreateProvider(handler, webUrl: "", baseUrl: "");
 
-        // Act -- should return early without throwing
-        await provider.SendAsync(Guid.NewGuid(), ChannelType.DiscordDm, "u1", CreateTestPayload(), CancellationToken.None);
+        // Act
+        var act = () => provider.SendAsync(
+            Guid.NewGuid(), ChannelType.DiscordDm, "u1", CreateTestPayload(), CancellationToken.None);
 
-        // Assert -- no HTTP request was made
+        // Assert -- no HTTP request, and the reason reaches the delivery row
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*WEB_URL*");
         handler.CapturedRequest.Should().BeNull();
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/Providers/ChatBotProviderTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/Providers/ChatBotProviderTests.cs
@@ -180,24 +180,39 @@ public class ChatBotProviderTests
     }
 
     [Fact]
-    public async Task SendAsync_FallsBackToBaseUrl_WhenWebUrlNotConfigured()
+    public async Task SendAsync_PostsToTheInternalWebAddress()
     {
-        // Arrange -- no WEB_URL (the nocturne-cloud deployment shape), only the
-        // public base URL, which routes /api/v4/bot/dispatch to web via the gateway.
+        // Arrange -- WEB_URL is the web app's address on the deployment's internal
+        // network, so the dispatch never leaves it.
+        var handler = new MockHttpMessageHandler(HttpStatusCode.OK);
+        var provider = CreateProvider(handler, webUrl: "http://nocturne-web:5173");
+
+        // Act
+        await provider.SendAsync(Guid.NewGuid(), ChannelType.DiscordDm, "u1", CreateTestPayload(), CancellationToken.None);
+
+        // Assert
+        handler.CapturedRequest!.RequestUri!.ToString()
+            .Should().Be("http://nocturne-web:5173/api/v4/bot/dispatch");
+    }
+
+    [Fact]
+    public async Task SendAsync_DoesNotFallBackToThePublicBaseUrl()
+    {
+        // Arrange -- only the public base URL is configured. An edge proxy in front of
+        // it strips X-Instance-Key/X-Instance-Service (the /api/** prefix is
+        // internet-reachable), so dispatching there would 401 and drop the alert.
         var handler = new MockHttpMessageHandler(HttpStatusCode.OK);
         var provider = CreateProvider(handler, webUrl: "", baseUrl: "https://nocturne.run");
 
         // Act
         await provider.SendAsync(Guid.NewGuid(), ChannelType.DiscordDm, "u1", CreateTestPayload(), CancellationToken.None);
 
-        // Assert
-        handler.CapturedRequest.Should().NotBeNull();
-        handler.CapturedRequest!.RequestUri!.ToString()
-            .Should().Be("https://nocturne.run/api/v4/bot/dispatch");
+        // Assert -- no request at all, rather than one to the public URL
+        handler.CapturedRequest.Should().BeNull();
     }
 
     [Fact]
-    public async Task SendAsync_LogsWarning_WhenNeitherUrlConfigured()
+    public async Task SendAsync_LogsWarning_WhenWebUrlNotConfigured()
     {
         // Arrange
         var handler = new MockHttpMessageHandler(HttpStatusCode.OK);

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/Providers/ChatBotProviderTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/Providers/ChatBotProviderTests.cs
@@ -6,6 +6,9 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.API.Services.Alerts.Providers;
+using Nocturne.Connectors.Core.Utilities;
+using Nocturne.Core.Constants;
+using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Alerts;
 using Xunit;
@@ -31,10 +34,15 @@ public class ChatBotProviderTests
         Severity = AlertRuleSeverity.Critical,
     };
 
+    private const string TestInstanceKey = "test-instance-key";
+    private const string TestTenantSlug = "acme";
+
     private static ChatBotProvider CreateProvider(
         MockHttpMessageHandler handler,
         string? webUrl = "https://web.example.com",
-        string? baseUrl = null)
+        string? baseUrl = null,
+        string? instanceKey = TestInstanceKey,
+        string? tenantSlug = TestTenantSlug)
     {
         var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
 
@@ -46,10 +54,23 @@ public class ChatBotProviderTests
         var configMock = new Mock<IConfiguration>();
         configMock.Setup(c => c["WEB_URL"]).Returns(webUrl);
         configMock.Setup(c => c["BaseUrl"]).Returns(baseUrl);
+        configMock.Setup(c => c["INSTANCE_KEY"]).Returns(instanceKey);
+
+        var tenantAccessorMock = new Mock<ITenantAccessor>();
+        if (tenantSlug is not null)
+        {
+            tenantAccessorMock
+                .Setup(a => a.Context)
+                .Returns(new TenantContext(Guid.NewGuid(), tenantSlug, "Acme", true));
+        }
 
         var logger = NullLoggerFactory.Instance.CreateLogger<ChatBotProvider>();
 
-        return new ChatBotProvider(httpClientFactoryMock.Object, configMock.Object, logger);
+        return new ChatBotProvider(
+            httpClientFactoryMock.Object,
+            configMock.Object,
+            tenantAccessorMock.Object,
+            logger);
     }
 
     [Fact]
@@ -90,6 +111,72 @@ public class ChatBotProviderTests
         root.GetProperty("channelType").GetString().Should().Be("slack_dm");
         root.GetProperty("destination").GetString().Should().Be("dest-1");
         root.TryGetProperty("payload", out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SendAsync_SendsInstanceKeyServiceCredential()
+    {
+        // Arrange -- the dispatch route is internet-reachable through the gateway and
+        // authenticates the caller on the instance-key digest plus the service marker.
+        var handler = new MockHttpMessageHandler(HttpStatusCode.OK);
+        var provider = CreateProvider(handler);
+
+        // Act
+        await provider.SendAsync(Guid.NewGuid(), ChannelType.DiscordDm, "u1", CreateTestPayload(), CancellationToken.None);
+
+        // Assert
+        handler.CapturedRequest.Should().NotBeNull();
+        handler.CapturedRequest!.Headers
+            .GetValues(ServiceNames.Headers.InstanceKey).Single()
+            .Should().Be(HashUtils.Sha256Hex(TestInstanceKey));
+        handler.CapturedRequest.Headers
+            .GetValues(ServiceNames.Headers.InstanceService).Single()
+            .Should().Be(ServiceNames.NocturneApi);
+    }
+
+    [Fact]
+    public async Task SendAsync_NamesTargetTenantInBody()
+    {
+        // Arrange
+        var handler = new MockHttpMessageHandler(HttpStatusCode.OK);
+        var provider = CreateProvider(handler);
+
+        // Act
+        await provider.SendAsync(Guid.NewGuid(), ChannelType.DiscordDm, "u1", CreateTestPayload(), CancellationToken.None);
+
+        // Assert -- the route scopes its API calls to this slug rather than a forwarded host
+        handler.CapturedContent.Should().NotBeNullOrEmpty();
+        JsonDocument.Parse(handler.CapturedContent!).RootElement
+            .GetProperty("tenantSlug").GetString()
+            .Should().Be(TestTenantSlug);
+    }
+
+    [Fact]
+    public async Task SendAsync_SkipsDispatch_WhenInstanceKeyNotConfigured()
+    {
+        // Arrange
+        var handler = new MockHttpMessageHandler(HttpStatusCode.OK);
+        var provider = CreateProvider(handler, instanceKey: null);
+
+        // Act
+        await provider.SendAsync(Guid.NewGuid(), ChannelType.DiscordDm, "u1", CreateTestPayload(), CancellationToken.None);
+
+        // Assert -- an unauthenticated dispatch would be rejected, so none is sent
+        handler.CapturedRequest.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SendAsync_SkipsDispatch_WhenNoTenantResolved()
+    {
+        // Arrange
+        var handler = new MockHttpMessageHandler(HttpStatusCode.OK);
+        var provider = CreateProvider(handler, tenantSlug: null);
+
+        // Act
+        await provider.SendAsync(Guid.NewGuid(), ChannelType.DiscordDm, "u1", CreateTestPayload(), CancellationToken.None);
+
+        // Assert
+        handler.CapturedRequest.Should().BeNull();
     }
 
     [Fact]


### PR DESCRIPTION
Closes the anonymous `/api/v4/bot/dispatch` route (reachable from the internet via gateway `route7`, and directly on origin `:80` without passing Cloudflare), makes chat-bot dispatch require an internal `WEB_URL`, and fails the delivery row when a dispatch cannot be built. Also bounds `/api/otel/errors` on bytes read.

Supersedes `fix/internal-route-instance-key-auth`, whose commit is the first of the four here.

Detail is in the commit messages.

Context worth flagging for whoever looks at this:
- Chat-bot delivery has been failing in production for 11+ days (every Discord delivery 403, zero delivered) because `WEB_URL` was the public apex and the dispatch hairpinned out through the CDN. Production has been pointed at the internal address; the matching AppHost change lands separately in nocturne-cloud.
- CI runs neither the SvelteKit vitest suite nor the Aspire API integration tests, so the TypeScript half of this is verified locally only: 31 vitest assertions across `instance-key`, `dispatch` and `otel/errors`, plus 4247 C# unit tests.