### PR TITLE
feat(nightscout): persist a backfill low-water mark and resume below it

### DIFF
--- a/src/API/Nocturne.API/Services/ConnectorPublishing/MetadataPublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/MetadataPublisher.cs
@@ -301,6 +301,14 @@ internal sealed class MetadataPublisher : IMetadataPublisher
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// The update is a single jsonb-path statement on PostgreSQL so concurrent writers to
+    /// DIFFERENT collections on the same row (a manual sync or cursor-reset job racing the
+    /// background sync) can't clobber each other's keys — a read-modify-write of the whole map
+    /// could drop a mark, and a dropped mark is stranded history, the exact failure marks exist
+    /// to prevent. Same-key races stay last-writer-wins: any surviving mark is a valid resume
+    /// point because the resume crawl is unbounded below it.
+    /// </remarks>
     public async Task SetBackfillLowWaterMarkAsync(
         string source,
         string collection,
@@ -316,6 +324,37 @@ internal sealed class MetadataPublisher : IMetadataPublisher
             return;
         }
 
+        if (_db.Database.IsNpgsql())
+        {
+            if (lowWaterMark is null)
+            {
+                await _db.Database.ExecuteSqlAsync(
+                    $"""
+                     UPDATE connector_configurations
+                     SET backfill_low_water_marks =
+                         NULLIF(coalesce(backfill_low_water_marks, jsonb_build_object()) - {collection}, jsonb_build_object())
+                     WHERE id = {config.Id}
+                     """,
+                    cancellationToken);
+            }
+            else
+            {
+                // Serialized as an ISO-8601 UTC string ("...Z"), matching what
+                // System.Text.Json writes so Get round-trips without a timezone shift.
+                var value = lowWaterMark.Value.ToString("O");
+                await _db.Database.ExecuteSqlAsync(
+                    $"""
+                     UPDATE connector_configurations
+                     SET backfill_low_water_marks =
+                         jsonb_set(coalesce(backfill_low_water_marks, jsonb_build_object()), ARRAY[{collection}], to_jsonb({value}::text))
+                     WHERE id = {config.Id}
+                     """,
+                    cancellationToken);
+            }
+            return;
+        }
+
+        // Non-relational providers (tests): plain read-modify-write on the tracked entity.
         var marks = config.BackfillLowWaterMarks is null
             ? []
             : JsonSerializer.Deserialize<Dictionary<string, DateTime>>(config.BackfillLowWaterMarks) ?? new Dictionary<string, DateTime>();
@@ -333,7 +372,8 @@ internal sealed class MetadataPublisher : IMetadataPublisher
     /// Resolves the connector configuration row for a connector data source. Sources follow the
     /// <c>{connector-name}-connector</c> convention (<c>nightscout-connector</c>) while
     /// configuration rows carry the bare connector name, so the suffix is stripped for the
-    /// lookup, with an exact match as fallback.
+    /// lookup, with an exact match as fallback. Reads without tracking — marks are written via
+    /// jsonb-path updates, and a stale tracked snapshot must never flow back into the row.
     /// </summary>
     private async Task<ConnectorConfigurationEntity?> FindConnectorConfigurationAsync(
         string source,
@@ -344,7 +384,11 @@ internal sealed class MetadataPublisher : IMetadataPublisher
             ? source[..^suffix.Length]
             : source;
 
-        return await _db.ConnectorConfigurations
+        var query = _db.Database.IsNpgsql()
+            ? _db.ConnectorConfigurations.AsNoTracking()
+            : _db.ConnectorConfigurations;
+
+        return await query
             .FirstOrDefaultAsync(
                 c => c.ConnectorName.ToLower() == name.ToLower()
                     || c.ConnectorName.ToLower() == source.ToLower(),

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/MetadataPublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/MetadataPublisher.cs
@@ -1,4 +1,8 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
 using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Core.Contracts.Health;
 using Nocturne.Core.Contracts.Connectors;
 using Nocturne.Core.Contracts.Identity;
@@ -30,6 +34,7 @@ internal sealed class MetadataPublisher : IMetadataPublisher
     private readonly INoteRepository _noteRepository;
     private readonly ITenantOwnerResolver _tenantOwnerResolver;
     private readonly ITenantAccessor _tenantAccessor;
+    private readonly NocturneDbContext _db;
     private readonly ILogger<MetadataPublisher> _logger;
 
     public MetadataPublisher(
@@ -42,6 +47,7 @@ internal sealed class MetadataPublisher : IMetadataPublisher
         INoteRepository noteRepository,
         ITenantOwnerResolver tenantOwnerResolver,
         ITenantAccessor tenantAccessor,
+        NocturneDbContext db,
         ILogger<MetadataPublisher> logger)
     {
         _profileWriteService = profileWriteService ?? throw new ArgumentNullException(nameof(profileWriteService));
@@ -53,6 +59,7 @@ internal sealed class MetadataPublisher : IMetadataPublisher
         _noteRepository = noteRepository ?? throw new ArgumentNullException(nameof(noteRepository));
         _tenantOwnerResolver = tenantOwnerResolver ?? throw new ArgumentNullException(nameof(tenantOwnerResolver));
         _tenantAccessor = tenantAccessor ?? throw new ArgumentNullException(nameof(tenantAccessor));
+        _db = db ?? throw new ArgumentNullException(nameof(db));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -275,5 +282,72 @@ internal sealed class MetadataPublisher : IMetadataPublisher
             return DateTimeOffset.FromUnixTimeMilliseconds(latest.Mills).UtcDateTime;
 
         return null;
+    }
+
+    /// <inheritdoc />
+    public async Task<DateTime?> GetBackfillLowWaterMarkAsync(
+        string source,
+        string collection,
+        CancellationToken cancellationToken = default)
+    {
+        var config = await FindConnectorConfigurationAsync(source, cancellationToken);
+        if (config?.BackfillLowWaterMarks is null)
+            return null;
+
+        var marks = JsonSerializer.Deserialize<Dictionary<string, DateTime>>(config.BackfillLowWaterMarks);
+        return marks is not null && marks.TryGetValue(collection, out var mark)
+            ? DateTime.SpecifyKind(mark, DateTimeKind.Utc)
+            : null;
+    }
+
+    /// <inheritdoc />
+    public async Task SetBackfillLowWaterMarkAsync(
+        string source,
+        string collection,
+        DateTime? lowWaterMark,
+        CancellationToken cancellationToken = default)
+    {
+        var config = await FindConnectorConfigurationAsync(source, cancellationToken);
+        if (config is null)
+        {
+            _logger.LogWarning(
+                "No connector configuration found for {Source}; cannot persist backfill low-water mark",
+                source);
+            return;
+        }
+
+        var marks = config.BackfillLowWaterMarks is null
+            ? []
+            : JsonSerializer.Deserialize<Dictionary<string, DateTime>>(config.BackfillLowWaterMarks) ?? new Dictionary<string, DateTime>();
+
+        if (lowWaterMark is null)
+            marks.Remove(collection);
+        else
+            marks[collection] = lowWaterMark.Value;
+
+        config.BackfillLowWaterMarks = marks.Count == 0 ? null : JsonSerializer.Serialize(marks);
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Resolves the connector configuration row for a connector data source. Sources follow the
+    /// <c>{connector-name}-connector</c> convention (<c>nightscout-connector</c>) while
+    /// configuration rows carry the bare connector name, so the suffix is stripped for the
+    /// lookup, with an exact match as fallback.
+    /// </summary>
+    private async Task<ConnectorConfigurationEntity?> FindConnectorConfigurationAsync(
+        string source,
+        CancellationToken cancellationToken)
+    {
+        const string suffix = "-connector";
+        var name = source.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
+            ? source[..^suffix.Length]
+            : source;
+
+        return await _db.ConnectorConfigurations
+            .FirstOrDefaultAsync(
+                c => c.ConnectorName.ToLower() == name.ToLower()
+                    || c.ConnectorName.ToLower() == source.ToLower(),
+                cancellationToken);
     }
 }

--- a/src/Connectors/Nocturne.Connectors.Core/Interfaces/IMetadataPublisher.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Interfaces/IMetadataPublisher.cs
@@ -62,4 +62,35 @@ public interface IMetadataPublisher
     Task<DateTime?> GetLatestActivityTimestampAsync(
         string source,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reads the persisted backfill low-water mark for one of <paramref name="source"/>'s data
+    /// collections. A mark means an earlier backfill crawl of that collection stopped before
+    /// reaching the source's beginning — history older than the mark may be missing, and the
+    /// connector should resume the crawl below it. <c>null</c> means no incomplete backfill.
+    /// </summary>
+    /// <param name="source">The connector data source (e.g. <c>nightscout-connector</c>).</param>
+    /// <param name="collection">The data collection key (e.g. <c>Glucose</c>, <c>Treatments</c>).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<DateTime?> GetBackfillLowWaterMarkAsync(
+        string source,
+        string collection,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Persists (or clears, with <c>null</c>) the backfill low-water mark for one of
+    /// <paramref name="source"/>'s data collections. Connectors update the mark as each page of
+    /// a newest-first backfill lands, so a crawl killed mid-run (process restart, publish
+    /// failure) can resume from where it stopped instead of stranding the older history below
+    /// the resume cursor forever.
+    /// </summary>
+    /// <param name="source">The connector data source (e.g. <c>nightscout-connector</c>).</param>
+    /// <param name="collection">The data collection key (e.g. <c>Glucose</c>, <c>Treatments</c>).</param>
+    /// <param name="lowWaterMark">The oldest successfully published record time, or <c>null</c> once the crawl reaches the source's beginning.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task SetBackfillLowWaterMarkAsync(
+        string source,
+        string collection,
+        DateTime? lowWaterMark,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -22,6 +22,9 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     protected readonly ILogger _logger;
     private readonly IConnectorPublisher? _publisher;
 
+    /// <summary>The API publisher, or <c>null</c> when running detached (e.g. dry-run tooling).</summary>
+    protected IConnectorPublisher? Publisher => _publisher;
+
     // Broadcast origin for this run's glucose / care (treatment-family) publishes, resolved once from the
     // pre-run resume watermark and memoized so every batch and granular publish in the run agrees — a
     // paginated or multi-call first sync can't flip to Live mid-backfill. The connector service is

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
@@ -200,41 +200,31 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         // Each data type below streams fetch-page → publish-page rather than accumulating
         // the whole range first: a multi-year backfill of a high-volume collection held in
         // one list has taken the process out with OutOfMemory, failing unrelated tenants'
-        // publishes with it. Pages arrive newest first, and the resume cursor is the latest
-        // STORED record, so anything unpublished below an already-published page sits under
-        // the cursor forever — a background catch-up never returns for it. Every page is
-        // therefore still attempted after a publish failure, bounding holes to the failed
-        // pages (the pre-streaming behaviour bounded them to failed batches); only an
-        // explicit ranged re-pull (cursor reset / migration) heals them, so the sync is
-        // reported failed either way.
+        // publishes with it. Pages arrive newest first, so anything a broken crawl never
+        // stored sits BELOW the newest stored record where an ordinary catch-up never
+        // returns; CrawlAndPublishAsync persists a low-water mark as pages land and resumes
+        // below it on the next sync, so a crawl killed by a restart or a failing store
+        // self-heals instead of stranding the older history.
         if (activeTypes.Contains(SyncDataType.Glucose))
         {
             try
             {
-                var count = 0;
-                DateTime? lastTime = null;
-                var publishSuccess = true;
-
-                await foreach (var page in FetchGlucosePagesAsync(request.From, request.To))
-                {
-                    count += page.Length;
-                    var pageMax = page.Max(e => e.Date);
-                    if (lastTime is null || pageMax > lastTime)
-                        lastTime = pageMax;
-
-                    if (!await PublishGlucoseDataInBatchesAsync(page, config, cancellationToken))
-                        publishSuccess = false;
-                }
+                var outcome = await CrawlAndPublishAsync(
+                    "Glucose", request.From, request.To,
+                    FetchGlucosePagesAsync,
+                    newestOf: p => p.Max(e => e.Date),
+                    oldestOf: OldestEntryTime,
+                    publishAsync: p => PublishGlucoseDataInBatchesAsync(p, config, cancellationToken));
 
                 _logger.LogInformation(
                     "[{ConnectorSource}] Retrieved {Count} glucose entries from Nightscout",
                     ConnectorSource,
-                    count);
+                    outcome.Count);
 
-                result.ItemsSynced[SyncDataType.Glucose] = count;
-                if (lastTime.HasValue)
-                    result.LastEntryTimes[SyncDataType.Glucose] = lastTime.Value;
-                if (!publishSuccess)
+                result.ItemsSynced[SyncDataType.Glucose] = outcome.Count;
+                if (outcome.NewestTime.HasValue)
+                    result.LastEntryTimes[SyncDataType.Glucose] = outcome.NewestTime.Value;
+                if (!outcome.Success)
                 {
                     result.Success = false;
                     result.Errors.Add("Glucose publish failed");
@@ -264,40 +254,29 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
                     ? await CalculateTreatmentSinceTimestampAsync(config)
                     : request.From;
 
-                var count = 0;
-                DateTime? lastTime = null;
-                var publishSuccess = true;
-
-                await foreach (var page in FetchTreatmentPagesAsync(treatmentFrom, request.To))
-                {
-                    count += page.Length;
-                    var pageMax = page
-                        .Select(t => DateTime.TryParse(t.CreatedAt, out var dt) ? dt : (DateTime?)null)
-                        .Where(dt => dt.HasValue)
-                        .Max();
-                    if (pageMax.HasValue && (lastTime is null || pageMax > lastTime))
-                        lastTime = pageMax;
-
-                    if (!await PublishTreatmentDataInBatchesAsync(page, config, cancellationToken))
-                        publishSuccess = false;
-                }
+                var outcome = await CrawlAndPublishAsync(
+                    "Treatments", treatmentFrom, request.To,
+                    FetchTreatmentPagesAsync,
+                    newestOf: p => NewestCreatedAt(p, t => t.CreatedAt),
+                    oldestOf: p => OldestCreatedAt(p, t => t.CreatedAt),
+                    publishAsync: p => PublishTreatmentDataInBatchesAsync(p, config, cancellationToken));
 
                 _logger.LogInformation(
                     "[{ConnectorSource}] Retrieved {Count} treatments from Nightscout",
                     ConnectorSource,
-                    count);
+                    outcome.Count);
 
-                if (count > 0)
+                if (outcome.Count > 0)
                 {
                     // Report count under each enabled treatment sub-type
                     foreach (var tt in treatmentTypes.Where(t => activeTypes.Contains(t)))
                     {
-                        result.ItemsSynced[tt] = count;
-                        result.LastEntryTimes[tt] = lastTime;
+                        result.ItemsSynced[tt] = outcome.Count;
+                        result.LastEntryTimes[tt] = outcome.NewestTime;
                     }
                 }
 
-                if (!publishSuccess)
+                if (!outcome.Success)
                 {
                     result.Success = false;
                     result.Errors.Add("Treatments publish failed");
@@ -355,33 +334,22 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
                     ? await CalculateDeviceStatusCatchUpSinceAsync(config) ?? request.From
                     : request.From;
 
-                var count = 0;
-                DateTime? lastTime = null;
-                var publishSuccess = true;
-
-                await foreach (var page in FetchDeviceStatusPagesAsync(deviceStatusFrom, request.To))
-                {
-                    count += page.Length;
-                    var pageMax = page
-                        .Select(d => DateTimeOffset.TryParse(d.CreatedAt, out var dto) ? dto.UtcDateTime : (DateTime?)null)
-                        .Where(dt => dt.HasValue)
-                        .Max();
-                    if (pageMax.HasValue && (lastTime is null || pageMax > lastTime))
-                        lastTime = pageMax;
-
-                    if (!await PublishDeviceStatusAsync(page, config, cancellationToken))
-                        publishSuccess = false;
-                }
+                var outcome = await CrawlAndPublishAsync(
+                    "DeviceStatus", deviceStatusFrom, request.To,
+                    FetchDeviceStatusPagesAsync,
+                    newestOf: p => NewestCreatedAt(p, d => d.CreatedAt),
+                    oldestOf: p => OldestCreatedAt(p, d => d.CreatedAt),
+                    publishAsync: p => PublishDeviceStatusAsync(p, config, cancellationToken));
 
                 _logger.LogInformation(
                     "[{ConnectorSource}] Retrieved {Count} device statuses from Nightscout",
                     ConnectorSource,
-                    count);
+                    outcome.Count);
 
-                result.ItemsSynced[SyncDataType.DeviceStatus] = count;
-                if (lastTime.HasValue)
-                    result.LastEntryTimes[SyncDataType.DeviceStatus] = lastTime;
-                if (!publishSuccess)
+                result.ItemsSynced[SyncDataType.DeviceStatus] = outcome.Count;
+                if (outcome.NewestTime.HasValue)
+                    result.LastEntryTimes[SyncDataType.DeviceStatus] = outcome.NewestTime;
+                if (!outcome.Success)
                 {
                     result.Success = false;
                     result.Errors.Add("DeviceStatus publish failed");
@@ -433,33 +401,22 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
                     ? await CalculateActivityCatchUpSinceAsync(config) ?? request.From
                     : request.From;
 
-                var count = 0;
-                DateTime? lastTime = null;
-                var publishSuccess = true;
-
-                await foreach (var page in FetchActivityPagesAsync(activityFrom, request.To))
-                {
-                    count += page.Length;
-                    var pageMax = page
-                        .Select(a => DateTimeOffset.TryParse(a.CreatedAt, out var dto) ? dto.UtcDateTime : (DateTime?)null)
-                        .Where(dt => dt.HasValue)
-                        .Max();
-                    if (pageMax.HasValue && (lastTime is null || pageMax > lastTime))
-                        lastTime = pageMax;
-
-                    if (!await PublishActivityDataAsync(page, config, cancellationToken))
-                        publishSuccess = false;
-                }
+                var outcome = await CrawlAndPublishAsync(
+                    "Activity", activityFrom, request.To,
+                    FetchActivityPagesAsync,
+                    newestOf: p => NewestCreatedAt(p, a => a.CreatedAt),
+                    oldestOf: p => OldestCreatedAt(p, a => a.CreatedAt),
+                    publishAsync: p => PublishActivityDataAsync(p, config, cancellationToken));
 
                 _logger.LogInformation(
                     "[{ConnectorSource}] Retrieved {Count} activities from Nightscout",
                     ConnectorSource,
-                    count);
+                    outcome.Count);
 
-                result.ItemsSynced[SyncDataType.Activity] = count;
-                if (lastTime.HasValue)
-                    result.LastEntryTimes[SyncDataType.Activity] = lastTime;
-                if (!publishSuccess)
+                result.ItemsSynced[SyncDataType.Activity] = outcome.Count;
+                if (outcome.NewestTime.HasValue)
+                    result.LastEntryTimes[SyncDataType.Activity] = outcome.NewestTime;
+                if (!outcome.Success)
                 {
                     result.Success = false;
                     result.Errors.Add("Activity publish failed");
@@ -493,6 +450,136 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
     private static DateTime? AnchorUnboundedFetch(DateTime? from, DateTime? to) =>
         from is null && to is null ? DateTime.UtcNow : to;
 
+    private sealed record PagedCrawlOutcome(int Count, DateTime? NewestTime, bool Success);
+
+    private Task<DateTime?> GetBackfillLowWaterMarkAsync(string collection) =>
+        Publisher is { IsAvailable: true } p
+            ? p.Metadata.GetBackfillLowWaterMarkAsync(ConnectorSource, collection)
+            : Task.FromResult<DateTime?>(null);
+
+    private Task SetBackfillLowWaterMarkAsync(string collection, DateTime? mark) =>
+        Publisher is { IsAvailable: true } p
+            ? p.Metadata.SetBackfillLowWaterMarkAsync(ConnectorSource, collection, mark)
+            : Task.CompletedTask;
+
+    /// <summary>
+    ///     Crawls a collection newest-first, publishing each page as it lands, then — when an
+    ///     earlier crawl of the collection left a persisted low-water mark — resumes that
+    ///     incomplete backfill below the mark. Pages descend from "now", so anything a killed
+    ///     crawl never reached sits BELOW the newest stored record and an ordinary catch-up
+    ///     never returns for it; the mark is what carries "history below X is still missing"
+    ///     across process restarts and store failures.
+    /// </summary>
+    private async Task<PagedCrawlOutcome> CrawlAndPublishAsync<T>(
+        string collection,
+        DateTime? from,
+        DateTime? to,
+        Func<DateTime?, DateTime?, IAsyncEnumerable<T[]>> pages,
+        Func<T[], DateTime?> newestOf,
+        Func<T[], DateTime?> oldestOf,
+        Func<T[], Task<bool>> publishAsync)
+    {
+        var mark = await GetBackfillLowWaterMarkAsync(collection);
+
+        var primary = await CrawlRangeAsync(
+            collection, from, to, pages, newestOf, oldestOf, publishAsync, fullCrawl: from is null);
+
+        // Resume the incomplete backfill only when this cycle's primary crawl stored cleanly —
+        // a store that is failing right now shouldn't be hammered with the deep history too.
+        // A full primary crawl (open lower bound) already covers everything below the mark.
+        if (mark is null || !primary.Success || from is null)
+            return primary;
+
+        var resume = await CrawlRangeAsync(
+            collection, null, mark.Value.AddMilliseconds(-1),
+            pages, newestOf, oldestOf, publishAsync, fullCrawl: true);
+
+        var newest = primary.NewestTime is null || (resume.NewestTime is not null && resume.NewestTime > primary.NewestTime)
+            ? resume.NewestTime
+            : primary.NewestTime;
+        return new PagedCrawlOutcome(primary.Count + resume.Count, newest, resume.Success);
+    }
+
+    /// <summary>
+    ///     One newest-first crawl over a range. A page publish failure stops the crawl (pages
+    ///     below a gap would strand it above the resume point) and records the low-water mark
+    ///     so the next sync resumes there. Full crawls (open lower bound) also advance the mark
+    ///     after every published page — crash protection for multi-hour histories — and clear
+    ///     it on reaching the source's beginning; bounded catch-up crawls only ever raise it.
+    /// </summary>
+    private async Task<PagedCrawlOutcome> CrawlRangeAsync<T>(
+        string collection,
+        DateTime? from,
+        DateTime? to,
+        Func<DateTime?, DateTime?, IAsyncEnumerable<T[]>> pages,
+        Func<T[], DateTime?> newestOf,
+        Func<T[], DateTime?> oldestOf,
+        Func<T[], Task<bool>> publishAsync,
+        bool fullCrawl)
+    {
+        var count = 0;
+        DateTime? newestSeen = null;
+        DateTime? lowestPublished = null;
+        var success = true;
+
+        try
+        {
+            await foreach (var page in pages(from, to))
+            {
+                count += page.Length;
+                var pageNewest = newestOf(page);
+                if (pageNewest.HasValue && (newestSeen is null || pageNewest > newestSeen))
+                    newestSeen = pageNewest;
+
+                if (!await publishAsync(page))
+                {
+                    success = false;
+                    break;
+                }
+
+                var pageOldest = oldestOf(page);
+                if (pageOldest.HasValue)
+                    lowestPublished = pageOldest;
+
+                if (fullCrawl && lowestPublished.HasValue)
+                    await SetBackfillLowWaterMarkAsync(collection, lowestPublished);
+            }
+        }
+        catch
+        {
+            // A fetch failure mid-crawl leaves the same gap a publish failure does: record the
+            // resume point for what already published before surfacing the error.
+            await RaiseBackfillLowWaterMarkAsync(collection, lowestPublished);
+            throw;
+        }
+
+        if (success && fullCrawl)
+        {
+            // Reached the source's beginning: the backfill is complete.
+            await SetBackfillLowWaterMarkAsync(collection, null);
+        }
+        else if (!success)
+        {
+            await RaiseBackfillLowWaterMarkAsync(collection, lowestPublished);
+        }
+
+        return new PagedCrawlOutcome(count, newestSeen, success);
+    }
+
+    /// <summary>
+    ///     Raises the collection's low-water mark to <paramref name="candidate"/> — never lowers
+    ///     it: a deeper mark from an earlier failure still describes missing history further down.
+    /// </summary>
+    private async Task RaiseBackfillLowWaterMarkAsync(string collection, DateTime? candidate)
+    {
+        if (!candidate.HasValue)
+            return;
+
+        var existing = await GetBackfillLowWaterMarkAsync(collection);
+        if (existing is null || existing < candidate)
+            await SetBackfillLowWaterMarkAsync(collection, candidate);
+    }
+
     /// <summary>
     ///     Streams a paginated Nightscout collection newest-first, one page per iteration,
     ///     so callers never hold more than a page of a multi-year history in memory. Each
@@ -517,7 +604,14 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         {
             var page = await FetchDataAsync<T[]>(buildUrl(from, currentTo), operationName);
 
-            if (page == null || page.Length == 0)
+            // FetchDataAsync reports failure (retries exhausted, non-retryable HTTP, bad JSON)
+            // as null. That is not the end of the range — treating it as one silently truncated
+            // crawls into "successful" partial syncs, and would wrongly clear a backfill
+            // low-water mark. A genuinely exhausted range answers an empty array.
+            if (page == null)
+                throw new HttpRequestException($"{operationName} fetch failed; see preceding connector logs");
+
+            if (page.Length == 0)
                 yield break;
 
             yield return page;
@@ -566,6 +660,15 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
             .Select(item => DateTimeOffset.TryParse(createdAtOf(item), out var dto) ? dto.UtcDateTime : (DateTime?)null)
             .Where(dt => dt.HasValue)
             .Min();
+    }
+
+    /// <summary>Newest created_at on a page; the counterpart of <see cref="OldestCreatedAt{T}"/>.</summary>
+    private static DateTime? NewestCreatedAt<T>(T[] page, Func<T, string?> createdAtOf)
+    {
+        return page
+            .Select(item => DateTimeOffset.TryParse(createdAtOf(item), out var dto) ? dto.UtcDateTime : (DateTime?)null)
+            .Where(dt => dt.HasValue)
+            .Max();
     }
 
     private async IAsyncEnumerable<Entry[]> FetchGlucosePagesAsync(DateTime? from, DateTime? to)

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
@@ -470,6 +470,16 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
     ///     never returns for it; the mark is what carries "history below X is still missing"
     ///     across process restarts and store failures.
     /// </summary>
+    /// <remarks>
+    ///     The resume crawl is deliberately UNBOUNDED below the mark, and that is load-bearing:
+    ///     the mark's value only decides where re-crawling starts, never where it stops, so a
+    ///     raised or stale mark can only cost redundant (idempotent) re-fetching — every
+    ///     missing region below any surviving mark is eventually reached. Bounding the resume
+    ///     (e.g. stopping at a previous mark, or persisting gap floors) would turn those same
+    ///     states into data loss. The known cost: a failed bounded catch-up leaves a near-now
+    ///     mark whose resume re-crawls the full history for a minutes-wide gap — rare, safe,
+    ///     and preferred over a more fragile gap bookkeeping.
+    /// </remarks>
     private async Task<PagedCrawlOutcome> CrawlAndPublishAsync<T>(
         string collection,
         DateTime? from,

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ConnectorConfigurationEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ConnectorConfigurationEntity.cs
@@ -108,4 +108,14 @@ public class ConnectorConfigurationEntity : ITenantScoped, ISystemTimestamped
     /// </summary>
     [Column("is_healthy")]
     public bool IsHealthy { get; set; } = true;
+
+    /// <summary>
+    /// Per-collection backfill low-water marks, serialized as a JSON map of collection key
+    /// (e.g. "Glucose") to the oldest successfully published record time. A key means an
+    /// earlier backfill crawl of that collection stopped before reaching the source's
+    /// beginning; the connector resumes below the mark on its next sync. Runtime sync state
+    /// like <see cref="LastSuccessfulSync"/> — never part of the user-editable configuration.
+    /// </summary>
+    [Column("backfill_low_water_marks", TypeName = "jsonb")]
+    public string? BackfillLowWaterMarks { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260803035714_BackfillLowWaterMarks.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260803035714_BackfillLowWaterMarks.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260803035714_BackfillLowWaterMarks")]
+    partial class BackfillLowWaterMarks
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260803035714_BackfillLowWaterMarks.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260803035714_BackfillLowWaterMarks.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class BackfillLowWaterMarks : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "backfill_low_water_marks",
+                table: "connector_configurations",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "backfill_low_water_marks",
+                table: "connector_configurations");
+        }
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/MetadataPublisherBackfillMarkTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/MetadataPublisherBackfillMarkTests.cs
@@ -1,0 +1,114 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.ConnectorPublishing;
+using Nocturne.Core.Contracts.Connectors;
+using Nocturne.Core.Contracts.Glucose;
+using Nocturne.Core.Contracts.Health;
+using Nocturne.Core.Contracts.Identity;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Contracts.Profiles;
+using Nocturne.Core.Contracts.Repositories;
+using Nocturne.Core.Contracts.Treatments;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.ConnectorPublishing;
+
+/// <summary>
+/// Covers the real backfill low-water mark persistence in <see cref="MetadataPublisher"/>:
+/// the source→connector-configuration lookup (a <c>nightscout-connector</c> source must find
+/// the <c>nightscout</c> row), the JSON round-trip (no timezone shift), per-collection
+/// independence, remove-on-null, and the missing-configuration no-op.
+/// </summary>
+[Trait("Category", "Unit")]
+public class MetadataPublisherBackfillMarkTests
+{
+    private static readonly Guid TenantId = Guid.CreateVersion7();
+
+    private readonly NocturneDbContext _db;
+    private readonly MetadataPublisher _publisher;
+
+    public MetadataPublisherBackfillMarkTests()
+    {
+        _db = new NocturneDbContext(new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseInMemoryDatabase($"backfill-marks-{Guid.NewGuid():N}").Options)
+        {
+            TenantId = TenantId,
+        };
+
+        // Configuration rows store the bare, lowercased connector name.
+        _db.ConnectorConfigurations.Add(new ConnectorConfigurationEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            ConnectorName = "nightscout",
+        });
+        _db.SaveChanges();
+
+        _publisher = new MetadataPublisher(
+            Mock.Of<IProfileWriteService>(),
+            Mock.Of<IFoodService>(),
+            Mock.Of<IConnectorFoodEntryService>(),
+            Mock.Of<IActivityService>(),
+            Mock.Of<IStateSpanService>(),
+            Mock.Of<ISystemEventRepository>(),
+            Mock.Of<INoteRepository>(),
+            Mock.Of<ITenantOwnerResolver>(),
+            Mock.Of<ITenantAccessor>(),
+            _db,
+            NullLogger<MetadataPublisher>.Instance);
+    }
+
+    [Fact]
+    public async Task Marks_RoundTrip_ThroughTheConnectorSourceName()
+    {
+        var mark = new DateTime(2024, 6, 1, 12, 30, 15, DateTimeKind.Utc);
+
+        await _publisher.SetBackfillLowWaterMarkAsync("nightscout-connector", "Glucose", mark);
+
+        var read = await _publisher.GetBackfillLowWaterMarkAsync("nightscout-connector", "Glucose");
+        read.Should().Be(mark, "the value must round-trip without a timezone shift");
+        read!.Value.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    [Fact]
+    public async Task Marks_AreIndependentPerCollection()
+    {
+        var glucoseMark = new DateTime(2024, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var treatmentsMark = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        await _publisher.SetBackfillLowWaterMarkAsync("nightscout-connector", "Glucose", glucoseMark);
+        await _publisher.SetBackfillLowWaterMarkAsync("nightscout-connector", "Treatments", treatmentsMark);
+        await _publisher.SetBackfillLowWaterMarkAsync("nightscout-connector", "Glucose", null);
+
+        (await _publisher.GetBackfillLowWaterMarkAsync("nightscout-connector", "Glucose")).Should().BeNull();
+        (await _publisher.GetBackfillLowWaterMarkAsync("nightscout-connector", "Treatments")).Should().Be(treatmentsMark);
+    }
+
+    [Fact]
+    public async Task ClearingTheLastMark_EmptiesTheColumn()
+    {
+        await _publisher.SetBackfillLowWaterMarkAsync(
+            "nightscout-connector", "Glucose", new DateTime(2024, 6, 1, 0, 0, 0, DateTimeKind.Utc));
+        await _publisher.SetBackfillLowWaterMarkAsync("nightscout-connector", "Glucose", null);
+
+        _db.ChangeTracker.Clear();
+        _db.ConnectorConfigurations.Single().BackfillLowWaterMarks.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UnknownSource_IsANoOp_NotAThrow()
+    {
+        await _publisher.SetBackfillLowWaterMarkAsync(
+            "dexcom-connector", "Glucose", new DateTime(2024, 6, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        (await _publisher.GetBackfillLowWaterMarkAsync("dexcom-connector", "Glucose")).Should().BeNull();
+        _db.ChangeTracker.Clear();
+        _db.ConnectorConfigurations.Single().BackfillLowWaterMarks.Should().BeNull(
+            "a mark for an unconfigured connector must not land on another connector's row");
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/MetadataPublisherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/MetadataPublisherTests.cs
@@ -1,7 +1,9 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.EntityFrameworkCore;
 using Moq;
+using Nocturne.Infrastructure.Data;
 using Nocturne.API.Services.ConnectorPublishing;
 using Nocturne.Core.Contracts.Health;
 using Nocturne.Core.Contracts.Connectors;
@@ -66,6 +68,8 @@ public class MetadataPublisherTests
             _mockNoteRepository.Object,
             _mockTenantOwnerResolver.Object,
             _mockTenantAccessor.Object,
+            new NocturneDbContext(new DbContextOptionsBuilder<NocturneDbContext>()
+                .UseInMemoryDatabase($"metadata-publisher-{Guid.NewGuid():N}").Options),
             NullLogger<MetadataPublisher>.Instance
         );
     }

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutBackfillResumeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutBackfillResumeTests.cs
@@ -35,13 +35,15 @@ public class NightscoutBackfillResumeTests
 
         public Mock<IMetadataPublisher> BuildMetadataMock()
         {
+            // Bound to the exact connector source: a wrong source string must read as "no
+            // mark store" in these tests, not silently work.
             var mock = new Mock<IMetadataPublisher>();
             mock.Setup(m => m.GetBackfillLowWaterMarkAsync(
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    "nightscout-connector", It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((string _, string collection, CancellationToken _) =>
                     Marks.TryGetValue(collection, out var mark) ? mark : null);
             mock.Setup(m => m.SetBackfillLowWaterMarkAsync(
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+                    "nightscout-connector", It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
                 .Returns((string _, string collection, DateTime? mark, CancellationToken _) =>
                 {
                     if (mark is null) Marks.Remove(collection);
@@ -112,7 +114,7 @@ public class NightscoutBackfillResumeTests
         DataTypes = [SyncDataType.Glucose],
     };
 
-    private NightscoutConnectorConfiguration Config(NightscoutConnectorService service) => new()
+    private static NightscoutConnectorConfiguration Config() => new()
     {
         Url = "https://nightscout.example.com",
         ApiSecret = "test-secret",
@@ -140,7 +142,7 @@ public class NightscoutBackfillResumeTests
             .ReturnsAsync(() => ++calls == 1);
 
         var result = await service.SyncDataAsync(
-            GlucoseRequest(from: null, to: BaseTime.UtcDateTime), Config(service), CancellationToken.None);
+            GlucoseRequest(from: null, to: BaseTime.UtcDateTime), Config(), CancellationToken.None);
 
         result.Success.Should().BeFalse();
         marks.Marks.Should().ContainKey("Glucose")
@@ -167,7 +169,7 @@ public class NightscoutBackfillResumeTests
         }
 
         var result = await service.SyncDataAsync(
-            GlucoseRequest(from: null, to: BaseTime.UtcDateTime), Config(service), CancellationToken.None);
+            GlucoseRequest(from: null, to: BaseTime.UtcDateTime), Config(), CancellationToken.None);
 
         // Regression: a fetch failure used to read as a clean end-of-range — a "successful"
         // partial sync that would have wrongly cleared the mark.
@@ -185,7 +187,7 @@ public class NightscoutBackfillResumeTests
         handler.Enqueue(JsonResponse(CreateEntries(3, BaseTime))); // short page = source's beginning
 
         var result = await service.SyncDataAsync(
-            GlucoseRequest(from: null, to: BaseTime.UtcDateTime), Config(service), CancellationToken.None);
+            GlucoseRequest(from: null, to: BaseTime.UtcDateTime), Config(), CancellationToken.None);
 
         result.Success.Should().BeTrue();
         marks.Marks.Should().NotContainKey("Glucose", "the crawl reached the source's beginning");
@@ -204,7 +206,7 @@ public class NightscoutBackfillResumeTests
 
         var result = await service.SyncDataAsync(
             GlucoseRequest(from: BaseTime.UtcDateTime.AddHours(-1), to: BaseTime.UtcDateTime),
-            Config(service), CancellationToken.None);
+            Config(), CancellationToken.None);
 
         result.Success.Should().BeTrue();
 
@@ -221,6 +223,62 @@ public class NightscoutBackfillResumeTests
     }
 
     [Fact]
+    public async Task FailedPrimaryCrawl_SkipsTheResume_AndPreservesTheMark()
+    {
+        // A store that is failing right now must not be hammered with the deep history too;
+        // the mark survives untouched for the next healthy cycle.
+        var (service, handler, marks, glucose) = CreateService();
+        var mark = BaseTime.UtcDateTime.AddDays(-10);
+        marks.Marks["Glucose"] = mark;
+
+        handler.Enqueue(JsonResponse(Array.Empty<Entry>())); // auth check
+        handler.Enqueue(JsonResponse(CreateEntries(2, BaseTime))); // catch-up page
+
+        glucose.Setup(p => p.PublishEntriesAsync(
+                It.IsAny<IEnumerable<Entry>>(), It.IsAny<string>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await service.SyncDataAsync(
+            GlucoseRequest(from: BaseTime.UtcDateTime.AddHours(-1), to: BaseTime.UtcDateTime),
+            Config(), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        handler.RequestUrls.Count(u => u.Contains($"count={MaxCount}")).Should().Be(1,
+            "no resume crawl may run while the store is failing");
+        marks.Marks["Glucose"].Should().Be(mark);
+    }
+
+    [Fact]
+    public async Task BoundedCrawlFailure_NeverLowersADeeperMark()
+    {
+        // An admin re-pull of an old window failing must not pull an existing higher mark
+        // down: the higher mark's unbounded resume already covers everything below it.
+        var (service, handler, marks, glucose) = CreateService();
+        var highMark = BaseTime.UtcDateTime;
+        marks.Marks["Glucose"] = highMark;
+
+        var windowTop = new DateTimeOffset(BaseTime.UtcDateTime.AddDays(-50));
+        var page1 = CreateEntries(MaxCount, windowTop);
+        var page2 = CreateEntries(MaxCount, DateTimeOffset.FromUnixTimeMilliseconds(page1.Min(e => e.Mills)).AddMilliseconds(-1));
+
+        handler.Enqueue(JsonResponse(Array.Empty<Entry>())); // auth check
+        handler.Enqueue(JsonResponse(page1));
+        handler.Enqueue(JsonResponse(page2));
+
+        var calls = 0;
+        glucose.Setup(p => p.PublishEntriesAsync(
+                It.IsAny<IEnumerable<Entry>>(), It.IsAny<string>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => ++calls == 1); // page 1 stores, page 2 fails
+
+        var result = await service.SyncDataAsync(
+            GlucoseRequest(from: windowTop.UtcDateTime.AddDays(-10), to: windowTop.UtcDateTime),
+            Config(), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        marks.Marks["Glucose"].Should().Be(highMark);
+    }
+
+    [Fact]
     public async Task NoMark_MeansNoResumeCrawl()
     {
         var (service, handler, marks, _) = CreateService();
@@ -230,7 +288,7 @@ public class NightscoutBackfillResumeTests
 
         var result = await service.SyncDataAsync(
             GlucoseRequest(from: BaseTime.UtcDateTime.AddHours(-1), to: BaseTime.UtcDateTime),
-            Config(service), CancellationToken.None);
+            Config(), CancellationToken.None);
 
         result.Success.Should().BeTrue();
         handler.RequestUrls.Count(u => u.Contains($"count={MaxCount}")).Should().Be(1);

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutBackfillResumeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutBackfillResumeTests.cs
@@ -1,0 +1,239 @@
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.Nightscout.Configurations;
+using Nocturne.Connectors.Nightscout.Services;
+using Nocturne.Core.Models;
+using Xunit;
+using Nocturne.Core.Contracts.V4;
+
+namespace Nocturne.API.Tests.Services.Connectors;
+
+/// <summary>
+/// Covers the persisted backfill low-water mark: pages stream newest-first, so a crawl killed
+/// mid-run (publish failure, fetch failure, process restart) used to strand everything older
+/// than its last published page below the resume cursor forever. The mark carries "history
+/// below X is still missing" across syncs; the next sync resumes the crawl below it and clears
+/// it on reaching the source's beginning.
+/// </summary>
+public class NightscoutBackfillResumeTests
+{
+    private const int MaxCount = 10;
+
+    private static readonly DateTimeOffset BaseTime =
+        new(2025, 6, 15, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>In-memory stand-in for the persisted marks on connector_configurations.</summary>
+    private sealed class FakeMarkStore
+    {
+        public readonly Dictionary<string, DateTime> Marks = [];
+
+        public Mock<IMetadataPublisher> BuildMetadataMock()
+        {
+            var mock = new Mock<IMetadataPublisher>();
+            mock.Setup(m => m.GetBackfillLowWaterMarkAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string _, string collection, CancellationToken _) =>
+                    Marks.TryGetValue(collection, out var mark) ? mark : null);
+            mock.Setup(m => m.SetBackfillLowWaterMarkAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+                .Returns((string _, string collection, DateTime? mark, CancellationToken _) =>
+                {
+                    if (mark is null) Marks.Remove(collection);
+                    else Marks[collection] = mark.Value;
+                    return Task.CompletedTask;
+                });
+            return mock;
+        }
+    }
+
+    private static Entry[] CreateEntries(int count, DateTimeOffset startTime) =>
+        Enumerable.Range(0, count)
+            .Select(i => new Entry
+            {
+                Mills = startTime.AddMinutes(-5 * i).ToUnixTimeMilliseconds(),
+                Sgv = 100 + i,
+                Type = "sgv",
+            })
+            .ToArray();
+
+    private static HttpResponseMessage JsonResponse<T>(T data) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                JsonSerializer.Serialize(data), System.Text.Encoding.UTF8, "application/json"),
+        };
+
+    private static (NightscoutConnectorService Service, SequentialMockHandler Handler, FakeMarkStore Marks, Mock<IGlucosePublisher> Glucose)
+        CreateService(bool publishSucceeds = true)
+    {
+        var config = new NightscoutConnectorConfiguration
+        {
+            Url = "https://nightscout.example.com",
+            ApiSecret = "test-secret",
+            MaxCount = MaxCount,
+            BatchSize = MaxCount, // one publish call per page
+        };
+
+        var handler = new SequentialMockHandler();
+        var marks = new FakeMarkStore();
+
+        var glucoseMock = new Mock<IGlucosePublisher>();
+        glucoseMock.Setup(p => p.PublishEntriesAsync(
+                It.IsAny<IEnumerable<Entry>>(), It.IsAny<string>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(publishSucceeds);
+
+        var publisherMock = new Mock<IConnectorPublisher>();
+        publisherMock.Setup(p => p.IsAvailable).Returns(true);
+        publisherMock.Setup(p => p.Glucose).Returns(glucoseMock.Object);
+        publisherMock.Setup(p => p.Metadata).Returns(marks.BuildMetadataMock().Object);
+
+        var service = new NightscoutConnectorService(
+            new HttpClient(handler) { BaseAddress = new Uri(config.Url) },
+            new ConnectorServerResolver<NightscoutConnectorConfiguration>(null, null, null),
+            Mock.Of<ILogger<NightscoutConnectorService>>(),
+            Mock.Of<IRetryDelayStrategy>(),
+            Mock.Of<IRateLimitingStrategy>(),
+            new ConnectorRegistration<NightscoutConnectorConfiguration>(config, "Nightscout"),
+            publisherMock.Object);
+
+        return (service, handler, marks, glucoseMock);
+    }
+
+    private static Nocturne.Connectors.Core.Models.SyncRequest GlucoseRequest(DateTime? from, DateTime? to) => new()
+    {
+        From = from,
+        To = to,
+        DataTypes = [SyncDataType.Glucose],
+    };
+
+    private NightscoutConnectorConfiguration Config(NightscoutConnectorService service) => new()
+    {
+        Url = "https://nightscout.example.com",
+        ApiSecret = "test-secret",
+        MaxCount = MaxCount,
+        BatchSize = MaxCount,
+    };
+
+    [Fact]
+    public async Task PublishFailure_RecordsTheMark_AtTheBottomOfTheLastPublishedPage()
+    {
+        var (service, handler, marks, glucose) = CreateService();
+
+        var page1 = CreateEntries(MaxCount, BaseTime);
+        var page1Bottom = DateTimeOffset.FromUnixTimeMilliseconds(page1.Min(e => e.Mills)).UtcDateTime;
+        var page2 = CreateEntries(MaxCount, DateTimeOffset.FromUnixTimeMilliseconds(page1.Min(e => e.Mills)).AddMilliseconds(-1));
+
+        handler.Enqueue(JsonResponse(Array.Empty<Entry>())); // auth check
+        handler.Enqueue(JsonResponse(page1));
+        handler.Enqueue(JsonResponse(page2));
+
+        // Page 1 publishes, page 2 fails.
+        var calls = 0;
+        glucose.Setup(p => p.PublishEntriesAsync(
+                It.IsAny<IEnumerable<Entry>>(), It.IsAny<string>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => ++calls == 1);
+
+        var result = await service.SyncDataAsync(
+            GlucoseRequest(from: null, to: BaseTime.UtcDateTime), Config(service), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        marks.Marks.Should().ContainKey("Glucose")
+            .WhoseValue.Should().Be(page1Bottom, "the gap starts below the last page that stored");
+    }
+
+    [Fact]
+    public async Task FetchFailure_MidCrawl_RecordsTheMark_AndFailsTheSync()
+    {
+        var (service, handler, marks, _) = CreateService();
+
+        var page1 = CreateEntries(MaxCount, BaseTime);
+        var page1Bottom = DateTimeOffset.FromUnixTimeMilliseconds(page1.Min(e => e.Mills)).UtcDateTime;
+
+        handler.Enqueue(JsonResponse(Array.Empty<Entry>())); // auth check
+        handler.Enqueue(JsonResponse(page1));
+        // Enough failures to exhaust every retry attempt for the second page.
+        for (var i = 0; i < 6; i++)
+        {
+            handler.Enqueue(new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            {
+                Content = new StringContent("boom"),
+            });
+        }
+
+        var result = await service.SyncDataAsync(
+            GlucoseRequest(from: null, to: BaseTime.UtcDateTime), Config(service), CancellationToken.None);
+
+        // Regression: a fetch failure used to read as a clean end-of-range — a "successful"
+        // partial sync that would have wrongly cleared the mark.
+        result.Success.Should().BeFalse();
+        marks.Marks.Should().ContainKey("Glucose").WhoseValue.Should().Be(page1Bottom);
+    }
+
+    [Fact]
+    public async Task CompletedFullCrawl_ClearsTheMark()
+    {
+        var (service, handler, marks, _) = CreateService();
+        marks.Marks["Glucose"] = BaseTime.UtcDateTime.AddDays(-30); // stale mark from an earlier death
+
+        handler.Enqueue(JsonResponse(Array.Empty<Entry>())); // auth check
+        handler.Enqueue(JsonResponse(CreateEntries(3, BaseTime))); // short page = source's beginning
+
+        var result = await service.SyncDataAsync(
+            GlucoseRequest(from: null, to: BaseTime.UtcDateTime), Config(service), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        marks.Marks.Should().NotContainKey("Glucose", "the crawl reached the source's beginning");
+    }
+
+    [Fact]
+    public async Task ExistingMark_TriggersAResumeCrawlBelowIt_AfterTheCatchUp()
+    {
+        var (service, handler, marks, _) = CreateService();
+        var mark = BaseTime.UtcDateTime.AddDays(-10);
+        marks.Marks["Glucose"] = mark;
+
+        handler.Enqueue(JsonResponse(Array.Empty<Entry>())); // auth check
+        handler.Enqueue(JsonResponse(CreateEntries(2, BaseTime))); // catch-up page (short)
+        handler.Enqueue(JsonResponse(CreateEntries(3, new DateTimeOffset(mark).AddMinutes(-5)))); // resume page (short)
+
+        var result = await service.SyncDataAsync(
+            GlucoseRequest(from: BaseTime.UtcDateTime.AddHours(-1), to: BaseTime.UtcDateTime),
+            Config(service), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+
+        // The second data request is the resume crawl, bounded just below the mark.
+        var dataRequests = handler.RequestUrls.Where(u => u.Contains($"count={MaxCount}")).ToList();
+        dataRequests.Should().HaveCount(2);
+        var expectedLte = new DateTimeOffset(mark).AddMilliseconds(-1).ToUnixTimeMilliseconds();
+        dataRequests[1].Should().Contain($"find[date][$lte]={expectedLte}")
+            .And.NotContain("$gte", "the resume crawl reaches for the source's beginning");
+
+        // Both regions counted; the completed resume clears the mark.
+        result.ItemsSynced[SyncDataType.Glucose].Should().Be(5);
+        marks.Marks.Should().NotContainKey("Glucose");
+    }
+
+    [Fact]
+    public async Task NoMark_MeansNoResumeCrawl()
+    {
+        var (service, handler, marks, _) = CreateService();
+
+        handler.Enqueue(JsonResponse(Array.Empty<Entry>())); // auth check
+        handler.Enqueue(JsonResponse(CreateEntries(2, BaseTime)));
+
+        var result = await service.SyncDataAsync(
+            GlucoseRequest(from: BaseTime.UtcDateTime.AddHours(-1), to: BaseTime.UtcDateTime),
+            Config(service), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        handler.RequestUrls.Count(u => u.Contains($"count={MaxCount}")).Should().Be(1);
+        marks.Marks.Should().BeEmpty();
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutConnectorPaginationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutConnectorPaginationTests.cs
@@ -54,6 +54,7 @@ public class NightscoutConnectorPaginationTests
             mock.Setup(p => p.IsAvailable).Returns(true);
             mock.Setup(p => p.Glucose).Returns(glucoseMock.Object);
             mock.Setup(p => p.Treatments).Returns(treatmentMock.Object);
+            mock.Setup(p => p.Metadata).Returns(Mock.Of<IMetadataPublisher>());
             publisher = mock.Object;
         }
 
@@ -375,12 +376,12 @@ public class NightscoutConnectorPaginationTests
         // Regression: the sync used to fetch the ENTIRE range into one list before
         // publishing anything — a multi-year backfill of a high-volume collection OOMed
         // the process mid-publish. Streaming means each page is published before the next
-        // is fetched, and a failing publish marks the sync failed while every page is
-        // still attempted (holes stay bounded to the failed pages).
+        // is fetched, and a failing publish stops the crawl — the persisted low-water mark
+        // is what carries the un-crawled remainder to the next sync.
         var page1 = CreateEntries(MaxCount, BaseTime);
         var oldestPage1Ms = page1.Min(e => e.Mills);
         var page2Start = DateTimeOffset.FromUnixTimeMilliseconds(oldestPage1Ms).AddMilliseconds(-1);
-        var page2 = CreateEntries(3, page2Start); // short page ends the crawl
+        var page2 = CreateEntries(3, page2Start);
 
         var handler = new SequentialMockHandler();
         handler.Enqueue(JsonResponse(Array.Empty<Entry>())); // auth check
@@ -408,6 +409,7 @@ public class NightscoutConnectorPaginationTests
         var publisherMock = new Mock<IConnectorPublisher>();
         publisherMock.Setup(p => p.IsAvailable).Returns(true);
         publisherMock.Setup(p => p.Glucose).Returns(glucoseMock.Object);
+        publisherMock.Setup(p => p.Metadata).Returns(Mock.Of<IMetadataPublisher>());
 
         var service = new NightscoutConnectorService(
             new HttpClient(handler) { BaseAddress = new Uri(config.Url) },
@@ -429,12 +431,12 @@ public class NightscoutConnectorPaginationTests
 
         result.Success.Should().BeFalse();
         result.Errors.Should().Contain("Glucose publish failed");
-        // Both pages were attempted despite the first publish failing…
-        requestsAtPublish.Should().HaveCount(2);
-        // …and the first page was published before page 2 was fetched (auth + page 1 = 2 requests).
+        // The first page was published before page 2 was fetched (auth + page 1 = 2 requests)…
         requestsAtPublish[0].Should().Be(2,
             "the first page must be published before the next page is fetched");
-        result.ItemsSynced[Nocturne.Connectors.Core.Models.SyncDataType.Glucose].Should().Be(MaxCount + 3);
+        // …and its failure stopped the crawl there.
+        requestsAtPublish.Should().HaveCount(1);
+        handler.RequestUrls.Count(u => u.Contains("entries.json")).Should().Be(2);
     }
 
     [Fact]
@@ -471,31 +473,4 @@ public class NightscoutConnectorPaginationTests
 
     #endregion
 
-    /// <summary>
-    /// Mock handler that returns pre-queued responses in order and records request URLs.
-    /// </summary>
-    private class SequentialMockHandler : HttpMessageHandler
-    {
-        private readonly Queue<HttpResponseMessage> _responses = new();
-
-        public List<string> RequestUrls { get; } = [];
-
-        public void Enqueue(HttpResponseMessage response) =>
-            _responses.Enqueue(response);
-
-        protected override Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request,
-            CancellationToken cancellationToken)
-        {
-            RequestUrls.Add(request.RequestUri?.PathAndQuery ?? "");
-
-            if (_responses.Count == 0)
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = new StringContent("[]", System.Text.Encoding.UTF8, "application/json"),
-                });
-
-            return Task.FromResult(_responses.Dequeue());
-        }
-    }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/SequentialMockHandler.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/SequentialMockHandler.cs
@@ -1,0 +1,32 @@
+using System.Net;
+
+namespace Nocturne.API.Tests.Services.Connectors;
+
+/// <summary>
+/// Mock handler that returns pre-queued responses in order and records request URLs.
+/// An exhausted queue answers an empty JSON array (a cleanly exhausted range).
+/// </summary>
+internal class SequentialMockHandler : HttpMessageHandler
+{
+    private readonly Queue<HttpResponseMessage> _responses = new();
+
+    public List<string> RequestUrls { get; } = [];
+
+    public void Enqueue(HttpResponseMessage response) =>
+        _responses.Enqueue(response);
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        RequestUrls.Add(request.RequestUri?.PathAndQuery ?? "");
+
+        if (_responses.Count == 0)
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("[]", System.Text.Encoding.UTF8, "application/json"),
+            });
+
+        return Task.FromResult(_responses.Dequeue());
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.Tandem.Tests/Services/TandemE2eSyncTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Tandem.Tests/Services/TandemE2eSyncTests.cs
@@ -374,6 +374,10 @@ public class TandemE2eSyncTests
             Task.FromResult(true);
         public Task<DateTime?> GetLatestActivityTimestampAsync(string source, CancellationToken ct = default) =>
             Task.FromResult<DateTime?>(null);
+        public Task<DateTime?> GetBackfillLowWaterMarkAsync(string source, string collection, CancellationToken ct = default) =>
+            Task.FromResult<DateTime?>(null);
+        public Task SetBackfillLowWaterMarkAsync(string source, string collection, DateTime? lowWaterMark, CancellationToken ct = default) =>
+            Task.CompletedTask;
     }
 
     private sealed class Fixture


### PR DESCRIPTION
The resumability follow-up deferred from #626. Pages stream newest-first and every resume cursor derives from the latest *stored* record, so a backfill crawl killed mid-run — publish failure, fetch failure, or a process restart (the redeploy cron restarts the API routinely; it killed a real production backfill twice in one day) — stranded everything older than its last published page below the cursor, permanently invisible to catch-up syncs.

## Mechanism

- **A per-collection low-water mark** persists on `connector_configurations` (new `backfill_low_water_marks` jsonb — runtime sync state alongside `last_successful_sync`, never part of the user-editable configuration, so a config PUT can't clobber it). Connectors reach it through two new `IMetadataPublisher` members; the API-side implementation resolves the config row from the connector source (`nightscout-connector` → `nightscout`).
- **Full crawls (open lower bound) advance the mark after every published page** — crash protection for multi-hour histories — and **clear it on reaching the source's beginning**. The 3.5-hour, 533k-document device-status re-pull we ran yesterday would have resumed instead of restarting from scratch had it been killed.
- **On the next sync, an existing mark triggers a bounded resume crawl** (`…find[date][$lte]=mark−1ms`) after the ordinary catch-up — skipped when the primary crawl already failed, so a failing store isn't hammered with deep history too.
- **A page publish failure stops the crawl again** (reverting #626's attempt-every-page): with resume, stopping is now the correct behavior — older pages are no longer stranded, and holes never scatter (the mark describes one contiguous "missing below X" region). Bounded catch-up crawls only ever *raise* the mark, never lower or clear it (a deeper mark from an earlier failure still describes missing history further down).
- The four per-type sync blocks collapse into one `CrawlAndPublishAsync` helper (count/newest-time/publish/mark logic was 4× duplicated).

## Also fixes: silent truncation on fetch failure

`FetchDataAsync` reports failure (retries exhausted, non-retryable HTTP, bad JSON) as `null`, which the pagination loop treated as a clean end-of-range — a partial sync reported **successful** (flagged as pre-existing in #626's review). The mark machinery would have amplified this into wrongly *clearing* marks. A null page now fails the collection's sync; a genuinely exhausted range answers `[]`. Connector health goes unhealthy and the next cycle retries, instead of quiet data loss.

## Tests

New `NightscoutBackfillResumeTests` (in-memory mark store over the `IMetadataPublisher` seam):
- publish failure records the mark at the bottom of the last published page and stops the crawl
- fetch failure mid-crawl records the mark and fails the sync (regression for the silent-truncation hole)
- a completed full crawl clears a stale mark
- an existing mark triggers exactly one resume crawl bounded just below it, counts both regions, and clears on completion
- no mark → no resume crawl

`SequentialMockHandler` extracted from the pagination tests for reuse. Full `Nocturne.API.Tests`: 4553 passed; Connectors Core 62, Infrastructure.Data 481 passed. EF migration `BackfillLowWaterMarks` adds the column.

## Scope

Nightscout connector only — it is the one connector doing unbounded full-history crawls (`InitialSyncFloor => null`). Other connectors' 6-month floors bound the same failure shape; generalizing the helper into `BaseConnectorService` is a follow-up if it ever bites there.

https://claude.ai/code/session_01L2UR4WFuTactp8EEf6NcWr
