### PR TITLE
fix(connectors): gate Medtronic labeling on connector registration and show deviceId as subtitle

### DIFF
--- a/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
@@ -699,9 +699,10 @@ public class DataSourceService : IDataSourceService
             info.Description = "FreeStyle Libre CGM";
         }
         else if (
-            lowerDevice.Contains("medtronic")
-            || lowerDevice.Contains("minimed")
-            || lowerDevice.Contains("carelink")
+            (lowerDevice.Contains("medtronic")
+                || lowerDevice.Contains("minimed")
+                || lowerDevice.Contains("carelink"))
+            && ConnectorMetadataService.GetByDataSourceId(dataSource) != null
         )
         {
             info.Name = "Medtronic";

--- a/src/Web/packages/app/src/lib/components/settings/DataSourceRow.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/DataSourceRow.svelte
@@ -51,6 +51,7 @@
     badges?: Snippet;
     actions?: Snippet;
     onclick?: () => void;
+    subtitle?: string;
   }
 
   let {
@@ -69,6 +70,7 @@
     badges,
     actions,
     onclick,
+    subtitle,
   }: Props = $props();
 
   function getIconColors(s: DataSourceStatus): {
@@ -167,6 +169,9 @@
       <div class="min-w-0 flex-1">
         <div class="flex items-center gap-2 flex-wrap">
           <span class="font-medium">{name}</span>
+          {#if subtitle}
+            <span class="text-xs text-muted-foreground/80">— {subtitle}</span>
+          {/if}
 
           <!-- Status badge -->
           {#if syncProgress?.phase === "Syncing" || status === "syncing"}

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/+page.svelte
@@ -431,6 +431,7 @@
                 totalEntries={source.totalEntries}
                 entriesLast24h={source.entriesLast24h}
                 lastSeen={source.lastSeen}
+                subtitle={source.name !== source.deviceId ? source.deviceId : undefined}
                 onclick={() => openDataSourceDialog(source)}
               >
                 {#snippet badges()}


### PR DESCRIPTION
## Problem

Uploader apps and unregistered streams write free-text `Device` strings that often contain keywords like `medtronic`, `minimed`, or `carelink` (e.g. `Home Assistant Carelink`). `CreateDataSourceInfo` labeled any such device as **Medtronic**, even when it is not a registered Medtronic/CareLink connector source. On top of that, distinct sources that resolved to the same display name (e.g. a pump stream vs. its `/pump` device stream) were indistinguishable in the Active Data Sources list.

## Fix

- Medtronic detection in `CreateDataSourceInfo` is now gated on the source being a registered connector (`ConnectorMetadataService.GetByDataSourceId(dataSource) != null`). Free-text uploader devices are no longer mislabeled — they fall through to their proper type (xDrip, unknown, connector metadata, …).
- `DataSourceRow` gained an optional `subtitle`, and the Active Data Sources list renders the raw `deviceId` as subtitle whenever it differs from the display name, so otherwise-identical entries stay distinguishable.

## Changes

- **DataSourceService** (`CreateDataSourceInfo`): Medtronic category now requires the data source to be a registered connector
- **DataSourceRow.svelte**: new optional `subtitle` prop
- **settings/connectors/+page.svelte**: pass `deviceId` as subtitle when it differs from `name`

## Impact

- Non-Medtronic uploaders (e.g. `Home Assistant Carelink`, `MMT-1885/pump`) are no longer shown as Medtronic pumps
- Genuine Medtronic/CareLink connector sources are unaffected — their `DataSource` is a registered connector id, so the Medtronic branch still applies
- Sources that share a display name can now be told apart by their raw device id

## Tests

Display-only change on the backend; existing connector-categorization logic and tests are unaffected. The frontend change is a prop addition and one conditional in the connectors page.
