### PR TITLE
fix(tenants): 404 a delete of a missing tenant, and cascade chat directory rows

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/TenantController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/TenantController.cs
@@ -216,7 +216,21 @@ public class TenantController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
     {
-        await _tenantService.DeleteAsync(id, ct);
+        try
+        {
+            await _tenantService.DeleteAsync(id, ct);
+        }
+        catch (KeyNotFoundException)
+        {
+            // The 404 this action already advertises. ITenantService.DeleteAsync throws for an
+            // unknown id, and without this the caller gets a 500 — which reads as "the platform
+            // is broken", not "there is nothing here to delete". Callers that delete a tenant as
+            // part of a larger teardown (nocturne-cloud's retention purge) treat 404 as success
+            // so a partially-completed run can be retried; a 500 makes them fail forever on a
+            // tenant that was already removed out of band.
+            return NotFound();
+        }
+
         return NoContent();
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260802020559_AddChatIdentityDirectoryTenantCascade.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260802020559_AddChatIdentityDirectoryTenantCascade.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260802020559_AddChatIdentityDirectoryTenantCascade")]
+    partial class AddChatIdentityDirectoryTenantCascade
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260802020559_AddChatIdentityDirectoryTenantCascade.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260802020559_AddChatIdentityDirectoryTenantCascade.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChatIdentityDirectoryTenantCascade : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // The absence of this FK is exactly what let rows outlive their tenant, so any
+            // instance that has ever deleted a tenant may hold orphans — and AddForeignKey would
+            // fail on them. Drop them first: a directory row whose tenant is gone can route
+            // nowhere, and keeping it would preserve the chat-platform id and the old tenant's
+            // slug/display name that this cascade exists to remove.
+            migrationBuilder.Sql(
+                """
+                DELETE FROM chat_identity_directory d
+                WHERE NOT EXISTS (SELECT 1 FROM tenants t WHERE t.id = d.tenant_id);
+                """);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_chat_identity_directory_tenants_tenant_id",
+                table: "chat_identity_directory",
+                column: "tenant_id",
+                principalTable: "tenants",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_chat_identity_directory_tenants_tenant_id",
+                table: "chat_identity_directory");
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -2160,6 +2160,18 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
                 .HasDatabaseName("ux_directory_user_one_default");
 
             b.HasIndex(e => e.TenantId).HasDatabaseName("ix_directory_tenant_id");
+
+            // Not tenant-scoped (no RLS — the bot resolves across tenants), but the tenant
+            // reference is still a real FK so deleting a tenant takes its directory rows with it.
+            // Without it these rows outlive the tenant, and each one holds a chat-platform user id
+            // plus the tenant's slug and display name in Label/DisplayName — so a "delete
+            // everything" would leave a person's Discord/Telegram id still associated with the
+            // instance they had. No navigation property: nothing should traverse tenant -> chat
+            // links, this exists purely for the cascade.
+            b.HasOne<TenantEntity>()
+                .WithMany()
+                .HasForeignKey(e => e.TenantId)
+                .OnDelete(DeleteBehavior.Cascade);
         });
 
         modelBuilder.Entity<ChatIdentityPendingLinkEntity>(b =>

--- a/tests/Unit/Nocturne.API.Tests/Controllers/Admin/TenantControllerDeleteTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/Admin/TenantControllerDeleteTests.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Controllers.V4.PlatformAdmin;
+using Nocturne.Core.Contracts.Multitenancy;
+
+namespace Nocturne.API.Tests.Controllers.Admin;
+
+public class TenantControllerDeleteTests
+{
+    private readonly Mock<ITenantService> _tenantService = new();
+    private readonly Mock<ITenantRoleService> _roleService = new();
+    private readonly Mock<IMemberInviteService> _inviteService = new();
+    private readonly TenantController _controller;
+
+    public TenantControllerDeleteTests()
+    {
+        _controller = new TenantController(_tenantService.Object, _roleService.Object, _inviteService.Object)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+    }
+
+    [Fact]
+    public async Task Delete_ReturnsNoContent_WhenTenantExists()
+    {
+        var id = Guid.NewGuid();
+
+        var result = await _controller.Delete(id, CancellationToken.None);
+
+        result.Should().BeOfType<NoContentResult>();
+        _tenantService.Verify(s => s.DeleteAsync(id, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ITenantService.DeleteAsync throws for an unknown id. Unhandled, that surfaced as a 500,
+    // so a caller tearing an account down (nocturne-cloud's retention purge) could never finish
+    // one whose tenant had already been removed out of band — it retried and failed every sweep.
+    [Fact]
+    public async Task Delete_Returns404_WhenTenantIsAlreadyGone()
+    {
+        var id = Guid.NewGuid();
+        _tenantService
+            .Setup(s => s.DeleteAsync(id, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new KeyNotFoundException($"Tenant {id} not found"));
+
+        var result = await _controller.Delete(id, CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task Delete_DoesNotSwallowOtherFailures()
+    {
+        var id = Guid.NewGuid();
+        _tenantService
+            .Setup(s => s.DeleteAsync(id, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("database is on fire"));
+
+        var act = () => _controller.Delete(id, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Chat/ChatIdentityDirectoryServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Chat/ChatIdentityDirectoryServiceTests.cs
@@ -45,6 +45,24 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
 
     public void Dispose() => _connection.Dispose();
 
+    /// <summary>
+    /// Inserts a tenant and returns its id. chat_identity_directory.tenant_id is a real FK with
+    /// ON DELETE CASCADE, so a link cannot point at a tenant that was never created.
+    /// </summary>
+    private Guid NewTenant()
+    {
+        var id = Guid.CreateVersion7();
+        using var db = new NocturneDbContext(_options);
+        db.Tenants.Add(new TenantEntity
+        {
+            Id = id,
+            Slug = $"t-{id:n}"[..20],
+            DisplayName = "Test Tenant",
+        });
+        db.SaveChanges();
+        return id;
+    }
+
     private sealed class TestDbContextFactory(DbContextOptions<NocturneDbContext> options)
         : IDbContextFactory<NocturneDbContext>
     {
@@ -65,7 +83,7 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     [Fact]
     public async Task GetCandidatesAsync_returns_single_link_when_one_exists()
     {
-        await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "lily", "Lily", default);
+        await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "lily", "Lily", default);
         var result = await _service.GetCandidatesAsync(Platform, UserA, default);
         result.Should().HaveCount(1);
     }
@@ -73,8 +91,8 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     [Fact]
     public async Task GetCandidatesAsync_returns_all_links_when_multiple_exist()
     {
-        await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "lily", "Lily", default);
-        await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "oliver", "Oliver", default);
+        await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "lily", "Lily", default);
+        await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "oliver", "Oliver", default);
         var result = await _service.GetCandidatesAsync(Platform, UserA, default);
         result.Should().HaveCount(2);
     }
@@ -84,22 +102,22 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     [Fact]
     public async Task CreateLinkAsync_marks_first_link_as_default()
     {
-        var link = await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "lily", "Lily", default);
+        var link = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "lily", "Lily", default);
         link.IsDefault.Should().BeTrue();
     }
 
     [Fact]
     public async Task CreateLinkAsync_marks_subsequent_link_as_non_default()
     {
-        await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "lily", "Lily", default);
-        var second = await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "oliver", "Oliver", default);
+        await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "lily", "Lily", default);
+        var second = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "oliver", "Oliver", default);
         second.IsDefault.Should().BeFalse();
     }
 
     [Fact]
     public async Task CreateLinkAsync_is_idempotent_on_same_platform_user_tenant()
     {
-        var tenantId = Guid.CreateVersion7();
+        var tenantId = NewTenant();
         var userId = Guid.CreateVersion7();
         var first = await _service.CreateLinkAsync(Platform, UserA, tenantId, userId, "lily", "Lily", default);
         var second = await _service.CreateLinkAsync(Platform, UserA, tenantId, userId, "different", "Different", default);
@@ -111,17 +129,17 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     [Fact]
     public async Task CreateLinkAsync_auto_suffixes_label_collision()
     {
-        await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "lily", "Lily 1", default);
-        var second = await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "lily", "Lily 2", default);
+        await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "lily", "Lily 1", default);
+        var second = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "lily", "Lily 2", default);
         second.Label.Should().Be("lily-2");
     }
 
     [Fact]
     public async Task CreateLinkAsync_auto_suffixes_multiple_collisions()
     {
-        await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "lily", "Lily 1", default);
-        var b = await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "lily", "Lily 2", default);
-        var c = await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "lily", "Lily 3", default);
+        await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "lily", "Lily 1", default);
+        var b = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "lily", "Lily 2", default);
+        var c = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "lily", "Lily 3", default);
         b.Label.Should().Be("lily-2");
         c.Label.Should().Be("lily-3");
     }
@@ -131,8 +149,8 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     [Fact]
     public async Task SetDefaultAsync_promotes_target_and_clears_other_defaults()
     {
-        var a = await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "lily", "Lily", default);
-        var b = await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "oliver", "Oliver", default);
+        var a = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "lily", "Lily", default);
+        var b = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "oliver", "Oliver", default);
         a.IsDefault.Should().BeTrue();
         b.IsDefault.Should().BeFalse();
 
@@ -156,7 +174,7 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     [Fact]
     public async Task RenameLabelAsync_updates_label()
     {
-        var a = await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "lily", "Lily", default);
+        var a = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "lily", "Lily", default);
         await _service.RenameLabelAsync(a.Id, tenantScope: null, "rose", ct: default);
         var after = await _service.GetByIdAsync(a.Id, tenantScope: null, ct: default);
         after!.Label.Should().Be("rose");
@@ -165,8 +183,8 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     [Fact]
     public async Task RenameLabelAsync_throws_on_collision()
     {
-        await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "lily", "Lily", default);
-        var b = await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "oliver", "Oliver", default);
+        await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "lily", "Lily", default);
+        var b = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "oliver", "Oliver", default);
 
         var act = async () => await _service.RenameLabelAsync(b.Id, tenantScope: null, "lily", ct: default);
         await act.Should().ThrowAsync<InvalidOperationException>();
@@ -177,7 +195,7 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     [Fact]
     public async Task UpdateDisplayNameAsync_updates_display_name()
     {
-        var a = await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "lily", "Lily", default);
+        var a = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "lily", "Lily", default);
         await _service.UpdateDisplayNameAsync(a.Id, tenantScope: null, "Lily Renamed", ct: default);
         var after = await _service.GetByIdAsync(a.Id, tenantScope: null, ct: default);
         after!.DisplayName.Should().Be("Lily Renamed");
@@ -188,7 +206,7 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     [Fact]
     public async Task RevokeAsync_hard_deletes_row()
     {
-        var a = await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "lily", "Lily", default);
+        var a = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "lily", "Lily", default);
         await _service.RevokeAsync(a.Id, tenantScope: null, ct: default);
         var after = await _service.GetByIdAsync(a.Id, tenantScope: null, ct: default);
         after.Should().BeNull();
@@ -199,8 +217,8 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     [Fact]
     public async Task GetByTenantAsync_returns_only_links_for_that_tenant()
     {
-        var t1 = Guid.CreateVersion7();
-        var t2 = Guid.CreateVersion7();
+        var t1 = NewTenant();
+        var t2 = NewTenant();
         await _service.CreateLinkAsync(Platform, UserA, t1, Guid.CreateVersion7(), "lily", "Lily", default);
         await _service.CreateLinkAsync(Platform, UserB, t2, Guid.CreateVersion7(), "oliver", "Oliver", default);
 
@@ -214,8 +232,8 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     [Fact]
     public async Task GetByPlatformAndUserAsync_returns_exact_match_when_label_provided()
     {
-        await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "lily", "Lily", default);
-        await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "oliver", "Oliver", default);
+        await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "lily", "Lily", default);
+        await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "oliver", "Oliver", default);
 
         var result = await _service.GetByPlatformAndUserAsync(Platform, UserA, "oliver", default);
         result.Should().NotBeNull();
@@ -225,8 +243,8 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     [Fact]
     public async Task GetByPlatformAndUserAsync_returns_default_when_label_null_and_multiple_exist()
     {
-        var a = await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "lily", "Lily", default);
-        await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "oliver", "Oliver", default);
+        var a = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "lily", "Lily", default);
+        await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "oliver", "Oliver", default);
 
         var result = await _service.GetByPlatformAndUserAsync(Platform, UserA, null, default);
         result.Should().NotBeNull();
@@ -236,7 +254,7 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     [Fact]
     public async Task GetByPlatformAndUserAsync_returns_single_when_only_one_exists()
     {
-        var a = await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "lily", "Lily", default);
+        var a = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "lily", "Lily", default);
         // Force IsDefault=false to simulate "no default"
         using (var db = _factory.CreateDbContext())
         {
@@ -253,8 +271,8 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     [Fact]
     public async Task GetByPlatformAndUserAsync_returns_null_when_label_null_and_ambiguous()
     {
-        var a = await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "lily", "Lily", default);
-        await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "oliver", "Oliver", default);
+        var a = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "lily", "Lily", default);
+        await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "oliver", "Oliver", default);
         // Clear default flag without setting another
         using (var db = _factory.CreateDbContext())
         {
@@ -272,7 +290,7 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     [Fact]
     public async Task GetByIdAsync_returns_link_or_null()
     {
-        var a = await _service.CreateLinkAsync(Platform, UserA, Guid.CreateVersion7(), Guid.CreateVersion7(), "lily", "Lily", default);
+        var a = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), Guid.CreateVersion7(), "lily", "Lily", default);
         (await _service.GetByIdAsync(a.Id, tenantScope: null, ct: default)).Should().NotBeNull();
         (await _service.GetByIdAsync(Guid.CreateVersion7(), tenantScope: null, ct: default)).Should().BeNull();
     }


### PR DESCRIPTION
Two ways a tenant deletion currently ends up incomplete or unrecoverable. Both found auditing nocturne-cloud's retention purge, which deletes a tenant when a cancelled account's retention window expires.

## 1. Deleting an already-gone tenant returns 500, not 404

`Delete` declares `[ProducesResponseType(Status404NotFound)]` but never produces one — `ITenantService.DeleteAsync` throws `KeyNotFoundException` for an unknown id and nothing catches it. Every sibling endpoint in the codebase (`V4CrudControllerBase`, `ProfileController`, `SensorGlucoseController`, `ConnectorAdminController`, …) already does.

Why it bites: a caller deleting a tenant as part of a larger teardown treats 404 as success, so a partially-completed run can be retried. A 500 makes it fail on that account **forever, on every sweep**, with no way to finish — the tenant is gone but the account can never be marked done.

Three tests added: 204 on success, 404 when already gone, and that other exceptions still propagate rather than being swallowed into a 404.

## 2. `chat_identity_directory` has no foreign key to `tenants`

I audited all **118** tables carrying a `tenant_id` column against `pg_constraint`. Exactly one has no FK to `tenants`; every other one already cascades:

```
 table_name               | on_delete
--------------------------+--------------------------
 chat_identity_directory  | *** NO FK TO tenants ***
 alert_condition_timers   | CASCADE
 ...                      | CASCADE   (117 others)
```

So its rows outlive the tenant — and each row holds a chat-platform user id (`platform` + `platform_user_id`) alongside the tenant's slug and display name, since `Label` and `DisplayName` default to them. A "delete everything for this account" therefore left a person's Discord/Telegram id still associated with the instance they used to have.

Being global rather than tenant-scoped is why it has no RLS, but that isn't a reason to have no FK — nothing about cross-tenant routing requires a row to survive its tenant. Configured with **no navigation property**: nothing should traverse `tenant -> chat links`, the relationship exists purely for the cascade.

The migration **deletes orphans before adding the constraint**. Any instance that has ever deleted a tenant may already hold some — that is precisely the bug — and `AddForeignKey` would fail on them. Our production database has 4 rows and 0 orphans, so that step is defensive for self-hosters.

## Not covered

`chat_identity_directory.nocturne_user_id` has no FK to `subjects` either. The tenant cascade makes purges complete, but removing a single *member* still leaves a directory row pointing at a dead subject. Separate concern, happy to follow up.

## Verification

- New tests: 3 passed.
- `dotnet ef migrations add` generated against the current model; the orphan cleanup was added by hand on top.
- Note `main` is currently red for an unrelated reason — `error CS0103: The name 'DataSources' does not exist` in the CareLink mapper, fixed by #620. I had to apply that one-line `using` locally to build and generate the migration; it is **not** included here.

https://claude.ai/code/session_015nep4BaV3eeixbxBXZqXwb
