### PR TITLE
fix(alerts): bound the DND window read, share the DND resolver, and report the real shadow outcome

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -149,7 +149,10 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             crates/target
-          key: cargo-${{ runner.os }}-${{ hashFiles('crates/Cargo.lock') }}
+          # Sources, not just the lockfile: actions/cache restores crates/target with mtimes
+          # newer than the checkout, and cargo's path-package fingerprint is mtime-based, so a
+          # lockfile-only key lets a source-only change reuse a stale cdylib and never re-save it.
+          key: cargo-${{ runner.os }}-${{ hashFiles('crates/Cargo.lock', 'crates/**/*.rs', 'crates/**/Cargo.toml') }}
 
       - name: Build nocturne_alerts native library
         working-directory: crates

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -45,7 +45,10 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             crates/target
-          key: cargo-release-${{ matrix.rid }}-${{ hashFiles('crates/Cargo.lock') }}
+          # Sources, not just the lockfile — a restored crates/target has newer mtimes than
+          # the checkout, and cargo's path-package fingerprint is mtime-based, so a
+          # lockfile-only key can publish a release artifact built from stale sources.
+          key: cargo-release-${{ matrix.rid }}-${{ hashFiles('crates/Cargo.lock', 'crates/**/*.rs', 'crates/**/Cargo.toml') }}
       - name: Build cdylib
         working-directory: crates
         run: cargo build --release -p nocturne-alerts-ffi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,7 +97,10 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             crates/target
-          key: cargo-${{ runner.os }}-${{ hashFiles('crates/Cargo.lock') }}
+          # Sources, not just the lockfile: actions/cache restores crates/target with
+          # mtimes newer than the checked-out sources, and cargo's path-package fingerprint
+          # is mtime-based, so a lockfile-only key lets a source change reuse a stale build.
+          key: cargo-${{ runner.os }}-${{ hashFiles('crates/Cargo.lock', 'crates/**/*.rs', 'crates/**/Cargo.toml') }}
       - name: Cache NuGet
         uses: actions/cache@v4
         with:

--- a/crates/nocturne-alerts-core/src/eval/clock.rs
+++ b/crates/nocturne-alerts-core/src/eval/clock.rs
@@ -20,8 +20,31 @@ fn parse_hh_mm(s: &str) -> Option<NaiveTime> {
     NaiveTime::from_hms_opt(hh, mm, 0)
 }
 
+/// Resolves an IANA timezone id, mirroring the resolution order of the C#
+/// `TimeZoneHelper`: exact match first, then a case-insensitive match against
+/// the zone table.
+///
+/// The case-insensitive pass is not cosmetic. `chrono_tz`'s `FromStr` is an
+/// exact-match table lookup, while `TimeZoneHelper` deliberately resolves
+/// mis-cased ids because connector data carries them in bulk (production has
+/// ~240 rows spelling `Etc/GMT-2` as `ETC/GMT-2`). Without this the two engines
+/// disagree on every such rule: a mis-cased *per-rule* tz fails closed, so an
+/// overnight low rule never fires, and a mis-cased *tenant* tz silently shifts
+/// the whole rule set to UTC.
+///
+/// The two retries agree on that population but are not the same set. Windows
+/// ids (`AUS Eastern Standard Time`) resolve in C# and not here; conversely
+/// `TZ_VARIANTS` includes tzdb backward links (`Etc/Greenwich`, `US/Pacific`)
+/// that C#'s ICU-canonical scan rejects, so those resolve here and not there.
+/// Both divergences are cutover gates — see `docs/alerts/engine-semantics.md` §4.
 fn find_tz(id: &str) -> Option<Tz> {
-    id.parse::<Tz>().ok()
+    if let Ok(tz) = id.parse::<Tz>() {
+        return Some(tz);
+    }
+    chrono_tz::TZ_VARIANTS
+        .iter()
+        .find(|tz| tz.name().eq_ignore_ascii_case(id))
+        .copied()
 }
 
 fn local_now(now: DateTime<Utc>, tz: Option<Tz>) -> chrono::NaiveDateTime {
@@ -104,5 +127,62 @@ pub(super) fn time_since(p: &TimeSincePayload, anchor: Option<DateTime<Utc>>, en
         3 => elapsed <= threshold,
         4 => elapsed == threshold,
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_exact_iana_ids() {
+        assert_eq!(find_tz("Etc/GMT-2").map(Tz::name), Some("Etc/GMT-2"));
+        assert_eq!(
+            find_tz("Australia/Sydney").map(Tz::name),
+            Some("Australia/Sydney")
+        );
+    }
+
+    /// The production case: ~240 rows spell `Etc/GMT-2` as `ETC/GMT-2`.
+    #[test]
+    fn resolves_miscased_etc_ids() {
+        assert_eq!(find_tz("ETC/GMT-2").map(Tz::name), Some("Etc/GMT-2"));
+        assert_eq!(find_tz("etc/utc").map(Tz::name), Some("Etc/UTC"));
+    }
+
+    #[test]
+    fn resolves_miscased_region_ids() {
+        assert_eq!(
+            find_tz("australia/sydney").map(Tz::name),
+            Some("Australia/Sydney")
+        );
+        assert_eq!(
+            find_tz("AMERICA/NEW_YORK").map(Tz::name),
+            Some("America/New_York")
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_ids() {
+        assert!(find_tz("Not/AZone").is_none());
+        assert!(find_tz("").is_none());
+        // Windows ids stay unresolved here — documented divergence from TimeZoneHelper.
+        assert!(find_tz("AUS Eastern Standard Time").is_none());
+    }
+
+    /// The other half of the documented divergence: `TZ_VARIANTS` carries tzdb backward
+    /// links that C#'s ICU-canonical scan rejects, so these resolve here and fail closed
+    /// under the managed engine. Pinned so a change to the set is a deliberate one.
+    #[test]
+    fn resolves_backward_links_that_the_managed_engine_rejects() {
+        assert_eq!(
+            find_tz("Etc/Greenwich").map(Tz::name),
+            Some("Etc/Greenwich")
+        );
+        assert_eq!(find_tz("US/Pacific").map(Tz::name), Some("US/Pacific"));
+        assert_eq!(
+            find_tz("Asia/Calcutta").map(Tz::name),
+            Some("Asia/Calcutta")
+        );
     }
 }

--- a/docs/alerts/engine-semantics.md
+++ b/docs/alerts/engine-semantics.md
@@ -212,6 +212,26 @@ in §3 plus:
 - Timezone resolution order (where applicable): per-rule condition timezone → tenant
   timezone (`TenantTimeZoneId`, IANA id) → UTC. Failure modes differ by leaf (§3:
   `time_of_day` fails closed on a bad per-rule tz, falls back on a bad tenant tz).
+- **Which ids resolve** is itself normative, because it decides whether a rule fires at
+  all. Both engines resolve an exact IANA id, then retry case-insensitively — connector
+  data carries mis-cased ids in bulk (production has ~240 rows spelling `Etc/GMT-2` as
+  `ETC/GMT-2`), and dropping them would make an overnight low rule silently never fire.
+  The two retries agree on that population but are **not** the same set, in both
+  directions. Neither divergence is corpus-catchable (the corpus pins evaluation given a
+  resolved zone, not resolution itself), so both are cutover gates:
+  - **C# resolves more:** `TimeZoneHelper` accepts Windows ids
+    (`AUS Eastern Standard Time`) via `TryConvertWindowsIdToIanaId`. `chrono_tz` has no
+    equivalent, so the crate leaves them unresolved (per-rule ⇒ false, tenant ⇒ UTC).
+    Closing it means carrying a CLDR Windows↔IANA mapping in the crate, which would then
+    need its own drift check against .NET's.
+  - **Rust resolves more:** the crate scans `chrono_tz::TZ_VARIANTS`, which includes tzdb
+    *backward links* (`Etc/Greenwich`, `Etc/Zulu`, `US/Pacific`, `Asia/Calcutta`,
+    `Australia/ACT`). C# scans `TimeZoneInfo.GetSystemTimeZones()` — the ICU canonical
+    set, which excludes those — and its `Etc/*` fallback only uppercases the suffix, so
+    `Etc/GREENWICH` is produced and fails. A rule whose per-rule tz is a backward link
+    therefore evaluates under Rust and fails closed under managed. Closing it means
+    filtering the scan to canonical zones, at the cost of rejecting ids the tzdb still
+    considers valid.
 
 ---
 

--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/DndWindowsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/DndWindowsController.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -15,10 +16,13 @@ namespace Nocturne.API.Controllers.V4.Monitoring;
 /// state is computed on read, never stored; rows are retained after clear/expiry for audit.
 /// </summary>
 /// <remarks>
-/// One active window per scope is enforced here: creating a window supersedes any active window of
-/// the same scope (<c>cleared_by = "system:superseded"</c>). Creates are idempotent by the
-/// client-supplied id so a device/web retry never double-applies. A <c>scope=all</c> window is
-/// tenant-wide DND and additionally drives the <c>do_not_disturb</c> condition via the enricher.
+/// One active window per scope <em>at any instant</em> is enforced here: creating a window
+/// reconciles the same-scope windows whose span overlaps it — an earlier one is truncated to end
+/// where the new one begins, one it wholly covers is cleared
+/// (<c>cleared_by = "system:superseded"</c>), and a non-overlapping one is left alone. Creates are
+/// idempotent by the client-supplied id so a device/web retry never double-applies. A
+/// <c>scope=all</c> window is tenant-wide DND and additionally drives the <c>do_not_disturb</c>
+/// condition via the enricher.
 /// </remarks>
 /// <seealso cref="AlertRulesController"/>
 [ApiController]
@@ -74,6 +78,12 @@ public class DndWindowsController : ControllerBase
         if (request.Id == Guid.Empty)
             return BadRequest("A client-supplied window id is required.");
 
+        // Scope is nullable on the request so an omitted field is rejected rather than
+        // silently defaulting to the zero enum member (lows) — muting the wrong class of
+        // alert is not a reasonable reading of a malformed request.
+        if (request.Scope is not { } scope)
+            return BadRequest("scope is required (lows | highs | all).");
+
         var startedAt = AsUtc(request.StartedAt);
         var endsAt = request.EndsAt is { } e ? AsUtc(e) : (DateTime?)null;
         if (endsAt is { } ends && ends <= startedAt)
@@ -89,18 +99,34 @@ public class DndWindowsController : ControllerBase
         if (existing is not null)
             return Ok(MapToResponse(existing));
 
-        // Supersede so at most one window per scope is active. Only a window that is
-        // itself active now displaces the existing ones — an offline-authored window
-        // received after its expiry (or before its start) is recorded for audit
-        // without turning off a live mute.
+        // Keep "at most one window of a scope active at any instant" by reconciling against the
+        // *span* of the incoming window rather than against what happens to be active right now.
+        //
+        // Only same-scope windows whose span overlaps the new one are touched. A window that
+        // merely expired, or one scheduled for a later span that this one does not reach, is left
+        // exactly as it is — restamping the first would falsify the audit trail these rows are
+        // retained for, and clearing the second would destroy standing user intent that adding
+        // this mute said nothing about.
+        //
+        // Of the overlapping ones:
+        //  - one that started earlier is *truncated* to end where this one begins, so a running
+        //    mute is handed over at the boundary instead of being switched off;
+        //  - one that starts at or after this window's start is wholly covered, so it is cleared.
+        //
+        // A null EndsAt is an open-ended span, so [started, ∞).
         var now = DateTime.UtcNow;
-        var newWindowIsActive = startedAt <= now && (endsAt == null || now < endsAt);
-        if (newWindowIsActive)
+        var overlapping = await db.DndWindows
+            .Where(w => w.Scope == scope && w.ClearedAt == null
+                        && (w.EndsAt == null || w.EndsAt > startedAt)
+                        && (endsAt == null || w.StartedAt < endsAt))
+            .ToListAsync(ct);
+        foreach (var w in overlapping)
         {
-            var superseded = await db.DndWindows
-                .Where(w => w.Scope == request.Scope && w.ClearedAt == null)
-                .ToListAsync(ct);
-            foreach (var w in superseded)
+            if (w.StartedAt < startedAt)
+            {
+                w.EndsAt = startedAt;
+            }
+            else
             {
                 w.ClearedAt = now;
                 w.ClearedBy = SupersededBy;
@@ -111,7 +137,7 @@ public class DndWindowsController : ControllerBase
         {
             Id = request.Id,
             TenantId = tenantId,
-            Scope = request.Scope,
+            Scope = scope,
             StartedAt = startedAt,
             EndsAt = endsAt,
             Source = request.Source,
@@ -196,8 +222,11 @@ public class CreateDndWindowRequest
     /// <summary>Client-generated UUID. Re-sending the same id is a no-op that returns the stored window.</summary>
     public Guid Id { get; set; }
 
-    /// <summary>Which alerts to silence: <c>lows</c> | <c>highs</c> | <c>all</c>.</summary>
-    public DndScope Scope { get; set; }
+    /// <summary>
+    /// Which alerts to silence: <c>lows</c> | <c>highs</c> | <c>all</c>. Required — nullable so
+    /// an omitted value is a 400 rather than defaulting to the zero enum member.
+    /// </summary>
+    public DndScope? Scope { get; set; }
 
     /// <summary>When the mute takes effect (may predate receipt for offline authoring).</summary>
     public DateTime StartedAt { get; set; }
@@ -206,6 +235,7 @@ public class CreateDndWindowRequest
     public DateTime? EndsAt { get; set; }
 
     /// <summary>Audit label for what created the window (e.g. <c>web</c>, <c>prelude-device</c>).</summary>
+    [MaxLength(128)]
     public string? Source { get; set; }
 }
 

--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/TenantAlertSettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/TenantAlertSettingsController.cs
@@ -77,7 +77,9 @@ public class TenantAlertSettingsController : ControllerBase
         // guard): a past until would persist a never-active window (EndsAt <= StartedAt)
         // — or retroactively expire the kept one without an audit clear — and the
         // response would report DndManualActive=false despite the request saying true.
-        if (request.DndManualActive && AsUtc(request.DndManualUntil) is { } until && until <= now)
+        // Only when the request is actually turning the mute on: with the toggle absent the
+        // expiry is never read, so rejecting a stale echo of it would 400 a schedule-only save.
+        if (request.DndManualActive == true && AsUtc(request.DndManualUntil) is { } until && until <= now)
             return BadRequest("dnd_manual_until must be in the future.");
 
         var entity = await db.TenantAlertSettings.FirstOrDefaultAsync(ct);
@@ -90,46 +92,57 @@ public class TenantAlertSettingsController : ControllerBase
         entity.UpdatedAt = now;
         if (isNew) db.TenantAlertSettings.Add(entity);
 
-        // Manual DND is a scope=all window. Toggling on ensures exactly one active all-window
-        // (anchoring StartedAt on the existing one so a re-PUT doesn't reset the for_minutes
-        // anchor); toggling off clears every uncleared all-window (user-clear, cleared_by
-        // null) — including future-started ones, so an explicit "DND off" also cancels a
-        // pending mute instead of letting it silently activate later (Create's supersede
-        // clears the same set).
-        if (request.DndManualActive)
+        // Manual DND is a scope=all window in a table this controller shares with
+        // DndWindowsController (which devices post to directly). An absent dndManualActive
+        // therefore means "leave the mute alone", not false: treating it as false would make
+        // saving a *schedule* change silently cancel a mute a device had taken out, and would
+        // rewrite that window's expiry on the way through.
+        if (request.DndManualActive is { } manualActive)
         {
+            // Toggling on ensures exactly one active all-window (anchoring StartedAt on the
+            // existing one so a re-PUT doesn't reset the for_minutes anchor). Toggling off is an
+            // explicit "DND off" and clears every uncleared all-window (user-clear, cleared_by
+            // null) — including future-started ones, so it also cancels a pending mute rather
+            // than letting it silently activate later.
             var activeAll = await ActiveAllWindowsAsync(db, now, ct);
-            var endsAt = AsUtc(request.DndManualUntil);
-            if (activeAll.Count == 0)
+            if (manualActive)
             {
-                db.DndWindows.Add(new DndWindowEntity
+                var endsAt = AsUtc(request.DndManualUntil);
+                if (activeAll.Count == 0)
                 {
-                    Id = Guid.CreateVersion7(),
-                    TenantId = db.TenantId,
-                    Scope = DndScope.All,
-                    StartedAt = now,
-                    EndsAt = endsAt,
-                    Source = ManualSource,
-                });
+                    db.DndWindows.Add(new DndWindowEntity
+                    {
+                        Id = Guid.CreateVersion7(),
+                        TenantId = db.TenantId,
+                        Scope = DndScope.All,
+                        StartedAt = now,
+                        EndsAt = endsAt,
+                        Source = ManualSource,
+                    });
+                }
+                else
+                {
+                    var keep = activeAll.OrderBy(w => w.StartedAt).First();
+                    keep.EndsAt = endsAt;
+                    foreach (var extra in activeAll.Where(w => !ReferenceEquals(w, keep)))
+                    {
+                        extra.ClearedAt = now;
+                        extra.ClearedBy = DndWindowsController.SupersededBy;
+                    }
+                }
             }
             else
             {
-                var keep = activeAll.OrderBy(w => w.StartedAt).First();
-                keep.EndsAt = endsAt;
-                foreach (var extra in activeAll.Where(w => !ReferenceEquals(w, keep)))
-                {
-                    extra.ClearedAt = now;
-                    extra.ClearedBy = DndWindowsController.SupersededBy;
-                }
+                // Every uncleared all-window, not just the active ones: an explicit "DND off"
+                // should also cancel a mute that has not started yet rather than let it activate
+                // later. (DndWindowsController's overlap supersede leaves such a window alone,
+                // because adding one mute is not a statement about another span.)
+                var uncleared = await db.DndWindows
+                    .Where(w => w.Scope == DndScope.All && w.ClearedAt == null)
+                    .ToListAsync(ct);
+                foreach (var w in uncleared)
+                    w.ClearedAt = now;
             }
-        }
-        else
-        {
-            var uncleared = await db.DndWindows
-                .Where(w => w.Scope == DndScope.All && w.ClearedAt == null)
-                .ToListAsync(ct);
-            foreach (var w in uncleared)
-                w.ClearedAt = now;
         }
 
         await db.SaveChangesAsync(ct);
@@ -202,7 +215,12 @@ public class TenantAlertSettingsResponse
 
 public class UpdateTenantAlertSettingsRequest
 {
-    public bool DndManualActive { get; set; }
+    /// <summary>
+    /// Manual (scope=all) DND toggle. Omit to leave the tenant's manual mute untouched — the
+    /// mute lives in <c>dnd_windows</c>, which devices write to independently, so a settings
+    /// save that only changes the schedule must not disturb it.
+    /// </summary>
+    public bool? DndManualActive { get; set; }
     public DateTime? DndManualUntil { get; set; }
     public bool DndScheduleEnabled { get; set; }
     public TimeOnly? DndScheduleStart { get; set; }

--- a/src/API/Nocturne.API/Services/Alerts/AlertReplayService.cs
+++ b/src/API/Nocturne.API/Services/Alerts/AlertReplayService.cs
@@ -176,12 +176,16 @@ internal sealed class AlertReplayService(
             // Pin every fact in the per-tick context to `tick` — APS / pump / uploader /
             // state-span / temp-basal / device-event repos all support an as-of cutoff.
             var tickUtc = DateTime.SpecifyKind(tick, DateTimeKind.Utc);
+            // Receipt-gated, and through the same resolver the live enricher uses so the two
+            // cannot disagree about how a window resolves. No scheduled projection is passed:
+            // a recurring schedule's past state is not reconstructible from the settings row.
+            var tickDnd = DndWindowResolver.Resolve(dndWindows, tickUtc, receiptGated: true);
             var enrichedBase = (await enricher.EnrichAsOfAsync(
                 baseContext, ordered, tenantId, tickUtc, ct))
                 with
             {
-                ActiveDndScopes = ResolveDndScopes(dndWindows, tickUtc),
-                ActiveDoNotDisturb = ResolveDoNotDisturb(dndWindows, tickUtc),
+                ActiveDndScopes = tickDnd.Scopes,
+                ActiveDoNotDisturb = tickDnd.ActiveDoNotDisturb,
             };
 
             CaptureFactSnapshots(enrichedBase, DateTime.SpecifyKind(tick, DateTimeKind.Utc), factPrev, factPoints);
@@ -613,44 +617,6 @@ internal sealed class AlertReplayService(
     /// against the override rather than against a non-existent rule). The original list is
     /// returned unchanged when <paramref name="ruleOverride"/> is null.
     /// </summary>
-    private static readonly IReadOnlySet<DndScope> NoDndScopes = new HashSet<DndScope>();
-
-    /// <summary>
-    /// The DND scopes active at <paramref name="atUtc"/>, resolved from the tenant's windows with
-    /// receipt-gated <see cref="DndWindowSnapshot.WasActiveAt"/>. Returns a shared empty set when
-    /// none are active so the common no-DND tick allocates nothing.
-    /// </summary>
-    private static IReadOnlySet<DndScope> ResolveDndScopes(
-        IReadOnlyList<DndWindowSnapshot> windows, DateTime atUtc)
-    {
-        HashSet<DndScope>? scopes = null;
-        foreach (var w in windows)
-        {
-            if (w.WasActiveAt(atUtc))
-                (scopes ??= new HashSet<DndScope>()).Add(w.Scope);
-        }
-        return scopes ?? NoDndScopes;
-    }
-
-    /// <summary>
-    /// The tenant-wide DND snapshot at <paramref name="atUtc"/> for the <c>do_not_disturb</c>
-    /// leaf: the earliest StartedAt among receipt-gated active <c>scope=all</c> windows with
-    /// source <c>manual</c> (the live enricher's window branch produces the same projection),
-    /// or null when no all-window was active. Scheduled DND is not reconstructible
-    /// historically, so replay's snapshot considers windows only.
-    /// </summary>
-    private static DoNotDisturbSnapshot? ResolveDoNotDisturb(
-        IReadOnlyList<DndWindowSnapshot> windows, DateTime atUtc)
-    {
-        DateTime? earliest = null;
-        foreach (var w in windows)
-        {
-            if (w.Scope == DndScope.All && w.WasActiveAt(atUtc) && (earliest is null || w.StartedAt < earliest))
-                earliest = w.StartedAt;
-        }
-        return earliest is { } startedAt ? new DoNotDisturbSnapshot(startedAt, "manual") : null;
-    }
-
     private static IReadOnlyList<AlertRuleSnapshot> ApplyOverride(
         IReadOnlyList<AlertRuleSnapshot> stored,
         ReplayRuleOverride? ruleOverride,

--- a/src/API/Nocturne.API/Services/Alerts/Engines/RustBackedAlertEngine.cs
+++ b/src/API/Nocturne.API/Services/Alerts/Engines/RustBackedAlertEngine.cs
@@ -56,7 +56,7 @@ internal sealed class RustBackedAlertEngine(
         }
 
         var now = timeProvider.GetUtcNow().UtcDateTime;
-        var timers = await timerStore.GetAllForRuleAsync(rule.Id, ct);
+        var timers = RustEnvelopeMapper.BuildTimers(await timerStore.GetAllForRuleAsync(rule.Id, ct));
         var trackerState = await trackerRepository.GetTrackerStateAsync(rule.Id, ct);
         var priorExcursionId = trackerState?.ActiveExcursionId;
 
@@ -142,7 +142,7 @@ internal sealed class RustBackedAlertEngine(
             Root = pathRoot,
             Context = RustEnvelopeMapper.BuildContext(context),
             Now = timeProvider.GetUtcNow().UtcDateTime,
-            Timers = new Dictionary<string, DateTime>(await timerStore.GetAllForRuleAsync(ruleId, ct)),
+            Timers = RustEnvelopeMapper.BuildTimers(await timerStore.GetAllForRuleAsync(ruleId, ct)),
         });
 
         await ApplyTimerOpsAsync(ruleId, response.TimerOps, ct);
@@ -186,7 +186,7 @@ internal sealed class RustBackedAlertEngine(
                 Root = Evaluators.AlertConditionTypeNames.AutoResolvePathRoot,
                 Context = RustEnvelopeMapper.BuildContext(context),
                 Now = timeProvider.GetUtcNow().UtcDateTime,
-                Timers = new Dictionary<string, DateTime>(await timerStore.GetAllForRuleAsync(rule.Id, ct)),
+                Timers = RustEnvelopeMapper.BuildTimers(await timerStore.GetAllForRuleAsync(rule.Id, ct)),
             });
             await ApplyTimerOpsAsync(rule.Id, response.TimerOps, ct);
             shouldResolve = response.Value;
@@ -224,7 +224,7 @@ internal sealed class RustBackedAlertEngine(
             Root = wire,
             Context = RustEnvelopeMapper.BuildContext(context),
             Now = timeProvider.GetUtcNow().UtcDateTime,
-            Timers = new Dictionary<string, DateTime>(await timerStore.GetAllForRuleAsync(rule.Id, ct)),
+            Timers = RustEnvelopeMapper.BuildTimers(await timerStore.GetAllForRuleAsync(rule.Id, ct)),
         });
         await ApplyTimerOpsAsync(rule.Id, response.TimerOps, ct);
         return response.Value;

--- a/src/API/Nocturne.API/Services/Alerts/Engines/RustEnvelopeMapper.cs
+++ b/src/API/Nocturne.API/Services/Alerts/Engines/RustEnvelopeMapper.cs
@@ -100,6 +100,29 @@ internal static class RustEnvelopeMapper
     private static readonly ConditionalWeakTable<SensorContext, object> ContextElementCache = new();
 
     /// <summary>
+    /// Copies persisted sustained timers into the envelope with every instant pinned to
+    /// <see cref="DateTimeKind.Utc"/>.
+    /// </summary>
+    /// <remarks>
+    /// Defensive rather than a live fix: <c>alert_condition_timers.first_true_at</c> is
+    /// <c>timestamp with time zone</c>, so Npgsql already hands these back as
+    /// <see cref="DateTimeKind.Utc"/>, and the replay store round-trips whatever it was given.
+    /// The reason to pin it anyway is that the crate deserialises these as
+    /// <c>DateTime&lt;Utc&gt;</c>, which requires an offset in the wire form — a
+    /// <see cref="DateTimeKind.Unspecified"/> instant serialises without one and turns the whole
+    /// call into an error envelope. This is the one instant crossing the boundary that arrives
+    /// straight from a store rather than through a projection that normalises it, so a future
+    /// column or store change would otherwise land as a silent engine failure.
+    /// </remarks>
+    public static Dictionary<string, DateTime> BuildTimers(IReadOnlyDictionary<string, DateTime> timers)
+    {
+        var wire = new Dictionary<string, DateTime>(timers.Count, StringComparer.Ordinal);
+        foreach (var (path, at) in timers)
+            wire[path] = DateTime.SpecifyKind(at, DateTimeKind.Utc);
+        return wire;
+    }
+
+    /// <summary>
     /// Projects a <see cref="SensorContext"/> onto the corpus <c>ScenarioContext</c> wire
     /// shape. Field-by-field total against the generator's <c>ScenarioModels.cs</c>
     /// (its <c>ToSensorContext</c> is the inverse of this mapping).

--- a/src/API/Nocturne.API/Services/Alerts/Engines/ShadowAlertEngine.cs
+++ b/src/API/Nocturne.API/Services/Alerts/Engines/ShadowAlertEngine.cs
@@ -65,7 +65,7 @@ internal sealed class RustShadowRuleEvaluator : IShadowRuleEvaluator
             RustEnvelopeMapper.BuildRule(rule),
             RustEnvelopeMapper.BuildContext(context),
             now,
-            timers,
+            RustEnvelopeMapper.BuildTimers(timers),
             RustEnvelopeMapper.BuildTracker(trackerState));
         var result = RustAlertEngine.GetRuleResult(response);
 
@@ -141,7 +141,26 @@ internal sealed class ShadowAlertEngine(
             snapshotError = ex;
         }
 
-        var managed = await managedEngine.EvaluateRuleAsync(rule, context, options, ct);
+        // The managed engine stays authoritative, including when it throws — the orchestrator's
+        // per-rule catch is what decides a throwing rule is skipped, so the exception has to
+        // reach it unchanged. But a throw is precisely the divergence class shadow mode is
+        // otherwise blind to: the managed evaluators NRE on a missing payload field and the rule
+        // is skipped, whereas the Rust engine fails closed to `false` — which moves an active
+        // excursion into hysteresis and lets the 30s sweep force-close a live alert. The corpus
+        // can't cover it either (the generator has no try/catch, so a throwing scenario cannot
+        // be authored). Run the secondary engine on the same pre-state so the log carries what it
+        // actually produced — the whole point is to learn which side diverges, and "managed threw"
+        // on its own says nothing about the Rust half — then rethrow untouched.
+        AlertEngineEvaluation managed;
+        try
+        {
+            managed = await managedEngine.EvaluateRuleAsync(rule, context, options, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            await LogManagedThrewAsync(rule, context, ruleRow, preTimers, preTracker, now, ex, ct);
+            throw;
+        }
 
         if (snapshotError is not null)
         {
@@ -168,6 +187,54 @@ internal sealed class ShadowAlertEngine(
         }
 
         return managed;
+    }
+
+    /// <summary>
+    /// Logs the <c>managed_threw</c> divergence, including what the secondary engine produced for
+    /// the same rule and pre-state. Runs the secondary evaluation itself because the normal
+    /// comparison path is unreachable once the managed call has thrown; the evaluation is pure, so
+    /// running it here persists nothing. Reports the Rust side as <c>(unavailable)</c> when the
+    /// pre-state snapshot failed or the rule row was missing, and as its own error when the
+    /// secondary engine also fails — never as a value it did not produce.
+    /// </summary>
+    private async Task LogManagedThrewAsync(
+        AlertRuleSnapshot rule,
+        SensorContext context,
+        AlertRule? ruleRow,
+        IReadOnlyDictionary<string, DateTime>? preTimers,
+        AlertTrackerState? preTracker,
+        DateTime now,
+        Exception managedError,
+        CancellationToken ct)
+    {
+        string shadowOutcome;
+        if (ruleRow is null || preTimers is null)
+        {
+            shadowOutcome = "(unavailable: no pre-state snapshot)";
+        }
+        else
+        {
+            try
+            {
+                var shadow = await shadowEvaluator.EvaluateAsync(
+                    ruleRow, context, now, preTimers, preTracker, ct);
+                shadowOutcome = shadow.Skipped
+                    ? "skipped"
+                    : $"root={shadow.Root} transition={shadow.Transition} auto_resolved={shadow.AutoResolved}";
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                shadowOutcome = $"threw {ex.GetType().Name}";
+            }
+        }
+
+        logger.LogWarning(managedError,
+            "AlertEngineDivergence rule={RuleId} engine={Engine} field=managed_threw managed={Managed} rust={Rust}",
+            rule.Id, shadowEvaluator.Name, $"threw {managedError.GetType().Name}", shadowOutcome);
     }
 
     /// <inheritdoc/>

--- a/src/API/Nocturne.API/Services/Alerts/RuleScopeClassBackfillService.cs
+++ b/src/API/Nocturne.API/Services/Alerts/RuleScopeClassBackfillService.cs
@@ -42,19 +42,21 @@ public sealed class RuleScopeClassBackfillService : BackgroundService
 
         try
         {
+            using var scope = _serviceProvider.CreateScope();
+            var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
+            var classifier = scope.ServiceProvider.GetRequiredService<IRuleScopeClassifier>();
+
             // Without the native engine every Classify falls back to Undirected, and the
             // recompute-and-compare below would overwrite previously-correct low/high
             // classifications with that fallback. Skip the whole scan instead of persisting it.
-            if (!AlertsInterop.IsAvailable())
+            // Asked of the classifier rather than AlertsInterop directly: it is the thing whose
+            // availability actually matters here, and it caches the probe for the process lifetime.
+            if (!classifier.IsAvailable)
             {
                 _logger.LogWarning(
                     "nocturne_alerts native library unavailable; skipping scope-class backfill to preserve stored classifications");
                 return;
             }
-
-            using var scope = _serviceProvider.CreateScope();
-            var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
-            var classifier = scope.ServiceProvider.GetRequiredService<IRuleScopeClassifier>();
 
             // Tenants are not RLS-scoped, so this list read is safe without a tenant context.
             List<Guid> tenantIds;

--- a/src/API/Nocturne.API/Services/Alerts/RuleScopeClassifier.cs
+++ b/src/API/Nocturne.API/Services/Alerts/RuleScopeClassifier.cs
@@ -21,6 +21,14 @@ public interface IRuleScopeClassifier
     /// lets a scoped <c>lows</c>/<c>highs</c> mute wrongly silence a rule.
     /// </summary>
     RuleScopeClass Classify(AlertConditionType conditionType, string conditionParamsJson);
+
+    /// <summary>
+    /// Whether the native engine backing <see cref="Classify"/> can be loaded. False means
+    /// every call returns the <see cref="RuleScopeClass.Undirected"/> fallback, so scoped
+    /// <c>lows</c>/<c>highs</c> mutes cannot narrow-match any rule — callers that would
+    /// otherwise do bulk classification should skip the work and say so once.
+    /// </summary>
+    bool IsAvailable { get; }
 }
 
 /// <inheritdoc />
@@ -29,11 +37,18 @@ public sealed class RuleScopeClassifier : IRuleScopeClassifier
     private static readonly JsonElement EmptyParams = JsonDocument.Parse("{}").RootElement.Clone();
 
     private readonly ILogger<RuleScopeClassifier> _logger;
+    private readonly Lazy<bool> _available;
 
     public RuleScopeClassifier(ILogger<RuleScopeClassifier> logger)
     {
         _logger = logger;
+        // Probed once and cached: the answer cannot change over a process lifetime, and
+        // the alternative is one failed P/Invoke per rule on every classify.
+        _available = new Lazy<bool>(AlertsInterop.IsAvailable);
     }
+
+    /// <inheritdoc />
+    public bool IsAvailable => _available.Value;
 
     /// <inheritdoc />
     public RuleScopeClass Classify(AlertConditionType conditionType, string conditionParamsJson)
@@ -57,7 +72,11 @@ public sealed class RuleScopeClassifier : IRuleScopeClassifier
             ex is RustAlertEngineException
                 or JsonException
                 or DllNotFoundException
-                or EntryPointNotFoundException)
+                or EntryPointNotFoundException
+                // A wrong-architecture cdylib (an arm64 .so on the amd64 host) throws this
+                // rather than DllNotFoundException. Without it, classification faults out of
+                // the alert-rule create/update path as a 500 instead of degrading.
+                or BadImageFormatException)
         {
             return Fallback(conditionType, ex.Message, ex);
         }

--- a/src/API/Nocturne.API/Services/Alerts/SensorContextEnricher.cs
+++ b/src/API/Nocturne.API/Services/Alerts/SensorContextEnricher.cs
@@ -204,38 +204,19 @@ internal sealed class SensorContextEnricher : ISensorContextEnricher
             // resolved below); this projects the active scheduled window if any (ADR 0004 D5).
             var scheduled = settings?.Resolve(now, enriched.TenantTimeZoneId);
 
-            // Scoped DND windows: resolve each uncleared window active-at-now into its scope.
-            var windows = await _deps.Alerts.GetUnclearedDndWindowsAsync(tenantId, ct);
-            var activeScopes = new HashSet<DndScope>();
-            foreach (var w in windows)
-            {
-                if (w.IsActiveAt(now))
-                    activeScopes.Add(w.Scope);
-            }
-            if (scheduled is not null)
-                activeScopes.Add(DndScope.All);
-
-            // ActiveDoNotDisturb drives the do_not_disturb condition leaf and the tenant-wide
-            // notion of DND, so it is non-null exactly when `all` is active — lows/highs windows
-            // feed ActiveDndScopes (the gate) only. When a manual (all-window) mute and the
-            // scheduled window are both active, the manual path takes precedence for the
-            // for_minutes anchor and source — the pre-window TenantAlertSettingsSnapshot.Resolve
-            // contract, preserved so overlap doesn't shift the elapsed-time anchor.
-            DoNotDisturbSnapshot? dnd = null;
-            if (activeScopes.Contains(DndScope.All))
-            {
-                var activeAllWindows = windows
-                    .Where(w => w.Scope == DndScope.All && w.IsActiveAt(now))
-                    .ToList();
-                dnd = activeAllWindows.Count > 0
-                    ? new DoNotDisturbSnapshot(activeAllWindows.Min(w => w.StartedAt), "manual")
-                    : new DoNotDisturbSnapshot(scheduled!.StartedAt, scheduled.Source);
-            }
+            // Scoped DND windows + scheduled DND, folded into the active scope set and the
+            // tenant-wide projection by the shared resolver — the same call replay makes (there
+            // receipt-gated), so the live gate and replay cannot drift on how a window resolves.
+            // The read is bounded by expiry: a window that merely runs out is never cleared, so
+            // filtering on cleared_at alone would return every timed mute the tenant has ever set,
+            // on a path that runs once per reading.
+            var windows = await _deps.Alerts.GetUnexpiredDndWindowsAsync(tenantId, now, ct);
+            var dnd = DndWindowResolver.Resolve(windows, now, receiptGated: false, scheduled);
 
             enriched = enriched with
             {
-                ActiveDoNotDisturb = dnd,
-                ActiveDndScopes = activeScopes,
+                ActiveDoNotDisturb = dnd.ActiveDoNotDisturb,
+                ActiveDndScopes = dnd.Scopes,
             };
         }
 

--- a/src/API/Nocturne.API/Validators/Alerts/UpdateTenantAlertSettingsRequestValidator.cs
+++ b/src/API/Nocturne.API/Validators/Alerts/UpdateTenantAlertSettingsRequestValidator.cs
@@ -10,7 +10,10 @@ namespace Nocturne.API.Validators.Alerts;
 /// <list type="bullet">
 /// <item><description>When the schedule is enabled, both start and end must be set; cross-midnight
 /// windows are allowed so start &gt;= end is intentionally not rejected.</description></item>
-/// <item><description><c>DndManualUntil</c>, when present, must be in the future.</description></item>
+/// <item><description><c>DndManualUntil</c> must be in the future, but only when the request is
+/// actually turning manual DND on. An absent <c>DndManualActive</c> means "leave the mute alone",
+/// so the controller never reads the expiry — rejecting a schedule-only save that merely echoed a
+/// now-stale value back would 400 it over a field the server ignores.</description></item>
 /// </list>
 /// </remarks>
 public class UpdateTenantAlertSettingsRequestValidator
@@ -28,6 +31,7 @@ public class UpdateTenantAlertSettingsRequestValidator
 
         RuleFor(x => x.DndManualUntil)
             .Must(t => !t.HasValue || t.Value > DateTime.UtcNow)
+            .When(x => x.DndManualActive == true)
             .WithMessage("DndManualUntil must be in the future");
     }
 }

--- a/src/Core/Nocturne.Core.Alerts.Native/AlertsInterop.cs
+++ b/src/Core/Nocturne.Core.Alerts.Native/AlertsInterop.cs
@@ -173,6 +173,13 @@ public static partial class AlertsInterop
         {
             return false;
         }
+        catch (BadImageFormatException)
+        {
+            // A cdylib built for the wrong architecture (an arm64 .so on an amd64 host)
+            // loads far enough to fail here rather than to not be found at all. Treat it
+            // as unavailable so callers take their degraded path instead of faulting.
+            return false;
+        }
     }
 
     #endregion

--- a/src/Core/Nocturne.Core.Contracts/Alerts/IAlertRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/Alerts/IAlertRepository.cs
@@ -127,14 +127,22 @@ public interface IAlertRepository
     Task<TenantAlertSettingsSnapshot> GetTenantAlertSettingsAsync(Guid tenantId, CancellationToken ct);
 
     /// <summary>
-    /// Returns the tenant's uncleared DND windows (<c>cleared_at IS NULL</c>) as resolver
-    /// snapshots, for scoped Do Not Disturb (ADR 0004 D5). Every <see cref="DateTime"/> is
-    /// normalised to <see cref="DateTimeKind.Utc"/> so <see cref="DndWindowSnapshot.IsActiveAt"/>
-    /// (naive comparison) is sound. The caller resolves active-at-now; the enricher folds the
-    /// active scopes into <see cref="SensorContext.ActiveDndScopes"/>. Backed by the partial
-    /// index on <c>(tenant_id, scope) WHERE cleared_at IS NULL</c>.
+    /// Returns the tenant's DND windows that can still take effect at or after
+    /// <paramref name="nowUtc"/> — uncleared (<c>cleared_at IS NULL</c>) <b>and</b> not past
+    /// their expiry — as resolver snapshots, for scoped Do Not Disturb (ADR 0004 D5). Every
+    /// <see cref="DateTime"/> is normalised to <see cref="DateTimeKind.Utc"/> so
+    /// <see cref="DndWindowSnapshot.IsActiveAt"/> (naive comparison) is sound.
     /// </summary>
-    Task<IReadOnlyList<DndWindowSnapshot>> GetUnclearedDndWindowsAsync(Guid tenantId, CancellationToken ct);
+    /// <remarks>
+    /// The expiry bound is what keeps this bounded. A window that simply runs out is never
+    /// cleared — <c>cleared_at</c> stays null for audit — so filtering on <c>cleared_at</c>
+    /// alone would return every timed mute the tenant has ever set, growing without limit on a
+    /// path that runs once per glucose reading. The partial index on
+    /// <c>(tenant_id, scope) WHERE cleared_at IS NULL</c> still serves the lookup; only rows
+    /// that can still matter come back.
+    /// </remarks>
+    Task<IReadOnlyList<DndWindowSnapshot>> GetUnexpiredDndWindowsAsync(
+        Guid tenantId, DateTime nowUtc, CancellationToken ct);
 
     /// <summary>
     /// Returns every DND window for the tenant received by <paramref name="asOfReceiptUtc"/>

--- a/src/Core/Nocturne.Core.Models/Alerts/DndWindowResolver.cs
+++ b/src/Core/Nocturne.Core.Models/Alerts/DndWindowResolver.cs
@@ -1,0 +1,104 @@
+namespace Nocturne.Core.Models.Alerts;
+
+/// <summary>
+/// The Do Not Disturb picture at one instant: which scopes are in force, and the
+/// tenant-wide projection that drives the <c>do_not_disturb</c> condition leaf.
+/// </summary>
+/// <param name="Scopes">
+/// The active scopes, for <see cref="DndSuppressionGate"/>. Empty when no DND is active.
+/// </param>
+/// <param name="ActiveDoNotDisturb">
+/// Non-null exactly when <paramref name="Scopes"/> contains <see cref="DndScope.All"/> —
+/// <c>lows</c>/<c>highs</c> windows are gate-only and never trip the condition leaf.
+/// </param>
+/// <remarks>
+/// A record class, not a <c>readonly record struct</c>: a struct's <c>default</c> would carry a
+/// null <see cref="Scopes"/> and NRE on the first membership test, and there is no useful
+/// "empty resolution" literal — the only way to obtain one is <see cref="DndWindowResolver.Resolve"/>.
+/// </remarks>
+public sealed record DndResolution(
+    IReadOnlySet<DndScope> Scopes,
+    DoNotDisturbSnapshot? ActiveDoNotDisturb);
+
+/// <summary>
+/// Resolves a tenant's DND windows (plus scheduled DND) into the <see cref="DndResolution"/>
+/// the evaluation context carries. The single resolver for both paths: the live enricher and
+/// the replay walker call this instead of each assembling the scope set and the
+/// <see cref="DoNotDisturbSnapshot"/> themselves, so the two cannot drift on how a window
+/// resolves (ADR 0004 D5).
+/// </summary>
+/// <remarks>
+/// Shared window resolution is not the same as identical DND state: replay passes no
+/// <c>scheduled</c> projection, because a recurring schedule's past state is not reconstructible
+/// from the settings row as it stands today. Live and replay therefore still differ whenever
+/// scheduled DND is on — the windows half is what this guarantees.
+/// </remarks>
+/// <seealso cref="DndWindowSnapshot"/>
+/// <seealso cref="DndSuppressionGate"/>
+public static class DndWindowResolver
+{
+    /// <summary>Shared empty set so the common no-DND instant allocates nothing.</summary>
+    private static readonly IReadOnlySet<DndScope> NoScopes = new HashSet<DndScope>();
+
+    /// <summary>
+    /// The DND state in force at <paramref name="atUtc"/>.
+    /// </summary>
+    /// <param name="windows">The tenant's candidate windows (uncleared, or — for replay — receipt-bounded).</param>
+    /// <param name="atUtc">The evaluation instant.</param>
+    /// <param name="receiptGated">
+    /// <see langword="true"/> for replay: a window only counts once the server had received it
+    /// (<see cref="DndWindowSnapshot.WasActiveAt"/>), so replay never retroactively suppresses
+    /// the offline-authoring gap. <see langword="false"/> for the live path.
+    /// </param>
+    /// <param name="scheduled">
+    /// The active scheduled-DND projection, when any. Scheduled DND is tenant-wide, so it
+    /// contributes <see cref="DndScope.All"/> — but an active manual all-window *outranks* it as
+    /// the <c>for_minutes</c> anchor and source, so overlap never shifts the elapsed-time anchor.
+    /// </param>
+    public static DndResolution Resolve(
+        IEnumerable<DndWindowSnapshot> windows,
+        DateTime atUtc,
+        bool receiptGated,
+        TenantAlertSettingsSnapshot.ActiveProjection? scheduled = null)
+    {
+        HashSet<DndScope>? scopes = null;
+        DateTime? earliestAllStartedAt = null;
+
+        foreach (var window in windows)
+        {
+            var active = receiptGated ? window.WasActiveAt(atUtc) : window.IsActiveAt(atUtc);
+            if (!active)
+                continue;
+
+            (scopes ??= new HashSet<DndScope>()).Add(window.Scope);
+
+            if (window.Scope == DndScope.All
+                && (earliestAllStartedAt is null || window.StartedAt < earliestAllStartedAt))
+            {
+                earliestAllStartedAt = window.StartedAt;
+            }
+        }
+
+        if (scheduled is not null)
+            (scopes ??= new HashSet<DndScope>()).Add(DndScope.All);
+
+        var resolvedScopes = scopes is null ? NoScopes : scopes;
+
+        // Anchor for_minutes on the earliest active all-window (a manual mute) when there is
+        // one, and only fall back to the scheduled projection otherwise. Manual-wins is the
+        // pre-window `TenantAlertSettingsSnapshot.Resolve` contract — it checked the manual path
+        // first — and keeping it means a scheduled window opening on top of a running manual mute
+        // does not restart the elapsed-time anchor under a sustained `do_not_disturb` condition.
+        DoNotDisturbSnapshot? dnd = null;
+        if (resolvedScopes.Contains(DndScope.All))
+        {
+            dnd = earliestAllStartedAt is { } startedAt
+                ? new DoNotDisturbSnapshot(startedAt, "manual")
+                // Unreachable unless `scheduled` put All in the set, so the ! is sound; All is
+                // only ever present because one of these two branches produced it.
+                : new DoNotDisturbSnapshot(scheduled!.StartedAt, scheduled.Source);
+        }
+
+        return new DndResolution(resolvedScopes, dnd);
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/DndWindowEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/DndWindowEntity.cs
@@ -14,9 +14,10 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// <remarks>
 /// Rows are retained after they expire or are cleared (audit). Effective state is
 /// resolved on read — not cleared, started, not past <see cref="EndsAt"/> — never a
-/// stored "active" flag. The one-active-window-per-scope invariant is enforced on
-/// create (a same-scope window is superseded, its <see cref="ClearedBy"/> stamped
-/// <c>system:superseded</c>). <see cref="CreatedAt"/> is the server **receipt** time;
+/// stored "active" flag. The one-active-window-per-scope-per-instant invariant is
+/// enforced on create (a same-scope window whose span *overlaps* is superseded, its
+/// <see cref="ClearedBy"/> stamped <c>system:superseded</c>; one scheduled for a
+/// non-overlapping span is left alone). <see cref="CreatedAt"/> is the server **receipt** time;
 /// replay's "active at T" check uses it so it never retroactively suppresses the
 /// offline-authoring gap.
 /// </remarks>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/AlertRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/AlertRepository.cs
@@ -357,8 +357,8 @@ public class AlertRepository : IAlertRepository
     }
 
     /// <inheritdoc/>
-    public virtual async Task<IReadOnlyList<DndWindowSnapshot>> GetUnclearedDndWindowsAsync(
-        Guid tenantId, CancellationToken ct)
+    public virtual async Task<IReadOnlyList<DndWindowSnapshot>> GetUnexpiredDndWindowsAsync(
+        Guid tenantId, DateTime nowUtc, CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
         context.TenantId = tenantId;
@@ -366,9 +366,16 @@ public class AlertRepository : IAlertRepository
         // Project the raw columns first, then map in memory: DateTime.SpecifyKind isn't SQL-
         // translatable, and Npgsql can read a `timestamp` column back as Unspecified, which
         // would compare wrongly against the Utc `now` in DndWindowSnapshot's naive comparison.
+        //
+        // The ends_at bound is load-bearing rather than an optimisation: a window that simply
+        // runs out is never cleared (the row is kept for audit), so filtering on cleared_at
+        // alone returns every timed mute the tenant has ever set — on a query that runs once
+        // per glucose reading.
         var rows = await context.DndWindows
             .AsNoTracking()
-            .Where(w => w.TenantId == tenantId && w.ClearedAt == null)
+            .Where(w => w.TenantId == tenantId
+                        && w.ClearedAt == null
+                        && (w.EndsAt == null || w.EndsAt > nowUtc))
             .Select(w => new { w.Scope, w.StartedAt, w.EndsAt, w.CreatedAt })
             .ToListAsync(ct);
 

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/DndWindowRepositoryTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/DndWindowRepositoryTests.cs
@@ -1,0 +1,249 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Nocturne.Core.Models.Alerts;
+using Nocturne.Infrastructure.Data.Extensions;
+using Nocturne.Infrastructure.Data.Repositories;
+using Nocturne.Infrastructure.Data.Tests.Rls;
+using Npgsql;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests;
+
+/// <summary>
+/// The DND-window reads behind scoped Do Not Disturb (ADR 0004 D5), against real Postgres.
+/// </summary>
+/// <remarks>
+/// These belong here rather than with the unit tests because the behaviour under test *is* the
+/// SQL predicate. Every unit test of the enricher and the replay walker mocks
+/// <c>IAlertRepository</c>, so nothing there can catch the live read regressing to "every
+/// uncleared row" — which is unbounded, since a window that merely expires is never cleared and
+/// the read runs once per glucose reading.
+/// </remarks>
+[Trait("Category", "Integration")]
+[Collection("RLS completeness")]
+public class DndWindowRepositoryTests
+{
+    private readonly RlsCompletenessFixture _fx;
+
+    public DndWindowRepositoryTests(RlsCompletenessFixture fx) => _fx = fx;
+
+    [Fact]
+    public async Task GetUnexpiredDndWindows_excludesExpiredAndClearedWindows()
+    {
+        var tenant = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedTenantAsync(tenant);
+
+        await using var provider = BuildProvider();
+        var repository = NewRepository(provider);
+
+        // Two rows that must come back...
+        await InsertWindowAsync(tenant, DndScope.All, now.AddMinutes(-30), endsAt: null);
+        await InsertWindowAsync(tenant, DndScope.Lows, now.AddMinutes(-10), endsAt: now.AddHours(1));
+        // ...and three that must not.
+        await InsertWindowAsync(tenant, DndScope.Highs, now.AddHours(-4), endsAt: now.AddHours(-3));
+        await InsertWindowAsync(tenant, DndScope.Highs, now.AddDays(-30), endsAt: now.AddDays(-30).AddHours(8));
+        await InsertWindowAsync(tenant, DndScope.Lows, now.AddMinutes(-20), endsAt: null, clearedAt: now.AddMinutes(-1));
+
+        var windows = await repository.GetUnexpiredDndWindowsAsync(tenant, now, CancellationToken.None);
+
+        windows.Should().HaveCount(2, "expired and cleared windows must not reach the evaluation path");
+        windows.Select(w => w.Scope).Should().BeEquivalentTo(new[] { DndScope.All, DndScope.Lows });
+    }
+
+    /// <summary>
+    /// The rows are retained for audit, so the exclusion has to come from the query rather than
+    /// from deleting anything — this is what keeps the per-reading read bounded.
+    /// </summary>
+    [Fact]
+    public async Task GetUnexpiredDndWindows_leavesTheExpiredRowsInPlace()
+    {
+        var tenant = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedTenantAsync(tenant);
+
+        await using var provider = BuildProvider();
+        var repository = NewRepository(provider);
+
+        for (var day = 1; day <= 5; day++)
+        {
+            await InsertWindowAsync(
+                tenant, DndScope.All, now.AddDays(-day), endsAt: now.AddDays(-day).AddHours(1));
+        }
+
+        (await repository.GetUnexpiredDndWindowsAsync(tenant, now, CancellationToken.None))
+            .Should().BeEmpty();
+
+        await using var context = await provider
+            .GetRequiredService<IDbContextFactory<NocturneDbContext>>()
+            .CreateDbContextAsync();
+        context.TenantId = tenant;
+        (await context.DndWindows.CountAsync()).Should().Be(5, "cleared/expired rows are audit history");
+    }
+
+    /// <summary>
+    /// A window is unexpired up to but not including its <c>ends_at</c>, matching
+    /// <see cref="DndWindowSnapshot.IsActiveAt"/>'s half-open <c>atUtc &lt; ends</c>.
+    /// </summary>
+    [Fact]
+    public async Task GetUnexpiredDndWindows_treatsEndsAtAsExclusive()
+    {
+        var tenant = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedTenantAsync(tenant);
+
+        await using var provider = BuildProvider();
+        var repository = NewRepository(provider);
+
+        var endsAt = now.AddMinutes(15);
+        await InsertWindowAsync(tenant, DndScope.All, now.AddMinutes(-5), endsAt);
+
+        (await repository.GetUnexpiredDndWindowsAsync(tenant, endsAt.AddSeconds(-1), CancellationToken.None))
+            .Should().HaveCount(1);
+        (await repository.GetUnexpiredDndWindowsAsync(tenant, endsAt, CancellationToken.None))
+            .Should().BeEmpty("ends_at is exclusive, so the window is over at exactly that instant");
+    }
+
+    /// <summary>
+    /// Replay needs cleared and expired windows (it resolves <c>cleared_at</c> per tick), so the
+    /// receipt-bounded read must not inherit the live read's expiry filter.
+    /// </summary>
+    [Fact]
+    public async Task GetDndWindowsAsOf_stillReturnsClearedAndExpiredWindows()
+    {
+        var tenant = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedTenantAsync(tenant);
+
+        await using var provider = BuildProvider();
+        var repository = NewRepository(provider);
+
+        await InsertWindowAsync(tenant, DndScope.All, now.AddHours(-4), endsAt: now.AddHours(-3));
+        await InsertWindowAsync(tenant, DndScope.Lows, now.AddHours(-2), endsAt: null, clearedAt: now.AddHours(-1));
+
+        var windows = await repository.GetDndWindowsAsOfAsync(tenant, now, CancellationToken.None);
+
+        windows.Should().HaveCount(2);
+        windows.Should().Contain(w => w.ClearedAt != null);
+        windows.Should().Contain(w => w.EndsAt != null && w.ClearedAt == null);
+    }
+
+    [Fact]
+    public async Task GetUnexpiredDndWindows_isScopedToTheTenant()
+    {
+        var mine = Guid.NewGuid();
+        var theirs = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedTenantAsync(mine);
+        await SeedTenantAsync(theirs);
+
+        await using var provider = BuildProvider();
+        var repository = NewRepository(provider);
+
+        await InsertWindowAsync(mine, DndScope.Lows, now.AddMinutes(-5), endsAt: null);
+        await InsertWindowAsync(theirs, DndScope.All, now.AddMinutes(-5), endsAt: null);
+
+        var windows = await repository.GetUnexpiredDndWindowsAsync(mine, now, CancellationToken.None);
+
+        windows.Should().ContainSingle().Which.Scope.Should().Be(DndScope.Lows);
+    }
+
+    /// <summary>
+    /// Every returned instant must be <see cref="DateTimeKind.Utc"/>: the snapshot's active-at
+    /// checks compare naively against a UTC "now", so an Unspecified instant read back from the
+    /// column would resolve against the wrong offset.
+    /// </summary>
+    [Fact]
+    public async Task GetUnexpiredDndWindows_normalisesEveryInstantToUtc()
+    {
+        var tenant = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        await SeedTenantAsync(tenant);
+
+        await using var provider = BuildProvider();
+        var repository = NewRepository(provider);
+
+        await InsertWindowAsync(tenant, DndScope.All, now.AddMinutes(-5), endsAt: now.AddHours(2));
+
+        var window = (await repository.GetUnexpiredDndWindowsAsync(tenant, now, CancellationToken.None)).Single();
+
+        window.StartedAt.Kind.Should().Be(DateTimeKind.Utc);
+        window.EndsAt!.Value.Kind.Should().Be(DateTimeKind.Utc);
+        window.CreatedAt.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    // ---- helpers ----
+
+    private ServiceProvider BuildProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHttpContextAccessor();
+        services.AddPostgreSqlInfrastructure(_fx.AppConnectionString);
+        return services.BuildServiceProvider();
+    }
+
+    private static AlertRepository NewRepository(ServiceProvider provider) =>
+        new(provider.GetRequiredService<IDbContextFactory<NocturneDbContext>>());
+
+    private async Task SeedTenantAsync(Guid tenantId)
+    {
+        await using var conn = await _fx.OpenMigratorConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            INSERT INTO tenants (id, slug, display_name, is_active, sys_created_at, sys_updated_at)
+            VALUES (@id, @slug, 'dnd-window-repo-test', true, now(), now())
+            """;
+        AddParam(cmd, "@id", tenantId);
+        AddParam(cmd, "@slug", $"dnd-{tenantId:N}");
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task InsertWindowAsync(
+        Guid tenantId,
+        DndScope scope,
+        DateTime startedAt,
+        DateTime? endsAt,
+        DateTime? clearedAt = null)
+    {
+        await using var conn = await _fx.OpenMigratorConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        // dnd_windows is FORCE ROW LEVEL SECURITY, so the policy's WITH CHECK applies even to the
+        // migrator role — the tenant context has to be set for the INSERT to be admitted at all.
+        cmd.CommandText = """
+            SELECT set_config('app.current_tenant_id', @tid::text, false);
+            INSERT INTO dnd_windows
+                (id, tenant_id, scope, started_at, ends_at, cleared_at, source, created_at)
+            VALUES
+                (gen_random_uuid(), @tid, @scope, @started, @ends, @cleared, 'test', @started)
+            """;
+        AddParam(cmd, "@tid", tenantId);
+        AddParam(cmd, "@scope", ScopeWire(scope));
+        AddParam(cmd, "@started", startedAt);
+        AddParam(cmd, "@ends", endsAt);
+        AddParam(cmd, "@cleared", clearedAt);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    /// <summary>
+    /// The storage form of the scope enum. Spelled out rather than derived so a change to the
+    /// converter has to be made deliberately here too — the column is <c>text</c>, and a silent
+    /// casing change would make every one of these reads return nothing.
+    /// </summary>
+    private static string ScopeWire(DndScope scope) => scope switch
+    {
+        DndScope.Lows => "lows",
+        DndScope.Highs => "highs",
+        DndScope.All => "all",
+        _ => throw new ArgumentOutOfRangeException(nameof(scope)),
+    };
+
+    private static void AddParam(NpgsqlCommand cmd, string name, object? value)
+    {
+        var p = cmd.CreateParameter();
+        p.ParameterName = name;
+        p.Value = value ?? DBNull.Value;
+        cmd.Parameters.Add(p);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Monitoring/DndWindowsControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Monitoring/DndWindowsControllerTests.cs
@@ -252,6 +252,150 @@ public class DndWindowsControllerTests
         result.Result.Should().BeOfType<BadRequestObjectResult>();
     }
 
+    [Fact]
+    public async Task Create_rejectsAMissingScope()
+    {
+        var (controller, _) = NewController();
+
+        // An omitted scope must not fall through to the zero enum member (lows) — a malformed
+        // request that silently mutes low alerts is worse than a 400.
+        var result = await controller.Create(
+            new CreateDndWindowRequest { Id = Guid.NewGuid(), Scope = null, StartedAt = Now },
+            CancellationToken.None);
+
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task Create_leavesANonOverlappingFutureWindowAlone()
+    {
+        var (controller, options) = NewController();
+        var futureId = Guid.NewGuid();
+
+        // A mute scheduled for later tonight...
+        await controller.Create(
+            new CreateDndWindowRequest
+            {
+                Id = futureId,
+                Scope = DndScope.All,
+                StartedAt = Now.AddHours(6),
+                EndsAt = Now.AddHours(14),
+            },
+            CancellationToken.None);
+
+        // ...must survive a short mute taken out now that ends before it begins. Adding one mute
+        // says nothing about a span it never reaches.
+        await controller.Create(
+            new CreateDndWindowRequest
+            {
+                Id = Guid.NewGuid(),
+                Scope = DndScope.All,
+                StartedAt = Now,
+                EndsAt = Now.AddMinutes(30),
+            },
+            CancellationToken.None);
+
+        await using var db = new NocturneDbContext(options) { TenantId = Tenant };
+        var future = await db.DndWindows.SingleAsync(w => w.Id == futureId);
+        future.ClearedAt.Should().BeNull();
+        future.ClearedBy.Should().BeNull();
+        future.EndsAt.Should().BeCloseTo(Now.AddHours(14), TimeSpan.FromSeconds(1), "not truncated either");
+    }
+
+    [Fact]
+    public async Task Create_clearsAFutureWindowTheNewSpanWhollyCovers()
+    {
+        var (controller, options) = NewController();
+        var futureId = Guid.NewGuid();
+
+        await controller.Create(
+            new CreateDndWindowRequest
+            {
+                Id = futureId,
+                Scope = DndScope.All,
+                StartedAt = Now.AddHours(2),
+                EndsAt = Now.AddHours(4),
+            },
+            CancellationToken.None);
+
+        // An open-ended mute from now on covers the scheduled span, so the scheduled one goes —
+        // otherwise both would be active from +2h and the resolver would report the earlier
+        // one's expiry while the later kept suppressing past it.
+        await controller.Create(Request(Guid.NewGuid(), DndScope.All), CancellationToken.None);
+
+        await using var db = new NocturneDbContext(options) { TenantId = Tenant };
+        var future = await db.DndWindows.SingleAsync(w => w.Id == futureId);
+        future.ClearedAt.Should().NotBeNull();
+        future.ClearedBy.Should().Be(DndWindowsController.SupersededBy);
+    }
+
+    /// <summary>
+    /// A running mute is handed over at the boundary rather than switched off: it keeps suppressing
+    /// until the new window starts, and only one of the two is ever active at a given instant.
+    /// </summary>
+    [Fact]
+    public async Task Create_truncatesARunningWindowThatTheNewSpanOverlaps()
+    {
+        var (controller, options) = NewController();
+        var runningId = Guid.NewGuid();
+
+        await controller.Create(
+            new CreateDndWindowRequest
+            {
+                Id = runningId,
+                Scope = DndScope.All,
+                StartedAt = Now.AddHours(-1),
+                EndsAt = null,
+            },
+            CancellationToken.None);
+
+        var laterStart = Now.AddHours(10);
+        await controller.Create(
+            new CreateDndWindowRequest
+            {
+                Id = Guid.NewGuid(),
+                Scope = DndScope.All,
+                StartedAt = laterStart,
+                EndsAt = Now.AddHours(18),
+            },
+            CancellationToken.None);
+
+        await using var db = new NocturneDbContext(options) { TenantId = Tenant };
+        var running = await db.DndWindows.SingleAsync(w => w.Id == runningId);
+        running.ClearedAt.Should().BeNull("the mute is still in force until the new one starts");
+        running.EndsAt.Should().BeCloseTo(laterStart, TimeSpan.FromSeconds(1));
+
+        // Still muted right now, and exactly one window is active.
+        var active = OkValue(await controller.GetActive(CancellationToken.None));
+        active.Should().ContainSingle().Which.Id.Should().Be(runningId);
+    }
+
+    [Fact]
+    public async Task Create_doesNotStampSupersededOnAnAlreadyExpiredWindow()
+    {
+        var (controller, options) = NewController();
+        var expiredId = Guid.NewGuid();
+
+        await controller.Create(
+            new CreateDndWindowRequest
+            {
+                Id = expiredId,
+                Scope = DndScope.Highs,
+                StartedAt = Now.AddHours(-3),
+                EndsAt = Now.AddHours(-2),
+            },
+            CancellationToken.None);
+
+        await controller.Create(Request(Guid.NewGuid(), DndScope.Highs), CancellationToken.None);
+
+        // The window ran out on its own; rewriting it as system:superseded would falsify the
+        // audit trail these rows are retained for.
+        await using var db = new NocturneDbContext(options) { TenantId = Tenant };
+        var expired = await db.DndWindows.SingleAsync(w => w.Id == expiredId);
+        expired.ClearedAt.Should().BeNull();
+        expired.ClearedBy.Should().BeNull();
+    }
+
     // ---- helpers ----
 
     private static CreateDndWindowRequest Request(Guid id, DndScope scope) => new()

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Monitoring/TenantAlertSettingsControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Monitoring/TenantAlertSettingsControllerTests.cs
@@ -146,6 +146,54 @@ public class TenantAlertSettingsControllerTests
         got.DndScheduleEnd.Should().Be(new TimeOnly(7, 0));
     }
 
+    [Fact]
+    public async Task AnOmittedManualToggle_leavesTheMuteAlone()
+    {
+        var (controller, options) = NewController();
+        var muted = OkValue(await controller.Update(
+            new UpdateTenantAlertSettingsRequest { DndManualActive = true }, CancellationToken.None));
+
+        // A save that only touches the schedule — dndManualActive absent. dnd_windows is shared
+        // with DndWindowsController (devices post to it directly), so an absent toggle must not
+        // be read as "off" and cancel a mute this request said nothing about.
+        var resp = OkValue(await controller.Update(
+            new UpdateTenantAlertSettingsRequest
+            {
+                DndManualActive = null,
+                DndScheduleEnabled = true,
+                DndScheduleStart = new TimeOnly(22, 0),
+                DndScheduleEnd = new TimeOnly(7, 0),
+            },
+            CancellationToken.None));
+
+        resp.DndManualActive.Should().BeTrue();
+        resp.DndManualStartedAt.Should().Be(muted.DndManualStartedAt);
+        resp.DndScheduleEnabled.Should().BeTrue();
+
+        await using var db = new NocturneDbContext(options) { TenantId = Tenant };
+        (await db.DndWindows.CountAsync(w => w.Scope == DndScope.All && w.ClearedAt == null)).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task AnOmittedManualToggle_doesNotRewriteTheMutesExpiry()
+    {
+        var (controller, options) = NewController();
+        var until = DateTime.UtcNow.AddMinutes(30);
+        await controller.Update(
+            new UpdateTenantAlertSettingsRequest { DndManualActive = true, DndManualUntil = until },
+            CancellationToken.None);
+
+        // Without the manual toggle, a timed mute must keep its expiry rather than being
+        // silently promoted to indefinite by a schedule-only save.
+        await controller.Update(
+            new UpdateTenantAlertSettingsRequest { DndManualActive = null, DndScheduleEnabled = true },
+            CancellationToken.None);
+
+        await using var db = new NocturneDbContext(options) { TenantId = Tenant };
+        var window = await db.DndWindows.SingleAsync(w => w.Scope == DndScope.All && w.ClearedAt == null);
+        window.EndsAt.Should().BeCloseTo(until, TimeSpan.FromSeconds(1));
+    }
+
     // ---- helpers ----
 
     private static (TenantAlertSettingsController Controller, DbContextOptions<NocturneDbContext> Options) NewController()

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/AlertReplayServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/AlertReplayServiceTests.cs
@@ -54,7 +54,7 @@ public class AlertReplayServiceTests
             .Setup(r => r.GetDndWindowsAsOfAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<DndWindowSnapshot>());
         _alertRepository
-            .Setup(r => r.GetUnclearedDndWindowsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetUnexpiredDndWindowsAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<DndWindowSnapshot>());
 
         var enricherDeps = new SensorContextEnricherDependencies(

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/Engines/ShadowAlertEngineTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/Engines/ShadowAlertEngineTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text.Json;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Nocturne.Alerts.ParityCorpus.Generator.Harness;
@@ -166,6 +167,77 @@ public class ShadowAlertEngineTests
         (await timerStore.GetAllForRuleAsync(RuleId, CancellationToken.None)).Should().BeEmpty();
         var state = await trackerRepo.GetTrackerStateAsync(RuleId, CancellationToken.None);
         state!.State.Should().Be("active", "the managed write is the only persisted state");
+    }
+
+    /// <summary>
+    /// A managed throw is the one divergence class a comparison after the fact cannot see: the
+    /// managed evaluators throw and the orchestrator skips the rule, while the Rust engine fails
+    /// closed to <c>false</c> — which moves an active excursion into hysteresis and lets the sweep
+    /// force-close a live alert. Shadow mode has to surface it, and must still let the exception
+    /// through so the orchestrator's per-rule catch keeps deciding what a throwing rule means.
+    /// </summary>
+    [Fact]
+    public async Task Managed_throwing_logs_a_managed_threw_divergence_and_rethrows()
+    {
+        var rule = BuildThresholdRule();
+        rule.ConditionParams = "{ this is not json";
+        // The secondary engine reaches a definite answer where managed threw — the shape of the
+        // real divergence: managed skips the rule, the secondary carries on and returns false.
+        var fake = new FakeShadowEvaluator(() => new ShadowRuleOutcome
+        {
+            Root = false,
+            Transition = "hysteresis_started",
+            AutoResolved = false,
+            PostTimers = new Dictionary<string, DateTime>(),
+            PostTrackerState = "hysteresis",
+            PostConfirmationCount = 0,
+            PostHasActiveExcursion = true,
+        });
+        var (engine, logger, timerStore, trackerRepo, provider) = BuildShadowEngine(rule, fake);
+        await using var _ = provider;
+
+        var act = async () => await engine.EvaluateRuleAsync(
+            ToSnapshot(rule), LowGlucoseContext(), AlertEngineOptions.Default, CancellationToken.None);
+
+        await act.Should().ThrowAsync<JsonException>(
+            "the managed engine stays authoritative, throws included");
+
+        // The log has to carry what the secondary engine actually produced. Reporting a Rust
+        // outcome without running it would let an operator "confirm" a divergence class from a
+        // line that never observed the Rust half.
+        fake.Calls.Should().Be(1, "the secondary engine must run so its outcome can be reported");
+        var divergence = logger.Entries.Should().ContainSingle(e =>
+            e.Level == LogLevel.Warning
+            && e.Message.Contains("AlertEngineDivergence")
+            && e.Message.Contains("field=managed_threw")).Subject;
+        divergence.Message.Should().Contain("managed=threw JsonException");
+        divergence.Message.Should().Contain("root=False");
+        divergence.Message.Should().Contain("transition=hysteresis_started");
+
+        // Still side-effect-free: the shadow run persists nothing, and managed threw before it
+        // could write anything either.
+        timerStore.DrainOps().Should().BeEmpty();
+        (await trackerRepo.GetTrackerStateAsync(RuleId, CancellationToken.None)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Managed_throwing_reports_the_secondary_engines_own_failure_rather_than_a_value()
+    {
+        var rule = BuildThresholdRule();
+        rule.ConditionParams = "{ this is not json";
+        var fake = new FakeShadowEvaluator(throws: new InvalidOperationException("rust exploded"));
+        var (engine, logger, _, _, provider) = BuildShadowEngine(rule, fake);
+        await using var _ = provider;
+
+        var act = async () => await engine.EvaluateRuleAsync(
+            ToSnapshot(rule), LowGlucoseContext(), AlertEngineOptions.Default, CancellationToken.None);
+
+        await act.Should().ThrowAsync<JsonException>();
+
+        // Both engines failing is not the divergence class; the line must say so.
+        var divergence = logger.Entries.Should().ContainSingle(e =>
+            e.Message.Contains("field=managed_threw")).Subject;
+        divergence.Message.Should().Contain("rust=threw InvalidOperationException");
     }
 
     [NativeFact]

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/SensorContextEnricherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/SensorContextEnricherTests.cs
@@ -53,7 +53,7 @@ public class SensorContextEnricherTests
         // The repo never returns null; default the new DND-windows fetch to empty so the
         // unconditional enrichment block is exercised. Per-test setups override this.
         _alertRepository
-            .Setup(r => r.GetUnclearedDndWindowsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetUnexpiredDndWindowsAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<DndWindowSnapshot>());
     }
 
@@ -671,7 +671,7 @@ public class SensorContextEnricherTests
     {
         var now = _timeProvider.GetUtcNow().UtcDateTime;
         _alertRepository
-            .Setup(r => r.GetUnclearedDndWindowsAsync(_tenantId, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetUnexpiredDndWindowsAsync(_tenantId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<DndWindowSnapshot>
             {
                 new(DndScope.Lows, StartedAt: now.AddMinutes(-5), EndsAt: null, ClearedAt: null, CreatedAt: now.AddMinutes(-5)),
@@ -693,7 +693,7 @@ public class SensorContextEnricherTests
         var now = _timeProvider.GetUtcNow().UtcDateTime;
         var startedAt = now.AddMinutes(-30);
         _alertRepository
-            .Setup(r => r.GetUnclearedDndWindowsAsync(_tenantId, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetUnexpiredDndWindowsAsync(_tenantId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<DndWindowSnapshot>
             {
                 new(DndScope.All, StartedAt: startedAt, EndsAt: null, ClearedAt: null, CreatedAt: startedAt),
@@ -746,7 +746,7 @@ public class SensorContextEnricherTests
                 DndScheduleStart: new TimeOnly(0, 0),
                 DndScheduleEnd: new TimeOnly(23, 0)));
         _alertRepository
-            .Setup(r => r.GetUnclearedDndWindowsAsync(_tenantId, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetUnexpiredDndWindowsAsync(_tenantId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<DndWindowSnapshot>
             {
                 new(DndScope.All, StartedAt: manualStartedAt, EndsAt: null, ClearedAt: null, CreatedAt: manualStartedAt),

--- a/tests/Unit/Nocturne.Core.Models.Tests/Alerts/DndWindowResolverTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/Alerts/DndWindowResolverTests.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Nocturne.Core.Models.Alerts;
+using Xunit;
+
+namespace Nocturne.Core.Models.Tests.Alerts;
+
+/// <summary>
+/// <see cref="DndWindowResolver"/> (ADR 0004 D5): the single resolver both the live enricher
+/// and the replay walker use to turn a tenant's DND windows into the active scope set plus the
+/// tenant-wide <see cref="DoNotDisturbSnapshot"/>.
+/// </summary>
+[Trait("Category", "Unit")]
+public class DndWindowResolverTests
+{
+    private static readonly DateTime T0 = new(2026, 06, 21, 12, 00, 00, DateTimeKind.Utc);
+    private static DateTime Min(int m) => T0.AddMinutes(m);
+
+    private static DndWindowSnapshot Window(
+        DndScope scope,
+        DateTime? startedAt = null,
+        DateTime? endsAt = null,
+        DateTime? clearedAt = null,
+        DateTime? createdAt = null) =>
+        new(scope, startedAt ?? Min(-10), endsAt, clearedAt, createdAt ?? startedAt ?? Min(-10));
+
+    [Fact]
+    public void NoWindows_resolvesToNothingActive()
+    {
+        var resolved = DndWindowResolver.Resolve(Array.Empty<DndWindowSnapshot>(), T0, receiptGated: false);
+
+        resolved.Scopes.Should().BeEmpty();
+        resolved.ActiveDoNotDisturb.Should().BeNull();
+    }
+
+    [Fact]
+    public void AnAllWindow_populatesBothScopesAndTheProjection()
+    {
+        var resolved = DndWindowResolver.Resolve(
+            new[] { Window(DndScope.All, startedAt: Min(-30)) }, T0, receiptGated: false);
+
+        resolved.Scopes.Should().BeEquivalentTo(new[] { DndScope.All });
+        resolved.ActiveDoNotDisturb.Should().NotBeNull();
+        resolved.ActiveDoNotDisturb!.StartedAt.Should().Be(Min(-30));
+        resolved.ActiveDoNotDisturb.Source.Should().Be("manual");
+    }
+
+    [Fact]
+    public void ScopedWindows_feedTheGateOnly_andNeverTripTheConditionLeaf()
+    {
+        var resolved = DndWindowResolver.Resolve(
+            new[] { Window(DndScope.Lows), Window(DndScope.Highs) }, T0, receiptGated: false);
+
+        resolved.Scopes.Should().BeEquivalentTo(new[] { DndScope.Lows, DndScope.Highs });
+        // do_not_disturb is the tenant-wide notion; a lows/highs mute is not tenant-wide.
+        resolved.ActiveDoNotDisturb.Should().BeNull();
+    }
+
+    [Fact]
+    public void ExpiredClearedAndNotYetStartedWindows_areAllInert()
+    {
+        var windows = new[]
+        {
+            Window(DndScope.Lows, startedAt: Min(-60), endsAt: Min(-30)),   // expired
+            Window(DndScope.Highs, startedAt: Min(-60), clearedAt: Min(-5)), // cleared
+            Window(DndScope.All, startedAt: Min(30)),                        // not started
+        };
+
+        var resolved = DndWindowResolver.Resolve(windows, T0, receiptGated: false);
+
+        resolved.Scopes.Should().BeEmpty();
+        resolved.ActiveDoNotDisturb.Should().BeNull();
+    }
+
+    [Fact]
+    public void TheProjectionAnchorsOnTheEarliestActiveAllWindow()
+    {
+        var windows = new[]
+        {
+            Window(DndScope.All, startedAt: Min(-5)),
+            Window(DndScope.All, startedAt: Min(-45)),
+        };
+
+        var resolved = DndWindowResolver.Resolve(windows, T0, receiptGated: false);
+
+        // for_minutes measures from when the mute began, so the oldest active one wins.
+        resolved.ActiveDoNotDisturb!.StartedAt.Should().Be(Min(-45));
+    }
+
+    /// <summary>
+    /// Manual-wins is the pre-window <c>TenantAlertSettingsSnapshot.Resolve</c> contract — it
+    /// tested the manual path first. It matters because a scheduled window opening on top of a
+    /// running manual mute must not restart the anchor a sustained <c>do_not_disturb</c>
+    /// condition measures its elapsed time from.
+    /// </summary>
+    [Fact]
+    public void AnActiveManualWindow_outranksScheduledDndForTheAnchor()
+    {
+        var scheduled = new TenantAlertSettingsSnapshot.ActiveProjection(Min(-120), "schedule");
+
+        var resolved = DndWindowResolver.Resolve(
+            new[] { Window(DndScope.All, startedAt: Min(-20)) }, T0, receiptGated: false, scheduled);
+
+        resolved.Scopes.Should().Contain(DndScope.All);
+        resolved.ActiveDoNotDisturb!.StartedAt.Should().Be(Min(-20));
+        resolved.ActiveDoNotDisturb.Source.Should().Be("manual");
+    }
+
+    [Fact]
+    public void ScheduledDnd_aloneStillProducesTheAllScope()
+    {
+        var scheduled = new TenantAlertSettingsSnapshot.ActiveProjection(Min(-15), "schedule");
+
+        var resolved = DndWindowResolver.Resolve(
+            Array.Empty<DndWindowSnapshot>(), T0, receiptGated: false, scheduled);
+
+        resolved.Scopes.Should().BeEquivalentTo(new[] { DndScope.All });
+        resolved.ActiveDoNotDisturb!.Source.Should().Be("schedule");
+    }
+
+    [Fact]
+    public void ReceiptGating_hidesAWindowTheServerHadNotYetReceived()
+    {
+        // Authored as starting an hour ago, but only synced five minutes ago.
+        var window = Window(DndScope.All, startedAt: Min(-60), createdAt: Min(-5));
+        var beforeReceipt = Min(-30);
+
+        // Live: it is active now, whatever its receipt time.
+        DndWindowResolver.Resolve(new[] { window }, T0, receiptGated: false)
+            .Scopes.Should().Contain(DndScope.All);
+
+        // Replay at an instant before receipt: the live engine could not have known, so replay
+        // must not retroactively suppress the offline-authoring gap.
+        var replayed = DndWindowResolver.Resolve(new[] { window }, beforeReceipt, receiptGated: true);
+        replayed.Scopes.Should().BeEmpty();
+        replayed.ActiveDoNotDisturb.Should().BeNull();
+    }
+
+    [Fact]
+    public void ReceiptGating_admitsTheWindowOnceReceived()
+    {
+        var window = Window(DndScope.All, startedAt: Min(-60), createdAt: Min(-5));
+
+        var replayed = DndWindowResolver.Resolve(new[] { window }, T0, receiptGated: true);
+
+        replayed.Scopes.Should().Contain(DndScope.All);
+        replayed.ActiveDoNotDisturb!.StartedAt.Should().Be(Min(-60));
+    }
+
+    /// <summary>
+    /// The pairing the gate depends on: whenever <c>all</c> is in force the condition leaf sees
+    /// DND too, and whenever it is not, it does not. Replay set only the scope half at one point,
+    /// which made a tick the gate called suppressed evaluate its own do_not_disturb leaf false.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void TheProjectionIsNonNullExactlyWhenAllIsActive(bool receiptGated)
+    {
+        var windows = new List<DndWindowSnapshot>
+        {
+            Window(DndScope.Lows),
+            Window(DndScope.All, startedAt: Min(-60), endsAt: Min(-30)),
+        };
+
+        var withoutAll = DndWindowResolver.Resolve(windows, T0, receiptGated);
+        withoutAll.Scopes.Should().NotContain(DndScope.All);
+        withoutAll.ActiveDoNotDisturb.Should().BeNull();
+
+        windows.Add(Window(DndScope.All));
+        var withAll = DndWindowResolver.Resolve(windows, T0, receiptGated);
+        withAll.Scopes.Should().Contain(DndScope.All);
+        withAll.ActiveDoNotDisturb.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
Follow-ups from an adversarial review of the alert-engine port and scoped DND, rebased onto main.

Supersedes #590. That branch predated the squash of #398, so main already carries its feature content — and has since fixed several of the same findings, in a few cases better than the branch did. Only the remainder is here: 27 files instead of 337.

### Dropped as already-solved on main

- **cdylib missing from the API image** — main builds it in `docker-publish.yml` *and* cross-compiles `aarch64`, and the csproj packs all four RIDs. The branch's single-arch build plus MSBuild guard would have been a regression on a `linux-x64;linux-arm64` publish.
- **Backfill blocking startup** — already a `BackgroundService` on main, with an untracked projection and `ExecuteUpdateAsync`.
- **Replay not populating `ActiveDoNotDisturb`** — already fixed on main.
- **Cross-tenant id collision** — main re-checks under the tenant filter, so a same-tenant race resolves idempotently instead of returning 409.

### What's new here

**The live DND-window read was unbounded.** A window that merely runs out is never cleared — the row is kept for audit — so filtering on `cleared_at` alone returns every timed mute a tenant has ever set, on a query that runs once per glucose reading. Now bounded by expiry, and covered against real Postgres in `integration-db`: every enricher/replay unit test mocks `IAlertRepository`, so nothing there could catch that predicate regressing.

**DND resolution existed in three near-copies** (live enricher, replay scopes, replay projection). Now one `DndWindowResolver`. It adopts main's manual-wins anchor precedence — an active manual all-window outranks scheduled DND, the pre-window `TenantAlertSettingsSnapshot.Resolve` contract — which the branch version had silently inverted.

**Window reconciliation on create keyed off the wrong thing.** Clearing every uncleared same-scope row destroys a mute scheduled for a later, non-overlapping span. Gating on "is the incoming window active now" instead leaves a running mute and a window scheduled inside it both live — and the resolver then reports the earlier one's expiry while the later keeps suppressing past it, so the user is told alerts resume sooner than they do. Now only overlapping windows are touched: an earlier one is **truncated** to end where the new one begins (a running mute is handed over, not switched off), and one the new span wholly covers is cleared.

**An absent `dndManualActive` was read as `false`.** `dnd_windows` is shared with `DndWindowsController`, so a schedule-only save cancelled a mute a device had taken out and rewrote its expiry. Now absent means "leave it alone", and the validator and the controller's expiry guard are gated the same way so a schedule-only save isn't rejected over a field the server ignores.

**Mis-cased timezone ids didn't resolve in the crate.** Production carries ~240 rows spelling `Etc/GMT-2` as `ETC/GMT-2`, which made overnight low rules never fire under the Rust engine while firing correctly under managed. §4 now also records that the divergence runs *both* ways: `TZ_VARIANTS` accepts tzdb backward links (`Etc/Greenwich`, `US/Pacific`) that C#'s ICU-canonical scan rejects. Both remain cutover gates; the corpus structurally cannot catch either.

**The `managed_threw` divergence log stated an outcome it never computed** — `rust=(evaluated, no throw)` without having run the evaluator, which would let an operator "confirm" the throw-vs-false class from fabricated data. The secondary engine now runs on the same pre-state before the rethrow, and the log carries what it actually produced, its own error, or `(unavailable)`.

**Cargo caches were keyed on `Cargo.lock` alone.** A restored `crates/target` has newer mtimes than the checkout and cargo's path-package fingerprint is mtime-based, so a source-only change could reuse a stale cdylib and never re-save it — shipping an image built from the wrong Rust. All three workflows now hash the sources.

Smaller: `BadImageFormatException` in the classifier and availability probe (a wrong-arch `.so` throws that, not `DllNotFoundException`, and it faulted alert-rule create/update as a 500); the backfill asks the classifier rather than `AlertsInterop` for availability; a missing DND `scope` is rejected instead of defaulting to `lows`; `Source` capped at the column width; timer `DateTime` kinds normalised across the FFI.

### Deliberately not carried over

- SQLSTATE narrowing on the create-collision catch — Npgsql-specific, and it breaks main's Sqlite-based 409 test. Main's re-check already handles the case that matters; the residual risk is that an RLS/FK failure reads as 409 rather than 500.
- An image-pipeline load smoke check — main's `test -f` on both cargo outputs covers the motivating case. A runner-vs-base-image glibc gap would still get through.

### Verification

Run locally against this rebase: 517 + 4503 + 141 unit, 89 `integration-db` (real Postgres), 110 corpus scenarios up to date, `cargo test`/`clippy`/`fmt` clean, 0 skipped with `NOCTURNE_ALERTS_REQUIRE_NATIVE=1`.

`Nocturne.API.Tests.Services.CacheIntegrationTests.CreateEntriesAsync_DecomposesToV4AndFiresEvents` fails — **pre-existing, confirmed failing on a clean `origin/main` checkout**, unrelated to these changes.

The three regression tests for the bounded read, the absent-toggle guard and the `managed_threw` log were mutation-checked: each fix was reverted locally and the tests confirmed to fail.
