### PR TITLE
feat(jobs): persist migration and cursor-reset job records across restarts

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/ConnectorAdminController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/ConnectorAdminController.cs
@@ -104,11 +104,11 @@ public class ConnectorAdminController : ControllerBase
     [RemoteQuery]
     [ProducesResponseType(typeof(ConnectorResetJobStatus), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public ActionResult<ConnectorResetJobStatus> GetResetJobStatus(Guid jobId)
+    public async Task<ActionResult<ConnectorResetJobStatus>> GetResetJobStatus(Guid jobId, CancellationToken ct)
     {
         try
         {
-            return Ok(_resetJobService.GetStatus(jobId));
+            return Ok(await _resetJobService.GetStatusAsync(jobId, ct));
         }
         catch (KeyNotFoundException)
         {
@@ -125,11 +125,11 @@ public class ConnectorAdminController : ControllerBase
     [RemoteCommand(Invalidates = ["GetResetJobStatus"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public IActionResult CancelResetJob(Guid jobId)
+    public async Task<IActionResult> CancelResetJob(Guid jobId, CancellationToken ct)
     {
         try
         {
-            _resetJobService.Cancel(jobId);
+            await _resetJobService.CancelAsync(jobId, ct);
             return NoContent();
         }
         catch (KeyNotFoundException)

--- a/src/API/Nocturne.API/Controllers/V4/TenantAdmin/MigrationController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/TenantAdmin/MigrationController.cs
@@ -188,7 +188,7 @@ public class MigrationController : ControllerBase
     [ProducesResponseType(typeof(IReadOnlyList<MigrationSourceDto>), StatusCodes.Status200OK)]
     public async Task<ActionResult<IReadOnlyList<MigrationSourceDto>>> GetSources(CancellationToken ct)
     {
-        var sources = await _migrationService.GetSourcesAsync(ct);
+        var sources = await _migrationService.GetSourcesAsync(_tenantAccessor.TenantId, ct);
         return Ok(sources);
     }
 }

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -588,6 +588,10 @@ if (!isNSwagGeneration && !app.Environment.IsEnvironment("Testing"))
         // Apply the per-category public-share RLS policies, derived from the C# category map,
         // so they cannot drift from the code. Runs under the migrator role like migrations.
         await DatabaseInitializationExtensions.ReconcileShareRlsPoliciesAsync(migratorConnectionString, logger);
+
+        // Background job records left Pending/Running by a previous process are orphans —
+        // the detached tasks died with it. Mark them Interrupted so polls report the truth.
+        await DatabaseInitializationExtensions.MarkInterruptedJobsAsync(migratorConnectionString, logger);
     }
 
     // Validate RLS, ownership, default privileges, and NoResetOnClose under the app role.

--- a/src/API/Nocturne.API/Services/Connectors/ConnectorCursorResetJobService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/ConnectorCursorResetJobService.cs
@@ -1,6 +1,9 @@
 using System.Collections.Concurrent;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Nocturne.Connectors.Core.Models;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
 
 namespace Nocturne.API.Services.Connectors;
 
@@ -35,13 +38,16 @@ public interface IConnectorCursorResetJobService
         List<SyncDataType>? dataTypes,
         CancellationToken ct);
 
-    /// <summary>Returns a snapshot of a job's progress.</summary>
+    /// <summary>
+    /// Returns a snapshot of a job's progress — live from memory while the job runs, from the
+    /// persisted record when the job is no longer in memory (e.g. after an API restart).
+    /// </summary>
     /// <exception cref="KeyNotFoundException">Thrown when no job with that id exists.</exception>
-    ConnectorResetJobStatus GetStatus(Guid jobId);
+    Task<ConnectorResetJobStatus> GetStatusAsync(Guid jobId, CancellationToken ct = default);
 
     /// <summary>Requests cancellation of a running job.</summary>
     /// <exception cref="KeyNotFoundException">Thrown when no job with that id exists.</exception>
-    void Cancel(Guid jobId);
+    Task CancelAsync(Guid jobId, CancellationToken ct = default);
 }
 
 /// <inheritdoc cref="IConnectorCursorResetJobService"/>
@@ -96,6 +102,11 @@ public class ConnectorCursorResetJobService : IConnectorCursorResetJobService
             _serviceProvider);
         _jobs[jobId] = job;
 
+        // Record the job before the work starts. The in-process task cannot survive an API
+        // restart, but its record must — otherwise a restart mid-run leaves the operator
+        // polling a 404 with no way to tell "never existed" from "killed partway".
+        await job.PersistSnapshotAsync(ct);
+
         // Detached background task: deliberately uses CancellationToken.None, not the request token,
         // so the reset outlives the HTTP request that started it. User-initiated cancellation flows
         // through the job's own CancellationTokenSource via Cancel().
@@ -121,25 +132,43 @@ public class ConnectorCursorResetJobService : IConnectorCursorResetJobService
     }
 
     /// <inheritdoc />
-    public ConnectorResetJobStatus GetStatus(Guid jobId)
+    public async Task<ConnectorResetJobStatus> GetStatusAsync(Guid jobId, CancellationToken ct = default)
     {
         if (_jobs.TryGetValue(jobId, out var job))
             return job.GetStatus();
 
-        throw new KeyNotFoundException($"Connector cursor reset job {jobId} not found");
+        var record = await FindRecordAsync(jobId, ct)
+            ?? throw new KeyNotFoundException($"Connector cursor reset job {jobId} not found");
+
+        return ConnectorResetJob.StatusFromRecord(record);
     }
 
     /// <inheritdoc />
-    public void Cancel(Guid jobId)
+    public async Task CancelAsync(Guid jobId, CancellationToken ct = default)
     {
         if (_jobs.TryGetValue(jobId, out var job))
         {
             job.Cancel();
+            await job.PersistSnapshotAsync(ct);
             _logger.LogInformation("Cancelled connector cursor reset job {JobId}", jobId);
             return;
         }
 
-        throw new KeyNotFoundException($"Connector cursor reset job {jobId} not found");
+        var record = await FindRecordAsync(jobId, ct)
+            ?? throw new KeyNotFoundException($"Connector cursor reset job {jobId} not found");
+
+        // The record exists but the job is not in memory — terminal, or orphaned by a restart
+        // that the startup sweep hasn't reached. Either way there is nothing left to stop.
+        _logger.LogInformation(
+            "Cancel requested for connector cursor reset job {JobId} which is no longer running (state {State})",
+            jobId, record.State);
+    }
+
+    private async Task<ConnectorResetJobEntity?> FindRecordAsync(Guid jobId, CancellationToken ct)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
+        return await db.ConnectorResetJobs.FindAsync([jobId], ct);
     }
 }
 
@@ -214,6 +243,7 @@ internal sealed class ConnectorResetJob : IConnectorResetProgress
         _startedAt = DateTime.UtcNow;
         _state = ConnectorResetJobState.Running;
         var ct = _cts.Token;
+        await PersistSnapshotAsync(CancellationToken.None);
 
         try
         {
@@ -248,7 +278,72 @@ internal sealed class ConnectorResetJob : IConnectorResetProgress
         finally
         {
             _completedAt = DateTime.UtcNow;
+            await PersistSnapshotAsync(CancellationToken.None);
         }
+    }
+
+    /// <summary>
+    /// Upserts the job's persisted record from the current in-memory snapshot. Persistence
+    /// failures after start are logged, not thrown — the running work matters more than its
+    /// record, and the terminal snapshot in <see cref="ExecuteAsync"/>'s finally retries.
+    /// </summary>
+    public async Task PersistSnapshotAsync(CancellationToken ct)
+    {
+        try
+        {
+            var status = GetStatus();
+            using var scope = _serviceProvider.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
+
+            var record = await db.ConnectorResetJobs.FindAsync([_id], ct);
+            if (record is null)
+            {
+                record = new ConnectorResetJobEntity { Id = _id };
+                db.ConnectorResetJobs.Add(record);
+            }
+
+            record.TenantId = status.TenantId;
+            record.TenantSlug = status.TenantSlug;
+            record.State = status.State.ToString();
+            record.CreatedAt = status.CreatedAt;
+            record.StartedAt = status.StartedAt;
+            record.CompletedAt = status.CompletedAt;
+            record.ErrorMessage = status.ErrorMessage is { Length: > 1000 } e ? e[..1000] : status.ErrorMessage;
+            record.TotalConnectors = status.TotalConnectors;
+            record.CompletedConnectors = status.CompletedConnectors;
+            record.ConnectorsJson = JsonSerializer.Serialize(status.Connectors);
+
+            await db.SaveChangesAsync(ct);
+        }
+        catch (Exception ex) when (_state is not ConnectorResetJobState.Pending)
+        {
+            _logger.LogError(ex, "Failed to persist connector cursor reset job {JobId}", _id);
+        }
+    }
+
+    /// <summary>Reconstructs a pollable status from a persisted record (post-restart lookups).</summary>
+    public static ConnectorResetJobStatus StatusFromRecord(ConnectorResetJobEntity record)
+    {
+        var connectors = record.ConnectorsJson is null
+            ? []
+            : JsonSerializer.Deserialize<List<ConnectorResetConnectorProgress>>(record.ConnectorsJson) ?? [];
+
+        return new ConnectorResetJobStatus
+        {
+            JobId = record.Id,
+            TenantId = record.TenantId,
+            TenantSlug = record.TenantSlug,
+            State = Enum.TryParse<ConnectorResetJobState>(record.State, out var state)
+                ? state
+                : ConnectorResetJobState.Interrupted,
+            CreatedAt = record.CreatedAt,
+            StartedAt = record.StartedAt,
+            CompletedAt = record.CompletedAt,
+            ErrorMessage = record.ErrorMessage,
+            TotalConnectors = record.TotalConnectors,
+            CompletedConnectors = record.CompletedConnectors,
+            Connectors = connectors,
+        };
     }
 
     void IConnectorResetProgress.ConnectorStarted(string connectorName) =>
@@ -342,6 +437,8 @@ public enum ConnectorResetJobState
     Failed,
     /// <summary>The job was cancelled before completing.</summary>
     Cancelled,
+    /// <summary>The API restarted while the job was running; the work did not complete and must be re-run.</summary>
+    Interrupted,
 }
 
 /// <summary>State of a single connector within a reset job.</summary>

--- a/src/API/Nocturne.API/Services/Connectors/ConnectorCursorResetJobService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/ConnectorCursorResetJobService.cs
@@ -100,12 +100,13 @@ public class ConnectorCursorResetJobService : IConnectorCursorResetJobService
             connectors.Connectors.Select(c => c.ConnectorName),
             _logger,
             _serviceProvider);
-        _jobs[jobId] = job;
-
         // Record the job before the work starts. The in-process task cannot survive an API
         // restart, but its record must — otherwise a restart mid-run leaves the operator
-        // polling a 404 with no way to tell "never existed" from "killed partway".
-        await job.PersistSnapshotAsync(ct);
+        // polling a 404 with no way to tell "never existed" from "killed partway". Registered
+        // in the job map only after the record exists, so a failed persist doesn't leave a
+        // phantom Pending job answering status probes.
+        await job.PersistSnapshotAsync(CancellationToken.None);
+        _jobs[jobId] = job;
 
         // Detached background task: deliberately uses CancellationToken.None, not the request token,
         // so the reset outlives the HTTP request that started it. User-initiated cancellation flows

--- a/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
+++ b/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
@@ -36,7 +36,9 @@ public interface IMigrationJobService
         CancellationToken ct = default
     );
     PendingMigrationConfig GetPendingConfig();
-    Task<IReadOnlyList<MigrationSourceDto>> GetSourcesAsync(CancellationToken ct = default);
+
+    /// <summary>Lists the calling tenant's migration sources. Source URLs frequently identify a person, so sources are never listed cross-tenant.</summary>
+    Task<IReadOnlyList<MigrationSourceDto>> GetSourcesAsync(Guid tenantId, CancellationToken ct = default);
 }
 
 /// <summary>
@@ -95,13 +97,14 @@ public class MigrationJobService : IMigrationJobService
         };
 
         var job = new MigrationJob(jobId, tenantId, request, jobInfo, tenantContext, _logger, _serviceProvider);
-        _jobs[jobId] = job;
 
         // Record the job (and its source) before the work starts. The in-process task cannot
         // survive an API restart, but its record must — job history and "was this source ever
         // migrated?" checks read these rows, and without them a restart erases all evidence
-        // that the run happened.
+        // that the run happened. Registered in the job map only after the record exists, so a
+        // failed persist doesn't leave a phantom Pending job answering status probes.
         await job.PersistSnapshotAsync(ct);
+        _jobs[jobId] = job;
 
         // Start migration on a detached background task. This deliberately does NOT use the
         // request's CancellationToken (HttpContext.RequestAborted): the migration is designed to
@@ -356,6 +359,7 @@ public class MigrationJobService : IMigrationJobService
     }
 
     public async Task<IReadOnlyList<MigrationSourceDto>> GetSourcesAsync(
+        Guid tenantId,
         CancellationToken ct = default
     )
     {
@@ -363,7 +367,9 @@ public class MigrationJobService : IMigrationJobService
         var dbContext = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
 
         var sources = await dbContext
-            .MigrationSources.OrderByDescending(s => s.LastMigrationAt ?? s.CreatedAt)
+            .MigrationSources
+            .Where(s => s.TenantId == tenantId)
+            .OrderByDescending(s => s.LastMigrationAt ?? s.CreatedAt)
             .Select(s => new MigrationSourceDto
             {
                 Id = s.Id,
@@ -462,7 +468,11 @@ internal class MigrationJob
     public void Cancel()
     {
         _cts.Cancel();
-        _state = MigrationJobState.Cancelled;
+        // Leave terminal states untouched — cancelling a job that already Completed/Failed must
+        // not rewrite its (now persisted) outcome, which would also un-satisfy the startup
+        // "was this source ever migrated?" check.
+        if (_state is MigrationJobState.Pending or MigrationJobState.Validating or MigrationJobState.Running)
+            _state = MigrationJobState.Cancelled;
     }
 
     public async Task ExecuteAsync(CancellationToken externalCt)
@@ -542,8 +552,8 @@ internal class MigrationJob
             run.State = _state.ToString();
             run.StartedAt = _startedAt == default ? _info.CreatedAt : _startedAt;
             run.CompletedAt = _completedAt;
-            run.DateRangeStart = _request.StartDate;
-            run.DateRangeEnd = _request.EndDate;
+            run.DateRangeStart = AsUtc(_request.StartDate);
+            run.DateRangeEnd = AsUtc(_request.EndDate);
             run.ErrorMessage = _errorMessage;
             run.EntriesMigrated = (int)Math.Min(int.MaxValue, MigratedCount("entries"));
             run.TreatmentsMigrated = (int)Math.Min(int.MaxValue, MigratedCount("treatments"));
@@ -566,26 +576,27 @@ internal class MigrationJob
         _collectionProgress.TryGetValue(collection, out var p) ? p.DocumentsMigrated : 0;
 
     /// <summary>
-    /// Finds or creates the migration source row for this job's target. Sources dedupe on
-    /// <see cref="MigrationSourceEntity.SourceIdentifier"/>: the Nightscout URL for API mode,
-    /// a SHA-256 digest of the connection string for MongoDB mode. Only non-usable digests are
-    /// stored — never the API secret or connection string themselves.
+    /// Finds or creates the migration source row for this job's target. Sources dedupe per
+    /// tenant on <see cref="MigrationSourceEntity.SourceIdentifier"/>: the Nightscout URL for
+    /// API mode, a SHA-256 digest of the connection string for MongoDB mode. Only non-usable
+    /// digests are stored — never the API secret or connection string themselves.
     /// </summary>
     private async Task<Guid> UpsertSourceAsync(NocturneDbContext db, CancellationToken ct)
     {
         var isApi = _request.Mode == MigrationMode.Api;
         var identifier = isApi
-            ? _request.NightscoutUrl!.TrimEnd('/')
-            : Sha256Hex(_request.MongoConnectionString ?? string.Empty);
+            ? ApiSourceIdentifier(_request.NightscoutUrl!)
+            : MongoSourceIdentifier(_request.MongoConnectionString ?? string.Empty);
 
         var source = await db.MigrationSources.FirstOrDefaultAsync(
-            s => s.SourceIdentifier == identifier, ct);
+            s => s.TenantId == _tenantId && s.SourceIdentifier == identifier, ct);
         if (source is not null)
             return source.Id;
 
         source = new MigrationSourceEntity
         {
             Id = Guid.CreateVersion7(),
+            TenantId = _tenantId,
             Mode = _request.Mode.ToString(),
             SourceIdentifier = identifier,
             NightscoutUrl = isApi ? _request.NightscoutUrl : null,
@@ -599,8 +610,22 @@ internal class MigrationJob
         return source.Id;
     }
 
+    /// <summary>Canonical source identifier for an API-mode migration. Shared with the startup pending-migration check so the two always agree.</summary>
+    internal static string ApiSourceIdentifier(string nightscoutUrl) => nightscoutUrl.TrimEnd('/');
+
+    /// <summary>Canonical source identifier for a MongoDB-mode migration: a non-usable digest, never the connection string itself.</summary>
+    internal static string MongoSourceIdentifier(string connectionString) => Sha256Hex(connectionString);
+
     private static string Sha256Hex(string value) =>
         Convert.ToHexStringLower(System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(value)));
+
+    /// <summary>Npgsql rejects Local/Unspecified kinds for timestamptz; normalize optional caller-supplied dates.</summary>
+    private static DateTime? AsUtc(DateTime? value) => value switch
+    {
+        null => null,
+        { Kind: DateTimeKind.Unspecified } v => DateTime.SpecifyKind(v, DateTimeKind.Utc),
+        { } v => v.ToUniversalTime(),
+    };
 
     /// <summary>Reconstructs a status snapshot from a persisted run (post-restart lookups).</summary>
     public static MigrationJobStatus StatusFromRecord(MigrationRunEntity run)

--- a/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
+++ b/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
@@ -52,8 +52,6 @@ public class MigrationJobService : IMigrationJobService
     private readonly IServiceProvider _serviceProvider;
     private readonly IConfiguration _configuration;
     private readonly ConcurrentDictionary<Guid, MigrationJob> _jobs = new();
-    private readonly List<(Guid TenantId, MigrationJobInfo Info)> _history = [];
-    private readonly object _historyLock = new();
 
     public MigrationJobService(
         ILogger<MigrationJobService> logger,
@@ -99,10 +97,11 @@ public class MigrationJobService : IMigrationJobService
         var job = new MigrationJob(jobId, tenantId, request, jobInfo, tenantContext, _logger, _serviceProvider);
         _jobs[jobId] = job;
 
-        lock (_historyLock)
-        {
-            _history.Add((tenantId, jobInfo));
-        }
+        // Record the job (and its source) before the work starts. The in-process task cannot
+        // survive an API restart, but its record must — job history and "was this source ever
+        // migrated?" checks read these rows, and without them a restart erases all evidence
+        // that the run happened.
+        await job.PersistSnapshotAsync(ct);
 
         // Start migration on a detached background task. This deliberately does NOT use the
         // request's CancellationToken (HttpContext.RequestAborted): the migration is designed to
@@ -134,35 +133,57 @@ public class MigrationJobService : IMigrationJobService
         return jobInfo;
     }
 
-    public Task<MigrationJobStatus> GetStatusAsync(Guid tenantId, Guid jobId)
+    public async Task<MigrationJobStatus> GetStatusAsync(Guid tenantId, Guid jobId)
     {
         if (_jobs.TryGetValue(jobId, out var job) && job.TenantId == tenantId)
         {
-            return Task.FromResult(job.GetStatus());
+            return job.GetStatus();
         }
 
-        throw new KeyNotFoundException($"Migration job {jobId} not found");
+        // Not in memory (e.g. the API restarted since the job ran): serve the persisted record.
+        var record = await FindRunAsync(tenantId, jobId)
+            ?? throw new KeyNotFoundException($"Migration job {jobId} not found");
+
+        return MigrationJob.StatusFromRecord(record);
     }
 
-    public Task CancelAsync(Guid tenantId, Guid jobId)
+    public async Task CancelAsync(Guid tenantId, Guid jobId)
     {
         if (_jobs.TryGetValue(jobId, out var job) && job.TenantId == tenantId)
         {
             job.Cancel();
+            await job.PersistSnapshotAsync(CancellationToken.None);
             _logger.LogInformation("Cancelled migration job {JobId}", jobId);
-            return Task.CompletedTask;
+            return;
         }
 
-        throw new KeyNotFoundException($"Migration job {jobId} not found");
+        // A persisted record without a live job is terminal or orphaned by a restart — nothing
+        // left to stop, but the id is valid, so don't report it as unknown.
+        _ = await FindRunAsync(tenantId, jobId)
+            ?? throw new KeyNotFoundException($"Migration job {jobId} not found");
+
+        _logger.LogInformation("Cancel requested for migration job {JobId} which is no longer running", jobId);
     }
 
-    public Task<IReadOnlyList<MigrationJobInfo>> GetHistoryAsync(Guid tenantId)
+    public async Task<IReadOnlyList<MigrationJobInfo>> GetHistoryAsync(Guid tenantId)
     {
-        lock (_historyLock)
-        {
-            return Task.FromResult<IReadOnlyList<MigrationJobInfo>>(
-                _history.Where(h => h.TenantId == tenantId).Select(h => h.Info).ToList());
-        }
+        using var scope = _serviceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
+
+        var runs = await db.MigrationRuns.AsNoTracking()
+            .Where(r => r.TenantId == tenantId)
+            .OrderByDescending(r => r.CreatedAt)
+            .ToListAsync();
+
+        return runs.Select(MigrationJob.InfoFromRecord).ToList();
+    }
+
+    private async Task<MigrationRunEntity?> FindRunAsync(Guid tenantId, Guid jobId)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
+        return await db.MigrationRuns.AsNoTracking()
+            .FirstOrDefaultAsync(r => r.Id == jobId && r.TenantId == tenantId);
     }
 
     public async Task<TestMigrationConnectionResult> TestConnectionAsync(
@@ -454,6 +475,7 @@ internal class MigrationJob
 
         _startedAt = DateTime.UtcNow;
         _state = MigrationJobState.Running;
+        await PersistSnapshotAsync(CancellationToken.None);
 
         try
         {
@@ -485,7 +507,146 @@ internal class MigrationJob
             _completedAt = DateTime.UtcNow;
             _logger.LogError(ex, "Migration job {JobId} failed", _id);
         }
+        finally
+        {
+            await PersistSnapshotAsync(CancellationToken.None);
+        }
     }
+
+    /// <summary>
+    /// Upserts the job's persisted run record (and its migration source) from the current
+    /// in-memory state. The initial call (state Pending) propagates failures — a job whose
+    /// record cannot be written must not start; later calls log instead, because the running
+    /// work matters more than its record and the terminal snapshot retries.
+    /// </summary>
+    public async Task PersistSnapshotAsync(CancellationToken ct)
+    {
+        try
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
+
+            var sourceId = await UpsertSourceAsync(db, ct);
+
+            var run = await db.MigrationRuns.FirstOrDefaultAsync(r => r.Id == _id, ct);
+            if (run is null)
+            {
+                run = new MigrationRunEntity { Id = _id, CreatedAt = _info.CreatedAt };
+                db.MigrationRuns.Add(run);
+            }
+
+            run.SourceId = sourceId;
+            run.TenantId = _tenantId;
+            run.Mode = _request.Mode.ToString();
+            run.SourceDescription = _info.SourceDescription is { Length: > 512 } d ? d[..512] : _info.SourceDescription;
+            run.State = _state.ToString();
+            run.StartedAt = _startedAt == default ? _info.CreatedAt : _startedAt;
+            run.CompletedAt = _completedAt;
+            run.DateRangeStart = _request.StartDate;
+            run.DateRangeEnd = _request.EndDate;
+            run.ErrorMessage = _errorMessage;
+            run.EntriesMigrated = (int)Math.Min(int.MaxValue, MigratedCount("entries"));
+            run.TreatmentsMigrated = (int)Math.Min(int.MaxValue, MigratedCount("treatments"));
+
+            if (_state == MigrationJobState.Completed)
+            {
+                var source = await db.MigrationSources.FirstAsync(s => s.Id == sourceId, ct);
+                source.LastMigrationAt = _completedAt ?? DateTime.UtcNow;
+            }
+
+            await db.SaveChangesAsync(ct);
+        }
+        catch (Exception ex) when (_state is not MigrationJobState.Pending)
+        {
+            _logger.LogError(ex, "Failed to persist migration job {JobId}", _id);
+        }
+    }
+
+    private long MigratedCount(string collection) =>
+        _collectionProgress.TryGetValue(collection, out var p) ? p.DocumentsMigrated : 0;
+
+    /// <summary>
+    /// Finds or creates the migration source row for this job's target. Sources dedupe on
+    /// <see cref="MigrationSourceEntity.SourceIdentifier"/>: the Nightscout URL for API mode,
+    /// a SHA-256 digest of the connection string for MongoDB mode. Only non-usable digests are
+    /// stored — never the API secret or connection string themselves.
+    /// </summary>
+    private async Task<Guid> UpsertSourceAsync(NocturneDbContext db, CancellationToken ct)
+    {
+        var isApi = _request.Mode == MigrationMode.Api;
+        var identifier = isApi
+            ? _request.NightscoutUrl!.TrimEnd('/')
+            : Sha256Hex(_request.MongoConnectionString ?? string.Empty);
+
+        var source = await db.MigrationSources.FirstOrDefaultAsync(
+            s => s.SourceIdentifier == identifier, ct);
+        if (source is not null)
+            return source.Id;
+
+        source = new MigrationSourceEntity
+        {
+            Id = Guid.CreateVersion7(),
+            Mode = _request.Mode.ToString(),
+            SourceIdentifier = identifier,
+            NightscoutUrl = isApi ? _request.NightscoutUrl : null,
+            NightscoutApiSecretHash = isApi && !string.IsNullOrEmpty(_request.NightscoutApiSecret)
+                ? Sha256Hex(_request.NightscoutApiSecret)
+                : null,
+            MongoDatabaseName = isApi ? null : _request.MongoDatabaseName,
+            CreatedAt = DateTime.UtcNow,
+        };
+        db.MigrationSources.Add(source);
+        return source.Id;
+    }
+
+    private static string Sha256Hex(string value) =>
+        Convert.ToHexStringLower(System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(value)));
+
+    /// <summary>Reconstructs a status snapshot from a persisted run (post-restart lookups).</summary>
+    public static MigrationJobStatus StatusFromRecord(MigrationRunEntity run)
+    {
+        var state = Enum.TryParse<MigrationJobState>(run.State, out var s)
+            ? s
+            : MigrationJobState.Interrupted;
+
+        return new MigrationJobStatus
+        {
+            JobId = run.Id,
+            State = state,
+            ProgressPercentage = state == MigrationJobState.Completed ? 100 : 0,
+            ErrorMessage = run.ErrorMessage,
+            StartedAt = run.StartedAt,
+            CompletedAt = run.CompletedAt,
+            CollectionProgress = new Dictionary<string, CollectionProgress>
+            {
+                ["entries"] = new()
+                {
+                    CollectionName = "entries",
+                    DocumentsMigrated = run.EntriesMigrated,
+                    IsComplete = state == MigrationJobState.Completed,
+                },
+                ["treatments"] = new()
+                {
+                    CollectionName = "treatments",
+                    DocumentsMigrated = run.TreatmentsMigrated,
+                    IsComplete = state == MigrationJobState.Completed,
+                },
+            },
+        };
+    }
+
+    /// <summary>Reconstructs a history entry from a persisted run.</summary>
+    public static MigrationJobInfo InfoFromRecord(MigrationRunEntity run) => new()
+    {
+        Id = run.Id,
+        Mode = Enum.TryParse<MigrationMode>(run.Mode, out var m) ? m : MigrationMode.Api,
+        CreatedAt = run.CreatedAt,
+        SourceDescription = run.SourceDescription,
+        State = Enum.TryParse<MigrationJobState>(run.State, out var s) ? s : MigrationJobState.Interrupted,
+        StartedAt = run.StartedAt,
+        CompletedAt = run.CompletedAt,
+        ErrorMessage = run.ErrorMessage,
+    };
 
     private long _totalDocumentsAllCollections;
     private long _migratedDocumentsAllCollections; // computed by UpdateOverallProgress

--- a/src/API/Nocturne.API/Services/Migration/MigrationModels.cs
+++ b/src/API/Nocturne.API/Services/Migration/MigrationModels.cs
@@ -33,7 +33,9 @@ public enum MigrationJobState
     /// <summary>Migration terminated due to an unrecoverable error. See <see cref="MigrationJobInfo.ErrorMessage"/>.</summary>
     Failed,
     /// <summary>Migration was explicitly stopped by the user before completion.</summary>
-    Cancelled
+    Cancelled,
+    /// <summary>The API restarted while the migration was running; the work did not complete and must be re-run.</summary>
+    Interrupted
 }
 
 /// <summary>

--- a/src/API/Nocturne.API/Services/Migration/MigrationStartupService.cs
+++ b/src/API/Nocturne.API/Services/Migration/MigrationStartupService.cs
@@ -84,15 +84,18 @@ public class MigrationStartupService : IHostedService
 
     private string? GetSourceIdentifier(string migrationMode)
     {
+        // Must produce byte-identical identifiers to MigrationJob.UpsertSourceAsync, or the
+        // "was this source ever migrated?" check can never match and the pending-migration
+        // notification reappears on every boot.
         if (migrationMode.Equals("MongoDb", StringComparison.OrdinalIgnoreCase))
         {
-            // For MongoDB, we use the database name as identifier (don't want to hash connection string on every check)
-            return _configuration["MIGRATION_MONGO_DATABASE_NAME"];
+            var connectionString = _configuration["MIGRATION_MONGO_CONNECTION_STRING"];
+            return string.IsNullOrEmpty(connectionString)
+                ? null
+                : MigrationJob.MongoSourceIdentifier(connectionString);
         }
-        else
-        {
-            // For API mode, use the Nightscout URL as identifier
-            return _configuration["MIGRATION_NS_URL"];
-        }
+
+        var url = _configuration["MIGRATION_NS_URL"];
+        return string.IsNullOrEmpty(url) ? null : MigrationJob.ApiSourceIdentifier(url);
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ConnectorResetJobEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ConnectorResetJobEntity.cs
@@ -1,0 +1,67 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Nocturne.Infrastructure.Data.Entities;
+
+/// <summary>
+/// PostgreSQL entity recording a platform-admin connector cursor reset job. The job itself runs on
+/// a detached in-process task and cannot survive an API restart, but its record must: without a
+/// persisted row, a restart mid-run leaves the operator polling a 404 with no way to tell "job id
+/// never existed" from "the work was killed partway". Rows are written at every lifecycle
+/// transition; startup marks any row still Pending/Running as Interrupted.
+/// </summary>
+/// <remarks>
+/// Operator metadata, not tenant data: rows carry a <see cref="TenantId"/> for filtering but the
+/// table is deliberately not tenant-scoped (no RLS) — it is read cross-tenant by platform-admin
+/// endpoints and contains job lifecycle state only, no health data.
+/// </remarks>
+[Table("connector_reset_jobs")]
+public class ConnectorResetJobEntity
+{
+    /// <summary>Primary key — matches the reset job id handed to the polling client.</summary>
+    [Key]
+    public Guid Id { get; set; }
+
+    /// <summary>The tenant whose connectors the job resets.</summary>
+    [Column("tenant_id")]
+    public Guid TenantId { get; set; }
+
+    /// <summary>The target tenant's slug, denormalized for display in job listings.</summary>
+    [Column("tenant_slug")]
+    [MaxLength(64)]
+    public string TenantSlug { get; set; } = string.Empty;
+
+    /// <summary>Current state: Pending, Running, Completed, Failed, Cancelled, Interrupted.</summary>
+    [Column("state")]
+    [MaxLength(20)]
+    public string State { get; set; } = "Pending";
+
+    /// <summary>When the job was created.</summary>
+    [Column("created_at")]
+    public DateTime CreatedAt { get; set; }
+
+    /// <summary>When the background work started, or null if it never got that far.</summary>
+    [Column("started_at")]
+    public DateTime? StartedAt { get; set; }
+
+    /// <summary>When the job reached a terminal state.</summary>
+    [Column("completed_at")]
+    public DateTime? CompletedAt { get; set; }
+
+    /// <summary>Error message when the whole job failed (not a single connector).</summary>
+    [Column("error_message")]
+    [MaxLength(1000)]
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>Total connectors the job set out to reset.</summary>
+    [Column("total_connectors")]
+    public int TotalConnectors { get; set; }
+
+    /// <summary>How many connectors reached a terminal state.</summary>
+    [Column("completed_connectors")]
+    public int CompletedConnectors { get; set; }
+
+    /// <summary>Serialized per-connector progress snapshot (the status endpoint's Connectors list).</summary>
+    [Column("connectors_json", TypeName = "jsonb")]
+    public string? ConnectorsJson { get; set; }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/MigrationRunEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/MigrationRunEntity.cs
@@ -23,6 +23,33 @@ public class MigrationRunEntity
     public Guid SourceId { get; set; }
 
     /// <summary>
+    /// The tenant that started (and owns) this migration. Used to scope history and
+    /// status lookups; the table itself is operator metadata and not RLS-scoped.
+    /// </summary>
+    [Column("tenant_id")]
+    public Guid TenantId { get; set; }
+
+    /// <summary>
+    /// Migration mode: "Api" or "MongoDb"
+    /// </summary>
+    [Column("mode")]
+    [MaxLength(20)]
+    public string Mode { get; set; } = "Api";
+
+    /// <summary>
+    /// Human-readable source description shown in job history (URL or database name)
+    /// </summary>
+    [Column("source_description")]
+    [MaxLength(512)]
+    public string? SourceDescription { get; set; }
+
+    /// <summary>
+    /// When the migration job was created
+    /// </summary>
+    [Column("created_at")]
+    public DateTime CreatedAt { get; set; }
+
+    /// <summary>
     /// When the migration job started
     /// </summary>
     [Column("started_at")]
@@ -35,7 +62,7 @@ public class MigrationRunEntity
     public DateTime? CompletedAt { get; set; }
 
     /// <summary>
-    /// Current state: Pending, Running, Completed, Failed, Cancelled
+    /// Current state: Pending, Running, Completed, Failed, Cancelled, Interrupted
     /// </summary>
     [Column("state")]
     [MaxLength(20)]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/MigrationSourceEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/MigrationSourceEntity.cs
@@ -17,6 +17,14 @@ public class MigrationSourceEntity
     public Guid Id { get; set; }
 
     /// <summary>
+    /// The tenant that migrated from this source. Sources dedupe per tenant, and the
+    /// tenant-facing sources listing filters on this — a source URL frequently identifies
+    /// a person, so one tenant must never see another tenant's sources.
+    /// </summary>
+    [Column("tenant_id")]
+    public Guid TenantId { get; set; }
+
+    /// <summary>
     /// Migration mode: "Api" or "MongoDb"
     /// </summary>
     [Column("mode")]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs
@@ -174,6 +174,8 @@ public static class DatabaseInitializationExtensions
     /// connector cursor reset jobs run on detached in-process tasks that die with the process,
     /// so a row left in a live state at startup can only be an orphan from a previous run.
     /// Without this sweep, an operator polling such a job sees "Running" forever.
+    /// Assumes a single API instance: a second replica (or an overlapping deploy) booting
+    /// while another instance has a job genuinely running would mark that job Interrupted.
     /// </summary>
     public static async Task MarkInterruptedJobsAsync(
         string migratorConnectionString,

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs
@@ -170,6 +170,39 @@ public static class DatabaseInitializationExtensions
     }
 
     /// <summary>
+    /// Marks any background job record still Pending/Running as Interrupted. Migration and
+    /// connector cursor reset jobs run on detached in-process tasks that die with the process,
+    /// so a row left in a live state at startup can only be an orphan from a previous run.
+    /// Without this sweep, an operator polling such a job sees "Running" forever.
+    /// </summary>
+    public static async Task MarkInterruptedJobsAsync(
+        string migratorConnectionString,
+        ILogger logger,
+        CancellationToken cancellationToken = default)
+    {
+        await using var dataSource = new NpgsqlDataSourceBuilder(migratorConnectionString).Build();
+        await using var connection = await dataSource.OpenConnectionAsync(cancellationToken);
+
+        var total = 0;
+        foreach (var table in new[] { "migration_runs", "connector_reset_jobs" })
+        {
+            await using var command = connection.CreateCommand();
+            command.CommandText =
+                $"""
+                 UPDATE {table}
+                 SET state = 'Interrupted',
+                     completed_at = now(),
+                     error_message = 'The API restarted while this job was running; re-run it to finish the work.'
+                 WHERE state IN ('Pending', 'Running')
+                 """;
+            total += await command.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        if (total > 0)
+            logger.LogWarning("Marked {Count} orphaned background job records as Interrupted", total);
+    }
+
+    /// <summary>
     /// Repeatedly invokes <paramref name="probe"/> until it succeeds or the
     /// attempt budget is exhausted. Exceptions matching <paramref name="isTransient"/>
     /// are retried after <paramref name="retryDelay"/>; all others propagate

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260802070050_DurableJobRecords.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260802070050_DurableJobRecords.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260802070050_DurableJobRecords")]
+    partial class DurableJobRecords
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260802070050_DurableJobRecords.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260802070050_DurableJobRecords.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class DurableJobRecords : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "created_at",
+                table: "migration_runs",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<string>(
+                name: "mode",
+                table: "migration_runs",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "source_description",
+                table: "migration_runs",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "tenant_id",
+                table: "migration_runs",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.CreateTable(
+                name: "connector_reset_jobs",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    tenant_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    tenant_slug = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    state = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    started_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    completed_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    error_message = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    total_connectors = table.Column<int>(type: "integer", nullable: false),
+                    completed_connectors = table.Column<int>(type: "integer", nullable: false),
+                    connectors_json = table.Column<string>(type: "jsonb", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_connector_reset_jobs", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_migration_runs_tenant",
+                table: "migration_runs",
+                column: "tenant_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_connector_reset_jobs_state",
+                table: "connector_reset_jobs",
+                column: "state");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_connector_reset_jobs_tenant",
+                table: "connector_reset_jobs",
+                column: "tenant_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "connector_reset_jobs");
+
+            migrationBuilder.DropIndex(
+                name: "ix_migration_runs_tenant",
+                table: "migration_runs");
+
+            migrationBuilder.DropColumn(
+                name: "created_at",
+                table: "migration_runs");
+
+            migrationBuilder.DropColumn(
+                name: "mode",
+                table: "migration_runs");
+
+            migrationBuilder.DropColumn(
+                name: "source_description",
+                table: "migration_runs");
+
+            migrationBuilder.DropColumn(
+                name: "tenant_id",
+                table: "migration_runs");
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260802073145_DurableJobRecords.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260802073145_DurableJobRecords.Designer.cs
@@ -13,7 +13,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    [Migration("20260802070050_DurableJobRecords")]
+    [Migration("20260802073145_DurableJobRecords")]
     partial class DurableJobRecords
     {
         /// <inheritdoc />
@@ -2427,6 +2427,10 @@ namespace Nocturne.Infrastructure.Data.Migrations
                         .HasColumnType("character varying(255)")
                         .HasColumnName("source_identifier");
 
+                    b.Property<Guid>("TenantId")
+                        .HasColumnType("uuid")
+                        .HasColumnName("tenant_id");
+
                     b.HasKey("Id");
 
                     b.HasIndex("CreatedAt")
@@ -2439,9 +2443,9 @@ namespace Nocturne.Infrastructure.Data.Migrations
                     b.HasIndex("Mode")
                         .HasDatabaseName("ix_migration_sources_mode");
 
-                    b.HasIndex("SourceIdentifier")
+                    b.HasIndex("TenantId", "SourceIdentifier")
                         .IsUnique()
-                        .HasDatabaseName("ix_migration_sources_identifier");
+                        .HasDatabaseName("ix_migration_sources_tenant_identifier");
 
                     b.ToTable("migration_sources");
                 });

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260802073145_DurableJobRecords.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260802073145_DurableJobRecords.cs
@@ -11,6 +11,17 @@ namespace Nocturne.Infrastructure.Data.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.DropIndex(
+                name: "ix_migration_sources_identifier",
+                table: "migration_sources");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "tenant_id",
+                table: "migration_sources",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
             migrationBuilder.AddColumn<DateTime>(
                 name: "created_at",
                 table: "migration_runs",
@@ -62,6 +73,12 @@ namespace Nocturne.Infrastructure.Data.Migrations
                 });
 
             migrationBuilder.CreateIndex(
+                name: "ix_migration_sources_tenant_identifier",
+                table: "migration_sources",
+                columns: new[] { "tenant_id", "source_identifier" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
                 name: "ix_migration_runs_tenant",
                 table: "migration_runs",
                 column: "tenant_id");
@@ -84,8 +101,16 @@ namespace Nocturne.Infrastructure.Data.Migrations
                 name: "connector_reset_jobs");
 
             migrationBuilder.DropIndex(
+                name: "ix_migration_sources_tenant_identifier",
+                table: "migration_sources");
+
+            migrationBuilder.DropIndex(
                 name: "ix_migration_runs_tenant",
                 table: "migration_runs");
+
+            migrationBuilder.DropColumn(
+                name: "tenant_id",
+                table: "migration_sources");
 
             migrationBuilder.DropColumn(
                 name: "created_at",
@@ -102,6 +127,12 @@ namespace Nocturne.Infrastructure.Data.Migrations
             migrationBuilder.DropColumn(
                 name: "tenant_id",
                 table: "migration_runs");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_migration_sources_identifier",
+                table: "migration_sources",
+                column: "source_identifier",
+                unique: true);
         }
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/NocturneDbContextModelSnapshot.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/NocturneDbContextModelSnapshot.cs
@@ -2424,6 +2424,10 @@ namespace Nocturne.Infrastructure.Data.Migrations
                         .HasColumnType("character varying(255)")
                         .HasColumnName("source_identifier");
 
+                    b.Property<Guid>("TenantId")
+                        .HasColumnType("uuid")
+                        .HasColumnName("tenant_id");
+
                     b.HasKey("Id");
 
                     b.HasIndex("CreatedAt")
@@ -2436,9 +2440,9 @@ namespace Nocturne.Infrastructure.Data.Migrations
                     b.HasIndex("Mode")
                         .HasDatabaseName("ix_migration_sources_mode");
 
-                    b.HasIndex("SourceIdentifier")
+                    b.HasIndex("TenantId", "SourceIdentifier")
                         .IsUnique()
-                        .HasDatabaseName("ix_migration_sources_identifier");
+                        .HasDatabaseName("ix_migration_sources_tenant_identifier");
 
                     b.ToTable("migration_sources");
                 });

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -260,6 +260,11 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
     public DbSet<MigrationRunEntity> MigrationRuns { get; set; }
 
     /// <summary>
+    /// Gets or sets the ConnectorResetJobs table recording platform-admin cursor reset jobs
+    /// </summary>
+    public DbSet<ConnectorResetJobEntity> ConnectorResetJobs { get; set; }
+
+    /// <summary>
     /// Gets or sets the LinkedRecords table for deduplication linking
     /// </summary>
     public DbSet<LinkedRecordEntity> LinkedRecords { get; set; }
@@ -1297,6 +1302,22 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             .Entity<MigrationRunEntity>()
             .HasIndex(r => new { r.SourceId, r.State })
             .HasDatabaseName("ix_migration_runs_source_state");
+
+        modelBuilder
+            .Entity<MigrationRunEntity>()
+            .HasIndex(r => r.TenantId)
+            .HasDatabaseName("ix_migration_runs_tenant");
+
+        // Connector reset job indexes
+        modelBuilder
+            .Entity<ConnectorResetJobEntity>()
+            .HasIndex(j => j.TenantId)
+            .HasDatabaseName("ix_connector_reset_jobs_tenant");
+
+        modelBuilder
+            .Entity<ConnectorResetJobEntity>()
+            .HasIndex(j => j.State)
+            .HasDatabaseName("ix_connector_reset_jobs_state");
 
         // LinkedRecords indexes - optimized for deduplication queries
         modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -1258,11 +1258,13 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             .HasIndex(b => b.SleepSessionId)
             .HasDatabaseName("ix_sleep_biometric_samples_sleep_session_id");
 
-        // Migration source indexes
+        // Migration source indexes. Sources dedupe per tenant: the identifier alone must
+        // not be unique, or tenant B migrating from the same URL as tenant A would collide
+        // with (and read) A's source row.
         modelBuilder
             .Entity<MigrationSourceEntity>()
-            .HasIndex(s => s.SourceIdentifier)
-            .HasDatabaseName("ix_migration_sources_identifier")
+            .HasIndex(s => new { s.TenantId, s.SourceIdentifier })
+            .HasDatabaseName("ix_migration_sources_tenant_identifier")
             .IsUnique();
 
         modelBuilder

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/admin/connector-cursors/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/admin/connector-cursors/+page.svelte
@@ -66,6 +66,7 @@
     ConnectorResetJobState.Completed,
     ConnectorResetJobState.Failed,
     ConnectorResetJobState.Cancelled,
+    ConnectorResetJobState.Interrupted,
   ];
   function isTerminal(state: ConnectorResetJobState | undefined): boolean {
     return state !== undefined && TERMINAL_STATES.includes(state);

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/migration/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/migration/+page.svelte
@@ -145,7 +145,8 @@
         if (
           status.state === MigrationJobState.Completed ||
           status.state === MigrationJobState.Failed ||
-          status.state === MigrationJobState.Cancelled
+          status.state === MigrationJobState.Cancelled ||
+          status.state === MigrationJobState.Interrupted
         ) {
           pollingActive = false;
           await loadData(); // Refresh history
@@ -204,6 +205,8 @@
         return { variant: "destructive", label: "Failed" };
       case MigrationJobState.Cancelled:
         return { variant: "outline", label: "Cancelled" };
+      case MigrationJobState.Interrupted:
+        return { variant: "destructive", label: "Interrupted" };
       default:
         return { variant: "secondary", label: "Unknown" };
     }

--- a/src/Web/packages/app/src/routes/(unauthenticated)/setup/steps/ImportProgress.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/setup/steps/ImportProgress.svelte
@@ -172,7 +172,8 @@
           }
           if (
             status.state === MigrationJobState.Failed ||
-            status.state === MigrationJobState.Cancelled
+            status.state === MigrationJobState.Cancelled ||
+            status.state === MigrationJobState.Interrupted
           ) {
             failed = true;
             error =

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/PlatformAdmin/ConnectorAdminControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/PlatformAdmin/ConnectorAdminControllerTests.cs
@@ -127,23 +127,23 @@ public class ConnectorAdminControllerTests
     }
 
     [Fact]
-    public void GetResetJobStatus_UnknownJob_Returns404()
+    public async Task GetResetJobStatus_UnknownJob_Returns404()
     {
         var db = CreateDb();
         var jobService = new Mock<IConnectorCursorResetJobService>();
-        jobService.Setup(s => s.GetStatus(It.IsAny<Guid>()))
-            .Throws(new KeyNotFoundException());
+        jobService.Setup(s => s.GetStatusAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new KeyNotFoundException());
 
         var controller = CreateController(Engine(db), jobService.Object);
 
-        var result = controller.GetResetJobStatus(Guid.CreateVersion7());
+        var result = await controller.GetResetJobStatus(Guid.CreateVersion7(), CancellationToken.None);
 
         result.Result.Should().BeOfType<ObjectResult>()
             .Which.StatusCode.Should().Be(404);
     }
 
     [Fact]
-    public void GetResetJobStatus_KnownJob_ReturnsStatus()
+    public async Task GetResetJobStatus_KnownJob_ReturnsStatus()
     {
         var db = CreateDb();
         var jobId = Guid.CreateVersion7();
@@ -155,33 +155,34 @@ public class ConnectorAdminControllerTests
             State = ConnectorResetJobState.Running,
         };
         var jobService = new Mock<IConnectorCursorResetJobService>();
-        jobService.Setup(s => s.GetStatus(jobId)).Returns(status);
+        jobService.Setup(s => s.GetStatusAsync(jobId, It.IsAny<CancellationToken>())).ReturnsAsync(status);
 
         var controller = CreateController(Engine(db), jobService.Object);
 
-        var result = controller.GetResetJobStatus(jobId);
+        var result = await controller.GetResetJobStatus(jobId, CancellationToken.None);
 
         result.Result.Should().BeOfType<OkObjectResult>()
             .Which.Value.Should().BeSameAs(status);
     }
 
     [Fact]
-    public void CancelResetJob_UnknownJob_Returns404()
+    public async Task CancelResetJob_UnknownJob_Returns404()
     {
         var db = CreateDb();
         var jobService = new Mock<IConnectorCursorResetJobService>();
-        jobService.Setup(s => s.Cancel(It.IsAny<Guid>())).Throws(new KeyNotFoundException());
+        jobService.Setup(s => s.CancelAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new KeyNotFoundException());
 
         var controller = CreateController(Engine(db), jobService.Object);
 
-        var result = controller.CancelResetJob(Guid.CreateVersion7());
+        var result = await controller.CancelResetJob(Guid.CreateVersion7(), CancellationToken.None);
 
         result.Should().BeOfType<ObjectResult>()
             .Which.StatusCode.Should().Be(404);
     }
 
     [Fact]
-    public void CancelResetJob_KnownJob_Returns204()
+    public async Task CancelResetJob_KnownJob_Returns204()
     {
         var db = CreateDb();
         var jobId = Guid.CreateVersion7();
@@ -189,10 +190,10 @@ public class ConnectorAdminControllerTests
 
         var controller = CreateController(Engine(db), jobService.Object);
 
-        var result = controller.CancelResetJob(jobId);
+        var result = await controller.CancelResetJob(jobId, CancellationToken.None);
 
         result.Should().BeOfType<NoContentResult>();
-        jobService.Verify(s => s.Cancel(jobId), Times.Once);
+        jobService.Verify(s => s.CancelAsync(jobId, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Migration/MigrationJobServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Migration/MigrationJobServiceTests.cs
@@ -1,28 +1,42 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
 using Nocturne.API.Services.Migration;
 using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Infrastructure.Data;
 
 namespace Nocturne.API.Tests.Migration;
 
 /// <summary>
-/// Tenant-isolation behaviour for <see cref="MigrationJobService"/>. A migration job is owned by
-/// the tenant that started it, and status/cancel lookups must be scoped to that tenant so one
-/// tenant cannot read or cancel another tenant's job by guessing its id.
+/// Tenant-isolation and durability behaviour for <see cref="MigrationJobService"/>. A migration
+/// job is owned by the tenant that started it, and status/cancel lookups must be scoped to that
+/// tenant so one tenant cannot read or cancel another tenant's job by guessing its id. Job records
+/// are persisted, so lookups survive the in-memory job map being lost (e.g. an API restart).
 /// </summary>
 public class MigrationJobServiceTests
 {
-    private static MigrationJobService CreateService()
+    /// <summary>
+    /// Real DI provider with an InMemory NocturneDbContext so StartMigrationAsync can persist the
+    /// job record. The background migration task itself still fails fast (no HTTP/tenant services
+    /// are registered) — these tests exercise ownership, lookup, and record durability, not the
+    /// data transfer.
+    /// </summary>
+    private static (MigrationJobService Service, IServiceProvider Provider) CreateService(
+        IServiceProvider? existingProvider = null)
     {
-        // The background migration task will fail fast when it tries to create a DI scope from this
-        // empty provider — that's fine and intentional: these tests only exercise job ownership and
-        // lookup, which happen synchronously in StartMigrationAsync before any background work runs.
-        var serviceProvider = new Mock<IServiceProvider>().Object;
-        return new MigrationJobService(
+        var dbName = $"migration-jobs-{Guid.NewGuid():N}";
+        var provider = existingProvider ?? new ServiceCollection()
+            .AddDbContext<NocturneDbContext>(o => o.UseInMemoryDatabase(dbName))
+            .BuildServiceProvider();
+
+        var service = new MigrationJobService(
             NullLogger<MigrationJobService>.Instance,
-            serviceProvider,
+            provider,
             new ConfigurationBuilder().Build());
+
+        return (service, provider);
     }
 
     private static TenantContext Tenant(Guid id) => new(id, $"slug-{id:N}", "Test Tenant", true);
@@ -36,7 +50,7 @@ public class MigrationJobServiceTests
     [Fact]
     public async Task GetStatusAsync_returns_status_for_owning_tenant()
     {
-        var service = CreateService();
+        var (service, _) = CreateService();
         var tenant = Tenant(Guid.NewGuid());
 
         var job = await service.StartMigrationAsync(ApiRequest(), tenant);
@@ -49,7 +63,7 @@ public class MigrationJobServiceTests
     [Fact]
     public async Task GetStatusAsync_throws_for_a_different_tenant()
     {
-        var service = CreateService();
+        var (service, _) = CreateService();
         var owner = Tenant(Guid.NewGuid());
         var other = Tenant(Guid.NewGuid());
 
@@ -63,7 +77,7 @@ public class MigrationJobServiceTests
     [Fact]
     public async Task CancelAsync_throws_for_a_different_tenant()
     {
-        var service = CreateService();
+        var (service, _) = CreateService();
         var owner = Tenant(Guid.NewGuid());
         var other = Tenant(Guid.NewGuid());
 
@@ -79,7 +93,7 @@ public class MigrationJobServiceTests
     [Fact]
     public async Task GetHistoryAsync_only_returns_the_calling_tenants_jobs()
     {
-        var service = CreateService();
+        var (service, _) = CreateService();
         var tenantA = Tenant(Guid.NewGuid());
         var tenantB = Tenant(Guid.NewGuid());
 
@@ -95,7 +109,7 @@ public class MigrationJobServiceTests
     [Fact]
     public async Task StartMigrationAsync_throws_when_tenant_context_is_null()
     {
-        var service = CreateService();
+        var (service, _) = CreateService();
 
         // Refusing to start without a resolved tenant prevents the detached migration task from
         // falling back to a stale pooled DbContext tenant and importing into the wrong tenant.
@@ -106,9 +120,42 @@ public class MigrationJobServiceTests
     [Fact]
     public async Task StartMigrationAsync_throws_when_tenant_id_is_empty()
     {
-        var service = CreateService();
+        var (service, _) = CreateService();
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => service.StartMigrationAsync(ApiRequest(), Tenant(Guid.Empty)));
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_serves_the_persisted_record_when_the_job_is_not_in_memory()
+    {
+        // Regression: job state lived only in a ConcurrentDictionary, so an API restart made a
+        // running job's id answer 404 — indistinguishable from a job that never existed.
+        var (service, provider) = CreateService();
+        var tenant = Tenant(Guid.NewGuid());
+        var job = await service.StartMigrationAsync(ApiRequest(), tenant);
+
+        // A fresh service over the same store models the post-restart process: empty job map,
+        // same database.
+        var (restarted, _) = CreateService(provider);
+
+        var status = await restarted.GetStatusAsync(tenant.TenantId, job.Id);
+        status.JobId.Should().Be(job.Id);
+
+        var history = await restarted.GetHistoryAsync(tenant.TenantId);
+        history.Should().ContainSingle(h => h.Id == job.Id);
+    }
+
+    [Fact]
+    public async Task GetSourcesAsync_returns_the_persisted_source()
+    {
+        var (service, _) = CreateService();
+        var tenant = Tenant(Guid.NewGuid());
+
+        await service.StartMigrationAsync(ApiRequest(), tenant);
+
+        var sources = await service.GetSourcesAsync();
+
+        sources.Should().ContainSingle(s => s.NightscoutUrl == "https://example-nightscout.invalid");
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Migration/MigrationJobServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Migration/MigrationJobServiceTests.cs
@@ -147,15 +147,22 @@ public class MigrationJobServiceTests
     }
 
     [Fact]
-    public async Task GetSourcesAsync_returns_the_persisted_source()
+    public async Task GetSourcesAsync_only_returns_the_calling_tenants_sources()
     {
+        // A source URL frequently identifies a person; one tenant must never see another
+        // tenant's sources, even when both migrated from the same URL.
         var (service, _) = CreateService();
-        var tenant = Tenant(Guid.NewGuid());
+        var tenantA = Tenant(Guid.NewGuid());
+        var tenantB = Tenant(Guid.NewGuid());
 
-        await service.StartMigrationAsync(ApiRequest(), tenant);
+        await service.StartMigrationAsync(ApiRequest(), tenantA);
+        await service.StartMigrationAsync(ApiRequest(), tenantB);
 
-        var sources = await service.GetSourcesAsync();
+        var sourcesA = await service.GetSourcesAsync(tenantA.TenantId);
 
-        sources.Should().ContainSingle(s => s.NightscoutUrl == "https://example-nightscout.invalid");
+        sourcesA.Should().ContainSingle(s => s.NightscoutUrl == "https://example-nightscout.invalid");
+
+        var sourcesC = await service.GetSourcesAsync(Guid.NewGuid());
+        sourcesC.Should().BeEmpty();
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/ConnectorCursorResetJobServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/ConnectorCursorResetJobServiceTests.cs
@@ -1,19 +1,22 @@
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.API.Services.Connectors;
 using Nocturne.Connectors.Core.Models;
+using Nocturne.Infrastructure.Data;
 using Xunit;
 
 namespace Nocturne.API.Tests.Services.Connectors;
 
 /// <summary>
-/// Lifecycle behaviour of <see cref="ConnectorCursorResetJobService"/>: it validates the tenant up
-/// front (404 for unknown), seeds per-connector progress before any work runs, and drives the
-/// background fan-out to a terminal state while reflecting per-connector outcomes from the engine's
-/// <see cref="IConnectorResetProgress"/> callbacks. The engine itself is mocked so these tests are
-/// deterministic and need no database.
+/// Lifecycle and durability behaviour of <see cref="ConnectorCursorResetJobService"/>: it validates
+/// the tenant up front (404 for unknown), seeds per-connector progress before any work runs, drives
+/// the background fan-out to a terminal state while reflecting per-connector outcomes from the
+/// engine's <see cref="IConnectorResetProgress"/> callbacks, and persists job records so lookups
+/// survive the in-memory job map being lost (an API restart mid-run previously turned a running job
+/// into a bare 404). The engine itself is mocked so these tests are deterministic.
 /// </summary>
 public class ConnectorCursorResetJobServiceTests
 {
@@ -27,15 +30,23 @@ public class ConnectorCursorResetJobServiceTests
         ]);
 
     /// <summary>
-    /// Builds a job service whose background scope resolves the supplied engine mock.
+    /// Builds a job service whose background scope resolves the supplied engine mock, backed by an
+    /// InMemory NocturneDbContext for job record persistence. Pass an existing provider to model a
+    /// restarted process sharing the same database.
     /// </summary>
-    private static ConnectorCursorResetJobService BuildService(IConnectorCursorResetService engine)
+    private static (ConnectorCursorResetJobService Service, IServiceProvider Provider) BuildService(
+        IConnectorCursorResetService engine,
+        IServiceProvider? existingProvider = null)
     {
-        var services = new ServiceCollection();
-        services.AddScoped(_ => engine);
-        var provider = services.BuildServiceProvider();
-        return new ConnectorCursorResetJobService(
+        var dbName = $"reset-jobs-{Guid.NewGuid():N}";
+        var provider = existingProvider ?? new ServiceCollection()
+            .AddScoped(_ => engine)
+            .AddDbContext<NocturneDbContext>(o => o.UseInMemoryDatabase(dbName))
+            .BuildServiceProvider();
+
+        var service = new ConnectorCursorResetJobService(
             NullLogger<ConnectorCursorResetJobService>.Instance, provider);
+        return (service, provider);
     }
 
     private static async Task<ConnectorResetJobStatus> WaitForTerminalAsync(
@@ -43,7 +54,7 @@ public class ConnectorCursorResetJobServiceTests
     {
         for (var i = 0; i < 100; i++)
         {
-            var status = service.GetStatus(jobId);
+            var status = await service.GetStatusAsync(jobId);
             if (status.State is ConnectorResetJobState.Completed
                 or ConnectorResetJobState.Failed
                 or ConnectorResetJobState.Cancelled)
@@ -63,7 +74,7 @@ public class ConnectorCursorResetJobServiceTests
         engine.Setup(e => e.GetTenantConnectorsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((TenantConnectorsDto?)null);
 
-        var service = BuildService(engine.Object);
+        var (service, _) = BuildService(engine.Object);
 
         var info = await service.StartResetAsync(_tenantId, null, null, CancellationToken.None);
 
@@ -82,7 +93,7 @@ public class ConnectorCursorResetJobServiceTests
                 It.IsAny<IConnectorResetProgress?>(), It.IsAny<CancellationToken>()))
             .Returns(new TaskCompletionSource<TenantCursorResetResult?>().Task);
 
-        var service = BuildService(engine.Object);
+        var (service, _) = BuildService(engine.Object);
 
         var info = await service.StartResetAsync(_tenantId, null, null, CancellationToken.None);
 
@@ -90,7 +101,7 @@ public class ConnectorCursorResetJobServiceTests
         info!.TenantSlug.Should().Be("erik");
         info.TotalConnectors.Should().Be(2);
 
-        var status = service.GetStatus(info.JobId);
+        var status = await service.GetStatusAsync(info.JobId);
         status.TotalConnectors.Should().Be(2);
         status.CompletedConnectors.Should().Be(0);
         status.Connectors.Select(c => c.ConnectorName).Should().ContainInOrder("nightscout", "dexcom");
@@ -119,7 +130,7 @@ public class ConnectorCursorResetJobServiceTests
                         new TenantCursorResetResult(tenantId, "erik", []));
                 });
 
-        var service = BuildService(engine.Object);
+        var (service, _) = BuildService(engine.Object);
 
         var info = await service.StartResetAsync(_tenantId, null, null, CancellationToken.None);
         info.Should().NotBeNull();
@@ -135,16 +146,50 @@ public class ConnectorCursorResetJobServiceTests
     }
 
     [Fact]
-    public void GetStatus_UnknownJob_Throws()
+    public async Task GetStatusAsync_UnknownJob_Throws()
     {
-        var service = BuildService(Mock.Of<IConnectorCursorResetService>());
-        Assert.Throws<KeyNotFoundException>(() => service.GetStatus(Guid.CreateVersion7()));
+        var (service, _) = BuildService(Mock.Of<IConnectorCursorResetService>());
+        await Assert.ThrowsAsync<KeyNotFoundException>(
+            () => service.GetStatusAsync(Guid.CreateVersion7()));
     }
 
     [Fact]
-    public void Cancel_UnknownJob_Throws()
+    public async Task CancelAsync_UnknownJob_Throws()
     {
-        var service = BuildService(Mock.Of<IConnectorCursorResetService>());
-        Assert.Throws<KeyNotFoundException>(() => service.Cancel(Guid.CreateVersion7()));
+        var (service, _) = BuildService(Mock.Of<IConnectorCursorResetService>());
+        await Assert.ThrowsAsync<KeyNotFoundException>(
+            () => service.CancelAsync(Guid.CreateVersion7()));
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_ServesThePersistedRecord_WhenTheJobIsNotInMemory()
+    {
+        // Regression: reset jobs lived only in a ConcurrentDictionary, so an API restart mid-run
+        // made the job id answer 404 — indistinguishable from a job that never existed.
+        var engine = new Mock<IConnectorCursorResetService>();
+        engine.Setup(e => e.GetTenantConnectorsAsync(_tenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Connectors(_tenantId));
+        engine.Setup(e => e.ResetTenantCursorsAsync(
+                _tenantId, It.IsAny<DateTime?>(), It.IsAny<List<SyncDataType>?>(),
+                It.IsAny<IConnectorResetProgress?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TenantCursorResetResult(_tenantId, "erik", []));
+
+        var (service, provider) = BuildService(engine.Object);
+
+        var info = await service.StartResetAsync(_tenantId, null, null, CancellationToken.None);
+        await WaitForTerminalAsync(service, info!.JobId);
+
+        // A fresh service over the same store models the post-restart process: empty job map,
+        // same database.
+        var (restarted, _) = BuildService(engine.Object, provider);
+
+        var status = await restarted.GetStatusAsync(info.JobId);
+        status.JobId.Should().Be(info.JobId);
+        status.TenantId.Should().Be(_tenantId);
+        status.TenantSlug.Should().Be("erik");
+        status.State.Should().Be(ConnectorResetJobState.Completed);
+
+        // Cancel on the persisted terminal record must not 404 and must not throw.
+        await restarted.CancelAsync(info.JobId);
     }
 }


### PR DESCRIPTION
Companion to #625/#626, fixing the third failure mode from the same production migration: **background job state lived only in memory**.

## What that cost in practice

- The tenant's onboarding-wizard import ran on Aug 1; by the time we investigated, the API had restarted and there was **no evidence the import had ever run** — no job record, no history, nothing to distinguish "wizard never started it" from "it ran and died".
- The first recovery cursor-reset imported 253k readings, then the redeploy cron restarted the container: the poll went from `Running` to a **bare 404**, and the work silently died with it.
- `migration_runs` / `migration_sources` tables have existed in the schema all along but were **never written** — `GET /api/v4/migration/sources` always returned `[]`, and `MigrationStartupService`'s "has this source already been migrated?" check could never be satisfied, making the `MIGRATION_MODE` startup notification fire forever.

## Change

- **Records are persisted at every lifecycle transition** — migrations into the existing (previously write-orphaned) `migration_runs`/`migration_sources`, cursor resets into a new `connector_reset_jobs` table. The initial write happens before the detached task starts and propagates failure (a job whose record can't be written must not start); subsequent writes log instead of throwing, and the terminal snapshot in the `finally` retries.
- **Status/cancel fall back to the persisted record** when the job isn't in the in-memory map; history and sources are served from the database. Cancel of a persisted-but-not-running job is a logged no-op, not a 404.
- **Startup sweep marks orphans `Interrupted`** (new state on both job enums, with an explicit "re-run it" error message): the detached tasks die with the process, so a `Pending`/`Running` row at boot can only be an orphan. Runs under the migrator role alongside migrations/RLS reconciliation.
- `migration_runs` gains `tenant_id`, `mode`, `source_description`, `created_at` (EF migration `DurableJobRecords`). Lookups are tenant-scoped by query. Both tables are deliberately **not** RLS/`ITenantScoped`: they're operator metadata read cross-tenant (platform-admin endpoints, the startup sweep) and carry lifecycle state only, no health data. Only non-usable SHA-256 digests of source credentials are stored — never the API secret or connection string, and not the SHA-1 form Nightscout accepts as a credential.
- `IConnectorCursorResetJobService.GetStatus/Cancel` became async for the DB fallback; the admin controller endpoints follow.

## Deliberately out of scope

Resuming interrupted work automatically. Re-ingest is idempotent, so the honest and safe semantic is "Interrupted — re-run it": auto-resuming heavy crawls on every boot risks a stampede after a bad deploy.

## Tests

- Migration + reset job services: existing ownership/lifecycle tests updated to the persisted world (they now run against an InMemory `NocturneDbContext`), plus new regressions: status/history served from the persisted record by a fresh service instance over the same store (models the post-restart process), `GetSourcesAsync` returns the upserted source, cancel of a persisted terminal job doesn't 404.
- Full `Nocturne.API.Tests`: 4548 passed; `Nocturne.Infrastructure.Data.Tests`: 481 passed.

https://claude.ai/code/session_01L2UR4WFuTactp8EEf6NcWr
