### PR TITLE
fix: treat Device when DataSource is null for delete/count by source

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Admin/DemoAdminController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Admin/DemoAdminController.cs
@@ -144,9 +144,9 @@ public class DemoAdminController : ControllerBase
         db.TenantId = tenant.Id;
 
         var deleted = 0L;
-        deleted += await db.SensorGlucose.Where(e => e.DataSource == DataSources.DemoService).ExecuteDeleteAsync(ct);
-        deleted += await db.MeterGlucose.Where(e => e.DataSource == DataSources.DemoService).ExecuteDeleteAsync(ct);
-        deleted += await db.Calibrations.Where(e => e.DataSource == DataSources.DemoService).ExecuteDeleteAsync(ct);
+        deleted += await db.SensorGlucose.Where(e => e.DataSource == DataSources.DemoService || (e.DataSource == null && e.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
+        deleted += await db.MeterGlucose.Where(e => e.DataSource == DataSources.DemoService || (e.DataSource == null && e.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
+        deleted += await db.Calibrations.Where(e => e.DataSource == DataSources.DemoService || (e.DataSource == null && e.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
 
         return Ok(new DemoDeleteResultDto(deleted));
     }
@@ -168,13 +168,13 @@ public class DemoAdminController : ControllerBase
         db.TenantId = tenant.Id;
 
         var deleted = 0L;
-        deleted += await db.Boluses.Where(b => b.DataSource == DataSources.DemoService).ExecuteDeleteAsync(ct);
-        deleted += await db.CarbIntakes.Where(c => c.DataSource == DataSources.DemoService).ExecuteDeleteAsync(ct);
-        deleted += await db.BGChecks.Where(b => b.DataSource == DataSources.DemoService).ExecuteDeleteAsync(ct);
-        deleted += await db.Notes.Where(n => n.DataSource == DataSources.DemoService).ExecuteDeleteAsync(ct);
-        deleted += await db.DeviceEvents.Where(de => de.DataSource == DataSources.DemoService).ExecuteDeleteAsync(ct);
-        deleted += await db.BolusCalculations.Where(bc => bc.DataSource == DataSources.DemoService).ExecuteDeleteAsync(ct);
-        deleted += await db.TempBasals.Where(t => t.DataSource == DataSources.DemoService).ExecuteDeleteAsync(ct);
+        deleted += await db.Boluses.Where(b => b.DataSource == DataSources.DemoService || (b.DataSource == null && b.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
+        deleted += await db.CarbIntakes.Where(c => c.DataSource == DataSources.DemoService || (c.DataSource == null && c.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
+        deleted += await db.BGChecks.Where(b => b.DataSource == DataSources.DemoService || (b.DataSource == null && b.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
+        deleted += await db.Notes.Where(n => n.DataSource == DataSources.DemoService || (n.DataSource == null && n.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
+        deleted += await db.DeviceEvents.Where(de => de.DataSource == DataSources.DemoService || (de.DataSource == null && de.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
+        deleted += await db.BolusCalculations.Where(bc => bc.DataSource == DataSources.DemoService || (bc.DataSource == null && bc.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
+        deleted += await db.TempBasals.Where(t => t.DataSource == DataSources.DemoService || (t.DataSource == null && t.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
         deleted += await db.StateSpans.Where(s => s.Source == DataSources.DemoService).ExecuteDeleteAsync(ct);
         deleted += await db.ApsSnapshots.Where(a => a.Device == DataSources.DemoService).ExecuteDeleteAsync(ct);
 
@@ -200,26 +200,26 @@ public class DemoAdminController : ControllerBase
         var deleted = 0L;
 
         // Entries
-        deleted += await db.SensorGlucose.Where(e => e.DataSource == DataSources.DemoService).ExecuteDeleteAsync(ct);
-        deleted += await db.MeterGlucose.Where(e => e.DataSource == DataSources.DemoService).ExecuteDeleteAsync(ct);
-        deleted += await db.Calibrations.Where(e => e.DataSource == DataSources.DemoService).ExecuteDeleteAsync(ct);
+        deleted += await db.SensorGlucose.Where(e => e.DataSource == DataSources.DemoService || (e.DataSource == null && e.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
+        deleted += await db.MeterGlucose.Where(e => e.DataSource == DataSources.DemoService || (e.DataSource == null && e.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
+        deleted += await db.Calibrations.Where(e => e.DataSource == DataSources.DemoService || (e.DataSource == null && e.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
 
         // Treatments
-        deleted += await db.Boluses.Where(b => b.DataSource == DataSources.DemoService).ExecuteDeleteAsync(ct);
-        deleted += await db.CarbIntakes.Where(c => c.DataSource == DataSources.DemoService).ExecuteDeleteAsync(ct);
-        deleted += await db.BGChecks.Where(b => b.DataSource == DataSources.DemoService).ExecuteDeleteAsync(ct);
-        deleted += await db.Notes.Where(n => n.DataSource == DataSources.DemoService).ExecuteDeleteAsync(ct);
-        deleted += await db.DeviceEvents.Where(de => de.DataSource == DataSources.DemoService).ExecuteDeleteAsync(ct);
-        deleted += await db.BolusCalculations.Where(bc => bc.DataSource == DataSources.DemoService).ExecuteDeleteAsync(ct);
-        deleted += await db.TempBasals.Where(t => t.DataSource == DataSources.DemoService).ExecuteDeleteAsync(ct);
+        deleted += await db.Boluses.Where(b => b.DataSource == DataSources.DemoService || (b.DataSource == null && b.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
+        deleted += await db.CarbIntakes.Where(c => c.DataSource == DataSources.DemoService || (c.DataSource == null && c.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
+        deleted += await db.BGChecks.Where(b => b.DataSource == DataSources.DemoService || (b.DataSource == null && b.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
+        deleted += await db.Notes.Where(n => n.DataSource == DataSources.DemoService || (n.DataSource == null && n.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
+        deleted += await db.DeviceEvents.Where(de => de.DataSource == DataSources.DemoService || (de.DataSource == null && de.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
+        deleted += await db.BolusCalculations.Where(bc => bc.DataSource == DataSources.DemoService || (bc.DataSource == null && bc.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
+        deleted += await db.TempBasals.Where(t => t.DataSource == DataSources.DemoService || (t.DataSource == null && t.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
         deleted += await db.StateSpans.Where(s => s.Source == DataSources.DemoService).ExecuteDeleteAsync(ct);
         deleted += await db.ApsSnapshots.Where(a => a.Device == DataSources.DemoService).ExecuteDeleteAsync(ct);
 
         // Seed-extras data (sleep stages/samples cascade from their session).
         // Tracker definitions and alert rules are configuration, not data —
         // seed-extras re-upserts them, so only their instances/history go.
-        deleted += await db.HeartRates.Where(h => h.DataSource == DataSources.DemoService).ExecuteDeleteAsync(ct);
-        deleted += await db.StepCounts.Where(s => s.DataSource == DataSources.DemoService).ExecuteDeleteAsync(ct);
+        deleted += await db.HeartRates.Where(h => h.DataSource == DataSources.DemoService || (h.DataSource == null && h.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
+        deleted += await db.StepCounts.Where(s => s.DataSource == DataSources.DemoService || (s.DataSource == null && s.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
         deleted += await db.SleepSessions.Where(s => s.SourceApp == DataSources.DemoService).ExecuteDeleteAsync(ct);
         deleted += await db.TrackerInstances.ExecuteDeleteAsync(ct);
         deleted += await db.AlertInstances.ExecuteDeleteAsync(ct);

--- a/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
@@ -777,48 +777,48 @@ public class DataSourceService : IDataSourceService
 
         // Glucose
         var sensorGlucoseCount = await _context
-            .SensorGlucose.Where(sg => sg.DataSource == deviceId)
+            .SensorGlucose.Where(sg => sg.DataSource == deviceId || (sg.DataSource == null && sg.Device == deviceId))
             .LongCountAsync(cancellationToken);
         if (sensorGlucoseCount > 0) counts[nameof(SyncDataType.Glucose)] = sensorGlucoseCount;
 
         var meterGlucoseCount = await _context
-            .MeterGlucose.Where(mg => mg.DataSource == deviceId)
+            .MeterGlucose.Where(mg => mg.DataSource == deviceId || (mg.DataSource == null && mg.Device == deviceId))
             .LongCountAsync(cancellationToken);
         if (meterGlucoseCount > 0) counts[nameof(SyncDataType.ManualBG)] = meterGlucoseCount;
 
         var calibrationsCount = await _context
-            .Calibrations.Where(c => c.DataSource == deviceId)
+            .Calibrations.Where(c => c.DataSource == deviceId || (c.DataSource == null && c.Device == deviceId))
             .LongCountAsync(cancellationToken);
         if (calibrationsCount > 0) counts[nameof(SyncDataType.Calibrations)] = calibrationsCount;
 
         // Treatments
         var bolusCount = await _context
-            .Boluses.Where(b => b.DataSource == deviceId)
+            .Boluses.Where(b => b.DataSource == deviceId || (b.DataSource == null && b.Device == deviceId))
             .LongCountAsync(cancellationToken);
         if (bolusCount > 0) counts[nameof(SyncDataType.Boluses)] = bolusCount;
 
         var carbIntakeCount = await _context
-            .CarbIntakes.Where(c => c.DataSource == deviceId)
+            .CarbIntakes.Where(c => c.DataSource == deviceId || (c.DataSource == null && c.Device == deviceId))
             .LongCountAsync(cancellationToken);
         if (carbIntakeCount > 0) counts[nameof(SyncDataType.CarbIntake)] = carbIntakeCount;
 
         var bgChecksCount = await _context
-            .BGChecks.Where(b => b.DataSource == deviceId)
+            .BGChecks.Where(b => b.DataSource == deviceId || (b.DataSource == null && b.Device == deviceId))
             .LongCountAsync(cancellationToken);
         if (bgChecksCount > 0) counts[nameof(SyncDataType.BGChecks)] = bgChecksCount;
 
         var bolusCalcCount = await _context
-            .BolusCalculations.Where(bc => bc.DataSource == deviceId)
+            .BolusCalculations.Where(bc => bc.DataSource == deviceId || (bc.DataSource == null && bc.Device == deviceId))
             .LongCountAsync(cancellationToken);
         if (bolusCalcCount > 0) counts[nameof(SyncDataType.BolusCalculations)] = bolusCalcCount;
 
         var notesCount = await _context
-            .Notes.Where(n => n.DataSource == deviceId)
+            .Notes.Where(n => n.DataSource == deviceId || (n.DataSource == null && n.Device == deviceId))
             .LongCountAsync(cancellationToken);
         if (notesCount > 0) counts[nameof(SyncDataType.Notes)] = notesCount;
 
         var deviceEventsCount = await _context
-            .DeviceEvents.Where(de => de.DataSource == deviceId)
+            .DeviceEvents.Where(de => de.DataSource == deviceId || (de.DataSource == null && de.Device == deviceId))
             .LongCountAsync(cancellationToken);
         if (deviceEventsCount > 0) counts[nameof(SyncDataType.DeviceEvents)] = deviceEventsCount;
 
@@ -933,13 +933,13 @@ public class DataSourceService : IDataSourceService
 
         // Auditable + soft-deletable treatments: audited soft-delete, user-attributed.
         var bolusesDeleted = await _context.AuditedSoftDeleteAsync(
-            _context.Boluses.Where(b => b.DataSource == deviceId), _auditContext, cancellationToken);
+            _context.Boluses.Where(b => b.DataSource == deviceId || (b.DataSource == null && b.Device == deviceId)), _auditContext, cancellationToken);
         var carbIntakesDeleted = await _context.AuditedSoftDeleteAsync(
-            _context.CarbIntakes.Where(c => c.DataSource == deviceId), _auditContext, cancellationToken);
+            _context.CarbIntakes.Where(c => c.DataSource == deviceId || (c.DataSource == null && c.Device == deviceId)), _auditContext, cancellationToken);
         var bolusCalcsDeleted = await _context.AuditedSoftDeleteAsync(
-            _context.BolusCalculations.Where(bc => bc.DataSource == deviceId), _auditContext, cancellationToken);
+            _context.BolusCalculations.Where(bc => bc.DataSource == deviceId || (bc.DataSource == null && bc.Device == deviceId)), _auditContext, cancellationToken);
         var deviceEventsDeleted = await _context.AuditedSoftDeleteAsync(
-            _context.DeviceEvents.Where(de => de.DataSource == deviceId), _auditContext, cancellationToken);
+            _context.DeviceEvents.Where(de => de.DataSource == deviceId || (de.DataSource == null && de.Device == deviceId)), _auditContext, cancellationToken);
 
         // StateSpan is auditable but not soft-deletable: audited hard delete.
         var stateSpansDeleted = await _context.AuditedExecuteDeleteAsync(
@@ -947,9 +947,9 @@ public class DataSourceService : IDataSourceService
 
         // Soft-deletable but not auditable: soft-delete without an audit row.
         var bgChecksDeleted = await _context.SoftDeleteAsync(
-            _context.BGChecks.Where(b => b.DataSource == deviceId), cancellationToken);
+            _context.BGChecks.Where(b => b.DataSource == deviceId || (b.DataSource == null && b.Device == deviceId)), cancellationToken);
         var notesDeleted = await _context.SoftDeleteAsync(
-            _context.Notes.Where(n => n.DataSource == deviceId), cancellationToken);
+            _context.Notes.Where(n => n.DataSource == deviceId || (n.DataSource == null && n.Device == deviceId)), cancellationToken);
         var deviceStatusDeleted = await _context.SoftDeleteAsync(
             _context.ApsSnapshots.Where(ds => ds.Device == deviceId), cancellationToken);
 
@@ -1076,13 +1076,13 @@ public class DataSourceService : IDataSourceService
             );
 
             // Delete V4 treatment records by data source
-            var treatmentsDeleted = await _context.Boluses.Where(b => b.DataSource == DataSources.DemoService).ExecuteDeleteAsync(cancellationToken);
-            treatmentsDeleted += await _context.CarbIntakes.Where(c => c.DataSource == DataSources.DemoService).ExecuteDeleteAsync(cancellationToken);
-            treatmentsDeleted += await _context.BGChecks.Where(b => b.DataSource == DataSources.DemoService).ExecuteDeleteAsync(cancellationToken);
-            treatmentsDeleted += await _context.Notes.Where(n => n.DataSource == DataSources.DemoService).ExecuteDeleteAsync(cancellationToken);
-            treatmentsDeleted += await _context.DeviceEvents.Where(de => de.DataSource == DataSources.DemoService).ExecuteDeleteAsync(cancellationToken);
-            treatmentsDeleted += await _context.BolusCalculations.Where(bc => bc.DataSource == DataSources.DemoService).ExecuteDeleteAsync(cancellationToken);
-            treatmentsDeleted += await _context.TempBasals.Where(t => t.DataSource == DataSources.DemoService).ExecuteDeleteAsync(cancellationToken);
+            var treatmentsDeleted = await _context.Boluses.Where(b => b.DataSource == DataSources.DemoService || (b.DataSource == null && b.Device == DataSources.DemoService)).ExecuteDeleteAsync(cancellationToken);
+            treatmentsDeleted += await _context.CarbIntakes.Where(c => c.DataSource == DataSources.DemoService || (c.DataSource == null && c.Device == DataSources.DemoService)).ExecuteDeleteAsync(cancellationToken);
+            treatmentsDeleted += await _context.BGChecks.Where(b => b.DataSource == DataSources.DemoService || (b.DataSource == null && b.Device == DataSources.DemoService)).ExecuteDeleteAsync(cancellationToken);
+            treatmentsDeleted += await _context.Notes.Where(n => n.DataSource == DataSources.DemoService || (n.DataSource == null && n.Device == DataSources.DemoService)).ExecuteDeleteAsync(cancellationToken);
+            treatmentsDeleted += await _context.DeviceEvents.Where(de => de.DataSource == DataSources.DemoService || (de.DataSource == null && de.Device == DataSources.DemoService)).ExecuteDeleteAsync(cancellationToken);
+            treatmentsDeleted += await _context.BolusCalculations.Where(bc => bc.DataSource == DataSources.DemoService || (bc.DataSource == null && bc.Device == DataSources.DemoService)).ExecuteDeleteAsync(cancellationToken);
+            treatmentsDeleted += await _context.TempBasals.Where(t => t.DataSource == DataSources.DemoService || (t.DataSource == null && t.Device == DataSources.DemoService)).ExecuteDeleteAsync(cancellationToken);
             treatmentsDeleted += await _context.StateSpans.Where(s => s.Source == DataSources.DemoService).ExecuteDeleteAsync(cancellationToken);
 
             // Delete APS snapshots - demo data uses the demo-service device
@@ -1131,7 +1131,7 @@ public class DataSourceService : IDataSourceService
 
         // Query V4 sensor glucose stats
         var sgStats = await _context
-            .SensorGlucose.Where(sg => sg.DataSource == dataSource)
+            .SensorGlucose.Where(sg => sg.DataSource == dataSource || (sg.DataSource == null && sg.Device == dataSource))
             .GroupBy(_ => 1)
             .Select(g => new
             {
@@ -1157,56 +1157,56 @@ public class DataSourceService : IDataSourceService
 
         // Query V4 table counts for per-type breakdown
         var meterGlucoseTotal = await _context
-            .MeterGlucose.Where(mg => mg.DataSource == dataSource)
+            .MeterGlucose.Where(mg => mg.DataSource == dataSource || (mg.DataSource == null && mg.Device == dataSource))
             .LongCountAsync(cancellationToken);
         var meterGlucose24h = meterGlucoseTotal > 0
             ? await _context.MeterGlucose
-                .Where(mg => mg.DataSource == dataSource && mg.Timestamp >= oneDayAgoDate)
+                .Where(mg => (mg.DataSource == dataSource || (mg.DataSource == null && mg.Device == dataSource)) && mg.Timestamp >= oneDayAgoDate)
                 .CountAsync(cancellationToken)
             : 0;
 
         var bolusesTotal = await _context
-            .Boluses.Where(b => b.DataSource == dataSource)
+            .Boluses.Where(b => b.DataSource == dataSource || (b.DataSource == null && b.Device == dataSource))
             .LongCountAsync(cancellationToken);
         var boluses24h = bolusesTotal > 0
             ? await _context.Boluses
-                .Where(b => b.DataSource == dataSource && b.Timestamp >= oneDayAgoDate)
+                .Where(b => (b.DataSource == dataSource || (b.DataSource == null && b.Device == dataSource)) && b.Timestamp >= oneDayAgoDate)
                 .CountAsync(cancellationToken)
             : 0;
 
         var carbIntakesTotal = await _context
-            .CarbIntakes.Where(c => c.DataSource == dataSource)
+            .CarbIntakes.Where(c => c.DataSource == dataSource || (c.DataSource == null && c.Device == dataSource))
             .LongCountAsync(cancellationToken);
         var carbIntakes24h = carbIntakesTotal > 0
             ? await _context.CarbIntakes
-                .Where(c => c.DataSource == dataSource && c.Timestamp >= oneDayAgoDate)
+                .Where(c => (c.DataSource == dataSource || (c.DataSource == null && c.Device == dataSource)) && c.Timestamp >= oneDayAgoDate)
                 .CountAsync(cancellationToken)
             : 0;
 
         var bolusCalcsTotal = await _context
-            .BolusCalculations.Where(bc => bc.DataSource == dataSource)
+            .BolusCalculations.Where(bc => bc.DataSource == dataSource || (bc.DataSource == null && bc.Device == dataSource))
             .LongCountAsync(cancellationToken);
         var bolusCalcs24h = bolusCalcsTotal > 0
             ? await _context.BolusCalculations
-                .Where(bc => bc.DataSource == dataSource && bc.Timestamp >= oneDayAgoDate)
+                .Where(bc => (bc.DataSource == dataSource || (bc.DataSource == null && bc.Device == dataSource)) && bc.Timestamp >= oneDayAgoDate)
                 .CountAsync(cancellationToken)
             : 0;
 
         var notesTotal = await _context
-            .Notes.Where(n => n.DataSource == dataSource)
+            .Notes.Where(n => n.DataSource == dataSource || (n.DataSource == null && n.Device == dataSource))
             .LongCountAsync(cancellationToken);
         var notes24h = notesTotal > 0
             ? await _context.Notes
-                .Where(n => n.DataSource == dataSource && n.Timestamp >= oneDayAgoDate)
+                .Where(n => (n.DataSource == dataSource || (n.DataSource == null && n.Device == dataSource)) && n.Timestamp >= oneDayAgoDate)
                 .CountAsync(cancellationToken)
             : 0;
 
         var deviceEventsTotal = await _context
-            .DeviceEvents.Where(de => de.DataSource == dataSource)
+            .DeviceEvents.Where(de => de.DataSource == dataSource || (de.DataSource == null && de.Device == dataSource))
             .LongCountAsync(cancellationToken);
         var deviceEvents24h = deviceEventsTotal > 0
             ? await _context.DeviceEvents
-                .Where(de => de.DataSource == dataSource && de.Timestamp >= oneDayAgoDate)
+                .Where(de => (de.DataSource == dataSource || (de.DataSource == null && de.Device == dataSource)) && de.Timestamp >= oneDayAgoDate)
                 .CountAsync(cancellationToken)
             : 0;
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CalibrationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CalibrationRepository.cs
@@ -70,7 +70,7 @@ public class CalibrationRepository : V4RepositoryBase<Calibration, CalibrationEn
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.Calibrations
-            .Where(e => e.DataSource == source)
+            .Where(e => e.DataSource == source || (e.DataSource == null && e.Device == source))
             .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/MeterGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/MeterGlucoseRepository.cs
@@ -71,7 +71,7 @@ public class MeterGlucoseRepository : V4RepositoryBase<MeterGlucose, MeterGlucos
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.MeterGlucose
-            .Where(e => e.DataSource == source)
+            .Where(e => e.DataSource == source || (e.DataSource == null && e.Device == source))
             .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -451,7 +451,7 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.SensorGlucose
             .AsNoTracking()
-            .Where(e => e.DataSource == source)
+            .Where(e => e.DataSource == source || (e.DataSource == null && e.Device == source))
             .CountAsync(ct);
     }
 
@@ -465,7 +465,8 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
-            ctx.SensorGlucose.Where(e => e.DataSource == source), AuditContext, ct);
+            ctx.SensorGlucose.Where(e => e.DataSource == source || (e.DataSource == null && e.Device == source)),
+            AuditContext, ct);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Problem

Uploaders like xDrip+ and Home Assistant Carelink write the source identifier into the `Device` column but leave `DataSource` null. The delete/count-by-source paths only matched `DataSource == source`, so „Delete All Data“ ran with an empty `DeletedCounts` — the dialog closed successfully but no rows were deleted.

## Fix

All delete/count predicates now treat a row as belonging to a source when:

- `DataSource == source` (definitive), OR
- `DataSource IS NULL AND Device == source` (uploader wrote the source into Device only)

The `DataSource IS NULL` guard keeps collisions safe: rows with an explicit, different `DataSource` are never matched via the free-text `Device` field.

## Changes

- **SensorGlucoseRepository**: `CountBySourceAsync` + `DeleteBySourceAsync` — safe predicate (DataSource OR DataSource-null AND Device)
- **MeterGlucoseRepository**: `DeleteBySourceAsync` — safe predicate
- **CalibrationRepository**: `DeleteBySourceAsync` — safe predicate
- **DataSourceService**: `DeleteAllSourceDataAsync`, `DeleteDemoDataAsync`, `GetConnectorDataSummaryAsync`, `GetDataSourceStatsAsync` — consistent safe predicates
- **DemoAdminController**: `DeleteEntries`, `DeleteTreatments`, `DeleteAllData` — safe predicates incl. HeartRates/StepCounts

## Impact

- „Delete All Data“ now actually deletes device-based uploads (audited soft-delete path is preserved)
- Counts shown in the UI match what delete will remove
- No watermark/connector-cursor methods (`GetLatestTimestampAsync` etc.) were touched — those remain DataSource-only to avoid false resume cursors

## Tests

Predicate-only change; existing unit tests around delete counts may need updating where they assumed only DataSource matching.