### PR TITLE
fix: Entries NS-API parameter 'rr' was misinterpreted as 'reverseResults' instead of a simple cache-buster (as intended by xDrip+)

### DIFF
--- a/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
@@ -294,7 +294,6 @@ public class EntriesController : ControllerBase
     /// <param name="find">MongoDB-style find query filters (JSON format) - for unit tests</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <param name="dateString">ISO date string for date filtering</param>
-    /// <param name="rr">Reverse results (latest first)</param>
     /// <param name="format">Output format (json, csv, tsv, txt)</param>
     /// <returns>Array of entries matching the criteria</returns>
     [HttpGet]
@@ -308,7 +307,6 @@ public class EntriesController : ControllerBase
         [FromQuery] int? count = null,
         [FromQuery] string? dateString = null,
         [FromQuery] string? type = null,
-        [FromQuery] int rr = 0,
         [FromQuery] string? format = null,
         CancellationToken cancellationToken = default
     )
@@ -341,12 +339,11 @@ public class EntriesController : ControllerBase
         }
 
         _logger.LogInformation(
-            "Entries endpoint requested with count: {Count}, type: {Type}, findQuery: {FindQuery}, dateString: {DateString}, rr: {RR}, format: {Format} from {RemoteIpAddress}",
+            "Entries endpoint requested with count: {Count}, type: {Type}, findQuery: {FindQuery}, dateString: {DateString}, format: {Format} from {RemoteIpAddress}",
             count,
             type,
             findQuery,
             dateString,
-            rr,
             format,
             HttpContext?.Connection?.RemoteIpAddress?.ToString() ?? "unknown"
         );
@@ -380,17 +377,16 @@ public class EntriesController : ControllerBase
             // Nightscout defaults to 10 when count is not specified
             var limitedCount = count ?? 10;
 
-            // Convert rr parameter to boolean (non-zero means reverse)
-            var reverseResults = rr != 0;
-
             // Use advanced filtering if any advanced parameters are provided
+            // reverseResults stays false (newest-first): legacy Nightscout ignores the cache-busting
+            // "rr" query parameter, so a nonzero "rr" value must never flip the sort order.
             var entries = await _entryService.GetEntriesWithAdvancedFilterAsync(
                 type: entryType,
                 count: limitedCount,
                 skip: 0,
                 findQuery: findQuery,
                 dateString: dateString,
-                reverseResults: reverseResults,
+                reverseResults: false,
                 cancellationToken: cancellationToken
             );
             var entriesArray = entries.ToArray();

--- a/tests/Unit/Nocturne.API.Tests/GoldenFiles/V1/EntriesGoldenTests.GetEntries_WithCacheBustingRrParam_StillReturnsNewestFirst.verified.txt
+++ b/tests/Unit/Nocturne.API.Tests/GoldenFiles/V1/EntriesGoldenTests.GetEntries_WithCacheBustingRrParam_StillReturnsNewestFirst.verified.txt
@@ -1,0 +1,81 @@
+﻿{
+  StatusCode: 200,
+  ContentType: application/json; charset=utf-8,
+  Body: [
+    {
+      _id: aaaaaaaaaaaaaaaaaaaaa001,
+      date: 1711454400000,
+      mills: 1711454400000,
+      dateString: DateTimeOffset_1,
+      sysTime: DateTimeOffset_1,
+      mgdl: 100,
+      sgv: 100,
+      mmol: 5.54994394556615,
+      direction: Flat,
+      trend: 4,
+      type: sgv,
+      device: xDrip-DexcomG6,
+      isValid: true
+    },
+    {
+      _id: aaaaaaaaaaaaaaaaaaaaa002,
+      date: 1711454100000,
+      mills: 1711454100000,
+      dateString: DateTimeOffset_2,
+      sysTime: DateTimeOffset_2,
+      mgdl: 110,
+      sgv: 110,
+      mmol: 6.104938340122764,
+      direction: Flat,
+      trend: 4,
+      type: sgv,
+      device: xDrip-DexcomG6,
+      isValid: true
+    },
+    {
+      _id: aaaaaaaaaaaaaaaaaaaaa003,
+      date: 1711453800000,
+      mills: 1711453800000,
+      dateString: DateTimeOffset_3,
+      sysTime: DateTimeOffset_3,
+      mgdl: 120,
+      sgv: 120,
+      mmol: 6.65993273467938,
+      direction: Flat,
+      trend: 4,
+      type: sgv,
+      device: xDrip-DexcomG6,
+      isValid: true
+    },
+    {
+      _id: aaaaaaaaaaaaaaaaaaaaa004,
+      date: 1711453500000,
+      mills: 1711453500000,
+      dateString: DateTimeOffset_4,
+      sysTime: DateTimeOffset_4,
+      mgdl: 130,
+      sgv: 130,
+      mmol: 7.214927129235995,
+      direction: Flat,
+      trend: 4,
+      type: sgv,
+      device: xDrip-DexcomG6,
+      isValid: true
+    },
+    {
+      _id: aaaaaaaaaaaaaaaaaaaaa005,
+      date: 1711453200000,
+      mills: 1711453200000,
+      dateString: DateTimeOffset_5,
+      sysTime: DateTimeOffset_5,
+      mgdl: 140,
+      sgv: 140,
+      mmol: 7.769921523792609,
+      direction: Flat,
+      trend: 4,
+      type: sgv,
+      device: xDrip-DexcomG6,
+      isValid: true
+    }
+  ]
+}

--- a/tests/Unit/Nocturne.API.Tests/GoldenFiles/V1/EntriesGoldenTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/GoldenFiles/V1/EntriesGoldenTests.cs
@@ -188,6 +188,20 @@ public class EntriesGoldenTests : GoldenFileTestBase
         await Verify(captured);
     }
 
+    [Fact]
+    public async Task GetEntries_WithCacheBustingRrParam_StillReturnsNewestFirst()
+    {
+        // xDrip+ appends ?rr=<timestamp> purely to bypass cached server responses; legacy
+        // Nightscout ignores it, so the sort order must remain newest-first.
+        var entries = Enumerable.Range(0, 5).Select(i => CreateSgvEntry(i, sgv: 100 + i * 10)).ToArray();
+        await SeedSensorGlucose(entries);
+
+        var response = await Client.GetAsync("/api/v1/entries?rr=1711454400000");
+        var captured = await CaptureResponse(response);
+
+        await Verify(captured);
+    }
+
     #endregion
 
     #region GET /api/v1/entries/sgv (type filter)


### PR DESCRIPTION
xDrip+ configured as Nighscout Follower usually sends requests like:
`https://<Nocturne-Server-Domain>/api/v1/entries.json?count=2880&find%5Bdate%5D%5B%24gt%5D=1785654900000&rr=1785718699569`

This leads to the following Nocturne response:
`{"type":"https://tools.ietf.org/html/rfc9110#section-15.5.1","title":"One or more validation errors occurred.","status":400,"errors":{"rr":["The value \u00271785718699569\u0027 is not valid."]},"traceId":"00-126d6d56db69711f1df77ed9e1b5d24b-4410b6c181b9f3e8-00"}`

This is an unintended deviation from legacy Nightscout API and should be fixed by this PR.