### PR TITLE
refactor(rls): pin every membership read and write to the tenant or subject it asks about

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
@@ -971,7 +971,13 @@ public class PasskeyController : ControllerBase
                 .Select(s => s.AccessRequestMessage)
                 .FirstOrDefaultAsync();
 
-            var ownerIds = await _dbContext.TenantMembers
+            // Pinned, not the request-scoped context: "Request access" is rendered on the login
+            // page of a share host too, where the scoped context is marked as a share and
+            // membership is denied. Resolved there, this would find no owners and the request would
+            // be filed with nobody notified.
+            await using var ownerCtx = await _dbContextFactory.CreateTenantPinnedContextAsync(
+                tenant.Id, HttpContext.RequestAborted);
+            var ownerIds = await ownerCtx.TenantMembers
                 .Where(tm => tm.TenantId == tenant.Id
                     && tm.MemberRoles.Any(mr => mr.TenantRole.Slug == Core.Models.Authorization.TenantPermissions.SeedRoles.Owner))
                 .Select(tm => tm.SubjectId)

--- a/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
@@ -15,6 +15,7 @@ using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Models;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Extensions;
 
 namespace Nocturne.API.Controllers.Authentication;
 
@@ -72,6 +73,7 @@ public class PasskeyController : ControllerBase
     private readonly ITenantService _tenantService;
     private readonly ITenantMemberService _tenantMemberService;
     private readonly NocturneDbContext _dbContext;
+    private readonly IDbContextFactory<NocturneDbContext> _dbContextFactory;
     private readonly OidcOptions _oidcOptions;
     private readonly ILogger<PasskeyController> _logger;
 
@@ -90,6 +92,7 @@ public class PasskeyController : ControllerBase
         ITenantService tenantService,
         ITenantMemberService tenantMemberService,
         NocturneDbContext dbContext,
+        IDbContextFactory<NocturneDbContext> dbContextFactory,
         IOptions<OidcOptions> oidcOptions,
         ILogger<PasskeyController> logger)
     {
@@ -104,6 +107,7 @@ public class PasskeyController : ControllerBase
         _tenantService = tenantService;
         _tenantMemberService = tenantMemberService;
         _dbContext = dbContext;
+        _dbContextFactory = dbContextFactory;
         _oidcOptions = oidcOptions.Value;
         _logger = logger;
     }
@@ -318,6 +322,12 @@ public class PasskeyController : ControllerBase
     /// Returns the subject named by <paramref name="username"/> when the tenant is in recovery
     /// mode and that subject has no primary auth factor, otherwise <see langword="null"/>.
     /// </summary>
+    /// <remarks>
+    /// The subject lookup stays on the request-scoped context, deliberately, unlike the two
+    /// preconditions above it. A recovery ceremony enrols a credential, so on a share host — where
+    /// the scoped context is marked as a share and membership is denied — it must resolve nobody
+    /// and fail closed. Pinning it would make the ceremony reachable there.
+    /// </remarks>
     private async Task<SubjectEntity?> ResolveRecoveryModeSubjectAsync(string? username)
     {
         if (string.IsNullOrWhiteSpace(username))
@@ -768,31 +778,45 @@ public class PasskeyController : ControllerBase
     /// Whether any member of the tenant has a passkey or a linked provider, i.e. whether the
     /// tenant is past first-run setup.
     /// </summary>
-    private Task<bool> TenantHasCredentialsAsync(Guid tenantId)
+    /// <remarks>
+    /// On a tenant-pinned context of its own, not the request-scoped one, for the same reason as
+    /// <c>TenantSetupMiddleware</c>: <see cref="GetAuthStatus"/> is anonymous and reachable on a
+    /// share host, where the scoped context is marked as a share. Membership is not share-visible
+    /// data, so once tenant_members is behind Row Level Security a share is denied every row of it
+    /// — and this would report a configured tenant as needing first-run setup.
+    /// </remarks>
+    private async Task<bool> TenantHasCredentialsAsync(Guid tenantId)
     {
-        return _dbContext.TenantMembers
+        await using var db = await _dbContextFactory.CreateTenantPinnedContextAsync(tenantId, HttpContext.RequestAborted);
+
+        return await db.TenantMembers
             .Where(m => m.TenantId == tenantId)
             .AnyAsync(m =>
-                _dbContext.PasskeyCredentials.Any(c => c.SubjectId == m.SubjectId) ||
-                _dbContext.SubjectOidcIdentities.Any(o => o.SubjectId == m.SubjectId));
+                db.PasskeyCredentials.Any(c => c.SubjectId == m.SubjectId) ||
+                db.SubjectOidcIdentities.Any(o => o.SubjectId == m.SubjectId));
     }
 
     /// <summary>
     /// Whether the tenant has an active, non-system member with no passkey and no linked
     /// provider — an account that cannot sign in at all.
     /// </summary>
-    private Task<bool> HasOrphanedSubjectAsync(Guid tenantId)
+    /// <remarks>
+    /// Pinned for the same reason as <see cref="TenantHasCredentialsAsync"/>.
+    /// </remarks>
+    private async Task<bool> HasOrphanedSubjectAsync(Guid tenantId)
     {
-        return _dbContext.TenantMembers
+        await using var db = await _dbContextFactory.CreateTenantPinnedContextAsync(tenantId, HttpContext.RequestAborted);
+
+        return await db.TenantMembers
             .Where(tm => tm.TenantId == tenantId)
             .Join(
-                _dbContext.Subjects.Where(s => s.IsActive && !s.IsSystemSubject),
+                db.Subjects.Where(s => s.IsActive && !s.IsSystemSubject),
                 tm => tm.SubjectId,
                 s => s.Id,
                 (tm, s) => s)
             .Where(s =>
-                !_dbContext.SubjectOidcIdentities.Any(i => i.SubjectId == s.Id) &&
-                !_dbContext.PasskeyCredentials.Any(p => p.SubjectId == s.Id))
+                !db.SubjectOidcIdentities.Any(i => i.SubjectId == s.Id) &&
+                !db.PasskeyCredentials.Any(p => p.SubjectId == s.Id))
             .AnyAsync();
     }
 

--- a/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
@@ -70,6 +70,7 @@ public class PasskeyController : ControllerBase
     private readonly IAuthAuditService _auditService;
     private readonly ITenantAccessor _tenantAccessor;
     private readonly ITenantService _tenantService;
+    private readonly ITenantMemberService _tenantMemberService;
     private readonly NocturneDbContext _dbContext;
     private readonly OidcOptions _oidcOptions;
     private readonly ILogger<PasskeyController> _logger;
@@ -87,6 +88,7 @@ public class PasskeyController : ControllerBase
         IAuthAuditService auditService,
         ITenantAccessor tenantAccessor,
         ITenantService tenantService,
+        ITenantMemberService tenantMemberService,
         NocturneDbContext dbContext,
         IOptions<OidcOptions> oidcOptions,
         ILogger<PasskeyController> logger)
@@ -100,6 +102,7 @@ public class PasskeyController : ControllerBase
         _auditService = auditService;
         _tenantAccessor = tenantAccessor;
         _tenantService = tenantService;
+        _tenantMemberService = tenantMemberService;
         _dbContext = dbContext;
         _oidcOptions = oidcOptions.Value;
         _logger = logger;
@@ -376,22 +379,48 @@ public class PasskeyController : ControllerBase
     /// check to the current tenant would let a tenant claim another tenant's credential-less member
     /// — the locked-out state recovery mode exists for — by enrolling a passkey onto them.
     /// </para>
+    /// <para>
+    /// Hence the two steps. The candidate list comes from tables that are not tenant-scoped, so one
+    /// query answers it. The membership check cannot join to them in the same statement: a single
+    /// anti-join spans every candidate at once, and the reach that makes it cross-tenant is granted
+    /// one subject at a time (<c>app.current_subject_id</c>), so no one pin can cover the statement.
+    /// It is asked per candidate instead, through <see cref="ITenantMemberService"/>, whose
+    /// enumeration carries that subject's own reach.
+    /// </para>
     /// The preconditions mean only a half-finished enrolment can match, never an account that can
     /// already sign in or that belongs to a tenant — so with several candidates (duplicates left by
     /// an older build of the options step) every one of them is an empty shell and the newest, which
     /// the caller's ceremony was minted against, wins. Ids are UUID v7, which sort in creation order.
+    /// Walking the candidates newest-first and taking the first with no membership is the same
+    /// answer as the newest candidate satisfying all four conditions at once.
+    /// <para>
+    /// A membership that has been revoked does not count, here or in
+    /// <see cref="ITenantMemberService.GetTenantIdsForSubjectAsync"/>: the global
+    /// <c>RevokedAt == null</c> filter excludes it either way. A revoked member is a shell with no
+    /// remaining access, so enrolling onto it takes nothing over.
+    /// </para>
     /// </remarks>
     private async Task<Guid?> FindEnrollingSubjectIdAsync(Expression<Func<SubjectEntity, bool>> match)
     {
-        return await _dbContext.Subjects
+        var candidateIds = await _dbContext.Subjects
             .Where(match)
             .Where(s => !s.IsSystemSubject
                 && !_dbContext.PasskeyCredentials.Any(c => c.SubjectId == s.Id)
-                && !_dbContext.SubjectOidcIdentities.Any(o => o.SubjectId == s.Id)
-                && !_dbContext.TenantMembers.Any(m => m.SubjectId == s.Id))
+                && !_dbContext.SubjectOidcIdentities.Any(o => o.SubjectId == s.Id))
             .OrderByDescending(s => s.Id)
-            .Select(s => (Guid?)s.Id)
-            .FirstOrDefaultAsync();
+            .Select(s => s.Id)
+            .ToListAsync();
+
+        foreach (var candidateId in candidateIds)
+        {
+            var memberships = await _tenantMemberService.GetTenantIdsForSubjectAsync(candidateId);
+            if (memberships.Count == 0)
+            {
+                return candidateId;
+            }
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Controllers/V4/DevOnly/DevAdminController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/DevOnly/DevAdminController.cs
@@ -16,6 +16,7 @@ using Nocturne.Core.Contracts.Connectors;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Extensions;
 
 namespace Nocturne.API.Controllers.V4.DevOnly;
 
@@ -87,7 +88,7 @@ public class DevAdminController : ControllerBase
         foreach (var tenant in tenants)
         {
             // Set RLS GUC for tenant-scoped queries
-            await SetTenantGuc(tenant.Id, ct);
+            await _db.PinTenantAsync(tenant.Id, ct);
 
             // Query tenant-scoped entities
             var roles = await _db.TenantRoles
@@ -310,7 +311,7 @@ public class DevAdminController : ControllerBase
                 foreach (var ts in snapshot.Tenants)
                 {
                     var tenantId = ts.Tenant.Id;
-                    await SetTenantGuc(tenantId, ct);
+                    await _db.PinTenantAsync(tenantId, ct);
 
                     // Delete in FK-safe order: member-roles -> members -> roles -> OAuth clients -> connector configs
                     var existingMemberRoles = await _db.TenantMemberRoles
@@ -443,7 +444,7 @@ public class DevAdminController : ControllerBase
                 foreach (var ts in snapshot.Tenants)
                 {
                     var tenantId = ts.Tenant.Id;
-                    await SetTenantGuc(tenantId, ct);
+                    await _db.PinTenantAsync(tenantId, ct);
 
                     // Insert roles
                     foreach (var r in ts.Roles)
@@ -587,7 +588,7 @@ public class DevAdminController : ControllerBase
 
         foreach (var tenant in tenants)
         {
-            await SetTenantGuc(tenant.Id, ct);
+            await _db.PinTenantAsync(tenant.Id, ct);
 
             var configs = await _db.ConnectorConfigurations
                 .AsNoTracking()
@@ -655,7 +656,7 @@ public class DevAdminController : ControllerBase
 
         foreach (var tenant in tenants)
         {
-            await SetTenantGuc(tenant.Id, ct);
+            await _db.PinTenantAsync(tenant.Id, ct);
 
             var entryCount = (long)await _db.SensorGlucose.CountAsync(ct)
                 + await _db.MeterGlucose.CountAsync(ct)
@@ -778,7 +779,7 @@ public class DevAdminController : ControllerBase
         try
         {
             // Phase 1: Clean existing scoped data for this tenant
-            await SetTenantGuc(id, ct);
+            await _db.PinTenantAsync(id, ct);
 
             var existingMemberRoles = await _db.TenantMemberRoles
                 .Where(mr => _db.TenantMembers
@@ -997,7 +998,7 @@ public class DevAdminController : ControllerBase
         await _db.SaveChangesAsync(ct);
 
         // 4. Owner membership with full permissions
-        await SetTenantGuc(tenant.Id, ct);
+        await _db.PinTenantAsync(tenant.Id, ct);
         var ownerRole = await _db.TenantRoles
             .Where(r => r.TenantId == tenant.Id && r.IsSystem && r.Slug == TenantPermissions.SeedRoles.Owner)
             .FirstAsync(ct);
@@ -1087,7 +1088,7 @@ public class DevAdminController : ControllerBase
         if (tenant is null)
             return NotFound(new { error = $"Tenant {id} not found" });
 
-        await SetTenantGuc(tenant.Id, ct);
+        await _db.PinTenantAsync(tenant.Id, ct);
         var members = await _db.TenantMembers
             .AsNoTracking()
             .Include(m => m.Subject)
@@ -1130,7 +1131,7 @@ public class DevAdminController : ControllerBase
         if (tenant is null)
             return NotFound(new { error = $"Tenant {id} not found" });
 
-        await SetTenantGuc(tenant.Id, ct);
+        await _db.PinTenantAsync(tenant.Id, ct);
 
         var members = await _db.TenantMembers
             .Include(m => m.Subject)
@@ -1207,14 +1208,6 @@ public class DevAdminController : ControllerBase
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────
-
-    private async Task SetTenantGuc(Guid tenantId, CancellationToken ct)
-    {
-        await _db.Database.ExecuteSqlRawAsync(
-            "SELECT set_config('app.current_tenant_id', {0}, false)",
-            [tenantId.ToString()],
-            ct);
-    }
 
     /// <summary>
     /// 400 for a rejected slug, with up to three valid alternatives so callers

--- a/src/API/Nocturne.API/Controllers/V4/SetupController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/SetupController.cs
@@ -15,6 +15,7 @@ using Nocturne.API.Extensions;
 using Nocturne.API.Services.Auth;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.API.Configuration;
 using SameSiteMode = Nocturne.Core.Models.Configuration.SameSiteMode;
 
@@ -90,11 +91,7 @@ public partial class SetupController : ControllerBase
         await using var context = await _dbFactory.CreateDbContextAsync(ct);
 
         // Block if any tenant already has a member with credentials (passkey or OIDC).
-        var hasConfiguredTenant = await context.TenantMembers
-            .AnyAsync(m =>
-                context.PasskeyCredentials.Any(c => c.SubjectId == m.SubjectId) ||
-                context.SubjectOidcIdentities.Any(o => o.SubjectId == m.SubjectId), ct);
-        if (hasConfiguredTenant)
+        if (await AnyTenantHasCredentialedMemberAsync(context, ct))
             return Conflict(new { error = "setup_already_complete" });
 
         if (string.IsNullOrWhiteSpace(request.Slug) || string.IsNullOrWhiteSpace(request.DisplayName))
@@ -137,9 +134,7 @@ public partial class SetupController : ControllerBase
         if (tenant == null)
             return Ok(new SlugValidationResult(false, "No tenant exists"));
 
-        await context.Database.ExecuteSqlRawAsync(
-            "SELECT set_config('app.current_tenant_id', {0}, false)",
-            tenant.Id.ToString());
+        await context.PinTenantAsync(tenant.Id, ct);
 
         var exists = await context.TenantMembers.AsNoTracking()
             .AnyAsync(m => m.TenantId == tenant.Id && m.Username == normalized, ct);
@@ -391,6 +386,39 @@ public partial class SetupController : ControllerBase
     #region Private Helpers
 
     /// <summary>
+    /// Whether any tenant on the instance already has a member holding a real credential (passkey
+    /// or linked OIDC identity), i.e. whether first-run setup has already produced a usable
+    /// account somewhere.
+    /// </summary>
+    /// <remarks>
+    /// Asked per tenant under that tenant's own pin, then OR'd. The equivalent single query over
+    /// every tenant's memberships has no tenant to be pinned to, and a membership hidden from it
+    /// would read as "no credentialed member exists" — re-opening setup on a configured instance.
+    /// </remarks>
+    private static async Task<bool> AnyTenantHasCredentialedMemberAsync(
+        NocturneDbContext context, CancellationToken ct)
+    {
+        var tenantIds = await context.Tenants.AsNoTracking()
+            .Select(t => t.Id)
+            .ToListAsync(ct);
+
+        foreach (var tenantId in tenantIds)
+        {
+            await context.PinTenantAsync(tenantId, ct);
+
+            var hasCredentialedMember = await context.TenantMembers.AsNoTracking()
+                .Where(m => m.TenantId == tenantId)
+                .AnyAsync(m =>
+                    context.PasskeyCredentials.Any(c => c.SubjectId == m.SubjectId) ||
+                    context.SubjectOidcIdentities.Any(o => o.SubjectId == m.SubjectId), ct);
+
+            if (hasCredentialedMember) return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Returns the sole tenant if exactly one exists and it has no non-system members,
     /// or an error result if the preconditions are not met.
     /// </summary>
@@ -408,10 +436,8 @@ public partial class SetupController : ControllerBase
 
         var tenant = tenants[0];
 
-        // Set RLS context to query tenant-scoped members table
-        await context.Database.ExecuteSqlRawAsync(
-            "SELECT set_config('app.current_tenant_id', {0}, false)",
-            tenant.Id.ToString());
+        // Pin the RLS context to query the tenant-scoped members table
+        await context.PinTenantAsync(tenant.Id, ct);
 
         // Setup is "complete" only once a member holds real credentials (passkey or
         // OIDC). A credential-less member is a half-finished setup left behind by an
@@ -447,9 +473,7 @@ public partial class SetupController : ControllerBase
     {
         await using var context = await _dbFactory.CreateDbContextAsync(ct);
 
-        await context.Database.ExecuteSqlRawAsync(
-            "SELECT set_config('app.current_tenant_id', {0}, false)",
-            tenant.Id.ToString());
+        await context.PinTenantAsync(tenant.Id, ct);
 
         return await SetupOwnerSubjects(context)
             .AsNoTracking()
@@ -468,9 +492,7 @@ public partial class SetupController : ControllerBase
     {
         await using var context = await _dbFactory.CreateDbContextAsync(ct);
 
-        await context.Database.ExecuteSqlRawAsync(
-            "SELECT set_config('app.current_tenant_id', {0}, false)",
-            tenant.Id.ToString());
+        await context.PinTenantAsync(tenant.Id, ct);
 
         var existingSubject = await SetupOwnerSubjects(context).FirstOrDefaultAsync(ct);
 
@@ -514,9 +536,7 @@ public partial class SetupController : ControllerBase
 
         // Set per-tenant username on the membership
         await using var memberCtx = await _dbFactory.CreateDbContextAsync(ct);
-        await memberCtx.Database.ExecuteSqlRawAsync(
-            "SELECT set_config('app.current_tenant_id', {0}, false)",
-            tenant.Id.ToString());
+        await memberCtx.PinTenantAsync(tenant.Id, ct);
         var membership = await memberCtx.TenantMembers
             .FirstOrDefaultAsync(m => m.TenantId == tenant.Id && m.SubjectId == subjectId, ct);
         if (membership != null)

--- a/src/API/Nocturne.API/Controllers/V4/SetupController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/SetupController.cs
@@ -88,10 +88,8 @@ public partial class SetupController : ControllerBase
     public async Task<IActionResult> CreateTenant(
         [FromBody] SetupTenantRequest request, CancellationToken ct)
     {
-        await using var context = await _dbFactory.CreateDbContextAsync(ct);
-
         // Block if any tenant already has a member with credentials (passkey or OIDC).
-        if (await AnyTenantHasCredentialedMemberAsync(context, ct))
+        if (await AnyTenantHasCredentialedMemberAsync(ct))
             return Conflict(new { error = "setup_already_complete" });
 
         if (string.IsNullOrWhiteSpace(request.Slug) || string.IsNullOrWhiteSpace(request.DisplayName))
@@ -394,10 +392,15 @@ public partial class SetupController : ControllerBase
     /// Asked per tenant under that tenant's own pin, then OR'd. The equivalent single query over
     /// every tenant's memberships has no tenant to be pinned to, and a membership hidden from it
     /// would read as "no credentialed member exists" — re-opening setup on a configured instance.
+    /// <para>
+    /// The per-iteration re-pin is confined to a context of its own, so the caller is not left
+    /// holding one pinned to whichever tenant happened to be enumerated last.
+    /// </para>
     /// </remarks>
-    private static async Task<bool> AnyTenantHasCredentialedMemberAsync(
-        NocturneDbContext context, CancellationToken ct)
+    private async Task<bool> AnyTenantHasCredentialedMemberAsync(CancellationToken ct)
     {
+        await using var context = await _dbFactory.CreateDbContextAsync(ct);
+
         var tenantIds = await context.Tenants.AsNoTracking()
             .Select(t => t.Id)
             .ToListAsync(ct);

--- a/src/API/Nocturne.API/Middleware/MemberScopeMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/MemberScopeMiddleware.cs
@@ -209,9 +209,11 @@ public class MemberScopeMiddleware
                 }
                 catch (Exception ex)
                 {
-                    // Best-effort — don't let tracking failures affect the request. Logged so a
-                    // write the database refuses is visible rather than silent.
-                    _logger.LogDebug(
+                    // Best-effort — don't let tracking failures affect the request. Warned rather
+                    // than debugged: a write the database refuses would otherwise be invisible at
+                    // production log levels. The 5-minute refresh window bounds the rate to one
+                    // per member.
+                    _logger.LogWarning(
                         ex, "Failed to record last-used for membership {MembershipId}", membershipId);
                 }
             });

--- a/src/API/Nocturne.API/Middleware/MemberScopeMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/MemberScopeMiddleware.cs
@@ -185,6 +185,7 @@ public class MemberScopeMiddleware
                 || (DateTime.UtcNow - membership.LastUsedAt.Value).TotalMinutes > 5))
         {
             var membershipId = membership.Id;
+            var tenantId = authContext.TenantId.Value;
             var ip = context.Connection.RemoteIpAddress?.ToString();
             var userAgent = context.Request.Headers.UserAgent.FirstOrDefault();
             var serviceScopeFactory = context.RequestServices.GetRequiredService<IServiceScopeFactory>();
@@ -193,18 +194,25 @@ public class MemberScopeMiddleware
             {
                 try
                 {
+                    // The fresh scope outlives the request, so its context resolves without an
+                    // ambient tenant and carries no pin of its own. Pin it, and key the update on
+                    // the tenant as well as the membership id.
                     using var scope = serviceScopeFactory.CreateScope();
                     var db = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
+                    db.TenantId = tenantId;
                     await db.TenantMembers
-                        .Where(tm => tm.Id == membershipId)
+                        .Where(tm => tm.Id == membershipId && tm.TenantId == tenantId)
                         .ExecuteUpdateAsync(s => s
                             .SetProperty(tm => tm.LastUsedAt, DateTime.UtcNow)
                             .SetProperty(tm => tm.LastUsedIp, ip)
                             .SetProperty(tm => tm.LastUsedUserAgent, userAgent));
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // Best-effort — don't let tracking failures affect the request
+                    // Best-effort — don't let tracking failures affect the request. Logged so a
+                    // write the database refuses is visible rather than silent.
+                    _logger.LogDebug(
+                        ex, "Failed to record last-used for membership {MembershipId}", membershipId);
                 }
             });
         }

--- a/src/API/Nocturne.API/Middleware/TenantSetupMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/TenantSetupMiddleware.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Nocturne.API.Authorization;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Extensions;
 
 namespace Nocturne.API.Middleware;
 
@@ -57,13 +58,13 @@ public class TenantSetupMiddleware
     /// </summary>
     /// <param name="context">The current HTTP context.</param>
     /// <param name="tenantAccessor">Accessor for the resolved tenant identity.</param>
-    /// <param name="db">Database context for querying passkey credentials and orphaned subjects.</param>
+    /// <param name="dbFactory">Factory for the tenant-pinned context the checks below run on.</param>
     /// <param name="instanceKeyValidator">Validator used to let trusted instance-key callers bypass the setup gate.</param>
     /// <returns>A task that completes when the middleware has finished processing.</returns>
     public async Task InvokeAsync(
         HttpContext context,
         ITenantAccessor tenantAccessor,
-        NocturneDbContext db,
+        IDbContextFactory<NocturneDbContext> dbFactory,
         IInstanceKeyValidator instanceKeyValidator)
     {
         // Only check when a tenant has been resolved
@@ -115,7 +116,16 @@ public class TenantSetupMiddleware
 
         // Check 1: Does this tenant have any members with auth credentials (passkey or OIDC)?
         // These entities are subject-scoped (not tenant-scoped), so we join through TenantMembers.
+        //
+        // On its own context rather than the request-scoped one. A public-share request marks the
+        // scoped context as a share, and membership is not share-visible data: once tenant_members
+        // is behind Row Level Security, the restrictive share_category_read policy denies a share
+        // every row of it. Read there, this gate would see no members and answer 503
+        // setup_required to every share request. Whether the instance is configured is a property
+        // of the instance, not of what a share may see, so the check runs on a plain tenant-pinned
+        // context that is never flagged as a share.
         var tenantId = tenantAccessor.TenantId;
+        await using var db = await dbFactory.CreateTenantPinnedContextAsync(tenantId, context.RequestAborted);
         var memberCount = await db.TenantMembers
             .Where(m => m.TenantId == tenantId)
             .CountAsync();

--- a/src/API/Nocturne.API/Middleware/TenantSetupMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/TenantSetupMiddleware.cs
@@ -114,39 +114,92 @@ public class TenantSetupMiddleware
             return;
         }
 
+        // Evaluated in a scope of its own so the extra context is disposed before the rest of the
+        // pipeline runs, rather than being held open for the whole downstream request.
+        switch (await EvaluateGateAsync(dbFactory, tenantAccessor.TenantId, path, context.RequestAborted))
+        {
+            case SetupGate.SetupRequired:
+                context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                await context.Response.WriteAsJsonAsync(new
+                {
+                    error = "setup_required",
+                    message = "Initial setup required. Please register a passkey to secure your account.",
+                    setupRequired = true,
+                    recoveryMode = false,
+                });
+                return;
+
+            case SetupGate.RecoveryMode:
+                context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                await context.Response.WriteAsJsonAsync(new
+                {
+                    error = "recovery_mode_active",
+                    message = "Instance is in recovery mode. Please register a passkey or authenticator app to continue.",
+                    setupRequired = false,
+                    recoveryMode = true,
+                });
+                return;
+        }
+
+        await _next(context);
+    }
+
+    /// <summary>What the setup and recovery checks decided for this tenant.</summary>
+    private enum SetupGate
+    {
+        /// <summary>The tenant is configured and has no locked-out accounts.</summary>
+        Pass,
+
+        /// <summary>No member holds a credential yet — first-run setup has not completed.</summary>
+        SetupRequired,
+
+        /// <summary>A member cannot sign in at all, so the recovery flow has to be reachable.</summary>
+        RecoveryMode,
+    }
+
+    /// <summary>
+    /// Runs the setup and recovery checks and logs the diagnostics for a refusal.
+    /// </summary>
+    /// <remarks>
+    /// On its own context rather than the request-scoped one. A public-share request marks the
+    /// scoped context as a share, and membership is not share-visible data: once tenant_members is
+    /// behind Row Level Security, the restrictive share_category_read policy denies a share every
+    /// row of it. Read there, this gate would see no members and answer 503 setup_required to every
+    /// share request. Whether the instance is configured is a property of the instance, not of what
+    /// a share may see, so the checks run on a plain tenant-pinned context that is never flagged as
+    /// a share. Scoped to this method so the context is released before the pipeline continues.
+    /// </remarks>
+    private async Task<SetupGate> EvaluateGateAsync(
+        IDbContextFactory<NocturneDbContext> dbFactory,
+        Guid tenantId,
+        string path,
+        CancellationToken ct)
+    {
+        await using var db = await dbFactory.CreateTenantPinnedContextAsync(tenantId, ct);
+
         // Check 1: Does this tenant have any members with auth credentials (passkey or OIDC)?
         // These entities are subject-scoped (not tenant-scoped), so we join through TenantMembers.
-        //
-        // On its own context rather than the request-scoped one. A public-share request marks the
-        // scoped context as a share, and membership is not share-visible data: once tenant_members
-        // is behind Row Level Security, the restrictive share_category_read policy denies a share
-        // every row of it. Read there, this gate would see no members and answer 503
-        // setup_required to every share request. Whether the instance is configured is a property
-        // of the instance, not of what a share may see, so the check runs on a plain tenant-pinned
-        // context that is never flagged as a share.
-        var tenantId = tenantAccessor.TenantId;
-        await using var db = await dbFactory.CreateTenantPinnedContextAsync(tenantId, context.RequestAborted);
         var memberCount = await db.TenantMembers
             .Where(m => m.TenantId == tenantId)
-            .CountAsync();
+            .CountAsync(ct);
         var hasCredentials = memberCount > 0 && await db.TenantMembers
             .Where(m => m.TenantId == tenantId)
             .AnyAsync(m =>
                 db.PasskeyCredentials.Any(c => c.SubjectId == m.SubjectId) ||
-                db.SubjectOidcIdentities.Any(i => i.SubjectId == m.SubjectId));
+                db.SubjectOidcIdentities.Any(i => i.SubjectId == m.SubjectId), ct);
         if (!hasCredentials)
         {
             var passkeyCount = memberCount > 0
                 ? await db.TenantMembers
                     .Where(m => m.TenantId == tenantId)
                     .SelectMany(m => db.PasskeyCredentials.Where(c => c.SubjectId == m.SubjectId))
-                    .CountAsync()
+                    .CountAsync(ct)
                 : 0;
             var oidcCount = memberCount > 0
                 ? await db.TenantMembers
                     .Where(m => m.TenantId == tenantId)
                     .SelectMany(m => db.SubjectOidcIdentities.Where(i => i.SubjectId == m.SubjectId))
-                    .CountAsync()
+                    .CountAsync(ct)
                 : 0;
 
             _logger.LogWarning(
@@ -155,20 +208,12 @@ public class TenantSetupMiddleware
                 "DbContextTenantId={DbContextTenantId}",
                 tenantId, path, memberCount, passkeyCount, oidcCount, db.TenantId);
 
-            context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
-            await context.Response.WriteAsJsonAsync(new
-            {
-                error = "setup_required",
-                message = "Initial setup required. Please register a passkey to secure your account.",
-                setupRequired = true,
-                recoveryMode = false,
-            });
-            return;
+            return SetupGate.SetupRequired;
         }
 
         // Check 2: Does this tenant have any orphaned subjects?
         // Subjects are not tenant-scoped — join through TenantMembers to scope to this tenant.
-        var hasOrphaned = await db.TenantMembers
+        var orphanedSubjects = await db.TenantMembers
             .Where(tm => tm.TenantId == tenantId)
             .Join(
                 db.Subjects.Where(s => s.IsActive && !s.IsSystemSubject),
@@ -178,39 +223,19 @@ public class TenantSetupMiddleware
             .Where(s =>
                 !db.SubjectOidcIdentities.Any(i => i.SubjectId == s.Id) &&
                 !db.PasskeyCredentials.Any(p => p.SubjectId == s.Id))
-            .AnyAsync();
+            .Select(s => new { s.Id, s.Name, s.Username })
+            .ToListAsync(ct);
 
-        if (hasOrphaned)
+        if (orphanedSubjects.Count > 0)
         {
-            var orphanedSubjects = await db.TenantMembers
-                .Where(tm => tm.TenantId == tenantId)
-                .Join(
-                    db.Subjects.Where(s => s.IsActive && !s.IsSystemSubject),
-                    tm => tm.SubjectId,
-                    s => s.Id,
-                    (tm, s) => s)
-                .Where(s =>
-                    !db.SubjectOidcIdentities.Any(i => i.SubjectId == s.Id) &&
-                    !db.PasskeyCredentials.Any(p => p.SubjectId == s.Id))
-                .Select(s => new { s.Id, s.Name, s.Username })
-                .ToListAsync();
-
             _logger.LogWarning(
                 "Tenant {TenantId} has orphaned subjects — returning 503 recovery_mode. " +
                 "Path={Path}, OrphanedSubjects={@OrphanedSubjects}",
                 tenantId, path, orphanedSubjects);
 
-            context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
-            await context.Response.WriteAsJsonAsync(new
-            {
-                error = "recovery_mode_active",
-                message = "Instance is in recovery mode. Please register a passkey or authenticator app to continue.",
-                setupRequired = false,
-                recoveryMode = true,
-            });
-            return;
+            return SetupGate.RecoveryMode;
         }
 
-        await _next(context);
+        return SetupGate.Pass;
     }
 }

--- a/src/API/Nocturne.API/Services/Auth/PlatformAdminBootstrapService.cs
+++ b/src/API/Nocturne.API/Services/Auth/PlatformAdminBootstrapService.cs
@@ -1,7 +1,9 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.Configuration;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Extensions;
 
 namespace Nocturne.API.Services.Auth;
 
@@ -50,17 +52,43 @@ public class PlatformAdminBootstrapService
         if (await _db.Subjects.AnyAsync(s => s.IsPlatformAdmin, cancellationToken))
             return;
 
-        // Option 2: grant to owner of oldest tenant
-        var firstOwnerSubjectId = await _db.TenantMembers
-            .Where(tm => tm.MemberRoles.Any(mr => mr.TenantRole!.Slug == "owner"))
-            .OrderBy(tm => tm.Tenant!.SysCreatedAt)
-            .Select(tm => tm.SubjectId)
-            .FirstOrDefaultAsync(cancellationToken);
-
-        if (firstOwnerSubjectId == default) return;
+        // Option 2: grant to the owner of the oldest tenant that has one. Resolved by walking
+        // tenants oldest-first and looking the owner up under each tenant's own pin, because a
+        // single query over every tenant's memberships has no tenant to be pinned to.
+        var firstOwnerSubjectId = await FindOldestTenantOwnerAsync(cancellationToken);
+        if (firstOwnerSubjectId is null) return;
 
         await _db.Subjects
             .Where(s => s.Id == firstOwnerSubjectId)
             .ExecuteUpdateAsync(s => s.SetProperty(x => x.IsPlatformAdmin, true), cancellationToken);
+    }
+
+    /// <summary>
+    /// The subject holding the owner role on the oldest tenant that has one, or
+    /// <see langword="null"/> when no tenant does. Tenants without an owner are skipped, matching
+    /// the ordered membership scan this replaces.
+    /// </summary>
+    private async Task<Guid?> FindOldestTenantOwnerAsync(CancellationToken cancellationToken)
+    {
+        // tenants is not tenant-scoped, so the ordering can be resolved unpinned.
+        var tenantIds = await _db.Tenants
+            .OrderBy(t => t.SysCreatedAt)
+            .Select(t => t.Id)
+            .ToListAsync(cancellationToken);
+
+        foreach (var tenantId in tenantIds)
+        {
+            await _db.PinTenantAsync(tenantId, cancellationToken);
+
+            var ownerSubjectId = await _db.TenantMembers
+                .Where(tm => tm.TenantId == tenantId
+                    && tm.MemberRoles.Any(mr => mr.TenantRole!.Slug == TenantPermissions.SeedRoles.Owner))
+                .Select(tm => tm.SubjectId)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (ownerSubjectId != default) return ownerSubjectId;
+        }
+
+        return null;
     }
 }

--- a/src/API/Nocturne.API/Services/Auth/PublicAccessCacheService.cs
+++ b/src/API/Nocturne.API/Services/Auth/PublicAccessCacheService.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Extensions;
 
 namespace Nocturne.API.Services.Auth;
 
@@ -85,7 +86,9 @@ public sealed class PublicAccessCacheService
 
     private async Task<PublicAccessInfo?> ResolvePublicAccessAsync(Guid tenantId)
     {
-        await using var dbContext = await _dbContextFactory.CreateDbContextAsync();
+        // Pinned to the tenant being resolved: this service is a singleton on the
+        // anonymous-share request path and has no ambient tenant to inherit.
+        await using var dbContext = await _dbContextFactory.CreateTenantPinnedContextAsync(tenantId);
 
         var membership = await dbContext.TenantMembers
             .AsNoTracking()

--- a/src/API/Nocturne.API/Services/Connectors/ConnectorCursorResetService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/ConnectorCursorResetService.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Nocturne.Connectors.Core.Models;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Extensions;
 
 namespace Nocturne.API.Services.Connectors;
 
@@ -146,12 +147,11 @@ public class ConnectorCursorResetService : IConnectorCursorResetService
         // The TenantConnectionInterceptor sets the RLS GUC from NocturneDbContext.TenantId on each
         // connection open (and RESETs it on close), so the *DbContext's* TenantId is what actually
         // scopes our own queries below — updating ITenantAccessor alone does not retro-fit the
-        // already-created _db. Set it explicitly, otherwise the ConnectorConfigurations query runs
-        // under the admin's (or empty) tenant and silently finds no connectors. SetTenantGucAsync is
-        // belt-and-suspenders for the current connection; SetTenant propagates to the executor scope
+        // already-created _db. Pin it explicitly, otherwise the ConnectorConfigurations query runs
+        // under the admin's (or empty) tenant and silently finds no connectors. PinTenantAsync also
+        // sets the GUC on the current connection; SetTenant propagates to the executor scope
         // that IConnectorSyncService.TriggerSyncAsync creates.
-        _db.TenantId = tenantId;
-        await SetTenantGucAsync(tenantId, ct);
+        await _db.PinTenantAsync(tenantId, ct);
         _tenantAccessor.SetTenant(new TenantContext(
             tenant.Id, tenant.Slug, tenant.DisplayName, tenant.IsActive, tenant.IsDemo));
 
@@ -225,9 +225,8 @@ public class ConnectorCursorResetService : IConnectorCursorResetService
             return null;
 
         // See ResetTenantCursorsAsync: the interceptor scopes connections by DbContext.TenantId,
-        // so set it on _db before the RLS-scoped query below.
-        _db.TenantId = tenantId;
-        await SetTenantGucAsync(tenantId, ct);
+        // so pin _db before the RLS-scoped query below.
+        await _db.PinTenantAsync(tenantId, ct);
 
         var connectors = await _db.ConnectorConfigurations.AsNoTracking()
             .Where(c => c.TenantId == tenantId)
@@ -243,18 +242,4 @@ public class ConnectorCursorResetService : IConnectorCursorResetService
         return new TenantConnectorsDto(tenant.Id, tenant.Slug, connectors);
     }
 
-    /// <summary>
-    /// Sets the PostgreSQL RLS GUC for the target tenant. No-op on non-relational providers
-    /// (e.g. the EF Core in-memory provider used by unit tests), where RLS does not apply.
-    /// </summary>
-    private async Task SetTenantGucAsync(Guid tenantId, CancellationToken ct)
-    {
-        if (!_db.Database.IsRelational())
-            return;
-
-        await _db.Database.ExecuteSqlRawAsync(
-            "SELECT set_config('app.current_tenant_id', {0}, false)",
-            [tenantId.ToString()],
-            ct);
-    }
 }

--- a/src/API/Nocturne.API/Services/Identity/TenantMemberService.cs
+++ b/src/API/Nocturne.API/Services/Identity/TenantMemberService.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Extensions;
 
 namespace Nocturne.API.Services.Identity;
 
@@ -9,6 +10,14 @@ namespace Nocturne.API.Services.Identity;
 /// listing all tenants a subject has access to. Uses a factory-created <see cref="NocturneDbContext"/>
 /// per operation to avoid context lifetime issues in singleton-scoped callers.
 /// </summary>
+/// <remarks>
+/// Each operation pins its context to the tenant it was asked about, so the lookup carries its
+/// own RLS reach rather than inheriting the caller's. This runs on the authentication hot path
+/// (<c>AuthenticationMiddleware</c>) and from SignalR and OIDC, where no ambient tenant is
+/// resolved. <see cref="GetTenantIdsForSubjectAsync"/> is the one cross-tenant read and pins the
+/// subject instead — it answers "which tenants does this person belong to", which no single
+/// tenant pin can express.
+/// </remarks>
 /// <seealso cref="ITenantMemberService"/>
 public class TenantMemberService : ITenantMemberService
 {
@@ -21,14 +30,14 @@ public class TenantMemberService : ITenantMemberService
 
     public async Task<bool> IsMemberAsync(Guid subjectId, Guid tenantId, CancellationToken ct = default)
     {
-        await using var context = await _factory.CreateDbContextAsync(ct);
+        await using var context = await _factory.CreateTenantPinnedContextAsync(tenantId, ct);
         return await context.TenantMembers.AsNoTracking()
             .AnyAsync(tm => tm.SubjectId == subjectId && tm.TenantId == tenantId, ct);
     }
 
     public async Task<List<Guid>> GetTenantIdsForSubjectAsync(Guid subjectId, CancellationToken ct = default)
     {
-        await using var context = await _factory.CreateDbContextAsync(ct);
+        await using var context = await _factory.CreateSubjectPinnedContextAsync(subjectId, ct);
         return await context.TenantMembers.AsNoTracking()
             .Where(tm => tm.SubjectId == subjectId)
             .Select(tm => tm.TenantId)
@@ -37,14 +46,14 @@ public class TenantMemberService : ITenantMemberService
 
     public async Task<int> GetMemberCountAsync(Guid tenantId, CancellationToken ct = default)
     {
-        await using var context = await _factory.CreateDbContextAsync(ct);
+        await using var context = await _factory.CreateTenantPinnedContextAsync(tenantId, ct);
         return await context.TenantMembers.AsNoTracking()
             .CountAsync(tm => tm.TenantId == tenantId, ct);
     }
 
     public async Task<List<string>> GetMemberRoleNamesAsync(Guid subjectId, Guid tenantId, CancellationToken ct = default)
     {
-        await using var context = await _factory.CreateDbContextAsync(ct);
+        await using var context = await _factory.CreateTenantPinnedContextAsync(tenantId, ct);
         return await context.TenantMembers.AsNoTracking()
             .Where(tm => tm.SubjectId == subjectId && tm.TenantId == tenantId)
             .SelectMany(tm => tm.MemberRoles)
@@ -56,7 +65,7 @@ public class TenantMemberService : ITenantMemberService
     public async Task<IReadOnlySet<string>?> GetEffectivePermissionsAsync(
         Guid subjectId, Guid tenantId, CancellationToken ct = default)
     {
-        await using var context = await _factory.CreateDbContextAsync(ct);
+        await using var context = await _factory.CreateTenantPinnedContextAsync(tenantId, ct);
         var membership = await context.TenantMembers.AsNoTracking()
             .Include(tm => tm.MemberRoles)
                 .ThenInclude(mr => mr.TenantRole)

--- a/src/API/Nocturne.API/Services/Identity/TenantOverviewService.cs
+++ b/src/API/Nocturne.API/Services/Identity/TenantOverviewService.cs
@@ -9,12 +9,13 @@ using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Extensions;
 
 namespace Nocturne.API.Services.Identity;
 
 /// <summary>
-/// Cross-tenant caregiver overview. Enumerates the subject's active memberships from an
-/// unpinned factory context (same pattern as <see cref="TenantService.GetTenantsForSubjectAsync"/>),
+/// Cross-tenant caregiver overview. Enumerates the subject's active memberships from a
+/// subject-pinned factory context (same pattern as <see cref="TenantService.GetTenantsForSubjectAsync"/>),
 /// then fans out per tenant: a fresh DI scope pinned via <see cref="ITenantAccessor"/> for the
 /// canonical glucose read, and a factory context pinned via <see cref="NocturneDbContext.TenantId"/>
 /// for alert rules and active excursions. Never touches the request-scoped DbContext, so the
@@ -45,8 +46,9 @@ public class TenantOverviewService : ITenantOverviewService
         CancellationToken ct = default)
     {
         // tenant_members has a global RevokedAt == null query filter, so revoked
-        // memberships are already excluded here.
-        await using var context = await _factory.CreateDbContextAsync(ct);
+        // memberships are already excluded here. The read spans tenants for one person, so the
+        // context is pinned to the subject rather than to a tenant.
+        await using var context = await _factory.CreateSubjectPinnedContextAsync(subjectId, ct);
         var memberships = await context.TenantMembers.AsNoTracking()
             .Include(tm => tm.Tenant)
             .Include(tm => tm.MemberRoles).ThenInclude(mr => mr.TenantRole)
@@ -122,8 +124,7 @@ public class TenantOverviewService : ITenantOverviewService
                 .GetLatestAsync(ct);
         }
 
-        await using var db = await _factory.CreateDbContextAsync(ct);
-        db.TenantId = tenant.Id;
+        await using var db = await _factory.CreateTenantPinnedContextAsync(tenant.Id, ct);
 
         int? activeAlertCount = null;
         AlertRuleSeverity? highestSeverity = null;

--- a/src/API/Nocturne.API/Services/Identity/TenantOwnerResolver.cs
+++ b/src/API/Nocturne.API/Services/Identity/TenantOwnerResolver.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Nocturne.Core.Contracts.Identity;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Extensions;
 
 namespace Nocturne.API.Services.Identity;
 
@@ -20,7 +21,11 @@ public class TenantOwnerResolver : ITenantOwnerResolver
         Guid tenantId,
         CancellationToken cancellationToken = default)
     {
-        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        // Pinned to the tenant asked about: the callers are background services
+        // (metadata publishing, compression-low detection, share-link notifications) with no
+        // ambient tenant, so the context carries no pin of its own.
+        await using var context = await _contextFactory.CreateTenantPinnedContextAsync(
+            tenantId, cancellationToken);
 
         var ownerSubjectId = await context.TenantMembers.AsNoTracking()
             .Where(tm => tm.TenantId == tenantId

--- a/src/API/Nocturne.API/Services/Identity/TenantRoleService.cs
+++ b/src/API/Nocturne.API/Services/Identity/TenantRoleService.cs
@@ -4,6 +4,7 @@ using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Extensions;
 
 namespace Nocturne.API.Services.Identity;
 
@@ -18,7 +19,9 @@ namespace Nocturne.API.Services.Identity;
 /// alone is not an authorization decision.
 /// </remarks>
 /// <seealso cref="ITenantRoleService"/>
-public partial class TenantRoleService(NocturneDbContext context) : ITenantRoleService
+public partial class TenantRoleService(
+    NocturneDbContext context,
+    IDbContextFactory<NocturneDbContext> contextFactory) : ITenantRoleService
 {
     public async Task<List<TenantRoleDto>> GetRolesAsync(Guid tenantId, CancellationToken ct = default)
     {
@@ -177,9 +180,22 @@ public partial class TenantRoleService(NocturneDbContext context) : ITenantRoleS
         return new DeleteRoleResult(true, null, null);
     }
 
+    /// <summary>
+    /// Seeds the tenant's default roles, skipping slugs that already exist.
+    /// </summary>
+    /// <remarks>
+    /// Runs on its own context pinned to <paramref name="tenantId"/>, not the injected
+    /// request-scoped one. Every caller is a tenant-creation flow reached without a resolved
+    /// tenant (first-run setup, platform admin, demo and dev provisioning), so the scoped context
+    /// is pinned to no tenant and would seed outside the RLS reach the rows belong to.
+    /// </remarks>
+    /// <param name="tenantId">The tenant to seed roles for.</param>
+    /// <param name="ct">The cancellation token.</param>
     public async Task SeedRolesForTenantAsync(Guid tenantId, CancellationToken ct = default)
     {
-        var existingSlugs = await context.TenantRoles
+        await using var seedContext = await contextFactory.CreateTenantPinnedContextAsync(tenantId, ct);
+
+        var existingSlugs = await seedContext.TenantRoles
             .Where(r => r.TenantId == tenantId)
             .Select(r => r.Slug)
             .ToListAsync(ct);
@@ -192,7 +208,7 @@ public partial class TenantRoleService(NocturneDbContext context) : ITenantRoleS
                 continue;
 
             var name = TenantPermissions.SeedRoleNames[slug];
-            context.TenantRoles.Add(new TenantRoleEntity
+            seedContext.TenantRoles.Add(new TenantRoleEntity
             {
                 Id = Guid.CreateVersion7(),
                 TenantId = tenantId,
@@ -206,7 +222,7 @@ public partial class TenantRoleService(NocturneDbContext context) : ITenantRoleS
             });
         }
 
-        await context.SaveChangesAsync(ct);
+        await seedContext.SaveChangesAsync(ct);
     }
 
     /// <inheritdoc />
@@ -240,12 +256,21 @@ public partial class TenantRoleService(NocturneDbContext context) : ITenantRoleS
             : new RoleGrantValidation(false, exceeded.Code, exceeded.Description);
     }
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// Keyed on the membership id alone, which is not an authorization decision — the caller has
+    /// already established that the id belongs to its tenant. A membership the context cannot
+    /// reach resolves to no permissions rather than throwing.
+    /// </remarks>
     public async Task<List<string>> GetEffectivePermissionsAsync(Guid memberId, CancellationToken ct = default)
     {
         var member = await context.TenantMembers
             .Include(m => m.MemberRoles)
                 .ThenInclude(mr => mr.TenantRole)
-            .FirstAsync(m => m.Id == memberId, ct);
+            .FirstOrDefaultAsync(m => m.Id == memberId, ct);
+
+        if (member is null)
+            return [];
 
         var rolePermissions = member.MemberRoles
             .SelectMany(mr => mr.TenantRole.Permissions);

--- a/src/API/Nocturne.API/Services/Identity/TenantService.cs
+++ b/src/API/Nocturne.API/Services/Identity/TenantService.cs
@@ -11,6 +11,7 @@ using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Extensions;
 
 namespace Nocturne.API.Services.Identity;
 
@@ -107,7 +108,7 @@ public partial class TenantService : ITenantService
         // tables (roles, members, OAuth clients) are permitted. The factory-
         // created context has no TenantId, so the connection interceptor
         // won't set the GUC automatically.
-        await SetTenantGuc(context, tenant.Id);
+        await context.PinTenantAsync(tenant.Id, ct);
 
         // Seed default roles for this tenant
         await _roleService.SeedRolesForTenantAsync(tenant.Id, ct);
@@ -144,7 +145,7 @@ public partial class TenantService : ITenantService
 
         // Set the RLS tenant context so subsequent writes to tenant-scoped
         // tables (roles, members, OAuth clients) are permitted.
-        await SetTenantGuc(context, tenant.Id);
+        await context.PinTenantAsync(tenant.Id, ct);
 
         // Seed default roles for this tenant (but don't assign an owner)
         await _roleService.SeedRolesForTenantAsync(tenant.Id, ct);
@@ -166,7 +167,7 @@ public partial class TenantService : ITenantService
     public async Task SeedAfterResetAsync(Guid tenantId, CancellationToken ct = default)
     {
         await using var context = await _factory.CreateDbContextAsync(ct);
-        await SetTenantGuc(context, tenantId);
+        await context.PinTenantAsync(tenantId, ct);
 
         await _roleService.SeedRolesForTenantAsync(tenantId, ct);
         await CreatePublicSubjectMembershipAsync(context, tenantId, ct);
@@ -183,7 +184,10 @@ public partial class TenantService : ITenantService
 
     public async Task<TenantDetailDto?> GetByIdAsync(Guid id, CancellationToken ct = default)
     {
-        await using var context = await _factory.CreateDbContextAsync(ct);
+        // Pinned to the tenant asked about — the member list this returns is an authorization
+        // primitive (TenantController.IsCallerTenantOwnerAsync reads it), so it must not depend
+        // on whatever tenant the caller's context happened to carry.
+        await using var context = await _factory.CreateTenantPinnedContextAsync(id, ct);
         var tenant = await context.Tenants.AsNoTracking()
             .Include(t => t.Members)
                 .ThenInclude(m => m.Subject)
@@ -252,7 +256,7 @@ public partial class TenantService : ITenantService
         Guid tenantId, Guid subjectId, List<Guid> roleIds, List<string>? directPermissions = null,
         string? label = null, bool limitTo24Hours = false, CancellationToken ct = default)
     {
-        await using var context = await _factory.CreateDbContextAsync(ct);
+        await using var context = await _factory.CreateTenantPinnedContextAsync(tenantId, ct);
 
         // Check if already a member
         var exists = await context.TenantMembers
@@ -301,7 +305,7 @@ public partial class TenantService : ITenantService
     public async Task<MemberRemovalResult> RemoveMemberAsync(
         Guid tenantId, Guid subjectId, CancellationToken ct = default)
     {
-        await using var context = await _factory.CreateDbContextAsync(ct);
+        await using var context = await _factory.CreateTenantPinnedContextAsync(tenantId, ct);
         var member = await context.TenantMembers
             .Include(tm => tm.Subject)
             .FirstOrDefaultAsync(tm => tm.TenantId == tenantId && tm.SubjectId == subjectId, ct);
@@ -338,7 +342,9 @@ public partial class TenantService : ITenantService
     public async Task<List<TenantDto>> GetTenantsForSubjectAsync(
         Guid subjectId, CancellationToken ct = default)
     {
-        await using var context = await _factory.CreateDbContextAsync(ct);
+        // Genuinely cross-tenant: the answer is the set of tenants this person belongs to, which
+        // no single tenant pin can express. The subject pin gives reach over their own rows only.
+        await using var context = await _factory.CreateSubjectPinnedContextAsync(subjectId, ct);
         return await context.TenantMembers.AsNoTracking()
             .Where(tm => tm.SubjectId == subjectId)
             .Include(tm => tm.Tenant)
@@ -419,9 +425,7 @@ public partial class TenantService : ITenantService
                 // Set RLS tenant context for the remainder of this transaction.
                 // The connection is already open, so the TenantConnectionInterceptor
                 // won't fire again — we must set the GUC manually.
-                await context.Database.ExecuteSqlRawAsync(
-                    "SELECT set_config('app.current_tenant_id', {0}, false)",
-                    tenant.Id.ToString());
+                await context.PinTenantAsync(tenant.Id, ct);
 
                 // Seed default roles for this tenant (inline to share transaction context)
                 var now = DateTime.UtcNow;
@@ -623,11 +627,6 @@ public partial class TenantService : ITenantService
 
 
     /// <summary>
-    /// Sets the RLS tenant context on a factory-created DbContext. Sets both
-    /// the context's TenantId (so the connection interceptor fires on new
-    /// connections) and the PostgreSQL GUC on the current connection.
-    /// </summary>
-    /// <summary>
     /// Chooses the owner subject for a provision from the candidates already resolved
     /// from the database. An OAuth account maps to a single subject reused across
     /// tenants, so a subject that already owns the incoming OIDC identity wins over one
@@ -641,14 +640,6 @@ public partial class TenantService : ITenantService
         SubjectEntity? existingOidcIdentitySubject,
         SubjectEntity? existingEmailSubject)
         => existingOidcIdentitySubject ?? existingEmailSubject;
-
-    private static async Task SetTenantGuc(NocturneDbContext context, Guid tenantId)
-    {
-        context.TenantId = tenantId;
-        await context.Database.ExecuteSqlRawAsync(
-            "SELECT set_config('app.current_tenant_id', {0}, false)",
-            tenantId.ToString());
-    }
 
     private static TenantDto ToDto(TenantEntity t) =>
         new(t.Id, t.Slug, t.DisplayName, t.IsActive, t.SysCreatedAt);

--- a/src/Core/Nocturne.Core.Contracts/Multitenancy/ITenantRoleService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Multitenancy/ITenantRoleService.cs
@@ -35,7 +35,11 @@ public interface ITenantRoleService
     /// <summary>Creates the default system roles (owner, member, follower) for a newly provisioned tenant.</summary>
     Task SeedRolesForTenantAsync(Guid tenantId, CancellationToken ct = default);
 
-    /// <summary>Returns the combined set of permissions a member has through their roles and direct grants.</summary>
+    /// <summary>
+    /// Returns the combined set of permissions a member has through their roles and direct grants,
+    /// or an empty set when the membership does not resolve. Keyed on the membership id alone, so
+    /// the caller must have established that the id belongs to its tenant.
+    /// </summary>
     Task<List<string>> GetEffectivePermissionsAsync(Guid memberId, CancellationToken ct = default);
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/RlsPinningExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/RlsPinningExtensions.cs
@@ -1,0 +1,89 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Nocturne.Infrastructure.Data.Extensions;
+
+/// <summary>
+/// Pins a <see cref="NocturneDbContext"/> to the tenant or subject whose rows a caller is
+/// entitled to, for callers that take the raw <see cref="IDbContextFactory{TContext}"/> and
+/// therefore get no pin from <c>ITenantDbContextFactory</c> (singletons, background services,
+/// and the tenantless entry points, which have no resolved ambient tenant to pin from).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The pin has two carriers and both matter: the context property drives the EF global query
+/// filters, and the <c>app.current_tenant_id</c> / <c>app.current_subject_id</c> GUCs drive the
+/// PostgreSQL Row Level Security policies. <c>TenantConnectionInterceptor</c> writes the GUCs
+/// from the properties when the connection opens, so pinning before the first query needs
+/// nothing else — which is why the create-and-pin methods here cost no extra round-trip.
+/// </para>
+/// <para>
+/// <see cref="PinTenantAsync"/> exists for the sites whose tenant is only known after the
+/// connection is already open (provisioning reads the new tenant's id off the same context,
+/// and the setup flow resolves the sole tenant before it can pin to it). There the interceptor
+/// has already run, so the GUC has to be written explicitly as well.
+/// </para>
+/// </remarks>
+public static class RlsPinningExtensions
+{
+    /// <summary>
+    /// Creates a <see cref="NocturneDbContext"/> pinned to <paramref name="tenantId"/>.
+    /// </summary>
+    /// <param name="factory">The context factory.</param>
+    /// <param name="tenantId">The tenant whose rows the caller is entitled to.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A tenant-pinned context. Dispose it when done (use <c>await using</c>).</returns>
+    public static async ValueTask<NocturneDbContext> CreateTenantPinnedContextAsync(
+        this IDbContextFactory<NocturneDbContext> factory, Guid tenantId, CancellationToken ct = default)
+    {
+        var context = await factory.CreateDbContextAsync(ct);
+        context.TenantId = tenantId;
+        return context;
+    }
+
+    /// <summary>
+    /// Creates a <see cref="NocturneDbContext"/> pinned to <paramref name="subjectId"/> for a
+    /// subject-scoped read that spans tenants, e.g. enumerating the tenants a person belongs to.
+    /// The pin grants reach over that subject's own rows only; it is never write reach.
+    /// </summary>
+    /// <param name="factory">The context factory.</param>
+    /// <param name="subjectId">The subject whose own rows the caller is entitled to.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A subject-pinned context. Dispose it when done (use <c>await using</c>).</returns>
+    public static async ValueTask<NocturneDbContext> CreateSubjectPinnedContextAsync(
+        this IDbContextFactory<NocturneDbContext> factory, Guid subjectId, CancellationToken ct = default)
+    {
+        var context = await factory.CreateDbContextAsync(ct);
+        context.SubjectId = subjectId;
+        return context;
+    }
+
+    /// <summary>
+    /// Pins an existing context to <paramref name="tenantId"/>, including the GUC on the current
+    /// connection so the pin also applies to a connection that is already open. Use
+    /// <see cref="CreateTenantPinnedContextAsync"/> instead when the tenant is known before the
+    /// context's first query.
+    /// </summary>
+    /// <param name="context">The context to pin.</param>
+    /// <param name="tenantId">The tenant whose rows the caller is entitled to.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <remarks>
+    /// The GUC write is skipped on non-PostgreSQL providers (the SQLite and in-memory providers
+    /// used by unit tests), where there is no Row Level Security and <c>set_config</c> does not
+    /// exist. Those tests therefore exercise the property pin only.
+    /// </remarks>
+    public static async Task PinTenantAsync(
+        this NocturneDbContext context, Guid tenantId, CancellationToken ct = default)
+    {
+        context.TenantId = tenantId;
+
+        if (!context.Database.IsNpgsql())
+        {
+            return;
+        }
+
+        await context.Database.ExecuteSqlRawAsync(
+            "SELECT set_config('app.current_tenant_id', {0}, false)",
+            [tenantId.ToString()],
+            ct);
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/ServiceCollectionExtensions.cs
@@ -105,8 +105,8 @@ public static class ServiceCollectionExtensions
             }
         );
 
-        // Normalize the four context carriers to fail-closed defaults on every acquisition, so raw
-        // IDbContextFactory callers start from a known-safe tenant/share state. See
+        // Normalize the context carriers to fail-closed defaults on every acquisition, so raw
+        // IDbContextFactory callers start from a known-safe tenant/subject/share state. See
         // CarrierResettingDbContextFactory.
         DecorateWithCarrierReset(services);
 
@@ -277,8 +277,8 @@ public static class ServiceCollectionExtensions
             }
         );
 
-        // Normalize the four context carriers to fail-closed defaults on every acquisition, so raw
-        // IDbContextFactory callers start from a known-safe tenant/share state. See
+        // Normalize the context carriers to fail-closed defaults on every acquisition, so raw
+        // IDbContextFactory callers start from a known-safe tenant/subject/share state. See
         // CarrierResettingDbContextFactory.
         DecorateWithCarrierReset(services);
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Interceptors/TenantConnectionInterceptor.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Interceptors/TenantConnectionInterceptor.cs
@@ -12,6 +12,11 @@ namespace Nocturne.Infrastructure.Data.Interceptors;
 /// On connection open: SELECT set_config('app.current_tenant_id', $1, false)
 /// On connection close: RESET app.current_tenant_id
 ///
+/// The same open/reset pair carries app.current_subject_id, which gives the
+/// subject-scoped cross-tenant reads (tenant switcher, caregiver overview,
+/// membership enumeration) reach over one subject's own rows. Both are set only
+/// when non-empty, so an unpinned context leaves the GUC unset and matches nothing.
+///
 /// Additionally, on the first open against any given connection string, the
 /// interceptor verifies that the connected role is neither a superuser nor
 /// has BYPASSRLS. Both attributes silently defeat Row Level Security, so
@@ -48,12 +53,18 @@ public class TenantConnectionInterceptor : DbConnectionInterceptor
         }
 
         await using var cmd = connection.CreateCommand();
-        var clauses = new List<string>(4);
+        var clauses = new List<string>(5);
 
         if (ctx.TenantId != Guid.Empty)
         {
             clauses.Add("set_config('app.current_tenant_id', @tenant_id, false)");
             AddParameter(cmd, "tenant_id", ctx.TenantId.ToString());
+        }
+
+        if (ctx.SubjectId != Guid.Empty)
+        {
+            clauses.Add("set_config('app.current_subject_id', @subject_id, false)");
+            AddParameter(cmd, "subject_id", ctx.SubjectId.ToString());
         }
 
         // app.is_share, app.visible_categories and app.share_full_history gate the
@@ -95,14 +106,14 @@ public class TenantConnectionInterceptor : DbConnectionInterceptor
         ConnectionEventData eventData,
         InterceptionResult result)
     {
-        // Reset the session variable before the connection returns to the pool.
-        // This prevents a stale tenant ID from leaking to the next request.
+        // Reset the session variables before the connection returns to the pool.
+        // This prevents a stale tenant or subject ID from leaking to the next request.
         try
         {
             await using var cmd = connection.CreateCommand();
             cmd.CommandText =
-                "RESET app.current_tenant_id; RESET app.is_share; RESET app.visible_categories; " +
-                "RESET app.share_full_history";
+                "RESET app.current_tenant_id; RESET app.current_subject_id; RESET app.is_share; " +
+                "RESET app.visible_categories; RESET app.share_full_history";
             await cmd.ExecuteNonQueryAsync();
         }
         catch

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -46,6 +46,16 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
     public Guid TenantId { get; set; }
 
     /// <summary>
+    /// The subject whose own rows a subject-scoped cross-tenant read may reach. Set per-lease by
+    /// the few callers that legitimately read one subject's rows across tenants (the tenant
+    /// switcher, the caregiver overview, membership enumeration). The
+    /// <see cref="Interceptors.TenantConnectionInterceptor"/> carries it to the
+    /// <c>app.current_subject_id</c> GUC. <see cref="Guid.Empty"/> leaves the GUC unset, so a
+    /// policy arm reading it matches no row (fail-closed).
+    /// </summary>
+    public Guid SubjectId { get; set; }
+
+    /// <summary>
     /// Audit context for the current operation. Populated from HttpContext for HTTP
     /// requests (via <see cref="Interceptors.MutationAuditInterceptor"/>), or set
     /// directly by background services that have no HttpContext.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/CarrierResettingDbContextFactory.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/CarrierResettingDbContextFactory.cs
@@ -8,7 +8,8 @@ namespace Nocturne.Infrastructure.Data.Services;
 ///
 /// <para>
 /// The context carries per-request state — <see cref="NocturneDbContext.TenantId"/>,
-/// <see cref="NocturneDbContext.AuditContext"/>, <see cref="NocturneDbContext.IsShareContext"/>
+/// <see cref="NocturneDbContext.SubjectId"/>, <see cref="NocturneDbContext.AuditContext"/>,
+/// <see cref="NocturneDbContext.IsShareContext"/>
 /// and <see cref="NocturneDbContext.VisibleCategories"/> — that the RLS policy reads. The
 /// <c>ITenantDbContextFactory</c> and scoped-context registration stamp those on acquisition;
 /// callers that take the raw factory and call <see cref="IDbContextFactory{TContext}.CreateDbContext"/>
@@ -35,6 +36,7 @@ internal sealed class CarrierResettingDbContextFactory(IDbContextFactory<Nocturn
     private static NocturneDbContext Reset(NocturneDbContext context)
     {
         context.TenantId = Guid.Empty;
+        context.SubjectId = Guid.Empty;
         context.AuditContext = null;
         context.IsShareContext = false;
         context.VisibleCategories = null;

--- a/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyControllerTests.cs
@@ -103,6 +103,7 @@ public class PasskeyControllerTests : IDisposable
             // assert the mock.
             new TenantMemberService(new SharedSqliteFactory(_dbOptions)),
             _dbContext,
+            new SharedSqliteFactory(_dbOptions),
             oidcOptions,
             logger.Object);
 

--- a/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyControllerTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Options;
 using Moq;
 using Nocturne.API.Controllers.Authentication;
 using Nocturne.API.Services.Auth;
+using Nocturne.API.Services.Identity;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Contracts.Notifications;
@@ -22,6 +23,16 @@ namespace Nocturne.API.Tests.Controllers;
 
 public class PasskeyControllerTests : IDisposable
 {
+    /// <summary>
+    /// Hands out contexts over the test's own SQLite connection, so the real
+    /// <see cref="TenantMemberService"/> sees the seeded rows.
+    /// </summary>
+    private sealed class SharedSqliteFactory(DbContextOptions<NocturneDbContext> options)
+        : IDbContextFactory<NocturneDbContext>
+    {
+        public NocturneDbContext CreateDbContext() => new(options);
+    }
+
     private readonly SqliteConnection _connection;
     private readonly DbContextOptions<NocturneDbContext> _dbOptions;
     private readonly NocturneDbContext _dbContext;
@@ -87,6 +98,10 @@ public class PasskeyControllerTests : IDisposable
             auditService.Object,
             _tenantAccessor.Object,
             _tenantService.Object,
+            // The real service, not a mock: the enrolment probe's cross-tenant reach and its
+            // revoked-membership filtering are the properties under test, and a mock would
+            // assert the mock.
+            new TenantMemberService(new SharedSqliteFactory(_dbOptions)),
             _dbContext,
             oidcOptions,
             logger.Object);
@@ -653,6 +668,104 @@ public class PasskeyControllerTests : IDisposable
     }
 
     /// <summary>
+    /// The enrolment probe asks each candidate separately whether it belongs to any tenant, so a
+    /// candidate whose membership is in a tenant other than the resolved one is still excluded —
+    /// the same answer the single anti-join gave, which is what stops one tenant enrolling a
+    /// passkey onto another tenant's credential-less member.
+    /// </summary>
+    [Fact]
+    public async Task InviteComplete_WhenTheOnlyCandidateBelongsToAnotherTenant_ResolvesNoSubject()
+    {
+        var elsewhereId = await SeedMemberAsync("shared-name", tenantId: Guid.CreateVersion7());
+        var inviteService = StubValidInvite();
+        StubRegistrationChallengeMintedFor(elsewhereId);
+
+        var result = await _controller.InviteComplete(
+            new InviteCompleteRequest
+            {
+                Token = "invite-token",
+                Username = "shared-name",
+                AttestationResponseJson = "{}",
+                ChallengeToken = "challenge-for-elsewhere",
+            },
+            inviteService.Object);
+
+        Assert.Equal(400, Assert.IsType<ObjectResult>(result.Result).StatusCode);
+        _passkeyService.Verify(
+            s => s.CompleteRegistrationAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), elsewhereId, It.IsAny<string?>()),
+            Times.Never,
+            "membership of any tenant, not just this one, disqualifies a candidate");
+    }
+
+    /// <summary>
+    /// Walking candidates newest-first and taking the first with no membership must give the same
+    /// answer as the newest candidate satisfying every condition at once: when the newest shares
+    /// the username but belongs to a tenant, the older shell still resolves rather than the
+    /// enrolment dead-ending.
+    /// </summary>
+    [Fact]
+    public async Task InviteComplete_WhenTheNewestCandidateBelongsToATenant_ResolvesTheOlderShell()
+    {
+        var shell = await SeedEnrollingSubjectAsync("contested");
+        var newerMember = await SeedMemberAsync("contested", tenantId: Guid.CreateVersion7());
+        newerMember.CompareTo(shell).Should().BePositive("UUID v7 ids sort in creation order");
+        var inviteService = StubValidInvite();
+        StubRegistrationChallengeMintedFor(shell);
+        _recoveryCodeService.Setup(s => s.GenerateCodesAsync(shell)).ReturnsAsync(["code-1"]);
+        _sessionService
+            .Setup(s => s.IssueSessionAsync(shell, It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SessionTokenPair("access", "refresh", 900));
+
+        var result = await _controller.InviteComplete(
+            new InviteCompleteRequest
+            {
+                Token = "invite-token",
+                Username = "contested",
+                AttestationResponseJson = "{}",
+                ChallengeToken = "challenge-for-shell",
+            },
+            inviteService.Object);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+        inviteService.Verify(s => s.AcceptInviteAsync("invite-token", shell, _tenantId), Times.Once);
+        _passkeyService.Verify(
+            s => s.CompleteRegistrationAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), newerMember, It.IsAny<string?>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// A revoked membership does not disqualify a candidate: it carries no access, so the subject
+    /// is the same empty shell as one that never had a membership. Current behaviour of the single
+    /// anti-join too — the global <c>RevokedAt == null</c> filter excluded it there as well.
+    /// </summary>
+    [Fact]
+    public async Task InviteComplete_WhenTheCandidatesOnlyMembershipIsRevoked_ResolvesThatSubject()
+    {
+        var revokedId = await SeedRevokedMemberAsync("returning", tenantId: Guid.CreateVersion7());
+        var inviteService = StubValidInvite();
+        StubRegistrationChallengeMintedFor(revokedId);
+        _recoveryCodeService.Setup(s => s.GenerateCodesAsync(revokedId)).ReturnsAsync(["code-1"]);
+        _sessionService
+            .Setup(s => s.IssueSessionAsync(revokedId, It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SessionTokenPair("access", "refresh", 900));
+
+        var result = await _controller.InviteComplete(
+            new InviteCompleteRequest
+            {
+                Token = "invite-token",
+                Username = "returning",
+                AttestationResponseJson = "{}",
+                ChallengeToken = "challenge-for-returning",
+            },
+            inviteService.Object);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+        inviteService.Verify(s => s.AcceptInviteAsync("invite-token", revokedId, _tenantId), Times.Once);
+    }
+
+    /// <summary>
     /// Duplicate subjects left behind by an older build of the options step are all credential-less
     /// shells that nobody can sign in as, so the completion resolves the newest — the one the
     /// caller's ceremony was minted against — rather than refusing the invite forever.
@@ -829,6 +942,35 @@ public class PasskeyControllerTests : IDisposable
     /// Adds the subject that <c>invite/options</c> creates: active, no credentials, and not yet a
     /// member of the tenant.
     /// </summary>
+    /// <summary>
+    /// Seeds an active subject whose only membership — of another tenant — has been revoked, and
+    /// returns the subject id. A revoked membership carries no access, so the subject is the same
+    /// credential-less shell as one that never had a membership at all.
+    /// </summary>
+    private async Task<Guid> SeedRevokedMemberAsync(string username, Guid tenantId)
+    {
+        await EnsureTenantAsync(tenantId);
+
+        var subjectId = Guid.CreateVersion7();
+        _dbContext.Subjects.Add(new SubjectEntity
+        {
+            Id = subjectId,
+            Name = username,
+            Username = username,
+            IsActive = true,
+            IsSystemSubject = false,
+        });
+        _dbContext.TenantMembers.Add(new TenantMemberEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = tenantId,
+            SubjectId = subjectId,
+            RevokedAt = DateTime.UtcNow.AddDays(-1),
+        });
+        await _dbContext.SaveChangesAsync();
+        return subjectId;
+    }
+
     private async Task<Guid> SeedEnrollingSubjectAsync(string username)
     {
         var subjectId = Guid.CreateVersion7();

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/MemberInviteControllerGrantCeilingTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/MemberInviteControllerGrantCeilingTests.cs
@@ -133,7 +133,10 @@ public sealed class MemberInviteControllerGrantCeilingTests : IDisposable
             Mock.Of<ITenantService>(),
             // The real service, not a mock: the tenant check and the ceiling are the properties
             // under test, and a mock would assert the mock.
-            new TenantRoleService(_dbContext),
+            new TenantRoleService(
+                _dbContext,
+                // Only SeedRolesForTenantAsync takes a context of its own, and nothing here seeds.
+                Mock.Of<IDbContextFactory<NocturneDbContext>>()),
             Mock.Of<ITenantMemberService>(),
             tenantAccessor.Object,
             _dbContext)

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/SetupControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/SetupControllerTests.cs
@@ -22,6 +22,10 @@ namespace Nocturne.API.Tests.Controllers.V4;
 /// Tests for the setup flow, focusing on the soft-lock scenario where a tenant
 /// exists but owner passkey registration was never completed.
 /// </summary>
+/// <remarks>
+/// SQLite has no Row Level Security, so every row is visible here. These tests pin the guard
+/// logic and the shape of the per-tenant scan, not the policies that make the scan necessary.
+/// </remarks>
 public class SetupControllerTests : IDisposable
 {
     private readonly SqliteConnection _connection;
@@ -39,14 +43,6 @@ public class SetupControllerTests : IDisposable
     {
         _connection = new SqliteConnection("DataSource=:memory:");
         _connection.Open();
-
-        // GetSoleTenantWithoutOwnerAsync/EnsureOwnerSubjectAsync scope their queries
-        // with `SELECT set_config('app.current_tenant_id', ...)`, a PostgreSQL-only
-        // function. Register a no-op stand-in so the sole-tenant guard paths execute
-        // under SQLite (there is no RLS here, so all rows are visible — which is what
-        // we want for asserting the credential-based guard logic).
-        _connection.CreateFunction<string, string, bool, string>(
-            "set_config", (_, value, _) => value);
 
         _dbOptions = new DbContextOptionsBuilder<NocturneDbContext>()
             .UseSqlite(_connection)
@@ -178,6 +174,62 @@ public class SetupControllerTests : IDisposable
     }
 
     [Fact]
+    public async Task CreateTenant_WhenTheConfiguredTenantIsNotTheFirstOne_Returns409()
+    {
+        // The gate asks each tenant in turn, so it must not stop at the first one that answers no.
+        _dbContext.Set<TenantEntity>().Add(new TenantEntity
+        {
+            Id = Guid.CreateVersion7(),
+            Slug = "unconfigured-first",
+            DisplayName = "Unconfigured First",
+        });
+        await _dbContext.SaveChangesAsync();
+        await SeedConfiguredTenantAsync("configured-second", "Configured Second");
+
+        var result = await _controller.CreateTenant(
+            new SetupTenantRequest("tenant-c", "Tenant C"), CancellationToken.None);
+
+        result.Should().BeOfType<ConflictObjectResult>();
+    }
+
+    [Fact]
+    public async Task CreateTenant_WhenACredentialBelongsToNoTenantsMember_Succeeds()
+    {
+        // The gate is anchored on membership: a credentialed subject who belongs to no tenant is
+        // a half-finished enrolment, not a configured instance.
+        var subjectId = Guid.CreateVersion7();
+        _dbContext.Set<TenantEntity>().Add(new TenantEntity
+        {
+            Id = Guid.CreateVersion7(), Slug = "ownerless", DisplayName = "Ownerless",
+        });
+        _dbContext.Subjects.Add(new SubjectEntity
+        {
+            Id = subjectId, Name = "Stray", Username = "stray", IsActive = true,
+        });
+        _dbContext.PasskeyCredentials.Add(new PasskeyCredentialEntity
+        {
+            Id = Guid.CreateVersion7(),
+            SubjectId = subjectId,
+            CredentialId = System.Text.Encoding.UTF8.GetBytes("cred-stray"),
+            PublicKey = [],
+            SignCount = 0,
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var newTenantId = Guid.CreateVersion7();
+        _tenantService.Setup(s => s.ValidateSlugAsync("retry", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SlugValidationResult(true));
+        _tenantService.Setup(s => s.CreateWithoutOwnerAsync("retry", "Retry", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TenantCreatedDto(newTenantId, "retry", "Retry", true, DateTime.UtcNow));
+
+        var result = await _controller.CreateTenant(
+            new SetupTenantRequest("retry", "Retry"), CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ok.Value.Should().BeOfType<SetupTenantResponse>().Subject.TenantId.Should().Be(newTenantId);
+    }
+
+    [Fact]
     public async Task CreateTenant_WithInvalidSlug_Returns400()
     {
         // Arrange — no tenants, but slug validation fails
@@ -259,9 +311,8 @@ public class SetupControllerTests : IDisposable
         result.Should().BeOfType<ConflictObjectResult>();
     }
 
-    // OwnerOptions tests that require a sole tenant with members are skipped
-    // in unit tests because GetSoleTenantWithoutOwnerAsync calls set_config(),
-    // a PostgreSQL-only function. These scenarios are covered by integration tests.
+    // OwnerOptions scenarios whose outcome depends on RLS rather than on the guard logic live
+    // in the integration suite: SQLite has no policies for the pinned reads to be gated by.
 
     // ── Soft-lock scenario: the full sequence ─────────────────────────────
 
@@ -400,14 +451,10 @@ public class SetupControllerTests : IDisposable
         conflict.Value.Should().BeEquivalentTo(new { error = "owner_already_exists" });
     }
 
-    // SoftLock_TenantWithOnlySystemMembers_OwnerOptionsSucceeds is an
-    // integration test — it requires PostgreSQL's set_config() function
-    // which is not available in SQLite.
+    // SoftLock_TenantWithOnlySystemMembers_OwnerOptionsSucceeds is an integration test — it
+    // asserts what the tenant pin makes reachable, which needs real policies.
 
     // ── ValidateUsername ──────────────────────────────────────────────────
-    // Tests that hit the DB after format checks (valid usernames) are skipped
-    // because ValidateUsername calls ExecuteSqlRawAsync("set_config(...)"),
-    // a PostgreSQL-only function not available in SQLite.
 
     [Theory]
     [InlineData("ab")]           // too short
@@ -576,10 +623,8 @@ public class SetupControllerTests : IDisposable
         result.Should().BeOfType<ConflictObjectResult>();
     }
 
-    // OwnerOidc tests that require a sole tenant (e.g. validation of empty
-    // username/ProviderId) are skipped in unit tests because
-    // GetSoleTenantWithoutOwnerAsync calls set_config(), a PostgreSQL-only
-    // function. These scenarios are covered by integration tests.
+    // OwnerOidc scenarios that require a sole tenant (e.g. validation of empty
+    // username/ProviderId) are covered by the integration suite.
 
     // ── Helpers ──────────────────────────────────────────────────────────
 

--- a/tests/Unit/Nocturne.API.Tests/Middleware/TenantSetupMiddlewareTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/TenantSetupMiddlewareTests.cs
@@ -23,7 +23,19 @@ public class TenantSetupMiddlewareTests : IDisposable
 {
     private readonly SqliteConnection _connection;
     private readonly NocturneDbContext _dbContext;
+    private readonly IDbContextFactory<NocturneDbContext> _dbFactory;
     private readonly Mock<ITenantAccessor> _tenantAccessor;
+
+    /// <summary>
+    /// Hands the middleware contexts over the test's own SQLite connection. The middleware takes a
+    /// factory rather than the request-scoped context so its reads are never flagged as a public
+    /// share, which the restrictive share policy on tenant_members would deny.
+    /// </summary>
+    private sealed class SharedSqliteFactory(DbContextOptions<NocturneDbContext> options)
+        : IDbContextFactory<NocturneDbContext>
+    {
+        public NocturneDbContext CreateDbContext() => new(options);
+    }
     private readonly Guid _tenantId = Guid.CreateVersion7();
 
     // Default validator with no instance key configured — Classify() always returns
@@ -44,6 +56,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         _dbContext = new NocturneDbContext(options);
         _dbContext.TenantId = _tenantId;
         _dbContext.Database.EnsureCreated();
+        _dbFactory = new SharedSqliteFactory(options);
 
         // Seed the tenant entity so FK constraints are satisfied for TenantMembers
         _dbContext.Set<TenantEntity>().Add(new TenantEntity
@@ -91,7 +104,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         ctx.Response.Body = new MemoryStream();
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbFactory, _noInstanceKey);
 
         // Assert
         ctx.Response.StatusCode.Should().Be(503);
@@ -133,7 +146,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         var (mw, ctx) = Build(onNext: () => nextCalled = true);
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbFactory, _noInstanceKey);
 
         // Assert
         nextCalled.Should().BeTrue();
@@ -149,7 +162,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         var (mw, ctx) = Build(onNext: () => nextCalled = true);
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbFactory, _noInstanceKey);
 
         // Assert
         nextCalled.Should().BeTrue();
@@ -205,7 +218,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         var (mw, ctx) = Build();
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbFactory, _noInstanceKey);
 
         // Assert
         ctx.Response.StatusCode.Should().Be(503);
@@ -275,7 +288,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         var (mw, ctx) = Build(onNext: () => nextCalled = true);
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbFactory, _noInstanceKey);
 
         // Assert
         nextCalled.Should().BeTrue();
@@ -316,7 +329,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         var (mw, ctx) = Build(onNext: () => nextCalled = true);
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbFactory, _noInstanceKey);
 
         // Assert
         nextCalled.Should().BeTrue();
@@ -337,7 +350,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         ctx.SetEndpoint(CreateEndpoint(new AllowDuringSetupAttribute()));
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbFactory, _noInstanceKey);
 
         // Assert
         nextCalled.Should().BeTrue();
@@ -352,7 +365,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         ctx.SetEndpoint(CreateEndpoint());
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbFactory, _noInstanceKey);
 
         // Assert
         ctx.Response.StatusCode.Should().Be(503);
@@ -367,7 +380,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         // (no SetEndpoint call)
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbFactory, _noInstanceKey);
 
         // Assert
         nextCalled.Should().BeTrue();
@@ -387,7 +400,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         ctx.Response.Body = new MemoryStream();
 
         // Act — tenant is resolved (simulating single-tenant auto-resolution)
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbFactory, _noInstanceKey);
 
         // Assert
         ctx.Response.StatusCode.Should().Be(503);
@@ -428,7 +441,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         var (mw, ctx) = Build(onNext: () => nextCalled = true);
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbFactory, _noInstanceKey);
 
         // Assert
         nextCalled.Should().BeTrue();
@@ -485,7 +498,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         var (mw, ctx) = Build(onNext: () => nextCalled = true);
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbFactory, _noInstanceKey);
 
         // Assert
         nextCalled.Should().BeTrue("OIDC identity alone should satisfy the setup check");
@@ -567,7 +580,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         var (mw, ctx) = Build(onNext: () => nextCalled = true);
 
         // Act — middleware checks tenant B
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbFactory, _noInstanceKey);
 
         // Assert
         nextCalled.Should().BeTrue(
@@ -633,7 +646,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         var (mw, ctx) = Build(onNext: () => nextCalled = true);
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbFactory, _noInstanceKey);
 
         // Assert — should pass through cleanly, no 503, no recovery mode
         nextCalled.Should().BeTrue();
@@ -666,7 +679,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         var (mw, ctx) = Build();
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, _noInstanceKey);
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbFactory, _noInstanceKey);
 
         // Assert
         ctx.Response.StatusCode.Should().Be(503);
@@ -695,7 +708,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         ctx.Request.Headers[ServiceNames.Headers.InstanceService] = "nocturne-setup-agent";
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, ValidatorFor(key));
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbFactory, ValidatorFor(key));
 
         // Assert
         nextCalled.Should().BeTrue("a trusted instance-key caller must reach config endpoints during setup");
@@ -739,7 +752,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         ctx.Request.Headers[ServiceNames.Headers.InstanceService] = "nocturne-setup-agent";
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, ValidatorFor(key));
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbFactory, ValidatorFor(key));
 
         // Assert
         nextCalled.Should().BeTrue();
@@ -758,7 +771,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         // no X-Instance-Service marker
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, ValidatorFor(key));
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbFactory, ValidatorFor(key));
 
         // Assert
         ctx.Response.StatusCode.Should().Be(503);
@@ -773,7 +786,7 @@ public class TenantSetupMiddlewareTests : IDisposable
         ctx.Request.Headers[ServiceNames.Headers.InstanceService] = "nocturne-setup-agent";
 
         // Act
-        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbContext, ValidatorFor("bootstrap-key"));
+        await mw.InvokeAsync(ctx, _tenantAccessor.Object, _dbFactory, ValidatorFor("bootstrap-key"));
 
         // Assert
         ctx.Response.StatusCode.Should().Be(503);

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/PlatformAdminBootstrapServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/PlatformAdminBootstrapServiceTests.cs
@@ -1,0 +1,183 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Options;
+using Nocturne.API.Services.Auth;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Core.Models.Configuration;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+
+namespace Nocturne.API.Tests.Services.Auth;
+
+/// <summary>
+/// Pins which subject the startup bootstrap promotes. The owner lookup walks tenants oldest-first
+/// and asks each under its own tenant pin, so these tests fix the ordering and the skip-a-tenant-
+/// without-an-owner behaviour that the per-tenant scan has to preserve.
+/// </summary>
+/// <remarks>
+/// SQLite has no Row Level Security, so every row is visible regardless of the pin. These tests
+/// prove the resolution logic, not that a policy would hide anything.
+/// </remarks>
+public class PlatformAdminBootstrapServiceTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly NocturneDbContext _db;
+
+    public PlatformAdminBootstrapServiceTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+
+        _db = new NocturneDbContext(options);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose()
+    {
+        _db.Dispose();
+        _connection.Dispose();
+    }
+
+    [Fact]
+    public async Task WhenAdminSubjectIdsAreConfigured_ThoseSubjectsAreGranted()
+    {
+        var configured = await AddSubjectAsync("configured");
+        var oldestOwner = await AddTenantWithOwnerAsync("oldest", new DateTime(2020, 1, 1));
+
+        await BootstrapAsync(adminSubjectIds: [configured]);
+
+        (await IsPlatformAdminAsync(configured)).Should().BeTrue();
+        (await IsPlatformAdminAsync(oldestOwner)).Should().BeFalse(
+            "explicit configuration takes precedence over the implicit owner bootstrap");
+    }
+
+    [Fact]
+    public async Task WhenAPlatformAdminAlreadyExists_NobodyElseIsGranted()
+    {
+        var existing = await AddSubjectAsync("existing", isPlatformAdmin: true);
+        var oldestOwner = await AddTenantWithOwnerAsync("oldest", new DateTime(2020, 1, 1));
+
+        await BootstrapAsync();
+
+        (await IsPlatformAdminAsync(existing)).Should().BeTrue();
+        (await IsPlatformAdminAsync(oldestOwner)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task TheOwnerOfTheOldestTenantIsGranted()
+    {
+        var olderOwner = await AddTenantWithOwnerAsync("older", new DateTime(2020, 1, 1));
+        var newerOwner = await AddTenantWithOwnerAsync("newer", new DateTime(2024, 1, 1));
+
+        await BootstrapAsync();
+
+        (await IsPlatformAdminAsync(olderOwner)).Should().BeTrue();
+        (await IsPlatformAdminAsync(newerOwner)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ATenantWithNoOwnerIsSkippedForTheNextOldest()
+    {
+        await AddTenantWithoutOwnerAsync("ownerless-oldest", new DateTime(2019, 1, 1));
+        var owner = await AddTenantWithOwnerAsync("owned", new DateTime(2020, 1, 1));
+
+        await BootstrapAsync();
+
+        (await IsPlatformAdminAsync(owner)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task WhenNoTenantHasAnOwner_NobodyIsGranted()
+    {
+        var memberOnly = await AddTenantWithoutOwnerAsync("ownerless", new DateTime(2020, 1, 1));
+
+        await BootstrapAsync();
+
+        (await IsPlatformAdminAsync(memberOnly)).Should().BeFalse();
+        (await _db.Subjects.AsNoTracking().AnyAsync(s => s.IsPlatformAdmin)).Should().BeFalse();
+    }
+
+    private Task BootstrapAsync(List<Guid>? adminSubjectIds = null) =>
+        new PlatformAdminBootstrapService(
+            _db,
+            Options.Create(new PlatformOptions { AdminSubjectIds = adminSubjectIds ?? [] }))
+            .BootstrapAsync(CancellationToken.None);
+
+    private async Task<bool> IsPlatformAdminAsync(Guid subjectId) =>
+        await _db.Subjects.AsNoTracking()
+            .Where(s => s.Id == subjectId)
+            .Select(s => s.IsPlatformAdmin)
+            .SingleAsync();
+
+    private async Task<Guid> AddSubjectAsync(string name, bool isPlatformAdmin = false)
+    {
+        var subject = new SubjectEntity
+        {
+            Id = Guid.CreateVersion7(),
+            Name = name,
+            Username = name,
+            IsActive = true,
+            IsPlatformAdmin = isPlatformAdmin,
+        };
+        _db.Subjects.Add(subject);
+        await _db.SaveChangesAsync();
+        _db.ChangeTracker.Clear();
+        return subject.Id;
+    }
+
+    /// <summary>Seeds a tenant whose sole member holds the owner role, and returns that subject's id.</summary>
+    private async Task<Guid> AddTenantWithOwnerAsync(string slug, DateTime createdAt) =>
+        await AddTenantAsync(slug, createdAt, TenantPermissions.SeedRoles.Owner);
+
+    /// <summary>Seeds a tenant whose sole member holds a non-owner role, and returns that subject's id.</summary>
+    private async Task<Guid> AddTenantWithoutOwnerAsync(string slug, DateTime createdAt) =>
+        await AddTenantAsync(slug, createdAt, TenantPermissions.SeedRoles.Viewer);
+
+    private async Task<Guid> AddTenantAsync(string slug, DateTime createdAt, string roleSlug)
+    {
+        var tenantId = Guid.CreateVersion7();
+        var subjectId = await AddSubjectAsync($"{slug}-member");
+        var roleId = Guid.CreateVersion7();
+        var memberId = Guid.CreateVersion7();
+
+        _db.Tenants.Add(new TenantEntity
+        {
+            Id = tenantId,
+            Slug = slug,
+            DisplayName = slug,
+            IsActive = true,
+            SysCreatedAt = createdAt,
+        });
+        _db.TenantRoles.Add(new TenantRoleEntity
+        {
+            Id = roleId,
+            TenantId = tenantId,
+            Name = roleSlug,
+            Slug = roleSlug,
+            Permissions = [],
+            IsSystem = true,
+        });
+        _db.TenantMembers.Add(new TenantMemberEntity
+        {
+            Id = memberId,
+            TenantId = tenantId,
+            SubjectId = subjectId,
+        });
+        _db.TenantMemberRoles.Add(new TenantMemberRoleEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantMemberId = memberId,
+            TenantRoleId = roleId,
+        });
+        await _db.SaveChangesAsync();
+        _db.ChangeTracker.Clear();
+        return subjectId;
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Identity/MemberInviteServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Identity/MemberInviteServiceTests.cs
@@ -68,7 +68,10 @@ public class MemberInviteServiceTests : IDisposable
             _dbContext,
             _jwtService.Object,
             _tenantService.Object,
-            new TenantRoleService(_dbContext),
+            new TenantRoleService(
+                _dbContext,
+                // Only SeedRolesForTenantAsync takes a context of its own, and nothing here seeds.
+                Mock.Of<IDbContextFactory<NocturneDbContext>>()),
             configuration,
             logger.Object);
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Identity/MembershipRequestServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Identity/MembershipRequestServiceTests.cs
@@ -59,7 +59,10 @@ public class MembershipRequestServiceTests : IDisposable
         _service = new MembershipRequestService(
             _dbContext,
             _tenantService.Object,
-            new TenantRoleService(_dbContext),
+            new TenantRoleService(
+                _dbContext,
+                // Only SeedRolesForTenantAsync takes a context of its own, and nothing here seeds.
+                Mock.Of<IDbContextFactory<NocturneDbContext>>()),
             _notificationService.Object,
             NullLogger<MembershipRequestService>.Instance);
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Identity/TenantRoleServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Identity/TenantRoleServiceTests.cs
@@ -4,21 +4,45 @@ using Nocturne.API.Services.Identity;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Tests.Shared.Infrastructure;
 
 namespace Nocturne.API.Tests.Services.Identity;
 
+/// <summary>
+/// In-memory provider tests: they exercise the service's own tenant predicates and the context
+/// pin it sets, not the PostgreSQL Row Level Security policies, which have no equivalent here.
+/// </summary>
 public class TenantRoleServiceTests : IDisposable
 {
     private readonly NocturneDbContext _context;
     private readonly TenantRoleService _service;
     private readonly Guid _tenantId = Guid.CreateVersion7();
 
+    /// <summary>
+    /// Hands out contexts over the same in-memory database, so the seed context
+    /// <see cref="TenantRoleService.SeedRolesForTenantAsync"/> creates writes where the test's
+    /// own context can read it.
+    /// </summary>
+    private sealed class SharedInMemoryFactory(string dbName) : IDbContextFactory<NocturneDbContext>
+    {
+        public List<NocturneDbContext> Handed { get; } = [];
+
+        public NocturneDbContext CreateDbContext()
+        {
+            var context = TestDbContextFactory.CreateInMemoryContext(dbName);
+            Handed.Add(context);
+            return context;
+        }
+    }
+
+    private readonly SharedInMemoryFactory _factory;
+
     public TenantRoleServiceTests()
     {
-        var options = new DbContextOptionsBuilder<NocturneDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-        _context = new NocturneDbContext(options);
+        var dbName = Guid.NewGuid().ToString();
+        var factory = new SharedInMemoryFactory(dbName);
+        _factory = factory;
+        _context = TestDbContextFactory.CreateInMemoryContext(dbName);
         _context.Tenants.Add(new TenantEntity
         {
             Id = _tenantId,
@@ -26,7 +50,7 @@ public class TenantRoleServiceTests : IDisposable
             DisplayName = "Test Tenant",
         });
         _context.SaveChanges();
-        _service = new TenantRoleService(_context);
+        _service = new TenantRoleService(_context, factory);
     }
 
     [Fact]
@@ -41,6 +65,29 @@ public class TenantRoleServiceTests : IDisposable
         roles.Should().Contain(r => r.Slug == "viewer" && r.IsSystem);
         roles.Should().Contain(r => r.Slug == "clinician" && r.IsSystem);
         roles.Should().Contain(r => r.Slug == "denied" && r.IsSystem);
+    }
+
+    [Fact]
+    public async Task SeedRolesForTenantAsync_SeedsOnAContextPinnedToTheTenant()
+    {
+        // The injected context is the request-scoped one, which on every tenant-creation entry
+        // point carries no pin. The seed must not write through it.
+        _context.TenantId.Should().Be(Guid.Empty);
+
+        await _service.SeedRolesForTenantAsync(_tenantId);
+
+        _factory.Handed.Should().ContainSingle("the seed takes exactly one context of its own");
+        _factory.Handed[0].TenantId.Should().Be(_tenantId);
+        _context.TenantId.Should().Be(Guid.Empty, "the request-scoped context must not be re-pinned");
+    }
+
+    [Fact]
+    public async Task GetEffectivePermissionsAsync_ForAnUnreachableMember_ReturnsNoPermissions()
+    {
+        // A membership id the context cannot resolve is a refusal, not a fault.
+        var effective = await _service.GetEffectivePermissionsAsync(Guid.CreateVersion7());
+
+        effective.Should().BeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
Phase A of putting `tenant_members`, `tenant_member_roles` and `tenant_roles` behind Row Level Security (deferred from #640). This PR is deliberately **behavior-neutral**: it contains every code-side change the policies will rely on, and no policies. Phase B (the `ITenantScoped` declarations, the migration with the policies, and the RLS integration tests) follows once this has merged and deployed.

## Why two phases

Migrations run at boot and are not reverted by an image rollback. If the pins and the policies shipped together, rolling back that image would leave the policies live against code that never sets the GUCs — an instance-wide lockout on the authentication hot path, and a permanent share-host outage from the reconciler's restrictive policies (which the older image's reconciler doesn't enumerate and therefore never drops). With this PR deployed first, the rollback target for Phase B is an image that already pins everything.

## What it does

- **New `app.current_subject_id` GUC**, carried by `TenantConnectionInterceptor` exactly like the tenant GUC (set at connection open when non-empty, RESET on close, reset on pooled-context acquisition). Nothing reads it yet; Phase B's `tenant_members` policy gives it read-only reach over a subject's own rows.
- **`RlsPinningExtensions`** — one helper set replacing four hand-rolled `set_config` copies (three of which set only the GUC and not the context property, which would have made the EF filter and the policy disagree in Phase B).
- **Tenant pins on every factory-context membership read/write**: `TenantMemberService` (the `AuthenticationMiddleware` membership check on every request, SignalR token authorization, OIDC login), `TenantService.AddMemberAsync`/`RemoveMemberAsync`/`GetByIdAsync`, `TenantOwnerResolver`, `PublicAccessCacheService`, the fire-and-forget last-used touch in `MemberScopeMiddleware` (which also gains a tenant predicate and a Warning on refusal), and `TenantRoleService.SeedRolesForTenantAsync`, which previously seeded on the request-scoped context while its callers pinned a different one — on tenantless entry points that context is pinned to nothing, and Phase B's WITH CHECK would have broken tenant creation from setup, platform admin, and demo provisioning.
- **Subject pins on the three genuinely cross-tenant reads** (tenant switcher, caregiver overview, membership enumeration), which no tenant pin can express.
- **Rewrites of the reads that had no pinnable identity at all**: the first-run setup gate (which under a naive policy would have *failed open* and re-offered setup on a configured instance), the platform-admin bootstrap (walks tenants oldest-first under each tenant's own pin), and the passkey enrolment probe — the anti-join over all tenants' memberships is now a per-candidate probe under each candidate's subject pin, because a single statement spanning many candidates has no one subject to pin. A membership hidden from that anti-join reads as "anonymous enrolment" and enrols the caller's authenticator onto somebody else's account, so the takeover guard is pinned by tests that fail under the naive current-tenant-only rewrite.
- **Share-host fixes for reads that predate share-marked contexts**: the setup/recovery gate in `TenantSetupMiddleware`, the two membership preconditions behind the anonymous `GET /api/auth/passkey/status`, and the access-request owner notification all read membership on the request-scoped context, which a public-share request marks as a share. Under Phase B's restrictive policies those reads return nothing — 503 for every share request in the middleware's case. They now read on tenant-pinned factory contexts; recovery ceremonies deliberately stay share-blind (fail closed).

## Verification

- 4807 API + 501 Infrastructure.Data unit tests green; `dotnet ef migrations has-pending-model-changes` reports none (this PR makes no model change).
- Semantic-preservation tests were mutation-verified: each deliberate mutation (gate short-circuit, bootstrap ordering flip, seed-context unpinning, enrolment probe removal, the naive current-tenant-only probe, newest-only probing, revoked-filter dropping) fails exactly its named test.
- Reviewed twice (orchestrated review with change requests, then an independent fresh-eyes review); all findings addressed.

https://claude.ai/code/session_0144D1ugAVBuasghMSEcG6ox
