### PR TITLE
fix(auth): pin guest sessions to their grant's tenant

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/OAuthController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/OAuthController.cs
@@ -816,6 +816,7 @@ public class OAuthController : ControllerBase
     [HttpPatch("grants/{grantId}")]
     [Consumes("application/json")]
     [ProducesResponseType(typeof(OAuthGrantDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(OAuthError), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<OAuthGrantDto>> UpdateGrant(
         Guid grantId,
@@ -863,6 +864,8 @@ public class OAuthController : ControllerBase
         }
         catch (ArgumentException ex)
         {
+            // OAuthScopes.ValidateGrantScopes rejects a scope outside the vocabulary, and a scope
+            // wider than the grant type may hold — a guest link is capped at read.
             return BadRequest(new OAuthError
             {
                 Error = "invalid_scope",

--- a/src/API/Nocturne.API/Controllers/V4/Identity/GuestLinkController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/GuestLinkController.cs
@@ -89,8 +89,10 @@ public class GuestLinkController : ControllerBase
         [FromQuery] bool includeDismissed = false,
         CancellationToken ct = default)
     {
+        // SubjectId excludes a guest session, whose EffectiveSubjectId resolves to the data owner
+        // and would otherwise list the owner's links — labels, scopes and each guest's ActivatedIp.
         var auth = HttpContext.GetAuthContext();
-        if (auth is not { IsAuthenticated: true })
+        if (auth is not { IsAuthenticated: true, SubjectId: not null })
             return Unauthorized();
 
         var effectiveSubjectId = auth.EffectiveSubjectId;

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -198,6 +198,7 @@ public static class ServiceRegistrationExtensions
 
         services.AddHostedService<AuthorizationSeedService>();
 
+        services.AddSingleton<GuestSessionCacheService>();
         services.AddSingleton<PublicAccessCacheService>();
         services.AddSingleton<ShareTokenCacheService>();
         services.AddSingleton<IShareTokenGenerator, ShareTokenGenerator>();

--- a/src/API/Nocturne.API/Middleware/Handlers/GuestSessionHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/GuestSessionHandler.cs
@@ -1,5 +1,5 @@
 using Microsoft.AspNetCore.DataProtection;
-using Microsoft.Extensions.Caching.Memory;
+using Nocturne.API.Services.Auth;
 using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Authorization;
@@ -9,14 +9,15 @@ namespace Nocturne.API.Middleware.Handlers;
 /// <summary>
 /// Authentication handler for guest session cookies. Validates an encrypted
 /// grant ID stored in the <c>nocturne-guest-session</c> cookie against
-/// <see cref="IGuestLinkService.ValidateSessionAsync"/>, with a 30-second
-/// memory cache to avoid per-request database hits.
+/// <see cref="IGuestLinkService.ValidateSessionAsync"/>, via
+/// <see cref="GuestSessionCacheService"/> to avoid per-request database hits.
+/// The resolved grant's tenant must match the tenant resolved for the request.
 /// </summary>
 public class GuestSessionHandler : IAuthHandler
 {
     private const string CookieName = "nocturne-guest-session";
     private const string ProtectorPurpose = "GuestSession";
-    private static readonly TimeSpan CacheDuration = TimeSpan.FromSeconds(30);
+    private const string InvalidSessionError = "Guest session expired or revoked";
 
     /// <inheritdoc />
     public int Priority => 52;
@@ -26,7 +27,7 @@ public class GuestSessionHandler : IAuthHandler
 
     private readonly IDataProtector _protector;
     private readonly IServiceScopeFactory _scopeFactory;
-    private readonly IMemoryCache _cache;
+    private readonly GuestSessionCacheService _sessionCache;
     private readonly ILogger<GuestSessionHandler> _logger;
 
     /// <summary>
@@ -35,12 +36,12 @@ public class GuestSessionHandler : IAuthHandler
     public GuestSessionHandler(
         IDataProtectionProvider dataProtectionProvider,
         IServiceScopeFactory scopeFactory,
-        IMemoryCache cache,
+        GuestSessionCacheService sessionCache,
         ILogger<GuestSessionHandler> logger)
     {
         _protector = dataProtectionProvider.CreateProtector(ProtectorPurpose);
         _scopeFactory = scopeFactory;
-        _cache = cache;
+        _sessionCache = sessionCache;
         _logger = logger;
     }
 
@@ -70,31 +71,47 @@ public class GuestSessionHandler : IAuthHandler
             return AuthResult.Skip();
         }
 
+        // A guest grant belongs to exactly one tenant, so a session cannot be validated
+        // without a resolved tenant to validate it against.
+        if (context.Items["TenantContext"] is not TenantContext tenantCtx)
+        {
+            _logger.LogDebug("Guest session {GrantId} presented with no resolved tenant, clearing cookie", grantId);
+            ClearGuestSessionCookie(context);
+            return AuthResult.Failure(InvalidSessionError);
+        }
+
         // Check cache first, then validate against the database
-        var cacheKey = $"guest-session:{grantId}";
-        if (!_cache.TryGetValue(cacheKey, out GuestSessionInfo? session))
+        if (!_sessionCache.TryGet(tenantCtx.TenantId, grantId, out var session))
         {
             using var scope = _scopeFactory.CreateScope();
 
             // Propagate tenant context into the child scope so RLS allows
             // the oauth_grants query. Without this, the scoped DbContext has
             // TenantId = Guid.Empty and RLS silently filters out the row.
-            if (context.Items["TenantContext"] is TenantContext tenantCtx)
-            {
-                var tenantAccessor = scope.ServiceProvider.GetRequiredService<ITenantAccessor>();
-                tenantAccessor.SetTenant(tenantCtx);
-            }
+            var tenantAccessor = scope.ServiceProvider.GetRequiredService<ITenantAccessor>();
+            tenantAccessor.SetTenant(tenantCtx);
 
             var guestLinkService = scope.ServiceProvider.GetRequiredService<IGuestLinkService>();
             session = await guestLinkService.ValidateSessionAsync(grantId);
-            _cache.Set(cacheKey, session, CacheDuration);
+            _sessionCache.Set(tenantCtx.TenantId, grantId, session);
         }
 
         if (session is null)
         {
             _logger.LogDebug("Guest session {GrantId} is no longer valid, clearing cookie", grantId);
             ClearGuestSessionCookie(context);
-            return AuthResult.Failure("Guest session expired or revoked");
+            return AuthResult.Failure(InvalidSessionError);
+        }
+
+        // Re-bind the session to the resolved tenant independently of the cache key: the grant
+        // carries its own tenant, so a resolution reached by any route is still checked here.
+        if (session.TenantId != tenantCtx.TenantId)
+        {
+            _logger.LogWarning(
+                "Guest session {GrantId} belongs to tenant {GrantTenantId} but was presented to tenant {ResolvedTenantId}",
+                grantId, session.TenantId, tenantCtx.TenantId);
+            ClearGuestSessionCookie(context);
+            return AuthResult.Failure(InvalidSessionError);
         }
 
         var authContext = new AuthContext

--- a/src/API/Nocturne.API/Services/Auth/GuestLinkService.cs
+++ b/src/API/Nocturne.API/Services/Auth/GuestLinkService.cs
@@ -21,14 +21,6 @@ public class GuestLinkService : IGuestLinkService
     private const string CodeAlphabet = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
     private const int CodeLength = 7;
 
-    private static readonly HashSet<string> AllowedGuestScopes = new(StringComparer.OrdinalIgnoreCase)
-    {
-        OAuthScopes.GlucoseRead, OAuthScopes.TreatmentsRead, OAuthScopes.DevicesRead,
-        OAuthScopes.TherapyRead, OAuthScopes.HeartRateRead, OAuthScopes.StepCountRead,
-        OAuthScopes.SleepRead, OAuthScopes.AlertsRead, OAuthScopes.ReportsRead,
-        OAuthScopes.IdentityRead, OAuthScopes.HealthRead,
-    };
-
     private static readonly List<string> DefaultScopes =
         [OAuthScopes.HealthRead, OAuthScopes.TherapyRead, OAuthScopes.ReportsRead];
 
@@ -55,16 +47,8 @@ public class GuestLinkService : IGuestLinkService
         IEnumerable<string>? scopes = null,
         CancellationToken ct = default)
     {
-        var scopeList = (scopes ?? DefaultScopes).ToList();
-
-        foreach (var scope in scopeList)
-        {
-            if (!AllowedGuestScopes.Contains(scope))
-            {
-                throw new ArgumentException(
-                    $"Scope '{scope}' is not allowed for guest links. Only read scopes are permitted.");
-            }
-        }
+        var scopeList = OAuthScopes.ValidateGrantScopes(
+            scopes ?? DefaultScopes, OAuthGrantTypes.Guest);
 
         var activeCount = await GetActiveCountAsync(dataOwnerSubjectId, ct);
         if (activeCount >= MaxActiveLinks)

--- a/src/API/Nocturne.API/Services/Auth/GuestLinkService.cs
+++ b/src/API/Nocturne.API/Services/Auth/GuestLinkService.cs
@@ -33,13 +33,16 @@ public class GuestLinkService : IGuestLinkService
         [OAuthScopes.HealthRead, OAuthScopes.TherapyRead, OAuthScopes.ReportsRead];
 
     private readonly NocturneDbContext _dbContext;
+    private readonly GuestSessionCacheService _sessionCache;
     private readonly ILogger<GuestLinkService> _logger;
 
     public GuestLinkService(
         NocturneDbContext dbContext,
+        GuestSessionCacheService sessionCache,
         ILogger<GuestLinkService> logger)
     {
         _dbContext = dbContext;
+        _sessionCache = sessionCache;
         _logger = logger;
     }
 
@@ -132,6 +135,7 @@ public class GuestLinkService : IGuestLinkService
 
         var session = new GuestSessionInfo(
             grant.Id,
+            grant.TenantId,
             grant.SubjectId,
             grant.Scopes.AsReadOnly(),
             grant.Label,
@@ -160,6 +164,7 @@ public class GuestLinkService : IGuestLinkService
 
         return new GuestSessionInfo(
             grant.Id,
+            grant.TenantId,
             grant.SubjectId,
             grant.Scopes.AsReadOnly(),
             grant.Label,
@@ -207,6 +212,8 @@ public class GuestLinkService : IGuestLinkService
         grant.RevokedAt = DateTime.UtcNow;
         await _dbContext.SaveChangesAsync(ct);
 
+        _sessionCache.Evict(grant.TenantId, grant.Id);
+
         _logger.LogInformation("Guest link {GrantId} revoked by {RequestingSubjectId}", grantId, requestingSubjectId);
         return true;
     }
@@ -243,6 +250,8 @@ public class GuestLinkService : IGuestLinkService
 
         grant.DismissedAt = now;
         await _dbContext.SaveChangesAsync(ct);
+
+        _sessionCache.Evict(grant.TenantId, grant.Id);
 
         _logger.LogInformation("Guest link {GrantId} dismissed by {RequestingSubjectId}", grantId, requestingSubjectId);
         return true;

--- a/src/API/Nocturne.API/Services/Auth/GuestSessionCacheService.cs
+++ b/src/API/Nocturne.API/Services/Auth/GuestSessionCacheService.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.Caching.Memory;
+using Nocturne.Core.Contracts.Auth;
+
+namespace Nocturne.API.Services.Auth;
+
+/// <summary>
+/// Caches validated guest sessions to keep repeated reads off the database. Used by
+/// <see cref="Middleware.Handlers.GuestSessionHandler"/> on every request that carries a
+/// guest session cookie.
+/// </summary>
+/// <remarks>
+/// Entries have a fixed TTL of 30 seconds and are keyed by tenant as well as grant, so a
+/// resolution warmed on one tenant is never served to a request resolved to another. Both
+/// hits and misses are cached. Call <see cref="Evict"/> when a grant is revoked or dismissed
+/// so the link stops resolving immediately instead of at the end of the TTL.
+/// </remarks>
+public sealed class GuestSessionCacheService
+{
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromSeconds(30);
+
+    private readonly IMemoryCache _cache;
+
+    public GuestSessionCacheService(IMemoryCache cache)
+    {
+        _cache = cache;
+    }
+
+    /// <summary>
+    /// Returns the cached resolution for the grant on the given tenant. A <see langword="true"/>
+    /// return with a <see langword="null"/> <paramref name="session"/> is a cached miss.
+    /// </summary>
+    public bool TryGet(Guid tenantId, Guid grantId, out GuestSessionInfo? session)
+        => _cache.TryGetValue(CacheKey(tenantId, grantId), out session);
+
+    /// <summary>Caches the resolution (or the absence of one) for the grant on the given tenant.</summary>
+    public void Set(Guid tenantId, Guid grantId, GuestSessionInfo? session)
+        => _cache.Set(CacheKey(tenantId, grantId), session, CacheTtl);
+
+    /// <summary>Evicts the cached resolution. Call on revoke or dismiss.</summary>
+    public void Evict(Guid tenantId, Guid grantId)
+        => _cache.Remove(CacheKey(tenantId, grantId));
+
+    private static string CacheKey(Guid tenantId, Guid grantId) => $"guest-session:{tenantId}:{grantId}";
+}

--- a/src/API/Nocturne.API/Services/Auth/OAuthGrantService.cs
+++ b/src/API/Nocturne.API/Services/Auth/OAuthGrantService.cs
@@ -16,6 +16,7 @@ public class OAuthGrantService : IOAuthGrantService
     private readonly NocturneDbContext _dbContext;
     private readonly IDbContextFactory<NocturneDbContext> _dbContextFactory;
     private readonly IOAuthClientService _clientService;
+    private readonly GuestSessionCacheService _guestSessionCache;
     private readonly ILogger<OAuthGrantService> _logger;
 
     /// <summary>
@@ -25,16 +26,19 @@ public class OAuthGrantService : IOAuthGrantService
     /// <param name="dbContextFactory">Factory used by <see cref="IsGrantRevokedAsync"/>, which runs
     /// during authentication and so cannot rely on the scoped context being tenant-pinned yet.</param>
     /// <param name="clientService">Used to resolve client metadata (currently unused in this implementation).</param>
+    /// <param name="guestSessionCache">Cache evicted when a grant is revoked, so a revoked guest link stops resolving.</param>
     /// <param name="logger">Logger instance.</param>
     public OAuthGrantService(
         NocturneDbContext dbContext,
         IDbContextFactory<NocturneDbContext> dbContextFactory,
         IOAuthClientService clientService,
+        GuestSessionCacheService guestSessionCache,
         ILogger<OAuthGrantService> logger)
     {
         _dbContext = dbContext;
         _dbContextFactory = dbContextFactory;
         _clientService = clientService;
+        _guestSessionCache = guestSessionCache;
         _logger = logger;
     }
 
@@ -172,6 +176,13 @@ public class OAuthGrantService : IOAuthGrantService
         }
 
         await _dbContext.SaveChangesAsync(ct);
+
+        // Guest sessions are cached for 30 seconds, so revoking the grant is not enough on its
+        // own. Evicting here rather than in GuestLinkService covers every revoke path: a guest
+        // grant's SubjectId is the data owner, and DeleteGrant filters only on SubjectId, so the
+        // owner can revoke their own guest link through the OAuth grants API without ever
+        // entering GuestLinkService.
+        _guestSessionCache.Evict(grant.TenantId, grant.Id);
 
         _logger.LogInformation(
             "OAuthAudit: {Event} grant_id={GrantId} subject_id={SubjectId} revoked_tokens={TokenCount}",

--- a/src/API/Nocturne.API/Services/Auth/OAuthGrantService.cs
+++ b/src/API/Nocturne.API/Services/Auth/OAuthGrantService.cs
@@ -273,19 +273,23 @@ public class OAuthGrantService : IOAuthGrantService
         if (grant == null || grant.SubjectId != ownerSubjectId)
             return null;
 
+        // Validated before anything is assigned, so a rejected update leaves the tracked entity
+        // untouched. This method filters on the grant id and the owning subject with no GrantType
+        // filter, and a guest grant records the DATA OWNER's subject id, so the owner reaches their
+        // own guest link here; the cap is what stops a PATCH turning a read-only share into full
+        // access.
+        var validatedScopes = scopes is null
+            ? null
+            : OAuthScopes.ValidateGrantScopes(scopes, grant.GrantType);
+
         if (label != null)
         {
             grant.Label = label;
         }
 
-        if (scopes != null)
+        if (validatedScopes != null)
         {
-            // This method filters on the grant id and the owning subject only, with no GrantType
-            // filter, and a guest grant records the DATA OWNER's subject id — so the owner reaches
-            // their own guest link here. ValidateGrantScopes rejects a scope outside the vocabulary
-            // and caps a guest grant at the read scopes a guest link may hold, so a read-only share
-            // cannot be turned into full access by a PATCH.
-            grant.Scopes = OAuthScopes.ValidateGrantScopes(scopes, grant.GrantType);
+            grant.Scopes = validatedScopes;
         }
 
         await _dbContext.SaveChangesAsync(ct);

--- a/src/API/Nocturne.API/Services/Auth/OAuthGrantService.cs
+++ b/src/API/Nocturne.API/Services/Auth/OAuthGrantService.cs
@@ -280,10 +280,20 @@ public class OAuthGrantService : IOAuthGrantService
 
         if (scopes != null)
         {
-            grant.Scopes = scopes.Distinct().OrderBy(s => s).ToList();
+            // This method filters on the grant id and the owning subject only, with no GrantType
+            // filter, and a guest grant records the DATA OWNER's subject id — so the owner reaches
+            // their own guest link here. ValidateGrantScopes rejects a scope outside the vocabulary
+            // and caps a guest grant at the read scopes a guest link may hold, so a read-only share
+            // cannot be turned into full access by a PATCH.
+            grant.Scopes = OAuthScopes.ValidateGrantScopes(scopes, grant.GrantType);
         }
 
         await _dbContext.SaveChangesAsync(ct);
+
+        // The cached guest session carries the grant's scopes, so narrowing a guest link's scopes
+        // would otherwise leave the wider set live for the rest of the 30-second TTL. Mirrors
+        // RevokeGrantAsync, and for the same reason: this path never enters GuestLinkService.
+        _guestSessionCache.Evict(grant.TenantId, grant.Id);
 
         _logger.LogInformation(
             "OAuthAudit: {Event} grant_id={GrantId} subject_id={SubjectId}",

--- a/src/Core/Nocturne.Core.Contracts/Auth/IGuestLinkService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Auth/IGuestLinkService.cs
@@ -39,8 +39,14 @@ public record GuestLinkCreationResult(string Code, string FullUrl, GuestLinkInfo
 
 public record GuestLinkActivationResult(bool Success, GuestSessionInfo? Session, string? Error);
 
+/// <summary>
+/// A validated guest session. <paramref name="TenantId"/> is the tenant the underlying grant
+/// belongs to; callers must compare it against the tenant resolved for the request before
+/// honouring the session.
+/// </summary>
 public record GuestSessionInfo(
     Guid GrantId,
+    Guid TenantId,
     Guid DataOwnerSubjectId,
     IReadOnlyList<string> Scopes,
     string? Label,

--- a/src/Core/Nocturne.Core.Models/Authorization/OAuthScopes.cs
+++ b/src/Core/Nocturne.Core.Models/Authorization/OAuthScopes.cs
@@ -149,6 +149,19 @@ public static class OAuthScopes
         new HashSet<string>(ValidRequestScopes.Concat(TenantPermissions.All));
 
     /// <summary>
+    /// The scopes a guest grant may hold. A guest link is a short-lived share of one person's data
+    /// with no account behind it, so it is capped at read and cannot be widened past this set by
+    /// anyone — including the data owner whose subject id the grant records.
+    /// </summary>
+    /// <seealso cref="ValidateGrantScopes"/>
+    public static readonly IReadOnlySet<string> AllowedGuestScopes =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            GlucoseRead, TreatmentsRead, DevicesRead, TherapyRead, HeartRateRead, StepCountRead,
+            SleepRead, AlertsRead, ReportsRead, IdentityRead, HealthRead,
+        };
+
+    /// <summary>
     /// Expansion of the health.read convenience alias.
     /// </summary>
     public static readonly IReadOnlyList<string> HealthReadExpansion = new[]
@@ -214,6 +227,43 @@ public static class OAuthScopes
     public static bool TryGetImpliedReadScope(string readWriteScope, out string readScope)
     {
         return ReadWriteImpliesRead.TryGetValue(readWriteScope, out readScope!);
+
+    /// <summary>
+    /// The scope list to store on a grant of <paramref name="grantType"/>: deduplicated, ordered, every
+    /// scope in the vocabulary, and — for a guest grant — within <see cref="AllowedGuestScopes"/>.
+    /// </summary>
+    /// <param name="scopes">The requested scopes.</param>
+    /// <param name="grantType">The grant's type, from the <c>GrantType*</c> constants.</param>
+    /// <returns>The scopes to store.</returns>
+    /// <exception cref="ArgumentException">
+    /// A scope is not a recognised scope, or is wider than the grant type may hold. Callers surface
+    /// this as <c>invalid_scope</c>.
+    /// </exception>
+    /// <remarks>
+    /// Both paths that take a grant's scopes from a caller go through here — creating a guest link and
+    /// updating a grant — so the cap on a guest link holds whichever one the scopes arrive on. The
+    /// authorization-code and device-code flows validate the requested scopes before a grant is
+    /// created and do not reach a guest grant.
+    /// </remarks>
+    public static List<string> ValidateGrantScopes(IEnumerable<string> scopes, string grantType)
+    {
+        var requested = scopes.Distinct().OrderBy(s => s).ToList();
+
+        foreach (var scope in requested)
+        {
+            if (!IsValid(scope))
+            {
+                throw new ArgumentException($"Scope '{scope}' is not a recognised scope.");
+            }
+
+            if (grantType == GrantTypeGuest && !AllowedGuestScopes.Contains(scope))
+            {
+                throw new ArgumentException(
+                    $"Scope '{scope}' is not allowed for guest links. Only read scopes are permitted.");
+            }
+        }
+
+        return requested;
     }
 
     /// <summary>

--- a/src/Core/Nocturne.Core.Models/Authorization/OAuthScopes.cs
+++ b/src/Core/Nocturne.Core.Models/Authorization/OAuthScopes.cs
@@ -227,6 +227,7 @@ public static class OAuthScopes
     public static bool TryGetImpliedReadScope(string readWriteScope, out string readScope)
     {
         return ReadWriteImpliesRead.TryGetValue(readWriteScope, out readScope!);
+    }
 
     /// <summary>
     /// The scope list to store on a grant of <paramref name="grantType"/>: deduplicated, ordered, every

--- a/src/Core/Nocturne.Core.Models/Authorization/OAuthScopes.cs
+++ b/src/Core/Nocturne.Core.Models/Authorization/OAuthScopes.cs
@@ -155,7 +155,7 @@ public static class OAuthScopes
     /// </summary>
     /// <seealso cref="ValidateGrantScopes"/>
     public static readonly IReadOnlySet<string> AllowedGuestScopes =
-        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        new HashSet<string>(StringComparer.Ordinal)
         {
             GlucoseRead, TreatmentsRead, DevicesRead, TherapyRead, HeartRateRead, StepCountRead,
             SleepRead, AlertsRead, ReportsRead, IdentityRead, HealthRead,
@@ -241,10 +241,10 @@ public static class OAuthScopes
     /// this as <c>invalid_scope</c>.
     /// </exception>
     /// <remarks>
-    /// Both paths that take a grant's scopes from a caller go through here — creating a guest link and
-    /// updating a grant — so the cap on a guest link holds whichever one the scopes arrive on. The
-    /// authorization-code and device-code flows validate the requested scopes before a grant is
-    /// created and do not reach a guest grant.
+    /// The two paths that can set a guest grant's scopes go through here: creating a guest link and
+    /// updating a grant. <c>OAuthGrantService.CreateOrUpdateGrantAsync</c> also assigns scopes but
+    /// matches on a client id, which a guest grant does not have, so it cannot reach one. The
+    /// authorization-code and device-code flows validate before a grant is created.
     /// </remarks>
     public static List<string> ValidateGrantScopes(IEnumerable<string> scopes, string grantType)
     {

--- a/tests/Integration/Nocturne.API.Tests/Auth/GuestLinkLifecycleIntegrationTests.cs
+++ b/tests/Integration/Nocturne.API.Tests/Auth/GuestLinkLifecycleIntegrationTests.cs
@@ -434,6 +434,52 @@ public class GuestLinkLifecycleIntegrationTests : AspireIntegrationTestBase
         Log($"Guest session admin access rejected, status: {response.StatusCode}");
     }
 
+    [Fact]
+    public async Task GuestSession_ReplayedAtAnotherTenantHost_Rejected()
+    {
+        // Arrange - seed a second tenant to replay the session cookie against
+        var connStr = await GetPostgresConnectionStringAsync();
+        await using var conn = new NpgsqlConnection(connStr);
+        await conn.OpenAsync();
+
+        var victimSlug = $"victim-{Guid.NewGuid():N}"[..20];
+        await AuthTestHelpers.SeedTenantAsync(conn, victimSlug, "Victim Tenant");
+
+        var code = await CreateGuestLinkCodeAsync();
+
+        var handler = new HttpClientHandler { UseCookies = true };
+        using var cookieClient = new HttpClient(handler)
+        {
+            BaseAddress = ApiClient.BaseAddress
+        };
+
+        var activateResponse = await cookieClient.PostAsJsonAsync("/api/v4/guest-links/activate", new
+        {
+            code
+        });
+        activateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Warm the guest-session cache on the tenant the grant belongs to.
+        var ownTenantResponse = await cookieClient.GetAsync("/api/v1/entries/current");
+        ownTenantResponse.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+
+        var guestCookie = handler.CookieContainer
+            .GetCookies(ApiClient.BaseAddress!)
+            .Cast<System.Net.Cookie>()
+            .Single(c => c.Name == "nocturne-guest-session");
+
+        // Act - present the same cookie at the other tenant's host, inside the cache TTL
+        using var victimClient = AuthTestHelpers.CreateTenantClient(
+            Fixture, victimSlug, AuthTestHelpers.GetBaseDomain(ApiClient));
+        victimClient.DefaultRequestHeaders.Add("Cookie", $"{guestCookie.Name}={guestCookie.Value}");
+
+        var response = await victimClient.GetAsync("/api/v1/entries/current");
+
+        // Assert
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+        Log($"Cross-tenant guest session replay rejected, status: {response.StatusCode}");
+    }
+
     #endregion
 
     #region Revoke Guest Link

--- a/tests/Integration/Nocturne.API.Tests/Auth/GuestLinkLifecycleIntegrationTests.cs
+++ b/tests/Integration/Nocturne.API.Tests/Auth/GuestLinkLifecycleIntegrationTests.cs
@@ -57,7 +57,7 @@ public class GuestLinkLifecycleIntegrationTests : AspireIntegrationTestBase
         var response = await client.PostAsJsonAsync("/api/v4/guest-links", new
         {
             label = "Test Link",
-            scopes = new[] { "entries.read" }
+            scopes = new[] { "glucose.read" }
         });
 
         // Assert
@@ -70,7 +70,7 @@ public class GuestLinkLifecycleIntegrationTests : AspireIntegrationTestBase
         code.Should().NotBeNullOrWhiteSpace();
         code.Should().MatchRegex(@"^[A-Z0-9]{3}-[A-Z0-9]{4}$", "code should be formatted as ABC-DEFG");
 
-        var url = body.GetProperty("url").GetString();
+        var url = body.GetProperty("fullUrl").GetString();
         url.Should().NotBeNullOrWhiteSpace();
         url.Should().Contain("/guest/");
 
@@ -84,7 +84,7 @@ public class GuestLinkLifecycleIntegrationTests : AspireIntegrationTestBase
         var response = await ApiClient.PostAsJsonAsync("/api/v4/guest-links", new
         {
             label = "Unauthenticated Link",
-            scopes = new[] { "entries.read" }
+            scopes = new[] { "glucose.read" }
         });
 
         // Assert
@@ -103,7 +103,7 @@ public class GuestLinkLifecycleIntegrationTests : AspireIntegrationTestBase
             var createResponse = await client.PostAsJsonAsync("/api/v4/guest-links", new
             {
                 label = $"Link {i + 1}",
-                scopes = new[] { "entries.read" }
+                scopes = new[] { "glucose.read" }
             });
             createResponse.StatusCode.Should().Be(HttpStatusCode.OK, $"link {i + 1} creation should succeed");
         }
@@ -112,7 +112,7 @@ public class GuestLinkLifecycleIntegrationTests : AspireIntegrationTestBase
         var response = await client.PostAsJsonAsync("/api/v4/guest-links", new
         {
             label = "Link 6 - Over Limit",
-            scopes = new[] { "entries.read" }
+            scopes = new[] { "glucose.read" }
         });
 
         // Assert
@@ -129,11 +129,17 @@ public class GuestLinkLifecycleIntegrationTests : AspireIntegrationTestBase
         var response = await client.PostAsJsonAsync("/api/v4/guest-links", new
         {
             label = "Write Scope Link",
-            scopes = new[] { "entries.readwrite" }
+            scopes = new[] { "glucose.readwrite" }
         });
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        // glucose.readwrite is a recognised request scope, so this reaches the guest cap rather than
+        // the recognised-scope guard. Asserted so the case cannot silently start passing for the
+        // wrong reason if the scope name changes again.
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("error").GetString().Should().Contain("not allowed for guest links");
     }
 
     #endregion
@@ -148,7 +154,7 @@ public class GuestLinkLifecycleIntegrationTests : AspireIntegrationTestBase
         var createResponse = await client.PostAsJsonAsync("/api/v4/guest-links", new
         {
             label = "Activate Test",
-            scopes = new[] { "entries.read" }
+            scopes = new[] { "glucose.read" }
         });
         createResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
@@ -493,7 +499,7 @@ public class GuestLinkLifecycleIntegrationTests : AspireIntegrationTestBase
         var createResponse = await client.PostAsJsonAsync("/api/v4/guest-links", new
         {
             label = "Revoke Test",
-            scopes = new[] { "entries.read" }
+            scopes = new[] { "glucose.read" }
         });
         createResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
@@ -521,7 +527,7 @@ public class GuestLinkLifecycleIntegrationTests : AspireIntegrationTestBase
         var createResponse = await ownerClient.PostAsJsonAsync("/api/v4/guest-links", new
         {
             label = "Non-Owner Revoke Test",
-            scopes = new[] { "entries.read" }
+            scopes = new[] { "glucose.read" }
         });
         createResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
@@ -563,7 +569,7 @@ public class GuestLinkLifecycleIntegrationTests : AspireIntegrationTestBase
             var createResponse = await client.PostAsJsonAsync("/api/v4/guest-links", new
             {
                 label = $"List Test Link {i + 1}",
-                scopes = new[] { "entries.read" }
+                scopes = new[] { "glucose.read" }
             });
             createResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         }
@@ -595,7 +601,7 @@ public class GuestLinkLifecycleIntegrationTests : AspireIntegrationTestBase
         var response = await client.PostAsJsonAsync("/api/v4/guest-links", new
         {
             label = "Session Test",
-            scopes = new[] { "entries.read" }
+            scopes = new[] { "glucose.read" }
         });
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 

--- a/tests/Unit/Nocturne.API.Tests/Authorization/OAuthGrantServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/OAuthGrantServiceTests.cs
@@ -296,6 +296,107 @@ public class OAuthGrantServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task UpdateGrantAsync_EvictsTheCachedGuestSession()
+    {
+        using var db = CreateDbContext();
+        await SeedClientAsync(db);
+        await SeedSubjectAsync(db, _ownerSubjectId, "Owner");
+        var grantId = await SeedGrantAsync(db,
+            grantType: OAuthGrantTypes.Guest,
+            scopes: [OAuthScopes.GlucoseRead, OAuthScopes.TreatmentsRead]);
+
+        // The cached session carries the grant's scopes, so narrowing them has to take effect now
+        // rather than at the end of the 30-second TTL. Same structural hole as the DELETE path: this
+        // method filters on the grant id and the owning subject with no GrantType filter, and a guest
+        // grant's SubjectId is the data owner.
+        _guestSessionCache.Set(
+            _testTenantId,
+            grantId,
+            new GuestSessionInfo(
+                grantId,
+                _testTenantId,
+                _ownerSubjectId,
+                [OAuthScopes.GlucoseRead, OAuthScopes.TreatmentsRead],
+                null,
+                DateTime.UtcNow.AddHours(1)));
+
+        var service = CreateService(db);
+        var result = await service.UpdateGrantAsync(
+            grantId, _ownerSubjectId, scopes: [OAuthScopes.GlucoseRead]);
+
+        result!.Scopes.Should().Equal([OAuthScopes.GlucoseRead]);
+        _guestSessionCache.TryGet(_testTenantId, grantId, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UpdateGrantAsync_RefusesToWidenAGuestGrant()
+    {
+        using var db = CreateDbContext();
+        await SeedClientAsync(db);
+        await SeedSubjectAsync(db, _ownerSubjectId, "Owner");
+        var grantId = await SeedGrantAsync(db,
+            grantType: OAuthGrantTypes.Guest,
+            scopes: [OAuthScopes.GlucoseRead]);
+
+        var service = CreateService(db);
+
+        // A guest link is a read-only share with no account behind it. The data owner it belongs to
+        // reaches it here, so the cap has to hold against the owner too.
+        foreach (var widened in new[] { OAuthScopes.FullAccess, OAuthScopes.GlucoseReadWrite })
+        {
+            var attempt = () => service.UpdateGrantAsync(
+                grantId, _ownerSubjectId, scopes: [widened]);
+
+            await attempt.Should().ThrowAsync<ArgumentException>()
+                .Where(e => e.Message.Contains("not allowed for guest links"));
+        }
+
+        var entity = await db.OAuthGrants.AsNoTracking().FirstAsync(g => g.Id == grantId);
+        entity.Scopes.Should().Equal([OAuthScopes.GlucoseRead]);
+    }
+
+    [Fact]
+    public async Task UpdateGrantAsync_RefusesAnUnrecognisedScope()
+    {
+        using var db = CreateDbContext();
+        await SeedClientAsync(db);
+        await SeedSubjectAsync(db, _ownerSubjectId, "Owner");
+        var grantId = await SeedGrantAsync(db, scopes: [OAuthScopes.GlucoseRead]);
+
+        var service = CreateService(db);
+
+        // OAuthController.UpdateGrant catches ArgumentException as invalid_scope; nothing threw it
+        // before, so the API advertised validation it did not perform.
+        var attempt = () => service.UpdateGrantAsync(
+            grantId, _ownerSubjectId, scopes: ["glucose.everything"]);
+
+        await attempt.Should().ThrowAsync<ArgumentException>()
+            .Where(e => e.Message.Contains("not a recognised scope"));
+
+        var entity = await db.OAuthGrants.AsNoTracking().FirstAsync(g => g.Id == grantId);
+        entity.Scopes.Should().Equal([OAuthScopes.GlucoseRead]);
+    }
+
+    [Fact]
+    public async Task UpdateGrantAsync_AllowsAWriteScopeOnAnAppGrant()
+    {
+        using var db = CreateDbContext();
+        await SeedClientAsync(db);
+        await SeedSubjectAsync(db, _ownerSubjectId, "Owner");
+        var grantId = await SeedGrantAsync(db,
+            grantType: OAuthGrantTypes.App,
+            scopes: [OAuthScopes.GlucoseRead]);
+
+        var service = CreateService(db);
+        var result = await service.UpdateGrantAsync(
+            grantId, _ownerSubjectId, scopes: [OAuthScopes.FullAccess]);
+
+        // The guest cap is scoped to guest grants: an app grant is still whatever the user consented
+        // to, including full access.
+        result!.Scopes.Should().Equal([OAuthScopes.FullAccess]);
+    }
+
+    [Fact]
     public async Task UpdateGrantAsync_ReturnsNullForWrongOwner()
     {
         using var db = CreateDbContext();

--- a/tests/Unit/Nocturne.API.Tests/Authorization/OAuthGrantServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/OAuthGrantServiceTests.cs
@@ -1,9 +1,12 @@
+using FluentAssertions;
 using System.Data.Common;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Nocturne.API.Services.Auth;
+using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
@@ -23,6 +26,8 @@ public class OAuthGrantServiceTests : IDisposable
     private readonly DbContextOptions<NocturneDbContext> _contextOptions;
     private readonly Mock<IOAuthClientService> _mockClientService;
     private readonly Mock<ILogger<OAuthGrantService>> _mockLogger;
+    private readonly GuestSessionCacheService _guestSessionCache =
+        new(new MemoryCache(new MemoryCacheOptions()));
 
     private const string TestClientId = "test-client-id";
 
@@ -74,6 +79,7 @@ public class OAuthGrantServiceTests : IDisposable
             dbContext,
             new TestDbContextFactory(_contextOptions, _testTenantId),
             _mockClientService.Object,
+            _guestSessionCache,
             _mockLogger.Object);
     }
 
@@ -191,6 +197,30 @@ public class OAuthGrantServiceTests : IDisposable
 
         var entity = await db.OAuthGrants.FirstAsync(g => g.Id == grantId);
         Assert.NotNull(entity.RevokedAt);
+    }
+
+    [Fact]
+    public async Task RevokeGrantAsync_EvictsTheCachedGuestSession()
+    {
+        using var db = CreateDbContext();
+        await SeedClientAsync(db);
+        await SeedSubjectAsync(db, _ownerSubjectId, "Owner");
+        var grantId = await SeedGrantAsync(db);
+
+        // A guest grant's SubjectId is the data owner, and DELETE /api/oauth/grants/{id} filters
+        // only on SubjectId — so the owner can revoke a guest link through this service without
+        // GuestLinkService being involved. Without eviction here the guest keeps reading health
+        // data until the cache entry expires.
+        _guestSessionCache.Set(
+            _testTenantId,
+            grantId,
+            new GuestSessionInfo(
+                grantId, _testTenantId, _ownerSubjectId, [], null, DateTime.UtcNow.AddHours(1)));
+
+        var service = CreateService(db);
+        await service.RevokeGrantAsync(grantId);
+
+        _guestSessionCache.TryGet(_testTenantId, grantId, out _).Should().BeFalse();
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/GuestSessionHandlerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/GuestSessionHandlerTests.cs
@@ -1,0 +1,205 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.API.Middleware.Handlers;
+using Nocturne.API.Multitenancy;
+using Nocturne.API.Services.Auth;
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Xunit;
+
+namespace Nocturne.API.Tests.Middleware.Handlers;
+
+/// <summary>
+/// Verifies that <see cref="GuestSessionHandler"/> only authenticates a guest session on the
+/// tenant its grant belongs to, and that a revoked grant stops authenticating without waiting
+/// for the session cache to expire.
+/// </summary>
+public class GuestSessionHandlerTests
+{
+    private const string CookieName = "nocturne-guest-session";
+
+    private readonly Guid _tenantId = Guid.CreateVersion7();
+    private readonly Guid _otherTenantId = Guid.CreateVersion7();
+    private readonly Guid _dataOwnerId = Guid.CreateVersion7();
+
+    private readonly DbContextOptions<NocturneDbContext> _dbOptions;
+    private readonly GuestSessionCacheService _sessionCache;
+    private readonly GuestSessionHandler _handler;
+
+    public GuestSessionHandlerTests()
+    {
+        _dbOptions = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        using (var seed = new NocturneDbContext(_dbOptions))
+        {
+            seed.Tenants.Add(new TenantEntity { Id = _tenantId, Slug = "acme", DisplayName = "Acme" });
+            seed.Tenants.Add(new TenantEntity { Id = _otherTenantId, Slug = "other", DisplayName = "Other" });
+            seed.SaveChanges();
+        }
+
+        _sessionCache = new GuestSessionCacheService(new MemoryCache(new MemoryCacheOptions()));
+
+        // Mirrors the request pipeline: the handler sets the tenant on the scope's accessor and
+        // the scoped DbContext is pinned from it, so the grant lookup is tenant-filtered.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(_sessionCache);
+        services.AddScoped<ITenantAccessor, HttpContextTenantAccessor>();
+        services.AddScoped(sp => new NocturneDbContext(_dbOptions)
+        {
+            TenantId = sp.GetRequiredService<ITenantAccessor>().TenantId,
+        });
+        services.AddScoped<IGuestLinkService, GuestLinkService>();
+        var provider = services.BuildServiceProvider();
+
+        _handler = new GuestSessionHandler(
+            new EphemeralDataProtectionProvider(),
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            _sessionCache,
+            NullLogger<GuestSessionHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task NoCookie_Skips()
+    {
+        var result = await _handler.AuthenticateAsync(BuildContext(_tenantId, cookie: null));
+
+        result.ShouldSkip.Should().BeTrue();
+        result.Succeeded.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ActivatedGrant_OnItsOwnTenant_Authenticates()
+    {
+        var grantId = await SeedActivatedGrantAsync(_tenantId);
+        var cookie = ProtectCookie(grantId);
+
+        var result = await _handler.AuthenticateAsync(BuildContext(_tenantId, cookie));
+
+        result.Succeeded.Should().BeTrue();
+        result.AuthContext!.AuthType.Should().Be(AuthType.Guest);
+        result.AuthContext.ActingAsSubjectId.Should().Be(_dataOwnerId);
+    }
+
+    [Fact]
+    public async Task SessionWarmedOnOneTenant_IsRejectedOnAnother()
+    {
+        var grantId = await SeedActivatedGrantAsync(_tenantId);
+        var cookie = ProtectCookie(grantId);
+
+        // Warm the cache on the grant's own tenant, then replay the same cookie at another
+        // tenant's host inside the cache TTL.
+        (await _handler.AuthenticateAsync(BuildContext(_tenantId, cookie))).Succeeded.Should().BeTrue();
+
+        var result = await _handler.AuthenticateAsync(BuildContext(_otherTenantId, cookie));
+
+        result.Succeeded.Should().BeFalse();
+        result.ShouldSkip.Should().BeFalse();
+
+        // The legitimate tenant's session is unaffected.
+        (await _handler.AuthenticateAsync(BuildContext(_tenantId, cookie))).Succeeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CachedSessionBelongingToAnotherTenant_IsRejected()
+    {
+        // Cached under the requested tenant's key but carrying another tenant's grant: the
+        // handler's own comparison must reject it regardless of how it got into the cache.
+        var grantId = await SeedActivatedGrantAsync(_tenantId);
+        var cookie = ProtectCookie(grantId);
+        _sessionCache.Set(_otherTenantId, grantId, new GuestSessionInfo(
+            grantId,
+            _tenantId,
+            _dataOwnerId,
+            [OAuthScopes.GlucoseRead],
+            "Caregiver",
+            DateTime.UtcNow.AddHours(1)));
+
+        var result = await _handler.AuthenticateAsync(BuildContext(_otherTenantId, cookie));
+
+        result.Succeeded.Should().BeFalse();
+        result.ShouldSkip.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task NoResolvedTenant_IsRejected()
+    {
+        var grantId = await SeedActivatedGrantAsync(_tenantId);
+        var cookie = ProtectCookie(grantId);
+
+        var result = await _handler.AuthenticateAsync(BuildContext(tenantId: null, cookie));
+
+        result.Succeeded.Should().BeFalse();
+        result.ShouldSkip.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RevokedGrant_IsRejectedWithoutWaitingForCacheExpiry()
+    {
+        var grantId = await SeedActivatedGrantAsync(_tenantId);
+        var cookie = ProtectCookie(grantId);
+
+        (await _handler.AuthenticateAsync(BuildContext(_tenantId, cookie))).Succeeded.Should().BeTrue();
+
+        await using (var ctx = new NocturneDbContext(_dbOptions) { TenantId = _tenantId })
+        {
+            var service = new GuestLinkService(ctx, _sessionCache, NullLogger<GuestLinkService>.Instance);
+            (await service.RevokeAsync(grantId, _dataOwnerId)).Should().BeTrue();
+        }
+
+        var result = await _handler.AuthenticateAsync(BuildContext(_tenantId, cookie));
+
+        result.Succeeded.Should().BeFalse();
+        result.ShouldSkip.Should().BeFalse();
+    }
+
+    private async Task<Guid> SeedActivatedGrantAsync(Guid tenantId)
+    {
+        await using var ctx = new NocturneDbContext(_dbOptions) { TenantId = tenantId };
+        var service = new GuestLinkService(ctx, _sessionCache, NullLogger<GuestLinkService>.Instance);
+
+        var created = await service.CreateGuestLinkAsync(
+            _dataOwnerId, _dataOwnerId, "Caregiver", "https://acme.example.test");
+        var activation = await service.ActivateAsync(created.Code, "1.2.3.4", "TestAgent");
+
+        activation.Success.Should().BeTrue();
+        return activation.Session!.GrantId;
+    }
+
+    /// <summary>
+    /// Produces a cookie value using the handler's own protector.
+    /// </summary>
+    private string ProtectCookie(Guid grantId)
+    {
+        var writer = new DefaultHttpContext();
+        _handler.SetGuestSessionCookie(writer, grantId, DateTime.UtcNow.AddHours(1));
+
+        var setCookie = writer.Response.Headers.SetCookie.ToString();
+        return setCookie.Split(';')[0].Split('=', 2)[1];
+    }
+
+    private static DefaultHttpContext BuildContext(Guid? tenantId, string? cookie)
+    {
+        var context = new DefaultHttpContext();
+        if (cookie is not null)
+        {
+            context.Request.Headers["Cookie"] = $"{CookieName}={cookie}";
+        }
+        if (tenantId is not null)
+        {
+            context.Items["TenantContext"] =
+                new TenantContext(tenantId.Value, "acme", "Acme", IsActive: true);
+        }
+        return context;
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/GuestSessionCacheServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/GuestSessionCacheServiceTests.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Nocturne.API.Services.Auth;
+using Nocturne.Core.Contracts.Auth;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Auth;
+
+/// <summary>
+/// Pins the tenant in the cache key directly. The handler also compares the cached session's
+/// tenant against the resolved one, and that comparison alone makes a cross-tenant replay fail —
+/// so a key that dropped the tenant would leave the handler tests green. These assert the key
+/// itself, which is the half that stops one tenant's entry from ever being served to another.
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class GuestSessionCacheServiceTests
+{
+    private static readonly Guid TenantA = Guid.CreateVersion7();
+    private static readonly Guid TenantB = Guid.CreateVersion7();
+    private static readonly Guid GrantId = Guid.CreateVersion7();
+
+    private static GuestSessionCacheService Build() =>
+        new(new MemoryCache(new MemoryCacheOptions()));
+
+    private static GuestSessionInfo SessionFor(Guid tenantId) =>
+        new(GrantId, tenantId, Guid.CreateVersion7(), [], null, DateTime.UtcNow.AddHours(1));
+
+    [Fact]
+    public void An_entry_cached_for_one_tenant_is_not_returned_for_another()
+    {
+        var cache = Build();
+
+        cache.Set(TenantA, GrantId, SessionFor(TenantA));
+
+        cache.TryGet(TenantB, GrantId, out var other).Should().BeFalse(
+            "the same grant id under a different tenant must be a cache miss, so the miss falls "
+            + "through to the tenant-scoped database lookup");
+        other.Should().BeNull();
+    }
+
+    [Fact]
+    public void An_entry_is_returned_for_the_tenant_it_was_cached_under()
+    {
+        var cache = Build();
+
+        cache.Set(TenantA, GrantId, SessionFor(TenantA));
+
+        cache.TryGet(TenantA, GrantId, out var hit).Should().BeTrue();
+        hit!.TenantId.Should().Be(TenantA);
+    }
+
+    [Fact]
+    public void Eviction_only_removes_the_entry_for_the_tenant_it_names()
+    {
+        var cache = Build();
+        cache.Set(TenantA, GrantId, SessionFor(TenantA));
+        cache.Set(TenantB, GrantId, SessionFor(TenantB));
+
+        cache.Evict(TenantA, GrantId);
+
+        cache.TryGet(TenantA, GrantId, out _).Should().BeFalse();
+        cache.TryGet(TenantB, GrantId, out _).Should().BeTrue(
+            "eviction is keyed on the revoked grant's own tenant, so it must not clear another "
+            + "tenant's entry for the same grant id");
+    }
+
+    [Fact]
+    public void A_negative_entry_is_cached_per_tenant()
+    {
+        var cache = Build();
+
+        cache.Set(TenantA, GrantId, null);
+
+        cache.TryGet(TenantA, GrantId, out var cached).Should().BeTrue();
+        cached.Should().BeNull();
+        cache.TryGet(TenantB, GrantId, out _).Should().BeFalse();
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/GuestLinkServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/GuestLinkServiceTests.cs
@@ -101,8 +101,14 @@ public class GuestLinkServiceTests : IDisposable
         var act = () => _service.CreateGuestLinkAsync(
             _dataOwnerId, _creatorId, "Admin Scopes", "https://example.com", [scope]);
 
-        await act.Should().ThrowAsync<ArgumentException>()
-            .WithMessage("*not allowed*");
+        // Rejected, but by the recognised-scope guard rather than the guest cap, so the message is
+        // not asserted. A tenant-administration atom is deliberately absent from ValidRequestScopes
+        // — no client may request one and no user may consent to one — so OAuthScopes.IsValid fails
+        // it before ValidateGrantScopes reaches AllowedGuestScopes. Both guards reject it; which one
+        // speaks first is incidental, and pinning the wording made this test fail the moment guest
+        // validation moved into the shared helper. CreateGuestLink_RejectsWriteScopes covers the
+        // guest-cap message, using a scope that IS requestable.
+        await act.Should().ThrowAsync<ArgumentException>();
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/GuestLinkServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/GuestLinkServiceTests.cs
@@ -101,14 +101,12 @@ public class GuestLinkServiceTests : IDisposable
         var act = () => _service.CreateGuestLinkAsync(
             _dataOwnerId, _creatorId, "Admin Scopes", "https://example.com", [scope]);
 
-        // Rejected, but by the recognised-scope guard rather than the guest cap, so the message is
-        // not asserted. A tenant-administration atom is deliberately absent from ValidRequestScopes
-        // — no client may request one and no user may consent to one — so OAuthScopes.IsValid fails
-        // it before ValidateGrantScopes reaches AllowedGuestScopes. Both guards reject it; which one
-        // speaks first is incidental, and pinning the wording made this test fail the moment guest
-        // validation moved into the shared helper. CreateGuestLink_RejectsWriteScopes covers the
-        // guest-cap message, using a scope that IS requestable.
-        await act.Should().ThrowAsync<ArgumentException>();
+        // An administration atom is absent from ValidRequestScopes, so the recognised-scope guard
+        // rejects it before the guest cap is consulted. Either guard is a correct rejection, so the
+        // assertion accepts both rather than pinning one wording.
+        await act.Should().ThrowAsync<ArgumentException>()
+            .Where(e => e.Message.Contains("not a recognised scope")
+                        || e.Message.Contains("not allowed for guest links"));
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/GuestLinkServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/GuestLinkServiceTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using Nocturne.API.Services.Auth;
 using Nocturne.Core.Contracts.Auth;
@@ -15,6 +16,7 @@ namespace Nocturne.API.Tests.Services;
 public class GuestLinkServiceTests : IDisposable
 {
     private readonly NocturneDbContext _dbContext;
+    private readonly GuestSessionCacheService _sessionCache;
     private readonly GuestLinkService _service;
     private readonly Guid _tenantId = Guid.CreateVersion7();
     private readonly Guid _dataOwnerId = Guid.CreateVersion7();
@@ -36,8 +38,11 @@ public class GuestLinkServiceTests : IDisposable
         });
         _dbContext.SaveChanges();
 
+        _sessionCache = new GuestSessionCacheService(new MemoryCache(new MemoryCacheOptions()));
+
         _service = new GuestLinkService(
             _dbContext,
+            _sessionCache,
             NullLogger<GuestLinkService>.Instance);
     }
 
@@ -198,6 +203,53 @@ public class GuestLinkServiceTests : IDisposable
         var session = await _service.ValidateSessionAsync(created.Info.Id);
 
         session.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ValidateSessionAsync_CarriesGrantTenant()
+    {
+        var created = await _service.CreateGuestLinkAsync(_dataOwnerId, _creatorId, "Tenant Test", "https://example.com");
+        await _service.ActivateAsync(created.Code, "1.2.3.4", "Agent");
+
+        var session = await _service.ValidateSessionAsync(created.Info.Id);
+
+        session.Should().NotBeNull();
+        session!.TenantId.Should().Be(_tenantId);
+    }
+
+    [Fact]
+    public async Task ActivateAsync_SessionCarriesGrantTenant()
+    {
+        var created = await _service.CreateGuestLinkAsync(_dataOwnerId, _creatorId, "Tenant Activate", "https://example.com");
+
+        var result = await _service.ActivateAsync(created.Code, "1.2.3.4", "Agent");
+
+        result.Session!.TenantId.Should().Be(_tenantId);
+    }
+
+    [Fact]
+    public async Task RevokeAsync_EvictsCachedSession()
+    {
+        var created = await _service.CreateGuestLinkAsync(_dataOwnerId, _creatorId, "Evict On Revoke", "https://example.com");
+        var activation = await _service.ActivateAsync(created.Code, "1.2.3.4", "Agent");
+        _sessionCache.Set(_tenantId, created.Info.Id, activation.Session);
+
+        await _service.RevokeAsync(created.Info.Id, _dataOwnerId);
+
+        _sessionCache.TryGet(_tenantId, created.Info.Id, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DismissAsync_EvictsCachedSession()
+    {
+        var created = await _service.CreateGuestLinkAsync(_dataOwnerId, _creatorId, "Evict On Dismiss", "https://example.com");
+        var activation = await _service.ActivateAsync(created.Code, "1.2.3.4", "Agent");
+        await _service.RevokeAsync(created.Info.Id, _dataOwnerId);
+        _sessionCache.Set(_tenantId, created.Info.Id, activation.Session);
+
+        await _service.DismissAsync(created.Info.Id, _dataOwnerId);
+
+        _sessionCache.TryGet(_tenantId, created.Info.Id, out _).Should().BeFalse();
     }
 
     [Fact]


### PR DESCRIPTION
A guest link issued for one tenant resolved on any tenant. Guest sessions are now pinned to the tenant their grant belongs to, enforced on every request by a tenant-keyed cache and an independent `TenantId` comparison; a mid-session mismatch rejects and clears the cookie. Guest grants are capped at read scopes on both paths that can set them, and every revoke, dismiss and update path evicts the cached session.

Detail is in the commit messages.

**From review, fixed here:**
- `GET /api/v4/guest-links` gated on `IsAuthenticated` without the `SubjectId` check its siblings have, so a guest cookie listed the owner's links including each guest's `ActivatedIp`.
- The lifecycle integration tests requested `entries.read`, renamed to `glucose.read` months ago, so every create 400'd and the tenant-replay test failed at arrangement — the branch's headline property had no working end-to-end coverage.
- `UpdateGrantAsync` mutated `Label` before validation could throw.

**Known limitation:** cache eviction is process-local, so above one replica a revoke leaves the link live elsewhere for up to the 30s TTL — same as `ShareTokenCacheService`. Production runs one replica.

4394 unit tests pass. CI runs neither the Aspire integration suite nor the frontend tests, so the lifecycle tests above are verified by reading and local build only.