### PR TITLE
build(glucose-chart): declare the repository the package publishes from

### DIFF
--- a/src/Web/packages/glucose-chart/package.json
+++ b/src/Web/packages/glucose-chart/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@nightscout/glucose-chart",
   "version": "0.4.1",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nightscout/nocturne.git",
+    "directory": "src/Web/packages/glucose-chart"
+  },
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
`publish-glucose-chart` has been failing on `main`:

```
[E403] 403 Forbidden - PUT https://npm.pkg.github.com/@nightscout%2fglucose-chart
       - Permission permission_denied: write_package
```

The job already grants `packages: write`, so this is not a workflow-permission problem. `glucose-chart/package.json` carries no `repository` field, and that field is what GitHub Packages uses to link an npm package to a repository — without it, a publish authenticated with `GITHUB_TOKEN` is denied.

`0.4.1` is therefore unpublished. The job's `npm view` guard skips only versions that already exist, so the next `main` build will retry it.

**If this does not fix it,** the package is linked to a different repository at the org level and only an admin can relink it — that would be worth knowing definitively, and this PR is what distinguishes the two cases.

No other workspace package sets `repository`, but none of the others publish; every `@nocturne/*` package is internal.

https://claude.ai/code/session_01Wk3jH4N16htaBqGod2j7y8