### PR TITLE
fix(glucose): maintain tenants.last_reading_at at the write chokepoint

### DIFF
--- a/src/API/Nocturne.API/Services/ConnectorPublishing/GlucosePublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/GlucosePublisher.cs
@@ -26,8 +26,6 @@ internal sealed class GlucosePublisher : IGlucosePublisher
     private readonly ISensorGlucoseRepository _sensorGlucoseRepository;
     private readonly IMeterGlucoseRepository _meterGlucoseRepository;
     private readonly IPatientDeviceStamper _patientDeviceStamper;
-    private readonly IDbContextFactory<NocturneDbContext> _contextFactory;
-    private readonly ITenantAccessor _tenantAccessor;
     private readonly ICanonicalAlertEvaluator _alertEvaluator;
     private readonly IAuditContext _auditContext;
     private readonly ILogger<GlucosePublisher> _logger;
@@ -37,8 +35,6 @@ internal sealed class GlucosePublisher : IGlucosePublisher
         ISensorGlucoseRepository sensorGlucoseRepository,
         IMeterGlucoseRepository meterGlucoseRepository,
         IPatientDeviceStamper patientDeviceStamper,
-        IDbContextFactory<NocturneDbContext> contextFactory,
-        ITenantAccessor tenantAccessor,
         ICanonicalAlertEvaluator alertEvaluator,
         IAuditContext auditContext,
         ILogger<GlucosePublisher> logger)
@@ -47,8 +43,6 @@ internal sealed class GlucosePublisher : IGlucosePublisher
         _sensorGlucoseRepository = sensorGlucoseRepository ?? throw new ArgumentNullException(nameof(sensorGlucoseRepository));
         _meterGlucoseRepository = meterGlucoseRepository ?? throw new ArgumentNullException(nameof(meterGlucoseRepository));
         _patientDeviceStamper = patientDeviceStamper ?? throw new ArgumentNullException(nameof(patientDeviceStamper));
-        _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
-        _tenantAccessor = tenantAccessor ?? throw new ArgumentNullException(nameof(tenantAccessor));
         _alertEvaluator = alertEvaluator ?? throw new ArgumentNullException(nameof(alertEvaluator));
         _auditContext = auditContext;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -63,7 +57,6 @@ internal sealed class GlucosePublisher : IGlucosePublisher
         {
             var entryList = entries.ToList();
             await _entryService.CreateEntriesAsync(entryList, origin, cancellationToken);
-            await UpdateLastReadingAtAsync(cancellationToken);
             await _alertEvaluator.EvaluateAsync(cancellationToken);
             return true;
         }
@@ -88,7 +81,6 @@ internal sealed class GlucosePublisher : IGlucosePublisher
             await _patientDeviceStamper.StampAsync(recordList, [DeviceCategory.CGM], source, cancellationToken);
             using (SystemAuditScope.Push(_auditContext))
                 await _sensorGlucoseRepository.BulkCreateAsync(recordList, origin, cancellationToken);
-            await UpdateLastReadingAtAsync(cancellationToken);
             await _alertEvaluator.EvaluateAsync(cancellationToken);
 
             _logger.LogDebug("Published {Count} SensorGlucose records for {Source}", recordList.Count, source);
@@ -127,29 +119,6 @@ internal sealed class GlucosePublisher : IGlucosePublisher
         CancellationToken cancellationToken = default)
     {
         return await _sensorGlucoseRepository.GetLatestTimestampAsync(source, cancellationToken);
-    }
-
-    /// <summary>
-    /// Updates the tenant's LastReadingAt timestamp after successful glucose publish.
-    /// Uses ExecuteUpdateAsync to avoid materializing the tenant entity.
-    /// </summary>
-    private async Task UpdateLastReadingAtAsync(CancellationToken cancellationToken)
-    {
-        try
-        {
-            var tenantId = _tenantAccessor.TenantId;
-            if (tenantId == Guid.Empty) return;
-
-            await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
-            var now = DateTime.UtcNow;
-            await context.Tenants
-                .Where(t => t.Id == tenantId)
-                .ExecuteUpdateAsync(s => s.SetProperty(t => t.LastReadingAt, now), cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to update tenant LastReadingAt timestamp");
-        }
     }
 
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -278,6 +278,14 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
         if (newest == default)
             return;
 
+        // Clamp to wall clock: advance-only means a single future-dated reading (device clock
+        // skew, a double-applied timezone offset) would otherwise pin the column ahead of now
+        // for good — and the staleness/signal-loss evaluators compare "now - LastReadingAt",
+        // so a pinned-future value silently disables the alerts that watch for silence.
+        var now = DateTime.UtcNow;
+        if (newest > now)
+            newest = now;
+
         try
         {
             await using var ctx = await ContextFactory.CreateAsync(ct);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -237,6 +237,7 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
                 var upserted = SensorGlucoseMapper.ToDomainModel(existing);
                 // A single explicit upsert always broadcasts (no material-change gate on the single path).
                 await RaiseBroadcastAsync([], [upserted], [], origin, ct);
+                await AdvanceTenantLastReadingAsync([upserted], ct);
                 return upserted;
             }
         }
@@ -246,7 +247,52 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
         await ctx.SaveChangesAsync(ct);
         var created = SensorGlucoseMapper.ToDomainModel(entity);
         await RaiseBroadcastAsync([created], [], [], origin, ct);
+        await AdvanceTenantLastReadingAsync([created], ct);
         return created;
+    }
+
+    /// <inheritdoc />
+    public override async Task<IEnumerable<SensorGlucose>> BulkCreateAsync(
+        IEnumerable<SensorGlucose> recordsParam, WriteOrigin origin, CancellationToken ct = default)
+    {
+        var written = (await base.BulkCreateAsync(recordsParam, origin, ct)).ToList();
+        await AdvanceTenantLastReadingAsync(written, ct);
+        return written;
+    }
+
+    /// <summary>
+    /// Advances the tenant's LastReadingAt to the newest written reading timestamp (never
+    /// backwards). Maintained here — the one chokepoint every sensor glucose write passes
+    /// through — so uploader POSTs, connector publishes, and imports all keep it current;
+    /// the alert sweep and tenant overview read the column as the cheap "when did CGM data
+    /// last arrive" signal without querying the readings table. Reading time, not ingestion
+    /// time: a backfill of old history must not make a silent sensor look fresh.
+    /// </summary>
+    private async Task AdvanceTenantLastReadingAsync(
+        IReadOnlyCollection<SensorGlucose> written, CancellationToken ct)
+    {
+        if (written.Count == 0)
+            return;
+
+        var newest = written.Max(r => r.Timestamp);
+        if (newest == default)
+            return;
+
+        try
+        {
+            await using var ctx = await ContextFactory.CreateAsync(ct);
+            if (ctx.TenantId == Guid.Empty)
+                return;
+
+            await ctx.Tenants
+                .Where(t => t.Id == ctx.TenantId
+                    && (t.LastReadingAt == null || t.LastReadingAt < newest))
+                .ExecuteUpdateAsync(s => s.SetProperty(t => t.LastReadingAt, newest), ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Failed to advance tenant LastReadingAt");
+        }
     }
 
     /// <inheritdoc />

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/GlucosePublisherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/GlucosePublisherTests.cs
@@ -39,8 +39,6 @@ public class GlucosePublisherTests
             _mockSensorGlucoseRepository.Object,
             _mockMeterGlucoseRepository.Object,
             _mockPatientDeviceStamper.Object,
-            Mock.Of<IDbContextFactory<NocturneDbContext>>(),
-            Mock.Of<ITenantAccessor>(),
             Mock.Of<ICanonicalAlertEvaluator>(),
             Mock.Of<IAuditContext>(),
             NullLogger<GlucosePublisher>.Instance

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SensorGlucoseRepositoryLastReadingTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SensorGlucoseRepositoryLastReadingTests.cs
@@ -1,0 +1,120 @@
+using System.Data.Common;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Infrastructure;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+/// <summary>
+/// Covers the tenant LastReadingAt maintenance in <see cref="SensorGlucoseRepository"/>. The
+/// column is the alert sweep's and tenant overview's cheap "when did CGM data last arrive"
+/// signal, and it used to be written only by the connector publish path — tenants whose glucose
+/// arrived via direct uploader POSTs (Trio, xDrip) kept a NULL forever, reading as "no data
+/// ever" to the staleness evaluators. Maintaining it at the repository chokepoint covers every
+/// write path; advance-only semantics keep a backfill of old history from moving it backwards
+/// or a re-upload from regressing it.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+[Trait("Category", "SensorGlucose")]
+public class SensorGlucoseRepositoryLastReadingTests : IDisposable
+{
+    private static readonly Guid TestTenantId = Guid.Parse("00000000-0000-0000-0000-000000000002");
+    private readonly DbConnection _connection;
+    private readonly NocturneDbContext _context;
+    private readonly SensorGlucoseRepository _repo;
+
+    public SensorGlucoseRepositoryLastReadingTests()
+    {
+        _connection = new SqliteConnection("Filename=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        using (var seedContext = new NocturneDbContext(options))
+        {
+            seedContext.TenantId = TestTenantId;
+            seedContext.Database.EnsureCreated();
+            seedContext.Tenants.Add(new TenantEntity { Id = TestTenantId, Slug = "test" });
+            seedContext.SaveChanges();
+        }
+
+        _context = new NocturneDbContext(options) { TenantId = TestTenantId };
+
+        _repo = new SensorGlucoseRepository(
+            new TestTenantDbContextFactory(_context),
+            new Mock<IDeduplicationService>().Object,
+            new Mock<IAuditContext>().Object,
+            NullLogger<SensorGlucoseRepository>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static SensorGlucose Reading(DateTime timestamp, double mgdl = 120) => new()
+    {
+        Mgdl = mgdl,
+        Timestamp = timestamp,
+        DataSource = "test-source",
+    };
+
+    private DateTime? TenantLastReading()
+    {
+        _context.ChangeTracker.Clear();
+        return _context.Tenants.AsNoTracking().Single(t => t.Id == TestTenantId).LastReadingAt;
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_AdvancesLastReadingAt_ToTheNewestReadingTimestamp()
+    {
+        var newest = new DateTime(2026, 8, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        await _repo.BulkCreateAsync(
+            [Reading(newest.AddMinutes(-10)), Reading(newest), Reading(newest.AddMinutes(-5))],
+            WriteOrigin.Live);
+
+        TenantLastReading().Should().Be(newest);
+    }
+
+    [Fact]
+    public async Task BulkCreateAsync_NeverMovesLastReadingAtBackwards()
+    {
+        // A backfill of old history (or a late-arriving out-of-order batch) must not make a
+        // currently-silent sensor look like it stopped even earlier — or a live one look stale.
+        var current = new DateTime(2026, 8, 1, 12, 0, 0, DateTimeKind.Utc);
+        await _repo.BulkCreateAsync([Reading(current)], WriteOrigin.Live);
+
+        await _repo.BulkCreateAsync(
+            [Reading(current.AddYears(-1)), Reading(current.AddMonths(-6))],
+            WriteOrigin.Backfill);
+
+        TenantLastReading().Should().Be(current);
+    }
+
+    [Fact]
+    public async Task CreateAsync_AdvancesLastReadingAt()
+    {
+        var timestamp = new DateTime(2026, 8, 1, 12, 5, 0, DateTimeKind.Utc);
+
+        await _repo.CreateAsync(Reading(timestamp), WriteOrigin.Live);
+
+        TenantLastReading().Should().Be(timestamp);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SensorGlucoseRepositoryLastReadingTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SensorGlucoseRepositoryLastReadingTests.cs
@@ -117,4 +117,38 @@ public class SensorGlucoseRepositoryLastReadingTests : IDisposable
 
         TenantLastReading().Should().Be(timestamp);
     }
+
+    [Fact]
+    public async Task CreateAsync_SyncIdUpsertOfTheNewestReading_AdvancesLastReadingAt()
+    {
+        // A connector replay of the newest reading is still an arrival.
+        var timestamp = new DateTime(2026, 8, 1, 12, 10, 0, DateTimeKind.Utc);
+        var first = Reading(timestamp);
+        first.SyncIdentifier = "sync-1";
+        await _repo.CreateAsync(first, WriteOrigin.Live);
+        _context.ChangeTracker.Clear();
+
+        var replay = Reading(timestamp);
+        replay.SyncIdentifier = "sync-1";
+        replay.Mgdl = 121;
+        await _repo.CreateAsync(replay, WriteOrigin.Live);
+
+        TenantLastReading().Should().Be(timestamp);
+    }
+
+    [Fact]
+    public async Task FutureDatedReadings_ClampToWallClock()
+    {
+        // Advance-only would let one future-dated reading (device clock skew, a double-applied
+        // timezone offset) pin the column ahead of now for good — silently disabling the
+        // staleness and signal-loss evaluators that compare "now - LastReadingAt".
+        var before = DateTime.UtcNow;
+        await _repo.BulkCreateAsync([Reading(before.AddYears(1))], WriteOrigin.Live);
+        var after = DateTime.UtcNow;
+
+        var lastReading = TenantLastReading();
+        lastReading.Should().NotBeNull();
+        lastReading!.Value.Should().BeOnOrAfter(before).And.BeOnOrBefore(after,
+            "a future reading timestamp must clamp to the wall clock");
+    }
 }


### PR DESCRIPTION
Eight active production tenants have glucose data but `tenants.last_reading_at IS NULL` — because the only writer was `GlucosePublisher` (the connector publish path). Tenants whose glucose arrives via **direct uploader POSTs** (Trio, xDrip, AAPS via v1) never got it set. The column is load-bearing: `AlertSweepService` uses it as the staleness signal (`LastReadingAt ?? DateTime.MinValue`), so these tenants permanently read as "no data ever" to the sweep, and `TenantOverviewService` shows their glucose status from the same column.

## Change

- The update moves into `SensorGlucoseRepository` (`CreateAsync` + a `BulkCreateAsync` override) — the one chokepoint every sensor glucose write passes through: uploader POSTs (via the entry decomposer), connector publishes, and imports. The publisher's private copy is deleted along with its now-unneeded `IDbContextFactory`/`ITenantAccessor` dependencies.
- Semantics tightened from *ingestion wall-clock* to *newest reading timestamp, advance-only* (`WHERE last_reading_at IS NULL OR last_reading_at < newest`). Rationale: the canonical alert evaluator already derives recency from `latest.Timestamp`, and the old behavior let a backfill of years-old history stamp `now` — making a silent sensor look fresh and suppressing real staleness alerts during imports. Meter-only (fingerstick) publishes no longer bump it; CGM staleness is what the readers measure.
- Failure to advance is logged, never thrown — the reading write matters more than the recency column.

## Healing

No data migration: affected tenants self-heal on their next reading (minutes, for the live-uploader tenants). Tenants with no active source keep NULL, which is the honest value.

## Tests

New `SensorGlucoseRepositoryLastReadingTests` (SQLite harness): bulk create advances to the newest timestamp of the batch, backfill/out-of-order batches never move it backwards, single create advances. Full API suite 4548 passed, infra suite 484 passed.

https://claude.ai/code/session_01L2UR4WFuTactp8EEf6NcWr
