### PR TITLE
fix(carelink): record the signed-in account so a connect actually yields a syncing connector

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Connectors/CareLinkConnectController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Connectors/CareLinkConnectController.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -150,6 +152,8 @@ public partial class CareLinkConnectController : ControllerBase
             _logger.LogDebug(ex, "CareLink connect: profile auto-fill fetch failed (non-fatal)");
         }
 
+        await PersistSignedInAccountAsync(flowState.Server, username, country, ct);
+
         _logger.LogInformation("CareLink connect completed for tenant {Tenant}", _tenantAccessor.Context?.TenantId);
 
         return Ok(new CareLinkConnectCompleteResponse
@@ -207,6 +211,58 @@ public partial class CareLinkConnectController : ControllerBase
             LinkCode = $"nocturne-connect://link?server={Uri.EscapeDataString(serverUrl)}&token={Uri.EscapeDataString(token)}",
             ExpiresInSeconds = (int)DesktopTokenLifetime.TotalSeconds,
         });
+    }
+
+    /// <summary>
+    /// Writes what the sign-in established into the connector configuration: the region whose tokens
+    /// were just stored, and the account that authenticated. Without this the connector has
+    /// credentials but no username, which is a required setting — so it never syncs — and its region
+    /// can point at the other CareLink cloud, sending every data request to a host that rejects the
+    /// token. The desktop companion has no settings form at all, so only the server can do this.
+    /// Never fails the connect: the credentials are already stored and the user can fill the form in.
+    /// </summary>
+    private async Task PersistSignedInAccountAsync(
+        string server, string? username, string? country, CancellationToken ct)
+    {
+        try
+        {
+            var existing = await _configService.GetConfigurationAsync(ConnectorName, ct);
+            using var merged = MergeSignedInAccount(existing?.Configuration, server, username, country);
+            await _configService.SaveConfigurationAsync(
+                ConnectorName, merged, User.Identity?.Name ?? "carelink-connect", ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "CareLink connect: could not persist the signed-in account to the configuration");
+        }
+    }
+
+    /// <summary>
+    /// Applies the signed-in account to the stored configuration. The region is authoritative — it is
+    /// the cloud the stored tokens belong to — while a username or country the profile did not report
+    /// leaves whatever is configured alone. Merges into <paramref name="existing"/> because
+    /// <see cref="IConnectorConfigurationService.SaveConfigurationAsync"/> replaces the whole
+    /// document, and dropping the tenant's sync toggles and intervals here would be silent.
+    /// </summary>
+    public static JsonDocument MergeSignedInAccount(
+        JsonDocument? existing, string server, string? username, string? country)
+    {
+        var config = existing is not null
+            ? JsonNode.Parse(existing.RootElement.GetRawText())?.AsObject() ?? new JsonObject()
+            : new JsonObject();
+
+        config["server"] = server;
+        if (!string.IsNullOrWhiteSpace(username))
+            config["username"] = username;
+        if (!string.IsNullOrWhiteSpace(country))
+            config["countryCode"] = country.ToLowerInvariant();
+
+        return JsonDocument.Parse(config.ToJsonString());
     }
 
     private static string ExtractCode(string input)

--- a/src/Web/packages/app/src/lib/components/connectors/CareLinkConnectPanel.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/CareLinkConnectPanel.svelte
@@ -44,8 +44,13 @@
   let {
     onConnected,
   }: {
-    // Called after a refresh token is stored, with the auto-detected profile (if any).
-    onConnected?: (info: { username?: string | null; country?: string | null }) => void;
+    // Called after a refresh token is stored, with the region signed in to and the
+    // auto-detected profile (if any).
+    onConnected?: (info: {
+      server: "EU" | "US";
+      username?: string | null;
+      country?: string | null;
+    }) => void;
   } = $props();
 
   type Phase = "idle" | "awaiting-code" | "done";
@@ -96,7 +101,7 @@
       }
       connectedUsername = res.username ?? null;
       phase = "done";
-      onConnected?.({ username: res.username, country: res.country });
+      onConnected?.({ server: region, username: res.username, country: res.country });
     } catch (e) {
       error = e instanceof Error ? e.message : "Could not complete CareLink sign-in.";
     } finally {

--- a/src/Web/packages/app/src/lib/components/connectors/ConnectorSetup.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/ConnectorSetup.svelte
@@ -143,7 +143,15 @@
   // CareLink uses a browser-based sign-in (manual-paste OAuth) instead of a stored password.
   const isCareLink = $derived(connectorInfo?.id?.toLowerCase() === "carelink");
 
-  function onCareLinkConnected(info: { username?: string | null; country?: string | null }) {
+  function onCareLinkConnected(info: {
+    server: "EU" | "US";
+    username?: string | null;
+    country?: string | null;
+  }) {
+    // The region is not a preference here — it is the CareLink cloud the stored tokens belong to,
+    // and the server has already recorded it. Leaving a stale value in the form would let a save
+    // put it back, pointing every data request at a host that rejects those tokens.
+    configuration = { ...configuration, server: info.server };
     // Auto-fill identity the sign-in discovered, without clobbering anything already set.
     if (info.username && !configuration.username) {
       configuration = { ...configuration, username: info.username };

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Connectors/CareLinkConnectControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Connectors/CareLinkConnectControllerTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -142,5 +143,40 @@ public sealed class CareLinkConnectControllerTests
     {
         var result = Build(tenant: null, Auth()).DesktopToken();
         result.Result.Should().BeOfType<UnauthorizedResult>();
+    }
+
+    /// <summary>
+    /// The connect flow stores credentials, but the connector also needs a username (a required
+    /// setting) and the region those tokens belong to. The desktop companion has no settings form,
+    /// so without this the tenant ends up with credentials and a connector that never syncs.
+    /// </summary>
+    [Fact]
+    public void MergeSignedInAccount_AppliesAccountAndRegion_KeepingOtherSettings()
+    {
+        using var existing = JsonDocument.Parse(
+            """{"enabled":true,"server":"US","syncIntervalMinutes":5,"username":""}""");
+
+        using var merged = CareLinkConnectController.MergeSignedInAccount(
+            existing, "EU", "carer@example.com", "AU");
+
+        var root = merged.RootElement;
+        root.GetProperty("server").GetString().Should().Be("EU",
+            "the stored tokens belong to the region signed in to — a stale region sends every data "
+            + "request to a host that rejects them");
+        root.GetProperty("username").GetString().Should().Be("carer@example.com");
+        root.GetProperty("countryCode").GetString().Should().Be("au");
+        root.GetProperty("syncIntervalMinutes").GetInt32().Should().Be(5,
+            "SaveConfigurationAsync replaces the whole document, so unrelated settings must survive");
+        root.GetProperty("enabled").GetBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void MergeSignedInAccount_WithNoStoredConfiguration_StillRecordsTheRegion()
+    {
+        using var merged = CareLinkConnectController.MergeSignedInAccount(null, "EU", null, null);
+
+        merged.RootElement.GetProperty("server").GetString().Should().Be("EU");
+        merged.RootElement.TryGetProperty("username", out _).Should().BeFalse(
+            "a username the profile did not report must not be invented");
     }
 }


### PR DESCRIPTION
Follow-up to #602, found while working out whether the desktop companion path still works. It does â€” its blocker was the same CloudFront rejection #602 fixed â€” but a companion connect still could not produce a working connector.

## What was wrong

`connect/complete` stored the credentials (`refresh_token`, `client_id`, `token_url`, `audience`) and nothing else. The connector also needs:

- **a username** â€” `[ConnectorProperty(ConnectorPropertyKey.Username, Required = true)]`, so with it blank the loader disables the connector outright;
- **a region** â€” `CareLinkConnectorService.GetServerHost` picks the data host from `config.Server`, which is separate from the region the flow signed in to.

In the browser the panel auto-filled username/country into the form and left the user to save it. The desktop companion has no settings form, and its success copy says "Nocturne stored the refresh token and will sync automatically" â€” which was not true: it stored credentials behind a connector that never synced.

The region could also diverge. Sign in as EU (correct for AU/NZ and most of the world) while `Server` still says `US`, and every data request goes to `carelink.minimed.com` with an OUS-issued token.

Both together are the state a real tenant has been in since June: credentials present, username blank, `server: US` with `countryCode: au`, no attempt logged in seven weeks.

## The change

`Complete` merges what the sign-in established into the stored configuration:

- **region, unconditionally** â€” it describes the tokens just stored, not a user preference, so a stale value is always wrong;
- **username and country when the profile reports them** â€” a value Medtronic did not give us must not be invented.

It merges rather than writes, because `SaveConfigurationAsync` replaces the whole document and quietly dropping the tenant's sync toggles and interval would be worse than the bug. The write is best-effort: the credentials are already saved, and a failure here leaves the form as the fallback rather than failing a sign-in the user just completed.

The panel now also passes the region back to the form, so a later save cannot put a stale one over what the server recorded.

## Tests

- `MergeSignedInAccount` applies region, username and lowercased country while preserving unrelated settings
- with no stored configuration it still records the region, and does not invent a username the profile never reported

## Verification

`Nocturne.API.Tests` builds clean and the CareLink connect tests pass locally (6, including the two new ones). CI covers the full suite.

https://claude.ai/code/session_01TzMucNR3XSShSDbGgMr3gH
