### PR TITLE
fix(api): gate every V4 write action on a data-category scope

### DIFF
--- a/src/API/Nocturne.API/Attributes/RequireDeclaredWriteScopeAttribute.cs
+++ b/src/API/Nocturne.API/Attributes/RequireDeclaredWriteScopeAttribute.cs
@@ -1,0 +1,78 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Nocturne.API.Extensions;
+using Nocturne.Core.Models.Authorization;
+
+namespace Nocturne.API.Attributes;
+
+/// <summary>
+/// Implemented by a controller that declares a single OAuth scope covering all of its write
+/// actions. <see cref="RequireDeclaredWriteScopeAttribute"/> reads the declaration and enforces it.
+/// </summary>
+/// <remarks>
+/// Declaring the scope on the controller (rather than repeating a
+/// <see cref="RequireScopeAttribute"/> on every action) lets a shared base class carry the
+/// enforcement attribute while each concrete controller supplies its own data category. When the
+/// member is abstract on that base class, the compiler requires every derived controller to
+/// declare one.
+/// </remarks>
+/// <seealso cref="RequireDeclaredWriteScopeAttribute"/>
+/// <seealso cref="OAuthScopes"/>
+public interface IWriteScopedController
+{
+    /// <summary>
+    /// The OAuth scope required to execute this controller's write actions, from
+    /// <see cref="OAuthScopes"/>.
+    /// </summary>
+    string WriteScope { get; }
+}
+
+/// <summary>
+/// Requires the OAuth scope the controller declares through
+/// <see cref="IWriteScopedController.WriteScope"/>. Denies the request when the controller declares
+/// no scope, so an action carrying this attribute can never execute unauthorized.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Runs as an action filter, not an authorization filter: the required scope comes from the
+/// controller instance, which <see cref="AuthorizationFilterContext"/> does not carry. Short
+/// circuiting here still precedes the action body, so no record is created, updated, or deleted.
+/// </para>
+/// <para>
+/// Method attributes are inherited by overrides, so placing this on a base-class action covers
+/// every derived controller's override of it.
+/// </para>
+/// </remarks>
+/// <seealso cref="IWriteScopedController"/>
+/// <seealso cref="RequireScopeAttribute"/>
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class RequireDeclaredWriteScopeAttribute : Attribute, IActionFilter
+{
+    /// <summary>
+    /// Evaluates the controller's declared write scope against the current request's granted scopes.
+    /// </summary>
+    /// <param name="context">The action filter context.</param>
+    public void OnActionExecuting(ActionExecutingContext context)
+    {
+        if (!context.HttpContext.IsAuthenticated())
+        {
+            context.Result = new UnauthorizedResult();
+            return;
+        }
+
+        if (context.Controller is not IWriteScopedController { WriteScope: { Length: > 0 } writeScope })
+        {
+            context.Result = new ForbidResult();
+            return;
+        }
+
+        if (!OAuthScopes.SatisfiesScope(context.HttpContext.GetGrantedScopes(), writeScope))
+            context.Result = new ForbidResult();
+    }
+
+    /// <summary>No-op; the check runs before the action executes.</summary>
+    /// <param name="context">The action executed context.</param>
+    public void OnActionExecuted(ActionExecutedContext context)
+    {
+    }
+}

--- a/src/API/Nocturne.API/Attributes/RequireScopeAttribute.cs
+++ b/src/API/Nocturne.API/Attributes/RequireScopeAttribute.cs
@@ -29,6 +29,12 @@ public class RequireScopeAttribute : Attribute, IAuthorizationFilter
     private readonly bool _requireAll;
 
     /// <summary>
+    /// The scopes this attribute requires, in declaration order. Read by the guard test that asserts
+    /// each write action requires the scope for its data category.
+    /// </summary>
+    public IReadOnlyList<string> Scopes => _requiredScopes;
+
+    /// <summary>
     /// Require one or more OAuth scopes.
     /// By default, any one of the listed scopes is sufficient (OR logic).
     /// </summary>

--- a/src/API/Nocturne.API/Authorization/ScopeForbiddenExtensions.cs
+++ b/src/API/Nocturne.API/Authorization/ScopeForbiddenExtensions.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Nocturne.API.Authorization;
+
+/// <summary>
+/// Shared 403 response for the controllers that enforce a write scope in the handler rather than
+/// through <see cref="Attributes.RequireScopeAttribute"/> — the ones whose required scope depends on
+/// the record being written, so no attribute scan can determine it.
+/// </summary>
+/// <seealso cref="ActivityWriteScopeGuard"/>
+/// <seealso cref="StateSpanWriteScopeGuard"/>
+internal static class ScopeForbiddenExtensions
+{
+    /// <summary>
+    /// Returns the 403 a per-record scope guard produces, worded the same way for every caller so
+    /// the response does not reveal which controller enforced it.
+    /// </summary>
+    /// <param name="controller">The controller producing the response.</param>
+    /// <param name="scope">The scope the caller is missing.</param>
+    public static ObjectResult ForbiddenForScope(this ControllerBase controller, string scope) =>
+        controller.Problem(
+            detail: $"This operation requires the '{scope}' scope.",
+            statusCode: StatusCodes.Status403Forbidden,
+            title: "Forbidden");
+}

--- a/src/API/Nocturne.API/Authorization/StateSpanWriteScopeGuard.cs
+++ b/src/API/Nocturne.API/Authorization/StateSpanWriteScopeGuard.cs
@@ -1,0 +1,90 @@
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
+
+namespace Nocturne.API.Authorization;
+
+/// <summary>
+/// Enforces per-record OAuth write scopes on the state-span write endpoints.
+/// <c>state_spans</c> holds four different data categories behind one table and one controller,
+/// and the caller chooses which by setting <see cref="StateSpan.Category"/> in the request body,
+/// so a single declared controller scope would either under-gate the other three categories or
+/// deny the common one. The same shape as <see cref="ActivityWriteScopeGuard"/>: the controller
+/// applies this before delegating to the service.
+/// </summary>
+/// <remarks>
+/// The category that matters most here is <see cref="StateSpanCategory.DataExclusion"/>. Excluding
+/// a window marks glucose readings as not to be counted, so it changes what analytics and reports
+/// show — it is a glucose-integrity write, not a treatment annotation, and gating it on the
+/// treatments scope would let a treatments-only credential hide a hypo from every report.
+/// <para>
+/// Connector publishing writes state spans through <c>IStateSpanService</c> directly rather than
+/// through this controller, so it is not gated here — the same carve-out
+/// <see cref="ActivityWriteScopeGuard"/> documents.
+/// </para>
+/// </remarks>
+/// <seealso cref="ShareDataCategories"/>
+internal static class StateSpanWriteScopeGuard
+{
+    /// <summary>
+    /// The write scope each state-span category belongs to. Chosen from the category the record's
+    /// content belongs to, matching what the equivalent V1/V3 endpoint requires:
+    /// <list type="bullet">
+    /// <item><see cref="StateSpanCategory.PumpMode"/> and
+    /// <see cref="StateSpanCategory.PumpConnectivity"/> describe the pump, so they are the devices
+    /// category — the same category <c>ReservoirReportsController</c> and the pump-snapshot
+    /// surface use.</item>
+    /// <item><see cref="StateSpanCategory.Profile"/> is a profile switch, which V1/V3 profile
+    /// writes gate on the therapy scope.</item>
+    /// <item><see cref="StateSpanCategory.DataExclusion"/> governs which glucose readings count,
+    /// so it is the glucose category.</item>
+    /// <item><see cref="StateSpanCategory.Override"/>, <see cref="StateSpanCategory.Exercise"/>,
+    /// <see cref="StateSpanCategory.Illness"/>, <see cref="StateSpanCategory.Travel"/> and
+    /// <see cref="StateSpanCategory.TemporaryTarget"/> are the decomposed form of the legacy
+    /// treatment events, which V1 <c>ActivityController</c> and V3 <c>TreatmentsController</c>
+    /// both gate on the treatments scope.</item>
+    /// </list>
+    /// </summary>
+    public static readonly IReadOnlyDictionary<StateSpanCategory, string> CategoryWriteScopes =
+        new Dictionary<StateSpanCategory, string>
+        {
+            [StateSpanCategory.PumpMode] = OAuthScopes.DevicesReadWrite,
+            [StateSpanCategory.PumpConnectivity] = OAuthScopes.DevicesReadWrite,
+            [StateSpanCategory.Profile] = OAuthScopes.TherapyReadWrite,
+            [StateSpanCategory.DataExclusion] = OAuthScopes.GlucoseReadWrite,
+            [StateSpanCategory.Override] = OAuthScopes.TreatmentsReadWrite,
+            [StateSpanCategory.Exercise] = OAuthScopes.TreatmentsReadWrite,
+            [StateSpanCategory.Illness] = OAuthScopes.TreatmentsReadWrite,
+            [StateSpanCategory.Travel] = OAuthScopes.TreatmentsReadWrite,
+            [StateSpanCategory.TemporaryTarget] = OAuthScopes.TreatmentsReadWrite,
+        };
+
+    /// <summary>
+    /// Returns the write scope required for <paramref name="category"/>. An unmapped category —
+    /// one added to the enum without being classified here — resolves to
+    /// <see cref="OAuthScopes.FullAccess"/> so a new category fails closed rather than inheriting
+    /// whichever scope happened to be listed first.
+    /// </summary>
+    public static string RequiredWriteScope(StateSpanCategory category) =>
+        CategoryWriteScopes.TryGetValue(category, out var scope) ? scope : OAuthScopes.FullAccess;
+
+    /// <summary>
+    /// Returns the first write scope the caller is missing across
+    /// <paramref name="categories"/>, or <see langword="null"/> when all are satisfied. An update
+    /// that moves a span between categories passes both, so the caller needs write access to the
+    /// category it is leaving as well as the one it is entering.
+    /// </summary>
+    /// <param name="grantedScopes">The caller's resolved granted scopes.</param>
+    /// <param name="categories">The categories the write touches.</param>
+    public static string? FindMissingScope(
+        IReadOnlySet<string> grantedScopes,
+        params StateSpanCategory[] categories)
+    {
+        foreach (var scope in categories.Select(RequiredWriteScope).Distinct())
+        {
+            if (!OAuthScopes.SatisfiesScope(grantedScopes, scope))
+                return scope;
+        }
+
+        return null;
+    }
+}

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/StateSpansController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/StateSpansController.cs
@@ -1,8 +1,10 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
 using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
 
 namespace Nocturne.API.Controllers.V4.Analytics;
@@ -31,8 +33,19 @@ namespace Nocturne.API.Controllers.V4.Analytics;
 [Tags("State Spans")]
 [Route("api/v4/state-spans")]
 [Authorize]
-public class StateSpansController : ControllerBase
+public class StateSpansController : ControllerBase, IWriteScopedController
 {
+    /// <summary>
+    /// The OAuth scope every write action on this controller requires. <c>state_spans</c> is not in
+    /// <see cref="ShareDataCategories.GovernedTables"/>, but its rows are the decomposed form of
+    /// legacy treatment events — temporary targets, profile switches, exercise, illness and travel
+    /// are <c>treatments</c> in V1/V3, and the temp-basal spans are written by
+    /// <c>V3 TreatmentsController</c>. Both V1 <c>ActivityController</c> and V3
+    /// <c>TreatmentsController</c> gate their writes on <c>treatments.readwrite</c>. The class-level
+    /// <c>[Authorize]</c> alone is satisfied by read-only credentials such as a guest-link session.
+    /// </summary>
+    public string WriteScope => OAuthScopes.TreatmentsReadWrite;
+
     private readonly IStateSpanService _stateSpanService;
 
     public StateSpansController(IStateSpanService stateSpanService)
@@ -310,6 +323,7 @@ public class StateSpansController : ControllerBase
     /// Create a new state span (manual entry)
     /// </summary>
     [HttpPost]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetStateSpans"])]
     [ProducesResponseType(typeof(StateSpan), StatusCodes.Status201Created)]
     public async Task<ActionResult<StateSpan>> CreateStateSpan(
@@ -335,6 +349,7 @@ public class StateSpansController : ControllerBase
     /// Update an existing state span
     /// </summary>
     [HttpPut("{id}")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetStateSpans", "GetStateSpan"])]
     [ProducesResponseType(typeof(StateSpan), StatusCodes.Status200OK)]
     public async Task<ActionResult<StateSpan>> UpdateStateSpan(
@@ -370,6 +385,7 @@ public class StateSpansController : ControllerBase
     /// Delete a state span
     /// </summary>
     [HttpDelete("{id}")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetStateSpans"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<IActionResult> DeleteStateSpan(string id, CancellationToken cancellationToken = default)

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/StateSpansController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/StateSpansController.cs
@@ -2,6 +2,8 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
 using Nocturne.API.Attributes;
+using Nocturne.API.Authorization;
+using Nocturne.API.Extensions;
 using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Authorization;
@@ -33,18 +35,17 @@ namespace Nocturne.API.Controllers.V4.Analytics;
 [Tags("State Spans")]
 [Route("api/v4/state-spans")]
 [Authorize]
-public class StateSpansController : ControllerBase, IWriteScopedController
+public class StateSpansController : ControllerBase
 {
-    /// <summary>
-    /// The OAuth scope every write action on this controller requires. <c>state_spans</c> is not in
-    /// <see cref="ShareDataCategories.GovernedTables"/>, but its rows are the decomposed form of
-    /// legacy treatment events — temporary targets, profile switches, exercise, illness and travel
-    /// are <c>treatments</c> in V1/V3, and the temp-basal spans are written by
-    /// <c>V3 TreatmentsController</c>. Both V1 <c>ActivityController</c> and V3
-    /// <c>TreatmentsController</c> gate their writes on <c>treatments.readwrite</c>. The class-level
-    /// <c>[Authorize]</c> alone is satisfied by read-only credentials such as a guest-link session.
-    /// </summary>
-    public string WriteScope => OAuthScopes.TreatmentsReadWrite;
+    // Writes are gated per record by StateSpanWriteScopeGuard rather than by a single declared
+    // controller scope. state_spans is not in ShareDataCategories.GovernedTables and holds four
+    // different data categories behind one table: the caller picks which by setting
+    // StateSpan.Category in the body, so the required scope is not known until the body is read.
+    // A flat treatments.readwrite would let a treatments-only credential write PumpMode and
+    // PumpConnectivity spans (devices), Profile switches (therapy), and DataExclusion windows —
+    // which decide whether glucose readings count towards analytics and reports, so excluding one
+    // can hide a hypo. The class-level [Authorize] alone is satisfied by read-only credentials
+    // such as a guest-link session, which is what this closes.
 
     private readonly IStateSpanService _stateSpanService;
 
@@ -323,13 +324,18 @@ public class StateSpansController : ControllerBase, IWriteScopedController
     /// Create a new state span (manual entry)
     /// </summary>
     [HttpPost]
-    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetStateSpans"])]
     [ProducesResponseType(typeof(StateSpan), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<StateSpan>> CreateStateSpan(
         [FromBody] CreateStateSpanRequest request,
         CancellationToken cancellationToken = default)
     {
+        var missingScope = StateSpanWriteScopeGuard.FindMissingScope(
+            HttpContext.GetGrantedScopes(), request.Category);
+        if (missingScope is not null)
+            return this.ForbiddenForScope(missingScope);
+
         var stateSpan = new StateSpan
         {
             Category = request.Category,
@@ -349,9 +355,9 @@ public class StateSpansController : ControllerBase, IWriteScopedController
     /// Update an existing state span
     /// </summary>
     [HttpPut("{id}")]
-    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetStateSpans", "GetStateSpan"])]
     [ProducesResponseType(typeof(StateSpan), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<StateSpan>> UpdateStateSpan(
         string id,
         [FromBody] UpdateStateSpanRequest request,
@@ -360,6 +366,13 @@ public class StateSpansController : ControllerBase, IWriteScopedController
         var existing = await _stateSpanService.GetStateSpanByIdAsync(id, cancellationToken);
         if (existing == null)
             return NotFound();
+
+        // Both categories: moving a span out of one category and into another needs write access to
+        // each, or a caller could relocate a record into a category it may not write.
+        var missingScope = StateSpanWriteScopeGuard.FindMissingScope(
+            HttpContext.GetGrantedScopes(), existing.Category, request.Category ?? existing.Category);
+        if (missingScope is not null)
+            return this.ForbiddenForScope(missingScope);
 
         var updated = new StateSpan
         {
@@ -385,11 +398,21 @@ public class StateSpansController : ControllerBase, IWriteScopedController
     /// Delete a state span
     /// </summary>
     [HttpDelete("{id}")]
-    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetStateSpans"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> DeleteStateSpan(string id, CancellationToken cancellationToken = default)
     {
+        // The stored record's own category decides the scope, so the span has to be read first.
+        var existing = await _stateSpanService.GetStateSpanByIdAsync(id, cancellationToken);
+        if (existing == null)
+            return NotFound();
+
+        var missingScope = StateSpanWriteScopeGuard.FindMissingScope(
+            HttpContext.GetGrantedScopes(), existing.Category);
+        if (missingScope is not null)
+            return this.ForbiddenForScope(missingScope);
+
         var deleted = await _stateSpanService.DeleteStateSpanAsync(id, cancellationToken);
         if (!deleted)
             return NotFound();

--- a/src/API/Nocturne.API/Controllers/V4/Base/V4CrudControllerBase.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Base/V4CrudControllerBase.cs
@@ -1,7 +1,9 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
 using Nocturne.Core.Contracts.V4;
 
@@ -21,17 +23,27 @@ namespace Nocturne.API.Controllers.V4.Base;
 /// post-creation side effects (e.g., alert evaluation).
 /// Create and update methods are annotated with <see cref="RemoteFormAttribute"/>;
 /// delete uses <see cref="RemoteCommandAttribute"/>.
+/// Every write action is gated on <see cref="WriteScope"/>, which derived controllers must declare.
 /// </remarks>
 /// <seealso cref="V4ReadOnlyControllerBase{TModel, TRepository}"/>
 /// <seealso cref="IV4Record"/>
 /// <seealso cref="IV4Repository{TModel}"/>
+/// <seealso cref="RequireDeclaredWriteScopeAttribute"/>
 public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateRequest, TRepository>(TRepository repository)
-    : V4ReadOnlyControllerBase<TModel, TRepository>(repository)
+    : V4ReadOnlyControllerBase<TModel, TRepository>(repository), IWriteScopedController
     where TModel : class, IV4Record
     where TCreateRequest : class
     where TUpdateRequest : class
     where TRepository : IV4Repository<TModel>
 {
+    /// <summary>
+    /// The OAuth readwrite scope for this controller's data category (see <see cref="OAuthScopes"/>),
+    /// required by every write action. Abstract so a new V4 CRUD controller cannot ship without
+    /// declaring one: the class-level <c>[Authorize]</c> is satisfied by read-only credentials
+    /// (guest links, follower and public-share grants), which must not be able to write.
+    /// </summary>
+    public abstract string WriteScope { get; }
+
     /// <summary>
     /// Maps a create request DTO to the domain model.
     /// </summary>
@@ -58,8 +70,10 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
     /// </remarks>
     [HttpPost]
     [RemoteForm]
+    [RequireDeclaredWriteScope]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public virtual async Task<ActionResult<TModel>> Create([FromBody] TCreateRequest request, CancellationToken ct = default)
     {
         var model = MapCreateToModel(request);
@@ -83,8 +97,10 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
     /// </remarks>
     [HttpPut("{id:guid}")]
     [RemoteForm]
+    [RequireDeclaredWriteScope]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public virtual async Task<ActionResult<TModel>> Update(Guid id, [FromBody] TUpdateRequest request, CancellationToken ct = default)
     {
@@ -114,7 +130,9 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
     /// <remarks>Returns `204 No Content` on success, or `404 Not Found` if no record with the given <paramref name="id"/> exists.</remarks>
     [HttpDelete("{id:guid}")]
     [RemoteCommand]
+    [RequireDeclaredWriteScope]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public virtual async Task<ActionResult> Delete(Guid id, CancellationToken ct = default)
     {
@@ -151,7 +169,9 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
     /// <remarks>Returns `200 OK` with the restored record, or `404 Not Found` if no soft-deleted record with the given <paramref name="id"/> exists.</remarks>
     [HttpPost("{id:guid}/restore")]
     [RemoteCommand]
+    [RequireDeclaredWriteScope]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public virtual async Task<ActionResult<TModel>> Restore(Guid id, CancellationToken ct = default)
     {
@@ -173,7 +193,9 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
     /// <remarks>Returns `200 OK` with the restored records. IDs that don't match a soft-deleted record are silently ignored.</remarks>
     [HttpPost("restore")]
     [RemoteCommand]
+    [RequireDeclaredWriteScope]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public virtual async Task<ActionResult<IEnumerable<TModel>>> BulkRestore(
         [FromBody] Guid[] ids, CancellationToken ct = default)
     {

--- a/src/API/Nocturne.API/Controllers/V4/Devices/DeviceEventController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/DeviceEventController.cs
@@ -1,10 +1,12 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
 using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
 using Nocturne.Core.Contracts.V4;
 
@@ -41,6 +43,14 @@ public class DeviceEventController(
     IPatientDeviceStamper deviceStamper)
     : V4CrudControllerBase<DeviceEvent, UpsertDeviceEventRequest, UpsertDeviceEventRequest, IDeviceEventRepository>(repo)
 {
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Device events record hardware lifecycle (site/sensor/reservoir/battery changes) and sit under
+    /// the <c>devices.read</c> share category, so they follow devices rather than the treatments
+    /// category their legacy event types came from.
+    /// </remarks>
+    public override string WriteScope => OAuthScopes.DevicesReadWrite;
+
     /// <summary>
     /// Lists device events. Adds an optional <c>patientDeviceId</c> query filter on top of the base list
     /// surface: when set, only events linked to that registered device are returned. Pagination totals
@@ -185,7 +195,9 @@ public class DeviceEventController(
     /// Delete a device event by its external sync identifier (dataSource + syncIdentifier pair).
     /// </summary>
     [HttpDelete("by-sync-id")]
+    [RequireDeclaredWriteScope]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> DeleteBySyncIdentifier(

--- a/src/API/Nocturne.API/Controllers/V4/Devices/ReservoirReportsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/ReservoirReportsController.cs
@@ -1,11 +1,13 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
 
 namespace Nocturne.API.Controllers.V4.Devices;
@@ -43,7 +45,14 @@ public class ReservoirReportsController(
     /// <param name="request">The reservoir report.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The stored pump snapshot carrying the reported value.</returns>
+    /// <remarks>
+    /// Writes <c>pump_snapshots</c> and, for a fill, <c>device_events</c> — both the devices category
+    /// in <see cref="ShareDataCategories.GovernedTables"/>, matching the scope
+    /// <c>PumpSnapshotController</c> and <c>DeviceEventController</c> require. The class-level
+    /// <c>[Authorize]</c> alone is satisfied by read-only credentials such as a guest-link session.
+    /// </remarks>
     [HttpPost]
+    [RequireScope(OAuthScopes.DevicesReadWrite)]
     [RemoteCommand]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/src/API/Nocturne.API/Controllers/V4/Glucose/BGCheckController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/BGCheckController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
 
 namespace Nocturne.API.Controllers.V4.Glucose;
@@ -30,6 +31,14 @@ namespace Nocturne.API.Controllers.V4.Glucose;
 public class BGCheckController(IBGCheckRepository repo)
     : V4CrudControllerBase<BGCheck, UpsertBGCheckRequest, UpsertBGCheckRequest, IBGCheckRepository>(repo)
 {
+    /// <inheritdoc/>
+    /// <remarks>
+    /// BG checks hold a glucose value and sit under the <c>glucose.read</c> share category with the
+    /// other glucose tables, so they follow glucose rather than the treatments category their
+    /// legacy <c>BG Check</c> event type came from.
+    /// </remarks>
+    public override string WriteScope => OAuthScopes.GlucoseReadWrite;
+
     /// <summary>
     /// Maps a <see cref="UpsertBGCheckRequest"/> to a new <see cref="BGCheck"/> domain model for creation.
     /// </summary>

--- a/src/API/Nocturne.API/Controllers/V4/Glucose/CalibrationController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/CalibrationController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
 
 namespace Nocturne.API.Controllers.V4.Glucose;
@@ -30,6 +31,10 @@ namespace Nocturne.API.Controllers.V4.Glucose;
 public class CalibrationController(ICalibrationRepository repo)
     : V4CrudControllerBase<Calibration, UpsertCalibrationRequest, UpsertCalibrationRequest, ICalibrationRepository>(repo)
 {
+    /// <inheritdoc/>
+    /// <remarks>Calibrations are glucose data; the legacy equivalent is a v1 <c>cal</c> entry.</remarks>
+    public override string WriteScope => OAuthScopes.GlucoseReadWrite;
+
     /// <inheritdoc/>
     /// <remarks>Response is cached for 120 seconds, varied by all query parameters.</remarks>
     [ResponseCache(Duration = 120, VaryByQueryKeys = new[] { "*" })]

--- a/src/API/Nocturne.API/Controllers/V4/Glucose/MeterGlucoseController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/MeterGlucoseController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
 
 namespace Nocturne.API.Controllers.V4.Glucose;
@@ -29,6 +30,10 @@ namespace Nocturne.API.Controllers.V4.Glucose;
 public class MeterGlucoseController(IMeterGlucoseRepository repo)
     : V4CrudControllerBase<MeterGlucose, UpsertMeterGlucoseRequest, UpsertMeterGlucoseRequest, IMeterGlucoseRepository>(repo)
 {
+    /// <inheritdoc/>
+    /// <remarks>Meter readings are glucose data; the legacy equivalent is a v1 <c>mbg</c> entry.</remarks>
+    public override string WriteScope => OAuthScopes.GlucoseReadWrite;
+
     /// <inheritdoc/>
     /// <remarks>Response is cached for 120 seconds, varied by all query parameters.</remarks>
     [ResponseCache(Duration = 120, VaryByQueryKeys = new[] { "*" })]

--- a/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
 using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.API.Services.Glucose;
@@ -8,6 +9,7 @@ using Nocturne.Core.Contracts.Alerts;
 using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
 using Nocturne.Core.Contracts.V4;
 
@@ -37,6 +39,10 @@ public class SensorGlucoseController(
     ILogger<SensorGlucoseController> logger)
     : V4CrudControllerBase<SensorGlucose, UpsertSensorGlucoseRequest, UpsertSensorGlucoseRequest, ISensorGlucoseRepository>(repo)
 {
+    /// <inheritdoc/>
+    /// <remarks>CGM readings are glucose data; the legacy equivalent is a v1 entry.</remarks>
+    public override string WriteScope => OAuthScopes.GlucoseReadWrite;
+
     /// <summary>
     /// Lists sensor glucose readings. Adds an optional <c>patientDeviceId</c> query filter on top of the base
     /// list surface: when set, results are that registered device's raw readings (canonical stream selection is
@@ -161,8 +167,10 @@ public class SensorGlucoseController(
     /// Create multiple sensor glucose readings in bulk (max 1000).
     /// </summary>
     [HttpPost("bulk")]
+    [RequireDeclaredWriteScope]
     [ProducesResponseType(typeof(SensorGlucose[]), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<SensorGlucose[]>> CreateSensorGlucoseBulk(
         [FromBody] UpsertSensorGlucoseRequest[] requests,
         CancellationToken ct = default)

--- a/src/API/Nocturne.API/Controllers/V4/Health/ActivityController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/ActivityController.cs
@@ -94,7 +94,7 @@ public class ActivityController : ControllerBase
         var missingScope = ActivityWriteScopeGuard.FindMissingScope(
             activityList, _activityDecomposer, HttpContext.GetGrantedScopes());
         if (missingScope is not null)
-            return ForbiddenForScope(missingScope);
+            return this.ForbiddenForScope(missingScope);
 
         var result = await _activityService.CreateActivitiesAsync(activityList, cancellationToken);
         return StatusCode(StatusCodes.Status201Created, result);
@@ -123,7 +123,7 @@ public class ActivityController : ControllerBase
         var missingScope = ActivityWriteScopeGuard.FindMissingScope(
             toCheck, _activityDecomposer, HttpContext.GetGrantedScopes());
         if (missingScope is not null)
-            return ForbiddenForScope(missingScope);
+            return this.ForbiddenForScope(missingScope);
 
         var updated = await _activityService.UpdateActivityAsync(id, activity, cancellationToken);
         if (updated == null)
@@ -150,7 +150,7 @@ public class ActivityController : ControllerBase
             var missingScope = ActivityWriteScopeGuard.FindMissingScope(
                 [existing], _activityDecomposer, HttpContext.GetGrantedScopes());
             if (missingScope is not null)
-                return ForbiddenForScope(missingScope);
+                return this.ForbiddenForScope(missingScope);
         }
 
         var deleted = await _activityService.DeleteActivityAsync(id, cancellationToken);
@@ -159,11 +159,6 @@ public class ActivityController : ControllerBase
 
         return NoContent();
     }
-
-    private ObjectResult ForbiddenForScope(string scope) => Problem(
-        detail: $"This operation requires the '{scope}' scope.",
-        statusCode: StatusCodes.Status403Forbidden,
-        title: "Forbidden");
 
     private static Activity MapToActivity(UpsertActivityRequest request) => new()
     {

--- a/src/API/Nocturne.API/Controllers/V4/Health/BodyWeightController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/BodyWeightController.cs
@@ -1,8 +1,10 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
 using Nocturne.Core.Contracts.Health;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.API.Controllers.V4.Health;
 
@@ -18,8 +20,18 @@ namespace Nocturne.API.Controllers.V4.Health;
 [Tags("Health")]
 [Route("api/v4/body-weight")]
 [Authorize]
-public class BodyWeightController : ControllerBase
+public class BodyWeightController : ControllerBase, IWriteScopedController
 {
+    /// <summary>
+    /// The OAuth scope every write action on this controller requires. Body weight has no category
+    /// scope of its own: the record is patient clinical configuration, written from the Patient
+    /// Record settings form together with the therapy settings, so it is gated on
+    /// <c>therapy.readwrite</c>. The <c>health.readwrite</c> alias cannot be required —
+    /// <see cref="OAuthScopes.Normalize"/> expands it into per-category scopes, so no granted set
+    /// ever contains it.
+    /// </summary>
+    public string WriteScope => OAuthScopes.TherapyReadWrite;
+
     private readonly IBodyWeightService _bodyWeightService;
     private readonly ILogger<BodyWeightController> _logger;
 
@@ -92,6 +104,7 @@ public class BodyWeightController : ControllerBase
     /// Create a single body weight record
     /// </summary>
     [HttpPost]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetBodyWeights"])]
     [ProducesResponseType(typeof(BodyWeight), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -120,6 +133,7 @@ public class BodyWeightController : ControllerBase
     /// Create one or more body weight records (single object or array)
     /// </summary>
     [HttpPost("batch")]
+    [RequireDeclaredWriteScope]
     [ProducesResponseType(typeof(IEnumerable<BodyWeight>), 200)]
     [ProducesResponseType(400)]
     [ProducesResponseType(500)]
@@ -174,6 +188,7 @@ public class BodyWeightController : ControllerBase
     /// Update an existing body weight record
     /// </summary>
     [HttpPut("{id}")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetBodyWeights", "GetBodyWeight"])]
     [ProducesResponseType(typeof(BodyWeight), 200)]
     [ProducesResponseType(404)]
@@ -203,6 +218,7 @@ public class BodyWeightController : ControllerBase
     /// Delete a body weight record by ID
     /// </summary>
     [HttpDelete("{id}")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetBodyWeights", "GetBodyWeight"])]
     [ProducesResponseType(200)]
     [ProducesResponseType(404)]

--- a/src/API/Nocturne.API/Controllers/V4/Health/PatientRecordController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/PatientRecordController.cs
@@ -1,9 +1,11 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
 using Nocturne.API.Services.Devices;
 using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.Projections;
 using Nocturne.Core.Models.V4;
 using Nocturne.Core.Contracts.V4;
@@ -20,6 +22,12 @@ namespace Nocturne.API.Controllers.V4.Health;
 ///   <item><description><b>Devices</b> — devices (pumps, CGMs) linked to the patient record via <see cref="IPatientDeviceRepository"/>.</description></item>
 ///   <item><description><b>Insulins</b> — insulin types configured for the patient via the insulin catalog and patient insulin repository.</description></item>
 /// </list>
+///
+/// Write actions span two data categories, so each carries its own <see cref="RequireScopeAttribute"/>
+/// rather than one controller-wide declaration: the patient record and its insulin configuration
+/// (DIA, peak, curve — the inputs to the IOB calculation) are therapy settings, while the patient
+/// device registry is the devices category. The class-level <c>[Authorize]</c> alone is satisfied by
+/// read-only credentials such as a guest-link session.
 /// </remarks>
 /// <seealso cref="IPatientRecordRepository"/>
 /// <seealso cref="IPatientDeviceRepository"/>
@@ -74,6 +82,7 @@ public class PatientRecordController : ControllerBase
     /// Update the patient record
     /// </summary>
     [HttpPut]
+    [RequireScope(OAuthScopes.TherapyReadWrite)]
     [RemoteForm(Invalidates = ["GetPatientRecord"])]
     [ProducesResponseType(typeof(PatientRecord), StatusCodes.Status200OK)]
     public async Task<ActionResult<PatientRecord>> UpdatePatientRecord(
@@ -118,6 +127,7 @@ public class PatientRecordController : ControllerBase
     /// Create a new patient device
     /// </summary>
     [HttpPost("devices")]
+    [RequireScope(OAuthScopes.DevicesReadWrite)]
     [RemoteForm(Invalidates = ["GetDevices", "GetDiscoveredSources"])]
     [ProducesResponseType(typeof(PatientDevice), StatusCodes.Status201Created)]
     public async Task<ActionResult<PatientDevice>> CreateDevice(
@@ -135,6 +145,7 @@ public class PatientRecordController : ControllerBase
     /// Update a patient device
     /// </summary>
     [HttpPut("devices/{id:guid}")]
+    [RequireScope(OAuthScopes.DevicesReadWrite)]
     [RemoteForm(Invalidates = ["GetDevices"])]
     [ProducesResponseType(typeof(PatientDevice), StatusCodes.Status200OK)]
     public async Task<ActionResult<PatientDevice>> UpdateDevice(
@@ -151,6 +162,7 @@ public class PatientRecordController : ControllerBase
     /// Delete a patient device
     /// </summary>
     [HttpDelete("devices/{id:guid}")]
+    [RequireScope(OAuthScopes.DevicesReadWrite)]
     [RemoteCommand(Invalidates = ["GetDevices"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<ActionResult> DeleteDevice(Guid id, CancellationToken cancellationToken = default)
@@ -165,6 +177,7 @@ public class PatientRecordController : ControllerBase
     /// of one PUT per device. An imperative command (no HTML form), mirroring the delete/restore surface.
     /// </summary>
     [HttpPost("devices/reorder")]
+    [RequireScope(OAuthScopes.DevicesReadWrite)]
     [RemoteCommand(Invalidates = ["GetDevices"])]
     [ProducesResponseType(typeof(IEnumerable<PatientDevice>), StatusCodes.Status200OK)]
     public async Task<ActionResult<IEnumerable<PatientDevice>>> ReorderDevices(
@@ -209,6 +222,7 @@ public class PatientRecordController : ControllerBase
     /// Create a new patient insulin
     /// </summary>
     [HttpPost("insulins")]
+    [RequireScope(OAuthScopes.TherapyReadWrite)]
     [RemoteForm(Invalidates = ["GetInsulins"])]
     [ProducesResponseType(typeof(PatientInsulin), StatusCodes.Status201Created)]
     public async Task<ActionResult<PatientInsulin>> CreateInsulin(
@@ -225,6 +239,7 @@ public class PatientRecordController : ControllerBase
     /// Update a patient insulin
     /// </summary>
     [HttpPut("insulins/{id:guid}")]
+    [RequireScope(OAuthScopes.TherapyReadWrite)]
     [RemoteForm(Invalidates = ["GetInsulins"])]
     [ProducesResponseType(typeof(PatientInsulin), StatusCodes.Status200OK)]
     public async Task<ActionResult<PatientInsulin>> UpdateInsulin(
@@ -242,6 +257,7 @@ public class PatientRecordController : ControllerBase
     /// Delete a patient insulin
     /// </summary>
     [HttpDelete("insulins/{id:guid}")]
+    [RequireScope(OAuthScopes.TherapyReadWrite)]
     [RemoteCommand(Invalidates = ["GetInsulins"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<ActionResult> DeleteInsulin(Guid id, CancellationToken cancellationToken = default)

--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/TrackersController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/TrackersController.cs
@@ -4,10 +4,12 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
 using Nocturne.API.Extensions;
 using Nocturne.API.Services.Monitoring;
 using Nocturne.Core.Contracts.Alerts;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Abstractions;
 using Nocturne.Infrastructure.Data.Services;
@@ -23,8 +25,21 @@ namespace Nocturne.API.Controllers.V4.Monitoring;
 [ApiController]
 [Tags("Monitoring")]
 [Route("api/v4/trackers")]
-public class TrackersController : ControllerBase
+public class TrackersController : ControllerBase, IWriteScopedController
 {
+    /// <summary>
+    /// The OAuth scope every write action on this controller requires. The <c>tracker_*</c> tables
+    /// are not in <see cref="ShareDataCategories.GovernedTables"/> and have no V1/V3 data
+    /// equivalent: a tracker is monitoring state, not a patient observation. A definition's
+    /// notification thresholds are synthesised into managed alert rules
+    /// (<see cref="ITrackerAlertRuleSyncService"/>), an instance is keyed to the treatment that
+    /// triggered it rather than storing one, and acknowledging an instance acknowledges an alert
+    /// excursion (<see cref="IAlertAcknowledgementService"/>). V1 and V2 gate their notification
+    /// writes on <c>alerts.readwrite</c>. The per-action <c>[Authorize]</c> alone is satisfied by
+    /// read-only credentials such as a guest-link session, which holds <c>alerts.read</c>.
+    /// </summary>
+    public string WriteScope => OAuthScopes.AlertsReadWrite;
+
     private readonly ITrackerRepository _repository;
     private readonly ISignalRBroadcastService _broadcast;
     private readonly ITrackerAlertRuleSyncService _ruleSync;
@@ -221,6 +236,7 @@ public class TrackersController : ControllerBase
     /// Create a new tracker definition
     /// </summary>
     [HttpPost("definitions")]
+    [RequireDeclaredWriteScope]
     [Authorize]
     [RemoteForm(Invalidates = ["GetDefinitions"])]
     [ProducesResponseType(typeof(TrackerDefinitionDto), StatusCodes.Status201Created)]
@@ -315,6 +331,7 @@ public class TrackersController : ControllerBase
     /// Update a tracker definition
     /// </summary>
     [HttpPut("definitions/{id:guid}")]
+    [RequireDeclaredWriteScope]
     [Authorize]
     [RemoteForm(Invalidates = ["GetDefinitions", "GetDefinition"])]
     [ProducesResponseType(typeof(TrackerDefinitionDto), StatusCodes.Status200OK)]
@@ -420,6 +437,7 @@ public class TrackersController : ControllerBase
     /// Delete a tracker definition
     /// </summary>
     [HttpDelete("definitions/{id:guid}")]
+    [RequireDeclaredWriteScope]
     [Authorize]
     [RemoteCommand(Invalidates = ["GetDefinitions"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -518,6 +536,7 @@ public class TrackersController : ControllerBase
     /// Start a new tracker instance
     /// </summary>
     [HttpPost("instances")]
+    [RequireDeclaredWriteScope]
     [Authorize]
     [RemoteCommand(Invalidates = ["GetActiveInstances"])]
     [ProducesResponseType(typeof(TrackerInstanceDto), StatusCodes.Status201Created)]
@@ -573,6 +592,7 @@ public class TrackersController : ControllerBase
     /// Complete a tracker instance
     /// </summary>
     [HttpPut("instances/{id:guid}/complete")]
+    [RequireDeclaredWriteScope]
     [Authorize]
     [RemoteCommand(Invalidates = ["GetActiveInstances", "GetInstanceHistory"])]
     [ProducesResponseType(typeof(TrackerInstanceDto), StatusCodes.Status200OK)]
@@ -623,6 +643,7 @@ public class TrackersController : ControllerBase
     /// alert_state escalation rules' job, not a snooze re-fire.
     /// </summary>
     [HttpPost("instances/{id:guid}/ack")]
+    [RequireDeclaredWriteScope]
     [Authorize]
     [RemoteCommand(Invalidates = ["GetActiveInstances"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -663,6 +684,7 @@ public class TrackersController : ControllerBase
     /// Delete a tracker instance
     /// </summary>
     [HttpDelete("instances/{id:guid}")]
+    [RequireDeclaredWriteScope]
     [Authorize]
     [RemoteCommand(Invalidates = ["GetActiveInstances"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -709,6 +731,7 @@ public class TrackersController : ControllerBase
     /// Create a new preset
     /// </summary>
     [HttpPost("presets")]
+    [RequireDeclaredWriteScope]
     [Authorize]
     [RemoteCommand(Invalidates = ["GetPresets"])]
     [ProducesResponseType(typeof(TrackerPresetDto), StatusCodes.Status201Created)]
@@ -751,6 +774,7 @@ public class TrackersController : ControllerBase
     /// Apply a preset (starts a new instance)
     /// </summary>
     [HttpPost("presets/{id:guid}/apply")]
+    [RequireDeclaredWriteScope]
     [Authorize]
     [RemoteCommand(Invalidates = ["GetActiveInstances"])]
     [ProducesResponseType(typeof(TrackerInstanceDto), StatusCodes.Status200OK)]
@@ -784,6 +808,7 @@ public class TrackersController : ControllerBase
     /// Delete a preset
     /// </summary>
     [HttpDelete("presets/{id:guid}")]
+    [RequireDeclaredWriteScope]
     [Authorize]
     [RemoteCommand(Invalidates = ["GetPresets"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]

--- a/src/API/Nocturne.API/Controllers/V4/Profiles/ProfileController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Profiles/ProfileController.cs
@@ -1,7 +1,9 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
 using Nocturne.Core.Contracts.Profiles;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
@@ -23,8 +25,17 @@ namespace Nocturne.API.Controllers.V4.Profiles;
 [Route("api/v4/profile")]
 [Authorize]
 [Produces("application/json")]
-public class ProfileController : ControllerBase
+public class ProfileController : ControllerBase, IWriteScopedController
 {
+    /// <summary>
+    /// The OAuth scope every write action on this controller requires. Therapy settings, basal,
+    /// carb ratio, sensitivity and target range schedules are the therapy category — governed by
+    /// <c>therapy.read</c> for reads, and gated with <c>therapy.readwrite</c> on the V1 and V3
+    /// profile write endpoints. The class-level <c>[Authorize]</c> alone is satisfied by read-only
+    /// credentials such as a guest-link session.
+    /// </summary>
+    public string WriteScope => OAuthScopes.TherapyReadWrite;
+
     private readonly ITherapySettingsRepository _therapyRepo;
     private readonly IBasalScheduleRepository _basalRepo;
     private readonly ICarbRatioScheduleRepository _carbRatioRepo;
@@ -152,6 +163,7 @@ public class ProfileController : ControllerBase
     /// Set a profile as the active (default) profile. Clears IsDefault on all other profiles.
     /// </summary>
     [HttpPost("set-default/{profileName}")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetProfileSummary", "GetTherapySettings"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -294,6 +306,7 @@ public class ProfileController : ControllerBase
     /// Create a new therapy settings record
     /// </summary>
     [HttpPost("settings")]
+    [RequireDeclaredWriteScope]
     [RemoteForm(Invalidates = ["GetProfileSummary", "GetTherapySettings"])]
     [ProducesResponseType(typeof(TherapySettings), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -312,6 +325,7 @@ public class ProfileController : ControllerBase
     /// Update an existing therapy settings record
     /// </summary>
     [HttpPut("settings/{id:guid}")]
+    [RequireDeclaredWriteScope]
     [RemoteForm(
         Invalidates = ["GetProfileSummary", "GetTherapySettings", "GetTherapySettingsById"]
     )]
@@ -341,6 +355,7 @@ public class ProfileController : ControllerBase
     /// Delete a therapy settings record
     /// </summary>
     [HttpDelete("settings/{id:guid}")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetProfileSummary", "GetTherapySettings"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -396,6 +411,7 @@ public class ProfileController : ControllerBase
     /// Create a new basal schedule
     /// </summary>
     [HttpPost("basal")]
+    [RequireDeclaredWriteScope]
     [RemoteForm(Invalidates = ["GetProfileSummary", "GetBasalSchedulesByName"])]
     [ProducesResponseType(typeof(BasalSchedule), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -414,6 +430,7 @@ public class ProfileController : ControllerBase
     /// Update an existing basal schedule
     /// </summary>
     [HttpPut("basal/{id:guid}")]
+    [RequireDeclaredWriteScope]
     [RemoteForm(
         Invalidates = ["GetProfileSummary", "GetBasalSchedulesByName", "GetBasalScheduleById"]
     )]
@@ -443,6 +460,7 @@ public class ProfileController : ControllerBase
     /// Delete a basal schedule
     /// </summary>
     [HttpDelete("basal/{id:guid}")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetProfileSummary", "GetBasalSchedulesByName"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -498,6 +516,7 @@ public class ProfileController : ControllerBase
     /// Create a new carb ratio schedule
     /// </summary>
     [HttpPost("carb-ratio")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetProfileSummary", "GetCarbRatioSchedulesByName"])]
     [ProducesResponseType(typeof(CarbRatioSchedule), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -516,6 +535,7 @@ public class ProfileController : ControllerBase
     /// Update an existing carb ratio schedule
     /// </summary>
     [HttpPut("carb-ratio/{id:guid}")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(
         Invalidates = [
             "GetProfileSummary",
@@ -549,6 +569,7 @@ public class ProfileController : ControllerBase
     /// Delete a carb ratio schedule
     /// </summary>
     [HttpDelete("carb-ratio/{id:guid}")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetProfileSummary", "GetCarbRatioSchedulesByName"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -604,6 +625,7 @@ public class ProfileController : ControllerBase
     /// Create a new sensitivity schedule
     /// </summary>
     [HttpPost("sensitivity")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetProfileSummary", "GetSensitivitySchedulesByName"])]
     [ProducesResponseType(typeof(SensitivitySchedule), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -626,6 +648,7 @@ public class ProfileController : ControllerBase
     /// Update an existing sensitivity schedule
     /// </summary>
     [HttpPut("sensitivity/{id:guid}")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(
         Invalidates = [
             "GetProfileSummary",
@@ -659,6 +682,7 @@ public class ProfileController : ControllerBase
     /// Delete a sensitivity schedule
     /// </summary>
     [HttpDelete("sensitivity/{id:guid}")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetProfileSummary", "GetSensitivitySchedulesByName"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -717,6 +741,7 @@ public class ProfileController : ControllerBase
     /// Create a new target range schedule
     /// </summary>
     [HttpPost("target-range")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetProfileSummary", "GetTargetRangeSchedulesByName"])]
     [ProducesResponseType(typeof(TargetRangeSchedule), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -739,6 +764,7 @@ public class ProfileController : ControllerBase
     /// Update an existing target range schedule
     /// </summary>
     [HttpPut("target-range/{id:guid}")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(
         Invalidates = [
             "GetProfileSummary",
@@ -772,6 +798,7 @@ public class ProfileController : ControllerBase
     /// Delete a target range schedule
     /// </summary>
     [HttpDelete("target-range/{id:guid}")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetProfileSummary", "GetTargetRangeSchedulesByName"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/src/API/Nocturne.API/Controllers/V4/Profiles/UISettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Profiles/UISettingsController.cs
@@ -2,8 +2,10 @@ using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Core.Contracts.Profiles;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.Configuration;
 
 namespace Nocturne.API.Controllers.V4.Profiles;
@@ -19,8 +21,21 @@ namespace Nocturne.API.Controllers.V4.Profiles;
 [Route("api/v4/ui-settings")]
 [ClientPropertyName("uiSettings")]
 [Authorize]
-public class UISettingsController : ControllerBase
+public class UISettingsController : ControllerBase, IWriteScopedController
 {
+    /// <summary>
+    /// The OAuth scope every write action on this controller requires. These writes are
+    /// tenant-wide configuration, not per-user presentation state:
+    /// <see cref="IUISettingsService.SaveSettingsAsync"/> takes no subject, and
+    /// <see cref="UISettingsConfiguration"/> carries <see cref="NotificationSettings"/> — the alarm
+    /// thresholds and profiles that decide whether a low-glucose alert fires — so the whole-blob PUT
+    /// reaches alarm behaviour as directly as the <c>/notifications/alarms</c> routes do. V1 and V2
+    /// gate their notification writes on <c>alerts.readwrite</c>. The class-level <c>[Authorize]</c>
+    /// alone is satisfied by read-only credentials such as a guest-link session, which holds
+    /// <c>alerts.read</c>.
+    /// </summary>
+    public string WriteScope => OAuthScopes.AlertsReadWrite;
+
     private readonly ILogger<UISettingsController> _logger;
     private readonly IConfiguration _configuration;
     private readonly IHttpClientFactory _httpClientFactory;
@@ -165,6 +180,7 @@ public class UISettingsController : ControllerBase
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The saved settings</returns>
     [HttpPut]
+    [RequireDeclaredWriteScope]
     [ProducesResponseType(typeof(UISettingsConfiguration), 200)]
     [ProducesResponseType(400)]
     [ProducesResponseType(500)]
@@ -210,6 +226,7 @@ public class UISettingsController : ControllerBase
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The saved notification settings</returns>
     [HttpPut("notifications")]
+    [RequireDeclaredWriteScope]
     [ProducesResponseType(typeof(NotificationSettings), 200)]
     [ProducesResponseType(400)]
     [ProducesResponseType(500)]
@@ -283,6 +300,7 @@ public class UISettingsController : ControllerBase
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The saved alarm configuration</returns>
     [HttpPut("notifications/alarms")]
+    [RequireDeclaredWriteScope]
     [ProducesResponseType(typeof(UserAlarmConfiguration), 200)]
     [ProducesResponseType(400)]
     [ProducesResponseType(500)]
@@ -325,6 +343,7 @@ public class UISettingsController : ControllerBase
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The saved alarm configuration</returns>
     [HttpPost("notifications/alarms/profiles")]
+    [RequireDeclaredWriteScope]
     [ProducesResponseType(typeof(UserAlarmConfiguration), 200)]
     [ProducesResponseType(400)]
     [ProducesResponseType(500)]
@@ -365,6 +384,7 @@ public class UISettingsController : ControllerBase
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The updated alarm configuration</returns>
     [HttpDelete("notifications/alarms/profiles/{profileId}")]
+    [RequireDeclaredWriteScope]
     [ProducesResponseType(typeof(UserAlarmConfiguration), 200)]
     [ProducesResponseType(404)]
     [ProducesResponseType(500)]

--- a/src/API/Nocturne.API/Controllers/V4/TimezoneTimelineController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/TimezoneTimelineController.cs
@@ -1,8 +1,10 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
 using Nocturne.API.Services.Connectors;
 using Nocturne.Connectors.Core.Models;
 using Nocturne.Core.Contracts.Timezones;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.Timezones;
 using OpenApi.Remote.Attributes;
 
@@ -18,8 +20,19 @@ namespace Nocturne.API.Controllers.V4;
 [Route("api/v4/timezone-timeline")]
 [Tags("Timezone Timeline")]
 [Authorize]
-public class TimezoneTimelineController : ControllerBase
+public class TimezoneTimelineController : ControllerBase, IWriteScopedController
 {
+    /// <summary>
+    /// The OAuth scope every write action on this controller requires. The timeline is patient
+    /// clinical configuration in the same sense as the timezone on <c>patient_records</c>, which
+    /// <c>PatientRecordController</c> gates on <c>therapy.readwrite</c>, and V1/V3 profile writes
+    /// require the same scope. <see cref="Recorrect"/> additionally triggers a Glooko re-import; the
+    /// records it rewrites are written by the connector's own publish path, so the scope here bounds
+    /// who may request the re-correction, not what the connector may write. The class-level
+    /// <c>[Authorize]</c> alone is satisfied by read-only credentials such as a guest-link session.
+    /// </summary>
+    public string WriteScope => OAuthScopes.TherapyReadWrite;
+
     private const string GlookoConnectorId = "glooko";
 
     private readonly ITimezoneTimelineService _timeline;
@@ -51,6 +64,7 @@ public class TimezoneTimelineController : ControllerBase
     /// move is a single entry; the origin entry covers all earlier history.
     /// </summary>
     [HttpPut]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetTimeline"])]
     public async Task<ActionResult<TimezoneTimelineEntry>> Upsert(
         [FromBody] UpsertTimezoneEntryRequest request,
@@ -70,6 +84,7 @@ public class TimezoneTimelineController : ControllerBase
 
     /// <summary>Delete a timeline entry.</summary>
     [HttpDelete("{id:guid}")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetTimeline"])]
     public async Task<ActionResult> Delete(Guid id, CancellationToken cancellationToken)
     {
@@ -85,6 +100,7 @@ public class TimezoneTimelineController : ControllerBase
     /// </summary>
     /// <param name="request">Optional lower bound (UTC). When null, the connector's default window is used.</param>
     [HttpPost("recorrect")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand]
     public async Task<ActionResult<RecorrectResult>> Recorrect(
         [FromBody] RecorrectRequest request,

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/BasalInjectionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/BasalInjectionController.cs
@@ -1,8 +1,10 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
 using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
 using Nocturne.Core.Contracts.V4;
 
@@ -39,6 +41,10 @@ public class BasalInjectionController(
 {
     private const double UnitsHardCeiling = 500.0;
     private const int FutureToleranceMinutes = 5;
+
+    /// <inheritdoc/>
+    /// <remarks>Basal injections are treatments; the legacy equivalent is a v1 insulin treatment.</remarks>
+    public override string WriteScope => OAuthScopes.TreatmentsReadWrite;
 
     /// <inheritdoc/>
     public override async Task<ActionResult<BasalInjection>> Create(
@@ -144,8 +150,10 @@ public class BasalInjectionController(
     /// failures reject the whole request with `400 Bad Request` before anything is persisted.
     /// </remarks>
     [HttpPost("bulk")]
+    [RequireDeclaredWriteScope]
     [ProducesResponseType(typeof(BasalInjection[]), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<BasalInjection[]>> CreateBasalInjectionsBulk(
         [FromBody] CreateBasalInjectionRequest[] requests,
         CancellationToken ct = default)

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/BolusCalculationController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/BolusCalculationController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
 
 namespace Nocturne.API.Controllers.V4.Treatments;
@@ -28,6 +29,10 @@ namespace Nocturne.API.Controllers.V4.Treatments;
 public class BolusCalculationController(IBolusCalculationRepository repo)
     : V4CrudControllerBase<BolusCalculation, UpsertBolusCalculationRequest, UpsertBolusCalculationRequest, IBolusCalculationRepository>(repo)
 {
+    /// <inheritdoc/>
+    /// <remarks>Bolus calculations sit in the treatments share category alongside the boluses they explain.</remarks>
+    public override string WriteScope => OAuthScopes.TreatmentsReadWrite;
+
     protected override BolusCalculation MapCreateToModel(UpsertBolusCalculationRequest request) => new()
     {
         Timestamp = request.Timestamp.UtcDateTime,

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/BolusController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/BolusController.cs
@@ -1,8 +1,10 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
 using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
 using Nocturne.Core.Contracts.V4;
 
@@ -33,6 +35,10 @@ namespace Nocturne.API.Controllers.V4.Treatments;
 public class BolusController(IBolusRepository repo, IPatientInsulinRepository insulinRepo)
     : V4CrudControllerBase<Bolus, CreateBolusRequest, UpdateBolusRequest, IBolusRepository>(repo)
 {
+    /// <inheritdoc/>
+    /// <remarks>Boluses are treatments; the legacy equivalent is a v1 insulin treatment.</remarks>
+    public override string WriteScope => OAuthScopes.TreatmentsReadWrite;
+
     /// <inheritdoc/>
     /// <remarks>Response is cached for 90 seconds, varying by all query parameters.</remarks>
     [ResponseCache(Duration = 90, VaryByQueryKeys = new[] { "*" })]
@@ -152,8 +158,10 @@ public class BolusController(IBolusRepository repo, IPatientInsulinRepository in
     /// is persisted.
     /// </remarks>
     [HttpPost("bulk")]
+    [RequireDeclaredWriteScope]
     [ProducesResponseType(typeof(Bolus[]), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<Bolus[]>> CreateBolusesBulk(
         [FromBody] CreateBolusRequest[] requests,
         CancellationToken ct = default)
@@ -186,7 +194,9 @@ public class BolusController(IBolusRepository repo, IPatientInsulinRepository in
     /// Delete a bolus by its external sync identifier (dataSource + syncIdentifier pair).
     /// </summary>
     [HttpDelete("by-sync-id")]
+    [RequireDeclaredWriteScope]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> DeleteBySyncIdentifier(

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/FoodsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/FoodsController.cs
@@ -2,9 +2,11 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
 using Nocturne.API.Extensions;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 
@@ -39,8 +41,16 @@ namespace Nocturne.API.Controllers.V4.Treatments;
 [Tags("Treatments")]
 [Route("api/v4/foods")]
 [ClientPropertyName("foodsV4")]
-public class FoodsController : ControllerBase
+public class FoodsController : ControllerBase, IWriteScopedController
 {
+    /// <summary>
+    /// The OAuth scope every write action on this controller requires. The food catalog
+    /// (<c>foods</c>) is the food category, and the V1 and V3 food write endpoints are gated with
+    /// <c>food.readwrite</c>; the per-subject favourite list is the same category. The per-action
+    /// <c>[Authorize]</c> alone is satisfied by read-only credentials such as a guest-link session.
+    /// </summary>
+    public string WriteScope => OAuthScopes.FoodReadWrite;
+
     private const string DefaultUserId = "00000000-0000-0000-0000-000000000001";
 
     private readonly NocturneDbContext _context;
@@ -98,6 +108,7 @@ public class FoodsController : ControllerBase
     /// Create a new food record.
     /// </summary>
     [HttpPost]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetFoods", "GetFavorites", "GetRecentFoods"])]
     [Authorize]
     [ProducesResponseType(typeof(Food), StatusCodes.Status201Created)]
@@ -119,6 +130,7 @@ public class FoodsController : ControllerBase
     /// Update an existing food record by ID.
     /// </summary>
     [HttpPut("{foodId}")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetFoods", "GetFood", "GetFavorites", "GetRecentFoods"])]
     [Authorize]
     [ProducesResponseType(typeof(Food), StatusCodes.Status200OK)]
@@ -157,6 +169,7 @@ public class FoodsController : ControllerBase
     /// Add a food to favorites.
     /// </summary>
     [HttpPost("{foodId}/favorite")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetFavorites"])]
     [Authorize]
     public async Task<ActionResult> AddFavorite(string foodId)
@@ -182,6 +195,7 @@ public class FoodsController : ControllerBase
     /// Remove a food from favorites.
     /// </summary>
     [HttpDelete("{foodId}/favorite")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetFavorites"])]
     [Authorize]
     public async Task<ActionResult> RemoveFavorite(string foodId)
@@ -256,6 +270,7 @@ public class FoodsController : ControllerBase
     /// <param name="foodId">The food ID to delete.</param>
     /// <param name="attributionMode">How to handle existing attributions: "clear" (default) sets them to Other, "remove" deletes them.</param>
     [HttpDelete("{foodId}")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetFavorites", "GetRecentFoods"])]
     [Authorize]
     [ProducesResponseType(StatusCodes.Status204NoContent)]

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/MealMatchingController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/MealMatchingController.cs
@@ -1,11 +1,13 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
 using Nocturne.API.Extensions;
 using Nocturne.Core.Contracts.Notifications;
 using Nocturne.Core.Contracts.Connectors;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.API.Controllers.V4.Treatments;
 
@@ -107,7 +109,14 @@ public class MealMatchingController : ControllerBase
     /// <summary>
     /// Accept a meal match
     /// </summary>
+    /// <remarks>
+    /// Writes a <c>treatment_foods</c> row keyed by the carb intake, which
+    /// <see cref="NutritionController"/> gates on <c>treatments.readwrite</c>, and marks the
+    /// connector food entry matched. Gated on the treatments category rather than food because the
+    /// carb breakdown is a COB input.
+    /// </remarks>
     [HttpPost("accept")]
+    [RequireScope(OAuthScopes.TreatmentsReadWrite)]
     [RemoteCommand(Invalidates = ["GetSuggestions"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -149,7 +158,13 @@ public class MealMatchingController : ControllerBase
     /// <summary>
     /// Dismiss a meal match
     /// </summary>
+    /// <remarks>
+    /// Writes only the <c>connector_food_entries</c> status, which is the food category in
+    /// <see cref="ShareDataCategories.GovernedTables"/>, so this action is gated on the food
+    /// category while <see cref="AcceptMatch"/> is gated on treatments.
+    /// </remarks>
     [HttpPost("dismiss")]
+    [RequireScope(OAuthScopes.FoodReadWrite)]
     [RemoteCommand(Invalidates = ["GetSuggestions"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<ActionResult> DismissMatch([FromBody] DismissMatchRequest request)

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/NoteController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/NoteController.cs
@@ -1,8 +1,10 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
 using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
 using Nocturne.Core.Contracts.V4;
 
@@ -29,6 +31,10 @@ namespace Nocturne.API.Controllers.V4.Treatments;
 public class NoteController(INoteRepository repo)
     : V4CrudControllerBase<Note, UpsertNoteRequest, UpsertNoteRequest, INoteRepository>(repo)
 {
+    /// <inheritdoc/>
+    /// <remarks>Notes are the V4 form of a legacy text treatment (Note/Announcement/Question).</remarks>
+    public override string WriteScope => OAuthScopes.TreatmentsReadWrite;
+
     protected override Note MapCreateToModel(UpsertNoteRequest request) => new()
     {
         Timestamp = request.Timestamp.UtcDateTime,
@@ -64,7 +70,9 @@ public class NoteController(INoteRepository repo)
     /// Delete a note by its external sync identifier (dataSource + syncIdentifier pair).
     /// </summary>
     [HttpDelete("by-sync-id")]
+    [RequireDeclaredWriteScope]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> DeleteBySyncIdentifier(

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/NutritionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/NutritionController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.API.Services.Platform;
 using Nocturne.API.Services.Treatments;
@@ -9,6 +10,7 @@ using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
@@ -44,8 +46,17 @@ namespace Nocturne.API.Controllers.V4.Treatments;
 [Route("api/v4/nutrition")]
 [Authorize]
 [Produces("application/json")]
-public class NutritionController : ControllerBase
+public class NutritionController : ControllerBase, IWriteScopedController
 {
+    /// <summary>
+    /// The OAuth scope every write action on this controller requires. Carb intakes, and the boluses
+    /// <c>POST /meals</c> creates alongside them, are the treatments category
+    /// (<see cref="ShareDataCategories"/>), gated with <c>treatments.readwrite</c> on the V1 and V3
+    /// treatment write endpoints. The per-carb-intake food breakdown is keyed by carb intake and
+    /// reads the food catalog without mutating it, so it is gated with the treatment it describes.
+    /// </summary>
+    public string WriteScope => OAuthScopes.TreatmentsReadWrite;
+
     private readonly ICarbIntakeRepository _carbIntakeRepo;
     private readonly IBolusRepository _bolusRepo;
     private readonly ITreatmentFoodService _treatmentFoodService;
@@ -107,6 +118,7 @@ public class NutritionController : ControllerBase
     /// Create a new carb intake
     /// </summary>
     [HttpPost("carbs")]
+    [RequireDeclaredWriteScope]
     [RemoteForm(Invalidates = ["GetCarbIntakes"])]
     [ProducesResponseType(typeof(CarbIntake), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -131,6 +143,7 @@ public class NutritionController : ControllerBase
     /// is persisted.
     /// </remarks>
     [HttpPost("carbs/bulk")]
+    [RequireDeclaredWriteScope]
     [ProducesResponseType(typeof(CarbIntake[]), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<CarbIntake[]>> CreateCarbIntakesBulk(
@@ -176,6 +189,7 @@ public class NutritionController : ControllerBase
     /// Update an existing carb intake
     /// </summary>
     [HttpPut("carbs/{id:guid}")]
+    [RequireDeclaredWriteScope]
     [RemoteForm(Invalidates = ["GetCarbIntakes", "GetCarbIntakeById"])]
     [ProducesResponseType(typeof(CarbIntake), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -224,6 +238,7 @@ public class NutritionController : ControllerBase
     /// Delete a carb intake
     /// </summary>
     [HttpDelete("carbs/{id:guid}")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetCarbIntakes"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -244,6 +259,7 @@ public class NutritionController : ControllerBase
     /// Delete a carb intake by its external sync identifier (dataSource + syncIdentifier pair).
     /// </summary>
     [HttpDelete("carbs/by-sync-id")]
+    [RequireDeclaredWriteScope]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -280,6 +296,7 @@ public class NutritionController : ControllerBase
     /// Add a food breakdown entry to a carb intake record.
     /// </summary>
     [HttpPost("carbs/{id:guid}/foods")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetCarbIntakeFoods"])]
     [ProducesResponseType(typeof(TreatmentFoodBreakdown), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -310,6 +327,7 @@ public class NutritionController : ControllerBase
     /// Update a food breakdown entry.
     /// </summary>
     [HttpPut("carbs/{id:guid}/foods/{foodEntryId:guid}")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetCarbIntakeFoods"])]
     [ProducesResponseType(typeof(TreatmentFoodBreakdown), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -342,6 +360,7 @@ public class NutritionController : ControllerBase
     /// Remove a food breakdown entry.
     /// </summary>
     [HttpDelete("carbs/{id:guid}/foods/{foodEntryId:guid}")]
+    [RequireDeclaredWriteScope]
     [RemoteCommand(Invalidates = ["GetCarbIntakeFoods"])]
     [ProducesResponseType(typeof(TreatmentFoodBreakdown), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -374,6 +393,7 @@ public class NutritionController : ControllerBase
     /// response returns 200 instead of 201.
     /// </summary>
     [HttpPost("meals")]
+    [RequireDeclaredWriteScope]
     [RemoteForm(Invalidates = ["GetCarbIntakes", "GetMeals"])]
     [ProducesResponseType(typeof(CreateMealResponse), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(CreateMealResponse), StatusCodes.Status200OK)]

--- a/tests/Integration/Nocturne.API.Tests/Auth/GuestLinkLifecycleIntegrationTests.cs
+++ b/tests/Integration/Nocturne.API.Tests/Auth/GuestLinkLifecycleIntegrationTests.cs
@@ -378,6 +378,37 @@ public class GuestLinkLifecycleIntegrationTests : AspireIntegrationTestBase
     }
 
     [Fact]
+    public async Task GuestSession_CannotWriteV4TrackerDefinitions()
+    {
+        // TrackersController carries [Authorize] per action and no scope gate before this change, so
+        // a guest session could create and delete the tracker definitions that drive sensor and
+        // site-change care reminders. A guest holds alerts.read at most.
+        var code = await CreateGuestLinkCodeAsync();
+
+        var handler = new HttpClientHandler { UseCookies = true };
+        using var cookieClient = new HttpClient(handler)
+        {
+            BaseAddress = ApiClient.BaseAddress
+        };
+
+        var activateResponse = await cookieClient.PostAsJsonAsync("/api/v4/guest-links/activate", new
+        {
+            code
+        });
+        activateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var response = await cookieClient.PostAsJsonAsync("/api/v4/trackers/definitions", new
+        {
+            name = "fabricated",
+            category = "consumable",
+            lifespanHours = 72,
+        });
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+        Log($"Guest session V4 tracker definition write rejected, status: {response.StatusCode}");
+    }
+
+    [Fact]
     public async Task GuestSession_CannotAccessAdminEndpoints()
     {
         // Arrange - create and activate a guest link with cookie-enabled client

--- a/tests/Integration/Nocturne.API.Tests/Auth/GuestLinkLifecycleIntegrationTests.cs
+++ b/tests/Integration/Nocturne.API.Tests/Auth/GuestLinkLifecycleIntegrationTests.cs
@@ -316,6 +316,37 @@ public class GuestLinkLifecycleIntegrationTests : AspireIntegrationTestBase
     }
 
     [Fact]
+    public async Task GuestSession_CannotWriteV4SensorGlucose()
+    {
+        // The V4 plane carries only [Authorize], which a guest session satisfies. Enforcement is
+        // the per-controller write scope (RequireDeclaredWriteScopeAttribute), not the RLS policies:
+        // the share policy is FOR SELECT and the tenant policy's WITH CHECK admits the write.
+        var code = await CreateGuestLinkCodeAsync();
+
+        var handler = new HttpClientHandler { UseCookies = true };
+        using var cookieClient = new HttpClient(handler)
+        {
+            BaseAddress = ApiClient.BaseAddress
+        };
+
+        var activateResponse = await cookieClient.PostAsJsonAsync("/api/v4/guest-links/activate", new
+        {
+            code
+        });
+        activateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var response = await cookieClient.PostAsJsonAsync("/api/v4/glucose/sensor", new
+        {
+            timestamp = DateTimeOffset.UtcNow,
+            mgdl = 120.0,
+            device = "fabricated",
+        });
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+        Log($"Guest session V4 glucose write rejected, status: {response.StatusCode}");
+    }
+
+    [Fact]
     public async Task GuestSession_CannotAccessAdminEndpoints()
     {
         // Arrange - create and activate a guest link with cookie-enabled client

--- a/tests/Integration/Nocturne.API.Tests/Auth/GuestLinkLifecycleIntegrationTests.cs
+++ b/tests/Integration/Nocturne.API.Tests/Auth/GuestLinkLifecycleIntegrationTests.cs
@@ -347,6 +347,37 @@ public class GuestLinkLifecycleIntegrationTests : AspireIntegrationTestBase
     }
 
     [Fact]
+    public async Task GuestSession_CannotWriteV4TherapySettings()
+    {
+        // ProfileController does not derive from V4CrudControllerBase, so it carries the write-scope
+        // gate on its own actions. A guest session holds therapy.read at most; therapy settings are
+        // the values the bolus calculator reads.
+        var code = await CreateGuestLinkCodeAsync();
+
+        var handler = new HttpClientHandler { UseCookies = true };
+        using var cookieClient = new HttpClient(handler)
+        {
+            BaseAddress = ApiClient.BaseAddress
+        };
+
+        var activateResponse = await cookieClient.PostAsJsonAsync("/api/v4/guest-links/activate", new
+        {
+            code
+        });
+        activateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var response = await cookieClient.PostAsJsonAsync("/api/v4/profile/settings", new
+        {
+            timestamp = DateTimeOffset.UtcNow,
+            profileName = "fabricated",
+            isDefault = true,
+        });
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+        Log($"Guest session V4 therapy settings write rejected, status: {response.StatusCode}");
+    }
+
+    [Fact]
     public async Task GuestSession_CannotAccessAdminEndpoints()
     {
         // Arrange - create and activate a guest link with cookie-enabled client

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ActivityControllerScopeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ActivityControllerScopeTests.cs
@@ -1,0 +1,97 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Nocturne.API.Controllers.V4.Health;
+using Nocturne.API.Models.Requests.V4;
+using Nocturne.Core.Contracts.Health;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
+using Xunit;
+
+namespace Nocturne.API.Tests.Authorization;
+
+/// <summary>
+/// Asserts that <c>ActivityController</c> actually calls
+/// <see cref="Nocturne.API.Authorization.ActivityWriteScopeGuard"/>. <c>ActivityWriteScopeGuardTests</c>
+/// exercises the guard function in isolation, so removing the call from the handler would leave both
+/// that suite and the attribute sweep in <see cref="V4WriteScopeGatingTests"/> green while the
+/// endpoint became ungated — the activity endpoints are exempted from the sweep precisely because
+/// their gate is a method call.
+/// </summary>
+public class ActivityControllerScopeTests
+{
+    private const string HeartRateRecordType = "heartrate";
+
+    [Fact]
+    public async Task CreateActivities_DeniesARecordWhoseCategoryScopeIsMissing()
+    {
+        var (controller, service) = Build(
+            requiredScope: OAuthScopes.HeartRateReadWrite,
+            grantedScopes: [OAuthScopes.TreatmentsReadWrite]);
+
+        var result = await controller.CreateActivities(
+            [new UpsertActivityRequest { Mills = 1, Type = HeartRateRecordType }]);
+
+        Denied(result.Result);
+        service.Verify(
+            s => s.CreateActivitiesAsync(It.IsAny<List<Activity>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateActivities_AllowsARecordWhoseCategoryScopeIsHeld()
+    {
+        var (controller, service) = Build(
+            requiredScope: OAuthScopes.HeartRateReadWrite,
+            grantedScopes: [OAuthScopes.HeartRateReadWrite]);
+        service.Setup(s => s.CreateActivitiesAsync(It.IsAny<List<Activity>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var result = await controller.CreateActivities(
+            [new UpsertActivityRequest { Mills = 1, Type = HeartRateRecordType }]);
+
+        result.Result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status201Created);
+    }
+
+    [Fact]
+    public async Task CreateActivities_AllowsARecordThatNeedsNoCategoryScope()
+    {
+        // A plain activity has no dedicated destination table, so the decomposer returns null and
+        // the guard must not invent a requirement.
+        var (controller, service) = Build(requiredScope: null, grantedScopes: []);
+        service.Setup(s => s.CreateActivitiesAsync(It.IsAny<List<Activity>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var result = await controller.CreateActivities(
+            [new UpsertActivityRequest { Mills = 1, Type = "walk" }]);
+
+        result.Result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status201Created);
+    }
+
+    private static void Denied(object? result) =>
+        result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+
+    private static (ActivityController Controller, Mock<IActivityService> Service) Build(
+        string? requiredScope, string[] grantedScopes)
+    {
+        var service = new Mock<IActivityService>(MockBehavior.Strict);
+        var decomposer = new Mock<IActivityDecomposer>(MockBehavior.Loose);
+        decomposer.Setup(d => d.RequiredWriteScope(It.IsAny<Activity>())).Returns(requiredScope);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["AuthContext"] = new AuthContext { IsAuthenticated = true };
+        httpContext.Items["GrantedScopes"] = (IReadOnlySet<string>)new HashSet<string>(grantedScopes);
+
+        var controller = new ActivityController(service.Object, decomposer.Object)
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext },
+        };
+
+        return (controller, service);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Authorization/StateSpanWriteScopeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/StateSpanWriteScopeTests.cs
@@ -1,0 +1,189 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Nocturne.API.Authorization;
+using Nocturne.API.Controllers.V4.Analytics;
+using Nocturne.Core.Contracts.Glucose;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
+using Xunit;
+
+namespace Nocturne.API.Tests.Authorization;
+
+/// <summary>
+/// <c>state_spans</c> holds four data categories behind one table and the caller picks which by
+/// setting <see cref="StateSpan.Category"/> in the request body, so the write scope is resolved per
+/// record in the handler rather than by an attribute. These drive the real handlers, because the
+/// attribute sweep in <see cref="V4WriteScopeGatingTests"/> cannot see a gate that is a method call
+/// — deleting the guard call would leave that sweep green.
+/// </summary>
+/// <seealso cref="StateSpanWriteScopeGuard"/>
+public class StateSpanWriteScopeTests
+{
+    private static readonly string[] TreatmentsOnly = [OAuthScopes.TreatmentsReadWrite];
+
+    [Theory]
+    [InlineData(StateSpanCategory.PumpMode, OAuthScopes.DevicesReadWrite)]
+    [InlineData(StateSpanCategory.PumpConnectivity, OAuthScopes.DevicesReadWrite)]
+    [InlineData(StateSpanCategory.Profile, OAuthScopes.TherapyReadWrite)]
+    [InlineData(StateSpanCategory.DataExclusion, OAuthScopes.GlucoseReadWrite)]
+    [InlineData(StateSpanCategory.Override, OAuthScopes.TreatmentsReadWrite)]
+    [InlineData(StateSpanCategory.Exercise, OAuthScopes.TreatmentsReadWrite)]
+    [InlineData(StateSpanCategory.Illness, OAuthScopes.TreatmentsReadWrite)]
+    [InlineData(StateSpanCategory.Travel, OAuthScopes.TreatmentsReadWrite)]
+    [InlineData(StateSpanCategory.TemporaryTarget, OAuthScopes.TreatmentsReadWrite)]
+    public void EveryCategory_MapsToItsDataCategoryScope(StateSpanCategory category, string expected)
+    {
+        StateSpanWriteScopeGuard.RequiredWriteScope(category).Should().Be(expected);
+    }
+
+    [Fact]
+    public void EveryEnumMember_IsClassified()
+    {
+        // A category added to the enum without a scope here would otherwise inherit whichever
+        // mapping happened to be first. RequiredWriteScope fails it closed to "*", and this makes
+        // the omission visible instead of silently owner-only.
+        Enum.GetValues<StateSpanCategory>()
+            .Should().OnlyContain(c => StateSpanWriteScopeGuard.CategoryWriteScopes.ContainsKey(c));
+    }
+
+    [Fact]
+    public void AnUnmappedCategory_FailsClosed()
+    {
+        StateSpanWriteScopeGuard.RequiredWriteScope((StateSpanCategory)9999)
+            .Should().Be(OAuthScopes.FullAccess);
+    }
+
+    [Fact]
+    public void FindMissingScope_ReportsTheFirstUnsatisfiedCategory()
+    {
+        var granted = (IReadOnlySet<string>)new HashSet<string>(TreatmentsOnly);
+
+        StateSpanWriteScopeGuard.FindMissingScope(granted, StateSpanCategory.Exercise)
+            .Should().BeNull();
+        StateSpanWriteScopeGuard.FindMissingScope(granted, StateSpanCategory.DataExclusion)
+            .Should().Be(OAuthScopes.GlucoseReadWrite);
+    }
+
+    [Fact]
+    public void FullAccess_SatisfiesEveryCategory()
+    {
+        var granted = (IReadOnlySet<string>)new HashSet<string> { OAuthScopes.FullAccess };
+
+        StateSpanWriteScopeGuard.FindMissingScope(granted, Enum.GetValues<StateSpanCategory>())
+            .Should().BeNull();
+    }
+
+    // --- handler-level: the gate is a method call, so it has to be driven ---
+
+    [Fact]
+    public async Task Create_WithTreatmentsOnly_IsDeniedADataExclusionSpan()
+    {
+        // The one that matters: a data-exclusion window decides whether glucose readings count
+        // towards analytics and reports, so a treatments-only credential marking one could hide a
+        // hypo from every report.
+        var service = new Mock<IStateSpanService>(MockBehavior.Strict);
+        var controller = Build(service, TreatmentsOnly);
+
+        var result = await controller.CreateStateSpan(
+            new CreateStateSpanRequest { Category = StateSpanCategory.DataExclusion, StartMills = 1 });
+
+        Denied(result.Result);
+        service.Verify(s => s.UpsertStateSpanAsync(It.IsAny<StateSpan>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Create_WithTheMatchingCategoryScope_IsAllowed()
+    {
+        var service = new Mock<IStateSpanService>(MockBehavior.Strict);
+        service.Setup(s => s.UpsertStateSpanAsync(It.IsAny<StateSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StateSpan { Id = "s1", Category = StateSpanCategory.DataExclusion });
+        var controller = Build(service, [OAuthScopes.GlucoseReadWrite]);
+
+        var result = await controller.CreateStateSpan(
+            new CreateStateSpanRequest { Category = StateSpanCategory.DataExclusion, StartMills = 1 });
+
+        result.Result.Should().BeOfType<CreatedAtActionResult>();
+    }
+
+    [Fact]
+    public async Task Create_WithTreatmentsOnly_IsAllowedATreatmentsSpan()
+    {
+        var service = new Mock<IStateSpanService>(MockBehavior.Strict);
+        service.Setup(s => s.UpsertStateSpanAsync(It.IsAny<StateSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StateSpan { Id = "s1", Category = StateSpanCategory.Exercise });
+        var controller = Build(service, TreatmentsOnly);
+
+        var result = await controller.CreateStateSpan(
+            new CreateStateSpanRequest { Category = StateSpanCategory.Exercise, StartMills = 1 });
+
+        result.Result.Should().BeOfType<CreatedAtActionResult>();
+    }
+
+    [Fact]
+    public async Task Delete_ScopesOnTheStoredRecordsCategory()
+    {
+        // The category is not in the request, so the stored row decides. A treatments-only caller
+        // must not be able to delete a pump-mode span.
+        var service = new Mock<IStateSpanService>(MockBehavior.Strict);
+        service.Setup(s => s.GetStateSpanByIdAsync("s1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StateSpan { Id = "s1", Category = StateSpanCategory.PumpMode });
+        var controller = Build(service, TreatmentsOnly);
+
+        var result = await controller.DeleteStateSpan("s1");
+
+        Denied(result);
+        service.Verify(s => s.DeleteStateSpanAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Update_RequiresBothTheOldAndTheNewCategory()
+    {
+        // Moving a span from a category the caller may write into one it may not, or vice versa,
+        // needs write access to both — otherwise relocation is a way around the gate.
+        var service = new Mock<IStateSpanService>(MockBehavior.Strict);
+        service.Setup(s => s.GetStateSpanByIdAsync("s1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StateSpan { Id = "s1", Category = StateSpanCategory.Exercise });
+        var controller = Build(service, TreatmentsOnly);
+
+        var result = await controller.UpdateStateSpan(
+            "s1", new UpdateStateSpanRequest { Category = StateSpanCategory.DataExclusion });
+
+        Denied(result.Result);
+        service.Verify(
+            s => s.UpdateStateSpanAsync(It.IsAny<string>(), It.IsAny<StateSpan>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Update_WithinOneAllowedCategory_IsAllowed()
+    {
+        var service = new Mock<IStateSpanService>(MockBehavior.Strict);
+        service.Setup(s => s.GetStateSpanByIdAsync("s1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StateSpan { Id = "s1", Category = StateSpanCategory.Exercise });
+        service.Setup(s => s.UpdateStateSpanAsync("s1", It.IsAny<StateSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StateSpan { Id = "s1", Category = StateSpanCategory.Exercise });
+        var controller = Build(service, TreatmentsOnly);
+
+        var result = await controller.UpdateStateSpan("s1", new UpdateStateSpanRequest { State = "walk" });
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+    }
+
+    private static void Denied(object? result) =>
+        result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+
+    private static StateSpansController Build(Mock<IStateSpanService> service, string[] grantedScopes)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["AuthContext"] = new AuthContext { IsAuthenticated = true };
+        httpContext.Items["GrantedScopes"] = (IReadOnlySet<string>)new HashSet<string>(grantedScopes);
+
+        return new StateSpansController(service.Object)
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext },
+        };
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
@@ -17,7 +18,8 @@ namespace Nocturne.API.Tests.Authorization;
 /// only (<c>GuestLinkService</c>) but is an authenticated session, and neither the share RLS policy
 /// (<c>FOR SELECT</c>) nor the tenant policy's <c>WITH CHECK</c> blocks a write. Enforcement is
 /// therefore <see cref="RequireDeclaredWriteScopeAttribute"/> reading the scope each controller
-/// declares through <see cref="IWriteScopedController.WriteScope"/>.
+/// declares through <see cref="IWriteScopedController.WriteScope"/>, or an explicit
+/// <see cref="RequireScopeAttribute"/> where one controller's writes span two data categories.
 /// </summary>
 /// <remarks>
 /// The V1/V2/V3 counterpart lives in <see cref="WriteEndpointScopeEnforcementTests"/>.
@@ -27,10 +29,32 @@ public class V4WriteScopeGatingTests
     private static readonly string[] WriteVerbs = ["POST", "PUT", "PATCH", "DELETE"];
 
     /// <summary>
-    /// The write scope each V4 CRUD controller is expected to declare. Derived from the data
+    /// Every read scope in the taxonomy. Used to assert that no write action can be executed with
+    /// read-only credentials (the guest-link, follower and public-share grant shape).
+    /// </summary>
+    private static readonly string[] AllReadScopes =
+        OAuthScopes.AllScopes.Where(s => s.EndsWith(".read", StringComparison.Ordinal)).ToArray();
+
+    /// <summary>
+    /// V4 controllers that do not derive from <see cref="V4CrudControllerBase{TModel, TCreateRequest, TUpdateRequest, TRepository}"/>
+    /// and so cannot inherit its gated write actions. Enumerated by type rather than by namespace
+    /// sweep because <c>V4.Health.ActivityController</c> gates in the handler (its category depends
+    /// on what the payload decomposes into, per record) and carries no attribute to find.
+    /// </summary>
+    private static readonly Type[] NonBaseControllersUnderGuard =
+    [
+        typeof(Nocturne.API.Controllers.V4.Profiles.ProfileController),
+        typeof(Nocturne.API.Controllers.V4.Treatments.NutritionController),
+        typeof(Nocturne.API.Controllers.V4.Treatments.FoodsController),
+        typeof(Nocturne.API.Controllers.V4.Health.BodyWeightController),
+        typeof(Nocturne.API.Controllers.V4.Health.PatientRecordController),
+    ];
+
+    /// <summary>
+    /// The write scope each write-scoped V4 controller is expected to declare. Derived from the data
     /// category the record's table belongs to in <see cref="ShareDataCategories"/> (the read-side
     /// classification) and from the scope the equivalent V1 endpoint requires. Asserted exhaustively,
-    /// so a new V4 CRUD controller must be added here with a deliberate category.
+    /// so a new write-scoped V4 controller must be added here with a deliberate category.
     /// </summary>
     private static readonly IReadOnlyDictionary<string, string> ExpectedWriteScopes =
         new Dictionary<string, string>(StringComparer.Ordinal)
@@ -53,6 +77,47 @@ public class V4WriteScopeGatingTests
             // devices: device_events sits under devices.read, matching the sibling snapshot
             // controllers (ApsSnapshotController's bulk write requires devices.readwrite).
             ["DeviceEventController"] = OAuthScopes.DevicesReadWrite,
+
+            // therapy: therapy_settings and the basal / carb ratio / sensitivity / target range
+            // schedules are the therapy category (therapy.read on the read side); v1 and v3 profile
+            // writes require therapy.readwrite.
+            ["ProfileController"] = OAuthScopes.TherapyReadWrite,
+
+            // treatments: carb_intakes sits under treatments.read, POST /meals also writes a bolus,
+            // and treatment_foods is keyed by carb intake (the food catalog is only read).
+            ["NutritionController"] = OAuthScopes.TreatmentsReadWrite,
+
+            // food: foods sits under food.read and user_food_favorites is the same category;
+            // v1 and v3 food writes require food.readwrite.
+            ["FoodsController"] = OAuthScopes.FoodReadWrite,
+
+            // therapy: body_weights has no category scope of its own. The record is patient clinical
+            // configuration written from the Patient Record settings form alongside therapy settings.
+            ["BodyWeightController"] = OAuthScopes.TherapyReadWrite,
+        };
+
+    /// <summary>
+    /// Per-action expectations for controllers whose writes span two data categories, so a single
+    /// declared scope would either over- or under-gate. Asserted exhaustively against the
+    /// controller's write actions.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> ExpectedActionScopes =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            // patient_records carries the clinical configuration (diabetes type, timezone) the
+            // profile and bolus maths read; patient_insulins carries DIA / peak / curve, the inputs
+            // to the IOB calculation. Both are therapy settings.
+            ["PatientRecordController.UpdatePatientRecord"] = OAuthScopes.TherapyReadWrite,
+            ["PatientRecordController.CreateInsulin"] = OAuthScopes.TherapyReadWrite,
+            ["PatientRecordController.UpdateInsulin"] = OAuthScopes.TherapyReadWrite,
+            ["PatientRecordController.DeleteInsulin"] = OAuthScopes.TherapyReadWrite,
+
+            // patient_devices is the device registry (and CreateDevice/UpdateDevice resolve a row in
+            // the `devices` master table), matching devices.readwrite on the v1/v3 device endpoints.
+            ["PatientRecordController.CreateDevice"] = OAuthScopes.DevicesReadWrite,
+            ["PatientRecordController.UpdateDevice"] = OAuthScopes.DevicesReadWrite,
+            ["PatientRecordController.DeleteDevice"] = OAuthScopes.DevicesReadWrite,
+            ["PatientRecordController.ReorderDevices"] = OAuthScopes.DevicesReadWrite,
         };
 
     [Fact]
@@ -119,41 +184,47 @@ public class V4WriteScopeGatingTests
     }
 
     [Fact]
-    public void EveryV4CrudController_DeclaresItsExpectedWriteScope()
+    public void EveryWriteScopedController_DeclaresItsExpectedWriteScope()
     {
-        var controllers = CrudControllers().ToList();
+        var controllers = WriteScopedControllers().ToList();
 
         controllers.Select(t => t.Name).Should().BeEquivalentTo(ExpectedWriteScopes.Keys,
-            "every V4 CRUD controller must be mapped to a data category in ExpectedWriteScopes");
+            "every write-scoped V4 controller must be mapped to a data category in ExpectedWriteScopes");
 
         foreach (var controller in controllers)
         {
-            var declared = ((IWriteScopedController)Instantiate(controller)).WriteScope;
+            var declared = ((IWriteScopedController)ScopeDeclarationInstance(controller)).WriteScope;
 
             declared.Should().Be(ExpectedWriteScopes[controller.Name],
                 $"{controller.Name} must gate its writes on its own data category");
-            OAuthScopes.SatisfiesScope([OAuthScopes.GlucoseRead, OAuthScopes.TreatmentsRead, OAuthScopes.DevicesRead], declared)
+            OAuthScopes.SatisfiesScope(AllReadScopes, declared)
                 .Should().BeFalse($"{controller.Name}'s write scope must not be satisfiable by read-only scopes");
         }
+    }
+
+    [Fact]
+    public void MixedCategoryController_MapsEveryWriteActionToItsCategory()
+    {
+        // PatientRecordController writes two categories, so its expectations are per action and must
+        // stay exhaustive: a new write action there has to name the category it mutates.
+        var actions = WriteActions(typeof(Nocturne.API.Controllers.V4.Health.PatientRecordController))
+            .Select(a => $"PatientRecordController.{a.Name}");
+
+        actions.Should().BeEquivalentTo(ExpectedActionScopes.Keys,
+            "every write action on a mixed-category controller must be mapped in ExpectedActionScopes");
     }
 
     [Fact]
     public void EveryV4WriteAction_IsScopeGated()
     {
         var violations = new List<string>();
+        var readSatisfiable = new List<string>();
         var writeActionsChecked = 0;
 
-        foreach (var controller in V4ControllerBaseSubclasses())
+        foreach (var controller in V4ControllerBaseSubclasses().Concat(NonBaseControllersUnderGuard).Distinct())
         {
-            foreach (var action in controller.GetMethods(BindingFlags.Public | BindingFlags.Instance))
+            foreach (var action in WriteActions(controller))
             {
-                var verbs = action.GetCustomAttributes<HttpMethodAttribute>(inherit: true)
-                    .SelectMany(a => a.HttpMethods)
-                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-                if (!verbs.Overlaps(WriteVerbs))
-                    continue;
-
                 writeActionsChecked++;
 
                 var attributes = action.GetCustomAttributes(inherit: true);
@@ -162,30 +233,93 @@ public class V4WriteScopeGatingTests
                                                      or RequirePermissionAttribute);
 
                 if (!gated)
+                {
+                    var verbs = HttpVerbs(action);
                     violations.Add($"{controller.Name}.{action.Name} [{string.Join(",", verbs)}]");
+                    continue;
+                }
+
+                // A gate naming a read scope would admit read-only credentials, which the presence
+                // check alone cannot catch.
+                foreach (var required in RequiredScopes(controller, action))
+                {
+                    if (OAuthScopes.SatisfiesScope(AllReadScopes, required))
+                        readSatisfiable.Add($"{controller.Name}.{action.Name} requires '{required}'");
+                }
             }
         }
 
-        // Sanity: the scan must find the write surface, or the assertion below passes vacuously.
-        writeActionsChecked.Should().BeGreaterThan(40,
-            "the reflection scan should discover the V4 base-controller write endpoints");
+        // Sanity: the scan must find the write surface, or the assertions below pass vacuously.
+        writeActionsChecked.Should().BeGreaterThan(80,
+            "the reflection scan should discover the V4 base-controller and non-base write endpoints");
 
         violations.Should().BeEmpty(
-            "every write action on a V4 base controller must carry [RequireDeclaredWriteScope] "
+            "every write action on a guarded V4 controller must carry [RequireDeclaredWriteScope] "
             + "(base CRUD actions and their overrides) or an explicit [RequireScope]. Unprotected: "
             + string.Join("; ", violations));
+
+        readSatisfiable.Should().BeEmpty(
+            "a write action must require a readwrite (or full-access) scope: " + string.Join("; ", readSatisfiable));
+    }
+
+    [Theory]
+    [MemberData(nameof(NonBaseWriteActions))]
+    public void NonBaseWriteAction_AdmitsItsCategoryAndDeniesReadOnlyCredentials(
+        string controllerTypeName, string actionName, string expectedScope)
+    {
+        var controller = ApiAssembly.GetType(controllerTypeName)!;
+
+        // The maximum a guest link holds (GuestLinkService.AllowedGuestScopes, read-only).
+        var guestScopes = OAuthScopes.Normalize([OAuthScopes.HealthRead, OAuthScopes.TherapyRead, OAuthScopes.ReportsRead]);
+
+        EvaluateAction(controller, actionName, authenticated: true, guestScopes.ToArray())
+            .Should().BeOfType<ForbidResult>("a read-only session must not reach this write action");
+
+        EvaluateAction(controller, actionName, authenticated: true, expectedScope)
+            .Should().BeNull($"a credential holding {expectedScope} must keep writing here");
+
+        EvaluateAction(controller, actionName, authenticated: true, OAuthScopes.FullAccess)
+            .Should().BeNull("a tenant owner and a legacy api-secret both normalise to \"*\"");
+
+        EvaluateAction(controller, actionName, authenticated: false, expectedScope)
+            .Should().BeOfType<UnauthorizedResult>();
+
+        var otherCategory = expectedScope == OAuthScopes.GlucoseReadWrite
+            ? OAuthScopes.FoodReadWrite
+            : OAuthScopes.GlucoseReadWrite;
+        EvaluateAction(controller, actionName, authenticated: true, otherCategory)
+            .Should().BeOfType<ForbidResult>("another category's readwrite scope must not unlock this write");
+    }
+
+    /// <summary>
+    /// Every write action on the five non-base V4 controllers, paired with the scope its category
+    /// requires. Generated by reflection so a new write action is covered without editing the theory.
+    /// </summary>
+    public static TheoryData<string, string, string> NonBaseWriteActions()
+    {
+        var data = new TheoryData<string, string, string>();
+
+        foreach (var controller in NonBaseControllersUnderGuard)
+        {
+            foreach (var action in WriteActions(controller))
+            {
+                var expected = ExpectedActionScopes.TryGetValue($"{controller.Name}.{action.Name}", out var perAction)
+                    ? perAction
+                    : ExpectedWriteScopes[controller.Name];
+
+                data.Add(controller.FullName!, action.Name, expected);
+            }
+        }
+
+        return data;
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────────────────────
 
     private static IActionResult? Evaluate(object controller, bool authenticated, params string[] grantedScopes)
     {
-        var httpContext = new DefaultHttpContext();
-        if (authenticated)
-            httpContext.Items["AuthContext"] = new AuthContext { IsAuthenticated = true };
-        httpContext.Items["GrantedScopes"] = (IReadOnlySet<string>)new HashSet<string>(grantedScopes);
-
-        var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+        var actionContext = new ActionContext(
+            NewHttpContext(authenticated, grantedScopes), new RouteData(), new ActionDescriptor());
         var context = new ActionExecutingContext(
             actionContext, new List<IFilterMetadata>(), new Dictionary<string, object?>(), controller);
 
@@ -193,14 +327,84 @@ public class V4WriteScopeGatingTests
         return context.Result;
     }
 
+    /// <summary>
+    /// Runs the filters an action actually declares (authorization filters first, as MVC does), so
+    /// the assertion covers both which gate is present and the scope it names.
+    /// </summary>
+    private static IActionResult? EvaluateAction(
+        Type controller, string actionName, bool authenticated, params string[] grantedScopes)
+    {
+        var action = controller.GetMethod(actionName, BindingFlags.Public | BindingFlags.Instance)
+            ?? throw new InvalidOperationException($"{controller.Name} has no action named {actionName}");
+        var filters = action.GetCustomAttributes(inherit: true);
+
+        var actionContext = new ActionContext(
+            NewHttpContext(authenticated, grantedScopes), new RouteData(), new ActionDescriptor());
+
+        foreach (var filter in filters.OfType<IAuthorizationFilter>())
+        {
+            var authorizationContext = new AuthorizationFilterContext(actionContext, new List<IFilterMetadata>());
+            filter.OnAuthorization(authorizationContext);
+            if (authorizationContext.Result is not null)
+                return authorizationContext.Result;
+        }
+
+        var executingContext = new ActionExecutingContext(
+            actionContext,
+            new List<IFilterMetadata>(),
+            new Dictionary<string, object?>(),
+            ScopeDeclarationInstance(controller));
+
+        foreach (var filter in filters.OfType<IActionFilter>())
+        {
+            filter.OnActionExecuting(executingContext);
+            if (executingContext.Result is not null)
+                return executingContext.Result;
+        }
+
+        return null;
+    }
+
+    private static DefaultHttpContext NewHttpContext(bool authenticated, string[] grantedScopes)
+    {
+        var httpContext = new DefaultHttpContext();
+        if (authenticated)
+            httpContext.Items["AuthContext"] = new AuthContext { IsAuthenticated = true };
+        httpContext.Items["GrantedScopes"] = (IReadOnlySet<string>)new HashSet<string>(grantedScopes);
+        return httpContext;
+    }
+
+    /// <summary>The scopes an action's gate requires: the controller's declaration, or the explicit list.</summary>
+    private static IEnumerable<string> RequiredScopes(Type controller, MethodInfo action)
+    {
+        var attributes = action.GetCustomAttributes(inherit: true);
+
+        if (attributes.Any(a => a is RequireDeclaredWriteScopeAttribute)
+            && ScopeDeclarationInstance(controller) is IWriteScopedController declared)
+            yield return declared.WriteScope;
+
+        foreach (var scope in attributes.OfType<RequireScopeAttribute>().SelectMany(a => a.Scopes))
+            yield return scope;
+    }
+
     private static Assembly ApiAssembly => typeof(RequireDeclaredWriteScopeAttribute).Assembly;
 
-    private static IEnumerable<Type> CrudControllers() =>
-        V4ControllerBaseSubclasses().Where(t => typeof(IWriteScopedController).IsAssignableFrom(t));
+    private static IEnumerable<Type> WriteScopedControllers() =>
+        ApiAssembly.GetTypes()
+            .Where(t => t is { IsClass: true, IsAbstract: false } && typeof(IWriteScopedController).IsAssignableFrom(t));
 
     private static IEnumerable<Type> V4ControllerBaseSubclasses() =>
         ApiAssembly.GetTypes()
             .Where(t => t is { IsClass: true, IsAbstract: false } && DerivesFromV4Base(t));
+
+    private static IEnumerable<MethodInfo> WriteActions(Type controller) =>
+        controller.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .Where(action => HttpVerbs(action).Overlaps(WriteVerbs));
+
+    private static HashSet<string> HttpVerbs(MethodInfo action) =>
+        action.GetCustomAttributes<HttpMethodAttribute>(inherit: true)
+            .SelectMany(a => a.HttpMethods)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
     private static bool DerivesFromV4Base(Type type)
     {
@@ -215,22 +419,20 @@ public class V4WriteScopeGatingTests
         return false;
     }
 
-    /// <summary>Builds a controller with every constructor dependency mocked.</summary>
-    private static object Instantiate(Type controller)
-    {
-        var constructor = controller.GetConstructors().Single();
-        var arguments = constructor.GetParameters()
-            .Select(p => ((Mock)Activator.CreateInstance(typeof(Mock<>).MakeGenericType(p.ParameterType))!).Object)
-            .ToArray();
-
-        return constructor.Invoke(arguments);
-    }
+    /// <summary>
+    /// A controller instance for reading <see cref="IWriteScopedController.WriteScope"/> and for
+    /// running the write-scope filters. The getters return a constant, and the filters touch nothing
+    /// else, so the controller is left unconstructed — several of these controllers take a
+    /// <c>NocturneDbContext</c>, which has no mockable constructor.
+    /// </summary>
+    private static object ScopeDeclarationInstance(Type controller) =>
+        RuntimeHelpers.GetUninitializedObject(controller);
 
     private static object NewSensorGlucoseController() =>
-        Instantiate(typeof(Nocturne.API.Controllers.V4.Glucose.SensorGlucoseController));
+        ScopeDeclarationInstance(typeof(Nocturne.API.Controllers.V4.Glucose.SensorGlucoseController));
 
     private static object NewBolusController() =>
-        Instantiate(typeof(Nocturne.API.Controllers.V4.Treatments.BolusController));
+        ScopeDeclarationInstance(typeof(Nocturne.API.Controllers.V4.Treatments.BolusController));
 
     /// <summary>Stands in for a controller that never declared a write scope.</summary>
     private sealed class UndeclaredController : ControllerBase;

--- a/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
@@ -96,6 +96,26 @@ public class V4WriteScopeGatingTests
         public const string PresentationState = "presentation state, no patient data";
 
         /// <summary>
+        /// The required scope depends on the record being written, so no attribute scan can see it.
+        /// The controller calls a per-record guard in the handler instead. Every action filed under
+        /// this reason must be covered by a route-level test that drives the real gate, so the
+        /// exemption is asserted rather than trusted — see
+        /// <see cref="PerRecordGuardedActions_AreCoveredByARouteLevelTest"/>.
+        /// </summary>
+        public const string PerRecordGuard = "per-record scope enforced in the handler";
+
+        /// <summary>
+        /// Mints a capability rather than storing an observation, and the vocabulary that should
+        /// govern it is split: the permission atoms are <c>sharing.manage</c>/<c>sharing.guest</c>
+        /// while the OAuth scope is <c>sharing.readwrite</c>, which no seed role maps to and
+        /// <see cref="OAuthScopes.Normalize"/> keeps only for a client that was granted it
+        /// directly. Requiring either would strip the capability from every non-owner role, so it
+        /// stays ungated until the vocabulary is unified. NOT presentation state — the capability
+        /// this mints serves patient glucose to an anonymous caller.
+        /// </summary>
+        public const string SplitSharingVocabulary = "sharing capability, vocabulary split between atom and scope";
+
+        /// <summary>
         /// Writes alert, notification or DND state. <c>alerts.readwrite</c> is the category, but
         /// gating this surface is the alert-authorization work, not the data-plane taxonomy: the
         /// alert engine, the chat-bot dispatch and the invite redemption all post here with
@@ -178,7 +198,7 @@ public class V4WriteScopeGatingTests
             ["DebugController"] = NotDataCategory.ComputeOverPostBody,
             ["StatisticsController"] = NotDataCategory.ComputeOverPostBody,
 
-            ["ClockFacesController"] = NotDataCategory.PresentationState,
+            ["ClockFacesController"] = NotDataCategory.SplitSharingVocabulary,
             ["CoachMarkController"] = NotDataCategory.PresentationState,
             ["UserPreferencesController"] = NotDataCategory.PresentationState,
 
@@ -213,10 +233,18 @@ public class V4WriteScopeGatingTests
             // A single activity payload decomposes into a different data category per record, so the
             // required scope is not known until the handler has read the body. ActivityController
             // calls ActivityWriteScopeGuard.FindMissingScope per record instead, which no attribute
-            // scan can see. Covered behaviourally by ActivityWriteScopeGuardTests.
-            ["ActivityController.CreateActivities"] = "per-record scope via ActivityWriteScopeGuard",
-            ["ActivityController.UpdateActivity"] = "per-record scope via ActivityWriteScopeGuard",
-            ["ActivityController.DeleteActivity"] = "per-record scope via ActivityWriteScopeGuard",
+            // scan can see.
+            ["ActivityController.CreateActivities"] = NotDataCategory.PerRecordGuard,
+            ["ActivityController.UpdateActivity"] = NotDataCategory.PerRecordGuard,
+            ["ActivityController.DeleteActivity"] = NotDataCategory.PerRecordGuard,
+
+            // state_spans holds four data categories behind one table and the caller picks which by
+            // setting Category in the body, so StateSpanWriteScopeGuard resolves the scope per
+            // record. A flat controller scope under-gated three of the four — notably DataExclusion,
+            // which decides whether glucose readings count towards analytics and reports.
+            ["StateSpansController.CreateStateSpan"] = NotDataCategory.PerRecordGuard,
+            ["StateSpansController.UpdateStateSpan"] = NotDataCategory.PerRecordGuard,
+            ["StateSpansController.DeleteStateSpan"] = NotDataCategory.PerRecordGuard,
 
             // The rest of DiscrepancyController is [RequireAdmin]; the ingest route is deliberately
             // [AllowAnonymous], so there is no credential whose scopes could be checked.
@@ -274,7 +302,6 @@ public class V4WriteScopeGatingTests
             // treatments: state_spans is the decomposed form of the legacy treatment events
             // (temporary target, profile switch, exercise, illness, travel) and of the temp-basal
             // spans V3 TreatmentsController writes. v1 activity writes require treatments.readwrite.
-            ["StateSpansController"] = OAuthScopes.TreatmentsReadWrite,
 
             // therapy: the timezone timeline is the same patient clinical configuration as the
             // timezone on patient_records, which PatientRecordController gates on therapy.readwrite.
@@ -415,6 +442,21 @@ public class V4WriteScopeGatingTests
                 $"{controller.Name} must gate its writes on its own data category");
             OAuthScopes.SatisfiesScope(AllReadScopes, declared)
                 .Should().BeFalse($"{controller.Name}'s write scope must not be satisfiable by read-only scopes");
+
+            // A declared scope that is not in the taxonomy, or that no seed role can hold, silently
+            // makes the controller owner-only: SatisfiesScope short-circuits on "*", so an owner
+            // never notices. sharing.readwrite is the live example — a real constant that survives
+            // Normalize but that no role maps to.
+            OAuthScopes.AllScopes.Should().Contain(declared,
+                $"{controller.Name} declares '{declared}', which is not a scope in the taxonomy");
+
+            TenantPermissions.SeedRolePermissions
+                .Where(role => role.Key != TenantPermissions.SeedRoles.Owner)
+                .Should().Contain(
+                    role => OAuthScopes.SatisfiesScope(
+                        OAuthScopes.NormalizeMemberPermissions(role.Value), declared),
+                    $"{controller.Name}'s write scope '{declared}' must be reachable by at least one "
+                    + "non-owner seed role, or the controller is owner-only by accident");
         }
     }
 
@@ -506,6 +548,74 @@ public class V4WriteScopeGatingTests
             .Select(c => c.Name)
             .ToHashSet(StringComparer.Ordinal);
         GateExemptControllers.Keys.Should().BeSubsetOf(controllersWithWrites);
+    }
+
+    /// <summary>
+    /// The per-record exemptions are the one reason whose mechanism is a method call in the handler,
+    /// which no attribute scan can see — delete the call and the sweep stays green. So each one must
+    /// be covered by a test that drives the real handler. That coverage is listed here rather than
+    /// discovered, so adding a per-record exemption without adding a behavioural test fails.
+    /// </summary>
+    [Fact]
+    public void PerRecordGuardedActions_HaveABehaviouralTest()
+    {
+        var covered = new[]
+        {
+            // StateSpanWriteScopeTests drives all three through the real handler.
+            "StateSpansController.CreateStateSpan",
+            "StateSpansController.UpdateStateSpan",
+            "StateSpansController.DeleteStateSpan",
+            // ActivityWriteScopeGuardTests covers the guard; the handler wiring is asserted by
+            // ActivityControllerScopeTests.
+            "ActivityController.CreateActivities",
+            "ActivityController.UpdateActivity",
+            "ActivityController.DeleteActivity",
+        };
+
+        GateExemptWriteActions
+            .Where(entry => entry.Value == NotDataCategory.PerRecordGuard)
+            .Select(entry => entry.Key)
+            .Should().BeEquivalentTo(covered,
+                "every per-record-guarded action needs a test that drives its handler");
+    }
+
+    /// <summary>
+    /// An attribute-routed action with no verb constraint answers EVERY verb, so it accepts POST
+    /// while carrying no <c>HttpPost</c> for the write sweep to find. There are none today; this
+    /// keeps it that way rather than leaving a silent hole in the sweep's selector.
+    /// </summary>
+    [Fact]
+    public void EveryV4Action_ConstrainsItsVerb()
+    {
+        var unconstrained = V4Controllers()
+            .SelectMany(c => ActionCandidates(c).Select(a => (Controller: c, Action: a)))
+            .Where(x => x.Action.GetCustomAttributes(inherit: true).OfType<IRouteTemplateProvider>().Any()
+                        || x.Action.GetCustomAttributes(inherit: true).OfType<IActionHttpMethodProvider>().Any())
+            .Where(x => HttpVerbs(x.Action).Count == 0)
+            .Select(x => $"{x.Controller.Name}.{x.Action.Name}")
+            .ToList();
+
+        unconstrained.Should().BeEmpty(
+            "an action with no verb constraint answers POST too, so the write sweep would miss it");
+    }
+
+    /// <summary>
+    /// The sweep selects by namespace, so a controller routed under <c>api/v4</c> from a different
+    /// namespace would be invisible to it. Assert the two agree rather than relying on convention.
+    /// </summary>
+    [Fact]
+    public void EveryControllerRoutedUnderApiV4_IsInTheV4Namespace()
+    {
+        var strays = ApiAssembly.GetTypes()
+            .Where(t => t is { IsClass: true, IsAbstract: false } && typeof(ControllerBase).IsAssignableFrom(t))
+            .Where(t => !IsUnderV4Namespace(t))
+            .Where(t => t.GetCustomAttributes<RouteAttribute>(inherit: true)
+                .Any(r => r.Template.StartsWith("api/v4", StringComparison.OrdinalIgnoreCase)))
+            .Select(t => $"{t.Namespace}.{t.Name}")
+            .ToList();
+
+        strays.Should().BeEmpty(
+            "a controller routed under api/v4 outside the V4 namespace escapes the write-scope sweep");
     }
 
     [Fact]
@@ -752,10 +862,29 @@ public class V4WriteScopeGatingTests
         controller.GetMethods(BindingFlags.Public | BindingFlags.Instance)
             .Where(action => HttpVerbs(action).Overlaps(WriteVerbs));
 
+    /// <summary>
+    /// The verbs an action answers. Keyed off <see cref="IActionHttpMethodProvider"/> rather than
+    /// <see cref="HttpMethodAttribute"/>, because <c>[AcceptVerbs]</c> implements the interface
+    /// without deriving from the attribute and would otherwise be invisible to the sweep.
+    /// </summary>
     private static HashSet<string> HttpVerbs(MethodInfo action) =>
-        action.GetCustomAttributes<HttpMethodAttribute>(inherit: true)
+        action.GetCustomAttributes(inherit: true)
+            .OfType<IActionHttpMethodProvider>()
             .SelectMany(a => a.HttpMethods)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The methods MVC would treat as actions: declared on the controller itself rather than
+    /// inherited from <see cref="ControllerBase"/>, not a property accessor, not <c>[NonAction]</c>.
+    /// Used by <see cref="EveryV4Action_ConstrainsItsVerb"/>, since an action with no verb constraint
+    /// answers every verb — including POST — and would otherwise be invisible to the write sweep.
+    /// </summary>
+    private static IEnumerable<MethodInfo> ActionCandidates(Type controller) =>
+        controller.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .Where(m => !m.IsSpecialName
+                        && m.DeclaringType != typeof(ControllerBase)
+                        && m.DeclaringType != typeof(object)
+                        && !m.GetCustomAttributes(inherit: true).Any(a => a is NonActionAttribute));
 
     private static bool DerivesFromV4Base(Type type)
     {

--- a/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
@@ -19,10 +20,20 @@ namespace Nocturne.API.Tests.Authorization;
 /// (<c>FOR SELECT</c>) nor the tenant policy's <c>WITH CHECK</c> blocks a write. Enforcement is
 /// therefore <see cref="RequireDeclaredWriteScopeAttribute"/> reading the scope each controller
 /// declares through <see cref="IWriteScopedController.WriteScope"/>, or an explicit
-/// <see cref="RequireScopeAttribute"/> where one controller's writes span two data categories.
+/// <see cref="RequireScopeAttribute"/> where a controller's writes span two data categories.
 /// </summary>
 /// <remarks>
+/// <para>
+/// The guard sweeps every <see cref="ControllerBase"/> subclass under
+/// <c>Nocturne.API.Controllers.V4</c> by namespace rather than from a list of types, so a new
+/// non-base V4 controller is under it the moment it exists. A write action there must carry a gate,
+/// or be named in <see cref="GateExemptControllers"/> / <see cref="GateExemptWriteActions"/> with
+/// the mechanism that governs it instead — and where that mechanism is an attribute or a namespace,
+/// <see cref="EveryExemptionClaimingAnAttribute_ActuallyCarriesIt"/> asserts it is really there.
+/// </para>
+/// <para>
 /// The V1/V2/V3 counterpart lives in <see cref="WriteEndpointScopeEnforcementTests"/>.
+/// </para>
 /// </remarks>
 public class V4WriteScopeGatingTests
 {
@@ -35,26 +46,185 @@ public class V4WriteScopeGatingTests
     private static readonly string[] AllReadScopes =
         OAuthScopes.AllScopes.Where(s => s.EndsWith(".read", StringComparison.Ordinal)).ToArray();
 
-    /// <summary>
-    /// V4 controllers that do not derive from <see cref="V4CrudControllerBase{TModel, TCreateRequest, TUpdateRequest, TRepository}"/>
-    /// and so cannot inherit its gated write actions. Enumerated by type rather than by namespace
-    /// sweep because <c>V4.Health.ActivityController</c> gates in the handler (its category depends
-    /// on what the payload decomposes into, per record) and carries no attribute to find.
-    /// </summary>
-    private static readonly Type[] NonBaseControllersUnderGuard =
-    [
-        typeof(Nocturne.API.Controllers.V4.Profiles.ProfileController),
-        typeof(Nocturne.API.Controllers.V4.Treatments.NutritionController),
-        typeof(Nocturne.API.Controllers.V4.Treatments.FoodsController),
-        typeof(Nocturne.API.Controllers.V4.Health.BodyWeightController),
-        typeof(Nocturne.API.Controllers.V4.Health.PatientRecordController),
-    ];
+    /// <summary>The namespace the guard sweeps. Every controller under it is in scope.</summary>
+    private const string V4Namespace = "Nocturne.API.Controllers.V4";
 
     /// <summary>
-    /// The write scope each write-scoped V4 controller is expected to declare. Derived from the data
-    /// category the record's table belongs to in <see cref="ShareDataCategories"/> (the read-side
-    /// classification) and from the scope the equivalent V1 endpoint requires. Asserted exhaustively,
-    /// so a new write-scoped V4 controller must be added here with a deliberate category.
+    /// Why a controller's write actions are not gated on a data-category scope. The category, not
+    /// free prose, so the same decision cannot be restated three ways for three controllers.
+    /// </summary>
+    private static class NotDataCategory
+    {
+        /// <summary>Platform operator surface; the class carries [Authorize(Roles = "platform_admin")].</summary>
+        public const string PlatformAdminRole = "platform-admin role, not a data scope";
+
+        /// <summary>Tenant operator surface; the class carries [RequireAdmin].</summary>
+        public const string TenantAdminAttribute = "tenant-admin attribute, not a data scope";
+
+        /// <summary>Service-to-service surface; the class carries [RequireInstanceKeyAuth].</summary>
+        public const string InstanceKey = "instance-key service credential, not a data scope";
+
+        /// <summary>Registered only when the API runs in Development.</summary>
+        public const string DevelopmentOnly = "dev-only controller, absent outside Development";
+
+        /// <summary>First-run tenant creation, before any tenant or credential exists.</summary>
+        public const string Setup = "pre-tenant setup, no credential to scope";
+
+        /// <summary>
+        /// Writes membership, invite, session, role, share or linked-account state — the caller's own
+        /// identity and delegation graph, not patient records. Governed by the RBAC permission atoms
+        /// (members.manage, roles.manage, sharing.manage), which are a separate vocabulary from the
+        /// data-category scopes and are not reachable through SatisfiesScope.
+        /// </summary>
+        public const string IdentityAndDelegation = "identity/delegation state, governed by RBAC atoms";
+
+        /// <summary>
+        /// Configures a connector: credentials, cursors, sync triggers and webhook targets. The data
+        /// a sync then writes is written by the connector's own publish path, not by the caller.
+        /// </summary>
+        public const string ConnectorAdministration = "connector configuration, not a data write";
+
+        /// <summary>
+        /// POST carrying a request body for a pure computation or a report render. Nothing is
+        /// persisted, so there is no write to scope.
+        /// </summary>
+        public const string ComputeOverPostBody = "computes from the body, persists nothing";
+
+        /// <summary>Per-user or per-tenant presentation state with no patient observation in it.</summary>
+        public const string PresentationState = "presentation state, no patient data";
+
+        /// <summary>
+        /// Writes alert, notification or DND state. <c>alerts.readwrite</c> is the category, but
+        /// gating this surface is the alert-authorization work, not the data-plane taxonomy: the
+        /// alert engine, the chat-bot dispatch and the invite redemption all post here with
+        /// credentials whose scope resolution is being changed on sibling branches.
+        /// </summary>
+        public const string AlertSurface = "alert surface, pending the alert-authorization work";
+
+        /// <summary>
+        /// Deliberately <c>[AllowAnonymous]</c>. There is no credential to scope, so a scope gate
+        /// cannot apply; whether the endpoint should be anonymous at all is the anonymous-endpoint
+        /// audit's question, not this taxonomy's.
+        /// </summary>
+        public const string AnonymousByDeclaration = "anonymous endpoint, no credential to scope";
+
+        /// <summary>
+        /// Tenant-wide operational configuration or an operational log row: audit and analytics
+        /// collection settings, glucose-processing preferences, system events. Not a patient record,
+        /// and the taxonomy has no scope that names it — <see cref="ShareDataCategories"/> classifies
+        /// tables of observations. Needs a scope of its own before it can be gated.
+        /// </summary>
+        public const string TenantOperationalConfig = "tenant operational config, no scope in the taxonomy";
+
+        /// <summary>Sends to an external service and persists no tenant row.</summary>
+        public const string OutboundOnly = "outbound call, persists no tenant data";
+    }
+
+    /// <summary>
+    /// Controllers under <see cref="V4Namespace"/> whose write actions are governed by something
+    /// other than a data-category write scope. Listed per controller with the mechanism that governs
+    /// it instead, because the whole controller shares one answer;
+    /// <see cref="GateExemptWriteActions"/> carries the per-action exceptions. A controller absent
+    /// from both must gate every write action, so a new V4 controller fails the guard until someone
+    /// decides which of these it is.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> GateExemptControllers =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["AccessRequestController"] = NotDataCategory.PlatformAdminRole,
+            ["ConnectorAdminController"] = NotDataCategory.PlatformAdminRole,
+            ["DemoAdminController"] = NotDataCategory.PlatformAdminRole,
+            ["OidcProviderAdminController"] = NotDataCategory.PlatformAdminRole,
+            ["PlatformSettingsController"] = NotDataCategory.PlatformAdminRole,
+            ["SubjectAdminController"] = NotDataCategory.PlatformAdminRole,
+            ["TenantController"] = NotDataCategory.PlatformAdminRole,
+
+            ["DeduplicationController"] = NotDataCategory.TenantAdminAttribute,
+            ["MigrationController"] = NotDataCategory.TenantAdminAttribute,
+
+            ["ChatIdentityDirectoryController"] = NotDataCategory.InstanceKey,
+
+            ["DevAdminController"] = NotDataCategory.DevelopmentOnly,
+            ["DevAuthController"] = NotDataCategory.DevelopmentOnly,
+
+            ["SetupController"] = NotDataCategory.Setup,
+            ["PlatformController"] = NotDataCategory.Setup,
+            ["MyTenantsController"] = NotDataCategory.Setup,
+
+            ["AvatarController"] = NotDataCategory.IdentityAndDelegation,
+            ["ChatIdentityController"] = NotDataCategory.IdentityAndDelegation,
+            ["ConnectedAppsController"] = NotDataCategory.IdentityAndDelegation,
+            ["GuestLinkController"] = NotDataCategory.IdentityAndDelegation,
+            ["MemberInviteController"] = NotDataCategory.IdentityAndDelegation,
+            ["MembershipRequestController"] = NotDataCategory.IdentityAndDelegation,
+            ["RoleController"] = NotDataCategory.IdentityAndDelegation,
+            ["SessionsController"] = NotDataCategory.IdentityAndDelegation,
+            ["ShareLinkController"] = NotDataCategory.IdentityAndDelegation,
+
+            ["CareLinkConnectController"] = NotDataCategory.ConnectorAdministration,
+            ["ConfigurationController"] = NotDataCategory.ConnectorAdministration,
+            ["ConnectorFoodEntriesController"] = NotDataCategory.ConnectorAdministration,
+            ["MyFitnessPalSettingsController"] = NotDataCategory.ConnectorAdministration,
+            ["ServicesController"] = NotDataCategory.ConnectorAdministration,
+            ["WebhookSettingsController"] = NotDataCategory.ConnectorAdministration,
+
+            ["CompatibilityController"] = NotDataCategory.ComputeOverPostBody,
+            ["DebugController"] = NotDataCategory.ComputeOverPostBody,
+            ["StatisticsController"] = NotDataCategory.ComputeOverPostBody,
+
+            ["ClockFacesController"] = NotDataCategory.PresentationState,
+            ["CoachMarkController"] = NotDataCategory.PresentationState,
+            ["UserPreferencesController"] = NotDataCategory.PresentationState,
+
+            ["AlertCustomSoundsController"] = NotDataCategory.AlertSurface,
+            ["AlertInvitesController"] = NotDataCategory.AlertSurface,
+            ["AlertReplayController"] = NotDataCategory.AlertSurface,
+            ["AlertRulesController"] = NotDataCategory.AlertSurface,
+            ["AlertsController"] = NotDataCategory.AlertSurface,
+            ["CompressionLowController"] = NotDataCategory.AlertSurface,
+            ["DndWindowsController"] = NotDataCategory.AlertSurface,
+            ["NotificationsController"] = NotDataCategory.AlertSurface,
+            ["TenantAlertSettingsController"] = NotDataCategory.AlertSurface,
+
+            ["AnalyticsController"] = NotDataCategory.TenantOperationalConfig,
+            ["AuditController"] = NotDataCategory.TenantOperationalConfig,
+            ["GlucoseProcessingSettingsController"] = NotDataCategory.TenantOperationalConfig,
+            ["SystemEventsController"] = NotDataCategory.TenantOperationalConfig,
+
+            ["SupportController"] = NotDataCategory.OutboundOnly,
+            ["SystemController"] = NotDataCategory.OutboundOnly,
+        };
+
+    /// <summary>
+    /// Write actions under <see cref="V4Namespace"/> that deliberately carry no scope attribute,
+    /// keyed <c>Controller.Action</c> with the reason. Any other ungated write action fails the
+    /// guard, so a new non-base V4 controller cannot be added without either a gate or a decision
+    /// recorded here.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> GateExemptWriteActions =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            // A single activity payload decomposes into a different data category per record, so the
+            // required scope is not known until the handler has read the body. ActivityController
+            // calls ActivityWriteScopeGuard.FindMissingScope per record instead, which no attribute
+            // scan can see. Covered behaviourally by ActivityWriteScopeGuardTests.
+            ["ActivityController.CreateActivities"] = "per-record scope via ActivityWriteScopeGuard",
+            ["ActivityController.UpdateActivity"] = "per-record scope via ActivityWriteScopeGuard",
+            ["ActivityController.DeleteActivity"] = "per-record scope via ActivityWriteScopeGuard",
+
+            // The rest of DiscrepancyController is [RequireAdmin]; the ingest route is deliberately
+            // [AllowAnonymous], so there is no credential whose scopes could be checked.
+            ["DiscrepancyController.IngestDiscrepancy"] = NotDataCategory.AnonymousByDeclaration,
+        };
+
+    /// <summary>
+    /// The write scope each single-category V4 controller requires, whether it declares it through
+    /// <see cref="IWriteScopedController"/> or repeats a <see cref="RequireScopeAttribute"/> per
+    /// action. Derived from the data category the record's table belongs to in
+    /// <see cref="ShareDataCategories"/> (the read-side classification) and from the scope the
+    /// equivalent V1 endpoint requires.
+    /// <see cref="EveryNonBaseV4WriteAction_HasAnExpectedScopeOrAnExemption"/> keeps it exhaustive,
+    /// so a new V4 controller must be added here with a deliberate category or exempted.
     /// </summary>
     private static readonly IReadOnlyDictionary<string, string> ExpectedWriteScopes =
         new Dictionary<string, string>(StringComparer.Ordinal)
@@ -94,6 +264,40 @@ public class V4WriteScopeGatingTests
             // therapy: body_weights has no category scope of its own. The record is patient clinical
             // configuration written from the Patient Record settings form alongside therapy settings.
             ["BodyWeightController"] = OAuthScopes.TherapyReadWrite,
+
+            // treatments: state_spans is the decomposed form of the legacy treatment events
+            // (temporary target, profile switch, exercise, illness, travel) and of the temp-basal
+            // spans V3 TreatmentsController writes. v1 activity writes require treatments.readwrite.
+            ["StateSpansController"] = OAuthScopes.TreatmentsReadWrite,
+
+            // therapy: the timezone timeline is the same patient clinical configuration as the
+            // timezone on patient_records, which PatientRecordController gates on therapy.readwrite.
+            ["TimezoneTimelineController"] = OAuthScopes.TherapyReadWrite,
+
+            // alerts: the tracker_* tables are monitoring state, not patient observations — a
+            // definition's thresholds become managed alert rules and acking an instance acks an
+            // alert excursion. v1/v2 notification writes require alerts.readwrite.
+            ["TrackersController"] = OAuthScopes.AlertsReadWrite,
+
+            // alerts: UISettingsConfiguration is tenant-wide and carries NotificationSettings, the
+            // alarm thresholds and profiles that decide whether a low-glucose alert fires.
+            ["UISettingsController"] = OAuthScopes.AlertsReadWrite,
+
+            // devices: a reservoir report is stored as a manual-source pump_snapshots row, and a fill
+            // additionally writes a device_events row. Both are the devices category.
+            ["ReservoirReportsController"] = OAuthScopes.DevicesReadWrite,
+
+            // Controllers that gate with a per-action [RequireScope] rather than a declaration. Their
+            // categories are their own dedicated tables.
+            ["SleepController"] = OAuthScopes.SleepReadWrite,
+            ["HeartRateController"] = OAuthScopes.HeartRateReadWrite,
+            ["StepCountController"] = OAuthScopes.StepCountReadWrite,
+            ["TempBasalController"] = OAuthScopes.TreatmentsReadWrite,
+
+            // client_devices is the member's own registered notification targets, not patient data.
+            // The actions accept either member-personal capability scope; device.notify is the one
+            // asserted, and neither is satisfiable by a read-only credential.
+            ["ClientDevicesController"] = OAuthScopes.DeviceNotify,
         };
 
     /// <summary>
@@ -118,6 +322,12 @@ public class V4WriteScopeGatingTests
             ["PatientRecordController.UpdateDevice"] = OAuthScopes.DevicesReadWrite,
             ["PatientRecordController.DeleteDevice"] = OAuthScopes.DevicesReadWrite,
             ["PatientRecordController.ReorderDevices"] = OAuthScopes.DevicesReadWrite,
+
+            // Accepting a match writes a treatment_foods row keyed by the carb intake — a COB input,
+            // the same table NutritionController gates on treatments.readwrite. Dismissing writes
+            // only the connector_food_entries status, which is the food category.
+            ["MealMatchingController.AcceptMatch"] = OAuthScopes.TreatmentsReadWrite,
+            ["MealMatchingController.DismissMatch"] = OAuthScopes.FoodReadWrite,
         };
 
     [Fact]
@@ -188,7 +398,7 @@ public class V4WriteScopeGatingTests
     {
         var controllers = WriteScopedControllers().ToList();
 
-        controllers.Select(t => t.Name).Should().BeEquivalentTo(ExpectedWriteScopes.Keys,
+        controllers.Select(t => t.Name).Should().BeSubsetOf(ExpectedWriteScopes.Keys,
             "every write-scoped V4 controller must be mapped to a data category in ExpectedWriteScopes");
 
         foreach (var controller in controllers)
@@ -203,12 +413,18 @@ public class V4WriteScopeGatingTests
     }
 
     [Fact]
-    public void MixedCategoryController_MapsEveryWriteActionToItsCategory()
+    public void MixedCategoryControllers_MapEveryWriteActionToItsCategory()
     {
-        // PatientRecordController writes two categories, so its expectations are per action and must
-        // stay exhaustive: a new write action there has to name the category it mutates.
-        var actions = WriteActions(typeof(Nocturne.API.Controllers.V4.Health.PatientRecordController))
-            .Select(a => $"PatientRecordController.{a.Name}");
+        // A controller that writes two categories has per-action expectations, and they must stay
+        // exhaustive: a new write action there has to name the category it mutates. The controllers
+        // are derived from the map's own keys rather than listed, so adding one is a single edit.
+        var mixedCategory = ExpectedActionScopes.Keys
+            .Select(key => key.Split('.', 2)[0])
+            .ToHashSet(StringComparer.Ordinal);
+
+        var actions = V4Controllers()
+            .Where(c => mixedCategory.Contains(c.Name))
+            .SelectMany(c => WriteActions(c).Select(a => $"{c.Name}.{a.Name}"));
 
         actions.Should().BeEquivalentTo(ExpectedActionScopes.Keys,
             "every write action on a mixed-category controller must be mapped in ExpectedActionScopes");
@@ -221,11 +437,14 @@ public class V4WriteScopeGatingTests
         var readSatisfiable = new List<string>();
         var writeActionsChecked = 0;
 
-        foreach (var controller in V4ControllerBaseSubclasses().Concat(NonBaseControllersUnderGuard).Distinct())
+        foreach (var controller in V4Controllers())
         {
             foreach (var action in WriteActions(controller))
             {
                 writeActionsChecked++;
+
+                if (IsGateExempt(controller, action))
+                    continue;
 
                 var attributes = action.GetCustomAttributes(inherit: true);
                 var gated = attributes.Any(a => a is RequireDeclaredWriteScopeAttribute
@@ -249,18 +468,76 @@ public class V4WriteScopeGatingTests
             }
         }
 
-        // Sanity: the scan must find the write surface, or the assertions below pass vacuously.
-        writeActionsChecked.Should().BeGreaterThan(80,
-            "the reflection scan should discover the V4 base-controller and non-base write endpoints");
+        // Sanity: the scan must find the write surface, or the assertions below pass vacuously. The
+        // floor tracks the namespace sweep (301 write actions when it was widened), so a sweep that
+        // silently narrows back to a subset fails here rather than passing on the remainder.
+        writeActionsChecked.Should().BeGreaterThan(280,
+            "the reflection scan should discover every write endpoint under " + V4Namespace);
 
         violations.Should().BeEmpty(
-            "every write action on a guarded V4 controller must carry [RequireDeclaredWriteScope] "
-            + "(base CRUD actions and their overrides) or an explicit [RequireScope]. Unprotected: "
-            + string.Join("; ", violations));
+            "every write action under " + V4Namespace + " must carry [RequireDeclaredWriteScope] "
+            + "(base CRUD actions and their overrides), an explicit [RequireScope], or an entry in "
+            + "GateExemptWriteActions stating why. Unprotected: " + string.Join("; ", violations));
 
         readSatisfiable.Should().BeEmpty(
             "a write action must require a readwrite (or full-access) scope: " + string.Join("; ", readSatisfiable));
     }
+
+    [Fact]
+    public void EveryGateExemption_NamesALiveWriteAction()
+    {
+        // An exemption left behind after its action was gated, renamed, or deleted would silently
+        // excuse a future action that reuses the name.
+        var controllers = V4Controllers().ToList();
+
+        var writeActions = controllers
+            .SelectMany(c => WriteActions(c).Select(a => $"{c.Name}.{a.Name}"))
+            .ToHashSet(StringComparer.Ordinal);
+        GateExemptWriteActions.Keys.Should().BeSubsetOf(writeActions);
+
+        var controllersWithWrites = controllers
+            .Where(c => WriteActions(c).Any())
+            .Select(c => c.Name)
+            .ToHashSet(StringComparer.Ordinal);
+        GateExemptControllers.Keys.Should().BeSubsetOf(controllersWithWrites);
+    }
+
+    [Fact]
+    public void EveryExemptionClaimingAnAttribute_ActuallyCarriesIt()
+    {
+        // The reason a controller is exempt has to stay true. Where the mechanism is an attribute or
+        // a namespace, assert it rather than trusting the prose: a controller that loses its
+        // [Authorize(Roles = "platform_admin")] must fail here, not sit exempt on a stale claim.
+        var broken = new List<string>();
+
+        foreach (var (name, reason) in GateExemptControllers)
+        {
+            var controller = V4Controllers().Single(t => t.Name == name);
+            var attributes = controller.GetCustomAttributes(inherit: true);
+
+            var holds = reason switch
+            {
+                NotDataCategory.PlatformAdminRole => attributes
+                    .OfType<AuthorizeAttribute>()
+                    .Any(a => a.Roles?.Contains("platform_admin", StringComparison.Ordinal) == true),
+                NotDataCategory.TenantAdminAttribute => attributes
+                    .Any(a => a.GetType().Name == "RequireAdminAttribute"),
+                NotDataCategory.InstanceKey => attributes
+                    .Any(a => a.GetType().Name == "RequireInstanceKeyAuthAttribute"),
+                NotDataCategory.DevelopmentOnly => controller.Namespace == V4Namespace + ".DevOnly",
+                _ => true,
+            };
+
+            if (!holds)
+                broken.Add($"{name} claims '{reason}' but does not carry it");
+        }
+
+        broken.Should().BeEmpty(string.Join("; ", broken));
+    }
+
+    private static bool IsGateExempt(Type controller, MethodInfo action) =>
+        GateExemptControllers.ContainsKey(controller.Name)
+        || GateExemptWriteActions.ContainsKey($"{controller.Name}.{action.Name}");
 
     [Theory]
     [MemberData(nameof(NonBaseWriteActions))]
@@ -292,26 +569,60 @@ public class V4WriteScopeGatingTests
     }
 
     /// <summary>
-    /// Every write action on the five non-base V4 controllers, paired with the scope its category
-    /// requires. Generated by reflection so a new write action is covered without editing the theory.
+    /// Every write action on a non-base V4 controller, paired with the scope its category requires.
+    /// Generated by reflection over <see cref="NonBaseV4Controllers"/> so a new controller or action
+    /// is covered without editing the theory.
+    /// <see cref="EveryNonBaseV4WriteAction_HasAnExpectedScopeOrAnExemption"/> keeps the mapping
+    /// exhaustive, so an unmapped action fails loudly rather than dropping out of this data set.
     /// </summary>
     public static TheoryData<string, string, string> NonBaseWriteActions()
     {
         var data = new TheoryData<string, string, string>();
 
-        foreach (var controller in NonBaseControllersUnderGuard)
+        foreach (var (controller, action, expected) in MappedNonBaseWriteActions())
         {
-            foreach (var action in WriteActions(controller))
-            {
-                var expected = ExpectedActionScopes.TryGetValue($"{controller.Name}.{action.Name}", out var perAction)
-                    ? perAction
-                    : ExpectedWriteScopes[controller.Name];
-
-                data.Add(controller.FullName!, action.Name, expected);
-            }
+            data.Add(controller.FullName!, action.Name, expected);
         }
 
         return data;
+    }
+
+    [Fact]
+    public void EveryNonBaseV4WriteAction_HasAnExpectedScopeOrAnExemption()
+    {
+        var unmapped = NonBaseV4Controllers()
+            .SelectMany(c => WriteActions(c).Select(a => (Controller: c, Action: a)))
+            .Where(x => !IsGateExempt(x.Controller, x.Action)
+                        && !ExpectedActionScopes.ContainsKey($"{x.Controller.Name}.{x.Action.Name}")
+                        && !ExpectedWriteScopes.ContainsKey(x.Controller.Name))
+            .Select(x => $"{x.Controller.Name}.{x.Action.Name}")
+            .ToList();
+
+        unmapped.Should().BeEmpty(
+            "every non-base V4 write action must name the data category it mutates, in "
+            + "ExpectedWriteScopes (single-category controller) or ExpectedActionScopes "
+            + "(mixed-category), or be exempted in GateExemptWriteActions. Unmapped: "
+            + string.Join("; ", unmapped));
+    }
+
+    /// <summary>
+    /// The non-base V4 write actions that have a declared scope expectation, with that scope.
+    /// </summary>
+    private static IEnumerable<(Type Controller, MethodInfo Action, string Expected)> MappedNonBaseWriteActions()
+    {
+        foreach (var controller in NonBaseV4Controllers().OrderBy(t => t.FullName, StringComparer.Ordinal))
+        {
+            foreach (var action in WriteActions(controller))
+            {
+                if (IsGateExempt(controller, action))
+                    continue;
+
+                if (ExpectedActionScopes.TryGetValue($"{controller.Name}.{action.Name}", out var perAction))
+                    yield return (controller, action, perAction);
+                else if (ExpectedWriteScopes.TryGetValue(controller.Name, out var perController))
+                    yield return (controller, action, perController);
+            }
+        }
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────────────────────
@@ -396,6 +707,28 @@ public class V4WriteScopeGatingTests
     private static IEnumerable<Type> V4ControllerBaseSubclasses() =>
         ApiAssembly.GetTypes()
             .Where(t => t is { IsClass: true, IsAbstract: false } && DerivesFromV4Base(t));
+
+    /// <summary>
+    /// Every concrete controller under <see cref="V4Namespace"/>. Swept by namespace rather than
+    /// listed, so a new V4 controller is under the guard the moment it exists.
+    /// </summary>
+    private static IEnumerable<Type> V4Controllers() =>
+        ApiAssembly.GetTypes()
+            .Where(t => t is { IsClass: true, IsAbstract: false }
+                        && typeof(ControllerBase).IsAssignableFrom(t)
+                        && IsUnderV4Namespace(t));
+
+    /// <summary>
+    /// The V4 controllers that cannot inherit
+    /// <see cref="V4CrudControllerBase{TModel, TCreateRequest, TUpdateRequest, TRepository}"/>'s
+    /// gated write actions and so carry their own gates.
+    /// </summary>
+    private static IEnumerable<Type> NonBaseV4Controllers() =>
+        V4Controllers().Except(V4ControllerBaseSubclasses());
+
+    private static bool IsUnderV4Namespace(Type type) =>
+        type.Namespace == V4Namespace
+        || type.Namespace?.StartsWith(V4Namespace + ".", StringComparison.Ordinal) == true;
 
     private static IEnumerable<MethodInfo> WriteActions(Type controller) =>
         controller.GetMethods(BindingFlags.Public | BindingFlags.Instance)

--- a/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
@@ -58,7 +58,9 @@ public class V4WriteScopeGatingTests
         /// <summary>Platform operator surface; the class carries [Authorize(Roles = "platform_admin")].</summary>
         public const string PlatformAdminRole = "platform-admin role, not a data scope";
 
-        /// <summary>Tenant operator surface; the class carries [RequireAdmin].</summary>
+        /// <summary>
+        /// Tenant operator surface; [RequireAdmin] on the class or on every write action.
+        /// </summary>
         public const string TenantAdminAttribute = "tenant-admin attribute, not a data scope";
 
         /// <summary>Service-to-service surface; the class carries [RequireInstanceKeyAuth].</summary>
@@ -142,6 +144,12 @@ public class V4WriteScopeGatingTests
             ["DeduplicationController"] = NotDataCategory.TenantAdminAttribute,
             ["MigrationController"] = NotDataCategory.TenantAdminAttribute,
 
+            // Both repeat [RequireAdmin] per action rather than carrying it on the class.
+            // ServicesController's data deletions and sync triggers are behind it, so they are not
+            // reachable by a read-only session despite having no scope gate.
+            ["CompatibilityController"] = NotDataCategory.TenantAdminAttribute,
+            ["ServicesController"] = NotDataCategory.TenantAdminAttribute,
+
             ["ChatIdentityDirectoryController"] = NotDataCategory.InstanceKey,
 
             ["DevAdminController"] = NotDataCategory.DevelopmentOnly,
@@ -165,10 +173,8 @@ public class V4WriteScopeGatingTests
             ["ConfigurationController"] = NotDataCategory.ConnectorAdministration,
             ["ConnectorFoodEntriesController"] = NotDataCategory.ConnectorAdministration,
             ["MyFitnessPalSettingsController"] = NotDataCategory.ConnectorAdministration,
-            ["ServicesController"] = NotDataCategory.ConnectorAdministration,
             ["WebhookSettingsController"] = NotDataCategory.ConnectorAdministration,
 
-            ["CompatibilityController"] = NotDataCategory.ComputeOverPostBody,
             ["DebugController"] = NotDataCategory.ComputeOverPostBody,
             ["StatisticsController"] = NotDataCategory.ComputeOverPostBody,
 
@@ -520,8 +526,7 @@ public class V4WriteScopeGatingTests
                 NotDataCategory.PlatformAdminRole => attributes
                     .OfType<AuthorizeAttribute>()
                     .Any(a => a.Roles?.Contains("platform_admin", StringComparison.Ordinal) == true),
-                NotDataCategory.TenantAdminAttribute => attributes
-                    .Any(a => a.GetType().Name == "RequireAdminAttribute"),
+                NotDataCategory.TenantAdminAttribute => CarriesAttribute(controller, "RequireAdminAttribute"),
                 NotDataCategory.InstanceKey => attributes
                     .Any(a => a.GetType().Name == "RequireInstanceKeyAuthAttribute"),
                 NotDataCategory.DevelopmentOnly => controller.Namespace == V4Namespace + ".DevOnly",
@@ -533,6 +538,19 @@ public class V4WriteScopeGatingTests
         }
 
         broken.Should().BeEmpty(string.Join("; ", broken));
+    }
+
+    /// <summary>
+    /// Whether the named attribute governs every write action on the controller — present on the
+    /// class, or repeated on each write action.
+    /// </summary>
+    private static bool CarriesAttribute(Type controller, string attributeTypeName)
+    {
+        bool Named(IEnumerable<object> attributes) =>
+            attributes.Any(a => a.GetType().Name == attributeTypeName);
+
+        return Named(controller.GetCustomAttributes(inherit: true))
+               || WriteActions(controller).All(a => Named(a.GetCustomAttributes(inherit: true)));
     }
 
     private static bool IsGateExempt(Type controller, MethodInfo action) =>

--- a/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
@@ -1,0 +1,243 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Routing;
+using Nocturne.API.Attributes;
+using Nocturne.API.Controllers.V4.Base;
+using Nocturne.Core.Models.Authorization;
+
+namespace Nocturne.API.Tests.Authorization;
+
+/// <summary>
+/// Guards write-scope enforcement on the V4 plane. The V4 controllers carry only a class-level
+/// <c>[Authorize]</c>, which read-only credentials satisfy — a guest link is issued read scopes
+/// only (<c>GuestLinkService</c>) but is an authenticated session, and neither the share RLS policy
+/// (<c>FOR SELECT</c>) nor the tenant policy's <c>WITH CHECK</c> blocks a write. Enforcement is
+/// therefore <see cref="RequireDeclaredWriteScopeAttribute"/> reading the scope each controller
+/// declares through <see cref="IWriteScopedController.WriteScope"/>.
+/// </summary>
+/// <remarks>
+/// The V1/V2/V3 counterpart lives in <see cref="WriteEndpointScopeEnforcementTests"/>.
+/// </remarks>
+public class V4WriteScopeGatingTests
+{
+    private static readonly string[] WriteVerbs = ["POST", "PUT", "PATCH", "DELETE"];
+
+    /// <summary>
+    /// The write scope each V4 CRUD controller is expected to declare. Derived from the data
+    /// category the record's table belongs to in <see cref="ShareDataCategories"/> (the read-side
+    /// classification) and from the scope the equivalent V1 endpoint requires. Asserted exhaustively,
+    /// so a new V4 CRUD controller must be added here with a deliberate category.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> ExpectedWriteScopes =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            // glucose: sensor_glucose / meter_glucose / calibrations / bg_checks all sit under
+            // glucose.read; v1 entries create requires glucose.readwrite.
+            ["SensorGlucoseController"] = OAuthScopes.GlucoseReadWrite,
+            ["MeterGlucoseController"] = OAuthScopes.GlucoseReadWrite,
+            ["CalibrationController"] = OAuthScopes.GlucoseReadWrite,
+            ["BGCheckController"] = OAuthScopes.GlucoseReadWrite,
+
+            // treatments: boluses / basal_injections / bolus_calculations sit under treatments.read;
+            // notes are the V4 form of a legacy text treatment. v1 treatments create requires
+            // treatments.readwrite.
+            ["BolusController"] = OAuthScopes.TreatmentsReadWrite,
+            ["BasalInjectionController"] = OAuthScopes.TreatmentsReadWrite,
+            ["BolusCalculationController"] = OAuthScopes.TreatmentsReadWrite,
+            ["NoteController"] = OAuthScopes.TreatmentsReadWrite,
+
+            // devices: device_events sits under devices.read, matching the sibling snapshot
+            // controllers (ApsSnapshotController's bulk write requires devices.readwrite).
+            ["DeviceEventController"] = OAuthScopes.DevicesReadWrite,
+        };
+
+    [Fact]
+    public void ReadOnlyGuestLinkScopes_CannotWriteGlucose()
+    {
+        // The maximum a guest link can hold: GuestLinkService.AllowedGuestScopes is read-only.
+        var guestScopes = OAuthScopes.Normalize([OAuthScopes.HealthRead, OAuthScopes.TherapyRead, OAuthScopes.ReportsRead]);
+
+        var result = Evaluate(NewSensorGlucoseController(), authenticated: true, guestScopes.ToArray());
+
+        result.Should().BeOfType<ForbidResult>(
+            "a read-only guest session must not be able to create, update, or delete a glucose reading");
+    }
+
+    [Fact]
+    public void ReadScopedCredential_CannotWriteTreatments()
+    {
+        var result = Evaluate(NewBolusController(), authenticated: true, OAuthScopes.TreatmentsRead, OAuthScopes.GlucoseRead);
+
+        result.Should().BeOfType<ForbidResult>();
+    }
+
+    [Fact]
+    public void ReadWriteScopedCredential_CanWrite()
+    {
+        Evaluate(NewBolusController(), authenticated: true, OAuthScopes.TreatmentsReadWrite)
+            .Should().BeNull();
+        Evaluate(NewSensorGlucoseController(), authenticated: true, OAuthScopes.GlucoseReadWrite)
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void ReadWriteScopeForAnotherCategory_DoesNotUnlockWrites()
+    {
+        Evaluate(NewBolusController(), authenticated: true, OAuthScopes.GlucoseReadWrite)
+            .Should().BeOfType<ForbidResult>();
+    }
+
+    [Fact]
+    public void FullAccessGrant_CanWrite()
+    {
+        // A legacy api-secret normalises to "*" — the uploaders that authenticate that way
+        // (AAPS/Loop/Trio/xDrip+) must keep writing.
+        Evaluate(NewSensorGlucoseController(), authenticated: true, OAuthScopes.FullAccess)
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void UnauthenticatedRequest_IsRejectedWith401()
+    {
+        Evaluate(NewSensorGlucoseController(), authenticated: false, OAuthScopes.GlucoseReadWrite)
+            .Should().BeOfType<UnauthorizedResult>();
+    }
+
+    [Fact]
+    public void ControllerDeclaringNoWriteScope_IsDenied()
+    {
+        // Fail closed: the filter denies rather than admits when there is no declaration to check,
+        // including on a controller that does not implement IWriteScopedController at all.
+        Evaluate(new UndeclaredController(), authenticated: true, OAuthScopes.FullAccess)
+            .Should().BeOfType<ForbidResult>();
+        Evaluate(new EmptyScopeController(), authenticated: true, OAuthScopes.FullAccess)
+            .Should().BeOfType<ForbidResult>();
+    }
+
+    [Fact]
+    public void EveryV4CrudController_DeclaresItsExpectedWriteScope()
+    {
+        var controllers = CrudControllers().ToList();
+
+        controllers.Select(t => t.Name).Should().BeEquivalentTo(ExpectedWriteScopes.Keys,
+            "every V4 CRUD controller must be mapped to a data category in ExpectedWriteScopes");
+
+        foreach (var controller in controllers)
+        {
+            var declared = ((IWriteScopedController)Instantiate(controller)).WriteScope;
+
+            declared.Should().Be(ExpectedWriteScopes[controller.Name],
+                $"{controller.Name} must gate its writes on its own data category");
+            OAuthScopes.SatisfiesScope([OAuthScopes.GlucoseRead, OAuthScopes.TreatmentsRead, OAuthScopes.DevicesRead], declared)
+                .Should().BeFalse($"{controller.Name}'s write scope must not be satisfiable by read-only scopes");
+        }
+    }
+
+    [Fact]
+    public void EveryV4WriteAction_IsScopeGated()
+    {
+        var violations = new List<string>();
+        var writeActionsChecked = 0;
+
+        foreach (var controller in V4ControllerBaseSubclasses())
+        {
+            foreach (var action in controller.GetMethods(BindingFlags.Public | BindingFlags.Instance))
+            {
+                var verbs = action.GetCustomAttributes<HttpMethodAttribute>(inherit: true)
+                    .SelectMany(a => a.HttpMethods)
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+                if (!verbs.Overlaps(WriteVerbs))
+                    continue;
+
+                writeActionsChecked++;
+
+                var attributes = action.GetCustomAttributes(inherit: true);
+                var gated = attributes.Any(a => a is RequireDeclaredWriteScopeAttribute
+                                                     or RequireScopeAttribute
+                                                     or RequirePermissionAttribute);
+
+                if (!gated)
+                    violations.Add($"{controller.Name}.{action.Name} [{string.Join(",", verbs)}]");
+            }
+        }
+
+        // Sanity: the scan must find the write surface, or the assertion below passes vacuously.
+        writeActionsChecked.Should().BeGreaterThan(40,
+            "the reflection scan should discover the V4 base-controller write endpoints");
+
+        violations.Should().BeEmpty(
+            "every write action on a V4 base controller must carry [RequireDeclaredWriteScope] "
+            + "(base CRUD actions and their overrides) or an explicit [RequireScope]. Unprotected: "
+            + string.Join("; ", violations));
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────────────────────
+
+    private static IActionResult? Evaluate(object controller, bool authenticated, params string[] grantedScopes)
+    {
+        var httpContext = new DefaultHttpContext();
+        if (authenticated)
+            httpContext.Items["AuthContext"] = new AuthContext { IsAuthenticated = true };
+        httpContext.Items["GrantedScopes"] = (IReadOnlySet<string>)new HashSet<string>(grantedScopes);
+
+        var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+        var context = new ActionExecutingContext(
+            actionContext, new List<IFilterMetadata>(), new Dictionary<string, object?>(), controller);
+
+        new RequireDeclaredWriteScopeAttribute().OnActionExecuting(context);
+        return context.Result;
+    }
+
+    private static Assembly ApiAssembly => typeof(RequireDeclaredWriteScopeAttribute).Assembly;
+
+    private static IEnumerable<Type> CrudControllers() =>
+        V4ControllerBaseSubclasses().Where(t => typeof(IWriteScopedController).IsAssignableFrom(t));
+
+    private static IEnumerable<Type> V4ControllerBaseSubclasses() =>
+        ApiAssembly.GetTypes()
+            .Where(t => t is { IsClass: true, IsAbstract: false } && DerivesFromV4Base(t));
+
+    private static bool DerivesFromV4Base(Type type)
+    {
+        for (var current = type.BaseType; current is not null; current = current.BaseType)
+        {
+            if (current.IsGenericType
+                && current.GetGenericTypeDefinition() is var definition
+                && (definition == typeof(V4CrudControllerBase<,,,>) || definition == typeof(V4ReadOnlyControllerBase<,>)))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>Builds a controller with every constructor dependency mocked.</summary>
+    private static object Instantiate(Type controller)
+    {
+        var constructor = controller.GetConstructors().Single();
+        var arguments = constructor.GetParameters()
+            .Select(p => ((Mock)Activator.CreateInstance(typeof(Mock<>).MakeGenericType(p.ParameterType))!).Object)
+            .ToArray();
+
+        return constructor.Invoke(arguments);
+    }
+
+    private static object NewSensorGlucoseController() =>
+        Instantiate(typeof(Nocturne.API.Controllers.V4.Glucose.SensorGlucoseController));
+
+    private static object NewBolusController() =>
+        Instantiate(typeof(Nocturne.API.Controllers.V4.Treatments.BolusController));
+
+    /// <summary>Stands in for a controller that never declared a write scope.</summary>
+    private sealed class UndeclaredController : ControllerBase;
+
+    /// <summary>Stands in for a controller whose declaration is present but empty.</summary>
+    private sealed class EmptyScopeController : ControllerBase, IWriteScopedController
+    {
+        public string WriteScope => string.Empty;
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4CrudControllerBaseTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4CrudControllerBaseTests.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Nocturne.API.Controllers.V4.Base;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
 using Xunit;
 using Nocturne.Core.Contracts.V4;
@@ -47,6 +48,8 @@ public interface ITestRecordRepository : IV4Repository<TestRecord>;
 public class TestCrudController(ITestRecordRepository repository)
     : V4CrudControllerBase<TestRecord, TestCreateRequest, TestUpdateRequest, ITestRecordRepository>(repository)
 {
+    public override string WriteScope => OAuthScopes.GlucoseReadWrite;
+
     protected override TestRecord MapCreateToModel(TestCreateRequest request) => new()
     {
         Timestamp = request.Timestamp,


### PR DESCRIPTION
The V4 plane carried only a class-level `[Authorize]`, which a read-only credential satisfies — a guest link is an authenticated session issued read scopes, and neither the share RLS policy (`FOR SELECT`) nor the tenant policy's `WITH CHECK` blocks a write. A read-only session could create, edit or delete therapy settings (what the bolus calculator reads), carb entries, patient insulins, patient devices, foods and body weight.

Gates them on the data category the record's table belongs to, then widens the exhaustiveness guard from a hand-maintained list of 96 write actions to a namespace sweep of all 301 — which is the real product here — and gates the six controllers that exposed as ungated.

Supersedes `fix/v4-write-scope-gating`, whose commit is the first of the five here.

Detail is in the commit messages. Two things worth surfacing:

- **`StateSpansController` needed a per-record guard, not a flat scope.** `state_spans` holds four data categories behind one table and the caller picks which in the body; a flat `treatments.readwrite` would have let a treatments-only credential write `DataExclusion` windows, which decide whether glucose readings count towards analytics and reports.
- **Uploaders are unaffected.** Every production direct grant is owner-held and carries the seven readwrite categories; the migrated legacy api-secret normalises to the `health.readwrite` expansion. There are no caretaker, clinician or viewer members in production, so the role-narrowing this implies is latent rather than live.

CI runs neither the Aspire integration tests nor the SvelteKit suite, so the numbers here are local: 4362 unit tests pass, 22 of them added by the review pass.