### PR TITLE
fix(models): guarantee srvModified/srvCreated on every broadcastable v3 doc

### DIFF
--- a/src/API/Nocturne.API/Controllers/V3/DeviceStatusController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/DeviceStatusController.cs
@@ -717,8 +717,8 @@ public class DeviceStatusController : BaseV3Controller<DeviceStatus>
             ["utcOffset"] = status.UtcOffset,
             // 24-hex ObjectId so AAPS's isObjectId() passes; resolved back via GetByIdAsync.
             ["identifier"] = MongoObjectId.Coerce(status.Id),
-            ["srvModified"] = status.Mills,
-            ["srvCreated"] = status.Mills,
+            ["srvModified"] = status.SrvModified,
+            ["srvCreated"] = status.SrvCreated,
         };
 
         // Only include optional complex fields if they have values (Nightscout omits nulls)

--- a/src/API/Nocturne.API/Services/Devices/DeviceStatusProjectionService.cs
+++ b/src/API/Nocturne.API/Services/Devices/DeviceStatusProjectionService.cs
@@ -526,6 +526,14 @@ public class DeviceStatusProjectionService
                 case "mmtune":
                     ds.MmTune = DeserializeValue<OpenApsMmTune>(value, logger);
                     break;
+                // Route to the typed properties: leaving these in ExtensionData would
+                // serialize the key twice (typed Mills fallback + stored extras value).
+                case "srvModified":
+                    ds.SrvModified = CoerceLong(value);
+                    break;
+                case "srvCreated":
+                    ds.SrvCreated = CoerceLong(value);
+                    break;
                 default:
                     // Unknown keys go into ExtensionData
                     var jsonBytes = JsonSerializer.SerializeToUtf8Bytes(value, JsonOptions);
@@ -709,6 +717,19 @@ public class DeviceStatusProjectionService
             return null;
         }
     }
+
+    private static long? CoerceLong(object value) =>
+        value switch
+        {
+            long l => l,
+            int i => i,
+            double d => (long)d,
+            string s when long.TryParse(s, out var parsed) => parsed,
+            JsonElement { ValueKind: JsonValueKind.Number } e when e.TryGetInt64(out var el) => el,
+            JsonElement { ValueKind: JsonValueKind.String } e
+                when long.TryParse(e.GetString(), out var es) => es,
+            _ => null,
+        };
 
     private static T? DeserializeValue<T>(object value, ILogger? logger = null) where T : class
     {

--- a/src/Core/Nocturne.Core.Models/DeviceStatus.cs
+++ b/src/Core/Nocturne.Core.Models/DeviceStatus.cs
@@ -48,6 +48,34 @@ public class DeviceStatus : ProcessableDocumentBase
         DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
 
     /// <summary>
+    /// Gets or sets the server-modified timestamp (Unix milliseconds). V3 compatibility field.
+    /// Falls back to Mills, matching the V3 REST projection: NS v3 socket clients (AAPS)
+    /// read it unconditionally from realtime storage events and drop docs without it.
+    /// </summary>
+    private long? _srvModified;
+
+    [JsonPropertyName("srvModified")]
+    [JsonConverter(typeof(FlexibleNullableLongConverter))]
+    public long? SrvModified
+    {
+        get => _srvModified ?? (Mills > 0 ? Mills : null);
+        set => _srvModified = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the server-created timestamp (Unix milliseconds). V3 compatibility field.
+    /// </summary>
+    private long? _srvCreated;
+
+    [JsonPropertyName("srvCreated")]
+    [JsonConverter(typeof(FlexibleNullableLongConverter))]
+    public long? SrvCreated
+    {
+        get => _srvCreated ?? (Mills > 0 ? Mills : null);
+        set => _srvCreated = value;
+    }
+
+    /// <summary>
     /// Gets or sets the UTC offset in minutes
     /// </summary>
     [JsonPropertyName("utcOffset")]

--- a/src/Core/Nocturne.Core.Models/Entry.cs
+++ b/src/Core/Nocturne.Core.Models/Entry.cs
@@ -403,15 +403,31 @@ public class Entry : ProcessableDocumentBase
 
     /// <summary>
     /// Gets or sets the server-modified timestamp (Unix milliseconds). V3 compatibility field.
+    /// Falls back to Mills so every serialized entry carries it: NS v3 socket clients (AAPS)
+    /// read it unconditionally from realtime storage events and drop docs without it.
     /// </summary>
+    private long? _srvModified;
+
     [JsonPropertyName("srvModified")]
-    public long? SrvModified { get; set; }
+    [JsonConverter(typeof(FlexibleNullableLongConverter))]
+    public long? SrvModified
+    {
+        get => _srvModified ?? (Mills > 0 ? Mills : null);
+        set => _srvModified = value;
+    }
 
     /// <summary>
     /// Gets or sets the server-created timestamp (Unix milliseconds). V3 compatibility field.
     /// </summary>
+    private long? _srvCreated;
+
     [JsonPropertyName("srvCreated")]
-    public long? SrvCreated { get; set; }
+    [JsonConverter(typeof(FlexibleNullableLongConverter))]
+    public long? SrvCreated
+    {
+        get => _srvCreated ?? (Mills > 0 ? Mills : null);
+        set => _srvCreated = value;
+    }
 
     /// <summary>
     /// Gets or sets the subject identifier. V3 compatibility field.

--- a/src/Core/Nocturne.Core.Models/Extensions/EntryResponseExtensions.cs
+++ b/src/Core/Nocturne.Core.Models/Extensions/EntryResponseExtensions.cs
@@ -237,11 +237,11 @@ public class EntryV3Response
 
     [JsonPropertyName("srvModified")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public long? SrvModified => _entry.SrvModified ?? (_entry.Mills > 0 ? _entry.Mills : null);
+    public long? SrvModified => _entry.SrvModified;
 
     [JsonPropertyName("srvCreated")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public long? SrvCreated => _entry.SrvCreated ?? (_entry.Mills > 0 ? _entry.Mills : null);
+    public long? SrvCreated => _entry.SrvCreated;
 
     [JsonPropertyName("subject")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/Core/Nocturne.Core.Models/Profile.cs
+++ b/src/Core/Nocturne.Core.Models/Profile.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json.Serialization;
 using Nocturne.Core.Models.Serializers;
 using Nocturne.Core.Models.Attributes;
@@ -40,6 +41,49 @@ public class Profile
     [JsonPropertyName("mills")]
     [JsonConverter(typeof(FlexibleLongConverter))]
     public long Mills { get; set; }
+
+    /// <summary>
+    /// Gets or sets the server-modified timestamp (Unix milliseconds). V3 compatibility field.
+    /// Falls back to Mills, then StartDate (profiles are often uploaded without mills):
+    /// NS v3 socket clients (AAPS) read it unconditionally from realtime storage events
+    /// and drop docs without it.
+    /// </summary>
+    private long? _srvModified;
+
+    [JsonPropertyName("srvModified")]
+    [JsonConverter(typeof(FlexibleNullableLongConverter))]
+    public long? SrvModified
+    {
+        get => _srvModified ?? FallbackTimestampMills();
+        set => _srvModified = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the server-created timestamp (Unix milliseconds). V3 compatibility field.
+    /// </summary>
+    private long? _srvCreated;
+
+    [JsonPropertyName("srvCreated")]
+    [JsonConverter(typeof(FlexibleNullableLongConverter))]
+    public long? SrvCreated
+    {
+        get => _srvCreated ?? FallbackTimestampMills();
+        set => _srvCreated = value;
+    }
+
+    private long? FallbackTimestampMills()
+    {
+        if (Mills > 0)
+            return Mills;
+        return DateTimeOffset.TryParse(
+            StartDate,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out var startDate
+        )
+            ? startDate.ToUnixTimeMilliseconds()
+            : null;
+    }
 
     /// <summary>
     /// Gets or sets when this profile was created

--- a/tests/Unit/Nocturne.API.Tests/Services/Devices/DeviceStatusProjectionServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Devices/DeviceStatusProjectionServiceTests.cs
@@ -334,6 +334,35 @@ public class DeviceStatusProjectionServiceTests
         result.ExtensionData.Should().ContainKey("configuration");
     }
 
+    [Fact]
+    public void ProjectAsync_WithSrvTimestampsInExtras_AssignsTypedPropertiesNotExtensionData()
+    {
+        // NS-migrated docs carry srvModified/srvCreated in extras. Splatting them into
+        // ExtensionData would serialize each key twice (typed Mills fallback + extras
+        // value); strict client parsers reject duplicate keys.
+        var aps = CreateApsSnapshot(AidAlgorithm.OpenAps);
+        aps.SuggestedJson = JsonSerializer.Serialize(new OpenApsSuggested { Bg = 120 }, JsonOptions);
+
+        var extras = new DeviceStatusExtras
+        {
+            Id = Guid.NewGuid(),
+            CorrelationId = aps.CorrelationId!.Value,
+            Timestamp = ReferenceTime,
+            Extras = new Dictionary<string, object?>
+            {
+                ["srvModified"] = JsonSerializer.SerializeToElement(1_722_945_600_000L, JsonOptions),
+                ["srvCreated"] = JsonSerializer.SerializeToElement(1_722_945_500_000L, JsonOptions),
+            },
+        };
+
+        var result = DeviceStatusProjectionService.ProjectFromSnapshots(aps, null, null, null, extras);
+
+        result.SrvModified.Should().Be(1_722_945_600_000L);
+        result.SrvCreated.Should().Be(1_722_945_500_000L);
+        result.ExtensionData.Should().NotContainKey("srvModified");
+        result.ExtensionData.Should().NotContainKey("srvCreated");
+    }
+
     #endregion
 
     #region Correlation

--- a/tests/Unit/Nocturne.Core.Models.Tests/V3SrvTimestampFallbackTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/V3SrvTimestampFallbackTests.cs
@@ -1,0 +1,85 @@
+using System.Text.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace Nocturne.Core.Models.Tests;
+
+/// <summary>
+/// AAPS's NS v3 socket handler reads <c>doc.srvModified</c> with <c>getLong</c> before
+/// dispatching on the collection, so a realtime storage event whose doc lacks a numeric
+/// <c>srvModified</c> throws and is dropped client-side (#638). Every model broadcast as a
+/// storage event must therefore serialize <c>srvModified</c>/<c>srvCreated</c>, falling
+/// back to Mills — the same event-time timeline the V3 REST layer projects, so a
+/// socket-derived high-water mark stays coherent with REST catch-up loads.
+/// </summary>
+[Trait("Category", "Unit")]
+public class V3SrvTimestampFallbackTests
+{
+    private const long Mills = 1_722_945_600_000;
+
+    public static TheoryData<string, object> BroadcastDocsWithMills =>
+        new()
+        {
+            { "entries", new Entry { Mills = Mills } },
+            { "treatments", new Treatment { Mills = Mills } },
+            { "devicestatus", new DeviceStatus { Mills = Mills } },
+            { "profile", new Profile { Mills = Mills } },
+        };
+
+    [Theory]
+    [MemberData(nameof(BroadcastDocsWithMills))]
+    public void BroadcastDoc_WithMills_SerializesSrvTimestampsAsMills(
+        string collection,
+        object doc
+    )
+    {
+        var root = JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(doc));
+
+        root.GetProperty("srvModified")
+            .GetInt64()
+            .Should()
+            .Be(Mills, $"AAPS drops {collection} docs without a numeric srvModified");
+        root.GetProperty("srvCreated").GetInt64().Should().Be(Mills);
+    }
+
+    [Fact]
+    public void ExplicitSrvTimestamps_WinOverTheMillsFallback()
+    {
+        var entry = new Entry
+        {
+            Mills = Mills,
+            SrvModified = Mills + 5_000,
+            SrvCreated = Mills + 1_000,
+        };
+
+        entry.SrvModified.Should().Be(Mills + 5_000);
+        entry.SrvCreated.Should().Be(Mills + 1_000);
+    }
+
+    [Fact]
+    public void Entry_WithoutMills_DoesNotFabricateSrvTimestamps()
+    {
+        var entry = new Entry { Mills = 0 };
+
+        entry.SrvModified.Should().BeNull();
+        entry.SrvCreated.Should().BeNull();
+    }
+
+    [Fact]
+    public void Profile_WithoutMills_FallsBackToStartDate()
+    {
+        var profile = new Profile { Mills = 0, StartDate = "2026-08-06T12:00:00.000Z" };
+        var expected = DateTimeOffset.Parse("2026-08-06T12:00:00.000Z").ToUnixTimeMilliseconds();
+
+        profile.SrvModified.Should().Be(expected);
+        profile.SrvCreated.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Profile_WithUnparseableStartDate_DoesNotFabricateSrvTimestamps()
+    {
+        var profile = new Profile { Mills = 0, StartDate = "not-a-date" };
+
+        profile.SrvModified.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Problem

Discovered while reviewing #639 against AAPS's actual `NSClientV3Service`: the NS v3 `/storage` socket handler reads `doc.srvModified` with `getLong()` on **every** create/update event *before* dispatching on the collection, and `getLong` throws on a missing/null key — the doc is silently dropped client-side.

Of the four collections the API broadcasts as storage events, only `Treatment` guaranteed the field (its `SrvModified` getter falls back to `Mills`). The raw `Entry` broadcast never has it (no write path assigns `Entry.SrvModified`; the Mills fallback lived only on the V3 REST response wrapper), and `DeviceStatus`/`Profile` lacked the property entirely. So even with #639's namespaces in place, AAPS would receive realtime events for entries, devicestatus, and profile and drop every one of them — treatments alone would survive.

## What this does

- **Entry** — `srvModified`/`srvCreated` fall back to `Mills`, mirroring `Treatment`'s existing pattern. `EntryV3Response` now delegates instead of duplicating the fallback.
- **DeviceStatus** — adds both fields with the same Mills fallback its own V3 REST projection already emitted (`ToV3Dto` used `status.Mills`); the dict now delegates to the properties (which also lets a client-supplied value through instead of always overwriting it).
- **Profile** — adds both fields with a `Mills` → `StartDate` fallback, since profiles are commonly uploaded without `mills`.
- **`DeviceStatusProjectionService.SplatExtras`** — routes `srvModified`/`srvCreated` extras (present on NS-migrated docs) to the typed properties. Leaving them in `ExtensionData` would serialize each key **twice** with different values on v1 reads; strict parsers reject duplicate keys. This also restores the originally stored value for migrated rows instead of the Mills fallback.
- **`FlexibleNullableLongConverter`** on the new nullable properties, so a string-typed `srvModified` in an upload keeps deserializing (DeviceStatus previously swallowed it into `ExtensionData`; Profile ignored it).

## Why Mills, not broadcast wall-clock

AAPS uses the socket `srvModified` as its per-collection high-water mark for REST catch-up (`modifiedSince`), and the V3 REST history layer compares on the Mills/created_at (event-time) timeline. Stamping broadcast time would push the HWM ahead of the REST timeline and make clients **skip backfilled records**. Mills keeps the socket and REST timelines coherent — and it's what treatments (proven working with AAPS) and the devicestatus/entries REST projections already do.

## Scope notes

- `foods` and `settings` cannot reach `/storage` today — neither has a realtime category (`RealtimeCategories`), so nothing can subscribe to their broadcasts. Whoever wires them up later must also give those docs a numeric `srvModified`; note `Settings` currently carries a `DateTimeOffset` one that would serialize as an ISO string and fail the same `getLong`.
- Migration fidelity: an uploaded doc's client-supplied `srvModified` now binds to the typed property at ingest and is not persisted (no mapper stores it for these models), so reads project the Mills fallback — same as the V3 REST layer always did. Pre-existing migrated rows keep their stored value via the `SplatExtras` change.

## Tests

- `V3SrvTimestampFallbackTests` — serialization-level contract for all four broadcast collections (numeric `srvModified`/`srvCreated` present when Mills is set), explicit-value precedence, the no-fabrication edge (`Mills == 0` → null, not 0), and the Profile StartDate fallback incl. unparseable input.
- `DeviceStatusProjectionServiceTests` — migrated `srvModified` extras land on the typed properties, not `ExtensionData` (pins the duplicate-key regression).
- Full solution builds; Core.Models (535), API (4809), Infrastructure.Data (494) suites green.

Refs #638. Complements #639 (the bridge namespaces are necessary but not sufficient — without this, entries/devicestatus/profile events die in the AAPS handler).

https://claude.ai/code/session_011fV3JnGNSrEZrxBE81mi2T
