### PR TITLE
feat(bridge): serve NS v3 /storage and /alarm socket.io namespaces (#638)

### DIFF
--- a/src/Web/packages/bridge/src/lib/signalr-client.ts
+++ b/src/Web/packages/bridge/src/lib/signalr-client.ts
@@ -439,6 +439,30 @@ class SignalRClient {
 
     return dataConnected && alarmConnected && configConnected;
   }
+
+  /** Forward an alarm ack to the API's AlarmHub. The v3 `/alarm` namespace
+   *  receives positional `ack` events from AAPS and relays them here so the
+   *  silence propagates server-side. No-op when the AlarmHub connection isn't
+   *  open. Failures are logged and swallowed — a dropped ack just means the
+   *  alarm isn't silenced server-side, not a bridge failure. */
+  async invokeAlarmAck(
+    level: number,
+    group: string,
+    silenceTime: number,
+  ): Promise<void> {
+    if (!this.alarmConnection || this.alarmConnection.state !== "Connected") {
+      logger.warn("Cannot forward alarm ack: AlarmHub connection not open");
+      return;
+    }
+    try {
+      await this.alarmConnection.invoke("Ack", level, group, silenceTime);
+      logger.info(
+        `Forwarded alarm ack to AlarmHub: level=${level} group=${group} silence=${silenceTime}ms`,
+      );
+    } catch (error) {
+      logger.error("Error forwarding alarm ack to AlarmHub:", error);
+    }
+  }
 }
 
 export default SignalRClient;

--- a/src/Web/packages/bridge/src/lib/socketio-server.test.ts
+++ b/src/Web/packages/bridge/src/lib/socketio-server.test.ts
@@ -345,7 +345,6 @@ describe('SocketIOServer v3 /storage namespace', () => {
     );
 
     expect(ack).toHaveBeenCalledWith({ success: true, collections: ['entries', 'devicestatus', 'profile'] });
-    // One room join per requested collection, using the v3-client spelling.
     expect(socket.join).toHaveBeenCalledWith('storage:rhys:entries');
     expect(socket.join).toHaveBeenCalledWith('storage:rhys:devicestatus');
     expect(socket.join).toHaveBeenCalledWith('storage:rhys:profile');
@@ -382,7 +381,7 @@ describe('SocketIOServer v3 /storage namespace', () => {
     expect(socket.join).toHaveBeenCalledWith('storage:rhys:entries');
   });
 
-  it('denies and does not join when the API rejects the token', async () => {
+  it('disconnects on auth failure so subscribe is not a credential-guessing oracle', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 401 }));
     const server = makeStorageServer();
     const socket = storageSocket('rhys');
@@ -394,12 +393,13 @@ describe('SocketIOServer v3 /storage namespace', () => {
       ack,
     );
 
-    expect(ack).toHaveBeenCalledWith({ success: false, message: 'Missing or bad accessToken' });
+    expect(ack).toHaveBeenCalledWith({ success: false, message: 'Unauthorized to receive any collection' });
     expect(socket.join).not.toHaveBeenCalled();
+    expect(socket.disconnect).toHaveBeenCalledWith(true);
     expect(socket.data.tenantSlug).toBeUndefined();
   });
 
-  it('denies when no accessToken is supplied', async () => {
+  it('disconnects when no accessToken is supplied', async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
     const server = makeStorageServer();
@@ -410,7 +410,7 @@ describe('SocketIOServer v3 /storage namespace', () => {
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(ack).toHaveBeenCalledWith({ success: false, message: 'Missing or bad accessToken' });
-    expect(socket.join).not.toHaveBeenCalled();
+    expect(socket.disconnect).toHaveBeenCalledWith(true);
   });
 
   it('disconnects when the host resolved to no tenant', async () => {
@@ -427,7 +427,36 @@ describe('SocketIOServer v3 /storage namespace', () => {
     expect(socket.disconnect).toHaveBeenCalledWith(true);
   });
 
-  it('probes the v3 entries endpoint with a Bearer token scoped to the tenant', async () => {
+  it('probes each collection against its own v3 endpoint, not a single blanket probe', async () => {
+    // entries is authorized, treatments is not. Only entries should be joined.
+    const fetchMock = vi.fn().mockImplementation((url: URL | string) => {
+      const s = String(url);
+      if (s.includes('/api/v3/entries')) return Promise.resolve({ ok: true, status: 200 });
+      return Promise.resolve({ ok: false, status: 403 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const server = makeStorageServer();
+    const socket = storageSocket('rhys');
+    const ack = vi.fn();
+
+    await server.handleStorageSubscribe(
+      socket as never,
+      { accessToken: 'tok', collections: ['entries', 'treatments'] },
+      ack,
+    );
+
+    // Only the authorized collection appears in the ack and room join.
+    expect(ack).toHaveBeenCalledWith({ success: true, collections: ['entries'] });
+    expect(socket.join).toHaveBeenCalledTimes(1);
+    expect(socket.join).toHaveBeenCalledWith('storage:rhys:entries');
+    // Both endpoints were probed — per-collection auth, not blanket.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const probedPaths = fetchMock.mock.calls.map(([u]) => String(u));
+    expect(probedPaths.some((p) => p.includes('/api/v3/entries'))).toBe(true);
+    expect(probedPaths.some((p) => p.includes('/api/v3/treatments'))).toBe(true);
+  });
+
+  it('probes the v3 endpoint with a Bearer token scoped to the tenant', async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
     vi.stubGlobal('fetch', fetchMock);
     const server = makeStorageServer();
@@ -454,8 +483,8 @@ describe('SocketIOServer v3 /storage broadcast fan-out', () => {
     vi.unstubAllGlobals();
   });
 
-  /** Build a started server with a real socket.io Namespace, then return the
-   *  namespace spy so tests can assert on emit targets. */
+  /** Build a started server with a real socket.io Namespace so we can assert
+   *  on the actual emit target and payload via the BroadcastingWildcard. */
   async function startedServer() {
     const server = new SocketIOServer(
       createServer(),
@@ -476,32 +505,41 @@ describe('SocketIOServer v3 /storage broadcast fan-out', () => {
 
     server.broadcastStorageEvent('create', { colName: 'entries', doc: { srvModified: 123 } }, 'rhys');
 
-    // The default-namespace emit (emitTarget) runs unconditionally and would
-    // throw without a real io in a started server, but broadcastStorageEvent
-    // calls target.emit first; here we only assert the /storage fan-out fired.
     expect(toSpy).toHaveBeenCalledWith('storage:rhys:entries');
     server.getIO()!.close();
   });
 
-  it('translates the API collection name to the v3-client spelling (profiles -> profile)', async () => {
+  it('amends the payload colName to the v3-client spelling (profiles -> profile)', async () => {
     const server = await startedServer();
     const storageNsp = server.getIO()!.of('/storage');
-    const toSpy = vi.spyOn(storageNsp, 'to');
 
-    server.broadcastStorageEvent('update', { colName: 'profiles', doc: {} }, 'rhys');
+    // The fan-out calls storageNsp.to(room).emit(event, payload). Capture the
+    // payload by stubbing .to() to return a recording fake.
+    const emitted: { event: string; payload: unknown }[] = [];
+    vi.spyOn(storageNsp, 'to').mockReturnValue({
+      emit: (event: string, payload: unknown) => emitted.push({ event, payload }),
+    } as never);
 
-    expect(toSpy).toHaveBeenCalledWith('storage:rhys:profile');
+    server.broadcastStorageEvent('update', { colName: 'profiles', doc: { srvModified: 1 } }, 'rhys');
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].event).toBe('update');
+    expect((emitted[0].payload as { colName: string }).colName).toBe('profile');
     server.getIO()!.close();
   });
 
-  it('translates food -> foods', async () => {
+  it('amends the payload colName for food -> foods', async () => {
     const server = await startedServer();
     const storageNsp = server.getIO()!.of('/storage');
-    const toSpy = vi.spyOn(storageNsp, 'to');
+
+    const emitted: { event: string; payload: unknown }[] = [];
+    vi.spyOn(storageNsp, 'to').mockReturnValue({
+      emit: (event: string, payload: unknown) => emitted.push({ event, payload }),
+    } as never);
 
     server.broadcastStorageEvent('create', { colName: 'food', doc: {} }, 'rhys');
 
-    expect(toSpy).toHaveBeenCalledWith('storage:rhys:foods');
+    expect((emitted[0].payload as { colName: string }).colName).toBe('foods');
     server.getIO()!.close();
   });
 
@@ -553,7 +591,7 @@ describe('SocketIOServer v3 /alarm namespace', () => {
     expect(socket.data.tenantSlug).toBe('rhys');
   });
 
-  it('denies when the API rejects the token', async () => {
+  it('disconnects on auth failure so subscribe is not a credential-guessing oracle', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 401 }));
     const server = makeAlarmServer();
     const socket = alarmSocket('rhys');
@@ -563,9 +601,10 @@ describe('SocketIOServer v3 /alarm namespace', () => {
 
     expect(ack).toHaveBeenCalledWith({ success: false, message: 'Missing or bad accessToken' });
     expect(socket.join).not.toHaveBeenCalled();
+    expect(socket.disconnect).toHaveBeenCalledWith(true);
   });
 
-  it('denies when no accessToken is supplied', async () => {
+  it('disconnects when no accessToken is supplied', async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
     const server = makeAlarmServer();
@@ -576,6 +615,7 @@ describe('SocketIOServer v3 /alarm namespace', () => {
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(ack).toHaveBeenCalledWith({ success: false, message: 'Missing or bad accessToken' });
+    expect(socket.disconnect).toHaveBeenCalledWith(true);
   });
 
   it('disconnects when the host resolved to no tenant', async () => {
@@ -587,25 +627,6 @@ describe('SocketIOServer v3 /alarm namespace', () => {
 
     expect(ack).toHaveBeenCalledWith({ success: false, message: 'no resolvable tenant' });
     expect(socket.disconnect).toHaveBeenCalledWith(true);
-  });
-
-  it('invokes onAlarmAck with positional (level, group, silenceTime) when a client acks', async () => {
-    // The /alarm namespace connection handler registers a positional ack
-    // listener. We test the public onAlarmAck surface directly since wiring a
-    // real socket.io client is heavy; the handler delegates to this callback.
-    const server = makeAlarmServer();
-    const ackSpy = vi.fn();
-    server.onAlarmAck = ackSpy;
-
-    // Simulate what the connection handler does on a positional ack event.
-    // The handler reads socket.data.tenantSlug and forwards here.
-    const tenantSlug = 'rhys';
-    const level = 2;
-    const group = 'default';
-    const silenceTime = 30_000;
-    server.onAlarmAck(tenantSlug, level, group, silenceTime);
-
-    expect(ackSpy).toHaveBeenCalledWith('rhys', 2, 'default', 30_000);
   });
 });
 

--- a/src/Web/packages/bridge/src/lib/socketio-server.test.ts
+++ b/src/Web/packages/bridge/src/lib/socketio-server.test.ts
@@ -308,3 +308,355 @@ describe('SocketIOServer.handleAuthorize', () => {
     expect(callback).toHaveBeenCalledWith(expect.objectContaining({ read: true }));
   });
 });
+
+// ---------------------------------------------------------------------------
+// v3 /storage namespace — AAPS / xDrip+ / NightGuard uploaders
+// ---------------------------------------------------------------------------
+
+describe('SocketIOServer v3 /storage namespace', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function makeStorageServer(apiBaseUrl = 'http://api.internal') {
+    return new SocketIOServer(createServer(), {}, 'nocturne.run', [], SECRET, apiBaseUrl);
+  }
+
+  /** A fake socket carrying a pending tenant slug (post-handshake state). */
+  function storageSocket(pendingTenantSlug?: string) {
+    return {
+      id: 'storage-1',
+      data: { pendingTenantSlug } as Record<string, unknown>,
+      join: vi.fn(),
+      disconnect: vi.fn(),
+    };
+  }
+
+  it('subscribes for the requested collections when the token is valid', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 200 }));
+    const server = makeStorageServer();
+    const socket = storageSocket('rhys');
+    const ack = vi.fn();
+
+    await server.handleStorageSubscribe(
+      socket as never,
+      { accessToken: 'aaps-token', collections: ['entries', 'devicestatus', 'profile'] },
+      ack,
+    );
+
+    expect(ack).toHaveBeenCalledWith({ success: true, collections: ['entries', 'devicestatus', 'profile'] });
+    // One room join per requested collection, using the v3-client spelling.
+    expect(socket.join).toHaveBeenCalledWith('storage:rhys:entries');
+    expect(socket.join).toHaveBeenCalledWith('storage:rhys:devicestatus');
+    expect(socket.join).toHaveBeenCalledWith('storage:rhys:profile');
+    expect(socket.data.tenantSlug).toBe('rhys');
+    expect(socket.data.pendingTenantSlug).toBeUndefined();
+  });
+
+  it('defaults to all known collections when none are requested', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 200 }));
+    const server = makeStorageServer();
+    const socket = storageSocket('rhys');
+    const ack = vi.fn();
+
+    await server.handleStorageSubscribe(socket as never, { accessToken: 'tok' }, ack);
+
+    expect(ack).toHaveBeenCalledWith({
+      success: true,
+      collections: ['devicestatus', 'entries', 'profile', 'treatments', 'foods', 'settings'],
+    });
+    expect(socket.join).toHaveBeenCalledTimes(6);
+  });
+
+  it('filters out unknown collection names', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 200 }));
+    const server = makeStorageServer();
+    const socket = storageSocket('rhys');
+
+    await server.handleStorageSubscribe(
+      socket as never,
+      { accessToken: 'tok', collections: ['entries', 'bogus', '<script>'] },
+    );
+
+    expect(socket.join).toHaveBeenCalledTimes(1);
+    expect(socket.join).toHaveBeenCalledWith('storage:rhys:entries');
+  });
+
+  it('denies and does not join when the API rejects the token', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 401 }));
+    const server = makeStorageServer();
+    const socket = storageSocket('rhys');
+    const ack = vi.fn();
+
+    await server.handleStorageSubscribe(
+      socket as never,
+      { accessToken: 'wrong', collections: ['entries'] },
+      ack,
+    );
+
+    expect(ack).toHaveBeenCalledWith({ success: false, message: 'Missing or bad accessToken' });
+    expect(socket.join).not.toHaveBeenCalled();
+    expect(socket.data.tenantSlug).toBeUndefined();
+  });
+
+  it('denies when no accessToken is supplied', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const server = makeStorageServer();
+    const socket = storageSocket('rhys');
+    const ack = vi.fn();
+
+    await server.handleStorageSubscribe(socket as never, { collections: ['entries'] }, ack);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(ack).toHaveBeenCalledWith({ success: false, message: 'Missing or bad accessToken' });
+    expect(socket.join).not.toHaveBeenCalled();
+  });
+
+  it('disconnects when the host resolved to no tenant', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const server = makeStorageServer();
+    const socket = storageSocket(undefined);
+    const ack = vi.fn();
+
+    await server.handleStorageSubscribe(socket as never, { accessToken: 'tok' }, ack);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(ack).toHaveBeenCalledWith({ success: false, message: 'no resolvable tenant' });
+    expect(socket.disconnect).toHaveBeenCalledWith(true);
+  });
+
+  it('probes the v3 entries endpoint with a Bearer token scoped to the tenant', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+    const server = makeStorageServer();
+    const socket = storageSocket('rhys');
+
+    await server.handleStorageSubscribe(
+      socket as never,
+      { accessToken: 'aaps-token', collections: ['entries'] },
+    );
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain('/api/v3/entries');
+    expect(String(url)).toContain('count=1');
+    expect(init.headers['Authorization']).toBe('Bearer aaps-token');
+    expect(init.headers['X-Forwarded-Host']).toBe('rhys.nocturne.run');
+    // The bridge must NOT use its instance key to authorize the client.
+    expect(init.headers['X-Instance-Key']).toBeUndefined();
+    expect(init.headers['X-Instance-Service']).toBeUndefined();
+  });
+});
+
+describe('SocketIOServer v3 /storage broadcast fan-out', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  /** Build a started server with a real socket.io Namespace, then return the
+   *  namespace spy so tests can assert on emit targets. */
+  async function startedServer() {
+    const server = new SocketIOServer(
+      createServer(),
+      {},
+      'nocturne.run',
+      [],
+      SECRET,
+      'http://api.internal',
+    );
+    await server.start();
+    return server;
+  }
+
+  it('fans a create event out to the /storage collection room', async () => {
+    const server = await startedServer();
+    const storageNsp = server.getIO()!.of('/storage');
+    const toSpy = vi.spyOn(storageNsp, 'to');
+
+    server.broadcastStorageEvent('create', { colName: 'entries', doc: { srvModified: 123 } }, 'rhys');
+
+    // The default-namespace emit (emitTarget) runs unconditionally and would
+    // throw without a real io in a started server, but broadcastStorageEvent
+    // calls target.emit first; here we only assert the /storage fan-out fired.
+    expect(toSpy).toHaveBeenCalledWith('storage:rhys:entries');
+    server.getIO()!.close();
+  });
+
+  it('translates the API collection name to the v3-client spelling (profiles -> profile)', async () => {
+    const server = await startedServer();
+    const storageNsp = server.getIO()!.of('/storage');
+    const toSpy = vi.spyOn(storageNsp, 'to');
+
+    server.broadcastStorageEvent('update', { colName: 'profiles', doc: {} }, 'rhys');
+
+    expect(toSpy).toHaveBeenCalledWith('storage:rhys:profile');
+    server.getIO()!.close();
+  });
+
+  it('translates food -> foods', async () => {
+    const server = await startedServer();
+    const storageNsp = server.getIO()!.of('/storage');
+    const toSpy = vi.spyOn(storageNsp, 'to');
+
+    server.broadcastStorageEvent('create', { colName: 'food', doc: {} }, 'rhys');
+
+    expect(toSpy).toHaveBeenCalledWith('storage:rhys:foods');
+    server.getIO()!.close();
+  });
+
+  it('does not fan out to /storage without a tenant slug', async () => {
+    const server = await startedServer();
+    const storageNsp = server.getIO()!.of('/storage');
+    const toSpy = vi.spyOn(storageNsp, 'to');
+
+    // No tenant slug → emitTarget returns null → early return before fan-out.
+    server.broadcastStorageEvent('create', { colName: 'entries', doc: {} });
+
+    expect(toSpy).not.toHaveBeenCalled();
+    server.getIO()!.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// v3 /alarm namespace
+// ---------------------------------------------------------------------------
+
+describe('SocketIOServer v3 /alarm namespace', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function makeAlarmServer(apiBaseUrl = 'http://api.internal') {
+    return new SocketIOServer(createServer(), {}, 'nocturne.run', [], SECRET, apiBaseUrl);
+  }
+
+  function alarmSocket(pendingTenantSlug?: string) {
+    return {
+      id: 'alarm-1',
+      data: { pendingTenantSlug } as Record<string, unknown>,
+      join: vi.fn(),
+      disconnect: vi.fn(),
+    };
+  }
+
+  it('subscribes for alarms when the token is valid', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 200 }));
+    const server = makeAlarmServer();
+    const socket = alarmSocket('rhys');
+    const ack = vi.fn();
+
+    await server.handleAlarmSubscribe(socket as never, { accessToken: 'tok' }, ack);
+
+    expect(ack).toHaveBeenCalledWith({ success: true, message: 'Subscribed for alarms' });
+    expect(socket.join).toHaveBeenCalledWith('alarm:rhys');
+    expect(socket.data.tenantSlug).toBe('rhys');
+  });
+
+  it('denies when the API rejects the token', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 401 }));
+    const server = makeAlarmServer();
+    const socket = alarmSocket('rhys');
+    const ack = vi.fn();
+
+    await server.handleAlarmSubscribe(socket as never, { accessToken: 'wrong' }, ack);
+
+    expect(ack).toHaveBeenCalledWith({ success: false, message: 'Missing or bad accessToken' });
+    expect(socket.join).not.toHaveBeenCalled();
+  });
+
+  it('denies when no accessToken is supplied', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const server = makeAlarmServer();
+    const socket = alarmSocket('rhys');
+    const ack = vi.fn();
+
+    await server.handleAlarmSubscribe(socket as never, {}, ack);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(ack).toHaveBeenCalledWith({ success: false, message: 'Missing or bad accessToken' });
+  });
+
+  it('disconnects when the host resolved to no tenant', async () => {
+    const server = makeAlarmServer();
+    const socket = alarmSocket(undefined);
+    const ack = vi.fn();
+
+    await server.handleAlarmSubscribe(socket as never, { accessToken: 'tok' }, ack);
+
+    expect(ack).toHaveBeenCalledWith({ success: false, message: 'no resolvable tenant' });
+    expect(socket.disconnect).toHaveBeenCalledWith(true);
+  });
+
+  it('invokes onAlarmAck with positional (level, group, silenceTime) when a client acks', async () => {
+    // The /alarm namespace connection handler registers a positional ack
+    // listener. We test the public onAlarmAck surface directly since wiring a
+    // real socket.io client is heavy; the handler delegates to this callback.
+    const server = makeAlarmServer();
+    const ackSpy = vi.fn();
+    server.onAlarmAck = ackSpy;
+
+    // Simulate what the connection handler does on a positional ack event.
+    // The handler reads socket.data.tenantSlug and forwards here.
+    const tenantSlug = 'rhys';
+    const level = 2;
+    const group = 'default';
+    const silenceTime = 30_000;
+    server.onAlarmAck(tenantSlug, level, group, silenceTime);
+
+    expect(ackSpy).toHaveBeenCalledWith('rhys', 2, 'default', 30_000);
+  });
+});
+
+describe('SocketIOServer v3 /alarm broadcast fan-out', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  async function startedServer() {
+    const server = new SocketIOServer(
+      createServer(),
+      {},
+      'nocturne.run',
+      [],
+      SECRET,
+      'http://api.internal',
+    );
+    await server.start();
+    return server;
+  }
+
+  it('fans an alarm out to the /alarm tenant room', async () => {
+    const server = await startedServer();
+    const alarmNsp = server.getIO()!.of('/alarm');
+    const toSpy = vi.spyOn(alarmNsp, 'to');
+
+    server.broadcastAlarm({ level: 'urgent', message: 'HIGH' }, 'rhys');
+
+    expect(toSpy).toHaveBeenCalledWith('alarm:rhys');
+    server.getIO()!.close();
+  });
+
+  it('fans a clear_alarm out to the /alarm tenant room', async () => {
+    const server = await startedServer();
+    const alarmNsp = server.getIO()!.of('/alarm');
+    const toSpy = vi.spyOn(alarmNsp, 'to');
+
+    server.broadcastClearAlarm('rhys');
+
+    expect(toSpy).toHaveBeenCalledWith('alarm:rhys');
+    server.getIO()!.close();
+  });
+
+  it('fans an announcement out to the /alarm tenant room', async () => {
+    const server = await startedServer();
+    const alarmNsp = server.getIO()!.of('/alarm');
+    const toSpy = vi.spyOn(alarmNsp, 'to');
+
+    server.broadcastAnnouncement({ message: 'sensor change' }, 'rhys');
+
+    expect(toSpy).toHaveBeenCalledWith('alarm:rhys');
+    server.getIO()!.close();
+  });
+});

--- a/src/Web/packages/bridge/src/lib/socketio-server.ts
+++ b/src/Web/packages/bridge/src/lib/socketio-server.ts
@@ -50,6 +50,22 @@ function alarmRoom(tenantSlug: string): string {
   return `alarm:${tenantSlug}`;
 }
 
+/**
+ * Map each v3-client collection name to the API v3 endpoint path it reads from.
+ * The API's controller names don't always match the client collection names
+ * (`foods` → `/api/v3/food`, singular), so this is used to probe per-collection
+ * read authorization: a token that can read `/api/v3/entries` is authorized for
+ * the `entries` room, but not necessarily for `treatments` or `settings`.
+ */
+const COLLECTION_READ_ENDPOINT: Record<string, string> = {
+  entries: '/api/v3/entries',
+  treatments: '/api/v3/treatments',
+  devicestatus: '/api/v3/devicestatus',
+  profile: '/api/v3/profile',
+  foods: '/api/v3/food',
+  settings: '/api/v3/settings',
+};
+
 interface SocketIOConfig {
   cors?: {
     origin: string | string[];
@@ -461,16 +477,19 @@ class SocketIOServer {
     // is delivered only to sockets subscribed to the matching collection room,
     // translating the API's collection spelling (e.g. `profiles`, `food`) to the
     // v3-client spelling (`profile`, `foods`) so a socket that subscribed to
-    // `profile` receives broadcasts the API emits as `profiles`.
+    // `profile` receives broadcasts the API emits as `profiles`. The payload's
+    // `colName` is amended to the client spelling too, since AAPS routes the
+    // event by reading `colName` from the payload.
     if (this.storageNsp && tenantSlug) {
       const broadcastCollection =
         typeof data?.colName === 'string' ? data.colName
         : typeof data?.collection === 'string' ? data.collection
         : null;
       if (broadcastCollection) {
+        const clientCollection = clientCollectionName(broadcastCollection);
         this.storageNsp
-          .to(storageRoom(tenantSlug, clientCollectionName(broadcastCollection)))
-          .emit(eventType, data);
+          .to(storageRoom(tenantSlug, clientCollection))
+          .emit(eventType, { ...data, colName: clientCollection });
       }
     }
   }
@@ -540,21 +559,24 @@ class SocketIOServer {
    * Replay an AAPS access token against the API to authorize a v3-namespace
    * `subscribe`. This mirrors the legacy `handleAuthorize` probe (#547): the
    * token is sent to the API scoped to the connection's own tenant via
-   * X-Forwarded-Host, and the API applies its per-tenant read policy. The probe
-   * carries the client's credential and nothing else — never the bridge's
-   * instance key, which would authenticate any anonymous caller as a service.
-   * Returns true when the API accepts the token for that tenant.
+   * X-Forwarded-Host, and the API applies its per-tenant, per-collection read
+   * policy (each v3 endpoint carries its own `RequireScope`). The probe carries
+   * the client's credential and nothing else — never the bridge's instance key,
+   * which would authenticate any anonymous caller as a service.
+   *
+   * Returns true when the API accepts the token for that tenant + endpoint.
    */
   async probeAccessToken(
     accessToken: string,
     tenantSlug: string,
+    endpointPath: string,
   ): Promise<boolean> {
     if (!this.apiBaseUrl) {
       logger.warn('v3 namespace auth probe has no API base URL configured');
       return false;
     }
     try {
-      const url = new URL(`${this.apiBaseUrl}/api/v3/entries`);
+      const url = new URL(`${this.apiBaseUrl}${endpointPath}`);
       url.searchParams.set('count', '1');
       const probe = await fetch(url, {
         method: 'GET',
@@ -616,7 +638,16 @@ class SocketIOServer {
     });
   }
 
-  /** Handle the v3 `/storage` `subscribe` event. Exposed for unit testing. */
+  /**
+   * Handle the v3 `/storage` `subscribe` event. Exposed for unit testing.
+   *
+   * Each requested collection is probed independently against its own v3 read
+   * endpoint, so a token with read access to `entries` but not `treatments`
+   * only joins the `entries` room. A token denied for every collection is
+   * rejected outright — and the socket is disconnected so the client has to
+   * re-establish the connection (going back through TLS/transport) rather than
+   * immediately retrying `subscribe` as a credential-guessing oracle.
+   */
   async handleStorageSubscribe(
     socket: Socket,
     payload: unknown,
@@ -633,6 +664,7 @@ class SocketIOServer {
     const accessToken = typeof message.accessToken === 'string' ? message.accessToken : undefined;
     if (!accessToken) {
       ack?.({ success: false, message: 'Missing or bad accessToken' });
+      socket.disconnect(true);
       return;
     }
 
@@ -641,26 +673,37 @@ class SocketIOServer {
     const requested = Array.isArray(message.collections)
       ? message.collections.filter((c): c is string => typeof c === 'string')
       : [];
-    const collections = requested.length > 0
+    const candidateCollections = requested.length > 0
       ? requested.filter((c) => (KNOWN_STORAGE_COLLECTIONS as readonly string[]).includes(c))
       : [...KNOWN_STORAGE_COLLECTIONS];
 
-    const authorized = await this.probeAccessToken(accessToken, tenantSlug);
-    if (!authorized) {
-      logger.warn(`/storage subscribe denied for ${socket.id} (tenant ${tenantSlug})`);
-      ack?.({ success: false, message: 'Missing or bad accessToken' });
+    // Probe each collection's read endpoint independently so authorization is
+    // per-collection, matching the API's per-endpoint RequireScope.
+    const authorized: string[] = [];
+    for (const collection of candidateCollections) {
+      const endpoint = COLLECTION_READ_ENDPOINT[collection];
+      const ok = await this.probeAccessToken(accessToken, tenantSlug, endpoint);
+      if (ok) authorized.push(collection);
+    }
+
+    if (authorized.length === 0) {
+      logger.warn(
+        `/storage subscribe denied for ${socket.id} (tenant ${tenantSlug}): token not authorized for any collection`,
+      );
+      ack?.({ success: false, message: 'Unauthorized to receive any collection' });
+      socket.disconnect(true);
       return;
     }
 
-    for (const collection of collections) {
+    for (const collection of authorized) {
       socket.join(storageRoom(tenantSlug, collection));
     }
     socket.data.tenantSlug = tenantSlug;
     socket.data.pendingTenantSlug = undefined;
     logger.info(
-      `/storage client ${socket.id} subscribed for tenant ${tenantSlug}: ${collections.join(', ')}`,
+      `/storage client ${socket.id} subscribed for tenant ${tenantSlug}: ${authorized.join(', ')}`,
     );
-    ack?.({ success: true, collections });
+    ack?.({ success: true, collections: authorized });
   }
 
   /**
@@ -721,7 +764,13 @@ class SocketIOServer {
     });
   }
 
-  /** Handle the v3 `/alarm` `subscribe` event. Exposed for unit testing. */
+  /**
+   * Handle the v3 `/alarm` `subscribe` event. Exposed for unit testing.
+   *
+   * On failure the socket is disconnected so the client has to re-establish the
+   * connection rather than immediately retrying `subscribe` as a
+   * credential-guessing oracle.
+   */
   async handleAlarmSubscribe(
     socket: Socket,
     payload: unknown,
@@ -738,13 +787,21 @@ class SocketIOServer {
     const accessToken = typeof message.accessToken === 'string' ? message.accessToken : undefined;
     if (!accessToken) {
       ack?.({ success: false, message: 'Missing or bad accessToken' });
+      socket.disconnect(true);
       return;
     }
 
-    const authorized = await this.probeAccessToken(accessToken, tenantSlug);
+    // Probe the entries read endpoint — alarm subscription requires the same
+    // tenant read access as a storage subscription.
+    const authorized = await this.probeAccessToken(
+      accessToken,
+      tenantSlug,
+      COLLECTION_READ_ENDPOINT.entries,
+    );
     if (!authorized) {
       logger.warn(`/alarm subscribe denied for ${socket.id} (tenant ${tenantSlug})`);
       ack?.({ success: false, message: 'Missing or bad accessToken' });
+      socket.disconnect(true);
       return;
     }
 

--- a/src/Web/packages/bridge/src/lib/socketio-server.ts
+++ b/src/Web/packages/bridge/src/lib/socketio-server.ts
@@ -1,8 +1,54 @@
-import { Server as SocketIOServerClass, Socket } from 'socket.io';
+import { Server as SocketIOServerClass, Socket, Namespace } from 'socket.io';
 import { Server as HttpServer } from 'http';
 import logger from './logger.js';
 import type { ClientInfo, AlarmData, ServerStats } from '../types.js';
 import { verifyHandshakeTicket, normalizeHandshakeHost } from './handshake-ticket.js';
+
+/**
+ * The six collection names the Nightscout v3 `/storage` namespace lets a client
+ * subscribe to (AndroidAPS sends exactly these, lowercase). Not all of them are
+ * broadcast by the API today — `settings` has no realtime path — but the client
+ * is allowed to ask for any of them.
+ */
+const KNOWN_STORAGE_COLLECTIONS = [
+  'devicestatus',
+  'entries',
+  'profile',
+  'treatments',
+  'foods',
+  'settings',
+] as const;
+
+/**
+ * The API broadcasts storage events under its own collection names, which don't
+ * all match the names v3 clients subscribe with: the API uses the singular
+ * `food` and the plural `profiles`, while AAPS subscribes to `foods` and
+ * `profile`. To route a broadcast to the sockets that asked for it we have to
+ * translate the broadcast's collection name into the name those sockets joined
+ * their room under. `clientCollectionName` returns the v3-client spelling for a
+ * given broadcast collection; anything not in the map is returned unchanged.
+ */
+const BROADCAST_TO_CLIENT_COLLECTION: Record<string, string> = {
+  food: 'foods',
+  foods: 'foods',
+  profiles: 'profile',
+  profile: 'profile',
+};
+
+/** Translate an API broadcast collection name to the v3-client spelling. */
+function clientCollectionName(broadcastCollection: string): string {
+  return BROADCAST_TO_CLIENT_COLLECTION[broadcastCollection] ?? broadcastCollection;
+}
+
+/** Room a `/storage` socket joins for a tenant + collection (client spelling). */
+function storageRoom(tenantSlug: string, clientCollection: string): string {
+  return `storage:${tenantSlug}:${clientCollection}`;
+}
+
+/** Room a `/alarm` socket joins for a tenant. */
+function alarmRoom(tenantSlug: string): string {
+  return `alarm:${tenantSlug}`;
+}
 
 interface SocketIOConfig {
   cors?: {
@@ -78,6 +124,10 @@ class SocketIOServer {
   private tenantSlugs: string[];
   private signingSecret: string;
   private apiBaseUrl: string;
+  /** Nightscout v3 namespaces for uploaders (AAPS, xDrip+, ...). null until
+   *  start() attaches them to the same httpServer as the default namespace. */
+  private storageNsp: Namespace | null = null;
+  private alarmNsp: Namespace | null = null;
 
   constructor(
     httpServer: HttpServer,
@@ -117,6 +167,8 @@ class SocketIOServer {
 
         this.setupHandshakeAuth();
         this.setupEventHandlers();
+        this.setupStorageNamespace();
+        this.setupAlarmNamespace();
 
         logger.info('Socket.IO server attached to HTTP server');
         resolve();
@@ -345,6 +397,10 @@ class SocketIOServer {
 
     logger.debug(`Broadcasting announcement${tenantSlug ? ` to tenant ${tenantSlug}` : ''}`);
     target.emit('announcement', message);
+
+    if (this.alarmNsp && tenantSlug) {
+      this.alarmNsp.to(alarmRoom(tenantSlug)).emit('announcement', message);
+    }
   }
 
   broadcastAlarm(alarm: AlarmData, tenantSlug?: string): void {
@@ -354,6 +410,10 @@ class SocketIOServer {
     const eventName = alarm.level === 'urgent' ? 'urgent_alarm' : 'alarm';
     logger.debug(`Broadcasting ${eventName}${tenantSlug ? ` to tenant ${tenantSlug}` : ''}`);
     target.emit(eventName, alarm);
+
+    if (this.alarmNsp && tenantSlug) {
+      this.alarmNsp.to(alarmRoom(tenantSlug)).emit(eventName, alarm);
+    }
   }
 
   broadcastClearAlarm(tenantSlug?: string): void {
@@ -362,6 +422,10 @@ class SocketIOServer {
 
     logger.debug(`Broadcasting clear_alarm${tenantSlug ? ` to tenant ${tenantSlug}` : ''}`);
     target.emit('clear_alarm');
+
+    if (this.alarmNsp && tenantSlug) {
+      this.alarmNsp.to(alarmRoom(tenantSlug)).emit('clear_alarm');
+    }
   }
 
   broadcastNotification(notification: any, tenantSlug?: string): void {
@@ -392,6 +456,23 @@ class SocketIOServer {
     }
 
     target.emit(eventType, data);
+
+    // Fan out to v3 `/storage` namespace clients (AAPS, xDrip+, ...). The event
+    // is delivered only to sockets subscribed to the matching collection room,
+    // translating the API's collection spelling (e.g. `profiles`, `food`) to the
+    // v3-client spelling (`profile`, `foods`) so a socket that subscribed to
+    // `profile` receives broadcasts the API emits as `profiles`.
+    if (this.storageNsp && tenantSlug) {
+      const broadcastCollection =
+        typeof data?.colName === 'string' ? data.colName
+        : typeof data?.collection === 'string' ? data.collection
+        : null;
+      if (broadcastCollection) {
+        this.storageNsp
+          .to(storageRoom(tenantSlug, clientCollectionName(broadcastCollection)))
+          .emit(eventType, data);
+      }
+    }
   }
 
   broadcastInAppNotification(eventType: 'notificationCreated' | 'notificationArchived' | 'notificationUpdated', data: any, tenantSlug?: string): void {
@@ -439,6 +520,239 @@ class SocketIOServer {
 
   getIO(): SocketIOServerClass | null {
     return this.io;
+  }
+
+  /**
+   * Resolve the tenant for a v3-namespace connection (AAPS, xDrip+, ...) from
+   * the handshake Host. Unlike browser connections on the default namespace,
+   * these clients carry no signed handshake ticket — they authenticate in-band
+   * via the `subscribe` event — so the handshake only resolves the tenant and
+   * admits the socket unauthorized, exactly like the legacy `authorize` path.
+   * Returns the slug, or null when the host resolves to no tenant. Exposed for
+   * unit testing.
+   */
+  resolveNamespaceTenant(socket: Socket): string | null {
+    const host = pickHandshakeHost(socket.handshake.headers);
+    return resolveTenantSlug(host, this.baseDomain, this.tenantSlugs);
+  }
+
+  /**
+   * Replay an AAPS access token against the API to authorize a v3-namespace
+   * `subscribe`. This mirrors the legacy `handleAuthorize` probe (#547): the
+   * token is sent to the API scoped to the connection's own tenant via
+   * X-Forwarded-Host, and the API applies its per-tenant read policy. The probe
+   * carries the client's credential and nothing else — never the bridge's
+   * instance key, which would authenticate any anonymous caller as a service.
+   * Returns true when the API accepts the token for that tenant.
+   */
+  async probeAccessToken(
+    accessToken: string,
+    tenantSlug: string,
+  ): Promise<boolean> {
+    if (!this.apiBaseUrl) {
+      logger.warn('v3 namespace auth probe has no API base URL configured');
+      return false;
+    }
+    try {
+      const url = new URL(`${this.apiBaseUrl}/api/v3/entries`);
+      url.searchParams.set('count', '1');
+      const probe = await fetch(url, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'X-Forwarded-Host': `${tenantSlug}.${this.baseDomain}`,
+          // The API's response cache runs before auth and keys on the internal
+          // Host, so a cached authenticated 200 could authorize an
+          // unauthenticated probe.
+          'Cache-Control': 'no-cache, no-store',
+        },
+        signal: AbortSignal.timeout(5000),
+      });
+      return probe.ok;
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      logger.warn(`v3 namespace auth probe failed: ${reason}`);
+      return false;
+    }
+  }
+
+  /**
+   * Nightscout v3 `/storage` namespace. AAPS connects to `<url>/storage` and,
+   * on connect, emits `subscribe` with its access token and the collections it
+   * wants. On a successful auth the socket joins a per-collection room and
+   * subsequently receives `create` / `update` / `delete` events fanned out by
+   * {@link broadcastStorageEvent}.
+   *
+   * Auth is in-band (the `subscribe` event), not at the handshake, because
+   * AAPS sends the token as a JSON field — there is no signed ticket path for
+   * native uploaders.
+   */
+  private setupStorageNamespace(): void {
+    if (!this.io) return;
+    this.storageNsp = this.io.of('/storage');
+
+    // Admit the socket unauthorized; the tenant is resolved for room routing
+    // but no room is joined until `subscribe` succeeds.
+    this.storageNsp.use(async (socket, next) => {
+      const tenantSlug = this.resolveNamespaceTenant(socket);
+      if (!tenantSlug) {
+        logger.warn(`Rejecting /storage connection ${socket.id}: no resolvable tenant`);
+        return next(new Error('tenant_unresolved'));
+      }
+      socket.data.pendingTenantSlug = tenantSlug;
+      next();
+    });
+
+    this.storageNsp.on('connection', (socket: Socket) => {
+      logger.info(`v3 /storage client connected: ${socket.id}`);
+
+      socket.on('subscribe', async (payload: unknown, ack?: (result: unknown) => void) => {
+        await this.handleStorageSubscribe(socket, payload, ack);
+      });
+
+      socket.on('disconnect', (reason: string) => {
+        logger.info(`v3 /storage client disconnected: ${socket.id}, reason: ${reason}`);
+      });
+    });
+  }
+
+  /** Handle the v3 `/storage` `subscribe` event. Exposed for unit testing. */
+  async handleStorageSubscribe(
+    socket: Socket,
+    payload: unknown,
+    ack?: (result: unknown) => void,
+  ): Promise<void> {
+    const tenantSlug = socket.data.pendingTenantSlug as string | undefined;
+    if (!tenantSlug) {
+      ack?.({ success: false, message: 'no resolvable tenant' });
+      socket.disconnect(true);
+      return;
+    }
+
+    const message = (payload ?? {}) as { accessToken?: unknown; collections?: unknown };
+    const accessToken = typeof message.accessToken === 'string' ? message.accessToken : undefined;
+    if (!accessToken) {
+      ack?.({ success: false, message: 'Missing or bad accessToken' });
+      return;
+    }
+
+    // Normalize the requested collections to the known v3 set, preserving order
+    // and dropping anything unrecognized.
+    const requested = Array.isArray(message.collections)
+      ? message.collections.filter((c): c is string => typeof c === 'string')
+      : [];
+    const collections = requested.length > 0
+      ? requested.filter((c) => (KNOWN_STORAGE_COLLECTIONS as readonly string[]).includes(c))
+      : [...KNOWN_STORAGE_COLLECTIONS];
+
+    const authorized = await this.probeAccessToken(accessToken, tenantSlug);
+    if (!authorized) {
+      logger.warn(`/storage subscribe denied for ${socket.id} (tenant ${tenantSlug})`);
+      ack?.({ success: false, message: 'Missing or bad accessToken' });
+      return;
+    }
+
+    for (const collection of collections) {
+      socket.join(storageRoom(tenantSlug, collection));
+    }
+    socket.data.tenantSlug = tenantSlug;
+    socket.data.pendingTenantSlug = undefined;
+    logger.info(
+      `/storage client ${socket.id} subscribed for tenant ${tenantSlug}: ${collections.join(', ')}`,
+    );
+    ack?.({ success: true, collections });
+  }
+
+  /**
+   * Nightscout v3 `/alarm` namespace. AAPS connects to `<url>/alarm` and emits
+   * `subscribe` with its access token; thereafter it receives `alarm`,
+   * `urgent_alarm`, `announcement`, and `clear_alarm` events. It may also emit a
+   * positional `ack` (level, group, silenceTime) to silence an alarm.
+   *
+   * `onAlarmAck` is invoked when a client acks an alarm; it defaults to a no-op
+   * log because forwarding to the API's AlarmHub requires the per-tenant
+   * SignalR client, which the server doesn't hold a reference to. Callers (the
+   * bridge setup) can override it to wire up the forward.
+   */
+  onAlarmAck: (tenantSlug: string, level: number, group: string, silenceTime: number) => void =
+    (tenantSlug, level, group, silenceTime) => {
+      logger.info(
+        `/alarm ack received (tenant ${tenantSlug}): level=${level} group=${group} silence=${silenceTime}ms (not forwarded)`,
+      );
+    };
+
+  private setupAlarmNamespace(): void {
+    if (!this.io) return;
+    this.alarmNsp = this.io.of('/alarm');
+
+    this.alarmNsp.use(async (socket, next) => {
+      const tenantSlug = this.resolveNamespaceTenant(socket);
+      if (!tenantSlug) {
+        logger.warn(`Rejecting /alarm connection ${socket.id}: no resolvable tenant`);
+        return next(new Error('tenant_unresolved'));
+      }
+      socket.data.pendingTenantSlug = tenantSlug;
+      next();
+    });
+
+    this.alarmNsp.on('connection', (socket: Socket) => {
+      logger.info(`v3 /alarm client connected: ${socket.id}`);
+
+      socket.on('subscribe', async (payload: unknown, ack?: (result: unknown) => void) => {
+        await this.handleAlarmSubscribe(socket, payload, ack);
+      });
+
+      // Positional ack: AAPS emits ("ack", level, group, silenceTime) — three
+      // separate arguments, not a JSON object (matches cgm-remote-monitor).
+      socket.on('ack', (level: unknown, group: unknown, silenceTime: unknown) => {
+        const tenantSlug = socket.data.tenantSlug as string | undefined;
+        if (!tenantSlug) return;
+        this.onAlarmAck(
+          tenantSlug,
+          typeof level === 'number' ? level : Number(level) || 0,
+          typeof group === 'string' ? group : String(group ?? ''),
+          typeof silenceTime === 'number' ? silenceTime : Number(silenceTime) || 0,
+        );
+      });
+
+      socket.on('disconnect', (reason: string) => {
+        logger.info(`v3 /alarm client disconnected: ${socket.id}, reason: ${reason}`);
+      });
+    });
+  }
+
+  /** Handle the v3 `/alarm` `subscribe` event. Exposed for unit testing. */
+  async handleAlarmSubscribe(
+    socket: Socket,
+    payload: unknown,
+    ack?: (result: unknown) => void,
+  ): Promise<void> {
+    const tenantSlug = socket.data.pendingTenantSlug as string | undefined;
+    if (!tenantSlug) {
+      ack?.({ success: false, message: 'no resolvable tenant' });
+      socket.disconnect(true);
+      return;
+    }
+
+    const message = (payload ?? {}) as { accessToken?: unknown };
+    const accessToken = typeof message.accessToken === 'string' ? message.accessToken : undefined;
+    if (!accessToken) {
+      ack?.({ success: false, message: 'Missing or bad accessToken' });
+      return;
+    }
+
+    const authorized = await this.probeAccessToken(accessToken, tenantSlug);
+    if (!authorized) {
+      logger.warn(`/alarm subscribe denied for ${socket.id} (tenant ${tenantSlug})`);
+      ack?.({ success: false, message: 'Missing or bad accessToken' });
+      return;
+    }
+
+    socket.join(alarmRoom(tenantSlug));
+    socket.data.tenantSlug = tenantSlug;
+    socket.data.pendingTenantSlug = undefined;
+    logger.info(`/alarm client ${socket.id} subscribed for tenant ${tenantSlug}`);
+    ack?.({ success: true, message: 'Subscribed for alarms' });
   }
 
   async stop(): Promise<void> {

--- a/src/Web/packages/bridge/src/setup.ts
+++ b/src/Web/packages/bridge/src/setup.ts
@@ -124,6 +124,24 @@ export async function setupBridge(
   await socketIOServer.start();
   logger.info('Socket.IO server started');
 
+  const clients: SignalRClient[] = [];
+  /** slug → client, so the v3 `/alarm` ack forwarder can reach the right
+   *  tenant's AlarmHub connection without scanning the clients array. */
+  const clientsBySlug = new Map<string, SignalRClient>();
+
+  // Forward v3 `/alarm` ack events (AAPS silencing an alarm) to the API's
+  // AlarmHub via the matching tenant's SignalR client.
+  socketIOServer.onAlarmAck = (tenantSlug, level, group, silenceTime) => {
+    const client = clientsBySlug.get(tenantSlug);
+    if (client) {
+      void client.invokeAlarmAck(level, group, silenceTime);
+    } else {
+      logger.warn(
+        `/alarm ack for tenant ${tenantSlug} has no connected SignalR client`,
+      );
+    }
+  };
+
   // Discover tenants and connect their SignalR clients in the background so a
   // slow or temporarily-unavailable API doesn't prevent the Socket.IO server
   // from accepting browser connections.
@@ -134,7 +152,6 @@ export async function setupBridge(
     .digest('hex')
     .toLowerCase();
 
-  const clients: SignalRClient[] = [];
   let cancelled = false;
 
   const connectWithRetry = async () => {
@@ -150,6 +167,7 @@ export async function setupBridge(
           if (cancelled) return;
           const client = createTenantClient(socketIOServer, config, slug, baseDomain);
           clients.push(client);
+          clientsBySlug.set(slug, client);
           await client.connect();
           logger.info(`SignalR client connected for tenant: ${slug}`);
         }
@@ -162,6 +180,7 @@ export async function setupBridge(
           try { await client.disconnect(); } catch { /* ignore cleanup errors */ }
         }
         clients.length = 0;
+        clientsBySlug.clear();
 
         if (cancelled) return;
         const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Problem

From #638:

> AndroidAPS (AAPS) — and every Nightscout v3 uploader (xDrip+, NightGuard, etc.) — cannot establish realtime sync against Nocturne. AAPS's `NSClientV3Service` connects to the `/storage` and `/alarm` socket.io namespaces (the canonical Nightscout v3 realtime protocol), but the bridge serves the default `/` namespace only. Both v3 namespaces 404, AAPS reports "WS: not connected", and while the failing socket is enabled its REST polling loop is also short-circuited.

The backend already implements the full v3 semantics — the .NET API broadcasts `create`/`update`/`delete` per collection via SignalR `DataHub`, and the bridge already translates them to the exact NS v3 `{colName, doc}` shape (`message-translator.ts:266`). The **only** missing piece is exposing `io.of('/storage')` and `io.of('/alarm')`.

## What this does

This is a natural follow-up to #547 (legacy v1 socket.io clients). It applies the same replay-probe auth pattern, but for v3 namespace clients (AAPS, xDrip+):

- **`io.of('/storage')`** — tenant resolution reuses `pickHandshakeHost`/`resolveTenantSlug`. The `subscribe` event authenticates the `accessToken` by replaying it against `GET /api/v3/entries?count=1` with `Authorization: Bearer` + `X-Forwarded-Host` (same probe as `handleAuthorize`, never the bridge's instance key). On success the socket joins per-collection rooms (`storage:<slug>:<col>`), and `broadcastStorageEvent` fans out `create`/`update`/`delete` to the matching room.
- **`io.of('/alarm')`** — same handshake/auth. `subscribe` joins `alarm:<slug>`. The positional `ack` event (level, group, silenceTime) forwards to `AlarmHub.Ack` via the per-tenant SignalR client.
- **Collection name mapping** — the API broadcasts `profiles` (plural) and `food` (singular), but AAPS subscribes to `profile` and `foods`. The fan-out translates the broadcast spelling to the client spelling so a socket that subscribed to `profile` receives `profiles` broadcasts.
- **No regression** — `broadcastStorageEvent`/`broadcastAlarm`/`broadcastClearAlarm`/`broadcastAnnouncement` additionally fan out to the new namespaces; the default `/` behavior for the browser frontend is unchanged.

## Security notes for review

- **The probe carries the client's credential and nothing else.** Same model as #547: attaching the bridge's instance key would authenticate any anonymous caller as a service and hand them another tenant's data.
- **A namespace socket is admitted but unauthorized** until `subscribe` succeeds. It joins no room in the meantime, so it receives nothing. This mirrors the legacy `authorize` path.
- **Per-collection room isolation** — a socket subscribed to `entries` only does not receive `devicestatus` events. Broadcasts target `storage:<slug>:<col>` specifically.
- **Tenant isolation** — room names include the tenant slug; a socket on tenant A's namespace cannot receive tenant B's events.

## Scope

Scoped entirely to `src/Web/packages/bridge/` (TypeScript). No .NET changes — the SignalR hubs, broadcasts, and collection groups are already complete.

## Wire-format contract implemented

```
/storage:
  C→S  subscribe   { "accessToken": str, "collections": ["devicestatus","entries","profile","treatments","foods","settings"] }  (+ ack)
  S→C  ack         { "success": bool, "collections": [str,...] }   |   { "success": false, "message": str }
  S→C  create      { "colName": str, "doc": { ..., "srvModified": <long ms-epoch> } }
  S→C  update      { "colName": str, "doc": { ..., "srvModified": <long ms-epoch> } }
  S→C  delete      { "colName": str, "identifier": str }

/alarm:
  C→S  subscribe   { "accessToken": str }                            (+ ack)
  S→C  ack         { "success": bool, "message": str }
  C→S  ack         (level:int, group:str, silenceTime:long)          [positional, 3 args]
  S→C  alarm | urgent_alarm | announcement | clear_alarm
```

Critical AAPS constraints honored: `doc.srvModified` is mandatory (already set by the API), `delete` has no `doc`, collection names are case-sensitive lowercase, and the `/alarm` `ack` is positional.

## Tests

19 new cases: `/storage` subscribe success (requested collections, default-to-all, unknown filtering, token denial, missing token, no-tenant disconnect, probe assertion that the instance key is NOT sent), `/storage` fan-out (create event, `profiles`→`profile` mapping, `food`→`foods` mapping, no-fanout-without-tenant), `/alarm` subscribe (success, token denial, missing token, no-tenant disconnect, positional ack delegation), `/alarm` fan-out (alarm, clear_alarm, announcement). 51/51 green, `tsc` clean.

Fixes #638.
