### PR TITLE
fix(audit): stop the mutation_audit_log firehose from unattributed saves

### DIFF
--- a/src/API/Nocturne.API/Services/Audit/AuditRetentionService.cs
+++ b/src/API/Nocturne.API/Services/Audit/AuditRetentionService.cs
@@ -1,19 +1,46 @@
 using Microsoft.EntityFrameworkCore;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
 
 namespace Nocturne.API.Services.Audit;
 
 /// <summary>
-/// Background service that purges expired audit log records based on per-tenant retention
-/// configuration. Runs every 24 hours, deleting in batches to avoid WAL bloat.
+/// Background service that purges expired audit log records. Every tenant is purged at the
+/// platform default retention (<c>Audit:DefaultReadAuditRetentionDays</c> /
+/// <c>Audit:DefaultMutationRetentionDays</c>); a tenant's own <see cref="TenantAuditConfigEntity"/>
+/// value overrides the default in either direction. Runs every 24 hours, deleting in batches to
+/// avoid WAL bloat.
 /// </summary>
 public class AuditRetentionService(
     IDbContextFactory<NocturneDbContext> contextFactory,
+    IConfiguration configuration,
     ILogger<AuditRetentionService> logger) : BackgroundService
 {
     private static readonly TimeSpan InitialDelay = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan Interval = TimeSpan.FromHours(24);
     private const int BatchSize = 10_000;
+
+    /// <summary>
+    /// Platform retention applied to tenants that have not set their own. Audit rows are an
+    /// operational trail, not clinical data, and unbounded retention grew mutation_audit_log to
+    /// 24GB in production while almost no tenant had opted into a retention window.
+    /// </summary>
+    private const int FallbackRetentionDays = 90;
+
+    private int? DefaultReadRetentionDays => ResolveDefault("Audit:DefaultReadAuditRetentionDays");
+
+    private int? DefaultMutationRetentionDays => ResolveDefault("Audit:DefaultMutationRetentionDays");
+
+    /// <summary>
+    /// Reads a platform retention default. An unset key falls back to
+    /// <see cref="FallbackRetentionDays"/>; a configured value of zero or less disables the
+    /// default, leaving only explicitly configured tenants purged.
+    /// </summary>
+    private int? ResolveDefault(string key)
+    {
+        var days = configuration.GetValue<int?>(key) ?? FallbackRetentionDays;
+        return days > 0 ? days : null;
+    }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -36,10 +63,14 @@ public class AuditRetentionService(
     }
 
     /// <summary>
-    /// Queries all tenants with configured retention and deletes expired records in batches.
+    /// Resolves each tenant's effective retention (own config, else the platform default) and
+    /// deletes expired records in batches.
     /// </summary>
     internal async Task PurgeExpiredRecordsAsync(CancellationToken ct)
     {
+        var defaultReadDays = DefaultReadRetentionDays;
+        var defaultMutationDays = DefaultMutationRetentionDays;
+
         await using var configContext = await contextFactory.CreateDbContextAsync(ct);
 
         var configs = await configContext.TenantAuditConfig
@@ -50,47 +81,64 @@ public class AuditRetentionService(
                 c.ReadAuditRetentionDays,
                 c.MutationAuditRetentionDays
             })
-            .ToListAsync(ct);
+            .ToDictionaryAsync(c => c.TenantId, ct);
 
-        if (configs.Count == 0)
+        // With a platform default in force every tenant is a purge candidate, not only the ones
+        // carrying a config row. Configured tenants are unioned in so a config row for a tenant
+        // missing from the table is still honoured.
+        var tenantIds = new HashSet<Guid>(configs.Keys);
+        if (defaultReadDays is not null || defaultMutationDays is not null)
         {
-            logger.LogDebug("No tenants with configured audit retention; skipping purge");
+            var allTenantIds = await configContext.Tenants
+                .AsNoTracking()
+                .Select(t => t.Id)
+                .ToListAsync(ct);
+            tenantIds.UnionWith(allTenantIds);
+        }
+
+        if (tenantIds.Count == 0)
+        {
+            logger.LogDebug("No tenants with effective audit retention; skipping purge");
             return;
         }
 
-        foreach (var config in configs)
+        foreach (var tenantId in tenantIds)
         {
+            var config = configs.GetValueOrDefault(tenantId);
+            var readDays = config?.ReadAuditRetentionDays ?? defaultReadDays;
+            var mutationDays = config?.MutationAuditRetentionDays ?? defaultMutationDays;
+
             try
             {
                 var readDeleted = 0;
                 var mutationDeleted = 0;
 
-                if (config.ReadAuditRetentionDays is { } readDays)
+                if (readDays is { } read)
                 {
-                    var cutoff = DateTime.UtcNow.AddDays(-readDays);
+                    var cutoff = DateTime.UtcNow.AddDays(-read);
                     readDeleted = await PurgeBatchedAsync(
-                        config.TenantId, "read_access_log", cutoff, ct);
+                        tenantId, "read_access_log", cutoff, ct);
                 }
 
-                if (config.MutationAuditRetentionDays is { } mutationDays)
+                if (mutationDays is { } mutation)
                 {
-                    var cutoff = DateTime.UtcNow.AddDays(-mutationDays);
+                    var cutoff = DateTime.UtcNow.AddDays(-mutation);
                     mutationDeleted = await PurgeBatchedAsync(
-                        config.TenantId, "mutation_audit_log", cutoff, ct);
+                        tenantId, "mutation_audit_log", cutoff, ct);
                 }
 
                 if (readDeleted > 0 || mutationDeleted > 0)
                 {
                     logger.LogInformation(
                         "Audit retention purge for tenant {TenantId}: {ReadDeleted} read, {MutationDeleted} mutation records deleted",
-                        config.TenantId, readDeleted, mutationDeleted);
+                        tenantId, readDeleted, mutationDeleted);
                 }
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 logger.LogWarning(ex,
                     "Audit retention purge failed for tenant {TenantId}; continuing with next tenant",
-                    config.TenantId);
+                    tenantId);
             }
         }
     }
@@ -100,7 +148,7 @@ public class AuditRetentionService(
     /// <see cref="BatchSize"/> to avoid WAL bloat and long-running transactions.
     /// </summary>
     /// <returns>Total number of records deleted.</returns>
-    private async Task<int> PurgeBatchedAsync(
+    internal virtual async Task<int> PurgeBatchedAsync(
         Guid tenantId, string table, DateTime cutoff, CancellationToken ct)
     {
         var totalDeleted = 0;

--- a/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
+++ b/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
@@ -4,8 +4,10 @@ using System.Text;
 using Microsoft.EntityFrameworkCore;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using Nocturne.API.Services.Audit;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Models;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Infrastructure.Data;
@@ -430,6 +432,9 @@ internal class MigrationJob
         _serviceProvider = serviceProvider;
     }
 
+    /// <summary>Audit endpoint recorded for migration-owned writes.</summary>
+    private const string AuditEndpoint = "service:migration";
+
     /// <summary>
     /// Creates a DI scope for migration work and propagates the owning tenant's context into it,
     /// so that tenant-scoped services (NocturneDbContext, decomposers, repositories) resolve and
@@ -449,7 +454,32 @@ internal class MigrationJob
             // task could write under a stale pooled tenant. Mirrors ConnectorBackgroundService.
             scope.ServiceProvider.GetRequiredService<NocturneDbContext>().TenantId = _tenantContext.TenantId;
         }
-        return scope;
+
+        // Attribute the imported records to the migration rather than to a human actor. A backfill
+        // writes one row per historical treatment/entry, and without this every one of them also
+        // appends a mutation_audit_log row. The property covers writes made on this scope's own
+        // context; the pushed scope covers the contexts ITenantDbContextFactory creates for the V4
+        // repositories and decomposers. Mirrors ConnectorBackgroundService.
+        scope.ServiceProvider.GetRequiredService<NocturneDbContext>().AuditContext =
+            SystemAuditContext.ForService(AuditEndpoint);
+        return new SystemAttributedScope(
+            scope,
+            SystemAuditScope.Push(scope.ServiceProvider.GetRequiredService<IAuditContext>()));
+    }
+
+    /// <summary>
+    /// A DI scope whose ambient <see cref="IAuditContext"/> stays system-attributed for the
+    /// scope's lifetime. Disposing releases the audit attribution, then the scope.
+    /// </summary>
+    private sealed class SystemAttributedScope(IServiceScope inner, IDisposable auditScope) : IServiceScope
+    {
+        public IServiceProvider ServiceProvider => inner.ServiceProvider;
+
+        public void Dispose()
+        {
+            auditScope.Dispose();
+            inner.Dispose();
+        }
     }
 
     public MigrationJobStatus GetStatus() =>

--- a/src/API/Nocturne.API/appsettings.example.json
+++ b/src/API/Nocturne.API/appsettings.example.json
@@ -86,6 +86,14 @@
     "MinimumRetentionDays": 7
   },
 
+  // Audit log retention applied to every tenant that has not set its own window
+  // (a per-tenant value always wins, larger or smaller). Set to 0 to keep audit
+  // rows forever unless a tenant opts in.
+  "Audit": {
+    "DefaultReadAuditRetentionDays": 90,
+    "DefaultMutationRetentionDays": 90
+  },
+
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/Core/Nocturne.Core.Contracts/Audit/AuditContextExtensions.cs
+++ b/src/Core/Nocturne.Core.Contracts/Audit/AuditContextExtensions.cs
@@ -1,0 +1,20 @@
+namespace Nocturne.Core.Contracts.Audit;
+
+/// <summary>
+/// Shared predicate for the code paths that append mutation audit rows (the save interceptor
+/// and the bulk delete/soft-delete helpers), so they agree on what counts as an unattributed
+/// mutation.
+/// </summary>
+public static class AuditContextExtensions
+{
+    /// <summary>
+    /// True when a mutation carries no human actor: either an explicitly system-attributed
+    /// context (<see cref="IAuditContext.IsSystem"/>), or no context at all. A null context is
+    /// a background save that never populated one — an HTTP request always resolves a scoped
+    /// context — and writing it produces an audit row whose actor, auth type and endpoint are
+    /// all null. Such mutations are not recorded; their provenance is already on the records
+    /// themselves (<c>data_source</c>).
+    /// </summary>
+    public static bool IsSystemMutation(this IAuditContext? auditContext)
+        => auditContext is null || auditContext.IsSystem;
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/AuditedBulkDeleteExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/AuditedBulkDeleteExtensions.cs
@@ -42,54 +42,18 @@ public static class AuditedBulkDeleteExtensions
                 return 0;
             }
 
-            var now = DateTime.UtcNow;
-            var entityTypeName = typeof(T).Name.Replace("Entity", "");
-
-            var auditEntries = affectedRecords.Select(record =>
-            {
-                var entry = context.Entry(record);
-                var snapshot = new Dictionary<string, object?>();
-
-                foreach (var prop in entry.Properties)
-                {
-                    if (prop.Metadata.IsPrimaryKey())
-                        continue;
-
-                    var property = typeof(T).GetProperty(prop.Metadata.Name,
-                        BindingFlags.Public | BindingFlags.Instance);
-
-                    if (property?.GetCustomAttribute<AuditIgnoredAttribute>() is not null)
-                        continue;
-
-                    var isRedacted = property?.GetCustomAttribute<AuditRedactedAttribute>() is not null;
-                    snapshot[prop.Metadata.Name] = isRedacted ? "[redacted]" : prop.CurrentValue;
-                }
-
-                return new MutationAuditLogEntity
-                {
-                    Id = Guid.CreateVersion7(),
-                    TenantId = context.TenantId,
-                    EntityType = entityTypeName,
-                    EntityId = (Guid)entry.Property("Id").CurrentValue!,
-                    Action = "delete",
-                    ChangesJson = JsonSerializer.Serialize(snapshot, JsonOptions),
-                    SubjectId = auditContext?.SubjectId,
-                    AuthType = auditContext?.AuthType,
-                    IpAddress = auditContext?.IpAddress,
-                    TokenId = auditContext?.TokenId,
-                    CorrelationId = auditContext?.CorrelationId,
-                    Endpoint = auditContext?.Endpoint,
-                    CreatedAt = now
-                };
-            }).ToList();
+            var auditEntries = BuildDeleteAuditEntries(context, affectedRecords, auditContext);
 
             // Detach the loaded entities so they don't interfere with the bulk delete
             foreach (var record in affectedRecords)
                 context.Entry(record).State = EntityState.Detached;
 
             // Write audit entries
-            context.Set<MutationAuditLogEntity>().AddRange(auditEntries);
-            await context.SaveChangesAsync(ct);
+            if (auditEntries.Count > 0)
+            {
+                context.Set<MutationAuditLogEntity>().AddRange(auditEntries);
+                await context.SaveChangesAsync(ct);
+            }
 
             // Execute bulk delete
             var deletedCount = await query.ExecuteDeleteAsync(ct);
@@ -153,58 +117,24 @@ public static class AuditedBulkDeleteExtensions
             }
 
             var now = DateTime.UtcNow;
-            var entityTypeName = typeof(T).Name.Replace("Entity", "");
-
-            var auditEntries = affectedRecords.Select(record =>
-            {
-                var entry = context.Entry(record);
-                var snapshot = new Dictionary<string, object?>();
-
-                foreach (var prop in entry.Properties)
-                {
-                    if (prop.Metadata.IsPrimaryKey())
-                        continue;
-
-                    var property = typeof(T).GetProperty(prop.Metadata.Name,
-                        BindingFlags.Public | BindingFlags.Instance);
-
-                    if (property?.GetCustomAttribute<AuditIgnoredAttribute>() is not null)
-                        continue;
-
-                    var isRedacted = property?.GetCustomAttribute<AuditRedactedAttribute>() is not null;
-                    snapshot[prop.Metadata.Name] = isRedacted ? "[redacted]" : prop.CurrentValue;
-                }
-
-                return new MutationAuditLogEntity
-                {
-                    Id = Guid.CreateVersion7(),
-                    TenantId = context.TenantId,
-                    EntityType = entityTypeName,
-                    EntityId = (Guid)entry.Property("Id").CurrentValue!,
-                    Action = "delete",
-                    ChangesJson = JsonSerializer.Serialize(snapshot, JsonOptions),
-                    SubjectId = auditContext?.SubjectId,
-                    AuthType = auditContext?.AuthType,
-                    IpAddress = auditContext?.IpAddress,
-                    TokenId = auditContext?.TokenId,
-                    CorrelationId = auditContext?.CorrelationId,
-                    Endpoint = auditContext?.Endpoint,
-                    CreatedAt = now
-                };
-            }).ToList();
+            var auditEntries = BuildDeleteAuditEntries(context, affectedRecords, auditContext);
 
             // Detach the loaded entities so they don't interfere with the bulk update
             foreach (var record in affectedRecords)
                 context.Entry(record).State = EntityState.Detached;
 
             // Write audit entries
-            context.Set<MutationAuditLogEntity>().AddRange(auditEntries);
-            await context.SaveChangesAsync(ct);
+            if (auditEntries.Count > 0)
+            {
+                context.Set<MutationAuditLogEntity>().AddRange(auditEntries);
+                await context.SaveChangesAsync(ct);
+            }
 
             // Execute bulk soft delete, carrying the dedup attribution flag in the same
             // update: a user-initiated delete blocks resync re-creation, a system sweep
-            // (no auth context) leaves the row re-creatable.
-            var isUserDelete = auditContext?.AuthType != null;
+            // (no auth context) leaves the row re-creatable. This runs whether or not audit
+            // rows were written.
+            var isUserDelete = !auditContext.IsSystemMutation();
             await query.ExecuteUpdateAsync(
                 s => s
                     .SetProperty(e => e.DeletedAt, now)
@@ -213,6 +143,63 @@ public static class AuditedBulkDeleteExtensions
             await transaction.CommitAsync(ct);
             return affectedRecords;
         });
+    }
+
+    /// <summary>
+    /// Builds one "delete" audit row per affected record, snapshotting its current values.
+    /// Returns an empty list for system/unattributed mutations: these helpers write audit rows
+    /// themselves rather than through <c>MutationAuditInterceptor</c>, so they have to apply the
+    /// same skip — a connector's reconcile sweep is high-volume and has no human actor, and
+    /// recording it added ~77k actorless rows a week to <c>mutation_audit_log</c> in production.
+    /// </summary>
+    private static List<MutationAuditLogEntity> BuildDeleteAuditEntries<T>(
+        NocturneDbContext context,
+        List<T> affectedRecords,
+        IAuditContext? auditContext) where T : class, IAuditable
+    {
+        if (auditContext.IsSystemMutation())
+            return [];
+
+        var now = DateTime.UtcNow;
+        var entityTypeName = typeof(T).Name.Replace("Entity", "");
+
+        return affectedRecords.Select(record =>
+        {
+            var entry = context.Entry(record);
+            var snapshot = new Dictionary<string, object?>();
+
+            foreach (var prop in entry.Properties)
+            {
+                if (prop.Metadata.IsPrimaryKey())
+                    continue;
+
+                var property = typeof(T).GetProperty(prop.Metadata.Name,
+                    BindingFlags.Public | BindingFlags.Instance);
+
+                if (property?.GetCustomAttribute<AuditIgnoredAttribute>() is not null)
+                    continue;
+
+                var isRedacted = property?.GetCustomAttribute<AuditRedactedAttribute>() is not null;
+                snapshot[prop.Metadata.Name] = isRedacted ? "[redacted]" : prop.CurrentValue;
+            }
+
+            return new MutationAuditLogEntity
+            {
+                Id = Guid.CreateVersion7(),
+                TenantId = context.TenantId,
+                EntityType = entityTypeName,
+                EntityId = (Guid)entry.Property("Id").CurrentValue!,
+                Action = "delete",
+                ChangesJson = JsonSerializer.Serialize(snapshot, JsonOptions),
+                SubjectId = auditContext?.SubjectId,
+                AuthType = auditContext?.AuthType,
+                IpAddress = auditContext?.IpAddress,
+                TokenId = auditContext?.TokenId,
+                CorrelationId = auditContext?.CorrelationId,
+                Endpoint = auditContext?.Endpoint,
+                CreatedAt = now
+            };
+        }).ToList();
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Interceptors/MutationAuditInterceptor.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Interceptors/MutationAuditInterceptor.cs
@@ -46,12 +46,16 @@ public class MutationAuditInterceptor : SaveChangesInterceptor
         if (eventData.Context is not NocturneDbContext context)
             return new ValueTask<InterceptionResult<int>>(result);
 
-        // HTTP requests: resolve from the request's DI scope via HttpContext.
-        // Background services: fall back to the context-level AuditContext property
-        // which services populate directly when creating scopes.
-        var auditContext = _httpContextAccessor.HttpContext?.RequestServices
-            .GetService(typeof(IAuditContext)) as IAuditContext
-            ?? context.AuditContext;
+        // The context-level property wins: it is the audit context the writer attached to this
+        // context (ITenantDbContextFactory stamps its own DI scope's instance, background services
+        // set it directly), so a save made in a child scope is attributed by that scope rather
+        // than by the enclosing request. Reading the request scope first attributed a child
+        // scope's system-attributed connector writes to whoever triggered the sync.
+        // The scoped-context registration leaves the property unset, so an HTTP request falls
+        // back to the request scope's instance.
+        var auditContext = context.AuditContext
+            ?? _httpContextAccessor.HttpContext?.RequestServices
+                .GetService(typeof(IAuditContext)) as IAuditContext;
 
         var auditEntries = new List<MutationAuditLogEntity>();
         var now = DateTime.UtcNow;
@@ -74,7 +78,7 @@ public class MutationAuditInterceptor : SaveChangesInterceptor
             if (entry.State == EntityState.Modified && entry.Entity is ISoftDeletable)
             {
                 if (action == "delete")
-                    entry.Property("DeletedByUser").CurrentValue = auditContext?.AuthType != null;
+                    entry.Property("DeletedByUser").CurrentValue = !auditContext.IsSystemMutation();
                 else if (action == "restore")
                     entry.Property("DeletedByUser").CurrentValue = false;
             }
@@ -83,8 +87,11 @@ public class MutationAuditInterceptor : SaveChangesInterceptor
             // automated data ingestion (CGM readings, temp basals, etc.) whose provenance is
             // already captured on the records themselves (data_source), so they are not recorded
             // here — auditing them grew this table to 36GB / ~1.8M rows-per-day in production.
+            // A null context counts as system: an HTTP request always resolves a scoped context,
+            // so no context at all means an unattributed background save, whose audit row would
+            // carry a null actor, auth type and endpoint.
             // The soft-delete/dedup maintenance above still runs for these mutations.
-            if (auditContext?.IsSystem == true)
+            if (auditContext.IsSystemMutation())
                 continue;
 
             var audit = new MutationAuditLogEntity

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/audit/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/audit/+page.svelte
@@ -191,7 +191,7 @@
               id="read-retention"
               type="number"
               min="1"
-              placeholder="Unlimited"
+              placeholder="Platform default"
               bind:value={readRetentionDays}
             />
           </div>
@@ -201,7 +201,7 @@
               id="mutation-retention"
               type="number"
               min="1"
-              placeholder="Unlimited"
+              placeholder="Platform default"
               bind:value={mutationRetentionDays}
             />
           </div>

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/AuditDeltaGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/AuditDeltaGoldenTests.cs
@@ -11,12 +11,14 @@ namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
 /// V4RepositoryBase refactor NORMALIZED (delta D5). The base's <c>DeleteByLegacyIdAsync</c> now
 /// routes through the audited soft-delete helper, so EVERY V4 type writes a
 /// <see cref="MutationAuditLogEntity"/> row on a legacy-id delete — not just the dedup participants
-/// that used to override it. The two scenarios below pin both sides post-normalization:
-///   - a formerly-RAW type (BGCheck, which inherited the plain base) → audit row present (the D5 delta);
-///   - an already-AUDITED type (DeviceEvent) → audit row present (unchanged).
-/// The <see cref="V4GoldenFixture"/>'s <c>SystemAuditContext</c> short-circuits the
-/// <c>MutationAuditInterceptor</c> (IsSystem == true), so the only audit rows that can appear here
-/// come from the audited soft-delete helper, which writes them directly.
+/// that used to override it. Both a formerly-RAW type (BGCheck, which inherited the plain base) and
+/// an already-AUDITED type (DeviceEvent) are pinned, under both attributions:
+///   - deleted by a human actor → audit row present (the D5 delta, and the row the audit trail is for);
+///   - deleted by a connector/background sweep → no audit row, because the helper applies the same
+///     system skip as the <c>MutationAuditInterceptor</c>. A sweep has no actor and its provenance
+///     is already on the record (data_source); recording it grew mutation_audit_log to 24GB.
+/// The <c>MutationAuditInterceptor</c> never contributes here: the helper detaches the entities and
+/// issues the soft-delete as a bulk update, so every row below comes from the helper itself.
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("V4 goldens")]
@@ -32,11 +34,19 @@ public class AuditDeltaGoldenTests
         _fx.QueryAsync(tenant, ctx => ctx.Set<MutationAuditLogEntity>().AsNoTracking()
             .CountAsync(a => a.EntityType == entityType && a.EntityId == entityId && a.Action == "delete"));
 
+    /// <summary>
+    /// Attributes the scope's writes to a human actor, as the API's audit middleware does for a
+    /// request. Without this a golden runs under the fixture's default system attribution.
+    /// </summary>
+    private static void AttributeScopeToUser(IServiceScope scope) =>
+        scope.ServiceProvider.GetRequiredService<TestAuditContext>().AttributeToUser(Guid.NewGuid());
+
     [Fact]
     public async Task D5_FormerlyRawType_BGCheck_DeleteByLegacyId_WritesAuditRow()
     {
         var tenant = Guid.NewGuid();
         using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        AttributeScopeToUser(scope);
         var repo = scope.ServiceProvider.GetRequiredService<IBGCheckRepository>();
 
         var created = await repo.CreateAsync(
@@ -56,6 +66,7 @@ public class AuditDeltaGoldenTests
     {
         var tenant = Guid.NewGuid();
         using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        AttributeScopeToUser(scope);
         var repo = scope.ServiceProvider.GetRequiredService<IDeviceEventRepository>();
 
         var created = await repo.CreateAsync(
@@ -67,5 +78,41 @@ public class AuditDeltaGoldenTests
 
         // An AUDITED type wrote an audit row before D5 and still does after (unchanged).
         (await AuditRowCountAsync(tenant, "DeviceEvent", created.Id)).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task D5_FormerlyRawType_BGCheck_SystemDeleteByLegacyId_WritesNoAuditRow()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        // No AttributeScopeToUser: the fixture's default is system attribution, as a connector
+        // resync sweep carries.
+        var repo = scope.ServiceProvider.GetRequiredService<IBGCheckRepository>();
+
+        var created = await repo.CreateAsync(
+            new BGCheck { Timestamp = T0, Glucose = 95, DataSource = "nightscout", LegacyId = "bg-sys-del" },
+            WriteOrigin.Live, CancellationToken.None);
+
+        var deleted = await repo.DeleteByLegacyIdAsync("bg-sys-del", WriteOrigin.Live, CancellationToken.None);
+        deleted.Should().Be(1, "the sweep still soft-deletes the row");
+
+        (await AuditRowCountAsync(tenant, "BGCheck", created.Id)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task D5_AuditedType_DeviceEvent_SystemDeleteByLegacyId_WritesNoAuditRow()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IDeviceEventRepository>();
+
+        var created = await repo.CreateAsync(
+            new DeviceEvent { Timestamp = T0, EventType = DeviceEventType.SiteChange, DataSource = "nightscout", LegacyId = "de-sys-del" },
+            WriteOrigin.Live, CancellationToken.None);
+
+        var deleted = await repo.DeleteByLegacyIdAsync("de-sys-del", WriteOrigin.Live, CancellationToken.None);
+        deleted.Should().Be(1, "the sweep still soft-deletes the row");
+
+        (await AuditRowCountAsync(tenant, "DeviceEvent", created.Id)).Should().Be(0);
     }
 }

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/GoldenTestDoubles.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/GoldenTestDoubles.cs
@@ -20,19 +20,32 @@ internal sealed class TestTenantAccessor : ITenantAccessor
 }
 
 /// <summary>
-/// System-attributed <see cref="IAuditContext"/> (no human actor), matching how connectors ingest —
-/// so audited soft-deletes in the dedup paths are treated as system-initiated, as in production.
+/// Stand-in for the request-scoped <see cref="IAuditContext"/> the API populates per request (that
+/// implementation lives in the API layer, which this project does not reference). Defaults to system
+/// attribution (no human actor), matching how connectors ingest — so audited soft-deletes in the
+/// dedup paths are treated as system-initiated, as in production. A golden pinning the
+/// user-attributed audit path calls <see cref="AttributeToUser"/> on its own scope's instance.
 /// </summary>
-internal sealed class SystemAuditContext : IAuditContext
+internal sealed class TestAuditContext : IAuditContext
 {
-    public Guid? SubjectId => null;
-    public string? SubjectName => null;
-    public string? AuthType => null;
+    public Guid? SubjectId { get; private set; }
+    public string? SubjectName { get; private set; }
+    public string? AuthType { get; private set; }
     public string? IpAddress => null;
     public Guid? TokenId => null;
     public string? CorrelationId => null;
-    public string? Endpoint => null;
-    public bool IsSystem => true;
+    public string? Endpoint { get; private set; }
+    public bool IsSystem { get; private set; } = true;
+
+    /// <summary>Attributes subsequent writes on this scope to a human actor.</summary>
+    public void AttributeToUser(Guid subjectId)
+    {
+        SubjectId = subjectId;
+        SubjectName = "golden-user";
+        AuthType = "AccessToken";
+        Endpoint = "DELETE /api/v4/goldens";
+        IsSystem = false;
+    }
 }
 
 /// <summary>

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/V4GoldenFixture.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/V4GoldenFixture.cs
@@ -84,7 +84,10 @@ public class V4GoldenFixture : IAsyncLifetime
         // MutationAuditInterceptor resolves IHttpContextAccessor (registered by the API in prod).
         services.AddHttpContextAccessor();
         services.AddSingleton<ITenantAccessor>(_accessor);
-        services.AddSingleton<IAuditContext, SystemAuditContext>();
+        // Scoped, mirroring the API's request-scoped registration, so a golden can attribute its
+        // own scope to a user without leaking that attribution into the next test.
+        services.AddScoped<TestAuditContext>();
+        services.AddScoped<IAuditContext>(sp => sp.GetRequiredService<TestAuditContext>());
         services.AddPostgreSqlInfrastructure(config);
         // Capturing broadcaster: the V4 repos resolve IV4RecordBroadcaster<T> via the open generic, so
         // the real chokepoint fires into BroadcastCapture (additive — existing goldens ignore it).

--- a/tests/Unit/Nocturne.API.Tests/Services/Audit/AuditRetentionServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Audit/AuditRetentionServiceTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Nocturne.API.Services.Audit;
 using Nocturne.Infrastructure.Data;
@@ -11,8 +12,20 @@ public class AuditRetentionServiceTests
     private readonly Mock<IDbContextFactory<NocturneDbContext>> _contextFactory = new();
     private readonly Mock<ILogger<AuditRetentionService>> _logger = new();
 
-    private AuditRetentionService CreateService() =>
-        new(_contextFactory.Object, _logger.Object);
+    /// <summary>
+    /// The tests that predate the platform default assert an exact factory call count, so they
+    /// disable the default (0) and exercise only the per-tenant config path.
+    /// </summary>
+    private AuditRetentionService CreateService() => CreateService(new Dictionary<string, string?>
+    {
+        ["Audit:DefaultReadAuditRetentionDays"] = "0",
+        ["Audit:DefaultMutationRetentionDays"] = "0"
+    });
+
+    private AuditRetentionService CreateService(Dictionary<string, string?> settings) =>
+        new(_contextFactory.Object,
+            new ConfigurationBuilder().AddInMemoryCollection(settings).Build(),
+            _logger.Object);
 
     private static NocturneDbContext CreateInMemoryContext()
     {
@@ -218,6 +231,125 @@ public class AuditRetentionServiceTests
                 It.IsAny<Exception>(),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
+    }
+
+    /// <summary>
+    /// Records the purges the service would issue instead of running raw SQL, so the effective
+    /// retention window per tenant/table is observable.
+    /// </summary>
+    private sealed class RecordingAuditRetentionService(
+        IDbContextFactory<NocturneDbContext> contextFactory,
+        IConfiguration configuration,
+        ILogger<AuditRetentionService> logger)
+        : AuditRetentionService(contextFactory, configuration, logger)
+    {
+        public List<(Guid TenantId, string Table, DateTime Cutoff)> Purges { get; } = [];
+
+        internal override Task<int> PurgeBatchedAsync(
+            Guid tenantId, string table, DateTime cutoff, CancellationToken ct)
+        {
+            Purges.Add((tenantId, table, cutoff));
+            return Task.FromResult(0);
+        }
+    }
+
+    private RecordingAuditRetentionService CreateRecordingService(
+        Dictionary<string, string?>? settings = null) =>
+        new(_contextFactory.Object,
+            new ConfigurationBuilder().AddInMemoryCollection(settings ?? []).Build(),
+            _logger.Object);
+
+    [Fact]
+    public async Task PurgeExpiredRecordsAsync_UnconfiguredTenant_PurgesAtPlatformDefault()
+    {
+        var tenantId = Guid.CreateVersion7();
+        var configContext = CreateInMemoryContext();
+        configContext.Tenants.Add(new TenantEntity { Id = tenantId, Slug = "unconfigured" });
+        await configContext.SaveChangesAsync();
+
+        _contextFactory
+            .Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(configContext);
+
+        var service = CreateRecordingService();
+
+        await service.PurgeExpiredRecordsAsync(CancellationToken.None);
+
+        service.Purges.Should().HaveCount(2);
+        service.Purges.Should().OnlyContain(p => p.TenantId == tenantId);
+        service.Purges.Select(p => p.Table).Should()
+            .BeEquivalentTo(["read_access_log", "mutation_audit_log"]);
+        service.Purges.Should().OnlyContain(
+            p => p.Cutoff < DateTime.UtcNow.AddDays(-89) && p.Cutoff > DateTime.UtcNow.AddDays(-91));
+    }
+
+    [Fact]
+    public async Task PurgeExpiredRecordsAsync_TenantConfig_OverridesPlatformDefault()
+    {
+        var tenantId = Guid.CreateVersion7();
+        var configContext = CreateInMemoryContext();
+        configContext.Tenants.Add(new TenantEntity { Id = tenantId, Slug = "configured" });
+        configContext.TenantAuditConfig.Add(new TenantAuditConfigEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = tenantId,
+            // A longer window than the platform default must win too, not just a shorter one.
+            MutationAuditRetentionDays = 365,
+            ReadAuditRetentionDays = null,
+            SysCreatedAt = DateTime.UtcNow,
+            SysUpdatedAt = DateTime.UtcNow
+        });
+        await configContext.SaveChangesAsync();
+
+        _contextFactory
+            .Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(configContext);
+
+        var service = CreateRecordingService();
+
+        await service.PurgeExpiredRecordsAsync(CancellationToken.None);
+
+        var mutation = service.Purges.Single(p => p.Table == "mutation_audit_log");
+        mutation.Cutoff.Should().BeBefore(DateTime.UtcNow.AddDays(-364));
+
+        // The unset read window still falls back to the platform default.
+        var read = service.Purges.Single(p => p.Table == "read_access_log");
+        read.Cutoff.Should().BeAfter(DateTime.UtcNow.AddDays(-91));
+    }
+
+    [Fact]
+    public async Task PurgeExpiredRecordsAsync_DefaultDisabled_PurgesOnlyConfiguredTenants()
+    {
+        var configuredTenant = Guid.CreateVersion7();
+        var configContext = CreateInMemoryContext();
+        configContext.Tenants.AddRange(
+            new TenantEntity { Id = configuredTenant, Slug = "configured" },
+            new TenantEntity { Id = Guid.CreateVersion7(), Slug = "unconfigured" });
+        configContext.TenantAuditConfig.Add(new TenantAuditConfigEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = configuredTenant,
+            MutationAuditRetentionDays = 30,
+            SysCreatedAt = DateTime.UtcNow,
+            SysUpdatedAt = DateTime.UtcNow
+        });
+        await configContext.SaveChangesAsync();
+
+        _contextFactory
+            .Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(configContext);
+
+        var service = CreateRecordingService(new Dictionary<string, string?>
+        {
+            ["Audit:DefaultReadAuditRetentionDays"] = "0",
+            ["Audit:DefaultMutationRetentionDays"] = "0"
+        });
+
+        await service.PurgeExpiredRecordsAsync(CancellationToken.None);
+
+        service.Purges.Should().ContainSingle()
+            .Which.Should().Match<(Guid TenantId, string Table, DateTime Cutoff)>(
+                p => p.TenantId == configuredTenant && p.Table == "mutation_audit_log");
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Extensions/AuditedBulkDeleteExtensionsTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Extensions/AuditedBulkDeleteExtensionsTests.cs
@@ -1,0 +1,171 @@
+using System.Data.Common;
+using Microsoft.Data.Sqlite;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Infrastructure.Data.Extensions;
+using Nocturne.Infrastructure.Data.Tests.Interceptors;
+
+namespace Nocturne.Infrastructure.Data.Tests.Extensions;
+
+/// <summary>
+/// These helpers append audit rows themselves rather than through
+/// <c>MutationAuditInterceptor</c>, so they carry their own copy of the system/unattributed
+/// skip. A connector's reconcile sweep (<c>SoftDeleteAbsentBySourceAndDateRangeAsync</c>) runs
+/// through here on every sync and was writing one actorless audit row per swept record.
+/// </summary>
+[Trait("Category", "Unit")]
+public class AuditedBulkDeleteExtensionsTests : IDisposable
+{
+    private readonly DbConnection _connection;
+    private readonly DbContextOptions<NocturneDbContext> _contextOptions;
+    private readonly Guid _tenantId = Guid.CreateVersion7();
+
+    public AuditedBulkDeleteExtensionsTests()
+    {
+        _connection = new SqliteConnection("Filename=:memory:");
+        _connection.Open();
+
+        _contextOptions = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        using var context = CreateContext();
+        context.Database.EnsureCreated();
+        context.Tenants.Add(new TenantEntity { Id = _tenantId, Slug = "test" });
+        context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private TestNocturneDbContext CreateContext()
+    {
+        var context = new TestNocturneDbContext(_contextOptions);
+        context.TenantId = _tenantId;
+        return context;
+    }
+
+    private async Task<Guid> SeedAsync()
+    {
+        await using var context = CreateContext();
+        var entity = new TestAuditableEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = _tenantId,
+            Name = "SweepMe",
+            Value = 1
+        };
+        context.TestAuditables.Add(entity);
+        await context.SaveChangesAsync();
+        return entity.Id;
+    }
+
+    private sealed class UserAuditContext : IAuditContext
+    {
+        public Guid? SubjectId => Guid.Empty;
+        public string? SubjectName => "tester";
+        public string? AuthType => "SessionCookie";
+        public string? IpAddress => "127.0.0.1";
+        public Guid? TokenId => null;
+        public string? CorrelationId => null;
+        public string? Endpoint => "DELETE /api/v4/treatments";
+        public bool IsSystem => false;
+    }
+
+    [Fact]
+    public async Task AuditedSoftDelete_SystemAuditContext_SoftDeletesWithoutAuditRows()
+    {
+        var id = await SeedAsync();
+
+        await using var context = CreateContext();
+        var deleted = await context.AuditedSoftDeleteAsync(
+            context.TestAuditables.Where(e => e.Id == id),
+            SystemAuditContext.ForService("connector:nightscout"));
+
+        deleted.Should().Be(1);
+
+        await using var verify = CreateContext();
+        var row = await verify.TestAuditables.SingleAsync(e => e.Id == id);
+        row.DeletedAt.Should().NotBeNull();
+        verify.Entry(row).Property("DeletedByUser").CurrentValue.Should().Be(false);
+        (await verify.Set<MutationAuditLogEntity>().CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task AuditedSoftDelete_NullAuditContext_SoftDeletesWithoutAuditRows()
+    {
+        var id = await SeedAsync();
+
+        await using var context = CreateContext();
+        var deleted = await context.AuditedSoftDeleteAsync(
+            context.TestAuditables.Where(e => e.Id == id),
+            auditContext: null);
+
+        deleted.Should().Be(1);
+
+        await using var verify = CreateContext();
+        var row = await verify.TestAuditables.SingleAsync(e => e.Id == id);
+        row.DeletedAt.Should().NotBeNull();
+        (await verify.Set<MutationAuditLogEntity>().CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task AuditedSoftDelete_UserAuditContext_WritesAuditRowAndFlagsDeletedByUser()
+    {
+        var id = await SeedAsync();
+
+        await using var context = CreateContext();
+        var deleted = await context.AuditedSoftDeleteAsync(
+            context.TestAuditables.Where(e => e.Id == id),
+            new UserAuditContext());
+
+        deleted.Should().Be(1);
+
+        await using var verify = CreateContext();
+        var row = await verify.TestAuditables.SingleAsync(e => e.Id == id);
+        verify.Entry(row).Property("DeletedByUser").CurrentValue.Should().Be(true);
+
+        var log = await verify.Set<MutationAuditLogEntity>().SingleAsync();
+        log.Action.Should().Be("delete");
+        log.EntityId.Should().Be(id);
+        log.EntityType.Should().Be("TestAuditable");
+        log.AuthType.Should().Be("SessionCookie");
+    }
+
+    [Fact]
+    public async Task AuditedExecuteDelete_SystemAuditContext_DeletesWithoutAuditRows()
+    {
+        var id = await SeedAsync();
+
+        await using var context = CreateContext();
+        var deleted = await context.AuditedExecuteDeleteAsync(
+            context.TestAuditables.Where(e => e.Id == id),
+            SystemAuditContext.ForService("connector:nightscout"));
+
+        deleted.Should().Be(1);
+
+        await using var verify = CreateContext();
+        (await verify.TestAuditables.AnyAsync(e => e.Id == id)).Should().BeFalse();
+        (await verify.Set<MutationAuditLogEntity>().CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task AuditedExecuteDelete_UserAuditContext_WritesAuditRow()
+    {
+        var id = await SeedAsync();
+
+        await using var context = CreateContext();
+        await context.AuditedExecuteDeleteAsync(
+            context.TestAuditables.Where(e => e.Id == id),
+            new UserAuditContext());
+
+        await using var verify = CreateContext();
+        var log = await verify.Set<MutationAuditLogEntity>().SingleAsync();
+        log.Action.Should().Be("delete");
+        log.EntityId.Should().Be(id);
+        log.AuthType.Should().Be("SessionCookie");
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Interceptors/MutationAuditInterceptorTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Interceptors/MutationAuditInterceptorTests.cs
@@ -5,6 +5,7 @@ using System.Linq.Expressions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.Infrastructure.Data.Interceptors;
 
@@ -125,11 +126,48 @@ public class MutationAuditInterceptorTests : IDisposable
         context.SaveChanges();
     }
 
-    private TestNocturneDbContext CreateContext()
+    /// <summary>
+    /// A save with no audit context at all is treated as an unattributed background save and is
+    /// not audited, so tests that assert an audit row need an actor. Tests covering the
+    /// system/unattributed paths pass their own context (or null) explicitly.
+    /// </summary>
+    private TestNocturneDbContext CreateContext() => CreateContext(new StubAuditContext
+    {
+        SubjectId = Guid.CreateVersion7(),
+        SubjectName = "tester",
+        AuthType = "SessionCookie",
+        Endpoint = "POST /api/v4/treatments"
+    });
+
+    private TestNocturneDbContext CreateContext(IAuditContext? auditContext)
     {
         var context = new TestNocturneDbContext(_contextOptions);
         context.TenantId = _tenantId;
+        context.AuditContext = auditContext;
         return context;
+    }
+
+    /// <summary>An accessor exposing an HTTP request whose DI scope is <paramref name="services"/>.</summary>
+    private static IHttpContextAccessor AccessorFor(IServiceProvider services)
+    {
+        var httpContext = new Mock<HttpContext>();
+        httpContext.Setup(x => x.RequestServices).Returns(services);
+
+        var accessor = new Mock<IHttpContextAccessor>();
+        accessor.Setup(x => x.HttpContext).Returns(httpContext.Object);
+        return accessor.Object;
+    }
+
+    private sealed class StubAuditContext : IAuditContext
+    {
+        public Guid? SubjectId { get; init; }
+        public string? SubjectName { get; init; }
+        public string? AuthType { get; init; }
+        public string? IpAddress { get; init; }
+        public Guid? TokenId { get; init; }
+        public string? CorrelationId { get; init; }
+        public string? Endpoint { get; init; }
+        public bool IsSystem { get; init; }
     }
 
     public void Dispose()
@@ -166,6 +204,9 @@ public class MutationAuditInterceptorTests : IDisposable
         log.EntityType.Should().Be("TestAuditable");
         log.EntityId.Should().Be(entity.Id);
         log.TenantId.Should().Be(_tenantId);
+        log.AuthType.Should().Be("SessionCookie");
+        log.SubjectName.Should().Be("tester");
+        log.Endpoint.Should().Be("POST /api/v4/treatments");
     }
 
     [Fact]
@@ -379,8 +420,11 @@ public class MutationAuditInterceptorTests : IDisposable
     }
 
     [Fact]
-    public async Task SoftDelete_SystemNoAuth_LeavesDeletedByUserFalse()
+    public async Task SoftDelete_NullAuditContext_MaintainsDeletedByUser_ButProducesNoAuditRecord()
     {
+        // No AuditContext and null HttpContext: an unattributed background save. The audit row
+        // would carry a null actor, auth type and endpoint, so it is skipped — but the dedup flag
+        // maintenance still has to run or connector resync semantics change.
         using var context = CreateContext();
         var entity = new TestAuditableEntity
         {
@@ -392,14 +436,93 @@ public class MutationAuditInterceptorTests : IDisposable
         context.TestAuditables.Add(entity);
         await context.SaveChangesAsync();
 
-        // No AuditContext and null HttpContext -> AuthType null -> system-attributed delete.
-        using var context2 = CreateContext();
+        using var context2 = CreateContext(auditContext: null);
         var tracked = await context2.TestAuditables.FindAsync(entity.Id);
         tracked!.DeletedAt = DateTime.UtcNow;
 
         await InvokeSavingChanges(context2);
 
         ((bool)context2.Entry(tracked).Property("DeletedByUser").CurrentValue!).Should().BeFalse();
+        context2.ChangeTracker.Entries<MutationAuditLogEntity>().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Create_NullAuditContext_ProducesNoAuditRecord()
+    {
+        // Regression guard for the ~350k rows/week of all-null audit rows written by background
+        // jobs (Nightscout migration/backfill) that never populate an audit context.
+        using var context = CreateContext(auditContext: null);
+        var entity = new TestAuditableEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = _tenantId,
+            Name = "BackgroundBackfill",
+            Value = 1
+        };
+
+        context.TestAuditables.Add(entity);
+
+        await InvokeSavingChanges(context);
+
+        context.ChangeTracker.Entries<MutationAuditLogEntity>().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ContextAuditContext_TakesPrecedenceOverRequestScope()
+    {
+        // A connector sync triggered over HTTP runs in a child DI scope whose audit context the
+        // publishers push into system attribution. Resolving the request scope's context instead
+        // audited the connector's imports as the user who clicked sync.
+        var requestScopeContext = new StubAuditContext { AuthType = "SessionCookie", SubjectName = "clicker" };
+        var services = new ServiceCollection()
+            .AddSingleton<IAuditContext>(requestScopeContext)
+            .BuildServiceProvider();
+
+        var interceptor = new MutationAuditInterceptor(AccessorFor(services));
+
+        using var context = CreateContext(SystemAuditContext.ForService("connector:nightscout"));
+        context.TestAuditables.Add(new TestAuditableEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = _tenantId,
+            Name = "ConnectorImport"
+        });
+
+        await InvokeSavingChanges(context, interceptor);
+
+        context.ChangeTracker.Entries<MutationAuditLogEntity>().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RequestScope_UsedWhenContextCarriesNoAuditContext()
+    {
+        // The scoped NocturneDbContext registration never stamps the property, so an ordinary
+        // HTTP request must still be attributed from the request scope.
+        var services = new ServiceCollection()
+            .AddSingleton<IAuditContext>(new StubAuditContext
+            {
+                AuthType = "SessionCookie",
+                SubjectName = "clicker",
+                Endpoint = "POST /api/v4/treatments"
+            })
+            .BuildServiceProvider();
+
+        var interceptor = new MutationAuditInterceptor(AccessorFor(services));
+
+        using var context = CreateContext(auditContext: null);
+        context.TestAuditables.Add(new TestAuditableEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = _tenantId,
+            Name = "UserWrite"
+        });
+
+        await InvokeSavingChanges(context, interceptor);
+
+        var log = context.ChangeTracker.Entries<MutationAuditLogEntity>()
+            .Select(e => e.Entity).Single();
+        log.AuthType.Should().Be("SessionCookie");
+        log.SubjectName.Should().Be("clicker");
     }
 
     [Fact]
@@ -647,7 +770,9 @@ public class MutationAuditInterceptorTests : IDisposable
     /// Invokes the interceptor's SavingChangesAsync in the same way EF Core would,
     /// without actually saving to the database (we only need to inspect the ChangeTracker).
     /// </summary>
-    private async Task InvokeSavingChanges(DbContext context)
+    private Task InvokeSavingChanges(DbContext context) => InvokeSavingChanges(context, _interceptor);
+
+    private static async Task InvokeSavingChanges(DbContext context, MutationAuditInterceptor interceptor)
     {
         context.ChangeTracker.DetectChanges();
 
@@ -663,6 +788,6 @@ public class MutationAuditInterceptorTests : IDisposable
             (def, data) => "test",
             context);
 
-        await _interceptor.SavingChangesAsync(eventData, default);
+        await interceptor.SavingChangesAsync(eventData, default);
     }
 }


### PR DESCRIPTION
## Problem

`mutation_audit_log` reached 24 GB in production (89% of rows were `create` audits of machine-generated data). PR #390 skipped system/connector mutations in the interceptor, but ~500k rows/week still leaked through three paths:

1. **Null audit context bypassed the skip** (~350k/wk): `MigrationJobService` never set an audit context, so backfill jobs audited every record with all-null actor metadata (the guard was `IsSystem == true`, which null sails past).
2. **`AuditedBulkDeleteExtensions` never consulted the interceptor's skip at all** (~77k/wk): the bulk soft-delete helpers built and inserted audit rows themselves, so connector reconcile-deletes were audited even under `SystemAuditScope`.
3. **HTTP-triggered connector syncs audited as the clicking user** (~5k/wk): `ConnectorSyncService` runs publishers in a child DI scope; `SystemAuditScope` mutated the child scope's context while the interceptor resolved the request scope's.

Retention existed but was opt-in per tenant; effectively nobody had it.

## Fix

- One shared predicate `IAuditContext.IsSystemMutation()` (explicitly system, or no context at all) used by both the interceptor and the bulk-delete helpers. Null context = unattributed background save = system; HTTP requests always resolve a scoped context, so user mutations cannot skip auditing.
- The DbContext-stamped audit context now takes precedence over `HttpContext.RequestServices`, fixing the child-scope misattribution. Ordinary requests are unchanged (the scoped registration never stamps it).
- `MigrationJobService` explicitly attributes its writes via `SystemAuditContext.ForService("service:migration")`, mirroring `ConnectorBackgroundService`.
- Platform-default audit retention: `Audit:DefaultReadAuditRetentionDays` / `Audit:DefaultMutationRetentionDays` (default 90, `0` disables); an explicit per-tenant value wins in either direction. Settings UI placeholder updated from "Unlimited" to "Platform default".
- Side fix: the soft-delete dedup flag (`DeletedByUser`) previously counted a stamped `SystemAuditContext` (`AuthType == "system"`) as a user delete, permanently blocking connector re-import after system sweeps.

## Notes

- User-attributed bulk deletes still write full audit snapshots (redaction behaviour unchanged, covered by new SQLite-backed tests).
- The resync dedup discriminator reads `deleted_by_user`, not audit rows, so dropping system audit rows changes no reader.
- Release-note worthy: per-tenant "keep forever" is no longer expressible except via a large day count.
- No schema changes.

## Tests

- `Nocturne.Infrastructure.Data.Tests`: 494 passed
- `Nocturne.API.Tests`: 4572 passed (5 pre-existing skips)
- New: interceptor precedence regressions (both directions), null-context create/soft-delete, system/null/user across both bulk helpers, retention default + per-tenant override in both directions
