### PR TITLE
fix(api): cap the legacy v1 count parameter server-side

### DIFF
--- a/src/API/Nocturne.API/Controllers/V1/ActivityController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/ActivityController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
 using Nocturne.API.Authorization;
 using Nocturne.API.Extensions;
+using Nocturne.API.Helpers;
 using Nocturne.Core.Contracts.Health;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Models;
@@ -73,8 +74,22 @@ public class ActivityController : ControllerBase
     {
         try
         {
+            // Normalize skip parameter (negative is not valid)
+            if (skip < 0)
+            {
+                skip = 0; // Normalize to 0 for Nightscout compatibility
+            }
+
+            // An empty array covers both a 0-or-negative count (Nightscout behavior) and a page
+            // starting past the merged paging window.
+            var pageCount = LegacyReadLimits.ClampMergedPage(count, skip);
+            if (pageCount <= 0)
+            {
+                return Ok(Array.Empty<Activity>());
+            }
+
             var activities = await _activityService.GetActivitiesAsync(
-                count: count,
+                count: pageCount,
                 skip: skip,
                 cancellationToken: cancellationToken
             );

--- a/src/API/Nocturne.API/Controllers/V1/DeviceStatusController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/DeviceStatusController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
 using Nocturne.API.Authorization;
+using Nocturne.API.Helpers;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.API.Services.Devices;
 using Nocturne.API.Services.Legacy;
@@ -120,7 +121,7 @@ public class DeviceStatusController : ControllerBase
             }
 
             var deviceStatusEntries = await _projection.GetAsync(
-                count, skip, findQuery, cancellationToken
+                LegacyReadLimits.ClampMergedCount(count), skip, findQuery, cancellationToken
             );
             var deviceStatusArray = deviceStatusEntries.ToArray();
 

--- a/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
@@ -5,6 +5,7 @@ using Nocturne.API.Attributes;
 using Nocturne.API.Authorization;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.API.Extensions;
+using Nocturne.API.Helpers;
 using Nocturne.API.Services.Legacy;
 using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Contracts.Legacy;
@@ -289,7 +290,7 @@ public class EntriesController : ControllerBase
     /// Get entries with optional query parameters
     /// Supports advanced query features including find filters, date ranges, and pagination
     /// </summary>
-    /// <param name="count">Maximum number of entries to return (if not specified, returns all matching entries)</param>
+    /// <param name="count">Maximum number of entries to return (default 10, capped at <see cref="LegacyReadLimits.MaxCount"/>)</param>
     /// <param name="type">Entry type filter (default: "sgv")</param>
     /// <param name="find">MongoDB-style find query filters (JSON format) - for unit tests</param>
     /// <param name="cancellationToken">Cancellation token</param>
@@ -374,8 +375,8 @@ public class EntriesController : ControllerBase
                 // Nightscout returns empty array for count=0 or negative values
                 return Ok(Array.Empty<Entry>());
             }
-            // Nightscout defaults to 10 when count is not specified
-            var limitedCount = count ?? 10;
+            // Nightscout defaults to 10 when count is not specified; the upper bound is ours.
+            var limitedCount = LegacyReadLimits.ClampCount(count ?? 10);
 
             // Use advanced filtering if any advanced parameters are provided
             // reverseResults stays false (newest-first): legacy Nightscout ignores the cache-busting

--- a/src/API/Nocturne.API/Controllers/V1/TreatmentsController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/TreatmentsController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
 using Nocturne.API.Authorization;
+using Nocturne.API.Helpers;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Contracts.Legacy;
 using Nocturne.Core.Contracts.Treatments;
@@ -115,7 +116,7 @@ public class TreatmentsController : ControllerBase
 
             var treatments = await _treatmentService.GetTreatmentsAsync(
                 find: findQuery,
-                count: count,
+                count: LegacyReadLimits.ClampCount(count),
                 skip: skip,
                 cancellationToken: cancellationToken
             );

--- a/src/API/Nocturne.API/Helpers/LegacyReadLimits.cs
+++ b/src/API/Nocturne.API/Helpers/LegacyReadLimits.cs
@@ -1,0 +1,111 @@
+namespace Nocturne.API.Helpers;
+
+/// <summary>
+/// Server-side ceilings on how many records a legacy v1 read may return.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The v1 <c>count</c> query parameter is 1:1 Nightscout-compatible, and Nightscout applies no
+/// upper bound of its own — a single request can ask for an arbitrary number of records. On a
+/// shared multi-tenant deployment that is a cost-amplification vector, so the ceilings here are
+/// applied independently of each endpoint's compat default.
+/// </para>
+/// <para>
+/// Both ceilings sit at or above 10,000, which is the largest page any first-party caller asks
+/// for: the migration job pages at 10,000 and the Nightscout connector's configurable page size
+/// is attribute-capped at 10,000.
+/// </para>
+/// <para>
+/// Not every v1 read needs a ceiling here. <c>times/</c> and <c>slice/</c> take a <c>count</c> but
+/// are already bounded by <c>TimeQueryService</c>, which fetches a fixed 1,000 rows per storage
+/// before the controller paginates, so their responses cannot exceed that regardless of
+/// <c>count</c>. <c>pebble</c> (10) and <c>profile</c> (1,000) carry their own tighter clamps, and
+/// every v3 read clamps in <c>BaseV3Controller.ParseV3QueryParameters</c> or inline on the
+/// <c>history/</c> routes.
+/// </para>
+/// <para>
+/// Only the upper bound lives here. Zero and negative counts stay with each route, because
+/// Nightscout's behaviour differs per route: entries, treatments, devicestatus and activity answer
+/// an empty array, while <c>times/</c> and <c>slice/</c> answer 400.
+/// </para>
+/// <para>
+/// <c>MaxCount</c> shares a value with <c>EntryReadService.MaxFilterFetch</c> and
+/// <c>ActivityService.MaxOverFetch</c> by coincidence, not by coupling. Those constants bound rows
+/// pulled into memory to satisfy a request; these bound what a caller may ask to be returned. Each
+/// may move alone, so nothing here is referenced from a service's own internal over-fetch bound.
+/// </para>
+/// </remarks>
+public static class LegacyReadLimits
+{
+    /// <summary>
+    /// Maximum number of records returned by a v1 read that projects one stored row into one
+    /// response record — entries and treatments.
+    /// </summary>
+    /// <remarks>
+    /// Sits above every known caller: uploaders and followers (AAPS, xDrip, Trio) request tens to
+    /// hundreds, the Nightscout migration connector pages at 1,000, and report exports ask for tens
+    /// of thousands. A tenant's full multi-year entry history is on the order of a few hundred
+    /// thousand records, so this bounds a single response to a fraction of it while leaving
+    /// legitimate bulk reads untouched.
+    /// </remarks>
+    public const int MaxCount = 100_000;
+
+    /// <summary>
+    /// Maximum number of records returned by a v1 read that merges several storages into each
+    /// response record — activity and devicestatus.
+    /// </summary>
+    /// <remarks>
+    /// An order of magnitude below <see cref="MaxCount"/> because <c>count</c> multiplies at these
+    /// routes rather than tracking the row count. <c>ActivityService</c> issues four independent
+    /// fetches of <c>count</c> records each (state spans, heart rate, step count, sleep) and merges
+    /// them in memory, so the objects materialized are a multiple of what is returned; at 1 Hz,
+    /// heart-rate data alone reaches 10,000 rows in under three hours.
+    /// <c>DeviceStatusProjectionService</c> runs two windowed queries plus three correlation-id
+    /// batch loads and an overlapping-override scan, then emits a composite document carrying the
+    /// APS, pump and uploader payloads. Ten thousand still clears the 10,000-record page every
+    /// first-party bulk caller uses.
+    /// </remarks>
+    /// <remarks>
+    /// Governs the v1 routes only. <c>/api/v4/activity</c> reaches the same four-source fan-out
+    /// with no ceiling of its own; capping it is queued separately, because v4 should not import a
+    /// legacy-compat helper.
+    /// </remarks>
+    public const int MaxMergedCount = 10_000;
+
+    /// <summary>
+    /// The number of records a merged v1 read may return for a page starting at
+    /// <paramref name="skip"/>, so that <c>skip</c> cannot walk past the budget
+    /// <see cref="MaxMergedCount"/> sets.
+    /// </summary>
+    /// <remarks>
+    /// Activity merges its four sources in memory and therefore over-fetches <c>count + skip</c>
+    /// records from each, so clamping <c>count</c> alone leaves the cost proportional to <c>skip</c>
+    /// — <c>?count=10000&amp;skip=90000</c> would still materialize ten times the intended budget.
+    /// Bounding the window instead means the merged set is reachable only to its first
+    /// <see cref="MaxMergedCount"/> records and deeper pages come back empty. No first-party caller
+    /// pages these routes with <c>skip</c> at all: the migration job and the Nightscout connector
+    /// both page by time cursor.
+    /// </remarks>
+    /// <param name="count">The requested record count.</param>
+    /// <param name="skip">The requested offset, already normalized to be non-negative.</param>
+    /// <returns>
+    /// The records this page may return: <paramref name="count"/> clamped to whatever remains of
+    /// the window, and zero once <paramref name="skip"/> reaches <see cref="MaxMergedCount"/>.
+    /// </returns>
+    public static int ClampMergedPage(int count, int skip) =>
+        Math.Min(count, MaxMergedCount - Math.Min(skip, MaxMergedCount));
+
+    /// <summary>
+    /// Clamp a caller-supplied v1 <c>count</c> to <see cref="MaxCount"/>.
+    /// </summary>
+    /// <param name="count">The requested record count.</param>
+    /// <returns><paramref name="count"/>, or <see cref="MaxCount"/> if it exceeds the ceiling.</returns>
+    public static int ClampCount(int count) => Math.Min(count, MaxCount);
+
+    /// <summary>
+    /// Clamp a caller-supplied v1 <c>count</c> to <see cref="MaxMergedCount"/>.
+    /// </summary>
+    /// <param name="count">The requested record count.</param>
+    /// <returns><paramref name="count"/>, or <see cref="MaxMergedCount"/> if it exceeds the ceiling.</returns>
+    public static int ClampMergedCount(int count) => Math.Min(count, MaxMergedCount);
+}

--- a/src/API/Nocturne.API/Services/Health/ActivityService.cs
+++ b/src/API/Nocturne.API/Services/Health/ActivityService.cs
@@ -37,6 +37,13 @@ public class ActivityService : IActivityService
     private readonly ILogger<ActivityService> _logger;
 
     /// <summary>
+    /// Upper bound on rows pulled from each source when reads merge the four sources in memory and
+    /// re-paginate, which defeats limit pushdown. Independent of any controller-level ceiling on
+    /// what a caller may request.
+    /// </summary>
+    private const int MaxOverFetch = 100_000;
+
+    /// <summary>
     /// Initializes a new instance of <see cref="ActivityService"/>.
     /// </summary>
     public ActivityService(
@@ -92,8 +99,10 @@ public class ActivityService : IActivityService
                 actualSkip
             );
 
-            // Over-fetch from each source so we can merge and re-paginate
-            var fetchCount = actualCount + actualSkip;
+            // Over-fetch from each source so we can merge and re-paginate. Clamped into range: a
+            // large skip overflows the sum, and a non-positive fetch count faults every source
+            // query. Callers with no ceiling of their own rely on the upper bound here.
+            var fetchCount = (int)Math.Clamp((long)actualCount + actualSkip, 1, MaxOverFetch);
 
             // Source 1: Regular activities from StateSpans (exercise, illness, travel — no longer sleep)
             var stateSpanActivities = await _stateSpanService.GetActivitiesAsync(

--- a/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
+++ b/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Microsoft.EntityFrameworkCore;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using Nocturne.API.Helpers;
 using Nocturne.API.Services.Audit;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Models;
@@ -1000,7 +1001,9 @@ internal class MigrationJob
         var totalMigrated = 0L;
         var totalFailed = 0L;
         DateTime? currentTo = FirstPageAnchor;
-        const int pageSize = 10000;
+        // The v1 read clamps to this, and the loop below terminates on a short page, so a larger
+        // page size here would silently end the pull after one page.
+        const int pageSize = LegacyReadLimits.MaxMergedCount;
 
         using var scope = CreateTenantScope();
         var decomposer = scope.ServiceProvider.GetRequiredService<IDeviceStatusDecomposer>();
@@ -1236,7 +1239,9 @@ internal class MigrationJob
         var totalMigrated = 0L;
         var totalFailed = 0L;
         DateTime? currentTo = FirstPageAnchor;
-        const int pageSize = 10000;
+        // The v1 read clamps to this, and the loop below terminates on a short page, so a larger
+        // page size here would silently end the pull after one page.
+        const int pageSize = LegacyReadLimits.MaxMergedCount;
 
         using var scope = CreateTenantScope();
         var decomposer = scope.ServiceProvider.GetRequiredService<IActivityDecomposer>();

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V1/LegacyReadCountCapTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V1/LegacyReadCountCapTests.cs
@@ -1,0 +1,370 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Nocturne.API.Controllers.V1;
+using Nocturne.API.Helpers;
+using Nocturne.API.Services.Devices;
+using Nocturne.Core.Contracts.Alerts;
+using Nocturne.Core.Contracts.Effects;
+using Nocturne.Core.Contracts.Events;
+using Nocturne.Core.Contracts.Glucose;
+using Nocturne.Core.Contracts.Health;
+using Nocturne.Core.Contracts.Legacy;
+using Nocturne.Core.Contracts.Repositories;
+using Nocturne.Core.Contracts.Treatments;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Core.Models.V4;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V1;
+
+/// <summary>
+/// Boundary tests for the server-side ceilings on the legacy v1 <c>count</c> query parameter.
+/// Each read is exercised at exactly its own ceiling (must pass through unchanged) and at one
+/// above it (must be clamped), so the assertions pin the edge rather than a value somewhere
+/// inside the window.
+/// </summary>
+/// <remarks>
+/// <c>times/</c> and <c>slice/</c> are deliberately absent: <c>TimeQueryService</c> fetches a
+/// fixed 1,000 rows per storage, so those routes cannot exceed that regardless of <c>count</c>
+/// and carry no ceiling of their own to test.
+/// </remarks>
+[Trait("Category", "Unit")]
+public class LegacyReadCountCapTests
+{
+    private const int AtCap = LegacyReadLimits.MaxCount;
+    private const int AboveCap = LegacyReadLimits.MaxCount + 1;
+    private const int AtMergedCap = LegacyReadLimits.MaxMergedCount;
+    private const int AboveMergedCap = LegacyReadLimits.MaxMergedCount + 1;
+
+    /// <summary>
+    /// The compat floor the ceilings are chosen against: the migration job pages at 10,000 and the
+    /// Nightscout connector's page size is attribute-capped at 10,000, so neither ceiling may drop
+    /// below that without breaking a first-party bulk caller. Without this, lowering a ceiling to
+    /// an arbitrarily small value leaves every boundary case below still green.
+    /// </summary>
+    [Fact]
+    public void Ceilings_StayAboveTheLargestFirstPartyPageSize()
+    {
+        LegacyReadLimits.MaxCount.Should().BeGreaterThanOrEqualTo(10_000);
+        LegacyReadLimits.MaxMergedCount.Should().BeGreaterThanOrEqualTo(10_000);
+        LegacyReadLimits.MaxCount.Should().BeGreaterThanOrEqualTo(LegacyReadLimits.MaxMergedCount);
+    }
+
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(10, 10)]
+    [InlineData(AtCap - 1, AtCap - 1)]
+    [InlineData(AtCap, AtCap)]
+    [InlineData(AboveCap, AtCap)]
+    [InlineData(int.MaxValue, AtCap)]
+    public void ClampCount_CapsAtCeilingAndLeavesEverythingBelowUntouched(
+        int requested,
+        int expected
+    )
+    {
+        LegacyReadLimits.ClampCount(requested).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(10, 10)]
+    [InlineData(AtMergedCap - 1, AtMergedCap - 1)]
+    [InlineData(AtMergedCap, AtMergedCap)]
+    [InlineData(AboveMergedCap, AtMergedCap)]
+    [InlineData(int.MaxValue, AtMergedCap)]
+    public void ClampMergedCount_CapsAtCeilingAndLeavesEverythingBelowUntouched(
+        int requested,
+        int expected
+    )
+    {
+        LegacyReadLimits.ClampMergedCount(requested).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(AtCap, AtCap)]
+    [InlineData(AboveCap, AtCap)]
+    public async Task Entries_ClampsCountPassedToTheEntryService(int requested, int expected)
+    {
+        var entryService = new Mock<IEntryService>();
+        int? observedCount = null;
+        entryService
+            .Setup(x =>
+                x.GetEntriesWithAdvancedFilterAsync(
+                    It.IsAny<string?>(),
+                    It.IsAny<int>(),
+                    It.IsAny<int>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Callback(
+                (
+                    string? _,
+                    int count,
+                    int _,
+                    string? _,
+                    string? _,
+                    bool _,
+                    CancellationToken _
+                ) => observedCount = count
+            )
+            .ReturnsAsync(Array.Empty<Entry>());
+
+        var controller = new EntriesController(
+            entryService.Object,
+            Mock.Of<IDocumentProcessingService>(),
+            Mock.Of<IProcessingStatusService>(),
+            Mock.Of<ICanonicalAlertEvaluator>(),
+            Mock.Of<ILogger<EntriesController>>()
+        )
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+        };
+
+        await controller.GetEntries(count: requested);
+
+        observedCount.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(AtCap, AtCap)]
+    [InlineData(AboveCap, AtCap)]
+    public async Task Treatments_ClampsCountPassedToTheTreatmentService(
+        int requested,
+        int expected
+    )
+    {
+        var treatmentService = new Mock<ITreatmentService>();
+        int? observedCount = null;
+        treatmentService
+            .Setup(x =>
+                x.GetTreatmentsAsync(
+                    It.IsAny<string?>(),
+                    It.IsAny<int?>(),
+                    It.IsAny<int?>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Callback(
+                (string? _, int? count, int? _, CancellationToken _) => observedCount = count
+            )
+            .ReturnsAsync(Array.Empty<Treatment>());
+
+        var controller = new TreatmentsController(
+            treatmentService.Object,
+            Mock.Of<IDocumentProcessingService>(),
+            Mock.Of<ILogger<TreatmentsController>>()
+        )
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+        };
+
+        await controller.GetTreatments(count: requested);
+
+        observedCount.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(AtMergedCap, AtMergedCap)]
+    [InlineData(AboveMergedCap, AtMergedCap)]
+    public async Task Activity_ClampsCountPassedToTheActivityService(int requested, int expected)
+    {
+        var activityService = new Mock<IActivityService>();
+        int? observedCount = null;
+        activityService
+            .Setup(x =>
+                x.GetActivitiesAsync(
+                    It.IsAny<string?>(),
+                    It.IsAny<int?>(),
+                    It.IsAny<int?>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Callback(
+                (string? _, int? count, int? _, CancellationToken _) => observedCount = count
+            )
+            .ReturnsAsync(Array.Empty<Activity>());
+
+        var controller = NewActivityController(activityService.Object);
+
+        await controller.GetActivities(count: requested);
+
+        observedCount.Should().Be(expected);
+    }
+
+    /// <summary>
+    /// Zero and negative counts answer an empty array without reaching the service, matching the
+    /// Nightscout behaviour treatments and devicestatus already implement. Before this handling a
+    /// negative count reached <c>Take(-1)</c>.
+    /// </summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task Activity_ReturnsEmptyWithoutReadingForANonPositiveCount(int requested)
+    {
+        var activityService = new Mock<IActivityService>(MockBehavior.Strict);
+        var controller = NewActivityController(activityService.Object);
+
+        var result = await controller.GetActivities(count: requested);
+
+        result.Result.Should().BeOfType<OkObjectResult>()
+            .Subject.Value.Should().BeAssignableTo<IEnumerable<Activity>>()
+            .Subject.Should().BeEmpty();
+        activityService.VerifyNoOtherCalls();
+    }
+
+    /// <summary>
+    /// Activity merges its sources in memory and over-fetches <c>count + skip</c> from each, so the
+    /// ceiling has to bound the window rather than the page: <c>skip</c> may reach the last record
+    /// inside the window, and one past it reads nothing at all.
+    /// </summary>
+    [Theory]
+    [InlineData(AtMergedCap - 1, 1)]
+    [InlineData(AtMergedCap - 100, 100)]
+    [InlineData(0, AtMergedCap)]
+    public async Task Activity_ClampsThePageToWhatRemainsOfThePagingWindow(
+        int skip,
+        int expected
+    )
+    {
+        var activityService = new Mock<IActivityService>();
+        int? observedCount = null;
+        activityService
+            .Setup(x =>
+                x.GetActivitiesAsync(
+                    It.IsAny<string?>(),
+                    It.IsAny<int?>(),
+                    It.IsAny<int?>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Callback(
+                (string? _, int? count, int? _, CancellationToken _) => observedCount = count
+            )
+            .ReturnsAsync(Array.Empty<Activity>());
+
+        var controller = NewActivityController(activityService.Object);
+
+        await controller.GetActivities(count: AtMergedCap, skip: skip);
+
+        observedCount.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(AtMergedCap)]
+    [InlineData(AtMergedCap + 1)]
+    [InlineData(int.MaxValue)]
+    public async Task Activity_ReadsNothingForAPageStartingPastThePagingWindow(int skip)
+    {
+        var activityService = new Mock<IActivityService>(MockBehavior.Strict);
+        var controller = NewActivityController(activityService.Object);
+
+        var result = await controller.GetActivities(count: AtMergedCap, skip: skip);
+
+        result.Result.Should().BeOfType<OkObjectResult>()
+            .Subject.Value.Should().BeAssignableTo<IEnumerable<Activity>>()
+            .Subject.Should().BeEmpty();
+        activityService.VerifyNoOtherCalls();
+    }
+
+    [Theory]
+    [InlineData(AtMergedCap, AtMergedCap)]
+    [InlineData(AboveMergedCap, AtMergedCap)]
+    public async Task DeviceStatus_ClampsCountPassedToTheSnapshotRepository(
+        int requested,
+        int expected
+    )
+    {
+        var apsRepo = new Mock<IApsSnapshotRepository>();
+        int? observedLimit = null;
+        apsRepo
+            .Setup(x =>
+                x.GetAsync(
+                    It.IsAny<DateTime?>(),
+                    It.IsAny<DateTime?>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<int>(),
+                    It.IsAny<int>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Callback(
+                (
+                    DateTime? _,
+                    DateTime? _,
+                    string? _,
+                    string? _,
+                    int limit,
+                    int _,
+                    bool _,
+                    CancellationToken _
+                ) => observedLimit = limit
+            )
+            .ReturnsAsync(Array.Empty<ApsSnapshot>());
+
+        var pumpRepo = new Mock<IPumpSnapshotRepository>();
+        pumpRepo
+            .Setup(x =>
+                x.GetAsync(
+                    It.IsAny<DateTime?>(),
+                    It.IsAny<DateTime?>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<int>(),
+                    It.IsAny<int>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(Array.Empty<PumpSnapshot>());
+
+        var projection = new DeviceStatusProjectionService(
+            apsRepo.Object,
+            pumpRepo.Object,
+            Mock.Of<IUploaderSnapshotRepository>(),
+            Mock.Of<IStateSpanRepository>(),
+            Mock.Of<IDeviceStatusExtrasRepository>(),
+            Mock.Of<ILogger<DeviceStatusProjectionService>>()
+        );
+
+        var controller = new DeviceStatusController(
+            projection,
+            Mock.Of<IDeviceStatusDecomposer>(),
+            Mock.Of<IWriteSideEffects>(),
+            Mock.Of<IDataEventSink<DeviceStatus>>(),
+            Mock.Of<ILogger<DeviceStatusController>>()
+        )
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+        };
+
+        await controller.GetDeviceStatus(count: requested);
+
+        observedLimit.Should().Be(expected);
+    }
+
+    private static ActivityController NewActivityController(IActivityService activityService)
+    {
+        var controller = new ActivityController(
+            activityService,
+            Mock.Of<IActivityDecomposer>(),
+            Mock.Of<ILogger<ActivityController>>()
+        )
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+        };
+        controller.HttpContext.Items["GrantedScopes"] = (IReadOnlySet<string>)
+            new HashSet<string> { OAuthScopes.TreatmentsRead };
+        return controller;
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Health/ActivityServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Health/ActivityServiceTests.cs
@@ -1,3 +1,4 @@
+using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Nocturne.API.Services.Health;
@@ -1123,5 +1124,34 @@ public class ActivityServiceTests
 
         // Assert
         Assert.Equal(5, count);
+    }
+
+    /// <summary>
+    /// The over-fetch is <c>count + skip</c>, which overflows int for a large skip and hands every
+    /// source a negative fetch count. Clamping keeps it inside the service's own over-fetch bound;
+    /// paging past the end of the merged set then yields nothing, which is correct. The expected
+    /// value mirrors the service's private <c>MaxOverFetch</c>, which is deliberately not shared
+    /// with the controller-level ceilings.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetActivitiesAsync_SaturatesTheOverFetchInsteadOfOverflowing()
+    {
+        int observedFetchCount = 0;
+        _mockHeartRateService
+            .Setup(s => s.GetHeartRatesAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback((int count, int _, CancellationToken _) => observedFetchCount = count)
+            .ReturnsAsync(Enumerable.Empty<HeartRate>());
+        _mockStateSpanService
+            .Setup(s => s.GetActivitiesAsync(
+                It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Enumerable.Empty<Activity>());
+
+        var result = await _activityService.GetActivitiesAsync(
+            count: 1, skip: int.MaxValue, cancellationToken: CancellationToken.None);
+
+        observedFetchCount.Should().Be(100_000);
+        result.Should().BeEmpty();
     }
 }


### PR DESCRIPTION
## What

The v1 `count` query parameter had no server-side ceiling on several reads, so a single request could ask a shared multi-tenant deployment to materialize an arbitrary number of records (`?count=5000000`). This adds explicit caps at the controller edge via a shared `LegacyReadLimits` helper.

Two ceilings, because `count` doesn't cost the same everywhere:

| Ceiling | Routes | Why |
|---|---|---|
| `MaxCount` = 100,000 | `/api/v1/entries`, `/api/v1/treatments` | one stored row → one response record |
| `MaxMergedCount` = 10,000 | `/api/v1/activity`, `/api/v1/devicestatus` | `count` multiplies: activity fans out to four source fetches and merges in memory; devicestatus projects fat composite documents through multiple queries |

Clamped, not rejected — legacy Nightscout clients tolerate a short array but not a 400. Every route's existing zero/negative behavior is preserved (activity gains the same guard its siblings already had; it previously passed negative counts to `Take(-1)`).

Deliberately untouched: `times/`/`slice/` (already bounded by TimeQueryService's fixed 1,000-row fetch — a clamp there would be inert), v3 (spec-clamped to 1,000 in `BaseV3Controller`), pebble/profile (already capped).

Also fixed in passing: `ActivityService` computed its over-fetch as `count + skip` in unchecked int, so `?count=1&skip=2147483647` wrapped negative and 500'd. Now saturated against a private per-service bound.

## One deliberate Nightscout divergence

On activity the ceiling must bound the paging *window*, not just the page — the route over-fetches `count + skip` from each of four sources, so clamping `count` alone leaves cost proportional to `skip`. Deeper pages than 10,000 merged records now answer empty. Verified no first-party caller pages these routes with `skip` (the migration job and Nightscout connector page by time cursor; the frontend never pages activity). A third-party client paging `/api/v1/activity` by skip past 10,000 would now see an empty page where Nightscout returns records.

## Testing

- 4858 passed / 0 failed / 5 skipped (30 new tests), independently reproduced by a reviewer run.
- Boundary pairs at each site's exact ceiling and one above; floor tests pin `MaxCount >= 10_000` and `MaxCount >= MaxMergedCount` so the compat floor (migration job pages at 10,000) is test-enforced.
- Proven non-vacuous by five independent mutations, each failing exactly its own site's above-ceiling cases and nothing else.

## Noted for follow-up (not in this PR)

- `/api/v4/activity` reaches the same four-source fan-out with an uncapped `limit`; v4 shouldn't import a legacy-compat helper, so it needs its own convention.
- The explicit `~/api/v1/{devicestatus,food,status}.json` routes are unreachable at runtime (`JsonExtensionMiddleware` strips the suffix before routing) — vestigial, candidates for cleanup.

https://claude.ai/code/session_01V2H2GSE3UWEgkMvsJE8Kfw
