### PR TITLE
fix(alerts): gate the alert surface writes on alerts.readwrite

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertCustomSoundsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertCustomSoundsController.cs
@@ -2,6 +2,8 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Services;
@@ -11,6 +13,12 @@ namespace Nocturne.API.Controllers.V4.Monitoring;
 /// <summary>
 /// Controller for managing custom alert sounds (upload, list, stream, delete).
 /// </summary>
+/// <remarks>
+/// Uploading and deleting require <see cref="OAuthScopes.AlertsReadWrite"/>: the stored audio is
+/// what an alert plays, and an upload writes tenant-scoped caller-supplied bytes. The class-level
+/// <c>[Authorize]</c> alone is satisfied by read-only credentials such as a guest-link session,
+/// which holds <c>alerts.read</c>.
+/// </remarks>
 /// <seealso cref="NocturneDbContext"/>
 [ApiController]
 [Tags("Monitoring")]
@@ -38,6 +46,7 @@ public class AlertCustomSoundsController : ControllerBase
     /// Upload a custom alert sound file.
     /// </summary>
     [HttpPost]
+    [RequireScope(OAuthScopes.AlertsReadWrite)]
     [RemoteCommand(Invalidates = ["GetSounds"])]
     [RequestSizeLimit(512_000)]
     [ProducesResponseType(typeof(AlertCustomSoundResponse), StatusCodes.Status201Created)]
@@ -133,6 +142,7 @@ public class AlertCustomSoundsController : ControllerBase
     /// Delete a custom sound.
     /// </summary>
     [HttpDelete("{id:guid}")]
+    [RequireScope(OAuthScopes.AlertsReadWrite)]
     [RemoteCommand(Invalidates = ["GetSounds"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertInvitesController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertInvitesController.cs
@@ -3,7 +3,9 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
 using Nocturne.API.Extensions;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Services;
@@ -13,6 +15,13 @@ namespace Nocturne.API.Controllers.V4.Monitoring;
 /// <summary>
 /// Controller for managing alert invite links (create, validate, redeem, revoke).
 /// </summary>
+/// <remarks>
+/// An invite attaches a follower to an alert rule channel, so creating, redeeming and revoking one
+/// all change who an alert reaches and require <see cref="OAuthScopes.AlertsReadWrite"/>. The
+/// per-action <c>[Authorize]</c> alone is satisfied by read-only credentials such as a guest-link
+/// session, which holds <c>alerts.read</c>. Validation stays <c>[AllowAnonymous]</c> — the
+/// redemption flow reads it before the invitee has signed in.
+/// </remarks>
 /// <seealso cref="NocturneDbContext"/>
 [ApiController]
 [Tags("Monitoring")]
@@ -40,6 +49,7 @@ public class AlertInvitesController : ControllerBase
     /// </summary>
     [HttpPost]
     [Authorize]
+    [RequireScope(OAuthScopes.AlertsReadWrite)]
     [RemoteCommand]
     [ProducesResponseType(typeof(AlertInviteResponse), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -136,6 +146,7 @@ public class AlertInvitesController : ControllerBase
     /// </summary>
     [HttpPost("{token}/redeem")]
     [Authorize]
+    [RequireScope(OAuthScopes.AlertsReadWrite)]
     [RemoteCommand]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -172,6 +183,7 @@ public class AlertInvitesController : ControllerBase
     /// </summary>
     [HttpDelete("{id:guid}")]
     [Authorize]
+    [RequireScope(OAuthScopes.AlertsReadWrite)]
     [RemoteCommand]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertRulesController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertRulesController.cs
@@ -3,11 +3,13 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
 using Nocturne.API.Services.Alerts;
 using Nocturne.API.Services.Alerts.Evaluators;
 using Nocturne.Core.Contracts.Alerts;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Alerts;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.ClientDevices;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
@@ -22,11 +24,18 @@ namespace Nocturne.API.Controllers.V4.Monitoring;
 /// than as side-channel schedule/step structures.
 /// </summary>
 /// <remarks>
+/// <para>
+/// Every write action requires <see cref="OAuthScopes.AlertsReadWrite"/>: a rule decides whether a
+/// low-glucose alert reaches anyone, and the class-level <c>[Authorize]</c> alone is satisfied by
+/// read-only credentials such as a guest-link session, which holds <c>alerts.read</c>.
+/// </para>
+/// <para>
 /// The runtime evaluation pipeline that operates on these rules is documented in
 /// <c>docs/diagrams/alert-evaluation-pipeline.mmd</c> — the rendered SVG appears under
 /// the Monitoring tag in the Scalar OpenAPI docs (wired via
 /// <c>diagrams.yaml</c>'s <c>tags: [Monitoring]</c> entry and
 /// <see cref="Configuration.TagDescriptionDocumentTransformer"/>).
+/// </para>
 /// </remarks>
 /// <seealso cref="NocturneDbContext"/>
 /// <seealso cref="IAlertReferenceService"/>
@@ -105,6 +114,7 @@ public class AlertRulesController : ControllerBase
     /// Create an alert rule with a flat channel list.
     /// </summary>
     [HttpPost]
+    [RequireScope(OAuthScopes.AlertsReadWrite)]
     [RemoteCommand(Invalidates = ["GetRules"])]
     [ProducesResponseType(typeof(AlertRuleResponse), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -178,6 +188,7 @@ public class AlertRulesController : ControllerBase
     /// Update an alert rule.
     /// </summary>
     [HttpPut("{id:guid}")]
+    [RequireScope(OAuthScopes.AlertsReadWrite)]
     [RemoteCommand(Invalidates = ["GetRules", "GetRule"])]
     [ProducesResponseType(typeof(AlertRuleResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -265,6 +276,7 @@ public class AlertRulesController : ControllerBase
     /// Delete an alert rule (cascades to its channels).
     /// </summary>
     [HttpDelete("{id:guid}")]
+    [RequireScope(OAuthScopes.AlertsReadWrite)]
     [RemoteCommand(Invalidates = ["GetRules"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -308,6 +320,7 @@ public class AlertRulesController : ControllerBase
     /// Toggle an alert rule enabled/disabled.
     /// </summary>
     [HttpPatch("{id:guid}/toggle")]
+    [RequireScope(OAuthScopes.AlertsReadWrite)]
     [RemoteCommand(Invalidates = ["GetRules", "GetRule"])]
     [ProducesResponseType(typeof(AlertRuleResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -335,6 +348,7 @@ public class AlertRulesController : ControllerBase
     /// without polluting the active-alerts surface.
     /// </summary>
     [HttpPost("{id:guid}/test-fire")]
+    [RequireScope(OAuthScopes.AlertsReadWrite)]
     [RemoteCommand]
     [ProducesResponseType(StatusCodes.Status202Accepted)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -365,6 +379,7 @@ public class AlertRulesController : ControllerBase
     /// rule lookup — channels and metadata come straight from the request body.
     /// </summary>
     [HttpPost("test-fire-dry-run")]
+    [RequireScope(OAuthScopes.AlertsReadWrite)]
     [RemoteCommand]
     [ProducesResponseType(StatusCodes.Status202Accepted)]
     public async Task<IActionResult> TestFireDryRun(

--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertsController.cs
@@ -4,9 +4,11 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
 using Nocturne.Core.Contracts.Alerts;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Alerts;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Services;
 
@@ -15,6 +17,13 @@ namespace Nocturne.API.Controllers.V4.Monitoring;
 /// <summary>
 /// Controller for active alert state, history, and acknowledgement.
 /// </summary>
+/// <remarks>
+/// Acknowledging, snoozing and recording a delivery outcome all silence or close an excursion, so
+/// every write action here requires <see cref="OAuthScopes.AlertsReadWrite"/>; the class-level
+/// <c>[Authorize]</c> alone is satisfied by read-only credentials such as a guest-link session,
+/// which holds <c>alerts.read</c>. <see cref="AcknowledgeExcursion"/> additionally accepts
+/// <see cref="OAuthScopes.DeviceNotify"/> — see the note on that action.
+/// </remarks>
 /// <seealso cref="IAlertAcknowledgementService"/>
 /// <seealso cref="IAlertDeliveryService"/>
 [ApiController]
@@ -207,6 +216,7 @@ public class AlertsController : ControllerBase
 
     /// <inheritdoc cref="IAlertAcknowledgementService.AcknowledgeAllAsync"/>
     [HttpPost("acknowledge")]
+    [RequireScope(OAuthScopes.AlertsReadWrite)]
     [RemoteCommand(Invalidates = ["GetActiveAlerts"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<ActionResult> Acknowledge(
@@ -228,8 +238,22 @@ public class AlertsController : ControllerBase
     /// or already closed is a no-op. Returns 404 when the excursion does not
     /// exist for the current tenant.
     /// </summary>
+    /// <remarks>
+    /// Accepts <see cref="OAuthScopes.DeviceNotify"/> as well as
+    /// <see cref="OAuthScopes.AlertsReadWrite"/>: this is the endpoint behind the Acknowledge
+    /// action on a device toast, and a registered client device's grant carries the device
+    /// capability scopes rather than the alert data scope. A scoped credential is intersected with
+    /// membership (<see cref="MemberScopeResolver"/>), so even a tenant owner's Companion token
+    /// resolves to <c>device.notify</c> without <c>alerts.readwrite</c>. A guest link reaches
+    /// neither scope, its grant being capped at <see cref="OAuthScopes.AllowedGuestScopes"/>, but a
+    /// member does: the Clinician and Viewer seed roles hold <c>device.notify</c> outright (and the
+    /// resolver grants it to any member holding at least one permission), so both acknowledge here
+    /// while holding no <c>alerts.readwrite</c> — Clinician holding <c>alerts.read</c>, Viewer no
+    /// alert scope at all.
+    /// </remarks>
     /// <seealso cref="IAlertAcknowledgementService.AcknowledgeExcursionAsync"/>
     [HttpPost("excursions/{excursionId:guid}/acknowledge")]
+    [RequireScope(OAuthScopes.AlertsReadWrite, OAuthScopes.DeviceNotify)]
     [RemoteCommand(Invalidates = ["GetActiveAlerts"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -263,6 +287,7 @@ public class AlertsController : ControllerBase
     /// Snooze an alert instance for the specified duration.
     /// </summary>
     [HttpPost("instances/{instanceId:guid}/snooze")]
+    [RequireScope(OAuthScopes.AlertsReadWrite)]
     [RemoteCommand(Invalidates = ["GetActiveAlerts"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -306,6 +331,7 @@ public class AlertsController : ControllerBase
 
     /// <inheritdoc cref="IAlertDeliveryService.MarkDeliveredAsync"/>
     [HttpPost("deliveries/{deliveryId:guid}/delivered")]
+    [RequireScope(OAuthScopes.AlertsReadWrite)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<ActionResult> MarkDelivered(
         Guid deliveryId, [FromBody] MarkDeliveredRequest request, CancellationToken ct)
@@ -317,6 +343,7 @@ public class AlertsController : ControllerBase
 
     /// <inheritdoc cref="IAlertDeliveryService.MarkFailedAsync"/>
     [HttpPost("deliveries/{deliveryId:guid}/failed")]
+    [RequireScope(OAuthScopes.AlertsReadWrite)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<ActionResult> MarkFailed(
         Guid deliveryId, [FromBody] MarkFailedRequest request, CancellationToken ct)

--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/DndWindowsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/DndWindowsController.cs
@@ -3,7 +3,9 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
 using Nocturne.Core.Models.Alerts;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Services;
 
@@ -16,6 +18,7 @@ namespace Nocturne.API.Controllers.V4.Monitoring;
 /// state is computed on read, never stored; rows are retained after clear/expiry for audit.
 /// </summary>
 /// <remarks>
+/// <para>
 /// One active window per scope <em>at any instant</em> is enforced here: creating a window
 /// reconciles the same-scope windows whose span overlaps it — an earlier one is truncated to end
 /// where the new one begins, one it wholly covers is cleared
@@ -23,6 +26,12 @@ namespace Nocturne.API.Controllers.V4.Monitoring;
 /// idempotent by the client-supplied id so a device/web retry never double-applies. A
 /// <c>scope=all</c> window is tenant-wide DND and additionally drives the <c>do_not_disturb</c>
 /// condition via the enricher.
+/// </para>
+/// <para>
+/// Opening and clearing a window both decide whether alerts are delivered, so they require
+/// <see cref="OAuthScopes.AlertsReadWrite"/>; the class-level <c>[Authorize]</c> alone is satisfied
+/// by read-only credentials such as a guest-link session, which holds <c>alerts.read</c>.
+/// </para>
 /// </remarks>
 /// <seealso cref="AlertRulesController"/>
 [ApiController]
@@ -67,6 +76,7 @@ public class DndWindowsController : ControllerBase
     /// scope so at most one is ever active per scope.
     /// </summary>
     [HttpPost]
+    [RequireScope(OAuthScopes.AlertsReadWrite)]
     [RemoteCommand(Invalidates = ["GetActive"])]
     [ProducesResponseType(typeof(DndWindowResponse), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(DndWindowResponse), StatusCodes.Status200OK)]
@@ -172,6 +182,7 @@ public class DndWindowsController : ControllerBase
     /// or by supersede) is returned unchanged so a retry never rewrites the audit timestamp.
     /// </summary>
     [HttpPost("{id:guid}/clear")]
+    [RequireScope(OAuthScopes.AlertsReadWrite)]
     [RemoteCommand(Invalidates = ["GetActive"])]
     [ProducesResponseType(typeof(DndWindowResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/NotificationsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/NotificationsController.cs
@@ -1,15 +1,44 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
 using Nocturne.API.Extensions;
+using Nocturne.API.Services.Alerts.Providers;
 using Nocturne.Core.Contracts.Notifications;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.API.Controllers.V4.Monitoring;
 
 /// <summary>
 /// Controller for managing in-app notifications.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Creating a notification requires <see cref="OAuthScopes.AlertsReadWrite"/>: an in-app
+/// notification is a delivery channel for an alert, so minting one puts an alert in front of a
+/// user. The per-action <c>[Authorize]</c> alone is satisfied by any credential carrying a subject,
+/// including a read-only follower token holding nothing but <c>glucose.read</c>.
+/// </para>
+/// <para>
+/// <see cref="ExecuteAction"/> additionally accepts <see cref="OAuthScopes.DeviceNotify"/>, for the
+/// same reason <see cref="AlertsController.AcknowledgeExcursion"/> does, but only for an
+/// <c>alert.firing</c> notification — see that action's remarks.
+/// </para>
+/// <para>
+/// <see cref="MarkAsRead"/>, <see cref="MarkAllAsRead"/> and <see cref="DismissNotification"/>
+/// carry no scope gate. They write only the caller's own bookkeeping — <c>read_at</c>, and the
+/// archive flags — on a row the service confines to the caller's subject, and they change no alert
+/// state: archiving an <c>alert.firing</c> notification does not acknowledge or silence the
+/// excursion behind it. Gating them on <c>alerts.readwrite</c> left every role that receives alerts
+/// without holding that scope with a bell badge it could never clear.
+/// </para>
+/// <para>
+/// Every action here resolves the caller through <see cref="HttpContextExtensions.GetSubjectIdString"/>
+/// and returns 401 when it is absent, so a guest session — which authenticates with
+/// <c>SubjectId = null</c> — reaches none of them.
+/// </para>
+/// </remarks>
 /// <seealso cref="IInAppNotificationService"/>
 [ApiController]
 [Tags("Monitoring")]
@@ -38,6 +67,7 @@ public class NotificationsController : ControllerBase
     /// </summary>
     [HttpPost]
     [Authorize]
+    [RequireScope(OAuthScopes.AlertsReadWrite)]
     [ProducesResponseType(typeof(InAppNotificationDto), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -106,11 +136,43 @@ public class NotificationsController : ControllerBase
     }
 
     /// <inheritdoc cref="IInAppNotificationService.ExecuteActionAsync"/>
+    /// <remarks>
+    /// <para>
+    /// Accepts <see cref="OAuthScopes.DeviceNotify"/> as well as
+    /// <see cref="OAuthScopes.AlertsReadWrite"/>, because this is the second path to the excursion
+    /// acknowledgement <see cref="AlertsController.AcknowledgeExcursion"/> serves: the Acknowledge
+    /// action on an <c>alert.firing</c> in-app notification dispatches through
+    /// <see cref="IInAppNotificationService.ExecuteActionAsync"/> to
+    /// <c>AlertActionHandler</c>, which calls
+    /// <see cref="Core.Contracts.Alerts.IAlertAcknowledgementService.AcknowledgeExcursionAsync"/>.
+    /// The resolver grants <c>device.notify</c> to any member holding at least one permission, and
+    /// the Clinician and Viewer seed roles hold it outright, so requiring
+    /// <c>alerts.readwrite</c> alone gave those members an alert they could see but not stop.
+    /// </para>
+    /// <para>
+    /// <see cref="IInAppNotificationService.ExecuteActionAsync"/> is a generic dispatcher, not an
+    /// acknowledgement endpoint: past the built-in <c>dismiss</c>/<c>navigate</c> cases it hands the
+    /// action to whichever <see cref="INotificationActionHandler"/> is registered for the
+    /// notification's type, and those handlers mutate their own domains — the tracker handler's
+    /// <c>accept</c> completes and restarts tracker instances, a write
+    /// <c>TrackersController</c> gates on <c>alerts.readwrite</c>. So the capability arm is confined
+    /// here to <see cref="InAppProvider.NotificationType"/>: a caller holding only
+    /// <c>device.notify</c> is refused any other notification type, and only a holder of
+    /// <c>alerts.readwrite</c> reaches the rest of the dispatch table.
+    /// </para>
+    /// <para>
+    /// Ownership is enforced downstream rather than by the scope: <c>ExecuteActionAsync</c> rejects
+    /// the call unless <c>notification.UserId</c> equals the caller's subject, so the wider gate
+    /// reaches only the caller's own notifications.
+    /// </para>
+    /// </remarks>
     [HttpPost("{id:guid}/actions/{actionId}")]
     [RemoteCommand(Invalidates = ["GetNotifications"])]
     [Authorize]
+    [RequireScope(OAuthScopes.AlertsReadWrite, OAuthScopes.DeviceNotify)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> ExecuteAction(Guid id, string actionId)
     {
@@ -119,6 +181,32 @@ public class NotificationsController : ControllerBase
         if (string.IsNullOrEmpty(userId))
         {
             return Unauthorized();
+        }
+
+        if (!HttpContext.HasScope(OAuthScopes.AlertsReadWrite))
+        {
+            var type = await _notificationService.GetNotificationTypeAsync(
+                id,
+                userId,
+                HttpContext.RequestAborted
+            );
+
+            if (type == null)
+            {
+                return NotFound();
+            }
+
+            if (!string.Equals(type, InAppProvider.NotificationType, StringComparison.Ordinal))
+            {
+                _logger.LogWarning(
+                    "User {UserId} holding only device.notify attempted action {ActionId} on {Type} notification {NotificationId}",
+                    userId,
+                    actionId,
+                    type,
+                    id
+                );
+                return Forbid();
+            }
         }
 
         _logger.LogDebug(
@@ -218,6 +306,7 @@ public class NotificationsController : ControllerBase
         var success = await _notificationService.ArchiveNotificationAsync(
             id,
             NotificationArchiveReason.Dismissed,
+            userId,
             HttpContext.RequestAborted
         );
 

--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/TenantAlertSettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/TenantAlertSettingsController.cs
@@ -2,7 +2,9 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
 using Nocturne.Core.Models.Alerts;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Services;
@@ -40,6 +42,11 @@ public class TenantAlertSettingsController : ControllerBase
     /// <summary>
     /// Get the current tenant's alert settings, creating a default row if one does not exist.
     /// </summary>
+    /// <remarks>
+    /// The get-or-create is a write, but of server-defined defaults and idempotently, so it carries
+    /// no <see cref="OAuthScopes.AlertsReadWrite"/> gate: a read-only caller cannot choose what it
+    /// stores and a repeat call stores nothing further.
+    /// </remarks>
     [HttpGet]
     [RemoteQuery]
     [ProducesResponseType(typeof(TenantAlertSettingsResponse), StatusCodes.Status200OK)]
@@ -63,7 +70,14 @@ public class TenantAlertSettingsController : ControllerBase
     /// Replace the current tenant's alert settings. Upserts on first call. The manual-DND toggle
     /// creates/clears the tenant's <c>scope=all</c> window; scheduled fields persist on the row.
     /// </summary>
+    /// <remarks>
+    /// Requires <see cref="OAuthScopes.AlertsReadWrite"/>: this toggles tenant-wide Do Not Disturb,
+    /// which suppresses delivery of every non-critical alert. The class-level <c>[Authorize]</c>
+    /// alone is satisfied by read-only credentials such as a guest-link session, which holds
+    /// <c>alerts.read</c>.
+    /// </remarks>
     [HttpPut]
+    [RequireScope(OAuthScopes.AlertsReadWrite)]
     [RemoteCommand(Invalidates = ["Get"])]
     [ProducesResponseType(typeof(TenantAlertSettingsResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/src/API/Nocturne.API/Controllers/V4/TenantAdmin/CompressionLowController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/TenantAdmin/CompressionLowController.cs
@@ -1,14 +1,25 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
 using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.API.Controllers.V4.TenantAdmin;
 
 /// <summary>
 /// Controller for compression low detection and review.
 /// </summary>
+/// <remarks>
+/// Every write here is the glucose category and requires <see cref="OAuthScopes.GlucoseReadWrite"/>.
+/// Accepting a suggestion writes a <see cref="StateSpanCategory.DataExclusion"/> span
+/// (<c>CompressionLowService.AcceptSuggestionAsync</c>), which decides whether the flagged readings
+/// count towards analytics and reports — the same category-to-scope mapping
+/// <c>StateSpanWriteScopeGuard</c> applies — and dismiss, delete and detection all write the
+/// suggestions that propose one. The class-level <c>[Authorize]</c> alone is satisfied by read-only
+/// credentials such as a guest-link session, which holds <c>glucose.read</c>.
+/// </remarks>
 /// <seealso cref="ICompressionLowService"/>
 /// <seealso cref="ICompressionLowDetectionService"/>
 [ApiController]
@@ -71,6 +82,7 @@ public class CompressionLowController : ControllerBase
     /// Accept a suggestion with adjusted bounds
     /// </summary>
     [HttpPost("suggestions/{id:guid}/accept")]
+    [RequireScope(OAuthScopes.GlucoseReadWrite)]
     [RemoteCommand(Invalidates = ["GetSuggestions"])]
     [ProducesResponseType(typeof(StateSpan), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -96,6 +108,7 @@ public class CompressionLowController : ControllerBase
     /// Dismiss a suggestion
     /// </summary>
     [HttpPost("suggestions/{id:guid}/dismiss")]
+    [RequireScope(OAuthScopes.GlucoseReadWrite)]
     [RemoteCommand(Invalidates = ["GetSuggestions"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -119,6 +132,7 @@ public class CompressionLowController : ControllerBase
     /// Delete a suggestion and its associated state span
     /// </summary>
     [HttpDelete("suggestions/{id:guid}")]
+    [RequireScope(OAuthScopes.GlucoseReadWrite)]
     [RemoteCommand(Invalidates = ["GetSuggestions"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -143,8 +157,11 @@ public class CompressionLowController : ControllerBase
     /// <remarks>
     /// Provide either a single `nightOf` date or a range with `startDate` and `endDate`.
     /// When using a range, detection runs for each night in the range (inclusive).
+    /// Each night analysed persists the <c>compression_low_suggestions</c> rows it finds
+    /// (<c>CompressionLowDetectionService.DetectForNightAsync</c>), so this is a write.
     /// </remarks>
     [HttpPost("detect")]
+    [RequireScope(OAuthScopes.GlucoseReadWrite)]
     [RemoteCommand(Invalidates = ["GetSuggestions"])]
     [ProducesResponseType(typeof(DetectionResult), StatusCodes.Status200OK)]
     public async Task<ActionResult<DetectionResult>> TriggerDetection(

--- a/src/API/Nocturne.API/Services/Notifications/InAppNotificationService.cs
+++ b/src/API/Nocturne.API/Services/Notifications/InAppNotificationService.cs
@@ -161,9 +161,31 @@ public class InAppNotificationService : IInAppNotificationService
     public async Task<bool> ArchiveNotificationAsync(
         Guid notificationId,
         NotificationArchiveReason reason,
+        string userId,
         CancellationToken cancellationToken = default
     )
     {
+        var notification = await _repository.GetByIdAsync(notificationId, cancellationToken);
+
+        if (notification == null)
+        {
+            _logger.LogWarning(
+                "Attempted to archive non-existent notification {NotificationId}",
+                notificationId
+            );
+            return false;
+        }
+
+        if (notification.UserId != userId)
+        {
+            _logger.LogWarning(
+                "User {UserId} attempted to archive notification {NotificationId} belonging to another user",
+                userId,
+                notificationId
+            );
+            return false;
+        }
+
         var archived = await _repository.ArchiveAsync(notificationId, reason, cancellationToken);
 
         if (archived == null)
@@ -273,6 +295,23 @@ public class InAppNotificationService : IInAppNotificationService
     }
 
     /// <inheritdoc />
+    public async Task<string?> GetNotificationTypeAsync(
+        Guid notificationId,
+        string userId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var notification = await _repository.GetByIdAsync(notificationId, cancellationToken);
+
+        if (notification == null || notification.UserId != userId)
+        {
+            return null;
+        }
+
+        return notification.Type;
+    }
+
+    /// <inheritdoc />
     public async Task<bool> ExecuteActionAsync(
         Guid notificationId,
         string actionId,
@@ -315,6 +354,7 @@ public class InAppNotificationService : IInAppNotificationService
                 return await ArchiveNotificationAsync(
                     notificationId,
                     NotificationArchiveReason.Dismissed,
+                    userId,
                     cancellationToken
                 );
 
@@ -322,6 +362,7 @@ public class InAppNotificationService : IInAppNotificationService
                 return await ArchiveNotificationAsync(
                     notificationId,
                     NotificationArchiveReason.Completed,
+                    userId,
                     cancellationToken
                 );
 
@@ -341,7 +382,7 @@ public class InAppNotificationService : IInAppNotificationService
 
                     if (result.Archive is { } reason)
                     {
-                        await ArchiveNotificationAsync(notificationId, reason, cancellationToken);
+                        await ArchiveNotificationAsync(notificationId, reason, userId, cancellationToken);
                     }
 
                     return result.Handled;
@@ -356,6 +397,7 @@ public class InAppNotificationService : IInAppNotificationService
                 return await ArchiveNotificationAsync(
                     notificationId,
                     NotificationArchiveReason.Completed,
+                    userId,
                     cancellationToken
                 );
         }
@@ -388,7 +430,7 @@ public class InAppNotificationService : IInAppNotificationService
             return false;
         }
 
-        return await ArchiveNotificationAsync(notification.Id, reason, cancellationToken);
+        return await ArchiveNotificationAsync(notification.Id, reason, userId, cancellationToken);
     }
 
     private static readonly JsonSerializerOptions JsonOptions = new()

--- a/src/Core/Nocturne.Core.Contracts/Notifications/IInAppNotificationService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Notifications/IInAppNotificationService.cs
@@ -52,15 +52,31 @@ public interface IInAppNotificationService
     );
 
     /// <summary>
-    /// Archive a notification with a reason
+    /// Archive a notification with a reason, confined to a notification the given user owns
     /// </summary>
     /// <param name="notificationId">The notification ID to archive</param>
     /// <param name="reason">The reason for archiving</param>
+    /// <param name="userId">The user the notification must belong to</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>True if archived successfully, false if not found</returns>
+    /// <returns>True if archived successfully, false if not found or owned by another user</returns>
     Task<bool> ArchiveNotificationAsync(
         Guid notificationId,
         NotificationArchiveReason reason,
+        string userId,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    /// Get the type discriminator of a notification the given user owns, for a caller that must
+    /// authorize on the notification's type before executing an action on it
+    /// </summary>
+    /// <param name="notificationId">The notification ID</param>
+    /// <param name="userId">The user the notification must belong to</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The notification type, or null if not found or owned by another user</returns>
+    Task<string?> GetNotificationTypeAsync(
+        Guid notificationId,
+        string userId,
         CancellationToken cancellationToken = default
     );
 

--- a/src/Web/packages/app/src/lib/components/alerts/DndPanel.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/DndPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { goto } from "$app/navigation";
+  import { page } from "$app/state";
   import {
     get as getDnd,
     update as updateDnd,
@@ -16,10 +17,21 @@
 
   const { onNavigate }: Props = $props();
 
+  const effectivePermissions: string[] = $derived(
+    (page.data as any).effectivePermissions ?? [],
+  );
+  // Manual DND is tenant-wide — it suppresses delivery of every non-critical
+  // alert for every member — so the server gates it on alerts.readwrite.
+  const canSetDnd = $derived(
+    effectivePermissions.includes("*") ||
+      effectivePermissions.includes("alerts.readwrite"),
+  );
+
   let settings = $state<TenantAlertSettingsResponse | null>(null);
   let loading = $state(true);
   let saving = $state(false);
   let expanded = $state(false);
+  let errorMessage = $state<string | null>(null);
 
   async function load(): Promise<void> {
     try {
@@ -33,6 +45,7 @@
 
   async function setActive(active: boolean, untilMinutes?: number): Promise<void> {
     saving = true;
+    errorMessage = null;
     try {
       const until =
         active && untilMinutes
@@ -47,13 +60,17 @@
       });
       settings = r;
       expanded = false;
+    } catch {
+      errorMessage = "Couldn't change Do Not Disturb. Please try again.";
     } finally {
       saving = false;
     }
   }
 
   // `.run()` rejects during the render flush, so defer the bootstrap to a microtask.
-  onMount(() => queueMicrotask(load));
+  onMount(() => {
+    if (canSetDnd) queueMicrotask(load);
+  });
 
   // Only the manual mute is knowable as "on now"; a configured schedule reads as
   // "Scheduled" without muting the bell. See lib/components/alerts/dnd.ts.
@@ -69,70 +86,75 @@
   );
 </script>
 
-<div class="px-2 py-2">
-  <button
-    type="button"
-    class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-muted {isActive ? 'text-status-info' : ''}"
-    onclick={() => (expanded = !expanded)}
-    aria-expanded={expanded}
-  >
-    {#if isActive}
-      <BellOff class="h-4 w-4" />
-    {:else}
-      <Bell class="h-4 w-4" />
-    {/if}
-    <span class="flex-1 text-left truncate">Do Not Disturb</span>
-    <span class="text-xs text-muted-foreground">{loading ? "…" : label}</span>
-  </button>
-
-  {#if expanded}
-    <div class="mt-1 rounded border bg-muted/30 p-1">
-      {#if loading}
-        <div class="px-2 py-1.5 text-sm text-muted-foreground">Loading…</div>
-      {:else if isActive}
-        <button
-          type="button"
-          class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-muted"
-          onclick={() => setActive(false)}
-          disabled={saving}
-        >
-          {#if saving}<Loader2 class="h-3.5 w-3.5 animate-spin" />{:else}<Bell class="h-3.5 w-3.5" />{/if}
-          Turn off
-        </button>
+{#if canSetDnd}
+  <div class="border-b px-2 py-2">
+    <button
+      type="button"
+      class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-muted {isActive ? 'text-status-info' : ''}"
+      onclick={() => (expanded = !expanded)}
+      aria-expanded={expanded}
+    >
+      {#if isActive}
+        <BellOff class="h-4 w-4" />
       {:else}
-        <div class="px-2 pt-1 pb-1 text-[10px] uppercase tracking-wider text-muted-foreground">
-          Mute alerts for
-        </div>
-        {#each [30, 60, 120, 240] as mins (mins)}
+        <Bell class="h-4 w-4" />
+      {/if}
+      <span class="flex-1 text-left truncate">Do Not Disturb</span>
+      <span class="text-xs text-muted-foreground">{loading ? "…" : label}</span>
+    </button>
+
+    {#if expanded}
+      <div class="mt-1 rounded border bg-muted/30 p-1">
+        {#if loading}
+          <div class="px-2 py-1.5 text-sm text-muted-foreground">Loading…</div>
+        {:else if isActive}
           <button
             type="button"
-            class="flex w-full items-center justify-between rounded px-2 py-1.5 text-sm hover:bg-muted"
-            onclick={() => setActive(true, mins)}
+            class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-muted"
+            onclick={() => setActive(false)}
             disabled={saving}
           >
-            <span>{mins < 60 ? `${mins} minutes` : `${mins / 60} hour${mins > 60 ? "s" : ""}`}</span>
+            {#if saving}<Loader2 class="h-3.5 w-3.5 animate-spin" />{:else}<Bell class="h-3.5 w-3.5" />{/if}
+            Turn off
           </button>
-        {/each}
+        {:else}
+          <div class="px-2 pt-1 pb-1 text-[10px] uppercase tracking-wider text-muted-foreground">
+            Mute alerts for
+          </div>
+          {#each [30, 60, 120, 240] as mins (mins)}
+            <button
+              type="button"
+              class="flex w-full items-center justify-between rounded px-2 py-1.5 text-sm hover:bg-muted"
+              onclick={() => setActive(true, mins)}
+              disabled={saving}
+            >
+              <span>{mins < 60 ? `${mins} minutes` : `${mins / 60} hour${mins > 60 ? "s" : ""}`}</span>
+            </button>
+          {/each}
+          <button
+            type="button"
+            class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-muted"
+            onclick={() => setActive(true)}
+            disabled={saving}
+          >
+            Until I turn it off
+          </button>
+        {/if}
+        {#if errorMessage}
+          <p class="px-2 py-1.5 text-sm text-destructive">{errorMessage}</p>
+        {/if}
+        <div class="my-1 border-t"></div>
         <button
           type="button"
           class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-muted"
-          onclick={() => setActive(true)}
-          disabled={saving}
+          onclick={() => {
+            onNavigate?.();
+            goto("/alerts/dnd");
+          }}
         >
-          Until I turn it off
+          <SettingsIcon class="h-3.5 w-3.5" /> Configure…
         </button>
-      {/if}
-      <div class="my-1 border-t"></div>
-      <button
-        type="button"
-        class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-muted"
-        onclick={() => {
-          onNavigate?.();
-          goto("/alerts/dnd");
-        }}
-      >
-        <SettingsIcon class="h-3.5 w-3.5" /> Configure…
-      </button>
-    </div>
-  {/if}
-</div>
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/src/Web/packages/app/src/lib/components/alerts/DndPanel.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/alerts/DndPanel.svelte.test.ts
@@ -1,0 +1,70 @@
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { page as pageState } from "$app/state";
+import type { TenantAlertSettingsResponse } from "$api-clients";
+
+// The panel reads DND state through the generated remote functions; `update`
+// is swapped per test so a rejection can stand in for the server's 403.
+const settings: TenantAlertSettingsResponse = {
+  dndManualActive: false,
+  dndScheduleEnabled: false,
+} as TenantAlertSettingsResponse;
+
+let updateImpl: () => Promise<TenantAlertSettingsResponse>;
+
+vi.mock("$api/generated/tenantAlertSettings.generated.remote", () => ({
+  get: () => ({ run: () => Promise.resolve(settings) }),
+  update: () => updateImpl(),
+}));
+
+import DndPanel from "./DndPanel.svelte";
+
+const dndToggle = () => page.getByRole("button", { name: /Do Not Disturb/i });
+
+describe("DndPanel", () => {
+  beforeEach(() => {
+    updateImpl = () => Promise.resolve(settings);
+    pageState.data = {};
+  });
+
+  it("renders nothing for a member without alerts.readwrite", async () => {
+    pageState.data = { effectivePermissions: ["alerts.read"] };
+
+    render(DndPanel, {});
+
+    await expect.element(dndToggle()).not.toBeInTheDocument();
+  });
+
+  it("renders for a member holding alerts.readwrite", async () => {
+    pageState.data = { effectivePermissions: ["alerts.readwrite"] };
+
+    render(DndPanel, {});
+
+    await expect.element(dndToggle()).toBeVisible();
+  });
+
+  // The Owner resolves to the raw superuser set rather than the expanded scopes,
+  // so the wildcard arm is the only thing keeping this control for them.
+  it("renders for an owner holding the wildcard scope", async () => {
+    pageState.data = { effectivePermissions: ["*"] };
+
+    render(DndPanel, {});
+
+    await expect.element(dndToggle()).toBeVisible();
+  });
+
+  it("surfaces an error when the update is rejected", async () => {
+    pageState.data = { effectivePermissions: ["alerts.readwrite"] };
+    updateImpl = () => Promise.reject(new Error("Forbidden"));
+
+    render(DndPanel, {});
+
+    await dndToggle().click();
+    await page.getByRole("button", { name: "30 minutes" }).click();
+
+    await expect
+      .element(page.getByText(/Couldn't change Do Not Disturb/i))
+      .toBeVisible();
+  });
+});

--- a/src/Web/packages/app/src/lib/components/alerts/SidebarDndToggle.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/SidebarDndToggle.svelte
@@ -10,8 +10,19 @@
   import { Bell, BellOff } from "lucide-svelte";
   import { isDndActiveNow, isDndScheduleConfigured } from "./dnd";
 
+  const effectivePermissions: string[] = $derived(
+    (page.data as any).effectivePermissions ?? [],
+  );
+  // Manual DND is tenant-wide — it suppresses delivery of every non-critical
+  // alert for every member — so the server gates it on alerts.readwrite.
+  const canSetDnd = $derived(
+    effectivePermissions.includes("*") ||
+      effectivePermissions.includes("alerts.readwrite"),
+  );
+
   let settings = $state<TenantAlertSettingsResponse | null>(null);
   let saving = $state(false);
+  let failed = $state(false);
 
   // A configured schedule is not the same as DND being on now — the backend
   // evaluates the window and the response carries no "active now" field. See
@@ -33,6 +44,7 @@
   async function toggleManual(checked: boolean): Promise<void> {
     if (saving) return;
     saving = true;
+    failed = false;
     try {
       const r = await updateDnd({
         dndManualActive: checked,
@@ -42,40 +54,53 @@
         dndScheduleEnd: settings?.dndScheduleEnd,
       });
       settings = r;
+    } catch {
+      failed = true;
     } finally {
       saving = false;
     }
   }
 
   // `.run()` rejects during the render flush, so defer the bootstrap to a microtask.
-  onMount(() => queueMicrotask(load));
+  onMount(() => {
+    if (canSetDnd) queueMicrotask(load);
+  });
 </script>
 
-<div
-  class="text-sidebar-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 group-data-[collapsible=icon]:hidden {isActive
-    ? 'bg-sidebar-accent text-sidebar-accent-foreground'
-    : ''}"
-  data-slot="sidebar-menu-sub-button"
->
-  <a
-    {href}
-    class="flex flex-1 items-center gap-2 min-w-0 text-sm hover:text-sidebar-accent-foreground"
-    title={isScheduled && !isManualActive
-      ? "Scheduled Do Not Disturb window configured"
-      : undefined}
+{#if canSetDnd}
+  <div
+    class="text-sidebar-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 group-data-[collapsible=icon]:hidden {isActive
+      ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+      : ''}"
+    data-slot="sidebar-menu-sub-button"
   >
-    {#if isManualActive}
-      <BellOff class="size-4 shrink-0 text-status-info" />
-    {:else}
-      <Bell class="size-4 shrink-0" />
-    {/if}
-    <span class="truncate">Do Not Disturb</span>
-  </a>
-  <Switch
-    class="scale-75 -mr-1"
-    checked={isManualActive}
-    onCheckedChange={toggleManual}
-    disabled={saving}
-    aria-label="Toggle Do Not Disturb"
-  />
-</div>
+    <a
+      {href}
+      class="flex flex-1 items-center gap-2 min-w-0 text-sm hover:text-sidebar-accent-foreground"
+      title={isScheduled && !isManualActive
+        ? "Scheduled Do Not Disturb window configured"
+        : undefined}
+    >
+      {#if isManualActive}
+        <BellOff class="size-4 shrink-0 text-status-info" />
+      {:else}
+        <Bell class="size-4 shrink-0" />
+      {/if}
+      <span class="truncate">Do Not Disturb</span>
+    </a>
+    <Switch
+      class="scale-75 -mr-1"
+      checked={isManualActive}
+      onCheckedChange={toggleManual}
+      disabled={saving}
+      aria-label="Toggle Do Not Disturb"
+    />
+  </div>
+  {#if failed}
+    <p
+      class="px-2 pb-1 text-xs text-destructive group-data-[collapsible=icon]:hidden"
+    >
+      Couldn't change Do Not Disturb. Please try again.
+    </p>
+  {/if}
+{/if}

--- a/src/Web/packages/app/src/lib/components/layout/SidebarNotifications.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/SidebarNotifications.svelte
@@ -178,9 +178,7 @@
         </div>
       </div>
 
-      <div class="border-b">
-        <DndPanel onNavigate={() => (isOpen = false)} />
-      </div>
+      <DndPanel onNavigate={() => (isOpen = false)} />
 
       {#if totalCount === 0}
         <div class="flex flex-col items-center justify-center py-8 text-center">

--- a/src/Web/packages/app/src/lib/test-stubs/sveltekit.ts
+++ b/src/Web/packages/app/src/lib/test-stubs/sveltekit.ts
@@ -17,3 +17,9 @@ export function json(data: any, init?: ResponseInit) {
 export function fail(status: number, data?: any) {
   return { status, data };
 }
+
+// Returns never in @sveltejs/kit: callers invoke it bare and rely on it aborting,
+// so returning here would let a rejected validation fall through to the success path.
+export function invalid(...issues: any[]): never {
+  throw new Error(`Invalid: ${JSON.stringify(issues)}`);
+}

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/dnd/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/dnd/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { untrack } from "svelte";
   import { goto } from "$app/navigation";
+  import { page } from "$app/state";
   import {
     get as getDnd,
     update as updateDnd,
@@ -18,10 +19,20 @@
     CardTitle,
     CardDescription,
   } from "$lib/components/ui/card";
-  import { ArrowLeft, BellOff, Save, Loader2 } from "lucide-svelte";
+  import { ArrowLeft, BellOff, Save, Loader2, ShieldAlert } from "lucide-svelte";
   import { EditorActionBar } from "$lib/components/layout";
 
-  const dndQuery = getDnd();
+  const effectivePermissions: string[] = $derived(
+    (page.data as any).effectivePermissions ?? [],
+  );
+  // Manual DND is tenant-wide — it suppresses delivery of every non-critical
+  // alert for every member — so the server gates it on alerts.readwrite.
+  const canSetDnd = $derived(
+    effectivePermissions.includes("*") ||
+      effectivePermissions.includes("alerts.readwrite"),
+  );
+
+  const dndQuery = $derived(canSetDnd ? getDnd() : undefined);
 
   let saving = $state(false);
   let error = $state<string | null>(null);
@@ -61,7 +72,7 @@
   // Seed form state from query results on first successful response. Subsequent
   // refreshes do NOT clobber user edits.
   $effect(() => {
-    const dnd = dndQuery.current;
+    const dnd = dndQuery?.current;
     if (seeded || dnd === undefined) return;
     untrack(() => {
       applyResponse(dnd ?? null);
@@ -93,115 +104,147 @@
   <title>Do Not Disturb · Alerts · Nocturne</title>
 </svelte:head>
 
-<div class="@container container mx-auto max-w-3xl p-3 @md:p-6 space-y-6 max-md:pb-24">
-  <EditorActionBar>
-    {#snippet leading()}
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon"
-        onclick={() => goto("/alerts")}
-        aria-label="Back to alerts"
-      >
-        <ArrowLeft class="h-4 w-4" />
-      </Button>
-      <div>
-        <h1 class="text-2xl font-bold tracking-tight flex items-center gap-2">
-          <BellOff class="h-5 w-5" /> Do Not Disturb
-        </h1>
-        <p class="text-sm text-muted-foreground">
-          Suppress non-critical alerts. Critical-severity rules and rules opted in via "Allow through DND" still fire.
-        </p>
-      </div>
-    {/snippet}
-    {#snippet actions()}
-      <Button class="shrink-0" onclick={save} disabled={saving || !seeded}>
-        {#if saving}
-          <Loader2 class="h-4 w-4 mr-2 animate-spin" />
-        {:else}
-          <Save class="h-4 w-4 mr-2" />
-        {/if}
-        Save
-      </Button>
-    {/snippet}
-  </EditorActionBar>
+{#snippet heading()}
+  <Button
+    type="button"
+    variant="ghost"
+    size="icon"
+    onclick={() => goto("/alerts")}
+    aria-label="Back to alerts"
+  >
+    <ArrowLeft class="h-4 w-4" />
+  </Button>
+  <div>
+    <h1 class="text-2xl font-bold tracking-tight flex items-center gap-2">
+      <BellOff class="h-5 w-5" /> Do Not Disturb
+    </h1>
+    <p class="text-sm text-muted-foreground">
+      Suppress non-critical alerts. Critical-severity rules and rules opted in via "Allow through DND" still fire.
+    </p>
+  </div>
+{/snippet}
 
-  {#if error}
-    <div class="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">{error}</div>
+<!-- EditorActionBar pins its actions container to the bottom of the viewport below md, so
+     without a save action it would leave an empty bar there; the reserved space it asks
+     consumers for goes with it. -->
+<div
+  class="@container container mx-auto max-w-3xl p-3 @md:p-6 space-y-6 {canSetDnd
+    ? 'max-md:pb-24'
+    : ''}"
+>
+  {#if canSetDnd}
+    <EditorActionBar>
+      {#snippet leading()}
+        {@render heading()}
+      {/snippet}
+      {#snippet actions()}
+        <Button class="shrink-0" onclick={save} disabled={saving || !seeded}>
+          {#if saving}
+            <Loader2 class="h-4 w-4 mr-2 animate-spin" />
+          {:else}
+            <Save class="h-4 w-4 mr-2" />
+          {/if}
+          Save
+        </Button>
+      {/snippet}
+    </EditorActionBar>
+  {:else}
+    <div class="mb-6 flex min-w-0 items-center gap-2">
+      {@render heading()}
+    </div>
   {/if}
 
-  <Card>
-    <CardHeader>
-      <CardTitle>Manual</CardTitle>
-      <CardDescription>Toggle DND on right now, optionally with an automatic expiry.</CardDescription>
-    </CardHeader>
-    <CardContent class="space-y-4">
-      <div class="flex items-center justify-between">
-        <Label for="dnd-manual">Do Not Disturb is currently</Label>
-        <Switch
-          id="dnd-manual"
-          checked={dndManualActive}
-          onCheckedChange={(c: boolean) => (dndManualActive = c)}
-        />
-      </div>
-      {#if dndManualActive}
-        <div class="space-y-2">
-          <Label for="dnd-until">Auto-expire (optional)</Label>
-          <Input
-            id="dnd-until"
-            type="datetime-local"
-            value={dndManualUntilLocal}
-            oninput={(e: Event & { currentTarget: HTMLInputElement }) =>
-              (dndManualUntilLocal = e.currentTarget.value)}
-          />
-          <p class="text-xs text-muted-foreground">Leave blank to keep DND on indefinitely.</p>
-        </div>
-      {/if}
-    </CardContent>
-  </Card>
+  {#if canSetDnd}
+    {#if error}
+      <div class="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">{error}</div>
+    {/if}
 
-  <Card>
-    <CardHeader>
-      <CardTitle>Schedule</CardTitle>
-      <CardDescription>Recurring quiet hours. Cross-midnight windows are allowed.</CardDescription>
-    </CardHeader>
-    <CardContent class="space-y-4">
-      <div class="flex items-center justify-between">
-        <Label for="dnd-schedule">Use a recurring quiet-hours window</Label>
-        <Switch
-          id="dnd-schedule"
-          checked={dndScheduleEnabled}
-          onCheckedChange={(c: boolean) => (dndScheduleEnabled = c)}
-        />
-      </div>
-      {#if dndScheduleEnabled}
-        <div class="grid gap-4 @sm:grid-cols-2">
-          <div class="space-y-2">
-            <Label for="dnd-start">From</Label>
-            <Input
-              id="dnd-start"
-              type="time"
-              value={dndScheduleStart}
-              oninput={(e: Event & { currentTarget: HTMLInputElement }) =>
-                (dndScheduleStart = e.currentTarget.value)}
-            />
-          </div>
-          <div class="space-y-2">
-            <Label for="dnd-end">To</Label>
-            <Input
-              id="dnd-end"
-              type="time"
-              value={dndScheduleEnd}
-              oninput={(e: Event & { currentTarget: HTMLInputElement }) =>
-                (dndScheduleEnd = e.currentTarget.value)}
-            />
-          </div>
+    <Card>
+      <CardHeader>
+        <CardTitle>Manual</CardTitle>
+        <CardDescription>Toggle DND on right now, optionally with an automatic expiry.</CardDescription>
+      </CardHeader>
+      <CardContent class="space-y-4">
+        <div class="flex items-center justify-between">
+          <Label for="dnd-manual">Do Not Disturb is currently</Label>
+          <Switch
+            id="dnd-manual"
+            checked={dndManualActive}
+            onCheckedChange={(c: boolean) => (dndManualActive = c)}
+          />
         </div>
-        <p class="text-xs text-muted-foreground">
-          Scheduled windows are interpreted in your timezone, set on your
-          <a href="/settings/patient" class="underline">patient record</a>.
+        {#if dndManualActive}
+          <div class="space-y-2">
+            <Label for="dnd-until">Auto-expire (optional)</Label>
+            <Input
+              id="dnd-until"
+              type="datetime-local"
+              value={dndManualUntilLocal}
+              oninput={(e: Event & { currentTarget: HTMLInputElement }) =>
+                (dndManualUntilLocal = e.currentTarget.value)}
+            />
+            <p class="text-xs text-muted-foreground">Leave blank to keep DND on indefinitely.</p>
+          </div>
+        {/if}
+      </CardContent>
+    </Card>
+
+    <Card>
+      <CardHeader>
+        <CardTitle>Schedule</CardTitle>
+        <CardDescription>Recurring quiet hours. Cross-midnight windows are allowed.</CardDescription>
+      </CardHeader>
+      <CardContent class="space-y-4">
+        <div class="flex items-center justify-between">
+          <Label for="dnd-schedule">Use a recurring quiet-hours window</Label>
+          <Switch
+            id="dnd-schedule"
+            checked={dndScheduleEnabled}
+            onCheckedChange={(c: boolean) => (dndScheduleEnabled = c)}
+          />
+        </div>
+        {#if dndScheduleEnabled}
+          <div class="grid gap-4 @sm:grid-cols-2">
+            <div class="space-y-2">
+              <Label for="dnd-start">From</Label>
+              <Input
+                id="dnd-start"
+                type="time"
+                value={dndScheduleStart}
+                oninput={(e: Event & { currentTarget: HTMLInputElement }) =>
+                  (dndScheduleStart = e.currentTarget.value)}
+              />
+            </div>
+            <div class="space-y-2">
+              <Label for="dnd-end">To</Label>
+              <Input
+                id="dnd-end"
+                type="time"
+                value={dndScheduleEnd}
+                oninput={(e: Event & { currentTarget: HTMLInputElement }) =>
+                  (dndScheduleEnd = e.currentTarget.value)}
+              />
+            </div>
+          </div>
+          <p class="text-xs text-muted-foreground">
+            Scheduled windows are interpreted in your timezone, set on your
+            <a href="/settings/patient" class="underline">patient record</a>.
+          </p>
+        {/if}
+      </CardContent>
+    </Card>
+  {:else}
+    <Card>
+      <CardContent class="flex flex-col items-center justify-center py-12 text-center">
+        <div class="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10">
+          <ShieldAlert class="h-6 w-6 text-destructive" />
+        </div>
+        <h2 class="text-lg font-semibold">Access Denied</h2>
+        <p class="mt-2 max-w-sm text-sm text-muted-foreground">
+          You do not have permission to change Do Not Disturb. Contact your
+          tenant administrator for access.
         </p>
-      {/if}
-    </CardContent>
-  </Card>
+      </CardContent>
+    </Card>
+  {/if}
 </div>

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/dnd/dnd-page.svelte.test.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/dnd/dnd-page.svelte.test.ts
@@ -1,0 +1,49 @@
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { page as pageState } from "$app/state";
+import type { TenantAlertSettingsResponse } from "$api-clients";
+
+// The page seeds its form from the generated remote query; the mock resolves
+// synchronously so `current` is populated on first render.
+const settings: TenantAlertSettingsResponse = {
+  dndManualActive: false,
+  dndScheduleEnabled: false,
+} as TenantAlertSettingsResponse;
+
+vi.mock("$api/generated/tenantAlertSettings.generated.remote", () => ({
+  get: () => ({ current: settings }),
+  update: () => Promise.resolve(settings),
+}));
+
+import DndPage from "./+page.svelte";
+
+const saveButton = () => page.getByRole("button", { name: "Save" });
+const accessDenied = () => page.getByText("Access Denied");
+
+describe("alerts/dnd page", () => {
+  beforeEach(() => {
+    pageState.data = {};
+  });
+
+  it("shows the access-denied card for a member without alerts.readwrite", async () => {
+    pageState.data = { effectivePermissions: ["alerts.read"] };
+
+    render(DndPage, {});
+
+    await expect.element(accessDenied()).toBeVisible();
+    await expect.element(saveButton()).not.toBeInTheDocument();
+  });
+
+  it("shows the settings form for a member holding alerts.readwrite", async () => {
+    pageState.data = { effectivePermissions: ["alerts.readwrite"] };
+
+    render(DndPage, {});
+
+    await expect.element(saveButton()).toBeVisible();
+    await expect
+      .element(page.getByText("Do Not Disturb is currently"))
+      .toBeVisible();
+    await expect.element(accessDenied()).not.toBeInTheDocument();
+  });
+});

--- a/src/Web/packages/app/vitest.browser.config.ts
+++ b/src/Web/packages/app/vitest.browser.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
   // pnpm 11's global links store lives outside the workspace root, so vite's strict fs
   // allow-list blocks serving vitest-browser-svelte to the browser runner.
   server: { fs: { strict: false } },
+  // runed/kit imports `$app/*`, which esbuild's dep pre-bundler can't resolve —
+  // the stubs below are vitest aliases, applied only in vite's own pipeline.
+  optimizeDeps: { exclude: ["runed/kit"] },
   test: {
     include: ["src/**/*.svelte.test.ts"],
     setupFiles: ["vitest-browser-svelte", "./vitest.browser.setup.ts"],

--- a/tests/Unit/Nocturne.API.Tests/Authorization/AlertSurfaceWriteScopeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/AlertSurfaceWriteScopeTests.cs
@@ -1,0 +1,426 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Routing;
+using Nocturne.API.Attributes;
+using Nocturne.API.Controllers.V4.Base;
+using Nocturne.Core.Models.Authorization;
+
+namespace Nocturne.API.Tests.Authorization;
+
+/// <summary>
+/// Guards the alert surface — the controllers under
+/// <c>Nocturne.API.Controllers.V4.Monitoring</c> — against a write reachable with read-only
+/// credentials. Every action there that changes alert state requires
+/// <see cref="OAuthScopes.AlertsReadWrite"/>, because a rule decides whether a low-glucose alert
+/// reaches anyone, a DND window suppresses delivery, and an acknowledgement closes a firing
+/// excursion. The exceptions are enumerated: <see cref="Ungated"/> for actions that change no alert
+/// state, and <see cref="DeviceCapabilityActions"/> for the acknowledgement paths that additionally
+/// accept a device capability scope.
+/// </summary>
+/// <remarks>
+/// The namespace sweep in <see cref="V4WriteScopeGatingTests"/> covers the whole V4 plane and its
+/// exemption map; this class pins the alert surface specifically, so a future Monitoring controller
+/// cannot be waved through by adding it to that map, and asserts the scope resolution that decides
+/// who keeps access — a seed role through <see cref="MemberScopeResolver"/>, a guest grant through
+/// <see cref="OAuthScopes.ValidateGrantScopes"/>, and a client device's capability grant.
+/// </remarks>
+public class AlertSurfaceWriteScopeTests
+{
+    private const string MonitoringNamespace = "Nocturne.API.Controllers.V4.Monitoring";
+
+    private static readonly string[] WriteVerbs = ["POST", "PUT", "PATCH", "DELETE"];
+
+    /// <summary>
+    /// The scopes the desktop Companion's OAuth grant holds (<c>DEFAULT_SCOPES</c> in
+    /// <c>src/Web/packages/desktop/src-tauri/src/auth.rs</c>). No alert scope: the companion is a
+    /// read-scoped poller that additionally registers as an actuation target.
+    /// </summary>
+    private static readonly string[] CompanionGrantScopes =
+    [
+        OAuthScopes.GlucoseRead, OAuthScopes.TherapyRead, OAuthScopes.DevicesRead,
+        OAuthScopes.DeviceNotify, OAuthScopes.DeviceActuate,
+    ];
+
+    /// <summary>
+    /// Write actions on the alert surface that deliberately carry no scope gate, with the reason.
+    /// Anything else fails <see cref="EveryAlertSurfaceWriteAction_RequiresAlertsReadWrite"/>.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> Ungated =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            // Both actions read the saved rules over a historical window and return the events that
+            // would have fired. AlertReplayService has no SaveChangesAsync and adds to no DbSet, so
+            // these are reads the request-body shape forced off GET; gating them would deny replay
+            // to an alerts.read holder.
+            ["AlertReplayController.Replay"] = "reads and returns; persists nothing",
+            ["AlertReplayController.ReplayDryRun"] = "reads and returns; persists nothing",
+
+            // The caller's own notification bookkeeping — read_at, and the archive flags — on a row
+            // InAppNotificationService confines to the caller's subject. Neither acknowledges nor
+            // silences an excursion: archiving an alert.firing notification leaves escalation
+            // running. Gating them on alerts.readwrite pinned a bell badge that a Clinician or
+            // Viewer could never clear. V4WriteScopeGatingTests records the same decision under its
+            // presentation-state category, alongside CoachMarkController and
+            // UserPreferencesController.
+            ["NotificationsController.MarkAsRead"] = "read state on the caller's own row",
+            ["NotificationsController.MarkAllAsRead"] = "read state on the caller's own rows",
+            ["NotificationsController.DismissNotification"] = "archive flag on the caller's own row",
+        };
+
+    /// <summary>
+    /// The two alert-surface writes that also accept a client device's capability scope, and why.
+    /// <c>AlertsController.AcknowledgeExcursion</c> calls
+    /// <c>IAlertAcknowledgementService.AcknowledgeExcursionAsync</c> outright, from a device toast's
+    /// Acknowledge button. <c>NotificationsController.ExecuteAction</c> is a generic dispatcher:
+    /// <c>InAppNotificationService.ExecuteActionAsync</c> hands the action to whichever
+    /// <c>INotificationActionHandler</c> is registered for the notification's type, of which
+    /// <c>AlertActionHandler</c> — the one that acknowledges the excursion — is only one. The
+    /// action confines the <c>device.notify</c> arm to <c>InAppProvider.NotificationType</c> before
+    /// dispatching, so a caller admitted only by that scope reaches no other handler; that check is
+    /// pinned by <c>NotificationsControllerExecuteActionScopeTests</c>. Membership here is asserted
+    /// exhaustively by <see cref="OnlyTheExcursionAckPaths_AcceptADeviceCapabilityScope"/> so the
+    /// exception cannot spread to a third action unnoticed.
+    /// </summary>
+    private static readonly string[] DeviceCapabilityActions =
+    [
+        "AlertsController.AcknowledgeExcursion",
+        "NotificationsController.ExecuteAction",
+    ];
+
+    [Fact]
+    public void EveryAlertSurfaceWriteAction_RequiresAlertsReadWrite()
+    {
+        var ungated = new List<string>();
+        var wrongScope = new List<string>();
+        var checkedActions = 0;
+
+        foreach (var controller in MonitoringControllers())
+        {
+            foreach (var action in WriteActions(controller))
+            {
+                var key = $"{controller.Name}.{action.Name}";
+                if (Ungated.ContainsKey(key))
+                    continue;
+
+                checkedActions++;
+
+                var required = RequiredScopes(controller, action).ToList();
+                if (required.Count == 0)
+                {
+                    ungated.Add($"{key} [{string.Join(",", HttpVerbs(action))}]");
+                    continue;
+                }
+
+                if (!required.Contains(OAuthScopes.AlertsReadWrite, StringComparer.Ordinal))
+                    wrongScope.Add($"{key} requires {string.Join("/", required)}");
+            }
+        }
+
+        // Sanity: the sweep must find the surface, or the assertions below pass vacuously. The
+        // floor tracks the namespace sweep (31 gated write actions today: 21 carrying their own
+        // [RequireScope] plus TrackersController's 10 declared ones), so a sweep that silently
+        // narrows to a subset fails here rather than passing on the remainder.
+        checkedActions.Should().BeGreaterThan(30,
+            "the reflection scan should discover every write action under " + MonitoringNamespace);
+
+        ungated.Should().BeEmpty(
+            "a write on the alert surface must carry [RequireScope(alerts.readwrite)] or "
+            + "[RequireDeclaredWriteScope], or be listed in Ungated with a reason. Unprotected: "
+            + string.Join("; ", ungated));
+
+        wrongScope.Should().BeEmpty(
+            "every alert-surface write must name alerts.readwrite: " + string.Join("; ", wrongScope));
+    }
+
+    [Fact]
+    public void EveryUngatedEntry_NamesALiveWriteAction()
+    {
+        // An entry left behind after its action was gated, renamed or deleted would silently excuse
+        // a future action that reuses the name.
+        var writeActions = MonitoringControllers()
+            .SelectMany(c => WriteActions(c).Select(a => $"{c.Name}.{a.Name}"))
+            .ToHashSet(StringComparer.Ordinal);
+
+        Ungated.Keys.Should().BeSubsetOf(writeActions);
+        writeActions.Should().Contain(DeviceCapabilityActions);
+    }
+
+    [Fact]
+    public void OwnerSession_KeepsEveryAlertSurfaceWrite()
+    {
+        // A browser session is AuthType.SessionCookie, which carries no scopes of its own, so
+        // membership is the whole authority and the owner's "*" is published raw.
+        var ownerScopes = MemberScopeResolver.Resolve(
+            new HashSet<string>(TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Owner]),
+            AuthType.SessionCookie,
+            new HashSet<string>());
+
+        ownerScopes.Should().Contain(TenantPermissions.Superuser);
+
+        foreach (var (controller, action) in GatedWriteActions())
+        {
+            Evaluate(controller, action, authenticated: true, ownerScopes)
+                .Should().BeNull($"a tenant owner's session must keep {controller.Name}.{action.Name}");
+        }
+    }
+
+    [Theory]
+    [InlineData(TenantPermissions.SeedRoles.Admin)]
+    [InlineData(TenantPermissions.SeedRoles.Caretaker)]
+    public void SeedRoleHoldingAlertsReadWrite_KeepsEveryAlertSurfaceWrite(string role)
+    {
+        var scopes = MemberScopeResolver.Resolve(
+            new HashSet<string>(TenantPermissions.SeedRolePermissions[role]),
+            AuthType.SessionCookie,
+            new HashSet<string>());
+
+        foreach (var (controller, action) in GatedWriteActions())
+        {
+            Evaluate(controller, action, authenticated: true, scopes)
+                .Should().BeNull($"the {role} role holds alerts.readwrite, so it must keep {controller.Name}.{action.Name}");
+        }
+    }
+
+    /// <summary>
+    /// The read-only seed roles keep both excursion-acknowledgement paths and no other
+    /// alert-surface write. Neither holds <c>alerts.readwrite</c> — Clinician holds
+    /// <c>alerts.read</c>, Viewer no alert scope at all — so that gate denies them everywhere. But
+    /// both list <see cref="OAuthScopes.DeviceNotify"/> outright in
+    /// <see cref="TenantPermissions.SeedRolePermissions"/> (and <see cref="MemberScopeResolver"/>
+    /// would grant it anyway, as it gives <see cref="TenantPermissions.MemberPersonalScopes"/> to
+    /// any member holding at least one permission), so the <c>device.notify</c> arm of each
+    /// <see cref="DeviceCapabilityActions"/> gate admits them. This pins that matrix: a change that
+    /// leaves a Clinician or a Viewer unable to stop an alert they are being shown, or that widens
+    /// any other alert write to them, fails here.
+    /// </summary>
+    /// <remarks>
+    /// The read-state actions on <c>NotificationsController</c> are not in
+    /// <see cref="GatedWriteActions"/> — they carry no scope gate at all, for the reason recorded in
+    /// <see cref="Ungated"/>, so these roles reach them too.
+    /// </remarks>
+    [Theory]
+    [InlineData(TenantPermissions.SeedRoles.Clinician)]
+    [InlineData(TenantPermissions.SeedRoles.Viewer)]
+    public void ReadOnlySeedRole_KeepsBothExcursionAckPathsAndNoOtherAlertSurfaceWrite(string role)
+    {
+        var permissions = new HashSet<string>(TenantPermissions.SeedRolePermissions[role]);
+        var scopes = MemberScopeResolver.Resolve(permissions, AuthType.SessionCookie, new HashSet<string>());
+
+        scopes.Should().NotContain(OAuthScopes.AlertsReadWrite);
+        scopes.Should().NotContain(OAuthScopes.FullAccess);
+        permissions.Should().Contain(OAuthScopes.DeviceNotify,
+            $"the {role} seed role lists device.notify in its own permission set");
+        scopes.Should().Contain(OAuthScopes.DeviceNotify);
+
+        foreach (var (controller, action) in GatedWriteActions())
+        {
+            var key = $"{controller.Name}.{action.Name}";
+            var result = Evaluate(controller, action, authenticated: true, scopes);
+
+            if (DeviceCapabilityActions.Contains(key, StringComparer.Ordinal))
+            {
+                result.Should().BeNull(
+                    $"a {role} member holds device.notify, which {key} accepts alongside alerts.readwrite");
+            }
+            else
+            {
+                result.Should().BeOfType<ForbidResult>(
+                    $"the {role} role holds no alerts.readwrite, so it must not reach {key}");
+            }
+        }
+    }
+
+    [Fact]
+    public void ReadOnlyGuestSession_IsDeniedEveryAlertSurfaceWrite()
+    {
+        // The widest grant a guest link can hold: ValidateGrantScopes caps a guest at
+        // AllowedGuestScopes, which is read-only and includes alerts.read. MemberScopeMiddleware
+        // publishes Normalize() of exactly that list for AuthType.Guest — no membership widening.
+        var stored = OAuthScopes.ValidateGrantScopes(
+            OAuthScopes.AllowedGuestScopes, OAuthScopes.GrantTypeGuest);
+        var guestScopes = OAuthScopes.Normalize(stored);
+
+        guestScopes.Should().Contain(OAuthScopes.AlertsRead);
+        guestScopes.Should().NotContain(OAuthScopes.AlertsReadWrite);
+        guestScopes.Should().NotContain(OAuthScopes.DeviceNotify);
+
+        foreach (var (controller, action) in GatedWriteActions())
+        {
+            Evaluate(controller, action, authenticated: true, guestScopes)
+                .Should().BeOfType<ForbidResult>(
+                    $"a read-only guest session must not reach {controller.Name}.{action.Name}");
+        }
+    }
+
+    [Fact]
+    public void UnauthenticatedCaller_IsDeniedEveryAlertSurfaceWrite()
+    {
+        foreach (var (controller, action) in GatedWriteActions())
+        {
+            Evaluate(controller, action, authenticated: false, new HashSet<string> { OAuthScopes.AlertsReadWrite })
+                .Should().BeOfType<UnauthorizedResult>(
+                    $"{controller.Name}.{action.Name} must reject an unauthenticated caller");
+        }
+    }
+
+    [Fact]
+    public void WildcardGrant_KeepsEveryAlertSurfaceWrite()
+    {
+        // A legacy api-secret and an instance-key service credential both normalise to "*", and
+        // production direct grants carry it too.
+        var wildcard = new HashSet<string> { OAuthScopes.FullAccess };
+
+        OAuthScopes.SatisfiesScope(wildcard, OAuthScopes.AlertsReadWrite).Should().BeTrue();
+
+        foreach (var (controller, action) in GatedWriteActions())
+        {
+            Evaluate(controller, action, authenticated: true, wildcard)
+                .Should().BeNull($"a full-access grant must keep {controller.Name}.{action.Name}");
+        }
+    }
+
+    [Fact]
+    public void CompanionDeviceGrant_KeepsTheExcursionAckPathsAndNothingElse()
+    {
+        // Even a tenant OWNER's companion token resolves without alerts.readwrite: an OAuth access
+        // token is a scoped credential, so membership is intersected with the grant rather than
+        // replacing it, and the grant never asked for an alert scope.
+        var companionScopes = MemberScopeResolver.Resolve(
+            new HashSet<string>(TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Owner]),
+            AuthType.OAuthAccessToken,
+            OAuthScopes.Normalize(CompanionGrantScopes).ToHashSet());
+
+        companionScopes.Should().Contain(OAuthScopes.DeviceNotify);
+        companionScopes.Should().NotContain(OAuthScopes.AlertsReadWrite);
+        companionScopes.Should().NotContain(OAuthScopes.FullAccess);
+
+        foreach (var (controller, action) in GatedWriteActions())
+        {
+            var key = $"{controller.Name}.{action.Name}";
+            var result = Evaluate(controller, action, authenticated: true, companionScopes);
+
+            if (DeviceCapabilityActions.Contains(key, StringComparer.Ordinal))
+            {
+                result.Should().BeNull(
+                    $"the Acknowledge action posts to {key} with the device's own grant");
+            }
+            else
+            {
+                result.Should().BeOfType<ForbidResult>(
+                    $"a device capability grant must not reach {key}");
+            }
+        }
+    }
+
+    [Fact]
+    public void OnlyTheExcursionAckPaths_AcceptADeviceCapabilityScope()
+    {
+        var accepting = GatedWriteActions()
+            .Where(x => RequiredScopes(x.Controller, x.Action)
+                .Any(TenantPermissions.MemberPersonalScopes.Contains))
+            .Select(x => $"{x.Controller.Name}.{x.Action.Name}")
+            .ToList();
+
+        accepting.Should().BeEquivalentTo(DeviceCapabilityActions,
+            "device.notify / device.actuate are held by every member with any permission, so "
+            + "accepting one widens the gate to a read-only member — only the two excursion "
+            + "acknowledgement paths may do so, and ExecuteAction narrows its arm to an "
+            + "alert.firing notification in the action body");
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────────────────────
+
+    private static Assembly ApiAssembly => typeof(RequireScopeAttribute).Assembly;
+
+    private static IEnumerable<Type> MonitoringControllers() =>
+        ApiAssembly.GetTypes()
+            .Where(t => t is { IsClass: true, IsAbstract: false }
+                        && typeof(ControllerBase).IsAssignableFrom(t)
+                        && t.Namespace == MonitoringNamespace)
+            .OrderBy(t => t.Name, StringComparer.Ordinal);
+
+    /// <summary>Every alert-surface write action that is expected to carry a gate.</summary>
+    private static IEnumerable<(Type Controller, MethodInfo Action)> GatedWriteActions() =>
+        MonitoringControllers()
+            .SelectMany(c => WriteActions(c).Select(a => (Controller: c, Action: a)))
+            .Where(x => !Ungated.ContainsKey($"{x.Controller.Name}.{x.Action.Name}"));
+
+    private static IEnumerable<MethodInfo> WriteActions(Type controller) =>
+        controller.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .Where(action => HttpVerbs(action).Overlaps(WriteVerbs))
+            .OrderBy(a => a.Name, StringComparer.Ordinal);
+
+    private static HashSet<string> HttpVerbs(MethodInfo action) =>
+        action.GetCustomAttributes(inherit: true)
+            .OfType<IActionHttpMethodProvider>()
+            .SelectMany(a => a.HttpMethods)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The scopes an action's gate requires: an explicit <see cref="RequireScopeAttribute"/>, or the
+    /// controller's <see cref="IWriteScopedController.WriteScope"/> when it defers to
+    /// <see cref="RequireDeclaredWriteScopeAttribute"/>. Empty when the action carries neither.
+    /// </summary>
+    private static IEnumerable<string> RequiredScopes(Type controller, MethodInfo action)
+    {
+        var attributes = action.GetCustomAttributes(inherit: true);
+
+        foreach (var scope in attributes.OfType<RequireScopeAttribute>().SelectMany(a => a.Scopes))
+            yield return scope;
+
+        if (attributes.Any(a => a is RequireDeclaredWriteScopeAttribute)
+            && ControllerInstance(controller) is IWriteScopedController declared)
+            yield return declared.WriteScope;
+    }
+
+    /// <summary>
+    /// Runs the gate an action actually declares, in MVC's order: the authorization filters first,
+    /// then the action filters (<see cref="RequireDeclaredWriteScopeAttribute"/> is one). Returns
+    /// the short-circuit result, or null when the request would proceed to the handler.
+    /// </summary>
+    private static IActionResult? Evaluate(
+        Type controller, MethodInfo action, bool authenticated, IReadOnlySet<string> grantedScopes)
+    {
+        var httpContext = new DefaultHttpContext();
+        if (authenticated)
+            httpContext.Items["AuthContext"] = new AuthContext { IsAuthenticated = true };
+        httpContext.Items["GrantedScopes"] = grantedScopes;
+
+        var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+        var filters = action.GetCustomAttributes(inherit: true);
+
+        foreach (var filter in filters.OfType<IAuthorizationFilter>())
+        {
+            var authorizationContext = new AuthorizationFilterContext(actionContext, []);
+            filter.OnAuthorization(authorizationContext);
+            if (authorizationContext.Result is not null)
+                return authorizationContext.Result;
+        }
+
+        var executingContext = new ActionExecutingContext(
+            actionContext, [], new Dictionary<string, object?>(), ControllerInstance(controller));
+
+        foreach (var filter in filters.OfType<IActionFilter>())
+        {
+            filter.OnActionExecuting(executingContext);
+            if (executingContext.Result is not null)
+                return executingContext.Result;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// A controller instance for reading <see cref="IWriteScopedController.WriteScope"/> and for
+    /// running the write-scope filters. The getter returns a constant and the filters touch nothing
+    /// else, so the controller is left unconstructed — these controllers take services with no
+    /// mockable constructor.
+    /// </summary>
+    private static object ControllerInstance(Type controller) =>
+        RuntimeHelpers.GetUninitializedObject(controller);
+}

--- a/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
@@ -87,10 +87,11 @@ public class V4WriteScopeGatingTests
         public const string ConnectorAdministration = "connector configuration, not a data write";
 
         /// <summary>
-        /// POST carrying a request body for a pure computation or a report render. Nothing is
-        /// persisted, so there is no write to scope.
+        /// POST whose handler computes and returns: a statistic over the values in the request
+        /// body, a report render, or a replay over stored history for a window the body supplies.
+        /// Nothing is persisted, so there is no write to scope.
         /// </summary>
-        public const string ComputeOverPostBody = "computes from the body, persists nothing";
+        public const string ComputesAndReturns = "computes and returns, persists nothing";
 
         /// <summary>Per-user or per-tenant presentation state with no patient observation in it.</summary>
         public const string PresentationState = "presentation state, no patient data";
@@ -114,14 +115,6 @@ public class V4WriteScopeGatingTests
         /// this mints serves patient glucose to an anonymous caller.
         /// </summary>
         public const string SplitSharingVocabulary = "sharing capability, vocabulary split between atom and scope";
-
-        /// <summary>
-        /// Writes alert, notification or DND state. <c>alerts.readwrite</c> is the category, but
-        /// gating this surface is the alert-authorization work, not the data-plane taxonomy: the
-        /// alert engine, the chat-bot dispatch and the invite redemption all post here with
-        /// credentials whose scope resolution is being changed on sibling branches.
-        /// </summary>
-        public const string AlertSurface = "alert surface, pending the alert-authorization work";
 
         /// <summary>
         /// Deliberately <c>[AllowAnonymous]</c>. There is no credential to scope, so a scope gate
@@ -195,22 +188,18 @@ public class V4WriteScopeGatingTests
             ["MyFitnessPalSettingsController"] = NotDataCategory.ConnectorAdministration,
             ["WebhookSettingsController"] = NotDataCategory.ConnectorAdministration,
 
-            ["DebugController"] = NotDataCategory.ComputeOverPostBody,
-            ["StatisticsController"] = NotDataCategory.ComputeOverPostBody,
+            ["DebugController"] = NotDataCategory.ComputesAndReturns,
+            ["StatisticsController"] = NotDataCategory.ComputesAndReturns,
+
+            // Both replay actions compute over the STORED alert rules and glucose history — the
+            // body supplies only the window — and return the events that would have fired.
+            // AlertReplayService has no SaveChangesAsync and adds to no DbSet, so a POST here is a
+            // read the body shape forced off GET.
+            ["AlertReplayController"] = NotDataCategory.ComputesAndReturns,
 
             ["ClockFacesController"] = NotDataCategory.SplitSharingVocabulary,
             ["CoachMarkController"] = NotDataCategory.PresentationState,
             ["UserPreferencesController"] = NotDataCategory.PresentationState,
-
-            ["AlertCustomSoundsController"] = NotDataCategory.AlertSurface,
-            ["AlertInvitesController"] = NotDataCategory.AlertSurface,
-            ["AlertReplayController"] = NotDataCategory.AlertSurface,
-            ["AlertRulesController"] = NotDataCategory.AlertSurface,
-            ["AlertsController"] = NotDataCategory.AlertSurface,
-            ["CompressionLowController"] = NotDataCategory.AlertSurface,
-            ["DndWindowsController"] = NotDataCategory.AlertSurface,
-            ["NotificationsController"] = NotDataCategory.AlertSurface,
-            ["TenantAlertSettingsController"] = NotDataCategory.AlertSurface,
 
             ["AnalyticsController"] = NotDataCategory.TenantOperationalConfig,
             ["AuditController"] = NotDataCategory.TenantOperationalConfig,
@@ -249,6 +238,17 @@ public class V4WriteScopeGatingTests
             // The rest of DiscrepancyController is [RequireAdmin]; the ingest route is deliberately
             // [AllowAnonymous], so there is no credential whose scopes could be checked.
             ["DiscrepancyController.IngestDiscrepancy"] = NotDataCategory.AnonymousByDeclaration,
+
+            // The caller's own notification bookkeeping: MarkAsRead / MarkAllAsRead set read_at,
+            // DismissNotification sets the archive flags. Each is confined to a row whose UserId is
+            // the caller's subject (InAppNotificationService checks it, and the mark-all repository
+            // query is keyed by user), and none changes alert state — archiving an alert.firing
+            // notification neither acknowledges nor silences the excursion behind it. Same category
+            // as CoachMarkController and UserPreferencesController above; the rest of
+            // NotificationsController is gated on alerts.readwrite.
+            ["NotificationsController.MarkAsRead"] = NotDataCategory.PresentationState,
+            ["NotificationsController.MarkAllAsRead"] = NotDataCategory.PresentationState,
+            ["NotificationsController.DismissNotification"] = NotDataCategory.PresentationState,
         };
 
     /// <summary>
@@ -269,6 +269,12 @@ public class V4WriteScopeGatingTests
             ["MeterGlucoseController"] = OAuthScopes.GlucoseReadWrite,
             ["CalibrationController"] = OAuthScopes.GlucoseReadWrite,
             ["BGCheckController"] = OAuthScopes.GlucoseReadWrite,
+
+            // glucose: accepting a compression-low suggestion writes a DataExclusion state span,
+            // which decides whether the flagged readings count towards analytics and reports —
+            // the category StateSpanWriteScopeGuard maps to glucose.readwrite. Dismiss, delete and
+            // detection write the compression_low_suggestions rows that propose one.
+            ["CompressionLowController"] = OAuthScopes.GlucoseReadWrite,
 
             // treatments: boluses / basal_injections / bolus_calculations sit under treatments.read;
             // notes are the V4 form of a legacy text treatment. v1 treatments create requires
@@ -315,6 +321,20 @@ public class V4WriteScopeGatingTests
             // alerts: UISettingsConfiguration is tenant-wide and carries NotificationSettings, the
             // alarm thresholds and profiles that decide whether a low-glucose alert fires.
             ["UISettingsController"] = OAuthScopes.AlertsReadWrite,
+
+            // alerts: the rest of the alert surface. A rule and its channels decide whether an
+            // alert reaches anyone; acknowledging, snoozing and recording a delivery outcome close
+            // or silence an excursion; a DND window and the tenant-wide manual toggle suppress
+            // delivery outright; a custom sound is what an alert plays; an invite attaches a
+            // follower to a rule channel; an in-app notification is a delivery channel. v1/v2
+            // notification writes require alerts.readwrite.
+            ["AlertRulesController"] = OAuthScopes.AlertsReadWrite,
+            ["AlertsController"] = OAuthScopes.AlertsReadWrite,
+            ["DndWindowsController"] = OAuthScopes.AlertsReadWrite,
+            ["TenantAlertSettingsController"] = OAuthScopes.AlertsReadWrite,
+            ["AlertCustomSoundsController"] = OAuthScopes.AlertsReadWrite,
+            ["AlertInvitesController"] = OAuthScopes.AlertsReadWrite,
+            ["NotificationsController"] = OAuthScopes.AlertsReadWrite,
 
             // devices: a reservoir report is stored as a manual-source pump_snapshots row, and a fill
             // additionally writes a device_events row. Both are the devices category.

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Monitoring/NotificationsControllerExecuteActionScopeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Monitoring/NotificationsControllerExecuteActionScopeTests.cs
@@ -1,0 +1,142 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Nocturne.API.Controllers.V4.Monitoring;
+using Nocturne.API.Services.Alerts.Providers;
+using Nocturne.Core.Contracts.Notifications;
+using Nocturne.Core.Models.Authorization;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4.Monitoring;
+
+/// <summary>
+/// Pins the type narrowing on <see cref="NotificationsController.ExecuteAction"/>. Its
+/// <c>[RequireScope]</c> gate accepts <c>device.notify</c> alongside <c>alerts.readwrite</c> so a
+/// read-only member or the desktop Companion can acknowledge a firing alert, but the action it
+/// guards is a dispatcher: <c>InAppNotificationService.ExecuteActionAsync</c> routes on the
+/// notification's type to whichever <c>INotificationActionHandler</c> is registered, and those
+/// handlers mutate their own domains — <c>TrackerSuggestionActionHandler</c>'s <c>accept</c>
+/// completes and restarts tracker instances. So a caller admitted only by <c>device.notify</c>
+/// reaches the dispatcher for an <c>alert.firing</c> notification and nothing else.
+/// </summary>
+[Trait("Category", "Unit")]
+public class NotificationsControllerExecuteActionScopeTests
+{
+    /// <summary><c>TrackerSuggestionActionHandler.NotificationType</c>, a property rather than a
+    /// constant, so it is repeated here to be usable in <see cref="InlineDataAttribute"/>.</summary>
+    private const string TrackerSuggestionType = "tracker.suggested_match";
+
+    private static readonly Guid Subject = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    private readonly Mock<IInAppNotificationService> _notifications = new();
+
+    /// <summary>
+    /// The scopes a read-only member or the Companion's grant resolves to: <c>device.notify</c>
+    /// admits it through the gate, and no alert write scope.
+    /// </summary>
+    private static readonly HashSet<string> DeviceNotifyOnly =
+        [OAuthScopes.GlucoseRead, OAuthScopes.AlertsRead, OAuthScopes.DeviceNotify];
+
+    private static readonly HashSet<string> AlertsWriter = [OAuthScopes.AlertsReadWrite];
+
+    private NotificationsController CreateController(IReadOnlySet<string> grantedScopes)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["AuthContext"] = new AuthContext
+        {
+            IsAuthenticated = true,
+            SubjectId = Subject,
+        };
+        httpContext.Items["GrantedScopes"] = grantedScopes;
+
+        return new NotificationsController(
+            _notifications.Object,
+            Mock.Of<ILogger<NotificationsController>>())
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext },
+        };
+    }
+
+    private void NotificationIsOfType(Guid id, string type) =>
+        _notifications
+            .Setup(s => s.GetNotificationTypeAsync(id, Subject.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(type);
+
+    private void ActionSucceeds(Guid id, string actionId) =>
+        _notifications
+            .Setup(s => s.ExecuteActionAsync(id, actionId, Subject.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+    [Fact]
+    public async Task DeviceNotifyOnly_OnANonAlertNotification_IsForbiddenWithoutDispatching()
+    {
+        var id = Guid.CreateVersion7();
+        NotificationIsOfType(id, TrackerSuggestionType);
+        // Arranged to succeed, so a lost narrowing shows up as the dispatch it would allow rather
+        // than as the 404 an unstubbed dispatcher returns.
+        ActionSucceeds(id, "accept");
+
+        var result = await CreateController(DeviceNotifyOnly).ExecuteAction(id, "accept");
+
+        result.Should().BeOfType<ForbidResult>(
+            "device.notify buys the excursion acknowledgement, not the tracker handler's accept");
+        _notifications.Verify(
+            s => s.ExecuteActionAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task DeviceNotifyOnly_OnAnAlertNotification_Dispatches()
+    {
+        var id = Guid.CreateVersion7();
+        NotificationIsOfType(id, InAppProvider.NotificationType);
+        ActionSucceeds(id, InAppProvider.AckActionId);
+
+        var result = await CreateController(DeviceNotifyOnly)
+            .ExecuteAction(id, InAppProvider.AckActionId);
+
+        result.Should().BeOfType<NoContentResult>();
+        _notifications.Verify(
+            s => s.ExecuteActionAsync(
+                id, InAppProvider.AckActionId, Subject.ToString(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DeviceNotifyOnly_OnANotificationTheCallerDoesNotOwn_IsNotFound()
+    {
+        var id = Guid.CreateVersion7();
+        _notifications
+            .Setup(s => s.GetNotificationTypeAsync(id, Subject.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        var result = await CreateController(DeviceNotifyOnly).ExecuteAction(id, "accept");
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Theory]
+    [InlineData(TrackerSuggestionType, "accept")]
+    [InlineData(InAppProvider.NotificationType, InAppProvider.AckActionId)]
+    public async Task AlertsReadWrite_DispatchesEveryNotificationType(string type, string actionId)
+    {
+        var id = Guid.CreateVersion7();
+        NotificationIsOfType(id, type);
+        ActionSucceeds(id, actionId);
+
+        var result = await CreateController(AlertsWriter).ExecuteAction(id, actionId);
+
+        result.Should().BeOfType<NoContentResult>();
+        _notifications.Verify(
+            s => s.ExecuteActionAsync(id, actionId, Subject.ToString(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _notifications.Verify(
+            s => s.GetNotificationTypeAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the narrowing is only for a caller the capability scope admitted");
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Notifications/InAppNotificationServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Notifications/InAppNotificationServiceTests.cs
@@ -10,8 +10,10 @@ using Nocturne.Infrastructure.Data.Entities;
 namespace Nocturne.API.Tests.Services.Notifications;
 
 /// <summary>
-/// Unit tests for the read-state behaviour of <see cref="InAppNotificationService"/>:
-/// single mark-read ownership/no-op guards and bulk mark-all-read broadcasting.
+/// Unit tests for the per-subject bookkeeping on <see cref="InAppNotificationService"/>: the
+/// single mark-read ownership/no-op guards, bulk mark-all-read broadcasting, the archive
+/// ownership guard that confines <c>DELETE /api/v4/notifications/{id}</c> to the caller's own rows,
+/// and the type accessor that <c>NotificationsController.ExecuteAction</c> authorizes on.
 /// </summary>
 public class InAppNotificationServiceTests
 {
@@ -152,5 +154,117 @@ public class InAppNotificationServiceTests
         _broadcast.Verify(
             b => b.BroadcastNotificationUpdatedAsync(It.IsAny<string>(), It.IsAny<InAppNotificationDto>()),
             Times.Never);
+    }
+
+    /// <summary>
+    /// The archive path resolved by notification id alone before this guard, so any authenticated
+    /// subject could clear another member's notification by forwarding its id — the same forged-id
+    /// hole <c>MarkAsReadAsync</c> and <c>ExecuteActionAsync</c> already closed.
+    /// </summary>
+    [Fact]
+    public async Task ArchiveNotificationAsync_WhenOwnedByAnotherUser_ReturnsFalseAndDoesNotArchive()
+    {
+        var entity = Notification("owner");
+        _repository
+            .Setup(r => r.GetByIdAsync(entity.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entity);
+
+        var result = await _service.ArchiveNotificationAsync(
+            entity.Id, NotificationArchiveReason.Dismissed, "someone-else");
+
+        Assert.False(result);
+        _repository.Verify(
+            r => r.ArchiveAsync(
+                It.IsAny<Guid>(), It.IsAny<NotificationArchiveReason>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _broadcast.Verify(
+            b => b.BroadcastNotificationArchivedAsync(
+                It.IsAny<string>(),
+                It.IsAny<InAppNotificationDto>(),
+                It.IsAny<NotificationArchiveReason>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ArchiveNotificationAsync_WhenNotFound_ReturnsFalseAndDoesNotArchive()
+    {
+        _repository
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((InAppNotificationEntity?)null);
+
+        var result = await _service.ArchiveNotificationAsync(
+            Guid.NewGuid(), NotificationArchiveReason.Dismissed, "user-1");
+
+        Assert.False(result);
+        _repository.Verify(
+            r => r.ArchiveAsync(
+                It.IsAny<Guid>(), It.IsAny<NotificationArchiveReason>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// <c>NotificationsController.ExecuteAction</c> authorizes on the type before dispatching when
+    /// the caller was admitted by <c>device.notify</c> alone, so this accessor must be subject to
+    /// the same ownership confinement as the writes — otherwise it reports the type of another
+    /// member's notification.
+    /// </summary>
+    [Fact]
+    public async Task GetNotificationTypeAsync_WhenOwnedByTheCaller_ReturnsTheType()
+    {
+        var entity = Notification("user-1");
+        _repository
+            .Setup(r => r.GetByIdAsync(entity.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entity);
+
+        var type = await _service.GetNotificationTypeAsync(entity.Id, "user-1");
+
+        Assert.Equal(entity.Type, type);
+    }
+
+    [Fact]
+    public async Task GetNotificationTypeAsync_WhenOwnedByAnotherUser_ReturnsNull()
+    {
+        var entity = Notification("owner");
+        _repository
+            .Setup(r => r.GetByIdAsync(entity.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entity);
+
+        Assert.Null(await _service.GetNotificationTypeAsync(entity.Id, "someone-else"));
+    }
+
+    [Fact]
+    public async Task GetNotificationTypeAsync_WhenNotFound_ReturnsNull()
+    {
+        _repository
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((InAppNotificationEntity?)null);
+
+        Assert.Null(await _service.GetNotificationTypeAsync(Guid.NewGuid(), "user-1"));
+    }
+
+    [Fact]
+    public async Task ArchiveNotificationAsync_WhenOwnedByTheCaller_ArchivesAndBroadcasts()
+    {
+        var entity = Notification("user-1");
+        _repository
+            .Setup(r => r.GetByIdAsync(entity.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entity);
+        _repository
+            .Setup(r => r.ArchiveAsync(
+                entity.Id, NotificationArchiveReason.Dismissed, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entity);
+
+        var result = await _service.ArchiveNotificationAsync(
+            entity.Id, NotificationArchiveReason.Dismissed, "user-1");
+
+        Assert.True(result);
+        _repository.Verify(
+            r => r.ArchiveAsync(
+                entity.Id, NotificationArchiveReason.Dismissed, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _broadcast.Verify(
+            b => b.BroadcastNotificationArchivedAsync(
+                "user-1", It.IsAny<InAppNotificationDto>(), NotificationArchiveReason.Dismissed),
+            Times.Once);
     }
 }


### PR DESCRIPTION
The alert controllers carried only a class-level `[Authorize]`, which any authenticated credential satisfies — including a read-only guest-link session. That let a guest delete alert rules, silence excursions, change Do Not Disturb windows and rewrite tenant alert settings. Every state-mutating action in the V4 monitoring surface now names the scope it needs.

**Two actions also accept a client device's capability scope**, because both reach the same excursion acknowledgement and a device grant legitimately holds `device.notify` without `alerts.readwrite`: the desktop toast's acknowledge, and the in-app notification action. `ExecuteAction` is a dispatcher over registered handlers rather than an acknowledgement endpoint, so a caller admitted only by the capability scope may act on an alert notification and nothing else; the handler's own ownership check confines it to the caller's own row.

**Marking a notification read and dismissing it stay ungated** — they are per-subject presentation state, not alert state, and a member must be able to clear their own badge whatever their role. Archiving now takes the caller's subject, which the four sibling actions already threaded, so it can only touch the caller's own row.

**`CompressionLowController` is gated on `glucose.readwrite`.** Accepting a compression suggestion writes a `DataExclusion` state span, which removes readings from analytics and reports, and `StateSpanWriteScopeGuard` already maps that category to `glucose.readwrite`.

**Frontend:** tenant-wide Do Not Disturb suppresses delivery for every member, so its three entry points are hidden from members who cannot set it rather than left to fail on submit, and a rejected change now surfaces instead of vanishing.

Every gate is proven non-vacuous by a reflection sweep that fails if a write action is added without one, plus behavioural tests over the seed roles, a guest session, a wildcard grant and the Companion's own grant shape.

Unit suite 4596 passed, 0 failed. Frontend `check` unchanged from baseline; 6 component tests added. Reviewed adversarially across five rounds.

**Worth a maintainer's decision, not changed here:** `Caretaker` holds `glucose.read`, not `glucose.readwrite`, so the compression-low review page is now denied to that role — the one most likely to use it. The backend mapping is correct; the question is whether the Caretaker seed role should carry `glucose.readwrite`.

Known follow-ups, deliberately out of scope (each needs a permission gate plus several `catch` blocks, not a one-liner): the alert-rules list, the compression-low review page, and custom-sound deletion all still fail silently for a member who lacks the new scope.

https://claude.ai/code/session_01Wk3jH4N16htaBqGod2j7y8
