### PR TITLE
fix(auth): resolve the legacy read scope from the storage, and gate the v1 read plane

### DIFF
--- a/src/API/Nocturne.API/Attributes/RequireScopeAttribute.cs
+++ b/src/API/Nocturne.API/Attributes/RequireScopeAttribute.cs
@@ -17,6 +17,11 @@ namespace Nocturne.API.Attributes;
 /// hierarchical scope matching (e.g., <c>read</c> satisfies <c>read:entries</c>).
 /// The granted scopes are further refined by <see cref="Middleware.MemberScopeMiddleware"/>
 /// based on the user's tenant membership roles.
+/// <para>
+/// The check keys off the resolved scope set rather than an authenticated identity, so it also
+/// applies to the anonymous public-share principal, whose scopes are narrowed to
+/// <see cref="TenantPermissions.PublicShareScopes"/>. An empty scope set is rejected.
+/// </para>
 /// </remarks>
 /// <seealso cref="RequirePermissionAttribute"/>
 /// <seealso cref="Middleware.AuthenticationMiddleware"/>
@@ -64,13 +69,27 @@ public class RequireScopeAttribute : Attribute, IAuthorizationFilter
     {
         var httpContext = context.HttpContext;
 
-        if (!httpContext.IsAuthenticated())
+        var grantedScopes = httpContext.GetGrantedScopes();
+
+        // Eligibility is the presence of resolved scopes, not an authenticated identity. A public
+        // share link ({token}.share.{baseDomain}) is deliberately IsAuthenticated: false, yet
+        // AuthenticationMiddleware resolves its Public subject down to
+        // TenantPermissions.PublicShareScopes and publishes them here. Requiring authentication
+        // would 401 every share, so the scope set is the gate for both principals.
+        //
+        // This cannot widen writes: PublicShareScopes contains only ".read" scopes, and
+        // OAuthScopes.SatisfiesScope grants a required scope solely on an exact match, on "*", or
+        // on the matching ".readwrite" — so no share scope set can ever satisfy a write scope.
+        //
+        // No scopes at all means no resolved grant, which fails closed. An authenticated caller
+        // gets 403 (identity known, grant insufficient); anyone else gets 401.
+        if (grantedScopes.Count == 0)
         {
-            context.Result = new UnauthorizedResult();
+            context.Result = httpContext.IsAuthenticated()
+                ? new ForbidResult()
+                : new UnauthorizedResult();
             return;
         }
-
-        var grantedScopes = httpContext.GetGrantedScopes();
 
         var hasSufficientScope = _requireAll
             ? _requiredScopes.All(s => OAuthScopes.SatisfiesScope(grantedScopes, s))

--- a/src/API/Nocturne.API/Attributes/RequireScopeAttribute.cs
+++ b/src/API/Nocturne.API/Attributes/RequireScopeAttribute.cs
@@ -18,9 +18,11 @@ namespace Nocturne.API.Attributes;
 /// The granted scopes are further refined by <see cref="Middleware.MemberScopeMiddleware"/>
 /// based on the user's tenant membership roles.
 /// <para>
-/// The check keys off the resolved scope set rather than an authenticated identity, so it also
-/// applies to the anonymous public-share principal, whose scopes are narrowed to
-/// <see cref="TenantPermissions.PublicShareScopes"/>. An empty scope set is rejected.
+/// A read requirement is decided on the resolved scope set alone, so it admits the anonymous
+/// public-share principal, whose scopes are narrowed to
+/// <see cref="TenantPermissions.PublicShareScopes"/>. A requirement naming anything other than
+/// read also requires an authenticated caller, so no anonymous principal can pass a write gate
+/// however its scopes are resolved. An empty scope set is rejected either way.
 /// </para>
 /// </remarks>
 /// <seealso cref="RequirePermissionAttribute"/>

--- a/src/API/Nocturne.API/Attributes/RequireScopeAttribute.cs
+++ b/src/API/Nocturne.API/Attributes/RequireScopeAttribute.cs
@@ -61,6 +61,12 @@ public class RequireScopeAttribute : Attribute, IAuthorizationFilter
         _requireAll = requireAll;
     }
 
+    /// <summary>The scopes this attribute requires.</summary>
+    public IReadOnlyList<string> RequiredScopes => _requiredScopes;
+
+    /// <summary>Whether every scope in <see cref="RequiredScopes"/> is required (AND) or any one (OR).</summary>
+    public bool RequiresAll => _requireAll;
+
     /// <summary>
     /// Evaluates the scope requirement against the current request's granted scopes.
     /// </summary>

--- a/src/API/Nocturne.API/Attributes/RequireScopeAttribute.cs
+++ b/src/API/Nocturne.API/Attributes/RequireScopeAttribute.cs
@@ -77,16 +77,24 @@ public class RequireScopeAttribute : Attribute, IAuthorizationFilter
 
         var grantedScopes = httpContext.GetGrantedScopes();
 
-        // Eligibility is the presence of resolved scopes, not an authenticated identity. A public
-        // share link ({token}.share.{baseDomain}) is deliberately IsAuthenticated: false, yet
+        // An unauthenticated caller is eligible only for a read requirement. A public share link
+        // ({token}.share.{baseDomain}) is deliberately IsAuthenticated: false, yet
         // AuthenticationMiddleware resolves its Public subject down to
-        // TenantPermissions.PublicShareScopes and publishes them here. Requiring authentication
-        // would 401 every share, so the scope set is the gate for both principals.
+        // TenantPermissions.PublicShareScopes and publishes them here, so requiring authentication
+        // outright would 401 every share.
         //
-        // This cannot widen writes: PublicShareScopes contains only ".read" scopes, and
-        // OAuthScopes.SatisfiesScope grants a required scope solely on an exact match, on "*", or
-        // on the matching ".readwrite" — so no share scope set can ever satisfy a write scope.
-        //
+        // Restricting it to read requirements keeps "an unauthenticated principal can never pass a
+        // write gate" a property of this attribute. Deriving it from the scopes a share happens to
+        // hold would instead make it depend on every present and future anonymous path publishing
+        // only read scopes, and SatisfiesScope matches device.notify and device.actuate on an exact
+        // string — neither is ".read" nor ".readwrite".
+        if (!httpContext.IsAuthenticated()
+            && !_requiredScopes.All(scope => scope.EndsWith(".read", StringComparison.Ordinal)))
+        {
+            context.Result = new UnauthorizedResult();
+            return;
+        }
+
         // No scopes at all means no resolved grant, which fails closed. An authenticated caller
         // gets 403 (identity known, grant insufficient); anyone else gets 401.
         if (grantedScopes.Count == 0)

--- a/src/API/Nocturne.API/Authorization/ActivityReadScopeGuard.cs
+++ b/src/API/Nocturne.API/Authorization/ActivityReadScopeGuard.cs
@@ -1,0 +1,62 @@
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
+
+namespace Nocturne.API.Authorization;
+
+/// <summary>
+/// Enforces per-record OAuth read scopes on the merged activity read endpoints, the mirror of
+/// <see cref="ActivityWriteScopeGuard"/>. <c>IActivityService.GetActivitiesAsync</c> merges four
+/// storages into one response — StateSpans, heart rates, step counts and sleep sessions — and each
+/// dedicated storage has its own read scope, so a single <c>RequireScope</c> attribute on the
+/// action can only decide admission, not what the response may contain. The attribute therefore
+/// lists <see cref="AdmissionScopes"/> as an OR and this guard drops every record whose category
+/// the caller does not hold.
+/// </summary>
+/// <seealso cref="IActivityDecomposer.RequiredReadScope"/>
+internal static class ActivityReadScopeGuard
+{
+    /// <summary>
+    /// The read scopes that admit a caller to the merged activity read endpoints: holding any one
+    /// of them means at least one category in the response is visible. Kept here as documentation
+    /// of the set — attribute arguments must be compile-time constants, so the actions repeat the
+    /// constants inline.
+    /// </summary>
+    public static readonly IReadOnlyList<string> AdmissionScopes =
+    [
+        OAuthScopes.TreatmentsRead,
+        OAuthScopes.HeartRateRead,
+        OAuthScopes.StepCountRead,
+        OAuthScopes.SleepRead,
+    ];
+
+    /// <summary>
+    /// Returns whether the caller's granted scopes cover the storage the activity came from.
+    /// </summary>
+    /// <param name="activity">The activity about to be returned.</param>
+    /// <param name="decomposer">Classifier that maps each activity to its required read scope.</param>
+    /// <param name="grantedScopes">The caller's normalized granted scopes.</param>
+    public static bool CanRead(
+        Activity activity,
+        IActivityDecomposer decomposer,
+        IReadOnlySet<string> grantedScopes)
+    {
+        return OAuthScopes.SatisfiesScope(grantedScopes, decomposer.RequiredReadScope(activity));
+    }
+
+    /// <summary>
+    /// Drops every activity whose storage category the caller lacks the read scope for.
+    /// </summary>
+    /// <param name="activities">The activities about to be returned.</param>
+    /// <param name="decomposer">Classifier that maps each activity to its required read scope.</param>
+    /// <param name="grantedScopes">The caller's normalized granted scopes.</param>
+    public static List<Activity> Filter(
+        IEnumerable<Activity> activities,
+        IActivityDecomposer decomposer,
+        IReadOnlySet<string> grantedScopes)
+    {
+        return activities
+            .Where(activity => CanRead(activity, decomposer, grantedScopes))
+            .ToList();
+    }
+}

--- a/src/API/Nocturne.API/Authorization/ActivityReadScopeGuard.cs
+++ b/src/API/Nocturne.API/Authorization/ActivityReadScopeGuard.cs
@@ -18,9 +18,9 @@ internal static class ActivityReadScopeGuard
 {
     /// <summary>
     /// The read scopes that admit a caller to the merged activity read endpoints: holding any one
-    /// of them means at least one category in the response is visible. Kept here as documentation
-    /// of the set — attribute arguments must be compile-time constants, so the actions repeat the
-    /// constants inline.
+    /// of them means at least one category in the response is visible. Attribute arguments must be
+    /// compile-time constants, so the admission attributes repeat these constants inline; the
+    /// count endpoints, which cannot filter and so require all four, read them from here.
     /// </summary>
     public static readonly IReadOnlyList<string> AdmissionScopes =
     [

--- a/src/API/Nocturne.API/Authorization/ActivityReadScopeGuard.cs
+++ b/src/API/Nocturne.API/Authorization/ActivityReadScopeGuard.cs
@@ -1,3 +1,6 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Extensions;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Authorization;
@@ -29,6 +32,28 @@ internal static class ActivityReadScopeGuard
         OAuthScopes.StepCountRead,
         OAuthScopes.SleepRead,
     ];
+
+    /// <summary>
+    /// The result to return instead of a merged activity count, or <see langword="null"/> when the
+    /// caller may have it. A count cannot be filtered the way <see cref="Filter"/> filters records,
+    /// so it takes every category rather than any one of them.
+    /// </summary>
+    public static ActionResult? RefuseUnlessEveryCategory(HttpContext httpContext)
+    {
+        var granted = httpContext.GetGrantedScopes();
+        if (AdmissionScopes.All(scope => OAuthScopes.SatisfiesScope(granted, scope)))
+            return null;
+
+        return new ObjectResult(new
+        {
+            status = 403,
+            message = "Counting merged activity requires every activity category's read scope.",
+            type = "forbidden",
+        })
+        {
+            StatusCode = StatusCodes.Status403Forbidden,
+        };
+    }
 
     /// <summary>
     /// Returns whether the caller's granted scopes cover the storage the activity came from.

--- a/src/API/Nocturne.API/Authorization/LegacyStorageReadScopes.cs
+++ b/src/API/Nocturne.API/Authorization/LegacyStorageReadScopes.cs
@@ -1,3 +1,6 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Extensions;
 using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.API.Authorization;
@@ -7,7 +10,7 @@ namespace Nocturne.API.Authorization;
 /// </summary>
 /// <remarks>
 /// The V1 routes that take the collection as a parameter — <c>slice/{storage}/…</c>,
-/// <c>times?storage=</c>, <c>count/{storage}/where</c> — cannot be gated by an attribute, because a
+/// <c>times/echo?storage=</c>, <c>count/{storage}/where</c> — cannot be gated by an attribute, because a
 /// class- or action-level scope list is an OR across every collection the route can serve and so
 /// admits a caller holding any one of them to all of them. The storage is a route or query value, so
 /// the governing scope is resolvable per request and is checked in the action instead.
@@ -45,4 +48,28 @@ internal static class LegacyStorageReadScopes
     /// </summary>
     public static bool CanRead(IReadOnlySet<string> grantedScopes, string? storage) =>
         RequiredReadScope(storage) is { } scope && OAuthScopes.SatisfiesScope(grantedScopes, scope);
+
+    /// <summary>
+    /// The result to return instead of reading <paramref name="storage"/>, or <see langword="null"/>
+    /// when the caller may read it. An unclassified selector is refused rather than passed through,
+    /// so adding a collection to a route's accepted list without classifying it here closes the
+    /// route rather than opening it.
+    /// </summary>
+    public static ActionResult? RefuseRead(HttpContext httpContext, string? storage)
+    {
+        if (RequiredReadScope(storage) is not { } required)
+        {
+            return new BadRequestObjectResult(
+                new { status = 400, message = $"Unsupported storage type: {storage}", type = "bad_request" });
+        }
+
+        if (CanRead(httpContext.GetGrantedScopes(), storage))
+            return null;
+
+        return new ObjectResult(
+            new { status = 403, message = $"Reading '{storage}' requires the {required} scope.", type = "forbidden" })
+        {
+            StatusCode = StatusCodes.Status403Forbidden,
+        };
+    }
 }

--- a/src/API/Nocturne.API/Authorization/LegacyStorageReadScopes.cs
+++ b/src/API/Nocturne.API/Authorization/LegacyStorageReadScopes.cs
@@ -1,0 +1,48 @@
+using Nocturne.Core.Models.Authorization;
+
+namespace Nocturne.API.Authorization;
+
+/// <summary>
+/// Maps a legacy <c>storage</c> selector to the read scope that governs it.
+/// </summary>
+/// <remarks>
+/// The V1 routes that take the collection as a parameter — <c>slice/{storage}/…</c>,
+/// <c>times?storage=</c>, <c>count/{storage}/where</c> — cannot be gated by an attribute, because a
+/// class- or action-level scope list is an OR across every collection the route can serve and so
+/// admits a caller holding any one of them to all of them. The storage is a route or query value, so
+/// the governing scope is resolvable per request and is checked in the action instead.
+/// </remarks>
+/// <seealso cref="ActivityReadScopeGuard"/>
+internal static class LegacyStorageReadScopes
+{
+    /// <summary>
+    /// The read scope each storage selector requires, keyed case-insensitively because the services
+    /// dispatch on <c>storage.ToLowerInvariant()</c>. <c>activity</c> is absent: it merges
+    /// heart-rate, step-count, sleep and plain activity, so it has no single governing scope and is
+    /// handled by <see cref="ActivityReadScopeGuard"/>.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> ScopesByStorage =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["entries"] = OAuthScopes.GlucoseRead,
+            ["treatments"] = OAuthScopes.TreatmentsRead,
+            ["devicestatus"] = OAuthScopes.DevicesRead,
+            ["profile"] = OAuthScopes.TherapyRead,
+            ["food"] = OAuthScopes.FoodRead,
+        };
+
+    /// <summary>
+    /// The read scope <paramref name="storage"/> requires, or <see langword="null"/> when the
+    /// selector names no known collection. A null means the caller supplied something the service
+    /// will reject anyway, so the caller reports it as a bad request rather than a refusal.
+    /// </summary>
+    public static string? RequiredReadScope(string? storage) =>
+        storage is not null && ScopesByStorage.TryGetValue(storage, out var scope) ? scope : null;
+
+    /// <summary>
+    /// Whether <paramref name="grantedScopes"/> may read <paramref name="storage"/>. False for an
+    /// unknown selector, so a new collection is denied until it is classified here.
+    /// </summary>
+    public static bool CanRead(IReadOnlySet<string> grantedScopes, string? storage) =>
+        RequiredReadScope(storage) is { } scope && OAuthScopes.SatisfiesScope(grantedScopes, scope);
+}

--- a/src/API/Nocturne.API/Controllers/V1/ActivityController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/ActivityController.cs
@@ -50,10 +50,21 @@ public class ActivityController : ControllerBase
     /// Get all activities with optional filtering and pagination.
     /// Returns regular activities, heart rate, and step count data merged by timestamp.
     /// </summary>
+    /// <remarks>
+    /// The scope requirement is an OR because the response merges four storages, each with its own
+    /// read scope. Admission means the caller holds at least one of those categories;
+    /// <see cref="ActivityReadScopeGuard"/> then removes the records whose category the caller does
+    /// not hold. Pagination is applied by the service before the filter, so a caller holding a
+    /// subset of the categories can receive fewer than <paramref name="count"/> records.
+    /// </remarks>
     [HttpGet]
     [ProducesResponseType(typeof(IEnumerable<Activity>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    [RequireScope(OAuthScopes.TreatmentsRead)]
+    [RequireScope(
+        OAuthScopes.TreatmentsRead,
+        OAuthScopes.HeartRateRead,
+        OAuthScopes.StepCountRead,
+        OAuthScopes.SleepRead)]
     public async Task<ActionResult<IEnumerable<Activity>>> GetActivities(
         [FromQuery] int count = 10,
         [FromQuery] int skip = 0,
@@ -68,7 +79,8 @@ public class ActivityController : ControllerBase
                 cancellationToken: cancellationToken
             );
 
-            var activitiesList = activities.ToList();
+            var activitiesList = ActivityReadScopeGuard.Filter(
+                activities, _activityDecomposer, HttpContext.GetGrantedScopes());
             if (activitiesList.Count > 0)
             {
                 var latestActivity = activitiesList.FirstOrDefault();
@@ -94,13 +106,23 @@ public class ActivityController : ControllerBase
     }
 
     /// <summary>
-    /// Get a specific activity by ID (checks StateSpans, heart_rates, and step_counts)
+    /// Get a specific activity by ID (checks StateSpans, sleep_sessions, heart_rates, and step_counts)
     /// </summary>
+    /// <remarks>
+    /// The scope requirement is an OR over the four storages this route resolves against, and
+    /// <see cref="ActivityReadScopeGuard"/> then checks the resolved record's own category. A record
+    /// in a category the caller does not hold answers 404 rather than 403, so the response does not
+    /// disclose that the record exists.
+    /// </remarks>
     [HttpGet("{id}")]
     [ProducesResponseType(typeof(Activity), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    [RequireScope(OAuthScopes.TreatmentsRead)]
+    [RequireScope(
+        OAuthScopes.TreatmentsRead,
+        OAuthScopes.HeartRateRead,
+        OAuthScopes.StepCountRead,
+        OAuthScopes.SleepRead)]
     public async Task<ActionResult<Activity>> GetActivity(
         string id,
         CancellationToken cancellationToken = default
@@ -110,6 +132,10 @@ public class ActivityController : ControllerBase
         {
             var activity = await _activityService.GetActivityByIdAsync(id, cancellationToken);
             if (activity == null)
+                return NotFound(new { error = $"Activity with ID {id} not found" });
+
+            if (!ActivityReadScopeGuard.CanRead(
+                activity, _activityDecomposer, HttpContext.GetGrantedScopes()))
                 return NotFound(new { error = $"Activity with ID {id} not found" });
 
             return Ok(activity);

--- a/src/API/Nocturne.API/Controllers/V1/ActivityController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/ActivityController.cs
@@ -53,6 +53,7 @@ public class ActivityController : ControllerBase
     [HttpGet]
     [ProducesResponseType(typeof(IEnumerable<Activity>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [RequireScope(OAuthScopes.TreatmentsRead)]
     public async Task<ActionResult<IEnumerable<Activity>>> GetActivities(
         [FromQuery] int count = 10,
         [FromQuery] int skip = 0,
@@ -99,6 +100,7 @@ public class ActivityController : ControllerBase
     [ProducesResponseType(typeof(Activity), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [RequireScope(OAuthScopes.TreatmentsRead)]
     public async Task<ActionResult<Activity>> GetActivity(
         string id,
         CancellationToken cancellationToken = default

--- a/src/API/Nocturne.API/Controllers/V1/CountController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/CountController.cs
@@ -205,10 +205,23 @@ public class CountController : ControllerBase
     /// <param name="find">MongoDB-style find query filters (JSON format)</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Count of activity entries matching the criteria</returns>
+    /// <remarks>
+    /// <c>CountActivitiesAsync</c> sums four storages — StateSpans, heart rates, step counts and
+    /// sleep sessions — into a single number, so unlike the record-returning activity endpoints
+    /// the result cannot be filtered down to the categories the caller holds. The requirement is
+    /// therefore every category's read scope (AND), which is what the legacy admin, <c>api:*:read</c>
+    /// and <c>readable</c> grants carry. Serving a per-category count needs a source-aware count on
+    /// <c>IActivityService</c>.
+    /// </remarks>
     [HttpGet("activity/where")]
     [NightscoutEndpoint("/api/v1/count/activity/where")]
     [ProducesResponseType(typeof(CountResponse), 200)]
-    [RequireScope(OAuthScopes.TreatmentsRead)]
+    [RequireScope(
+        requireAll: true,
+        OAuthScopes.TreatmentsRead,
+        OAuthScopes.HeartRateRead,
+        OAuthScopes.StepCountRead,
+        OAuthScopes.SleepRead)]
     public async Task<ActionResult<CountResponse>> CountActivity(
         [FromQuery] string? find = null,
         CancellationToken cancellationToken = default

--- a/src/API/Nocturne.API/Controllers/V1/CountController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/CountController.cs
@@ -6,6 +6,7 @@ using Nocturne.Core.Contracts.Profiles;
 using Nocturne.Core.Contracts.Repositories;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.API.Controllers.V1;
 
@@ -71,6 +72,7 @@ public class CountController : ControllerBase
     [HttpGet("entries/where")]
     [NightscoutEndpoint("/api/v1/count/entries/where")]
     [ProducesResponseType(typeof(CountResponse), 200)]
+    [RequireScope(OAuthScopes.GlucoseRead)]
     public async Task<ActionResult<CountResponse>> CountEntries(
         [FromQuery] string? find = null,
         [FromQuery] string? type = null,
@@ -120,6 +122,7 @@ public class CountController : ControllerBase
     [HttpGet("treatments/where")]
     [NightscoutEndpoint("/api/v1/count/treatments/where")]
     [ProducesResponseType(typeof(CountResponse), 200)]
+    [RequireScope(OAuthScopes.TreatmentsRead)]
     public async Task<ActionResult<CountResponse>> CountTreatments(
         [FromQuery] string? find = null,
         CancellationToken cancellationToken = default
@@ -162,6 +165,7 @@ public class CountController : ControllerBase
     [HttpGet("devicestatus/where")]
     [NightscoutEndpoint("/api/v1/count/devicestatus/where")]
     [ProducesResponseType(typeof(CountResponse), 200)]
+    [RequireScope(OAuthScopes.DevicesRead)]
     public async Task<ActionResult<CountResponse>> CountDeviceStatus(
         [FromQuery] string? find = null,
         CancellationToken cancellationToken = default
@@ -204,6 +208,7 @@ public class CountController : ControllerBase
     [HttpGet("activity/where")]
     [NightscoutEndpoint("/api/v1/count/activity/where")]
     [ProducesResponseType(typeof(CountResponse), 200)]
+    [RequireScope(OAuthScopes.TreatmentsRead)]
     public async Task<ActionResult<CountResponse>> CountActivity(
         [FromQuery] string? find = null,
         CancellationToken cancellationToken = default
@@ -249,6 +254,7 @@ public class CountController : ControllerBase
     [ProducesResponseType(typeof(CountResponse), 200)]
     [ProducesResponseType(400)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.GlucoseRead, OAuthScopes.TreatmentsRead, OAuthScopes.DevicesRead, OAuthScopes.FoodRead, OAuthScopes.TherapyRead)]
     public async Task<ActionResult<CountResponse>> CountGeneric(
         string storage,
         [FromQuery] string? find = null,

--- a/src/API/Nocturne.API/Controllers/V1/CountController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/CountController.cs
@@ -249,6 +249,13 @@ public class CountController : ControllerBase
     /// <param name="type">Additional type filter (for entries: sgv, mbg, cal)</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Count of records matching the criteria</returns>
+    /// <remarks>
+    /// The scope requirement is an OR across every storage this route can serve, because the
+    /// storage is a route parameter. It therefore lets a grant scoped to one category learn a
+    /// row COUNT for another; the per-storage sibling routes above (<c>entries/where</c>,
+    /// <c>treatments/where</c>, …) are each gated on their own category. Narrowing this route
+    /// needs a per-storage check inside the action.
+    /// </remarks>
     [HttpGet("{storage}/where")]
     [NightscoutEndpoint("/api/v1/count/:storage/where")]
     [ProducesResponseType(typeof(CountResponse), 200)]

--- a/src/API/Nocturne.API/Controllers/V1/CountController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/CountController.cs
@@ -27,6 +27,14 @@ namespace Nocturne.API.Controllers.V1;
 [Route("api/v1/[controller]")]
 public class CountController : ControllerBase
 {
+    /// <summary>
+    /// The selectors <c>{storage}/where</c> dispatches on. Every one must be classified in
+    /// <see cref="LegacyStorageReadScopes"/> or handled by <see cref="ActivityReadScopeGuard"/>,
+    /// which <c>CountableStorage_IsFullyClassified</c> asserts.
+    /// </summary>
+    internal static readonly string[] CountableStorage =
+        ["entries", "treatments", "devicestatus", "profile", "food", "activity"];
+
     private readonly IEntryStore _entryStore;
     private readonly ITreatmentStore _treatmentStore;
     private readonly IApsSnapshotRepository _apsSnapshotRepository;
@@ -223,12 +231,8 @@ public class CountController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
-        // Every category, because the number merges four of them and cannot be filtered down to the
-        // ones the caller holds. A grant without sleep.read therefore loses this count; the scopes
-        // come from ActivityReadScopeGuard so the set cannot drift from the record endpoints'.
-        var granted = HttpContext.GetGrantedScopes();
-        if (!ActivityReadScopeGuard.AdmissionScopes.All(s => OAuthScopes.SatisfiesScope(granted, s)))
-            return StatusCode(403, new { status = 403, message = "Counting merged activity requires every activity category's read scope.", type = "forbidden" });
+        if (ActivityReadScopeGuard.RefuseUnlessEveryCategory(HttpContext) is { } refusal)
+            return refusal;
 
         _logger.LogDebug(
             "Count activity endpoint requested with find: {Find} from {RemoteIpAddress}",
@@ -283,19 +287,26 @@ public class CountController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
+        if (!CountableStorage.Contains(storage, StringComparer.OrdinalIgnoreCase))
+        {
+            _logger.LogWarning("Invalid storage type requested: {Storage}", storage);
+            return BadRequest(
+                new
+                {
+                    status = 400,
+                    message = $"Invalid storage type: {storage}. Supported types: {string.Join(", ", CountableStorage)}",
+                    type = "client",
+                }
+            );
+        }
+
         // "activity" reaches CountActivitiesAsync, which merges four categories into one number, so
         // it needs every category's read scope rather than one storage's.
-        if (string.Equals(storage, "activity", StringComparison.OrdinalIgnoreCase))
-        {
-            var granted = HttpContext.GetGrantedScopes();
-            if (!ActivityReadScopeGuard.AdmissionScopes.All(s => OAuthScopes.SatisfiesScope(granted, s)))
-                return StatusCode(403, new { status = 403, message = "Counting merged activity requires every activity category's read scope.", type = "forbidden" });
-        }
-        else if (LegacyStorageReadScopes.RequiredReadScope(storage) is { } required)
-        {
-            if (!OAuthScopes.SatisfiesScope(HttpContext.GetGrantedScopes(), required))
-                return StatusCode(403, new { status = 403, message = $"Counting '{storage}' requires the {required} scope.", type = "forbidden" });
-        }
+        var refusal = string.Equals(storage, "activity", StringComparison.OrdinalIgnoreCase)
+            ? ActivityReadScopeGuard.RefuseUnlessEveryCategory(HttpContext)
+            : LegacyStorageReadScopes.RefuseRead(HttpContext, storage);
+        if (refusal is not null)
+            return refusal;
 
         _logger.LogDebug(
             "Generic count endpoint requested for storage: {Storage}, find: {Find}, type: {Type} from {RemoteIpAddress}",
@@ -307,29 +318,6 @@ public class CountController : ControllerBase
 
         try
         {
-            // Validate storage type
-            var validStorageTypes = new[]
-            {
-                "entries",
-                "treatments",
-                "devicestatus",
-                "profile",
-                "food",
-                "activity",
-            };
-            if (!validStorageTypes.Contains(storage.ToLowerInvariant()))
-            {
-                _logger.LogWarning("Invalid storage type requested: {Storage}", storage);
-                return BadRequest(
-                    new
-                    {
-                        status = 400,
-                        message = $"Invalid storage type: {storage}. Supported types: {string.Join(", ", validStorageTypes)}",
-                        type = "client",
-                    }
-                );
-            }
-
             long count;
             switch (storage.ToLowerInvariant())
             {

--- a/src/API/Nocturne.API/Controllers/V1/CountController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/CountController.cs
@@ -7,6 +7,8 @@ using Nocturne.Core.Contracts.Repositories;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.Authorization;
+using Nocturne.API.Extensions;
+using Nocturne.API.Authorization;
 
 namespace Nocturne.API.Controllers.V1;
 
@@ -216,17 +218,18 @@ public class CountController : ControllerBase
     [HttpGet("activity/where")]
     [NightscoutEndpoint("/api/v1/count/activity/where")]
     [ProducesResponseType(typeof(CountResponse), 200)]
-    [RequireScope(
-        requireAll: true,
-        OAuthScopes.TreatmentsRead,
-        OAuthScopes.HeartRateRead,
-        OAuthScopes.StepCountRead,
-        OAuthScopes.SleepRead)]
     public async Task<ActionResult<CountResponse>> CountActivity(
         [FromQuery] string? find = null,
         CancellationToken cancellationToken = default
     )
     {
+        // Every category, because the number merges four of them and cannot be filtered down to the
+        // ones the caller holds. A grant without sleep.read therefore loses this count; the scopes
+        // come from ActivityReadScopeGuard so the set cannot drift from the record endpoints'.
+        var granted = HttpContext.GetGrantedScopes();
+        if (!ActivityReadScopeGuard.AdmissionScopes.All(s => OAuthScopes.SatisfiesScope(granted, s)))
+            return StatusCode(403, new { status = 403, message = "Counting merged activity requires every activity category's read scope.", type = "forbidden" });
+
         _logger.LogDebug(
             "Count activity endpoint requested with find: {Find} from {RemoteIpAddress}",
             find,
@@ -263,18 +266,16 @@ public class CountController : ControllerBase
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Count of records matching the criteria</returns>
     /// <remarks>
-    /// The scope requirement is an OR across every storage this route can serve, because the
-    /// storage is a route parameter. It therefore lets a grant scoped to one category learn a
-    /// row COUNT for another; the per-storage sibling routes above (<c>entries/where</c>,
-    /// <c>treatments/where</c>, …) are each gated on their own category. Narrowing this route
-    /// needs a per-storage check inside the action.
+    /// The storage is a route parameter, so the governing scope is resolved per request through
+    /// <see cref="LegacyStorageReadScopes"/>. An attribute here would be an OR across every
+    /// collection the route serves and would let a grant scoped to one category learn a row count
+    /// for another. <c>activity</c> merges four categories and keeps the AND below.
     /// </remarks>
     [HttpGet("{storage}/where")]
     [NightscoutEndpoint("/api/v1/count/:storage/where")]
     [ProducesResponseType(typeof(CountResponse), 200)]
     [ProducesResponseType(400)]
     [ProducesResponseType(500)]
-    [RequireScope(OAuthScopes.GlucoseRead, OAuthScopes.TreatmentsRead, OAuthScopes.DevicesRead, OAuthScopes.FoodRead, OAuthScopes.TherapyRead)]
     public async Task<ActionResult<CountResponse>> CountGeneric(
         string storage,
         [FromQuery] string? find = null,
@@ -282,6 +283,20 @@ public class CountController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
+        // "activity" reaches CountActivitiesAsync, which merges four categories into one number, so
+        // it needs every category's read scope rather than one storage's.
+        if (string.Equals(storage, "activity", StringComparison.OrdinalIgnoreCase))
+        {
+            var granted = HttpContext.GetGrantedScopes();
+            if (!ActivityReadScopeGuard.AdmissionScopes.All(s => OAuthScopes.SatisfiesScope(granted, s)))
+                return StatusCode(403, new { status = 403, message = "Counting merged activity requires every activity category's read scope.", type = "forbidden" });
+        }
+        else if (LegacyStorageReadScopes.RequiredReadScope(storage) is { } required)
+        {
+            if (!OAuthScopes.SatisfiesScope(HttpContext.GetGrantedScopes(), required))
+                return StatusCode(403, new { status = 403, message = $"Counting '{storage}' requires the {required} scope.", type = "forbidden" });
+        }
+
         _logger.LogDebug(
             "Generic count endpoint requested for storage: {Storage}, find: {Find}, type: {Type} from {RemoteIpAddress}",
             storage,

--- a/src/API/Nocturne.API/Controllers/V1/DebugController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/DebugController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
 using Nocturne.Core.Contracts.Entries;
 using Nocturne.Core.Models;
 
@@ -9,9 +10,14 @@ namespace Nocturne.API.Controllers.V1;
 /// Provides basic database connectivity tests against the PostgreSQL data store.
 /// </summary>
 /// <seealso cref="IEntryStore"/>
+/// <remarks>
+/// Admin-only: the responses carry real glucose rows and raw exception/inner-exception text from
+/// the data layer, so this is a diagnostics surface rather than a data API.
+/// </remarks>
 [ApiController]
 [Tags("V1")]
 [Route("api/v1/[controller]")]
+[RequireAdmin]
 public class DebugController : ControllerBase
 {
     private readonly IEntryStore _store;

--- a/src/API/Nocturne.API/Controllers/V1/DeviceStatusController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/DeviceStatusController.cs
@@ -70,6 +70,7 @@ public class DeviceStatusController : ControllerBase
     [ProducesResponseType(typeof(DeviceStatus[]), 200)]
     [ProducesResponseType(400)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.DevicesRead)]
     public async Task<ActionResult> GetDeviceStatus(
         [FromQuery] int count = 10,
         [FromQuery] int skip = 0,
@@ -446,6 +447,7 @@ public class DeviceStatusController : ControllerBase
     [ProducesResponseType(typeof(DeviceStatus[]), 200)]
     [ProducesResponseType(400)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.DevicesRead)]
     public async Task<ActionResult<DeviceStatus[]>> GetDeviceStatusJson(
         [FromQuery] int count = 10,
         [FromQuery] int skip = 0,

--- a/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
@@ -68,6 +68,7 @@ public class EntriesController : ControllerBase
     [ResponseCache(Duration = 60, VaryByHeader = "If-Modified-Since")]
     [ProducesResponseType(typeof(Entry[]), 200)]
     [ProducesResponseType(typeof(Entry[]), 304)] // Not Modified response
+    [RequireScope(OAuthScopes.GlucoseRead)]
     public async Task<ActionResult<Entry[]>> GetCurrentEntry(
         CancellationToken cancellationToken = default
     )
@@ -161,6 +162,7 @@ public class EntriesController : ControllerBase
     [NightscoutEndpoint("/api/v1/entries/{spec}")]
     [ProducesResponseType(typeof(Entry[]), 200)]
     [ProducesResponseType(typeof(Entry[]), 304)] // Not Modified response
+    [RequireScope(OAuthScopes.GlucoseRead)]
     public async Task<ActionResult<Entry[]>> GetEntry(
         string spec,
         CancellationToken cancellationToken = default
@@ -300,6 +302,7 @@ public class EntriesController : ControllerBase
     [ResponseCache(Duration = 60, VaryByQueryKeys = new[] { "*" }, VaryByHeader = "If-Modified-Since")]
     [ProducesResponseType(typeof(Entry[]), 200)]
     [ProducesResponseType(typeof(Entry[]), 304)] // Not Modified response
+    [RequireScope(OAuthScopes.GlucoseRead)]
     public async Task<ActionResult> GetEntries(
         [FromQuery] string? find = null,
         [FromQuery] int? count = null,

--- a/src/API/Nocturne.API/Controllers/V1/FoodController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/FoodController.cs
@@ -43,6 +43,7 @@ public class FoodController : ControllerBase
     [NightscoutEndpoint("/api/v1/food")]
     [ProducesResponseType(typeof(Food[]), 200)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.FoodRead)]
     public async Task<ActionResult<Food[]>> GetFood(CancellationToken cancellationToken = default)
     {
         _logger.LogDebug(
@@ -86,6 +87,7 @@ public class FoodController : ControllerBase
     [NightscoutEndpoint("/api/v1/food.json")]
     [ProducesResponseType(typeof(Food[]), 200)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.FoodRead)]
     public async Task<ActionResult<Food[]>> GetFoodJson(
         CancellationToken cancellationToken = default
     )
@@ -102,6 +104,7 @@ public class FoodController : ControllerBase
     [NightscoutEndpoint("/api/v1/food/regular")]
     [ProducesResponseType(typeof(Food[]), 200)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.FoodRead)]
     public async Task<ActionResult<Food[]>> GetRegularFood(
         CancellationToken cancellationToken = default
     )
@@ -144,6 +147,7 @@ public class FoodController : ControllerBase
     [NightscoutEndpoint("/api/v1/food/quickpicks")]
     [ProducesResponseType(typeof(Food[]), 200)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.FoodRead)]
     public async Task<ActionResult<Food[]>> GetQuickPickFood(
         CancellationToken cancellationToken = default
     )
@@ -195,6 +199,7 @@ public class FoodController : ControllerBase
     [ProducesResponseType(404)]
     [ProducesResponseType(400)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.FoodRead)]
     public async Task<ActionResult<Food>> GetFoodById(
         string id,
         CancellationToken cancellationToken = default

--- a/src/API/Nocturne.API/Controllers/V1/IobController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/IobController.cs
@@ -1,9 +1,10 @@
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
-using OpenApi.Remote.Attributes;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models;
+using OpenApi.Remote.Attributes;
 
 namespace Nocturne.API.Controllers.V1;
 
@@ -56,6 +57,7 @@ public class IobController : ControllerBase
     [NightscoutEndpoint("/api/v1/iob")]
     [ProducesResponseType(typeof(IobResult), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [RequireScope(OAuthScopes.TreatmentsRead)]
     public async Task<ActionResult<IobResult>> GetCurrentIob(
         [FromQuery] long? time = null,
         CancellationToken cancellationToken = default
@@ -105,6 +107,7 @@ public class IobController : ControllerBase
     [NightscoutEndpoint("/api/v1/iob/treatments")]
     [ProducesResponseType(typeof(IobResult), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [RequireScope(OAuthScopes.TreatmentsRead)]
     public async Task<ActionResult<IobResult>> GetIobFromTreatments(
         [FromQuery] long? time = null,
         CancellationToken cancellationToken = default
@@ -149,6 +152,7 @@ public class IobController : ControllerBase
     [ProducesResponseType(typeof(HourlyIobResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [RequireScope(OAuthScopes.TreatmentsRead)]
     public async Task<ActionResult<HourlyIobResponse>> GetHourlyIob(
         [FromQuery] int intervalMinutes = 5,
         [FromQuery] int hours = 24,

--- a/src/API/Nocturne.API/Controllers/V1/NotificationsController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/NotificationsController.cs
@@ -239,6 +239,7 @@ public class NotificationsController : ControllerBase
     [NightscoutEndpoint("/api/v1/adminnotifies")]
     [ProducesResponseType(typeof(AdminNotifiesResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [RequireScope(OAuthScopes.AlertsRead)]
     public async Task<ActionResult<AdminNotifiesResponse>> GetAdminNotifies(
         CancellationToken cancellationToken = default
     )

--- a/src/API/Nocturne.API/Controllers/V1/NotificationsController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/NotificationsController.cs
@@ -239,7 +239,11 @@ public class NotificationsController : ControllerBase
     [NightscoutEndpoint("/api/v1/adminnotifies")]
     [ProducesResponseType(typeof(AdminNotifiesResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    [RequireScope(OAuthScopes.AlertsRead)]
+    // No scope gate. NotificationV1Service.GetAdminNotifiesAsync checks *:*:admin itself and
+    // returns the notification bodies only to an admin, otherwise just notifyCount — the legacy
+    // Nightscout contract. A scope requirement would replace that degradation with a 403, and
+    // alerts.read is the wrong category for site notices in any case. Recorded in
+    // ReadEndpointScopeEnforcementTests.ExemptReadActions.
     public async Task<ActionResult<AdminNotifiesResponse>> GetAdminNotifies(
         CancellationToken cancellationToken = default
     )

--- a/src/API/Nocturne.API/Controllers/V1/PebbleController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/PebbleController.cs
@@ -1,8 +1,9 @@
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
 using Nocturne.API.Services.Devices;
-using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.Glucose;
+using Nocturne.Core.Contracts.Treatments;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models;
 
 namespace Nocturne.API.Controllers.V1;
@@ -57,6 +58,7 @@ public class PebbleController : ControllerBase
     [NightscoutEndpoint("/pebble")]
     [Produces("application/json")]
     [ProducesResponseType(typeof(PebbleResponse), 200)]
+    [RequireScope(OAuthScopes.GlucoseRead)]
     public async Task<ActionResult<PebbleResponse>> GetPebbleData(
         [FromQuery] string? units = null,
         [FromQuery] int count = 1,

--- a/src/API/Nocturne.API/Controllers/V1/PebbleController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/PebbleController.cs
@@ -13,6 +13,11 @@ namespace Nocturne.API.Controllers.V1;
 /// Used by smartwatch apps, Loop, and other CGM monitoring applications.
 /// Based on the legacy pebble.js implementation.
 /// </summary>
+/// <remarks>
+/// The action requires only <c>glucose.read</c> while the response also carries IOB and COB from
+/// treatments and pump/uploader battery from device status. This is the accepted narrowing described
+/// on <see cref="V2.PropertiesController"/>, which names the per-category follow-up.
+/// </remarks>
 /// <seealso cref="IEntryService"/>
 /// <seealso cref="DeviceStatusProjectionService"/>
 /// <seealso cref="ITreatmentService"/>

--- a/src/API/Nocturne.API/Controllers/V1/ProfileController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/ProfileController.cs
@@ -52,6 +52,7 @@ public class ProfileController : ControllerBase
     [NightscoutEndpoint("/api/v1/profile")]
     [ProducesResponseType(typeof(Profile[]), 200)]
     [ProducesResponseType(typeof(Profile[]), 304)] // Not Modified response
+    [RequireScope(OAuthScopes.TherapyRead)]
     public async Task<ActionResult<Profile[]>> GetProfiles(
         [FromQuery] int count = 10,
         CancellationToken cancellationToken = default
@@ -134,6 +135,7 @@ public class ProfileController : ControllerBase
     [HttpGet("/api/v1/profiles")]
     [NightscoutEndpoint("/api/v1/profiles")]
     [ProducesResponseType(typeof(Profile[]), 200)]
+    [RequireScope(OAuthScopes.TherapyRead)]
     public async Task<ActionResult<Profile[]>> GetProfileHistory(
         [FromQuery] int count = 10,
         CancellationToken cancellationToken = default
@@ -250,6 +252,7 @@ public class ProfileController : ControllerBase
     [ProducesResponseType(typeof(Profile), 200)]
     [ProducesResponseType(typeof(Profile[]), 200)] // Empty array when no profile
     [ProducesResponseType(typeof(Profile[]), 304)] // Not Modified response
+    [RequireScope(OAuthScopes.TherapyRead)]
     public async Task<ActionResult> GetCurrentProfile(
         CancellationToken cancellationToken = default
     )
@@ -312,6 +315,7 @@ public class ProfileController : ControllerBase
     [NightscoutEndpoint("/api/v1/profile/{spec}")]
     [ProducesResponseType(typeof(Profile[]), 200)]
     [ProducesResponseType(typeof(Profile[]), 304)] // Not Modified response
+    [RequireScope(OAuthScopes.TherapyRead)]
     public async Task<ActionResult<Profile[]>> GetProfile(
         string spec,
         CancellationToken cancellationToken = default

--- a/src/API/Nocturne.API/Controllers/V1/TimeQueryController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/TimeQueryController.cs
@@ -4,6 +4,7 @@ using Nocturne.API.Services.Legacy;
 using Nocturne.API.Services.Platform;
 using Nocturne.Core.Contracts.Platform;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.API.Controllers.V1;
 
@@ -12,9 +13,15 @@ namespace Nocturne.API.Controllers.V1;
 /// Supports bash-style brace expansion for complex time pattern matching.
 /// </summary>
 /// <seealso cref="ITimeQueryService"/>
+/// <remarks>
+/// The scope requirement is class-level and an OR of the three storages these endpoints can
+/// serve: the storage is a route/query parameter (<c>slice/{storage}/...</c>,
+/// <c>?storage=</c>), so the data category is not knowable per action.
+/// </remarks>
 [ApiController]
 [Tags("V1")]
 [Route("api/v1")]
+[RequireScope(OAuthScopes.GlucoseRead, OAuthScopes.TreatmentsRead, OAuthScopes.DevicesRead)]
 public class TimeQueryController : ControllerBase
 {
     private readonly ITimeQueryService _timeQueryService;

--- a/src/API/Nocturne.API/Controllers/V1/TimeQueryController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/TimeQueryController.cs
@@ -26,6 +26,13 @@ namespace Nocturne.API.Controllers.V1;
 [Route("api/v1")]
 public class TimeQueryController : ControllerBase
 {
+    /// <summary>
+    /// The collections <c>slice</c> and <c>times/echo</c> dispatch on. Every one must be classified
+    /// in <see cref="LegacyStorageReadScopes"/>, which <c>SliceableStorage_IsFullyClassified</c>
+    /// asserts.
+    /// </summary>
+    internal static readonly string[] SliceableStorage = ["entries", "treatments", "devicestatus"];
+
     private readonly ITimeQueryService _timeQueryService;
     private readonly ILogger<TimeQueryController> _logger;
 
@@ -219,6 +226,7 @@ public class TimeQueryController : ControllerBase
         [FromQuery] string field = "dateString"
     )
     {
+        if (RefuseUnsupportedStorage(storage) is { } unsupported) return unsupported;
         if (LegacyStorageReadScopes.RefuseRead(HttpContext, storage) is { } refusal) return refusal;
 
         return GetTimeQueryEchoInternal(null, null, storage, field);
@@ -243,6 +251,7 @@ public class TimeQueryController : ControllerBase
         [FromQuery] string field = "dateString"
     )
     {
+        if (RefuseUnsupportedStorage(storage) is { } unsupported) return unsupported;
         if (LegacyStorageReadScopes.RefuseRead(HttpContext, storage) is { } refusal) return refusal;
 
         return GetTimeQueryEchoInternal(prefix, null, storage, field);
@@ -269,6 +278,7 @@ public class TimeQueryController : ControllerBase
         [FromQuery] string field = "dateString"
     )
     {
+        if (RefuseUnsupportedStorage(storage) is { } unsupported) return unsupported;
         if (LegacyStorageReadScopes.RefuseRead(HttpContext, storage) is { } refusal) return refusal;
 
         return GetTimeQueryEchoInternal(prefix, regex, storage, field);
@@ -367,6 +377,7 @@ public class TimeQueryController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
+        if (RefuseUnsupportedStorage(storage) is { } unsupported) return unsupported;
         if (LegacyStorageReadScopes.RefuseRead(HttpContext, storage) is { } refusal) return refusal;
 
         return await GetSlicedDataInternal(
@@ -405,6 +416,7 @@ public class TimeQueryController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
+        if (RefuseUnsupportedStorage(storage) is { } unsupported) return unsupported;
         if (LegacyStorageReadScopes.RefuseRead(HttpContext, storage) is { } refusal) return refusal;
 
         return await GetSlicedDataInternal(
@@ -445,6 +457,7 @@ public class TimeQueryController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
+        if (RefuseUnsupportedStorage(storage) is { } unsupported) return unsupported;
         if (LegacyStorageReadScopes.RefuseRead(HttpContext, storage) is { } refusal) return refusal;
 
         return await GetSlicedDataInternal(
@@ -487,6 +500,7 @@ public class TimeQueryController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
+        if (RefuseUnsupportedStorage(storage) is { } unsupported) return unsupported;
         if (LegacyStorageReadScopes.RefuseRead(HttpContext, storage) is { } refusal) return refusal;
 
         return await GetSlicedDataInternal(
@@ -536,16 +550,6 @@ public class TimeQueryController : ControllerBase
             {
                 _logger.LogWarning("Storage and field parameters are required");
                 return BadRequest("Storage and field parameters are required");
-            }
-
-            // Validate storage type
-            var validStorageTypes = new[] { "entries", "treatments", "devicestatus" };
-            if (!validStorageTypes.Contains(storage.ToLowerInvariant()))
-            {
-                _logger.LogWarning("Invalid storage type: {Storage}", storage);
-                return BadRequest(
-                    $"Storage must be one of: {string.Join(", ", validStorageTypes)}"
-                );
             }
 
             // Extract query parameters for additional filtering
@@ -620,5 +624,19 @@ public class TimeQueryController : ControllerBase
                 }
             );
         }
+    }
+
+    /// <summary>
+    /// Refuses a collection these routes do not dispatch on. Checked ahead of the scope gate so the
+    /// answer is the same whatever the caller holds, rather than 403 for one grant and 400 for
+    /// another on a collection the route never served.
+    /// </summary>
+    private ActionResult? RefuseUnsupportedStorage(string storage)
+    {
+        if (SliceableStorage.Contains(storage, StringComparer.OrdinalIgnoreCase))
+            return null;
+
+        _logger.LogWarning("Invalid storage type requested: {Storage}", storage);
+        return BadRequest($"Storage must be one of: {string.Join(", ", SliceableStorage)}");
     }
 }

--- a/src/API/Nocturne.API/Controllers/V1/TimeQueryController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/TimeQueryController.cs
@@ -16,10 +16,10 @@ namespace Nocturne.API.Controllers.V1;
 /// </summary>
 /// <seealso cref="ITimeQueryService"/>
 /// <remarks>
-/// The scope requirement is class-level and an OR of the three storages these endpoints can
-/// serve. The storage is a route or query value, so the governing scope is resolved per request
-/// through <see cref="Authorization.LegacyStorageReadScopes"/> instead: a class-level OR would let a
-/// caller holding one category read another's records through <c>slice/{storage}/…</c>.
+/// The <c>slice</c> and <c>echo</c> actions take the collection as a route or query value, so
+/// their governing scope is resolved per request through <see cref="LegacyStorageReadScopes"/>; a
+/// class-level OR would let a caller holding one category read another's records. The <c>times</c>
+/// actions always read entries, so they carry <c>glucose.read</c> directly.
 /// </remarks>
 [ApiController]
 [Tags("V1")]
@@ -45,11 +45,13 @@ public class TimeQueryController : ControllerBase
 
     /// <summary>
     /// /api/v1/times without prefix is not a valid Nightscout endpoint.
-    /// Nightscout returns 404 for this path. We match that behavior for parity.
+    /// Nightscout returns 404 for this path. We match that behavior for parity, behind the same
+    /// scope the prefixed routes carry so the 404 is not itself readable without a grant.
     /// </summary>
     /// <returns>404 Not Found to match Nightscout behavior</returns>
     [HttpGet("times")]
     [ApiExplorerSettings(IgnoreApi = true)] // Hide from OpenAPI as it's not a real endpoint
+    [RequireScope(OAuthScopes.GlucoseRead)]
     public ActionResult GetTimeBasedEntries()
     {
         return NotFound();
@@ -65,6 +67,7 @@ public class TimeQueryController : ControllerBase
     /// <returns>Entries matching the time patterns</returns>
     [HttpGet("times/{prefix}")]
     [NightscoutEndpoint("/api/v1/times/{prefix}")]
+    [RequireScope(OAuthScopes.GlucoseRead)]
     [ProducesResponseType(typeof(Entry[]), 200)]
     [ProducesResponseType(400)]
     [ProducesResponseType(500)]
@@ -89,6 +92,7 @@ public class TimeQueryController : ControllerBase
     /// <returns>Entries matching the time patterns</returns>
     [HttpGet("times/{prefix}/{regex}")]
     [NightscoutEndpoint("/api/v1/times/{prefix}/{regex}")]
+    [RequireScope(OAuthScopes.GlucoseRead)]
     [ProducesResponseType(typeof(Entry[]), 200)]
     [ProducesResponseType(400)]
     [ProducesResponseType(500)]
@@ -215,7 +219,7 @@ public class TimeQueryController : ControllerBase
         [FromQuery] string field = "dateString"
     )
     {
-        if (RefuseStorage(storage) is { } refusal) return refusal;
+        if (LegacyStorageReadScopes.RefuseRead(HttpContext, storage) is { } refusal) return refusal;
 
         return GetTimeQueryEchoInternal(null, null, storage, field);
     }
@@ -239,7 +243,7 @@ public class TimeQueryController : ControllerBase
         [FromQuery] string field = "dateString"
     )
     {
-        if (RefuseStorage(storage) is { } refusal) return refusal;
+        if (LegacyStorageReadScopes.RefuseRead(HttpContext, storage) is { } refusal) return refusal;
 
         return GetTimeQueryEchoInternal(prefix, null, storage, field);
     }
@@ -265,7 +269,7 @@ public class TimeQueryController : ControllerBase
         [FromQuery] string field = "dateString"
     )
     {
-        if (RefuseStorage(storage) is { } refusal) return refusal;
+        if (LegacyStorageReadScopes.RefuseRead(HttpContext, storage) is { } refusal) return refusal;
 
         return GetTimeQueryEchoInternal(prefix, regex, storage, field);
     }
@@ -363,7 +367,7 @@ public class TimeQueryController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
-        if (RefuseStorage(storage) is { } refusal) return refusal;
+        if (LegacyStorageReadScopes.RefuseRead(HttpContext, storage) is { } refusal) return refusal;
 
         return await GetSlicedDataInternal(
             storage,
@@ -401,7 +405,7 @@ public class TimeQueryController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
-        if (RefuseStorage(storage) is { } refusal) return refusal;
+        if (LegacyStorageReadScopes.RefuseRead(HttpContext, storage) is { } refusal) return refusal;
 
         return await GetSlicedDataInternal(
             storage,
@@ -441,7 +445,7 @@ public class TimeQueryController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
-        if (RefuseStorage(storage) is { } refusal) return refusal;
+        if (LegacyStorageReadScopes.RefuseRead(HttpContext, storage) is { } refusal) return refusal;
 
         return await GetSlicedDataInternal(
             storage,
@@ -483,7 +487,7 @@ public class TimeQueryController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
-        if (RefuseStorage(storage) is { } refusal) return refusal;
+        if (LegacyStorageReadScopes.RefuseRead(HttpContext, storage) is { } refusal) return refusal;
 
         return await GetSlicedDataInternal(
             storage,
@@ -617,19 +621,4 @@ public class TimeQueryController : ControllerBase
             );
         }
     }
-    /// <summary>
-    /// Refuses a storage the caller's scopes do not cover. Returns null when the request may proceed.
-    /// </summary>
-    private ActionResult? RefuseStorage(string storage)
-    {
-        if (LegacyStorageReadScopes.RequiredReadScope(storage) is null)
-        {
-            return BadRequest(new { status = 400, message = $"Unsupported storage type: {storage}", type = "bad_request" });
-        }
-
-        return LegacyStorageReadScopes.CanRead(HttpContext.GetGrantedScopes(), storage)
-            ? null
-            : StatusCode(403, new { status = 403, message = $"Reading '{storage}' requires the {LegacyStorageReadScopes.RequiredReadScope(storage)} scope.", type = "forbidden" });
-    }
-
 }

--- a/src/API/Nocturne.API/Controllers/V1/TimeQueryController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/TimeQueryController.cs
@@ -1,3 +1,5 @@
+using Nocturne.API.Extensions;
+using Nocturne.API.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
 using Nocturne.API.Services.Legacy;
@@ -15,13 +17,13 @@ namespace Nocturne.API.Controllers.V1;
 /// <seealso cref="ITimeQueryService"/>
 /// <remarks>
 /// The scope requirement is class-level and an OR of the three storages these endpoints can
-/// serve: the storage is a route/query parameter (<c>slice/{storage}/...</c>,
-/// <c>?storage=</c>), so the data category is not knowable per action.
+/// serve. The storage is a route or query value, so the governing scope is resolved per request
+/// through <see cref="Authorization.LegacyStorageReadScopes"/> instead: a class-level OR would let a
+/// caller holding one category read another's records through <c>slice/{storage}/…</c>.
 /// </remarks>
 [ApiController]
 [Tags("V1")]
 [Route("api/v1")]
-[RequireScope(OAuthScopes.GlucoseRead, OAuthScopes.TreatmentsRead, OAuthScopes.DevicesRead)]
 public class TimeQueryController : ControllerBase
 {
     private readonly ITimeQueryService _timeQueryService;
@@ -213,6 +215,8 @@ public class TimeQueryController : ControllerBase
         [FromQuery] string field = "dateString"
     )
     {
+        if (RefuseStorage(storage) is { } refusal) return refusal;
+
         return GetTimeQueryEchoInternal(null, null, storage, field);
     }
 
@@ -235,6 +239,8 @@ public class TimeQueryController : ControllerBase
         [FromQuery] string field = "dateString"
     )
     {
+        if (RefuseStorage(storage) is { } refusal) return refusal;
+
         return GetTimeQueryEchoInternal(prefix, null, storage, field);
     }
 
@@ -259,6 +265,8 @@ public class TimeQueryController : ControllerBase
         [FromQuery] string field = "dateString"
     )
     {
+        if (RefuseStorage(storage) is { } refusal) return refusal;
+
         return GetTimeQueryEchoInternal(prefix, regex, storage, field);
     }
 
@@ -355,6 +363,8 @@ public class TimeQueryController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
+        if (RefuseStorage(storage) is { } refusal) return refusal;
+
         return await GetSlicedDataInternal(
             storage,
             field,
@@ -391,6 +401,8 @@ public class TimeQueryController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
+        if (RefuseStorage(storage) is { } refusal) return refusal;
+
         return await GetSlicedDataInternal(
             storage,
             field,
@@ -429,6 +441,8 @@ public class TimeQueryController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
+        if (RefuseStorage(storage) is { } refusal) return refusal;
+
         return await GetSlicedDataInternal(
             storage,
             field,
@@ -469,6 +483,8 @@ public class TimeQueryController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
+        if (RefuseStorage(storage) is { } refusal) return refusal;
+
         return await GetSlicedDataInternal(
             storage,
             field,
@@ -601,4 +617,19 @@ public class TimeQueryController : ControllerBase
             );
         }
     }
+    /// <summary>
+    /// Refuses a storage the caller's scopes do not cover. Returns null when the request may proceed.
+    /// </summary>
+    private ActionResult? RefuseStorage(string storage)
+    {
+        if (LegacyStorageReadScopes.RequiredReadScope(storage) is null)
+        {
+            return BadRequest(new { status = 400, message = $"Unsupported storage type: {storage}", type = "bad_request" });
+        }
+
+        return LegacyStorageReadScopes.CanRead(HttpContext.GetGrantedScopes(), storage)
+            ? null
+            : StatusCode(403, new { status = 403, message = $"Reading '{storage}' requires the {LegacyStorageReadScopes.RequiredReadScope(storage)} scope.", type = "forbidden" });
+    }
+
 }

--- a/src/API/Nocturne.API/Controllers/V1/TreatmentsController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/TreatmentsController.cs
@@ -57,6 +57,7 @@ public class TreatmentsController : ControllerBase
     [ProducesResponseType(typeof(Treatment[]), 200)]
     [ProducesResponseType(400)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.TreatmentsRead)]
     public async Task<ActionResult> GetTreatments(
         [FromQuery] string? find = null,
         [FromQuery] int count = 10,
@@ -147,6 +148,7 @@ public class TreatmentsController : ControllerBase
     [ProducesResponseType(404)]
     [ProducesResponseType(400)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.TreatmentsRead)]
     public async Task<ActionResult<Treatment>> GetTreatmentById(
         string id,
         CancellationToken cancellationToken = default

--- a/src/API/Nocturne.API/Controllers/V2/DDataController.cs
+++ b/src/API/Nocturne.API/Controllers/V2/DDataController.cs
@@ -1,9 +1,11 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
 using Nocturne.API.Authorization;
-using OpenApi.Remote.Attributes;
 using Nocturne.Core.Contracts.Legacy;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models;
+using OpenApi.Remote.Attributes;
 
 namespace Nocturne.API.Controllers.V2;
 
@@ -45,6 +47,7 @@ public class DDataController : ControllerBase
     [HttpGet]
     [ProducesResponseType(typeof(DDataResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [RequireScope(OAuthScopes.GlucoseRead)]
     public async Task<ActionResult<DDataResponse>> GetDData(
         CancellationToken cancellationToken = default
     )
@@ -79,6 +82,7 @@ public class DDataController : ControllerBase
     [ProducesResponseType(typeof(DDataResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [RequireScope(OAuthScopes.GlucoseRead)]
     public async Task<ActionResult<DDataResponse>> GetDDataAt(
         string timestamp,
         CancellationToken cancellationToken = default
@@ -153,6 +157,7 @@ public class DDataController : ControllerBase
     [ProducesResponseType(typeof(DData), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [RequireScope(OAuthScopes.GlucoseRead)]
     public async Task<ActionResult<DData>> GetRawDData(
         [FromQuery] string? timestamp = null,
         CancellationToken cancellationToken = default

--- a/src/API/Nocturne.API/Controllers/V2/DDataController.cs
+++ b/src/API/Nocturne.API/Controllers/V2/DDataController.cs
@@ -13,6 +13,11 @@ namespace Nocturne.API.Controllers.V2;
 /// V2 DData controller providing direct data access endpoints.
 /// Implements the legacy /api/v2/ddata endpoints with 1:1 backwards compatibility.
 /// </summary>
+/// <remarks>
+/// The actions require only <c>glucose.read</c> while the response also carries treatments,
+/// profiles and device status. This is the accepted narrowing described on
+/// <see cref="PropertiesController"/>, which names the per-category follow-up.
+/// </remarks>
 /// <seealso cref="IDDataService"/>
 [ApiController]
 [Tags("V2")]

--- a/src/API/Nocturne.API/Controllers/V2/LoopController.cs
+++ b/src/API/Nocturne.API/Controllers/V2/LoopController.cs
@@ -134,6 +134,7 @@ public class LoopController : ControllerBase
     /// <response code="200">Configuration status retrieved successfully</response>
     [HttpGet("loop/status")]
     [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
+    [RequireScope(OAuthScopes.AlertsRead)]
     public ActionResult<object> GetLoopStatus()
     {
         var status = _loopService.GetConfigurationStatus();

--- a/src/API/Nocturne.API/Controllers/V2/LoopController.cs
+++ b/src/API/Nocturne.API/Controllers/V2/LoopController.cs
@@ -134,7 +134,8 @@ public class LoopController : ControllerBase
     /// <response code="200">Configuration status retrieved successfully</response>
     [HttpGet("loop/status")]
     [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
-    [RequireScope(OAuthScopes.AlertsRead)]
+    // APNS configuration diagnostics, not alert data. Gated like DebugController.
+    [RequireAdmin]
     public ActionResult<object> GetLoopStatus()
     {
         var status = _loopService.GetConfigurationStatus();

--- a/src/API/Nocturne.API/Controllers/V2/NotificationsController.cs
+++ b/src/API/Nocturne.API/Controllers/V2/NotificationsController.cs
@@ -222,6 +222,7 @@ public class NotificationsController : ControllerBase
     [NightscoutEndpoint("/api/v2/notifications/status")]
     [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [RequireScope(OAuthScopes.AlertsRead)]
     public async Task<ActionResult<object>> GetNotificationStatus(
         CancellationToken cancellationToken = default
     )

--- a/src/API/Nocturne.API/Controllers/V2/NotificationsController.cs
+++ b/src/API/Nocturne.API/Controllers/V2/NotificationsController.cs
@@ -222,7 +222,9 @@ public class NotificationsController : ControllerBase
     [NightscoutEndpoint("/api/v2/notifications/status")]
     [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    [RequireScope(OAuthScopes.AlertsRead)]
+    // Operator diagnostics, not alert data: alerts.read would be the wrong category, and no
+    // production grant carries it. Gated like DebugController.
+    [RequireAdmin]
     public async Task<ActionResult<object>> GetNotificationStatus(
         CancellationToken cancellationToken = default
     )

--- a/src/API/Nocturne.API/Controllers/V2/PropertiesController.cs
+++ b/src/API/Nocturne.API/Controllers/V2/PropertiesController.cs
@@ -13,6 +13,18 @@ namespace Nocturne.API.Controllers.V2;
 /// V2 Properties controller providing client properties and settings endpoints.
 /// Implements the legacy /api/v2/properties endpoints with 1:1 backwards compatibility.
 /// </summary>
+/// <remarks>
+/// Both actions require only <c>glucose.read</c>, while the assembled response carries values
+/// derived from other categories: IOB and COB from boluses and carbs (treatments), basal rates and
+/// ratios from the active profile (therapy), and cannula/sensor/insulin ages from device data.
+/// A <c>glucose.read</c> grant therefore reads across those categories here. This is narrower than
+/// what shipped before per-action scope gating, when any non-empty permission trie sufficed, and is
+/// the accepted position for now. Closing it means filtering by category inside
+/// <c>PropertiesService.BuildSandboxPropertiesAsync(ct, requested)</c>, which already skips building
+/// properties that were not requested and is the natural place to also skip the ones the caller has
+/// no scope for. The same narrowing applies to <see cref="DDataController"/>,
+/// <see cref="SummaryController"/> and <see cref="V1.PebbleController"/>.
+/// </remarks>
 /// <seealso cref="IPropertiesService"/>
 [ApiController]
 [Tags("V2")]

--- a/src/API/Nocturne.API/Controllers/V2/PropertiesController.cs
+++ b/src/API/Nocturne.API/Controllers/V2/PropertiesController.cs
@@ -1,9 +1,11 @@
-using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
 using Nocturne.API.Authorization;
-using OpenApi.Remote.Attributes;
 using Nocturne.Core.Contracts.Profiles;
+using Nocturne.Core.Models.Authorization;
+using OpenApi.Remote.Attributes;
+using System.Text.Json;
 
 namespace Nocturne.API.Controllers.V2;
 
@@ -49,6 +51,7 @@ public class PropertiesController : ControllerBase
     [HttpGet]
     [ProducesResponseType(typeof(Dictionary<string, object>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [RequireScope(OAuthScopes.GlucoseRead)]
     public async Task<ActionResult<Dictionary<string, object>>> GetAllProperties(
         [FromQuery] bool pretty = false,
         CancellationToken cancellationToken = default
@@ -91,6 +94,7 @@ public class PropertiesController : ControllerBase
     [ProducesResponseType(typeof(Dictionary<string, object>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [RequireScope(OAuthScopes.GlucoseRead)]
     public async Task<ActionResult<Dictionary<string, object>>> GetSpecificProperties(
         string propertyPath,
         [FromQuery] bool pretty = false,

--- a/src/API/Nocturne.API/Controllers/V2/SummaryController.cs
+++ b/src/API/Nocturne.API/Controllers/V2/SummaryController.cs
@@ -13,6 +13,11 @@ namespace Nocturne.API.Controllers.V2;
 /// V2 Summary controller providing aggregated data endpoints.
 /// Implements the legacy /api/v2/summary endpoints with 1:1 backwards compatibility.
 /// </summary>
+/// <remarks>
+/// The action requires only <c>glucose.read</c> while the response also carries treatments and the
+/// active profile. This is the accepted narrowing described on <see cref="PropertiesController"/>,
+/// which names the per-category follow-up.
+/// </remarks>
 /// <seealso cref="ISummaryService"/>
 /// <seealso cref="SummaryResponse"/>
 [ApiController]

--- a/src/API/Nocturne.API/Controllers/V2/SummaryController.cs
+++ b/src/API/Nocturne.API/Controllers/V2/SummaryController.cs
@@ -1,9 +1,11 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
 using Nocturne.API.Authorization;
-using OpenApi.Remote.Attributes;
 using Nocturne.Core.Contracts.Analytics;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models;
+using OpenApi.Remote.Attributes;
 
 namespace Nocturne.API.Controllers.V2;
 
@@ -51,6 +53,7 @@ public class SummaryController : ControllerBase
     [ProducesResponseType(typeof(SummaryResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [RequireScope(OAuthScopes.GlucoseRead)]
     public async Task<ActionResult<SummaryResponse>> GetSummary(
         [FromQuery] int? hours = null,
         CancellationToken cancellationToken = default

--- a/src/API/Nocturne.API/Controllers/V3/DeviceStatusController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/DeviceStatusController.cs
@@ -64,6 +64,7 @@ public class DeviceStatusController : BaseV3Controller<DeviceStatus>
     [ProducesResponseType(typeof(V3ErrorResponse), 400)]
     [ProducesResponseType(304)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.DevicesRead)]
     public async Task<IActionResult> GetDeviceStatus(CancellationToken cancellationToken = default)
     {
         _logger.LogDebug(
@@ -155,6 +156,7 @@ public class DeviceStatusController : BaseV3Controller<DeviceStatus>
     [ProducesResponseType(typeof(DeviceStatus), 200)]
     [ProducesResponseType(typeof(V3ErrorResponse), 404)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.DevicesRead)]
     public async Task<ActionResult> GetDeviceStatusById(
         string id,
         CancellationToken cancellationToken = default
@@ -497,6 +499,7 @@ public class DeviceStatusController : BaseV3Controller<DeviceStatus>
     [NightscoutEndpoint("/api/v3/devicestatus/history/{lastModified}")]
     [ProducesResponseType(typeof(object), 200)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.DevicesRead)]
     public async Task<ActionResult> GetDeviceStatusHistory(
         long lastModified,
         [FromQuery] int limit = 1000,

--- a/src/API/Nocturne.API/Controllers/V3/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/EntriesController.cs
@@ -65,6 +65,7 @@ public class EntriesController : BaseV3Controller<Entry>
     [ProducesResponseType(typeof(V3ErrorResponse), 400)]
     [ProducesResponseType(304)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.GlucoseRead)]
     public async Task<ActionResult> GetEntries(CancellationToken cancellationToken = default)
     {
         _logger.LogDebug(
@@ -145,6 +146,7 @@ public class EntriesController : BaseV3Controller<Entry>
     [ProducesResponseType(typeof(Entry), 200)]
     [ProducesResponseType(typeof(V3ErrorResponse), 404)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.GlucoseRead)]
     public async Task<ActionResult<Entry>> GetEntry(
         string id,
         CancellationToken cancellationToken = default
@@ -490,6 +492,7 @@ public class EntriesController : BaseV3Controller<Entry>
     [NightscoutEndpoint("/api/v3/entries/history/{lastModified}")]
     [ProducesResponseType(typeof(object), 200)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.GlucoseRead)]
     public async Task<ActionResult> GetEntryHistory(
         long lastModified,
         [FromQuery] int limit = 1000,

--- a/src/API/Nocturne.API/Controllers/V3/FoodController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/FoodController.cs
@@ -45,6 +45,7 @@ public class FoodController : BaseV3Controller<Food>
     [ProducesResponseType(typeof(V3ErrorResponse), 400)]
     [ProducesResponseType(304)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.FoodRead)]
     public async Task<ActionResult> GetFood(CancellationToken cancellationToken = default)
     {
         _logger.LogDebug(
@@ -140,6 +141,7 @@ public class FoodController : BaseV3Controller<Food>
     [NightscoutEndpoint("/api/v3/food/history/{lastModified}")]
     [ProducesResponseType(typeof(object), 200)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.FoodRead)]
     public async Task<ActionResult> GetFoodHistory(
         long lastModified,
         [FromQuery] int limit = 1000,
@@ -296,6 +298,7 @@ public class FoodController : BaseV3Controller<Food>
     [ProducesResponseType(typeof(Food), 200)]
     [ProducesResponseType(typeof(V3ErrorResponse), 404)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.FoodRead)]
     public async Task<ActionResult> GetFoodById(
         string id,
         CancellationToken cancellationToken = default

--- a/src/API/Nocturne.API/Controllers/V3/ProfileController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/ProfileController.cs
@@ -49,6 +49,7 @@ public class ProfileController : BaseV3Controller<Profile>
     [ProducesResponseType(typeof(V3ErrorResponse), 400)]
     [ProducesResponseType(304)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.TherapyRead)]
     public async Task<ActionResult> GetProfiles(CancellationToken cancellationToken = default)
     {
         _logger.LogDebug(
@@ -118,6 +119,7 @@ public class ProfileController : BaseV3Controller<Profile>
     [NightscoutEndpoint("/api/v3/profile/history/{lastModified}")]
     [ProducesResponseType(typeof(object), 200)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.TherapyRead)]
     public async Task<ActionResult> GetProfileHistory(
         long lastModified,
         [FromQuery] int limit = 10,
@@ -175,6 +177,7 @@ public class ProfileController : BaseV3Controller<Profile>
     [ProducesResponseType(typeof(Profile), 200)]
     [ProducesResponseType(typeof(V3ErrorResponse), 404)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.TherapyRead)]
     public async Task<ActionResult> GetProfileById(
         string id,
         CancellationToken cancellationToken = default

--- a/src/API/Nocturne.API/Controllers/V3/SettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/SettingsController.cs
@@ -48,6 +48,7 @@ public class SettingsController : BaseV3Controller<Settings>
     [ProducesResponseType(typeof(V3ErrorResponse), 403)]
     [ProducesResponseType(304)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.TherapyRead)]
     public async Task<ActionResult> GetSettings(CancellationToken cancellationToken = default)
     {
         _logger.LogDebug(
@@ -126,6 +127,7 @@ public class SettingsController : BaseV3Controller<Settings>
     [ProducesResponseType(typeof(V3ErrorResponse), 404)]
     [ProducesResponseType(typeof(V3ErrorResponse), 403)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.TherapyRead)]
     public async Task<ActionResult> GetSettingsById(
         string id,
         CancellationToken cancellationToken = default

--- a/src/API/Nocturne.API/Controllers/V3/TreatmentsController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/TreatmentsController.cs
@@ -61,6 +61,7 @@ public class TreatmentsController : BaseV3Controller<Treatment>
     [ProducesResponseType(typeof(V3ErrorResponse), 400)]
     [ProducesResponseType(304)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.TreatmentsRead)]
     public async Task<ActionResult> GetTreatments(CancellationToken cancellationToken = default)
     {
         _logger.LogDebug(
@@ -136,6 +137,7 @@ public class TreatmentsController : BaseV3Controller<Treatment>
     [ProducesResponseType(typeof(Treatment), 200)]
     [ProducesResponseType(typeof(V3ErrorResponse), 404)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.TreatmentsRead)]
     public async Task<ActionResult<Treatment>> GetTreatment(
         string id,
         CancellationToken cancellationToken = default
@@ -477,6 +479,7 @@ public class TreatmentsController : BaseV3Controller<Treatment>
     [NightscoutEndpoint("/api/v3/treatments/history/{lastModified}")]
     [ProducesResponseType(typeof(object), 200)]
     [ProducesResponseType(500)]
+    [RequireScope(OAuthScopes.TreatmentsRead)]
     public async Task<ActionResult> GetTreatmentHistory(
         long lastModified,
         [FromQuery] int limit = 1000,

--- a/src/API/Nocturne.API/Controllers/V4/TlsAuthorizationController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/TlsAuthorizationController.cs
@@ -16,8 +16,17 @@ namespace Nocturne.API.Controllers.V4;
 /// <remarks>
 /// Anonymous and tenantless by design: it lives under the <c>/api/v4/platform/</c>
 /// prefix, which <see cref="TenantResolutionMiddleware"/> allows through without a
-/// resolved tenant. Only reachable over the internal compose network from Caddy;
-/// it reveals nothing a visitor couldn't learn by loading the public subdomain.
+/// resolved tenant, and <see cref="Middleware.SiteSecurityMiddleware"/> allowlists it
+/// under lockdown (matched exactly, so sibling paths are not allowlisted).
+/// <para>
+/// It stays anonymous because Caddy's <c>on_demand_tls.ask</c> takes only a URL and sends no
+/// custom headers, so there is no credential to require. It is not authenticated-by-network
+/// either: the API is only <c>expose</c>d on the compose network, but the edge route
+/// <c>/api/{**catch-all}</c> reaches nocturne-web, whose <c>proxyHandle</c> forwards all of
+/// <c>/api</c> to this API. That path is what makes the 200-vs-404 answer an anonymous
+/// tenant-slug oracle, so <c>proxyHandle</c> refuses this specific path
+/// (<c>INTERNAL_ONLY_API_PATHS</c>); Caddy calls the API container directly and is unaffected.
+/// </para>
 /// </remarks>
 [ApiController]
 [AllowAnonymous]

--- a/src/API/Nocturne.API/Middleware/AuthenticationMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/AuthenticationMiddleware.cs
@@ -263,9 +263,10 @@ public class AuthenticationMiddleware
                 // Legacy (HasPermissions-gated) endpoints check the trie, so derive it from the
                 // narrowed scopes; a share that resolves to zero scopes gets an empty trie and
                 // is rejected by the policy instead of passing authorization and reading nothing.
-                // The scope atoms are added alongside because heartrate.read/stepcount.read have
-                // no legacy api:* equivalent — without them a share granting only those
-                // categories would carry an empty trie and be rejected outright.
+                // The scope atoms are added alongside so a share whose categories ToPermissions has
+                // no legacy api:* string for still carries a non-empty trie. Every scope in
+                // PublicShareScopes currently maps, so this is redundant today and guards the case
+                // where a new shareable category is added without a legacy equivalent.
                 var publicPermissionTrie = new PermissionTrie();
                 publicPermissionTrie.Add(ScopeTranslator.ToPermissions(publicScopes));
                 publicPermissionTrie.Add(publicScopes);

--- a/src/API/Nocturne.API/Middleware/SiteSecurityMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/SiteSecurityMiddleware.cs
@@ -122,7 +122,9 @@ public class SiteSecurityMiddleware
         // On-demand TLS authorization for the bundled Caddy proxy. Caddy's
         // unauthenticated internal "ask" call must stay reachable even under
         // lockdown, or no tenant-subdomain certificate can ever be issued.
-        if (path.StartsWith("/api/v4/platform/tls-authorize"))
+        // Matched exactly: the controller exposes this single route, and a bare
+        // StartsWith would also allowlist /api/v4/platform/tls-authorize<anything>.
+        if (path == "/api/v4/platform/tls-authorize")
         {
             return true;
         }

--- a/src/API/Nocturne.API/Services/V4/ActivityDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/ActivityDecomposer.cs
@@ -92,6 +92,24 @@ public class ActivityDecomposer : IActivityDecomposer, IDecomposer<Activity>
         return null;
     }
 
+    /// <summary>
+    /// Returns the OAuth read scope required to see this activity. Derived from
+    /// <see cref="RequiredWriteScope"/> so the read gate and the storage destination cannot drift
+    /// apart. A regular activity reads under <c>treatments.read</c>, which is the scope the legacy
+    /// activity read plane has always required for StateSpan-backed activities. A dedicated
+    /// destination with no read counterpart falls back to <see cref="OAuthScopes.FullAccess"/>,
+    /// which only an admin grant holds.
+    /// </summary>
+    /// <param name="activity">The activity to classify.</param>
+    public string RequiredReadScope(Activity activity)
+    {
+        var writeScope = RequiredWriteScope(activity);
+        if (writeScope is null)
+            return OAuthScopes.TreatmentsRead;
+
+        return OAuthScopes.ImpliedReadScope(writeScope) ?? OAuthScopes.FullAccess;
+    }
+
     /// <inheritdoc/>
     public async Task<DecompositionResult> DecomposeAsync(
         Activity activity,

--- a/src/Aspire/Nocturne.Aspire.Host/Program.cs
+++ b/src/Aspire/Nocturne.Aspire.Host/Program.cs
@@ -379,6 +379,7 @@ class Program
             builder.AddDemoService<Projects.Nocturne_Services_Demo>(
                 api,
                 managedDatabase,
+                instanceKey,
                 options => { }
             );
         }

--- a/src/Aspire/Nocturne.Aspire.Hosting/DemoServiceExtensions.cs
+++ b/src/Aspire/Nocturne.Aspire.Hosting/DemoServiceExtensions.cs
@@ -67,12 +67,18 @@ public static class DemoServiceExtensions
     /// <param name="builder">The distributed application builder.</param>
     /// <param name="api">The API resource that the demo service will reference.</param>
     /// <param name="database">The database resource for the demo service to use.</param>
+    /// <param name="instanceKey">
+    /// The instance key the demo service presents to the API. The demo admin endpoints
+    /// (<c>/api/v4/admin/demo/*</c>) require the <c>platform_admin</c> role, which the instance
+    /// key is what yields for a service caller, so without this the service is rejected.
+    /// </param>
     /// <param name="configure">Optional configuration action for demo service options.</param>
     /// <returns>The demo service resource builder, or null if demo mode is disabled.</returns>
     public static IResourceBuilder<ProjectResource>? AddDemoService<TDemoService>(
         this IDistributedApplicationBuilder builder,
         IResourceBuilder<ProjectResource> api,
         IResourceBuilder<IResourceWithConnectionString>? database,
+        IResourceBuilder<ParameterResource> instanceKey,
         Action<DemoServiceOptions>? configure = null)
         where TDemoService : IProjectMetadata, new()
     {
@@ -111,10 +117,11 @@ public static class DemoServiceExtensions
         // Demo service communicates with the API via HTTP, so wait for API availability
         demoService.WaitFor(api);
 
-        // Pass API URL and demo host for HTTP client configuration
+        // Pass API URL, demo host, and the instance key the demo admin endpoints authenticate on
         demoService
             .WithEnvironment("DemoService__ApiUrl", api.GetEndpoint("http"))
-            .WithEnvironment("DemoService__DemoHost", "demo.localhost");
+            .WithEnvironment("DemoService__DemoHost", "demo.localhost")
+            .WithEnvironment("DemoService__InstanceKey", instanceKey);
 
         // Pass demo configuration via environment variables
         demoService

--- a/src/Core/Nocturne.Core.Contracts/V4/IActivityDecomposer.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/IActivityDecomposer.cs
@@ -63,4 +63,13 @@ public interface IActivityDecomposer
     /// regular activity that routes to StateSpans and carries no category scope.
     /// </summary>
     string? RequiredWriteScope(Activity activity);
+
+    /// <summary>
+    /// Returns the OAuth read scope required to see the activity, based on the storage it came
+    /// from (heart rate, step count, sleep, or StateSpans). Unlike
+    /// <see cref="RequiredWriteScope"/> this is never <see langword="null"/>: the merged activity
+    /// read endpoints return records from all four storages in one response, so every record
+    /// needs a category to be filtered on.
+    /// </summary>
+    string RequiredReadScope(Activity activity);
 }

--- a/src/Core/Nocturne.Core.Models/Authorization/OAuthScopes.cs
+++ b/src/Core/Nocturne.Core.Models/Authorization/OAuthScopes.cs
@@ -209,6 +209,16 @@ public static class OAuthScopes
     };
 
     /// <summary>
+    /// Returns the read scope a readwrite scope implies, or <see langword="null"/> when the scope
+    /// has no read counterpart (a capability grant, an already-read scope, or full access).
+    /// </summary>
+    /// <param name="readWriteScope">The readwrite scope to downgrade.</param>
+    public static string? ImpliedReadScope(string readWriteScope)
+    {
+        return ReadWriteImpliesRead.TryGetValue(readWriteScope, out var readScope) ? readScope : null;
+    }
+
+    /// <summary>
     /// Check whether a scope string is a valid Nocturne OAuth scope.
     /// </summary>
     public static bool IsValid(string scope)

--- a/src/Core/Nocturne.Core.Models/Authorization/ScopeTranslator.cs
+++ b/src/Core/Nocturne.Core.Models/Authorization/ScopeTranslator.cs
@@ -43,6 +43,17 @@ public static class ScopeTranslator
         ["api:food:update"] = [OAuthScopes.FoodReadWrite],
         ["api:food:delete"] = [OAuthScopes.FullAccess],
 
+        // Activity. The legacy activity collection is the merged read plane over four Nocturne
+        // storages, so its read permission carries all three dedicated categories. StateSpan-backed
+        // activities read under treatments, which "api:treatments:read" grants separately — mapping
+        // it here as well would let an activity-only permission read /api/v1/treatments.
+        // The "readable" and "public" seed roles both grant "api:activity:read".
+        ["api:activity:read"] = [
+            OAuthScopes.HeartRateRead,
+            OAuthScopes.StepCountRead,
+            OAuthScopes.SleepRead,
+        ],
+
         // Profile
         ["api:profile:read"] = [OAuthScopes.TherapyRead],
         ["api:profile:create"] = [OAuthScopes.TherapyReadWrite],
@@ -59,6 +70,9 @@ public static class ScopeTranslator
             OAuthScopes.AlertsRead,
             OAuthScopes.ReportsRead,
             OAuthScopes.IdentityRead,
+            OAuthScopes.HeartRateRead,
+            OAuthScopes.StepCountRead,
+            OAuthScopes.SleepRead,
         ],
 
         // Wildcard writes
@@ -97,6 +111,9 @@ public static class ScopeTranslator
             OAuthScopes.AlertsRead,
             OAuthScopes.ReportsRead,
             OAuthScopes.IdentityRead,
+            OAuthScopes.HeartRateRead,
+            OAuthScopes.StepCountRead,
+            OAuthScopes.SleepRead,
         ],
     };
 
@@ -184,6 +201,23 @@ public static class ScopeTranslator
                     permissions.Add("api:profile:read");
                     permissions.Add("api:profile:create");
                     permissions.Add("api:profile:update");
+                    break;
+
+                // The three dedicated activity categories share one legacy collection. Without
+                // these the PermissionTrie built from a heart-rate/step/sleep-only grant would be
+                // empty, and the HasPermissions policy on the V1/V2/V3 controllers rejects an
+                // empty trie before any scope check runs.
+                case OAuthScopes.HeartRateRead:
+                case OAuthScopes.StepCountRead:
+                case OAuthScopes.SleepRead:
+                    permissions.Add("api:activity:read");
+                    break;
+                case OAuthScopes.HeartRateReadWrite:
+                case OAuthScopes.StepCountReadWrite:
+                case OAuthScopes.SleepReadWrite:
+                    permissions.Add("api:activity:read");
+                    permissions.Add("api:activity:create");
+                    permissions.Add("api:activity:update");
                     break;
 
                 case OAuthScopes.AlertsRead:

--- a/src/Web/packages/app/src/hooks.server.ts
+++ b/src/Web/packages/app/src/hooks.server.ts
@@ -1,3 +1,4 @@
+import { isInternalOnlyApiPath } from "$lib/server/internal-only-api-paths";
 import { type Handle } from "@sveltejs/kit";
 import { randomUUID } from "$lib/utils";
 import type { HandleServerError } from "@sveltejs/kit";
@@ -274,22 +275,14 @@ const siteSecurityHandle: Handle = async ({ event, resolve }) => {
   return resolve(event);
 };
 
-// API paths that must never be reachable from the internet. This proxy is the only route from
-// the edge to the API (the gateway sends /api/{**catch-all} here), so refusing them here makes
-// them internal-network-only, which is what their callers already assume.
-//
-// /api/v4/platform/tls-authorize is Caddy's on_demand_tls "ask" hook. Caddy calls the API
-// container directly, never through this proxy, so denying it costs nothing; proxying it would
-// expose an anonymous "is this tenant slug active?" oracle (200 vs 404) to the internet. The ask
-// hook cannot be header-authenticated — Caddy's `ask` takes only a URL and sends no custom
-// headers — so blocking the external path is the gate.
-const INTERNAL_ONLY_API_PATHS = ["/api/v4/platform/tls-authorize"];
+// This proxy is the only route from the edge to the API (the gateway sends /api/{**catch-all}
+// here), so refusing a path here makes it internal-network-only. See internal-only-api-paths.
 
 // Proxy handler for /api requests
 const proxyHandle: Handle = async ({ event, resolve }) => {
   // Check if the request is for /api (but not SvelteKit-handled routes like webhooks and bot dispatch)
   const path = event.url.pathname;
-  if (INTERNAL_ONLY_API_PATHS.includes(path)) {
+  if (isInternalOnlyApiPath(path)) {
     return new Response("Not Found", { status: 404 });
   }
   if (path.startsWith("/api") && !path.startsWith("/api/v4/webhooks") && !path.startsWith("/api/v4/bot") && !path.startsWith("/api/otel")) {

--- a/src/Web/packages/app/src/hooks.server.ts
+++ b/src/Web/packages/app/src/hooks.server.ts
@@ -274,10 +274,24 @@ const siteSecurityHandle: Handle = async ({ event, resolve }) => {
   return resolve(event);
 };
 
+// API paths that must never be reachable from the internet. This proxy is the only route from
+// the edge to the API (the gateway sends /api/{**catch-all} here), so refusing them here makes
+// them internal-network-only, which is what their callers already assume.
+//
+// /api/v4/platform/tls-authorize is Caddy's on_demand_tls "ask" hook. Caddy calls the API
+// container directly, never through this proxy, so denying it costs nothing; proxying it would
+// expose an anonymous "is this tenant slug active?" oracle (200 vs 404) to the internet. The ask
+// hook cannot be header-authenticated — Caddy's `ask` takes only a URL and sends no custom
+// headers — so blocking the external path is the gate.
+const INTERNAL_ONLY_API_PATHS = ["/api/v4/platform/tls-authorize"];
+
 // Proxy handler for /api requests
 const proxyHandle: Handle = async ({ event, resolve }) => {
   // Check if the request is for /api (but not SvelteKit-handled routes like webhooks and bot dispatch)
   const path = event.url.pathname;
+  if (INTERNAL_ONLY_API_PATHS.includes(path)) {
+    return new Response("Not Found", { status: 404 });
+  }
   if (path.startsWith("/api") && !path.startsWith("/api/v4/webhooks") && !path.startsWith("/api/v4/bot") && !path.startsWith("/api/otel")) {
     const apiBaseUrl = getApiBaseUrl();
     if (!apiBaseUrl) {

--- a/src/Web/packages/app/src/lib/server/internal-only-api-paths.test.ts
+++ b/src/Web/packages/app/src/lib/server/internal-only-api-paths.test.ts
@@ -8,6 +8,14 @@ describe("isInternalOnlyApiPath", () => {
     "/api/v4/Platform/TLS-Authorize",
     "/api/v4/platform/tls-authorize/",
     "/api/v4/platform/tls-authorize///",
+    "/api/v4/platform/%74ls-authorize",
+    "/api/v4/platform/tls-%61uthorize",
+    "/%61pi/v4/platform/tls-authorize",
+    "/api/v4/platform/%74%6C%73-authorize/",
+    "/API/v4/PLATFORM/%54LS-AUTHORIZE",
+    // Rejoined as a separator rather than kept literal. Kestrel 404s on an encoded slash, so
+    // refusing it is the safe side of the mismatch.
+    "/api/v4/platform%2Ftls-authorize",
   ])("refuses %s", (path) => {
     expect(isInternalOnlyApiPath(path)).toBe(true);
   });
@@ -17,6 +25,8 @@ describe("isInternalOnlyApiPath", () => {
     "/api/v4/platform/tls-authorize/extra",
     "/api/v4/platform",
     "/api/v1/entries",
+    "/api/v4/platform/tls-authorize/extra",
+    "/api/v4/platform/%zz",
   ])("does not refuse %s", (path) => {
     expect(isInternalOnlyApiPath(path)).toBe(false);
   });

--- a/src/Web/packages/app/src/lib/server/internal-only-api-paths.test.ts
+++ b/src/Web/packages/app/src/lib/server/internal-only-api-paths.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { isInternalOnlyApiPath } from "./internal-only-api-paths";
+
+describe("isInternalOnlyApiPath", () => {
+  it.each([
+    "/api/v4/platform/tls-authorize",
+    "/API/v4/platform/tls-authorize",
+    "/api/v4/Platform/TLS-Authorize",
+    "/api/v4/platform/tls-authorize/",
+    "/api/v4/platform/tls-authorize///",
+  ])("refuses %s", (path) => {
+    expect(isInternalOnlyApiPath(path)).toBe(true);
+  });
+
+  it.each([
+    "/api/v4/platform/tls-authorized",
+    "/api/v4/platform/tls-authorize/extra",
+    "/api/v4/platform",
+    "/api/v1/entries",
+  ])("does not refuse %s", (path) => {
+    expect(isInternalOnlyApiPath(path)).toBe(false);
+  });
+});

--- a/src/Web/packages/app/src/lib/server/internal-only-api-paths.test.ts
+++ b/src/Web/packages/app/src/lib/server/internal-only-api-paths.test.ts
@@ -25,7 +25,6 @@ describe("isInternalOnlyApiPath", () => {
     "/api/v4/platform/tls-authorize/extra",
     "/api/v4/platform",
     "/api/v1/entries",
-    "/api/v4/platform/tls-authorize/extra",
     "/api/v4/platform/%zz",
   ])("does not refuse %s", (path) => {
     expect(isInternalOnlyApiPath(path)).toBe(false);

--- a/src/Web/packages/app/src/lib/server/internal-only-api-paths.ts
+++ b/src/Web/packages/app/src/lib/server/internal-only-api-paths.ts
@@ -9,11 +9,34 @@
 const INTERNAL_ONLY_API_PATHS = ["/api/v4/platform/tls-authorize"];
 
 /**
- * Matched the way ASP.NET routing would rather than by string equality: routing is
- * case-insensitive and ignores trailing slashes, so `/API/v4/platform/tls-authorize` and
- * `/api/v4/platform/tls-authorize/` reach the same endpoint and must be refused too.
+ * Matched the way ASP.NET routing would rather than by string equality. Routing percent-decodes,
+ * is case-insensitive, and ignores trailing slashes, so `/api/v4/platform/%74ls-authorize`,
+ * `/API/v4/platform/tls-authorize` and `/api/v4/platform/tls-authorize/` all reach the same endpoint
+ * and must all be refused.
+ *
+ * A decoded `%2F` is rejoined as a separator here, which Kestrel does not do — it 404s on an
+ * encoded slash. The mismatch only ever refuses a path the API would not serve, so it errs the
+ * safe way.
+ *
+ * `path` must be an already-normalised pathname such as `URL.pathname`, which has had its dot
+ * segments removed. This does not remove them, and Kestrel resolves `..` after decoding.
  */
 export function isInternalOnlyApiPath(path: string): boolean {
-  const normalized = path.toLowerCase().replace(/\/+$/, "");
+  const normalized = path
+    .split("/")
+    .map(decodeSegment)
+    .join("/")
+    .toLowerCase()
+    .replace(/\/+$/, "");
+
   return INTERNAL_ONLY_API_PATHS.includes(normalized);
+}
+
+/** A malformed escape is left as written; it cannot then match a listed path. */
+function decodeSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
 }

--- a/src/Web/packages/app/src/lib/server/internal-only-api-paths.ts
+++ b/src/Web/packages/app/src/lib/server/internal-only-api-paths.ts
@@ -1,0 +1,19 @@
+/**
+ * API paths the proxy refuses, making them reachable only from inside the deployment network.
+ *
+ * `/api/v4/platform/tls-authorize` is Caddy's `on_demand_tls` "ask" hook. Caddy calls the API
+ * container directly, never through this proxy, so refusing it here costs nothing; proxying it would
+ * expose an anonymous "is this tenant slug active?" oracle (200 vs 404) to the internet. The hook
+ * cannot be header-authenticated — Caddy's `ask` takes only a URL and sends no custom headers.
+ */
+const INTERNAL_ONLY_API_PATHS = ["/api/v4/platform/tls-authorize"];
+
+/**
+ * Matched the way ASP.NET routing would rather than by string equality: routing is
+ * case-insensitive and ignores trailing slashes, so `/API/v4/platform/tls-authorize` and
+ * `/api/v4/platform/tls-authorize/` reach the same endpoint and must be refused too.
+ */
+export function isInternalOnlyApiPath(path: string): boolean {
+  const normalized = path.toLowerCase().replace(/\/+$/, "");
+  return INTERNAL_ONLY_API_PATHS.includes(normalized);
+}

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ActivityReadScopeGuardTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ActivityReadScopeGuardTests.cs
@@ -1,0 +1,152 @@
+using System.Reflection;
+using FluentAssertions;
+using Moq;
+using Nocturne.API.Attributes;
+using Nocturne.API.Authorization;
+using Nocturne.API.Controllers.V1;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
+using Xunit;
+
+namespace Nocturne.API.Tests.Authorization;
+
+[Trait("Category", "Unit")]
+public class ActivityReadScopeGuardTests
+{
+    private static Activity Activity(string id) => new() { Id = id, Mills = 1700000000000 };
+
+    /// <summary>
+    /// Stub decomposer mapping activity ids to a canned required read scope, so the guard's
+    /// scope-checking logic is exercised without a real classifier or DbContext.
+    /// </summary>
+    private static IActivityDecomposer Decomposer(Dictionary<string, string> idToScope)
+    {
+        var mock = new Mock<IActivityDecomposer>();
+        mock.Setup(d => d.RequiredReadScope(It.IsAny<Activity>()))
+            .Returns((Activity a) => idToScope[a.Id!]);
+        return mock.Object;
+    }
+
+    private static IReadOnlySet<string> Granted(params string[] scopes) =>
+        new HashSet<string>(scopes);
+
+    private static Dictionary<string, string> OneOfEachCategory() => new()
+    {
+        ["hr"] = OAuthScopes.HeartRateRead,
+        ["sc"] = OAuthScopes.StepCountRead,
+        ["sleep"] = OAuthScopes.SleepRead,
+        ["regular"] = OAuthScopes.TreatmentsRead,
+    };
+
+    private static Activity[] OneRecordPerCategory() =>
+        [Activity("hr"), Activity("sc"), Activity("sleep"), Activity("regular")];
+
+    [Fact]
+    public void Filter_TreatmentsOnlyGrant_KeepsOnlyRegularActivities()
+    {
+        var kept = ActivityReadScopeGuard.Filter(
+            OneRecordPerCategory(), Decomposer(OneOfEachCategory()), Granted(OAuthScopes.TreatmentsRead));
+
+        kept.Select(a => a.Id).Should().Equal("regular");
+    }
+
+    [Fact]
+    public void Filter_HeartRateOnlyGrant_KeepsOnlyHeartRate()
+    {
+        var kept = ActivityReadScopeGuard.Filter(
+            OneRecordPerCategory(), Decomposer(OneOfEachCategory()), Granted(OAuthScopes.HeartRateRead));
+
+        kept.Select(a => a.Id).Should().Equal("hr");
+    }
+
+    [Fact]
+    public void Filter_NoScopes_KeepsNothing()
+    {
+        var kept = ActivityReadScopeGuard.Filter(
+            OneRecordPerCategory(), Decomposer(OneOfEachCategory()), Granted());
+
+        kept.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Filter_FullAccess_KeepsEveryCategory()
+    {
+        var kept = ActivityReadScopeGuard.Filter(
+            OneRecordPerCategory(), Decomposer(OneOfEachCategory()), Granted(OAuthScopes.FullAccess));
+
+        kept.Should().HaveCount(4);
+    }
+
+    /// <summary>
+    /// A readwrite grant implies its read counterpart, so a sleep-writing client keeps reading back
+    /// what it wrote.
+    /// </summary>
+    [Fact]
+    public void Filter_ReadWriteGrant_SatisfiesTheReadCategory()
+    {
+        var kept = ActivityReadScopeGuard.Filter(
+            OneRecordPerCategory(), Decomposer(OneOfEachCategory()), Granted(OAuthScopes.SleepReadWrite));
+
+        kept.Select(a => a.Id).Should().Equal("sleep");
+    }
+
+    [Fact]
+    public void CanRead_UnheldCategory_IsFalse()
+    {
+        ActivityReadScopeGuard.CanRead(
+            Activity("hr"), Decomposer(OneOfEachCategory()), Granted(OAuthScopes.StepCountRead))
+            .Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The admission list on the read actions must cover exactly the categories the merged read can
+    /// return, or a caller holding one of them is refused the endpoint that serves its own data.
+    /// </summary>
+    [Fact]
+    public void AdmissionScopes_CoverEveryMergedCategory()
+    {
+        ActivityReadScopeGuard.AdmissionScopes.Should().BeEquivalentTo(new[]
+        {
+            OAuthScopes.TreatmentsRead,
+            OAuthScopes.HeartRateRead,
+            OAuthScopes.StepCountRead,
+            OAuthScopes.SleepRead,
+        });
+    }
+
+    /// <summary>
+    /// The action attributes are what the pipeline actually enforces, and the guard only runs on a
+    /// request the attribute admitted. Narrowing the attribute back to a single category would refuse
+    /// a caller the endpoint that serves exactly its own data.
+    /// </summary>
+    [Theory]
+    [InlineData(nameof(ActivityController.GetActivities))]
+    [InlineData(nameof(ActivityController.GetActivity))]
+    public void V1ActivityReadActions_AdmitAnyMergedCategory(string actionName)
+    {
+        var attribute = typeof(ActivityController)
+            .GetMethod(actionName)!
+            .GetCustomAttribute<RequireScopeAttribute>();
+
+        attribute.Should().NotBeNull();
+        attribute!.RequiresAll.Should().BeFalse("holding one category must admit the caller");
+        attribute.RequiredScopes.Should().BeEquivalentTo(ActivityReadScopeGuard.AdmissionScopes);
+    }
+
+    /// <summary>
+    /// The activity count sums all four storages into one number that cannot be filtered per
+    /// category, so it requires all four rather than any one.
+    /// </summary>
+    [Fact]
+    public void CountActivityRoute_RequiresEveryMergedCategory()
+    {
+        var attribute = typeof(CountController)
+            .GetMethod(nameof(CountController.CountActivity))!
+            .GetCustomAttribute<RequireScopeAttribute>();
+
+        attribute.Should().NotBeNull();
+        attribute!.RequiresAll.Should().BeTrue();
+        attribute.RequiredScopes.Should().BeEquivalentTo(ActivityReadScopeGuard.AdmissionScopes);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ActivityReadScopeGuardTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ActivityReadScopeGuardTests.cs
@@ -146,8 +146,8 @@ public class ActivityReadScopeGuardTests
     /// <summary>
     /// The activity count sums all four storages into one number that cannot be filtered per
     /// category, so it requires all four rather than any one. Driven through the action rather than
-    /// read off an attribute, because the check moved into the handler when the route's other
-    /// storages became per-request.
+    /// read off an attribute, because the handler makes the check and an attribute scan cannot
+    /// see it.
     /// </summary>
     [Theory]
     [InlineData(true)]

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ActivityReadScopeGuardTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ActivityReadScopeGuardTests.cs
@@ -8,6 +8,15 @@ using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Authorization;
 using Xunit;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Contracts.Entries;
+using Nocturne.Core.Contracts.Health;
+using Nocturne.Core.Contracts.Profiles;
+using Nocturne.Core.Contracts.Repositories;
+using Nocturne.Core.Contracts.Treatments;
+using Nocturne.Core.Contracts.V4.Repositories;
 
 namespace Nocturne.API.Tests.Authorization;
 
@@ -136,17 +145,48 @@ public class ActivityReadScopeGuardTests
 
     /// <summary>
     /// The activity count sums all four storages into one number that cannot be filtered per
-    /// category, so it requires all four rather than any one.
+    /// category, so it requires all four rather than any one. Driven through the action rather than
+    /// read off an attribute, because the check moved into the handler when the route's other
+    /// storages became per-request.
     /// </summary>
-    [Fact]
-    public void CountActivityRoute_RequiresEveryMergedCategory()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CountActivityRoute_RequiresEveryMergedCategory(bool holdsEveryCategory)
     {
-        var attribute = typeof(CountController)
-            .GetMethod(nameof(CountController.CountActivity))!
-            .GetCustomAttribute<RequireScopeAttribute>();
+        var granted = holdsEveryCategory
+            ? ActivityReadScopeGuard.AdmissionScopes.ToArray()
+            : ActivityReadScopeGuard.AdmissionScopes.Take(ActivityReadScopeGuard.AdmissionScopes.Count - 1).ToArray();
 
-        attribute.Should().NotBeNull();
-        attribute!.RequiresAll.Should().BeTrue();
-        attribute.RequiredScopes.Should().BeEquivalentTo(ActivityReadScopeGuard.AdmissionScopes);
+        var activityService = new Mock<IActivityService>();
+        activityService
+            .Setup(s => s.CountActivitiesAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(3L);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["GrantedScopes"] = OAuthScopes.Normalize(granted);
+
+        var controller = new CountController(
+            Mock.Of<IEntryStore>(), Mock.Of<ITreatmentStore>(), Mock.Of<IApsSnapshotRepository>(),
+            Mock.Of<IProfileProjectionService>(), Mock.Of<IFoodRepository>(),
+            activityService.Object, NullLogger<CountController>.Instance)
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext },
+        };
+
+        var result = await controller.CountActivity();
+
+        if (holdsEveryCategory)
+        {
+            result.Result.Should().NotBeOfType<ObjectResult>();
+        }
+        else
+        {
+            result.Result.Should().BeOfType<ObjectResult>()
+                .Which.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+            activityService.Verify(
+                s => s.CountActivitiesAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ControllerAuthorizationCoverageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ControllerAuthorizationCoverageTests.cs
@@ -68,12 +68,13 @@ public class ControllerAuthorizationCoverageTests
             // v1 endpoints authenticate via the api-secret / token trie and are gated by the
             // fallback policy plus in-handler scope checks, matching upstream Nightscout behaviour.
             // They deliberately do not use the v4 [Authorize] convention.
-            //
-            // Count/Iob/Pebble/TimeQuery/Debug used to be listed here. They now carry per-action
-            // (or class-level) gates, because the fallback admits any non-empty trie and so let a
-            // grant scoped to one category read every other one — see
-            // ReadEndpointScopeEnforcementTests.
             ["Nocturne.API.Controllers.V1.AlexaController"] = "legacy v1 (fallback trie + in-handler)",
+
+            // Its routes take the collection as a route or query value, so an attribute would be an
+            // OR across every collection they serve. LegacyStorageReadScopes resolves the governing
+            // scope per request in the action; ReadEndpointScopeEnforcementTests records each action.
+            ["Nocturne.API.Controllers.V1.TimeQueryController"] = "storage-derived scope, checked in the action",
+            ["Nocturne.API.Controllers.V1.CountController"] = "storage-derived scope, checked in the action",
 
             // ── Authentication credential-management surfaces ──────────────────────────────────
             // These live in the Authentication namespace and mix explicit [AllowAnonymous] public

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ControllerAuthorizationCoverageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ControllerAuthorizationCoverageTests.cs
@@ -68,12 +68,12 @@ public class ControllerAuthorizationCoverageTests
             // v1 endpoints authenticate via the api-secret / token trie and are gated by the
             // fallback policy plus in-handler scope checks, matching upstream Nightscout behaviour.
             // They deliberately do not use the v4 [Authorize] convention.
+            //
+            // Count/Iob/Pebble/TimeQuery/Debug used to be listed here. They now carry per-action
+            // (or class-level) gates, because the fallback admits any non-empty trie and so let a
+            // grant scoped to one category read every other one — see
+            // ReadEndpointScopeEnforcementTests.
             ["Nocturne.API.Controllers.V1.AlexaController"] = "legacy v1 (fallback trie + in-handler)",
-            ["Nocturne.API.Controllers.V1.CountController"] = "legacy v1 (fallback trie + in-handler)",
-            ["Nocturne.API.Controllers.V1.IobController"] = "legacy v1 (fallback trie + in-handler)",
-            ["Nocturne.API.Controllers.V1.PebbleController"] = "legacy v1 (fallback trie + in-handler)",
-            ["Nocturne.API.Controllers.V1.TimeQueryController"] = "legacy v1 (fallback trie + in-handler)",
-            ["Nocturne.API.Controllers.V1.DebugController"] = "legacy v1 debug (fallback trie)",
 
             // ── Authentication credential-management surfaces ──────────────────────────────────
             // These live in the Authentication namespace and mix explicit [AllowAnonymous] public

--- a/tests/Unit/Nocturne.API.Tests/Authorization/DemoAdminControllerAuthorizationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/DemoAdminControllerAuthorizationTests.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Nocturne.API.Controllers.V4.Admin;
+using Xunit;
+
+namespace Nocturne.API.Tests.Authorization;
+
+/// <summary>
+/// <see cref="DemoAdminController"/> lives on the tenantless-allowed <c>/api/v4/admin/demo/</c>
+/// prefix and its actions provision a tenant, grant the Public system subject the Admin role, and
+/// bulk-delete the demo tenant's glucose, treatments, heart rate, steps, sleep and alert data.
+/// It was <c>[AllowAnonymous]</c> while being reachable from the edge (the gateway sends
+/// <c>/api/{**catch-all}</c> to nocturne-web, whose proxy forwards all of <c>/api</c> to the API),
+/// so it is gated on the <c>platform_admin</c> role the instance key already yields.
+/// </summary>
+public class DemoAdminControllerAuthorizationTests
+{
+    [Fact]
+    public void DemoAdminController_RequiresPlatformAdmin()
+    {
+        typeof(DemoAdminController)
+            .GetCustomAttribute<AuthorizeAttribute>()
+            .Should().NotBeNull("the demo lifecycle endpoints are destructive")
+            .And.Subject.As<AuthorizeAttribute>()
+            .Roles.Should().Be("platform_admin");
+    }
+
+    [Fact]
+    public void DemoAdminController_IsNotAnonymous()
+    {
+        typeof(DemoAdminController)
+            .GetCustomAttribute<AllowAnonymousAttribute>()
+            .Should().BeNull();
+
+        typeof(DemoAdminController)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => m.GetCustomAttribute<AllowAnonymousAttribute>() != null)
+            .Should().BeEmpty("a per-action opt-out would reopen the anonymous path");
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Authorization/LegacyStorageReadScopeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/LegacyStorageReadScopeTests.cs
@@ -1,0 +1,100 @@
+using FluentAssertions;
+using Nocturne.API.Authorization;
+using Nocturne.Core.Models.Authorization;
+using Xunit;
+
+namespace Nocturne.API.Tests.Authorization;
+
+/// <summary>
+/// The V1 routes that take the collection as a parameter cannot be gated by an attribute: a scope
+/// list on the action or class is an OR across every collection the route serves, so a caller
+/// holding one category reaches all of them. These pin the per-request resolution that replaces it.
+/// </summary>
+public class LegacyStorageReadScopeTests
+{
+    [Theory]
+    [InlineData("entries", OAuthScopes.GlucoseRead)]
+    [InlineData("treatments", OAuthScopes.TreatmentsRead)]
+    [InlineData("devicestatus", OAuthScopes.DevicesRead)]
+    [InlineData("profile", OAuthScopes.TherapyRead)]
+    [InlineData("food", OAuthScopes.FoodRead)]
+    public void EachStorage_MapsToItsCategory(string storage, string expected)
+    {
+        LegacyStorageReadScopes.RequiredReadScope(storage).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Entries")]
+    [InlineData("TREATMENTS")]
+    public void StorageMatching_IsCaseInsensitive(string storage)
+    {
+        // The services dispatch on storage.ToLowerInvariant(), so a differently-cased selector
+        // reaches the same collection and must resolve to the same scope.
+        LegacyStorageReadScopes.RequiredReadScope(storage).Should().NotBeNull();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("activity")]
+    [InlineData("sensor_glucose")]
+    public void AnUnclassifiedStorage_IsNotReadable(string? storage)
+    {
+        // activity included deliberately: it merges four categories, so it has no single governing
+        // scope and must not resolve to one here.
+        LegacyStorageReadScopes.RequiredReadScope(storage).Should().BeNull();
+        LegacyStorageReadScopes.CanRead(Granted(OAuthScopes.FullAccess), storage).Should().BeFalse();
+    }
+
+    [Fact]
+    public void OneCategorysGrant_CannotReadAnother()
+    {
+        // The hole this replaces: a class-level OR of glucose|treatments|devices admitted a
+        // glucose-only grant to /api/v1/slice/treatments/... and every treatment record with it.
+        var glucoseOnly = Granted(OAuthScopes.GlucoseRead);
+
+        LegacyStorageReadScopes.CanRead(glucoseOnly, "entries").Should().BeTrue();
+        LegacyStorageReadScopes.CanRead(glucoseOnly, "treatments").Should().BeFalse();
+        LegacyStorageReadScopes.CanRead(glucoseOnly, "devicestatus").Should().BeFalse();
+        LegacyStorageReadScopes.CanRead(glucoseOnly, "profile").Should().BeFalse();
+        LegacyStorageReadScopes.CanRead(glucoseOnly, "food").Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReadWrite_SatisfiesTheReadRequirement()
+    {
+        LegacyStorageReadScopes
+            .CanRead(Granted(OAuthScopes.TreatmentsReadWrite), "treatments")
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void FullAccess_ReadsEveryClassifiedStorage()
+    {
+        var superuser = Granted(OAuthScopes.FullAccess);
+
+        foreach (var storage in new[] { "entries", "treatments", "devicestatus", "profile", "food" })
+        {
+            LegacyStorageReadScopes.CanRead(superuser, storage).Should().BeTrue(storage);
+        }
+    }
+
+    [Fact]
+    public void EveryProductionGrantShape_KeepsItsSliceReads()
+    {
+        // The shape every active direct grant in production carries. It holds no alerts scope and
+        // not always sleep, so the categories it does hold must keep working.
+        var productionGrant = Granted(
+            OAuthScopes.GlucoseReadWrite, OAuthScopes.TreatmentsReadWrite, OAuthScopes.DevicesReadWrite,
+            OAuthScopes.TherapyReadWrite, OAuthScopes.HeartRateReadWrite, OAuthScopes.StepCountReadWrite,
+            OAuthScopes.FoodReadWrite);
+
+        foreach (var storage in new[] { "entries", "treatments", "devicestatus", "profile", "food" })
+        {
+            LegacyStorageReadScopes.CanRead(productionGrant, storage).Should().BeTrue(storage);
+        }
+    }
+
+    private static IReadOnlySet<string> Granted(params string[] scopes) =>
+        OAuthScopes.Normalize(scopes);
+}

--- a/tests/Unit/Nocturne.API.Tests/Authorization/LegacyStorageReadScopeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/LegacyStorageReadScopeTests.cs
@@ -99,14 +99,23 @@ public class LegacyStorageReadScopeTests
     [Fact]
     public void CountableStorage_IsFullyClassified()
     {
-        // CountController validates against its own allow-list before the scope gate, so a selector
-        // it accepts but this does not classify would reach a count ungated.
+        // An accepted selector this does not classify is refused outright, so the count route would
+        // answer 400 for a collection it dispatches on rather than counting it.
         foreach (var storage in CountController.CountableStorage)
         {
             var classified = LegacyStorageReadScopes.RequiredReadScope(storage) is not null
                 || string.Equals(storage, "activity", StringComparison.OrdinalIgnoreCase);
 
             classified.Should().BeTrue(storage);
+        }
+    }
+
+    [Fact]
+    public void SliceableStorage_IsFullyClassified()
+    {
+        foreach (var storage in TimeQueryController.SliceableStorage)
+        {
+            LegacyStorageReadScopes.RequiredReadScope(storage).Should().NotBeNull(storage);
         }
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Authorization/LegacyStorageReadScopeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/LegacyStorageReadScopeTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Nocturne.API.Authorization;
+using Nocturne.API.Controllers.V1;
 using Nocturne.Core.Models.Authorization;
 using Xunit;
 
@@ -92,6 +93,20 @@ public class LegacyStorageReadScopeTests
         foreach (var storage in new[] { "entries", "treatments", "devicestatus", "profile", "food" })
         {
             LegacyStorageReadScopes.CanRead(productionGrant, storage).Should().BeTrue(storage);
+        }
+    }
+
+    [Fact]
+    public void CountableStorage_IsFullyClassified()
+    {
+        // CountController validates against its own allow-list before the scope gate, so a selector
+        // it accepts but this does not classify would reach a count ungated.
+        foreach (var storage in CountController.CountableStorage)
+        {
+            var classified = LegacyStorageReadScopes.RequiredReadScope(storage) is not null
+                || string.Equals(storage, "activity", StringComparison.OrdinalIgnoreCase);
+
+            classified.Should().BeTrue(storage);
         }
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ReadEndpointScopeEnforcementTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ReadEndpointScopeEnforcementTests.cs
@@ -61,9 +61,6 @@ public class ReadEndpointScopeEnforcementTests
             // all of them. LegacyStorageReadScopes resolves the governing scope per request inside
             // the action instead. LegacyStorageReadScopeTests covers the mapping and
             // TimeQueryStorageGateTests drives the actions.
-            ["TimeQueryController.GetTimeBasedEntries"] = PerRequestStorageScope,
-            ["TimeQueryController.GetTimeBasedEntriesWithPrefix"] = PerRequestStorageScope,
-            ["TimeQueryController.GetTimeBasedEntriesWithPrefixAndRegex"] = PerRequestStorageScope,
             ["TimeQueryController.GetTimeQueryEcho"] = PerRequestStorageScope,
             ["TimeQueryController.GetTimeQueryEchoWithPrefix"] = PerRequestStorageScope,
             ["TimeQueryController.GetTimeQueryEchoWithPrefixAndRegex"] = PerRequestStorageScope,

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ReadEndpointScopeEnforcementTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ReadEndpointScopeEnforcementTests.cs
@@ -26,24 +26,21 @@ public class ReadEndpointScopeEnforcementTests
     /// <summary>
     /// Controllers exempt from the per-action RequireScope rule, with justification.
     /// </summary>
+    /// <remarks>
+    /// Deliberately minimal. Controllers carrying <c>[AllowAnonymous]</c> (V1/V3 <c>StatusController</c>,
+    /// <c>VersionsController</c>, <c>VersionController</c>, V1 <c>AuthenticationController</c>,
+    /// V3 <c>LastModifiedController</c>) and write-only controllers (<c>AlexaController</c>, a read
+    /// exposed over POST that runs its own permission check) are skipped by the scan itself, so
+    /// listing them here would only create a way for a later change to silently lose its gate.
+    /// <see cref="ExemptControllers_AreStillNeeded"/> guards that.
+    /// </remarks>
     private static readonly HashSet<string> ExemptControllers = new()
     {
-        // Whole-controller [AllowAnonymous] compatibility surfaces that expose no tenant data:
-        // Nightscout clients probe these before they hold any credential.
-        "StatusController",        // V1 + V3 /status — server capabilities and settings echo
-        "VersionsController",      // V1 /api/versions
-        "VersionController",       // V3 /version
-        "AuthenticationController",// V1 /verifyauth — reports whether the caller's own secret works
-        "LastModifiedController",  // V3 /lastmodified — per-collection high-water marks
-
-        // Self-introspection only: class-level [Authorize] means an authenticated caller, and the
-        // responses describe that caller's OWN grants, so there is no cross-category read to gate.
-        // Every subject/role management action on it already carries [RequireAdmin].
+        // Self-introspection only. Class-level [Authorize] already requires an authenticated
+        // caller, and GetAllPermissions/GetPermissionTrie describe that caller's OWN grants — there
+        // is no cross-category tenant read to scope. Its subject/role management actions each carry
+        // [RequireAdmin], and its token-exchange action is explicitly [AllowAnonymous].
         "AuthorizationController",
-
-        // Reflection cannot see the gate: the actions are authorized per-storage inside the
-        // action body rather than by attribute.
-        "AlexaController",        // read exposed over POST; performs its own permission check
     };
 
     [Fact]
@@ -101,6 +98,43 @@ public class ReadEndpointScopeEnforcementTests
             "every V1/V2/V3 read endpoint must carry [RequireScope] or [RequirePermission] so a " +
             "grant scoped to one data category cannot read every other category. " +
             "Unprotected: " + string.Join("; ", violations));
+    }
+
+    /// <summary>
+    /// Guards the allow-list itself: an entry that no longer needs to be there would silently
+    /// exempt a controller that had lost its gate.
+    /// </summary>
+    [Fact]
+    public void ExemptControllers_AreStillNeeded()
+    {
+        var assembly = typeof(RequireScopeAttribute).Assembly;
+
+        foreach (var name in ExemptControllers)
+        {
+            var type = assembly.GetTypes().SingleOrDefault(t =>
+                t.Name == name
+                && t.Namespace is "Nocturne.API.Controllers.V1"
+                    or "Nocturne.API.Controllers.V2" or "Nocturne.API.Controllers.V3");
+
+            type.Should().NotBeNull($"{name} is exempted but no longer exists in V1/V2/V3");
+            type!.GetCustomAttribute<AllowAnonymousAttribute>().Should().BeNull(
+                $"{name} is [AllowAnonymous], which the scan already skips — remove the exemption");
+
+            var ungatedReads = type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Where(m => m.GetCustomAttributes<HttpMethodAttribute>()
+                    .SelectMany(a => a.HttpMethods)
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase)
+                    .Overlaps(ReadVerbs))
+                .Where(m => m.GetCustomAttribute<AllowAnonymousAttribute>() == null)
+                .Where(m => m.GetCustomAttribute<RequireScopeAttribute>() == null
+                            && m.GetCustomAttribute<RequirePermissionAttribute>() == null
+                            && type.GetCustomAttribute<RequireScopeAttribute>() == null
+                            && type.GetCustomAttribute<RequirePermissionAttribute>() == null)
+                .ToList();
+
+            ungatedReads.Should().NotBeEmpty(
+                $"{name} now gates every read action, so its exemption is stale — remove it");
+        }
     }
 
     /// <summary>

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ReadEndpointScopeEnforcementTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ReadEndpointScopeEnforcementTests.cs
@@ -1,0 +1,129 @@
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Nocturne.API.Attributes;
+using Xunit;
+
+namespace Nocturne.API.Tests.Authorization;
+
+/// <summary>
+/// Guards the per-action authorization invariant for the V1/V2/V3 (Nightscout-compat) READ plane,
+/// the mirror of <see cref="WriteEndpointScopeEnforcementTests"/>.
+///
+/// The controller-level <c>HasPermissions</c> policy is the same object as the global
+/// <c>FallbackPolicy</c>, and it succeeds on any non-empty <c>PermissionTrie</c>. So without a
+/// per-action <see cref="RequireScopeAttribute"/> a grant scoped to one category reads every
+/// category: a <c>sleep.read</c> token could GET glucose from <c>/api/v1/entries</c> and basal
+/// rates, carb ratios and ISF from <c>/api/v1/profile</c>. This test fails if a new read endpoint
+/// ships without per-action authorization.
+/// </summary>
+public class ReadEndpointScopeEnforcementTests
+{
+    private static readonly string[] ReadVerbs = ["GET", "HEAD"];
+
+    /// <summary>
+    /// Controllers exempt from the per-action RequireScope rule, with justification.
+    /// </summary>
+    private static readonly HashSet<string> ExemptControllers = new()
+    {
+        // Whole-controller [AllowAnonymous] compatibility surfaces that expose no tenant data:
+        // Nightscout clients probe these before they hold any credential.
+        "StatusController",        // V1 + V3 /status — server capabilities and settings echo
+        "VersionsController",      // V1 /api/versions
+        "VersionController",       // V3 /version
+        "AuthenticationController",// V1 /verifyauth — reports whether the caller's own secret works
+        "LastModifiedController",  // V3 /lastmodified — per-collection high-water marks
+
+        // Self-introspection only: class-level [Authorize] means an authenticated caller, and the
+        // responses describe that caller's OWN grants, so there is no cross-category read to gate.
+        // Every subject/role management action on it already carries [RequireAdmin].
+        "AuthorizationController",
+
+        // Reflection cannot see the gate: the actions are authorized per-storage inside the
+        // action body rather than by attribute.
+        "AlexaController",        // read exposed over POST; performs its own permission check
+    };
+
+    [Fact]
+    public void EveryV1V2AndV3ReadAction_RequiresAnOAuthScope()
+    {
+        var assembly = typeof(RequireScopeAttribute).Assembly;
+        var violations = new List<string>();
+        var readActionsChecked = 0;
+
+        foreach (var type in assembly.GetTypes())
+        {
+            if (type.Namespace is not ("Nocturne.API.Controllers.V1"
+                or "Nocturne.API.Controllers.V2"
+                or "Nocturne.API.Controllers.V3"))
+                continue;
+            if (type.IsAbstract || !typeof(ControllerBase).IsAssignableFrom(type))
+                continue;
+            if (ExemptControllers.Contains(type.Name))
+                continue;
+            if (type.GetCustomAttribute<AllowAnonymousAttribute>() != null)
+                continue;
+
+            foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            {
+                var verbs = method.GetCustomAttributes<HttpMethodAttribute>()
+                    .SelectMany(a => a.HttpMethods)
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+                if (!verbs.Overlaps(ReadVerbs))
+                    continue;
+
+                // Endpoints deliberately marked [AllowAnonymous] are intentionally public.
+                if (method.GetCustomAttribute<AllowAnonymousAttribute>() != null)
+                    continue;
+
+                readActionsChecked++;
+
+                var hasPerActionAuthz =
+                    method.GetCustomAttribute<RequireScopeAttribute>() != null
+                    || method.GetCustomAttribute<RequirePermissionAttribute>() != null
+                    || type.GetCustomAttribute<RequireScopeAttribute>() != null
+                    || type.GetCustomAttribute<RequirePermissionAttribute>() != null;
+
+                if (!hasPerActionAuthz)
+                    violations.Add($"{type.Name}.{method.Name} [{string.Join(",", verbs)}]");
+            }
+        }
+
+        // Sanity: the scan must actually discover the read surface, otherwise the assertion
+        // below would pass vacuously if the reflection query silently matched nothing.
+        readActionsChecked.Should().BeGreaterThan(50,
+            "the reflection scan should discover the V1/V2/V3 read endpoints");
+
+        violations.Should().BeEmpty(
+            "every V1/V2/V3 read endpoint must carry [RequireScope] or [RequirePermission] so a " +
+            "grant scoped to one data category cannot read every other category. " +
+            "Unprotected: " + string.Join("; ", violations));
+    }
+
+    /// <summary>
+    /// Public share links reach exactly this read surface, and their scopes are narrowed to
+    /// <see cref="Nocturne.Core.Models.Authorization.TenantPermissions.PublicShareScopes"/>. A read
+    /// scope outside that set is not a bug — the share RLS policies hide the underlying tables from
+    /// shares anyway (see <c>ShareDataCategories</c>) — but the scopes the share view depends on
+    /// must stay inside it, or every share link 403s.
+    /// </summary>
+    [Fact]
+    public void ShareReachableReadScopes_StayWithinPublicShareScopes()
+    {
+        var shareable = Nocturne.Core.Models.Authorization.TenantPermissions.PublicShareScopes;
+
+        shareable.Should().Contain(Nocturne.Core.Models.Authorization.OAuthScopes.GlucoseRead,
+            "the default share grant is glucose-only, so the glucose read endpoints " +
+            "(/api/v1/entries, /pebble, /api/v2/properties, ddata, summary) must be satisfiable by it");
+        shareable.Should().Contain(Nocturne.Core.Models.Authorization.OAuthScopes.TreatmentsRead);
+        shareable.Should().Contain(Nocturne.Core.Models.Authorization.OAuthScopes.DevicesRead);
+        shareable.Should().Contain(Nocturne.Core.Models.Authorization.OAuthScopes.FoodRead);
+
+        shareable.Should().OnlyContain(s => s.EndsWith(".read", StringComparison.Ordinal),
+            "RequireScope admits the anonymous share principal on its scope set alone, so the set " +
+            "must never contain a write scope");
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ReadEndpointScopeEnforcementTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ReadEndpointScopeEnforcementTests.cs
@@ -43,6 +43,43 @@ public class ReadEndpointScopeEnforcementTests
         "AuthorizationController",
     };
 
+    /// <summary>
+    /// Read actions exempt from the rule, keyed <c>Controller.Action</c> with the mechanism that
+    /// governs them instead. Action-granular so exempting one action cannot exempt a controller's
+    /// whole read surface. <see cref="ExemptReadActions_NameALiveReadAction"/> keeps it honest.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> ExemptReadActions =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            // NotificationV1Service.GetAdminNotifiesAsync checks *:*:admin itself and returns the
+            // notification bodies only to an admin, otherwise just notifyCount. A scope gate would
+            // turn that documented degradation into a 403, and site notices are not a data category.
+            ["NotificationsController.GetAdminNotifies"] = "service authorizes internally and degrades",
+
+            // The collection is a route or query value, so an attribute here would be an OR across
+            // every collection the route serves and would admit a caller holding one category to
+            // all of them. LegacyStorageReadScopes resolves the governing scope per request inside
+            // the action instead. LegacyStorageReadScopeTests covers the mapping and
+            // TimeQueryStorageGateTests drives the actions.
+            ["TimeQueryController.GetTimeBasedEntries"] = PerRequestStorageScope,
+            ["TimeQueryController.GetTimeBasedEntriesWithPrefix"] = PerRequestStorageScope,
+            ["TimeQueryController.GetTimeBasedEntriesWithPrefixAndRegex"] = PerRequestStorageScope,
+            ["TimeQueryController.GetTimeQueryEcho"] = PerRequestStorageScope,
+            ["TimeQueryController.GetTimeQueryEchoWithPrefix"] = PerRequestStorageScope,
+            ["TimeQueryController.GetTimeQueryEchoWithPrefixAndRegex"] = PerRequestStorageScope,
+            ["TimeQueryController.GetSlicedData"] = PerRequestStorageScope,
+            ["TimeQueryController.GetSlicedDataWithType"] = PerRequestStorageScope,
+            ["TimeQueryController.GetSlicedDataWithTypeAndPrefix"] = PerRequestStorageScope,
+            ["TimeQueryController.GetSlicedDataWithAll"] = PerRequestStorageScope,
+            ["CountController.CountGeneric"] = PerRequestStorageScope,
+
+            // Merges four categories into one number, so it cannot be filtered and requires every
+            // category's read scope. Read from ActivityReadScopeGuard.AdmissionScopes in the action.
+            ["CountController.CountActivity"] = "every activity category, checked in the action",
+        };
+
+    private const string PerRequestStorageScope = "storage-derived scope, checked in the action";
+
     [Fact]
     public void EveryV1V2AndV3ReadAction_RequiresAnOAuthScope()
     {
@@ -84,7 +121,7 @@ public class ReadEndpointScopeEnforcementTests
                     || type.GetCustomAttribute<RequireScopeAttribute>() != null
                     || type.GetCustomAttribute<RequirePermissionAttribute>() != null;
 
-                if (!hasPerActionAuthz)
+                if (!hasPerActionAuthz && !ExemptReadActions.ContainsKey($"{type.Name}.{method.Name}"))
                     violations.Add($"{type.Name}.{method.Name} [{string.Join(",", verbs)}]");
             }
         }
@@ -159,5 +196,41 @@ public class ReadEndpointScopeEnforcementTests
         shareable.Should().OnlyContain(s => s.EndsWith(".read", StringComparison.Ordinal),
             "RequireScope admits the anonymous share principal on its scope set alone, so the set " +
             "must never contain a write scope");
+    }
+
+    [Fact]
+    public void ExemptReadActions_NameALiveReadAction()
+    {
+        var assembly = typeof(RequireScopeAttribute).Assembly;
+
+        foreach (var (key, _) in ExemptReadActions)
+        {
+            var parts = key.Split('.', 2);
+
+            // Resolved by the type that declares the action: the same controller name exists in more
+            // than one version namespace (NotificationsController in V1 and V2).
+            var matches = assembly.GetTypes()
+                .Where(t => t.Name == parts[0]
+                    && t.Namespace is "Nocturne.API.Controllers.V1"
+                        or "Nocturne.API.Controllers.V2" or "Nocturne.API.Controllers.V3")
+                .Select(t => (Type: t, Method: t
+                    .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                    .FirstOrDefault(m => m.Name == parts[1])))
+                .Where(x => x.Method is not null)
+                .ToList();
+
+            matches.Should().HaveCount(1,
+                $"{key} must name exactly one live V1/V2/V3 read action");
+            var method = matches[0].Method!;
+
+            method!.GetCustomAttributes<HttpMethodAttribute>()
+                .SelectMany(a => a.HttpMethods)
+                .Should().Contain(v => ReadVerbs.Contains(v),
+                    $"{key} is exempted from the READ rule but is not a read action");
+
+            (method.GetCustomAttribute<RequireScopeAttribute>() is null
+                && method.GetCustomAttribute<RequirePermissionAttribute>() is null)
+                .Should().BeTrue($"{key} now carries a gate, so its exemption is stale — remove it");
+        }
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Authorization/RequireScopeAttributeShareTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/RequireScopeAttributeShareTests.cs
@@ -77,8 +77,9 @@ public class RequireScopeAttributeShareTests
 
         new RequireScopeAttribute(writeScope).OnAuthorization(context);
 
-        context.Result.Should().BeOfType<ForbidResult>(
-            "PublicShareScopes holds only .read scopes, so no share may write");
+        context.Result.Should().BeOfType<UnauthorizedResult>(
+            "an unauthenticated caller is refused before its scopes are consulted, so a write "
+            + "requirement can never be reached by a share");
     }
 
     [Theory]

--- a/tests/Unit/Nocturne.API.Tests/Authorization/RequireScopeAttributeShareTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/RequireScopeAttributeShareTests.cs
@@ -12,11 +12,11 @@ using Xunit;
 namespace Nocturne.API.Tests.Authorization;
 
 /// <summary>
-/// <see cref="RequireScopeAttribute"/> gates on the resolved scope set rather than on an
-/// authenticated identity, because a public share link is deliberately
-/// <c>IsAuthenticated: false</c> while still carrying scopes narrowed to
-/// <see cref="TenantPermissions.PublicShareScopes"/>. These tests pin both halves of that
-/// judgement: the share can satisfy a read requirement, and it can never satisfy a write one.
+/// <see cref="RequireScopeAttribute"/> decides a read requirement on the resolved scope set alone,
+/// because a public share link is deliberately <c>IsAuthenticated: false</c> while still carrying
+/// scopes narrowed to <see cref="TenantPermissions.PublicShareScopes"/>. A requirement naming
+/// anything other than read additionally demands an authenticated caller. These tests pin both
+/// halves: the share can satisfy a read requirement, and it can never satisfy a write one.
 /// </summary>
 public class RequireScopeAttributeShareTests
 {

--- a/tests/Unit/Nocturne.API.Tests/Authorization/RequireScopeAttributeShareTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/RequireScopeAttributeShareTests.cs
@@ -1,0 +1,174 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Nocturne.API.Attributes;
+using Nocturne.API.Middleware;
+using Nocturne.Core.Models.Authorization;
+using Xunit;
+
+namespace Nocturne.API.Tests.Authorization;
+
+/// <summary>
+/// <see cref="RequireScopeAttribute"/> gates on the resolved scope set rather than on an
+/// authenticated identity, because a public share link is deliberately
+/// <c>IsAuthenticated: false</c> while still carrying scopes narrowed to
+/// <see cref="TenantPermissions.PublicShareScopes"/>. These tests pin both halves of that
+/// judgement: the share can satisfy a read requirement, and it can never satisfy a write one.
+/// </summary>
+public class RequireScopeAttributeShareTests
+{
+    private static AuthorizationFilterContext Context(
+        bool isAuthenticated, IEnumerable<string> grantedScopes)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["AuthContext"] = new AuthContext { IsAuthenticated = isAuthenticated };
+        httpContext.Items["GrantedScopes"] =
+            (IReadOnlySet<string>)grantedScopes.ToHashSet(StringComparer.Ordinal);
+
+        return new AuthorizationFilterContext(
+            new ActionContext(httpContext, new RouteData(), new ActionDescriptor()),
+            []);
+    }
+
+    /// <summary>The scopes AuthenticationMiddleware resolves for a share granted every category.</summary>
+    private static IReadOnlySet<string> FullShareScopes() =>
+        TenantPermissions.PublicShareScopes.ToHashSet(StringComparer.Ordinal);
+
+    [Theory]
+    [InlineData(OAuthScopes.GlucoseRead)]
+    [InlineData(OAuthScopes.TreatmentsRead)]
+    [InlineData(OAuthScopes.DevicesRead)]
+    [InlineData(OAuthScopes.FoodRead)]
+    public void AnonymousShare_SatisfiesAReadScopeItWasGranted(string requiredScope)
+    {
+        var context = Context(isAuthenticated: false, FullShareScopes());
+
+        new RequireScopeAttribute(requiredScope).OnAuthorization(context);
+
+        context.Result.Should().BeNull(
+            "a share link must keep reading the categories its owner granted");
+    }
+
+    [Fact]
+    public void DefaultGlucoseOnlyShare_SatisfiesTheGlucoseReadEndpoints()
+    {
+        // DefaultPublicShareScopes is what a freshly-enabled share link carries.
+        var context = Context(isAuthenticated: false, TenantPermissions.DefaultPublicShareScopes);
+
+        new RequireScopeAttribute(OAuthScopes.GlucoseRead).OnAuthorization(context);
+
+        context.Result.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(OAuthScopes.GlucoseReadWrite)]
+    [InlineData(OAuthScopes.TreatmentsReadWrite)]
+    [InlineData(OAuthScopes.DevicesReadWrite)]
+    [InlineData(OAuthScopes.FoodReadWrite)]
+    [InlineData(OAuthScopes.TherapyReadWrite)]
+    [InlineData(OAuthScopes.AlertsReadWrite)]
+    [InlineData(OAuthScopes.FullAccess)]
+    public void AnonymousShare_NeverSatisfiesAWriteScope(string writeScope)
+    {
+        var context = Context(isAuthenticated: false, FullShareScopes());
+
+        new RequireScopeAttribute(writeScope).OnAuthorization(context);
+
+        context.Result.Should().BeOfType<ForbidResult>(
+            "PublicShareScopes holds only .read scopes, so no share may write");
+    }
+
+    [Theory]
+    [InlineData(OAuthScopes.TherapyRead)]
+    [InlineData(OAuthScopes.AlertsRead)]
+    [InlineData(OAuthScopes.SleepRead)]
+    public void AnonymousShare_IsDeniedCategoriesOutsideTheShareSet(string requiredScope)
+    {
+        // therapy/alerts/sleep are not shareable categories, and the share RLS policies already
+        // hide those tables from a share, so denial here matches what the data layer does.
+        var context = Context(isAuthenticated: false, FullShareScopes());
+
+        new RequireScopeAttribute(requiredScope).OnAuthorization(context);
+
+        context.Result.Should().BeOfType<ForbidResult>();
+    }
+
+    [Fact]
+    public void AnonymousCallerWithNoScopes_IsUnauthorized()
+    {
+        var context = Context(isAuthenticated: false, []);
+
+        new RequireScopeAttribute(OAuthScopes.GlucoseRead).OnAuthorization(context);
+
+        context.Result.Should().BeOfType<UnauthorizedResult>(
+            "no resolved scopes means no grant at all — the check fails closed");
+    }
+
+    [Fact]
+    public void AuthenticatedCallerWithNoScopes_IsForbidden()
+    {
+        var context = Context(isAuthenticated: true, []);
+
+        new RequireScopeAttribute(OAuthScopes.GlucoseRead).OnAuthorization(context);
+
+        context.Result.Should().BeOfType<ForbidResult>(
+            "the identity is known, so the failure is authorization, not authentication");
+    }
+
+    /// <summary>
+    /// The legacy uploader plane (AAPS/Loop/Trio/iAPS/xDrip+) authenticates with a pre-hashed
+    /// api-secret or a legacy access token, which AuthenticationMiddleware translates through
+    /// <see cref="ScopeTranslator.FromPermissions"/>. Every read scope the V1/V2/V3 endpoints now
+    /// require must survive that translation, or those clients break.
+    /// </summary>
+    [Theory]
+    [InlineData(OAuthScopes.GlucoseRead)]
+    [InlineData(OAuthScopes.TreatmentsRead)]
+    [InlineData(OAuthScopes.DevicesRead)]
+    [InlineData(OAuthScopes.TherapyRead)]
+    [InlineData(OAuthScopes.FoodRead)]
+    [InlineData(OAuthScopes.AlertsRead)]
+    public void LegacyApiSecretAndReadTokens_SatisfyEveryRequiredReadScope(string requiredScope)
+    {
+        // api-secret / admin subjects carry "*"; read-only legacy subjects carry the Shiro
+        // wildcard read or the named "readable" role.
+        foreach (var permissions in new[]
+                 {
+                     new[] { "*" },
+                     new[] { "api:*" },
+                     new[] { "api:*:read" },
+                     new[] { "readable" },
+                 })
+        {
+            var scopes = ScopeTranslator.FromPermissions(permissions);
+            var context = Context(isAuthenticated: true, scopes);
+
+            new RequireScopeAttribute(requiredScope).OnAuthorization(context);
+
+            context.Result.Should().BeNull(
+                $"permissions [{string.Join(",", permissions)}] must still satisfy {requiredScope}");
+        }
+    }
+
+    /// <summary>
+    /// A per-collection legacy token must satisfy its own collection and nothing else — this is the
+    /// vulnerability the read gating closes.
+    /// </summary>
+    [Fact]
+    public void LegacySingleCollectionToken_ReadsOnlyItsOwnCollection()
+    {
+        var scopes = ScopeTranslator.FromPermissions(["api:entries:read"]);
+        var granted = Context(isAuthenticated: true, scopes);
+        var denied = Context(isAuthenticated: true, scopes);
+
+        new RequireScopeAttribute(OAuthScopes.GlucoseRead).OnAuthorization(granted);
+        new RequireScopeAttribute(OAuthScopes.TherapyRead).OnAuthorization(denied);
+
+        granted.Result.Should().BeNull();
+        denied.Result.Should().BeOfType<ForbidResult>(
+            "an entries-scoped token must not read therapy settings");
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Authorization/RequireScopeAttributeShareTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/RequireScopeAttributeShareTests.cs
@@ -131,6 +131,9 @@ public class RequireScopeAttributeShareTests
     [InlineData(OAuthScopes.TherapyRead)]
     [InlineData(OAuthScopes.FoodRead)]
     [InlineData(OAuthScopes.AlertsRead)]
+    [InlineData(OAuthScopes.HeartRateRead)]
+    [InlineData(OAuthScopes.StepCountRead)]
+    [InlineData(OAuthScopes.SleepRead)]
     public void LegacyApiSecretAndReadTokens_SatisfyEveryRequiredReadScope(string requiredScope)
     {
         // api-secret / admin subjects carry "*"; read-only legacy subjects carry the Shiro
@@ -150,6 +153,39 @@ public class RequireScopeAttributeShareTests
 
             context.Result.Should().BeNull(
                 $"permissions [{string.Join(",", permissions)}] must still satisfy {requiredScope}");
+        }
+    }
+
+    /// <summary>
+    /// <c>/api/v1/activity</c> merges four storages, so it admits on an OR over their read scopes and
+    /// then filters the response per record. A legacy read subject carries the permissions the
+    /// <c>readable</c> seed role grants, and those must resolve to all four categories or the legacy
+    /// activity read silently starts returning a subset.
+    /// </summary>
+    [Fact]
+    public void LegacyReadableRolePermissions_ReadEveryMergedActivityCategory()
+    {
+        // The permission strings RoleService seeds for the "readable" and "public" roles.
+        var scopes = ScopeTranslator.FromPermissions([
+            "api:entries:read",
+            "api:treatments:read",
+            "api:devicestatus:read",
+            "api:profile:read",
+            "api:food:read",
+            "api:activity:read",
+            "api:trackers:read",
+        ]);
+
+        foreach (var category in new[]
+                 {
+                     OAuthScopes.TreatmentsRead,
+                     OAuthScopes.HeartRateRead,
+                     OAuthScopes.StepCountRead,
+                     OAuthScopes.SleepRead,
+                 })
+        {
+            OAuthScopes.SatisfiesScope(scopes, category).Should().BeTrue(
+                $"a legacy read subject must keep reading {category} data from /api/v1/activity");
         }
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Authorization/RequireScopeAttributeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/RequireScopeAttributeTests.cs
@@ -48,13 +48,14 @@ public class RequireScopeAttributeTests
     public void UnauthenticatedPublicShare_WithReadScopes_StillCannotWrite()
     {
         // The public-share path leaves AuthContext.IsAuthenticated = false while populating read
-        // scopes, and the filter now evaluates that scope set rather than requiring authentication
-        // (otherwise every share link would 401 on the read endpoints). The write must still be
-        // rejected — here on the scope check, so the rejection is 403 rather than 401.
+        // scopes, so the filter admits an unauthenticated caller for a read requirement — otherwise
+        // every share link would 401. A write requirement is refused before the scope set is
+        // consulted, which is what keeps write-immunity a property of the filter rather than of the
+        // scopes a share happens to hold.
         var result = Evaluate(new RequireScopeAttribute(OAuthScopes.GlucoseReadWrite),
             authenticated: false, OAuthScopes.GlucoseRead);
 
-        result.Should().BeOfType<ForbidResult>();
+        result.Should().BeOfType<UnauthorizedResult>();
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Authorization/RequireScopeAttributeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/RequireScopeAttributeTests.cs
@@ -35,14 +35,35 @@ public class RequireScopeAttributeTests
     }
 
     [Fact]
-    public void UnauthenticatedRequest_IsRejectedWith401()
+    public void UnauthenticatedRequestWithNoScopes_IsRejectedWith401()
     {
-        // The public-tenant path leaves AuthContext.IsAuthenticated = false, even though it
-        // populates read scopes. Writes must still be rejected before any scope check.
+        // No resolved scopes means no grant at all: neither an authenticated caller nor a share.
+        var result = Evaluate(new RequireScopeAttribute(OAuthScopes.GlucoseReadWrite),
+            authenticated: false);
+
+        result.Should().BeOfType<UnauthorizedResult>();
+    }
+
+    [Fact]
+    public void UnauthenticatedPublicShare_WithReadScopes_StillCannotWrite()
+    {
+        // The public-share path leaves AuthContext.IsAuthenticated = false while populating read
+        // scopes, and the filter now evaluates that scope set rather than requiring authentication
+        // (otherwise every share link would 401 on the read endpoints). The write must still be
+        // rejected — here on the scope check, so the rejection is 403 rather than 401.
         var result = Evaluate(new RequireScopeAttribute(OAuthScopes.GlucoseReadWrite),
             authenticated: false, OAuthScopes.GlucoseRead);
 
-        result.Should().BeOfType<UnauthorizedResult>();
+        result.Should().BeOfType<ForbidResult>();
+    }
+
+    [Fact]
+    public void UnauthenticatedPublicShare_WithReadScopes_CanRead()
+    {
+        var result = Evaluate(new RequireScopeAttribute(OAuthScopes.GlucoseRead),
+            authenticated: false, OAuthScopes.GlucoseRead);
+
+        result.Should().BeNull("public share links read the V1/V2/V3 surface");
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ScopeTranslatorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ScopeTranslatorTests.cs
@@ -67,6 +67,9 @@ public class ScopeTranslatorTests
         Assert.Contains(OAuthScopes.AlertsRead, scopes);
         Assert.Contains(OAuthScopes.ReportsRead, scopes);
         Assert.Contains(OAuthScopes.IdentityRead, scopes);
+        Assert.Contains(OAuthScopes.HeartRateRead, scopes);
+        Assert.Contains(OAuthScopes.StepCountRead, scopes);
+        Assert.Contains(OAuthScopes.SleepRead, scopes);
     }
 
     [Fact]
@@ -79,6 +82,45 @@ public class ScopeTranslatorTests
         Assert.Contains(OAuthScopes.TreatmentsRead, scopes);
         Assert.Contains(OAuthScopes.DevicesRead, scopes);
         Assert.Contains(OAuthScopes.TherapyRead, scopes);
+        Assert.Contains(OAuthScopes.HeartRateRead, scopes);
+        Assert.Contains(OAuthScopes.StepCountRead, scopes);
+        Assert.Contains(OAuthScopes.SleepRead, scopes);
+    }
+
+    /// <summary>
+    /// The legacy activity collection is Nocturne's merged read over heart rates, step counts, sleep
+    /// sessions and StateSpans. Its read permission carries the three dedicated categories; the
+    /// StateSpan half reads under treatments, which <c>api:treatments:read</c> grants separately.
+    /// </summary>
+    [Fact]
+    public void FromPermissions_ActivityRead_MapsToTheDedicatedActivityCategories()
+    {
+        var scopes = ScopeTranslator.FromPermissions(["api:activity:read"]);
+
+        Assert.Contains(OAuthScopes.HeartRateRead, scopes);
+        Assert.Contains(OAuthScopes.StepCountRead, scopes);
+        Assert.Contains(OAuthScopes.SleepRead, scopes);
+        Assert.DoesNotContain(OAuthScopes.TreatmentsRead, scopes);
+        Assert.DoesNotContain(OAuthScopes.GlucoseRead, scopes);
+    }
+
+    /// <summary>
+    /// The V1/V2/V3 controllers are gated by the HasPermissions policy, which rejects an empty
+    /// PermissionTrie before any scope check runs. A grant holding only a dedicated activity category
+    /// must therefore still produce a legacy permission string.
+    /// </summary>
+    [Theory]
+    [InlineData(OAuthScopes.HeartRateRead)]
+    [InlineData(OAuthScopes.StepCountRead)]
+    [InlineData(OAuthScopes.SleepRead)]
+    [InlineData(OAuthScopes.HeartRateReadWrite)]
+    [InlineData(OAuthScopes.StepCountReadWrite)]
+    [InlineData(OAuthScopes.SleepReadWrite)]
+    public void ToPermissions_ActivityCategories_MapBackToTheActivityCollection(string scope)
+    {
+        var permissions = ScopeTranslator.ToPermissions([scope]);
+
+        Assert.Contains("api:activity:read", permissions);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Authorization/TimeQueryStorageGateTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/TimeQueryStorageGateTests.cs
@@ -29,8 +29,6 @@ public class TimeQueryStorageGateTests
     [Theory]
     [InlineData("treatments")]
     [InlineData("devicestatus")]
-    [InlineData("profile")]
-    [InlineData("food")]
     public async Task Slice_RefusesACollectionOutsideTheGrant(string storage)
     {
         // A class-level OR of glucose|treatments|devices would admit this caller to
@@ -57,15 +55,23 @@ public class TimeQueryStorageGateTests
         result.Should().BeOfType<OkObjectResult>();
     }
 
-    [Fact]
-    public async Task Slice_RefusesAnUnknownCollection()
+    [Theory]
+    [InlineData("sensor_glucose")]
+    [InlineData("profile")]
+    [InlineData("food")]
+    public async Task Slice_RefusesACollectionItDoesNotServe(string storage)
     {
-        var (controller, service) = Build(OAuthScopes.FullAccess);
+        // Ahead of the scope gate, so the answer does not vary with the grant on a collection the
+        // route never served.
+        foreach (var scopes in new[] { new[] { OAuthScopes.FullAccess }, new[] { OAuthScopes.SleepRead } })
+        {
+            var (controller, service) = Build(scopes);
 
-        var result = await controller.GetSlicedData("sensor_glucose", "dateString");
+            var result = await controller.GetSlicedData(storage, "dateString");
 
-        result.Should().BeOfType<BadRequestObjectResult>();
-        service.VerifyNoOtherCalls();
+            result.Should().BeOfType<BadRequestObjectResult>(storage);
+            service.VerifyNoOtherCalls();
+        }
     }
 
     [Theory]

--- a/tests/Unit/Nocturne.API.Tests/Authorization/TimeQueryStorageGateTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/TimeQueryStorageGateTests.cs
@@ -1,8 +1,13 @@
+using System.Reflection;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using Nocturne.API.Attributes;
 using Nocturne.API.Controllers.V1;
 using Nocturne.Core.Contracts.Platform;
 using Nocturne.Core.Models;
@@ -12,12 +17,15 @@ using Xunit;
 namespace Nocturne.API.Tests.Authorization;
 
 /// <summary>
-/// Drives the actions, not the attribute set. The gate is a call inside the handler because the
-/// collection is a route or query value, so a scan for attributes cannot see it and a mapping test
-/// would still pass with the call deleted.
+/// Drives the actions rather than the attribute set. The <c>slice</c> and <c>echo</c> gates are
+/// calls inside the handler because the collection is a route or query value, so a scan for
+/// attributes cannot see them and a mapping test would still pass with the call deleted.
 /// </summary>
 public class TimeQueryStorageGateTests
 {
+    /// <summary>The collections <c>slice</c> dispatches to; the rest are rejected as bad input.</summary>
+    private static readonly string[] SliceableStorage = ["entries", "treatments", "devicestatus"];
+
     [Theory]
     [InlineData("treatments")]
     [InlineData("devicestatus")]
@@ -25,8 +33,8 @@ public class TimeQueryStorageGateTests
     [InlineData("food")]
     public async Task Slice_RefusesACollectionOutsideTheGrant(string storage)
     {
-        // A glucose-only grant reaching /api/v1/slice/treatments/... returned every treatment
-        // record while the route carried a class-level OR of glucose|treatments|devices.
+        // A class-level OR of glucose|treatments|devices would admit this caller to
+        // /api/v1/slice/treatments/... and every treatment record with it.
         var (controller, service) = Build(OAuthScopes.GlucoseRead);
 
         var result = await controller.GetSlicedData(storage, "dateString");
@@ -35,20 +43,18 @@ public class TimeQueryStorageGateTests
         service.VerifyNoOtherCalls();
     }
 
-    [Fact]
-    public async Task Slice_AllowsTheCollectionTheGrantCovers()
+    [Theory]
+    [InlineData("entries", OAuthScopes.GlucoseRead)]
+    [InlineData("treatments", OAuthScopes.TreatmentsRead)]
+    [InlineData("devicestatus", OAuthScopes.DevicesRead)]
+    public async Task Slice_AllowsTheCollectionTheGrantCovers(string storage, string scope)
     {
-        var (controller, service) = Build(OAuthScopes.GlucoseRead);
-        service
-            .Setup(s => s.ExecuteSliceQueryAsync(
-                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(),
-                It.IsAny<string?>(), It.IsAny<Dictionary<string, object>?>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync([]);
+        var (controller, service) = Build(scope);
+        StubSlice(service);
 
-        var result = await controller.GetSlicedData("entries", "dateString");
+        var result = await controller.GetSlicedData(storage, "dateString");
 
-        result.Should().NotBeOfType<ObjectResult>();
+        result.Should().BeOfType<OkObjectResult>();
     }
 
     [Fact]
@@ -78,22 +84,75 @@ public class TimeQueryStorageGateTests
     }
 
     [Fact]
-    public async Task FullAccess_ReadsEveryCollection()
+    public async Task FullAccess_ReadsEverySliceableCollection()
     {
         var (controller, service) = Build(OAuthScopes.FullAccess);
+        StubSlice(service);
+
+        foreach (var storage in SliceableStorage)
+        {
+            var result = await controller.GetSlicedData(storage, "dateString");
+            result.Should().BeOfType<OkObjectResult>(storage);
+        }
+    }
+
+    /// <summary>
+    /// The <c>times</c> actions take no collection selector — the internal call hardcodes
+    /// <c>entries</c> — so their gate is an attribute rather than a call in the handler, and the
+    /// category it names has to be the one they actually read.
+    /// </summary>
+    [Theory]
+    [InlineData(nameof(TimeQueryController.GetTimeBasedEntries))]
+    [InlineData(nameof(TimeQueryController.GetTimeBasedEntriesWithPrefix))]
+    [InlineData(nameof(TimeQueryController.GetTimeBasedEntriesWithPrefixAndRegex))]
+    public void Times_RequiresGlucoseRead(string actionName)
+    {
+        var action = typeof(TimeQueryController).GetMethod(actionName, BindingFlags.Public | BindingFlags.Instance);
+        action.Should().NotBeNull();
+
+        var required = action!.GetCustomAttributes<RequireScopeAttribute>()
+            .SelectMany(a => a.RequiredScopes)
+            .ToArray();
+
+        required.Should().Equal(OAuthScopes.GlucoseRead);
+    }
+
+    /// <summary>
+    /// Runs the attributes the action actually carries against a grant holding no glucose scope.
+    /// The scopes are ones that do not expand to glucose; <c>health.read</c> does, so a grant
+    /// carrying it reads entries legitimately.
+    /// </summary>
+    [Theory]
+    [InlineData(nameof(TimeQueryController.GetTimeBasedEntriesWithPrefix))]
+    [InlineData(nameof(TimeQueryController.GetTimeBasedEntriesWithPrefixAndRegex))]
+    public void Times_RefusesAGrantWithoutGlucose(string actionName)
+    {
+        var action = typeof(TimeQueryController).GetMethod(actionName, BindingFlags.Public | BindingFlags.Instance)!;
+        var attributes = action.GetCustomAttributes<RequireScopeAttribute>().ToArray();
+        attributes.Should().NotBeEmpty();
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["AuthContext"] = new AuthContext { IsAuthenticated = true };
+        httpContext.Items["GrantedScopes"] = OAuthScopes.Normalize(
+            [OAuthScopes.SleepRead, OAuthScopes.ReportsRead]);
+
+        var filterContext = new AuthorizationFilterContext(
+            new ActionContext(httpContext, new RouteData(), new ActionDescriptor()),
+            new List<IFilterMetadata>());
+
+        foreach (var attribute in attributes)
+            attribute.OnAuthorization(filterContext);
+
+        filterContext.Result.Should().BeOfType<ForbidResult>();
+    }
+
+    private static void StubSlice(Mock<ITimeQueryService> service) =>
         service
             .Setup(s => s.ExecuteSliceQueryAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(),
                 It.IsAny<string?>(), It.IsAny<Dictionary<string, object>?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
-
-        foreach (var storage in new[] { "entries", "treatments", "devicestatus", "profile", "food" })
-        {
-            var result = await controller.GetSlicedData(storage, "dateString");
-            result.Should().NotBeOfType<ObjectResult>(storage);
-        }
-    }
 
     private static void Refused(ActionResult result) =>
         result.Should().BeOfType<ObjectResult>()

--- a/tests/Unit/Nocturne.API.Tests/Authorization/TimeQueryStorageGateTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/TimeQueryStorageGateTests.cs
@@ -1,0 +1,117 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Controllers.V1;
+using Nocturne.Core.Contracts.Platform;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
+using Xunit;
+
+namespace Nocturne.API.Tests.Authorization;
+
+/// <summary>
+/// Drives the actions, not the attribute set. The gate is a call inside the handler because the
+/// collection is a route or query value, so a scan for attributes cannot see it and a mapping test
+/// would still pass with the call deleted.
+/// </summary>
+public class TimeQueryStorageGateTests
+{
+    [Theory]
+    [InlineData("treatments")]
+    [InlineData("devicestatus")]
+    [InlineData("profile")]
+    [InlineData("food")]
+    public async Task Slice_RefusesACollectionOutsideTheGrant(string storage)
+    {
+        // A glucose-only grant reaching /api/v1/slice/treatments/... returned every treatment
+        // record while the route carried a class-level OR of glucose|treatments|devices.
+        var (controller, service) = Build(OAuthScopes.GlucoseRead);
+
+        var result = await controller.GetSlicedData(storage, "dateString");
+
+        Refused(result);
+        service.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Slice_AllowsTheCollectionTheGrantCovers()
+    {
+        var (controller, service) = Build(OAuthScopes.GlucoseRead);
+        service
+            .Setup(s => s.ExecuteSliceQueryAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<string?>(), It.IsAny<Dictionary<string, object>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var result = await controller.GetSlicedData("entries", "dateString");
+
+        result.Should().NotBeOfType<ObjectResult>();
+    }
+
+    [Fact]
+    public async Task Slice_RefusesAnUnknownCollection()
+    {
+        var (controller, service) = Build(OAuthScopes.FullAccess);
+
+        var result = await controller.GetSlicedData("sensor_glucose", "dateString");
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+        service.VerifyNoOtherCalls();
+    }
+
+    [Theory]
+    [InlineData("treatments")]
+    [InlineData("devicestatus")]
+    public void TimesEcho_RefusesACollectionOutsideTheGrant(string storage)
+    {
+        // The echo variants take the collection as a query value and reach the same service.
+        var (controller, service) = Build(OAuthScopes.GlucoseRead);
+
+        var result = controller.GetTimeQueryEchoWithPrefix("2026-07", storage: storage);
+
+        result.Result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        service.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task FullAccess_ReadsEveryCollection()
+    {
+        var (controller, service) = Build(OAuthScopes.FullAccess);
+        service
+            .Setup(s => s.ExecuteSliceQueryAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<string?>(), It.IsAny<Dictionary<string, object>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        foreach (var storage in new[] { "entries", "treatments", "devicestatus", "profile", "food" })
+        {
+            var result = await controller.GetSlicedData(storage, "dateString");
+            result.Should().NotBeOfType<ObjectResult>(storage);
+        }
+    }
+
+    private static void Refused(ActionResult result) =>
+        result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+
+    private static (TimeQueryController Controller, Mock<ITimeQueryService> Service) Build(
+        params string[] grantedScopes)
+    {
+        var service = new Mock<ITimeQueryService>(MockBehavior.Loose);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["GrantedScopes"] = OAuthScopes.Normalize(grantedScopes);
+
+        var controller = new TimeQueryController(service.Object, NullLogger<TimeQueryController>.Instance)
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext },
+        };
+
+        return (controller, service);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/ActivityControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/ActivityControllerTests.cs
@@ -39,11 +39,27 @@ public class ActivityControllerTests
         // Set up HttpContext for the controller
         var httpContext = new DefaultHttpContext();
         _controller.ControllerContext = new ControllerContext() { HttpContext = httpContext };
+
+        // Default read classification: a regular StateSpan-backed activity, read under treatments.
+        // Tests that exercise a dedicated category override this per record.
+        _mockActivityDecomposer
+            .Setup(d => d.RequiredReadScope(It.IsAny<Activity>()))
+            .Returns(OAuthScopes.TreatmentsRead);
+        GrantScopes(OAuthScopes.TreatmentsRead);
     }
 
     /// <summary>Populates the request's granted scopes, as the auth middleware does at runtime.</summary>
     private void GrantScopes(params string[] scopes) =>
         _controller.HttpContext.Items["GrantedScopes"] = (IReadOnlySet<string>)new HashSet<string>(scopes);
+
+    /// <summary>
+    /// Classifies each activity's read scope by its <see cref="Activity.Type"/>, standing in for the
+    /// real decomposer's routing.
+    /// </summary>
+    private void ClassifyReadScopesByType(Dictionary<string, string> typeToReadScope) =>
+        _mockActivityDecomposer
+            .Setup(d => d.RequiredReadScope(It.IsAny<Activity>()))
+            .Returns((Activity a) => typeToReadScope.GetValueOrDefault(a.Type ?? "", OAuthScopes.TreatmentsRead));
 
     [Fact]
     public async Task GetActivities_WhenActivitiesExist_ShouldReturnActivities()
@@ -188,6 +204,102 @@ public class ActivityControllerTests
         // Assert
         result.Should().NotBeNull();
         result.Result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    /// <summary>
+    /// The merged activity read serves four storages. A caller holding one category must see that
+    /// category and nothing else, which is the cross-category read the per-action scope gate on its
+    /// own could not close.
+    /// </summary>
+    [Fact]
+    public async Task GetActivities_HeartRateOnlyGrant_ReturnsOnlyHeartRateRecords()
+    {
+        var merged = new List<Activity>
+        {
+            new() { Id = "hr", Type = "HeartRate", Mills = 4 },
+            new() { Id = "sc", Type = "StepCount", Mills = 3 },
+            new() { Id = "sleep", Type = "Sleep", Mills = 2 },
+            new() { Id = "ex", Type = "Exercise", Mills = 1 },
+        };
+        ClassifyReadScopesByType(new()
+        {
+            ["HeartRate"] = OAuthScopes.HeartRateRead,
+            ["StepCount"] = OAuthScopes.StepCountRead,
+            ["Sleep"] = OAuthScopes.SleepRead,
+            ["Exercise"] = OAuthScopes.TreatmentsRead,
+        });
+        GrantScopes(OAuthScopes.HeartRateRead);
+        _mockActivityService
+            .Setup(x => x.GetActivitiesAsync(It.IsAny<string?>(), 10, 0, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(merged);
+
+        var result = await _controller.GetActivities(cancellationToken: CancellationToken.None);
+
+        var returned = (result.Result as OkObjectResult)!.Value as List<Activity>;
+        returned!.Select(a => a.Id).Should().Equal("hr");
+    }
+
+    [Fact]
+    public async Task GetActivities_TreatmentsOnlyGrant_DropsHeartRateStepsAndSleep()
+    {
+        var merged = new List<Activity>
+        {
+            new() { Id = "hr", Type = "HeartRate", Mills = 4 },
+            new() { Id = "sc", Type = "StepCount", Mills = 3 },
+            new() { Id = "sleep", Type = "Sleep", Mills = 2 },
+            new() { Id = "ex", Type = "Exercise", Mills = 1 },
+        };
+        ClassifyReadScopesByType(new()
+        {
+            ["HeartRate"] = OAuthScopes.HeartRateRead,
+            ["StepCount"] = OAuthScopes.StepCountRead,
+            ["Sleep"] = OAuthScopes.SleepRead,
+            ["Exercise"] = OAuthScopes.TreatmentsRead,
+        });
+        GrantScopes(OAuthScopes.TreatmentsRead);
+        _mockActivityService
+            .Setup(x => x.GetActivitiesAsync(It.IsAny<string?>(), 10, 0, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(merged);
+
+        var result = await _controller.GetActivities(cancellationToken: CancellationToken.None);
+
+        var returned = (result.Result as OkObjectResult)!.Value as List<Activity>;
+        returned!.Select(a => a.Id).Should().Equal("ex");
+    }
+
+    /// <summary>
+    /// A record whose category the caller does not hold answers 404, the same as a record that does
+    /// not exist, so the response does not disclose the record.
+    /// </summary>
+    [Fact]
+    public async Task GetActivity_RecordInUnheldCategory_ReturnsNotFound()
+    {
+        var activityId = "hr-1";
+        ClassifyReadScopesByType(new() { ["HeartRate"] = OAuthScopes.HeartRateRead });
+        GrantScopes(OAuthScopes.TreatmentsRead);
+        _mockActivityService
+            .Setup(x => x.GetActivityByIdAsync(activityId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Activity { Id = activityId, Type = "HeartRate", Mills = 1 });
+
+        var result = await _controller.GetActivity(activityId, CancellationToken.None);
+
+        result.Result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetActivity_RecordInHeldCategory_IsReturned()
+    {
+        var activityId = "hr-1";
+        var record = new Activity { Id = activityId, Type = "HeartRate", Mills = 1 };
+        ClassifyReadScopesByType(new() { ["HeartRate"] = OAuthScopes.HeartRateRead });
+        GrantScopes(OAuthScopes.HeartRateRead);
+        _mockActivityService
+            .Setup(x => x.GetActivityByIdAsync(activityId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(record);
+
+        var result = await _controller.GetActivity(activityId, CancellationToken.None);
+
+        (result.Result as OkObjectResult)!.Value.Should().BeEquivalentTo(record);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V1/CountControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V1/CountControllerTests.cs
@@ -11,6 +11,7 @@ using Nocturne.Core.Contracts.Repositories;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Xunit;
+using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.API.Tests.Controllers.V1;
 
@@ -49,10 +50,33 @@ public class CountControllerTests
             _mockLogger.Object
         );
 
-        _controller.ControllerContext = new ControllerContext
-        {
-            HttpContext = new DefaultHttpContext(),
-        };
+        // CountGeneric resolves the required scope from the storage selector, so these delegation
+        // tests need a scope set. Full access keeps them about delegation;
+        // CountGeneric_RefusesAStorageOutsideTheGrant covers the refusal.
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["GrantedScopes"] = OAuthScopes.Normalize([OAuthScopes.FullAccess]);
+
+        _controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+    }
+
+    [Fact]
+    public async Task CountGeneric_RefusesAStorageOutsideTheGrant()
+    {
+        // The route serves five collections, so an attribute could only OR across them and would
+        // let a glucose-only grant learn a treatment row count.
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["GrantedScopes"] = OAuthScopes.Normalize([OAuthScopes.GlucoseRead]);
+        _controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+        var refused = await _controller.CountGeneric("treatments");
+
+        refused.Result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        _mockTreatmentStore.Verify(
+            s => s.CountAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        var allowed = await _controller.CountGeneric("entries");
+        allowed.Result.Should().NotBeOfType<ObjectResult>();
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V1/V1AuthenticationRegressionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V1/V1AuthenticationRegressionTests.cs
@@ -62,6 +62,9 @@ public class V1AuthenticationRegressionTests : IClassFixture<AuthenticationTestF
     [InlineData("/api/v1/activity")]
     [InlineData("/api/v1/count/activity/where")]
     [InlineData("/api/v1/adminnotifies")]
+    [InlineData("/api/v1/times/2026-07")]
+    [InlineData("/api/v1/times/2026-07/T13")]
+    [InlineData("/api/v1/slice/entries/dateString")]
     public async Task V1_GetEndpoints_OnBareHost_RejectUnauthenticatedRequests(string endpoint)
     {
         // Act
@@ -83,6 +86,9 @@ public class V1AuthenticationRegressionTests : IClassFixture<AuthenticationTestF
     [InlineData("/api/v1/activity")]
     [InlineData("/api/v1/count/activity/where")]
     [InlineData("/api/v1/adminnotifies")]
+    [InlineData("/api/v1/times/2026-07")]
+    [InlineData("/api/v1/times/2026-07/T13")]
+    [InlineData("/api/v1/slice/entries/dateString")]
     public async Task V1_GetEndpoints_WithValidApiSecret_AreAccessible(string endpoint)
     {
         // Act

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V1/V1AuthenticationRegressionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V1/V1AuthenticationRegressionTests.cs
@@ -60,6 +60,7 @@ public class V1AuthenticationRegressionTests : IClassFixture<AuthenticationTestF
     [InlineData("/api/v1/profile")]
     [InlineData("/api/v1/profile/current")]
     [InlineData("/api/v1/activity")]
+    [InlineData("/api/v1/count/activity/where")]
     [InlineData("/api/v1/adminnotifies")]
     public async Task V1_GetEndpoints_OnBareHost_RejectUnauthenticatedRequests(string endpoint)
     {
@@ -80,6 +81,7 @@ public class V1AuthenticationRegressionTests : IClassFixture<AuthenticationTestF
     [InlineData("/api/v1/profile")]
     [InlineData("/api/v1/profile/current")]
     [InlineData("/api/v1/activity")]
+    [InlineData("/api/v1/count/activity/where")]
     [InlineData("/api/v1/adminnotifies")]
     public async Task V1_GetEndpoints_WithValidApiSecret_AreAccessible(string endpoint)
     {

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/SelfServiceTenantCreationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/SelfServiceTenantCreationTests.cs
@@ -1,0 +1,97 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Moq;
+using Nocturne.API.Configuration;
+using Nocturne.API.Controllers.V4;
+using Nocturne.API.Controllers.V4.Identity;
+using Nocturne.API.Multitenancy;
+using Nocturne.API.Services.Identity;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.Authorization;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4;
+
+/// <summary>
+/// Both tenantless tenant-creation endpoints are bare <c>[Authorize]</c>, so any subject that
+/// reached an authenticated state — including one who only accepted an invite to someone else's
+/// tenant — reaches them. <c>OperatorConfiguration.AllowSelfServiceCreation</c> is the only gate,
+/// so it must be honoured by BOTH and must fail closed. Operators that gate tenant creation behind
+/// billing set <c>Operator__AllowSelfServiceCreation=false</c>.
+/// </summary>
+public class SelfServiceTenantCreationTests
+{
+    private static ControllerContext AuthenticatedContext()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["AuthContext"] = new AuthContext
+        {
+            IsAuthenticated = true,
+            SubjectId = Guid.NewGuid(),
+        };
+        return new ControllerContext { HttpContext = httpContext };
+    }
+
+    private static PlatformController Platform(bool allowSelfService)
+    {
+        var tenantService = new Mock<ITenantService>(MockBehavior.Strict);
+        return new PlatformController(
+            tenantService.Object,
+            Options.Create(new OperatorConfiguration { AllowSelfServiceCreation = allowSelfService }),
+            Options.Create(new BaseDomainOptions()))
+        {
+            ControllerContext = AuthenticatedContext(),
+        };
+    }
+
+    private static MyTenantsController MyTenants(bool allowSelfService)
+    {
+        var tenantService = new Mock<ITenantService>(MockBehavior.Strict);
+        var overviewService = new Mock<ITenantOverviewService>(MockBehavior.Strict);
+        return new MyTenantsController(
+            tenantService.Object,
+            overviewService.Object,
+            Options.Create(new OperatorConfiguration { AllowSelfServiceCreation = allowSelfService }))
+        {
+            ControllerContext = AuthenticatedContext(),
+        };
+    }
+
+    [Fact]
+    public async Task PlatformTenantCreation_IsForbiddenWhenSelfServiceIsDisabled()
+    {
+        // MockBehavior.Strict on ITenantService also proves the deny happens before any
+        // slug validation or tenant write is attempted.
+        var result = await Platform(allowSelfService: false)
+            .CreateTenant(new CreatePlatformTenantRequest("mine", "Mine"), default);
+
+        result.Should().BeOfType<ForbidResult>();
+    }
+
+    [Fact]
+    public async Task MyTenantsCreation_IsForbiddenWhenSelfServiceIsDisabled()
+    {
+        var result = await MyTenants(allowSelfService: false)
+            .CreateTenant(new CreateMyTenantRequest("mine", "Mine"), default);
+
+        result.Should().BeOfType<ForbidResult>();
+    }
+
+    [Fact]
+    public void SelfServiceCreation_DefaultsToEnabledForSelfHosters()
+    {
+        // Nocturne is self-hosted by individuals, for whom creating their own tenant IS the
+        // expected flow. SaaS operators turn it off via configuration.
+        new OperatorConfiguration().AllowSelfServiceCreation.Should().BeTrue();
+    }
+
+    [Fact]
+    public void OperatorSectionName_IsTheRootLevelSectionTheEnvVarDependsOn()
+    {
+        // Operator__AllowSelfServiceCreation=false is the documented deployment override, which is
+        // only correct while the bound section stays a single root-level "Operator".
+        OperatorConfiguration.SectionName.Should().Be("Operator");
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Middleware/SiteSecurityMiddlewareTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/SiteSecurityMiddlewareTests.cs
@@ -41,6 +41,27 @@ public sealed class SiteSecurityMiddlewareTests
         ctx.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
     }
 
+    [Theory]
+    [InlineData("/api/v4/platform/tls-authorizeanything")]
+    [InlineData("/api/v4/platform/tls-authorize-evil")]
+    [InlineData("/api/v4/platform/tls-authorize/../entries")]
+    public async Task Paths_that_only_share_the_tls_authorize_prefix_are_not_allowlisted(string path)
+    {
+        // The allowlist entry matches the exact route; a StartsWith would let any path with
+        // this prefix through lockdown.
+        var nextCalled = false;
+        var mw = Build(_ => { nextCalled = true; return Task.CompletedTask; });
+
+        var ctx = new DefaultHttpContext();
+        ctx.Response.Body = new MemoryStream();
+        ctx.Request.Path = path;
+
+        await mw.InvokeAsync(ctx);
+
+        nextCalled.Should().BeFalse();
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
     [Fact]
     public async Task Protected_route_is_denied_under_lockdown_when_unauthenticated()
     {

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/ActivityDecomposerBatchTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/ActivityDecomposerBatchTests.cs
@@ -196,6 +196,71 @@ public class ActivityDecomposerBatchTests : IDisposable
 
     #endregion
 
+    #region RequiredReadScope
+
+    [Fact]
+    public void RequiredReadScope_HeartRate_ReturnsHeartRateRead()
+    {
+        _decomposer.RequiredReadScope(CreateHeartRateActivity("hr", 72))
+            .Should().Be(OAuthScopes.HeartRateRead);
+    }
+
+    [Fact]
+    public void RequiredReadScope_StepCount_ReturnsStepCountRead()
+    {
+        _decomposer.RequiredReadScope(CreateStepCountActivity("sc", 1500))
+            .Should().Be(OAuthScopes.StepCountRead);
+    }
+
+    [Theory]
+    [InlineData("sleep")]
+    [InlineData("nap")]
+    [InlineData("Sleep")]
+    public void RequiredReadScope_SleepType_ReturnsSleepRead(string type)
+    {
+        _decomposer.RequiredReadScope(CreateRegularActivity("s", type))
+            .Should().Be(OAuthScopes.SleepRead);
+    }
+
+    /// <summary>
+    /// Regular activities route to StateSpans, which the merged read serves under treatments. Unlike
+    /// the write scope this is never null: every record in the merged response needs a category to
+    /// be filtered on, so "no category" would mean "visible to anyone admitted".
+    /// </summary>
+    [Theory]
+    [InlineData("exercise")]
+    [InlineData("running")]
+    [InlineData("illness")]
+    [InlineData("travel")]
+    [InlineData("restaurant")]
+    public void RequiredReadScope_RegularActivity_ReturnsTreatmentsRead(string type)
+    {
+        _decomposer.RequiredReadScope(CreateRegularActivity("r", type))
+            .Should().Be(OAuthScopes.TreatmentsRead);
+    }
+
+    /// <summary>
+    /// The read scope must be the read counterpart of the write scope for the same record, so the
+    /// read gate and the write gate cannot classify a record into different categories.
+    /// </summary>
+    [Fact]
+    public void RequiredReadScope_IsTheReadCounterpartOfRequiredWriteScope()
+    {
+        foreach (var activity in new[]
+                 {
+                     CreateHeartRateActivity("hr", 72),
+                     CreateStepCountActivity("sc", 1500),
+                     CreateRegularActivity("s", "sleep"),
+                 })
+        {
+            var writeScope = _decomposer.RequiredWriteScope(activity);
+            _decomposer.RequiredReadScope(activity)
+                .Should().Be(OAuthScopes.ImpliedReadScope(writeScope!));
+        }
+    }
+
+    #endregion
+
     #region Helpers
 
     private static Activity CreateHeartRateActivity(string id, int bpm)


### PR DESCRIPTION
Six commits closing the legacy (v1/v2/v3) read plane, plus two anonymous endpoints.

## What was open

`origin/main` carries **no** `RequireScope` on `TimeQueryController` or `CountController`. Any caller with a non-empty resolved scope set reached `slice/{storage}/…`, `times/…`, `times/echo?storage=` and `count/{storage}/where` for every collection those routes serve, regardless of which categories their grant covered.

## Approach

A class- or action-level scope list is an OR across every collection a route can serve, so it would admit a caller holding one category to all of them. Where the collection is a route or query value it is resolved per request instead, through a new `LegacyStorageReadScopes`; where it is statically known the attribute is correct and is used, so the attribute scan can see it.

- `slice/{storage}/…` and `times/echo?storage=` — per-request resolution in the handler.
- `times/{prefix}` and `times/{prefix}/{regex}` — `[RequireScope(glucose.read)]`; they take no selector, `GetTimeBasedEntriesInternal` hardcodes `entries`.
- `count/{storage}/where` — same resolution, except `activity`, which merges four categories into one unfilterable number and so requires all four.
- An unclassified selector is refused rather than passed through, so adding a collection to a route without classifying it closes the route rather than opening it. `CountController`'s allow-list is asserted fully classified by a test.

Also: `isInternalOnlyApiPath` did not percent-decode, so `/api/v4/platform/%74ls-authorize` reached an endpoint the proxy is supposed to make internal-only. It now decodes per segment.

## Verification

Every gate was proven non-vacuous by reverting it and confirming failure — removing the three `times` attributes fails 6 tests; removing the decoding fails 5 vitest cases; adding an unclassified selector to the count allow-list fails the classification guard.

4548 API tests pass. Two failures are pre-existing and unrelated: `CacheIntegrationTests.CreateEntriesAsync_DecomposesToV4AndFiresEvents` (reproduced on the unmodified branch) and `ConnectorCursorResetJobServiceTests` (passes in isolation; the branch touches no connector files).

## Reviewed

An independent review of the final commit found the `%2F` doc claim was false (`.join("/")` refolds it), an orphaned XML doc introducing a `CS1587` warning, `CanRead` left production-dead while `RefuseRead` reimplemented it, and an unannounced change to `CountController`'s 400 body. All are fixed here. Note that rows added to `V1AuthenticationRegressionTests` pin the anonymous bare-host contract — they pass with or without the scope gate, and are not the regression test for it; that is `TimeQueryStorageGateTests`.

## Known, not addressed here

`GET /api/v1/times/echo?storage=profile` passes the gate and then 500s out of `TimeQueryService`, which advertises 5 storages to a route serving 3. Pre-existing on main.

https://claude.ai/code/session_01Wk3jH4N16htaBqGod2j7y8