### PR TITLE
refactor(config): derive the public origin from BASE_DOMAIN everywhere

### DIFF
--- a/deploy/helm/nocturne/Chart.yaml
+++ b/deploy/helm/nocturne/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nocturne
 description: Nocturne — modern Nightscout for diabetes data, on Kubernetes.
 type: application
-version: 0.1.0-alpha.9
+version: 0.1.0-alpha.10
 appVersion: "latest"
 kubeVersion: ">=1.27.0-0"
 home: https://github.com/nightscout/nocturne

--- a/deploy/helm/nocturne/README.md
+++ b/deploy/helm/nocturne/README.md
@@ -79,7 +79,7 @@ kubectl create secret generic nocturne-db-web \
 
 # 2. Write a values file.
 cat > my-values.yaml <<EOF
-baseUrl: https://nocturne.example.com
+baseDomain: nocturne.example.com
 
 instanceKey:
   existingSecret: nocturne-instance-key
@@ -157,7 +157,7 @@ The full set of configurable values is in [`values.yaml`](./values.yaml). Highli
 
 | Key | Description |
 |---|---|
-| `baseUrl` | Public URL the deployment is reachable at. Used by the API for OIDC redirects, invite links, etc. |
+| `baseDomain` | Public base domain the deployment is reachable at (bare host, no scheme; HTTPS is assumed at the edge). Drives tenant subdomains, the WebAuthn RP ID, OIDC redirects, and invite links. |
 | `instanceKey.existingSecret` | Secret containing the shared HMAC key. **Required.** |
 | `externalDatabase.host` / `.port` / `.database` / `.sslMode` | Postgres connection details. |
 | `externalDatabase.{app,migrator,web}Secret.existingSecret` | Secret with each role's password under key `password` (override with `existingSecretKey`). |

--- a/deploy/helm/nocturne/ci/bundled-postgres-values.yaml
+++ b/deploy/helm/nocturne/ci/bundled-postgres-values.yaml
@@ -2,7 +2,7 @@
 # Postgres, the chart auto-generates the three Nocturne role passwords,
 # and a post-install Job runs bootstrap-roles.sql against it.
 
-baseUrl: https://nocturne.example.com
+baseDomain: nocturne.example.com
 
 instanceKey:
   existingSecret: nocturne-instance-key

--- a/deploy/helm/nocturne/ci/example-values.yaml
+++ b/deploy/helm/nocturne/ci/example-values.yaml
@@ -1,7 +1,7 @@
 # Example values for `helm template` smoke testing.
 # Not used at install time.
 
-baseUrl: https://nocturne.example.com
+baseDomain: nocturne.example.com
 
 instanceKey:
   existingSecret: nocturne-instance-key

--- a/deploy/helm/nocturne/ci/ha-values.yaml
+++ b/deploy/helm/nocturne/ci/ha-values.yaml
@@ -1,6 +1,6 @@
 # HA-style configuration with autoscaling and PDBs.
 
-baseUrl: https://nocturne.example.com
+baseDomain: nocturne.example.com
 
 instanceKey:
   existingSecret: nocturne-instance-key

--- a/deploy/helm/nocturne/ci/managed-postgres-values.yaml
+++ b/deploy/helm/nocturne/ci/managed-postgres-values.yaml
@@ -1,7 +1,7 @@
 # Managed Postgres (RDS / Cloud SQL / Neon) — bootstrap Job disabled.
 # User runs bootstrap-roles.sql out of band.
 
-baseUrl: https://nocturne.example.com
+baseDomain: nocturne.example.com
 
 instanceKey:
   existingSecret: nocturne-instance-key

--- a/deploy/helm/nocturne/ci/observability-values.yaml
+++ b/deploy/helm/nocturne/ci/observability-values.yaml
@@ -1,6 +1,6 @@
 # OTLP-enabled configuration. Pointed at an in-cluster otel-collector.
 
-baseUrl: https://nocturne.example.com
+baseDomain: nocturne.example.com
 
 instanceKey:
   existingSecret: nocturne-instance-key

--- a/deploy/helm/nocturne/templates/api-deployment.yaml
+++ b/deploy/helm/nocturne/templates/api-deployment.yaml
@@ -1,3 +1,6 @@
+{{- if .Values.baseUrl }}
+{{- fail "baseUrl has been replaced by baseDomain: set a bare host (e.g. nocturne.example.com, no scheme). The public origin is derived as https://{baseDomain}." }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -86,9 +89,9 @@ spec:
               value: {{ .Values.api.containerPort | quote }}
             - name: ASPNETCORE_URLS
               value: "http://+:{{ .Values.api.containerPort }}"
-            {{- if .Values.baseUrl }}
-            - name: BaseUrl
-              value: {{ .Values.baseUrl | quote }}
+            {{- if .Values.baseDomain }}
+            - name: BASE_DOMAIN
+              value: {{ .Values.baseDomain | quote }}
             {{- end }}
             - name: INSTANCE_KEY
               valueFrom:

--- a/deploy/helm/nocturne/templates/web-deployment.yaml
+++ b/deploy/helm/nocturne/templates/web-deployment.yaml
@@ -45,9 +45,9 @@ spec:
               value: {{ .Values.web.containerPort | quote }}
             - name: NOCTURNE_API_URL
               value: {{ include "nocturne.api.internalUrl" . | quote }}
-            {{- if .Values.baseUrl }}
+            {{- if .Values.baseDomain }}
             - name: BASE_DOMAIN
-              value: {{ .Values.baseUrl | quote }}
+              value: {{ .Values.baseDomain | quote }}
             {{- end }}
             - name: INSTANCE_KEY
               valueFrom:

--- a/deploy/helm/nocturne/values.yaml
+++ b/deploy/helm/nocturne/values.yaml
@@ -66,11 +66,11 @@ web:
     minAvailable: 1
     maxUnavailable: 0
 
-# Public base URL the deployment is reachable at (e.g. https://nocturne.example.com).
-# Used by the API for OIDC redirects, invite links, and the BaseUrl config key.
-# Also used as the web container's NOCTURNE_API_URL when ingress.enabled=true and
-# api.externalUrl is empty.
-baseUrl: ""
+# Public base domain the deployment is reachable at, as a bare host without a
+# scheme (e.g. nocturne.example.com). HTTPS is assumed at the edge — WebAuthn
+# (passkeys) requires it. The API derives everything from this: tenant subdomain
+# resolution, the WebAuthn RP ID, OIDC redirect URIs, and invite links.
+baseDomain: ""
 
 # Shared instance key (HMAC for JWT signing, shared between API and Web).
 # Provide either an existing Secret OR a literal value (NOT both).
@@ -126,7 +126,7 @@ ingress:
   enabled: false
   className: ""
   annotations: {}
-  host: ""                      # required when enabled=true; defaults to baseUrl host
+  host: ""                      # required when enabled=true; typically equals baseDomain
   # By default, only the web service is exposed at the host. The API is reached
   # internally via cluster DNS. Set api.externalPath to expose API at /api etc.
   api:

--- a/src/API/Nocturne.API/Controllers/Authentication/OidcController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/OidcController.cs
@@ -660,21 +660,23 @@ public class OidcController : ControllerBase
     /// </summary>
     private bool IsValidReturnUrl(string returnUrl)
     {
-        if (Uri.TryCreate(returnUrl, UriKind.Relative, out _))
+        // Site-local path: starts with "/" but not "//" or "/\", which browsers
+        // resolve as scheme-relative — "Location: //evil.com" leaves the site.
+        if (returnUrl.StartsWith('/'))
         {
-            return true;
+            return returnUrl.Length == 1 || (returnUrl[1] != '/' && returnUrl[1] != '\\');
         }
 
+        // Absolute URL: parse and compare scheme + authority against the public
+        // origin, so neither "https://example.com.evil.com" (prefix) nor
+        // "https://example.com@evil.com" (userinfo) can pass a string match.
         var origin = _baseDomain.PublicOrigin;
-        if (!string.IsNullOrEmpty(origin))
-        {
-            // Match on the origin boundary: "https://example.com/..." but not
-            // "https://example.com.evil.com".
-            return returnUrl.Equals(origin, StringComparison.OrdinalIgnoreCase)
-                || returnUrl.StartsWith(origin + "/", StringComparison.OrdinalIgnoreCase);
-        }
-
-        return false;
+        return !string.IsNullOrEmpty(origin)
+            && Uri.TryCreate(returnUrl, UriKind.Absolute, out var target)
+            && Uri.TryCreate(origin, UriKind.Absolute, out var expected)
+            && target.Scheme == expected.Scheme
+            && string.Equals(target.Authority, expected.Authority, StringComparison.OrdinalIgnoreCase)
+            && string.IsNullOrEmpty(target.UserInfo);
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Controllers/Authentication/OidcController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/OidcController.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Options;
 using OpenApi.Remote.Attributes;
 using Nocturne.API.Authorization;
 using Nocturne.API.Extensions;
+using Nocturne.API.Multitenancy;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Contracts.Multitenancy;
@@ -43,7 +44,7 @@ public class OidcController : ControllerBase
     private readonly IAuthAuditService _auditService;
     private readonly ITenantMemberService _tenantMemberService;
     private readonly OidcOptions _options;
-    private readonly IConfiguration _configuration;
+    private readonly BaseDomainOptions _baseDomain;
     private readonly ILogger<OidcController> _logger;
 
     /// <summary>
@@ -56,7 +57,7 @@ public class OidcController : ControllerBase
         IAuthAuditService auditService,
         ITenantMemberService tenantMemberService,
         IOptions<OidcOptions> options,
-        IConfiguration configuration,
+        IOptions<BaseDomainOptions> baseDomainOptions,
         ILogger<OidcController> logger
     )
     {
@@ -66,7 +67,7 @@ public class OidcController : ControllerBase
         _auditService = auditService;
         _tenantMemberService = tenantMemberService;
         _options = options.Value;
-        _configuration = configuration;
+        _baseDomain = baseDomainOptions.Value;
         _logger = logger;
     }
 
@@ -664,10 +665,13 @@ public class OidcController : ControllerBase
             return true;
         }
 
-        var baseUrl = _configuration[ServiceNames.ConfigKeys.BaseUrl];
-        if (!string.IsNullOrEmpty(baseUrl))
+        var origin = _baseDomain.PublicOrigin;
+        if (!string.IsNullOrEmpty(origin))
         {
-            return returnUrl.StartsWith(baseUrl, StringComparison.OrdinalIgnoreCase);
+            // Match on the origin boundary: "https://example.com/..." but not
+            // "https://example.com.evil.com".
+            return returnUrl.Equals(origin, StringComparison.OrdinalIgnoreCase)
+                || returnUrl.StartsWith(origin + "/", StringComparison.OrdinalIgnoreCase);
         }
 
         return false;

--- a/src/API/Nocturne.API/Controllers/V4/Platform/ServicesController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/ServicesController.cs
@@ -30,7 +30,6 @@ public class ServicesController : ControllerBase
     private readonly IConnectorHealthService _connectorHealthService;
     private readonly IConnectorSyncService _connectorSyncService;
     private readonly ILogger<ServicesController> _logger;
-    private readonly IConfiguration _configuration;
     private readonly ITenantAccessor _tenantAccessor;
     private readonly BaseDomainOptions _baseDomain;
 
@@ -41,7 +40,6 @@ public class ServicesController : ControllerBase
     /// <param name="connectorHealthService">Service for connector health state queries.</param>
     /// <param name="connectorSyncService">Service for triggering on-demand connector syncs.</param>
     /// <param name="logger">Logger instance.</param>
-    /// <param name="configuration">Application configuration for base URL resolution.</param>
     /// <param name="tenantAccessor">Resolved tenant context, used to build the tenant's subdomain base URL.</param>
     /// <param name="baseDomain">Platform base-domain options used to construct the tenant subdomain.</param>
     public ServicesController(
@@ -49,7 +47,6 @@ public class ServicesController : ControllerBase
         IConnectorHealthService connectorHealthService,
         IConnectorSyncService connectorSyncService,
         ILogger<ServicesController> logger,
-        IConfiguration configuration,
         ITenantAccessor tenantAccessor,
         IOptions<BaseDomainOptions> baseDomain
     )
@@ -58,7 +55,6 @@ public class ServicesController : ControllerBase
         _connectorHealthService = connectorHealthService;
         _connectorSyncService = connectorSyncService;
         _logger = logger;
-        _configuration = configuration;
         _tenantAccessor = tenantAccessor;
         _baseDomain = baseDomain.Value;
     }
@@ -627,7 +623,7 @@ public class ServicesController : ControllerBase
     {
         // Prefer the tenant's own subdomain ({slug}.{base-domain}). This is the URL
         // external uploaders (xDrip+, Loop, AAPS) must target, and it differs per
-        // tenant — unlike the configured BaseUrl (apex) or the internal request host
+        // tenant — unlike the apex origin or the internal request host
         // seen when the web app calls this endpoint server-side.
         var slug = _tenantAccessor.Context?.Slug;
         var baseDomain = _baseDomain.BaseDomain;
@@ -636,11 +632,10 @@ public class ServicesController : ControllerBase
             return $"https://{slug}.{baseDomain.TrimEnd('/')}";
         }
 
-        // Self-host / single-instance fallback: configured base URL, then request host.
-        var configuredUrl = _configuration["BaseUrl"];
-        if (!string.IsNullOrEmpty(configuredUrl))
+        // Self-host / single-instance fallback: apex origin, then request host.
+        if (!string.IsNullOrEmpty(_baseDomain.PublicOrigin))
         {
-            return configuredUrl.TrimEnd('/');
+            return _baseDomain.PublicOrigin;
         }
 
         var request = HttpContext.Request;

--- a/src/API/Nocturne.API/Controllers/WellKnownController.cs
+++ b/src/API/Nocturne.API/Controllers/WellKnownController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Multitenancy;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.Configuration;
 using Nocturne.Core.Constants;
@@ -32,18 +33,18 @@ namespace Nocturne.API.Controllers;
 public class WellKnownController : ControllerBase
 {
     private readonly JwtOptions _jwtOptions;
-    private readonly IConfiguration _configuration;
+    private readonly BaseDomainOptions _baseDomain;
 
     /// <summary>
     /// Creates a new instance of WellKnownController
     /// </summary>
     public WellKnownController(
         IOptions<JwtOptions> jwtOptions,
-        IConfiguration configuration
+        IOptions<BaseDomainOptions> baseDomainOptions
     )
     {
         _jwtOptions = jwtOptions.Value;
-        _configuration = configuration;
+        _baseDomain = baseDomainOptions.Value;
     }
 
     /// <summary>
@@ -169,13 +170,7 @@ public class WellKnownController : ControllerBase
 
     private string GetBaseUrl()
     {
-        var configuredUrl = _configuration[ServiceNames.ConfigKeys.BaseUrl];
-        if (!string.IsNullOrEmpty(configuredUrl))
-        {
-            return configuredUrl.TrimEnd('/');
-        }
-
-        return $"{Request.Scheme}://{Request.Host}";
+        return _baseDomain.PublicOrigin ?? $"{Request.Scheme}://{Request.Host}";
     }
 }
 

--- a/src/API/Nocturne.API/Multitenancy/MultitenancyConfiguration.cs
+++ b/src/API/Nocturne.API/Multitenancy/MultitenancyConfiguration.cs
@@ -3,7 +3,7 @@ namespace Nocturne.API.Multitenancy;
 /// <summary>
 /// Platform-wide base domain configuration.
 /// Used for subdomain tenant resolution, WebAuthn RP ID derivation, and URL construction.
-/// Bound from the flat "BaseDomain" configuration key (env var: BaseDomain).
+/// Bound from the flat "BASE_DOMAIN" configuration key (env var: BASE_DOMAIN).
 /// </summary>
 public class BaseDomainOptions
 {

--- a/src/API/Nocturne.API/Multitenancy/MultitenancyConfiguration.cs
+++ b/src/API/Nocturne.API/Multitenancy/MultitenancyConfiguration.cs
@@ -14,4 +14,14 @@ public class BaseDomainOptions
     /// Requests to rhys.nocturnecgm.com resolve tenant "rhys".
     /// </summary>
     public string BaseDomain { get; set; } = "";
+
+    /// <summary>
+    /// Public origin of the deployment apex: "https://{BaseDomain}", or null when
+    /// no base domain is configured. The platform serves HTTPS at the edge
+    /// (WebAuthn already requires it), so the scheme is not configurable.
+    /// Used for OIDC redirect URIs, invite links, Pushover callbacks, and other
+    /// externally visible URLs.
+    /// </summary>
+    public string? PublicOrigin =>
+        string.IsNullOrEmpty(BaseDomain) ? null : $"https://{BaseDomain}";
 }

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -70,17 +70,6 @@ builder.Configuration.AddJsonFile(
 // Ensure environment variables (injected by Aspire) take precedence over appsettings.json
 builder.Configuration.AddEnvironmentVariables();
 
-if (string.IsNullOrEmpty(builder.Configuration["NocturneApiUrl"]))
-{
-    var baseUrl = builder.Configuration["BaseUrl"];
-    if (!string.IsNullOrEmpty(baseUrl))
-    {
-        builder.Configuration.AddInMemoryCollection(
-            new Dictionary<string, string?> { ["NocturneApiUrl"] = baseUrl }
-        );
-    }
-}
-
 // Configure Kestrel to allow larger request bodies for analytics endpoints
 // 90 days of demo data can exceed the 30MB default limit
 builder.WebHost.ConfigureKestrel(options =>

--- a/src/API/Nocturne.API/Services/Alerts/Providers/ChatBotProvider.cs
+++ b/src/API/Nocturne.API/Services/Alerts/Providers/ChatBotProvider.cs
@@ -17,7 +17,7 @@ namespace Nocturne.API.Services.Alerts.Providers;
 /// The bot endpoint is derived from <c>WEB_URL</c>, which names the web app's
 /// deployment-internal address (the AppHost wires it from the web resource's
 /// endpoint; the Compose bundles set <c>http://nocturne-web:&lt;port&gt;</c>).
-/// The deployment's public base URL (<see cref="ServiceNames.ConfigKeys.BaseUrl"/>)
+/// The deployment's public origin (derived from <c>BASE_DOMAIN</c>)
 /// is deliberately not used as a fallback. It is a hairpin: an intra-cluster call
 /// between two containers on the same network would leave the deployment, traverse
 /// the CDN and the edge proxy, and come back in — carrying the instance-key service

--- a/src/API/Nocturne.API/Services/Auth/OidcAuthService.cs
+++ b/src/API/Nocturne.API/Services/Auth/OidcAuthService.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Options;
 using Nocturne.API.Helpers;
+using Nocturne.API.Multitenancy;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Configuration;
@@ -33,7 +34,7 @@ public class OidcAuthService : IOidcAuthService
     private readonly IMemberInviteService _memberInviteService;
     private readonly IDataProtector _stateProtector;
     private readonly OidcOptions _options;
-    private readonly IConfiguration _configuration;
+    private readonly BaseDomainOptions _baseDomain;
     private readonly ILogger<OidcAuthService> _logger;
 
     /// <summary>
@@ -49,7 +50,7 @@ public class OidcAuthService : IOidcAuthService
     /// <param name="memberInviteService">Service for accepting an invite named by the login's return URL.</param>
     /// <param name="dataProtectionProvider">Provider for the protector that authenticates the state parameter.</param>
     /// <param name="options">OIDC session and state configuration options.</param>
-    /// <param name="configuration">Application configuration for reading the base URL.</param>
+    /// <param name="baseDomainOptions">Base domain configuration for building the public redirect URIs.</param>
     /// <param name="logger">Logger instance.</param>
     public OidcAuthService(
         IOidcProviderService providerService,
@@ -62,7 +63,7 @@ public class OidcAuthService : IOidcAuthService
         IMemberInviteService memberInviteService,
         IDataProtectionProvider dataProtectionProvider,
         IOptions<OidcOptions> options,
-        IConfiguration configuration,
+        IOptions<BaseDomainOptions> baseDomainOptions,
         ILogger<OidcAuthService> logger
     )
     {
@@ -76,7 +77,7 @@ public class OidcAuthService : IOidcAuthService
         _memberInviteService = memberInviteService;
         _stateProtector = dataProtectionProvider.CreateProtector("Nocturne.Oidc.State");
         _options = options.Value;
-        _configuration = configuration;
+        _baseDomain = baseDomainOptions.Value;
         _logger = logger;
     }
 
@@ -571,7 +572,7 @@ public class OidcAuthService : IOidcAuthService
                     var logoutUrl = new UriBuilder(discoveryDoc.EndSessionEndpoint);
                     var query = System.Web.HttpUtility.ParseQueryString(string.Empty);
                     query["client_id"] = provider.ClientId;
-                    query["post_logout_redirect_uri"] = _configuration[ServiceNames.ConfigKeys.BaseUrl] ?? "";
+                    query["post_logout_redirect_uri"] = _baseDomain.PublicOrigin ?? "";
                     logoutUrl.Query = query.ToString();
                     providerLogoutUrl = logoutUrl.ToString();
                 }
@@ -813,14 +814,19 @@ public class OidcAuthService : IOidcAuthService
     private const string SetupCallbackPath = "/api/v4/setup/oidc/callback";
 
     /// <summary>
-    /// Builds the absolute redirect URI by combining the configured base URL with the specified callback path.
+    /// Builds the absolute redirect URI by combining the deployment's public origin
+    /// (derived from <c>BASE_DOMAIN</c>) with the specified callback path.
     /// </summary>
     /// <param name="callbackPath">The server-relative callback path (default: <see cref="LoginCallbackPath"/>).</param>
     /// <returns>The fully qualified redirect URI.</returns>
     private string GetRedirectUri(string callbackPath = LoginCallbackPath)
     {
-        var baseUrl = _configuration[ServiceNames.ConfigKeys.BaseUrl]?.TrimEnd('/') ?? "http://localhost:5000";
-        return $"{baseUrl}{callbackPath}";
+        var origin =
+            _baseDomain.PublicOrigin
+            ?? throw new InvalidOperationException(
+                $"Cannot build an OIDC redirect URI: {BaseDomainOptions.ConfigKey} is not configured"
+            );
+        return $"{origin}{callbackPath}";
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Services/Identity/MemberInviteService.cs
+++ b/src/API/Nocturne.API/Services/Identity/MemberInviteService.cs
@@ -1,4 +1,6 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Nocturne.API.Multitenancy;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Authorization;
@@ -21,7 +23,7 @@ public class MemberInviteService : IMemberInviteService
     private readonly IJwtService _jwtService;
     private readonly ITenantService _tenantService;
     private readonly ITenantRoleService _tenantRoleService;
-    private readonly IConfiguration _configuration;
+    private readonly BaseDomainOptions _baseDomain;
     private readonly ILogger<MemberInviteService> _logger;
 
     public MemberInviteService(
@@ -29,14 +31,14 @@ public class MemberInviteService : IMemberInviteService
         IJwtService jwtService,
         ITenantService tenantService,
         ITenantRoleService tenantRoleService,
-        IConfiguration configuration,
+        IOptions<BaseDomainOptions> baseDomainOptions,
         ILogger<MemberInviteService> logger)
     {
         _dbContext = dbContext;
         _jwtService = jwtService;
         _tenantService = tenantService;
         _tenantRoleService = tenantRoleService;
-        _configuration = configuration;
+        _baseDomain = baseDomainOptions.Value;
         _logger = logger;
     }
 
@@ -101,7 +103,7 @@ public class MemberInviteService : IMemberInviteService
         // The join page is served per tenant, so the invite has to point at the tenant's own host.
         // The configured base URL is the instance apex, which in a multi-tenant deployment serves a
         // different site entirely — only the caller knows the host the invite was minted on.
-        var origin = (baseUrl ?? _configuration[ServiceNames.ConfigKeys.BaseUrl])?.TrimEnd('/') ?? "";
+        var origin = (baseUrl ?? _baseDomain.PublicOrigin)?.TrimEnd('/') ?? "";
         var inviteUrl =
             $"{origin}{IMemberInviteService.JoinPath}?{IMemberInviteService.TokenQueryParameter}={token}";
 

--- a/src/API/Nocturne.API/Services/Notifications/PushoverService.cs
+++ b/src/API/Nocturne.API/Services/Notifications/PushoverService.cs
@@ -1,5 +1,7 @@
 using System.Text;
 using System.Text.Json;
+using Microsoft.Extensions.Options;
+using Nocturne.API.Multitenancy;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Notifications;
 using Nocturne.Core.Models;
@@ -18,6 +20,7 @@ public class PushoverService : IPushoverService
     private readonly ILogger<PushoverService> _logger;
     private readonly INotificationV1Service _notificationService;
     private readonly IConfiguration _configuration;
+    private readonly BaseDomainOptions _baseDomain;
 
     private const string PUSHOVER_API_URL = "https://api.pushover.net/1/messages.json";
 
@@ -25,13 +28,15 @@ public class PushoverService : IPushoverService
         HttpClient httpClient,
         ILogger<PushoverService> logger,
         INotificationV1Service notificationService,
-        IConfiguration configuration
+        IConfiguration configuration,
+        IOptions<BaseDomainOptions> baseDomainOptions
     )
     {
         _httpClient = httpClient;
         _logger = logger;
         _notificationService = notificationService;
         _configuration = configuration;
+        _baseDomain = baseDomainOptions.Value;
     }
 
     /// <summary>
@@ -82,13 +87,12 @@ public class PushoverService : IPushoverService
                 };
             }
 
-            // Build callback URL for receipt acknowledgment if priority is 2 (emergency)
+            // Build callback URL for receipt acknowledgment if priority is 2 (emergency).
+            // Requires a public origin — Pushover's servers must be able to reach it.
             string? callbackUrl = null;
-            if (request.Priority == 2)
+            if (request.Priority == 2 && _baseDomain.PublicOrigin is { } origin)
             {
-                var baseUrl =
-                    _configuration[ServiceNames.ConfigKeys.BaseUrl] ?? "http://localhost:5000";
-                callbackUrl = $"{baseUrl}/api/v1/notifications/pushovercallback";
+                callbackUrl = $"{origin}/api/v1/notifications/pushovercallback";
             }
 
             // Build form data for Pushover API

--- a/src/Core/Nocturne.Core.Constants/ServiceNames.cs
+++ b/src/Core/Nocturne.Core.Constants/ServiceNames.cs
@@ -214,12 +214,6 @@ public static class ServiceNames
         public const string InstanceKey = "INSTANCE_KEY";
 
         /// <summary>
-        /// Public base URL of the deployment, used for OIDC redirects, invite links,
-        /// Pushover callbacks, and other external-facing URLs.
-        /// </summary>
-        public const string BaseUrl = "BaseUrl";
-
-        /// <summary>
         /// Site name reported by the legacy Nightscout <c>/status</c> endpoint.
         /// </summary>
         public const string NightscoutSiteName = "Nightscout:SiteName";

--- a/src/Core/Nocturne.Core.Models/Configuration/OidcOptions.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/OidcOptions.cs
@@ -11,12 +11,6 @@ public class OidcOptions
     public const string SectionName = "Oidc";
 
     /// <summary>
-    /// Base URL of this application (used for redirect URIs).
-    /// If not set, will be auto-detected from the request.
-    /// </summary>
-    public string? BaseUrl { get; set; }
-
-    /// <summary>
     /// Session configuration
     /// </summary>
     public SessionOptions Session { get; set; } = new();

--- a/tests/Unit/Nocturne.API.Tests/Controllers/OidcControllerLinkTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/OidcControllerLinkTests.cs
@@ -1,11 +1,11 @@
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Nocturne.API.Controllers.Authentication;
+using Nocturne.API.Multitenancy;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.Configuration;
@@ -38,8 +38,6 @@ public class OidcControllerLinkTests
                 Path = "/",
             },
         };
-        var configuration = new ConfigurationBuilder().Build();
-
         _controller = new OidcController(
             _authService.Object,
             _providerService.Object,
@@ -47,7 +45,7 @@ public class OidcControllerLinkTests
             _auditService.Object,
             _tenantMemberService.Object,
             Options.Create(_options),
-            configuration,
+            Options.Create(new BaseDomainOptions { BaseDomain = "nocturne.example.com" }),
             NullLogger<OidcController>.Instance);
 
         _controller.ControllerContext = new ControllerContext

--- a/tests/Unit/Nocturne.API.Tests/Controllers/OidcControllerReturnUrlTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/OidcControllerReturnUrlTests.cs
@@ -1,0 +1,125 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Nocturne.API.Controllers.Authentication;
+using Nocturne.API.Multitenancy;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Core.Models.Configuration;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers;
+
+/// <summary>
+/// Tests for the return-URL validation on the OIDC login endpoint. A return URL is a
+/// post-login redirect target supplied by the caller, so it must never leave the site:
+/// only site-local paths and absolute URLs on the deployment's public origin
+/// (scheme + authority, derived from <c>BASE_DOMAIN</c>) are accepted.
+/// </summary>
+public class OidcControllerReturnUrlTests
+{
+    private readonly Mock<IOidcAuthService> _authService = new();
+    private readonly OidcController _controller;
+
+    public OidcControllerReturnUrlTests()
+    {
+        _authService
+            .Setup(s => s.GenerateAuthorizationUrlAsync(
+                It.IsAny<Guid?>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(new OidcAuthorizationRequest
+            {
+                AuthorizationUrl = "https://idp.example/auth?x=1",
+                State = "state",
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
+                ProviderId = Guid.NewGuid(),
+            });
+
+        var options = new OidcOptions
+        {
+            Cookie = new CookieSettings
+            {
+                LinkStateCookieName = ".Nocturne.OidcLinkState",
+                AccessTokenName = ".Nocturne.AccessToken",
+                RefreshTokenName = ".Nocturne.RefreshToken",
+                StateCookieName = ".Nocturne.OidcState",
+                Secure = true,
+                Path = "/",
+            },
+        };
+
+        _controller = new OidcController(
+            _authService.Object,
+            new Mock<IOidcProviderService>().Object,
+            new Mock<ISubjectService>().Object,
+            new Mock<IAuthAuditService>().Object,
+            new Mock<ITenantMemberService>().Object,
+            Options.Create(options),
+            Options.Create(new BaseDomainOptions { BaseDomain = "cgm.example.com" }),
+            NullLogger<OidcController>.Instance)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            },
+        };
+    }
+
+    [Theory]
+    [InlineData("/")]
+    [InlineData("/settings/account")]
+    [InlineData("/join?token=abc")]
+    [InlineData("https://cgm.example.com")]
+    [InlineData("https://cgm.example.com/reports")]
+    [InlineData("https://cgm.example.com?welcome=1")]
+    [InlineData("HTTPS://CGM.EXAMPLE.COM/reports")]
+    public async Task Login_WithSiteLocalOrOwnOriginReturnUrl_Redirects(string returnUrl)
+    {
+        var result = await _controller.Login(returnUrl: returnUrl);
+
+        result.Should().BeOfType<RedirectResult>();
+    }
+
+    [Theory]
+    [InlineData("//evil.com")] // scheme-relative: browsers resolve off-site
+    [InlineData("/\\evil.com")] // backslash variant some browsers normalize to //
+    [InlineData("https://evil.com/")]
+    [InlineData("https://cgm.example.com.evil.com/")] // origin as subdomain prefix
+    [InlineData("https://cgm.example.com@evil.com/")] // origin as userinfo
+    [InlineData("https://user@cgm.example.com/")] // userinfo on the real origin
+    [InlineData("http://cgm.example.com/")] // scheme downgrade
+    [InlineData("javascript:alert(1)")]
+    [InlineData("settings/account")] // path-relative: resolves against the current path
+    public async Task Login_WithOffsiteReturnUrl_ReturnsBadRequest(string returnUrl)
+    {
+        var result = await _controller.Login(returnUrl: returnUrl);
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task Login_WithAbsoluteReturnUrl_WhenNoBaseDomainConfigured_ReturnsBadRequest()
+    {
+        var controller = new OidcController(
+            _authService.Object,
+            new Mock<IOidcProviderService>().Object,
+            new Mock<ISubjectService>().Object,
+            new Mock<IAuthAuditService>().Object,
+            new Mock<ITenantMemberService>().Object,
+            Options.Create(new OidcOptions()),
+            Options.Create(new BaseDomainOptions()),
+            NullLogger<OidcController>.Instance)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            },
+        };
+
+        var result = await controller.Login(returnUrl: "https://cgm.example.com/reports");
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Platform/ServicesControllerResetCursorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Platform/ServicesControllerResetCursorTests.cs
@@ -1,6 +1,5 @@
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -28,7 +27,6 @@ public class ServicesControllerResetCursorTests
             Mock.Of<IConnectorHealthService>(),
             syncService,
             Mock.Of<ILogger<ServicesController>>(),
-            Mock.Of<IConfiguration>(),
             Mock.Of<ITenantAccessor>(),
             Options.Create(new BaseDomainOptions()));
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/Providers/ChatBotProviderTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/Providers/ChatBotProviderTests.cs
@@ -40,7 +40,7 @@ public class ChatBotProviderTests
     private static ChatBotProvider CreateProvider(
         MockHttpMessageHandler handler,
         string? webUrl = "https://web.example.com",
-        string? baseUrl = null,
+        string? baseDomain = null,
         string? instanceKey = TestInstanceKey,
         string? tenantSlug = TestTenantSlug)
     {
@@ -53,7 +53,7 @@ public class ChatBotProviderTests
 
         var configMock = new Mock<IConfiguration>();
         configMock.Setup(c => c["WEB_URL"]).Returns(webUrl);
-        configMock.Setup(c => c["BaseUrl"]).Returns(baseUrl);
+        configMock.Setup(c => c["BASE_DOMAIN"]).Returns(baseDomain);
         configMock.Setup(c => c["INSTANCE_KEY"]).Returns(instanceKey);
 
         var tenantAccessorMock = new Mock<ITenantAccessor>();
@@ -206,11 +206,11 @@ public class ChatBotProviderTests
     [Fact]
     public async Task SendAsync_DoesNotFallBackToThePublicBaseUrl()
     {
-        // Arrange -- only the public base URL is configured. Dispatching there would hairpin an
-        // intra-cluster call out through the CDN and edge and back in, carrying the instance-key
-        // service credential across the public internet.
+        // Arrange -- only the public base domain is configured. Dispatching to the public
+        // origin would hairpin an intra-cluster call out through the CDN and edge and back
+        // in, carrying the instance-key service credential across the public internet.
         var handler = new MockHttpMessageHandler(HttpStatusCode.OK);
-        var provider = CreateProvider(handler, webUrl: "", baseUrl: "https://nocturne.run");
+        var provider = CreateProvider(handler, webUrl: "", baseDomain: "nocturne.run");
 
         // Act
         var act = () => provider.SendAsync(
@@ -226,7 +226,7 @@ public class ChatBotProviderTests
     {
         // Arrange
         var handler = new MockHttpMessageHandler(HttpStatusCode.OK);
-        var provider = CreateProvider(handler, webUrl: "", baseUrl: "");
+        var provider = CreateProvider(handler, webUrl: "", baseDomain: "");
 
         // Act
         var act = () => provider.SendAsync(

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcAuthServiceLinkTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcAuthServiceLinkTests.cs
@@ -1,9 +1,9 @@
 using FluentAssertions;
 using Microsoft.AspNetCore.DataProtection;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
+using Nocturne.API.Multitenancy;
 using Nocturne.API.Services.Auth;
 using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Contracts.Multitenancy;
@@ -26,7 +26,6 @@ public class OidcAuthServiceLinkTests
     private readonly Mock<IRefreshTokenService> _refreshTokenService = new();
     private readonly Mock<IHttpClientFactory> _httpFactory = new();
     private readonly Mock<ITenantMemberService> _tenantMemberService = new();
-    private readonly Mock<IConfiguration> _configuration = new();
     private readonly OidcAuthService _service;
 
     public OidcAuthServiceLinkTests()
@@ -43,7 +42,7 @@ public class OidcAuthServiceLinkTests
             new Mock<IMemberInviteService>().Object,
             new EphemeralDataProtectionProvider(),
             options,
-            _configuration.Object,
+            Options.Create(new BaseDomainOptions { BaseDomain = "nocturne.example.com" }),
             NullLogger<OidcAuthService>.Instance);
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcAuthServiceLoginGateTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcAuthServiceLoginGateTests.cs
@@ -1,10 +1,10 @@
 using System.Threading;
 using FluentAssertions;
 using Microsoft.AspNetCore.DataProtection;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
+using Nocturne.API.Multitenancy;
 using Nocturne.API.Services.Auth;
 using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Contracts.Multitenancy;
@@ -32,7 +32,6 @@ public class OidcAuthServiceLoginGateTests
     private readonly Mock<IHttpClientFactory> _httpFactory = new();
     private readonly Mock<ITenantMemberService> _tenantMemberService = new();
     private readonly Mock<IMemberInviteService> _memberInviteService = new();
-    private readonly Mock<IConfiguration> _configuration = new();
     private readonly OidcAuthService _service;
 
     public OidcAuthServiceLoginGateTests()
@@ -49,7 +48,7 @@ public class OidcAuthServiceLoginGateTests
             _memberInviteService.Object,
             new EphemeralDataProtectionProvider(),
             options,
-            _configuration.Object,
+            Options.Create(new BaseDomainOptions { BaseDomain = "nocturne.example.com" }),
             NullLogger<OidcAuthService>.Instance);
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcAuthServiceOAuth2ClaimsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcAuthServiceOAuth2ClaimsTests.cs
@@ -2,10 +2,10 @@ using System.Net;
 using System.Text;
 using FluentAssertions;
 using Microsoft.AspNetCore.DataProtection;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
+using Nocturne.API.Multitenancy;
 using Nocturne.API.Services.Auth;
 using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Contracts.Multitenancy;
@@ -45,7 +45,7 @@ public class OidcAuthServiceOAuth2ClaimsTests
             new Mock<IMemberInviteService>().Object,
             new EphemeralDataProtectionProvider(),
             Options.Create(new OidcOptions()),
-            new Mock<IConfiguration>().Object,
+            Options.Create(new BaseDomainOptions { BaseDomain = "nocturne.example.com" }),
             NullLogger<OidcAuthService>.Instance);
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcAuthServiceRedirectUriTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcAuthServiceRedirectUriTests.cs
@@ -1,0 +1,87 @@
+using System.Web;
+using FluentAssertions;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Nocturne.API.Multitenancy;
+using Nocturne.API.Services.Auth;
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Core.Models.Configuration;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Auth;
+
+/// <summary>
+/// Tests that the OIDC <c>redirect_uri</c> sent to providers is derived from
+/// <c>BASE_DOMAIN</c> — the platform's single public-origin setting. Historically a
+/// separate <c>BaseUrl</c> key fed this and every self-hosted deployment that set only
+/// <c>BASE_DOMAIN</c> silently sent <c>http://localhost:5000</c> to its provider.
+/// </summary>
+public class OidcAuthServiceRedirectUriTests
+{
+    private static readonly Guid ProviderId = Guid.NewGuid();
+
+    private static OidcAuthService BuildService(BaseDomainOptions baseDomainOptions)
+    {
+        var providerService = new Mock<IOidcProviderService>();
+        providerService
+            .Setup(p => p.GetProviderByIdAsync(ProviderId))
+            .ReturnsAsync(new OidcProvider
+            {
+                Id = ProviderId,
+                Name = "Keycloak",
+                IssuerUrl = "https://issuer.example",
+                ClientId = "nocturne",
+                IsEnabled = true,
+            });
+        providerService
+            .Setup(p => p.GetDiscoveryDocumentAsync(ProviderId))
+            .ReturnsAsync(new OidcDiscoveryDocument
+            {
+                Issuer = "https://issuer.example",
+                AuthorizationEndpoint = "https://issuer.example/authorize",
+                TokenEndpoint = "https://issuer.example/token",
+            });
+
+        return new OidcAuthService(
+            providerService.Object,
+            new Mock<ISubjectService>().Object,
+            new Mock<ISessionService>().Object,
+            new Mock<IJwtService>().Object,
+            new Mock<IRefreshTokenService>().Object,
+            new Mock<IHttpClientFactory>().Object,
+            new Mock<ITenantMemberService>().Object,
+            new Mock<IMemberInviteService>().Object,
+            new EphemeralDataProtectionProvider(),
+            Options.Create(new OidcOptions()),
+            Options.Create(baseDomainOptions),
+            NullLogger<OidcAuthService>.Instance);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GenerateAuthorizationUrl_DerivesRedirectUriFromBaseDomain()
+    {
+        var service = BuildService(new BaseDomainOptions { BaseDomain = "cgm.example.com" });
+
+        var request = await service.GenerateAuthorizationUrlAsync(ProviderId);
+
+        var query = HttpUtility.ParseQueryString(new Uri(request.AuthorizationUrl).Query);
+        query["redirect_uri"].Should().Be("https://cgm.example.com/api/auth/oidc/callback");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GenerateAuthorizationUrl_WithoutBaseDomain_FailsInsteadOfSendingLocalhost()
+    {
+        var service = BuildService(new BaseDomainOptions { BaseDomain = "" });
+
+        var act = () => service.GenerateAuthorizationUrlAsync(ProviderId);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*BASE_DOMAIN*");
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcAuthServiceStateProtectionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/OidcAuthServiceStateProtectionTests.cs
@@ -2,11 +2,11 @@ using System.Text;
 using System.Text.Json;
 using FluentAssertions;
 using Microsoft.AspNetCore.DataProtection;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Nocturne.API.Helpers;
+using Nocturne.API.Multitenancy;
 using Nocturne.API.Services.Auth;
 using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Contracts.Multitenancy;
@@ -31,7 +31,6 @@ public class OidcAuthServiceStateProtectionTests
 
     public OidcAuthServiceStateProtectionTests()
     {
-        var configuration = new Mock<IConfiguration>();
         _service = new OidcAuthService(
             _providerService.Object,
             new Mock<ISubjectService>().Object,
@@ -43,7 +42,7 @@ public class OidcAuthServiceStateProtectionTests
             new Mock<IMemberInviteService>().Object,
             new EphemeralDataProtectionProvider(),
             Options.Create(new OidcOptions()),
-            configuration.Object,
+            Options.Create(new BaseDomainOptions { BaseDomain = "nocturne.example.com" }),
             NullLogger<OidcAuthService>.Instance);
 
         _providerService
@@ -193,7 +192,7 @@ public class OidcAuthServiceStateProtectionTests
             new Mock<IMemberInviteService>().Object,
             new EphemeralDataProtectionProvider(),
             Options.Create(new OidcOptions()),
-            new Mock<IConfiguration>().Object,
+            Options.Create(new BaseDomainOptions { BaseDomain = "nocturne.example.com" }),
             NullLogger<OidcAuthService>.Instance);
 
     private static JsonDocument? DecodeAsPlainJson(string state)

--- a/tests/Unit/Nocturne.API.Tests/Services/Identity/MemberInviteServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Identity/MemberInviteServiceTests.cs
@@ -2,9 +2,10 @@ using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
+using Nocturne.API.Multitenancy;
 using Nocturne.API.Services.Identity;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Authorization;
@@ -33,7 +34,7 @@ public class MemberInviteServiceTests : IDisposable
 
     private const string FakeToken = "fake-random-token-abc123";
     private const string FakeTokenHash = "hashed-fake-token";
-    private const string BaseUrl = "https://app.nocturnecgm.com";
+    private const string BaseDomain = "app.nocturnecgm.com";
 
     public MemberInviteServiceTests()
     {
@@ -58,10 +59,6 @@ public class MemberInviteServiceTests : IDisposable
 
         _tenantService = new Mock<ITenantService>();
 
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?> { ["BaseUrl"] = BaseUrl })
-            .Build();
-
         var logger = new Mock<ILogger<MemberInviteService>>();
 
         _service = new MemberInviteService(
@@ -72,7 +69,7 @@ public class MemberInviteServiceTests : IDisposable
                 _dbContext,
                 // Only SeedRolesForTenantAsync takes a context of its own, and nothing here seeds.
                 Mock.Of<IDbContextFactory<NocturneDbContext>>()),
-            configuration,
+            Options.Create(new BaseDomainOptions { BaseDomain = BaseDomain }),
             logger.Object);
 
         // Seed tenant and subjects
@@ -133,7 +130,7 @@ public class MemberInviteServiceTests : IDisposable
             [_followerRoleId]);
 
         result.Token.Should().Be(FakeToken);
-        result.InviteUrl.Should().Be($"{BaseUrl}/join?token={FakeToken}");
+        result.InviteUrl.Should().Be($"https://{BaseDomain}/join?token={FakeToken}");
         result.Id.Should().NotBeEmpty();
         result.ExpiresAt.Should().BeAfter(DateTime.UtcNow);
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Notifications/PushoverServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Notifications/PushoverServiceTests.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
+using Nocturne.API.Multitenancy;
 using Nocturne.API.Services.Notifications;
 using Nocturne.Core.Contracts.Notifications;
 using Xunit;
@@ -30,13 +32,13 @@ public class PushoverServiceTests
         // Setup configuration
         _mockConfiguration.Setup(c => c["Pushover:ApiToken"]).Returns("test-api-token");
         _mockConfiguration.Setup(c => c["Pushover:UserKey"]).Returns("test-user-key");
-        _mockConfiguration.Setup(c => c["BaseUrl"]).Returns("http://localhost:5000");
 
         _service = new PushoverService(
             _mockHttpClient.Object,
             _mockLogger.Object,
             _mockNotificationService.Object,
-            _mockConfiguration.Object
+            _mockConfiguration.Object,
+            Options.Create(new BaseDomainOptions { BaseDomain = "nocturne.example.com" })
         );
     }
 


### PR DESCRIPTION
## Problem

A self-hoster reported that the generic OIDC provider always sends `redirect_uri=http://localhost:5000/api/auth/oidc/callback` no matter what `BASE_DOMAIN` is set to.

Root cause: the public origin was configurable two ways. `BASE_DOMAIN` (required; drives tenant resolution and the WebAuthn RP ID/origin) and a separate top-level `BaseUrl` key read by OIDC redirects, post-logout redirects, return-URL validation, the well-known issuer, Pushover callbacks, and invite links. Nothing in the self-hosting path ever set `BaseUrl` — the compose bundle and the Aspire host only set `BASE_DOMAIN` — so `OidcAuthService.GetRedirectUri` always fell through to its hardcoded `http://localhost:5000`. (The Helm chart and the cloud wrapper set `BaseUrl` explicitly, which is why hosted deployments never hit this.)

## Change

`BASE_DOMAIN` is now the single source of truth. `BaseDomainOptions` gains a `PublicOrigin` property (`https://{BaseDomain}`; HTTPS is already a platform-wide assumption via the WebAuthn origin derivation, and both bundled edges — Caddy and Cloudflare — terminate TLS) and every former `BaseUrl` consumer reads it:

- `OidcAuthService` (redirect_uri + post_logout_redirect_uri) — now **throws** when `BASE_DOMAIN` is missing instead of silently sending localhost to the provider
- `OidcController.IsValidReturnUrl` — also tightened to match on the origin *boundary*; the old prefix check accepted `https://example.com.evil.com`
- `WellKnownController` (issuer; request-host fallback unchanged)
- `ServicesController` (apex fallback for uploader URLs)
- `PushoverService` — emergency-receipt callbacks are now omitted when no public origin is configured, rather than pointed at localhost
- `MemberInviteService` (apex fallback for invite links)

Deleted dead config surface: `ServiceNames.ConfigKeys.BaseUrl`, the never-read `Oidc:BaseUrl` property, and the `Program.cs` bridge filling `NocturneApiUrl` (which has no reader anywhere).

## Breaking changes

- The `BaseUrl` env var / config key is **removed** (it was undocumented for self-hosters; anyone setting it should set `BASE_DOMAIN` to the bare host instead).
- **Helm:** `values.baseUrl` → `values.baseDomain` (bare host, no scheme). Templates `fail` fast with a migration message if the legacy value is set. This also fixes the web container, whose `BASE_DOMAIN` env previously received a full URL its consumers don't expect. Chart bumped to `0.1.0-alpha.10`.
- The compose bundle needs **no change** — it already sets only `BASE_DOMAIN`, and simply starts working.

## Tests

- New `OidcAuthServiceRedirectUriTests`: `redirect_uri` is `https://{BASE_DOMAIN}/api/auth/oidc/callback`, and URL generation fails loudly without a base domain.
- Existing OIDC/invite/Pushover/ChatBot test fixtures migrated from mocked `BaseUrl` config to `BaseDomainOptions`.
- Full `Nocturne.API.Tests` run: green except two pre-existing local-only failures unrelated to this change (`CacheIntegrationTests` is `Category=Integration` so CI never runs it, and it has gone stale against the `DecomposeBatchAsync` switch; plus a memory benchmark that's environment-sensitive).

## Follow-ups (not in this PR)

- nocturne-cloud: drop the now-ignored `nocturneApi.WithEnvironment("BaseUrl", ...)` from its AppHost at the next submodule bump.
- `CacheIntegrationTests` staleness above deserves its own fix.

https://claude.ai/code/session_01Czjkxvbn2BbPmU3ideUJe4
