### PR TITLE
fix(auth): clear the principal when a credential is rejected

### DIFF
--- a/src/API/Nocturne.API/Authorization/AuthorizationConfiguration.cs
+++ b/src/API/Nocturne.API/Authorization/AuthorizationConfiguration.cs
@@ -39,6 +39,22 @@ public static class AuthorizationConfiguration
         {
             options.AddPolicy(PolicyNames.HasPermissions, hasPermissionsPolicy);
             options.FallbackPolicy = hasPermissionsPolicy;
+
+            // DefaultPolicy is deliberately left at the framework's RequireAuthenticatedUser.
+            // Adding HasPermissionsRequirement to it looks like a tightening but is unsatisfiable
+            // on the tenantless surface: those paths resolve no TenantContext, so
+            // MemberScopeMiddleware returns before rebuilding the trie, leaving whatever
+            // AuthenticationMiddleware built from the subject's *global* roles. A member who
+            // joined by invite has none, so the trie is empty and every bare-[Authorize]
+            // tenantless endpoint 403s — including the apex tenant list, the cross-tenant
+            // overview, and first-tenant creation.
+            //
+            // This leaves a gap that is OPEN, not covered elsewhere: a member of the resolved
+            // tenant holding a zero-permission role (the Denied seed role) has an empty trie and
+            // empty scopes, and can still read any bare-[Authorize] endpoint. Most of
+            // Controllers/V4 carries no scope attribute today, so per-action gating does not yet
+            // close it. Closing it belongs with those attributes rather than here, because a
+            // DefaultPolicy strong enough to catch it also breaks the tenantless surface above.
         });
 
         return services;

--- a/src/API/Nocturne.API/Hubs/HomeAssistantHub.cs
+++ b/src/API/Nocturne.API/Hubs/HomeAssistantHub.cs
@@ -1,3 +1,5 @@
+using Nocturne.Core.Models.Authorization;
+using Nocturne.API.Extensions;
 using System.Collections.Concurrent;
 using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
@@ -99,12 +101,19 @@ public class HomeAssistantHub : TenantAwareHub
         var tenantId = TenantContext?.TenantId
             ?? throw new HubException("No tenant context resolved.");
 
-        // Gate 1: OAuth scope check — require "alerts.readwrite"
-        var scopes = Context.User?.FindAll("scope")
-            .SelectMany(c => c.Value.Split(' ', StringSplitOptions.RemoveEmptyEntries))
-            .ToHashSet() ?? new HashSet<string>();
+        // Gate 1: OAuth scope check — require "alerts.readwrite".
+        //
+        // Read from GrantedScopes rather than a "scope" claim on the principal. That claim is minted
+        // only by JwtService and so only ever appeared on the principal the framework's JwtBearer
+        // scheme built; AuthenticationMiddleware's claim set has never carried it. Now that the
+        // custom chain owns the final principal on every path, FindAll("scope") is always empty and
+        // this gate would deny every acknowledge. GrantedScopes is the resolved, membership-
+        // intersected scope set, which is the right authority here anyway.
+        var httpContext = Context.GetHttpContext()
+            ?? throw new HubException("No HTTP context available.");
+        var scopes = httpContext.GetGrantedScopes();
 
-        if (!scopes.Contains("alerts.readwrite"))
+        if (!OAuthScopes.SatisfiesScope(scopes, OAuthScopes.AlertsReadWrite))
             throw new HubException("Insufficient permissions: alerts.readwrite scope required.");
 
         // Gate 2: Channel config check — find HA channels for this excursion's rule and verify allow_ack

--- a/src/API/Nocturne.API/Middleware/AuthenticationMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/AuthenticationMiddleware.cs
@@ -177,6 +177,21 @@ public class AuthenticationMiddleware
                 context.User = new System.Security.Claims.ClaimsPrincipal(identity);
 
             }
+            else
+            {
+                // This middleware owns the final principal on EVERY path, including rejection.
+                // The framework's authentication middleware runs ahead of this one (minimal hosting
+                // auto-inserts it at the head of the pipeline because AddAuthentication is
+                // registered), so by the time we get here context.User may already hold the
+                // JwtBearer scheme's principal — built with no issuer or audience check, no tenant
+                // pin and no revocation check. Without this else, a credential the handler chain
+                // REJECTED keeps that principal: [Authorize] reads the principal, not Items, so a
+                // revoked grant, a token pinned to another tenant, or a credential presented on a
+                // share host would still reach every bare-[Authorize] controller — including the
+                // sensor-glucose read. The membership check below cannot catch it either, since it
+                // only runs for IsAuthenticated: true.
+                SetUnauthenticated(context);
+            }
         }
         catch (Exception ex)
         {

--- a/src/API/Nocturne.API/Middleware/AuthenticationMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/AuthenticationMiddleware.cs
@@ -362,6 +362,13 @@ public class AuthenticationMiddleware
         context.Items["PermissionTrie"] = new PermissionTrie();
         context.Items["GrantedScopes"] = (IReadOnlySet<string>)new HashSet<string>();
         context.Items["AuthenticationContext"] = MapToLegacyContext(authContext);
+
+        // Clearing Items is not enough: this method is also the tenant-membership rejection
+        // path, and by then the principal above has already been built. [Authorize] reads
+        // HttpContext.User, not Items, so leaving a populated principal here authenticates a
+        // rejected caller against any endpoint whose only gate is [Authorize].
+        context.User = new System.Security.Claims.ClaimsPrincipal(
+            new System.Security.Claims.ClaimsIdentity());
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -439,8 +439,13 @@ app.UseMiddleware<AuditContextMiddleware>();
 // Add site security middleware (enforces authentication when site lockdown is enabled)
 app.UseMiddleware<SiteSecurityMiddleware>();
 
-// Add authentication and authorization middleware
-app.UseAuthentication();
+// AuthenticationMiddleware above is the only authenticator. UseAuthentication() is deliberately
+// absent: it runs the JwtBearer scheme and assigns its principal over whatever the chain decided,
+// and that scheme validates strictly less (no issuer or audience check, no tenant pin, no
+// revocation check) while trusting the same signing key. It would therefore re-admit exactly the
+// tokens the chain rejects — a token pinned to another tenant, or one that has been revoked — and
+// undo the membership rejection in SetUnauthenticated. The scheme stays registered only so
+// UseAuthorization has a challenge scheme to produce a 401 with.
 app.UseAuthorization();
 
 // Add rate limiting

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -439,13 +439,23 @@ app.UseMiddleware<AuditContextMiddleware>();
 // Add site security middleware (enforces authentication when site lockdown is enabled)
 app.UseMiddleware<SiteSecurityMiddleware>();
 
-// AuthenticationMiddleware above is the only authenticator. UseAuthentication() is deliberately
-// absent: it runs the JwtBearer scheme and assigns its principal over whatever the chain decided,
-// and that scheme validates strictly less (no issuer or audience check, no tenant pin, no
-// revocation check) while trusting the same signing key. It would therefore re-admit exactly the
-// tokens the chain rejects — a token pinned to another tenant, or one that has been revoked — and
-// undo the membership rejection in SetUnauthenticated. The scheme stays registered only so
-// UseAuthorization has a challenge scheme to produce a 401 with.
+// There is no app.UseAuthentication() call here, and adding one would be a security regression.
+//
+// The framework's authentication middleware is NOT absent — minimal hosting auto-inserts it at the
+// HEAD of the pipeline because AddAuthentication is registered, and an explicit app.UseAuthentication()
+// is what suppresses that auto-add. So calling it here would move the JwtBearer scheme from before
+// AuthenticationMiddleware to after it, letting the scheme's principal overwrite whatever the handler
+// chain decided. That scheme validates strictly less — no issuer or audience check, no tenant pin, no
+// revocation check — while trusting the same signing key, so it would re-admit exactly the tokens the
+// chain rejects and undo the rejection in SetUnauthenticated.
+//
+// Running ahead of the chain is harmless only because AuthenticationMiddleware assigns
+// context.User on every path, success and rejection alike, so it always owns the final principal.
+// That invariant is what makes this safe; do not weaken it.
+//
+// The scheme also gives UseAuthorization a challenge scheme, so an anonymous request gets 401
+// rather than 500. No policy names an authentication scheme, so PolicyEvaluator reads context.User
+// directly.
 app.UseAuthorization();
 
 // Add rate limiting

--- a/tests/Unit/Nocturne.API.Tests/Authorization/AuthorizationConfigurationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/AuthorizationConfigurationTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using FluentAssertions;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.Extensions.DependencyInjection;
@@ -39,6 +40,28 @@ public class AuthorizationConfigurationTests
         var hasPermissions = options.GetPolicy(PolicyNames.HasPermissions);
         hasPermissions.Should().NotBeNull();
         hasPermissions!.Requirements.Should().ContainItemsAssignableTo<HasPermissionsRequirement>();
+    }
+
+    [Fact]
+    public void AddNocturneAuthorization_DefaultPolicy_DoesNotRequireAPermissionTrie()
+    {
+        var services = new ServiceCollection();
+        services.AddNocturneAuthorization();
+        using var provider = services.BuildServiceProvider();
+
+        var options = provider.GetRequiredService<IOptions<AuthorizationOptions>>().Value;
+
+        // Pins a deliberate decision that reads backwards. A bare [Authorize] resolves
+        // DefaultPolicy, and requiring a non-empty trie there is unsatisfiable on the tenantless
+        // surface: no TenantContext resolves, so MemberScopeMiddleware never rebuilds the trie and
+        // it holds only the subject's global roles — empty for anyone who joined by invite. That
+        // 403s the apex tenant list, the cross-tenant overview and first-tenant creation, none of
+        // which any existing test covers.
+        options.DefaultPolicy.Requirements.Should().NotContain(r => r is HasPermissionsRequirement,
+            "the tenantless surface cannot satisfy a trie requirement; tenant-scoped endpoints are "
+            + "gated by their own per-action scope attributes instead");
+        options.DefaultPolicy.Requirements.OfType<DenyAnonymousAuthorizationRequirement>()
+            .Should().NotBeEmpty("a bare [Authorize] must still reject anonymous callers");
     }
 
     [Theory]

--- a/tests/Unit/Nocturne.API.Tests/Middleware/AuthenticationMiddlewarePrincipalTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/AuthenticationMiddlewarePrincipalTests.cs
@@ -1,0 +1,130 @@
+using System.Security.Claims;
+using System.Threading;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Nocturne.API.Middleware;
+using Nocturne.API.Middleware.Handlers;
+using Nocturne.API.Services.Auth;
+using Nocturne.API.Tests.Infrastructure;
+using Nocturne.Core.Contracts.Identity;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Core.Models.Configuration;
+using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.API.Tests.Middleware;
+
+/// <summary>
+/// Verifies that a tenant-membership rejection clears <see cref="HttpContext.User"/> and not just
+/// <see cref="HttpContext.Items"/>. <c>[Authorize]</c> reads the principal, so a populated
+/// principal left behind after rejection authorizes the caller against every endpoint whose only
+/// gate is <c>[Authorize]</c> — which is most of the V4 surface — against the tenant they were
+/// just rejected from.
+/// </summary>
+/// <remarks>
+/// The two cases are load-bearing as a pair, so do not delete or skip the member case. An
+/// exception anywhere before the principal is built also lands in the catch that calls
+/// SetUnauthenticated, which satisfies the non-member assertions for the wrong reason. The two
+/// runs differ only in what the membership mock returns, so a fault that broke one would fail the
+/// other. An earlier version of this file passed exactly that way.
+/// </remarks>
+[Trait("Category", "Unit")]
+public sealed class AuthenticationMiddlewarePrincipalTests
+{
+    private static readonly Guid TenantId = Guid.CreateVersion7();
+    private static readonly Guid SubjectId = Guid.CreateVersion7();
+
+    /// <summary>
+    /// Stub handler that authenticates unconditionally, standing in for any credential whose
+    /// validation does not itself pin the tenant (a session cookie carries no tenant claim).
+    /// </summary>
+    private sealed class StubHandler(AuthContext context) : IAuthHandler
+    {
+        public int Priority => 50;
+
+        public string Name => "Stub";
+
+        public Task<AuthResult> AuthenticateAsync(HttpContext httpContext) =>
+            Task.FromResult(AuthResult.Success(context));
+    }
+
+    private static (AuthenticationMiddleware Middleware, DefaultHttpContext Context) Build(bool isMember)
+    {
+        var memberService = new Mock<ITenantMemberService>();
+        memberService
+            .Setup(s => s.IsMemberAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(isMember);
+
+        // A real provider, not a mocked IServiceScopeFactory: the middleware resolves a
+        // NocturneDbContext from the scope to read IsPlatformAdmin, and a mock returning a null
+        // scope throws into the catch that calls SetUnauthenticated — which makes every case,
+        // including the ones that should succeed, look rejected.
+        var dbName = $"auth_principal_{Guid.NewGuid()}";
+        var services = new ServiceCollection();
+        services.AddScoped<ICategoryReadContext, CategoryReadContext>();
+        services.AddSingleton(memberService.Object);
+        services.AddScoped(_ => TestDbContextFactory.CreateInMemoryContext(dbName));
+        var provider = services.BuildServiceProvider();
+
+        var context = new DefaultHttpContext { RequestServices = provider };
+        context.Items["TenantContext"] = new TenantContext(TenantId, "victim", "Victim", true, false);
+
+        var authContext = new AuthContext
+        {
+            IsAuthenticated = true,
+            AuthType = AuthType.SessionCookie,
+            SubjectId = SubjectId,
+            TenantId = TenantId,
+            SubjectName = "someone",
+            Roles = ["admin"],
+        };
+
+        var middleware = new AuthenticationMiddleware(
+            next: _ => Task.CompletedTask,
+            logger: NullLogger<AuthenticationMiddleware>.Instance,
+            handlers: [new StubHandler(authContext)],
+            environment: Mock.Of<IHostEnvironment>(e => e.EnvironmentName == "Production"),
+            publicAccessCacheService: null!,
+            oidcOptions: Options.Create(new OidcOptions()),
+            scopeFactory: provider.GetRequiredService<IServiceScopeFactory>());
+
+        return (middleware, context);
+    }
+
+    [Fact]
+    public async Task Non_member_of_the_resolved_tenant_gets_no_authenticated_principal()
+    {
+        var (middleware, context) = Build(isMember: false);
+
+        await middleware.InvokeAsync(context);
+
+        context.Items["AuthContext"].Should().BeOfType<AuthContext>()
+            .Which.IsAuthenticated.Should().BeFalse();
+
+        context.User.Identity?.IsAuthenticated.Should().NotBe(true,
+            "[Authorize] reads the principal, so leaving one populated after a membership "
+            + "rejection authorizes the caller against the tenant they were rejected from");
+        context.User.Claims.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Member_of_the_resolved_tenant_keeps_an_authenticated_principal()
+    {
+        var (middleware, context) = Build(isMember: true);
+
+        await middleware.InvokeAsync(context);
+
+        context.Items["AuthContext"].Should().BeOfType<AuthContext>()
+            .Which.IsAuthenticated.Should().BeTrue();
+        context.User.Identity?.IsAuthenticated.Should().BeTrue();
+        context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value.Should().Be(SubjectId.ToString());
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Middleware/AuthenticationMiddlewarePrincipalTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/AuthenticationMiddlewarePrincipalTests.cs
@@ -1,3 +1,4 @@
+using Nocturne.API.Extensions;
 using System.Security.Claims;
 using System.Threading;
 using FluentAssertions;
@@ -55,6 +56,31 @@ public sealed class AuthenticationMiddlewarePrincipalTests
         public Task<AuthResult> AuthenticateAsync(HttpContext httpContext) =>
             Task.FromResult(AuthResult.Success(context));
     }
+
+    /// <summary>
+    /// Stub handler that rejects the credential, standing in for every chain rejection: a token
+    /// pinned to another tenant, a revoked grant, or any credential presented on a share host.
+    /// </summary>
+    private sealed class RejectingHandler : IAuthHandler
+    {
+        public int Priority => 50;
+
+        public string Name => "Rejecting";
+
+        public Task<AuthResult> AuthenticateAsync(HttpContext httpContext) =>
+            Task.FromResult(AuthResult.Failure("not valid for this tenant"));
+    }
+
+    /// <summary>
+    /// A principal shaped like the one the framework's JwtBearer scheme builds. The framework
+    /// authentication middleware runs at the HEAD of the pipeline (minimal hosting auto-inserts it
+    /// because AddAuthentication is registered), so this is what context.User already holds when
+    /// AuthenticationMiddleware runs.
+    /// </summary>
+    private static ClaimsPrincipal FrameworkPrincipal() =>
+        new(new ClaimsIdentity(
+            [new Claim(ClaimTypes.NameIdentifier, SubjectId.ToString()), new Claim("scope", "alerts.readwrite")],
+            "Bearer"));
 
     private static (AuthenticationMiddleware Middleware, DefaultHttpContext Context) Build(bool isMember)
     {
@@ -126,5 +152,46 @@ public sealed class AuthenticationMiddlewarePrincipalTests
             .Which.IsAuthenticated.Should().BeTrue();
         context.User.Identity?.IsAuthenticated.Should().BeTrue();
         context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value.Should().Be(SubjectId.ToString());
+    }
+
+    [Fact]
+    public async Task Rejected_credential_does_not_inherit_the_framework_principal()
+    {
+        // The other half of the same vulnerability. When the handler chain REJECTS a credential the
+        // middleware never entered the IsAuthenticated branch, so it never assigned context.User —
+        // and the principal the framework scheme built ahead of it survived untouched. The
+        // membership check cannot catch this either: it only runs for IsAuthenticated: true. So a
+        // token pinned to another tenant, a revoked grant, or a credential presented on a share host
+        // still satisfied bare [Authorize] on ~40 V4 controllers, including the sensor-glucose read.
+        var memberService = new Mock<ITenantMemberService>();
+        var dbName = $"auth_principal_reject_{Guid.NewGuid()}";
+        var services = new ServiceCollection();
+        services.AddScoped<ICategoryReadContext, CategoryReadContext>();
+        services.AddSingleton(memberService.Object);
+        services.AddScoped(_ => TestDbContextFactory.CreateInMemoryContext(dbName));
+        var provider = services.BuildServiceProvider();
+
+        var context = new DefaultHttpContext { RequestServices = provider };
+        context.Items["TenantContext"] = new TenantContext(TenantId, "victim", "Victim", true, false);
+        context.User = FrameworkPrincipal();
+
+        var middleware = new AuthenticationMiddleware(
+            next: _ => Task.CompletedTask,
+            logger: NullLogger<AuthenticationMiddleware>.Instance,
+            handlers: [new RejectingHandler()],
+            environment: Mock.Of<IHostEnvironment>(e => e.EnvironmentName == "Production"),
+            publicAccessCacheService: null!,
+            oidcOptions: Options.Create(new OidcOptions()),
+            scopeFactory: provider.GetRequiredService<IServiceScopeFactory>());
+
+        await middleware.InvokeAsync(context);
+
+        context.Items["AuthContext"].Should().BeOfType<AuthContext>()
+            .Which.IsAuthenticated.Should().BeFalse();
+
+        context.User.Identity?.IsAuthenticated.Should().NotBe(true,
+            "a credential the chain rejected must not keep the framework scheme's principal");
+        context.User.Claims.Should().BeEmpty();
+        context.GetGrantedScopes().Should().BeEmpty();
     }
 }


### PR DESCRIPTION
**Closes a live cross-tenant read of another patient's CGM stream.**

`AuthenticationMiddleware` built `HttpContext.User`, then verified tenant membership and called `SetUnauthenticated` on failure — but that only reset `HttpContext.Items`, and `[Authorize]` reads the principal. Session JWTs carry no tenant claim, so a member of tenant A could present their cookie against tenant B's subdomain, fail the membership check, and still reach ~40 bare-`[Authorize]` V4 controllers, `SensorGlucoseController` among them, with the victim tenant already pinned on the DbContext.

The middleware now owns the final principal on **every** path — success, membership rejection, and credential rejection.

That last one is the part the first pass missed, and it matters: `UseAuthentication()` is not actually removable by deleting the call. Minimal hosting auto-inserts the framework middleware at the *head* of the pipeline when `AddAuthentication` is registered, so the JwtBearer principal is already present when the chain runs. Without an `else` on the assignment, a credential the chain *rejected* kept it — meaning a token pinned to another tenant, a revoked grant, or a credential presented on a share host all still satisfied bare `[Authorize]`.

Also fixes an always-deny regression this introduced in `HomeAssistantHub.Acknowledge`, which gated on a `scope` claim only the framework principal ever carried.

Detail is in the commit messages.

**Verification.** The rejection test was confirmed to fail against the unfixed middleware ("found True"), as was the membership test. 4375 unit tests pass. Note CI runs neither the Aspire integration tests nor any frontend suite, so pipeline-level behaviour was checked by reasoning and a standalone probe rather than by CI.