### PR TITLE
fix(auth): bind passkey enrolment to the caller, and make TOTP a real second factor

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -24,11 +25,12 @@ namespace Nocturne.API.Controllers.Authentication;
 /// <remarks>
 /// Authentication flows:
 /// <list type="bullet">
-///   <item><description><b>Registration:</b> <c>POST /register/options</c> → <c>POST /register/complete</c></description></item>
+///   <item><description><b>Registration</b> (authenticated, enrols onto the caller's own account): <c>POST /register/options</c> → <c>POST /register/complete</c></description></item>
 ///   <item><description><b>Discoverable login</b> (no username): <c>POST /login/discoverable/options</c> → <c>POST /login/complete</c></description></item>
 ///   <item><description><b>Non-discoverable login</b> (with username): <c>POST /login/options</c> → <c>POST /login/complete</c></description></item>
 ///   <item><description><b>Recovery:</b> <c>POST /recovery/verify</c> issues a 10-minute restricted token allowing passkey management only.</description></item>
-///   <item><description><b>Initial setup:</b> <c>POST /setup/options</c> → <c>POST /setup/complete</c> (only available before any passkeys exist).</description></item>
+///   <item><description><b>Recovery mode:</b> <c>POST /recovery-mode/options</c> → <c>POST /recovery-mode/complete</c> (only for a member that has no passkey and no linked provider).</description></item>
+///   <item><description><b>Initial setup:</b> handled by the setup controller under <c>/api/v4/setup/</c>, not here.</description></item>
 ///   <item><description><b>Invite acceptance:</b> <c>POST /invite/options</c> → <c>POST /invite/complete</c> using a pre-issued invite token.</description></item>
 /// </list>
 ///
@@ -52,7 +54,15 @@ public class PasskeyController : ControllerBase
 {
     private const string RecoveryCookieName = ".Nocturne.RecoverySession";
 
+    /// <summary>
+    /// Shown for every recovery-mode refusal so the response never distinguishes an unknown
+    /// username from an account that still has a working sign-in method.
+    /// </summary>
+    private const string RecoveryModeUnavailable =
+        "That username can't have a passkey registered this way. Sign in with a recovery code instead.";
+
     private readonly IPasskeyService _passkeyService;
+    private readonly ITotpService _totpService;
     private readonly IRecoveryCodeService _recoveryCodeService;
     private readonly IJwtService _jwtService;
     private readonly ISessionService _sessionService;
@@ -69,6 +79,7 @@ public class PasskeyController : ControllerBase
     /// </summary>
     public PasskeyController(
         IPasskeyService passkeyService,
+        ITotpService totpService,
         IRecoveryCodeService recoveryCodeService,
         IJwtService jwtService,
         ISessionService sessionService,
@@ -81,6 +92,7 @@ public class PasskeyController : ControllerBase
         ILogger<PasskeyController> logger)
     {
         _passkeyService = passkeyService;
+        _totpService = totpService;
         _recoveryCodeService = recoveryCodeService;
         _jwtService = jwtService;
         _sessionService = sessionService;
@@ -94,28 +106,29 @@ public class PasskeyController : ControllerBase
     }
 
     /// <summary>
-    /// Generate registration options for a new passkey credential
+    /// Generate registration options for a new passkey credential on the caller's own account.
     /// </summary>
+    /// <remarks>
+    /// The subject comes from the caller's credentials, never from the request: a caller-supplied
+    /// subject id would let anyone enrol their own authenticator onto another account.
+    /// </remarks>
     [HttpPost("register/options")]
     [AllowAnonymous]
     [RemoteCommand]
     [ProducesResponseType(typeof(PasskeyOptionsResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
     public async Task<ActionResult<PasskeyOptionsResponse>> RegisterOptions([FromBody] PasskeyRegisterOptionsRequest request)
     {
+        var subjectId = ResolveRegistrationSubject();
+        if (subjectId == null)
+        {
+            return Problem(detail: "Authentication required", statusCode: 401, title: "Unauthorized");
+        }
+
         if (string.IsNullOrEmpty(request.Username))
         {
             return Problem(detail: "Username is required", statusCode: 400, title: "Bad Request");
-        }
-
-        var subjectId = await ResolveRegistrationSubjectAsync(request.Username);
-        if (subjectId == null)
-        {
-            // Deliberately not distinguishing "no such username" from "that account already
-            // has a credential", matching RecoveryVerify's non-disclosure.
-            return Problem(
-                detail: "Cannot register a passkey for this account",
-                statusCode: 400, title: "Bad Request");
         }
 
         var tenantId = _tenantAccessor.TenantId;
@@ -132,32 +145,27 @@ public class PasskeyController : ControllerBase
     /// <summary>
     /// Resolves which subject a registration ceremony is allowed to bind a credential to.
     /// </summary>
-    /// <param name="username">The account named on the request.</param>
     /// <returns>The subject to register against, or <see langword="null"/> when none qualifies.</returns>
     /// <remarks>
     /// <para>
     /// The request deliberately gets no say in this. The subject id is sealed into the challenge
-    /// token here and nothing downstream re-checks it, so honouring a caller-supplied one let an
-    /// anonymous caller bind their own authenticator to any subject whose id they knew and then
-    /// log in as them.
+    /// token here, so honouring a caller-supplied one let an anonymous caller bind their own
+    /// authenticator to any subject whose id they knew and then log in as them.
     /// </para>
     /// <para>
-    /// Three flows legitimately reach this endpoint, in precedence order: adding a passkey to
-    /// your own account, re-registering after spending a recovery code, and claiming an account
-    /// that holds no credential at all (first owner on a fresh install, or an orphaned subject
-    /// while the instance is in recovery mode).
+    /// Two flows reach these endpoints: adding a passkey to your own account, and re-registering
+    /// after spending a recovery code. The remaining enrolments — first owner, invite acceptance,
+    /// access request, and an account with no sign-in method left — each have their own endpoint
+    /// with its own precondition, so none of them resolve a subject here.
     /// </para>
     /// </remarks>
-    private async Task<Guid?> ResolveRegistrationSubjectAsync(string username)
+    private Guid? ResolveRegistrationSubject()
     {
         var auth = HttpContext.GetAuthContext();
         if (auth is { IsAuthenticated: true, SubjectId: not null })
             return auth.SubjectId;
 
-        if (TryReadRecoverySessionSubject() is { } recoverySubjectId)
-            return recoverySubjectId;
-
-        return await FindCredentiallessSubjectAsync(username);
+        return TryReadRecoverySessionSubject();
     }
 
     /// <summary>
@@ -180,37 +188,27 @@ public class PasskeyController : ControllerBase
     }
 
     /// <summary>
-    /// Finds the named subject in the current tenant only if it holds no passkey and no OIDC
-    /// identity. Such a subject cannot currently be logged into by anyone, so binding the first
-    /// credential to it takes nothing over — this is the same condition
-    /// <see cref="GetAuthStatus"/> reports as setup-required or recovery mode.
-    /// </summary>
-    private async Task<Guid?> FindCredentiallessSubjectAsync(string username)
-    {
-        var tenantId = _tenantAccessor.TenantId;
-
-        return await _dbContext.TenantMembers
-            .Where(tm => tm.TenantId == tenantId)
-            .Select(tm => tm.Subject!)
-            .Where(s => s.Username == username && s.IsActive && !s.IsSystemSubject)
-            .Where(s =>
-                !_dbContext.PasskeyCredentials.Any(c => c.SubjectId == s.Id) &&
-                !_dbContext.SubjectOidcIdentities.Any(o => o.SubjectId == s.Id))
-            .Select(s => (Guid?)s.Id)
-            .FirstOrDefaultAsync();
-    }
-
-    /// <summary>
     /// Complete passkey registration with attestation response
     /// </summary>
+    /// <remarks>
+    /// The challenge must have been issued for the subject the caller's credentials resolve to,
+    /// so a challenge minted by another flow cannot be redeemed as an enrolment onto it.
+    /// </remarks>
     [HttpPost("register/complete")]
     [AllowAnonymous]
     [RemoteCommand(Invalidates = ["ListCredentials"])]
     [ProducesResponseType(typeof(PasskeyRegisterCompleteResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
     public async Task<ActionResult<PasskeyRegisterCompleteResponse>> RegisterComplete(
         [FromBody] PasskeyRegisterCompleteRequest request)
     {
+        var subjectId = ResolveRegistrationSubject();
+        if (subjectId == null)
+        {
+            return Problem(detail: "Authentication required", statusCode: 401, title: "Unauthorized");
+        }
+
         if (string.IsNullOrEmpty(request.ChallengeToken))
         {
             return Problem(detail: "Challenge token not found or expired", statusCode: 400, title: "Bad Request");
@@ -221,7 +219,8 @@ public class PasskeyController : ControllerBase
         try
         {
             var result = await _passkeyService.CompleteRegistrationAsync(
-                request.AttestationResponseJson, request.ChallengeToken, tenantId, request.Label);
+                request.AttestationResponseJson, request.ChallengeToken, tenantId,
+                expectedSubjectId: subjectId.Value, request.Label);
 
             return Ok(new PasskeyRegisterCompleteResponse
             {
@@ -234,6 +233,165 @@ public class PasskeyController : ControllerBase
             _logger.LogWarning(ex, "Passkey registration completion failed");
             return Problem(detail: "Passkey registration failed", statusCode: 400, title: "Bad Request");
         }
+    }
+
+    /// <summary>
+    /// Generate passkey registration options for an account that has no sign-in method left,
+    /// while the tenant is in recovery mode.
+    /// </summary>
+    /// <remarks>
+    /// Unauthenticated by necessity — the target account cannot sign in. The server resolves the
+    /// subject from the username and refuses unless that subject has zero primary auth factors,
+    /// so this can only restore access to an account that is already locked out, never take over
+    /// an account that still has a passkey or a linked provider.
+    /// </remarks>
+    [HttpPost("recovery-mode/options")]
+    [AllowAnonymous]
+    [RemoteCommand]
+    [ProducesResponseType(typeof(PasskeyOptionsResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<PasskeyOptionsResponse>> RecoveryModeOptions(
+        [FromBody] PasskeyLoginOptionsRequest request)
+    {
+        var subject = await ResolveRecoveryModeSubjectAsync(request.Username);
+        if (subject == null)
+        {
+            return Problem(detail: RecoveryModeUnavailable, statusCode: 400, title: "Bad Request");
+        }
+
+        var result = await _passkeyService.GenerateRegistrationOptionsAsync(
+            subject.Id, subject.Username ?? subject.Name, _tenantAccessor.TenantId);
+
+        return Ok(new PasskeyOptionsResponse
+        {
+            Options = result.OptionsJson,
+            ChallengeToken = result.ChallengeToken,
+        });
+    }
+
+    /// <summary>
+    /// Complete recovery-mode passkey registration. Re-checks the recovery-mode conditions so a
+    /// challenge issued while the tenant was in recovery mode cannot be redeemed afterwards.
+    /// </summary>
+    [HttpPost("recovery-mode/complete")]
+    [AllowAnonymous]
+    [RemoteCommand]
+    [ProducesResponseType(typeof(PasskeyRegisterCompleteResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<PasskeyRegisterCompleteResponse>> RecoveryModeComplete(
+        [FromBody] RecoveryModeCompleteRequest request)
+    {
+        if (string.IsNullOrEmpty(request.ChallengeToken))
+        {
+            return Problem(detail: "Challenge token not found or expired", statusCode: 400, title: "Bad Request");
+        }
+
+        var subject = await ResolveRecoveryModeSubjectAsync(request.Username);
+        if (subject == null)
+        {
+            return Problem(detail: RecoveryModeUnavailable, statusCode: 400, title: "Bad Request");
+        }
+
+        try
+        {
+            var result = await _passkeyService.CompleteRegistrationAsync(
+                request.AttestationResponseJson, request.ChallengeToken, _tenantAccessor.TenantId,
+                expectedSubjectId: subject.Id, request.Label);
+
+            return Ok(new PasskeyRegisterCompleteResponse
+            {
+                CredentialId = result.CredentialId,
+                SubjectId = result.SubjectId,
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Recovery-mode passkey registration failed");
+            return Problem(detail: "Passkey registration failed", statusCode: 400, title: "Bad Request");
+        }
+    }
+
+    /// <summary>
+    /// Returns the subject named by <paramref name="username"/> when the tenant is in recovery
+    /// mode and that subject has no primary auth factor, otherwise <see langword="null"/>.
+    /// </summary>
+    private async Task<SubjectEntity?> ResolveRecoveryModeSubjectAsync(string? username)
+    {
+        if (string.IsNullOrWhiteSpace(username))
+        {
+            return null;
+        }
+
+        var tenantId = _tenantAccessor.TenantId;
+
+        // Recovery mode only exists once the tenant has at least one working sign-in method:
+        // before that the tenant is in first-run setup, which has its own owner-creation flow.
+        if (!await TenantHasCredentialsAsync(tenantId) || !await HasOrphanedSubjectAsync(tenantId))
+        {
+            return null;
+        }
+
+        var subject = await _dbContext.TenantMembers
+            .Where(tm => tm.TenantId == tenantId)
+            .Select(tm => tm.Subject!)
+            .FirstOrDefaultAsync(s =>
+                s.Username == username && s.IsActive && !s.IsSystemSubject);
+
+        if (subject == null)
+        {
+            return null;
+        }
+
+        // Fail closed: an account that still has a passkey or a linked provider is not locked
+        // out and must never be enrollable without a session.
+        return await _subjectService.CountPrimaryAuthFactorsAsync(subject.Id) == 0 ? subject : null;
+    }
+
+    /// <summary>
+    /// Names the subject an invite acceptance enrols. The options and complete steps share it, so
+    /// the subject the options step reuses or creates is the one the complete step re-resolves.
+    /// </summary>
+    private static Expression<Func<SubjectEntity, bool>> InviteEnrolmentMatch(string username) =>
+        s => s.Username == username && s.IsActive && s.ApprovalStatus != "Pending";
+
+    /// <summary>
+    /// Names the subject an anonymous access request enrols. Shared by the options and complete
+    /// steps for the same reason as <see cref="InviteEnrolmentMatch"/>.
+    /// </summary>
+    private static Expression<Func<SubjectEntity, bool>> AccessRequestEnrolmentMatch(string displayName) =>
+        s => s.Name == displayName && !s.IsActive && s.ApprovalStatus == "Pending";
+
+    /// <summary>
+    /// Returns the id of the most recently created subject matching <paramref name="match"/> that is
+    /// still part-way through an anonymous enrolment — no passkey, no linked provider, and no
+    /// membership in any tenant — or <see langword="null"/> when nothing matches.
+    /// </summary>
+    /// <remarks>
+    /// The invite and access-request options steps create the subject, so the complete step has to
+    /// re-resolve it: the enrolling subject must not be taken from the challenge token, and the
+    /// invite token is not a key for it because one invite can be accepted by several people.
+    /// <para>
+    /// A subject holding membership anywhere is somebody's account, not an anonymous enrolment.
+    /// Subjects are global and passkeys are stored against the subject, so scoping the membership
+    /// check to the current tenant would let a tenant claim another tenant's credential-less member
+    /// — the locked-out state recovery mode exists for — by enrolling a passkey onto them.
+    /// </para>
+    /// The preconditions mean only a half-finished enrolment can match, never an account that can
+    /// already sign in or that belongs to a tenant — so with several candidates (duplicates left by
+    /// an older build of the options step) every one of them is an empty shell and the newest, which
+    /// the caller's ceremony was minted against, wins. Ids are UUID v7, which sort in creation order.
+    /// </remarks>
+    private async Task<Guid?> FindEnrollingSubjectIdAsync(Expression<Func<SubjectEntity, bool>> match)
+    {
+        return await _dbContext.Subjects
+            .Where(match)
+            .Where(s => !s.IsSystemSubject
+                && !_dbContext.PasskeyCredentials.Any(c => c.SubjectId == s.Id)
+                && !_dbContext.SubjectOidcIdentities.Any(o => o.SubjectId == s.Id)
+                && !_dbContext.TenantMembers.Any(m => m.SubjectId == s.Id))
+            .OrderByDescending(s => s.Id)
+            .Select(s => (Guid?)s.Id)
+            .FirstOrDefaultAsync();
     }
 
     /// <summary>
@@ -302,6 +460,26 @@ public class PasskeyController : ControllerBase
         {
             var assertionResult = await _passkeyService.CompleteAssertionAsync(
                 request.AssertionResponseJson, request.ChallengeToken, tenantId);
+
+            // A subject with an authenticator enrolled finishes signing in at
+            // POST /api/auth/totp/login. No session is issued here, so the passkey alone does
+            // not grant access.
+            if (await _totpService.GetCredentialCountAsync(assertionResult.SubjectId) > 0)
+            {
+                // Not a completed login, so not a successful one; the success row is written when
+                // the second factor lands.
+                await _auditService.LogAsync(AuthAuditEventType.Login, assertionResult.SubjectId, success: false,
+                    ipAddress: HttpContext.Connection.RemoteIpAddress?.ToString(),
+                    userAgent: Request.Headers.UserAgent.ToString(),
+                    detailsJson: JsonSerializer.Serialize(new { method = "passkey", secondFactorPending = true }));
+
+                return Ok(new PasskeyLoginCompleteResponse
+                {
+                    Success = true,
+                    TotpRequired = true,
+                    StepUpToken = await _totpService.CreateStepUpTokenAsync(assertionResult.SubjectId),
+                });
+            }
 
             var session = await _sessionService.IssueSessionAsync(
                 assertionResult.SubjectId,
@@ -542,32 +720,9 @@ public class PasskeyController : ControllerBase
     {
         var tenantId = _tenantAccessor.TenantId;
 
-        var hasCredentials = await _dbContext.TenantMembers
-            .Where(m => m.TenantId == tenantId)
-            .AnyAsync(m =>
-                _dbContext.PasskeyCredentials.Any(c => c.SubjectId == m.SubjectId) ||
-                _dbContext.SubjectOidcIdentities.Any(o => o.SubjectId == m.SubjectId));
+        var hasCredentials = await TenantHasCredentialsAsync(tenantId);
         var setupRequired = !hasCredentials;
-
-        bool recoveryMode;
-        if (hasCredentials)
-        {
-            recoveryMode = await _dbContext.TenantMembers
-                .Where(tm => tm.TenantId == tenantId)
-                .Join(
-                    _dbContext.Subjects.Where(s => s.IsActive && !s.IsSystemSubject),
-                    tm => tm.SubjectId,
-                    s => s.Id,
-                    (tm, s) => s)
-                .Where(s =>
-                    !_dbContext.SubjectOidcIdentities.Any(i => i.SubjectId == s.Id) &&
-                    !_dbContext.PasskeyCredentials.Any(p => p.SubjectId == s.Id))
-                .AnyAsync();
-        }
-        else
-        {
-            recoveryMode = false;
-        }
+        var recoveryMode = hasCredentials && await HasOrphanedSubjectAsync(tenantId);
 
         var tenant = await _dbContext.Tenants.FirstOrDefaultAsync(t => t.Id == tenantId);
 
@@ -578,6 +733,38 @@ public class PasskeyController : ControllerBase
             AllowAccessRequests = tenant?.AllowAccessRequests ?? false,
             OnboardingCompleted = tenant?.OnboardingCompletedAt != null,
         });
+    }
+
+    /// <summary>
+    /// Whether any member of the tenant has a passkey or a linked provider, i.e. whether the
+    /// tenant is past first-run setup.
+    /// </summary>
+    private Task<bool> TenantHasCredentialsAsync(Guid tenantId)
+    {
+        return _dbContext.TenantMembers
+            .Where(m => m.TenantId == tenantId)
+            .AnyAsync(m =>
+                _dbContext.PasskeyCredentials.Any(c => c.SubjectId == m.SubjectId) ||
+                _dbContext.SubjectOidcIdentities.Any(o => o.SubjectId == m.SubjectId));
+    }
+
+    /// <summary>
+    /// Whether the tenant has an active, non-system member with no passkey and no linked
+    /// provider — an account that cannot sign in at all.
+    /// </summary>
+    private Task<bool> HasOrphanedSubjectAsync(Guid tenantId)
+    {
+        return _dbContext.TenantMembers
+            .Where(tm => tm.TenantId == tenantId)
+            .Join(
+                _dbContext.Subjects.Where(s => s.IsActive && !s.IsSystemSubject),
+                tm => tm.SubjectId,
+                s => s.Id,
+                (tm, s) => s)
+            .Where(s =>
+                !_dbContext.SubjectOidcIdentities.Any(i => i.SubjectId == s.Id) &&
+                !_dbContext.PasskeyCredentials.Any(p => p.SubjectId == s.Id))
+            .AnyAsync();
     }
 
     /// <summary>
@@ -631,36 +818,50 @@ public class PasskeyController : ControllerBase
             return Problem(detail: "Display name is required", statusCode: 400, title: "Bad Request");
 
         var displayName = request.DisplayName.Trim();
-
-        var existingPending = await _dbContext.Subjects
-            .AnyAsync(s => s.ApprovalStatus == "Pending" && s.Name == displayName);
-
-        if (existingPending)
-            return Conflict(new ProblemDetails
-            {
-                Detail = "A pending access request with this name already exists",
-                Status = 409,
-                Title = "Conflict",
-            });
-
-        var subjectId = Guid.CreateVersion7();
         var username = displayName.ToLowerInvariant().Replace(" ", "-");
 
-        _dbContext.Subjects.Add(new SubjectEntity
+        // Cancelling the OS prompt leaves the subject this step created behind. Resume that one
+        // rather than adding another under the same name: it holds no credential, so there is
+        // nothing to take over, and the complete step resolves the requestor by display name.
+        var subjectId = await FindEnrollingSubjectIdAsync(AccessRequestEnrolmentMatch(displayName));
+
+        if (subjectId == null)
         {
-            Id = subjectId,
-            Name = displayName,
-            Username = username,
-            IsActive = false,
-            IsSystemSubject = false,
-            ApprovalStatus = "Pending",
-            AccessRequestMessage = request.Message?.Trim(),
-        });
+            var existingPending = await _dbContext.Subjects
+                .AnyAsync(s => s.ApprovalStatus == "Pending" && s.Name == displayName);
+
+            if (existingPending)
+                return Conflict(new ProblemDetails
+                {
+                    Detail = "A pending access request with this name already exists",
+                    Status = 409,
+                    Title = "Conflict",
+                });
+
+            var subject = new SubjectEntity
+            {
+                Id = Guid.CreateVersion7(),
+                Name = displayName,
+                Username = username,
+                IsActive = false,
+                IsSystemSubject = false,
+                ApprovalStatus = "Pending",
+                AccessRequestMessage = request.Message?.Trim(),
+            };
+
+            _dbContext.Subjects.Add(subject);
+            subjectId = subject.Id;
+        }
+        else
+        {
+            var subject = await _dbContext.Subjects.FirstAsync(s => s.Id == subjectId.Value);
+            subject.AccessRequestMessage = request.Message?.Trim();
+        }
 
         await _dbContext.SaveChangesAsync();
 
         var result = await _passkeyService.GenerateRegistrationOptionsAsync(
-            subjectId, username, tenant.Id);
+            subjectId.Value, username, tenant.Id);
 
         return Ok(new PasskeyOptionsResponse
         {
@@ -674,7 +875,11 @@ public class PasskeyController : ControllerBase
     /// Verifies the attestation, stores the credential, and notifies tenant owners via
     /// <see cref="IInAppNotificationService"/>. The subject remains inactive until an owner approves.
     /// </summary>
-    /// <param name="request">The attestation response and challenge token from the WebAuthn ceremony.</param>
+    /// <remarks>
+    /// The display name is re-resolved to the pending subject the options step created rather than
+    /// trusted, so a registration challenge minted by another flow cannot be redeemed here.
+    /// </remarks>
+    /// <param name="request">The display name, attestation response, and challenge token from the WebAuthn ceremony.</param>
     /// <param name="notificationService">Injected notification service for alerting owners.</param>
     /// <returns><c>200 OK</c> on success, or <c>400</c> / <c>404</c> on error.</returns>
     [HttpPost("access-request/complete")]
@@ -694,16 +899,24 @@ public class PasskeyController : ControllerBase
         if (tenant == null || !tenant.AllowAccessRequests)
             return NotFound();
 
+        var displayName = request.DisplayName?.Trim();
+        var enrollingSubjectId = string.IsNullOrEmpty(displayName)
+            ? null
+            : await FindEnrollingSubjectIdAsync(AccessRequestEnrolmentMatch(displayName));
+
+        if (enrollingSubjectId == null)
+            return Problem(detail: "Start the access request again", statusCode: 400, title: "Bad Request");
+
         try
         {
             var credResult = await _passkeyService.CompleteRegistrationAsync(
-                request.AttestationResponseJson, request.ChallengeToken, tenant.Id);
+                request.AttestationResponseJson, request.ChallengeToken, tenant.Id,
+                expectedSubjectId: enrollingSubjectId.Value);
 
-            var subject = await _dbContext.Subjects
-                .FirstOrDefaultAsync(s => s.Id == credResult.SubjectId);
-
-            var displayName = subject?.Name ?? "Unknown";
-            var message = subject?.AccessRequestMessage;
+            var message = await _dbContext.Subjects
+                .Where(s => s.Id == credResult.SubjectId)
+                .Select(s => s.AccessRequestMessage)
+                .FirstOrDefaultAsync();
 
             var ownerIds = await _dbContext.TenantMembers
                 .Where(tm => tm.TenantId == tenant.Id
@@ -771,28 +984,44 @@ public class PasskeyController : ControllerBase
 
         var tenantId = _tenantAccessor.TenantId;
 
-        // Create the subject
-        var subjectId = Guid.CreateVersion7();
         var username = request.Username.Trim().ToLowerInvariant();
+        var displayName = request.DisplayName.Trim();
 
-        _dbContext.Subjects.Add(new SubjectEntity
+        // Cancelling the OS prompt leaves the subject this step created behind. Reuse that one
+        // rather than adding a second under the same username: the complete step resolves the
+        // enrolling subject by username, and it holds no credential, so there is nothing to take
+        // over.
+        var subjectId = await FindEnrollingSubjectIdAsync(InviteEnrolmentMatch(username));
+
+        if (subjectId == null)
         {
-            Id = subjectId,
-            Name = request.DisplayName.Trim(),
-            Username = username,
-            IsActive = true,
-            IsSystemSubject = false,
-        });
+            var subject = new SubjectEntity
+            {
+                Id = Guid.CreateVersion7(),
+                Name = displayName,
+                Username = username,
+                IsActive = true,
+                IsSystemSubject = false,
+            };
+
+            _dbContext.Subjects.Add(subject);
+            subjectId = subject.Id;
+        }
+        else
+        {
+            var subject = await _dbContext.Subjects.FirstAsync(s => s.Id == subjectId.Value);
+            subject.Name = displayName;
+        }
 
         await _dbContext.SaveChangesAsync();
 
         _logger.LogInformation(
-            "Invite: created subject {SubjectId} ({Username}) for invite acceptance",
+            "Invite: enrolling subject {SubjectId} ({Username}) for invite acceptance",
             subjectId, username);
 
         // Generate passkey registration options
         var result = await _passkeyService.GenerateRegistrationOptionsAsync(
-            subjectId, username, tenantId);
+            subjectId.Value, username, tenantId);
 
         return Ok(new PasskeyOptionsResponse
         {
@@ -805,6 +1034,11 @@ public class PasskeyController : ControllerBase
     /// Complete passkey registration for an invite acceptance.
     /// Verifies attestation, accepts the invite, generates recovery codes, and issues a session.
     /// </summary>
+    /// <remarks>
+    /// The username is re-resolved to the subject the options step created rather than trusted, so
+    /// a registration challenge minted by another flow cannot be redeemed here. Only a subject with
+    /// no sign-in method and no membership in any tenant can match.
+    /// </remarks>
     [HttpPost("invite/complete")]
     [AllowAnonymous]
     [RemoteCommand]
@@ -815,17 +1049,25 @@ public class PasskeyController : ControllerBase
         [FromBody] InviteCompleteRequest request,
         [FromServices] IMemberInviteService memberInviteService)
     {
-        if (string.IsNullOrEmpty(request.ChallengeToken) || string.IsNullOrEmpty(request.Token))
+        if (string.IsNullOrEmpty(request.ChallengeToken) || string.IsNullOrEmpty(request.Token)
+            || string.IsNullOrWhiteSpace(request.Username))
         {
-            return Problem(detail: "Challenge token and invite token are required", statusCode: 400, title: "Bad Request");
+            return Problem(detail: "Username, challenge token, and invite token are required", statusCode: 400, title: "Bad Request");
         }
 
         var tenantId = _tenantAccessor.TenantId;
 
+        var username = request.Username.Trim().ToLowerInvariant();
+        var enrollingSubjectId = await FindEnrollingSubjectIdAsync(InviteEnrolmentMatch(username));
+
+        if (enrollingSubjectId == null)
+            return Problem(detail: "Start again from your invite link", statusCode: 400, title: "Bad Request");
+
         try
         {
             var credResult = await _passkeyService.CompleteRegistrationAsync(
-                request.AttestationResponseJson, request.ChallengeToken, tenantId);
+                request.AttestationResponseJson, request.ChallengeToken, tenantId,
+                expectedSubjectId: enrollingSubjectId.Value);
 
             // Accept the invite
             var acceptResult = await memberInviteService.AcceptInviteAsync(request.Token, credResult.SubjectId);
@@ -880,16 +1122,28 @@ public class PasskeyOptionsResponse
 }
 
 /// <summary>
-/// Request for passkey registration options
+/// Request for passkey registration options. There is deliberately no subject id here — the
+/// server resolves the subject from the caller's credentials, because a caller-supplied one is an
+/// anonymous account-takeover.
 /// </summary>
 public class PasskeyRegisterOptionsRequest
 {
     /// <remarks>
-    /// Names the account only for the credentialless-claim flow. There is deliberately no
-    /// subject id here — the server resolves the subject, because a caller-supplied one is an
-    /// anonymous account-takeover.
+    /// Only the label the authenticator shows for the credential.
     /// </remarks>
     public string Username { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Request to complete a recovery-mode passkey registration. The username is re-checked against
+/// the recovery-mode conditions rather than trusted.
+/// </summary>
+public class RecoveryModeCompleteRequest
+{
+    public string Username { get; set; } = string.Empty;
+    public string AttestationResponseJson { get; set; } = string.Empty;
+    public string ChallengeToken { get; set; } = string.Empty;
+    public string? Label { get; set; }
 }
 
 /// <summary>
@@ -929,13 +1183,17 @@ public class PasskeyLoginCompleteRequest
 }
 
 /// <summary>
-/// Response for completed passkey login
+/// Response for completed passkey login. When <see cref="TotpRequired"/> is set the passkey was
+/// accepted but no session exists yet: the caller must post <see cref="StepUpToken"/> with an
+/// authenticator code to <c>/api/auth/totp/login</c>.
 /// </summary>
 public class PasskeyLoginCompleteResponse
 {
     public bool Success { get; set; }
     public string AccessToken { get; set; } = string.Empty;
     public int ExpiresIn { get; set; }
+    public bool TotpRequired { get; set; }
+    public string? StepUpToken { get; set; }
 }
 
 /// <summary>
@@ -1024,8 +1282,13 @@ public class AccessRequestOptionsRequest
     public string? Message { get; set; }
 }
 
+/// <summary>
+/// Request to complete an anonymous access request. The display name is re-resolved against the
+/// pending subject the options step created rather than trusted.
+/// </summary>
 public class AccessRequestCompleteRequest
 {
+    public string DisplayName { get; set; } = string.Empty;
     public string AttestationResponseJson { get; set; } = string.Empty;
     public string ChallengeToken { get; set; } = string.Empty;
 }
@@ -1037,9 +1300,14 @@ public class InviteOptionsRequest
     public string DisplayName { get; set; } = string.Empty;
 }
 
+/// <summary>
+/// Request to complete an invite acceptance. The username is re-resolved against the subject the
+/// options step created rather than trusted.
+/// </summary>
 public class InviteCompleteRequest
 {
     public string Token { get; set; } = string.Empty;
+    public string Username { get; set; } = string.Empty;
     public string AttestationResponseJson { get; set; } = string.Empty;
     public string ChallengeToken { get; set; } = string.Empty;
 }

--- a/src/API/Nocturne.API/Controllers/Authentication/TotpController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/TotpController.cs
@@ -20,9 +20,17 @@ namespace Nocturne.API.Controllers.Authentication;
 /// Handles setup, verification, credential listing/removal, and TOTP-based authentication.
 /// </summary>
 /// <remarks>
-/// TOTP is treated as a second factor. Setup requires at least one primary auth factor
-/// (passkey or OIDC link) to be configured first. This prevents a user from having TOTP
-/// as their only authentication method.
+/// TOTP is never a sole factor: <see cref="Setup"/> requires at least one primary auth factor
+/// (passkey or OIDC link) to already be configured, and <see cref="Login"/> requires a step-up
+/// token minted by a completed primary factor, so a code on its own can never produce a session.
+/// <para>
+/// Known limitation — TOTP is only <em>demanded</em> on the passkey sign-in path.
+/// <c>PasskeyController.LoginComplete</c> checks <see cref="ITotpService.GetCredentialCountAsync"/>
+/// and withholds the session until a code is supplied here. The OIDC login callback
+/// (<c>OidcAuthService.CompleteLoginAsync</c>) does not: a subject with TOTP enrolled and a linked
+/// provider signs in through that provider with no code. Closing it needs a pending-second-factor
+/// state carried across the provider redirect, which the web app has no route for today.
+/// </para>
 /// </remarks>
 /// <seealso cref="ITotpService"/>
 /// <seealso cref="ISessionService"/>
@@ -34,6 +42,12 @@ namespace Nocturne.API.Controllers.Authentication;
 [AllowDuringSetup]
 public class TotpController : ControllerBase
 {
+    /// <summary>
+    /// Returned for every rejected step-up so the response does not distinguish an expired token
+    /// from a wrong code, or reveal whether an account exists.
+    /// </summary>
+    private const string CodeNotAccepted = "That code wasn't accepted. Please sign in again.";
+
     private readonly ITotpService _totpService;
     private readonly ISessionService _sessionService;
     private readonly ISubjectService _subjectService;
@@ -207,17 +221,20 @@ public class TotpController : ControllerBase
     }
 
     /// <summary>
-    /// Authenticate using a TOTP code and username.
+    /// Complete sign-in with a TOTP code after a primary factor has been verified.
     /// </summary>
-    /// <param name="request">A <see cref="TotpLoginRequest"/> containing the username and 6-digit code.</param>
+    /// <param name="request">A <see cref="TotpLoginRequest"/> containing the step-up token and 6-digit code.</param>
     /// <returns>A <see cref="TotpLoginResponse"/> with access token on success.</returns>
     /// <remarks>
+    /// TOTP is a second factor, so this endpoint needs a step-up token from a completed passkey
+    /// assertion — it cannot be reached with a code alone. The token names the subject; a
+    /// caller-supplied username is not accepted.
     /// Rate-limited via the "totp-login" policy.
     /// On success: issues session cookies, updates last login time, and logs
     /// <see cref="AuthAuditEventType.Login"/>. On failure: logs <see cref="AuthAuditEventType.FailedAuth"/>.
     /// </remarks>
     /// <response code="200">Login successful with access token.</response>
-    /// <response code="400">Invalid username or code.</response>
+    /// <response code="400">Invalid step-up token or code.</response>
     [HttpPost("login")]
     [AllowAnonymous]
     [EnableRateLimiting("totp-login")]
@@ -229,25 +246,25 @@ public class TotpController : ControllerBase
         var ip = HttpContext.Connection.RemoteIpAddress?.ToString();
         var ua = Request.Headers.UserAgent.ToString();
 
-        var result = await _totpService.VerifyLoginAsync(request.Username, request.Code);
+        var result = await _totpService.VerifyStepUpAsync(request.StepUpToken, request.Code);
         if (result == null)
         {
             await _auditService.LogAsync(AuthAuditEventType.FailedAuth, subjectId: null, success: false,
                 ipAddress: ip, userAgent: ua,
-                detailsJson: JsonSerializer.Serialize(new { method = "totp", username = request.Username }));
-            return Problem(detail: "Invalid username or code", statusCode: 400, title: "Bad Request");
+                detailsJson: JsonSerializer.Serialize(new { method = "totp" }));
+            return Problem(detail: CodeNotAccepted, statusCode: 400, title: "Bad Request");
         }
 
-        // VerifyLoginAsync resolves the subject by username globally, so a member of another
-        // tenant with a valid TOTP credential could otherwise be issued a session here. Require
-        // membership of the tenant being logged into; respond as for an invalid code so the
-        // failure does not reveal that the account exists on a different tenant.
+        // The step-up token is minted by the passkey assertion, which is not tenant-scoped, so a
+        // member of another tenant could otherwise be issued a session here. Require membership of
+        // the tenant being logged into; respond as for an invalid code so the failure does not
+        // reveal that the account exists on a different tenant.
         if (!await _tenantMemberService.IsMemberAsync(result.SubjectId, _tenantAccessor.TenantId))
         {
             await _auditService.LogAsync(AuthAuditEventType.FailedAuth, result.SubjectId, success: false,
                 ipAddress: ip, userAgent: ua,
                 detailsJson: JsonSerializer.Serialize(new { method = "totp", reason = "not_a_member" }));
-            return Problem(detail: "Invalid username or code", statusCode: 400, title: "Bad Request");
+            return Problem(detail: CodeNotAccepted, statusCode: 400, title: "Bad Request");
         }
 
         var session = await _sessionService.IssueSessionAsync(
@@ -323,12 +340,13 @@ public class TotpCredentialDto
 }
 
 /// <summary>
-/// Request to authenticate using TOTP
+/// Request to complete sign-in with TOTP. The subject comes from the step-up token, which is
+/// issued only after a primary factor has been verified.
 /// </summary>
 public class TotpLoginRequest
 {
-    [Required, StringLength(255)]
-    public string Username { get; set; } = string.Empty;
+    [Required]
+    public string StepUpToken { get; set; } = string.Empty;
 
     [Required, RegularExpression(@"^\d{6}$")]
     public string Code { get; set; } = string.Empty;

--- a/src/API/Nocturne.API/Controllers/V4/SetupController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/SetupController.cs
@@ -233,10 +233,18 @@ public partial class SetupController : ControllerBase
         if (string.IsNullOrEmpty(request.ChallengeToken))
             return Problem(detail: "Challenge token is required", statusCode: 400, title: "Bad Request");
 
+        // The enrolling subject is looked up here rather than taken from the challenge token, so a
+        // registration challenge minted by another flow cannot be redeemed as the first owner.
+        var ownerSubjectId = await FindSetupOwnerSubjectIdAsync(tenant!, ct);
+        if (ownerSubjectId == null)
+            return Problem(detail: "Start setup again to create the owner account",
+                statusCode: 400, title: "Bad Request");
+
         try
         {
             var credResult = await _passkeyService.CompleteRegistrationAsync(
-                request.AttestationResponseJson, request.ChallengeToken, tenant!.Id);
+                request.AttestationResponseJson, request.ChallengeToken, tenant!.Id,
+                expectedSubjectId: ownerSubjectId.Value);
 
             // Generate recovery codes
             var recoveryCodes = await _recoveryCodeService.GenerateCodesAsync(credResult.SubjectId);
@@ -424,6 +432,32 @@ public partial class SetupController : ControllerBase
     }
 
     /// <summary>
+    /// The first-run owner subject: the earliest non-system active subject. Setup only runs while
+    /// no member of the tenant holds credentials, so this is the account the owner options step
+    /// created or reused. Ordered so the options and complete steps resolve the same row.
+    /// </summary>
+    private static IQueryable<SubjectEntity> SetupOwnerSubjects(NocturneDbContext context) =>
+        context.Subjects.Where(s => !s.IsSystemSubject && s.IsActive).OrderBy(s => s.Id);
+
+    /// <summary>
+    /// Returns the first-run owner subject's id as resolved from the database, or
+    /// <see langword="null"/> when the options step has not created it yet.
+    /// </summary>
+    private async Task<Guid?> FindSetupOwnerSubjectIdAsync(TenantEntity tenant, CancellationToken ct)
+    {
+        await using var context = await _dbFactory.CreateDbContextAsync(ct);
+
+        await context.Database.ExecuteSqlRawAsync(
+            "SELECT set_config('app.current_tenant_id', {0}, false)",
+            tenant.Id.ToString());
+
+        return await SetupOwnerSubjects(context)
+            .AsNoTracking()
+            .Select(s => (Guid?)s.Id)
+            .FirstOrDefaultAsync(ct);
+    }
+
+    /// <summary>
     /// Find or create the first non-system subject, ensure it is a member of the
     /// given tenant with the owner role, and assign the global admin role.
     /// Idempotent: safe to call on retries after a failed WebAuthn/OIDC ceremony,
@@ -438,8 +472,7 @@ public partial class SetupController : ControllerBase
             "SELECT set_config('app.current_tenant_id', {0}, false)",
             tenant.Id.ToString());
 
-        var existingSubject = await context.Subjects
-            .FirstOrDefaultAsync(s => !s.IsSystemSubject && s.IsActive, ct);
+        var existingSubject = await SetupOwnerSubjects(context).FirstOrDefaultAsync(ct);
 
         Guid subjectId;
         if (existingSubject != null)

--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -82,7 +82,6 @@ public class TenantResolutionMiddleware
         // Platform-admin tenant-access grant: minted at the apex (operator is not on
         // any tenant subdomain yet); the target tenant is resolved from the query string.
         "/api/auth/platform-access",
-        "/api/auth/passkey/setup/",
         "/api/v4/admin/demo/",
         "/api/v4/admin/platform-settings",
         "/api/v4/admin/tenants",

--- a/src/API/Nocturne.API/Services/Auth/OAuthCodeCleanupService.cs
+++ b/src/API/Nocturne.API/Services/Auth/OAuthCodeCleanupService.cs
@@ -4,8 +4,9 @@ using Nocturne.Infrastructure.Data;
 namespace Nocturne.API.Services.Auth;
 
 /// <summary>
-/// Background service that periodically removes expired OAuth device codes and authorisation codes
-/// to prevent database bloat. Runs every hour and removes codes that expired more than one hour ago.
+/// Background service that periodically removes expired OAuth device codes, authorisation codes and
+/// TOTP step-up tokens to prevent database bloat. Runs every hour and removes records that expired
+/// more than one hour ago.
 /// </summary>
 /// <remarks>
 /// The <see cref="RetentionBuffer"/> provides a grace window for in-flight exchanges to complete
@@ -103,12 +104,20 @@ public class OAuthCodeCleanupService : BackgroundService
             .OAuthAuthorizationCodes.Where(c => c.ExpiresAt < cutoff)
             .ExecuteDeleteAsync(ct);
 
-        if (deletedDeviceCodes > 0 || deletedAuthCodes > 0)
+        // TOTP step-up tokens are the same shape of short-lived single-use record: one row per
+        // minted token, redeemable once, kept only until it has been expired for the buffer.
+        var deletedStepUpTokens = await db
+            .TotpStepUpTokens.Where(t => t.ExpiresAt < cutoff)
+            .ExecuteDeleteAsync(ct);
+
+        if (deletedDeviceCodes > 0 || deletedAuthCodes > 0 || deletedStepUpTokens > 0)
         {
             _logger.LogInformation(
-                "OAuth code cleanup: removed {DeviceCodes} device codes and {AuthCodes} authorization codes",
+                "OAuth code cleanup: removed {DeviceCodes} device codes, {AuthCodes} authorization codes "
+                    + "and {StepUpTokens} TOTP step-up tokens",
                 deletedDeviceCodes,
-                deletedAuthCodes
+                deletedAuthCodes,
+                deletedStepUpTokens
             );
         }
     }

--- a/src/API/Nocturne.API/Services/Auth/OidcAuthService.cs
+++ b/src/API/Nocturne.API/Services/Auth/OidcAuthService.cs
@@ -290,6 +290,12 @@ public class OidcAuthService : IOidcAuthService
     /// issued — otherwise any external identity could mint a session on any tenant's subdomain.
     /// Extracted from <see cref="HandleCallbackAsync"/> so the membership gate can be unit-tested
     /// without exercising the OIDC code exchange.
+    /// <para>
+    /// No TOTP second-factor gate here. <c>PasskeyController.LoginComplete</c> withholds the session
+    /// when the subject has an authenticator enrolled; this path issues one regardless, so a subject
+    /// with TOTP and a linked provider signs in through the provider without a code. Adding the gate
+    /// needs a pending-second-factor state that survives the provider redirect.
+    /// </para>
     /// </summary>
     internal async Task<OidcCallbackResult> CompleteLoginAsync(
         OidcStateData stateData,

--- a/src/API/Nocturne.API/Services/Auth/PasskeyService.cs
+++ b/src/API/Nocturne.API/Services/Auth/PasskeyService.cs
@@ -127,15 +127,26 @@ public class PasskeyService : IPasskeyService
         });
 
         var optionsJson = JsonSerializer.Serialize(options, FidoModelSerializerContext.Default.CredentialCreateOptions);
-        var challengeToken = CreateChallengeToken(optionsJson, subjectId);
+        var challengeToken = CreateChallengeToken(optionsJson, subjectId, ChallengePurpose.Registration);
 
         return new PasskeyRegistrationOptions(optionsJson, challengeToken);
     }
 
     public async Task<PasskeyCredentialResult> CompleteRegistrationAsync(
-        string attestationResponseJson, string challengeToken, Guid tenantId, string? label = null)
+        string attestationResponseJson, string challengeToken, Guid tenantId, Guid expectedSubjectId,
+        string? label = null)
     {
-        var cookie = ReadChallengeToken(challengeToken);
+        var cookie = ReadChallengeToken(challengeToken, ChallengePurpose.Registration);
+
+        // Checked before the ceremony so a challenge for the wrong subject is rejected outright.
+        var subjectId = cookie.SubjectId
+            ?? throw new InvalidOperationException("Challenge cookie missing subject ID for registration.");
+
+        if (subjectId != expectedSubjectId)
+        {
+            throw new InvalidOperationException(
+                "Registration challenge was not issued for the enrolling subject.");
+        }
 
         var originalOptions = JsonSerializer.Deserialize(
             cookie.OptionsJson,
@@ -157,9 +168,6 @@ public class PasskeyService : IPasskeyService
                 return !exists;
             },
         });
-
-        var subjectId = cookie.SubjectId
-            ?? throw new InvalidOperationException("Challenge cookie missing subject ID for registration.");
 
         // Enforce 20 credential cap
         var existingCount = await _dbContext.PasskeyCredentials
@@ -203,7 +211,7 @@ public class PasskeyService : IPasskeyService
         });
 
         var optionsJson = JsonSerializer.Serialize(options, FidoModelSerializerContext.Default.AssertionOptions);
-        var challengeToken = CreateChallengeToken(optionsJson, subjectId: null);
+        var challengeToken = CreateChallengeToken(optionsJson, subjectId: null, ChallengePurpose.Assertion);
 
         return Task.FromResult(new PasskeyAssertionOptions(optionsJson, challengeToken));
     }
@@ -230,7 +238,7 @@ public class PasskeyService : IPasskeyService
         });
 
         var optionsJson = JsonSerializer.Serialize(options, FidoModelSerializerContext.Default.AssertionOptions);
-        var challengeToken = CreateChallengeToken(optionsJson, subject.Id);
+        var challengeToken = CreateChallengeToken(optionsJson, subject.Id, ChallengePurpose.Assertion);
 
         return new PasskeyAssertionOptions(optionsJson, challengeToken);
     }
@@ -238,7 +246,7 @@ public class PasskeyService : IPasskeyService
     public async Task<PasskeyAssertionResult> CompleteAssertionAsync(
         string assertionResponseJson, string challengeToken, Guid tenantId)
     {
-        var cookie = ReadChallengeToken(challengeToken);
+        var cookie = ReadChallengeToken(challengeToken, ChallengePurpose.Assertion);
 
         var originalOptions = JsonSerializer.Deserialize(
             cookie.OptionsJson,
@@ -320,12 +328,13 @@ public class PasskeyService : IPasskeyService
             .CountAsync(c => c.SubjectId == subjectId);
     }
 
-    private string CreateChallengeToken(string optionsJson, Guid? subjectId)
+    private string CreateChallengeToken(string optionsJson, Guid? subjectId, string purpose)
     {
         var payload = new ChallengeCookiePayload
         {
             OptionsJson = optionsJson,
             SubjectId = subjectId,
+            Purpose = purpose,
             ExpiresAt = DateTime.UtcNow.Add(ChallengeExpiry),
         };
 
@@ -333,7 +342,7 @@ public class PasskeyService : IPasskeyService
         return _protector.Protect(json);
     }
 
-    private ChallengeCookiePayload ReadChallengeToken(string challengeToken)
+    private ChallengeCookiePayload ReadChallengeToken(string challengeToken, string expectedPurpose)
     {
         string json;
         try
@@ -349,6 +358,14 @@ public class PasskeyService : IPasskeyService
         var payload = JsonSerializer.Deserialize<ChallengeCookiePayload>(json)
             ?? throw new InvalidOperationException("Failed to deserialize challenge token payload.");
 
+        // Registration and assertion tokens share one protector, so the purpose is checked
+        // here: an assertion token is bound to the subject named in the login request, and
+        // without this check it could be redeemed as a registration challenge for that subject.
+        if (payload.Purpose != expectedPurpose)
+        {
+            throw new InvalidOperationException("Challenge token was issued for a different ceremony.");
+        }
+
         if (payload.ExpiresAt < DateTime.UtcNow)
         {
             throw new InvalidOperationException("Challenge token has expired. Please restart the authentication flow.");
@@ -357,10 +374,17 @@ public class PasskeyService : IPasskeyService
         return payload;
     }
 
+    private static class ChallengePurpose
+    {
+        public const string Registration = "registration";
+        public const string Assertion = "assertion";
+    }
+
     private sealed class ChallengeCookiePayload
     {
         public string OptionsJson { get; set; } = string.Empty;
         public Guid? SubjectId { get; set; }
+        public string Purpose { get; set; } = string.Empty;
         public DateTime ExpiresAt { get; set; }
     }
 }

--- a/src/API/Nocturne.API/Services/Auth/TotpHelper.cs
+++ b/src/API/Nocturne.API/Services/Auth/TotpHelper.cs
@@ -64,23 +64,58 @@ public static class TotpHelper
     /// <param name="secret">The raw shared secret bytes.</param>
     /// <param name="code">The 6-digit code string provided by the user.</param>
     /// <returns><see langword="true"/> if the code matches any adjacent time step.</returns>
+    /// <remarks>
+    /// Applies no single-use floor, so it is only for verifications where no counter has been
+    /// recorded yet (initial setup) and for the constant-time dummy verification. Verifying a
+    /// stored credential uses <see cref="TryVerify"/> with the credential's recorded step.
+    /// </remarks>
     public static bool Verify(byte[] secret, string code)
+    {
+        return TryVerify(secret, code, lastUsedStep: null, out _);
+    }
+
+    /// <summary>
+    /// Verifies a TOTP code and reports which time step it matched, rejecting any step at or
+    /// below <paramref name="lastUsedStep"/>.
+    /// </summary>
+    /// <param name="secret">The raw shared secret bytes.</param>
+    /// <param name="code">The 6-digit code string provided by the user.</param>
+    /// <param name="lastUsedStep">
+    /// The most recent time step already consumed for this secret, or <see langword="null"/> if
+    /// none has been. The ±1 step window means one observed code stays computationally valid for
+    /// about 90 seconds; recording and comparing the step makes each code usable once.
+    /// </param>
+    /// <param name="matchedStep">The matched time step, or 0 when the code is rejected.</param>
+    /// <returns><see langword="true"/> if the code matches an unconsumed adjacent time step.</returns>
+    public static bool TryVerify(byte[] secret, string code, long? lastUsedStep, out long matchedStep)
     {
         var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
         var codeBytes = Encoding.UTF8.GetBytes(code);
 
+        var matched = false;
+        matchedStep = 0;
+
+        // Every candidate is compared even after a match so the running time does not reveal
+        // which step matched.
         for (var i = -1; i <= 1; i++)
         {
-            var candidate = ComputeTotp(secret, now + i * TimeStep);
-            var candidateBytes = Encoding.UTF8.GetBytes(candidate);
+            var candidateTime = now + i * TimeStep;
+            var candidateBytes = Encoding.UTF8.GetBytes(ComputeTotp(secret, candidateTime));
 
-            if (CryptographicOperations.FixedTimeEquals(codeBytes, candidateBytes))
+            if (!CryptographicOperations.FixedTimeEquals(codeBytes, candidateBytes))
             {
-                return true;
+                continue;
+            }
+
+            var step = candidateTime / TimeStep;
+            if (lastUsedStep is null || step > lastUsedStep)
+            {
+                matched = true;
+                matchedStep = step;
             }
         }
 
-        return false;
+        return matched;
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Services/Auth/TotpService.cs
+++ b/src/API/Nocturne.API/Services/Auth/TotpService.cs
@@ -21,6 +21,13 @@ public class TotpService : ITotpService
     private static readonly TimeSpan ChallengeExpiry = TimeSpan.FromMinutes(5);
 
     /// <summary>
+    /// How long a step-up token stays valid: long enough to open an authenticator app and type a
+    /// code, short enough that a leaked token is not a standing credential. Within that window the
+    /// token is still only redeemable once — see <see cref="TotpStepUpTokenEntity"/>.
+    /// </summary>
+    private static readonly TimeSpan StepUpExpiry = TimeSpan.FromMinutes(5);
+
+    /// <summary>
     /// A fixed dummy secret used for constant-time side-channel protection when a username
     /// is not found. This prevents timing attacks that could enumerate valid usernames.
     /// </summary>
@@ -28,6 +35,7 @@ public class TotpService : ITotpService
 
     private readonly NocturneDbContext _dbContext;
     private readonly IDataProtector _protector;
+    private readonly IDataProtector _stepUpProtector;
     private readonly ILogger<TotpService> _logger;
 
     /// <summary>
@@ -43,6 +51,9 @@ public class TotpService : ITotpService
     {
         _dbContext = dbContext;
         _protector = dataProtectionProvider.CreateProtector("Nocturne.Totp.Setup");
+        // A distinct purpose string keeps a setup challenge (which carries a secret the caller
+        // already knows) from being redeemed as proof that a primary factor completed.
+        _stepUpProtector = dataProtectionProvider.CreateProtector("Nocturne.Totp.StepUp");
         _logger = logger;
     }
 
@@ -60,7 +71,7 @@ public class TotpService : ITotpService
     {
         var payload = ReadChallengeToken(challengeToken);
 
-        if (!TotpHelper.Verify(payload.Secret, code))
+        if (!TotpHelper.TryVerify(payload.Secret, code, lastUsedStep: null, out var setupStep))
         {
             throw new InvalidOperationException("Invalid TOTP code. Please try again.");
         }
@@ -72,6 +83,9 @@ public class TotpService : ITotpService
             SecretKey = payload.Secret,
             Label = string.IsNullOrWhiteSpace(label) ? null : label.Trim(),
             CreatedAt = DateTime.UtcNow,
+            // The code proving setup is consumed, so it cannot also be used to sign in.
+            LastUsedStep = setupStep,
+            LastUsedAt = DateTime.UtcNow,
         };
 
         _dbContext.TotpCredentials.Add(entity);
@@ -84,11 +98,59 @@ public class TotpService : ITotpService
         return new TotpCredentialResult(entity.Id, payload.SubjectId);
     }
 
-    public async Task<TotpLoginResult?> VerifyLoginAsync(string username, string code)
+    public async Task<string> CreateStepUpTokenAsync(Guid subjectId)
     {
+        // The subject lives on the row, not in the token, so the token cannot assert an identity of
+        // its own and redemption reads the subject from state this service wrote.
+        var entity = new TotpStepUpTokenEntity
+        {
+            Id = Guid.CreateVersion7(),
+            SubjectId = subjectId,
+            CreatedAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.Add(StepUpExpiry),
+        };
+
+        _dbContext.TotpStepUpTokens.Add(entity);
+        await _dbContext.SaveChangesAsync();
+
+        var payload = new TotpStepUpPayload
+        {
+            TokenId = entity.Id,
+            ExpiresAt = entity.ExpiresAt,
+        };
+
+        return _stepUpProtector.Protect(JsonSerializer.Serialize(payload));
+    }
+
+    public async Task<TotpLoginResult?> VerifyStepUpAsync(string stepUpToken, string code)
+    {
+        Guid tokenId;
+        try
+        {
+            tokenId = ReadStepUpToken(stepUpToken);
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+
+        var stepUp = await _dbContext.TotpStepUpTokens
+            .AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == tokenId
+                && t.ConsumedAt == null
+                && t.ExpiresAt > DateTime.UtcNow);
+
+        if (stepUp is null)
+        {
+            // An unknown, already-redeemed or expired token: verify against a dummy secret so the
+            // response time does not distinguish it from a wrong code.
+            TotpHelper.Verify(DummySecret, code);
+            return null;
+        }
+
         var subject = await _dbContext.Subjects
-            .Where(s => s.Username == username && s.IsActive)
-            .FirstOrDefaultAsync();
+            .AsNoTracking()
+            .FirstOrDefaultAsync(s => s.Id == stepUp.SubjectId && s.IsActive);
 
         if (subject is null)
         {
@@ -108,6 +170,7 @@ public class TotpService : ITotpService
         try
         {
             credentials = await _dbContext.TotpCredentials
+                .AsNoTracking()
                 .Where(c => c.SubjectId == subject.Id)
                 .ToListAsync();
         }
@@ -131,11 +194,13 @@ public class TotpService : ITotpService
         // Verify against all credentials (don't short-circuit) to prevent
         // timing leaks that could reveal how many credentials a user has.
         TotpCredentialEntity? matchedCredential = null;
+        var matchedStep = 0L;
         foreach (var credential in credentials)
         {
-            if (TotpHelper.Verify(credential.SecretKey, code))
+            if (TotpHelper.TryVerify(credential.SecretKey, code, credential.LastUsedStep, out var step))
             {
                 matchedCredential = credential;
+                matchedStep = step;
             }
         }
 
@@ -144,8 +209,39 @@ public class TotpService : ITotpService
             return null;
         }
 
-        matchedCredential.LastUsedAt = DateTime.UtcNow;
-        await _dbContext.SaveChangesAsync();
+        // Consume the step-up token itself, conditionally, so the token yields one session however
+        // many valid codes are presented within its window. Consumed after the code is verified, so
+        // a mistyped code does not force the user back through the primary factor. No rows updated
+        // means a concurrent request already redeemed it.
+        var stepUpConsumed = await _dbContext.TotpStepUpTokens
+            .Where(t => t.Id == stepUp.Id && t.ConsumedAt == null && t.ExpiresAt > DateTime.UtcNow)
+            .ExecuteUpdateAsync(setters => setters
+                .SetProperty(t => t.ConsumedAt, DateTime.UtcNow));
+
+        if (stepUpConsumed == 0)
+        {
+            _logger.LogWarning(
+                "Step-up token {TokenId} for subject {SubjectId} was already redeemed",
+                stepUp.Id, subject.Id);
+            return null;
+        }
+
+        // Consume the time step with a conditional update so two concurrent requests carrying the
+        // same code cannot both succeed. No rows updated means another request already took it.
+        var consumed = await _dbContext.TotpCredentials
+            .Where(c => c.Id == matchedCredential.Id
+                && (c.LastUsedStep == null || c.LastUsedStep < matchedStep))
+            .ExecuteUpdateAsync(setters => setters
+                .SetProperty(c => c.LastUsedStep, matchedStep)
+                .SetProperty(c => c.LastUsedAt, DateTime.UtcNow));
+
+        if (consumed == 0)
+        {
+            _logger.LogWarning(
+                "TOTP code for subject {SubjectId} was already consumed for time step {TimeStep}",
+                subject.Id, matchedStep);
+            return null;
+        }
 
         _logger.LogInformation(
             "TOTP verification succeeded for subject {SubjectId}",
@@ -233,10 +329,51 @@ public class TotpService : ITotpService
         return payload;
     }
 
+    /// <summary>
+    /// Decrypts a step-up token and returns the id of the row it refers to. The row is the
+    /// authority on the subject, the expiry and whether the token is still redeemable; the expiry
+    /// carried in the payload only avoids a query for a token that is already stale.
+    /// </summary>
+    private Guid ReadStepUpToken(string stepUpToken)
+    {
+        string json;
+        try
+        {
+            json = _stepUpProtector.Unprotect(stepUpToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to decrypt TOTP step-up token");
+            throw new InvalidOperationException("Invalid or tampered step-up token.", ex);
+        }
+
+        var payload = JsonSerializer.Deserialize<TotpStepUpPayload>(json)
+            ?? throw new InvalidOperationException("Failed to deserialize step-up token payload.");
+
+        if (payload.ExpiresAt < DateTime.UtcNow)
+        {
+            throw new InvalidOperationException("Step-up token has expired.");
+        }
+
+        if (payload.TokenId == Guid.Empty)
+        {
+            throw new InvalidOperationException("Step-up token carries no token id.");
+        }
+
+        return payload.TokenId;
+    }
+
     private sealed class TotpChallengePayload
     {
         public byte[] Secret { get; set; } = [];
         public Guid SubjectId { get; set; }
+        public DateTime ExpiresAt { get; set; }
+    }
+
+    private sealed class TotpStepUpPayload
+    {
+        /// <summary>The <c>totp_step_up_tokens</c> row this token refers to.</summary>
+        public Guid TokenId { get; set; }
         public DateTime ExpiresAt { get; set; }
     }
 }

--- a/src/API/Nocturne.API/Validators/Auth/AccessRequestCompleteRequestValidator.cs
+++ b/src/API/Nocturne.API/Validators/Auth/AccessRequestCompleteRequestValidator.cs
@@ -8,6 +8,7 @@ namespace Nocturne.API.Validators.Auth;
 /// </summary>
 /// <remarks>
 /// <list type="bullet">
+/// <item><description>DisplayName is required and capped at 255 characters — it resolves the pending subject.</description></item>
 /// <item><description>AttestationResponseJson must be non-empty (contains the WebAuthn attestation response).</description></item>
 /// <item><description>ChallengeToken must be non-empty (ties the response back to the server-issued challenge).</description></item>
 /// </list>
@@ -22,6 +23,7 @@ public class AccessRequestCompleteRequestValidator : AbstractValidator<AccessReq
     /// </summary>
     public AccessRequestCompleteRequestValidator()
     {
+        RuleFor(x => x.DisplayName).NotEmpty().MaximumLength(255);
         RuleFor(x => x.AttestationResponseJson).NotEmpty();
         RuleFor(x => x.ChallengeToken).NotEmpty();
     }

--- a/src/Core/Nocturne.Core.Contracts/Auth/IPasskeyService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Auth/IPasskeyService.cs
@@ -12,8 +12,15 @@ public interface IPasskeyService
     Task<PasskeyRegistrationOptions> GenerateRegistrationOptionsAsync(Guid subjectId, string username, Guid tenantId);
 
     /// <summary>Validates the attestation response and stores the new passkey credential.</summary>
+    /// <param name="expectedSubjectId">
+    /// The subject the caller's flow resolved as the one enrolling. The challenge token must
+    /// have been issued for this subject or the registration is rejected, so a challenge minted
+    /// by one flow cannot be redeemed as an enrolment in another. Required: every enrolment flow
+    /// must name its own subject, and that subject must be one the server resolved rather than
+    /// one the request supplied.
+    /// </param>
     /// <param name="label">Optional user-assigned label for the credential.</param>
-    Task<PasskeyCredentialResult> CompleteRegistrationAsync(string attestationResponseJson, string challengeToken, Guid tenantId, string? label = null);
+    Task<PasskeyCredentialResult> CompleteRegistrationAsync(string attestationResponseJson, string challengeToken, Guid tenantId, Guid expectedSubjectId, string? label = null);
 
     /// <summary>Generates assertion options for a discoverable (usernameless) login flow.</summary>
     Task<PasskeyAssertionOptions> GenerateDiscoverableAssertionOptionsAsync(Guid tenantId);

--- a/src/Core/Nocturne.Core.Contracts/Auth/ITotpService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Auth/ITotpService.cs
@@ -14,8 +14,27 @@ public interface ITotpService
     /// <summary>Verifies a TOTP code against the pending setup challenge and registers the credential.</summary>
     Task<TotpCredentialResult> CompleteSetupAsync(string code, string label, string challengeToken);
 
-    /// <summary>Verifies a TOTP code for login and returns the authenticated subject, or null if invalid.</summary>
-    Task<TotpLoginResult?> VerifyLoginAsync(string username, string code);
+    /// <summary>
+    /// Mints a short-lived single-use token recording that a primary factor (passkey or linked
+    /// provider) has just been verified for this subject. It is the only way to reach
+    /// <see cref="VerifyStepUpAsync"/>, which keeps TOTP a second factor.
+    /// </summary>
+    /// <remarks>
+    /// This method verifies nothing itself. The caller must have completed a primary factor for
+    /// <paramref name="subjectId"/> in the same request before calling it — minting a token from
+    /// anything less turns TOTP into a single factor for that path. Nothing in the type system
+    /// enforces that, so a new call site is a security decision.
+    /// </remarks>
+    /// <param name="subjectId">The subject whose primary factor was just verified.</param>
+    Task<string> CreateStepUpTokenAsync(Guid subjectId);
+
+    /// <summary>
+    /// Verifies a TOTP code for the subject a step-up token was minted for and returns that subject,
+    /// or null if the token or the code is not valid. Both halves are single-use: the token is
+    /// consumed, so it yields at most one session, and the code's time step is consumed, so it
+    /// cannot be reused for the remainder of its acceptance window.
+    /// </summary>
+    Task<TotpLoginResult?> VerifyStepUpAsync(string stepUpToken, string code);
 
     /// <summary>Returns all registered TOTP credentials for the specified subject.</summary>
     Task<List<TotpCredentialInfo>> GetCredentialsAsync(Guid subjectId);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TotpCredentialEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TotpCredentialEntity.cs
@@ -52,6 +52,14 @@ public class TotpCredentialEntity
     [Column("last_used_at")]
     public DateTime? LastUsedAt { get; set; }
 
+    /// <summary>
+    /// The most recent RFC 6238 time step consumed by a successful verification, or null if the
+    /// credential has never been verified. A code at or below this step is rejected, so each
+    /// code is usable once rather than for the whole ±1 step acceptance window.
+    /// </summary>
+    [Column("last_used_step")]
+    public long? LastUsedStep { get; set; }
+
     // Navigation properties
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TotpStepUpTokenEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TotpStepUpTokenEntity.cs
@@ -1,0 +1,59 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Nocturne.Infrastructure.Data.Entities;
+
+/// <summary>
+/// One row per step-up token minted after a primary factor was verified, recording the subject the
+/// token stands for and whether it has been redeemed. The token handed to the client carries only
+/// this row's id, so the subject cannot be asserted by the token itself, and redemption consumes the
+/// row, so one token yields at most one session.
+/// </summary>
+/// <remarks>
+/// Not tenant-scoped (identity-level, like <see cref="TotpCredentialEntity"/> and
+/// <see cref="RecoveryCodeEntity"/>): the passkey assertion that mints a token is not tenant-scoped
+/// either, and tenant membership is checked when the session is issued. Expired rows are pruned by
+/// <c>OAuthCodeCleanupService</c>.
+/// </remarks>
+[Table("totp_step_up_tokens")]
+public class TotpStepUpTokenEntity
+{
+    /// <summary>
+    /// Primary key - UUID Version 7. This is the token identifier carried in the protected token.
+    /// </summary>
+    [Key]
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Foreign key to the subject whose primary factor was verified.
+    /// </summary>
+    [Required]
+    [Column("subject_id")]
+    public Guid SubjectId { get; set; }
+
+    /// <summary>
+    /// When the token was minted.
+    /// </summary>
+    [Column("created_at")]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// When the token stops being redeemable.
+    /// </summary>
+    [Column("expires_at")]
+    public DateTime ExpiresAt { get; set; }
+
+    /// <summary>
+    /// When the token was redeemed, or null if it has not been. A row with a value here is never
+    /// redeemable again.
+    /// </summary>
+    [Column("consumed_at")]
+    public DateTime? ConsumedAt { get; set; }
+
+    // Navigation properties
+
+    /// <summary>
+    /// The subject whose primary factor was verified.
+    /// </summary>
+    public SubjectEntity? Subject { get; set; }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260802120704_AddTotpStepUpTokensAndLastUsedStep.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260802120704_AddTotpStepUpTokensAndLastUsedStep.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260802120704_AddTotpStepUpTokensAndLastUsedStep")]
+    partial class AddTotpStepUpTokensAndLastUsedStep
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260802120704_AddTotpStepUpTokensAndLastUsedStep.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260802120704_AddTotpStepUpTokensAndLastUsedStep.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTotpStepUpTokensAndLastUsedStep : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "last_used_step",
+                table: "totp_credentials",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "totp_step_up_tokens",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    subject_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    expires_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    consumed_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_totp_step_up_tokens", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_totp_step_up_tokens_subjects_subject_id",
+                        column: x => x.subject_id,
+                        principalTable: "subjects",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_totp_step_up_tokens_expires_at",
+                table: "totp_step_up_tokens",
+                column: "expires_at");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_totp_step_up_tokens_subject_id",
+                table: "totp_step_up_tokens",
+                column: "subject_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "totp_step_up_tokens");
+
+            migrationBuilder.DropColumn(
+                name: "last_used_step",
+                table: "totp_credentials");
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -186,6 +186,11 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
     public DbSet<TotpCredentialEntity> TotpCredentials { get; set; }
 
     /// <summary>
+    /// Gets or sets the TotpStepUpTokens table recording each minted step-up token and its redemption
+    /// </summary>
+    public DbSet<TotpStepUpTokenEntity> TotpStepUpTokens { get; set; }
+
+    /// <summary>
     /// ASP.NET Core Data Protection key ring — persisted so keys survive container restarts.
     /// Not tenant-scoped; no RLS.
     /// </summary>
@@ -3273,6 +3278,16 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
         modelBuilder.Entity<RecoveryCodeEntity>(entity =>
         {
             entity.HasIndex(e => e.SubjectId);
+            entity.HasOne(e => e.Subject).WithMany().HasForeignKey(e => e.SubjectId);
+        });
+
+        // TotpStepUpTokenEntity
+        modelBuilder.Entity<TotpStepUpTokenEntity>(entity =>
+        {
+            entity.Property(e => e.Id).HasValueGenerator<GuidV7ValueGenerator>();
+            entity.HasIndex(e => e.SubjectId);
+            // The cleanup sweep deletes by expiry.
+            entity.HasIndex(e => e.ExpiresAt);
             entity.HasOne(e => e.Subject).WithMany().HasForeignKey(e => e.SubjectId);
         });
 

--- a/src/Web/packages/app/src/lib/components/auth/LoginForm.svelte
+++ b/src/Web/packages/app/src/lib/components/auth/LoginForm.svelte
@@ -72,6 +72,11 @@
   let totpCode = $state("");
   /** Submitted from the code field's onComplete, so a full code submits itself. */
   let totpFormEl = $state<HTMLFormElement | null>(null);
+  /**
+   * Proof from the API that the passkey step succeeded. The authenticator code is
+   * a second factor, so it is only accepted alongside this token.
+   */
+  let stepUpToken = $state("");
 
   async function handleAuthResult(result: {
     success?: boolean;
@@ -79,11 +84,27 @@
     refreshToken?: string;
     expiresIn?: number;
     refreshExpiresIn?: number;
+    totpRequired?: boolean;
+    stepUpToken?: string | null;
     error?: string;
   }) {
     if (!result.success) {
       passkeyError =
         result.error ?? "We couldn't sign you in. Please try again.";
+      return;
+    }
+
+    // The passkey was accepted but this account also has an authenticator, so there is
+    // no session yet — collect the code and finish there.
+    if (result.totpRequired) {
+      if (!result.stepUpToken) {
+        passkeyError = "We couldn't sign you in. Please try again.";
+        return;
+      }
+      stepUpToken = result.stepUpToken;
+      totpCode = "";
+      authenticator.clear();
+      mode = "totp";
       return;
     }
 
@@ -188,6 +209,11 @@
     passkeyError = null;
     recovery.clear();
     authenticator.clear();
+    // Leaving the authenticator step abandons the passkey step it belonged to.
+    if (newMode !== "totp") {
+      stepUpToken = "";
+      totpCode = "";
+    }
   }
 </script>
 
@@ -204,15 +230,6 @@
 {/snippet}
 
 {#snippet otherMethodLinks()}
-  <Button
-    variant="link"
-    size="sm"
-    class="h-auto p-0 text-xs"
-    onclick={() => switchMode("totp")}
-    disabled={isLoading}
-  >
-    {signInMethodLabels.authenticator}
-  </Button>
   <Button
     variant="link"
     size="sm"
@@ -450,7 +467,7 @@
       </div>
 
     {:else if mode === "totp"}
-      <!-- Authenticator-app sign-in. Also verified on the server. -->
+      <!-- Second step after the passkey: the authenticator code, verified on the server. -->
       <form
         bind:this={totpFormEl}
         class="space-y-3"
@@ -459,33 +476,14 @@
         })}
       >
         <input type="hidden" name="returnUrl" value={returnUrl} />
+        <input type="hidden" name="stepUpToken" value={stepUpToken} />
 
         <FormError issues={authenticator.error} focusOnShow />
 
-        <FormField
-          label="Username"
-          id="totp-username"
-          required
-          issues={signInWithAuthenticator.fields.username.issues()}
-        >
-          {#snippet control(field)}
-            <div class="relative">
-              <User class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                {...field}
-                name="username"
-                type="text"
-                placeholder="your-username"
-                class="pl-10"
-                autocomplete="username"
-                autocapitalize="none"
-                spellcheck={false}
-                autofocus
-                bind:value={username}
-              />
-            </div>
-          {/snippet}
-        </FormField>
+        <p class="text-sm text-muted-foreground">
+          Your passkey was accepted. Enter the current code from your authenticator
+          app to finish signing in.
+        </p>
 
         <div class="space-y-2">
           <Label for="totp-code-input">Authenticator code</Label>
@@ -527,7 +525,7 @@
           type="submit"
           class="w-full"
           disabled={signInWithAuthenticator.pending > 0 ||
-            !username.trim() ||
+            !stepUpToken ||
             totpCode.length !== 6}
         >
           {#if signInWithAuthenticator.pending > 0}

--- a/src/Web/packages/app/src/lib/components/auth/labels.ts
+++ b/src/Web/packages/app/src/lib/components/auth/labels.ts
@@ -5,6 +5,5 @@
 export const signInMethodLabels = {
   passkey: "Sign in with passkey",
   username: "Sign in with username",
-  authenticator: "Use authenticator app",
   recoveryCode: "Use a recovery code",
 } as const;

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/account/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/account/+page.svelte
@@ -128,11 +128,12 @@
   // ============================================================================
 
   async function handleAddPasskey() {
-    if (!user?.subjectId || !user?.name) return;
+    if (!user?.name) return;
     isRegistering = true;
     errorMessage = null;
 
     try {
+      // The account the passkey is added to comes from the session, not this call.
       const response = await registerOptions({ username: user.name });
       const options = JSON.parse(response.options ?? "");
       const challengeToken = response.challengeToken ?? "";

--- a/src/Web/packages/app/src/routes/(unauthenticated)/auth/auth.remote.ts
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/auth/auth.remote.ts
@@ -233,13 +233,27 @@ export const logoutSession = command(z.string().optional(), async (_providerId) 
 // ============================================================================
 
 /**
- * The credential fields shared by the code-based sign-in forms. `returnUrl` is
- * a hidden field so a submission without JavaScript lands where the user
- * started; it's reduced to a same-origin path before being used.
+ * Recovery-code sign-in fields. `returnUrl` is a hidden field so a submission
+ * without JavaScript lands where the user started; it's reduced to a same-origin
+ * path before being used.
  */
-const codeSignInSchema = z.object({
+const recoveryCodeSchema = z.object({
   username: z.string().trim().min(1, "Enter your username"),
   code: z.string().trim().min(1, "Enter your code"),
+  returnUrl: z.string().optional(),
+});
+
+/**
+ * Authenticator-code fields. The account is named by the step-up token the
+ * passkey step returned, not by the person signing in, because the code alone
+ * is not a sign-in method.
+ */
+const authenticatorSchema = z.object({
+  stepUpToken: z.string().min(1),
+  code: z
+    .string()
+    .trim()
+    .regex(/^\d{6}$/, "Enter the 6-digit code from your authenticator app"),
   returnUrl: z.string().optional(),
 });
 
@@ -251,7 +265,7 @@ const codeSignInSchema = z.object({
  * comes back as a field-level issue on the re-rendered page.
  */
 export const signInWithRecoveryCode = form(
-  codeSignInSchema,
+  recoveryCodeSchema,
   async (data, issue) => {
     const api = getApiClient();
 
@@ -280,23 +294,19 @@ export const signInWithRecoveryCode = form(
 );
 
 /**
- * Sign in with a code from an authenticator app. Server-side for the same
- * reason as {@link signInWithRecoveryCode}.
+ * Finish signing in with a code from an authenticator app, after the passkey
+ * step returned a step-up token. Server-side for the same reason as
+ * {@link signInWithRecoveryCode}.
  */
 export const signInWithAuthenticator = form(
-  codeSignInSchema.extend({
-    code: z
-      .string()
-      .trim()
-      .regex(/^\d{6}$/, "Enter the 6-digit code from your authenticator app"),
-  }),
+  authenticatorSchema,
   async (data, issue) => {
     const api = getApiClient();
 
     let verified = false;
     try {
       const result = await api.totp.login({
-        username: data.username,
+        stepUpToken: data.stepUpToken,
         code: data.code,
       });
       verified = result?.success === true;
@@ -310,7 +320,7 @@ export const signInWithAuthenticator = form(
     if (!verified) {
       invalid(
         issue.code(
-          "That code wasn't accepted. Codes expire after 30 seconds — try the current one."
+          "That code wasn't accepted. Each code works once and expires after 30 seconds — try the current one."
         )
       );
     }

--- a/src/Web/packages/app/src/routes/(unauthenticated)/auth/help/+page.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/auth/help/+page.svelte
@@ -75,15 +75,14 @@
       </Card.Header>
       <Card.Content>
         <p class="text-sm leading-relaxed text-muted-foreground">
-          If you've set up an authenticator app (such as Google Authenticator or
-          Authy), you can sign in using a 6-digit code that refreshes every 30
-          seconds.
+          An authenticator app (such as Google Authenticator or Authy) is a
+          second step, not a way to sign in on its own. It shows a 6-digit code
+          that refreshes every 30 seconds, and each code can be used once.
         </p>
         <p class="mt-2 text-sm leading-relaxed text-muted-foreground">
-          On the login page, choose
-          <strong>{signInMethodLabels.authenticator}</strong>, enter your
-          username, then type the code shown in your authenticator app. You can
-          set up an authenticator in your account settings after signing in.
+          If you've set one up, the login page asks for the code straight after
+          your passkey. You can set up an authenticator in your account settings
+          after signing in.
         </p>
       </Card.Content>
     </Card.Root>

--- a/src/Web/packages/app/src/routes/(unauthenticated)/auth/recovery/+page.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/auth/recovery/+page.svelte
@@ -14,8 +14,8 @@
     type PublicKeyCredentialCreationOptionsJSON,
   } from "@simplewebauthn/browser";
   import {
-    registerOptions,
-    registerComplete,
+    recoveryModeOptions,
+    recoveryModeComplete,
   } from "$lib/api/generated/passkeys.generated.remote";
   import RecoveryCodes from "$lib/components/auth/RecoveryCodes.svelte";
   import {
@@ -35,9 +35,9 @@
   let errorMessage = $state<string | null>(null);
   let recoveryCodes = $state<string[]>([]);
 
-  // In recovery mode, we need to find the orphaned subject.
-  // The register/options endpoint will look up the subject by username.
-  // For now, we collect username + display name and attempt registration.
+  // The server resolves the account from the username and only proceeds when that account
+  // has no passkey and no linked sign-in provider, so this can only restore access to an
+  // account that is already locked out.
 
   /**
    * The completion response only carries recovery codes when the account had
@@ -65,8 +65,7 @@
     errorMessage = null;
 
     try {
-      // registerOptions finds the account by username
-      const response = await registerOptions({
+      const response = await recoveryModeOptions({
         username: username.trim(),
       });
       const options = parseCeremonyOptions<PublicKeyCredentialCreationOptionsJSON>(
@@ -76,7 +75,8 @@
 
       const attestation = await startRegistration({ optionsJSON: options });
 
-      const result = await registerComplete({
+      const result = await recoveryModeComplete({
+        username: username.trim(),
         attestationResponseJson: JSON.stringify(attestation),
         challengeToken,
         label: `${displayName.trim() || username.trim()}'s passkey`,
@@ -90,7 +90,7 @@
       errorMessage = describePasskeyError(
         err,
         "register",
-        "We couldn't register a passkey. Check that the username is correct and try again."
+        "We couldn't register a passkey for that username. This page only works for an account that has no passkey and no linked sign-in provider — otherwise sign in with a recovery code."
       );
     } finally {
       isRegistering = false;

--- a/src/Web/packages/app/src/routes/(unauthenticated)/join/+page.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/join/+page.svelte
@@ -121,6 +121,7 @@
 
       const result = await inviteComplete({
         token,
+        username,
         attestationResponseJson: JSON.stringify(attestation),
         challengeToken,
       });

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/CredentialAtRestPassTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/CredentialAtRestPassTests.cs
@@ -78,7 +78,7 @@ public class CredentialAtRestPassTests
 
     /// <summary>
     /// The converter decrypts on materialization, so an unconverted row fails the read. Pins the
-    /// exception type, because <c>TotpService.VerifyLoginAsync</c> catches
+    /// exception type, because <c>TotpService.VerifyStepUpAsync</c> catches
     /// <see cref="CryptographicException"/> specifically to turn a lost key into an ordinary failed
     /// attempt instead of a 500 — EF passes it through unwrapped.
     /// </summary>

--- a/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyControllerTests.cs
@@ -11,6 +11,7 @@ using Nocturne.API.Controllers.Authentication;
 using Nocturne.API.Services.Auth;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Contracts.Notifications;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.Configuration;
 using Nocturne.Infrastructure.Data;
@@ -25,6 +26,7 @@ public class PasskeyControllerTests : IDisposable
     private readonly DbContextOptions<NocturneDbContext> _dbOptions;
     private readonly NocturneDbContext _dbContext;
     private readonly Mock<IPasskeyService> _passkeyService;
+    private readonly Mock<ITotpService> _totpService;
     private readonly Mock<IRecoveryCodeService> _recoveryCodeService;
     private readonly Mock<IJwtService> _jwtService;
     private readonly Mock<ISessionService> _sessionService;
@@ -34,6 +36,7 @@ public class PasskeyControllerTests : IDisposable
     private readonly PasskeyController _controller;
 
     private readonly Guid _tenantId = Guid.CreateVersion7();
+    private readonly Guid _subjectId = Guid.CreateVersion7();
 
     public PasskeyControllerTests()
     {
@@ -49,6 +52,7 @@ public class PasskeyControllerTests : IDisposable
         _dbContext.Database.EnsureCreated();
 
         _passkeyService = new Mock<IPasskeyService>();
+        _totpService = new Mock<ITotpService>();
         _recoveryCodeService = new Mock<IRecoveryCodeService>();
         _jwtService = new Mock<IJwtService>();
         _sessionService = new Mock<ISessionService>();
@@ -75,6 +79,7 @@ public class PasskeyControllerTests : IDisposable
 
         _controller = new PasskeyController(
             _passkeyService.Object,
+            _totpService.Object,
             _recoveryCodeService.Object,
             _jwtService.Object,
             _sessionService.Object,
@@ -102,8 +107,11 @@ public class PasskeyControllerTests : IDisposable
 
     // ── Helpers ──────────────────────────────────────────────────────────
 
-    /// <summary>Seeds an active subject that is a member of the given tenant (this one by default).</summary>
-    private async Task<Guid> SeedMemberAsync(string username, Guid? tenantId = null)
+    /// <summary>
+    /// Seeds an active subject that is a member of the given tenant (this one by default),
+    /// optionally holding a passkey credential.
+    /// </summary>
+    private async Task<Guid> SeedMemberAsync(string username, bool withPasskey = false, Guid? tenantId = null)
     {
         var resolvedTenantId = tenantId ?? _tenantId;
         await EnsureTenantAsync(resolvedTenantId);
@@ -123,6 +131,19 @@ public class PasskeyControllerTests : IDisposable
             TenantId = resolvedTenantId,
             SubjectId = subjectId,
         });
+
+        if (withPasskey)
+        {
+            _dbContext.PasskeyCredentials.Add(new PasskeyCredentialEntity
+            {
+                Id = Guid.CreateVersion7(),
+                SubjectId = subjectId,
+                CredentialId = Guid.CreateVersion7().ToByteArray(),
+                PublicKey = [1, 2, 3],
+                CreatedAt = DateTime.UtcNow,
+            });
+        }
+
         await _dbContext.SaveChangesAsync();
         return subjectId;
     }
@@ -132,53 +153,23 @@ public class PasskeyControllerTests : IDisposable
         if (await _dbContext.Set<TenantEntity>().AnyAsync(t => t.Id == tenantId))
             return;
 
+        // The whole id, not a prefix: two v7 GUIDs minted in the same millisecond share their
+        // leading hex digits, so a prefix collides on the unique slug.
         _dbContext.Set<TenantEntity>().Add(new TenantEntity
         {
             Id = tenantId,
-            Slug = "t" + tenantId.ToString("N")[..8],
+            Slug = "t" + tenantId.ToString("N"),
             DisplayName = "Tenant",
         });
         await _dbContext.SaveChangesAsync();
     }
 
-    private async Task SeedPasskeyCredentialAsync(Guid subjectId)
-    {
-        _dbContext.PasskeyCredentials.Add(new PasskeyCredentialEntity
-        {
-            Id = Guid.CreateVersion7(),
-            SubjectId = subjectId,
-            CredentialId = Guid.CreateVersion7().ToByteArray(),
-            PublicKey = [1, 2, 3],
-        });
-        await _dbContext.SaveChangesAsync();
-    }
-
-    private async Task SeedOidcIdentityAsync(Guid subjectId)
-    {
-        var providerId = Guid.CreateVersion7();
-        _dbContext.Set<OidcProviderEntity>().Add(new OidcProviderEntity
-        {
-            Id = providerId,
-            Name = "Keycloak",
-            IssuerUrl = "https://issuer.example",
-            ClientId = "nocturne",
-        });
-        _dbContext.SubjectOidcIdentities.Add(new SubjectOidcIdentityEntity
-        {
-            Id = Guid.CreateVersion7(),
-            SubjectId = subjectId,
-            ProviderId = providerId,
-            OidcSubjectId = "ext-" + subjectId,
-            Issuer = "https://issuer.example",
-        });
-        await _dbContext.SaveChangesAsync();
-    }
-
-    private void Authenticate(Guid subjectId) =>
+    /// <summary>Puts an authenticated subject on the request, as the auth middleware would.</summary>
+    private void Authenticate(Guid? subjectId = null) =>
         _controller.ControllerContext.HttpContext.Items["AuthContext"] = new AuthContext
         {
             IsAuthenticated = true,
-            SubjectId = subjectId,
+            SubjectId = subjectId ?? _subjectId,
             TenantId = _tenantId,
         };
 
@@ -202,66 +193,95 @@ public class PasskeyControllerTests : IDisposable
             .Setup(s => s.GenerateRegistrationOptionsAsync(subjectId, username, _tenantId))
             .ReturnsAsync(new PasskeyRegistrationOptions("{\"challenge\":\"abc\"}", "token-data"));
 
-    [Fact]
-    public async Task RegisterOptions_EmptyUsername_ReturnsBadRequest()
-    {
-        var request = new PasskeyRegisterOptionsRequest { Username = "" };
+    #region Passkey enrolment is bound to the caller
 
-        var result = await _controller.RegisterOptions(request);
+    [Fact]
+    public async Task RegisterOptions_WhenAnonymous_ReturnsUnauthorizedWithoutMintingAChallenge()
+    {
+        var result = await _controller.RegisterOptions(new PasskeyRegisterOptionsRequest { Username = "testuser" });
 
         var objectResult = Assert.IsType<ObjectResult>(result.Result);
-        Assert.Equal(400, objectResult.StatusCode);
+        objectResult.StatusCode.Should().Be(401);
+        _passkeyService.Verify(
+            s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>()),
+            Times.Never,
+            "an anonymous caller must not be able to start an enrolment ceremony");
     }
 
     [Fact]
-    public async Task RegisterOptions_ValidRequest_CallsServiceAndReturnsOptionsWithToken()
+    public async Task RegisterComplete_WhenAnonymous_ReturnsUnauthorizedWithoutStoringACredential()
     {
-        var subjectId = await SeedMemberAsync("testuser");
-        StubRegistrationOptions(subjectId, "testuser");
+        var result = await _controller.RegisterComplete(new PasskeyRegisterCompleteRequest
+        {
+            AttestationResponseJson = "{}",
+            ChallengeToken = "some-token",
+        });
 
-        var result = await _controller.RegisterOptions(
-            new PasskeyRegisterOptionsRequest { Username = "testuser" });
+        var objectResult = Assert.IsType<ObjectResult>(result.Result);
+        objectResult.StatusCode.Should().Be(401);
+        _passkeyService.Verify(
+            s => s.CompleteRegistrationAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string?>()),
+            Times.Never,
+            "an anonymous caller must not be able to store a credential");
+    }
+
+    [Fact]
+    public async Task RegisterOptions_UsesTheAuthenticatedSubject()
+    {
+        Authenticate();
+        _passkeyService
+            .Setup(s => s.GenerateRegistrationOptionsAsync(_subjectId, "testuser", _tenantId))
+            .ReturnsAsync(new PasskeyRegistrationOptions("{\"challenge\":\"abc\"}", "token-data"));
+
+        var result = await _controller.RegisterOptions(new PasskeyRegisterOptionsRequest { Username = "testuser" });
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var response = Assert.IsType<PasskeyOptionsResponse>(okResult.Value);
-        Assert.Contains("challenge", response.Options);
-        Assert.Equal("token-data", response.ChallengeToken);
-        _passkeyService.Verify(s => s.GenerateRegistrationOptionsAsync(subjectId, "testuser", _tenantId), Times.Once);
+        response.Options.Should().Contain("challenge");
+        response.ChallengeToken.Should().Be("token-data");
+        _passkeyService.Verify(
+            s => s.GenerateRegistrationOptionsAsync(_subjectId, "testuser", _tenantId),
+            Times.Once);
     }
 
-    // ── Registration subject binding ─────────────────────────────────────
+    [Fact]
+    public async Task RegisterComplete_BindsTheChallengeToTheAuthenticatedSubject()
+    {
+        var victimSubjectId = Guid.CreateVersion7();
+        Authenticate();
+        _passkeyService
+            .Setup(s => s.CompleteRegistrationAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), _subjectId, It.IsAny<string?>()))
+            .ReturnsAsync(new PasskeyCredentialResult(Guid.CreateVersion7(), _subjectId));
+
+        var result = await _controller.RegisterComplete(new PasskeyRegisterCompleteRequest
+        {
+            AttestationResponseJson = "{}",
+            ChallengeToken = "token-for-victim",
+        });
+
+        Assert.IsType<OkObjectResult>(result.Result);
+        _passkeyService.Verify(
+            s => s.CompleteRegistrationAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), _subjectId, It.IsAny<string?>()),
+            Times.Once,
+            "the enrolling subject is the session's, so a challenge minted for another subject is refused");
+        _passkeyService.Verify(
+            s => s.CompleteRegistrationAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), victimSubjectId, It.IsAny<string?>()),
+            Times.Never);
+    }
 
     [Fact]
-    public async Task RegisterOptions_WhenAnonymousAndTheAccountHasACredential_IsRefused()
+    public async Task RegisterOptions_EmptyUsername_ReturnsBadRequest()
     {
-        // The takeover: an anonymous caller naming an established account used to have its
-        // subject id honoured, binding their own authenticator to that account.
-        var victimId = await SeedMemberAsync("victim");
-        await SeedPasskeyCredentialAsync(victimId);
+        Authenticate();
 
-        var result = await _controller.RegisterOptions(
-            new PasskeyRegisterOptionsRequest { Username = "victim" });
+        var result = await _controller.RegisterOptions(new PasskeyRegisterOptionsRequest { Username = "" });
 
         var objectResult = Assert.IsType<ObjectResult>(result.Result);
         Assert.Equal(400, objectResult.StatusCode);
-        _passkeyService.Verify(
-            s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>()),
-            Times.Never);
-    }
-
-    [Fact]
-    public async Task RegisterOptions_WhenAnonymousAndTheAccountHasAnOidcIdentity_IsRefused()
-    {
-        var victimId = await SeedMemberAsync("victim");
-        await SeedOidcIdentityAsync(victimId);
-
-        var result = await _controller.RegisterOptions(
-            new PasskeyRegisterOptionsRequest { Username = "victim" });
-
-        Assert.Equal(400, Assert.IsType<ObjectResult>(result.Result).StatusCode);
-        _passkeyService.Verify(
-            s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>()),
-            Times.Never);
     }
 
     [Fact]
@@ -269,10 +289,8 @@ public class PasskeyControllerTests : IDisposable
     {
         // Adding a passkey to your own account. The username on the request is not the
         // authority — the session is — so naming someone else changes nothing.
-        var callerId = await SeedMemberAsync("caller");
-        await SeedPasskeyCredentialAsync(callerId);
-        var victimId = await SeedMemberAsync("victim");
-        await SeedPasskeyCredentialAsync(victimId);
+        var callerId = await SeedMemberAsync("caller", withPasskey: true);
+        var victimId = await SeedMemberAsync("victim", withPasskey: true);
         Authenticate(callerId);
         StubRegistrationOptions(callerId, "victim");
 
@@ -291,8 +309,7 @@ public class PasskeyControllerTests : IDisposable
     {
         // Re-registering after spending a recovery code: the account still holds its old
         // credential, so only the recovery session makes this allowed.
-        var subjectId = await SeedMemberAsync("owner");
-        await SeedPasskeyCredentialAsync(subjectId);
+        var subjectId = await SeedMemberAsync("owner", withPasskey: true);
         GiveRecoverySession(subjectId, "passkey:manage");
         StubRegistrationOptions(subjectId, "owner");
 
@@ -307,35 +324,46 @@ public class PasskeyControllerTests : IDisposable
     [Fact]
     public async Task RegisterOptions_WithARecoverySessionLackingPasskeyManage_IsRefused()
     {
-        var subjectId = await SeedMemberAsync("owner");
-        await SeedPasskeyCredentialAsync(subjectId);
+        var subjectId = await SeedMemberAsync("owner", withPasskey: true);
         GiveRecoverySession(subjectId, "glucose.read");
 
         var result = await _controller.RegisterOptions(
             new PasskeyRegisterOptionsRequest { Username = "owner" });
 
-        Assert.Equal(400, Assert.IsType<ObjectResult>(result.Result).StatusCode);
+        Assert.Equal(401, Assert.IsType<ObjectResult>(result.Result).StatusCode);
+        _passkeyService.Verify(
+            s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>()),
+            Times.Never);
     }
 
     [Fact]
-    public async Task RegisterOptions_ForAnotherTenantsMember_IsRefused()
+    public async Task RegisterComplete_WithARecoverySession_BindsToTheCookieSubject()
     {
-        // Subjects are global; membership is what scopes them. A credentialless subject in
-        // another tenant must not be claimable from this one.
-        var otherTenantSubjectId = await SeedMemberAsync("elsewhere", tenantId: Guid.CreateVersion7());
+        var subjectId = await SeedMemberAsync("owner", withPasskey: true);
+        GiveRecoverySession(subjectId, "passkey:manage");
+        _passkeyService
+            .Setup(s => s.CompleteRegistrationAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), subjectId, It.IsAny<string?>()))
+            .ReturnsAsync(new PasskeyCredentialResult(Guid.CreateVersion7(), subjectId));
 
-        var result = await _controller.RegisterOptions(
-            new PasskeyRegisterOptionsRequest { Username = "elsewhere" });
+        var result = await _controller.RegisterComplete(new PasskeyRegisterCompleteRequest
+        {
+            AttestationResponseJson = "{}",
+            ChallengeToken = "token",
+        });
 
-        Assert.Equal(400, Assert.IsType<ObjectResult>(result.Result).StatusCode);
+        Assert.IsType<OkObjectResult>(result.Result);
         _passkeyService.Verify(
-            s => s.GenerateRegistrationOptionsAsync(otherTenantSubjectId, It.IsAny<string>(), It.IsAny<Guid>()),
-            Times.Never);
+            s => s.CompleteRegistrationAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), subjectId, It.IsAny<string?>()),
+            Times.Once);
     }
 
     [Fact]
     public async Task RegisterComplete_NoChallengeToken_ReturnsBadRequest()
     {
+        Authenticate();
+
         var request = new PasskeyRegisterCompleteRequest
         {
             AttestationResponseJson = "{}",
@@ -347,6 +375,508 @@ public class PasskeyControllerTests : IDisposable
         var objectResult = Assert.IsType<ObjectResult>(result.Result);
         Assert.Equal(400, objectResult.StatusCode);
     }
+
+    #endregion
+
+    #region Recovery-mode enrolment
+
+    [Fact]
+    public async Task RecoveryModeOptions_WhenTenantIsNotInRecoveryMode_IsRefused()
+    {
+        // A tenant whose only member has a passkey is not in recovery mode.
+        await SeedMemberAsync("rhys", withPasskey: true);
+
+        var result = await _controller.RecoveryModeOptions(new PasskeyLoginOptionsRequest { Username = "rhys" });
+
+        var objectResult = Assert.IsType<ObjectResult>(result.Result);
+        objectResult.StatusCode.Should().Be(400);
+        _passkeyService.Verify(
+            s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task RecoveryModeOptions_WhenTheNamedAccountStillHasAPasskey_IsRefused()
+    {
+        // Recovery mode is active because of the orphan, but the named account is not the orphan.
+        var withPasskey = await SeedMemberAsync("rhys", withPasskey: true);
+        await SeedMemberAsync("orphan", withPasskey: false);
+        _subjectService
+            .Setup(s => s.CountPrimaryAuthFactorsAsync(withPasskey))
+            .ReturnsAsync(1);
+
+        var result = await _controller.RecoveryModeOptions(new PasskeyLoginOptionsRequest { Username = "rhys" });
+
+        var objectResult = Assert.IsType<ObjectResult>(result.Result);
+        objectResult.StatusCode.Should().Be(400);
+        _passkeyService.Verify(
+            s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>()),
+            Times.Never,
+            "an account that can still sign in must not be enrollable without a session");
+    }
+
+    [Fact]
+    public async Task RecoveryModeOptions_ForALockedOutAccount_MintsAChallengeForTheResolvedSubject()
+    {
+        await SeedMemberAsync("rhys", withPasskey: true);
+        var orphanId = await SeedMemberAsync("orphan", withPasskey: false);
+        _subjectService
+            .Setup(s => s.CountPrimaryAuthFactorsAsync(orphanId))
+            .ReturnsAsync(0);
+        _passkeyService
+            .Setup(s => s.GenerateRegistrationOptionsAsync(orphanId, "orphan", _tenantId))
+            .ReturnsAsync(new PasskeyRegistrationOptions("{\"challenge\":\"abc\"}", "token-data"));
+
+        var result = await _controller.RecoveryModeOptions(new PasskeyLoginOptionsRequest { Username = "orphan" });
+
+        Assert.IsType<OkObjectResult>(result.Result);
+        _passkeyService.Verify(
+            s => s.GenerateRegistrationOptionsAsync(orphanId, "orphan", _tenantId),
+            Times.Once,
+            "the subject comes from the server's lookup, not from the request");
+    }
+
+    [Fact]
+    public async Task RecoveryModeOptions_ForAnotherTenantsMember_IsRefused()
+    {
+        // Subjects are global; membership is what scopes them. A locked-out subject in another
+        // tenant must not be claimable from this one.
+        await SeedMemberAsync("rhys", withPasskey: true);
+        await SeedMemberAsync("orphan", withPasskey: false);
+        var elsewhereId = await SeedMemberAsync("elsewhere", tenantId: Guid.CreateVersion7());
+        _subjectService.Setup(s => s.CountPrimaryAuthFactorsAsync(elsewhereId)).ReturnsAsync(0);
+
+        var result = await _controller.RecoveryModeOptions(new PasskeyLoginOptionsRequest { Username = "elsewhere" });
+
+        Assert.Equal(400, Assert.IsType<ObjectResult>(result.Result).StatusCode);
+        _passkeyService.Verify(
+            s => s.GenerateRegistrationOptionsAsync(elsewhereId, It.IsAny<string>(), It.IsAny<Guid>()),
+            Times.Never);
+    }
+
+    #endregion
+
+    #region Anonymous enrolment binds to a server-resolved subject
+
+    [Fact]
+    public async Task InviteComplete_WithAChallengeForAnotherSubject_IsRefused()
+    {
+        var victimId = await SeedMemberAsync("rhys", withPasskey: true);
+        await SeedEnrollingSubjectAsync("invitee");
+        var inviteService = StubValidInvite();
+        StubRegistrationChallengeMintedFor(victimId);
+
+        var result = await _controller.InviteComplete(
+            new InviteCompleteRequest
+            {
+                Token = "invite-token",
+                Username = "invitee",
+                AttestationResponseJson = "{}",
+                ChallengeToken = "challenge-for-rhys",
+            },
+            inviteService.Object);
+
+        var objectResult = Assert.IsType<ObjectResult>(result.Result);
+        objectResult.StatusCode.Should().Be(400);
+        _passkeyService.Verify(
+            s => s.CompleteRegistrationAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), victimId, It.IsAny<string?>()),
+            Times.Never,
+            "the enrolling subject comes from the server's lookup, not from the challenge token");
+        inviteService.Verify(
+            s => s.AcceptInviteAsync(It.IsAny<string>(), It.IsAny<Guid>()),
+            Times.Never,
+            "a refused enrolment must not join anyone to the tenant");
+    }
+
+    [Fact]
+    public async Task InviteComplete_ForAnAccountThatCanAlreadySignIn_IsRefused()
+    {
+        // Naming an existing member resolves nothing: only a subject with no sign-in method that
+        // is not yet a member of this tenant can be enrolled anonymously.
+        await SeedMemberAsync("rhys", withPasskey: true);
+        var inviteService = StubValidInvite();
+
+        var result = await _controller.InviteComplete(
+            new InviteCompleteRequest
+            {
+                Token = "invite-token",
+                Username = "rhys",
+                AttestationResponseJson = "{}",
+                ChallengeToken = "challenge-token",
+            },
+            inviteService.Object);
+
+        var objectResult = Assert.IsType<ObjectResult>(result.Result);
+        objectResult.StatusCode.Should().Be(400);
+        _passkeyService.Verify(
+            s => s.CompleteRegistrationAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string?>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task InviteComplete_WithAChallengeForTheResolvedInvitee_Succeeds()
+    {
+        var inviteeId = await SeedEnrollingSubjectAsync("invitee");
+        var inviteService = StubValidInvite();
+        StubRegistrationChallengeMintedFor(inviteeId);
+        _recoveryCodeService.Setup(s => s.GenerateCodesAsync(inviteeId)).ReturnsAsync(["code-1"]);
+        _sessionService
+            .Setup(s => s.IssueSessionAsync(inviteeId, It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SessionTokenPair("access", "refresh", 900));
+
+        var result = await _controller.InviteComplete(
+            new InviteCompleteRequest
+            {
+                Token = "invite-token",
+                Username = "invitee",
+                AttestationResponseJson = "{}",
+                ChallengeToken = "challenge-for-invitee",
+            },
+            inviteService.Object);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.IsType<PasskeyRegistrationResponse>(ok.Value).Success.Should().BeTrue();
+        inviteService.Verify(s => s.AcceptInviteAsync("invite-token", inviteeId), Times.Once);
+    }
+
+    [Fact]
+    public async Task AccessRequestComplete_WithAChallengeForAnotherSubject_IsRefused()
+    {
+        var victimId = await SeedMemberAsync("rhys", withPasskey: true);
+        await AllowAccessRequestsAsync();
+        await SeedPendingAccessRequestAsync("Sam Smith");
+        StubRegistrationChallengeMintedFor(victimId);
+
+        var result = await _controller.AccessRequestComplete(
+            new AccessRequestCompleteRequest
+            {
+                DisplayName = "Sam Smith",
+                AttestationResponseJson = "{}",
+                ChallengeToken = "challenge-for-rhys",
+            },
+            new Mock<IInAppNotificationService>().Object);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        objectResult.StatusCode.Should().Be(400);
+        _passkeyService.Verify(
+            s => s.CompleteRegistrationAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), victimId, It.IsAny<string?>()),
+            Times.Never,
+            "the enrolling subject comes from the server's lookup, not from the challenge token");
+    }
+
+    [Fact]
+    public async Task AccessRequestComplete_WithAChallengeForTheResolvedRequestor_Succeeds()
+    {
+        await AllowAccessRequestsAsync();
+        var requestorId = await SeedPendingAccessRequestAsync("Sam Smith");
+        StubRegistrationChallengeMintedFor(requestorId);
+
+        var result = await _controller.AccessRequestComplete(
+            new AccessRequestCompleteRequest
+            {
+                DisplayName = "Sam Smith",
+                AttestationResponseJson = "{}",
+                ChallengeToken = "challenge-for-sam",
+            },
+            new Mock<IInAppNotificationService>().Object);
+
+        Assert.IsType<OkResult>(result);
+        _passkeyService.Verify(
+            s => s.CompleteRegistrationAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), requestorId, It.IsAny<string?>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Subjects are global; membership is what scopes them. A credential-less member of another
+    /// tenant is that tenant's locked-out account, not an abandoned enrolment here, so an invite
+    /// naming their username enrols a fresh subject and leaves theirs untouched.
+    /// </summary>
+    [Fact]
+    public async Task InviteOptions_ForAnotherTenantsMember_DoesNotBindToThatSubject()
+    {
+        var elsewhereId = await SeedMemberAsync("elsewhere", tenantId: Guid.CreateVersion7());
+        var inviteService = StubValidInvite();
+        _passkeyService
+            .Setup(s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), "elsewhere", _tenantId))
+            .ReturnsAsync(new PasskeyRegistrationOptions("{\"challenge\":\"abc\"}", "token-data"));
+
+        var result = await _controller.InviteOptions(
+            new InviteOptionsRequest { Token = "invite-token", Username = "elsewhere", DisplayName = "Attacker" },
+            inviteService.Object);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+        var victim = await _dbContext.Subjects.AsNoTracking().FirstAsync(s => s.Id == elsewhereId);
+        victim.Name.Should().Be("elsewhere", "another tenant's member must not be renamed by an invite here");
+        _passkeyService.Verify(
+            s => s.GenerateRegistrationOptionsAsync(elsewhereId, It.IsAny<string>(), It.IsAny<Guid>()),
+            Times.Never,
+            "the ceremony must not be bound to another tenant's member");
+        var subjects = await _dbContext.Subjects.AsNoTracking()
+            .Where(s => s.Username == "elsewhere").ToListAsync();
+        subjects.Should().HaveCount(2, "the invite enrols a new subject rather than claiming theirs");
+    }
+
+    /// <summary>
+    /// The completion half of the same claim: with no enrolling shell to resolve, the credential
+    /// never reaches another tenant's member.
+    /// </summary>
+    [Fact]
+    public async Task InviteComplete_ForAnotherTenantsMember_StoresNoCredential()
+    {
+        var elsewhereId = await SeedMemberAsync("elsewhere", tenantId: Guid.CreateVersion7());
+        var inviteService = StubValidInvite();
+        StubRegistrationChallengeMintedFor(elsewhereId);
+
+        var result = await _controller.InviteComplete(
+            new InviteCompleteRequest
+            {
+                Token = "invite-token",
+                Username = "elsewhere",
+                AttestationResponseJson = "{}",
+                ChallengeToken = "challenge-for-elsewhere",
+            },
+            inviteService.Object);
+
+        Assert.Equal(400, Assert.IsType<ObjectResult>(result.Result).StatusCode);
+        _passkeyService.Verify(
+            s => s.CompleteRegistrationAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), elsewhereId, It.IsAny<string?>()),
+            Times.Never,
+            "a member of any tenant is an account, not a half-finished enrolment");
+        inviteService.Verify(
+            s => s.AcceptInviteAsync(It.IsAny<string>(), It.IsAny<Guid>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Duplicate subjects left behind by an older build of the options step are all credential-less
+    /// shells that nobody can sign in as, so the completion resolves the newest — the one the
+    /// caller's ceremony was minted against — rather than refusing the invite forever.
+    /// </summary>
+    [Fact]
+    public async Task InviteComplete_WithDuplicateEnrollingSubjects_ResolvesTheNewest()
+    {
+        var older = await SeedEnrollingSubjectAsync("invitee");
+        var newest = await SeedEnrollingSubjectAsync("invitee");
+        newest.CompareTo(older).Should().BePositive("UUID v7 ids sort in creation order");
+        var inviteService = StubValidInvite();
+        StubRegistrationChallengeMintedFor(newest);
+        _recoveryCodeService.Setup(s => s.GenerateCodesAsync(newest)).ReturnsAsync(["code-1"]);
+        _sessionService
+            .Setup(s => s.IssueSessionAsync(newest, It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SessionTokenPair("access", "refresh", 900));
+
+        var result = await _controller.InviteComplete(
+            new InviteCompleteRequest
+            {
+                Token = "invite-token",
+                Username = "invitee",
+                AttestationResponseJson = "{}",
+                ChallengeToken = "challenge-for-invitee",
+            },
+            inviteService.Object);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+        inviteService.Verify(s => s.AcceptInviteAsync("invite-token", newest), Times.Once);
+    }
+
+    /// <summary>
+    /// Cancelling the OS prompt is the common failure, and it abandons the ceremony but not the
+    /// subject the options step created. A retry has to land on that same subject: the completion
+    /// step resolves the enrolling subject by username, so a second one under the same username
+    /// makes the invite unfinishable.
+    /// </summary>
+    [Fact]
+    public async Task InviteOptions_AfterAnAbandonedCeremony_ReusesTheSubject()
+    {
+        var inviteService = StubValidInvite();
+        _passkeyService
+            .Setup(s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), "invitee", _tenantId))
+            .ReturnsAsync(new PasskeyRegistrationOptions("{\"challenge\":\"abc\"}", "token-data"));
+
+        Assert.IsType<OkObjectResult>((await _controller.InviteOptions(
+            new InviteOptionsRequest { Token = "invite-token", Username = "Invitee", DisplayName = "Sam" },
+            inviteService.Object)).Result);
+        Assert.IsType<OkObjectResult>((await _controller.InviteOptions(
+            new InviteOptionsRequest { Token = "invite-token", Username = "invitee", DisplayName = "Sam Smith" },
+            inviteService.Object)).Result);
+
+        var subjects = await _dbContext.Subjects.AsNoTracking()
+            .Where(s => s.Username == "invitee").ToListAsync();
+        subjects.Should().ContainSingle("a retry must reuse the abandoned subject, not add another");
+        subjects[0].Name.Should().Be("Sam Smith");
+
+        StubRegistrationChallengeMintedFor(subjects[0].Id);
+        _recoveryCodeService.Setup(s => s.GenerateCodesAsync(subjects[0].Id)).ReturnsAsync(["code-1"]);
+        _sessionService
+            .Setup(s => s.IssueSessionAsync(subjects[0].Id, It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SessionTokenPair("access", "refresh", 900));
+
+        var result = await _controller.InviteComplete(
+            new InviteCompleteRequest
+            {
+                Token = "invite-token",
+                Username = "invitee",
+                AttestationResponseJson = "{}",
+                ChallengeToken = "challenge-for-invitee",
+            },
+            inviteService.Object);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.IsType<PasskeyRegistrationResponse>(ok.Value).Success.Should().BeTrue();
+        inviteService.Verify(s => s.AcceptInviteAsync("invite-token", subjects[0].Id), Times.Once);
+    }
+
+    /// <summary>
+    /// The same abandoned-ceremony retry on the access-request flow. The pending subject holds no
+    /// credential, so resuming it takes nothing over; the conflict is still reported for a request
+    /// that actually finished registering.
+    /// </summary>
+    [Fact]
+    public async Task AccessRequestOptions_AfterAnAbandonedCeremony_ReusesTheSubject()
+    {
+        await AllowAccessRequestsAsync();
+        _passkeyService
+            .Setup(s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), "sam-smith", _tenantId))
+            .ReturnsAsync(new PasskeyRegistrationOptions("{\"challenge\":\"abc\"}", "token-data"));
+
+        Assert.IsType<OkObjectResult>((await _controller.AccessRequestOptions(
+            new AccessRequestOptionsRequest { DisplayName = "Sam Smith" })).Result);
+        Assert.IsType<OkObjectResult>((await _controller.AccessRequestOptions(
+            new AccessRequestOptionsRequest { DisplayName = "Sam Smith", Message = "second try" })).Result);
+
+        var subjects = await _dbContext.Subjects.AsNoTracking()
+            .Where(s => s.Name == "Sam Smith").ToListAsync();
+        subjects.Should().ContainSingle("a retry must reuse the abandoned subject, not add another");
+        subjects[0].AccessRequestMessage.Should().Be("second try");
+
+        StubRegistrationChallengeMintedFor(subjects[0].Id);
+
+        var result = await _controller.AccessRequestComplete(
+            new AccessRequestCompleteRequest
+            {
+                DisplayName = "Sam Smith",
+                AttestationResponseJson = "{}",
+                ChallengeToken = "challenge-for-sam",
+            },
+            new Mock<IInAppNotificationService>().Object);
+
+        Assert.IsType<OkResult>(result);
+    }
+
+    /// <summary>
+    /// A pending request that finished registering is a real request awaiting approval, not an
+    /// abandoned ceremony, so a second one under the same name is still a conflict.
+    /// </summary>
+    [Fact]
+    public async Task AccessRequestOptions_WhenTheNameHasAFinishedPendingRequest_IsAConflict()
+    {
+        await AllowAccessRequestsAsync();
+        var requestorId = await SeedPendingAccessRequestAsync("Sam Smith");
+        _dbContext.PasskeyCredentials.Add(new PasskeyCredentialEntity
+        {
+            Id = Guid.CreateVersion7(),
+            SubjectId = requestorId,
+            CredentialId = Guid.CreateVersion7().ToByteArray(),
+            PublicKey = [1, 2, 3],
+            CreatedAt = DateTime.UtcNow,
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.AccessRequestOptions(
+            new AccessRequestOptionsRequest { DisplayName = "Sam Smith" });
+
+        Assert.IsType<ConflictObjectResult>(result.Result);
+        _passkeyService.Verify(
+            s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Makes the passkey service behave as the real one does for a challenge token minted for
+    /// <paramref name="subjectId"/>: it accepts that subject as the enrolling one and refuses
+    /// every other.
+    /// </summary>
+    private void StubRegistrationChallengeMintedFor(Guid subjectId)
+    {
+        _passkeyService
+            .Setup(s => s.CompleteRegistrationAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string?>()))
+            .ReturnsAsync((string _, string _, Guid _, Guid expectedSubjectId, string? _) =>
+                expectedSubjectId == subjectId
+                    ? new PasskeyCredentialResult(Guid.CreateVersion7(), subjectId)
+                    : throw new InvalidOperationException(
+                        "Registration challenge was not issued for the enrolling subject."));
+    }
+
+    private Mock<IMemberInviteService> StubValidInvite()
+    {
+        var inviteService = new Mock<IMemberInviteService>();
+        inviteService.Setup(s => s.GetInviteByTokenAsync("invite-token"))
+            .ReturnsAsync(new MemberInviteInfo(
+                Guid.CreateVersion7(), _tenantId, "Test", "Owner", [], null, null, false,
+                DateTime.UtcNow.AddDays(1), null, 0, true, false, false, DateTime.UtcNow, []));
+        inviteService.Setup(s => s.AcceptInviteAsync(It.IsAny<string>(), It.IsAny<Guid>()))
+            .ReturnsAsync(new AcceptMemberInviteResult(true, MembershipId: Guid.CreateVersion7()));
+        return inviteService;
+    }
+
+    /// <summary>
+    /// Adds the subject that <c>invite/options</c> creates: active, no credentials, and not yet a
+    /// member of the tenant.
+    /// </summary>
+    private async Task<Guid> SeedEnrollingSubjectAsync(string username)
+    {
+        var subjectId = Guid.CreateVersion7();
+        _dbContext.Subjects.Add(new SubjectEntity
+        {
+            Id = subjectId,
+            Name = username,
+            Username = username,
+            IsActive = true,
+            IsSystemSubject = false,
+        });
+        await _dbContext.SaveChangesAsync();
+        return subjectId;
+    }
+
+    /// <summary>
+    /// Adds the subject that <c>access-request/options</c> creates: pending and inactive.
+    /// </summary>
+    private async Task<Guid> SeedPendingAccessRequestAsync(string displayName)
+    {
+        var subjectId = Guid.CreateVersion7();
+        _dbContext.Subjects.Add(new SubjectEntity
+        {
+            Id = subjectId,
+            Name = displayName,
+            Username = displayName.ToLowerInvariant().Replace(" ", "-"),
+            IsActive = false,
+            IsSystemSubject = false,
+            ApprovalStatus = "Pending",
+        });
+        await _dbContext.SaveChangesAsync();
+        return subjectId;
+    }
+
+    private async Task AllowAccessRequestsAsync()
+    {
+        var tenant = await _dbContext.Tenants.FirstOrDefaultAsync(t => t.Id == _tenantId);
+        if (tenant == null)
+        {
+            tenant = new TenantEntity { Id = _tenantId, Slug = "test", DisplayName = "Test" };
+            _dbContext.Tenants.Add(tenant);
+        }
+
+        tenant.AllowAccessRequests = true;
+        await _dbContext.SaveChangesAsync();
+    }
+
+    #endregion
 
     [Fact]
     public async Task LoginOptions_EmptyUsername_ReturnsBadRequest()
@@ -403,6 +933,66 @@ public class PasskeyControllerTests : IDisposable
         var objectResult = Assert.IsType<ObjectResult>(result.Result);
         Assert.Equal(400, objectResult.StatusCode);
     }
+
+    #region The passkey alone is not a session when a second factor is enrolled
+
+    /// <summary>Stubs a passkey assertion that resolves to <paramref name="subjectId"/>.</summary>
+    private void StubSuccessfulAssertion(Guid subjectId, string username) =>
+        _passkeyService
+            .Setup(s => s.CompleteAssertionAsync("{}", "assertion-token", _tenantId))
+            .ReturnsAsync(new PasskeyAssertionResult(subjectId, username, username));
+
+    private Task<ActionResult<PasskeyLoginCompleteResponse>> LoginCompleteAsync() =>
+        _controller.LoginComplete(new PasskeyLoginCompleteRequest
+        {
+            AssertionResponseJson = "{}",
+            ChallengeToken = "assertion-token",
+        });
+
+    [Fact]
+    public async Task LoginComplete_WhenTheSubjectHasAnAuthenticator_WithholdsTheSession()
+    {
+        var subjectId = await SeedMemberAsync("rhys", withPasskey: true);
+        StubSuccessfulAssertion(subjectId, "rhys");
+        _totpService.Setup(s => s.GetCredentialCountAsync(subjectId)).ReturnsAsync(1);
+        _totpService.Setup(s => s.CreateStepUpTokenAsync(subjectId)).ReturnsAsync("step-up-token");
+
+        var result = await LoginCompleteAsync();
+
+        var response = Assert.IsType<PasskeyLoginCompleteResponse>(
+            Assert.IsType<OkObjectResult>(result.Result).Value);
+        response.TotpRequired.Should().BeTrue();
+        response.StepUpToken.Should().NotBeNullOrEmpty();
+        response.AccessToken.Should().BeEmpty();
+        _sessionService.Verify(
+            s => s.IssueSessionAsync(It.IsAny<Guid>(), It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the second factor is still outstanding, so the passkey alone must not grant access");
+    }
+
+    [Fact]
+    public async Task LoginComplete_WhenTheSubjectHasNoAuthenticator_IssuesTheSession()
+    {
+        var subjectId = await SeedMemberAsync("rhys", withPasskey: true);
+        StubSuccessfulAssertion(subjectId, "rhys");
+        _totpService.Setup(s => s.GetCredentialCountAsync(subjectId)).ReturnsAsync(0);
+        _sessionService
+            .Setup(s => s.IssueSessionAsync(subjectId, It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SessionTokenPair("access", "refresh", 900));
+
+        var result = await LoginCompleteAsync();
+
+        var response = Assert.IsType<PasskeyLoginCompleteResponse>(
+            Assert.IsType<OkObjectResult>(result.Result).Value);
+        response.TotpRequired.Should().BeFalse();
+        response.AccessToken.Should().Be("access");
+        _sessionService.Verify(
+            s => s.IssueSessionAsync(subjectId, It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _totpService.Verify(s => s.CreateStepUpTokenAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+    #endregion
 
     [Fact]
     public async Task RecoveryVerify_EmptyFields_ReturnsBadRequest()

--- a/tests/Unit/Nocturne.API.Tests/Controllers/TotpControllerLoginGateTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/TotpControllerLoginGateTests.cs
@@ -14,9 +14,10 @@ using Xunit;
 namespace Nocturne.API.Tests.Controllers;
 
 /// <summary>
-/// Tests for the cross-tenant guard on TOTP login. <see cref="ITotpService.VerifyLoginAsync"/>
-/// resolves the subject by username globally, so the controller must verify the resolved
-/// subject is a member of the tenant being logged into before issuing a session.
+/// Tests for the guards on TOTP sign-in: it is a second factor reached only with a step-up token
+/// from a completed primary factor, and the resolved subject must be a member of the tenant being
+/// signed into (<see cref="ITotpService.VerifyStepUpAsync"/> resolves the subject from the token,
+/// which is not tenant-scoped).
 /// </summary>
 public class TotpControllerLoginGateTests
 {
@@ -43,12 +44,37 @@ public class TotpControllerLoginGateTests
 
     [Fact]
     [Trait("Category", "Unit")]
+    public async Task Login_WithoutAValidStepUpToken_DeniesWithoutIssuingSession()
+    {
+        // No primary factor completed, so no step-up token was ever minted for this code.
+        _totpService
+            .Setup(s => s.VerifyStepUpAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((TotpLoginResult?)null);
+
+        var controller = CreateController();
+        var result = await controller.Login(new TotpLoginRequest
+        {
+            StepUpToken = "not-a-real-token",
+            Code = "123456",
+        });
+
+        result.Result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(400, "a code alone is not a sign-in method");
+
+        _sessionService.Verify(
+            s => s.IssueSessionAsync(It.IsAny<Guid>(), It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "TOTP must never mint a session without a completed primary factor");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
     public async Task Login_WhenSubjectIsNotMemberOfTenant_DeniesWithoutIssuingSession()
     {
         var subjectId = Guid.NewGuid();
         var tenantId = Guid.NewGuid();
         _totpService
-            .Setup(s => s.VerifyLoginAsync("rhys", "123456"))
+            .Setup(s => s.VerifyStepUpAsync("step-up", "123456"))
             .ReturnsAsync(new TotpLoginResult(subjectId, "rhys", "Rhys"));
         _tenantAccessor.Setup(a => a.TenantId).Returns(tenantId);
         _tenantMemberService
@@ -56,7 +82,7 @@ public class TotpControllerLoginGateTests
             .ReturnsAsync(false);
 
         var controller = CreateController();
-        var result = await controller.Login(new TotpLoginRequest { Username = "rhys", Code = "123456" });
+        var result = await controller.Login(new TotpLoginRequest { StepUpToken = "step-up", Code = "123456" });
 
         result.Result.Should().BeOfType<ObjectResult>()
             .Which.StatusCode.Should().Be(400, "a non-member must be rejected like an invalid code");
@@ -74,7 +100,7 @@ public class TotpControllerLoginGateTests
         var subjectId = Guid.NewGuid();
         var tenantId = Guid.NewGuid();
         _totpService
-            .Setup(s => s.VerifyLoginAsync("rhys", "123456"))
+            .Setup(s => s.VerifyStepUpAsync("step-up", "123456"))
             .ReturnsAsync(new TotpLoginResult(subjectId, "rhys", "Rhys"));
         _tenantAccessor.Setup(a => a.TenantId).Returns(tenantId);
         _tenantMemberService
@@ -85,7 +111,7 @@ public class TotpControllerLoginGateTests
             .ReturnsAsync(new SessionTokenPair("access-token", "refresh-token", 3600));
 
         var controller = CreateController();
-        var result = await controller.Login(new TotpLoginRequest { Username = "rhys", Code = "123456" });
+        var result = await controller.Login(new TotpLoginRequest { StepUpToken = "step-up", Code = "123456" });
 
         result.Result.Should().BeOfType<OkObjectResult>();
         _sessionService.Verify(

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/SetupControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/SetupControllerTests.cs
@@ -460,6 +460,85 @@ public class SetupControllerTests : IDisposable
         validation.IsValid.Should().BeFalse();
     }
 
+    // ── OwnerComplete binds the enrolment to a server-resolved subject ────
+
+    [Fact]
+    public async Task OwnerComplete_WithAChallengeForAnotherSubject_IsRefused()
+    {
+        var ownerSubjectId = await SeedOwnerlessTenantWithOwnerSubjectAsync();
+        var otherSubjectId = Guid.CreateVersion7();
+        StubRegistrationChallengeMintedFor(otherSubjectId);
+
+        var result = await _controller.OwnerComplete(
+            new SetupOwnerCompleteRequest
+            {
+                AttestationResponseJson = "{}",
+                ChallengeToken = "challenge-for-another-subject",
+            },
+            CancellationToken.None);
+
+        var problem = result.Should().BeOfType<ObjectResult>().Subject;
+        problem.StatusCode.Should().Be(400);
+        _passkeyService.Verify(
+            s => s.CompleteRegistrationAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), ownerSubjectId, It.IsAny<string?>()),
+            Times.Once,
+            "the enrolling subject comes from the server's lookup, not from the challenge token");
+        _sessionService.Verify(
+            s => s.IssueSessionAsync(It.IsAny<Guid>(), It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "a refused enrolment must not produce a session");
+    }
+
+    [Fact]
+    public async Task OwnerComplete_WithAChallengeForTheResolvedOwner_Succeeds()
+    {
+        var ownerSubjectId = await SeedOwnerlessTenantWithOwnerSubjectAsync();
+        StubRegistrationChallengeMintedFor(ownerSubjectId);
+        _recoveryCodeService.Setup(s => s.GenerateCodesAsync(ownerSubjectId))
+            .ReturnsAsync(["code-1"]);
+        _sessionService
+            .Setup(s => s.IssueSessionAsync(ownerSubjectId, It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SessionTokenPair("access", "refresh", 900));
+
+        var result = await _controller.OwnerComplete(
+            new SetupOwnerCompleteRequest
+            {
+                AttestationResponseJson = "{}",
+                ChallengeToken = "challenge-for-owner",
+            },
+            CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ok.Value.Should().BeOfType<SetupOwnerCompleteResponse>().Subject.Success.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task OwnerComplete_BeforeTheOptionsStepCreatedTheOwner_IsRefused()
+    {
+        _dbContext.Set<TenantEntity>().Add(new TenantEntity
+        {
+            Id = Guid.CreateVersion7(), Slug = "my-instance", DisplayName = "My Instance",
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.OwnerComplete(
+            new SetupOwnerCompleteRequest
+            {
+                AttestationResponseJson = "{}",
+                ChallengeToken = "challenge-from-nowhere",
+            },
+            CancellationToken.None);
+
+        var problem = result.Should().BeOfType<ObjectResult>().Subject;
+        problem.StatusCode.Should().Be(400);
+        _passkeyService.Verify(
+            s => s.CompleteRegistrationAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string?>()),
+            Times.Never,
+            "with no subject to resolve there is nothing to enrol onto");
+    }
+
     // ── OwnerOidc ────────────────────────────────────────────────────────
 
     [Fact]
@@ -503,6 +582,50 @@ public class SetupControllerTests : IDisposable
     // function. These scenarios are covered by integration tests.
 
     // ── Helpers ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Seeds the sole tenant plus the credential-less owner subject and membership that
+    /// <c>owner/options</c> leaves behind, and returns the subject id.
+    /// </summary>
+    private async Task<Guid> SeedOwnerlessTenantWithOwnerSubjectAsync()
+    {
+        var tenantId = Guid.CreateVersion7();
+        var subjectId = Guid.CreateVersion7();
+
+        _dbContext.Set<TenantEntity>().Add(new TenantEntity
+        {
+            Id = tenantId, Slug = "my-instance", DisplayName = "My Instance",
+        });
+        _dbContext.Subjects.Add(new SubjectEntity
+        {
+            Id = subjectId, Name = "Owner", Username = "owner",
+            IsActive = true, IsSystemSubject = false,
+        });
+        _dbContext.TenantMembers.Add(new TenantMemberEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = tenantId, SubjectId = subjectId,
+        });
+        await _dbContext.SaveChangesAsync();
+
+        return subjectId;
+    }
+
+    /// <summary>
+    /// Makes the passkey service behave as the real one does for a challenge token minted for
+    /// <paramref name="subjectId"/>: it accepts that subject as the enrolling one and refuses
+    /// every other.
+    /// </summary>
+    private void StubRegistrationChallengeMintedFor(Guid subjectId)
+    {
+        _passkeyService
+            .Setup(s => s.CompleteRegistrationAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string?>()))
+            .ReturnsAsync((string _, string _, Guid _, Guid expectedSubjectId, string? _) =>
+                expectedSubjectId == subjectId
+                    ? new PasskeyCredentialResult(Guid.CreateVersion7(), subjectId)
+                    : throw new InvalidOperationException(
+                        "Registration challenge was not issued for the enrolling subject."));
+    }
 
     /// <summary>
     /// Seeds a tenant with a member that has a passkey credential, making

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/PasskeyServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/PasskeyServiceTests.cs
@@ -319,6 +319,61 @@ public class PasskeyServiceTests
 
     #endregion
 
+    #region Challenge token binding
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CompleteRegistrationAsync_WithAChallengeForAnotherSubject_IsRejected()
+    {
+        var service = CreateService();
+        var victimSubjectId = Guid.CreateVersion7();
+
+        // A challenge minted for the victim — as the old caller-supplied subjectId allowed.
+        var options = await service.GenerateRegistrationOptionsAsync(victimSubjectId, "victim", _tenantId);
+
+        var act = () => service.CompleteRegistrationAsync(
+            "{}", options.ChallengeToken, _tenantId, expectedSubjectId: _subjectId);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*not issued for the enrolling subject*");
+
+        (await _dbContext.PasskeyCredentials.AnyAsync(c => c.SubjectId == victimSubjectId))
+            .Should().BeFalse("no credential may be stored for a subject the caller does not own");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CompleteRegistrationAsync_WithAnAssertionChallenge_IsRejected()
+    {
+        var service = CreateService();
+
+        // Login and registration challenges share one protector, so the ceremony a token was
+        // minted for has to be checked.
+        var assertion = await service.GenerateDiscoverableAssertionOptionsAsync(_tenantId);
+
+        var act = () => service.CompleteRegistrationAsync(
+            "{}", assertion.ChallengeToken, _tenantId, expectedSubjectId: _subjectId);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*different ceremony*");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CompleteAssertionAsync_WithARegistrationChallenge_IsRejected()
+    {
+        var service = CreateService();
+
+        var registration = await service.GenerateRegistrationOptionsAsync(_subjectId, "testuser", _tenantId);
+
+        var act = () => service.CompleteAssertionAsync("{}", registration.ChallengeToken, _tenantId);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*different ceremony*");
+    }
+
+    #endregion
+
     #region Helpers
 
     private PasskeyService CreateService()

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/TotpHelperTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/TotpHelperTests.cs
@@ -156,6 +156,51 @@ public class TotpHelperTests
 
     [Fact]
     [Trait("Category", "Unit")]
+    public void TryVerify_ReportsTheMatchedTimeStep()
+    {
+        var secret = TotpHelper.GenerateSecret();
+        var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var code = TotpHelper.ComputeTotp(secret, now);
+
+        var result = TotpHelper.TryVerify(secret, code, lastUsedStep: null, out var matchedStep);
+
+        result.Should().BeTrue();
+        matchedStep.Should().Be(now / 30);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void TryVerify_RejectsACodeWhoseStepWasAlreadyConsumed()
+    {
+        var secret = TotpHelper.GenerateSecret();
+        var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var code = TotpHelper.ComputeTotp(secret, now);
+
+        TotpHelper.TryVerify(secret, code, lastUsedStep: null, out var consumedStep).Should().BeTrue();
+
+        // Replayed inside the same +/- 1 step window, which without the floor would still match.
+        var replay = TotpHelper.TryVerify(secret, code, consumedStep, out _);
+
+        replay.Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void TryVerify_AcceptsACodeFromAStepAfterTheConsumedOne()
+    {
+        var secret = TotpHelper.GenerateSecret();
+        var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var code = TotpHelper.ComputeTotp(secret, now);
+
+        // A step before the current one was consumed, so the current code is still usable.
+        var result = TotpHelper.TryVerify(secret, code, lastUsedStep: (now / 30) - 1, out var matchedStep);
+
+        result.Should().BeTrue();
+        matchedStep.Should().Be(now / 30);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
     public void ComputeTotp_AlwaysReturnsSixDigits()
     {
         var secret = TotpHelper.GenerateSecret();

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/TotpSecretProtectionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/TotpSecretProtectionTests.cs
@@ -52,7 +52,7 @@ public class TotpSecretProtectionTests
 
         var read = () => converter.ConvertFromProvider(plaintext);
 
-        // CryptographicException specifically: that is what TotpService.VerifyLoginAsync catches to
+        // CryptographicException specifically: that is what TotpService.VerifyStepUpAsync catches to
         // turn a lost key into an ordinary failed attempt instead of a 500.
         read.Should().Throw<CryptographicException>(
             "an unencrypted column value must fail closed rather than be read as a secret");

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/TotpServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/TotpServiceTests.cs
@@ -1,11 +1,13 @@
+using System.Text.Json;
 using FluentAssertions;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging.Abstractions;
 using Nocturne.API.Services.Auth;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
-using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
 
 namespace Nocturne.API.Tests.Services.Auth;
@@ -13,8 +15,13 @@ namespace Nocturne.API.Tests.Services.Auth;
 /// <summary>
 /// Unit tests for TotpService covering setup, verification, and credential management.
 /// </summary>
-public class TotpServiceTests
+/// <remarks>
+/// Backed by SQLite rather than the InMemory provider: consuming a TOTP time step uses a
+/// conditional <c>ExecuteUpdate</c>, which only relational providers support.
+/// </remarks>
+public class TotpServiceTests : IDisposable
 {
+    private readonly SqliteConnection _connection;
     private readonly NocturneDbContext _dbContext;
     private readonly IDataProtectionProvider _dataProtectionProvider;
     private readonly Guid _subjectId = Guid.CreateVersion7();
@@ -22,8 +29,23 @@ public class TotpServiceTests
 
     public TotpServiceTests()
     {
-        _dbContext = TestDbContextFactory.CreateInMemoryContext();
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+
+        _dbContext = new NocturneDbContext(options);
+        _dbContext.Database.EnsureCreated();
         _dataProtectionProvider = new EphemeralDataProtectionProvider();
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        _connection.Dispose();
     }
 
     #region GenerateSetupAsync
@@ -74,6 +96,7 @@ public class TotpServiceTests
     public async Task CompleteSetupAsync_WithValidCode_PersistsCredential()
     {
         var service = CreateService();
+        SeedSubject(TestUsername, _subjectId);
         var setup = await service.GenerateSetupAsync(_subjectId, TestUsername);
 
         // Generate a valid TOTP code from the secret
@@ -120,11 +143,11 @@ public class TotpServiceTests
 
     #endregion
 
-    #region VerifyLoginAsync
+    #region VerifyStepUpAsync
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task VerifyLoginAsync_WithValidCredential_ReturnsSubject()
+    public async Task VerifyStepUpAsync_WithValidCredential_ReturnsSubject()
     {
         var service = CreateService();
 
@@ -135,7 +158,7 @@ public class TotpServiceTests
 
         var code = TotpHelper.ComputeTotp(secret, DateTimeOffset.UtcNow.ToUnixTimeSeconds());
 
-        var result = await service.VerifyLoginAsync(TestUsername, code);
+        var result = await service.VerifyStepUpAsync(await service.CreateStepUpTokenAsync(subject.Id), code);
 
         result.Should().NotBeNull();
         result!.SubjectId.Should().Be(subject.Id);
@@ -144,18 +167,7 @@ public class TotpServiceTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task VerifyLoginAsync_WithUnknownUsername_ReturnsNull()
-    {
-        var service = CreateService();
-
-        var result = await service.VerifyLoginAsync("nonexistent", "123456");
-
-        result.Should().BeNull();
-    }
-
-    [Fact]
-    [Trait("Category", "Unit")]
-    public async Task VerifyLoginAsync_WithWrongCode_ReturnsNull()
+    public async Task VerifyStepUpAsync_WithoutAStepUpToken_ReturnsNull()
     {
         var service = CreateService();
 
@@ -163,14 +175,86 @@ public class TotpServiceTests
         var subject = SeedSubject(TestUsername);
         SeedCredential(subject.Id, secret, "Test TOTP");
 
-        var result = await service.VerifyLoginAsync(TestUsername, "000000");
+        var code = TotpHelper.ComputeTotp(secret, DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+
+        // A correct code is worthless without proof that a primary factor completed.
+        var result = await service.VerifyStepUpAsync("not-a-real-token", code);
 
         result.Should().BeNull();
     }
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task VerifyLoginAsync_UpdatesLastUsedAt()
+    public async Task VerifyStepUpAsync_WithATokenForAnotherSubject_ReturnsNull()
+    {
+        var service = CreateService();
+
+        var secret = TotpHelper.GenerateSecret();
+        var subject = SeedSubject(TestUsername);
+        SeedCredential(subject.Id, secret, "Test TOTP");
+        var otherSubject = SeedSubject("othersubject");
+
+        var code = TotpHelper.ComputeTotp(secret, DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+
+        var result = await service.VerifyStepUpAsync(
+            await service.CreateStepUpTokenAsync(otherSubject.Id), code);
+
+        result.Should().BeNull("the step-up token names the account, so a code cannot be replayed onto another");
+    }
+
+    /// <summary>
+    /// A step-up token is a reference to a persisted row keyed on the subject, so one cannot be
+    /// minted for an account that does not exist.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CreateStepUpTokenAsync_ForAnUnknownSubject_Throws()
+    {
+        var service = CreateService();
+
+        var act = () => service.CreateStepUpTokenAsync(Guid.CreateVersion7());
+
+        await act.Should().ThrowAsync<DbUpdateException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task VerifyStepUpAsync_WithADeactivatedSubject_ReturnsNull()
+    {
+        var service = CreateService();
+
+        var secret = TotpHelper.GenerateSecret();
+        var subject = SeedSubject(TestUsername);
+        SeedCredential(subject.Id, secret, "Test TOTP");
+
+        var stepUpToken = await service.CreateStepUpTokenAsync(subject.Id);
+        await _dbContext.Subjects.Where(s => s.Id == subject.Id)
+            .ExecuteUpdateAsync(s => s.SetProperty(x => x.IsActive, false));
+
+        var code = TotpHelper.ComputeTotp(secret, DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+        var result = await service.VerifyStepUpAsync(stepUpToken, code);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task VerifyStepUpAsync_WithWrongCode_ReturnsNull()
+    {
+        var service = CreateService();
+
+        var secret = TotpHelper.GenerateSecret();
+        var subject = SeedSubject(TestUsername);
+        SeedCredential(subject.Id, secret, "Test TOTP");
+
+        var result = await service.VerifyStepUpAsync(await service.CreateStepUpTokenAsync(subject.Id), "000000");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task VerifyStepUpAsync_RecordsTheConsumedStepAndLastUsedAt()
     {
         var service = CreateService();
 
@@ -179,12 +263,232 @@ public class TotpServiceTests
         var credential = SeedCredential(subject.Id, secret, "Test TOTP");
 
         credential.LastUsedAt.Should().BeNull();
+        credential.LastUsedStep.Should().BeNull();
 
         var code = TotpHelper.ComputeTotp(secret, DateTimeOffset.UtcNow.ToUnixTimeSeconds());
-        await service.VerifyLoginAsync(TestUsername, code);
+        await service.VerifyStepUpAsync(await service.CreateStepUpTokenAsync(subject.Id), code);
 
-        var updated = await _dbContext.TotpCredentials.FirstAsync(c => c.Id == credential.Id);
+        var updated = await _dbContext.TotpCredentials.AsNoTracking().FirstAsync(c => c.Id == credential.Id);
         updated.LastUsedAt.Should().NotBeNull();
+        updated.LastUsedStep.Should().NotBeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task VerifyStepUpAsync_RejectsTheSameCodeASecondTimeWithinItsWindow()
+    {
+        var service = CreateService();
+
+        var secret = TotpHelper.GenerateSecret();
+        var subject = SeedSubject(TestUsername);
+        var credential = SeedCredential(subject.Id, secret, "Test TOTP");
+
+        var code = TotpHelper.ComputeTotp(secret, DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+
+        var first = await service.VerifyStepUpAsync(await service.CreateStepUpTokenAsync(subject.Id), code);
+        first.Should().NotBeNull();
+
+        var consumedStep = (await _dbContext.TotpCredentials.AsNoTracking()
+            .FirstAsync(c => c.Id == credential.Id)).LastUsedStep;
+        consumedStep.Should().NotBeNull();
+
+        // The code still matches an accepted time step, and it is the recorded one — so single use
+        // is the only thing left that can refuse it, not a crossed step boundary.
+        TotpHelper.TryVerify(secret, code, lastUsedStep: null, out var stillMatchedStep).Should().BeTrue();
+        stillMatchedStep.Should().Be(consumedStep!.Value);
+
+        // Same code, still inside the ±1 step acceptance window, fresh step-up token.
+        var freshToken = await service.CreateStepUpTokenAsync(subject.Id);
+        var second = await service.VerifyStepUpAsync(freshToken, code);
+
+        second.Should().BeNull("a code is consumed on first use, not valid for the whole window");
+
+        var freshRow = await _dbContext.TotpStepUpTokens.AsNoTracking()
+            .Where(t => t.SubjectId == subject.Id)
+            .OrderByDescending(t => t.Id)
+            .FirstAsync();
+        freshRow.ConsumedAt.Should().BeNull("the reused code is refused before the token is spent");
+    }
+
+    /// <summary>
+    /// A step-up token stands for one completed primary factor, so it must buy one session. Without
+    /// this, a captured token was worth a session for every valid code presented inside its
+    /// five-minute window — including the next window's code, which is not the one already consumed.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task VerifyStepUpAsync_RejectsAStepUpTokenRedeemedASecondTime()
+    {
+        var service = CreateService();
+
+        var secret = TotpHelper.GenerateSecret();
+        var subject = SeedSubject(TestUsername);
+        var credential = SeedCredential(subject.Id, secret, "Test TOTP");
+
+        var stepUpToken = await service.CreateStepUpTokenAsync(subject.Id);
+        var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+        var first = await service.VerifyStepUpAsync(
+            stepUpToken, TotpHelper.ComputeTotp(secret, now));
+        first.Should().NotBeNull();
+
+        var consumedStep = (await _dbContext.TotpCredentials.AsNoTracking()
+            .FirstAsync(c => c.Id == credential.Id)).LastUsedStep;
+        (await _dbContext.TotpStepUpTokens.AsNoTracking().SingleAsync(t => t.SubjectId == subject.Id))
+            .ConsumedAt.Should().NotBeNull();
+
+        // A different, still-valid code — asserted valid against the consumed step, so the reuse is
+        // caught by the token rather than by a crossed step boundary.
+        var nextCode = TotpHelper.ComputeTotp(secret, now + 30);
+        TotpHelper.TryVerify(secret, nextCode, consumedStep, out _).Should()
+            .BeTrue("the second attempt has to fail on the token, not on the code");
+
+        var second = await service.VerifyStepUpAsync(stepUpToken, nextCode);
+
+        second.Should().BeNull("a step-up token proves one primary factor, so it yields one session");
+        (await _dbContext.TotpCredentials.AsNoTracking().FirstAsync(c => c.Id == credential.Id))
+            .LastUsedStep.Should().Be(consumedStep, "a refused redemption consumes nothing further");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task VerifyStepUpAsync_MarksTheStepUpTokenConsumed()
+    {
+        var service = CreateService();
+
+        var secret = TotpHelper.GenerateSecret();
+        var subject = SeedSubject(TestUsername);
+        SeedCredential(subject.Id, secret, "Test TOTP");
+
+        var code = TotpHelper.ComputeTotp(secret, DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+        await service.VerifyStepUpAsync(await service.CreateStepUpTokenAsync(subject.Id), code);
+
+        var row = await _dbContext.TotpStepUpTokens.AsNoTracking()
+            .SingleAsync(t => t.SubjectId == subject.Id);
+        row.ConsumedAt.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// A wrong code must not burn the token, or a typo would send the user back through the passkey
+    /// assertion.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task VerifyStepUpAsync_WrongCode_LeavesTheStepUpTokenRedeemable()
+    {
+        var service = CreateService();
+
+        var secret = TotpHelper.GenerateSecret();
+        var subject = SeedSubject(TestUsername);
+        SeedCredential(subject.Id, secret, "Test TOTP");
+
+        var stepUpToken = await service.CreateStepUpTokenAsync(subject.Id);
+
+        (await service.VerifyStepUpAsync(stepUpToken, "000000")).Should().BeNull();
+
+        var code = TotpHelper.ComputeTotp(secret, DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+        var retried = await service.VerifyStepUpAsync(stepUpToken, code);
+
+        retried.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// The token carries a reference to server state, not the subject, so a token whose row is gone
+    /// (expired and pruned) cannot still name an account.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task VerifyStepUpAsync_WithNoMatchingStepUpRow_ReturnsNull()
+    {
+        var service = CreateService();
+
+        var secret = TotpHelper.GenerateSecret();
+        var subject = SeedSubject(TestUsername);
+        SeedCredential(subject.Id, secret, "Test TOTP");
+
+        var stepUpToken = await service.CreateStepUpTokenAsync(subject.Id);
+        await _dbContext.TotpStepUpTokens.Where(t => t.SubjectId == subject.Id).ExecuteDeleteAsync();
+
+        var code = TotpHelper.ComputeTotp(secret, DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+        var result = await service.VerifyStepUpAsync(stepUpToken, code);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task VerifyStepUpAsync_WithAnExpiredStepUpRow_ReturnsNull()
+    {
+        var service = CreateService();
+
+        var secret = TotpHelper.GenerateSecret();
+        var subject = SeedSubject(TestUsername);
+        SeedCredential(subject.Id, secret, "Test TOTP");
+
+        var stepUpToken = await service.CreateStepUpTokenAsync(subject.Id);
+        await _dbContext.TotpStepUpTokens
+            .Where(t => t.SubjectId == subject.Id)
+            .ExecuteUpdateAsync(s => s.SetProperty(t => t.ExpiresAt, DateTime.UtcNow.AddMinutes(-1)));
+
+        var code = TotpHelper.ComputeTotp(secret, DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+        var result = await service.VerifyStepUpAsync(stepUpToken, code);
+
+        result.Should().BeNull("the row is the authority on expiry, not the token payload");
+    }
+
+    /// <summary>
+    /// The setup protector and the step-up protector have distinct Data Protection purposes, so a
+    /// token minted under the setup purpose is not step-up proof. Everything else about this token
+    /// is genuine — it names a real unconsumed step-up row and is presented with a valid code — so
+    /// the purpose split is the only thing refusing it: unify the purposes and the redemption
+    /// succeeds. Setup is a flow where the caller already knows the secret, which is why a token
+    /// from it must never assert that a primary factor completed.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task VerifyStepUpAsync_WithATokenMintedUnderTheSetupPurpose_ReturnsNull()
+    {
+        var service = CreateService();
+
+        var secret = TotpHelper.GenerateSecret();
+        var subject = SeedSubject(TestUsername);
+        SeedCredential(subject.Id, secret, "Test TOTP");
+
+        await service.CreateStepUpTokenAsync(subject.Id);
+        var row = await _dbContext.TotpStepUpTokens.AsNoTracking()
+            .SingleAsync(t => t.SubjectId == subject.Id);
+
+        var setupProtector = _dataProtectionProvider.CreateProtector("Nocturne.Totp.Setup");
+        var mintedUnderSetup = setupProtector.Protect(JsonSerializer.Serialize(new
+        {
+            TokenId = row.Id,
+            row.ExpiresAt,
+        }));
+
+        var code = TotpHelper.ComputeTotp(secret, DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+        var result = await service.VerifyStepUpAsync(mintedUnderSetup, code);
+
+        result.Should().BeNull();
+        (await _dbContext.TotpStepUpTokens.AsNoTracking().SingleAsync(t => t.Id == row.Id))
+            .ConsumedAt.Should().BeNull("a token the step-up protector cannot read never reaches the row");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CompleteSetupAsync_ConsumesTheCodeThatProvedSetup()
+    {
+        var service = CreateService();
+        SeedSubject(TestUsername, _subjectId);
+        var setup = await service.GenerateSetupAsync(_subjectId, TestUsername);
+        var code = GenerateValidCode(setup.Base32Secret);
+
+        var created = await service.CompleteSetupAsync(code, "My Authenticator", setup.ChallengeToken);
+
+        var result = await service.VerifyStepUpAsync(await service.CreateStepUpTokenAsync(_subjectId), code);
+
+        result.Should().BeNull("the setup code is recorded as consumed, so it cannot also sign in");
+        var entity = await _dbContext.TotpCredentials.AsNoTracking().FirstAsync(c => c.Id == created.CredentialId);
+        entity.LastUsedStep.Should().NotBeNull();
     }
 
     #endregion
@@ -304,11 +608,11 @@ public class TotpServiceTests
         return new TotpService(_dbContext, _dataProtectionProvider, NullLogger<TotpService>.Instance);
     }
 
-    private SubjectEntity SeedSubject(string username)
+    private SubjectEntity SeedSubject(string username, Guid? subjectId = null)
     {
         var subject = new SubjectEntity
         {
-            Id = Guid.CreateVersion7(),
+            Id = subjectId ?? Guid.CreateVersion7(),
             Name = username,
             Username = username,
             IsActive = true,
@@ -321,6 +625,12 @@ public class TotpServiceTests
 
     private TotpCredentialEntity SeedCredential(Guid subjectId, byte[] secret, string label)
     {
+        // SQLite enforces the subject foreign key, so the owning subject has to exist.
+        if (!_dbContext.Subjects.Any(s => s.Id == subjectId))
+        {
+            SeedSubject($"user-{subjectId:N}", subjectId);
+        }
+
         var entity = new TotpCredentialEntity
         {
             Id = Guid.CreateVersion7(),


### PR DESCRIPTION
Three related gaps in the passkey and TOTP paths.

**Enrolment binding.** Passkey registration did not bind the ceremony to a server-resolved subject. All five completion paths (register, recovery mode, access request, invite acceptance, first-owner setup) now pass a required `expectedSubjectId` that the server resolved, checked before the ceremony completes — so a new enrolment path cannot compile without naming the subject it enrols.

**TOTP as a second factor.** A passkey assertion issued a session even when the account had an authenticator enrolled, making TOTP an alternative first factor rather than a second one. `LoginComplete` now withholds the session and returns a step-up token; `POST /api/auth/totp/login` issues the session only after the code verifies.

**Single-use step-up.** The step-up token was a bare protected payload, replayable within its lifetime. It is now backed by a row consumed with a conditional UPDATE (two concurrent redemptions cannot both succeed) and carries no identity of its own — the subject is read from the row. Setup challenges and step-up tokens use distinct Data Protection purposes, so a setup challenge cannot be presented as proof that a primary factor completed. Expired rows are swept by the existing OAuth code cleanup.

**Enrolment subject resolution.** The invite and access-request options steps create the subject, so their complete steps re-resolve it rather than trusting the challenge token. That resolution excludes any subject holding membership in *any* tenant, not merely the current one: subjects are global and passkey credentials hang off the subject, so a tenant-scoped check would let one tenant bind its passkey to another tenant's credential-less member and then authenticate as them on their own host. The options steps also reuse an existing half-finished enrolment rather than inserting a second subject, so abandoning the authenticator prompt and retrying no longer leaves the username unresolvable.

`TotpService` tests move to SQLite in memory, since the conditional updates the consume relies on are unsupported by the InMemory provider.

Tests: API 4587, Core.Models 527, Infrastructure.Data 481 — 0 failed. Reviewed adversarially across three rounds, each gate proven non-vacuous by removing it and confirming failure.

https://claude.ai/code/session_01Wk3jH4N16htaBqGod2j7y8
