### PR TITLE
fix(api): refresh connector status after saving secrets

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Connectors/ConfigurationController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Connectors/ConfigurationController.cs
@@ -278,7 +278,7 @@ public class ConfigurationController : ControllerBase
     /// <param name="secrets">Dictionary of secret property names to plaintext values</param>
     /// <param name="ct">Cancellation token</param>
     [HttpPut("{connectorName}/secrets")]
-    [RemoteCommand(Invalidates = ["GetConfiguration"])]
+    [RemoteCommand(Invalidates = ["GetConfiguration", "GetAllConnectorStatus"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> SaveSecrets(


### PR DESCRIPTION
## Problem

Saving connector credentials leaves the Credentials card's "Not configured" badge in place until a full page reload.

The badge is driven by `hasSecrets` from the `GetAllConnectorStatus` remote query, but `SaveSecrets` only declared `Invalidates = ["GetConfiguration"]`. On a connector's manage page (`save-only` mode) nothing else refreshes the status query, so it keeps serving the stale answer. The setup wizard masked the gap because it calls `setActive` after saving, which does invalidate `GetAllConnectorStatus` (#552 fixed that one but missed this endpoint).

There is also an ordering race even where `SaveConfiguration`'s invalidation fires: the form saves config before secrets, so that refetch can read the row before `SecretsJson` is written and cache `hasSecrets: false`.

## Fix

Declare `GetAllConnectorStatus` in `SaveSecrets`'s `Invalidates` list, matching `SaveConfiguration`, `SetActive`, and `DeleteConfiguration`. The invalidation now fires after the secrets are stored, so the final refetch sees them.

Attribute-only change; the regenerated remote client picks it up at build time.

https://claude.ai/code/session_01DpBFYnMdSUeSv33emATpZe
