### PR TITLE
fix(members): carry refusal reasons on the member edit endpoints

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Identity/MemberInviteController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/MemberInviteController.cs
@@ -291,11 +291,17 @@ public class MemberInviteController : ControllerBase
         if (member == null)
             return NotFound();
 
+        // Every refusal on this controller carries its reason in the title as well as the detail:
+        // openapi-remote-codegen 0.2.0 resolves a ProblemDetails to `title` before `detail`, so a
+        // reason carried only in the detail reaches the member list as the literal "Bad Request".
         if (IsCallersOwnMembership(member))
-            return Problem(detail: SelfEditDetail, statusCode: 400, title: "Bad Request");
+            return Problem(detail: SelfEditDetail, statusCode: 400, title: SelfEditDetail);
 
         if (request.RoleIds.Count == 0 && (member.DirectPermissions == null || member.DirectPermissions.Count == 0))
-            return Problem(detail: "Cannot remove all roles when member has no direct permissions", statusCode: 400, title: "Bad Request");
+        {
+            const string reason = "Cannot remove all roles when member has no direct permissions";
+            return Problem(detail: reason, statusCode: 400, title: reason);
+        }
 
         var roleGrant = await _tenantRoleService.ValidateRoleGrantAsync(
             tenantId, request.RoleIds, HttpContext.GetGrantedScopes(), ct);
@@ -356,10 +362,13 @@ public class MemberInviteController : ControllerBase
             return NotFound();
 
         if (IsCallersOwnMembership(member))
-            return Problem(detail: SelfEditDetail, statusCode: 400, title: "Bad Request");
+            return Problem(detail: SelfEditDetail, statusCode: 400, title: SelfEditDetail);
 
         if ((request.DirectPermissions == null || request.DirectPermissions.Count == 0) && member.MemberRoles.Count == 0)
-            return Problem(detail: "Cannot remove all permissions when member has no roles", statusCode: 400, title: "Bad Request");
+        {
+            const string reason = "Cannot remove all permissions when member has no roles";
+            return Problem(detail: reason, statusCode: 400, title: reason);
+        }
 
         // The Public system subject serves the anonymous share viewer, so the granter's own
         // permissions are the wrong bound: an owner holding "*" would otherwise be able to give an
@@ -373,10 +382,8 @@ public class MemberInviteController : ControllerBase
                 .ToList();
             if (outsideShareVocabulary.Count > 0)
             {
-                return Problem(
-                    detail: $"Public access cannot be granted: {string.Join(", ", outsideShareVocabulary)}.",
-                    statusCode: 400,
-                    title: "Bad Request");
+                var reason = $"Public access cannot be granted: {string.Join(", ", outsideShareVocabulary)}.";
+                return Problem(detail: reason, statusCode: 400, title: reason);
             }
         }
         else
@@ -451,7 +458,7 @@ public class MemberInviteController : ControllerBase
         // The clamp is enforced in RLS via app.share_full_history, so lifting your own is a
         // self-widening edit — the same class the role and permission editors refuse.
         if (IsCallersOwnMembership(member))
-            return Problem(detail: SelfEditDetail, statusCode: 400, title: "Bad Request");
+            return Problem(detail: SelfEditDetail, statusCode: 400, title: SelfEditDetail);
 
         member.LimitTo24Hours = request.LimitTo24Hours;
         member.SysUpdatedAt = DateTime.UtcNow;
@@ -479,20 +486,21 @@ public class MemberInviteController : ControllerBase
         => HttpContext.GetSubjectId() is { } subjectId && member.SubjectId == subjectId;
 
     /// <summary>
-    /// An unknown permission is malformed input; exceeding the ceiling is a refusal.
+    /// An unknown permission is malformed input; exceeding the ceiling is a refusal. Either way the
+    /// description is what the granter reads, so it travels in the title as well as the detail.
     /// </summary>
     private ObjectResult GrantProblem(GrantCeilingViolation violation) =>
         violation.Code == GrantCeilingViolation.UnknownPermission
-            ? Problem(detail: violation.Description, statusCode: 400, title: "Bad Request")
-            : Problem(detail: violation.Description, statusCode: 403, title: "Forbidden");
+            ? Problem(detail: violation.Description, statusCode: 400, title: violation.Description)
+            : Problem(detail: violation.Description, statusCode: 403, title: violation.Description);
 
     /// <summary>
     /// A foreign role id is malformed input; a role conferring more than the caller holds is a refusal.
     /// </summary>
     private ObjectResult RoleGrantProblem(RoleGrantValidation validation) =>
         validation.ErrorCode == RoleGrantValidation.ForeignRole
-            ? Problem(detail: validation.ErrorDescription, statusCode: 400, title: "Bad Request")
-            : Problem(detail: validation.ErrorDescription, statusCode: 403, title: "Forbidden");
+            ? Problem(detail: validation.ErrorDescription, statusCode: 400, title: validation.ErrorDescription)
+            : Problem(detail: validation.ErrorDescription, statusCode: 403, title: validation.ErrorDescription);
 }
 
 public class CreateMemberInviteRequest

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/MemberInviteControllerGrantCeilingTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/MemberInviteControllerGrantCeilingTests.cs
@@ -142,6 +142,25 @@ public sealed class MemberInviteControllerGrantCeilingTests : IDisposable
         };
     }
 
+    /// <summary>
+    /// Asserts the refusal the granter actually reads. openapi-remote-codegen 0.2.0 resolves a
+    /// ProblemDetails to <c>title</c> before <c>detail</c>, so a reason carried only in the detail
+    /// reaches the members page as the literal "Bad Request" or "Forbidden" — asserting the title is
+    /// what makes the reason testable.
+    /// </summary>
+    private static void ShouldRefuse(IActionResult result, int statusCode, string reason)
+    {
+        var problem = result.Should().BeOfType<ObjectResult>().Subject;
+        problem.StatusCode.Should().Be(statusCode);
+        var details = problem.Value.Should().BeOfType<ProblemDetails>().Subject;
+        details.Title.Should().Be(reason);
+        details.Detail.Should().Be(reason);
+    }
+
+    /// <summary>The reason both role and permission edits give for a self-edit.</summary>
+    private const string SelfEditReason =
+        "Cannot change your own roles or permissions; ask another member with members.manage.";
+
     private Task<List<string>?> TargetPermissionsAsync() => PermissionsOfAsync(_targetMemberId);
 
     private async Task<List<string>?> PermissionsOfAsync(Guid memberId)
@@ -161,8 +180,10 @@ public sealed class MemberInviteControllerGrantCeilingTests : IDisposable
             _publicAccessCache,
             CancellationToken.None);
 
-        result.Should().BeOfType<ObjectResult>()
-            .Which.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        ShouldRefuse(
+            result,
+            StatusCodes.Status403Forbidden,
+            "Cannot grant '*' because the caller does not hold it.");
 
         (await TargetPermissionsAsync()).Should().BeEquivalentTo([TenantPermissions.GlucoseRead]);
     }
@@ -179,8 +200,10 @@ public sealed class MemberInviteControllerGrantCeilingTests : IDisposable
             _publicAccessCache,
             CancellationToken.None);
 
-        result.Should().BeOfType<ObjectResult>()
-            .Which.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        ShouldRefuse(
+            result,
+            StatusCodes.Status403Forbidden,
+            "Cannot grant 'audit.manage' because the caller does not hold it.");
 
         (await TargetPermissionsAsync()).Should().BeEquivalentTo([TenantPermissions.GlucoseRead]);
     }
@@ -199,8 +222,10 @@ public sealed class MemberInviteControllerGrantCeilingTests : IDisposable
             _publicAccessCache,
             CancellationToken.None);
 
-        result.Should().BeOfType<ObjectResult>()
-            .Which.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        ShouldRefuse(
+            result,
+            StatusCodes.Status400BadRequest,
+            "'glucose.destroy' is not a known permission.");
 
         (await TargetPermissionsAsync()).Should().BeEquivalentTo([TenantPermissions.GlucoseRead]);
     }
@@ -267,8 +292,7 @@ public sealed class MemberInviteControllerGrantCeilingTests : IDisposable
             _publicAccessCache,
             CancellationToken.None);
 
-        result.Should().BeOfType<ObjectResult>()
-            .Which.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        ShouldRefuse(result, StatusCodes.Status400BadRequest, SelfEditReason);
 
         (await PermissionsOfAsync(_callerMemberId)).Should().BeEquivalentTo(AdministratorScopes);
     }
@@ -284,8 +308,10 @@ public sealed class MemberInviteControllerGrantCeilingTests : IDisposable
             _publicAccessCache,
             CancellationToken.None);
 
-        result.Should().BeOfType<ObjectResult>()
-            .Which.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        ShouldRefuse(
+            result,
+            StatusCodes.Status403Forbidden,
+            "Cannot grant '*' because the caller does not hold it.");
 
         (await _dbContext.TenantMemberRoles.AnyAsync()).Should().BeFalse();
     }
@@ -302,8 +328,12 @@ public sealed class MemberInviteControllerGrantCeilingTests : IDisposable
             _publicAccessCache,
             CancellationToken.None);
 
-        result.Should().BeOfType<ObjectResult>()
-            .Which.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        // Every Caretaker atom is within the Administrator ceiling, so the owner role's superuser
+        // is the only violation the union can report, whatever order the two roles resolve in.
+        ShouldRefuse(
+            result,
+            StatusCodes.Status403Forbidden,
+            "Cannot grant '*' because the caller does not hold it.");
 
         (await _dbContext.TenantMemberRoles.AnyAsync()).Should().BeFalse();
     }
@@ -335,10 +365,27 @@ public sealed class MemberInviteControllerGrantCeilingTests : IDisposable
             _publicAccessCache,
             CancellationToken.None);
 
-        result.Should().BeOfType<ObjectResult>()
-            .Which.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        ShouldRefuse(result, StatusCodes.Status400BadRequest, SelfEditReason);
 
         (await _dbContext.TenantMemberRoles.AnyAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SetMemberLimitTo24Hours_rejectsEditingTheCallersOwnMembership()
+    {
+        // The clamp is the third self-edit refusal, and the only one whose reason had no test.
+        var controller = BuildController(TenantPermissions.Superuser);
+
+        var result = await controller.SetMemberLimitTo24Hours(
+            _callerMemberId,
+            new SetMemberLimitTo24HoursRequest(true),
+            _publicAccessCache,
+            CancellationToken.None);
+
+        ShouldRefuse(result, StatusCodes.Status400BadRequest, SelfEditReason);
+
+        var caller = await _dbContext.TenantMembers.AsNoTracking().FirstAsync(m => m.Id == _callerMemberId);
+        caller.LimitTo24Hours.Should().BeFalse("the refusal returned before the clamp was written");
     }
 
     public void Dispose() => _dbContext.Dispose();


### PR DESCRIPTION
Finishes what #640 started on this controller. `openapi-remote-codegen` 0.2.0 resolves a `ProblemDetails` to `title` before `detail`, so any refusal returned with `title: "Bad Request"` reaches the members page as that literal string — the customer-reported symptom #640 fixed on the endpoints it exposed, while these sibling sites kept the old shape.

Ten sites in `MemberInviteController` now carry the reason in the title as well as the detail: the three self-edit refusals (roles, permissions, the 24-hour clamp), the two "cannot remove all roles/permissions" refusals, the public-share vocabulary refusal, and both branches of `GrantProblem`/`RoleGrantProblem`. The last pair includes the two 403s (`title: "Forbidden"`) — exceeding the grant ceiling is the likeliest refusal on these endpoints, and `describeSubmitError` treats any 4xx identically, so the most common case would otherwise still have surfaced a status phrase instead of the reason.

Tests: the grant-ceiling suite previously asserted only status codes; its refusal assertions now check `Title` and `Detail` (the pattern #640's authorization tests use), and the 24-hour clamp self-edit — the only self-edit refusal with no coverage — gets a test that also proves the clamp wasn't written. With the controller fix stashed, 8 of the 12 grant-ceiling tests fail on `Title`, so the assertions are load-bearing.

The durable fix remains upstream in the codegen's resolution order; until then the title is what the member reads.

https://claude.ai/code/session_0144D1ugAVBuasghMSEcG6ox
