### PR TITLE
chore: lift TODO markers into issues, and fix meal matching's legacy treatment ids

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Connectors/WebhookSettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Connectors/WebhookSettingsController.cs
@@ -34,7 +34,8 @@ public class WebhookSettingsController(
         CancellationToken cancellationToken = default
     )
     {
-        // TODO: Re-implement with new alert engine storage
+        // Not wired to the current alert engine's storage, so this reports disabled
+        // regardless of what the tenant configured.
         return Task.FromResult<ActionResult<WebhookNotificationSettings>>(Ok(
             new WebhookNotificationSettings
             {
@@ -57,7 +58,6 @@ public class WebhookSettingsController(
         CancellationToken cancellationToken = default
     )
     {
-        // TODO: Re-implement with new alert engine storage
         logger.LogWarning("Webhook settings save is a no-op until new alert engine is implemented");
         return Task.FromResult<ActionResult<WebhookNotificationSettings>>(Ok(settings));
     }

--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/TrackersController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/TrackersController.cs
@@ -93,7 +93,8 @@ public class TrackersController : ControllerBase, IWriteScopedController
         if (tracker.Visibility == TrackerVisibility.Private && tracker.UserId == currentUserId)
             return true;
 
-        // TODO: RoleRestricted visibility check
+        // RoleRestricted has no check yet, so it falls through to hidden — including from
+        // the tracker's own owner.
         return false;
     }
 

--- a/src/API/Nocturne.API/Controllers/V4/Profiles/UISettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Profiles/UISettingsController.cs
@@ -367,7 +367,8 @@ public class UISettingsController : ControllerBase, IWriteScopedController
                 );
             }
 
-            // TODO: Re-implement with new alert engine
+            // The profile is discarded: this is not wired to the current alert engine's
+            // storage.
             return await GetAlarmConfiguration(cancellationToken);
         }
         catch (Exception ex)
@@ -405,8 +406,8 @@ public class UISettingsController : ControllerBase, IWriteScopedController
                 );
             }
 
-            // TODO: Re-implement with new alert engine
-
+            // The profile id is discarded: this is not wired to the current alert engine's
+            // storage.
             return await GetAlarmConfiguration(cancellationToken);
         }
         catch (Exception ex)

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/MealMatchingController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/MealMatchingController.cs
@@ -97,9 +97,9 @@ public class MealMatchingController : ControllerBase
             MealName = s.MealName,
             Carbs = s.Carbs,
             ConsumedAt = s.ConsumedAt,
-            TreatmentId = s.TreatmentId,
-            TreatmentCarbs = s.TreatmentCarbs,
-            TreatmentMills = s.TreatmentMills,
+            CarbIntakeId = s.CarbIntakeId,
+            CarbIntakeCarbs = s.CarbIntakeCarbs,
+            CarbIntakeMills = s.CarbIntakeMills,
             MatchScore = s.MatchScore,
         }).ToArray();
 
@@ -132,7 +132,7 @@ public class MealMatchingController : ControllerBase
         {
             await _mealMatchingService.AcceptMatchAsync(
                 request.FoodEntryId,
-                request.TreatmentId,
+                request.CarbIntakeId,
                 request.Carbs,
                 request.TimeOffsetMinutes,
                 HttpContext.RequestAborted);
@@ -149,8 +149,8 @@ public class MealMatchingController : ControllerBase
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to accept meal match for food entry {FoodEntryId} and treatment {TreatmentId}",
-                request.FoodEntryId, request.TreatmentId);
+            _logger.LogError(ex, "Failed to accept meal match for food entry {FoodEntryId} and carb intake {CarbIntakeId}",
+                request.FoodEntryId, request.CarbIntakeId);
             return Problem(detail: ex.Message, statusCode: 500, title: "Internal Server Error");
         }
     }
@@ -195,7 +195,10 @@ public class MealMatchingController : ControllerBase
 public class AcceptMatchRequest
 {
     public Guid FoodEntryId { get; set; }
-    public Guid TreatmentId { get; set; }
+
+    /// <summary>The carb intake to link the food to, from <see cref="SuggestedMealMatch.CarbIntakeId"/>.</summary>
+    public Guid CarbIntakeId { get; set; }
+
     public decimal Carbs { get; set; }
     public int TimeOffsetMinutes { get; set; }
 }
@@ -209,7 +212,7 @@ public class DismissMatchRequest
 }
 
 /// <summary>
-/// A suggested meal match between a food entry and treatment
+/// A suggested meal match between a food entry and a carb intake
 /// </summary>
 public class SuggestedMealMatch
 {
@@ -218,8 +221,8 @@ public class SuggestedMealMatch
     public string? MealName { get; set; }
     public decimal Carbs { get; set; }
     public DateTimeOffset ConsumedAt { get; set; }
-    public Guid TreatmentId { get; set; }
-    public decimal TreatmentCarbs { get; set; }
-    public long TreatmentMills { get; set; }
+    public Guid CarbIntakeId { get; set; }
+    public decimal CarbIntakeCarbs { get; set; }
+    public long CarbIntakeMills { get; set; }
     public double MatchScore { get; set; }
 }

--- a/src/API/Nocturne.API/Services/Alerts/AlertReplayService.cs
+++ b/src/API/Nocturne.API/Services/Alerts/AlertReplayService.cs
@@ -103,13 +103,13 @@ internal sealed class AlertReplayService(
         // change history), so — as before D5 — replay considers windows only.
         var dndWindows = await alertRepository.GetDndWindowsAsOfAsync(tenantId, windowEnd, ct);
 
-        // TODO(alerts-engine-seam): replay still evaluates through the managed
-        // ConditionEvaluatorRegistry directly rather than IAlertEvaluationEngine. The seam
-        // contract assumes engine-owned persistence, while replay needs a replay-local
-        // in-memory timer store and a fake clock per pass — wiring the rust path here means
-        // threading that state through per-tick envelopes like the parity tests do. Replay
-        // is read-only and its semantics are pinned by the golden corpus
-        // (tests/Parity/AlertEngineCorpus), so it stays managed until the cutover phase.
+        // Replay evaluates through the managed ConditionEvaluatorRegistry directly rather
+        // than IAlertEvaluationEngine. The seam contract assumes engine-owned persistence,
+        // while replay needs a replay-local in-memory timer store and a fake clock per
+        // pass — wiring the rust path here means threading that state through per-tick
+        // envelopes like the parity tests do. Replay is read-only and its semantics are
+        // pinned by the golden corpus (tests/Parity/AlertEngineCorpus), so it stays
+        // managed until the cutover phase.
         var fakeTime = new ReplayTimeProvider();
         var timerStore = new InMemoryConditionTimerStore();
         await using var replayServices = BuildReplayServices(timerStore, fakeTime);

--- a/src/API/Nocturne.API/Services/Chat/ChatIdentityPendingLinkService.cs
+++ b/src/API/Nocturne.API/Services/Chat/ChatIdentityPendingLinkService.cs
@@ -114,10 +114,9 @@ public sealed class ChatIdentityPendingLinkService(
         });
     }
 
-    // TODO(v1.1): wire CleanupExpiredAsync into a scheduled IHostedService.
     /// <summary>
-    /// Deletes all expired rows. Call periodically from a background sweep
-    /// (cleanup wiring is deferred to v1.1 per plan).
+    /// Deletes all expired rows. Call periodically from a background sweep; nothing
+    /// schedules it yet, so expired rows currently accumulate.
     /// </summary>
     public async Task<int> CleanupExpiredAsync(CancellationToken ct)
     {

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/MetadataPublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/MetadataPublisher.cs
@@ -264,7 +264,6 @@ internal sealed class MetadataPublisher : IMetadataPublisher
         string source,
         CancellationToken cancellationToken = default)
     {
-        // TODO: Filter by source to support multi-connector catch-up. Currently returns global latest.
         var latest = (await _activityService.GetActivitiesAsync(
                 count: 1,
                 skip: 0,

--- a/src/API/Nocturne.API/Services/Devices/LoopService.cs
+++ b/src/API/Nocturne.API/Services/Devices/LoopService.cs
@@ -476,13 +476,6 @@ public class LoopService : ILoopService, IDisposable
         }
     }
 
-    // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
-    // ~LoopService()
-    // {
-    //     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-    //     Dispose(disposing: false);
-    // }
-
     public void Dispose()
     {
         // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method

--- a/src/API/Nocturne.API/Services/Treatments/MealMatchingService.cs
+++ b/src/API/Nocturne.API/Services/Treatments/MealMatchingService.cs
@@ -1,14 +1,16 @@
 using Nocturne.Core.Contracts.Notifications;
 using Nocturne.Core.Contracts.Connectors;
 using Nocturne.Core.Contracts.Treatments;
+using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Configuration;
+using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Abstractions;
 
 namespace Nocturne.API.Services.Treatments;
 
 /// <summary>
-/// Matches connector food entries (primarily from MyFitnessPal) to existing meal-bolus treatments
+/// Matches connector food entries (primarily from MyFitnessPal) to existing carb intake records
 /// within a configurable time window, linking them via <see cref="ITreatmentFoodService"/>. Raises
 /// an in-app notification for new matches so users can review auto-linked meals.
 /// </summary>
@@ -21,8 +23,11 @@ public class MealMatchingService : IMealMatchingService
     /// </summary>
     public const string SuggestedMatchNotificationType = "meal_matching.suggested_match";
 
+    /// <summary>Cap on carb intake records pulled per matching window.</summary>
+    private const int CandidateLimit = 1000;
+
     private readonly IConnectorFoodEntryRepository _foodEntryRepository;
-    private readonly ITreatmentStore _treatmentStore;
+    private readonly ICarbIntakeRepository _carbIntakeRepository;
     private readonly ITreatmentFoodService _treatmentFoodService;
     private readonly IInAppNotificationService _notificationService;
     private readonly IInAppNotificationRepository _notificationRepository;
@@ -31,7 +36,7 @@ public class MealMatchingService : IMealMatchingService
 
     public MealMatchingService(
         IConnectorFoodEntryRepository foodEntryRepository,
-        ITreatmentStore treatmentStore,
+        ICarbIntakeRepository carbIntakeRepository,
         ITreatmentFoodService treatmentFoodService,
         IInAppNotificationService notificationService,
         IInAppNotificationRepository notificationRepository,
@@ -39,7 +44,7 @@ public class MealMatchingService : IMealMatchingService
         ILogger<MealMatchingService> logger)
     {
         _foodEntryRepository = foodEntryRepository;
-        _treatmentStore = treatmentStore;
+        _carbIntakeRepository = carbIntakeRepository;
         _treatmentFoodService = treatmentFoodService;
         _notificationService = notificationService;
         _notificationRepository = notificationRepository;
@@ -80,46 +85,6 @@ public class MealMatchingService : IMealMatchingService
         }
     }
 
-    public async Task ProcessNewTreatmentAsync(string userId, Guid treatmentId, CancellationToken ct = default)
-    {
-        var settings = await GetSettingsAsync(ct);
-        if (!settings.EnableMatchNotifications)
-        {
-            _logger.LogDebug("Match notifications disabled, skipping processing");
-            return;
-        }
-
-        var treatment = await _treatmentStore.GetByIdAsync(treatmentId.ToString(), ct);
-        if (treatment == null)
-        {
-            _logger.LogWarning("Treatment {TreatmentId} not found", treatmentId);
-            return;
-        }
-
-        // Only process meal treatments
-        if (treatment.Carbs is null or <= 0 &&
-            (treatment.EventType == null || !treatment.EventType.Contains("Meal", StringComparison.OrdinalIgnoreCase)))
-        {
-            return;
-        }
-
-        var treatmentTime = DateTimeOffset.FromUnixTimeMilliseconds(treatment.Mills);
-        var timeWindow = TimeSpan.FromMinutes(settings.MatchTimeWindowMinutes);
-
-        var pendingEntries = await _foodEntryRepository.GetPendingInTimeRangeAsync(
-            treatmentTime - timeWindow,
-            treatmentTime + timeWindow,
-            ct);
-
-        foreach (var entry in pendingEntries)
-        {
-            if (IsMatch(entry, treatment, settings))
-            {
-                await CreateMatchNotificationAsync(userId, entry, treatment, ct);
-            }
-        }
-    }
-
     public async Task AcceptMatchAsync(Guid foodEntryId, Guid carbIntakeId, decimal carbs, int timeOffsetMinutes, CancellationToken ct = default)
     {
         var foodEntry = await _foodEntryRepository.GetByIdAsync(foodEntryId, ct);
@@ -129,8 +94,6 @@ public class MealMatchingService : IMealMatchingService
             return;
         }
 
-        // The suggestion path still passes a legacy Treatment id here, so that path keys
-        // the row against the wrong record. The Glooko caller passes a real carb intake.
         var treatmentFood = new TreatmentFood
         {
             Id = Guid.CreateVersion7(),
@@ -193,42 +156,30 @@ public class MealMatchingService : IMealMatchingService
             return Array.Empty<SuggestedMealMatchResult>();
         }
 
-        // Expand the search window for treatments to account for matching window
-        var treatmentsFrom = from - timeWindow;
-        var treatmentsTo = to + timeWindow;
-        var treatments = await _treatmentStore.QueryAsync(new TreatmentQuery
-        {
-            Find = $"date[$gte]={treatmentsFrom.ToUnixTimeMilliseconds()}&date[$lte]={treatmentsTo.ToUnixTimeMilliseconds()}",
-            Count = 1000,
-        }, ct);
+        // Expand the search window for carb intakes to account for matching window
+        var carbIntakes = await GetCarbIntakesInWindowAsync(from - timeWindow, to + timeWindow, ct);
 
         var results = new List<SuggestedMealMatchResult>();
 
         foreach (var entry in pendingEntries)
         {
-            foreach (var treatment in treatments)
+            foreach (var carbIntake in carbIntakes)
             {
-                if (!IsMatch(entry, treatment, settings))
+                if (!IsMatch(entry, carbIntake, settings))
                 {
                     continue;
                 }
 
-                var score = CalculateMatchScore(entry, treatment, settings);
-                if (treatment.DbId == null)
-                {
-                    _logger.LogWarning("Treatment {TreatmentId} has no DbId, skipping", treatment.Id);
-                    continue;
-                }
                 results.Add(new SuggestedMealMatchResult(
                     FoodEntryId: entry.Id,
                     FoodName: entry.Food?.Name,
                     MealName: entry.MealName,
                     Carbs: entry.Carbs,
                     ConsumedAt: entry.ConsumedAt,
-                    TreatmentId: treatment.DbId.Value,
-                    TreatmentCarbs: (decimal)(treatment.Carbs ?? 0),
-                    TreatmentMills: treatment.Mills,
-                    MatchScore: score
+                    CarbIntakeId: carbIntake.Id,
+                    CarbIntakeCarbs: (decimal)carbIntake.Carbs,
+                    CarbIntakeMills: carbIntake.Mills,
+                    MatchScore: CalculateMatchScore(entry, carbIntake, settings)
                 ));
             }
         }
@@ -247,92 +198,106 @@ public class MealMatchingService : IMealMatchingService
         CancellationToken ct)
     {
         var timeWindow = TimeSpan.FromMinutes(settings.MatchTimeWindowMinutes);
-        var from = entry.ConsumedAt - timeWindow;
-        var to = entry.ConsumedAt + timeWindow;
-        var treatments = await _treatmentStore.QueryAsync(new TreatmentQuery
-        {
-            Find = $"date[$gte]={from.ToUnixTimeMilliseconds()}&date[$lte]={to.ToUnixTimeMilliseconds()}",
-            Count = 1000,
-        }, ct);
+        var carbIntakes = await GetCarbIntakesInWindowAsync(
+            entry.ConsumedAt - timeWindow,
+            entry.ConsumedAt + timeWindow,
+            ct);
 
-        var bestMatch = FindBestMatch(entry, treatments, settings);
+        var bestMatch = FindBestMatch(entry, carbIntakes, settings);
         if (bestMatch != null)
         {
             await CreateMatchNotificationAsync(userId, entry, bestMatch, ct);
         }
     }
 
-    private Treatment? FindBestMatch(
+    private async Task<IReadOnlyList<CarbIntake>> GetCarbIntakesInWindowAsync(
+        DateTimeOffset from,
+        DateTimeOffset to,
+        CancellationToken ct)
+    {
+        var carbIntakes = await _carbIntakeRepository.GetAsync(
+            from: from.UtcDateTime,
+            to: to.UtcDateTime,
+            device: null,
+            source: null,
+            limit: CandidateLimit,
+            offset: 0,
+            descending: false,
+            ct: ct);
+
+        return carbIntakes.ToList();
+    }
+
+    private CarbIntake? FindBestMatch(
         ConnectorFoodEntry entry,
-        IReadOnlyList<Treatment> treatments,
+        IReadOnlyList<CarbIntake> carbIntakes,
         MyFitnessPalMatchingSettings settings)
     {
-        Treatment? bestMatch = null;
+        CarbIntake? bestMatch = null;
         double bestScore = 0;
 
-        foreach (var treatment in treatments)
+        foreach (var carbIntake in carbIntakes)
         {
-            if (!IsMatch(entry, treatment, settings))
+            if (!IsMatch(entry, carbIntake, settings))
             {
                 continue;
             }
 
-            var score = CalculateMatchScore(entry, treatment, settings);
+            var score = CalculateMatchScore(entry, carbIntake, settings);
             if (score > bestScore)
             {
                 bestScore = score;
-                bestMatch = treatment;
+                bestMatch = carbIntake;
             }
         }
 
         return bestMatch;
     }
 
-    private bool IsMatch(ConnectorFoodEntry entry, Treatment treatment, MyFitnessPalMatchingSettings settings)
+    private static bool IsMatch(ConnectorFoodEntry entry, CarbIntake carbIntake, MyFitnessPalMatchingSettings settings)
     {
-        var treatmentTime = DateTimeOffset.FromUnixTimeMilliseconds(treatment.Mills);
-        var timeDiff = Math.Abs((entry.ConsumedAt - treatmentTime).TotalMinutes);
+        var timeDiff = Math.Abs((entry.ConsumedAt - CarbIntakeTime(carbIntake)).TotalMinutes);
 
         if (timeDiff > settings.MatchTimeWindowMinutes)
         {
             return false;
         }
 
-        var treatmentCarbs = treatment.Carbs ?? 0;
-        var carbDiff = Math.Abs((double)(entry.Carbs - (decimal)treatmentCarbs));
-        var carbPercent = treatmentCarbs > 0 ? (carbDiff / treatmentCarbs) * 100 : 100;
+        var carbDiff = Math.Abs((double)entry.Carbs - carbIntake.Carbs);
+        var carbPercent = carbIntake.Carbs > 0 ? (carbDiff / carbIntake.Carbs) * 100 : 100;
 
         return carbDiff <= settings.MatchCarbToleranceGrams ||
                carbPercent <= settings.MatchCarbTolerancePercent;
     }
 
-    private double CalculateMatchScore(
+    private static double CalculateMatchScore(
         ConnectorFoodEntry entry,
-        Treatment treatment,
+        CarbIntake carbIntake,
         MyFitnessPalMatchingSettings settings)
     {
-        var treatmentTime = DateTimeOffset.FromUnixTimeMilliseconds(treatment.Mills);
-        var timeDiff = Math.Abs((entry.ConsumedAt - treatmentTime).TotalMinutes);
+        var timeDiff = Math.Abs((entry.ConsumedAt - CarbIntakeTime(carbIntake)).TotalMinutes);
         var timeScore = 1 - (timeDiff / settings.MatchTimeWindowMinutes);
 
-        var treatmentCarbs = treatment.Carbs ?? 0;
-        var carbDiff = Math.Abs((double)(entry.Carbs - (decimal)treatmentCarbs));
-        var carbRatio = treatmentCarbs > 0 ? carbDiff / treatmentCarbs : 1;
+        var carbDiff = Math.Abs((double)entry.Carbs - carbIntake.Carbs);
+        var carbRatio = carbIntake.Carbs > 0 ? carbDiff / carbIntake.Carbs : 1;
         var carbScore = 1 - Math.Min(carbRatio, 1);
 
         return (timeScore * 0.6) + (carbScore * 0.4);
     }
 
+    private static DateTimeOffset CarbIntakeTime(CarbIntake carbIntake) =>
+        DateTimeOffset.FromUnixTimeMilliseconds(carbIntake.Mills);
+
     private async Task CreateMatchNotificationAsync(
         string userId,
         ConnectorFoodEntry entry,
-        Treatment treatment,
+        CarbIntake carbIntake,
         CancellationToken ct)
     {
         // The notification store does not dedupe on source, and an entry reaches this more than once
-        // — re-imported with a corrected consumed time, restored after a withdrawal, or scanned again
-        // by ProcessNewTreatmentAsync — so without this check the same suggestion stacks up until the
-        // source's active-notification cap trips and starts throwing.
+        // — re-imported with a corrected consumed time, or restored after a withdrawal — so without
+        // this check the same suggestion stacks up until the source's active-notification cap trips
+        // and starts throwing.
         var existing = await _notificationRepository.FindBySourceAsync(
             userId,
             SuggestedMatchNotificationType,
@@ -348,8 +313,7 @@ public class MealMatchingService : IMealMatchingService
         }
 
         var foodName = entry.Food?.Name ?? entry.MealName;
-        var treatmentTime = DateTimeOffset.FromUnixTimeMilliseconds(treatment.Mills);
-        var timeDisplay = FormatTimeDisplay(treatmentTime);
+        var timeDisplay = FormatTimeDisplay(CarbIntakeTime(carbIntake));
 
         var title = $"Confirm you ate \"{foodName}\" {timeDisplay}";
         var subtitle = $"{entry.MealName} · {entry.Carbs:0}g carbs · via MyFitnessPal";
@@ -363,9 +327,9 @@ public class MealMatchingService : IMealMatchingService
 
         var metadata = new Dictionary<string, object>
         {
-            ["treatmentId"] = treatment.Id!,
-            ["treatmentCarbs"] = treatment.Carbs ?? 0,
-            ["treatmentMills"] = treatment.Mills,
+            ["carbIntakeId"] = carbIntake.Id,
+            ["carbIntakeCarbs"] = carbIntake.Carbs,
+            ["carbIntakeMills"] = carbIntake.Mills,
             ["foodEntryCarbs"] = entry.Carbs,
             ["consumedAtMills"] = entry.ConsumedAt.ToUnixTimeMilliseconds(),
         };
@@ -381,9 +345,9 @@ public class MealMatchingService : IMealMatchingService
             cancellationToken: ct);
 
         _logger.LogInformation(
-            "Created meal match notification for food entry {FoodEntryId} and treatment {TreatmentId}",
+            "Created meal match notification for food entry {FoodEntryId} and carb intake {CarbIntakeId}",
             entry.Id,
-            treatment.Id);
+            carbIntake.Id);
     }
 
     private static string FormatTimeDisplay(DateTimeOffset time)

--- a/src/API/Nocturne.API/Services/Treatments/MealMatchingService.cs
+++ b/src/API/Nocturne.API/Services/Treatments/MealMatchingService.cs
@@ -94,6 +94,16 @@ public class MealMatchingService : IMealMatchingService
             return;
         }
 
+        // treatment_foods.carb_intake_id carries no foreign key, so an unknown id here would
+        // persist a row no breakdown can ever resolve — and flip the food entry to Matched,
+        // so it never resurfaces as a suggestion.
+        var carbIntake = await _carbIntakeRepository.GetByIdAsync(carbIntakeId, ct);
+        if (carbIntake == null)
+        {
+            _logger.LogWarning("Carb intake {CarbIntakeId} not found", carbIntakeId);
+            return;
+        }
+
         var treatmentFood = new TreatmentFood
         {
             Id = Guid.CreateVersion7(),
@@ -215,6 +225,9 @@ public class MealMatchingService : IMealMatchingService
         DateTimeOffset to,
         CancellationToken ct)
     {
+        // Newest-first: a window wider than CandidateLimit is truncated by the database, and
+        // the pending food entries being matched are the recent ones. Fetching oldest-first
+        // would spend the budget on the far end of the range and find nothing.
         var carbIntakes = await _carbIntakeRepository.GetAsync(
             from: from.UtcDateTime,
             to: to.UtcDateTime,
@@ -222,7 +235,7 @@ public class MealMatchingService : IMealMatchingService
             source: null,
             limit: CandidateLimit,
             offset: 0,
-            descending: false,
+            descending: true,
             ct: ct);
 
         return carbIntakes.ToList();

--- a/src/API/Nocturne.API/Services/Treatments/MealMatchingService.cs
+++ b/src/API/Nocturne.API/Services/Treatments/MealMatchingService.cs
@@ -120,7 +120,7 @@ public class MealMatchingService : IMealMatchingService
         }
     }
 
-    public async Task AcceptMatchAsync(Guid foodEntryId, Guid treatmentId, decimal carbs, int timeOffsetMinutes, CancellationToken ct = default)
+    public async Task AcceptMatchAsync(Guid foodEntryId, Guid carbIntakeId, decimal carbs, int timeOffsetMinutes, CancellationToken ct = default)
     {
         var foodEntry = await _foodEntryRepository.GetByIdAsync(foodEntryId, ct);
         if (foodEntry == null)
@@ -129,12 +129,12 @@ public class MealMatchingService : IMealMatchingService
             return;
         }
 
-        // TODO: Phase 9 — MealMatchingService needs to be updated to work with CarbIntake records
-        // instead of legacy Treatments. For now, treatmentId is passed as CarbIntakeId.
+        // The suggestion path still passes a legacy Treatment id here, so that path keys
+        // the row against the wrong record. The Glooko caller passes a real carb intake.
         var treatmentFood = new TreatmentFood
         {
             Id = Guid.CreateVersion7(),
-            CarbIntakeId = treatmentId,
+            CarbIntakeId = carbIntakeId,
             FoodId = foodEntry.FoodId,
             Portions = foodEntry.Servings,
             Carbs = carbs,
@@ -152,9 +152,9 @@ public class MealMatchingService : IMealMatchingService
             ct);
 
         _logger.LogInformation(
-            "Accepted meal match: food entry {FoodEntryId} linked to treatment {TreatmentId}",
+            "Accepted meal match: food entry {FoodEntryId} linked to carb intake {CarbIntakeId}",
             foodEntryId,
-            treatmentId);
+            carbIntakeId);
     }
 
     public async Task DismissMatchAsync(Guid foodEntryId, CancellationToken ct = default)

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -72,8 +72,8 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     ];
 
     // ── Per-sync state (populated in PerformSyncInternalAsync) ─────────
-    // TODO: These instance fields are not safe for concurrent multi-tenant syncs.
-    // They should be refactored to local variables threaded through helper methods.
+    // These fields are not safe for concurrent syncs on one instance: a second
+    // InitializeMappers overwrites the first sync's session and mappers.
 
     private string? _sessionCookie;
     private GlookoUserData? _userData;

--- a/src/Core/Nocturne.Core.Contracts/Treatments/IMealMatchingService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Treatments/IMealMatchingService.cs
@@ -19,14 +19,6 @@ public interface IMealMatchingService
     Task ProcessNewFoodEntriesAsync(string userId, IEnumerable<Guid> foodEntryIds, CancellationToken ct = default);
 
     /// <summary>
-    /// Process a newly created treatment and create match notifications for pending food entries.
-    /// </summary>
-    /// <param name="userId">The user ID for notification delivery.</param>
-    /// <param name="treatmentId">ID of the newly created treatment to evaluate against pending food entries.</param>
-    /// <param name="ct">Cancellation token.</param>
-    Task ProcessNewTreatmentAsync(string userId, Guid treatmentId, CancellationToken ct = default);
-
-    /// <summary>
     /// Accept a meal match, creating a TreatmentFood entry
     /// </summary>
     /// <param name="foodEntryId">The connector food entry ID</param>
@@ -59,16 +51,16 @@ public interface IMealMatchingService
 }
 
 /// <summary>
-/// A suggested meal match pairing a connector food entry with a treatment.
+/// A suggested meal match pairing a connector food entry with a carb intake.
 /// </summary>
 /// <param name="FoodEntryId">The ID of the pending <see cref="ConnectorFoodEntry"/>.</param>
 /// <param name="FoodName">Individual food item name, if available.</param>
 /// <param name="MealName">Meal name from the connector, if available.</param>
 /// <param name="Carbs">Carbohydrate amount in grams from the food entry.</param>
 /// <param name="ConsumedAt">When the food was consumed according to the connector.</param>
-/// <param name="TreatmentId">The ID of the candidate matching treatment.</param>
-/// <param name="TreatmentCarbs">Carbohydrate amount in grams recorded on the treatment.</param>
-/// <param name="TreatmentMills">Treatment timestamp in Unix milliseconds.</param>
+/// <param name="CarbIntakeId">The ID of the candidate matching carb intake.</param>
+/// <param name="CarbIntakeCarbs">Carbohydrate amount in grams recorded on the carb intake.</param>
+/// <param name="CarbIntakeMills">Carb intake timestamp in Unix milliseconds.</param>
 /// <param name="MatchScore">Computed match score (higher is a better match).</param>
 public record SuggestedMealMatchResult(
     Guid FoodEntryId,
@@ -76,8 +68,8 @@ public record SuggestedMealMatchResult(
     string? MealName,
     decimal Carbs,
     DateTimeOffset ConsumedAt,
-    Guid TreatmentId,
-    decimal TreatmentCarbs,
-    long TreatmentMills,
+    Guid CarbIntakeId,
+    decimal CarbIntakeCarbs,
+    long CarbIntakeMills,
     double MatchScore
 );

--- a/src/Core/Nocturne.Core.Contracts/Treatments/IMealMatchingService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Treatments/IMealMatchingService.cs
@@ -30,10 +30,10 @@ public interface IMealMatchingService
     /// Accept a meal match, creating a TreatmentFood entry
     /// </summary>
     /// <param name="foodEntryId">The connector food entry ID</param>
-    /// <param name="treatmentId">The treatment to link to</param>
+    /// <param name="carbIntakeId">The carb intake to link the food to</param>
     /// <param name="carbs">The carb amount (may be adjusted from original)</param>
-    /// <param name="timeOffsetMinutes">Minutes offset from treatment time (0 = ate at bolus time)</param>
-    Task AcceptMatchAsync(Guid foodEntryId, Guid treatmentId, decimal carbs, int timeOffsetMinutes, CancellationToken ct = default);
+    /// <param name="timeOffsetMinutes">Minutes offset from the carb intake time (0 = ate at bolus time)</param>
+    Task AcceptMatchAsync(Guid foodEntryId, Guid carbIntakeId, decimal carbs, int timeOffsetMinutes, CancellationToken ct = default);
 
     /// <summary>
     /// Dismiss a match, marking the food entry as standalone

--- a/src/Core/Nocturne.Core.Models/Treatment.cs
+++ b/src/Core/Nocturne.Core.Models/Treatment.cs
@@ -834,14 +834,6 @@ public class Treatment : ProcessableDocumentBase
     public Guid? CanonicalId { get; set; }
 
     /// <summary>
-    /// Gets or sets the PostgreSQL database ID.
-    /// This is the actual UUID primary key in the treatments table.
-    /// </summary>
-    [JsonPropertyName("dbId")]
-    [NocturneOnly]
-    public Guid? DbId { get; set; }
-
-    /// <summary>
     /// Gets or sets the list of data sources that contributed to this unified record.
     /// Only populated when returning merged/unified DTOs.
     /// </summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -2184,9 +2184,8 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
                 .IsUnique()
                 .HasDatabaseName("ux_directory_user_tenant");
 
-            // TODO(Task 1.5): ChatIdentityDirectoryService.CreateLinkAsync must
-            // auto-suffix label collisions within a (platform, platform_user_id)
-            // set before insert — this unique index will throw otherwise.
+            // ChatIdentityDirectoryService.CreateLinkAsync auto-suffixes label collisions
+            // within a (platform, platform_user_id) set before insert, so this holds.
             b.HasIndex(e => new { e.Platform, e.PlatformUserId, e.Label })
                 .IsUnique()
                 .HasDatabaseName("ux_directory_user_label");

--- a/src/Web/packages/app/src/lib/components/entries/FoodBreakdown.svelte
+++ b/src/Web/packages/app/src/lib/components/entries/FoodBreakdown.svelte
@@ -215,7 +215,7 @@
     if (!value) editEntry = null;
   }}
   entry={editEntry}
-  treatmentId={carbIntakeId}
+  {carbIntakeId}
   {totalCarbs}
   {remainingCarbs}
   onSave={handleEditSaved}

--- a/src/Web/packages/app/src/lib/components/meal-matching/MealMatchReviewDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/meal-matching/MealMatchReviewDialog.svelte
@@ -33,16 +33,16 @@
   let isLoading = $state(false);
 
   // Extract data from notification OR match
-  const treatmentId = $derived(
-    match?.treatmentId ??
-      notification?.metadata?.["treatmentId"]?.toString() ??
+  const carbIntakeId = $derived(
+    match?.carbIntakeId ??
+      notification?.metadata?.["carbIntakeId"]?.toString() ??
       ""
   );
-  const treatmentCarbs = $derived(
-    match?.treatmentCarbs ?? (Number(notification?.metadata?.["treatmentCarbs"]) || 0)
+  const carbIntakeCarbs = $derived(
+    match?.carbIntakeCarbs ?? (Number(notification?.metadata?.["carbIntakeCarbs"]) || 0)
   );
-  const treatmentMills = $derived(
-    match?.treatmentMills ?? (Number(notification?.metadata?.["treatmentMills"]) || 0)
+  const carbIntakeMills = $derived(
+    match?.carbIntakeMills ?? (Number(notification?.metadata?.["carbIntakeMills"]) || 0)
   );
   const foodEntryCarbs = $derived(
     match?.carbs ?? (Number(notification?.metadata?.["foodEntryCarbs"]) || 0)
@@ -96,10 +96,10 @@
   let selectedDate = $state<string>("");
 
   // Derived times for comparison
-  const bolusTimeInput = $derived(formatTimeInput(treatmentMills));
+  const bolusTimeInput = $derived(formatTimeInput(carbIntakeMills));
   const loggedTimeInput = $derived(formatTimeInput(consumedAtMills));
-  const bolusDateInput = $derived(formatDateInput(treatmentMills));
-  const bolusDateDisplay = $derived(formatDateDisplay(treatmentMills));
+  const bolusDateInput = $derived(formatDateInput(carbIntakeMills));
+  const bolusDateDisplay = $derived(formatDateDisplay(carbIntakeMills));
 
   // Check which preset is selected (if any)
   const isBolusTime = $derived(selectedTime === bolusTimeInput);
@@ -107,19 +107,19 @@
 
   // Calculate offset minutes from selected date and time
   const timeOffsetMinutes = $derived.by(() => {
-    if (!treatmentMills || !selectedTime || !selectedDate) return 0;
+    if (!carbIntakeMills || !selectedTime || !selectedDate) return 0;
     const [hours, minutes] = selectedTime.split(":").map(Number);
     const [year, month, day] = selectedDate.split("-").map(Number);
     const customDate = new Date(year, month - 1, day, hours, minutes, 0, 0);
-    return Math.round((customDate.getTime() - treatmentMills) / 60000);
+    return Math.round((customDate.getTime() - carbIntakeMills) / 60000);
   });
 
   // Initialize form when dialog opens
   $effect(() => {
     if (open && (notification || match)) {
       carbs = foodEntryCarbs;
-      selectedTime = formatTimeInput(treatmentMills);
-      selectedDate = formatDateInput(treatmentMills);
+      selectedTime = formatTimeInput(carbIntakeMills);
+      selectedDate = formatDateInput(carbIntakeMills);
     }
   });
 
@@ -133,7 +133,7 @@
   }
 
   async function handleAccept() {
-    if (!foodEntryId || !treatmentId) {
+    if (!foodEntryId || !carbIntakeId) {
       toast.error("Missing required data");
       return;
     }
@@ -142,7 +142,7 @@
     try {
       await acceptMatch({
         foodEntryId,
-        treatmentId,
+        carbIntakeId,
         carbs,
         timeOffsetMinutes,
       });
@@ -259,19 +259,19 @@
             bind:value={carbs}
             class="tabular-nums"
           />
-          {#if treatmentCarbs > 0 && carbs !== treatmentCarbs}
+          {#if carbIntakeCarbs > 0 && carbs !== carbIntakeCarbs}
             <Button
               type="button"
               variant="outline"
               size="sm"
-              onclick={() => (carbs = treatmentCarbs)}
+              onclick={() => (carbs = carbIntakeCarbs)}
             >
-              Scale to {treatmentCarbs}g
+              Scale to {carbIntakeCarbs}g
             </Button>
           {/if}
         </div>
         <p class="text-xs text-muted-foreground">
-          Treatment has {treatmentCarbs}g total carbs
+          The logged carb entry has {carbIntakeCarbs}g total carbs
         </p>
       </div>
 

--- a/src/Web/packages/app/src/lib/components/treatments/TreatmentFoodBreakdown.svelte
+++ b/src/Web/packages/app/src/lib/components/treatments/TreatmentFoodBreakdown.svelte
@@ -17,7 +17,7 @@
   import { CarbBreakdownBar, FoodEntryDetails } from "./index";
 
   interface Props {
-    treatmentId?: string;
+    carbIntakeId?: string;
     /**
      * Total carbs from the treatment - shown so user knows what they're working
      * toward
@@ -25,7 +25,7 @@
     totalCarbs?: number;
   }
 
-  let { treatmentId, totalCarbs = 0 }: Props = $props();
+  let { carbIntakeId, totalCarbs = 0 }: Props = $props();
 
   let breakdown = $state<TreatmentFoodBreakdown | null>(null);
   let isLoading = $state(false);
@@ -36,12 +36,12 @@
   let editEntry = $state<TreatmentFood | null>(null);
 
   $effect(() => {
-    if (!treatmentId) {
+    if (!carbIntakeId) {
       breakdown = null;
       return;
     }
     // `.run()` rejects during the render/effect flush, so defer out of it.
-    const id = treatmentId;
+    const id = carbIntakeId;
     queueMicrotask(() => loadBreakdown(id));
   });
 
@@ -59,9 +59,9 @@
   }
 
   async function handleAddFood(request: CarbIntakeFoodRequest) {
-    if (!treatmentId) return;
+    if (!carbIntakeId) return;
     try {
-      const updated = await addCarbIntakeFood({ id: treatmentId!, request });
+      const updated = await addCarbIntakeFood({ id: carbIntakeId!, request });
       breakdown = updated;
       showAddFood = false;
     } catch (err) {
@@ -75,22 +75,22 @@
   }
 
   async function handleDelete(entry: TreatmentFood) {
-    if (!treatmentId || !entry.id) return;
+    if (!carbIntakeId || !entry.id) return;
     try {
       await deleteCarbIntakeFood({
-        id: treatmentId!,
+        id: carbIntakeId!,
         foodEntryId: entry.id!,
       });
       // Reload the breakdown after deletion
-      await loadBreakdown(treatmentId);
+      await loadBreakdown(carbIntakeId);
     } catch (err) {
       console.error("Failed to delete food entry:", err);
     }
   }
 
   async function handleEditSaved() {
-    if (treatmentId) {
-      await loadBreakdown(treatmentId);
+    if (carbIntakeId) {
+      await loadBreakdown(carbIntakeId);
     }
   }
 
@@ -212,7 +212,7 @@
     if (!value) editEntry = null;
   }}
   entry={editEntry}
-  {treatmentId}
+  {carbIntakeId}
   {totalCarbs}
   {remainingCarbs}
   onSave={handleEditSaved}

--- a/src/Web/packages/app/src/lib/components/treatments/TreatmentFoodEntryEditDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/treatments/TreatmentFoodEntryEditDialog.svelte
@@ -22,7 +22,7 @@
     /** The treatment food entry to edit */
     entry: TreatmentFood | null;
     /** The treatment ID */
-    treatmentId: string | undefined;
+    carbIntakeId: string | undefined;
     /** Total carbs from the treatment */
     totalCarbs?: number;
     /** Remaining unspecified carbs (excluding this entry) */
@@ -35,7 +35,7 @@
     open = $bindable(),
     onOpenChange,
     entry,
-    treatmentId,
+    carbIntakeId,
     totalCarbs = 0,
     remainingCarbs = 0,
     onSave,
@@ -184,12 +184,12 @@
 
   async function handleSubmit(event: SubmitEvent) {
     event.preventDefault();
-    if (!treatmentId || !entry?.id) return;
+    if (!carbIntakeId || !entry?.id) return;
 
     isSubmitting = true;
     try {
       await updateCarbIntakeFood({
-        id: treatmentId,
+        id: carbIntakeId,
         foodEntryId: entry.id,
         request: {
           foodId: entry.foodId ?? null,

--- a/src/Web/packages/app/src/routes/(authenticated)/meals/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/meals/+page.svelte
@@ -93,12 +93,12 @@
   const suggestionsByCarbIntake = $derived.by(() => {
     const map = new Map<string, SuggestedMealMatch[]>();
     for (const match of suggestedMatches) {
-      const treatmentId = match.treatmentId;
-      if (!treatmentId) continue;
-      if (!map.has(treatmentId)) {
-        map.set(treatmentId, []);
+      const carbIntakeId = match.carbIntakeId;
+      if (!carbIntakeId) continue;
+      if (!map.has(carbIntakeId)) {
+        map.set(carbIntakeId, []);
       }
-      map.get(treatmentId)!.push(match);
+      map.get(carbIntakeId)!.push(match);
     }
     return map;
   });
@@ -348,7 +348,7 @@
     try {
       await acceptMatch({
         foodEntryId: match.foodEntryId!,
-        treatmentId: match.treatmentId!,
+        carbIntakeId: match.carbIntakeId!,
         carbs: match.carbs ?? 0,
         timeOffsetMinutes: 0,
       });
@@ -466,7 +466,7 @@
     }
   }}
   entry={editFoodEntry}
-  treatmentId={editFoodEntryMeal?.carbIntakes?.[0]?.id}
+  carbIntakeId={editFoodEntryMeal?.carbIntakes?.[0]?.id}
   totalCarbs={editFoodEntryMeal?.totalCarbs ?? 0}
   remainingCarbs={editFoodEntryMeal
     ? getRemainingCarbsForEntry(editFoodEntryMeal, editFoodEntry?.id)

--- a/src/Web/packages/bot/src/commands/alerts.ts
+++ b/src/Web/packages/bot/src/commands/alerts.ts
@@ -6,11 +6,10 @@ const logger = createLogger();
 
 export function registerAlertCommands(bot: Chat) {
   bot.onAction("ack_alert", async (event) => {
-    // TODO: requireLink for actions — see plan Task 3.4 notes.
-    // ActionEvent shape differs from SlashCommandEvent (no `channel`, `text`,
-    // or `command`), so it can't be passed to requireLink as-is. Until a
-    // dedicated helper exists this will call the ambient (unscoped) api and
-    // fail if no tenant is in scope. Secondary surface; fix in a follow-up.
+    // ActionEvent shape differs from SlashCommandEvent (no `channel`, `text`, or
+    // `command`), so it can't be passed to requireLink as-is. Until a dedicated
+    // helper exists this calls the ambient (unscoped) api and fails if no tenant
+    // is in scope.
     try {
       const api = getApi();
       await api.alerts.acknowledge({ acknowledgedBy: event.user.fullName ?? "Unknown" });

--- a/src/Web/packages/cms/src/lib/components/edra/shadcn/drag-handle-extended.svelte
+++ b/src/Web/packages/cms/src/lib/components/edra/shadcn/drag-handle-extended.svelte
@@ -78,9 +78,6 @@
 
 	const handleCopyToClipboard = () => {
 		editor.chain().setMeta('hideDragHandle', true).setNodeSelection(currentNodePos).run();
-		/**
-		 * !FIXME: document.execCommand is deprecated, use navigator.clipboard.writeText instead
-		 */
 		document.execCommand('copy');
 	};
 

--- a/src/Widgets/Nocturne.Widget.Windows11/WidgetProvider.cs
+++ b/src/Widgets/Nocturne.Widget.Windows11/WidgetProvider.cs
@@ -1079,7 +1079,6 @@ public sealed class NocturneWidgetProvider : IWidgetProvider, IWidgetProvider2
             if (!result.Success)
             {
                 _logger.LogWarning("Failed to initiate device authorization: {Error}", result.Error);
-                // TODO: Show error in widget
                 return;
             }
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Treatments/MealMatchingServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Treatments/MealMatchingServiceTests.cs
@@ -185,4 +185,54 @@ public class MealMatchingServiceTests
         suggestions.Should().ContainSingle()
             .Which.CarbIntakeId.Should().Be(carbIntakeId);
     }
+
+    /// <summary>
+    /// A window holding more candidates than the fetch limit is truncated by the database, so
+    /// the fetch has to be newest-first — the pending entries being matched are the recent
+    /// ones, and oldest-first spends the whole budget on the far end of the range.
+    /// </summary>
+    [Fact]
+    public async Task GetSuggestionsAsync_FetchesTheNewestCandidatesWhenTheWindowIsTruncated()
+    {
+        _foodEntryRepository
+            .Setup(r => r.GetPendingInTimeRangeAsync(
+                It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([Entry(Guid.NewGuid())]);
+
+        await NewService().GetSuggestionsAsync(ConsumedAt.AddMonths(-6), ConsumedAt);
+
+        _carbIntakeRepository.Verify(
+            s => s.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<int>(), true, It.IsAny<bool>(),
+                It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+    }
+
+    /// <summary>
+    /// <c>treatment_foods.carb_intake_id</c> has no foreign key, so an unknown id would persist
+    /// a row nothing can resolve and strand the food entry in Matched.
+    /// </summary>
+    [Fact]
+    public async Task AcceptMatchAsync_WritesNothingWhenTheCarbIntakeDoesNotExist()
+    {
+        var foodEntryId = Guid.NewGuid();
+        _foodEntryRepository
+            .Setup(r => r.GetByIdAsync(foodEntryId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Entry(foodEntryId));
+
+        _carbIntakeRepository
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CarbIntake?)null);
+
+        await NewService().AcceptMatchAsync(foodEntryId, Guid.CreateVersion7(), 30, 0);
+
+        _treatmentFoodService.Verify(
+            s => s.AddAsync(It.IsAny<TreatmentFood>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _foodEntryRepository.Verify(
+            r => r.UpdateStatusAsync(
+                It.IsAny<Guid>(), It.IsAny<ConnectorFoodEntryStatus>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Treatments/MealMatchingServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Treatments/MealMatchingServiceTests.cs
@@ -5,8 +5,10 @@ using Nocturne.API.Services.Treatments;
 using Nocturne.Core.Contracts.Connectors;
 using Nocturne.Core.Contracts.Notifications;
 using Nocturne.Core.Contracts.Treatments;
+using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Configuration;
+using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Abstractions;
 using Nocturne.Infrastructure.Data.Entities;
 using Xunit;
@@ -23,7 +25,7 @@ public class MealMatchingServiceTests
     private const string UserId = "user-1";
 
     private readonly Mock<IConnectorFoodEntryRepository> _foodEntryRepository = new();
-    private readonly Mock<ITreatmentStore> _treatmentStore = new();
+    private readonly Mock<ICarbIntakeRepository> _carbIntakeRepository = new();
     private readonly Mock<ITreatmentFoodService> _treatmentFoodService = new();
     private readonly Mock<IInAppNotificationService> _notificationService = new();
     private readonly Mock<IInAppNotificationRepository> _notificationRepository = new();
@@ -37,20 +39,23 @@ public class MealMatchingServiceTests
             .Setup(s => s.GetSettingsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MyFitnessPalMatchingSettings());
 
-        // Every entry has a treatment it matches, so each one wants to raise a notification.
-        _treatmentStore
-            .Setup(s => s.QueryAsync(It.IsAny<TreatmentQuery>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([new Treatment
+        // Every entry has a carb intake it matches, so each one wants to raise a notification.
+        _carbIntakeRepository
+            .Setup(s => s.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<bool>(),
+                It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new CarbIntake
             {
-                Id = Guid.NewGuid().ToString(),
+                Id = Guid.CreateVersion7(),
                 Carbs = 30,
-                Mills = ConsumedAt.ToUnixTimeMilliseconds(),
+                Timestamp = ConsumedAt.UtcDateTime,
             }]);
     }
 
     private MealMatchingService NewService() =>
         new(_foodEntryRepository.Object,
-            _treatmentStore.Object,
+            _carbIntakeRepository.Object,
             _treatmentFoodService.Object,
             _notificationService.Object,
             _notificationRepository.Object,
@@ -144,5 +149,40 @@ public class MealMatchingServiceTests
                 It.IsAny<List<NotificationActionDto>?>(), It.IsAny<ResolutionConditions?>(),
                 It.IsAny<Dictionary<string, object>?>(), It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    /// <summary>
+    /// The suggestion carries the carb intake's own id, which is the key
+    /// <see cref="MealMatchingService.AcceptMatchAsync"/> writes to
+    /// <c>treatment_foods.carb_intake_id</c>. Reading candidates through the legacy treatment
+    /// projection produced either a bolus id or, once a never-populated <c>DbId</c> gated the
+    /// result, no suggestions at all.
+    /// </summary>
+    [Fact]
+    public async Task GetSuggestionsAsync_ReturnsTheMatchedCarbIntakeId()
+    {
+        var carbIntakeId = Guid.CreateVersion7();
+        _carbIntakeRepository
+            .Setup(s => s.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<bool>(),
+                It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new CarbIntake
+            {
+                Id = carbIntakeId,
+                Carbs = 30,
+                Timestamp = ConsumedAt.UtcDateTime,
+            }]);
+
+        _foodEntryRepository
+            .Setup(r => r.GetPendingInTimeRangeAsync(
+                It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([Entry(Guid.NewGuid())]);
+
+        var suggestions = await NewService().GetSuggestionsAsync(
+            ConsumedAt.AddHours(-1), ConsumedAt.AddHours(1));
+
+        suggestions.Should().ContainSingle()
+            .Which.CarbIntakeId.Should().Be(carbIntakeId);
     }
 }


### PR DESCRIPTION
Two commits. The first sweeps every TODO/FIXME marker out of `src/` into the issue tracker. The second fixes one of the things the sweep turned up — read that one on its own, it's a behaviour change.

## 1. `chore:` lift TODO markers into tracked issues

Comments only, no behaviour change.

| Issue | Site |
|---|---|
| #652 | `WebhookSettingsController`, `UISettingsController` — webhook settings and alarm profile writes are silent no-ops |
| #653 | `TrackersController` — `RoleRestricted` hides a tracker from its own owner |
| #654 | `AlertReplayService` — replay should evaluate through `IAlertEvaluationEngine` |
| #655 | `ChatIdentityPendingLinkService` — expired pending-link tokens are never swept |
| #656 | `MetadataPublisher` — `GetLatestActivityTimestampAsync` ignores its `source` argument |
| #657 | `GlookoConnectorService` — per-sync state on instance fields |
| #658 | `MealMatchingService` — accept writes a legacy Treatment id into `TreatmentFood.CarbIntakeId` |
| #659 | `bot/commands/alerts.ts` — `ack_alert` runs against the unscoped ambient API client |
| #660 | `WidgetProvider`, CMS `drag-handle-extended` — silent widget auth failure, deprecated `execCommand` |

No issue numbers in the code — a `#NNN` in a comment is just a TODO wearing a hat. Where behaviour is surprising on its own terms the marker becomes a plain comment stating what the code does; where an adjacent log line or XML doc already said it, the marker is deleted.

Deleted without an issue: `LoopService`'s commented-out IDisposable-template finalizer, and `NocturneDbContext`'s `TODO(Task 1.5)` note, which was **stale** — `CreateLinkAsync` already resolves label collisions via `ResolveUniqueLabel`.

## 2. `fix:` match on carb intakes instead of projected treatments

Closes #658. Verifying that marker turned up a second, larger defect.

Matching read candidates through `ITreatmentStore`, which projects legacy `Treatment` records out of the decomposed v4 tables:

- **`Treatment.DbId` is never assigned anywhere in the codebase.** So `if (treatment.DbId == null) continue;` in `GetSuggestionsAsync` skipped every candidate — `GET /api/v4/meal-matching/suggestions` has been returning `[]` unconditionally, logging a warning per skipped row.
- **On the live path, the id was a bolus id.** The notification metadata carried `treatment.Id`, and per `TreatmentReadService` a CarbIntake paired into a meal bolus is projected with the *bolus's* id. Accepting such a suggestion wrote that bolus id into `treatment_foods.carb_intake_id`. Only unpaired carb corrections happened to carry a real carb intake id — which is why #658's marker described it as a naming problem.

`MealMatchingService` now reads from `ICarbIntakeRepository`; `IsMatch`/`CalculateMatchScore`/`FindBestMatch` take `CarbIntake`. Renamed through the chain so names describe what they hold — `SuggestedMealMatchResult`, `SuggestedMealMatch`, `AcceptMatchRequest.CarbIntakeId`, the notification metadata keys, and the frontend.

Dead code removed: `ProcessNewTreatmentAsync` (no callers) and `Treatment.DbId` (never assigned; this was its last reader).

### Please check these three

- **`AcceptMatchRequest` and `SuggestedMealMatch` are v4 wire contracts.** Property names change. Fine for our own UI, breaking for any third-party consumer.
- **Notification metadata keys change.** Suggestion notifications already in the database can't be accepted, and get re-raised on the next connector sync. I chose that over honouring the old key, because those rows hold a bolus id and accepting one writes the bad FK. Anyone with a pending suggestion sees one "Missing required data" until the resync.
- **One user-facing string changed** — "Treatment has {n}g total carbs" → "The logged carb entry has {n}g total carbs", since "treatment" no longer describes the record. Needs a translation sync.

I stopped short of renaming `treatmentId` on the glucose-chart marker components (`IobCobTrack`, `DeviceEventMarkers`): those genuinely carry projected treatment ids for cross-entity lookup via `getEntryByTreatmentId`.

### Verification

- `dotnet build src/API/Nocturne.API/Nocturne.API.csproj` — 0 errors.
- `dotnet test --filter "FullyQualifiedName~MealMatching"` — 5 passed.
- New test `GetSuggestionsAsync_ReturnsTheMatchedCarbIntakeId` pins the id end to end. **Mutation-checked**: replacing `CarbIntakeId: carbIntake.Id` with a fresh GUID fails it, so it isn't passing by discovering nothing.
- `pnpm run check` in `packages/app` — 64 errors, all in files this branch doesn't touch (generated clients, unbuilt `@nocturne/bot`/`@nocturne/bridge`, `RuleBuilderLeafEditor`, `SwimLaneTrack`). Typechecking caught a second consumer I'd missed, `routes/(authenticated)/meals/+page.svelte`, which is fixed here.
- `git grep -nE "TODO|FIXME" -- src` returns nothing.

https://claude.ai/code/session_01CbBp4z56n5WQ43NGV7m6nq
