### PR TITLE
fix(nightscout): backfill full history even when another uploader is live

### DIFF
--- a/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
@@ -633,7 +633,7 @@ public class EntriesController : ControllerBase
             // Create entries in database
             var createdEntries = await _entryService.CreateEntriesAsync(
                 uniqueEntries,
-                cancellationToken
+                cancellationToken: cancellationToken
             );
             var createdArray = createdEntries.ToArray();
 
@@ -1186,7 +1186,7 @@ public class EntriesController : ControllerBase
             // Create entries in database synchronously
             var createdEntries = await _entryService.CreateEntriesAsync(
                 uniqueEntries,
-                cancellationToken
+                cancellationToken: cancellationToken
             );
 
             // Mark processing as completed

--- a/src/API/Nocturne.API/Controllers/V3/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/EntriesController.cs
@@ -251,7 +251,7 @@ public class EntriesController : BaseV3Controller<Entry>
             var processedEntry = _documentProcessingService.ProcessEntry(entry); // Save to database
             var createdEntries = await _entryService.CreateEntriesAsync(
                 new[] { processedEntry },
-                cancellationToken
+                cancellationToken: cancellationToken
             );
             var createdEntry = createdEntries.FirstOrDefault();
 
@@ -339,7 +339,7 @@ public class EntriesController : BaseV3Controller<Entry>
             // Save to database
             var createdEntries = await _entryService.CreateEntriesAsync(
                 processedEntries,
-                cancellationToken
+                cancellationToken: cancellationToken
             );
 
             _logger.LogDebug(

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/GlucosePublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/GlucosePublisher.cs
@@ -62,7 +62,7 @@ internal sealed class GlucosePublisher : IGlucosePublisher
         try
         {
             var entryList = entries.ToList();
-            await _entryService.CreateEntriesAsync(entryList, cancellationToken);
+            await _entryService.CreateEntriesAsync(entryList, origin, cancellationToken);
             await UpdateLastReadingAtAsync(cancellationToken);
             await _alertEvaluator.EvaluateAsync(cancellationToken);
             return true;

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/GlucosePublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/GlucosePublisher.cs
@@ -25,6 +25,7 @@ internal sealed class GlucosePublisher : IGlucosePublisher
 {
     private readonly IEntryService _entryService;
     private readonly ISensorGlucoseRepository _sensorGlucoseRepository;
+    private readonly IMeterGlucoseRepository _meterGlucoseRepository;
     private readonly IPatientDeviceStamper _patientDeviceStamper;
     private readonly IDbContextFactory<NocturneDbContext> _contextFactory;
     private readonly ITenantAccessor _tenantAccessor;
@@ -35,6 +36,7 @@ internal sealed class GlucosePublisher : IGlucosePublisher
     public GlucosePublisher(
         IEntryService entryService,
         ISensorGlucoseRepository sensorGlucoseRepository,
+        IMeterGlucoseRepository meterGlucoseRepository,
         IPatientDeviceStamper patientDeviceStamper,
         IDbContextFactory<NocturneDbContext> contextFactory,
         ITenantAccessor tenantAccessor,
@@ -44,6 +46,7 @@ internal sealed class GlucosePublisher : IGlucosePublisher
     {
         _entryService = entryService ?? throw new ArgumentNullException(nameof(entryService));
         _sensorGlucoseRepository = sensorGlucoseRepository ?? throw new ArgumentNullException(nameof(sensorGlucoseRepository));
+        _meterGlucoseRepository = meterGlucoseRepository ?? throw new ArgumentNullException(nameof(meterGlucoseRepository));
         _patientDeviceStamper = patientDeviceStamper ?? throw new ArgumentNullException(nameof(patientDeviceStamper));
         _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
         _tenantAccessor = tenantAccessor ?? throw new ArgumentNullException(nameof(tenantAccessor));
@@ -104,25 +107,20 @@ internal sealed class GlucosePublisher : IGlucosePublisher
         string source,
         CancellationToken cancellationToken = default)
     {
+        // The v1 entries collection spans CGM readings (sensor glucose) and manual BG
+        // checks (meter glucose), so the resume watermark is the latest of either —
+        // scoped to THIS source. Never fall back across sources: when another uploader
+        // is already writing glucose (e.g. Trio pushing directly while a Nightscout
+        // migration runs), a cross-source "current entry" mis-classifies the
+        // connector's first-ever sync as incremental and skips its full-history
+        // backfill.
         var sgTimestamp = await _sensorGlucoseRepository.GetLatestTimestampAsync(source, cancellationToken);
-        if (sgTimestamp.HasValue)
-            return sgTimestamp.Value;
+        var mgTimestamp = await _meterGlucoseRepository.GetLatestTimestampAsync(source, cancellationToken);
 
-        // Entry has no source column — only fall back for nightscout-connector.
-        if (source == DataSources.NightscoutConnector)
-        {
-            var entry = await _entryService.GetCurrentEntryAsync(cancellationToken);
-            if (entry == null)
-                return null;
+        if (sgTimestamp.HasValue && mgTimestamp.HasValue)
+            return sgTimestamp.Value > mgTimestamp.Value ? sgTimestamp.Value : mgTimestamp.Value;
 
-            if (entry.Date != default)
-                return entry.Date;
-
-            if (entry.Mills > 0)
-                return DateTimeOffset.FromUnixTimeMilliseconds(entry.Mills).UtcDateTime;
-        }
-
-        return null;
+        return sgTimestamp ?? mgTimestamp;
     }
 
     public async Task<DateTime?> GetLatestSensorGlucoseTimestampAsync(

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/GlucosePublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/GlucosePublisher.cs
@@ -1,7 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Nocturne.API.Services.Audit;
 using Nocturne.Connectors.Core.Interfaces;
-using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.Glucose;

--- a/src/API/Nocturne.API/Services/Glucose/EntryService.cs
+++ b/src/API/Nocturne.API/Services/Glucose/EntryService.cs
@@ -171,6 +171,7 @@ public class EntryService : IEntryService
     /// </remarks>
     public async Task<IEnumerable<Entry>> CreateEntriesAsync(
         IEnumerable<Entry> entries,
+        WriteOrigin origin = WriteOrigin.Live,
         CancellationToken cancellationToken = default)
     {
         var validEntries = entries
@@ -180,7 +181,7 @@ public class EntryService : IEntryService
         if (validEntries.Count == 0)
             return [];
 
-        await _decomposer.DecomposeBatchAsync(validEntries, WriteOrigin.Live, cancellationToken);
+        await _decomposer.DecomposeBatchAsync(validEntries, origin, cancellationToken);
 
         return validEntries;
     }

--- a/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
+++ b/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
@@ -614,6 +614,15 @@ internal class MigrationJob
         };
     }
 
+    /// <summary>
+    ///     Anchor for the first page of a collection fetch. Nightscout applies an implicit
+    ///     recency window (roughly the last four days) to any query carrying no date filter,
+    ///     which truncates an unbounded first page — the short page then ends pagination,
+    ///     silently importing days of history instead of years. Anchoring the upper bound
+    ///     keeps every request explicitly dated.
+    /// </summary>
+    private static DateTime FirstPageAnchor => DateTime.UtcNow;
+
     private async Task MigrateEntriesViaApiAsync(
         HttpClient httpClient,
         NocturneDbContext dbContext,
@@ -627,7 +636,7 @@ internal class MigrationJob
 
         var totalMigrated = 0L;
         var totalFailed = 0L;
-        DateTime? currentTo = null;
+        DateTime? currentTo = FirstPageAnchor;
         const int pageSize = 10000;
 
         using var scope = CreateTenantScope();
@@ -701,7 +710,7 @@ internal class MigrationJob
 
         var totalMigrated = 0L;
         var totalFailed = 0L;
-        DateTime? currentTo = null;
+        DateTime? currentTo = FirstPageAnchor;
         const int pageSize = 10000;
 
         using var scope = CreateTenantScope();
@@ -774,7 +783,7 @@ internal class MigrationJob
 
         var totalMigrated = 0L;
         var totalFailed = 0L;
-        DateTime? currentTo = null;
+        DateTime? currentTo = FirstPageAnchor;
         const int pageSize = 10000;
 
         using var scope = CreateTenantScope();
@@ -1010,7 +1019,7 @@ internal class MigrationJob
 
         var totalMigrated = 0L;
         var totalFailed = 0L;
-        DateTime? currentTo = null;
+        DateTime? currentTo = FirstPageAnchor;
         const int pageSize = 10000;
 
         using var scope = CreateTenantScope();

--- a/src/API/Nocturne.API/Services/Seeding/SampleDataSeeder.cs
+++ b/src/API/Nocturne.API/Services/Seeding/SampleDataSeeder.cs
@@ -151,7 +151,7 @@ public class SampleDataSeeder
 
             foreach (var batch in entries.Chunk(BatchSize))
             {
-                var created = await _entryService.CreateEntriesAsync(batch, ct);
+                var created = await _entryService.CreateEntriesAsync(batch, cancellationToken: ct);
                 entryCount += created.Count();
             }
 

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -119,12 +119,16 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(
+            // Do not swallow: a null watermark means "no prior data", which triggers an
+            // initial backfill — unbounded for connectors with a null InitialSyncFloor.
+            // A transient read failure must fail this cycle (retried next interval), not
+            // be amplified into a full-history recrawl and republish.
+            _logger.LogError(
                 ex,
                 "Failed to fetch latest entry timestamp for {ConnectorSource}",
                 ConnectorSource
             );
-            return null;
+            throw;
         }
     }
 
@@ -160,12 +164,14 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(
+            // See FetchLatestEntryTimestampAsync: a swallowed failure reads as "no prior
+            // data" and triggers an unbounded initial backfill for null-floor connectors.
+            _logger.LogError(
                 ex,
                 "Failed to fetch latest treatment timestamp for {ConnectorSource}",
                 ConnectorSource
             );
-            return null;
+            throw;
         }
     }
 

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
@@ -414,11 +414,22 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         return await FetchGlucoseDataRangeAsync(since, null);
     }
 
+    /// <summary>
+    ///     Upper bound for the first page of a paginated fetch. Nightscout applies an
+    ///     implicit recency window (roughly the last four days) to any query carrying no
+    ///     date filter at all, so a fully unbounded first page silently truncates a
+    ///     full-history backfill — the short page then reads as end-of-history to the
+    ///     pagination loop. Anchoring the bound to "now" keeps every request explicitly
+    ///     dated; requests that already carry a bound pass through unchanged.
+    /// </summary>
+    private static DateTime? AnchorUnboundedFetch(DateTime? from, DateTime? to) =>
+        from is null && to is null ? DateTime.UtcNow : to;
+
     protected override async Task<IEnumerable<Entry>> FetchGlucoseDataRangeAsync(
         DateTime? from, DateTime? to)
     {
         var allEntries = new List<Entry>();
-        var currentTo = to;
+        var currentTo = AnchorUnboundedFetch(from, to);
 
         while (true)
         {
@@ -475,7 +486,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         DateTime? from, DateTime? to)
     {
         var allTreatments = new List<Treatment>();
-        var currentTo = to;
+        var currentTo = AnchorUnboundedFetch(from, to);
 
         while (true)
         {
@@ -553,7 +564,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         DateTime? from, DateTime? to)
     {
         var allStatuses = new List<DeviceStatus>();
-        var currentTo = to;
+        var currentTo = AnchorUnboundedFetch(from, to);
 
         while (true)
         {
@@ -626,7 +637,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         DateTime? from, DateTime? to)
     {
         var allActivities = new List<Activity>();
-        var currentTo = to;
+        var currentTo = AnchorUnboundedFetch(from, to);
 
         while (true)
         {

--- a/src/Core/Nocturne.Core.Contracts/Glucose/IEntryService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Glucose/IEntryService.cs
@@ -1,3 +1,4 @@
+using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Models;
 
 namespace Nocturne.Core.Contracts.Glucose;
@@ -74,10 +75,15 @@ public interface IEntryService
     /// Create new entries with WebSocket broadcasting
     /// </summary>
     /// <param name="entries">Entries to create</param>
+    /// <param name="origin">
+    /// Write origin for the decomposed records. <see cref="WriteOrigin.Backfill"/> suppresses
+    /// the real-time broadcast so a historical import doesn't flood connected clients.
+    /// </param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Created entries with assigned IDs</returns>
     Task<IEnumerable<Entry>> CreateEntriesAsync(
         IEnumerable<Entry> entries,
+        WriteOrigin origin = WriteOrigin.Live,
         CancellationToken cancellationToken = default
     );
 

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V1/EntriesControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V1/EntriesControllerTests.cs
@@ -6,6 +6,7 @@ using Moq;
 using Nocturne.API.Controllers.V1;
 using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Contracts.Legacy;
+using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Contracts.Alerts;
 using Nocturne.Core.Models;
 using Xunit;
@@ -89,7 +90,7 @@ public class EntriesControllerTests
 
         _mockEntryService
             .Setup(x =>
-                x.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<CancellationToken>())
+                x.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>())
             )
             .ReturnsAsync(new[] { expectedProcessedEntry });
 
@@ -152,7 +153,7 @@ public class EntriesControllerTests
 
         _mockEntryService
             .Setup(x =>
-                x.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<CancellationToken>())
+                x.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>())
             )
             .ReturnsAsync(
                 new[]
@@ -219,7 +220,7 @@ public class EntriesControllerTests
 
         _mockEntryService
             .Setup(x =>
-                x.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<CancellationToken>())
+                x.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>())
             )
             .ReturnsAsync(
                 new[]
@@ -278,7 +279,7 @@ public class EntriesControllerTests
 
         _mockEntryService
             .Setup(x =>
-                x.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<CancellationToken>())
+                x.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>())
             )
             .ReturnsAsync(
                 new[]
@@ -333,7 +334,7 @@ public class EntriesControllerTests
 
         _mockEntryService
             .Setup(x =>
-                x.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<CancellationToken>())
+                x.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>())
             )
             .ReturnsAsync(
                 new[]
@@ -393,7 +394,7 @@ public class EntriesControllerTests
 
         _mockEntryService
             .Setup(x =>
-                x.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<CancellationToken>())
+                x.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>())
             )
             .ReturnsAsync(new[] { new Entry { Id = "created-id", Sgv = 120 } });
 

--- a/tests/Unit/Nocturne.API.Tests/Services/CacheIntegrationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/CacheIntegrationTests.cs
@@ -181,7 +181,7 @@ public class CacheIntegrationTests
         );
 
         // Act
-        var result = await entryService.CreateEntriesAsync(newEntries, CancellationToken.None);
+        var result = await entryService.CreateEntriesAsync(newEntries, cancellationToken: CancellationToken.None);
 
         // Assert
         Assert.NotNull(result);

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/GlucosePublisherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/GlucosePublisherTests.cs
@@ -52,14 +52,32 @@ public class GlucosePublisherTests
     {
         var entries = new List<Entry> { new() { Id = "1" } };
         _mockEntryService
-            .Setup(s => s.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(entries);
 
         var result = await _publisher.PublishEntriesAsync(entries, "test-source", WriteOrigin.Live);
 
         result.Should().BeTrue();
         _mockEntryService.Verify(
-            s => s.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<CancellationToken>()),
+            s => s.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task PublishEntriesAsync_ForwardsWriteOrigin_SoBackfillsDoNotBroadcastAsLive()
+    {
+        // Regression: the publisher dropped its origin, so a first-ever full-history import
+        // decomposed everything as Live — broadcasting years of entries to connected clients.
+        var entries = new List<Entry> { new() { Id = "1" } };
+        _mockEntryService
+            .Setup(s => s.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entries);
+
+        await _publisher.PublishEntriesAsync(entries, "test-source", WriteOrigin.Backfill);
+
+        _mockEntryService.Verify(
+            s => s.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), WriteOrigin.Backfill, It.IsAny<CancellationToken>()),
             Times.Once
         );
     }
@@ -68,7 +86,7 @@ public class GlucosePublisherTests
     public async Task PublishEntriesAsync_ReturnsFalse_OnException()
     {
         _mockEntryService
-            .Setup(s => s.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("test error"));
 
         var result = await _publisher.PublishEntriesAsync(new List<Entry>(), "test-source", WriteOrigin.Live);

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/GlucosePublisherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/GlucosePublisherTests.cs
@@ -23,6 +23,7 @@ public class GlucosePublisherTests
 {
     private readonly Mock<IEntryService> _mockEntryService;
     private readonly Mock<ISensorGlucoseRepository> _mockSensorGlucoseRepository;
+    private readonly Mock<IMeterGlucoseRepository> _mockMeterGlucoseRepository;
     private readonly Mock<IPatientDeviceStamper> _mockPatientDeviceStamper;
     private readonly GlucosePublisher _publisher;
 
@@ -30,11 +31,13 @@ public class GlucosePublisherTests
     {
         _mockEntryService = new Mock<IEntryService>();
         _mockSensorGlucoseRepository = new Mock<ISensorGlucoseRepository>();
+        _mockMeterGlucoseRepository = new Mock<IMeterGlucoseRepository>();
         _mockPatientDeviceStamper = new Mock<IPatientDeviceStamper>();
 
         _publisher = new GlucosePublisher(
             _mockEntryService.Object,
             _mockSensorGlucoseRepository.Object,
+            _mockMeterGlucoseRepository.Object,
             _mockPatientDeviceStamper.Object,
             Mock.Of<IDbContextFactory<NocturneDbContext>>(),
             Mock.Of<ITenantAccessor>(),
@@ -124,12 +127,12 @@ public class GlucosePublisherTests
     }
 
     [Fact]
-    public async Task GetLatestEntryTimestampAsync_ReturnsDate_WhenEntryHasDate()
+    public async Task GetLatestEntryTimestampAsync_ReturnsSensorTimestamp_WhenPresent()
     {
         var expectedDate = new DateTime(2026, 1, 15, 12, 0, 0, DateTimeKind.Utc);
-        _mockEntryService
-            .Setup(s => s.GetCurrentEntryAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Entry { Date = expectedDate });
+        _mockSensorGlucoseRepository
+            .Setup(r => r.GetLatestTimestampAsync(DataSources.NightscoutConnector, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedDate);
 
         var result = await _publisher.GetLatestEntryTimestampAsync(DataSources.NightscoutConnector);
 
@@ -137,27 +140,61 @@ public class GlucosePublisherTests
     }
 
     [Fact]
-    public async Task GetLatestEntryTimestampAsync_ReturnsMills_WhenDateIsDefault()
+    public async Task GetLatestEntryTimestampAsync_FallsBackToMeterTimestamp_ForManualBgOnlySource()
     {
-        var mills = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-        _mockEntryService
-            .Setup(s => s.GetCurrentEntryAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Entry { Mills = mills });
+        var meterDate = new DateTime(2026, 1, 15, 12, 0, 0, DateTimeKind.Utc);
+        _mockSensorGlucoseRepository
+            .Setup(r => r.GetLatestTimestampAsync(DataSources.NightscoutConnector, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DateTime?)null);
+        _mockMeterGlucoseRepository
+            .Setup(r => r.GetLatestTimestampAsync(DataSources.NightscoutConnector, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(meterDate);
 
         var result = await _publisher.GetLatestEntryTimestampAsync(DataSources.NightscoutConnector);
 
-        result.Should().Be(DateTimeOffset.FromUnixTimeMilliseconds(mills).UtcDateTime);
+        result.Should().Be(meterDate);
     }
 
     [Fact]
-    public async Task GetLatestEntryTimestampAsync_ReturnsNull_WhenNoEntry()
+    public async Task GetLatestEntryTimestampAsync_ReturnsLatestOfSensorAndMeter()
     {
+        var sensorDate = new DateTime(2026, 1, 15, 12, 0, 0, DateTimeKind.Utc);
+        var meterDate = new DateTime(2026, 1, 20, 8, 0, 0, DateTimeKind.Utc);
+        _mockSensorGlucoseRepository
+            .Setup(r => r.GetLatestTimestampAsync(DataSources.NightscoutConnector, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sensorDate);
+        _mockMeterGlucoseRepository
+            .Setup(r => r.GetLatestTimestampAsync(DataSources.NightscoutConnector, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(meterDate);
+
+        var result = await _publisher.GetLatestEntryTimestampAsync(DataSources.NightscoutConnector);
+
+        result.Should().Be(meterDate);
+    }
+
+    [Fact]
+    public async Task GetLatestEntryTimestampAsync_ReturnsNull_WhenSourceHasNoData_EvenIfAnotherSourceIsLive()
+    {
+        // Regression: a tenant migrating from Nightscout while their uploader (e.g. Trio)
+        // already pushes glucose directly. The connector has never written a row, so its
+        // watermark must be null — a cross-source fallback here made the first sync look
+        // incremental and permanently skipped the full-history backfill.
+        _mockSensorGlucoseRepository
+            .Setup(r => r.GetLatestTimestampAsync(DataSources.NightscoutConnector, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DateTime?)null);
+        _mockMeterGlucoseRepository
+            .Setup(r => r.GetLatestTimestampAsync(DataSources.NightscoutConnector, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DateTime?)null);
         _mockEntryService
             .Setup(s => s.GetCurrentEntryAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Entry?)null);
+            .ReturnsAsync(new Entry { Date = DateTime.UtcNow });
 
-        var result = await _publisher.GetLatestEntryTimestampAsync("test-source");
+        var result = await _publisher.GetLatestEntryTimestampAsync(DataSources.NightscoutConnector);
 
         result.Should().BeNull();
+        _mockEntryService.Verify(
+            s => s.GetCurrentEntryAsync(It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the watermark must never consult cross-source data");
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutConnectorPaginationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutConnectorPaginationTests.cs
@@ -236,6 +236,46 @@ public class NightscoutConnectorPaginationTests
     }
 
     [Fact]
+    public async Task FetchGlucoseData_UnboundedFetch_AnchorsFirstPageToNow()
+    {
+        // Regression: a query with no find[date] bound at all makes Nightscout apply an
+        // implicit recency window (~4 days), so an unbounded full-history backfill got a
+        // truncated first page that the short-page check read as end-of-history.
+        var handler = new SequentialMockHandler();
+        handler.Enqueue(JsonResponse(CreateEntries(5, BaseTime)));
+
+        var service = CreateService(handler);
+
+        var before = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        await service.FetchGlucoseDataAsync();
+        var after = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        var firstUrl = handler.RequestUrls[0];
+        firstUrl.Should().Contain("find[date][$lte]=",
+            "an unbounded fetch must carry an explicit upper bound so the source cannot window it");
+
+        var lte = long.Parse(System.Text.RegularExpressions.Regex
+            .Match(firstUrl, @"find\[date\]\[\$lte\]=(\d+)").Groups[1].Value);
+        lte.Should().BeInRange(before, after, "the anchor should be the moment of the fetch");
+    }
+
+    [Fact]
+    public async Task FetchGlucoseData_CatchUpWithSince_DoesNotAddUpperBound()
+    {
+        // A catch-up fetch (since set, no upper bound) must stay unbounded at the top so
+        // future-dated readings from a fast device clock are still picked up immediately.
+        var handler = new SequentialMockHandler();
+        handler.Enqueue(JsonResponse(CreateEntries(3, BaseTime)));
+
+        var service = CreateService(handler);
+
+        await service.FetchGlucoseDataAsync(BaseTime.AddHours(-1).UtcDateTime);
+
+        handler.RequestUrls[0].Should().Contain("find[date][$gte]=")
+            .And.NotContain("find[date][$lte]=");
+    }
+
+    [Fact]
     public async Task FetchGlucoseData_SetsDataSourceOnAllEntries()
     {
         var page1 = CreateEntries(MaxCount, BaseTime);
@@ -327,6 +367,38 @@ public class NightscoutConnectorPaginationTests
         result.ItemsSynced[Nocturne.Connectors.Core.Models.SyncDataType.Boluses]
             .Should().Be(MaxCount + 4,
                 "pagination must retrieve treatments across all pages");
+    }
+
+    [Fact]
+    public async Task FetchTreatments_OpenEndedInitialSync_AnchorsFirstPageToNow()
+    {
+        // Same implicit-window regression as glucose: an open-ended first-ever treatments
+        // sync (no watermark, no floor) must not issue a fully unbounded query.
+        var handler = new SequentialMockHandler();
+        handler.Enqueue(JsonResponse(Array.Empty<Entry>())); // auth check
+        handler.Enqueue(JsonResponse(CreateTreatments(3, BaseTime)));
+
+        var config = new NightscoutConnectorConfiguration
+        {
+            Url = "https://nightscout.example.com",
+            ApiSecret = "test-secret",
+            MaxCount = MaxCount,
+        };
+        var service = CreateService(handler, config, withPublisher: true);
+
+        var request = new Nocturne.Connectors.Core.Models.SyncRequest
+        {
+            From = null,
+            To = null,
+            DataTypes = [Nocturne.Connectors.Core.Models.SyncDataType.Boluses],
+        };
+
+        var result = await service.SyncDataAsync(request, config, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        var treatmentsUrl = handler.RequestUrls.First(u => u.Contains("treatments.json"));
+        treatmentsUrl.Should().Contain("find[created_at][$lte]=",
+            "an unbounded fetch must carry an explicit upper bound so the source cannot window it");
     }
 
     #endregion

--- a/tests/Unit/Nocturne.API.Tests/Services/Glucose/EntryServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Glucose/EntryServiceTests.cs
@@ -353,7 +353,7 @@ public class EntryServiceTests
         };
 
         // Act
-        var result = await _sut.CreateEntriesAsync(entries, CancellationToken.None);
+        var result = await _sut.CreateEntriesAsync(entries, cancellationToken: CancellationToken.None);
 
         // Assert
         Assert.Equal(2, result.Count());
@@ -388,7 +388,7 @@ public class EntryServiceTests
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _sut.CreateEntriesAsync(entries, CancellationToken.None));
+            () => _sut.CreateEntriesAsync(entries, cancellationToken: CancellationToken.None));
 
         _cache.Verify(x => x.InvalidateAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
@@ -407,7 +407,7 @@ public class EntryServiceTests
         };
 
         // Act
-        var result = await _sut.CreateEntriesAsync(entries, CancellationToken.None);
+        var result = await _sut.CreateEntriesAsync(entries, cancellationToken: CancellationToken.None);
 
         // Assert
         Assert.Single(result);
@@ -433,7 +433,7 @@ public class EntryServiceTests
         };
 
         // Act
-        var result = await _sut.CreateEntriesAsync(entries, CancellationToken.None);
+        var result = await _sut.CreateEntriesAsync(entries, cancellationToken: CancellationToken.None);
 
         // Assert — unknown types are silently filtered out (empty batch never decomposed)
         Assert.Empty(result);
@@ -455,7 +455,7 @@ public class EntryServiceTests
         };
 
         // Act
-        var result = await _sut.CreateEntriesAsync(entries, CancellationToken.None);
+        var result = await _sut.CreateEntriesAsync(entries, cancellationToken: CancellationToken.None);
 
         // Assert — only the two valid entries reach the batch decompose
         Assert.Equal(2, result.Count());


### PR DESCRIPTION
## The incident

A tenant migrating from a hosted Nightscout (Trio-based AID) ended up with **zero historical glucose and ~4 days of treatments**, while the connector reported healthy with no errors, no failed syncs, and no notifications. Their live data was fine — Trio was pushing directly — which is exactly what broke the import.

## Root causes (three, stacked)

**1. Cross-source glucose watermark.** `GlucosePublisher.GetLatestEntryTimestampAsync` fell back to the tenant's *current entry regardless of source* when the connector had no `sensor_glucose` rows. With Trio live, the connector's first-ever sync resolved a watermark of "just now", was classified as incremental, and requested `find[date][$gte]=<now-5min>` forever — the full-history backfill never ran. This fallback had already been narrowed twice (global → nightscout-only) for the same defect class between *connectors*; a direct uploader was the remaining case. The watermark is now strictly source-scoped: `max(sensor_glucose, meter_glucose)` for the connector's own `data_source`. The meter check keeps a manual-BG-only source resumable, which is what the old fallback existed for.

**2. Implicit recency window truncates unbounded first pages.** Nightscout applies a default window (~4 days) to any query with no date filter. An unbounded backfill first page came back short of `MaxCount`, and the pagination loop read that as end-of-history. Verified against the live source: unbounded `entries.json?count=1000` returned 822 rows (exactly now−4d); the same query with `find[date][$lte]` returned a full 1000 reaching further back. Unbounded fetches now anchor their upper bound to "now" (`AnchorUnboundedFetch`) in all four paginated loops; catch-up fetches (`from` set) keep an open top so future-dated readings from fast device clocks still arrive immediately.

**3. The migration wizard had the same unbounded first page.** All four of `MigrationJobService`'s API-mode collection fetchers started with `currentTo = null`, so a wizard "full import" silently brought over ~4 days and reported success. They now anchor too.

## Review follow-ups included

- `PublishEntriesAsync` dropped its `WriteOrigin`, so the newly-working full-history import would have decomposed everything as **Live** — broadcasting years of entries to connected clients. `CreateEntriesAsync` now takes the origin (default `Live`; v1/v3 upload paths unchanged) and the publisher forwards it, so the repository chokepoint suppresses Backfill broadcasts as designed.
- The entry/treatment watermark fetchers swallowed exceptions into `null`, which reads as "no prior data" — previously ~4 wasted days, now a full recrawl. A transient watermark read failure now fails the sync cycle (surfaced in connector health, retried next interval) instead.

## Known limitations (deliberately not in this PR)

- Legacy NS compares `created_at` bounds lexicographically; documents stored with positive-UTC-offset strings (some very old uploaders) can compare greater than the Z-formatted anchor and stay outside a backfill. Entries use numeric mills and are immune.
- `Tools.Connect` dry-run calls `FetchGlucoseDataAsync()` unbounded and will now crawl full history per iteration; worth a cap if the dry-run tool sees use.
- `FetchGlucoseDataRangeAsync` accumulates the whole history in memory before publishing; a decade of CGM is ~1M entries. Streaming per-page like `MigrationJobService` would be the fix.
- The integration-test mock Nightscout ignores query strings, so it can't simulate the implicit window; the regression is pinned by unit tests asserting the anchored `$lte` on first pages.

## Tests

- `GetLatestEntryTimestampAsync_ReturnsNull_WhenSourceHasNoData_EvenIfAnotherSourceIsLive` — pins the watermark regression, asserts the cross-source path is never consulted.
- Sensor/meter watermark max + manual-BG-only fallback.
- Anchored `$lte` within `[before, after]` on unbounded glucose fetches; treatments equivalent via `SyncDataAsync`; catch-up fetches stay open-topped.
- `PublishEntriesAsync_ForwardsWriteOrigin_SoBackfillsDoNotBroadcastAsLive`.
- Full `Nocturne.API.Tests`: 4541 passed. Connectors Core/MyLife/Tandem suites green.

https://claude.ai/code/session_01L2UR4WFuTactp8EEf6NcWr
