### PR TITLE
fix(hubs): authorize hub method invocations, and scope the tenant-wide groups

### DIFF
--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -656,11 +656,20 @@ public static class ServiceRegistrationExtensions
     )
     {
         // SignalR
-        services.AddSignalR();
-        services.AddSingleton<
-            Microsoft.AspNetCore.SignalR.IHubFilter,
-            Nocturne.API.Hubs.TenantHubFilter
-        >();
+        // Global hub filters have to be added to HubOptions — SignalR reads HubOptions.HubFilters
+        // and never resolves IHubFilter from the container, so a filter registered only in DI never
+        // runs. TenantHubFilter is outermost so the invocation scope's ITenantAccessor is populated
+        // before anything inside resolves a tenant-scoped service; HubAuthorizationFilter needs none
+        // of that itself, since it reads the credential out of HttpContext.Items.
+        services.AddSignalR(options =>
+        {
+            Microsoft.AspNetCore.SignalR.HubOptionsExtensions
+                .AddFilter<Nocturne.API.Hubs.TenantHubFilter>(options);
+            Microsoft.AspNetCore.SignalR.HubOptionsExtensions
+                .AddFilter<Nocturne.API.Hubs.HubAuthorizationFilter>(options);
+        });
+        services.AddSingleton<Nocturne.API.Hubs.TenantHubFilter>();
+        services.AddSingleton<Nocturne.API.Hubs.HubAuthorizationFilter>();
         services.AddScoped<ISignalRBroadcastService, SignalRBroadcastService>();
         services.AddScoped<ISyncProgressReporter, SignalRSyncProgressReporter>();
 

--- a/src/API/Nocturne.API/Hubs/AlarmHub.cs
+++ b/src/API/Nocturne.API/Hubs/AlarmHub.cs
@@ -1,34 +1,38 @@
 using Microsoft.AspNetCore.SignalR;
-using Nocturne.API.Middleware;
-using Nocturne.Core.Constants;
-using Nocturne.Core.Contracts.Identity;
+using Nocturne.API.Services.Identity;
 using Nocturne.Core.Contracts.Notifications;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.API.Hubs;
 
 /// <summary>
 /// SignalR hub for alarm notifications, replacing socket.io alarm namespace
 /// </summary>
-// Connections authenticate in-band after negotiate and are reachable only via the internal
-// realtime bridge, so the HTTP fallback authorization policy must not gate the handshake.
+// The handshake is anonymous because clients authenticate in-band, after negotiate: a client that
+// can only present its credential once the connection is up would otherwise be refused before it
+// could. The hub endpoint is internet-reachable (the cloud gateway publishes /hubs/**), so
+// authorization happens per method in HubAuthorizationFilter, not at the handshake.
 [Microsoft.AspNetCore.Authorization.AllowAnonymous]
 public class AlarmHub : TenantAwareHub
 {
     private readonly ILogger<AlarmHub> _logger;
-    private readonly IAuthorizationService _authorizationService;
+    private readonly IHubTokenAuthorizer _tokenAuthorizer;
 
-    public AlarmHub(ILogger<AlarmHub> logger, IAuthorizationService authorizationService)
+    public AlarmHub(ILogger<AlarmHub> logger, IHubTokenAuthorizer tokenAuthorizer)
     {
         _logger = logger;
-        _authorizationService = authorizationService;
+        _tokenAuthorizer = tokenAuthorizer;
     }
 
     /// <summary>
-    /// Subscribe to alarm notifications (replaces socket.io 'subscribe' event)
+    /// Subscribe to alarm notifications (replaces socket.io 'subscribe' event). Legacy alarms carry
+    /// the glucose reading that triggered them, so glucose read is the gate.
     /// </summary>
     /// <param name="authData">Authorization data containing secret and JWT token</param>
     /// <returns>Subscription result</returns>
+    [HubAuthenticationMethod]
+    [HubTenantGroup]
     public async Task<object> Subscribe(AlarmSubscribeRequest authData)
     {
         try
@@ -36,66 +40,36 @@ public class AlarmHub : TenantAwareHub
             _logger.LogInformation(
                 "Client {ConnectionId} subscribing to alarms",
                 Context.ConnectionId
-            ); // Check authentication through existing middleware context
-            var authContext =
-                Context.GetHttpContext()?.Items["AuthContext"] as Middleware.AuthenticationContext;
-            bool isAuthorized = authContext?.IsAuthenticated ?? false;
+            );
 
-            // If not already authenticated through middleware, try to authenticate with provided credentials
-            if (!isAuthorized)
+            // A connection that presented a credential on the HTTP upgrade is already authenticated
+            // and scoped; otherwise authenticate from the in-band payload. Both credential shapes go
+            // through IHubTokenAuthorizer so the tenant pin and scope check match DataHub's.
+            var authorization = HubAuthorizationState.Resolve(Context);
+
+            if (authorization is null && !string.IsNullOrEmpty(authData.JwtToken))
             {
-                if (!string.IsNullOrEmpty(authData.JwtToken))
-                {
-                    // Try to generate JWT from access token
-                    var authResponse = await _authorizationService.GenerateJwtFromAccessTokenAsync(
-                        authData.JwtToken
-                    );
-                    isAuthorized = authResponse != null;
-                }
-                else if (!string.IsNullOrEmpty(authData.Secret))
-                {
-                    // For API secret, we need to validate it against the configured secret
-                    // This would normally be done by the authentication middleware
-                    // For SignalR hubs, we need to implement the same logic
-                    var configuration = Context
-                        .GetHttpContext()
-                        ?.RequestServices.GetRequiredService<IConfiguration>();
-                    var configuredSecret =
-                        configuration?[$"Parameters:{ServiceNames.Parameters.InstanceKey}"]
-                        ?? configuration?[ServiceNames.ConfigKeys.InstanceKey];
-                    if (!string.IsNullOrEmpty(configuredSecret))
-                    {
-                        // Calculate SHA1 hash of the configured secret
-                        using var sha1 = System.Security.Cryptography.SHA1.Create();
-                        var secretBytes = System.Text.Encoding.UTF8.GetBytes(configuredSecret);
-                        var hashBytes = sha1.ComputeHash(secretBytes);
-                        var expectedHash = BitConverter
-                            .ToString(hashBytes)
-                            .Replace("-", "")
-                            .ToLowerInvariant();
-
-                        // Compare with provided secret (should be the hashed value)
-                        isAuthorized = authData.Secret.ToLowerInvariant() == expectedHash;
-                    }
-                }
+                authorization = await _tokenAuthorizer.AuthorizeTokenAsync(
+                    authData.JwtToken,
+                    TenantContext?.TenantId,
+                    OAuthScopes.GlucoseRead
+                );
+            }
+            else if (authorization is null && !string.IsNullOrEmpty(authData.Secret))
+            {
+                authorization = _tokenAuthorizer.AuthorizeInstanceKey(
+                    authData.Secret,
+                    TenantContext?.TenantId
+                );
             }
 
-            if (isAuthorized)
-            {
-                // Add connection to tenant-scoped alarm subscribers group
-                await Groups.AddToGroupAsync(
-                    Context.ConnectionId,
-                    TenantGroup("alarm-subscribers")
-                );
-
-                _logger.LogInformation(
-                    "Client {ConnectionId} subscribed to alarms successfully",
-                    Context.ConnectionId
-                );
-
-                return new { read = true, success = true };
-            }
-            else
+            // The group carries the tenant's alarms, announcements and notifications, not one data
+            // category, so a share-style grant is refused here as it is on DataHub's tenant groups.
+            // [HubTenantGroup] declares that requirement; HubAuthorizationFilter cannot enforce it on
+            // an authentication entry point, because the credential arrives in this invocation.
+            if (authorization is null
+                || !authorization.CanJoinTenantRelay
+                || !authorization.Satisfies(OAuthScopes.GlucoseRead))
             {
                 _logger.LogWarning(
                     "Client {ConnectionId} alarm subscription failed - unauthorized",
@@ -103,6 +77,21 @@ public class AlarmHub : TenantAwareHub
                 );
                 return new { read = false, success = false };
             }
+
+            HubAuthorizationState.Grant(Context, authorization);
+
+            // Add connection to tenant-scoped alarm subscribers group
+            await Groups.AddToGroupAsync(
+                Context.ConnectionId,
+                TenantGroup("alarm-subscribers")
+            );
+
+            _logger.LogInformation(
+                "Client {ConnectionId} subscribed to alarms successfully",
+                Context.ConnectionId
+            );
+
+            return new { read = true, success = true };
         }
         catch (Exception ex)
         {
@@ -126,6 +115,7 @@ public class AlarmHub : TenantAwareHub
     /// <param name="level">Alarm level to acknowledge</param>
     /// <param name="group">Alarm group to acknowledge</param>
     /// <param name="silenceTime">Time to silence alarm in milliseconds</param>
+    [HubScope(OAuthScopes.AlertsReadWrite)]
     public async Task Ack(int level, string group, int silenceTime)
     {
         try

--- a/src/API/Nocturne.API/Hubs/AlertHub.cs
+++ b/src/API/Nocturne.API/Hubs/AlertHub.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using Nocturne.Core.Contracts.Alerts;
+using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.API.Hubs;
 
@@ -9,14 +10,21 @@ namespace Nocturne.API.Hubs;
 /// (dispatch, resolved, acknowledged) and can acknowledge all active excursions.
 /// Mounted at /hubs/alerts — the legacy AlarmHub remains at /hubs/alarms for compat.
 /// </summary>
-// Connections authenticate in-band after negotiate and are reachable only via the internal
-// realtime bridge, so the HTTP fallback authorization policy must not gate the handshake.
+// The handshake is anonymous so it does not gate on the HTTP fallback authorization policy; this hub
+// has no in-band handshake method, so callers must present a credential on the HTTP upgrade request.
+// The hub endpoint is internet-reachable (the cloud gateway publishes /hubs/**), so authorization
+// happens per method in HubAuthorizationFilter.
 [AllowAnonymous]
 public class AlertHub : TenantAwareHub
 {
     /// <summary>
     /// Subscribe the calling connection to alert events for the current tenant.
     /// </summary>
+    // alert-subscribers carries every rule's dispatches, resolutions and acknowledgements for the
+    // whole tenant, including the alert text and who acknowledged it, so it is not one data category
+    // and a share-style credential is refused it.
+    [HubScope(OAuthScopes.AlertsRead)]
+    [HubTenantGroup]
     public async Task Subscribe()
     {
         await Groups.AddToGroupAsync(Context.ConnectionId, TenantGroup("alert-subscribers"));
@@ -27,6 +35,7 @@ public class AlertHub : TenantAwareHub
     /// This halts escalation but does not close excursions.
     /// </summary>
     /// <param name="acknowledgedBy">Display name or identifier of the person acknowledging.</param>
+    [HubScope(OAuthScopes.AlertsReadWrite)]
     public async Task Acknowledge(string acknowledgedBy)
     {
         var ackService = Context.GetHttpContext()!.RequestServices

--- a/src/API/Nocturne.API/Hubs/ConfigHub.cs
+++ b/src/API/Nocturne.API/Hubs/ConfigHub.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
+using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.API.Hubs;
 
@@ -7,6 +8,15 @@ namespace Nocturne.API.Hubs;
 /// SignalR hub for real-time configuration change notifications.
 /// Connectors can subscribe to receive notifications when their configuration changes.
 /// </summary>
+/// <remarks>
+/// Every method requires <see cref="OAuthScopes.FullAccess"/>. Connector configuration is tenant
+/// administration and the OAuth vocabulary has no narrower scope for it, and the broadcasts name the
+/// member who made each change. The consumers are the realtime bridge (instance key) and the tenant
+/// owner, both of which hold full access.
+///
+/// The two subscribe methods also carry <see cref="HubTenantGroupAttribute"/>: the config groups carry
+/// the tenant's connector administration, not one data category.
+/// </remarks>
 [Authorize]
 public class ConfigHub : TenantAwareHub
 {
@@ -21,6 +31,8 @@ public class ConfigHub : TenantAwareHub
     /// Subscribe to configuration changes for a specific connector.
     /// </summary>
     /// <param name="connectorName">The connector name to subscribe to</param>
+    [HubScope(OAuthScopes.FullAccess)]
+    [HubTenantGroup]
     public async Task Subscribe(string connectorName)
     {
         _logger.LogDebug("Client {ConnectionId} subscribing to config changes for {ConnectorName}",
@@ -33,6 +45,7 @@ public class ConfigHub : TenantAwareHub
     /// Unsubscribe from configuration changes for a specific connector.
     /// </summary>
     /// <param name="connectorName">The connector name to unsubscribe from</param>
+    [HubScope(OAuthScopes.FullAccess)]
     public async Task Unsubscribe(string connectorName)
     {
         _logger.LogDebug("Client {ConnectionId} unsubscribing from config changes for {ConnectorName}",
@@ -44,6 +57,8 @@ public class ConfigHub : TenantAwareHub
     /// <summary>
     /// Subscribe to configuration changes for all connectors.
     /// </summary>
+    [HubScope(OAuthScopes.FullAccess)]
+    [HubTenantGroup]
     public async Task SubscribeAll()
     {
         _logger.LogDebug("Client {ConnectionId} subscribing to all config changes", Context.ConnectionId);
@@ -54,6 +69,7 @@ public class ConfigHub : TenantAwareHub
     /// <summary>
     /// Unsubscribe from all connector configuration changes.
     /// </summary>
+    [HubScope(OAuthScopes.FullAccess)]
     public async Task UnsubscribeAll()
     {
         _logger.LogDebug("Client {ConnectionId} unsubscribing from all config changes", Context.ConnectionId);

--- a/src/API/Nocturne.API/Hubs/DataHub.cs
+++ b/src/API/Nocturne.API/Hubs/DataHub.cs
@@ -1,11 +1,9 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using Nocturne.API.Extensions;
-using Nocturne.API.Middleware;
 using Nocturne.API.Services.Devices;
 using Nocturne.API.Services.Identity;
-using Nocturne.Connectors.Core.Utilities;
-using Nocturne.Core.Constants;
+using Nocturne.API.Services.Realtime;
 using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Models.Authorization;
@@ -15,8 +13,10 @@ namespace Nocturne.API.Hubs;
 /// <summary>
 /// SignalR hub for real-time data updates, replacing socket.io main data connection
 /// </summary>
-// Connections authenticate in-band after negotiate and are reachable only via the internal
-// realtime bridge, so the HTTP fallback authorization policy must not gate the handshake.
+// The handshake is anonymous because clients authenticate in-band, after negotiate: a client that
+// can only present its credential once the connection is up would otherwise be refused before it
+// could. The hub endpoint is internet-reachable (the cloud gateway publishes /hubs/**), so
+// authorization happens per method in HubAuthorizationFilter, not at the handshake.
 [AllowAnonymous]
 public class DataHub : TenantAwareHub
 {
@@ -30,10 +30,14 @@ public class DataHub : TenantAwareHub
     }
 
     /// <summary>
-    /// Client authorization method (replaces socket.io 'authorize' event)
+    /// Client authorization method (replaces socket.io 'authorize' event). Joins the tenant-scoped
+    /// authorized group, which receives the tenant's live data broadcasts, and records the
+    /// connection's credential for every subsequent hub method.
     /// </summary>
     /// <param name="authData">Authorization data containing client info, secret, token, and history</param>
     /// <returns>Authorization result</returns>
+    [HubAuthenticationMethod]
+    [HubTenantGroup]
     public async Task<object> Authorize(AuthorizeRequest authData)
     {
         try
@@ -43,80 +47,30 @@ public class DataHub : TenantAwareHub
                 Context.ConnectionId
             );
 
-            // Check authentication through existing middleware context
-            var authContext =
-                Context.GetHttpContext()?.Items["AuthContext"] as Middleware.AuthenticationContext;
-            bool isAuthorized = authContext?.IsAuthenticated ?? false;
+            // A connection that presented a credential on the HTTP upgrade is already authenticated
+            // and scoped; otherwise authenticate from the in-band payload.
+            var authorization = HubAuthorizationState.Resolve(Context);
 
-            // If not already authenticated through middleware, try to authenticate with provided credentials
-            if (!isAuthorized)
+            if (authorization is null && !string.IsNullOrEmpty(authData.Token))
             {
-                if (!string.IsNullOrEmpty(authData.Token))
-                {
-                    // OAuth JWT (validated + tenant-pinned + scope-checked) or legacy opaque
-                    // access token. Glucose read is the gate: the authorized group receives the
-                    // tenant's live data broadcasts.
-                    isAuthorized = await _tokenAuthorizer.IsTokenAuthorizedAsync(
-                        authData.Token,
-                        TenantContext?.TenantId,
-                        OAuthScopes.GlucoseRead
-                    );
-                }
-                else if (!string.IsNullOrEmpty(authData.Secret))
-                {
-                    // For API secret, we need to validate it against the configured secret
-                    // This would normally be done by the authentication middleware
-                    // For SignalR hubs, we need to implement the same logic
-                    var configuration = Context
-                        .GetHttpContext()
-                        ?.RequestServices.GetRequiredService<IConfiguration>();
-                    // Match InstanceKeyHandler's lookup: Aspire dev sets the
-                    // value under Parameters:instance-key (user-secrets);
-                    // production sets it as the INSTANCE_KEY env var, which
-                    // ASP.NET Core surfaces as a top-level config key.
-                    var configuredSecret =
-                        configuration?[$"Parameters:{ServiceNames.Parameters.InstanceKey}"]
-                        ?? configuration?[ServiceNames.ConfigKeys.InstanceKey];
-                    if (!string.IsNullOrEmpty(configuredSecret))
-                    {
-                        // Calculate SHA-256 hash of the configured secret
-                        var expectedHash = HashUtils.Sha256Hex(configuredSecret);
-
-                        // Compare with provided secret (should be the hashed value)
-                        isAuthorized = authData.Secret.ToLowerInvariant() == expectedHash;
-                    }
-                }
-            }
-
-            if (isAuthorized)
-            {
-                // Add connection to tenant-scoped authorized group
-                await Groups.AddToGroupAsync(Context.ConnectionId, TenantGroup("authorized"));
-
-                // If user is admin, also add to admin group for admin-specific notifications
-                var httpContext = Context.GetHttpContext();
-                if (httpContext?.IsAdmin() == true)
-                {
-                    await Groups.AddToGroupAsync(Context.ConnectionId, TenantGroup("admin"));
-                    _logger.LogDebug(
-                        "Client {ConnectionId} added to admin group",
-                        Context.ConnectionId
-                    );
-                }
-
-                _logger.LogInformation(
-                    "Client {ConnectionId} authorized successfully",
-                    Context.ConnectionId
+                // OAuth JWT (validated + tenant-pinned + scope-checked) or legacy opaque access
+                // token. Glucose read is the gate: the authorized group receives the tenant's live
+                // data broadcasts.
+                authorization = await _tokenAuthorizer.AuthorizeTokenAsync(
+                    authData.Token,
+                    TenantContext?.TenantId,
+                    OAuthScopes.GlucoseRead
                 );
-
-                return new
-                {
-                    read = true,
-                    write = true,
-                    success = true,
-                };
             }
-            else
+            else if (authorization is null && !string.IsNullOrEmpty(authData.Secret))
+            {
+                authorization = _tokenAuthorizer.AuthorizeInstanceKey(
+                    authData.Secret,
+                    TenantContext?.TenantId
+                );
+            }
+
+            if (authorization is null || !authorization.Satisfies(OAuthScopes.GlucoseRead))
             {
                 _logger.LogWarning(
                     "Client {ConnectionId} authorization failed",
@@ -129,6 +83,62 @@ public class DataHub : TenantAwareHub
                     success = false,
                 };
             }
+
+            HubAuthorizationState.Grant(Context, authorization);
+
+            // The tenant-wide groups carry more than the glucose read this method gates on —
+            // tracker state, device action intents, arbitrary dataUpdate payloads — so only a
+            // credential that belongs to the tenant joins them. [HubTenantGroup] declares that
+            // requirement; HubAuthorizationFilter cannot enforce it on an authentication entry
+            // point, because the credential arrives in this invocation, so the check is here. A
+            // guest is not refused outright: it still authorizes, and joins nothing tenant-wide,
+            // reaching the categories it was shared through Subscribe.
+            if (authorization.CanJoinTenantRelay)
+            {
+                await Groups.AddToGroupAsync(
+                    Context.ConnectionId, TenantGroup(RealtimeGroups.Authorized));
+
+                // Per-subject payloads (in-app notifications, device notification mirrors) go to the
+                // owning subject's group, so one member's notifications never reach another's client.
+                if (authorization.OwnSubjectId is { } subjectId)
+                {
+                    await Groups.AddToGroupAsync(
+                        Context.ConnectionId, TenantGroup(RealtimeGroups.ForSubject(subjectId)));
+                }
+
+                // The bridge consumes no payload itself; it relays every subject's to its own
+                // clients, so it takes the tenant-wide copy of the per-subject broadcasts.
+                if (authorization.IsInfrastructure)
+                {
+                    await Groups.AddToGroupAsync(
+                        Context.ConnectionId, TenantGroup(RealtimeGroups.Relay));
+                }
+
+                // If user is admin, also add to admin group for admin-specific notifications
+                var httpContext = Context.GetHttpContext();
+                if (httpContext?.IsAdmin() == true)
+                {
+                    await Groups.AddToGroupAsync(
+                        Context.ConnectionId, TenantGroup(RealtimeGroups.Admin));
+                    _logger.LogDebug(
+                        "Client {ConnectionId} added to admin group",
+                        Context.ConnectionId
+                    );
+                }
+            }
+
+            _logger.LogInformation(
+                "Client {ConnectionId} authorized successfully ({Kind})",
+                Context.ConnectionId,
+                authorization.Kind
+            );
+
+            return new
+            {
+                read = true,
+                write = authorization.Satisfies(OAuthScopes.GlucoseReadWrite),
+                success = true,
+            };
         }
         catch (Exception ex)
         {
@@ -148,9 +158,12 @@ public class DataHub : TenantAwareHub
     }
 
     /// <summary>
-    /// Request retro data load (replaces socket.io 'loadRetro' event)
+    /// Request retro data load (replaces socket.io 'loadRetro' event). Each collection in the
+    /// response is gated on its own read scope, so a narrowly-scoped credential receives only the
+    /// categories it holds.
     /// </summary>
     /// <param name="request">Retro load request containing loadedMills timestamp</param>
+    [HubScope(OAuthScopes.GlucoseRead)]
     public async Task LoadRetro(RetroLoadRequest request)
     {
         try
@@ -185,23 +198,34 @@ public class DataHub : TenantAwareHub
             var endTime = request.LoadedMills;
             var startTime = endTime - (48 * 60 * 60 * 1000); // 48 hours before
 
-            // Load retro data from multiple collections
+            var authorization = HubAuthorizationState.Resolve(Context)!;
+
+            // Load retro data from multiple collections. The glucose gate is the method's declared
+            // scope; treatments and device status answer to their own.
             var entries = await entryService.GetEntriesAsync(
                 find: $"{{\"mills\": {{\"$gte\": {startTime}, \"$lt\": {endTime}}}}}",
                 count: 1000
             );
 
-            var treatments = await treatmentService.GetTreatmentsAsync(
-                find: $"{{\"mills\": {{\"$gte\": {startTime}, \"$lt\": {endTime}}}}}",
-                count: 1000
-            );
+            IEnumerable<Core.Models.Treatment> treatments = [];
+            if (authorization.Satisfies(OAuthScopes.TreatmentsRead))
+            {
+                treatments = await treatmentService.GetTreatmentsAsync(
+                    find: $"{{\"mills\": {{\"$gte\": {startTime}, \"$lt\": {endTime}}}}}",
+                    count: 1000
+                );
+            }
 
-            var deviceStatuses = await projectionService.GetAsync(
-                count: 1000,
-                skip: 0,
-                find: null,
-                ct: default
-            );
+            IEnumerable<Core.Models.DeviceStatus> deviceStatuses = [];
+            if (authorization.Satisfies(OAuthScopes.DevicesRead))
+            {
+                deviceStatuses = await projectionService.GetAsync(
+                    count: 1000,
+                    skip: 0,
+                    find: null,
+                    ct: default
+                );
+            }
 
             var retroData = new
             {
@@ -243,7 +267,9 @@ public class DataHub : TenantAwareHub
     }
 
     /// <summary>
-    /// Subscribe to storage collections (replaces socket.io '/storage' namespace 'subscribe' event)
+    /// Subscribe to storage collections (replaces socket.io '/storage' namespace 'subscribe' event).
+    /// Each collection is joined only when the connection's credential satisfies the read scope
+    /// governing it, so the returned list may be narrower than the one requested.
     /// </summary>
     /// <param name="request">Storage subscription request</param>
     /// <returns>Subscription result</returns>
@@ -251,22 +277,37 @@ public class DataHub : TenantAwareHub
     {
         try
         {
-            var enabledCollections = Services.Realtime.RealtimeCategories.All;
-            var collections = request.Collections ?? enabledCollections;
+            var governingScopes = RealtimeCategories.GoverningScopes;
+            var collections = request.Collections ?? RealtimeCategories.All;
+            var authorization = HubAuthorizationState.Resolve(Context)!;
             var subscribed = new List<string>();
 
             foreach (var collection in collections)
             {
-                if (enabledCollections.Contains(collection))
+                // An unclassified collection has no governing scope and cannot be subscribed to.
+                if (!governingScopes.TryGetValue(collection, out var requiredScope))
                 {
-                    await Groups.AddToGroupAsync(Context.ConnectionId, TenantGroup(collection));
-                    subscribed.Add(collection);
+                    continue;
+                }
+
+                if (!authorization.Satisfies(requiredScope))
+                {
                     _logger.LogDebug(
-                        "Client {ConnectionId} subscribed to collection {Collection}",
+                        "Client {ConnectionId} lacks {RequiredScope} for collection {Collection}",
                         Context.ConnectionId,
+                        requiredScope,
                         collection
                     );
+                    continue;
                 }
+
+                await Groups.AddToGroupAsync(Context.ConnectionId, TenantGroup(collection));
+                subscribed.Add(collection);
+                _logger.LogDebug(
+                    "Client {ConnectionId} subscribed to collection {Collection}",
+                    Context.ConnectionId,
+                    collection
+                );
             }
 
             return new { success = true, collections = subscribed };

--- a/src/API/Nocturne.API/Hubs/HomeAssistantHub.cs
+++ b/src/API/Nocturne.API/Hubs/HomeAssistantHub.cs
@@ -1,5 +1,4 @@
 using Nocturne.Core.Models.Authorization;
-using Nocturne.API.Extensions;
 using System.Collections.Concurrent;
 using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
@@ -18,8 +17,10 @@ namespace Nocturne.API.Hubs;
 /// when the channel is configured to allow it.
 /// Mounted at /hubs/home-assistant.
 /// </summary>
-// Connections authenticate in-band after negotiate and are reachable only via the internal
-// realtime bridge, so the HTTP fallback authorization policy must not gate the handshake.
+// The handshake is anonymous so it does not gate on the HTTP fallback authorization policy; this hub
+// has no in-band handshake method, so callers must present a credential on the HTTP upgrade request.
+// The hub endpoint is internet-reachable (the cloud gateway publishes /hubs/**), so authorization
+// happens per method in HubAuthorizationFilter.
 [AllowAnonymous]
 public class HomeAssistantHub : TenantAwareHub
 {
@@ -35,6 +36,11 @@ public class HomeAssistantHub : TenantAwareHub
     /// Also performs catch-up delivery for any failed HA deliveries targeting this instance.
     /// </summary>
     /// <param name="instanceId">The Home Assistant instance identifier (matches channel Destination).</param>
+    // ha-glucose and ha-alerts carry the tenant's glucose relay and every alert dispatch, and the
+    // catch-up replays undelivered alert payloads to the caller, so a share-style credential is
+    // refused. The instanceId is caller-chosen, so ha:{instanceId} is tenant-wide too.
+    [HubScope(OAuthScopes.AlertsRead)]
+    [HubTenantGroup]
     public async Task Subscribe(string instanceId)
     {
         var ct = Context.ConnectionAborted;
@@ -94,27 +100,18 @@ public class HomeAssistantHub : TenantAwareHub
     /// </summary>
     /// <param name="excursionId">The excursion to acknowledge.</param>
     /// <param name="acknowledgedBy">Display name or identifier of the person acknowledging.</param>
+    // Gate 1 is the declared scope, enforced by HubAuthorizationFilter against the connection's
+    // resolved credential. The authority is the resolved, membership-intersected GrantedScopes set,
+    // not a "scope" claim on the principal: that claim is minted only by JwtService and so only ever
+    // appeared on the principal the framework's JwtBearer scheme built, and the custom chain owns the
+    // final principal on every path.
+    [HubScope(OAuthScopes.AlertsReadWrite)]
     public async Task Acknowledge(Guid excursionId, string acknowledgedBy)
     {
         var ct = Context.ConnectionAborted;
 
         var tenantId = TenantContext?.TenantId
             ?? throw new HubException("No tenant context resolved.");
-
-        // Gate 1: OAuth scope check — require "alerts.readwrite".
-        //
-        // Read from GrantedScopes rather than a "scope" claim on the principal. That claim is minted
-        // only by JwtService and so only ever appeared on the principal the framework's JwtBearer
-        // scheme built; AuthenticationMiddleware's claim set has never carried it. Now that the
-        // custom chain owns the final principal on every path, FindAll("scope") is always empty and
-        // this gate would deny every acknowledge. GrantedScopes is the resolved, membership-
-        // intersected scope set, which is the right authority here anyway.
-        var httpContext = Context.GetHttpContext()
-            ?? throw new HubException("No HTTP context available.");
-        var scopes = httpContext.GetGrantedScopes();
-
-        if (!OAuthScopes.SatisfiesScope(scopes, OAuthScopes.AlertsReadWrite))
-            throw new HubException("Insufficient permissions: alerts.readwrite scope required.");
 
         // Gate 2: Channel config check — find HA channels for this excursion's rule and verify allow_ack
         var services = Context.GetHttpContext()!.RequestServices;

--- a/src/API/Nocturne.API/Hubs/HubAuthorization.cs
+++ b/src/API/Nocturne.API/Hubs/HubAuthorization.cs
@@ -1,0 +1,270 @@
+using System.Reflection;
+using Microsoft.AspNetCore.SignalR;
+using Nocturne.API.Extensions;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.Authorization;
+
+namespace Nocturne.API.Hubs;
+
+/// <summary>
+/// What kind of credential a hub connection presented. Scopes say which data categories the
+/// connection may see; this says whether it belongs to the tenant or is a narrow share of it, which
+/// is what decides access to the groups that carry more than one category.
+/// </summary>
+/// <remarks>
+/// "Belongs to the tenant" is what the handshake proved, which for most types is a tenant-membership
+/// row — <see cref="Middleware.AuthenticationMiddleware"/> rejects a subject that has none.
+/// <see cref="AuthType.ApiKey"/> is the type it exempts from that check (see
+/// <see cref="Middleware.MemberScopeMiddleware"/>: an api-secret grant row is matched on TenantId and
+/// keeps the grant's own scopes), so an api-secret credential whose subject is not a member of the
+/// tenant still classifies as <see cref="Subject"/> and reaches the tenant-wide and subject groups on
+/// its grant alone.
+/// </remarks>
+/// <seealso cref="HubAuthorization.CanJoinTenantRelay"/>
+public enum HubCredentialKind
+{
+    /// <summary>
+    /// A share of the tenant's data with no account behind it: a guest link. May join the data
+    /// category groups it holds a read scope for, and nothing else — the tenant-wide groups carry
+    /// other members' in-app notifications and alert state, which no guest scope covers.
+    /// </summary>
+    /// <remarks>
+    /// The default, so a credential whose kind was not classified cannot reach a tenant-wide group.
+    /// </remarks>
+    Restricted = 0,
+
+    /// <summary>
+    /// A credential belonging to a subject: a member session, an OAuth app grant, a follower or
+    /// direct grant, or platform access. Joins the tenant-wide live data group and its own subject
+    /// group.
+    /// </summary>
+    Subject,
+
+    /// <summary>
+    /// The instance key — infrastructure auth, currently the socket.io bridge. Additionally joins
+    /// <see cref="Services.Realtime.RealtimeGroups.Relay"/>, because it relays every subject's
+    /// payloads onward itself rather than consuming them.
+    /// </summary>
+    Infrastructure,
+}
+
+/// <summary>
+/// The credential a hub connection has proven: the tenant it is pinned to, the OAuth scopes it
+/// carries, what kind of credential it is, and the subject behind it when there is one.
+/// </summary>
+/// <param name="TenantId">The tenant the credential authorizes, always the connection's own tenant.</param>
+/// <param name="Scopes">The granted OAuth scopes, normalized.</param>
+/// <param name="Kind">
+/// The credential's kind. Required rather than defaulted so every construction site states it.
+/// </param>
+/// <param name="SubjectId">
+/// The subject the credential belongs to, or null when it belongs to none (the instance key, and a
+/// guest session — <c>GuestSessionHandler</c> leaves <c>SubjectId</c> null and records the data owner
+/// it acts for on <c>ActingAsSubjectId</c>). Read only through <see cref="OwnSubjectId"/>, which
+/// refuses a non-<see cref="HubCredentialKind.Subject"/> credential a subject group whatever it
+/// carries here.
+/// </param>
+public sealed record HubAuthorization(
+    Guid TenantId,
+    IReadOnlySet<string> Scopes,
+    HubCredentialKind Kind,
+    Guid? SubjectId)
+{
+    /// <summary>Whether the credential satisfies <paramref name="scope"/>.</summary>
+    public bool Satisfies(string scope) => OAuthScopes.SatisfiesScope(Scopes, scope);
+
+    /// <summary>
+    /// Whether the credential may join a group carrying the whole tenant's live payloads rather than
+    /// a single data category.
+    /// </summary>
+    /// <remarks>
+    /// False for a share-style grant. Those groups are gated on <c>glucose.read</c> alone but carry
+    /// tracker state, device action intents and arbitrary <c>dataUpdate</c> payloads, so a read-only
+    /// share holding glucose would otherwise receive categories it was never granted.
+    /// </remarks>
+    public bool CanJoinTenantRelay => Kind is not HubCredentialKind.Restricted;
+
+    /// <summary>
+    /// Whether the credential is the infrastructure bridge, which relays per-subject payloads to its
+    /// own clients and therefore needs the tenant-wide copy of them.
+    /// </summary>
+    public bool IsInfrastructure => Kind is HubCredentialKind.Infrastructure;
+
+    /// <summary>
+    /// The subject group this credential owns, or null when it owns none. A share-style credential
+    /// owns none even if a subject id reaches <see cref="SubjectId"/> by some route.
+    /// </summary>
+    public Guid? OwnSubjectId => Kind is HubCredentialKind.Subject ? SubjectId : null;
+
+    /// <summary>
+    /// Classifies the credential an HTTP upgrade handshake authenticated.
+    /// </summary>
+    /// <remarks>
+    /// Lists the types that belong to the tenant, so an authentication type added later lands on
+    /// <see cref="HubCredentialKind.Restricted"/> and has to be classified deliberately before it
+    /// reaches a tenant-wide group. A public share never reaches here: it resolves with
+    /// <c>IsAuthenticated: false</c> and so cannot authorize a hub connection at all.
+    /// </remarks>
+    /// <param name="authType">The authentication type resolved for the handshake.</param>
+    public static HubCredentialKind Classify(AuthType authType) => authType switch
+    {
+        AuthType.InstanceKey => HubCredentialKind.Infrastructure,
+
+        AuthType.OidcToken
+            or AuthType.LegacyJwt
+            or AuthType.LegacyAccessToken
+            or AuthType.ApiKey
+            or AuthType.SessionCookie
+            or AuthType.OAuthAccessToken
+            or AuthType.DirectGrant
+            or AuthType.PlatformAccess => HubCredentialKind.Subject,
+
+        _ => HubCredentialKind.Restricted,
+    };
+}
+
+/// <summary>
+/// Marks a hub method as an in-band authentication entry point: it is reachable on a connection that
+/// has not yet proven a credential, and records the result with
+/// <see cref="HubAuthorizationState.Grant"/> when one is presented. Every hub method without this
+/// attribute is denied on an unauthorized connection by <see cref="HubAuthorizationFilter"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class HubAuthenticationMethodAttribute : Attribute;
+
+/// <summary>
+/// The OAuth scope a hub method requires, enforced by <see cref="HubAuthorizationFilter"/> against
+/// the connection's <see cref="HubAuthorization.Scopes"/>. A method without it still requires an
+/// authorized connection; declare a scope on any method that reads or changes tenant data.
+/// </summary>
+/// <param name="scope">The required scope, from <see cref="OAuthScopes"/>.</param>
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class HubScopeAttribute(string scope) : Attribute
+{
+    /// <summary>The required scope.</summary>
+    public string Scope { get; } = scope;
+}
+
+/// <summary>
+/// Marks a hub method as joining a group that carries the whole tenant's live payloads rather than a
+/// single data category. <see cref="HubAuthorizationFilter"/> refuses the invocation unless the
+/// connection's credential satisfies <see cref="HubAuthorization.CanJoinTenantRelay"/>, so the check
+/// is declared once per method instead of written out at each join.
+/// </summary>
+/// <remarks>
+/// A method carrying <see cref="HubAuthenticationMethodAttribute"/> as well runs before the filter can
+/// see a credential — the credential arrives in the invocation itself — so it checks
+/// <see cref="HubAuthorization.CanJoinTenantRelay"/> against what it just authenticated. The attribute
+/// is declared on those methods too, which is what lets
+/// <c>HubAuthorizationFilterTests.Every_hub_method_that_joins_a_tenant_wide_group_declares_it</c> hold
+/// every method that joins one to it: a method added later that joins a tenant-wide group without
+/// declaring it fails that test rather than shipping ungated.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class HubTenantGroupAttribute : Attribute;
+
+/// <summary>
+/// Reads and writes the <see cref="HubAuthorization"/> carried by a SignalR connection.
+/// </summary>
+public static class HubAuthorizationState
+{
+    /// <summary>Key the authorization is stored under in <see cref="HubCallerContext.Items"/>.</summary>
+    private const string ItemKey = "HubAuthorization";
+
+    /// <summary>
+    /// Records the result of a successful in-band authentication on the connection. Only an
+    /// authentication method that has verified a credential may call this.
+    /// </summary>
+    /// <param name="context">The connection to record the credential on.</param>
+    /// <param name="authorization">The verified credential.</param>
+    public static HubAuthorization Grant(HubCallerContext context, HubAuthorization authorization)
+    {
+        context.Items[ItemKey] = authorization;
+        return authorization;
+    }
+
+    /// <summary>
+    /// The connection's proven credential, or null when it has none.
+    /// </summary>
+    /// <remarks>
+    /// Falls back to the HTTP upgrade handshake. A connection that presented a session cookie,
+    /// api-secret or bearer token on the upgrade request was already authenticated by
+    /// <see cref="Middleware.AuthenticationMiddleware"/> and scoped by
+    /// <see cref="Middleware.MemberScopeMiddleware"/>, so it needs no in-band handshake. Clients that
+    /// present their credential only after the connection is up authenticate in-band instead.
+    /// </remarks>
+    public static HubAuthorization? Resolve(HubCallerContext context)
+    {
+        if (context.Items.TryGetValue(ItemKey, out var existing)
+            && existing is HubAuthorization granted)
+        {
+            return granted;
+        }
+
+        var httpContext = context.GetHttpContext();
+
+        // GetAuthContext() reads Items["AuthContext"] as Core.Models.Authorization.AuthContext —
+        // the type AuthenticationMiddleware actually stores there.
+        if (httpContext?.GetAuthContext() is not { IsAuthenticated: true } authContext)
+        {
+            return null;
+        }
+
+        if (httpContext.Items[TenantAwareHub.TenantContextKey] is not TenantContext tenantContext)
+        {
+            return null;
+        }
+
+        // Scopes come from the handshake, which is where membership and token scopes were resolved;
+        // they cannot change for the life of the connection.
+        return Grant(context, new HubAuthorization(
+            tenantContext.TenantId,
+            httpContext.GetGrantedScopes(),
+            HubAuthorization.Classify(authContext.AuthType),
+            authContext.SubjectId));
+    }
+}
+
+/// <summary>
+/// SignalR hub filter that denies every hub method invocation on a connection that has not proven a
+/// credential, and enforces the scope declared by <see cref="HubScopeAttribute"/> and the credential
+/// kind required by <see cref="HubTenantGroupAttribute"/>.
+/// </summary>
+/// <remarks>
+/// The hubs are <c>[AllowAnonymous]</c> because in-band authentication requires the connection to be
+/// accepted before the credential arrives, and <see cref="TenantAwareHub.OnConnectedAsync"/> accepts
+/// any connection whose tenant resolves and is active. Authorization therefore has to happen at the
+/// method boundary. It lives in a filter rather than in each method so a method added later is
+/// denied unless it explicitly opts out with <see cref="HubAuthenticationMethodAttribute"/>.
+/// </remarks>
+public sealed class HubAuthorizationFilter : IHubFilter
+{
+    /// <inheritdoc />
+    public async ValueTask<object?> InvokeMethodAsync(
+        HubInvocationContext invocationContext,
+        Func<HubInvocationContext, ValueTask<object?>> next)
+    {
+        var method = invocationContext.HubMethod;
+
+        if (method.GetCustomAttribute<HubAuthenticationMethodAttribute>() is null)
+        {
+            var authorization = HubAuthorizationState.Resolve(invocationContext.Context)
+                ?? throw new HubException($"{method.Name} requires an authorized connection.");
+
+            var requiredScope = method.GetCustomAttribute<HubScopeAttribute>()?.Scope;
+            if (requiredScope is not null && !authorization.Satisfies(requiredScope))
+            {
+                throw new HubException($"{method.Name} requires the {requiredScope} scope.");
+            }
+
+            if (method.GetCustomAttribute<HubTenantGroupAttribute>() is not null
+                && !authorization.CanJoinTenantRelay)
+            {
+                throw new HubException(
+                    $"{method.Name} requires a credential belonging to the tenant.");
+            }
+        }
+
+        return await next(invocationContext);
+    }
+}

--- a/src/API/Nocturne.API/Hubs/TenantHubFilter.cs
+++ b/src/API/Nocturne.API/Hubs/TenantHubFilter.cs
@@ -4,28 +4,36 @@ using Nocturne.Core.Contracts.Multitenancy;
 namespace Nocturne.API.Hubs;
 
 /// <summary>
-/// SignalR hub filter that ensures the ITenantAccessor is populated for every hub method invocation.
-///
-/// Each hub method invocation gets a fresh DI scope, so the scoped ITenantAccessor starts empty.
-/// This filter reads the TenantContext stored in HttpContext.Items (set by TenantResolutionMiddleware
-/// during the initial HTTP upgrade handshake) and sets it on the ITenantAccessor before each method runs.
-///
-/// This ensures all downstream services (DbContext query filters, services, etc.) have proper tenant context.
+/// SignalR hub filter that populates the <see cref="ITenantAccessor"/> for every hub method
+/// invocation and lifetime event, from the <see cref="TenantContext"/> that
+/// <see cref="Multitenancy.TenantResolutionMiddleware"/> stored in <c>HttpContext.Items</c> during the
+/// upgrade handshake.
 /// </summary>
+/// <remarks>
+/// The accessor is scoped and SignalR builds a fresh DI scope per invocation, so the scope set here is
+/// the invocation's own — <see cref="HubInvocationContext.ServiceProvider"/> — which covers services
+/// resolved from it inside a method body.
+///
+/// It does not reach the hub's constructor dependencies. <c>DefaultHubDispatcher</c> activates the hub
+/// from the invocation scope before the filter pipeline runs (the hub instance is an argument of
+/// <see cref="HubInvocationContext"/>), so a service that latches the tenant at construction — the
+/// scoped <c>NocturneDbContext</c>, which reads the accessor in its factory — has already latched
+/// <see cref="Guid.Empty"/> by the time this runs. Hub method bodies are unaffected because they
+/// resolve tenant-scoped services from the handshake request's scope
+/// (<c>Context.GetHttpContext().RequestServices</c>), which
+/// <see cref="Multitenancy.TenantResolutionMiddleware"/> pinned.
+///
+/// No hub method resolves a service from the invocation scope today, so nothing currently depends on
+/// this. It is here so that one which does gets the connection's tenant rather than
+/// <see cref="Guid.Empty"/>, and <c>TenantHubFilterTests</c> pins that behaviour.
+/// </remarks>
 public class TenantHubFilter : IHubFilter
 {
     public async ValueTask<object?> InvokeMethodAsync(
         HubInvocationContext invocationContext,
         Func<HubInvocationContext, ValueTask<object?>> next)
     {
-        var httpContext = invocationContext.Context.GetHttpContext();
-        var tenantContext = httpContext?.Items[TenantAwareHub.TenantContextKey] as TenantContext;
-
-        if (tenantContext != null)
-        {
-            var tenantAccessor = httpContext!.RequestServices.GetRequiredService<ITenantAccessor>();
-            tenantAccessor.SetTenant(tenantContext);
-        }
+        SetTenant(invocationContext.Context, invocationContext.ServiceProvider);
 
         return await next(invocationContext);
     }
@@ -34,17 +42,9 @@ public class TenantHubFilter : IHubFilter
         HubLifetimeContext context,
         Func<HubLifetimeContext, Task> next)
     {
-        // Tenant validation is handled by TenantAwareHub.OnConnectedAsync.
-        // We still need to set the accessor here for any OnConnectedAsync logic
-        // in derived hubs that uses tenant-scoped services.
-        var httpContext = context.Context.GetHttpContext();
-        var tenantContext = httpContext?.Items[TenantAwareHub.TenantContextKey] as TenantContext;
-
-        if (tenantContext != null)
-        {
-            var tenantAccessor = httpContext!.RequestServices.GetRequiredService<ITenantAccessor>();
-            tenantAccessor.SetTenant(tenantContext);
-        }
+        // Tenant validation is handled by TenantAwareHub.OnConnectedAsync. The accessor is still set
+        // here for any OnConnectedAsync logic in derived hubs that uses tenant-scoped services.
+        SetTenant(context.Context, context.ServiceProvider);
 
         return next(context);
     }
@@ -54,15 +54,19 @@ public class TenantHubFilter : IHubFilter
         Exception? exception,
         Func<HubLifetimeContext, Exception?, Task> next)
     {
-        var httpContext = context.Context.GetHttpContext();
-        var tenantContext = httpContext?.Items[TenantAwareHub.TenantContextKey] as TenantContext;
-
-        if (tenantContext != null)
-        {
-            var tenantAccessor = httpContext!.RequestServices.GetRequiredService<ITenantAccessor>();
-            tenantAccessor.SetTenant(tenantContext);
-        }
+        SetTenant(context.Context, context.ServiceProvider);
 
         return next(context, exception);
+    }
+
+    private static void SetTenant(HubCallerContext callerContext, IServiceProvider services)
+    {
+        if (callerContext.GetHttpContext()?.Items[TenantAwareHub.TenantContextKey]
+            is not TenantContext tenantContext)
+        {
+            return;
+        }
+
+        services.GetRequiredService<ITenantAccessor>().SetTenant(tenantContext);
     }
 }

--- a/src/API/Nocturne.API/Middleware/Handlers/DirectGrantTokenHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/DirectGrantTokenHandler.cs
@@ -20,7 +20,7 @@ public class DirectGrantTokenHandler : IAuthHandler
     /// <summary>
     /// Prefix identifying opaque direct grant tokens (see <see cref="Controllers.Authentication.DirectGrantController"/>).
     /// </summary>
-    private const string TokenPrefix = "noc_";
+    internal const string TokenPrefix = "noc_";
 
     /// <summary>
     /// Handler priority (150 - after session cookies, before OIDC/legacy JWT)
@@ -68,19 +68,7 @@ public class DirectGrantTokenHandler : IAuthHandler
             return AuthResult.Skip();
         }
 
-        var tokenHash = ComputeSha256Hex(token);
-
-        await using var dbContext = await _dbContextFactory.CreateDbContextAsync();
-        dbContext.TenantId = tenantCtx.TenantId;
-
-        var grant = await dbContext.OAuthGrants
-            .AsNoTracking()
-            .IgnoreQueryFilters()
-            .Where(g => g.TokenHash == tokenHash
-                     && g.TenantId == tenantCtx.TenantId
-                     && g.GrantType == OAuthGrantTypes.Direct
-                     && g.RevokedAt == null)
-            .FirstOrDefaultAsync();
+        var grant = await FindActiveGrantAsync(_dbContextFactory, token, tenantCtx.TenantId);
 
         if (grant == null)
         {
@@ -105,6 +93,42 @@ public class DirectGrantTokenHandler : IAuthHandler
             TokenId = grant.Id,
             LimitTo24Hours = false, // Direct grants defer to MemberScopeMiddleware for 24-hour limits
         });
+    }
+
+    /// <summary>
+    /// Finds the active direct grant <paramref name="token"/> identifies on
+    /// <paramref name="tenantId"/>, or null when there is none.
+    /// </summary>
+    /// <remarks>
+    /// Runs on its own context pinned to <paramref name="tenantId"/>: callers hold a scope whose
+    /// context may carry no tenant, and <c>oauth_grants</c> is tenant-scoped by both a global query
+    /// filter and the <c>tenant_isolation</c> RLS policy, so an unpinned read matches no row. The
+    /// grant's own <c>TenantId</c> is matched explicitly as well, so the tenant a grant authorizes is
+    /// decided here rather than by whatever tenant state the connection carries.
+    /// </remarks>
+    /// <param name="dbContextFactory">Factory for the tenant-pinned context.</param>
+    /// <param name="token">The presented token, <c>noc_</c>-prefixed.</param>
+    /// <param name="tenantId">The tenant the grant must belong to.</param>
+    /// <param name="ct">Cancellation token.</param>
+    internal static async Task<OAuthGrantEntity?> FindActiveGrantAsync(
+        IDbContextFactory<NocturneDbContext> dbContextFactory,
+        string token,
+        Guid tenantId,
+        CancellationToken ct = default)
+    {
+        var tokenHash = ComputeSha256Hex(token);
+
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(ct);
+        dbContext.TenantId = tenantId;
+
+        return await dbContext.OAuthGrants
+            .AsNoTracking()
+            .IgnoreQueryFilters()
+            .Where(g => g.TokenHash == tokenHash
+                     && g.TenantId == tenantId
+                     && g.GrantType == OAuthGrantTypes.Direct
+                     && g.RevokedAt == null)
+            .FirstOrDefaultAsync(ct);
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Middleware/Handlers/OAuthAccessTokenHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/OAuthAccessTokenHandler.cs
@@ -39,21 +39,16 @@ public class OAuthAccessTokenHandler : IAuthHandler
         _logger = logger;
     }
 
+    /// <summary>
+    /// Path prefix of the SignalR hub endpoints, the only place the token is accepted on the query
+    /// string.
+    /// </summary>
+    private static readonly PathString HubPathPrefix = new("/hubs");
+
     /// <inheritdoc />
     public async Task<AuthResult> AuthenticateAsync(HttpContext context)
     {
-        // Check for Bearer token in Authorization header
-        var authHeader = context.Request.Headers.Authorization.FirstOrDefault();
-
-        if (
-            string.IsNullOrEmpty(authHeader)
-            || !authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)
-        )
-        {
-            return AuthResult.Skip();
-        }
-
-        var token = authHeader["Bearer ".Length..].Trim();
+        var token = ExtractToken(context);
 
         // Must be a JWT (3 dot-separated parts)
         if (string.IsNullOrEmpty(token) || token.Count(c => c == '.') != 2)
@@ -169,5 +164,35 @@ public class OAuthAccessTokenHandler : IAuthHandler
         );
 
         return AuthResult.Success(authContext);
+    }
+
+    /// <summary>
+    /// Extracts the bearer token from the Authorization header, or — on a SignalR hub path only —
+    /// from the <c>access_token</c> query parameter.
+    /// </summary>
+    /// <remarks>
+    /// The SignalR clients cannot set headers on a WebSocket or SSE request, so they append the token
+    /// to the query string under <c>access_token</c> (the JS <c>accessTokenFactory</c>, the .NET
+    /// <c>AccessTokenProvider</c>, and the desktop companion's hand-built URL all use that key); the
+    /// hub connection's <see cref="HttpContext"/> is that upgrade request, so without this a hub
+    /// connection carries no authentication context. Restricted to <see cref="HubPathPrefix"/>
+    /// because a query-string credential ends up in access logs and referrers.
+    /// </remarks>
+    private static string? ExtractToken(HttpContext context)
+    {
+        var authHeader = context.Request.Headers.Authorization.FirstOrDefault();
+
+        if (!string.IsNullOrEmpty(authHeader)
+            && authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        {
+            return authHeader["Bearer ".Length..].Trim();
+        }
+
+        if (context.Request.Path.StartsWithSegments(HubPathPrefix))
+        {
+            return context.Request.Query["access_token"].FirstOrDefault();
+        }
+
+        return null;
     }
 }

--- a/src/API/Nocturne.API/Services/Identity/HubTokenAuthorizer.cs
+++ b/src/API/Nocturne.API/Services/Identity/HubTokenAuthorizer.cs
@@ -1,28 +1,56 @@
+using Microsoft.EntityFrameworkCore;
+using Nocturne.API.Hubs;
+using Nocturne.API.Middleware.Handlers;
+using Nocturne.Connectors.Core.Utilities;
+using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Contracts.Identity;
+using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Authorization;
+using Nocturne.Infrastructure.Data;
 
 namespace Nocturne.API.Services.Identity;
 
 /// <summary>
-/// Authorizes in-band tokens presented to SignalR hubs (the socket.io-style <c>authorize</c>
-/// handshake). Accepts both OAuth access-token JWTs (validated statelessly, tenant-pinned,
-/// scope-checked) and legacy opaque subject access tokens (hash lookup).
+/// Authorizes the credentials presented in-band to a SignalR hub (the socket.io-style
+/// <c>authorize</c> / <c>subscribe</c> handshake). Accepts OAuth access-token JWTs (validated
+/// statelessly, tenant-pinned, then intersected with the subject's membership), legacy opaque subject
+/// access tokens (hash lookup plus an explicit tenant-membership check), <c>noc_</c> direct grants
+/// (grant row read on the connection's tenant, then intersected with its subject's membership), and
+/// the hashed instance key.
 /// </summary>
 /// <seealso cref="Hubs.DataHub"/>
+/// <seealso cref="Hubs.AlarmHub"/>
 public interface IHubTokenAuthorizer
 {
     /// <summary>
-    /// Whether <paramref name="token"/> authorizes the connection. OAuth JWTs must be valid,
-    /// unrevoked, pinned to <paramref name="connectionTenantId"/> (the hub connection's tenant
-    /// group is immutable, so a token from another tenant must never authorize it), and satisfy
-    /// <paramref name="requiredScope"/>. Non-JWT tokens fall back to the legacy opaque
-    /// access-token lookup.
+    /// Authorizes <paramref name="token"/> for the connection, returning the tenant and scopes it
+    /// grants, or null when it does not authorize.
     /// </summary>
+    /// <remarks>
+    /// A token must be pinned to <paramref name="connectionTenantId"/> — the hub connection's tenant
+    /// group is immutable, so a token from another tenant must never authorize it — and must satisfy
+    /// <paramref name="requiredScope"/>. This holds on every branch: an OAuth JWT is checked against
+    /// its <c>tenant</c> claim and then against a membership row on that tenant, a legacy opaque
+    /// token against a membership row alone, a direct grant against its row's own <c>TenantId</c>,
+    /// read on a context pinned to the connection's tenant rather than on whatever tenant state the
+    /// caller's scope carries.
+    /// </remarks>
     /// <param name="token">The token supplied in the hub's authorize payload.</param>
     /// <param name="connectionTenantId">The tenant resolved for the connection's HTTP handshake.</param>
-    /// <param name="requiredScope">OAuth scope a JWT must satisfy to join the group.</param>
-    Task<bool> IsTokenAuthorizedAsync(string token, Guid? connectionTenantId, string requiredScope);
+    /// <param name="requiredScope">OAuth scope the token must satisfy to join the group.</param>
+    Task<HubAuthorization?> AuthorizeTokenAsync(
+        string token, Guid? connectionTenantId, string requiredScope);
+
+    /// <summary>
+    /// Authorizes a hashed instance key presented in-band, returning full access on the connection's
+    /// tenant, or null when it does not match. The instance key is infrastructure auth (the
+    /// SignalR-to-socket.io bridge), so it carries the superuser scope exactly as
+    /// <see cref="Middleware.MemberScopeMiddleware"/> grants it over HTTP.
+    /// </summary>
+    /// <param name="presentedHash">Lowercase hex SHA-256 of the instance key, as sent by the client.</param>
+    /// <param name="connectionTenantId">The tenant resolved for the connection's HTTP handshake.</param>
+    HubAuthorization? AuthorizeInstanceKey(string presentedHash, Guid? connectionTenantId);
 }
 
 /// <inheritdoc cref="IHubTokenAuthorizer"/>
@@ -32,6 +60,9 @@ public class HubTokenAuthorizer : IHubTokenAuthorizer
     private readonly IOAuthTokenRevocationCache _revocationCache;
     private readonly IOAuthGrantService _grantService;
     private readonly IAuthorizationService _authorizationService;
+    private readonly ITenantMemberService _memberService;
+    private readonly IDbContextFactory<NocturneDbContext> _dbContextFactory;
+    private readonly IConfiguration _configuration;
     private readonly ILogger<HubTokenAuthorizer> _logger;
 
     public HubTokenAuthorizer(
@@ -39,66 +70,272 @@ public class HubTokenAuthorizer : IHubTokenAuthorizer
         IOAuthTokenRevocationCache revocationCache,
         IOAuthGrantService grantService,
         IAuthorizationService authorizationService,
+        ITenantMemberService memberService,
+        IDbContextFactory<NocturneDbContext> dbContextFactory,
+        IConfiguration configuration,
         ILogger<HubTokenAuthorizer> logger)
     {
         _jwtService = jwtService;
         _revocationCache = revocationCache;
         _grantService = grantService;
         _authorizationService = authorizationService;
+        _memberService = memberService;
+        _dbContextFactory = dbContextFactory;
+        _configuration = configuration;
         _logger = logger;
     }
 
-    public async Task<bool> IsTokenAuthorizedAsync(
+    /// <inheritdoc />
+    public async Task<HubAuthorization?> AuthorizeTokenAsync(
         string token, Guid? connectionTenantId, string requiredScope)
     {
+        if (connectionTenantId is null)
+        {
+            _logger.LogWarning("Hub token presented on a connection with no resolved tenant");
+            return null;
+        }
+
+        // A direct grant is a row in oauth_grants, not a subject token, so it is decided on the
+        // prefix that identifies it — the same discriminator DirectGrantTokenHandler and the
+        // token-exchange endpoint use.
+        if (token.StartsWith(DirectGrantTokenHandler.TokenPrefix, StringComparison.Ordinal))
+        {
+            return await AuthorizeDirectGrantAsync(token, connectionTenantId.Value, requiredScope);
+        }
+
         // JWTs are three-segment; legacy opaque tokens are not. Mirrors OAuthAccessTokenHandler:
         // once a token reads as a JWT it is decided on the JWT path only.
         if (token.Count(c => c == '.') == 2)
         {
-            return await IsJwtAuthorizedAsync(token, connectionTenantId, requiredScope);
+            return await AuthorizeJwtAsync(token, connectionTenantId.Value, requiredScope);
         }
 
-        var authResponse = await _authorizationService.GenerateJwtFromAccessTokenAsync(token);
-        return authResponse != null;
+        return await AuthorizeOpaqueTokenAsync(token, connectionTenantId.Value, requiredScope);
     }
 
-    private async Task<bool> IsJwtAuthorizedAsync(
-        string token, Guid? connectionTenantId, string requiredScope)
+    /// <inheritdoc />
+    public HubAuthorization? AuthorizeInstanceKey(string presentedHash, Guid? connectionTenantId)
+    {
+        if (connectionTenantId is null)
+        {
+            return null;
+        }
+
+        // Match InstanceKeyHandler's lookup: Aspire dev sets the value under
+        // Parameters:instance-key (user-secrets); production sets it as the INSTANCE_KEY env var,
+        // which ASP.NET Core surfaces as a top-level config key.
+        var configuredKey =
+            _configuration[$"Parameters:{ServiceNames.Parameters.InstanceKey}"]
+            ?? _configuration[ServiceNames.ConfigKeys.InstanceKey];
+
+        if (string.IsNullOrEmpty(configuredKey))
+        {
+            return null;
+        }
+
+        var expectedHash = HashUtils.Sha256Hex(configuredKey);
+        if (!string.Equals(presentedHash, expectedHash, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return new HubAuthorization(
+            connectionTenantId.Value,
+            new HashSet<string> { OAuthScopes.FullAccess },
+            HubCredentialKind.Infrastructure,
+            SubjectId: null);
+    }
+
+    private async Task<HubAuthorization?> AuthorizeJwtAsync(
+        string token, Guid connectionTenantId, string requiredScope)
     {
         var validation = _jwtService.ValidateAccessToken(token);
         if (!validation.IsValid || validation.Claims is null)
         {
             _logger.LogDebug("Hub JWT validation failed: {Error}", validation.Error);
-            return false;
+            return null;
         }
 
         var claims = validation.Claims;
 
         // Unlike the HTTP handler, an unpinned (null-tenant) JWT is rejected outright: the hub
         // group is tenant-scoped and there is no per-request middleware to re-check access.
-        if (connectionTenantId is null || claims.TenantId != connectionTenantId)
+        if (claims.TenantId != connectionTenantId)
         {
             _logger.LogWarning(
                 "Hub JWT tenant mismatch: token tenant {TokenTenant}, connection tenant {ConnectionTenant}",
                 claims.TenantId, connectionTenantId);
-            return false;
+            return null;
         }
 
         if (!string.IsNullOrEmpty(claims.JwtId)
             && await _revocationCache.IsRevokedAsync(claims.JwtId))
         {
             _logger.LogDebug("Hub JWT has been revoked (jti: {Jti})", claims.JwtId);
-            return false;
+            return null;
         }
 
         // A grant revocation reaches outstanding access tokens through the grant id they carry.
         if (claims.GrantId.HasValue
-            && await _grantService.IsGrantRevokedAsync(claims.GrantId.Value, connectionTenantId.Value))
+            && await _grantService.IsGrantRevokedAsync(claims.GrantId.Value, connectionTenantId))
         {
             _logger.LogDebug("Hub JWT's grant has been revoked (grant: {GrantId})", claims.GrantId);
-            return false;
+            return null;
         }
 
-        return OAuthScopes.SatisfiesScope(claims.Scopes, requiredScope);
+        if (claims.SubjectId == Guid.Empty)
+        {
+            return null;
+        }
+
+        // Membership is intersected in, exactly as it is over HTTP: MemberScopeMiddleware resolves
+        // every JWT credential through the membership row and AuthenticationMiddleware rejects a
+        // subject that has none. A token's scopes are frozen at issue, so without this a member
+        // demoted or removed after issue keeps the access the token was minted with until it expires.
+        var effectivePermissions = await _memberService.GetEffectivePermissionsAsync(
+            claims.SubjectId, connectionTenantId);
+
+        if (effectivePermissions is null)
+        {
+            _logger.LogWarning(
+                "Hub JWT subject {SubjectId} is not a member of connection tenant {ConnectionTenant}",
+                claims.SubjectId, connectionTenantId);
+            return null;
+        }
+
+        var scopes = MemberScopeResolver.Resolve(
+            effectivePermissions,
+            AuthType.OAuthAccessToken,
+            OAuthScopes.Normalize(claims.Scopes));
+
+        if (!OAuthScopes.SatisfiesScope(scopes, requiredScope))
+        {
+            return null;
+        }
+
+        // A bearer JWT always belongs to a subject: guest links are cookie-only (activation returns
+        // no token), so no share-style credential reaches this path.
+        return new HubAuthorization(
+            connectionTenantId, scopes, HubCredentialKind.Subject, claims.SubjectId);
+    }
+
+    /// <summary>
+    /// Authorizes a <c>noc_</c> direct-grant token against the connection's tenant.
+    /// </summary>
+    /// <remarks>
+    /// The grant row is read on a context pinned to the connection's tenant and matched on that
+    /// tenant explicitly, so the pin is what admits it; its subject must then hold a membership
+    /// there, which bounds the grant's scopes. Those are the same two gates the credential passes
+    /// over HTTP, where <see cref="DirectGrantTokenHandler"/> matches the row on the request's tenant
+    /// and <see cref="Middleware.MemberScopeMiddleware"/> intersects the grant's scopes with the
+    /// membership — <see cref="AuthType.DirectGrant"/> is a scoped credential, so membership cannot
+    /// widen it and a demotion narrows it.
+    ///
+    /// It does not go through the token-exchange endpoint's direct-grant path: that reads
+    /// <c>oauth_grants</c> off the scoped context, which on a hub invocation was built before any
+    /// tenant was known and so matches no row.
+    /// </remarks>
+    private async Task<HubAuthorization?> AuthorizeDirectGrantAsync(
+        string token, Guid connectionTenantId, string requiredScope)
+    {
+        var grant = await DirectGrantTokenHandler.FindActiveGrantAsync(
+            _dbContextFactory, token, connectionTenantId);
+
+        if (grant is null)
+        {
+            _logger.LogDebug(
+                "No active direct grant on tenant {ConnectionTenant} matches the hub token",
+                connectionTenantId);
+            return null;
+        }
+
+        var effectivePermissions = await _memberService.GetEffectivePermissionsAsync(
+            grant.SubjectId, connectionTenantId);
+
+        if (effectivePermissions is null)
+        {
+            _logger.LogWarning(
+                "Hub direct grant {GrantId} belongs to subject {SubjectId}, who is not a member of connection tenant {ConnectionTenant}",
+                grant.Id, grant.SubjectId, connectionTenantId);
+            return null;
+        }
+
+        var scopes = MemberScopeResolver.Resolve(
+            effectivePermissions, AuthType.DirectGrant, grant.Scopes.ToHashSet());
+
+        if (!OAuthScopes.SatisfiesScope(scopes, requiredScope))
+        {
+            return null;
+        }
+
+        return new HubAuthorization(
+            connectionTenantId, scopes, HubCredentialKind.Subject, grant.SubjectId);
+    }
+
+    /// <summary>
+    /// Authorizes a legacy opaque subject access token. The exchange only proves the token exists, so
+    /// the resulting identity is then pinned to the connection's tenant by an explicit
+    /// tenant-membership row, which does not rely on the database's tenant scoping being in place.
+    /// </summary>
+    private async Task<HubAuthorization?> AuthorizeOpaqueTokenAsync(
+        string token, Guid connectionTenantId, string requiredScope)
+    {
+        var authResponse = await _authorizationService.GenerateJwtFromAccessTokenAsync(token);
+        if (authResponse?.Token is null)
+        {
+            return null;
+        }
+
+        // The exchange mints a JWT for the resolved identity; re-reading it is how the subject id
+        // comes back out.
+        var validation = _jwtService.ValidateAccessToken(authResponse.Token);
+        if (!validation.IsValid || validation.Claims is null)
+        {
+            _logger.LogDebug(
+                "Hub opaque token exchange produced an unusable JWT: {Error}", validation.Error);
+            return null;
+        }
+
+        var claims = validation.Claims;
+
+        // A subject-token exchange mints an unpinned JWT; only the direct-grant exchange pins a
+        // tenant, and direct grants are routed away from this path. A pinned JWT here therefore
+        // resolved something this path does not decide, and is refused rather than guessed at.
+        if (claims.TenantId is not null)
+        {
+            _logger.LogWarning(
+                "Hub opaque token exchange returned a tenant-pinned JWT on the subject-token path");
+            return null;
+        }
+
+        if (claims.SubjectId == Guid.Empty)
+        {
+            return null;
+        }
+
+        // Legacy subject tokens carry no tenant pin, so membership is the pin.
+        var effectivePermissions = await _memberService.GetEffectivePermissionsAsync(
+            claims.SubjectId, connectionTenantId);
+
+        if (effectivePermissions is null)
+        {
+            _logger.LogWarning(
+                "Hub opaque token subject {SubjectId} is not a member of connection tenant {ConnectionTenant}",
+                claims.SubjectId, connectionTenantId);
+            return null;
+        }
+
+        // AuthType.LegacyAccessToken is in MemberScopeResolver.UnscopedCredentialTypes, so membership
+        // is the whole authority and the credential's own scope list is not consulted at all —
+        // matching what MemberScopeMiddleware resolves for the same credential presented over HTTP.
+        var memberScopes = MemberScopeResolver.Resolve(
+            effectivePermissions,
+            AuthType.LegacyAccessToken,
+            credentialScopes: new HashSet<string>());
+
+        return OAuthScopes.SatisfiesScope(memberScopes, requiredScope)
+            ? new HubAuthorization(
+                connectionTenantId, memberScopes, HubCredentialKind.Subject, claims.SubjectId)
+            : null;
     }
 }

--- a/src/API/Nocturne.API/Services/Identity/TenantMemberService.cs
+++ b/src/API/Nocturne.API/Services/Identity/TenantMemberService.cs
@@ -52,4 +52,25 @@ public class TenantMemberService : ITenantMemberService
             .Distinct()
             .ToListAsync(ct);
     }
+
+    public async Task<IReadOnlySet<string>?> GetEffectivePermissionsAsync(
+        Guid subjectId, Guid tenantId, CancellationToken ct = default)
+    {
+        await using var context = await _factory.CreateDbContextAsync(ct);
+        var membership = await context.TenantMembers.AsNoTracking()
+            .Include(tm => tm.MemberRoles)
+                .ThenInclude(mr => mr.TenantRole)
+            .Where(tm => tm.SubjectId == subjectId && tm.TenantId == tenantId)
+            .FirstOrDefaultAsync(ct);
+
+        if (membership is null)
+        {
+            return null;
+        }
+
+        return membership.MemberRoles
+            .SelectMany(mr => mr.TenantRole.Permissions)
+            .Union(membership.DirectPermissions ?? [])
+            .ToHashSet();
+    }
 }

--- a/src/API/Nocturne.API/Services/Realtime/RealtimeCategories.cs
+++ b/src/API/Nocturne.API/Services/Realtime/RealtimeCategories.cs
@@ -1,3 +1,5 @@
+using Nocturne.Core.Models.Authorization;
+
 namespace Nocturne.API.Services.Realtime;
 
 /// <summary>
@@ -32,4 +34,31 @@ public static class RealtimeCategories
 
     /// <summary>Every subscribable category (v1 + V4) — the <c>DataHub.Subscribe</c> allowlist.</summary>
     public static readonly string[] All = [.. V1, .. V4];
+
+    /// <summary>
+    /// The OAuth read scope governing each category. Security-critical: a subscriber joins a
+    /// category's broadcast group only when its credential satisfies the scope listed here, and the
+    /// broadcasts carry the records themselves. A category absent from this map cannot be subscribed
+    /// to at all (fail-closed), so a new category must be classified here to become reachable.
+    /// </summary>
+    /// <remarks>
+    /// The vocabulary is the OAuth read scopes in <see cref="OAuthScopes"/>. It is not the same set as
+    /// <see cref="ShareDataCategories.GoverningScopes"/>, which covers only the share-reachable
+    /// categories — <c>profiles</c>/<c>therapy</c> here answer to <see cref="OAuthScopes.TherapyRead"/>,
+    /// which no share link can hold. <c>care</c> and <c>treatments</c> are the treatment family, so
+    /// they answer to <see cref="OAuthScopes.TreatmentsRead"/> as a whole even though a BG check inside
+    /// <c>care</c> is governed by glucose.read for share links.
+    /// </remarks>
+    public static readonly IReadOnlyDictionary<string, string> GoverningScopes =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [Entries] = OAuthScopes.GlucoseRead,
+            [Treatments] = OAuthScopes.TreatmentsRead,
+            [DeviceStatus] = OAuthScopes.DevicesRead,
+            [Profiles] = OAuthScopes.TherapyRead,
+            [Glucose] = OAuthScopes.GlucoseRead,
+            [Care] = OAuthScopes.TreatmentsRead,
+            [Device] = OAuthScopes.DevicesRead,
+            [Therapy] = OAuthScopes.TherapyRead,
+        };
 }

--- a/src/API/Nocturne.API/Services/Realtime/RealtimeGroups.cs
+++ b/src/API/Nocturne.API/Services/Realtime/RealtimeGroups.cs
@@ -1,0 +1,58 @@
+namespace Nocturne.API.Services.Realtime;
+
+/// <summary>
+/// The SignalR group tokens a connection joins as a consequence of the credential it presented,
+/// shared by the hub that joins them and the broadcasters that publish to them.
+/// </summary>
+/// <remarks>
+/// Distinct from <see cref="RealtimeCategories"/>, which names the per-data-category groups a client
+/// opts into by calling <c>DataHub.Subscribe</c>. A category group carries one category of the
+/// tenant's records; the groups here carry either the whole tenant's live payloads or one subject's.
+/// </remarks>
+/// <seealso cref="RealtimeCategories"/>
+/// <seealso cref="Hubs.HubCredentialKind"/>
+public static class RealtimeGroups
+{
+    /// <summary>
+    /// Tenant-wide live data: the <c>dataUpdate</c>, <c>trackerUpdate</c> and <c>device_action</c>
+    /// broadcasts a connection receives after <c>DataHub.Authorize</c>. Restricted to a credential
+    /// that belongs to the tenant — see <c>HubAuthorization.CanJoinTenantRelay</c>.
+    /// </summary>
+    public const string Authorized = "authorized";
+
+    /// <summary>Tenant administrators, for admin-only notices.</summary>
+    public const string Admin = "admin";
+
+    /// <summary>
+    /// Infrastructure relay. Every per-subject payload is published here as well as to the owning
+    /// subject's group, because the socket.io bridge holds a single instance-key connection per
+    /// tenant and does its own per-browser fan-out. Only an
+    /// <see cref="Hubs.HubCredentialKind.Infrastructure"/> credential may join, so no direct SignalR
+    /// consumer — widget, tray, desktop, follower connector — receives another subject's payload.
+    /// </summary>
+    /// <remarks>
+    /// That is the guarantee for direct SignalR consumers only. The browser app is a socket.io client
+    /// of the bridge, and the bridge's own fan-out
+    /// (<c>src/Web/packages/bridge/src/lib/socketio-server.ts</c>,
+    /// <c>broadcastInAppNotification</c>) emits <c>notificationCreated</c>,
+    /// <c>notificationUpdated</c> and <c>notificationArchived</c> to the whole tenant room with no
+    /// per-subject filter, so a browser client still sees every member's in-app notifications.
+    /// Closing that needs a per-subject room in the bridge.
+    /// </remarks>
+    public const string Relay = "relay";
+
+    /// <summary>
+    /// The group carrying one subject's own payloads: its in-app notifications and the device
+    /// notification mirrors addressed to it.
+    /// </summary>
+    /// <param name="subjectId">The subject identifier, as carried on the payload.</param>
+    /// <remarks>
+    /// Normalizes the identifier because SignalR group names are compared byte for byte, and the
+    /// subject arrives as a <see cref="Guid"/> on the hub side but as a string on the payloads.
+    /// </remarks>
+    public static string ForSubject(string subjectId) =>
+        $"user-{(Guid.TryParse(subjectId, out var parsed) ? parsed.ToString("D") : subjectId)}";
+
+    /// <inheritdoc cref="ForSubject(string)"/>
+    public static string ForSubject(Guid subjectId) => $"user-{subjectId:D}";
+}

--- a/src/API/Nocturne.API/Services/Realtime/SignalRBroadcastService.cs
+++ b/src/API/Nocturne.API/Services/Realtime/SignalRBroadcastService.cs
@@ -218,7 +218,7 @@ public class SignalRBroadcastService : ISignalRBroadcastService
     {
         try
         {
-            var group = TenantGroup("authorized");
+            var group = TenantGroup(RealtimeGroups.Authorized);
             _logger.LogInformation(
                 "Broadcasting data update to {Group}: {DataType}",
                 group,
@@ -414,7 +414,7 @@ public class SignalRBroadcastService : ISignalRBroadcastService
             );
             var payload = new { action, instance = trackerInstance };
             await _dataHubContext
-                .Clients.Group(TenantGroup("authorized"))
+                .Clients.Group(TenantGroup(RealtimeGroups.Authorized))
                 .SendCoreAsync("trackerUpdate", new[] { payload });
             _logger.LogDebug("Tracker update broadcast completed for action {Action}", action);
         }
@@ -470,14 +470,16 @@ public class SignalRBroadcastService : ISignalRBroadcastService
             );
 
             // Broadcast to tenant-scoped user-specific group for multi-user scenarios
-            var userGroup = $"user-{userId}";
+            var userGroup = RealtimeGroups.ForSubject(userId);
             await _dataHubContext
                 .Clients.Group(TenantGroup(userGroup))
                 .SendCoreAsync("notificationCreated", new object[] { notification });
 
-            // Also broadcast to tenant-scoped authorized group for single-user deployments and bridge relay
+            // The socket.io bridge holds one instance-key connection per tenant and fans out to
+            // browser clients itself, so it needs the tenant-wide copy. What the relay group does and
+            // does not guarantee is on RealtimeGroups.Relay.
             await _dataHubContext
-                .Clients.Group(TenantGroup("authorized"))
+                .Clients.Group(TenantGroup(RealtimeGroups.Relay))
                 .SendCoreAsync("notificationCreated", new object[] { notification });
 
             _logger.LogDebug("Notification created broadcast completed for user {UserId}", userId);
@@ -504,7 +506,7 @@ public class SignalRBroadcastService : ISignalRBroadcastService
                 archiveReason
             );
 
-            var userGroup = $"user-{userId}";
+            var userGroup = RealtimeGroups.ForSubject(userId);
             var payload = new { notification, archiveReason };
 
             // Broadcast to tenant-scoped user-specific group for multi-user scenarios
@@ -512,9 +514,11 @@ public class SignalRBroadcastService : ISignalRBroadcastService
                 .Clients.Group(TenantGroup(userGroup))
                 .SendCoreAsync("notificationArchived", new object[] { payload });
 
-            // Also broadcast to tenant-scoped authorized group for single-user deployments and bridge relay
+            // The socket.io bridge holds one instance-key connection per tenant and fans out to
+            // browser clients itself, so it needs the tenant-wide copy. What the relay group does and
+            // does not guarantee is on RealtimeGroups.Relay.
             await _dataHubContext
-                .Clients.Group(TenantGroup("authorized"))
+                .Clients.Group(TenantGroup(RealtimeGroups.Relay))
                 .SendCoreAsync("notificationArchived", new object[] { payload });
 
             _logger.LogDebug("Notification archived broadcast completed for user {UserId}", userId);
@@ -540,16 +544,18 @@ public class SignalRBroadcastService : ISignalRBroadcastService
                 notification.Id
             );
 
-            var userGroup = $"user-{userId}";
+            var userGroup = RealtimeGroups.ForSubject(userId);
 
             // Broadcast to tenant-scoped user-specific group for multi-user scenarios
             await _dataHubContext
                 .Clients.Group(TenantGroup(userGroup))
                 .SendCoreAsync("notificationUpdated", new object[] { notification });
 
-            // Also broadcast to tenant-scoped authorized group for single-user deployments and bridge relay
+            // The socket.io bridge holds one instance-key connection per tenant and fans out to
+            // browser clients itself, so it needs the tenant-wide copy. What the relay group does and
+            // does not guarantee is on RealtimeGroups.Relay.
             await _dataHubContext
-                .Clients.Group(TenantGroup("authorized"))
+                .Clients.Group(TenantGroup(RealtimeGroups.Relay))
                 .SendCoreAsync("notificationUpdated", new object[] { notification });
 
             _logger.LogDebug("Notification updated broadcast completed for user {UserId}", userId);
@@ -602,7 +608,7 @@ public class SignalRBroadcastService : ISignalRBroadcastService
                 intent.Intent, intent.ExcursionId, intent.TargetKind);
 
             await _dataHubContext
-                .Clients.Group(TenantGroup("authorized"))
+                .Clients.Group(TenantGroup(RealtimeGroups.Authorized))
                 .SendCoreAsync("device_action", new object[] { intent });
         }
         catch (Exception ex)
@@ -620,8 +626,15 @@ public class SignalRBroadcastService : ISignalRBroadcastService
                 "Broadcasting device_notification mirror for user {UserId}: {NotificationId}",
                 mirror.UserId, mirror.Notification.Id);
 
+            // The mirror names the subject it belongs to, so it goes to that subject's group rather
+            // than the tenant. A device is expected to filter to its owner, but relying on the
+            // client to do so made the mirror readable by every other connection in the tenant.
             await _dataHubContext
-                .Clients.Group(TenantGroup("authorized"))
+                .Clients.Group(TenantGroup(RealtimeGroups.ForSubject(mirror.UserId)))
+                .SendCoreAsync("device_notification", new object[] { mirror });
+
+            await _dataHubContext
+                .Clients.Group(TenantGroup(RealtimeGroups.Relay))
                 .SendCoreAsync("device_notification", new object[] { mirror });
         }
         catch (Exception ex)

--- a/src/Core/Nocturne.Core.Contracts/Multitenancy/ITenantMemberService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Multitenancy/ITenantMemberService.cs
@@ -41,4 +41,20 @@ public interface ITenantMemberService
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The subject's tenant role names, or an empty list if they have none or are not a member.</returns>
     Task<List<string>> GetMemberRoleNamesAsync(Guid subjectId, Guid tenantId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the membership's effective permissions — its role permissions unioned with its direct
+    /// permissions — or null when the subject is not a member of the tenant.
+    /// </summary>
+    /// <remarks>
+    /// The input to <c>MemberScopeResolver.Resolve</c>, for callers that resolve a membership outside
+    /// the HTTP pipeline and so cannot rely on <c>MemberScopeMiddleware</c> having run. Null and
+    /// empty are distinct: null is "not a member of this tenant", empty is "a member the tenant
+    /// granted nothing".
+    /// </remarks>
+    /// <param name="subjectId">The subject (user) identifier.</param>
+    /// <param name="tenantId">The tenant identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<IReadOnlySet<string>?> GetEffectivePermissionsAsync(
+        Guid subjectId, Guid tenantId, CancellationToken ct = default);
 }

--- a/tests/Integration/Nocturne.API.Tests/Hubs/AlertHubIntegrationTests.cs
+++ b/tests/Integration/Nocturne.API.Tests/Hubs/AlertHubIntegrationTests.cs
@@ -18,6 +18,7 @@ namespace Nocturne.API.Tests.Integration.Hubs;
 public class AlertHubIntegrationTests : AspireIntegrationTestBase
 {
     private Guid _tenantId;
+    private Guid _subjectId;
     private string _accessToken = null!;
 
     public AlertHubIntegrationTests(
@@ -40,7 +41,11 @@ public class AlertHubIntegrationTests : AspireIntegrationTestBase
         await conn.OpenAsync();
 
         _tenantId = await AuthTestHelpers.GetTenantIdAsync(conn);
-        (_, _accessToken) = await AuthTestHelpers.SeedAuthenticatedSubjectAsync(conn, _tenantId, "AlertHub Test User");
+        (_subjectId, _accessToken) = await AuthTestHelpers.SeedAuthenticatedSubjectAsync(conn, _tenantId, "AlertHub Test User");
+
+        // The hub connections present the api-secret header and nothing else, and the hub's methods
+        // require a credential carrying alerts.read / alerts.readwrite.
+        await AuthTestHelpers.SeedApiSecretGrantAsync(conn, _tenantId, _subjectId, TestApiSecret);
 
         Log($"Seeded tenant {_tenantId}");
     }

--- a/tests/Integration/Nocturne.API.Tests/Infrastructure/AuthTestHelpers.cs
+++ b/tests/Integration/Nocturne.API.Tests/Infrastructure/AuthTestHelpers.cs
@@ -102,6 +102,55 @@ public static class AuthTestHelpers
     }
 
     /// <summary>
+    /// Seeds the full-access direct grant that the <c>api-secret</c> header used across these tests
+    /// authenticates against, and returns its id.
+    /// </summary>
+    /// <remarks>
+    /// <c>ApiKeyHandler</c> matches a non-<c>noc_</c> header value against <c>legacy_secret_hash</c>
+    /// verbatim, and <c>CleanupDatabaseAsync</c> truncates <c>oauth_grants</c> before every test, so
+    /// without this row the header matches nothing. A request that also carries a bearer token is
+    /// unaffected either way — <c>ApiKeyHandler</c> runs last — but a SignalR hub connection carries
+    /// the header alone, so it is this row that decides whether the connection has a credential.
+    /// </remarks>
+    /// <param name="conn">Open connection to the test database.</param>
+    /// <param name="tenantId">The tenant the grant belongs to.</param>
+    /// <param name="subjectId">An existing subject to own the grant.</param>
+    /// <param name="apiSecret">The value sent in the <c>api-secret</c> header.</param>
+    public static async Task<Guid> SeedApiSecretGrantAsync(
+        NpgsqlConnection conn,
+        Guid tenantId,
+        Guid subjectId,
+        string apiSecret = "test-secret-for-integration-tests")
+    {
+        var grantId = Guid.CreateVersion7();
+
+        // Set RLS context
+        await using (var cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = "SELECT set_config('app.current_tenant_id', @tenantId, false);";
+            cmd.Parameters.AddWithValue("tenantId", tenantId.ToString());
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        await using (var cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = """
+                INSERT INTO oauth_grants (id, tenant_id, subject_id, grant_type, scopes, legacy_secret_hash, created_at)
+                VALUES (@id, @tenantId, @subjectId, @grantType, @scopes, @legacySecretHash, now());
+                """;
+            cmd.Parameters.AddWithValue("id", grantId);
+            cmd.Parameters.AddWithValue("tenantId", tenantId);
+            cmd.Parameters.AddWithValue("subjectId", subjectId);
+            cmd.Parameters.AddWithValue("grantType", OAuthScopes.GrantTypeDirect);
+            cmd.Parameters.AddWithValue("scopes", new[] { OAuthScopes.FullAccess });
+            cmd.Parameters.AddWithValue("legacySecretHash", apiSecret.ToLowerInvariant());
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        return grantId;
+    }
+
+    /// <summary>
     /// Creates a subject with tenant membership and admin role but WITHOUT a passkey credential.
     /// Used for testing tenant setup guard scenarios where passkey enrollment is required.
     /// </summary>

--- a/tests/Unit/Nocturne.API.Tests/Hubs/DataHubAuthorizeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Hubs/DataHubAuthorizeTests.cs
@@ -15,13 +15,15 @@ namespace Nocturne.API.Tests.Hubs;
 
 /// <summary>
 /// Covers the in-band Authorize wiring on <see cref="DataHub"/>: a token is routed through
-/// <see cref="IHubTokenAuthorizer"/> against the connection's immutable tenant, and only an
-/// authorized token joins the tenant-scoped "authorized" group.
+/// <see cref="IHubTokenAuthorizer"/> against the connection's immutable tenant, only an authorized
+/// token joins the tenant-scoped "authorized" group, and Subscribe joins a category group only when
+/// the connection's credential holds the scope governing it.
 /// </summary>
 [Trait("Category", "Unit")]
 public class DataHubAuthorizeTests
 {
     private static readonly Guid Tenant = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid Subject = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
     private const string ConnectionId = "conn-1";
 
     private sealed class TestHttpContextFeature : IHttpContextFeature
@@ -44,6 +46,7 @@ public class DataHubAuthorizeTests
         var callerContext = new Mock<HubCallerContext>();
         callerContext.SetupGet(c => c.ConnectionId).Returns(ConnectionId);
         callerContext.SetupGet(c => c.Features).Returns(features);
+        callerContext.SetupGet(c => c.Items).Returns(new Dictionary<object, object?>());
 
         var groups = new Mock<IGroupManager>();
 
@@ -52,13 +55,16 @@ public class DataHubAuthorizeTests
         return (hub, groups, authorizer);
     }
 
+    private static HubAuthorization Authorized(params string[] scopes) =>
+        new(Tenant, OAuthScopes.Normalize(scopes), HubCredentialKind.Subject, Subject);
+
     [Fact]
     public async Task Authorize_with_token_accepted_by_authorizer_joins_tenant_authorized_group()
     {
         var (hub, groups, authorizer) = CreateHub();
         authorizer
-            .Setup(a => a.IsTokenAuthorizedAsync("oauth-jwt", Tenant, OAuthScopes.GlucoseRead))
-            .ReturnsAsync(true);
+            .Setup(a => a.AuthorizeTokenAsync("oauth-jwt", Tenant, OAuthScopes.GlucoseRead))
+            .ReturnsAsync(Authorized(OAuthScopes.GlucoseRead));
 
         var result = await hub.Authorize(new AuthorizeRequest { Token = "oauth-jwt" });
 
@@ -73,9 +79,9 @@ public class DataHubAuthorizeTests
     {
         var (hub, groups, authorizer) = CreateHub();
         authorizer
-            .Setup(a => a.IsTokenAuthorizedAsync(
+            .Setup(a => a.AuthorizeTokenAsync(
                 It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<string>()))
-            .ReturnsAsync(false);
+            .ReturnsAsync((HubAuthorization?)null);
 
         var result = await hub.Authorize(new AuthorizeRequest { Token = "bad-token" });
 
@@ -90,15 +96,77 @@ public class DataHubAuthorizeTests
     {
         var (hub, _, authorizer) = CreateHub();
         authorizer
-            .Setup(a => a.IsTokenAuthorizedAsync(It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<string>()))
-            .ReturnsAsync(false);
+            .Setup(a => a.AuthorizeTokenAsync(It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<string>()))
+            .ReturnsAsync((HubAuthorization?)null);
 
         await hub.Authorize(new AuthorizeRequest { Token = "tok" });
 
         // The tenant handed to the authorizer is the connection's resolved tenant — a token
         // from another tenant can never be checked against anything else.
         authorizer.Verify(
-            a => a.IsTokenAuthorizedAsync("tok", Tenant, OAuthScopes.GlucoseRead),
+            a => a.AuthorizeTokenAsync("tok", Tenant, OAuthScopes.GlucoseRead),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task Authorize_reports_write_only_when_the_credential_can_write()
+    {
+        var (hub, _, authorizer) = CreateHub();
+        authorizer
+            .Setup(a => a.AuthorizeTokenAsync(It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<string>()))
+            .ReturnsAsync(Authorized(OAuthScopes.GlucoseRead));
+
+        var result = await hub.Authorize(new AuthorizeRequest { Token = "tok" });
+
+        var json = System.Text.Json.JsonSerializer.Serialize(result);
+        json.Should().Contain("\"read\":true");
+        json.Should().Contain("\"write\":false");
+    }
+
+    [Fact]
+    public async Task Subscribe_joins_only_the_categories_the_credential_is_scoped_for()
+    {
+        var (hub, groups, authorizer) = CreateHub();
+        authorizer
+            .Setup(a => a.AuthorizeTokenAsync(It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<string>()))
+            .ReturnsAsync(Authorized(OAuthScopes.GlucoseRead));
+        await hub.Authorize(new AuthorizeRequest { Token = "tok" });
+
+        var result = await hub.Subscribe(new StorageSubscribeRequest
+        {
+            Collections = ["entries", "glucose", "treatments", "care", "devicestatus"],
+        });
+
+        groups.Verify(
+            g => g.AddToGroupAsync(ConnectionId, $"{Tenant}:entries", It.IsAny<CancellationToken>()),
+            Times.Once);
+        groups.Verify(
+            g => g.AddToGroupAsync(ConnectionId, $"{Tenant}:glucose", It.IsAny<CancellationToken>()),
+            Times.Once);
+        foreach (var denied in new[] { "treatments", "care", "devicestatus" })
+        {
+            groups.Verify(
+                g => g.AddToGroupAsync(ConnectionId, $"{Tenant}:{denied}", It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        System.Text.Json.JsonSerializer.Serialize(result)
+            .Should().Contain("[\"entries\",\"glucose\"]");
+    }
+
+    [Fact]
+    public async Task Subscribe_never_joins_an_unclassified_collection()
+    {
+        var (hub, groups, authorizer) = CreateHub();
+        authorizer
+            .Setup(a => a.AuthorizeTokenAsync(It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<string>()))
+            .ReturnsAsync(Authorized(OAuthScopes.FullAccess));
+        await hub.Authorize(new AuthorizeRequest { Token = "tok" });
+
+        await hub.Subscribe(new StorageSubscribeRequest { Collections = ["subjects"] });
+
+        groups.Verify(
+            g => g.AddToGroupAsync(It.IsAny<string>(), $"{Tenant}:subjects", It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Hubs/HubAuthorizationFilterTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Hubs/HubAuthorizationFilterTests.cs
@@ -1,0 +1,419 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Connections.Features;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.SignalR;
+using Nocturne.API.Hubs;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.Authorization;
+
+namespace Nocturne.API.Tests.Hubs;
+
+/// <summary>
+/// Covers <see cref="HubAuthorizationFilter"/>, the gate that makes hub methods fail closed. The hubs
+/// accept an anonymous connection (in-band authentication needs the connection first), so every hub
+/// method other than an explicit authentication entry point has to be denied until the connection has
+/// proven a credential, and has to satisfy the scope it declares.
+/// </summary>
+[Trait("Category", "Unit")]
+public class HubAuthorizationFilterTests
+{
+    private static readonly Guid Tenant = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    private sealed class TestHttpContextFeature : IHttpContextFeature
+    {
+        public HttpContext? HttpContext { get; set; }
+    }
+
+    /// <summary>
+    /// Builds an invocation context for <paramref name="hubType"/>.<paramref name="methodName"/> on a
+    /// connection carrying <paramref name="authorization"/> (null = anonymous).
+    /// </summary>
+    private static HubInvocationContext CreateInvocation(
+        Type hubType, string methodName, HubAuthorization? authorization)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["TenantContext"] =
+            new TenantContext(Tenant, "default", "Default", IsActive: true);
+
+        var features = new FeatureCollection();
+        features.Set<IHttpContextFeature>(new TestHttpContextFeature { HttpContext = httpContext });
+
+        var items = new Dictionary<object, object?>();
+
+        var callerContext = new Mock<HubCallerContext>();
+        callerContext.SetupGet(c => c.ConnectionId).Returns("conn-1");
+        callerContext.SetupGet(c => c.Features).Returns(features);
+        callerContext.SetupGet(c => c.Items).Returns(items);
+
+        if (authorization is not null)
+        {
+            HubAuthorizationState.Grant(callerContext.Object, authorization);
+        }
+
+        var method = hubType.GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance)!;
+
+        // The filter decides on the MethodInfo and the connection only; the hub instance is never
+        // touched, so a stub stands in for hubs whose constructors take services.
+        return new HubInvocationContext(
+            callerContext.Object,
+            Mock.Of<IServiceProvider>(),
+            hub: new StubHub(),
+            hubMethod: method,
+            hubMethodArguments: []);
+    }
+
+    private sealed class StubHub : Hub;
+
+    /// <summary>A member credential on the connection's own tenant carrying <paramref name="scopes"/>.</summary>
+    private static HubAuthorization Member(params string[] scopes) => new(
+        Tenant, OAuthScopes.Normalize(scopes), HubCredentialKind.Subject, Guid.NewGuid());
+
+    /// <summary>
+    /// A share-style credential — a guest link — carrying <paramref name="scopes"/>.
+    /// </summary>
+    /// <remarks>
+    /// A subject id is passed deliberately even though <c>GuestSessionHandler</c> resolves a guest
+    /// session with none (the data owner it acts for goes on <c>AuthContext.ActingAsSubjectId</c>):
+    /// the refusal must hold on the kind alone, not on the subject id happening to be absent.
+    /// </remarks>
+    private static HubAuthorization Guest(params string[] scopes) => new(
+        Tenant, OAuthScopes.Normalize(scopes), HubCredentialKind.Restricted, Guid.NewGuid());
+
+    private static async Task<bool> InvokeAsync(HubInvocationContext invocation)
+    {
+        var filter = new HubAuthorizationFilter();
+        var reached = false;
+        await filter.InvokeMethodAsync(invocation, _ =>
+        {
+            reached = true;
+            return ValueTask.FromResult<object?>(null);
+        });
+        return reached;
+    }
+
+    private static Func<Task> Attempt(
+        Type hubType, string methodName, HubAuthorization? authorization) =>
+        () => InvokeAsync(CreateInvocation(hubType, methodName, authorization));
+
+    public static TheoryData<Type, string> GatedMethods => new()
+    {
+        { typeof(DataHub), nameof(DataHub.LoadRetro) },
+        { typeof(DataHub), nameof(DataHub.Subscribe) },
+        { typeof(AlertHub), nameof(AlertHub.Subscribe) },
+        { typeof(AlertHub), nameof(AlertHub.Acknowledge) },
+        { typeof(AlarmHub), nameof(AlarmHub.Ack) },
+        { typeof(HomeAssistantHub), nameof(HomeAssistantHub.Subscribe) },
+        { typeof(HomeAssistantHub), nameof(HomeAssistantHub.Acknowledge) },
+        { typeof(ConfigHub), nameof(ConfigHub.Subscribe) },
+        { typeof(ConfigHub), nameof(ConfigHub.Unsubscribe) },
+        { typeof(ConfigHub), nameof(ConfigHub.SubscribeAll) },
+        { typeof(ConfigHub), nameof(ConfigHub.UnsubscribeAll) },
+    };
+
+    [Fact]
+    public async Task Config_changes_are_not_readable_by_a_read_only_credential()
+    {
+        // ConfigurationChangeEvent names the member who made each change, and connector
+        // configuration is tenant administration with no narrower scope in the vocabulary.
+        var readOnly = Member(OAuthScopes.GlucoseRead, OAuthScopes.AlertsRead);
+
+        var attempt = Attempt(typeof(ConfigHub), nameof(ConfigHub.SubscribeAll), readOnly);
+
+        await attempt.Should().ThrowAsync<HubException>()
+            .Where(e => e.Message.Contains(OAuthScopes.FullAccess));
+    }
+
+    [Theory]
+    [MemberData(nameof(GatedMethods))]
+    public async Task Unauthorized_connection_is_denied(Type hubType, string methodName)
+    {
+        var attempt = Attempt(hubType, methodName, authorization: null);
+
+        await attempt.Should().ThrowAsync<HubException>()
+            .Where(e => e.Message.Contains("requires an authorized connection"));
+    }
+
+    [Theory]
+    [MemberData(nameof(GatedMethods))]
+    public async Task Full_access_connection_is_allowed(Type hubType, string methodName)
+    {
+        var authorization = Member(OAuthScopes.FullAccess);
+
+        var reached = await InvokeAsync(CreateInvocation(hubType, methodName, authorization));
+
+        reached.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Authorized_connection_without_the_declared_scope_is_denied()
+    {
+        // A read-only credential must not be able to silence alarms.
+        var readOnly = Member(OAuthScopes.GlucoseRead, OAuthScopes.AlertsRead);
+
+        var attempt = Attempt(typeof(AlarmHub), nameof(AlarmHub.Ack), readOnly);
+
+        await attempt.Should().ThrowAsync<HubException>()
+            .Where(e => e.Message.Contains(OAuthScopes.AlertsReadWrite));
+    }
+
+    [Fact]
+    public async Task LoadRetro_requires_glucose_read()
+    {
+        var therapyOnly = Member(OAuthScopes.TherapyRead);
+
+        var attempt = Attempt(typeof(DataHub), nameof(DataHub.LoadRetro), therapyOnly);
+
+        await attempt.Should().ThrowAsync<HubException>()
+            .Where(e => e.Message.Contains(OAuthScopes.GlucoseRead));
+    }
+
+    [Fact]
+    public async Task Home_assistant_acknowledge_requires_alerts_readwrite()
+    {
+        var readOnly = Member(OAuthScopes.AlertsRead);
+
+        var attempt = Attempt(
+            typeof(HomeAssistantHub), nameof(HomeAssistantHub.Acknowledge), readOnly);
+
+        await attempt.Should().ThrowAsync<HubException>()
+            .Where(e => e.Message.Contains(OAuthScopes.AlertsReadWrite));
+    }
+
+    [Fact]
+    public async Task Authentication_entry_points_are_reachable_anonymously()
+    {
+        // In-band authentication cannot work otherwise: the credential arrives in the invocation.
+        foreach (var (hubType, methodName) in new (Type, string)[]
+                 {
+                     (typeof(DataHub), nameof(DataHub.Authorize)),
+                     (typeof(AlarmHub), nameof(AlarmHub.Subscribe)),
+                 })
+        {
+            var reached = await InvokeAsync(
+                CreateInvocation(hubType, methodName, authorization: null));
+            reached.Should().BeTrue($"{hubType.Name}.{methodName} is an authentication entry point");
+        }
+    }
+
+    /// <summary>
+    /// The methods the filter gates that join a group carrying the whole tenant's payloads. Scope alone
+    /// does not constrain them: a guest link's scopes are the data owner's own read scopes, so the
+    /// credential kind is the only thing separating a share of one patient's glucose from the tenant's
+    /// alert stream.
+    /// </summary>
+    public static TheoryData<Type, string> TenantWideMethods => new()
+    {
+        { typeof(AlertHub), nameof(AlertHub.Subscribe) },
+        { typeof(HomeAssistantHub), nameof(HomeAssistantHub.Subscribe) },
+        { typeof(ConfigHub), nameof(ConfigHub.Subscribe) },
+        { typeof(ConfigHub), nameof(ConfigHub.SubscribeAll) },
+    };
+
+    [Theory]
+    [MemberData(nameof(TenantWideMethods))]
+    public async Task A_share_scoped_credential_is_refused_a_tenant_wide_group(
+        Type hubType, string methodName)
+    {
+        // Full access on purpose: the refusal must not depend on the guest scope set happening to
+        // exclude alerts.read, because a grant update can widen a guest link's scopes.
+        var attempt = Attempt(hubType, methodName, Guest(OAuthScopes.FullAccess));
+
+        await attempt.Should().ThrowAsync<HubException>()
+            .Where(e => e.Message.Contains("requires a credential belonging to the tenant"));
+    }
+
+    [Theory]
+    [MemberData(nameof(TenantWideMethods))]
+    public async Task A_tenant_credential_reaches_a_tenant_wide_group(Type hubType, string methodName)
+    {
+        // The bridge (instance key) and any subject credential holding the declared scope must still
+        // subscribe.
+        foreach (var authorization in new[]
+                 {
+                     Member(OAuthScopes.FullAccess),
+                     new HubAuthorization(
+                         Tenant,
+                         OAuthScopes.Normalize([OAuthScopes.FullAccess]),
+                         HubCredentialKind.Infrastructure,
+                         SubjectId: null),
+                 })
+        {
+            var reached = await InvokeAsync(CreateInvocation(hubType, methodName, authorization));
+            reached.Should().BeTrue($"{hubType.Name}.{methodName} with {authorization.Kind}");
+        }
+    }
+
+    /// <summary>
+    /// Every hub method that joins a tenant-wide group declares
+    /// <see cref="HubTenantGroupAttribute"/>, so the credential-kind check is not left to whoever writes
+    /// the next hub method.
+    /// </summary>
+    /// <remarks>
+    /// The joins are found by scanning the compiled bodies for a call to
+    /// <see cref="IGroupManager.AddToGroupAsync"/> rather than listed here, so a method added later is
+    /// covered without this test being edited. <c>DataHub.Subscribe</c> is the one join that is not
+    /// tenant-wide: it joins the per-data-category groups and gates each on the read scope governing
+    /// that category, which is how a guest link receives the categories it was shared.
+    /// </remarks>
+    [Fact]
+    public void Every_hub_method_that_joins_a_tenant_wide_group_declares_it()
+    {
+        var declared = HubMethods()
+            .Where(m => m.GetCustomAttribute<HubTenantGroupAttribute>() is not null)
+            .Select(Describe)
+            .ToList();
+
+        HubMethods().Where(JoinsAGroup).Select(Describe).Should().BeEquivalentTo(
+            [.. declared, $"{nameof(DataHub)}.{nameof(DataHub.Subscribe)}"],
+            "a hub method that joins a tenant-wide group must declare [HubTenantGroup], and the "
+            + "per-data-category groups DataHub.Subscribe joins are gated per category instead");
+    }
+
+    [Fact]
+    public void Every_invocable_hub_method_either_authenticates_or_is_gated()
+    {
+        // The guarantee this filter exists for: a method added to a hub later is denied by default.
+        // A method that opts out with [HubAuthenticationMethod] must be doing in-band authentication.
+        var entryPoints = HubMethods()
+            .Where(m => m.GetCustomAttribute<HubAuthenticationMethodAttribute>() is not null)
+            .Select(Describe)
+            .ToList();
+
+        entryPoints.Should().BeEquivalentTo(["DataHub.Authorize", "AlarmHub.Subscribe"]);
+    }
+
+    /// <summary>
+    /// Every method a client can invoke on a hub: declared on the hub itself and not an override of a
+    /// <see cref="Hub"/> lifetime member.
+    /// </summary>
+    /// <remarks>
+    /// The lifetime overrides (<c>OnConnectedAsync</c>, <c>OnDisconnectedAsync</c>) are excluded
+    /// because <see cref="IHubFilter.InvokeMethodAsync"/> never sees them — SignalR routes them through
+    /// <see cref="IHubFilter.OnConnectedAsync"/> and <see cref="IHubFilter.OnDisconnectedAsync"/>
+    /// instead — so an attribute declared on one would be inert. Neither of the tests below can say
+    /// anything about them.
+    /// </remarks>
+    private static IEnumerable<MethodInfo> HubMethods() =>
+        typeof(DataHub).Assembly.GetTypes()
+            .Where(t => t.IsAssignableTo(typeof(TenantAwareHub)) && !t.IsAbstract)
+            .SelectMany(t => t.GetMethods(
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            .Where(m => m.GetBaseDefinition().DeclaringType == m.DeclaringType);
+
+    private static string Describe(MethodInfo method) => $"{method.DeclaringType!.Name}.{method.Name}";
+
+    /// <summary>
+    /// Whether <paramref name="method"/> reaches <see cref="IGroupManager.AddToGroupAsync"/>, following
+    /// the async state machine the compiler moved the body into and any helper the method calls on its
+    /// own hub — including the ones the compiler moved into a type nested inside that hub (state
+    /// machines, closure display classes, local-function holders).
+    /// </summary>
+    private static bool JoinsAGroup(MethodInfo method)
+    {
+        var pending = new Queue<MethodBase>();
+        pending.Enqueue(method);
+        var seen = new HashSet<MethodBase>();
+
+        while (pending.Count > 0)
+        {
+            var current = pending.Dequeue();
+            if (!seen.Add(current))
+            {
+                continue;
+            }
+
+            if (current.GetCustomAttribute<AsyncStateMachineAttribute>()?.StateMachineType is { } machine)
+            {
+                foreach (var moveNext in machine
+                             .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                             .Where(m => m.Name.EndsWith("MoveNext", StringComparison.Ordinal)))
+                {
+                    pending.Enqueue(moveNext);
+                }
+            }
+
+            foreach (var called in CalledMethods(current))
+            {
+                if (called.Name == nameof(IGroupManager.AddToGroupAsync))
+                {
+                    return true;
+                }
+
+                if (DeclaredWithin(called.DeclaringType, method.DeclaringType!))
+                {
+                    pending.Enqueue(called);
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="candidate"/> is <paramref name="hubType"/> or a type nested inside it.
+    /// </summary>
+    /// <remarks>
+    /// An async body's calls come out of a <c>MoveNext</c> on a compiler-generated type nested in the
+    /// hub, and its lambdas and closures out of further nested display classes, so an exact match on
+    /// the hub type alone stops the walk at the first such boundary and leaves only direct calls
+    /// followed.
+    /// </remarks>
+    private static bool DeclaredWithin(Type? candidate, Type hubType)
+    {
+        for (var type = candidate; type is not null; type = type.DeclaringType)
+        {
+            if (type == hubType)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The methods called from <paramref name="method"/>'s IL, found by resolving the token after every
+    /// <c>call</c> and <c>callvirt</c> opcode byte.
+    /// </summary>
+    /// <remarks>
+    /// A byte that is not an instruction boundary yields a token that does not resolve and is skipped,
+    /// so the result is a superset of the real calls. That errs toward reporting a group join, which is
+    /// the direction that makes the caller's assertion fail rather than silently pass.
+    /// </remarks>
+    private static IEnumerable<MethodBase> CalledMethods(MethodBase method)
+    {
+        const byte Call = 0x28;
+        const byte CallVirt = 0x6F;
+
+        var il = method.GetMethodBody()?.GetILAsByteArray();
+        if (il is null)
+        {
+            yield break;
+        }
+
+        for (var i = 0; i + 4 < il.Length; i++)
+        {
+            if (il[i] is not (Call or CallVirt))
+            {
+                continue;
+            }
+
+            MethodBase? called = null;
+            try
+            {
+                called = method.Module.ResolveMethod(BitConverter.ToInt32(il, i + 1));
+            }
+            catch (Exception)
+            {
+                // Not an instruction boundary, or a token needing generic context to resolve.
+            }
+
+            if (called is not null)
+            {
+                yield return called;
+            }
+        }
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Hubs/HubCredentialKindTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Hubs/HubCredentialKindTests.cs
@@ -1,0 +1,365 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Connections.Features;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Nocturne.API.Extensions;
+using Nocturne.API.Hubs;
+using Nocturne.API.Services.Identity;
+using Nocturne.API.Services.Realtime;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.ClientDevices;
+using Nocturne.Core.Models.Authorization;
+
+namespace Nocturne.API.Tests.Hubs;
+
+/// <summary>
+/// Covers which SignalR groups a credential may join. Scopes decide which data categories a
+/// connection sees; <see cref="HubCredentialKind"/> decides whether it may join a group that carries
+/// more than one category, or another subject's payloads.
+/// </summary>
+/// <remarks>
+/// The tenant-wide groups are gated on <c>glucose.read</c> but carry tracker state, device action
+/// intents and arbitrary <c>dataUpdate</c> payloads, and the per-subject broadcasts are published to
+/// them as well. A guest link holds glucose read, so without the kind check it would receive every
+/// member's in-app notifications and device notification mirrors.
+/// </remarks>
+[Trait("Category", "Unit")]
+public class HubCredentialKindTests
+{
+    private static readonly Guid Tenant = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid Subject = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static readonly Guid OtherSubject = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private const string ConnectionId = "conn-1";
+
+    // ── credential classification ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The classification is asserted for every <see cref="AuthType"/>, so a new authentication type
+    /// cannot reach a tenant-wide group without a deliberate decision recorded here.
+    /// </summary>
+    public static TheoryData<AuthType, HubCredentialKind> Classifications => new()
+    {
+        { AuthType.None, HubCredentialKind.Restricted },
+        { AuthType.Guest, HubCredentialKind.Restricted },
+        { AuthType.InstanceKey, HubCredentialKind.Infrastructure },
+        { AuthType.OidcToken, HubCredentialKind.Subject },
+        { AuthType.LegacyJwt, HubCredentialKind.Subject },
+        { AuthType.LegacyAccessToken, HubCredentialKind.Subject },
+        { AuthType.ApiKey, HubCredentialKind.Subject },
+        { AuthType.SessionCookie, HubCredentialKind.Subject },
+        { AuthType.OAuthAccessToken, HubCredentialKind.Subject },
+        { AuthType.DirectGrant, HubCredentialKind.Subject },
+        { AuthType.PlatformAccess, HubCredentialKind.Subject },
+    };
+
+    [Theory]
+    [MemberData(nameof(Classifications))]
+    public void Every_auth_type_classifies_as_expected(AuthType authType, HubCredentialKind expected)
+    {
+        HubAuthorization.Classify(authType).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Classifications_cover_every_auth_type()
+    {
+        var classified = Classifications
+            .Select(row => (AuthType)((object?[])row)[0]!)
+            .ToHashSet();
+
+        classified.Should().BeEquivalentTo(Enum.GetValues<AuthType>(),
+            "a new AuthType must be classified deliberately, not default into a tenant-wide group");
+    }
+
+    [Fact]
+    public void An_unclassified_credential_is_restricted()
+    {
+        // Fail closed: the zero value is Restricted, so a default-constructed or unmapped kind
+        // cannot join a tenant-wide group.
+        default(HubCredentialKind).Should().Be(HubCredentialKind.Restricted);
+        HubAuthorization.Classify((AuthType)9999).Should().Be(HubCredentialKind.Restricted);
+    }
+
+    [Theory]
+    [InlineData(HubCredentialKind.Restricted, false)]
+    [InlineData(HubCredentialKind.Subject, true)]
+    [InlineData(HubCredentialKind.Infrastructure, true)]
+    public void CanJoinTenantRelay_follows_the_kind(HubCredentialKind kind, bool expected)
+    {
+        Authorization(kind).CanJoinTenantRelay.Should().Be(expected);
+    }
+
+    [Fact]
+    public void A_restricted_credential_owns_no_subject_group()
+    {
+        // Held on the kind alone, so it does not rest on GuestSessionHandler continuing to resolve a
+        // guest session with SubjectId null (the data owner it acts for is carried separately, on
+        // AuthContext.ActingAsSubjectId). A subject group carries that subject's in-app
+        // notifications, which no guest scope covers.
+        Authorization(HubCredentialKind.Restricted).OwnSubjectId.Should().BeNull();
+        Authorization(HubCredentialKind.Subject).OwnSubjectId.Should().Be(Subject);
+    }
+
+    // ── which groups DataHub.Authorize joins ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task A_guest_credential_joins_no_tenant_group()
+    {
+        var (hub, groups) = CreateHub(Authorization(HubCredentialKind.Restricted));
+
+        var result = await hub.Authorize(new AuthorizeRequest { Token = "guest" });
+
+        System.Text.Json.JsonSerializer.Serialize(result).Should().Contain("\"success\":true");
+        groups.Verify(
+            g => g.AddToGroupAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "a guest link reaches data through Subscribe's category groups, never a tenant-wide group");
+    }
+
+    [Fact]
+    public async Task A_member_credential_joins_the_data_group_and_its_own_subject_group()
+    {
+        var (hub, groups) = CreateHub(Authorization(HubCredentialKind.Subject));
+
+        await hub.Authorize(new AuthorizeRequest { Token = "member" });
+
+        VerifyJoined(groups, RealtimeGroups.Authorized);
+        VerifyJoined(groups, RealtimeGroups.ForSubject(Subject));
+        VerifyNotJoined(groups, RealtimeGroups.Relay);
+        VerifyNotJoined(groups, RealtimeGroups.ForSubject(OtherSubject));
+    }
+
+    [Fact]
+    public async Task The_bridge_joins_the_relay_group()
+    {
+        var (hub, groups) = CreateHub(new HubAuthorization(
+            Tenant,
+            OAuthScopes.Normalize([OAuthScopes.FullAccess]),
+            HubCredentialKind.Infrastructure,
+            SubjectId: null));
+
+        await hub.Authorize(new AuthorizeRequest { Secret = "instance-key" });
+
+        VerifyJoined(groups, RealtimeGroups.Authorized);
+        VerifyJoined(groups, RealtimeGroups.Relay);
+    }
+
+    // ── who the per-subject broadcasts reach ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task A_notification_never_goes_to_the_tenant_data_group()
+    {
+        var (broadcast, sends) = CreateBroadcastService();
+
+        await broadcast.BroadcastNotificationCreatedAsync(Subject.ToString(), new InAppNotificationDto());
+
+        sends.Should().Contain(Group(RealtimeGroups.ForSubject(Subject)));
+        sends.Should().Contain(Group(RealtimeGroups.Relay));
+        sends.Should().NotContain(Group(RealtimeGroups.Authorized),
+            "the tenant data group is reachable by any member holding glucose read, so a "
+            + "notification addressed to one subject must not be published to it");
+    }
+
+    [Fact]
+    public async Task A_device_notification_mirror_goes_only_to_its_own_subject()
+    {
+        var (broadcast, sends) = CreateBroadcastService();
+
+        await broadcast.BroadcastDeviceNotificationAsync(new DeviceNotificationMirror
+        {
+            UserId = Subject.ToString(),
+            Notification = new InAppNotificationDto(),
+        });
+
+        sends.Should().Contain(Group(RealtimeGroups.ForSubject(Subject)));
+        sends.Should().Contain(Group(RealtimeGroups.Relay));
+        sends.Should().NotContain(Group(RealtimeGroups.Authorized));
+        sends.Should().NotContain(Group(RealtimeGroups.ForSubject(OtherSubject)));
+    }
+
+    [Fact]
+    public void The_subject_group_name_is_stable_across_guid_and_string_callers()
+    {
+        // The hub has a Guid, the payloads carry a string. SignalR compares group names byte for
+        // byte, so an uppercase or braced identifier would silently deliver to nobody.
+        RealtimeGroups.ForSubject(Subject)
+            .Should().Be(RealtimeGroups.ForSubject(Subject.ToString().ToUpperInvariant()))
+            .And.Be(RealtimeGroups.ForSubject(Subject.ToString("B")));
+    }
+
+    // ── registration ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// SignalR reads <c>HubOptions.HubFilters</c> and never resolves <see cref="IHubFilter"/> from the
+    /// container, so a filter registered only in DI is silently inert — which is how the hub methods
+    /// went unauthorized in the first place.
+    /// </summary>
+    [Fact]
+    public void The_hub_filters_are_registered_in_HubOptions()
+    {
+        var provider = BuildRealtimeServices();
+
+        RegisteredFilters(provider.GetRequiredService<IOptions<HubOptions>>().Value)
+            .Should().BeEquivalentTo([typeof(TenantHubFilter), typeof(HubAuthorizationFilter)],
+                options => options.WithStrictOrdering(),
+                "the tenant accessor must be populated before anything inside resolves a "
+                + "tenant-scoped service");
+
+        provider.GetService<HubAuthorizationFilter>().Should().NotBeNull(
+            "the filter type is resolved from the container when the pipeline is built");
+        provider.GetService<TenantHubFilter>().Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// Per-hub filters replace the global list rather than adding to it, so a per-hub
+    /// <c>HubFilters</c> collection would drop the authorization filter for that hub.
+    /// </summary>
+    [Fact]
+    public void No_hub_overrides_the_global_filter_list()
+    {
+        var provider = BuildRealtimeServices();
+
+        foreach (var hubOptionsType in new[]
+                 {
+                     typeof(HubOptions<DataHub>), typeof(HubOptions<AlarmHub>), typeof(HubOptions<AlertHub>),
+                     typeof(HubOptions<ConfigHub>), typeof(HubOptions<HomeAssistantHub>),
+                 })
+        {
+            var options = provider.GetRequiredService(
+                typeof(IOptions<>).MakeGenericType(hubOptionsType));
+            var value = options.GetType().GetProperty("Value")!.GetValue(options)!;
+
+            RegisteredFilters(value).Should().BeNull(
+                $"{hubOptionsType.GenericTypeArguments[0].Name} must inherit the global filters");
+        }
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────────────────────
+
+    private static ServiceProvider BuildRealtimeServices()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddRealTimeAndNotifications(new ConfigurationBuilder().Build());
+        return services.BuildServiceProvider();
+    }
+
+    private static HubAuthorization Authorization(HubCredentialKind kind) => new(
+        Tenant, OAuthScopes.Normalize([OAuthScopes.GlucoseRead]), kind, Subject);
+
+    private static string Group(string name) => TenantAwareHub.FormatTenantGroup(Tenant.ToString(), name);
+
+    private static void VerifyJoined(Mock<IGroupManager> groups, string group) =>
+        groups.Verify(
+            g => g.AddToGroupAsync(ConnectionId, Group(group), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+    private static void VerifyNotJoined(Mock<IGroupManager> groups, string group) =>
+        groups.Verify(
+            g => g.AddToGroupAsync(It.IsAny<string>(), Group(group), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+    /// <summary>Reads the internal <c>HubOptions.HubFilters</c> list.</summary>
+    private static List<Type>? RegisteredFilters(object hubOptions)
+    {
+        var property = hubOptions.GetType().GetProperty("HubFilters",
+            System.Reflection.BindingFlags.Instance
+            | System.Reflection.BindingFlags.Public
+            | System.Reflection.BindingFlags.NonPublic);
+
+        if (property?.GetValue(hubOptions) is not System.Collections.IEnumerable filters)
+            return null;
+
+        // AddFilter<T>() stores an internal factory holding the filter type; AddFilter(instance)
+        // stores the instance itself.
+        return filters.Cast<object>().Select(FilterType).ToList();
+    }
+
+    private static Type FilterType(object filter)
+    {
+        if (filter is Type type)
+            return type;
+
+        var held = filter.GetType()
+            .GetFields(System.Reflection.BindingFlags.Instance
+                | System.Reflection.BindingFlags.Public
+                | System.Reflection.BindingFlags.NonPublic)
+            .Select(field => field.GetValue(filter))
+            .OfType<Type>()
+            .FirstOrDefault();
+
+        return held ?? filter.GetType();
+    }
+
+    private static (DataHub Hub, Mock<IGroupManager> Groups) CreateHub(HubAuthorization authorization)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["TenantContext"] =
+            new TenantContext(Tenant, "default", "Default", IsActive: true);
+
+        var features = new FeatureCollection();
+        features.Set<IHttpContextFeature>(new StubHttpContextFeature { HttpContext = httpContext });
+
+        var callerContext = new Mock<HubCallerContext>();
+        callerContext.SetupGet(c => c.ConnectionId).Returns(ConnectionId);
+        callerContext.SetupGet(c => c.Features).Returns(features);
+        callerContext.SetupGet(c => c.Items).Returns(new Dictionary<object, object?>());
+
+        var authorizer = new Mock<IHubTokenAuthorizer>();
+        authorizer
+            .Setup(a => a.AuthorizeTokenAsync(It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<string>()))
+            .ReturnsAsync(authorization);
+        authorizer
+            .Setup(a => a.AuthorizeInstanceKey(It.IsAny<string>(), It.IsAny<Guid?>()))
+            .Returns(authorization);
+
+        var groups = new Mock<IGroupManager>();
+        var hub = new DataHub(Mock.Of<ILogger<DataHub>>(), authorizer.Object)
+        {
+            Context = callerContext.Object,
+            Groups = groups.Object,
+        };
+
+        return (hub, groups);
+    }
+
+    private sealed class StubHttpContextFeature : IHttpContextFeature
+    {
+        public HttpContext? HttpContext { get; set; }
+    }
+
+    /// <summary>A broadcast service recording the group name of every send.</summary>
+    private static (ISignalRBroadcastService Service, List<string> Sends) CreateBroadcastService()
+    {
+        var sends = new List<string>();
+
+        var clients = new Mock<IHubClients>();
+        clients.Setup(c => c.Group(It.IsAny<string>()))
+            .Returns((string group) =>
+            {
+                sends.Add(group);
+                return Mock.Of<IClientProxy>();
+            });
+
+        var dataHub = new Mock<IHubContext<DataHub>>();
+        dataHub.SetupGet(h => h.Clients).Returns(clients.Object);
+
+        var tenantAccessor = new Mock<ITenantAccessor>();
+        tenantAccessor.SetupGet(a => a.Context)
+            .Returns(new TenantContext(Tenant, "default", "Default", IsActive: true));
+
+        var service = new SignalRBroadcastService(
+            dataHub.Object,
+            Mock.Of<IHubContext<AlarmHub>>(),
+            Mock.Of<IHubContext<ConfigHub>>(),
+            Mock.Of<IHubContext<AlertHub>>(),
+            Mock.Of<IHubContext<HomeAssistantHub>>(),
+            tenantAccessor.Object,
+            Mock.Of<ILogger<SignalRBroadcastService>>());
+
+        return (service, sends);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Hubs/TenantHubFilterTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Hubs/TenantHubFilterTests.cs
@@ -1,0 +1,132 @@
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Connections.Features;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Nocturne.API.Hubs;
+using Nocturne.API.Multitenancy;
+using Nocturne.Core.Contracts.Multitenancy;
+using Xunit;
+
+namespace Nocturne.API.Tests.Hubs;
+
+/// <summary>
+/// Covers <see cref="TenantHubFilter"/>, which carries the tenant resolved on the upgrade handshake
+/// into each hub invocation. SignalR builds a fresh DI scope per invocation, so the scoped
+/// <see cref="ITenantAccessor"/> a service resolved from
+/// <see cref="HubInvocationContext.ServiceProvider"/> inside a method body sees is the invocation's,
+/// not the handshake request's.
+/// </summary>
+[Trait("Category", "Unit")]
+public class TenantHubFilterTests
+{
+    private static readonly Guid Tenant = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    private sealed class TestHttpContextFeature : IHttpContextFeature
+    {
+        public HttpContext? HttpContext { get; set; }
+    }
+
+    private sealed class StubHub : Hub
+    {
+        public void Method()
+        {
+        }
+    }
+
+    /// <summary>
+    /// A connection whose handshake resolved <see cref="Tenant"/>, with a distinct
+    /// <see cref="ITenantAccessor"/> on the handshake scope and on the invocation scope.
+    /// </summary>
+    private static (HubCallerContext Caller, ITenantAccessor Handshake, IServiceProvider Invocation, ITenantAccessor InvocationAccessor)
+        CreateConnection(bool withTenant = true)
+    {
+        var handshakeAccessor = new HttpContextTenantAccessor();
+        var handshakeServices = new ServiceCollection()
+            .AddSingleton<ITenantAccessor>(handshakeAccessor)
+            .BuildServiceProvider();
+
+        var httpContext = new DefaultHttpContext { RequestServices = handshakeServices };
+        if (withTenant)
+        {
+            httpContext.Items[TenantAwareHub.TenantContextKey] =
+                new TenantContext(Tenant, "default", "Default", IsActive: true);
+        }
+
+        var features = new FeatureCollection();
+        features.Set<IHttpContextFeature>(new TestHttpContextFeature { HttpContext = httpContext });
+
+        var caller = new Mock<HubCallerContext>();
+        caller.SetupGet(c => c.ConnectionId).Returns("conn-1");
+        caller.SetupGet(c => c.Features).Returns(features);
+        caller.SetupGet(c => c.Items).Returns(new Dictionary<object, object?>());
+
+        var invocationAccessor = new HttpContextTenantAccessor();
+        var invocationServices = new ServiceCollection()
+            .AddSingleton<ITenantAccessor>(invocationAccessor)
+            .BuildServiceProvider();
+
+        return (caller.Object, handshakeAccessor, invocationServices, invocationAccessor);
+    }
+
+    [Fact]
+    public async Task The_invocation_scopes_accessor_is_the_one_that_gets_the_tenant()
+    {
+        // A service a method body resolves from HubInvocationContext.ServiceProvider comes from the
+        // invocation scope. The hub's own constructor dependencies do not: the dispatcher activates
+        // the hub before the filter pipeline runs, so those latch Guid.Empty whatever this sets.
+        var (caller, handshake, invocationServices, invocationAccessor) = CreateConnection();
+
+        var invocation = new HubInvocationContext(
+            caller,
+            invocationServices,
+            hub: new StubHub(),
+            hubMethod: typeof(StubHub).GetMethod(nameof(StubHub.Method), BindingFlags.Public | BindingFlags.Instance)!,
+            hubMethodArguments: []);
+
+        var reached = false;
+        await new TenantHubFilter().InvokeMethodAsync(invocation, _ =>
+        {
+            reached = true;
+            invocationAccessor.TenantId.Should().Be(Tenant, "the tenant must be set before the method runs");
+            return ValueTask.FromResult<object?>(null);
+        });
+
+        reached.Should().BeTrue();
+        invocationAccessor.TenantId.Should().Be(Tenant);
+        handshake.IsResolved.Should().BeFalse(
+            "the handshake request's scope is not the one the invocation resolves services from");
+    }
+
+    [Fact]
+    public async Task Lifetime_events_populate_their_own_scope()
+    {
+        var (caller, _, invocationServices, invocationAccessor) = CreateConnection();
+        var lifetime = new HubLifetimeContext(caller, invocationServices, new StubHub());
+
+        await new TenantHubFilter().OnConnectedAsync(lifetime, _ => Task.CompletedTask);
+
+        invocationAccessor.TenantId.Should().Be(Tenant);
+    }
+
+    [Fact]
+    public async Task A_connection_with_no_resolved_tenant_leaves_the_accessor_unset()
+    {
+        var (caller, _, invocationServices, invocationAccessor) = CreateConnection(withTenant: false);
+
+        var invocation = new HubInvocationContext(
+            caller,
+            invocationServices,
+            hub: new StubHub(),
+            hubMethod: typeof(StubHub).GetMethod(nameof(StubHub.Method), BindingFlags.Public | BindingFlags.Instance)!,
+            hubMethodArguments: []);
+
+        await new TenantHubFilter().InvokeMethodAsync(
+            invocation, _ => ValueTask.FromResult<object?>(null));
+
+        invocationAccessor.IsResolved.Should().BeFalse();
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/OAuthAccessTokenHandlerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/OAuthAccessTokenHandlerTests.cs
@@ -109,6 +109,16 @@ public class OAuthAccessTokenHandlerTests
         return context;
     }
 
+    /// <summary>A request carrying the token on the query string as a SignalR client does.</summary>
+    private static DefaultHttpContext QueryRequest(string path, string token, TenantContext tenant)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = path;
+        context.Request.QueryString = QueryString.Create("access_token", token);
+        context.Items["TenantContext"] = tenant;
+        return context;
+    }
+
     private TenantContext Tenant(Guid? id = null) =>
         new(id ?? _tenantId, "acme", "Acme", IsActive: true);
 
@@ -200,5 +210,37 @@ public class OAuthAccessTokenHandlerTests
         var result = await _handler.AuthenticateAsync(context);
 
         result.ShouldSkip.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("/hubs/data")]
+    [InlineData("/hubs")]
+    public async Task Accepts_an_access_token_query_parameter_on_a_hub_path(string path)
+    {
+        // A WebSocket or SSE upgrade cannot carry an Authorization header, so every SignalR client
+        // puts the token in access_token. Without this the hub connection is anonymous and every
+        // method HubAuthorizationFilter gates is denied.
+        var context = QueryRequest(path, MintDesktopStyleToken(), Tenant());
+
+        var result = await _handler.AuthenticateAsync(context);
+
+        result.Succeeded.Should().BeTrue(result.Error);
+        result.AuthContext!.AuthType.Should().Be(AuthType.OAuthAccessToken);
+        result.AuthContext.SubjectId.Should().Be(_subjectId);
+    }
+
+    [Theory]
+    [InlineData("/api/v1/entries")]
+    [InlineData("/hubsomething")]
+    public async Task Ignores_an_access_token_query_parameter_off_a_hub_path(string path)
+    {
+        // A query-string credential lands in access logs and referrers, so it is honoured only where
+        // the transport leaves no alternative.
+        var context = QueryRequest(path, MintDesktopStyleToken(), Tenant());
+
+        var result = await _handler.AuthenticateAsync(context);
+
+        result.ShouldSkip.Should().BeTrue();
+        result.Succeeded.Should().BeFalse();
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantIsolationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantIsolationTests.cs
@@ -47,6 +47,7 @@ public class TenantIsolationTests
         var mock = new Mock<HubCallerContext>();
         mock.Setup(c => c.Features).Returns(features);
         mock.Setup(c => c.ConnectionId).Returns(connectionId);
+        mock.Setup(c => c.Items).Returns(new Dictionary<object, object?>());
         return mock;
     }
 
@@ -217,15 +218,16 @@ public class TenantIsolationTests
         if (tenantContext != null)
             httpContext.Items["TenantContext"] = tenantContext;
 
+        var mockCallerContext = CreateMockHubCallerContext(httpContext, Guid.NewGuid().ToString());
+
+        // The accessor goes on the invocation's own provider, not the handshake request's: SignalR
+        // builds a fresh DI scope per invocation and that is the one the hub method resolves from.
         var services = new ServiceCollection();
         services.AddSingleton(accessor);
-        httpContext.RequestServices = services.BuildServiceProvider();
-
-        var mockCallerContext = CreateMockHubCallerContext(httpContext, Guid.NewGuid().ToString());
 
         var invocationContext = new HubInvocationContext(
             mockCallerContext.Object,
-            Mock.Of<IServiceProvider>(),
+            services.BuildServiceProvider(),
             Mock.Of<Hub>(),
             typeof(Hub).GetMethod(nameof(Hub.OnConnectedAsync))!,
             Array.Empty<object>());
@@ -240,13 +242,13 @@ public class TenantIsolationTests
         if (tenantContext != null)
             httpContext.Items["TenantContext"] = tenantContext;
 
-        var services = new ServiceCollection();
-        services.AddSingleton(accessor);
-        httpContext.RequestServices = services.BuildServiceProvider();
-
         var mockCallerContext = CreateMockHubCallerContext(httpContext, Guid.NewGuid().ToString());
 
-        return new HubLifetimeContext(mockCallerContext.Object, Mock.Of<IServiceProvider>(), Mock.Of<Hub>());
+        var services = new ServiceCollection();
+        services.AddSingleton(accessor);
+
+        return new HubLifetimeContext(
+            mockCallerContext.Object, services.BuildServiceProvider(), Mock.Of<Hub>());
     }
 
     #endregion
@@ -424,7 +426,7 @@ public class TenantIsolationTests
     }
 
     [Fact]
-    public async Task Broadcast_NotificationCreated_TargetsTenantSpecificUserAndAuthorizedGroups()
+    public async Task Broadcast_NotificationCreated_TargetsTenantSpecificUserAndRelayGroups()
     {
         var (service, dataClients, _, _, _, _, _) = CreateBroadcastService(TenantA);
         var notification = new InAppNotificationDto { Id = Guid.NewGuid() };
@@ -432,8 +434,12 @@ public class TenantIsolationTests
         await service.BroadcastNotificationCreatedAsync("user-123", notification);
 
         dataClients.Verify(c => c.Group($"{TenantAId}:user-user-123"), Times.Once);
-        dataClients.Verify(c => c.Group($"{TenantAId}:authorized"), Times.Once);
+        // The tenant-wide copy goes to the infrastructure relay, which only the bridge joins — not
+        // to the data group, which any member holding glucose read joins.
+        dataClients.Verify(c => c.Group($"{TenantAId}:relay"), Times.Once);
+        dataClients.Verify(c => c.Group($"{TenantAId}:authorized"), Times.Never);
         dataClients.Verify(c => c.Group("user-user-123"), Times.Never);
+        dataClients.Verify(c => c.Group("relay"), Times.Never);
     }
 
     [Fact]
@@ -863,6 +869,16 @@ public class TenantIsolationTests
 
         var mockCallerContext = CreateMockHubCallerContext(httpContext);
 
+        // Subscribe requires an authorized connection; these tests are about group naming, so grant
+        // full access on the connection's own tenant.
+        Nocturne.API.Hubs.HubAuthorizationState.Grant(
+            mockCallerContext.Object,
+            new Nocturne.API.Hubs.HubAuthorization(
+                tenantContext.TenantId,
+                new HashSet<string> { Nocturne.Core.Models.Authorization.OAuthScopes.FullAccess },
+                Nocturne.API.Hubs.HubCredentialKind.Subject,
+                Guid.NewGuid()));
+
         var mockGroups = new Mock<IGroupManager>();
         var mockClients = new Mock<IHubCallerClients>();
         mockClients.Setup(c => c.Caller).Returns(Mock.Of<ISingleClientProxy>());
@@ -912,8 +928,8 @@ public class TenantIsolationTests
     private static (AlarmHub hub, Mock<IGroupManager> groups) CreateAlarmHub(TenantContext tenantContext)
     {
         var mockLogger = new Mock<ILogger<AlarmHub>>();
-        var mockAuthService = new Mock<Core.Contracts.Identity.IAuthorizationService>();
-        var hub = new AlarmHub(mockLogger.Object, mockAuthService.Object);
+        var mockAuthorizer = new Mock<Nocturne.API.Services.Identity.IHubTokenAuthorizer>();
+        var hub = new AlarmHub(mockLogger.Object, mockAuthorizer.Object);
 
         var httpContext = new DefaultHttpContext();
         httpContext.Items["TenantContext"] = tenantContext;

--- a/tests/Unit/Nocturne.API.Tests/Services/Identity/HubTokenAuthorizerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Identity/HubTokenAuthorizerTests.cs
@@ -1,19 +1,31 @@
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using Nocturne.API.Hubs;
+using Nocturne.API.Middleware.Handlers;
 using Nocturne.API.Services.Identity;
+using Nocturne.Connectors.Core.Utilities;
 using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Contracts.Identity;
+using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Authorization;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
 using Xunit;
 
 namespace Nocturne.API.Tests.Services.Identity;
 
 /// <summary>
-/// Covers the in-band hub token authorization used by <c>DataHub.Authorize</c>: OAuth JWTs (the
-/// desktop Companion's device-flow tokens) must be validated, tenant-pinned to the connection, and
-/// scope-checked; non-JWT tokens fall back to the legacy opaque access-token lookup.
+/// Covers the in-band hub token authorization used by <c>DataHub.Authorize</c> and
+/// <c>AlarmHub.Subscribe</c>: OAuth JWTs (the desktop Companion's device-flow tokens) must be
+/// validated, tenant-pinned to the connection, and scope-checked; legacy opaque tokens are pinned to
+/// the connection's tenant by an explicit membership row and scoped by that membership;
+/// <c>noc_</c> direct grants are read out of a real <c>oauth_grants</c> store, so the tenant the
+/// lookup is pinned to is what decides them.
 /// </summary>
 [Trait("Category", "Unit")]
 public class HubTokenAuthorizerTests
@@ -21,32 +33,51 @@ public class HubTokenAuthorizerTests
     // Segment content is irrelevant — the authorizer only counts dots to route to the JWT path.
     private const string JwtShapedToken = "eyJhbGciOi.eyJzdWIiOi.c2ln";
     private const string LegacyToken = "subject-abc123def456";
+    private const string ExchangedJwt = "exchanged.jwt.token";
+    private const string DirectGrantToken = "noc_abc123def456";
 
     private static readonly Guid Tenant = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
     private static readonly Guid OtherTenant = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static readonly Guid JwtSubject = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
 
     private readonly Mock<IJwtService> _jwtService = new();
     private readonly Mock<IOAuthTokenRevocationCache> _revocationCache = new();
     private readonly Mock<IOAuthGrantService> _grantService = new();
     private readonly Mock<IAuthorizationService> _authorizationService = new();
+    private readonly Mock<ITenantMemberService> _memberService = new();
+    private readonly IDbContextFactory<NocturneDbContext> _dbContextFactory =
+        new ServiceCollection()
+            .AddDbContextFactory<NocturneDbContext>(options =>
+                options.UseInMemoryDatabase($"HubTokenAuthorizer_{Guid.NewGuid()}"))
+            .BuildServiceProvider()
+            .GetRequiredService<IDbContextFactory<NocturneDbContext>>();
 
-    private HubTokenAuthorizer CreateAuthorizer() => new(
+    private HubTokenAuthorizer CreateAuthorizer(IConfiguration? configuration = null) => new(
         _jwtService.Object,
         _revocationCache.Object,
         _grantService.Object,
         _authorizationService.Object,
+        _memberService.Object,
+        _dbContextFactory,
+        configuration ?? new ConfigurationBuilder().Build(),
         NullLogger<HubTokenAuthorizer>.Instance);
 
+    /// <summary>
+    /// A valid JWT for <see cref="JwtSubject"/>, who is seeded as a superuser member of
+    /// <see cref="Tenant"/>. Membership is the ceiling the token's scopes are intersected against, so
+    /// it is seeded wide here and re-seeded narrower only by the tests about that intersection.
+    /// </summary>
     private void SetupValidJwt(Guid? tenantId, params string[] scopes) =>
         SetupValidJwt(tenantId, grantId: null, scopes);
 
     private void SetupValidJwt(Guid? tenantId, Guid? grantId, params string[] scopes)
     {
+        SeedMember(Tenant, JwtSubject, TenantPermissions.Superuser);
         _jwtService
             .Setup(s => s.ValidateAccessToken(JwtShapedToken))
             .Returns(JwtValidationResult.Success(new JwtClaims
             {
-                SubjectId = Guid.NewGuid(),
+                SubjectId = JwtSubject,
                 TenantId = tenantId,
                 GrantId = grantId,
                 Scopes = [.. scopes],
@@ -59,16 +90,77 @@ public class HubTokenAuthorizerTests
             .ReturnsAsync(false);
     }
 
+    /// <summary>
+    /// Stubs the legacy subject-token exchange and the validation of the JWT it mints. That exchange
+    /// resolves a subject, so the JWT it returns carries permissions and no tenant pin.
+    /// </summary>
+    private void SetupExchangedToken(Guid subjectId, params string[] permissions)
+    {
+        _authorizationService
+            .Setup(s => s.GenerateJwtFromAccessTokenAsync(LegacyToken))
+            .ReturnsAsync(new AuthorizationResponse { Token = ExchangedJwt });
+        _jwtService
+            .Setup(s => s.ValidateAccessToken(ExchangedJwt))
+            .Returns(JwtValidationResult.Success(new JwtClaims
+            {
+                SubjectId = subjectId,
+                TenantId = null,
+                Scopes = [],
+                Permissions = [.. permissions],
+                IssuedAt = DateTimeOffset.UtcNow,
+                ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+            }));
+    }
+
+    /// <summary>Makes <paramref name="subjectId"/> a member of <paramref name="tenantId"/> only.</summary>
+    private void SeedMember(Guid tenantId, Guid subjectId, params string[] rolePermissions)
+    {
+        _memberService
+            .Setup(m => m.GetEffectivePermissionsAsync(
+                subjectId, It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid _, Guid queriedTenant, CancellationToken _) =>
+                queriedTenant == tenantId ? rolePermissions.ToHashSet() : null);
+    }
+
+    /// <summary>
+    /// Writes a <c>noc_</c> direct grant for <see cref="DirectGrantToken"/> into the store, owned by
+    /// <paramref name="tenantId"/>. The authorizer reads it back through its own tenant-pinned
+    /// lookup, so the row's tenant is what the pin is tested against.
+    /// </summary>
+    private async Task<Guid> SeedDirectGrantAsync(
+        Guid tenantId, Guid subjectId, DateTime? revokedAt = null, params string[] scopes)
+    {
+        await using var db = await _dbContextFactory.CreateDbContextAsync();
+        db.TenantId = tenantId;
+
+        var grant = new OAuthGrantEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = tenantId,
+            SubjectId = subjectId,
+            GrantType = OAuthGrantTypes.Direct,
+            TokenHash = DirectGrantTokenHandler.ComputeSha256Hex(DirectGrantToken),
+            Scopes = [.. scopes],
+            RevokedAt = revokedAt,
+        };
+
+        db.OAuthGrants.Add(grant);
+        await db.SaveChangesAsync();
+
+        return grant.Id;
+    }
+
     [Fact]
     public async Task Jwt_pinned_to_connection_tenant_with_required_scope_is_authorized()
     {
         SetupValidJwt(Tenant, OAuthScopes.GlucoseRead, OAuthScopes.DeviceNotify);
         var authorizer = CreateAuthorizer();
 
-        var result = await authorizer.IsTokenAuthorizedAsync(
+        var result = await authorizer.AuthorizeTokenAsync(
             JwtShapedToken, Tenant, OAuthScopes.GlucoseRead);
 
-        result.Should().BeTrue();
+        result.Should().NotBeNull();
+        result!.Kind.Should().Be(HubCredentialKind.Subject);
         // The JWT path must not fall through to the legacy hash lookup.
         _authorizationService.Verify(
             s => s.GenerateJwtFromAccessTokenAsync(It.IsAny<string>()), Times.Never);
@@ -80,10 +172,10 @@ public class HubTokenAuthorizerTests
         SetupValidJwt(OtherTenant, OAuthScopes.GlucoseRead);
         var authorizer = CreateAuthorizer();
 
-        var result = await authorizer.IsTokenAuthorizedAsync(
+        var result = await authorizer.AuthorizeTokenAsync(
             JwtShapedToken, Tenant, OAuthScopes.GlucoseRead);
 
-        result.Should().BeFalse();
+        result.Should().BeNull();
     }
 
     [Fact]
@@ -92,10 +184,10 @@ public class HubTokenAuthorizerTests
         SetupValidJwt(tenantId: null, OAuthScopes.GlucoseRead);
         var authorizer = CreateAuthorizer();
 
-        var result = await authorizer.IsTokenAuthorizedAsync(
+        var result = await authorizer.AuthorizeTokenAsync(
             JwtShapedToken, Tenant, OAuthScopes.GlucoseRead);
 
-        result.Should().BeFalse();
+        result.Should().BeNull();
     }
 
     [Fact]
@@ -104,10 +196,10 @@ public class HubTokenAuthorizerTests
         SetupValidJwt(Tenant, OAuthScopes.TherapyRead);
         var authorizer = CreateAuthorizer();
 
-        var result = await authorizer.IsTokenAuthorizedAsync(
+        var result = await authorizer.AuthorizeTokenAsync(
             JwtShapedToken, Tenant, OAuthScopes.GlucoseRead);
 
-        result.Should().BeFalse();
+        result.Should().BeNull();
     }
 
     [Fact]
@@ -120,10 +212,10 @@ public class HubTokenAuthorizerTests
             .ReturnsAsync(true);
         var authorizer = CreateAuthorizer();
 
-        var result = await authorizer.IsTokenAuthorizedAsync(
+        var result = await authorizer.AuthorizeTokenAsync(
             JwtShapedToken, Tenant, OAuthScopes.GlucoseRead);
 
-        result.Should().BeFalse();
+        result.Should().BeNull();
     }
 
     [Fact]
@@ -132,10 +224,10 @@ public class HubTokenAuthorizerTests
         SetupValidJwt(Tenant, OAuthScopes.GlucoseReadWrite);
         var authorizer = CreateAuthorizer();
 
-        var result = await authorizer.IsTokenAuthorizedAsync(
+        var result = await authorizer.AuthorizeTokenAsync(
             JwtShapedToken, Tenant, OAuthScopes.GlucoseRead);
 
-        result.Should().BeTrue();
+        result.Should().NotBeNull();
     }
 
     [Fact]
@@ -145,10 +237,10 @@ public class HubTokenAuthorizerTests
         _revocationCache.Setup(c => c.IsRevokedAsync("jti-1")).ReturnsAsync(true);
         var authorizer = CreateAuthorizer();
 
-        var result = await authorizer.IsTokenAuthorizedAsync(
+        var result = await authorizer.AuthorizeTokenAsync(
             JwtShapedToken, Tenant, OAuthScopes.GlucoseRead);
 
-        result.Should().BeFalse();
+        result.Should().BeNull();
     }
 
     [Fact]
@@ -159,12 +251,60 @@ public class HubTokenAuthorizerTests
             .Returns(JwtValidationResult.Failure("bad signature", JwtValidationError.InvalidSignature));
         var authorizer = CreateAuthorizer();
 
-        var result = await authorizer.IsTokenAuthorizedAsync(
+        var result = await authorizer.AuthorizeTokenAsync(
             JwtShapedToken, Tenant, OAuthScopes.GlucoseRead);
 
-        result.Should().BeFalse();
+        result.Should().BeNull();
         _authorizationService.Verify(
             s => s.GenerateJwtFromAccessTokenAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Jwt_carrying_a_scope_the_membership_no_longer_grants_is_rejected()
+    {
+        // A token's scopes are frozen at issue; a membership is not. A member demoted to read-only
+        // must lose alert acknowledgement on the hub the moment the demotion lands, exactly as
+        // MemberScopeMiddleware makes them lose it over HTTP.
+        SetupValidJwt(Tenant, OAuthScopes.AlertsReadWrite);
+        SeedMember(Tenant, JwtSubject, OAuthScopes.GlucoseRead, OAuthScopes.AlertsRead);
+        var authorizer = CreateAuthorizer();
+
+        var result = await authorizer.AuthorizeTokenAsync(
+            JwtShapedToken, Tenant, OAuthScopes.AlertsReadWrite);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Jwt_scopes_are_narrowed_to_what_the_membership_grants()
+    {
+        // The credential is the ceiling in the other direction too: the authorized connection must
+        // not carry a scope the token holds but the membership does not, because the hub freezes
+        // this scope set for the life of the connection.
+        SetupValidJwt(Tenant, OAuthScopes.GlucoseRead, OAuthScopes.TreatmentsRead);
+        SeedMember(Tenant, JwtSubject, OAuthScopes.GlucoseRead);
+        var authorizer = CreateAuthorizer();
+
+        var result = await authorizer.AuthorizeTokenAsync(
+            JwtShapedToken, Tenant, OAuthScopes.GlucoseRead);
+
+        result.Should().NotBeNull();
+        result!.Satisfies(OAuthScopes.TreatmentsRead).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Jwt_for_a_subject_with_no_membership_on_the_connection_tenant_is_rejected()
+    {
+        // AuthenticationMiddleware rejects a membership-less OAuth access token outright over HTTP;
+        // the hub must not be the one plane where it still authorizes.
+        SetupValidJwt(Tenant, OAuthScopes.GlucoseRead);
+        SeedMember(OtherTenant, JwtSubject, OAuthScopes.GlucoseRead);
+        var authorizer = CreateAuthorizer();
+
+        var result = await authorizer.AuthorizeTokenAsync(
+            JwtShapedToken, Tenant, OAuthScopes.GlucoseRead);
+
+        result.Should().BeNull();
     }
 
     [Fact]
@@ -173,25 +313,157 @@ public class HubTokenAuthorizerTests
         SetupValidJwt(Tenant, OAuthScopes.GlucoseRead);
         var authorizer = CreateAuthorizer();
 
-        var result = await authorizer.IsTokenAuthorizedAsync(
+        var result = await authorizer.AuthorizeTokenAsync(
             JwtShapedToken, connectionTenantId: null, OAuthScopes.GlucoseRead);
 
-        result.Should().BeFalse();
+        result.Should().BeNull();
     }
 
     [Fact]
-    public async Task Legacy_opaque_token_uses_hash_lookup()
+    public async Task Legacy_opaque_token_for_a_member_of_the_connection_tenant_is_authorized()
     {
-        _authorizationService
-            .Setup(s => s.GenerateJwtFromAccessTokenAsync(LegacyToken))
-            .ReturnsAsync(new AuthorizationResponse { Token = "jwt" });
+        var subjectId = Guid.CreateVersion7();
+        SetupExchangedToken(subjectId);
+        SeedMember(Tenant, subjectId, OAuthScopes.GlucoseRead);
         var authorizer = CreateAuthorizer();
 
-        var result = await authorizer.IsTokenAuthorizedAsync(
+        var result = await authorizer.AuthorizeTokenAsync(
             LegacyToken, Tenant, OAuthScopes.GlucoseRead);
 
-        result.Should().BeTrue();
-        _jwtService.Verify(s => s.ValidateAccessToken(It.IsAny<string>()), Times.Never);
+        result.Should().NotBeNull();
+        result!.TenantId.Should().Be(Tenant);
+    }
+
+    [Fact]
+    public async Task Legacy_opaque_token_from_another_tenants_member_is_rejected()
+    {
+        // The exchange only proves the token exists. Without the membership check a token minted on
+        // another tenant would authorize this connection's tenant-scoped groups.
+        var subjectId = Guid.CreateVersion7();
+        SetupExchangedToken(subjectId);
+        SeedMember(OtherTenant, subjectId, OAuthScopes.GlucoseRead);
+        var authorizer = CreateAuthorizer();
+
+        var result = await authorizer.AuthorizeTokenAsync(
+            LegacyToken, Tenant, OAuthScopes.GlucoseRead);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Legacy_opaque_token_without_the_required_scope_is_rejected()
+    {
+        var subjectId = Guid.CreateVersion7();
+        SetupExchangedToken(subjectId);
+        // Membership grants only therapy, so the glucose gate is not satisfied.
+        SeedMember(Tenant, subjectId, OAuthScopes.TherapyRead);
+        var authorizer = CreateAuthorizer();
+
+        var result = await authorizer.AuthorizeTokenAsync(
+            LegacyToken, Tenant, OAuthScopes.GlucoseRead);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Direct_grant_token_pinned_to_another_tenant_is_rejected()
+    {
+        // The grant exists and its subject is a member of the connection's tenant; only the grant
+        // row's own tenant differs. The lookup is pinned to the connection's tenant, so it finds
+        // nothing — a hub connection cannot reach another tenant's grant.
+        var subjectId = Guid.CreateVersion7();
+        await SeedDirectGrantAsync(OtherTenant, subjectId, revokedAt: null, OAuthScopes.GlucoseRead);
+        SeedMember(Tenant, subjectId, OAuthScopes.GlucoseRead);
+        var authorizer = CreateAuthorizer();
+
+        var result = await authorizer.AuthorizeTokenAsync(
+            DirectGrantToken, Tenant, OAuthScopes.GlucoseRead);
+
+        result.Should().BeNull();
+        _memberService.Verify(
+            m => m.GetEffectivePermissionsAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        // Direct grants never reach the subject-token exchange, whose grant read is unpinned.
+        _authorizationService.Verify(
+            s => s.GenerateJwtFromAccessTokenAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Direct_grant_token_pinned_to_the_connection_tenant_is_authorized()
+    {
+        var subjectId = Guid.CreateVersion7();
+        await SeedDirectGrantAsync(Tenant, subjectId, revokedAt: null, OAuthScopes.GlucoseRead);
+        SeedMember(Tenant, subjectId, OAuthScopes.GlucoseRead);
+        var authorizer = CreateAuthorizer();
+
+        var result = await authorizer.AuthorizeTokenAsync(
+            DirectGrantToken, Tenant, OAuthScopes.GlucoseRead);
+
+        result.Should().NotBeNull();
+        result!.TenantId.Should().Be(Tenant);
+        result.Kind.Should().Be(HubCredentialKind.Subject);
+        result.SubjectId.Should().Be(subjectId);
+        _authorizationService.Verify(
+            s => s.GenerateJwtFromAccessTokenAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Direct_grant_scopes_are_narrowed_to_what_the_membership_grants()
+    {
+        // A direct grant is a scoped credential, so membership is the other half of the ceiling
+        // exactly as MemberScopeMiddleware applies it to the same credential over HTTP.
+        var subjectId = Guid.CreateVersion7();
+        await SeedDirectGrantAsync(
+            Tenant, subjectId, revokedAt: null, OAuthScopes.GlucoseRead, OAuthScopes.TreatmentsRead);
+        SeedMember(Tenant, subjectId, OAuthScopes.GlucoseRead);
+        var authorizer = CreateAuthorizer();
+
+        var result = await authorizer.AuthorizeTokenAsync(
+            DirectGrantToken, Tenant, OAuthScopes.GlucoseRead);
+
+        result.Should().NotBeNull();
+        result!.Satisfies(OAuthScopes.TreatmentsRead).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Direct_grant_whose_subject_is_not_a_member_is_rejected()
+    {
+        var subjectId = Guid.CreateVersion7();
+        await SeedDirectGrantAsync(Tenant, subjectId, revokedAt: null, OAuthScopes.GlucoseRead);
+        SeedMember(OtherTenant, subjectId, OAuthScopes.GlucoseRead);
+        var authorizer = CreateAuthorizer();
+
+        var result = await authorizer.AuthorizeTokenAsync(
+            DirectGrantToken, Tenant, OAuthScopes.GlucoseRead);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Revoked_direct_grant_is_rejected()
+    {
+        var subjectId = Guid.CreateVersion7();
+        await SeedDirectGrantAsync(
+            Tenant, subjectId, DateTime.UtcNow.AddMinutes(-1), OAuthScopes.GlucoseRead);
+        SeedMember(Tenant, subjectId, OAuthScopes.GlucoseRead);
+        var authorizer = CreateAuthorizer();
+
+        var result = await authorizer.AuthorizeTokenAsync(
+            DirectGrantToken, Tenant, OAuthScopes.GlucoseRead);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Unknown_direct_grant_token_is_rejected()
+    {
+        var authorizer = CreateAuthorizer();
+
+        var result = await authorizer.AuthorizeTokenAsync(
+            DirectGrantToken, Tenant, OAuthScopes.GlucoseRead);
+
+        result.Should().BeNull();
     }
 
     [Fact]
@@ -202,9 +474,35 @@ public class HubTokenAuthorizerTests
             .ReturnsAsync((AuthorizationResponse?)null);
         var authorizer = CreateAuthorizer();
 
-        var result = await authorizer.IsTokenAuthorizedAsync(
+        var result = await authorizer.AuthorizeTokenAsync(
             LegacyToken, Tenant, OAuthScopes.GlucoseRead);
 
-        result.Should().BeFalse();
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Instance_key_is_authorized_only_when_the_hash_matches()
+    {
+        var authorizer = CreateAuthorizer(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["INSTANCE_KEY"] = "s3cret" })
+            .Build());
+
+        var expected = HashUtils.Sha256Hex("s3cret");
+
+        var granted = authorizer.AuthorizeInstanceKey(expected, Tenant);
+        granted.Should().NotBeNull();
+        granted!.Scopes.Should().Contain(OAuthScopes.FullAccess);
+        granted.Kind.Should().Be(HubCredentialKind.Infrastructure);
+
+        authorizer.AuthorizeInstanceKey("deadbeef", Tenant).Should().BeNull();
+        authorizer.AuthorizeInstanceKey(expected, connectionTenantId: null).Should().BeNull();
+    }
+
+    [Fact]
+    public void Instance_key_is_rejected_when_none_is_configured()
+    {
+        var authorizer = CreateAuthorizer();
+
+        authorizer.AuthorizeInstanceKey(HashUtils.Sha256Hex(""), Tenant).Should().BeNull();
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Realtime/RealtimeCategoriesTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Realtime/RealtimeCategoriesTests.cs
@@ -1,4 +1,5 @@
 using Nocturne.API.Services.Realtime;
+using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.API.Tests.Unit.Services.Realtime;
 
@@ -20,5 +21,21 @@ public class RealtimeCategoriesTests
     {
         RealtimeCategories.All.Should().HaveCount(RealtimeCategories.V1.Length + RealtimeCategories.V4.Length);
         RealtimeCategories.All.Should().BeEquivalentTo([.. RealtimeCategories.V1, .. RealtimeCategories.V4]);
+    }
+
+    [Fact]
+    public void EverySubscribableCategory_HasAGoverningScope()
+    {
+        // DataHub.Subscribe joins a category group only when the credential satisfies the scope this
+        // map lists, so a category in All but absent from the map is unsubscribable — the fail-closed
+        // direction, but a silent one. This makes adding a category without classifying it fail here.
+        RealtimeCategories.All.Should().BeSubsetOf(RealtimeCategories.GoverningScopes.Keys);
+    }
+
+    [Fact]
+    public void EveryGoverningScope_IsARealReadScope()
+    {
+        RealtimeCategories.GoverningScopes.Values.Distinct()
+            .Should().BeSubsetOf(OAuthScopes.AllScopes);
     }
 }


### PR DESCRIPTION
The SignalR hubs are internet-facing and reachable on any tenant's host. Hub methods checked nothing beyond the connection, and the filter meant to enforce tenant context had never actually run: SignalR reads `HubOptions.HubFilters`, and the filters were registered only as container singletons.

**Method invocation is now filtered.** A method either marks itself an in-band authentication entry point (`[HubAuthenticationMethod]`) or requires an authorized connection, so a method added with neither is denied rather than exposed. `[HubScope]` states the scope a method needs. `[HubTenantGroup]` must be declared by any method joining a tenant-wide group — a reflection guard walks the IL (including async state machines), so a new undeclared join fails a test instead of shipping.

**Tenant-wide groups are keyed on what the credential *is*, not only what it can read.** A guest link carries `glucose.read`, but the tenant relay carries tracker state, device-action intents and every member's in-app notifications — so a restricted credential is refused the relay outright. Per-subject payloads now go to the subject's own group rather than being fanned across the tenant.

**Credentials resolve against the connection's tenant on every path.** The opaque-token branch previously admitted a token regardless of which tenant minted it. Direct grants are read on a context pinned to the connection's tenant (an unpinned read matches nothing, since the grant table is tenant-scoped) and then intersected with the subject's membership — what the HTTP plane already does for the same credential. A subject with no membership is refused, as over HTTP.

**OAuth bearer tokens are accepted from the `access_token` query parameter on `/hubs` paths only** — the sole place a SignalR client can put a bearer on the WebSocket upgrade. Confining it keeps bearer tokens out of access logs and referrers everywhere else.

Note for reviewers: the alert hub's integration tests authenticated nobody — the `api-secret` they send matched no grant row, so the connections were anonymous and one test was passing for the wrong reason. They now seed the grant they present. (That project is not run by CI.)

Two externally visible changes: `HomeAssistantHub.Subscribe` now requires `alerts.read` and a tenant-belonging credential where it previously required nothing, and `AlarmHub.Subscribe`'s in-band secret comparison moves from SHA-1 to SHA-256 — repairing a path that never matched, since the bridge has always sent SHA-256.

Unit suite 4635 passed, 0 failed. Reviewed adversarially across four rounds; each guard proven non-vacuous by removing it and confirming failure.

https://claude.ai/code/session_01Wk3jH4N16htaBqGod2j7y8
