### PR TITLE
fix(auth): encrypt TOTP secrets and hash share tokens at rest

### DIFF
--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -202,6 +202,9 @@ public static class ServiceRegistrationExtensions
         services.AddSingleton<ShareTokenCacheService>();
         services.AddSingleton<IShareTokenGenerator, ShareTokenGenerator>();
         services.AddScoped<IShareLinkService, ShareLinkService>();
+        // Singleton because both consumers run at startup outside any request scope, and it creates
+        // its own scope per notification.
+        services.AddSingleton<IShareLinkResetNotifier, ShareLinkResetNotifier>();
         services.AddHostedService<ShareTokenBackfillService>();
 
         // Passkey (WebAuthn/FIDO2) services

--- a/src/API/Nocturne.API/Models/Responses/ShareLinkDto.cs
+++ b/src/API/Nocturne.API/Models/Responses/ShareLinkDto.cs
@@ -8,7 +8,11 @@ public class ShareLinkDto
     /// <summary>Whether a public share link is currently active.</summary>
     public bool Enabled { get; set; }
 
-    /// <summary>The full share URL when enabled; null otherwise. The raw token is never returned separately.</summary>
+    /// <summary>
+    /// The full share URL, returned only by the call that generates the link. Null on every other
+    /// call, including when <see cref="Enabled"/> is true: only the token's digest is stored, so the
+    /// URL cannot be reproduced afterwards. Generating a new link is the only way to see one again.
+    /// </summary>
     public string? Url { get; set; }
 
     /// <summary>When true the public view shows full history; when false, only the last 24 hours.</summary>

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -574,6 +574,15 @@ if (!isNSwagGeneration && !app.Environment.IsEnvironment("Testing"))
 
     // Sync config-managed OIDC providers to the database (satisfies FK constraints)
     await OidcProviderService.SyncConfigProvidersAsync(app.Services);
+
+    // Bring pre-existing credential columns onto their at-rest storage format. Runs after
+    // migrations (it depends on the widened share_token column) and before the server accepts
+    // requests, so no request can read a column in the old format.
+    {
+        using var scope = app.Services.CreateScope();
+        var logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
+        await CredentialAtRestStartupTask.RunAsync(app.Services, logger);
+    }
 }
 else if (isNSwagGeneration)
 {

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -578,11 +578,9 @@ if (!isNSwagGeneration && !app.Environment.IsEnvironment("Testing"))
     // Bring pre-existing credential columns onto their at-rest storage format. Runs after
     // migrations (it depends on the widened share_token column) and before the server accepts
     // requests, so no request can read a column in the old format.
-    {
-        using var scope = app.Services.CreateScope();
-        var logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
-        await CredentialAtRestStartupTask.RunAsync(app.Services, logger);
-    }
+    await CredentialAtRestStartupTask.RunAsync(
+        app.Services,
+        app.Services.GetRequiredService<ILogger<Program>>());
 }
 else if (isNSwagGeneration)
 {

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.DataProtection;
 using System.Text;
 using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -128,6 +129,14 @@ builder.Services.AddDiscrepancyAnalysisRepository();
 builder.Services.AddAlertRepositories();
 
 builder.Services.AddDataProtection()
+    // Pinned, not defaulted. Without this the application discriminator is
+    // IHostEnvironment.ContentRootPath, which becomes part of the root purpose — so payloads are
+    // keyed on (key ring) x (working directory). That was survivable while Data Protection only
+    // held in-flight OIDC state and passkey challenges, but TOTP secrets are now persisted with
+    // it: a changed container WORKDIR, or running the API from a host path against the same
+    // database, would make every stored secret permanently unreadable while DataProtectionKeys
+    // still looked healthy. Never change this string.
+    .SetApplicationName("Nocturne")
     .PersistKeysToNocturneDb();
 
 // Add compatibility proxy services

--- a/src/API/Nocturne.API/Services/Auth/CredentialAtRestStartupTask.cs
+++ b/src/API/Nocturne.API/Services/Auth/CredentialAtRestStartupTask.cs
@@ -1,8 +1,3 @@
-using Microsoft.EntityFrameworkCore;
-using Nocturne.Core.Contracts.Identity;
-using Nocturne.Core.Contracts.Multitenancy;
-using Nocturne.Core.Contracts.Notifications;
-using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Security;
 using Npgsql;
@@ -20,9 +15,6 @@ namespace Nocturne.API.Services.Auth;
 /// </remarks>
 public static class CredentialAtRestStartupTask
 {
-    /// <summary>Notification type for a share link retired by the rotation pass.</summary>
-    public const string ShareLinkResetNotificationType = "sharing.link_reset";
-
     /// <summary>
     /// Encrypts pre-existing TOTP secrets, rotates pre-existing plaintext share tokens, and
     /// notifies the affected tenants' owners.
@@ -39,90 +31,15 @@ public static class CredentialAtRestStartupTask
         await CredentialAtRestInitializationExtensions.ProtectTotpSecretsAsync(
             dataSource, protector, logger, cancellationToken);
 
+        var notifier = services.GetRequiredService<IShareLinkResetNotifier>();
         var tokenGenerator = services.GetRequiredService<IShareTokenGenerator>();
         var rotatedTenantIds = await CredentialAtRestInitializationExtensions.RotatePlaintextShareTokensAsync(
             dataSource, tokenGenerator.Generate, logger, cancellationToken);
 
         foreach (var tenantId in rotatedTenantIds)
         {
-            await NotifyShareLinkResetAsync(services, tenantId, logger, cancellationToken);
+            await notifier.NotifyAsync(tenantId, cancellationToken);
         }
     }
 
-    /// <summary>
-    /// Files an in-app notification for the tenant's owner. Best-effort: a tenant with no owner, or
-    /// a notification that cannot be filed, must not stop startup — the token has already been
-    /// rotated and the pass will not revisit it.
-    /// </summary>
-    private static async Task NotifyShareLinkResetAsync(
-        IServiceProvider services,
-        Guid tenantId,
-        ILogger logger,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            using var scope = services.CreateScope();
-
-            var ownerSubjectId = await scope.ServiceProvider
-                .GetRequiredService<ITenantOwnerResolver>()
-                .GetOwnerSubjectIdAsync(tenantId, cancellationToken);
-
-            if (ownerSubjectId is null)
-            {
-                logger.LogWarning(
-                    "Tenant {TenantId} has no owner; its share link was reset without a notification.",
-                    tenantId);
-                return;
-            }
-
-            var tenant = await LoadTenantAsync(scope.ServiceProvider, tenantId, cancellationToken);
-            if (tenant is null)
-                return;
-
-            scope.ServiceProvider.GetRequiredService<ITenantAccessor>()
-                .SetTenant(new TenantContext(tenant.Id, tenant.Slug, tenant.DisplayName, true));
-
-            // in_app_notifications is tenant-scoped and FORCE ROW LEVEL SECURITY is on, so the
-            // insert is only visible to the policy once the RLS tenant is pinned on the scoped
-            // context the repository writes through. Without this the write is rejected.
-            scope.ServiceProvider.GetRequiredService<NocturneDbContext>().TenantId = tenantId;
-
-            // Title and subtitle are i18n keys resolved by the frontend copy layer
-            // (notification-labels.ts); the backend has no copy layer. Neither the retired token
-            // nor the new one appears here.
-            await scope.ServiceProvider.GetRequiredService<IInAppNotificationService>()
-                .CreateNotificationAsync(
-                    userId: ownerSubjectId,
-                    type: ShareLinkResetNotificationType,
-                    title: "share_link_reset",
-                    subtitle: "share_link_reset_subtitle",
-                    sourceId: tenantId.ToString(),
-                    cancellationToken: cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(
-                ex,
-                "Failed to notify the owner of tenant {TenantId} that its share link was reset.",
-                tenantId);
-        }
-    }
-
-    private static async Task<TenantIdentity?> LoadTenantAsync(
-        IServiceProvider scopedServices,
-        Guid tenantId,
-        CancellationToken cancellationToken)
-    {
-        await using var db = await scopedServices
-            .GetRequiredService<IDbContextFactory<NocturneDbContext>>()
-            .CreateDbContextAsync(cancellationToken);
-
-        return await db.Tenants.AsNoTracking()
-            .Where(t => t.Id == tenantId)
-            .Select(t => new TenantIdentity(t.Id, t.Slug, t.DisplayName))
-            .FirstOrDefaultAsync(cancellationToken);
-    }
-
-    private sealed record TenantIdentity(Guid Id, string Slug, string DisplayName);
 }

--- a/src/API/Nocturne.API/Services/Auth/CredentialAtRestStartupTask.cs
+++ b/src/API/Nocturne.API/Services/Auth/CredentialAtRestStartupTask.cs
@@ -1,0 +1,128 @@
+using Microsoft.EntityFrameworkCore;
+using Nocturne.Core.Contracts.Identity;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Contracts.Notifications;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Extensions;
+using Nocturne.Infrastructure.Data.Security;
+using Npgsql;
+
+namespace Nocturne.API.Services.Auth;
+
+/// <summary>
+/// Runs the one-pass conversions of credential columns to their at-rest storage format, and
+/// notifies the owner of every tenant whose share link was retired by that pass.
+/// </summary>
+/// <remarks>
+/// Invoked inline during startup, before the server accepts requests, rather than as an
+/// <see cref="IHostedService"/>: hosted services start after Kestrel, so a login or a share-link
+/// request arriving mid-pass would meet a column in the old format and fail.
+/// </remarks>
+public static class CredentialAtRestStartupTask
+{
+    /// <summary>Notification type for a share link retired by the rotation pass.</summary>
+    public const string ShareLinkResetNotificationType = "sharing.link_reset";
+
+    /// <summary>
+    /// Encrypts pre-existing TOTP secrets, rotates pre-existing plaintext share tokens, and
+    /// notifies the affected tenants' owners.
+    /// </summary>
+    public static async Task RunAsync(
+        IServiceProvider services,
+        ILogger logger,
+        CancellationToken cancellationToken = default)
+    {
+        var dataSource = services.GetRequiredService<NpgsqlDataSource>();
+
+        // The same factory the EF model uses, so payloads written here are readable through it.
+        var protector = TotpSecretProtection.CreateProtector(services);
+        await CredentialAtRestInitializationExtensions.ProtectTotpSecretsAsync(
+            dataSource, protector, logger, cancellationToken);
+
+        var tokenGenerator = services.GetRequiredService<IShareTokenGenerator>();
+        var rotatedTenantIds = await CredentialAtRestInitializationExtensions.RotatePlaintextShareTokensAsync(
+            dataSource, tokenGenerator.Generate, logger, cancellationToken);
+
+        foreach (var tenantId in rotatedTenantIds)
+        {
+            await NotifyShareLinkResetAsync(services, tenantId, logger, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Files an in-app notification for the tenant's owner. Best-effort: a tenant with no owner, or
+    /// a notification that cannot be filed, must not stop startup — the token has already been
+    /// rotated and the pass will not revisit it.
+    /// </summary>
+    private static async Task NotifyShareLinkResetAsync(
+        IServiceProvider services,
+        Guid tenantId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var scope = services.CreateScope();
+
+            var ownerSubjectId = await scope.ServiceProvider
+                .GetRequiredService<ITenantOwnerResolver>()
+                .GetOwnerSubjectIdAsync(tenantId, cancellationToken);
+
+            if (ownerSubjectId is null)
+            {
+                logger.LogWarning(
+                    "Tenant {TenantId} has no owner; its share link was reset without a notification.",
+                    tenantId);
+                return;
+            }
+
+            var tenant = await LoadTenantAsync(scope.ServiceProvider, tenantId, cancellationToken);
+            if (tenant is null)
+                return;
+
+            scope.ServiceProvider.GetRequiredService<ITenantAccessor>()
+                .SetTenant(new TenantContext(tenant.Id, tenant.Slug, tenant.DisplayName, true));
+
+            // in_app_notifications is tenant-scoped and FORCE ROW LEVEL SECURITY is on, so the
+            // insert is only visible to the policy once the RLS tenant is pinned on the scoped
+            // context the repository writes through. Without this the write is rejected.
+            scope.ServiceProvider.GetRequiredService<NocturneDbContext>().TenantId = tenantId;
+
+            // Title and subtitle are i18n keys resolved by the frontend copy layer
+            // (notification-labels.ts); the backend has no copy layer. Neither the retired token
+            // nor the new one appears here.
+            await scope.ServiceProvider.GetRequiredService<IInAppNotificationService>()
+                .CreateNotificationAsync(
+                    userId: ownerSubjectId,
+                    type: ShareLinkResetNotificationType,
+                    title: "share_link_reset",
+                    subtitle: "share_link_reset_subtitle",
+                    sourceId: tenantId.ToString(),
+                    cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(
+                ex,
+                "Failed to notify the owner of tenant {TenantId} that its share link was reset.",
+                tenantId);
+        }
+    }
+
+    private static async Task<TenantIdentity?> LoadTenantAsync(
+        IServiceProvider scopedServices,
+        Guid tenantId,
+        CancellationToken cancellationToken)
+    {
+        await using var db = await scopedServices
+            .GetRequiredService<IDbContextFactory<NocturneDbContext>>()
+            .CreateDbContextAsync(cancellationToken);
+
+        return await db.Tenants.AsNoTracking()
+            .Where(t => t.Id == tenantId)
+            .Select(t => new TenantIdentity(t.Id, t.Slug, t.DisplayName))
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    private sealed record TenantIdentity(Guid Id, string Slug, string DisplayName);
+}

--- a/src/API/Nocturne.API/Services/Auth/GuestLinkService.cs
+++ b/src/API/Nocturne.API/Services/Auth/GuestLinkService.cs
@@ -5,6 +5,7 @@ using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Security;
 
 namespace Nocturne.API.Services.Auth;
 
@@ -279,11 +280,8 @@ public class GuestLinkService : IGuestLinkService
         return $"{code[..3]}-{code[3..]}";
     }
 
-    private static string HashCode(string code)
-    {
-        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(code.ToUpperInvariant()));
-        return Convert.ToHexString(bytes).ToLowerInvariant();
-    }
+    /// <summary>Digest of a guest code. Codes are displayed uppercase but typed either way.</summary>
+    private static string HashCode(string code) => CredentialHash.Sha256Hex(code.ToUpperInvariant());
 
     private static GuestLinkInfo MapToInfo(OAuthGrantEntity entity)
     {

--- a/src/API/Nocturne.API/Services/Auth/ShareLinkResetNotifier.cs
+++ b/src/API/Nocturne.API/Services/Auth/ShareLinkResetNotifier.cs
@@ -1,0 +1,109 @@
+using Microsoft.EntityFrameworkCore;
+using Nocturne.Core.Contracts.Identity;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Contracts.Notifications;
+using Nocturne.Infrastructure.Data;
+
+namespace Nocturne.API.Services.Auth;
+
+/// <summary>
+/// Tells a tenant's owner that their public share link no longer resolves and has to be
+/// regenerated. Used by both startup paths that leave a tenant in that state: the rotation pass in
+/// <see cref="CredentialAtRestStartupTask"/>, which retires a plaintext token, and
+/// <see cref="ShareTokenBackfillService"/>, which mints one for a legacy publicly-readable tenant.
+/// Only the digest is stored in either case, so neither can hand back a URL — the owner is the only
+/// one who can produce a working link, which is why they have to be told.
+/// </summary>
+public interface IShareLinkResetNotifier
+{
+    /// <summary>
+    /// Files the notification for the tenant's owner. Best-effort: a tenant with no owner, or a
+    /// notification that cannot be filed, must not stop startup — the token has already been
+    /// written and neither pass revisits it.
+    /// </summary>
+    Task NotifyAsync(Guid tenantId, CancellationToken cancellationToken = default);
+}
+
+/// <inheritdoc />
+public sealed class ShareLinkResetNotifier : IShareLinkResetNotifier
+{
+    /// <summary>Notification type for a share link that no longer resolves.</summary>
+    public const string NotificationType = "sharing.link_reset";
+
+    private readonly IServiceProvider _services;
+    private readonly ILogger<ShareLinkResetNotifier> _logger;
+
+    public ShareLinkResetNotifier(IServiceProvider services, ILogger<ShareLinkResetNotifier> logger)
+    {
+        _services = services;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task NotifyAsync(Guid tenantId, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var scope = _services.CreateScope();
+
+            var ownerSubjectId = await scope.ServiceProvider
+                .GetRequiredService<ITenantOwnerResolver>()
+                .GetOwnerSubjectIdAsync(tenantId, cancellationToken);
+
+            if (ownerSubjectId is null)
+            {
+                _logger.LogWarning(
+                    "Tenant {TenantId} has no owner; its share link was reset without a notification.",
+                    tenantId);
+                return;
+            }
+
+            var tenant = await LoadTenantAsync(scope.ServiceProvider, tenantId, cancellationToken);
+            if (tenant is null)
+                return;
+
+            scope.ServiceProvider.GetRequiredService<ITenantAccessor>()
+                .SetTenant(new TenantContext(tenant.Id, tenant.Slug, tenant.DisplayName, true));
+
+            // in_app_notifications is tenant-scoped and FORCE ROW LEVEL SECURITY is on, so the
+            // insert is only visible to the policy once the RLS tenant is pinned on the scoped
+            // context the repository writes through. Without this the write is rejected.
+            scope.ServiceProvider.GetRequiredService<NocturneDbContext>().TenantId = tenantId;
+
+            // Title and subtitle are i18n keys resolved by the frontend copy layer
+            // (notification-labels.ts); the backend has no copy layer. No token appears here.
+            await scope.ServiceProvider.GetRequiredService<IInAppNotificationService>()
+                .CreateNotificationAsync(
+                    userId: ownerSubjectId,
+                    type: NotificationType,
+                    title: "share_link_reset",
+                    subtitle: "share_link_reset_subtitle",
+                    sourceId: tenantId.ToString(),
+                    cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Failed to notify the owner of tenant {TenantId} that its share link was reset.",
+                tenantId);
+        }
+    }
+
+    private static async Task<TenantIdentity?> LoadTenantAsync(
+        IServiceProvider scopedServices,
+        Guid tenantId,
+        CancellationToken cancellationToken)
+    {
+        await using var db = await scopedServices
+            .GetRequiredService<IDbContextFactory<NocturneDbContext>>()
+            .CreateDbContextAsync(cancellationToken);
+
+        return await db.Tenants.AsNoTracking()
+            .Where(t => t.Id == tenantId)
+            .Select(t => new TenantIdentity(t.Id, t.Slug, t.DisplayName))
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    private sealed record TenantIdentity(Guid Id, string Slug, string DisplayName);
+}

--- a/src/API/Nocturne.API/Services/Auth/ShareLinkService.cs
+++ b/src/API/Nocturne.API/Services/Auth/ShareLinkService.cs
@@ -5,6 +5,7 @@ using Nocturne.API.Multitenancy;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Security;
 
 namespace Nocturne.API.Services.Auth;
 
@@ -16,7 +17,16 @@ namespace Nocturne.API.Services.Auth;
 /// </summary>
 public interface IShareLinkService
 {
+    /// <summary>
+    /// Reports the link's state. <see cref="ShareLinkDto.Url"/> is always null — only the token's
+    /// digest is stored, so the URL is knowable only to the caller of <see cref="RotateAsync"/>.
+    /// </summary>
     Task<ShareLinkDto> GetAsync(Guid tenantId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Mints a new token, replacing any existing one, and returns the resulting
+    /// <see cref="ShareLinkDto.Url"/>. This is the only call that can return the URL.
+    /// </summary>
     Task<ShareLinkDto> RotateAsync(Guid tenantId, CancellationToken ct = default);
     Task<ShareLinkDto> DisableAsync(Guid tenantId, CancellationToken ct = default);
     Task<ShareLinkDto> SetFullHistoryAsync(Guid tenantId, bool fullHistory, CancellationToken ct = default);
@@ -79,8 +89,8 @@ public sealed class ShareLinkService : IShareLinkService
         var member = await GetPublicMemberAsync(tenantId, ct)
             ?? throw new InvalidOperationException("Public subject membership not found");
 
-        var oldToken = tenant.ShareToken;
-        var wasEnabled = oldToken != null;
+        var oldTokenHash = tenant.ShareToken;
+        var wasEnabled = oldTokenHash != null;
         var newToken = await GenerateUniqueTokenAsync(ct);
         var now = DateTime.UtcNow;
 
@@ -93,17 +103,18 @@ public sealed class ShareLinkService : IShareLinkService
             member.LimitTo24Hours = true;
         }
 
-        tenant.ShareToken = newToken;
+        tenant.ShareToken = CredentialHash.ShareToken(newToken);
         tenant.ShareTokenSetAt = now;
         member.SysUpdatedAt = now;
 
         await _dbContext.SaveChangesAsync(ct);
 
-        if (oldToken != null)
-            _shareTokenCache.Evict(oldToken);
+        if (oldTokenHash != null)
+            _shareTokenCache.EvictByHash(oldTokenHash);
         _publicAccessCache.Evict(tenantId);
 
-        return ToDto(tenant, member);
+        // The only moment the URL can be produced: the token itself is not stored.
+        return ToDto(tenant, member, newToken);
     }
 
     public async Task<ShareLinkDto> DisableAsync(Guid tenantId, CancellationToken ct = default)
@@ -111,7 +122,7 @@ public sealed class ShareLinkService : IShareLinkService
         var tenant = await _dbContext.Tenants.FirstOrDefaultAsync(t => t.Id == tenantId, ct)
             ?? throw new InvalidOperationException($"Tenant {tenantId} not found");
         var member = await GetPublicMemberAsync(tenantId, ct);
-        var oldToken = tenant.ShareToken;
+        var oldTokenHash = tenant.ShareToken;
 
         tenant.ShareToken = null;
         tenant.ShareTokenSetAt = null;
@@ -127,8 +138,8 @@ public sealed class ShareLinkService : IShareLinkService
 
         await _dbContext.SaveChangesAsync(ct);
 
-        if (oldToken != null)
-            _shareTokenCache.Evict(oldToken);
+        if (oldTokenHash != null)
+            _shareTokenCache.EvictByHash(oldTokenHash);
         _publicAccessCache.Evict(tenantId);
 
         return ToDto(tenant, member);
@@ -186,12 +197,17 @@ public sealed class ShareLinkService : IShareLinkService
             .FirstOrDefaultAsync(m => m.TenantId == tenantId
                 && m.Subject!.IsSystemSubject && m.Subject.Name == PublicSubjectName, ct);
 
+    /// <summary>
+    /// Mints a token whose digest is not already stored. Returns the token itself; the caller
+    /// stores <see cref="CredentialHash.ShareToken"/> of it.
+    /// </summary>
     private async Task<string> GenerateUniqueTokenAsync(CancellationToken ct)
     {
         for (var attempt = 0; attempt < MaxTokenAttempts; attempt++)
         {
             var candidate = _tokenGenerator.Generate();
-            var exists = await _dbContext.Tenants.AnyAsync(t => t.ShareToken == candidate, ct);
+            var candidateHash = CredentialHash.ShareToken(candidate);
+            var exists = await _dbContext.Tenants.AnyAsync(t => t.ShareToken == candidateHash, ct);
             if (!exists)
                 return candidate;
         }
@@ -199,10 +215,15 @@ public sealed class ShareLinkService : IShareLinkService
         throw new InvalidOperationException("Unable to generate a unique share token after several attempts");
     }
 
-    private ShareLinkDto ToDto(TenantEntity tenant, TenantMemberEntity? member) => new()
+    /// <summary>
+    /// Projects the share link. <paramref name="token"/> is supplied only by the rotate path, which
+    /// has just minted it; every other path can only report that a link exists, because the stored
+    /// value is a digest and the URL cannot be reconstructed from it.
+    /// </summary>
+    private ShareLinkDto ToDto(TenantEntity tenant, TenantMemberEntity? member, string? token = null) => new()
     {
         Enabled = tenant.ShareToken != null,
-        Url = tenant.ShareToken != null ? $"https://{tenant.ShareToken}.share.{_baseDomain}" : null,
+        Url = token != null ? $"https://{token}.share.{_baseDomain}" : null,
         FullHistory = member is { LimitTo24Hours: false },
         Scopes = ComputeScopes(member),
         LastAccessedAt = tenant.ShareLastAccessedAt,

--- a/src/API/Nocturne.API/Services/Auth/ShareTokenBackfillService.cs
+++ b/src/API/Nocturne.API/Services/Auth/ShareTokenBackfillService.cs
@@ -11,6 +11,9 @@ namespace Nocturne.API.Services.Auth;
 /// public access working at the new {token}.share.{baseDomain} URL (the URL changes; operators are
 /// expected to notify affected tenants). Idempotent: only tenants with a null share token are touched,
 /// so it is safe to run on every startup.
+///
+/// Only the token's digest is stored, so a backfilled link's URL is knowable to nobody: the owner
+/// generates their own link from settings to obtain one.
 /// </summary>
 public sealed class ShareTokenBackfillService : IHostedService
 {

--- a/src/API/Nocturne.API/Services/Auth/ShareTokenBackfillService.cs
+++ b/src/API/Nocturne.API/Services/Auth/ShareTokenBackfillService.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Security;
 
 namespace Nocturne.API.Services.Auth;
 
@@ -65,14 +66,16 @@ public sealed class ShareTokenBackfillService : IHostedService
             var now = DateTime.UtcNow;
             foreach (var tenant in tenants)
             {
-                string token;
+                // Only the digest is stored, so the minted token is not recoverable afterwards and
+                // is never logged. The owner generates a link of their own to obtain a URL.
+                string digest;
                 do
                 {
-                    token = generator.Generate();
+                    digest = CredentialHash.ShareToken(generator.Generate());
                 }
-                while (!used.Add(token));
+                while (!used.Add(digest));
 
-                tenant.ShareToken = token;
+                tenant.ShareToken = digest;
                 tenant.ShareTokenSetAt = now;
             }
 

--- a/src/API/Nocturne.API/Services/Auth/ShareTokenBackfillService.cs
+++ b/src/API/Nocturne.API/Services/Auth/ShareTokenBackfillService.cs
@@ -7,13 +7,15 @@ namespace Nocturne.API.Services.Auth;
 /// <summary>
 /// One-time startup backfill that mints a share token for every tenant that was publicly readable
 /// under the legacy model — its Public subject holds at least one role or direct permission — but
-/// has no share token yet. After the bare {slug} host becomes login-only, this keeps those tenants'
-/// public access working at the new {token}.share.{baseDomain} URL (the URL changes; operators are
-/// expected to notify affected tenants). Idempotent: only tenants with a null share token are touched,
-/// so it is safe to run on every startup.
+/// has no share token yet, so the bare {slug} host becoming login-only does not leave the tenant
+/// with public access silently switched off. Idempotent: only tenants with a null share token are
+/// touched, so it is safe to run on every startup.
 ///
-/// Only the token's digest is stored, so a backfilled link's URL is knowable to nobody: the owner
-/// generates their own link from settings to obtain one.
+/// It cannot restore a working link. Only the digest is stored, so the minted token's URL is
+/// knowable to nobody — not even an operator with database access — and the owner has to regenerate
+/// from settings to obtain one. That is why every backfilled tenant's owner is notified through
+/// <see cref="IShareLinkResetNotifier"/>: without it the settings card would report public access as
+/// on, for a link nothing can resolve and nobody can produce.
 /// </summary>
 public sealed class ShareTokenBackfillService : IHostedService
 {
@@ -70,7 +72,7 @@ public sealed class ShareTokenBackfillService : IHostedService
             foreach (var tenant in tenants)
             {
                 // Only the digest is stored, so the minted token is not recoverable afterwards and
-                // is never logged. The owner generates a link of their own to obtain a URL.
+                // is never logged. The owner is notified below and generates their own link.
                 string digest;
                 do
                 {
@@ -85,6 +87,13 @@ public sealed class ShareTokenBackfillService : IHostedService
             await db.SaveChangesAsync(cancellationToken);
             _logger.LogInformation(
                 "Backfilled share tokens for {Count} previously-public tenant(s)", tenants.Count);
+
+            // After the save, so a tenant is never told its link was reset unless the row committed.
+            var notifier = scope.ServiceProvider.GetRequiredService<IShareLinkResetNotifier>();
+            foreach (var tenant in tenants)
+            {
+                await notifier.NotifyAsync(tenant.Id, cancellationToken);
+            }
         }
         catch (Exception ex)
         {

--- a/src/API/Nocturne.API/Services/Auth/ShareTokenCacheService.cs
+++ b/src/API/Nocturne.API/Services/Auth/ShareTokenCacheService.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Security;
 
 namespace Nocturne.API.Services.Auth;
 
@@ -13,8 +14,11 @@ namespace Nocturne.API.Services.Auth;
 /// <remarks>
 /// Only successful lookups are cached (2-minute TTL). Misses are never cached: a brute-force
 /// sweep uses distinct tokens, so caching misses would bloat memory without preventing the
-/// per-token database hit — that is the job of rate limiting. Call <see cref="Evict"/> when a
+/// per-token database hit — that is the job of rate limiting. Call <see cref="EvictByHash"/> when a
 /// token is rotated or removed so the previous link stops resolving immediately.
+///
+/// The token is only ever stored and cached as its SHA-256 digest, so neither the database nor the
+/// cache holds a value that can be replayed as a share link.
 /// </remarks>
 public sealed class ShareTokenCacheService
 {
@@ -40,7 +44,8 @@ public sealed class ShareTokenCacheService
     /// </summary>
     public async Task<TenantContext?> ResolveByTokenAsync(string token)
     {
-        var cacheKey = CacheKey(token);
+        var tokenHash = CredentialHash.ShareToken(token);
+        var cacheKey = CacheKey(tokenHash);
 
         if (_cache.TryGetValue(cacheKey, out TenantContext? cached))
             return cached;
@@ -49,7 +54,7 @@ public sealed class ShareTokenCacheService
 
         var tenant = await dbContext.Tenants
             .AsNoTracking()
-            .Where(t => t.ShareToken == token)
+            .Where(t => t.ShareToken == tokenHash)
             .Select(t => new { t.Id, t.Slug, t.DisplayName, t.IsActive, t.IsDemo })
             .FirstOrDefaultAsync();
 
@@ -83,8 +88,11 @@ public sealed class ShareTokenCacheService
         return tenantContext;
     }
 
-    /// <summary>Evicts the cached resolution for a token. Call on rotate or disable.</summary>
-    public void Evict(string token) => _cache.Remove(CacheKey(token));
+    /// <summary>
+    /// Evicts the cached resolution for a stored token digest. Call on rotate or disable, passing
+    /// the value held in <c>tenants.share_token</c>.
+    /// </summary>
+    public void EvictByHash(string tokenHash) => _cache.Remove(CacheKey(tokenHash));
 
-    private static string CacheKey(string token) => $"share-token:{token}";
+    private static string CacheKey(string tokenHash) => $"share-token:{tokenHash}";
 }

--- a/src/API/Nocturne.API/Services/Auth/ShareTokenGenerator.cs
+++ b/src/API/Nocturne.API/Services/Auth/ShareTokenGenerator.cs
@@ -12,14 +12,22 @@ public interface IShareTokenGenerator
 }
 
 /// <summary>
-/// Generates share tokens as 12 lowercase Crockford-base32 characters (60 bits of entropy)
+/// Generates share tokens as 16 lowercase Crockford-base32 characters (80 bits of entropy)
 /// from a cryptographically secure RNG. The alphabet excludes i, l, o, and u to avoid
 /// visual ambiguity. Uniqueness against existing tokens is enforced at the call site.
 /// </summary>
+/// <remarks>
+/// 16 rather than 12 because the token's entropy is now the whole security argument. It is stored
+/// only as an unsalted SHA-256 digest, which is the right choice for an exact-match lookup — but it
+/// means a leaked database gives an attacker an offline search target, and 60 bits is within reach
+/// of a well-funded one. The token is only ever copied and pasted, never typed, so the extra four
+/// characters cost nothing. Well inside the 63-character DNS label limit for
+/// <c>{token}.share.{domain}</c>.
+/// </remarks>
 public sealed class ShareTokenGenerator : IShareTokenGenerator
 {
     private const string Alphabet = "0123456789abcdefghjkmnpqrstvwxyz";
-    private const int TokenLength = 12;
+    private const int TokenLength = 16;
 
     public string Generate() =>
         new(RandomNumberGenerator.GetItems<char>(Alphabet, TokenLength));

--- a/src/API/Nocturne.API/Services/Auth/TotpService.cs
+++ b/src/API/Nocturne.API/Services/Auth/TotpService.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using System.Text.Json;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
@@ -97,9 +98,40 @@ public class TotpService : ITotpService
             return null;
         }
 
-        var credentials = await _dbContext.TotpCredentials
-            .Where(c => c.SubjectId == subject.Id)
-            .ToListAsync();
+        // secret_key is a Data Protection payload, and the value converter decrypts during
+        // MATERIALIZATION — so a payload this process cannot resolve (a lost key, a changed
+        // application discriminator) throws out of ToListAsync, not out of a property read. Caught
+        // here so the caller gets the ordinary invalid-code response with an audit record, rather
+        // than an unhandled CryptographicException surfacing as a 500 with nothing logged.
+        // Recovery is removing the credential and re-enrolling, which RemoveCredentialAsync
+        // deliberately does without materializing the entity.
+        //
+        // Necessarily all-or-nothing: the converter runs for the whole result set, so one
+        // unreadable row denies verification for that subject's other credentials too. Better than
+        // a 500, and the condition needs an operator either way.
+        //
+        // Not covered by a unit test, deliberately rather than by omission:
+        // TotpSecretProtection.EphemeralFallback is one static instance so that every context in a
+        // process stays mutually readable, so no in-process test can produce a payload this process
+        // fails to decrypt. Converter-level failure is covered by TotpSecretProtectionTests; this
+        // catch is reasoned, not asserted.
+        List<TotpCredentialEntity> credentials;
+        try
+        {
+            credentials = await _dbContext.TotpCredentials
+                .Where(c => c.SubjectId == subject.Id)
+                .ToListAsync();
+        }
+        catch (CryptographicException ex)
+        {
+            _logger.LogError(
+                ex,
+                "TOTP credentials for subject {SubjectId} could not be decrypted; treating the "
+                + "attempt as failed. They must be removed and re-enrolled.",
+                subject.Id);
+            TotpHelper.Verify(DummySecret, code);
+            return null;
+        }
 
         if (credentials.Count == 0)
         {
@@ -144,11 +176,26 @@ public class TotpService : ITotpService
 
     public async Task RemoveCredentialAsync(Guid credentialId, Guid subjectId)
     {
-        var credential = await _dbContext.TotpCredentials
-            .FirstOrDefaultAsync(c => c.Id == credentialId && c.SubjectId == subjectId)
-            ?? throw new InvalidOperationException("Credential not found.");
+        // Key-only projection, then delete a stub. Loading the entity would run the value converter
+        // over secret_key and throw for a payload this process cannot decrypt, so an undecryptable
+        // credential could not be removed — the one case where removal matters most, since
+        // re-enrolling is the documented recovery. ExecuteDeleteAsync would also avoid the
+        // materialization but is unsupported by the in-memory provider the unit tests use.
+        var existingId = await _dbContext.TotpCredentials
+            .Where(c => c.Id == credentialId && c.SubjectId == subjectId)
+            .Select(c => (Guid?)c.Id)
+            .FirstOrDefaultAsync();
 
-        _dbContext.TotpCredentials.Remove(credential);
+        if (existingId is null)
+            throw new InvalidOperationException("Credential not found.");
+
+        // Reuse the tracked instance when there is one, since attaching a second instance with the
+        // same key throws. An instance can only be tracked if it materialized, which means its
+        // payload decrypted — so the undecryptable case always takes the stub path.
+        var tracked = _dbContext.ChangeTracker.Entries<TotpCredentialEntity>()
+            .FirstOrDefault(e => e.Entity.Id == existingId.Value)?.Entity;
+
+        _dbContext.TotpCredentials.Remove(tracked ?? new TotpCredentialEntity { Id = existingId.Value });
         await _dbContext.SaveChangesAsync();
 
         _logger.LogInformation(

--- a/src/API/Nocturne.API/Services/NotificationTemplates/BuiltInNotificationTemplates.cs
+++ b/src/API/Nocturne.API/Services/NotificationTemplates/BuiltInNotificationTemplates.cs
@@ -114,6 +114,15 @@ public static class BuiltInNotificationTemplates
 
         registry.Register(new NotificationTemplate
         {
+            Type = "sharing.link_reset",
+            Category = NotificationCategory.ActionRequired,
+            DefaultUrgency = NotificationUrgency.Info,
+            Icon = "link",
+            Source = "sharing"
+        });
+
+        registry.Register(new NotificationTemplate
+        {
             Type = "membership.denied",
             Category = NotificationCategory.Informational,
             DefaultUrgency = NotificationUrgency.Info,

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TenantEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TenantEntity.cs
@@ -60,12 +60,14 @@ public class TenantEntity : ISystemTimestamped
     public bool IsDemo { get; set; }
 
     /// <summary>
-    /// Unguessable token for the tenant's public read-only dashboard, served at
-    /// {token}.share.{baseDomain}. Null when public sharing is disabled. Rotating replaces the
-    /// value and evicts the resolution cache, so the previous link stops resolving.
+    /// SHA-256 hex digest (<see cref="Security.CredentialHash.ShareToken"/>) of the unguessable
+    /// token for the tenant's public read-only dashboard, served at {token}.share.{baseDomain}.
+    /// Null when public sharing is disabled. The token itself is never stored: it is returned once
+    /// when the link is generated and resolved thereafter by digest. Rotating replaces the value
+    /// and evicts the resolution cache, so the previous link stops resolving.
     /// </summary>
     [Column("share_token")]
-    [MaxLength(32)]
+    [MaxLength(Security.CredentialHash.HexLength)]
     public string? ShareToken { get; set; }
 
     /// <summary>When <see cref="ShareToken"/> was last minted or rotated.</summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TotpCredentialEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TotpCredentialEntity.cs
@@ -25,7 +25,9 @@ public class TotpCredentialEntity
     public Guid SubjectId { get; set; }
 
     /// <summary>
-    /// The TOTP secret key used to generate one-time passwords
+    /// The TOTP secret key used to generate one-time passwords. Stored as a Data Protection
+    /// payload via the value converter registered in <c>NocturneDbContext.OnModelCreating</c>
+    /// (see <c>TotpSecretProtection</c>); this property always holds the decrypted secret.
     /// </summary>
     [Required]
     [Column("secret_key")]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/CredentialAtRestInitializationExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/CredentialAtRestInitializationExtensions.cs
@@ -46,12 +46,15 @@ public static class CredentialAtRestInitializationExtensions
         ILogger logger,
         CancellationToken cancellationToken = default)
     {
+        await using var connection = await dataSource.OpenConnectionAsync(cancellationToken);
+
+        // Buffered rather than streamed: the rewrite runs on this same connection, which cannot
+        // issue commands while a reader is open.
         var plaintextRows = new List<(Guid Id, byte[] Secret)>();
         var alreadyProtected = 0;
 
-        await using (var connection = await dataSource.OpenConnectionAsync(cancellationToken))
+        await using (var read = connection.CreateCommand())
         {
-            await using var read = connection.CreateCommand();
             read.CommandText = "SELECT id, secret_key FROM totp_credentials";
             await using var reader = await read.ExecuteReaderAsync(cancellationToken);
             while (await reader.ReadAsync(cancellationToken))
@@ -77,7 +80,6 @@ public static class CredentialAtRestInitializationExtensions
             return 0;
         }
 
-        await using (var connection = await dataSource.OpenConnectionAsync(cancellationToken))
         await using (var transaction = await connection.BeginTransactionAsync(cancellationToken))
         {
             foreach (var (id, secret) in plaintextRows)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/CredentialAtRestInitializationExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/CredentialAtRestInitializationExtensions.cs
@@ -18,8 +18,9 @@ namespace Nocturne.Infrastructure.Data.Extensions;
 /// <see cref="Entities.ITenantScoped"/>, neither table carries a <c>tenant_id</c>, and no migration
 /// enables row level security on them. So neither pass sets <c>app.current_tenant_id</c>: there is
 /// no policy to satisfy, and a pass over a tenant-scoped table without that GUC would silently
-/// affect zero rows. <c>CredentialAtRestSchemaFacts</c> in the integration suite asserts this
-/// remains true.
+/// affect zero rows. <c>CredentialAtRestPassTests</c> in the Infrastructure.Data integration suite
+/// asserts this remains true by reading <c>pg_class.relrowsecurity</c> for both tables, and that
+/// suite is one of the few this repository's CI actually runs.
 ///
 /// Both passes are idempotent, discriminating on the stored format rather than on a marker, so a
 /// restart or a re-deploy is a no-op.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/CredentialAtRestInitializationExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/CredentialAtRestInitializationExtensions.cs
@@ -1,0 +1,194 @@
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Logging;
+using Nocturne.Infrastructure.Data.Security;
+using Npgsql;
+
+namespace Nocturne.Infrastructure.Data.Extensions;
+
+/// <summary>
+/// One-pass conversions that bring pre-existing credential columns onto their at-rest storage
+/// format: TOTP secrets to Data Protection payloads, tenant share tokens to SHA-256 digests.
+/// Both run at startup, before the server accepts requests, because both need application code
+/// (a Data Protection protector, a token generator) that a SQL migration cannot call.
+///
+/// Both passes talk to PostgreSQL over raw ADO so they read and write the stored representation
+/// directly, bypassing the EF value converter that would otherwise reject the old format.
+///
+/// Neither <c>totp_credentials</c> nor <c>tenants</c> is tenant-scoped — neither entity implements
+/// <see cref="Entities.ITenantScoped"/>, neither table carries a <c>tenant_id</c>, and no migration
+/// enables row level security on them. So neither pass sets <c>app.current_tenant_id</c>: there is
+/// no policy to satisfy, and a pass over a tenant-scoped table without that GUC would silently
+/// affect zero rows. <c>CredentialAtRestSchemaFacts</c> in the integration suite asserts this
+/// remains true.
+///
+/// Both passes are idempotent, discriminating on the stored format rather than on a marker, so a
+/// restart or a re-deploy is a no-op.
+/// </summary>
+public static class CredentialAtRestInitializationExtensions
+{
+    /// <summary>
+    /// Encrypts every <c>totp_credentials.secret_key</c> that still holds a bare secret, so no
+    /// plaintext TOTP seed survives in the table or in a backup taken from it. Rows that already
+    /// hold a Data Protection payload are left untouched.
+    /// </summary>
+    /// <param name="dataSource">Data source for the runtime application role.</param>
+    /// <param name="protector">
+    /// Protector for the TOTP secret column. Must come from
+    /// <see cref="TotpSecretProtection.CreateProtector"/> so it matches the one the EF model uses;
+    /// a mismatch would write payloads the application cannot read.
+    /// </param>
+    /// <param name="logger">Logger for progress. Never receives a secret.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The number of rows encrypted by this pass.</returns>
+    public static async Task<int> ProtectTotpSecretsAsync(
+        NpgsqlDataSource dataSource,
+        IDataProtector protector,
+        ILogger logger,
+        CancellationToken cancellationToken = default)
+    {
+        var plaintextRows = new List<(Guid Id, byte[] Secret)>();
+        var alreadyProtected = 0;
+
+        await using (var connection = await dataSource.OpenConnectionAsync(cancellationToken))
+        {
+            await using var read = connection.CreateCommand();
+            read.CommandText = "SELECT id, secret_key FROM totp_credentials";
+            await using var reader = await read.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                var id = reader.GetGuid(0);
+                var stored = (byte[])reader.GetValue(1);
+
+                if (TotpSecretProtection.IsProtectedPayload(stored))
+                {
+                    alreadyProtected++;
+                    continue;
+                }
+
+                plaintextRows.Add((id, stored));
+            }
+        }
+
+        if (plaintextRows.Count == 0)
+        {
+            logger.LogDebug(
+                "TOTP secrets already encrypted at rest ({Count} credential(s) checked).",
+                alreadyProtected);
+            return 0;
+        }
+
+        await using (var connection = await dataSource.OpenConnectionAsync(cancellationToken))
+        await using (var transaction = await connection.BeginTransactionAsync(cancellationToken))
+        {
+            foreach (var (id, secret) in plaintextRows)
+            {
+                await using var update = connection.CreateCommand();
+                update.Transaction = transaction;
+                update.CommandText = "UPDATE totp_credentials SET secret_key = @payload WHERE id = @id";
+                update.Parameters.AddWithValue("@payload", protector.Protect(secret));
+                update.Parameters.AddWithValue("@id", id);
+                await update.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            await transaction.CommitAsync(cancellationToken);
+        }
+
+        logger.LogInformation(
+            "Encrypted {Encrypted} TOTP secret(s) at rest; {Skipped} were already encrypted.",
+            plaintextRows.Count, alreadyProtected);
+
+        return plaintextRows.Count;
+    }
+
+    /// <summary>
+    /// Replaces every plaintext <c>tenants.share_token</c> with the digest of a freshly generated
+    /// token. The stored plaintext was readable in the table and in every backup taken from it, so
+    /// it is not merely hashed in place — it is retired. The new token's plaintext is discarded, so
+    /// each affected tenant's previous share link stops resolving and the owner has to generate a
+    /// new one; callers are expected to notify the owners returned here.
+    /// </summary>
+    /// <param name="dataSource">Data source for the runtime application role.</param>
+    /// <param name="generateToken">Mints a new share token. Called until the digest is unique.</param>
+    /// <param name="logger">Logger for progress. Never receives a token.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The ids of the tenants whose share token was rotated by this pass.</returns>
+    public static async Task<IReadOnlyList<Guid>> RotatePlaintextShareTokensAsync(
+        NpgsqlDataSource dataSource,
+        Func<string> generateToken,
+        ILogger logger,
+        CancellationToken cancellationToken = default)
+    {
+        await using var connection = await dataSource.OpenConnectionAsync(cancellationToken);
+
+        // A digest is always CredentialHash.HexLength characters; a generated token is shorter, so
+        // length alone separates the not-yet-converted rows and makes the pass idempotent.
+        var stale = new List<Guid>();
+        await using (var read = connection.CreateCommand())
+        {
+            read.CommandText = """
+                SELECT id FROM tenants
+                WHERE share_token IS NOT NULL AND length(share_token) <> @hexLength
+                """;
+            read.Parameters.AddWithValue("@hexLength", CredentialHash.HexLength);
+            await using var reader = await read.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                stale.Add(reader.GetGuid(0));
+            }
+        }
+
+        if (stale.Count == 0)
+        {
+            logger.LogDebug("No plaintext tenant share tokens to rotate.");
+            return [];
+        }
+
+        var used = new HashSet<string>(StringComparer.Ordinal);
+        await using (var read = connection.CreateCommand())
+        {
+            read.CommandText = "SELECT share_token FROM tenants WHERE share_token IS NOT NULL";
+            await using var reader = await read.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                used.Add(reader.GetString(0));
+            }
+        }
+
+        var rotated = new List<Guid>(stale.Count);
+        var now = DateTime.UtcNow;
+
+        await using (var transaction = await connection.BeginTransactionAsync(cancellationToken))
+        {
+            foreach (var tenantId in stale)
+            {
+                string digest;
+                do
+                {
+                    digest = CredentialHash.ShareToken(generateToken());
+                }
+                while (!used.Add(digest));
+
+                await using var update = connection.CreateCommand();
+                update.Transaction = transaction;
+                update.CommandText = """
+                    UPDATE tenants
+                    SET share_token = @digest, share_token_set_at = @setAt
+                    WHERE id = @id
+                    """;
+                update.Parameters.AddWithValue("@digest", digest);
+                update.Parameters.AddWithValue("@setAt", now);
+                update.Parameters.AddWithValue("@id", tenantId);
+                await update.ExecuteNonQueryAsync(cancellationToken);
+                rotated.Add(tenantId);
+            }
+
+            await transaction.CommitAsync(cancellationToken);
+        }
+
+        logger.LogInformation(
+            "Rotated {Count} plaintext tenant share token(s); the previous links no longer resolve.",
+            rotated.Count);
+
+        return rotated;
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260726180135_HashTenantShareTokens.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260726180135_HashTenantShareTokens.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260726180135_HashTenantShareTokens")]
+    partial class HashTenantShareTokens
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260726180135_HashTenantShareTokens.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260726180135_HashTenantShareTokens.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class HashTenantShareTokens : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "share_token",
+                table: "tenants",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(32)",
+                oldMaxLength: 32,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "share_token",
+                table: "tenants",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260726180135_HashTenantShareTokens.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260726180135_HashTenantShareTokens.cs
@@ -25,6 +25,14 @@ namespace Nocturne.Infrastructure.Data.Migrations
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            // Narrowing back to 32 fails on any stored digest, which is every non-null row once the
+            // startup rotation has run — so clear the column first. That is not data loss beyond
+            // what rolling back already causes: the digests are unreadable to the older code, which
+            // compares the column against a plaintext token, so every share link is dead either
+            // way. Clearing makes the owner's "Public access is off, regenerate to re-enable" path
+            // the recovery, instead of leaving a link the UI reports as on and nothing can resolve.
+            migrationBuilder.Sql("UPDATE tenants SET share_token = NULL, share_token_set_at = NULL;");
+
             migrationBuilder.AlterColumn<string>(
                 name: "share_token",
                 table: "tenants",

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -17,12 +17,26 @@ namespace Nocturne.Infrastructure.Data;
 /// </summary>
 public class NocturneDbContext : DbContext, IDataProtectionKeyContext
 {
+    private readonly DbContextOptions<NocturneDbContext> _options;
+
     /// <summary>
     /// Initializes a new instance of the NocturneDbContext class
     /// </summary>
     /// <param name="options">The options for this context</param>
     public NocturneDbContext(DbContextOptions<NocturneDbContext> options)
-        : base(options) { }
+        : base(options)
+    {
+        _options = options;
+    }
+
+    /// <summary>
+    /// The application service provider these options were built with, or null when the context was
+    /// constructed from a bare <see cref="DbContextOptionsBuilder{TContext}"/> (design-time, tests).
+    /// Read during <see cref="OnModelCreating"/> to resolve services the model itself depends on.
+    /// </summary>
+    private IServiceProvider? ApplicationServices =>
+        _options.FindExtension<Microsoft.EntityFrameworkCore.Infrastructure.CoreOptionsExtension>()
+            ?.ApplicationServiceProvider;
 
     /// <summary>
     /// The current tenant ID. Set per-request by the DI factory.
@@ -593,6 +607,16 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
 
         // Configure table-specific settings
         ConfigureEntities(modelBuilder);
+
+        // The TOTP shared secret is a permanent second factor, so the column holds a Data
+        // Protection payload rather than the seed. Configured here rather than in the static
+        // ConfigureEntities because the converter closes over a runtime-resolved protector.
+        modelBuilder
+            .Entity<TotpCredentialEntity>()
+            .Property(e => e.SecretKey)
+            .HasConversion(
+                Security.TotpSecretProtection.CreateConverter(
+                    Security.TotpSecretProtection.CreateProtector(ApplicationServices)));
 
         // Configure per-tenant global query filters
         ConfigureTenantFilters(modelBuilder);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Security/CredentialHash.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Security/CredentialHash.cs
@@ -1,0 +1,25 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Nocturne.Infrastructure.Data.Security;
+
+/// <summary>
+/// SHA-256 hex digests for bearer credentials that are only ever resolved by exact match.
+/// Storing the digest instead of the credential means a database read or a restored backup
+/// yields nothing that can be replayed as the credential.
+/// </summary>
+public static class CredentialHash
+{
+    /// <summary>Length in characters of the values returned by this class.</summary>
+    public const int HexLength = 64;
+
+    /// <summary>Lowercase hex SHA-256 of the UTF-8 bytes of <paramref name="value"/>.</summary>
+    public static string Sha256Hex(string value) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value))).ToLowerInvariant();
+
+    /// <summary>
+    /// Digest of a public share token. Hostnames are case-insensitive and generated tokens are
+    /// lowercase, so the token is lower-cased before hashing.
+    /// </summary>
+    public static string ShareToken(string token) => Sha256Hex(token.ToLowerInvariant());
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Security/TotpSecretProtection.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Security/TotpSecretProtection.cs
@@ -54,12 +54,12 @@ public static class TotpSecretProtection
     /// (<c>0x09F0C9F0</c>, big-endian), i.e. the column already holds a protected payload.
     /// </summary>
     /// <remarks>
-    /// Used only by the one-pass encryption of pre-existing rows, to tell an unencrypted secret
-    /// from an already-encrypted one without attempting decryption — a failed decryption would be
-    /// ambiguous between "plaintext" and "protected under a key this instance has lost", and
-    /// re-protecting the latter would corrupt it. A random plaintext secret matches the header with
-    /// probability 2^-32; such a row is left alone and its next read fails, so the credential is
-    /// re-enrolled rather than silently trusted.
+    /// Exists so the one-pass encryption of pre-existing rows can tell an unencrypted secret from an
+    /// already-encrypted one without attempting decryption: a failed decryption is ambiguous between
+    /// "plaintext" and "protected under a key this instance has lost", and re-protecting the latter
+    /// would corrupt it. A random plaintext secret matches the header with probability 2^-32; such a
+    /// row is left alone and its next read fails, so the credential is re-enrolled rather than
+    /// silently trusted.
     /// </remarks>
     public static bool IsProtectedPayload(byte[] value) =>
         value.Length >= 4 && value[0] == 0x09 && value[1] == 0xF0 && value[2] == 0xC9 && value[3] == 0xF0;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Security/TotpSecretProtection.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Security/TotpSecretProtection.cs
@@ -1,0 +1,66 @@
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Nocturne.Infrastructure.Data.Security;
+
+/// <summary>
+/// Data Protection wrapping for the TOTP shared secret column. TOTP secrets are a permanent
+/// second factor: a plaintext column exposes them to any database read or restored backup, so
+/// the column is stored as a Data Protection payload and decrypted on materialization by an EF
+/// value converter.
+/// </summary>
+/// <remarks>
+/// The purpose string is distinct from the TOTP setup challenge (<c>Nocturne.Totp.Setup</c>), the
+/// passkey challenge, and the OIDC state, so a payload from one cannot be replayed as another.
+/// Data Protection keys are persisted to the database (<see cref="NocturneDbContext"/> implements
+/// <c>IDataProtectionKeyContext</c>), so stored secrets survive restarts and are readable by every
+/// instance.
+/// </remarks>
+public static class TotpSecretProtection
+{
+    /// <summary>Data Protection purpose for the persisted TOTP secret column.</summary>
+    public const string Purpose = "Nocturne.Totp.SecretKey";
+
+    /// <summary>
+    /// Process-lifetime provider used when no application <see cref="IDataProtectionProvider"/> is
+    /// reachable — design-time model builds and tests that construct a context from a bare
+    /// <c>DbContextOptionsBuilder</c>. Payloads written under it are unreadable by a later process,
+    /// which is the fail-closed outcome; the alternative, writing plaintext, is not.
+    /// A single static instance keeps every such context in one process mutually readable.
+    /// </summary>
+    private static readonly IDataProtectionProvider EphemeralFallback = new EphemeralDataProtectionProvider();
+
+    /// <summary>
+    /// Creates the protector for the TOTP secret column from the application's service provider,
+    /// falling back to the process-lifetime provider when one is not registered.
+    /// Callers that write the column outside EF must use this method so they agree with the model.
+    /// </summary>
+    public static IDataProtector CreateProtector(IServiceProvider? applicationServices) =>
+        (applicationServices?.GetService<IDataProtectionProvider>() ?? EphemeralFallback)
+            .CreateProtector(Purpose);
+
+    /// <summary>
+    /// EF value converter that protects on write and unprotects on read. A plaintext value in the
+    /// column throws on materialization rather than being read as a secret.
+    /// </summary>
+    public static ValueConverter<byte[], byte[]> CreateConverter(IDataProtector protector) =>
+        new ValueConverter<byte[], byte[]>(
+            plaintext => protector.Protect(plaintext),
+            payload => protector.Unprotect(payload));
+
+    /// <summary>
+    /// True when <paramref name="value"/> starts with the Data Protection payload magic header
+    /// (<c>0x09F0C9F0</c>, big-endian), i.e. the column already holds a protected payload.
+    /// </summary>
+    /// <remarks>
+    /// Used only by the one-pass encryption of pre-existing rows, to tell an unencrypted secret
+    /// from an already-encrypted one without attempting decryption — a failed decryption would be
+    /// ambiguous between "plaintext" and "protected under a key this instance has lost", and
+    /// re-protecting the latter would corrupt it. A random plaintext secret matches the header with
+    /// probability 2^-32; such a row is left alone and its next read fails, so the credential is
+    /// re-enrolled rather than silently trusted.
+    /// </remarks>
+    public static bool IsProtectedPayload(byte[] value) =>
+        value.Length >= 4 && value[0] == 0x09 && value[1] == 0xF0 && value[2] == 0xC9 && value[3] == 0xF0;
+}

--- a/src/Web/packages/app/src/lib/components/members/PublicAccessCard.svelte
+++ b/src/Web/packages/app/src/lib/components/members/PublicAccessCard.svelte
@@ -53,6 +53,10 @@
   let errorMessage = $state<string | null>(null);
   let scopeWritesInFlight = $state(0);
 
+  // The server stores only a fingerprint of the link, so it can return the URL once — when the
+  // link is created. Held here for the rest of the visit; a reload shows the hidden state.
+  let revealedUrl = $state<string | null>(null);
+
   const sharedLabels = $derived(
     publicDataCategories.filter((c) => scopes.includes(c.scope)).map((c) => c.name.toLowerCase()),
   );
@@ -66,8 +70,11 @@
     errorMessage = null;
     pendingEnabled = on;
     try {
-      if (on) await rotateShareLink();
-      else await disableShareLink();
+      if (on) revealedUrl = (await rotateShareLink()).url ?? null;
+      else {
+        await disableShareLink();
+        revealedUrl = null;
+      }
     } catch {
       errorMessage = on
         ? "Couldn't create the link. Please try again."
@@ -83,7 +90,7 @@
     errorMessage = null;
     confirmingRotate = false;
     try {
-      await rotateShareLink();
+      revealedUrl = (await rotateShareLink()).url ?? null;
     } catch {
       errorMessage = "Couldn't regenerate the link. Please try again.";
     } finally {
@@ -124,8 +131,8 @@
   }
 
   async function copyLink() {
-    if (!share?.url) return;
-    if (!(await copyToClipboard(share.url))) {
+    if (!revealedUrl) return;
+    if (!(await copyToClipboard(revealedUrl))) {
       errorMessage = "Couldn't copy the link to the clipboard. Copy it manually instead.";
       return;
     }
@@ -190,17 +197,25 @@
               class="flex h-11 min-w-0 flex-1 items-center gap-2 rounded-lg border border-border bg-background px-3 font-mono text-sm"
             >
               <LinkIcon class="h-4 w-4 shrink-0 text-muted-foreground" />
-              <span class="truncate">{share?.url ?? ""}</span>
+              {#if revealedUrl}
+                <span class="truncate">{revealedUrl}</span>
+              {:else}
+                <span class="truncate font-sans text-muted-foreground">
+                  Your link is only shown when you create it
+                </span>
+              {/if}
             </div>
             <div class="flex gap-2">
-              <Button variant="outline" class="shrink-0" onclick={copyLink}>
-                {#if copied}
-                  <Check class="mr-1.5 h-4 w-4 text-green-600" />
-                {:else}
-                  <Copy class="mr-1.5 h-4 w-4" />
-                {/if}
-                Copy
-              </Button>
+              {#if revealedUrl}
+                <Button variant="outline" class="shrink-0" onclick={copyLink}>
+                  {#if copied}
+                    <Check class="mr-1.5 h-4 w-4 text-green-600" />
+                  {:else}
+                    <Copy class="mr-1.5 h-4 w-4" />
+                  {/if}
+                  Copy
+                </Button>
+              {/if}
               <Button
                 variant="ghost"
                 class="shrink-0"
@@ -232,10 +247,19 @@
                 </Button>
               </div>
             </div>
-          {:else}
+          {:else if revealedUrl}
             <p class="text-xs text-muted-foreground">
               Anyone you send this link to can open the read-only view — no sign-in
-              needed. Last viewed {formatDate(share?.lastAccessedAt)}.
+              needed. Copy it now: it isn't shown again after you leave this page.
+              Last viewed {formatDate(share?.lastAccessedAt)}.
+            </p>
+          {:else}
+            <p class="text-xs text-muted-foreground">
+              Anyone who already has your link can open the read-only view — no
+              sign-in needed. To get a link you can send, regenerate it; that also
+              stops the previous one from working. Last viewed {formatDate(
+                share?.lastAccessedAt,
+              )}.
             </p>
           {/if}
         </div>

--- a/src/Web/packages/app/src/lib/utils/notification-labels.ts
+++ b/src/Web/packages/app/src/lib/utils/notification-labels.ts
@@ -8,6 +8,9 @@ const LABEL_MAP: Record<string, string> = {
   compression_low_detected_subtitle:
     "Possible overnight compression lows are ready to review",
   review: "Review",
+  share_link_reset: "Your sharing link has been reset",
+  share_link_reset_subtitle:
+    "The previous link no longer opens your data. Go to Public access in settings to create a new link, then send it to anyone who was using the old one.",
 };
 
 /** Resolve a notification title/subtitle/action label, mapping known i18n keys

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/CredentialAtRestPassTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/CredentialAtRestPassTests.cs
@@ -1,0 +1,267 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Extensions;
+using Nocturne.Infrastructure.Data.Security;
+using Nocturne.Infrastructure.Data.Tests.Rls;
+using Npgsql;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests;
+
+/// <summary>
+/// Verifies the one-pass conversions of the credential columns against a real PostgreSQL schema:
+/// that they actually write rows, that they are idempotent, and that neither table they touch is
+/// under row level security — so no <c>app.current_tenant_id</c> is required and the passes cannot
+/// silently affect zero rows.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("RLS completeness")]
+public class CredentialAtRestPassTests
+{
+    private readonly RlsCompletenessFixture _fx;
+
+    public CredentialAtRestPassTests(RlsCompletenessFixture fx)
+    {
+        _fx = fx;
+    }
+
+    /// <summary>
+    /// Both passes read and write without setting the tenant GUC. That is only correct while these
+    /// tables are outside row level security; were either brought under a policy, the passes would
+    /// match zero rows and silently do nothing, so pin the assumption here.
+    /// </summary>
+    [Theory]
+    [InlineData("totp_credentials")]
+    [InlineData("tenants")]
+    public async Task Table_touched_by_a_credential_pass_is_not_row_level_secured(string table)
+    {
+        await using var conn = await _fx.OpenMigratorConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT relrowsecurity FROM pg_class WHERE relname = @table";
+        cmd.Parameters.AddWithValue("@table", table);
+
+        var rowSecurity = await cmd.ExecuteScalarAsync();
+
+        rowSecurity.Should().Be(false,
+            $"the credential passes query {table} without setting app.current_tenant_id");
+    }
+
+    [Fact]
+    public async Task ProtectTotpSecretsAsync_encrypts_a_plaintext_secret_in_place()
+    {
+        await using var dataSource = NpgsqlDataSource.Create(_fx.AppConnectionString);
+        var protector = TotpSecretProtection.CreateProtector(null);
+
+        var plaintext = NewSecret();
+        var credentialId = await SeedPlaintextTotpCredentialAsync(dataSource, plaintext);
+
+        var encrypted = await CredentialAtRestInitializationExtensions.ProtectTotpSecretsAsync(
+            dataSource, protector, NullLogger.Instance);
+
+        encrypted.Should().BeGreaterThanOrEqualTo(1, "the seeded plaintext row must be rewritten");
+
+        var stored = await ReadSecretAsync(dataSource, credentialId);
+        stored.Should().NotEqual(plaintext, "the column must no longer hold the seed");
+        TotpSecretProtection.IsProtectedPayload(stored).Should().BeTrue();
+        protector.Unprotect(stored).Should().Equal(plaintext,
+            "verification reads the secret back through the same protector");
+
+        // Second run: the row is already protected, so it is skipped rather than double-encrypted.
+        var second = await CredentialAtRestInitializationExtensions.ProtectTotpSecretsAsync(
+            dataSource, protector, NullLogger.Instance);
+        second.Should().Be(0);
+        (await ReadSecretAsync(dataSource, credentialId)).Should().Equal(stored);
+    }
+
+    [Fact]
+    public async Task ProtectTotpSecretsAsync_leaves_a_secret_readable_through_the_EF_converter()
+    {
+        await using var dataSource = NpgsqlDataSource.Create(_fx.AppConnectionString);
+        var protector = TotpSecretProtection.CreateProtector(null);
+
+        var plaintext = NewSecret();
+        var credentialId = await SeedPlaintextTotpCredentialAsync(dataSource, plaintext);
+
+        await CredentialAtRestInitializationExtensions.ProtectTotpSecretsAsync(
+            dataSource, protector, NullLogger.Instance);
+
+        // The model's converter resolves the same process-lifetime fallback protector the pass used,
+        // so a converted row still verifies — this is the "TOTP still works after encryption" check.
+        await using var db = CreateContext(dataSource);
+        var credential = await db.TotpCredentials.AsNoTracking()
+            .FirstAsync(c => c.Id == credentialId);
+
+        credential.SecretKey.Should().Equal(plaintext);
+    }
+
+    [Fact]
+    public async Task The_EF_write_path_never_stores_a_TOTP_secret_as_plaintext()
+    {
+        await using var dataSource = NpgsqlDataSource.Create(_fx.AppConnectionString);
+        var plaintext = NewSecret();
+
+        var credentialId = Guid.CreateVersion7();
+        await using (var db = CreateContext(dataSource))
+        {
+            db.Subjects.Add(NewSubject(out var subjectId));
+            db.TotpCredentials.Add(new TotpCredentialEntity
+            {
+                Id = credentialId,
+                SubjectId = subjectId,
+                SecretKey = plaintext,
+                CreatedAt = DateTime.UtcNow,
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var stored = await ReadSecretAsync(dataSource, credentialId);
+        stored.Should().NotEqual(plaintext);
+        TotpSecretProtection.IsProtectedPayload(stored).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RotatePlaintextShareTokensAsync_retires_a_plaintext_token()
+    {
+        await using var dataSource = NpgsqlDataSource.Create(_fx.AppConnectionString);
+
+        const string oldToken = "k7m2q9x4r3wt";
+        var tenantId = await SeedTenantAsync(dataSource, shareToken: oldToken);
+
+        // A distinct token per call: the pass loops until the digest is unused, so a constant
+        // generator would spin if the sweep ever found more than one stale row.
+        var minted = new List<string>();
+        var rotated = await CredentialAtRestInitializationExtensions.RotatePlaintextShareTokensAsync(
+            dataSource,
+            () =>
+            {
+                var token = $"mint{minted.Count:00000000}";
+                minted.Add(token);
+                return token;
+            },
+            NullLogger.Instance);
+
+        rotated.Should().Contain(tenantId, "the seeded plaintext row must be rewritten");
+
+        var stored = await ReadShareTokenAsync(dataSource, tenantId);
+        stored.Should().NotBeNull();
+        stored!.Should().HaveLength(CredentialHash.HexLength).And.MatchRegex("^[0-9a-f]+$");
+        stored.Should().NotBe(oldToken);
+        stored.Should().NotBe(CredentialHash.ShareToken(oldToken),
+            "the token is retired, not merely hashed — its plaintext was already exposed");
+        minted.Select(CredentialHash.ShareToken).Should().Contain(stored,
+            "the stored digest must be of a freshly minted token");
+
+        // Second run: the digest is already in the target format, so nothing is rotated again.
+        var second = await CredentialAtRestInitializationExtensions.RotatePlaintextShareTokensAsync(
+            dataSource, () => "0000000000aa", NullLogger.Instance);
+        second.Should().BeEmpty();
+        (await ReadShareTokenAsync(dataSource, tenantId)).Should().Be(stored);
+    }
+
+    [Fact]
+    public async Task RotatePlaintextShareTokensAsync_leaves_a_tenant_without_a_link_alone()
+    {
+        await using var dataSource = NpgsqlDataSource.Create(_fx.AppConnectionString);
+        var tenantId = await SeedTenantAsync(dataSource, shareToken: null);
+
+        var rotated = await CredentialAtRestInitializationExtensions.RotatePlaintextShareTokensAsync(
+            dataSource, () => $"idle{Guid.NewGuid():N}"[..12], NullLogger.Instance);
+
+        rotated.Should().NotContain(tenantId);
+        (await ReadShareTokenAsync(dataSource, tenantId)).Should().BeNull();
+    }
+
+    private static NocturneDbContext CreateContext(NpgsqlDataSource dataSource) =>
+        new(new DbContextOptionsBuilder<NocturneDbContext>().UseNpgsql(dataSource).Options);
+
+    private static byte[] NewSecret()
+    {
+        var secret = new byte[20];
+        Random.Shared.NextBytes(secret);
+        // Keep the seed from accidentally matching the Data Protection payload header.
+        secret[0] = 0x00;
+        return secret;
+    }
+
+    private static SubjectEntity NewSubject(out Guid subjectId)
+    {
+        subjectId = Guid.CreateVersion7();
+        return new SubjectEntity { Id = subjectId, Name = $"credential-pass-{subjectId:N}" };
+    }
+
+    /// <summary>
+    /// Seeds a credential whose column holds the bare secret, exactly as a pre-fix release wrote it.
+    /// The row is created through EF (so schema defaults apply) and the column then overwritten with
+    /// raw SQL, because the EF write path would protect it and leave nothing to convert.
+    /// </summary>
+    private static async Task<Guid> SeedPlaintextTotpCredentialAsync(
+        NpgsqlDataSource dataSource, byte[] plaintext)
+    {
+        var credentialId = Guid.CreateVersion7();
+
+        await using (var db = CreateContext(dataSource))
+        {
+            db.Subjects.Add(NewSubject(out var subjectId));
+            db.TotpCredentials.Add(new TotpCredentialEntity
+            {
+                Id = credentialId,
+                SubjectId = subjectId,
+                SecretKey = [0x01],
+                CreatedAt = DateTime.UtcNow,
+            });
+            await db.SaveChangesAsync();
+        }
+
+        await using var conn = await dataSource.OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "UPDATE totp_credentials SET secret_key = @secret WHERE id = @id";
+        cmd.Parameters.AddWithValue("@secret", plaintext);
+        cmd.Parameters.AddWithValue("@id", credentialId);
+        (await cmd.ExecuteNonQueryAsync()).Should().Be(1);
+
+        return credentialId;
+    }
+
+    private static async Task<byte[]> ReadSecretAsync(NpgsqlDataSource dataSource, Guid credentialId)
+    {
+        await using var conn = await dataSource.OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT secret_key FROM totp_credentials WHERE id = @id";
+        cmd.Parameters.AddWithValue("@id", credentialId);
+        return (byte[])(await cmd.ExecuteScalarAsync())!;
+    }
+
+    private static async Task<Guid> SeedTenantAsync(NpgsqlDataSource dataSource, string? shareToken)
+    {
+        var tenantId = Guid.CreateVersion7();
+        var slug = $"t{tenantId:N}"[..20];
+
+        await using var db = CreateContext(dataSource);
+        db.Tenants.Add(new TenantEntity
+        {
+            Id = tenantId,
+            Slug = slug,
+            DisplayName = slug,
+            // ShareToken carries no value converter, so this lands in the column verbatim — the
+            // pre-fix representation the rotation pass has to find.
+            ShareToken = shareToken,
+            ShareTokenSetAt = shareToken is null ? null : DateTime.UtcNow,
+        });
+        await db.SaveChangesAsync();
+
+        return tenantId;
+    }
+
+    private static async Task<string?> ReadShareTokenAsync(NpgsqlDataSource dataSource, Guid tenantId)
+    {
+        await using var conn = await dataSource.OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT share_token FROM tenants WHERE id = @id";
+        cmd.Parameters.AddWithValue("@id", tenantId);
+        var value = await cmd.ExecuteScalarAsync();
+        return value is DBNull or null ? null : (string)value;
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantResolutionMiddlewareShareTokenTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantResolutionMiddlewareShareTokenTests.cs
@@ -13,6 +13,7 @@ using Nocturne.API.Services.Auth;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Security;
 using Nocturne.Infrastructure.Data.Services;
 using Xunit;
 
@@ -57,7 +58,8 @@ public sealed class TenantResolutionMiddlewareShareTokenTests : IDisposable
             Id = _tenantId,
             Slug = Slug,
             DisplayName = "Acme",
-            ShareToken = ShareToken,
+            // The column holds the token's digest; the host still carries the token itself.
+            ShareToken = CredentialHash.ShareToken(ShareToken),
             ShareTokenSetAt = DateTime.UtcNow,
         });
         seed.SaveChanges();

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareLinkServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareLinkServiceTests.cs
@@ -13,6 +13,7 @@ using Nocturne.API.Tests.Infrastructure;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Security;
 using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
 
@@ -84,9 +85,24 @@ public sealed class ShareLinkServiceTests : IDisposable
         var dto = await _service.RotateAsync(TenantId);
 
         dto.Enabled.Should().BeTrue();
+        dto.Url.Should().MatchRegex(@"^https://[0-9a-z]+\.share\.nocturne\.run$");
+
+        // The URL carries the token; the column carries only its digest.
+        var token = new Uri(dto.Url!).Host.Split('.')[0];
         var tenant = await _db.Tenants.AsNoTracking().FirstAsync(t => t.Id == TenantId);
-        tenant.ShareToken.Should().NotBeNullOrEmpty();
-        dto.Url.Should().Be($"https://{tenant.ShareToken}.share.nocturne.run");
+        tenant.ShareToken.Should().Be(CredentialHash.ShareToken(token))
+            .And.NotBe(token);
+    }
+
+    [Fact]
+    public async Task Get_reports_the_link_as_enabled_without_revealing_the_url()
+    {
+        await _service.RotateAsync(TenantId);
+
+        var dto = await _service.GetAsync(TenantId);
+
+        dto.Enabled.Should().BeTrue();
+        dto.Url.Should().BeNull("the token is not stored, so the URL cannot be reproduced");
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareTokenBackfillServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareTokenBackfillServiceTests.cs
@@ -9,6 +9,7 @@ using Nocturne.API.Services.Auth;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Security;
 using Xunit;
 
 namespace Nocturne.API.Tests.Services.Auth;
@@ -110,6 +111,9 @@ public sealed class ShareTokenBackfillServiceTests : IDisposable
         var priv = db.Tenants.Single(t => t.Id == _privateTenantId);
 
         pub.ShareToken.Should().NotBeNullOrEmpty();
+        pub.ShareToken.Should()
+            .HaveLength(CredentialHash.HexLength).And.MatchRegex("^[0-9a-f]+$",
+                "the backfill stores the token's digest, never the token");
         pub.ShareTokenSetAt.Should().NotBeNull();
         priv.ShareToken.Should().BeNull("a tenant that was never public must not get a link");
     }

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareTokenCacheServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareTokenCacheServiceTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Nocturne.API.Services.Auth;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Security;
 using Xunit;
 
 namespace Nocturne.API.Tests.Services.Auth;
@@ -37,7 +38,13 @@ public sealed class ShareTokenCacheServiceTests : IDisposable
 
         using var seed = _factory.CreateDbContext();
         seed.Database.EnsureCreated();
-        seed.Tenants.Add(new TenantEntity { Id = _tenantId, Slug = "acme", DisplayName = "Acme", ShareToken = Token });
+        seed.Tenants.Add(new TenantEntity
+        {
+            Id = _tenantId,
+            Slug = "acme",
+            DisplayName = "Acme",
+            ShareToken = CredentialHash.ShareToken(Token),
+        });
         seed.SaveChanges();
     }
 
@@ -109,20 +116,44 @@ public sealed class ShareTokenCacheServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task Evict_makes_a_rotated_token_stop_resolving()
+    public async Task EvictByHash_makes_a_rotated_token_stop_resolving()
     {
         var service = Service();
         (await service.ResolveByTokenAsync(Token)).Should().NotBeNull(); // caches the hit
 
-        // Rotate in the DB, then evict the cached entry for the old token.
+        // Rotate in the DB, then evict the cached entry keyed by the old token's digest.
         using (var db = _factory.CreateDbContext())
         {
-            db.Tenants.Single(t => t.Id == _tenantId).ShareToken = "newtoken0000";
+            db.Tenants.Single(t => t.Id == _tenantId).ShareToken =
+                CredentialHash.ShareToken("newtoken0000");
             db.SaveChanges();
         }
-        service.Evict(Token);
+        service.EvictByHash(CredentialHash.ShareToken(Token));
 
         (await service.ResolveByTokenAsync(Token)).Should().BeNull();
         (await service.ResolveByTokenAsync("newtoken0000"))!.TenantId.Should().Be(_tenantId);
+    }
+
+    [Fact]
+    public async Task ResolveByTokenAsync_does_not_resolve_a_token_stored_as_plaintext()
+    {
+        using (var db = _factory.CreateDbContext())
+        {
+            db.Tenants.Single(t => t.Id == _tenantId).ShareToken = Token;
+            db.SaveChanges();
+        }
+
+        (await Service().ResolveByTokenAsync(Token)).Should().BeNull(
+            "lookup is by digest, so a plaintext column value is not a usable credential");
+    }
+
+    [Fact]
+    public void The_stored_share_token_is_not_the_token()
+    {
+        using var db = _factory.CreateDbContext();
+        var stored = db.Tenants.Single(t => t.Id == _tenantId).ShareToken;
+
+        stored.Should().NotBe(Token);
+        stored.Should().HaveLength(CredentialHash.HexLength).And.MatchRegex("^[0-9a-f]+$");
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareTokenGeneratorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareTokenGeneratorTests.cs
@@ -11,9 +11,20 @@ public sealed class ShareTokenGeneratorTests
     private readonly ShareTokenGenerator _generator = new();
 
     [Fact]
-    public void Generate_returns_twelve_characters()
+    public void Generate_returns_sixteen_characters()
     {
-        _generator.Generate().Should().HaveLength(12);
+        // 16 Crockford-base32 characters = 80 bits. The token is stored only as an unsalted SHA-256
+        // digest, so its entropy is the whole security argument against an offline search of a
+        // leaked dump; 60 bits was within reach. It is only ever copy-pasted, never typed.
+        _generator.Generate().Should().HaveLength(16);
+    }
+
+    [Fact]
+    public void Generate_fits_a_dns_label()
+    {
+        // The token is the first label of {token}.share.{domain}, so it must stay inside the
+        // 63-character limit.
+        _generator.Generate().Length.Should().BeLessThanOrEqualTo(63);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/TotpSecretProtectionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/TotpSecretProtectionTests.cs
@@ -1,0 +1,77 @@
+using System.Text;
+using FluentAssertions;
+using Microsoft.AspNetCore.DataProtection;
+using Nocturne.Infrastructure.Data.Security;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Auth;
+
+/// <summary>
+/// Unit tests for the at-rest wrapping of the TOTP secret column: the value converter round-trips,
+/// the stored form is not the secret, and the purpose string is not shared with another flow.
+/// </summary>
+public class TotpSecretProtectionTests
+{
+    private static readonly IDataProtectionProvider Provider = new EphemeralDataProtectionProvider();
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Converter_round_trips_a_secret()
+    {
+        var converter = TotpSecretProtection.CreateConverter(Provider.CreateProtector(TotpSecretProtection.Purpose));
+        var secret = new byte[20];
+        Random.Shared.NextBytes(secret);
+
+        var stored = (byte[])converter.ConvertToProvider(secret)!;
+        var read = (byte[])converter.ConvertFromProvider(stored)!;
+
+        read.Should().Equal(secret);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Converter_does_not_store_the_secret_in_readable_form()
+    {
+        var converter = TotpSecretProtection.CreateConverter(Provider.CreateProtector(TotpSecretProtection.Purpose));
+        var secret = Encoding.UTF8.GetBytes("12345678901234567890");
+
+        var stored = (byte[])converter.ConvertToProvider(secret)!;
+
+        stored.Should().NotEqual(secret);
+        Encoding.UTF8.GetString(stored).Should().NotContain("12345678901234567890");
+        TotpSecretProtection.IsProtectedPayload(stored).Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Converter_rejects_a_plaintext_column_value()
+    {
+        var converter = TotpSecretProtection.CreateConverter(Provider.CreateProtector(TotpSecretProtection.Purpose));
+        var plaintext = new byte[20];
+
+        var read = () => converter.ConvertFromProvider(plaintext);
+
+        read.Should().Throw<Exception>(
+            "an unencrypted column value must fail closed rather than be read as a secret");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void A_payload_from_another_purpose_does_not_decrypt()
+    {
+        var stored = Provider.CreateProtector("Nocturne.Totp.Setup").Protect(new byte[20]);
+        var converter = TotpSecretProtection.CreateConverter(Provider.CreateProtector(TotpSecretProtection.Purpose));
+
+        var read = () => converter.ConvertFromProvider(stored);
+
+        read.Should().Throw<Exception>();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void IsProtectedPayload_is_false_for_a_bare_secret()
+    {
+        TotpSecretProtection.IsProtectedPayload(new byte[20]).Should().BeFalse();
+        TotpSecretProtection.IsProtectedPayload([]).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
TOTP secrets were stored as plaintext seeds and tenant share tokens as plaintext, both readable in the table and in every backup taken from it. TOTP secrets are now Data Protection payloads; share tokens are stored as a SHA-256 digest, with the column widened by a generated schema-only migration. Startup passes convert pre-existing rows.

Detail is in the commit messages.

**Production facts verified before merging**
- `tenants` and `totp_credentials` both have `relrowsecurity = false`, so the passes correctly need no `app.current_tenant_id`. `CredentialAtRestPassTests` asserts this, and it runs in the `integration-db` job.
- The rotation touches **4 tenants of 48**, each with exactly one human owner-role member, so every notification reaches a person.
- DataProtection keys are persisted to the database (1 key present), so encrypted secrets survive redeploys. This PR also pins `SetApplicationName`, without which they were keyed on the container working directory.
- `ShareTokenBackfillService` matches **0** tenants in production; its cutover has happened.
- Nothing in the deployment's `.env` or compose references a `{token}.share.` host.

**Behaviour change owners will see:** the 4 affected share links stop resolving and must be regenerated. Owners are notified in-app.

**Open decision, not resolved here.** The pass re-encrypts the existing TOTP seeds rather than retiring them, so historical offsite backups still contain all 6 in plaintext, permanently. Retiring them means deleting those rows for re-enrolment (no lockout — every affected subject holds a passkey or OIDC identity) or purging the historical backups. Flagged for the operator.