### PR TITLE
test(carelink): pin sg as mg/dL whatever the account's display units are

### DIFF
--- a/src/Connectors/Nocturne.Connectors.CareLink/Configurations/CareLinkConstants.cs
+++ b/src/Connectors/Nocturne.Connectors.CareLink/Configurations/CareLinkConstants.cs
@@ -38,7 +38,6 @@ public static class CareLinkConstants
     }
 
     public const int StaleDataThresholdMinutes = 20;
-    public const double MmolToMgdlFactor = 18.0182;
 
     /// <summary>
     /// BLE endpoint versions to try in order. Cached after first success.

--- a/tests/Unit/Nocturne.Connectors.CareLink.Tests/Mappers/CareLinkSensorGlucoseMapperTests.cs
+++ b/tests/Unit/Nocturne.Connectors.CareLink.Tests/Mappers/CareLinkSensorGlucoseMapperTests.cs
@@ -56,15 +56,21 @@ public class CareLinkSensorGlucoseMapperTests
         result[0].Mgdl.Should().Be(120);
     }
 
-    [Fact]
-    public void Map_ConvertsMmolToMgdl()
+    [Theory]
+    [InlineData("mmol/L")]
+    [InlineData("mg/dL")]
+    [InlineData(null)]
+    public void Map_TakesSgAsMgdl_WhateverTheDisplayUnitsAre(string? bgUnits)
     {
-        var data = CreateTestData(0, "mmol/L");
-        data.Sgs = [new CareLinkSensorGlucose { Sg = 7, Datetime = "2024-01-15T14:30:00", Kind = "SG" }];
+        // bgUnits is the account's display preference, not a unit for sg. sg is an int, so a value
+        // in mmol/L could only ever arrive quantised to whole numbers.
+        var data = CreateTestData(0, bgUnits);
+        data.Sgs = [new CareLinkSensorGlucose { Sg = 126, Datetime = "2024-01-15T14:30:00", Kind = "SG" }];
 
         var result = _mapper.Map(data);
+
         result.Should().NotBeEmpty();
-        result[0].Mgdl.Should().BeApproximately(7 * 18.0182, 0.01);
+        result[0].Mgdl.Should().Be(126);
     }
 
     [Fact]


### PR DESCRIPTION
`#618` stopped the CareLink glucose mapper converting `sg` when the account displays mmol/L, on the basis that `bgUnits` is a display preference rather than a unit for the value. It left `Map_ConvertsMmolToMgdl` asserting the old behaviour, so the `unit` job has been red on `main` since.

The premise looks right: `CareLinkSensorGlucose.Sg` has been an `int` since the connector was added in #213. A value in mmol/L arriving there could only ever be quantised to whole numbers (4, 7, 10), which no sensor feed would do. The old code multiplied that int by 18.0182 for mmol accounts, which would have turned a 126 mg/dL reading into roughly 2270.

This replaces the test with one that pins the actual contract across `mmol/L`, `mg/dL` and an absent value. `CareLinkConstants.MmolToMgdlFactor` was the only remaining reference and is removed with it.

**For a maintainer with a real CareLink account to confirm:** this is a glucose unit question, so it is worth eyeballing a live payload once. If `sg` ever does arrive in mmol/L, the correct fix is a wider `sg` type plus conversion, not restoring the old int multiply.

79 CareLink tests pass.

https://claude.ai/code/session_01Wk3jH4N16htaBqGod2j7y8