### PR TITLE
fix(rbac): apply a grant ceiling on every conferring path

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Identity/ChatIdentityController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/ChatIdentityController.cs
@@ -91,24 +91,40 @@ public class ChatIdentityController : ControllerBase
     [HttpPost("links/{id:guid}/set-default")]
     [RemoteCommand(Invalidates = ["GetLinks"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> SetDefault(Guid id, CancellationToken ct)
     {
         var tenantId = _tenantAccessor.TenantId;
-        await _service.SetDefaultAsync(tenantId, id, ct);
+        try
+        {
+            await _service.SetDefaultAsync(tenantId, id, ct);
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound();
+        }
         return NoContent();
     }
 
     [HttpPatch("links/{id:guid}")]
     [RemoteCommand(Invalidates = ["GetLinks"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> UpdateLink(
         Guid id, [FromBody] UpdateChatIdentityLinkRequest body, CancellationToken ct)
     {
         var tenantId = _tenantAccessor.TenantId;
-        if (body.Label is not null)
-            await _service.RenameLabelAsync(tenantId, id, body.Label, ct);
-        if (body.DisplayName is not null)
-            await _service.UpdateDisplayNameAsync(tenantId, id, body.DisplayName, ct);
+        try
+        {
+            if (body.Label is not null)
+                await _service.RenameLabelAsync(tenantId, id, body.Label, ct);
+            if (body.DisplayName is not null)
+                await _service.UpdateDisplayNameAsync(tenantId, id, body.DisplayName, ct);
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound();
+        }
         return NoContent();
     }
 
@@ -116,10 +132,18 @@ public class ChatIdentityController : ControllerBase
     [HttpDelete("links/{id:guid}")]
     [RemoteCommand(Invalidates = ["GetLinks"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> RevokeLink(Guid id, CancellationToken ct)
     {
         var tenantId = _tenantAccessor.TenantId;
-        await _service.RevokeAsync(tenantId, id, ct);
+        try
+        {
+            await _service.RevokeAsync(tenantId, id, ct);
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound();
+        }
         return NoContent();
     }
 

--- a/src/API/Nocturne.API/Controllers/V4/Identity/ChatIdentityDirectoryController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/ChatIdentityDirectoryController.cs
@@ -103,11 +103,13 @@ public class ChatIdentityDirectoryController : ControllerBase
         [FromBody] RevokeByPlatformUserRequest body,
         CancellationToken ct)
     {
-        var row = await _directory.GetByIdAsync(id, ct);
+        // Cross-tenant by design: the bot authenticates with the instance key from the apex host
+        // and identifies the row by the chat account on it, not by a tenant.
+        var row = await _directory.GetByIdAsync(id, tenantScope: null, ct);
         if (row is null) return NotFound();
         if (row.Platform != body.Platform || row.PlatformUserId != body.PlatformUserId)
             return Forbid();
-        await _directory.RevokeAsync(id, ct);
+        await _directory.RevokeAsync(id, tenantScope: null, ct);
         return NoContent();
     }
 }

--- a/src/API/Nocturne.API/Controllers/V4/Identity/MemberInviteController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/MemberInviteController.cs
@@ -134,6 +134,7 @@ public class MemberInviteController : ControllerBase
     [HttpPut("members/{id:guid}/roles")]
     [RemoteCommand(Invalidates = ["GetMembers"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> SetMemberRoles(
@@ -155,16 +156,29 @@ public class MemberInviteController : ControllerBase
         if (member == null)
             return NotFound();
 
+        if (IsCallersOwnMembership(member))
+            return Problem(detail: SelfEditDetail, statusCode: 400, title: "Bad Request");
+
         if (request.RoleIds.Count == 0 && (member.DirectPermissions == null || member.DirectPermissions.Count == 0))
             return Problem(detail: "Cannot remove all roles when member has no direct permissions", statusCode: 400, title: "Bad Request");
 
         // Validate roleIds belong to this tenant
         if (request.RoleIds.Count > 0)
         {
-            var validCount = await _dbContext.TenantRoles
-                .CountAsync(r => r.TenantId == tenantId && request.RoleIds.Contains(r.Id), ct);
-            if (validCount != request.RoleIds.Count)
+            var roles = await _dbContext.TenantRoles
+                .Where(r => r.TenantId == tenantId && request.RoleIds.Contains(r.Id))
+                .Select(r => r.Permissions)
+                .ToListAsync(ct);
+            if (roles.Count != request.RoleIds.Count)
                 return Problem(detail: "One or more role IDs do not belong to this tenant", statusCode: 400, title: "Bad Request");
+
+            // Assigning a role grants its permissions, so the same ceiling applies as for a
+            // direct grant: a caller cannot hand out access it does not hold itself.
+            var grantError = TenantPermissions.ValidateGrant(
+                roles.SelectMany(permissions => permissions),
+                HttpContext.GetGrantedScopes());
+            if (grantError != null)
+                return Problem(detail: grantError, statusCode: 403, title: "Forbidden");
         }
 
         // Remove existing role assignments
@@ -198,6 +212,7 @@ public class MemberInviteController : ControllerBase
     [HttpPut("members/{id:guid}/permissions")]
     [RemoteCommand(Invalidates = ["GetMembers"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> SetMemberPermissions(
@@ -219,8 +234,16 @@ public class MemberInviteController : ControllerBase
         if (member == null)
             return NotFound();
 
+        if (IsCallersOwnMembership(member))
+            return Problem(detail: SelfEditDetail, statusCode: 400, title: "Bad Request");
+
         if ((request.DirectPermissions == null || request.DirectPermissions.Count == 0) && member.MemberRoles.Count == 0)
             return Problem(detail: "Cannot remove all permissions when member has no roles", statusCode: 400, title: "Bad Request");
+
+        var grantError = TenantPermissions.ValidateGrant(
+            request.DirectPermissions, HttpContext.GetGrantedScopes());
+        if (grantError != null)
+            return Problem(detail: grantError, statusCode: 403, title: "Forbidden");
 
         member.DirectPermissions = request.DirectPermissions;
         member.SysUpdatedAt = DateTime.UtcNow;
@@ -294,11 +317,19 @@ public class MemberInviteController : ControllerBase
     }
 
     private bool HasPermission(string permission)
-    {
-        var grantedScopes = HttpContext.Items["GrantedScopes"] as IReadOnlySet<string>;
-        if (grantedScopes == null) return false;
-        return TenantPermissions.HasPermission(grantedScopes, permission);
-    }
+        => TenantPermissions.HasPermission(HttpContext.GetGrantedScopes(), permission);
+
+    private const string SelfEditDetail =
+        "Cannot change your own roles or permissions; ask another member with members.manage.";
+
+    /// <summary>
+    /// True when the target membership belongs to the calling subject. Role and permission
+    /// edits are routed away from the caller's own membership: a self-edit is the only way a
+    /// grant decision can widen the granter's own ceiling within a request, and it is also the
+    /// path by which a sole owner can strip their own administrative access.
+    /// </summary>
+    private bool IsCallersOwnMembership(TenantMemberEntity member)
+        => HttpContext.GetSubjectId() is { } subjectId && member.SubjectId == subjectId;
 }
 
 public record SetMemberRolesRequest(List<Guid> RoleIds);

--- a/src/API/Nocturne.API/Controllers/V4/Identity/MemberInviteController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/MemberInviteController.cs
@@ -162,24 +162,10 @@ public class MemberInviteController : ControllerBase
         if (request.RoleIds.Count == 0 && (member.DirectPermissions == null || member.DirectPermissions.Count == 0))
             return Problem(detail: "Cannot remove all roles when member has no direct permissions", statusCode: 400, title: "Bad Request");
 
-        // Validate roleIds belong to this tenant
-        if (request.RoleIds.Count > 0)
-        {
-            var roles = await _dbContext.TenantRoles
-                .Where(r => r.TenantId == tenantId && request.RoleIds.Contains(r.Id))
-                .Select(r => r.Permissions)
-                .ToListAsync(ct);
-            if (roles.Count != request.RoleIds.Count)
-                return Problem(detail: "One or more role IDs do not belong to this tenant", statusCode: 400, title: "Bad Request");
-
-            // Assigning a role grants its permissions, so the same ceiling applies as for a
-            // direct grant: a caller cannot hand out access it does not hold itself.
-            var grantError = TenantPermissions.ValidateGrant(
-                roles.SelectMany(permissions => permissions),
-                HttpContext.GetGrantedScopes());
-            if (grantError != null)
-                return Problem(detail: grantError, statusCode: 403, title: "Forbidden");
-        }
+        var roleGrant = await _tenantRoleService.ValidateRoleGrantAsync(
+            tenantId, request.RoleIds, HttpContext.GetGrantedScopes(), ct);
+        if (!roleGrant.Ok)
+            return RoleGrantProblem(roleGrant);
 
         // Remove existing role assignments
         _dbContext.TenantMemberRoles.RemoveRange(member.MemberRoles);
@@ -240,10 +226,31 @@ public class MemberInviteController : ControllerBase
         if ((request.DirectPermissions == null || request.DirectPermissions.Count == 0) && member.MemberRoles.Count == 0)
             return Problem(detail: "Cannot remove all permissions when member has no roles", statusCode: 400, title: "Bad Request");
 
-        var grantError = TenantPermissions.ValidateGrant(
-            request.DirectPermissions, HttpContext.GetGrantedScopes());
-        if (grantError != null)
-            return Problem(detail: grantError, statusCode: 403, title: "Forbidden");
+        // The Public system subject serves the anonymous share viewer, so the granter's own
+        // permissions are the wrong bound: an owner holding "*" would otherwise be able to give an
+        // unauthenticated reader everything. ShareLinkService.SetScopesAsync bounds the same rows to
+        // PublicShareScopes; both writers have to agree or the narrower one is decorative.
+        var isPublicSubject = member.Subject?.IsSystemSubject == true && member.Subject.Name == "Public";
+        if (isPublicSubject)
+        {
+            var outsideShareVocabulary = (request.DirectPermissions ?? [])
+                .Where(p => !TenantPermissions.PublicShareScopes.Contains(p))
+                .ToList();
+            if (outsideShareVocabulary.Count > 0)
+            {
+                return Problem(
+                    detail: $"Public access cannot be granted: {string.Join(", ", outsideShareVocabulary)}.",
+                    statusCode: 400,
+                    title: "Bad Request");
+            }
+        }
+        else
+        {
+            var violation = TenantPermissions.ValidateGrant(
+                request.DirectPermissions, HttpContext.GetGrantedScopes());
+            if (violation != null)
+                return GrantProblem(violation);
+        }
 
         member.DirectPermissions = request.DirectPermissions;
         member.SysUpdatedAt = DateTime.UtcNow;
@@ -306,6 +313,11 @@ public class MemberInviteController : ControllerBase
         if (member == null)
             return NotFound();
 
+        // The clamp is enforced in RLS via app.share_full_history, so lifting your own is a
+        // self-widening edit — the same class the role and permission editors refuse.
+        if (IsCallersOwnMembership(member))
+            return Problem(detail: SelfEditDetail, statusCode: 400, title: "Bad Request");
+
         member.LimitTo24Hours = request.LimitTo24Hours;
         member.SysUpdatedAt = DateTime.UtcNow;
         await _dbContext.SaveChangesAsync(ct);
@@ -330,6 +342,22 @@ public class MemberInviteController : ControllerBase
     /// </summary>
     private bool IsCallersOwnMembership(TenantMemberEntity member)
         => HttpContext.GetSubjectId() is { } subjectId && member.SubjectId == subjectId;
+
+    /// <summary>
+    /// An unknown permission is malformed input; exceeding the ceiling is a refusal.
+    /// </summary>
+    private ObjectResult GrantProblem(GrantCeilingViolation violation) =>
+        violation.Code == GrantCeilingViolation.UnknownPermission
+            ? Problem(detail: violation.Description, statusCode: 400, title: "Bad Request")
+            : Problem(detail: violation.Description, statusCode: 403, title: "Forbidden");
+
+    /// <summary>
+    /// A foreign role id is malformed input; a role conferring more than the caller holds is a refusal.
+    /// </summary>
+    private ObjectResult RoleGrantProblem(RoleGrantValidation validation) =>
+        validation.ErrorCode == RoleGrantValidation.ForeignRole
+            ? Problem(detail: validation.ErrorDescription, statusCode: 400, title: "Bad Request")
+            : Problem(detail: validation.ErrorDescription, statusCode: 403, title: "Forbidden");
 }
 
 public record SetMemberRolesRequest(List<Guid> RoleIds);

--- a/src/API/Nocturne.API/Controllers/V4/Identity/MembershipRequestController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/MembershipRequestController.cs
@@ -108,7 +108,7 @@ public class MembershipRequestController(
             return Unauthorized();
 
         var result = await membershipRequestService.ApproveRequestAsync(
-            id, tenantId, request.RoleIds, subjectId.Value, ct);
+            id, tenantId, request.RoleIds, subjectId.Value, HttpContext.GetGrantedScopes(), ct);
 
         if (!result.Success)
             return BadRequest(result);

--- a/src/API/Nocturne.API/Controllers/V4/Identity/RoleController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/RoleController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Extensions;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Authorization;
 
@@ -60,6 +61,10 @@ public class RoleController : ControllerBase
         if (!HasPermission(TenantPermissions.RolesManage))
             return Forbid();
 
+        var grantError = TenantPermissions.ValidateGrant(request.Permissions, HttpContext.GetGrantedScopes());
+        if (grantError != null)
+            return Problem(detail: grantError, statusCode: 403, title: "Forbidden");
+
         var role = await _roleService.CreateRoleAsync(
             _tenantAccessor.TenantId, request.Name, request.Description, request.Permissions, ct);
         return StatusCode(StatusCodes.Status201Created, role);
@@ -73,14 +78,23 @@ public class RoleController : ControllerBase
     [RemoteCommand(Invalidates = ["GetRoles"])]
     [ProducesResponseType(typeof(TenantRoleDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> UpdateRole(Guid id, [FromBody] UpdateRoleRequest request, CancellationToken ct)
     {
         if (!HasPermission(TenantPermissions.RolesManage))
             return Forbid();
 
+        var grantError = TenantPermissions.ValidateGrant(request.Permissions, HttpContext.GetGrantedScopes());
+        if (grantError != null)
+            return Problem(detail: grantError, statusCode: 403, title: "Forbidden");
+
         try
         {
-            var role = await _roleService.UpdateRoleAsync(id, request.Name, request.Description, request.Permissions, ct);
+            var role = await _roleService.UpdateRoleAsync(
+                _tenantAccessor.TenantId, id, request.Name, request.Description, request.Permissions, ct);
+            if (role == null)
+                return NotFound();
+
             return Ok(role);
         }
         catch (InvalidOperationException ex)
@@ -103,7 +117,7 @@ public class RoleController : ControllerBase
         if (!HasPermission(TenantPermissions.RolesManage))
             return Forbid();
 
-        var result = await _roleService.DeleteRoleAsync(id, ct);
+        var result = await _roleService.DeleteRoleAsync(_tenantAccessor.TenantId, id, ct);
         if (!result.Success)
             return Problem(detail: result.ErrorDescription, statusCode: 400, title: result.ErrorCode);
 
@@ -111,11 +125,7 @@ public class RoleController : ControllerBase
     }
 
     private bool HasPermission(string permission)
-    {
-        var grantedScopes = HttpContext.Items["GrantedScopes"] as IReadOnlySet<string>;
-        if (grantedScopes == null) return false;
-        return TenantPermissions.HasPermission(grantedScopes, permission);
-    }
+        => TenantPermissions.HasPermission(HttpContext.GetGrantedScopes(), permission);
 }
 
 public record CreateRoleRequest(string Name, string? Description, List<string> Permissions);

--- a/src/API/Nocturne.API/Controllers/V4/Identity/RoleController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/RoleController.cs
@@ -61,9 +61,9 @@ public class RoleController : ControllerBase
         if (!HasPermission(TenantPermissions.RolesManage))
             return Forbid();
 
-        var grantError = TenantPermissions.ValidateGrant(request.Permissions, HttpContext.GetGrantedScopes());
-        if (grantError != null)
-            return Problem(detail: grantError, statusCode: 403, title: "Forbidden");
+        var violation = TenantPermissions.ValidateGrant(request.Permissions, HttpContext.GetGrantedScopes());
+        if (violation != null)
+            return GrantProblem(violation);
 
         var role = await _roleService.CreateRoleAsync(
             _tenantAccessor.TenantId, request.Name, request.Description, request.Permissions, ct);
@@ -84,9 +84,9 @@ public class RoleController : ControllerBase
         if (!HasPermission(TenantPermissions.RolesManage))
             return Forbid();
 
-        var grantError = TenantPermissions.ValidateGrant(request.Permissions, HttpContext.GetGrantedScopes());
-        if (grantError != null)
-            return Problem(detail: grantError, statusCode: 403, title: "Forbidden");
+        var violation = TenantPermissions.ValidateGrant(request.Permissions, HttpContext.GetGrantedScopes());
+        if (violation != null)
+            return GrantProblem(violation);
 
         try
         {
@@ -123,6 +123,14 @@ public class RoleController : ControllerBase
 
         return NoContent();
     }
+
+    /// <summary>
+    /// An unknown permission is malformed input; exceeding the ceiling is a refusal.
+    /// </summary>
+    private ObjectResult GrantProblem(GrantCeilingViolation violation) =>
+        violation.Code == GrantCeilingViolation.UnknownPermission
+            ? Problem(detail: violation.Description, statusCode: 400, title: "Bad Request")
+            : Problem(detail: violation.Description, statusCode: 403, title: "Forbidden");
 
     private bool HasPermission(string permission)
         => TenantPermissions.HasPermission(HttpContext.GetGrantedScopes(), permission);

--- a/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/AccessRequestController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/AccessRequestController.cs
@@ -9,6 +9,7 @@ using Nocturne.Core.Models;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.API.Multitenancy;
 using Nocturne.Infrastructure.Data;
+using Nocturne.API.Extensions;
 
 namespace Nocturne.API.Controllers.V4.PlatformAdmin;
 
@@ -32,6 +33,7 @@ public class AccessRequestController(
     NocturneDbContext dbContext,
     ISubjectService subjectService,
     ITenantService tenantService,
+    ITenantRoleService tenantRoleService,
     ITenantAccessor tenantAccessor,
     IInAppNotificationService notificationService,
     ILogger<AccessRequestController> logger) : ControllerBase
@@ -85,13 +87,14 @@ public class AccessRequestController(
         {
             var tenantId = tenantContext.TenantId;
 
-            // Validate roleIds belong to this tenant
-            if (request.RoleIds.Count > 0)
+            var roleGrant = await tenantRoleService.ValidateRoleGrantAsync(
+                tenantId, request.RoleIds, HttpContext.GetGrantedScopes(), ct);
+            if (!roleGrant.Ok)
             {
-                var validCount = await dbContext.TenantRoles
-                    .CountAsync(r => r.TenantId == tenantId && request.RoleIds.Contains(r.Id), ct);
-                if (validCount != request.RoleIds.Count)
-                    return Problem(detail: "One or more role IDs do not belong to this tenant", statusCode: 400, title: "Bad Request");
+                return Problem(
+                    detail: roleGrant.ErrorDescription,
+                    statusCode: roleGrant.ErrorCode == RoleGrantValidation.ForeignRole ? 400 : 403,
+                    title: roleGrant.ErrorCode == RoleGrantValidation.ForeignRole ? "Bad Request" : "Forbidden");
             }
 
             await tenantService.AddMemberAsync(tenantId, subjectId, request.RoleIds, request.DirectPermissions, ct: ct);

--- a/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/TenantController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/TenantController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
 using Nocturne.API.Authorization;
+using Nocturne.API.Extensions;
 using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Authorization;
@@ -150,6 +151,7 @@ public class TenantController : ControllerBase
     [HttpPost("{id:guid}/invites")]
     [RemoteCommand(Invalidates = ["GetById", "ListInvites"])]
     [ProducesResponseType(typeof(MemberInviteResult), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> CreateInvite(
         Guid id, [FromBody] CreateMemberInviteRequest request, CancellationToken ct)
@@ -158,17 +160,25 @@ public class TenantController : ControllerBase
             return Forbid();
 
         var authContext = HttpContext.Items["AuthContext"] as AuthContext;
-        var result = await _memberInviteService.CreateInviteAsync(
-            id,
-            authContext!.SubjectId!.Value,
-            request.RoleIds,
-            request.DirectPermissions,
-            request.Label,
-            request.ExpiresInDays,
-            request.MaxUses,
-            request.LimitTo24Hours);
+        try
+        {
+            var result = await _memberInviteService.CreateInviteAsync(
+                id,
+                authContext!.SubjectId!.Value,
+                HttpContext.GetGrantedScopes(),
+                request.RoleIds,
+                request.DirectPermissions,
+                request.Label,
+                request.ExpiresInDays,
+                request.MaxUses,
+                request.LimitTo24Hours);
 
-        return StatusCode(StatusCodes.Status201Created, result);
+            return StatusCode(StatusCodes.Status201Created, result);
+        }
+        catch (ArgumentException ex)
+        {
+            return Problem(detail: ex.Message, statusCode: 400, title: "Bad Request");
+        }
     }
 
     /// <inheritdoc cref="IMemberInviteService.GetInvitesForTenantAsync"/>

--- a/src/API/Nocturne.API/Services/Chat/ChatIdentityDirectoryService.cs
+++ b/src/API/Nocturne.API/Services/Chat/ChatIdentityDirectoryService.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
@@ -82,11 +83,21 @@ public sealed class ChatIdentityDirectoryService(
             .ToListAsync(ct);
     }
 
-    /// <summary>Returns a directory entry by its ID, or null if not found.</summary>
-    public async Task<ChatIdentityDirectoryEntry?> GetByIdAsync(Guid id, CancellationToken ct)
+    /// <summary>
+    /// Returns a directory entry by its ID, or null if not found.
+    /// </summary>
+    /// <param name="id">The directory entry ID.</param>
+    /// <param name="tenantScope">
+    /// Tenant the entry must belong to, or <c>null</c> for a deliberately cross-tenant lookup
+    /// (the instance-key directory endpoints the chat bots call from the apex host).
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    public async Task<ChatIdentityDirectoryEntry?> GetByIdAsync(Guid id, Guid? tenantScope, CancellationToken ct)
     {
         await using var db = await contextFactory.CreateDbContextAsync(ct);
-        return await db.ChatIdentityDirectory.FirstOrDefaultAsync(d => d.Id == id, ct);
+        return await db.ChatIdentityDirectory
+            .Where(ScopedToId(id, tenantScope))
+            .FirstOrDefaultAsync(ct);
     }
 
     /// <summary>Creates a directory link between a chat platform user and a tenant, auto-suffixing the label if it collides.</summary>
@@ -137,11 +148,14 @@ public sealed class ChatIdentityDirectoryService(
     }
 
     /// <summary>Designates a link as the default for the platform user, clearing the previous default in a transaction.</summary>
-    public async Task SetDefaultAsync(Guid linkId, CancellationToken ct)
+    /// <param name="linkId">The directory entry to make default.</param>
+    /// <param name="tenantScope">Tenant the entry must belong to, or <c>null</c> for a cross-tenant caller.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public async Task SetDefaultAsync(Guid linkId, Guid? tenantScope, CancellationToken ct)
     {
         await using var db = await contextFactory.CreateDbContextAsync(ct);
-        var target = await db.ChatIdentityDirectory.FirstOrDefaultAsync(d => d.Id == linkId, ct)
-            ?? throw new InvalidOperationException($"Chat identity directory link {linkId} not found");
+        var target = await db.ChatIdentityDirectory.Where(ScopedToId(linkId, tenantScope)).FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Chat identity directory link {linkId} not found");
 
         // NpgsqlRetryingExecutionStrategy requires user-initiated transactions
         // to be wrapped in strategy.ExecuteAsync so the entire block can be
@@ -151,6 +165,9 @@ public sealed class ChatIdentityDirectoryService(
         {
             await using var tx = await db.Database.BeginTransactionAsync(ct);
 
+            // Cleared across tenants on purpose: ux_directory_user_one_default permits at most
+            // one default row per (platform, platform_user_id) for the whole table, because the
+            // default is which tenant a bare bot command resolves to for that chat account.
             await db.ChatIdentityDirectory
                 .Where(d => d.Platform == target.Platform
                             && d.PlatformUserId == target.PlatformUserId
@@ -169,11 +186,15 @@ public sealed class ChatIdentityDirectoryService(
     }
 
     /// <summary>Renames a link's label, throwing if the new label collides with an existing one.</summary>
-    public async Task RenameLabelAsync(Guid linkId, string newLabel, CancellationToken ct)
+    /// <param name="linkId">The directory entry to rename.</param>
+    /// <param name="tenantScope">Tenant the entry must belong to, or <c>null</c> for a cross-tenant caller.</param>
+    /// <param name="newLabel">The new routing label.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public async Task RenameLabelAsync(Guid linkId, Guid? tenantScope, string newLabel, CancellationToken ct)
     {
         await using var db = await contextFactory.CreateDbContextAsync(ct);
-        var target = await db.ChatIdentityDirectory.FirstOrDefaultAsync(d => d.Id == linkId, ct)
-            ?? throw new InvalidOperationException($"Chat identity directory link {linkId} not found");
+        var target = await db.ChatIdentityDirectory.Where(ScopedToId(linkId, tenantScope)).FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Chat identity directory link {linkId} not found");
 
         target.Label = newLabel;
         try
@@ -191,24 +212,43 @@ public sealed class ChatIdentityDirectoryService(
     }
 
     /// <summary>Updates the display name shown to the chat platform user for a link.</summary>
-    public async Task UpdateDisplayNameAsync(Guid linkId, string newDisplayName, CancellationToken ct)
+    /// <param name="linkId">The directory entry to update.</param>
+    /// <param name="tenantScope">Tenant the entry must belong to, or <c>null</c> for a cross-tenant caller.</param>
+    /// <param name="newDisplayName">The new display name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public async Task UpdateDisplayNameAsync(Guid linkId, Guid? tenantScope, string newDisplayName, CancellationToken ct)
     {
         await using var db = await contextFactory.CreateDbContextAsync(ct);
-        var target = await db.ChatIdentityDirectory.FirstOrDefaultAsync(d => d.Id == linkId, ct)
-            ?? throw new InvalidOperationException($"Chat identity directory link {linkId} not found");
+        var target = await db.ChatIdentityDirectory.Where(ScopedToId(linkId, tenantScope)).FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Chat identity directory link {linkId} not found");
 
         target.DisplayName = newDisplayName;
         await db.SaveChangesAsync(ct);
     }
 
     /// <summary>Permanently deletes a directory link.</summary>
-    public async Task RevokeAsync(Guid linkId, CancellationToken ct)
+    /// <param name="linkId">The directory entry to delete.</param>
+    /// <param name="tenantScope">Tenant the entry must belong to, or <c>null</c> for a cross-tenant caller.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The number of rows deleted: 0 when the entry does not exist in that scope.</returns>
+    public async Task<int> RevokeAsync(Guid linkId, Guid? tenantScope, CancellationToken ct)
     {
         await using var db = await contextFactory.CreateDbContextAsync(ct);
-        await db.ChatIdentityDirectory
-            .Where(d => d.Id == linkId)
+        return await db.ChatIdentityDirectory
+            .Where(ScopedToId(linkId, tenantScope))
             .ExecuteDeleteAsync(ct);
     }
+
+    /// <summary>
+    /// Predicate matching one directory entry by ID, additionally constrained to a tenant when
+    /// <paramref name="tenantScope"/> is supplied. <c>chat_identity_directory</c> is a global
+    /// table with no query filter and no RLS policy — the bots resolve it cross-tenant from the
+    /// apex host — so an ID on its own is never enough for a tenant-authenticated caller.
+    /// </summary>
+    private static Expression<Func<ChatIdentityDirectoryEntry, bool>> ScopedToId(Guid id, Guid? tenantScope)
+        => tenantScope is { } tenantId
+            ? d => d.Id == id && d.TenantId == tenantId
+            : d => d.Id == id;
 
     private static string ResolveUniqueLabel(
         IReadOnlyCollection<string> existingLabels, string suggested)

--- a/src/API/Nocturne.API/Services/Chat/ChatIdentityService.cs
+++ b/src/API/Nocturne.API/Services/Chat/ChatIdentityService.cs
@@ -89,19 +89,34 @@ public sealed class ChatIdentityService(
 
     /// <summary>Designates a chat identity link as the default for the platform user.</summary>
     public Task SetDefaultAsync(Guid tenantId, Guid linkId, CancellationToken ct)
-        => directory.SetDefaultAsync(linkId, ct);
+        => directory.SetDefaultAsync(linkId, RequireTenant(tenantId), ct);
 
     /// <summary>Renames the label on a chat identity link.</summary>
     public Task RenameLabelAsync(Guid tenantId, Guid linkId, string newLabel, CancellationToken ct)
-        => directory.RenameLabelAsync(linkId, newLabel, ct);
+        => directory.RenameLabelAsync(linkId, RequireTenant(tenantId), newLabel, ct);
 
     /// <summary>Updates the display name on a chat identity link.</summary>
     public Task UpdateDisplayNameAsync(Guid tenantId, Guid linkId, string newDisplayName, CancellationToken ct)
-        => directory.UpdateDisplayNameAsync(linkId, newDisplayName, ct);
+        => directory.UpdateDisplayNameAsync(linkId, RequireTenant(tenantId), newDisplayName, ct);
 
     /// <summary>Permanently removes a chat identity link.</summary>
-    public Task RevokeAsync(Guid tenantId, Guid linkId, CancellationToken ct)
-        => directory.RevokeAsync(linkId, ct);
+    /// <exception cref="KeyNotFoundException">The link does not belong to <paramref name="tenantId"/>.</exception>
+    public async Task RevokeAsync(Guid tenantId, Guid linkId, CancellationToken ct)
+    {
+        var deleted = await directory.RevokeAsync(linkId, RequireTenant(tenantId), ct);
+        if (deleted == 0)
+            throw new KeyNotFoundException($"Chat identity directory link {linkId} not found");
+    }
+
+    /// <summary>
+    /// Returns the tenant every mutation on this facade is scoped to. An unresolved tenant is
+    /// rejected rather than passed through as an unscoped (cross-tenant) operation.
+    /// </summary>
+    private static Guid RequireTenant(Guid tenantId)
+        => tenantId != Guid.Empty
+            ? tenantId
+            : throw new InvalidOperationException(
+                "Chat identity link management requires a resolved tenant.");
 
     /// <summary>
     /// Read-only lookup for the authorize page. Does NOT consume the token.

--- a/src/API/Nocturne.API/Services/Identity/MemberInviteService.cs
+++ b/src/API/Nocturne.API/Services/Identity/MemberInviteService.cs
@@ -17,6 +17,7 @@ public class MemberInviteService : IMemberInviteService
     private readonly NocturneDbContext _dbContext;
     private readonly IJwtService _jwtService;
     private readonly ITenantService _tenantService;
+    private readonly ITenantRoleService _tenantRoleService;
     private readonly IConfiguration _configuration;
     private readonly ILogger<MemberInviteService> _logger;
 
@@ -24,12 +25,14 @@ public class MemberInviteService : IMemberInviteService
         NocturneDbContext dbContext,
         IJwtService jwtService,
         ITenantService tenantService,
+        ITenantRoleService tenantRoleService,
         IConfiguration configuration,
         ILogger<MemberInviteService> logger)
     {
         _dbContext = dbContext;
         _jwtService = jwtService;
         _tenantService = tenantService;
+        _tenantRoleService = tenantRoleService;
         _configuration = configuration;
         _logger = logger;
     }
@@ -51,27 +54,13 @@ public class MemberInviteService : IMemberInviteService
 
         var granter = granterPermissions as IReadOnlyCollection<string> ?? granterPermissions.ToList();
 
-        var directGrantError = TenantPermissions.ValidateGrant(directPermissions, granter);
-        if (directGrantError != null)
-            throw new ArgumentException(directGrantError);
+        var directViolation = TenantPermissions.ValidateGrant(directPermissions, granter);
+        if (directViolation != null)
+            throw new ArgumentException(directViolation.Description);
 
-        // Validate roleIds belong to this tenant, and that the invite's roles do not carry
-        // permissions the creating caller lacks.
-        if (roleIds.Count > 0)
-        {
-            var rolePermissions = await _dbContext.TenantRoles
-                .Where(r => r.TenantId == tenantId && roleIds.Contains(r.Id))
-                .Select(r => r.Permissions)
-                .ToListAsync();
-
-            if (rolePermissions.Count != roleIds.Count)
-                throw new ArgumentException("One or more role IDs do not belong to this tenant.");
-
-            var roleGrantError = TenantPermissions.ValidateGrant(
-                rolePermissions.SelectMany(permissions => permissions), granter);
-            if (roleGrantError != null)
-                throw new ArgumentException(roleGrantError);
-        }
+        var roleGrant = await _tenantRoleService.ValidateRoleGrantAsync(tenantId, roleIds, granter);
+        if (!roleGrant.Ok)
+            throw new ArgumentException(roleGrant.ErrorDescription);
 
         // Generate token
         var token = _jwtService.GenerateRefreshToken();

--- a/src/API/Nocturne.API/Services/Identity/MemberInviteService.cs
+++ b/src/API/Nocturne.API/Services/Identity/MemberInviteService.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 
@@ -37,6 +38,7 @@ public class MemberInviteService : IMemberInviteService
     public async Task<MemberInviteResult> CreateInviteAsync(
         Guid tenantId,
         Guid createdBySubjectId,
+        IEnumerable<string> granterPermissions,
         List<Guid> roleIds,
         List<string>? directPermissions = null,
         string? label = null,
@@ -47,14 +49,28 @@ public class MemberInviteService : IMemberInviteService
         if (roleIds.Count == 0 && (directPermissions == null || directPermissions.Count == 0))
             throw new ArgumentException("At least one role or direct permission is required.");
 
-        // Validate roleIds belong to this tenant
+        var granter = granterPermissions as IReadOnlyCollection<string> ?? granterPermissions.ToList();
+
+        var directGrantError = TenantPermissions.ValidateGrant(directPermissions, granter);
+        if (directGrantError != null)
+            throw new ArgumentException(directGrantError);
+
+        // Validate roleIds belong to this tenant, and that the invite's roles do not carry
+        // permissions the creating caller lacks.
         if (roleIds.Count > 0)
         {
-            var validCount = await _dbContext.TenantRoles
-                .CountAsync(r => r.TenantId == tenantId && roleIds.Contains(r.Id));
+            var rolePermissions = await _dbContext.TenantRoles
+                .Where(r => r.TenantId == tenantId && roleIds.Contains(r.Id))
+                .Select(r => r.Permissions)
+                .ToListAsync();
 
-            if (validCount != roleIds.Count)
+            if (rolePermissions.Count != roleIds.Count)
                 throw new ArgumentException("One or more role IDs do not belong to this tenant.");
+
+            var roleGrantError = TenantPermissions.ValidateGrant(
+                rolePermissions.SelectMany(permissions => permissions), granter);
+            if (roleGrantError != null)
+                throw new ArgumentException(roleGrantError);
         }
 
         // Generate token

--- a/src/API/Nocturne.API/Services/Identity/MembershipRequestService.cs
+++ b/src/API/Nocturne.API/Services/Identity/MembershipRequestService.cs
@@ -14,17 +14,20 @@ public class MembershipRequestService : IMembershipRequestService
 {
     private readonly NocturneDbContext _dbContext;
     private readonly ITenantService _tenantService;
+    private readonly ITenantRoleService _tenantRoleService;
     private readonly IInAppNotificationService _notificationService;
     private readonly ILogger<MembershipRequestService> _logger;
 
     public MembershipRequestService(
         NocturneDbContext dbContext,
         ITenantService tenantService,
+        ITenantRoleService tenantRoleService,
         IInAppNotificationService notificationService,
         ILogger<MembershipRequestService> logger)
     {
         _dbContext = dbContext;
         _tenantService = tenantService;
+        _tenantRoleService = tenantRoleService;
         _notificationService = notificationService;
         _logger = logger;
     }
@@ -153,9 +156,15 @@ public class MembershipRequestService : IMembershipRequestService
     /// <inheritdoc />
     public async Task<DecideMembershipRequestResult> ApproveRequestAsync(
         Guid requestId, Guid tenantId, List<Guid> roleIds,
-        Guid decidedBySubjectId, CancellationToken ct = default)
+        Guid decidedBySubjectId, IReadOnlyCollection<string> granterScopes,
+        CancellationToken ct = default)
     {
         _dbContext.TenantId = tenantId;
+
+        var roleGrant = await _tenantRoleService.ValidateRoleGrantAsync(
+            tenantId, roleIds, granterScopes, ct);
+        if (!roleGrant.Ok)
+            return new DecideMembershipRequestResult(false, roleGrant.ErrorDescription);
 
         var request = await _dbContext.MembershipRequests
             .FirstOrDefaultAsync(r => r.Id == requestId, ct);

--- a/src/API/Nocturne.API/Services/Identity/TenantRoleService.cs
+++ b/src/API/Nocturne.API/Services/Identity/TenantRoleService.cs
@@ -209,6 +209,37 @@ public partial class TenantRoleService(NocturneDbContext context) : ITenantRoleS
         await context.SaveChangesAsync(ct);
     }
 
+    /// <inheritdoc />
+    public async Task<RoleGrantValidation> ValidateRoleGrantAsync(
+        Guid tenantId,
+        IReadOnlyCollection<Guid> roleIds,
+        IReadOnlyCollection<string> granterScopes,
+        CancellationToken ct = default)
+    {
+        if (roleIds.Count == 0)
+            return RoleGrantValidation.Valid;
+
+        var permissionSets = await context.TenantRoles
+            .Where(r => r.TenantId == tenantId && roleIds.Contains(r.Id))
+            .Select(r => r.Permissions)
+            .ToListAsync(ct);
+
+        // Counted rather than compared by id: a duplicate id would otherwise pass a set comparison
+        // while resolving fewer rows than requested.
+        if (permissionSets.Count != roleIds.Distinct().Count())
+        {
+            return new RoleGrantValidation(
+                false, RoleGrantValidation.ForeignRole, "One or more role IDs do not belong to this tenant.");
+        }
+
+        var exceeded = TenantPermissions.ValidateGrant(
+            permissionSets.SelectMany(permissions => permissions), granterScopes);
+
+        return exceeded is null
+            ? RoleGrantValidation.Valid
+            : new RoleGrantValidation(false, exceeded.Code, exceeded.Description);
+    }
+
     public async Task<List<string>> GetEffectivePermissionsAsync(Guid memberId, CancellationToken ct = default)
     {
         var member = await context.TenantMembers

--- a/src/API/Nocturne.API/Services/Identity/TenantRoleService.cs
+++ b/src/API/Nocturne.API/Services/Identity/TenantRoleService.cs
@@ -11,6 +11,12 @@ namespace Nocturne.API.Services.Identity;
 /// Manages tenant-scoped roles and their permission assignments. Supports creation, updating,
 /// deletion, and slug validation of <see cref="TenantRoleDto"/> records.
 /// </summary>
+/// <remarks>
+/// <c>tenant_roles</c> carries no global query filter and no Row Level Security policy (it sits
+/// in the identity cluster alongside <c>tenant_members</c>, which auth resolution reads before a
+/// tenant context exists), so every lookup here keys on the tenant AND the role ID. A role ID
+/// alone is not an authorization decision.
+/// </remarks>
 /// <seealso cref="ITenantRoleService"/>
 public partial class TenantRoleService(NocturneDbContext context) : ITenantRoleService
 {
@@ -31,10 +37,10 @@ public partial class TenantRoleService(NocturneDbContext context) : ITenantRoleS
             .ToListAsync(ct);
     }
 
-    public async Task<TenantRoleDto?> GetRoleByIdAsync(Guid roleId, CancellationToken ct = default)
+    public async Task<TenantRoleDto?> GetRoleByIdAsync(Guid tenantId, Guid roleId, CancellationToken ct = default)
     {
         return await context.TenantRoles
-            .Where(r => r.Id == roleId)
+            .Where(r => r.Id == roleId && r.TenantId == tenantId)
             .Select(r => new TenantRoleDto(
                 r.Id,
                 r.Name,
@@ -84,7 +90,8 @@ public partial class TenantRoleService(NocturneDbContext context) : ITenantRoleS
         );
     }
 
-    public async Task<TenantRoleDto> UpdateRoleAsync(
+    public async Task<TenantRoleDto?> UpdateRoleAsync(
+        Guid tenantId,
         Guid roleId,
         string name,
         string? description,
@@ -93,7 +100,10 @@ public partial class TenantRoleService(NocturneDbContext context) : ITenantRoleS
     {
         var entity = await context.TenantRoles
             .Include(r => r.MemberRoles)
-            .FirstAsync(r => r.Id == roleId, ct);
+            .FirstOrDefaultAsync(r => r.Id == roleId && r.TenantId == tenantId, ct);
+
+        if (entity is null)
+            return null;
 
         if (entity.Slug == TenantPermissions.SeedRoles.Owner)
             throw new InvalidOperationException("Cannot modify the owner role.");
@@ -118,11 +128,11 @@ public partial class TenantRoleService(NocturneDbContext context) : ITenantRoleS
         );
     }
 
-    public async Task<DeleteRoleResult> DeleteRoleAsync(Guid roleId, CancellationToken ct = default)
+    public async Task<DeleteRoleResult> DeleteRoleAsync(Guid tenantId, Guid roleId, CancellationToken ct = default)
     {
         var role = await context.TenantRoles
             .Include(r => r.MemberRoles)
-            .FirstOrDefaultAsync(r => r.Id == roleId, ct);
+            .FirstOrDefaultAsync(r => r.Id == roleId && r.TenantId == tenantId, ct);
 
         if (role is null)
             return new DeleteRoleResult(false, "role_not_found", "The specified role does not exist.");

--- a/src/Core/Nocturne.Core.Contracts/Identity/IMembershipRequestService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Identity/IMembershipRequestService.cs
@@ -23,9 +23,17 @@ public interface IMembershipRequestService
     Task<List<MembershipRequestDto>> GetPendingRequestsAsync(
         Guid tenantId, CancellationToken ct = default);
 
+    /// <summary>
+    /// Approves the request and adds the subject as a member with <paramref name="roleIds"/>.
+    /// </summary>
+    /// <param name="granterScopes">
+    /// The approving caller's resolved scopes. Required, not optional: approving confers the
+    /// requested roles, so it is bound by the same grant ceiling as a direct permission edit.
+    /// </param>
     Task<DecideMembershipRequestResult> ApproveRequestAsync(
         Guid requestId, Guid tenantId, List<Guid> roleIds,
-        Guid decidedBySubjectId, CancellationToken ct = default);
+        Guid decidedBySubjectId, IReadOnlyCollection<string> granterScopes,
+        CancellationToken ct = default);
 
     Task<DecideMembershipRequestResult> DenyRequestAsync(
         Guid requestId, Guid tenantId,

--- a/src/Core/Nocturne.Core.Contracts/Multitenancy/IMemberInviteService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Multitenancy/IMemberInviteService.cs
@@ -8,10 +8,29 @@ namespace Nocturne.Core.Contracts.Multitenancy;
 /// <seealso cref="ITenantRoleService"/>
 public interface IMemberInviteService
 {
-    /// <summary>Creates a new invite link that grants the specified roles and permissions when accepted.</summary>
+    /// <summary>
+    /// Creates a new invite link that grants the specified roles and permissions when accepted.
+    /// </summary>
+    /// <param name="tenantId">The tenant the invite joins.</param>
+    /// <param name="createdBySubjectId">Subject creating the invite.</param>
+    /// <param name="granterPermissions">
+    /// Permissions the creating caller holds. The invite's roles and direct permissions are
+    /// validated against this set, so an invite cannot carry more access than its creator has.
+    /// </param>
+    /// <param name="roleIds">Roles the invite assigns; must belong to <paramref name="tenantId"/>.</param>
+    /// <param name="directPermissions">Direct permission atoms the invite assigns.</param>
+    /// <param name="label">Optional label recorded on the invite and the resulting membership.</param>
+    /// <param name="expiresInDays">Days until the invite expires.</param>
+    /// <param name="maxUses">Optional cap on the number of acceptances.</param>
+    /// <param name="limitTo24Hours">Whether the resulting membership is clamped to 24 hours of data.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when no roles or permissions are supplied, a role does not belong to the tenant, or
+    /// the grant exceeds <paramref name="granterPermissions"/>.
+    /// </exception>
     Task<MemberInviteResult> CreateInviteAsync(
         Guid tenantId,
         Guid createdBySubjectId,
+        IEnumerable<string> granterPermissions,
         List<Guid> roleIds,
         List<string>? directPermissions = null,
         string? label = null,

--- a/src/Core/Nocturne.Core.Contracts/Multitenancy/ITenantRoleService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Multitenancy/ITenantRoleService.cs
@@ -37,6 +37,47 @@ public interface ITenantRoleService
 
     /// <summary>Returns the combined set of permissions a member has through their roles and direct grants.</summary>
     Task<List<string>> GetEffectivePermissionsAsync(Guid memberId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Checks that every id in <paramref name="roleIds"/> names a role of
+    /// <paramref name="tenantId"/>, and that <paramref name="granterScopes"/> already holds every
+    /// permission those roles confer.
+    /// </summary>
+    /// <remarks>
+    /// The single entry point for conferring a role, so that no conferring path can be added
+    /// without both checks. Assigning a role hands out its permissions, so the grant ceiling that
+    /// applies to a direct permission edit applies here too: the Administrator seed role holds
+    /// <c>members.manage</c> and <c>roles.manage</c>, which without the ceiling is enough to attach
+    /// the Owner role to a chosen subject and reach <c>*</c>.
+    /// </remarks>
+    /// <param name="tenantId">The tenant whose roles may be conferred.</param>
+    /// <param name="roleIds">The roles being conferred. An empty set is valid.</param>
+    /// <param name="granterScopes">
+    /// The caller's resolved scopes. Passed rather than read so a background or service caller has
+    /// to name the authority it is acting on. <see cref="TenantPermissions"/> atoms are a subset of
+    /// the member-grantable scope vocabulary, so a resolved scope set is a valid granter set.
+    /// </param>
+    /// <param name="ct">A cancellation token.</param>
+    Task<RoleGrantValidation> ValidateRoleGrantAsync(
+        Guid tenantId,
+        IReadOnlyCollection<Guid> roleIds,
+        IReadOnlyCollection<string> granterScopes,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Outcome of <see cref="ITenantRoleService.ValidateRoleGrantAsync"/>. <c>ErrorCode</c> is stable
+/// for the frontend to branch and localise on; <c>ErrorDescription</c> is diagnostic only.
+/// </summary>
+public record RoleGrantValidation(bool Ok, string? ErrorCode, string? ErrorDescription)
+{
+    /// <summary>A role id does not belong to the tenant.</summary>
+    public const string ForeignRole = "role_not_in_tenant";
+
+    /// <summary>The roles confer a permission the caller does not hold.</summary>
+    public const string ExceedsGranter = "grant_exceeds_granter";
+
+    public static RoleGrantValidation Valid { get; } = new(true, null, null);
 }
 
 /// <summary>

--- a/src/Core/Nocturne.Core.Contracts/Multitenancy/ITenantRoleService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Multitenancy/ITenantRoleService.cs
@@ -11,17 +11,26 @@ public interface ITenantRoleService
     /// <summary>Returns all roles defined for the specified tenant.</summary>
     Task<List<TenantRoleDto>> GetRolesAsync(Guid tenantId, CancellationToken ct = default);
 
-    /// <summary>Returns a role by its ID, or null if not found.</summary>
-    Task<TenantRoleDto?> GetRoleByIdAsync(Guid roleId, CancellationToken ct = default);
+    /// <summary>
+    /// Returns a role by its ID within <paramref name="tenantId"/>, or null if the tenant has
+    /// no such role. A role ID belonging to another tenant resolves to null.
+    /// </summary>
+    Task<TenantRoleDto?> GetRoleByIdAsync(Guid tenantId, Guid roleId, CancellationToken ct = default);
 
     /// <summary>Creates a new custom role with the specified permissions.</summary>
     Task<TenantRoleDto> CreateRoleAsync(Guid tenantId, string name, string? description, List<string> permissions, CancellationToken ct = default);
 
-    /// <summary>Updates a role's name, description, and permissions.</summary>
-    Task<TenantRoleDto> UpdateRoleAsync(Guid roleId, string name, string? description, List<string> permissions, CancellationToken ct = default);
+    /// <summary>
+    /// Updates a role's name, description, and permissions. Returns null when
+    /// <paramref name="tenantId"/> has no role with that ID.
+    /// </summary>
+    Task<TenantRoleDto?> UpdateRoleAsync(Guid tenantId, Guid roleId, string name, string? description, List<string> permissions, CancellationToken ct = default);
 
-    /// <summary>Deletes a role if it is not a system role and has no members assigned.</summary>
-    Task<DeleteRoleResult> DeleteRoleAsync(Guid roleId, CancellationToken ct = default);
+    /// <summary>
+    /// Deletes a role if it is not a system role and has no members assigned. A role ID
+    /// belonging to another tenant is reported as not found.
+    /// </summary>
+    Task<DeleteRoleResult> DeleteRoleAsync(Guid tenantId, Guid roleId, CancellationToken ct = default);
 
     /// <summary>Creates the default system roles (owner, member, follower) for a newly provisioned tenant.</summary>
     Task SeedRolesForTenantAsync(Guid tenantId, CancellationToken ct = default);

--- a/src/Core/Nocturne.Core.Models/Authorization/TenantPermissions.cs
+++ b/src/Core/Nocturne.Core.Models/Authorization/TenantPermissions.cs
@@ -255,4 +255,38 @@ public static class TenantPermissions
     {
         return permissions.Any(p => Satisfies(p, required));
     }
+
+    /// <summary>
+    /// Validates a set of permissions a caller is trying to grant (to a member, a role, or an
+    /// invite) against the permissions the caller itself holds. Every requested atom must be a
+    /// known permission and must be satisfied by <paramref name="granterPermissions"/>, so a
+    /// grant can never exceed the granter's own access. <see cref="Superuser"/> is satisfied
+    /// only by <see cref="Superuser"/>, so it cannot be minted by a non-superuser.
+    /// </summary>
+    /// <param name="requested">The permissions being granted. <c>null</c> or empty is always allowed.</param>
+    /// <param name="granterPermissions">The permissions the granting caller holds.</param>
+    /// <returns>
+    /// An error message describing the first rejected permission, or <c>null</c> when the
+    /// whole set is grantable.
+    /// </returns>
+    public static string? ValidateGrant(
+        IEnumerable<string>? requested,
+        IEnumerable<string> granterPermissions)
+    {
+        if (requested is null)
+            return null;
+
+        var granter = granterPermissions as IReadOnlyCollection<string> ?? granterPermissions.ToList();
+
+        foreach (var permission in requested)
+        {
+            if (permission != Superuser && !All.Contains(permission))
+                return $"'{permission}' is not a known permission.";
+
+            if (!HasPermission(granter, permission))
+                return $"Cannot grant '{permission}' because the caller does not hold it.";
+        }
+
+        return null;
+    }
 }

--- a/src/Core/Nocturne.Core.Models/Authorization/TenantPermissions.cs
+++ b/src/Core/Nocturne.Core.Models/Authorization/TenantPermissions.cs
@@ -259,34 +259,57 @@ public static class TenantPermissions
     /// <summary>
     /// Validates a set of permissions a caller is trying to grant (to a member, a role, or an
     /// invite) against the permissions the caller itself holds. Every requested atom must be a
-    /// known permission and must be satisfied by <paramref name="granterPermissions"/>, so a
-    /// grant can never exceed the granter's own access. <see cref="Superuser"/> is satisfied
-    /// only by <see cref="Superuser"/>, so it cannot be minted by a non-superuser.
+    /// known permission and must be satisfied by <paramref name="granterScopes"/>, so a grant can
+    /// never exceed the granter's own access. <see cref="Superuser"/> is satisfied only by
+    /// <see cref="Superuser"/>, so it cannot be minted by a non-superuser.
     /// </summary>
     /// <param name="requested">The permissions being granted. <c>null</c> or empty is always allowed.</param>
-    /// <param name="granterPermissions">The permissions the granting caller holds.</param>
-    /// <returns>
-    /// An error message describing the first rejected permission, or <c>null</c> when the
-    /// whole set is grantable.
-    /// </returns>
-    public static string? ValidateGrant(
+    /// <param name="granterScopes">
+    /// The granting caller's resolved scopes. Callers pass a scope set rather than a permission set:
+    /// the two vocabularies are deliberately separate, and this works because
+    /// <c>OAuthScopes.MemberGrantableScopes</c> is a superset of <see cref="All"/>, so every
+    /// permission atom survives scope resolution on an unscoped credential.
+    /// </param>
+    /// <returns>The first violation, or <c>null</c> when the whole set is grantable.</returns>
+    public static GrantCeilingViolation? ValidateGrant(
         IEnumerable<string>? requested,
-        IEnumerable<string> granterPermissions)
+        IEnumerable<string> granterScopes)
     {
         if (requested is null)
             return null;
 
-        var granter = granterPermissions as IReadOnlyCollection<string> ?? granterPermissions.ToList();
+        var granter = granterScopes as IReadOnlyCollection<string> ?? granterScopes.ToList();
 
         foreach (var permission in requested)
         {
             if (permission != Superuser && !All.Contains(permission))
-                return $"'{permission}' is not a known permission.";
+            {
+                return new GrantCeilingViolation(
+                    GrantCeilingViolation.UnknownPermission,
+                    $"'{permission}' is not a known permission.");
+            }
 
             if (!HasPermission(granter, permission))
-                return $"Cannot grant '{permission}' because the caller does not hold it.";
+            {
+                return new GrantCeilingViolation(
+                    GrantCeilingViolation.ExceedsGranter,
+                    $"Cannot grant '{permission}' because the caller does not hold it.");
+            }
         }
 
         return null;
     }
+}
+
+/// <summary>
+/// Why a grant was refused. <see cref="Code"/> is stable for a caller to branch on and for the
+/// frontend to localise; <see cref="Description"/> is diagnostic and names the offending permission.
+/// </summary>
+public record GrantCeilingViolation(string Code, string Description)
+{
+    /// <summary>The permission is not in the vocabulary — malformed input rather than a refusal.</summary>
+    public const string UnknownPermission = "unknown_permission";
+
+    /// <summary>The caller does not hold the permission it is trying to confer.</summary>
+    public const string ExceedsGranter = "grant_exceeds_granter";
 }

--- a/src/Web/packages/app/src/lib/components/members/MemberCard.svelte
+++ b/src/Web/packages/app/src/lib/components/members/MemberCard.svelte
@@ -9,7 +9,6 @@
   import PermissionCategorySelector from "$lib/components/rbac/PermissionCategorySelector.svelte";
   import PermissionSummary from "$lib/components/rbac/PermissionSummary.svelte";
   import * as Collapsible from "$lib/components/ui/collapsible";
-  import * as Tooltip from "$lib/components/ui/tooltip";
   import {
     Trash2,
     Clock,
@@ -48,6 +47,13 @@
     onSaveLimitTo24Hours,
     onRemove,
   }: Props = $props();
+
+  /**
+   * The server refuses role and permission changes to the caller's own membership, so the
+   * editor is not offered on your own row. Without this the card still rendered every
+   * checkbox and a Save that always failed.
+   */
+  const isSelf = $derived(!!currentSubjectId && member.subjectId === currentSubjectId);
 
   let editingRoleIds = $state<string[]>([]);
   let editingPermissions = $state<string[]>([]);
@@ -184,43 +190,29 @@
     </div>
   </Card.Header>
 
-  {#if isExpanded && canEditRoles}
+  {#if isExpanded && canEditRoles && isSelf}
+    <Card.Content class="border-t pt-4">
+      <p class="text-sm text-muted-foreground">
+        You cannot change your own roles or permissions. Ask another member who can manage
+        members to change them for you.
+      </p>
+    </Card.Content>
+  {:else if isExpanded && canEditRoles}
     <Card.Content class="space-y-4 border-t pt-4">
       <!-- Role selection -->
       <div class="space-y-2">
         <Label>Roles</Label>
         <div class="grid gap-2 @sm:grid-cols-2">
           {#each roles as role (role.id)}
-            {@const isOwnerSelf = role.slug === "owner" && member.subjectId === currentSubjectId}
-            {@const isOwnerRole = editingRoleIds.includes(role.id ?? '')}
             <div class="flex items-center gap-2">
-              {#if isOwnerSelf}
-                <Tooltip.Provider>
-                  <Tooltip.Root>
-                    <Tooltip.Trigger>
-                      <Checkbox
-                        id="member-role-{member.subjectId}-{role.id}"
-                        checked={isOwnerRole}
-                        disabled
-                      />
-                    </Tooltip.Trigger>
-                    <Tooltip.Content>
-                      The owner role cannot be removed from yourself
-                    </Tooltip.Content>
-                  </Tooltip.Root>
-                </Tooltip.Provider>
-              {:else}
-                <Checkbox
-                  id="member-role-{member.subjectId}-{role.id}"
-                  checked={editingRoleIds.includes(role.id ?? '')}
-                  onCheckedChange={() => toggleRole(role.id ?? '')}
-                />
-              {/if}
+              <Checkbox
+                id="member-role-{member.subjectId}-{role.id}"
+                checked={editingRoleIds.includes(role.id ?? '')}
+                onCheckedChange={() => toggleRole(role.id ?? '')}
+              />
               <label
                 for="member-role-{member.subjectId}-{role.id}"
-                class="text-sm text-foreground select-none"
-                class:cursor-pointer={!isOwnerSelf}
-                class:opacity-60={isOwnerSelf}
+                class="cursor-pointer text-sm text-foreground select-none"
               >
                 {role.name}
               </label>

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/MemberInviteControllerGrantCeilingTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/MemberInviteControllerGrantCeilingTests.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Moq;
 using Nocturne.API.Controllers.V4.Identity;
 using Nocturne.API.Services.Auth;
+using Nocturne.API.Services.Identity;
 using Nocturne.API.Tests.Infrastructure;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models;
@@ -130,7 +131,9 @@ public sealed class MemberInviteControllerGrantCeilingTests : IDisposable
         return new MemberInviteController(
             Mock.Of<IMemberInviteService>(),
             Mock.Of<ITenantService>(),
-            Mock.Of<ITenantRoleService>(),
+            // The real service, not a mock: the tenant check and the ceiling are the properties
+            // under test, and a mock would assert the mock.
+            new TenantRoleService(_dbContext),
             tenantAccessor.Object,
             _dbContext)
         {
@@ -184,7 +187,9 @@ public sealed class MemberInviteControllerGrantCeilingTests : IDisposable
     [Fact]
     public async Task SetMemberPermissions_rejectsAnUnknownPermission()
     {
-        // Superuser caller: an unrecognized atom is refused on validity, not on the ceiling.
+        // Superuser caller, so the ceiling cannot be what refuses this. 400 rather than 403
+        // distinguishes the two: an atom outside the vocabulary is malformed input, and asserting
+        // the status is what makes the stated reason testable.
         var controller = BuildController(TenantPermissions.Superuser);
 
         var result = await controller.SetMemberPermissions(
@@ -194,7 +199,7 @@ public sealed class MemberInviteControllerGrantCeilingTests : IDisposable
             CancellationToken.None);
 
         result.Should().BeOfType<ObjectResult>()
-            .Which.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+            .Which.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
 
         (await TargetPermissionsAsync()).Should().BeEquivalentTo([TenantPermissions.GlucoseRead]);
     }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/MemberInviteControllerGrantCeilingTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/MemberInviteControllerGrantCeilingTests.cs
@@ -1,0 +1,339 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Nocturne.API.Controllers.V4.Identity;
+using Nocturne.API.Services.Auth;
+using Nocturne.API.Tests.Infrastructure;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4.Identity;
+
+/// <summary>
+/// Verifies the grant ceiling on member role and permission assignment: a caller can only hand
+/// out permissions it holds itself, and cannot edit its own membership. Without the ceiling, a
+/// caller past the <c>members.manage</c> gate could write <c>directPermissions: ["*"]</c> onto
+/// any membership, including its own.
+/// </summary>
+public sealed class MemberInviteControllerGrantCeilingTests : IDisposable
+{
+    private readonly NocturneDbContext _dbContext;
+    private readonly PublicAccessCacheService _publicAccessCache = TestPublicAccessCache.Create();
+    private readonly Guid _tenantId = Guid.CreateVersion7();
+    private readonly Guid _callerSubjectId = Guid.CreateVersion7();
+    private readonly Guid _targetSubjectId = Guid.CreateVersion7();
+
+    private Guid _callerMemberId;
+    private Guid _targetMemberId;
+    private Guid _ownerRoleId;
+    private Guid _caretakerRoleId;
+
+    /// <summary>Effective permissions of the seeded Administrator role: manage rights, no superuser.</summary>
+    private static readonly string[] AdministratorScopes =
+        [.. TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Admin]];
+
+    public MemberInviteControllerGrantCeilingTests()
+    {
+        _dbContext = TestDbContextFactory.CreateInMemoryContext();
+        // The controller runs on a tenant-pinned context, and the seeded rows must be written
+        // under the same tenant for EnforceTenantOwnership to accept later modifications.
+        _dbContext.TenantId = _tenantId;
+        Seed();
+    }
+
+    private void Seed()
+    {
+        _dbContext.Tenants.Add(new TenantEntity
+        {
+            Id = _tenantId,
+            Slug = "test",
+            DisplayName = "Test Tenant",
+        });
+
+        var ownerRole = new TenantRoleEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = _tenantId,
+            Name = TenantPermissions.SeedRoleNames[TenantPermissions.SeedRoles.Owner],
+            Slug = TenantPermissions.SeedRoles.Owner,
+            Permissions = [TenantPermissions.Superuser],
+            IsSystem = true,
+        };
+        var caretakerRole = new TenantRoleEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = _tenantId,
+            Name = TenantPermissions.SeedRoleNames[TenantPermissions.SeedRoles.Caretaker],
+            Slug = TenantPermissions.SeedRoles.Caretaker,
+            Permissions = [.. TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Caretaker]],
+            IsSystem = true,
+        };
+        _dbContext.TenantRoles.AddRange(ownerRole, caretakerRole);
+        _ownerRoleId = ownerRole.Id;
+        _caretakerRoleId = caretakerRole.Id;
+
+        // Every membership needs its subject row. TenantMemberEntity.Subject is a required
+        // navigation (subject_id is non-nullable), so the controller's Include(m => m.Subject)
+        // drops a member whose subject row is missing and the endpoint answers 404 before
+        // reaching the check under test.
+        _dbContext.Subjects.AddRange(
+            new SubjectEntity { Id = _callerSubjectId, Name = "Caller" },
+            new SubjectEntity { Id = _targetSubjectId, Name = "Target" });
+
+        var callerMember = new TenantMemberEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = _tenantId,
+            SubjectId = _callerSubjectId,
+            DirectPermissions = [.. AdministratorScopes],
+        };
+        var targetMember = new TenantMemberEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = _tenantId,
+            SubjectId = _targetSubjectId,
+            DirectPermissions = [TenantPermissions.GlucoseRead],
+        };
+        _dbContext.TenantMembers.AddRange(callerMember, targetMember);
+        _callerMemberId = callerMember.Id;
+        _targetMemberId = targetMember.Id;
+
+        _dbContext.SaveChanges();
+        _dbContext.ChangeTracker.Clear();
+    }
+
+    /// <summary>
+    /// Builds the controller for a caller holding <paramref name="grantedScopes"/>, as
+    /// <c>MemberScopeMiddleware</c> leaves the request.
+    /// </summary>
+    private MemberInviteController BuildController(params string[] grantedScopes)
+    {
+        var tenantAccessor = new Mock<ITenantAccessor>();
+        tenantAccessor.SetupGet(t => t.TenantId).Returns(_tenantId);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["GrantedScopes"] = (IReadOnlySet<string>)new HashSet<string>(grantedScopes);
+        httpContext.Items["AuthContext"] = new AuthContext
+        {
+            IsAuthenticated = true,
+            SubjectId = _callerSubjectId,
+            TenantId = _tenantId,
+        };
+
+        return new MemberInviteController(
+            Mock.Of<IMemberInviteService>(),
+            Mock.Of<ITenantService>(),
+            Mock.Of<ITenantRoleService>(),
+            tenantAccessor.Object,
+            _dbContext)
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext },
+        };
+    }
+
+    private Task<List<string>?> TargetPermissionsAsync() => PermissionsOfAsync(_targetMemberId);
+
+    private async Task<List<string>?> PermissionsOfAsync(Guid memberId)
+    {
+        var member = await _dbContext.TenantMembers.AsNoTracking().FirstAsync(m => m.Id == memberId);
+        return member.DirectPermissions;
+    }
+
+    [Fact]
+    public async Task SetMemberPermissions_withoutSuperuser_cannotGrantSuperuser()
+    {
+        var controller = BuildController(AdministratorScopes);
+
+        var result = await controller.SetMemberPermissions(
+            _targetMemberId,
+            new SetMemberPermissionsRequest([TenantPermissions.Superuser]),
+            _publicAccessCache,
+            CancellationToken.None);
+
+        result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+
+        (await TargetPermissionsAsync()).Should().BeEquivalentTo([TenantPermissions.GlucoseRead]);
+    }
+
+    [Fact]
+    public async Task SetMemberPermissions_cannotGrantAPermissionTheCallerLacks()
+    {
+        // audit.manage is absent from the Administrator seed role.
+        var controller = BuildController(AdministratorScopes);
+
+        var result = await controller.SetMemberPermissions(
+            _targetMemberId,
+            new SetMemberPermissionsRequest([TenantPermissions.AuditManage]),
+            _publicAccessCache,
+            CancellationToken.None);
+
+        result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+
+        (await TargetPermissionsAsync()).Should().BeEquivalentTo([TenantPermissions.GlucoseRead]);
+    }
+
+    [Fact]
+    public async Task SetMemberPermissions_rejectsAnUnknownPermission()
+    {
+        // Superuser caller: an unrecognized atom is refused on validity, not on the ceiling.
+        var controller = BuildController(TenantPermissions.Superuser);
+
+        var result = await controller.SetMemberPermissions(
+            _targetMemberId,
+            new SetMemberPermissionsRequest(["glucose.destroy"]),
+            _publicAccessCache,
+            CancellationToken.None);
+
+        result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+
+        (await TargetPermissionsAsync()).Should().BeEquivalentTo([TenantPermissions.GlucoseRead]);
+    }
+
+    [Fact]
+    public async Task SetMemberPermissions_allowsAGrantWithinTheCallersOwnPermissions()
+    {
+        var controller = BuildController(AdministratorScopes);
+
+        var result = await controller.SetMemberPermissions(
+            _targetMemberId,
+            new SetMemberPermissionsRequest([TenantPermissions.GlucoseRead, TenantPermissions.TreatmentsReadWrite]),
+            _publicAccessCache,
+            CancellationToken.None);
+
+        result.Should().BeOfType<NoContentResult>();
+
+        (await TargetPermissionsAsync()).Should().BeEquivalentTo(
+            [TenantPermissions.GlucoseRead, TenantPermissions.TreatmentsReadWrite]);
+    }
+
+    [Fact]
+    public async Task SetMemberPermissions_allowsTheReadTierImpliedByAManageGrantTheCallerHolds()
+    {
+        // audit.manage implies audit.read, so a caller holding the manage tier may hand out read.
+        var controller = BuildController(TenantPermissions.MembersManage, TenantPermissions.AuditManage);
+
+        var result = await controller.SetMemberPermissions(
+            _targetMemberId,
+            new SetMemberPermissionsRequest([TenantPermissions.AuditRead]),
+            _publicAccessCache,
+            CancellationToken.None);
+
+        result.Should().BeOfType<NoContentResult>();
+
+        (await TargetPermissionsAsync()).Should().BeEquivalentTo([TenantPermissions.AuditRead]);
+    }
+
+    [Fact]
+    public async Task SetMemberPermissions_allowsASuperuserToGrantSuperuser()
+    {
+        // The ceiling is a ceiling, not a ban: an owner still delegates its own access.
+        var controller = BuildController(TenantPermissions.Superuser);
+
+        var result = await controller.SetMemberPermissions(
+            _targetMemberId,
+            new SetMemberPermissionsRequest([TenantPermissions.Superuser]),
+            _publicAccessCache,
+            CancellationToken.None);
+
+        result.Should().BeOfType<NoContentResult>();
+
+        (await TargetPermissionsAsync()).Should().BeEquivalentTo([TenantPermissions.Superuser]);
+    }
+
+    [Fact]
+    public async Task SetMemberPermissions_rejectsEditingTheCallersOwnMembership()
+    {
+        var controller = BuildController(AdministratorScopes);
+
+        var result = await controller.SetMemberPermissions(
+            _callerMemberId,
+            new SetMemberPermissionsRequest([TenantPermissions.GlucoseRead]),
+            _publicAccessCache,
+            CancellationToken.None);
+
+        result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+
+        (await PermissionsOfAsync(_callerMemberId)).Should().BeEquivalentTo(AdministratorScopes);
+    }
+
+    [Fact]
+    public async Task SetMemberRoles_cannotAssignTheOwnerRoleWithoutSuperuser()
+    {
+        var controller = BuildController(AdministratorScopes);
+
+        var result = await controller.SetMemberRoles(
+            _targetMemberId,
+            new SetMemberRolesRequest([_ownerRoleId]),
+            _publicAccessCache,
+            CancellationToken.None);
+
+        result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+
+        (await _dbContext.TenantMemberRoles.AnyAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SetMemberRoles_rejectsTheWholeSetWhenOneRoleExceedsTheCeiling()
+    {
+        // Roles are validated as a union, so a grantable role cannot smuggle in one that isn't.
+        var controller = BuildController(AdministratorScopes);
+
+        var result = await controller.SetMemberRoles(
+            _targetMemberId,
+            new SetMemberRolesRequest([_caretakerRoleId, _ownerRoleId]),
+            _publicAccessCache,
+            CancellationToken.None);
+
+        result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+
+        (await _dbContext.TenantMemberRoles.AnyAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SetMemberRoles_allowsARoleWithinTheCallersOwnPermissions()
+    {
+        var controller = BuildController(AdministratorScopes);
+
+        var result = await controller.SetMemberRoles(
+            _targetMemberId,
+            new SetMemberRolesRequest([_caretakerRoleId]),
+            _publicAccessCache,
+            CancellationToken.None);
+
+        result.Should().BeOfType<NoContentResult>();
+        (await _dbContext.TenantMemberRoles.CountAsync(mr => mr.TenantRoleId == _caretakerRoleId))
+            .Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SetMemberRoles_rejectsEditingTheCallersOwnMembership()
+    {
+        var controller = BuildController(TenantPermissions.Superuser);
+
+        var result = await controller.SetMemberRoles(
+            _callerMemberId,
+            new SetMemberRolesRequest([_ownerRoleId]),
+            _publicAccessCache,
+            CancellationToken.None);
+
+        result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+
+        (await _dbContext.TenantMemberRoles.AnyAsync()).Should().BeFalse();
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Chat/ChatIdentityDirectoryServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Chat/ChatIdentityDirectoryServiceTests.cs
@@ -136,10 +136,10 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
         a.IsDefault.Should().BeTrue();
         b.IsDefault.Should().BeFalse();
 
-        await _service.SetDefaultAsync(b.Id, default);
+        await _service.SetDefaultAsync(b.Id, tenantScope: null, ct: default);
 
-        var aAfter = await _service.GetByIdAsync(a.Id, default);
-        var bAfter = await _service.GetByIdAsync(b.Id, default);
+        var aAfter = await _service.GetByIdAsync(a.Id, tenantScope: null, ct: default);
+        var bAfter = await _service.GetByIdAsync(b.Id, tenantScope: null, ct: default);
         aAfter!.IsDefault.Should().BeFalse();
         bAfter!.IsDefault.Should().BeTrue();
     }
@@ -147,8 +147,8 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     [Fact]
     public async Task SetDefaultAsync_throws_when_link_not_found()
     {
-        var act = async () => await _service.SetDefaultAsync(Guid.CreateVersion7(), default);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        var act = async () => await _service.SetDefaultAsync(Guid.CreateVersion7(), tenantScope: null, ct: default);
+        await act.Should().ThrowAsync<KeyNotFoundException>();
     }
 
     // ---- RenameLabelAsync ----
@@ -157,8 +157,8 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     public async Task RenameLabelAsync_updates_label()
     {
         var a = await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "lily", "Lily", default);
-        await _service.RenameLabelAsync(a.Id, "rose", default);
-        var after = await _service.GetByIdAsync(a.Id, default);
+        await _service.RenameLabelAsync(a.Id, tenantScope: null, "rose", ct: default);
+        var after = await _service.GetByIdAsync(a.Id, tenantScope: null, ct: default);
         after!.Label.Should().Be("rose");
     }
 
@@ -168,7 +168,7 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
         await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "lily", "Lily", default);
         var b = await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "oliver", "Oliver", default);
 
-        var act = async () => await _service.RenameLabelAsync(b.Id, "lily", default);
+        var act = async () => await _service.RenameLabelAsync(b.Id, tenantScope: null, "lily", ct: default);
         await act.Should().ThrowAsync<InvalidOperationException>();
     }
 
@@ -178,8 +178,8 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     public async Task UpdateDisplayNameAsync_updates_display_name()
     {
         var a = await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "lily", "Lily", default);
-        await _service.UpdateDisplayNameAsync(a.Id, "Lily Renamed", default);
-        var after = await _service.GetByIdAsync(a.Id, default);
+        await _service.UpdateDisplayNameAsync(a.Id, tenantScope: null, "Lily Renamed", ct: default);
+        var after = await _service.GetByIdAsync(a.Id, tenantScope: null, ct: default);
         after!.DisplayName.Should().Be("Lily Renamed");
     }
 
@@ -189,8 +189,8 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     public async Task RevokeAsync_hard_deletes_row()
     {
         var a = await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "lily", "Lily", default);
-        await _service.RevokeAsync(a.Id, default);
-        var after = await _service.GetByIdAsync(a.Id, default);
+        await _service.RevokeAsync(a.Id, tenantScope: null, ct: default);
+        var after = await _service.GetByIdAsync(a.Id, tenantScope: null, ct: default);
         after.Should().BeNull();
     }
 
@@ -273,7 +273,7 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     public async Task GetByIdAsync_returns_link_or_null()
     {
         var a = await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "lily", "Lily", default);
-        (await _service.GetByIdAsync(a.Id, default)).Should().NotBeNull();
-        (await _service.GetByIdAsync(Guid.CreateVersion7(), default)).Should().BeNull();
+        (await _service.GetByIdAsync(a.Id, tenantScope: null, ct: default)).Should().NotBeNull();
+        (await _service.GetByIdAsync(Guid.CreateVersion7(), tenantScope: null, ct: default)).Should().BeNull();
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Identity/MemberInviteServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Identity/MemberInviteServiceTests.cs
@@ -28,6 +28,9 @@ public class MemberInviteServiceTests : IDisposable
     private readonly Guid _acceptorSubjectId = Guid.CreateVersion7();
     private Guid _followerRoleId;
 
+    /// <summary>Granter permissions of a tenant owner: satisfies any grant the invite can carry.</summary>
+    private static readonly string[] OwnerPermissions = [TenantPermissions.Superuser];
+
     private const string FakeToken = "fake-random-token-abc123";
     private const string FakeTokenHash = "hashed-fake-token";
     private const string BaseUrl = "https://app.nocturnecgm.com";
@@ -118,6 +121,7 @@ public class MemberInviteServiceTests : IDisposable
         var result = await _service.CreateInviteAsync(
             _tenantId,
             _creatorSubjectId,
+            OwnerPermissions,
             [_followerRoleId]);
 
         result.Token.Should().Be(FakeToken);
@@ -139,6 +143,7 @@ public class MemberInviteServiceTests : IDisposable
         var act = () => _service.CreateInviteAsync(
             _tenantId,
             _creatorSubjectId,
+            OwnerPermissions,
             []);
 
         await act.Should().ThrowAsync<ArgumentException>()
@@ -151,6 +156,7 @@ public class MemberInviteServiceTests : IDisposable
         var result = await _service.CreateInviteAsync(
             _tenantId,
             _creatorSubjectId,
+            OwnerPermissions,
             [],
             directPermissions: [TenantPermissions.GlucoseRead]);
 
@@ -162,11 +168,71 @@ public class MemberInviteServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task CreateInviteAsync_RejectsSuperuserFromNonSuperuserCreator()
+    {
+        var act = () => _service.CreateInviteAsync(
+            _tenantId,
+            _creatorSubjectId,
+            [TenantPermissions.MembersInvite, TenantPermissions.MembersManage],
+            [],
+            directPermissions: [TenantPermissions.Superuser]);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*Cannot grant '*'*");
+
+        (await _dbContext.MemberInvites.AnyAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CreateInviteAsync_RejectsPermissionTheCreatorDoesNotHold()
+    {
+        var act = () => _service.CreateInviteAsync(
+            _tenantId,
+            _creatorSubjectId,
+            [TenantPermissions.MembersInvite, TenantPermissions.GlucoseRead],
+            [],
+            directPermissions: [TenantPermissions.TreatmentsReadWrite]);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*treatments.readwrite*");
+    }
+
+    [Fact]
+    public async Task CreateInviteAsync_RejectsUnknownPermission()
+    {
+        var act = () => _service.CreateInviteAsync(
+            _tenantId,
+            _creatorSubjectId,
+            OwnerPermissions,
+            [],
+            directPermissions: ["glucose.destroy"]);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*not a known permission*");
+    }
+
+    [Fact]
+    public async Task CreateInviteAsync_RejectsRoleCarryingPermissionsTheCreatorLacks()
+    {
+        // The follower role carries glucose.read; a creator holding only members.invite may not
+        // hand it out even though the role ID is valid for the tenant.
+        var act = () => _service.CreateInviteAsync(
+            _tenantId,
+            _creatorSubjectId,
+            [TenantPermissions.MembersInvite],
+            [_followerRoleId]);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*Cannot grant*");
+    }
+
+    [Fact]
     public async Task AcceptInviteAsync_ExpiredToken_ReturnsError()
     {
         await _service.CreateInviteAsync(
             _tenantId,
             _creatorSubjectId,
+            OwnerPermissions,
             [_followerRoleId]);
 
         var invite = await _dbContext.MemberInvites.FirstAsync();
@@ -185,6 +251,7 @@ public class MemberInviteServiceTests : IDisposable
         await _service.CreateInviteAsync(
             _tenantId,
             _creatorSubjectId,
+            OwnerPermissions,
             [_followerRoleId]);
 
         var invite = await _dbContext.MemberInvites.FirstAsync();
@@ -203,6 +270,7 @@ public class MemberInviteServiceTests : IDisposable
         await _service.CreateInviteAsync(
             _tenantId,
             _creatorSubjectId,
+            OwnerPermissions,
             [_followerRoleId],
             maxUses: 1);
 
@@ -222,6 +290,7 @@ public class MemberInviteServiceTests : IDisposable
         await _service.CreateInviteAsync(
             _tenantId,
             _creatorSubjectId,
+            OwnerPermissions,
             [_followerRoleId]);
 
         // Add an existing active membership
@@ -246,6 +315,7 @@ public class MemberInviteServiceTests : IDisposable
         var createResult = await _service.CreateInviteAsync(
             _tenantId,
             _creatorSubjectId,
+            OwnerPermissions,
             [_followerRoleId]);
 
         var result = await _service.RevokeInviteAsync(createResult.Id, _tenantId);

--- a/tests/Unit/Nocturne.API.Tests/Services/Identity/MemberInviteServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Identity/MemberInviteServiceTests.cs
@@ -64,6 +64,7 @@ public class MemberInviteServiceTests : IDisposable
             _dbContext,
             _jwtService.Object,
             _tenantService.Object,
+            new TenantRoleService(_dbContext),
             configuration,
             logger.Object);
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Identity/MembershipRequestServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Identity/MembershipRequestServiceTests.cs
@@ -59,6 +59,7 @@ public class MembershipRequestServiceTests : IDisposable
         _service = new MembershipRequestService(
             _dbContext,
             _tenantService.Object,
+            new TenantRoleService(_dbContext),
             _notificationService.Object,
             NullLogger<MembershipRequestService>.Instance);
 
@@ -187,7 +188,7 @@ public class MembershipRequestServiceTests : IDisposable
         var roleIds = new List<Guid> { _adminRoleId };
 
         var result = await _service.ApproveRequestAsync(
-            request.Id, _tenantId, roleIds, _adminSubjectId);
+            request.Id, _tenantId, roleIds, _adminSubjectId, [TenantPermissions.Superuser]);
 
         result.Success.Should().BeTrue();
         result.Error.Should().BeNull();
@@ -209,7 +210,7 @@ public class MembershipRequestServiceTests : IDisposable
     public async Task ApproveRequestAsync_RequestNotFound_ReturnsFailure()
     {
         var result = await _service.ApproveRequestAsync(
-            Guid.CreateVersion7(), _tenantId, [_adminRoleId], _adminSubjectId);
+            Guid.CreateVersion7(), _tenantId, [_adminRoleId], _adminSubjectId, [TenantPermissions.Superuser]);
 
         result.Success.Should().BeFalse();
         result.Error.Should().Contain("not found");
@@ -226,7 +227,7 @@ public class MembershipRequestServiceTests : IDisposable
 
         // Try to approve the already-denied request
         var result = await _service.ApproveRequestAsync(
-            request.Id, _tenantId, [_adminRoleId], _adminSubjectId);
+            request.Id, _tenantId, [_adminRoleId], _adminSubjectId, [TenantPermissions.Superuser]);
 
         result.Success.Should().BeFalse();
         result.Error.Should().Contain("no longer pending");

--- a/tests/Unit/Nocturne.API.Tests/Services/Identity/TenantRoleServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Identity/TenantRoleServiceTests.cs
@@ -59,7 +59,7 @@ public class TenantRoleServiceTests : IDisposable
     {
         await _service.SeedRolesForTenantAsync(_tenantId);
         var ownerRole = await _context.TenantRoles.FirstAsync(r => r.Slug == "owner" && r.TenantId == _tenantId);
-        var result = await _service.DeleteRoleAsync(ownerRole.Id);
+        var result = await _service.DeleteRoleAsync(_tenantId, ownerRole.Id);
         result.Success.Should().BeFalse();
         result.ErrorCode.Should().Be("owner_role_protected");
     }
@@ -79,7 +79,7 @@ public class TenantRoleServiceTests : IDisposable
         );
         await _context.SaveChangesAsync();
 
-        var result = await _service.DeleteRoleAsync(followerRole.Id);
+        var result = await _service.DeleteRoleAsync(_tenantId, followerRole.Id);
         result.Success.Should().BeTrue();
 
         var remainingRoles = await _context.TenantMemberRoles.Where(mr => mr.TenantMemberId == member.Id).ToListAsync();
@@ -98,7 +98,7 @@ public class TenantRoleServiceTests : IDisposable
         _context.TenantMemberRoles.Add(new TenantMemberRoleEntity { Id = Guid.CreateVersion7(), TenantMemberId = member.Id, TenantRoleId = followerRole.Id });
         await _context.SaveChangesAsync();
 
-        var result = await _service.DeleteRoleAsync(followerRole.Id);
+        var result = await _service.DeleteRoleAsync(_tenantId, followerRole.Id);
         result.Success.Should().BeFalse();
         result.ErrorCode.Should().Be("members_would_lose_all_permissions");
     }
@@ -123,6 +123,67 @@ public class TenantRoleServiceTests : IDisposable
         var effective = await _service.GetEffectivePermissionsAsync(member.Id);
         effective.Should().BeEquivalentTo(
             ["glucose.read", "reports.read", "device.notify", "device.actuate", "treatments.read"]);
+    }
+
+    [Fact]
+    public async Task UpdateRoleAsync_ReturnsNull_ForAnotherTenantsRole()
+    {
+        var otherRoleId = await SeedOtherTenantViewerRoleAsync();
+
+        var result = await _service.UpdateRoleAsync(
+            _tenantId, otherRoleId, "Pwned", null, [TenantPermissions.Superuser]);
+
+        result.Should().BeNull("a role ID from another tenant must not resolve");
+
+        var untouched = await _context.TenantRoles.AsNoTracking().FirstAsync(r => r.Id == otherRoleId);
+        untouched.Name.Should().Be("Viewer");
+        untouched.Permissions.Should().BeEquivalentTo([TenantPermissions.GlucoseRead]);
+    }
+
+    [Fact]
+    public async Task DeleteRoleAsync_ReportsNotFound_ForAnotherTenantsRole()
+    {
+        var otherRoleId = await SeedOtherTenantViewerRoleAsync();
+
+        var result = await _service.DeleteRoleAsync(_tenantId, otherRoleId);
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be("role_not_found");
+        (await _context.TenantRoles.AsNoTracking().AnyAsync(r => r.Id == otherRoleId)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetRoleByIdAsync_ReturnsNull_ForAnotherTenantsRole()
+    {
+        var otherRoleId = await SeedOtherTenantViewerRoleAsync();
+
+        (await _service.GetRoleByIdAsync(_tenantId, otherRoleId)).Should().BeNull();
+    }
+
+    private async Task<Guid> SeedOtherTenantViewerRoleAsync()
+    {
+        var otherTenantId = Guid.CreateVersion7();
+        _context.Tenants.Add(new TenantEntity
+        {
+            Id = otherTenantId,
+            Slug = "other",
+            DisplayName = "Other Tenant",
+        });
+
+        var role = new TenantRoleEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = otherTenantId,
+            Name = "Viewer",
+            Slug = "viewer",
+            Permissions = [TenantPermissions.GlucoseRead],
+            IsSystem = true,
+        };
+        _context.TenantRoles.Add(role);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        return role.Id;
     }
 
     public void Dispose() => _context.Dispose();

--- a/tests/Unit/Nocturne.Core.Models.Tests/Authorization/TenantPermissionsTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/Authorization/TenantPermissionsTests.cs
@@ -123,8 +123,7 @@ public class TenantPermissionsTests
     {
         // Holding every named atom is not the same as holding "*": * additionally satisfies
         // atoms added in later versions, so it is only ever grantable by another superuser.
-        TenantPermissions.ValidateGrant([TenantPermissions.Superuser], TenantPermissions.All)
-            .Should().Contain("Cannot grant '*'");
+        TenantPermissions.ValidateGrant([TenantPermissions.Superuser], TenantPermissions.All)!.Description.Should().Contain("Cannot grant '*'");
     }
 
     [Fact]
@@ -137,8 +136,7 @@ public class TenantPermissionsTests
     [Fact]
     public void ValidateGrant_RefusesAnUnknownPermission_EvenFromASuperuser()
     {
-        TenantPermissions.ValidateGrant(["glucose.destroy"], [TenantPermissions.Superuser])
-            .Should().Contain("not a known permission");
+        TenantPermissions.ValidateGrant(["glucose.destroy"], [TenantPermissions.Superuser])!.Description.Should().Contain("not a known permission");
     }
 
     [Theory]
@@ -149,8 +147,7 @@ public class TenantPermissionsTests
     {
         // Comparison is exact and ordinal, so a case or whitespace variant is unknown rather
         // than silently equivalent to the atom it resembles.
-        TenantPermissions.ValidateGrant([requested], [TenantPermissions.Superuser])
-            .Should().Contain("not a known permission");
+        TenantPermissions.ValidateGrant([requested], [TenantPermissions.Superuser])!.Description.Should().Contain("not a known permission");
     }
 
     [Fact]
@@ -165,8 +162,7 @@ public class TenantPermissionsTests
     public void ValidateGrant_RefusesTheWriteTierOfAPermissionHeldAsReadOnly()
     {
         TenantPermissions.ValidateGrant(
-            [TenantPermissions.GlucoseReadWrite], [TenantPermissions.GlucoseRead])
-            .Should().Contain("Cannot grant 'glucose.readwrite'");
+            [TenantPermissions.GlucoseReadWrite], [TenantPermissions.GlucoseRead])!.Description.Should().Contain("Cannot grant 'glucose.readwrite'");
     }
 
     [Fact]
@@ -174,7 +170,6 @@ public class TenantPermissionsTests
     {
         TenantPermissions.ValidateGrant(
             [TenantPermissions.GlucoseRead, TenantPermissions.AuditManage],
-            [TenantPermissions.GlucoseRead, TenantPermissions.AuditRead])
-            .Should().Contain("Cannot grant 'audit.manage'");
+            [TenantPermissions.GlucoseRead, TenantPermissions.AuditRead])!.Description.Should().Contain("Cannot grant 'audit.manage'");
     }
 }

--- a/tests/Unit/Nocturne.Core.Models.Tests/Authorization/TenantPermissionsTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/Authorization/TenantPermissionsTests.cs
@@ -110,4 +110,71 @@ public class TenantPermissionsTests
         TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Denied]
             .Should().BeEmpty();
     }
+
+    [Fact]
+    public void ValidateGrant_AllowsNothingBeingGranted()
+    {
+        TenantPermissions.ValidateGrant(null, []).Should().BeNull();
+        TenantPermissions.ValidateGrant([], []).Should().BeNull();
+    }
+
+    [Fact]
+    public void ValidateGrant_RefusesSuperuser_ToAGranterHoldingEveryOtherPermission()
+    {
+        // Holding every named atom is not the same as holding "*": * additionally satisfies
+        // atoms added in later versions, so it is only ever grantable by another superuser.
+        TenantPermissions.ValidateGrant([TenantPermissions.Superuser], TenantPermissions.All)
+            .Should().Contain("Cannot grant '*'");
+    }
+
+    [Fact]
+    public void ValidateGrant_AllowsSuperuser_FromASuperuser()
+    {
+        TenantPermissions.ValidateGrant([TenantPermissions.Superuser], [TenantPermissions.Superuser])
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void ValidateGrant_RefusesAnUnknownPermission_EvenFromASuperuser()
+    {
+        TenantPermissions.ValidateGrant(["glucose.destroy"], [TenantPermissions.Superuser])
+            .Should().Contain("not a known permission");
+    }
+
+    [Theory]
+    [InlineData("GLUCOSE.READ")]
+    [InlineData("glucose.read ")]
+    [InlineData("")]
+    public void ValidateGrant_RefusesAPermissionThatIsNotAnExactAtom(string requested)
+    {
+        // Comparison is exact and ordinal, so a case or whitespace variant is unknown rather
+        // than silently equivalent to the atom it resembles.
+        TenantPermissions.ValidateGrant([requested], [TenantPermissions.Superuser])
+            .Should().Contain("not a known permission");
+    }
+
+    [Fact]
+    public void ValidateGrant_AllowsTheReadTierOfAPermissionHeldAsReadWrite()
+    {
+        TenantPermissions.ValidateGrant(
+            [TenantPermissions.GlucoseRead], [TenantPermissions.GlucoseReadWrite])
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void ValidateGrant_RefusesTheWriteTierOfAPermissionHeldAsReadOnly()
+    {
+        TenantPermissions.ValidateGrant(
+            [TenantPermissions.GlucoseReadWrite], [TenantPermissions.GlucoseRead])
+            .Should().Contain("Cannot grant 'glucose.readwrite'");
+    }
+
+    [Fact]
+    public void ValidateGrant_RefusesTheWholeSetWhenAnyMemberExceedsTheGranter()
+    {
+        TenantPermissions.ValidateGrant(
+            [TenantPermissions.GlucoseRead, TenantPermissions.AuditManage],
+            [TenantPermissions.GlucoseRead, TenantPermissions.AuditRead])
+            .Should().Contain("Cannot grant 'audit.manage'");
+    }
 }


### PR DESCRIPTION
A caller could confer more access than it holds. Every path that grants permissions — direct edits, role assignment, invites, membership-request approval, access-request approval — now goes through one entry point that resolves roles scoped to the tenant and applies the ceiling.

**The review found the ceiling was missing from two paths, one of them a live escalation.** `ApproveRequestAsync` passed `roleIds` straight through with neither the tenant check nor the ceiling, gated on the same `members.manage`. Since the Administrator seed role holds `members.manage` + `roles.manage`, `GET /api/v4/roles` returns the Owner role id, and any authenticated subject can self-serve a membership request, approving one with the Owner role attached reached `*`. Access-request approval had the same gap behind `platform_admin`.

The root cause was duplication — three copies of the role/tenant check, one path with none. There is now a single `ITenantRoleService.ValidateRoleGrantAsync`, and approval takes the approver's scopes as a required argument so it cannot be called without naming its authority.

Also fixed: the 24-hour clamp could be lifted on your own membership; the Public share subject's permissions were bounded by the granter rather than by `PublicShareScopes`, so an owner could grant an anonymous reader everything; and `ValidateGrant` returned prose that shipped as a Problem detail — it now returns a code plus description, which also separates malformed input (400) from a refusal (403).

Detail is in the commit messages, including a correction to the previous message, which claimed the ceiling was dormant and the Administrator role inert. It is neither — `MemberScopeResolver` keeps administration atoms on an unscoped credential by design, and there is an existing test pinning that.

4399 API and 527 Core.Models tests pass. The grant-ceiling tests now use the real role service rather than a mock.