### PR TITLE
fix(trackers): retire the RoleRestricted visibility trap

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/TrackersController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/TrackersController.cs
@@ -88,12 +88,16 @@ public class TrackersController : ControllerBase, IWriteScopedController
         if (tracker.Visibility == TrackerVisibility.Public)
             return true;
 
-        // Private trackers only visible to owner
+        // The owner sees their own tracker at every visibility, not just Private, so that a
+        // visibility value with no view rule of its own can never hide a tracker from the person
+        // who set it. RoleRestricted is rejected on write and migrated to Private, so this is
+        // belt-and-braces rather than the only thing standing between an owner and their data.
+        // An unattributed tracker (UserId defaulted to "") must not match a caller carrying no
+        // subject, so an empty id matches nothing.
         var currentUserId = HttpContext.GetSubjectIdString();
-        if (tracker.Visibility == TrackerVisibility.Private && tracker.UserId == currentUserId)
+        if (!string.IsNullOrEmpty(currentUserId) && tracker.UserId == currentUserId)
             return true;
 
-        // TODO: RoleRestricted visibility check
         return false;
     }
 
@@ -901,7 +905,7 @@ public class TrackerDefinitionDto
     public DashboardVisibility DashboardVisibility { get; set; } = DashboardVisibility.Always;
 
     /// <summary>
-    /// Visibility level for this tracker (Public, Private, RoleRestricted)
+    /// Visibility level for this tracker: Public or Private
     /// </summary>
     public TrackerVisibility Visibility { get; set; } = TrackerVisibility.Public;
 
@@ -1052,7 +1056,7 @@ public class CreateTrackerDefinitionRequest
     public DashboardVisibility DashboardVisibility { get; set; } = DashboardVisibility.Always;
 
     /// <summary>
-    /// Visibility level for this tracker (Public, Private, RoleRestricted)
+    /// Visibility level for this tracker: Public or Private. RoleRestricted is rejected.
     /// </summary>
     public TrackerVisibility Visibility { get; set; } = TrackerVisibility.Public;
 
@@ -1105,7 +1109,7 @@ public class UpdateTrackerDefinitionRequest
     public DashboardVisibility? DashboardVisibility { get; set; }
 
     /// <summary>
-    /// Visibility level for this tracker (Public, Private, RoleRestricted)
+    /// Visibility level for this tracker: Public or Private. RoleRestricted is rejected.
     /// </summary>
     public TrackerVisibility? Visibility { get; set; }
 

--- a/src/API/Nocturne.API/Validators/Alerts/CreateTrackerDefinitionRequestValidator.cs
+++ b/src/API/Nocturne.API/Validators/Alerts/CreateTrackerDefinitionRequestValidator.cs
@@ -1,0 +1,41 @@
+using FluentValidation;
+using Nocturne.API.Controllers.V4.Monitoring;
+using Nocturne.Core.Models;
+
+namespace Nocturne.API.Validators.Alerts;
+
+/// <summary>
+/// Validates <see cref="CreateTrackerDefinitionRequest"/> for the V4 tracker creation endpoint.
+/// </summary>
+/// <remarks>
+/// <list type="bullet">
+/// <item><description>Visibility must be a valid <see cref="TrackerVisibility"/> value.</description></item>
+/// <item><description>Visibility must not be <see cref="TrackerVisibility.RoleRestricted"/>, which has no
+/// view rule behind it: <c>TrackersController.CanViewTracker</c> grants only the owner and admins, and
+/// the tracker carries no roles to match a viewer against.</description></item>
+/// </list>
+/// </remarks>
+/// <seealso cref="CreateTrackerDefinitionRequest"/>
+/// <seealso cref="TrackersController"/>
+public class CreateTrackerDefinitionRequestValidator
+    : AbstractValidator<CreateTrackerDefinitionRequest>
+{
+    /// <summary>
+    /// Rejection message for a write that asks for RoleRestricted visibility, shared with
+    /// <see cref="UpdateTrackerDefinitionRequestValidator"/>.
+    /// </summary>
+    public const string RoleRestrictedMessage =
+        "RoleRestricted visibility is not implemented; use Public or Private";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CreateTrackerDefinitionRequestValidator"/>
+    /// class and configures all validation rules for tracker creation.
+    /// </summary>
+    public CreateTrackerDefinitionRequestValidator()
+    {
+        RuleFor(x => x.Visibility).IsInEnum();
+        RuleFor(x => x.Visibility)
+            .NotEqual(TrackerVisibility.RoleRestricted)
+            .WithMessage(RoleRestrictedMessage);
+    }
+}

--- a/src/API/Nocturne.API/Validators/Alerts/UpdateTrackerDefinitionRequestValidator.cs
+++ b/src/API/Nocturne.API/Validators/Alerts/UpdateTrackerDefinitionRequestValidator.cs
@@ -1,0 +1,34 @@
+using FluentValidation;
+using Nocturne.API.Controllers.V4.Monitoring;
+using Nocturne.Core.Models;
+
+namespace Nocturne.API.Validators.Alerts;
+
+/// <summary>
+/// Validates <see cref="UpdateTrackerDefinitionRequest"/> for the V4 tracker update endpoint.
+/// </summary>
+/// <remarks>
+/// <list type="bullet">
+/// <item><description>Visibility, when supplied, must be a valid <see cref="TrackerVisibility"/> value.</description></item>
+/// <item><description>Visibility must not be <see cref="TrackerVisibility.RoleRestricted"/>, which has no
+/// view rule behind it: <c>TrackersController.CanViewTracker</c> grants only the owner and admins, and
+/// the tracker carries no roles to match a viewer against.</description></item>
+/// </list>
+/// </remarks>
+/// <seealso cref="UpdateTrackerDefinitionRequest"/>
+/// <seealso cref="TrackersController"/>
+public class UpdateTrackerDefinitionRequestValidator
+    : AbstractValidator<UpdateTrackerDefinitionRequest>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UpdateTrackerDefinitionRequestValidator"/>
+    /// class and configures all validation rules for tracker updates.
+    /// </summary>
+    public UpdateTrackerDefinitionRequestValidator()
+    {
+        RuleFor(x => x.Visibility).IsInEnum();
+        RuleFor(x => x.Visibility)
+            .NotEqual(TrackerVisibility.RoleRestricted)
+            .WithMessage(CreateTrackerDefinitionRequestValidator.RoleRestrictedMessage);
+    }
+}

--- a/src/Core/Nocturne.Core.Models/TrackerVisibility.cs
+++ b/src/Core/Nocturne.Core.Models/TrackerVisibility.cs
@@ -21,7 +21,10 @@ public enum TrackerVisibility
     Private = 1,
 
     /// <summary>
-    /// Requires specific roles to view (future extension)
+    /// Requires specific roles to view. Not implemented and not accepted: a tracker carries no
+    /// roles to match a viewer against. Rejected on create and update, and stored rows were
+    /// migrated to <see cref="Private"/>. Retained only so the wire values of
+    /// <see cref="Public"/> and <see cref="Private"/> do not shift.
     /// </summary>
     RoleRestricted = 2
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TrackerDefinitionEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TrackerDefinitionEntity.cs
@@ -127,16 +127,10 @@ public class TrackerDefinitionEntity : ITenantScoped
     public TrackerMode Mode { get; set; } = TrackerMode.Duration;
 
     /// <summary>
-    /// Visibility level for this tracker (Public, Private, RoleRestricted)
+    /// Visibility level for this tracker: Public or Private
     /// </summary>
     [Column("visibility")]
     public TrackerVisibility Visibility { get; set; } = TrackerVisibility.Public;
-
-    /// <summary>
-    /// Required role names for RoleRestricted visibility (JSON array)
-    /// </summary>
-    [Column("required_roles", TypeName = "jsonb")]
-    public string? RequiredRoles { get; set; }
 
     /// <summary>
     /// When this definition was created

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260807125200_RetireTrackerRoleRestrictedVisibility.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260807125200_RetireTrackerRoleRestrictedVisibility.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260807125200_RetireTrackerRoleRestrictedVisibility")]
+    partial class RetireTrackerRoleRestrictedVisibility
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260807125200_RetireTrackerRoleRestrictedVisibility.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260807125200_RetireTrackerRoleRestrictedVisibility.cs
@@ -1,0 +1,55 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class RetireTrackerRoleRestrictedVisibility : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // TrackerVisibility.RoleRestricted (2) was settable through the API but never had a
+            // view rule, so such a tracker was visible only to its owner and admins. It is now
+            // rejected on create and update; convert the rows that already carry it to
+            // Private (1), which is what they behaved as, so no row is left holding a value the
+            // API will not accept back on the next save.
+            // visibility is an integer column (see AddTrackerVisibility).
+            // tracker_definitions is tenant-scoped under FORCE ROW LEVEL SECURITY, so the tenant
+            // context must be set per tenant or the UPDATE matches zero rows.
+            migrationBuilder.Sql("""
+                DO $$
+                DECLARE
+                    t RECORD;
+                BEGIN
+                    FOR t IN SELECT id FROM tenants LOOP
+                        PERFORM set_config('app.current_tenant_id', t.id::text, true);
+
+                        UPDATE tracker_definitions
+                        SET visibility = 1
+                        WHERE visibility = 2;
+                    END LOOP;
+                END $$;
+                """);
+
+            // required_roles was added alongside the visibility column to hold the role names for
+            // RoleRestricted. Nothing ever read or wrote it: no DTO, mapper, service or UI field.
+            migrationBuilder.DropColumn(
+                name: "required_roles",
+                table: "tracker_definitions");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // The visibility conversion is not reversed: a Private tracker cannot be told apart
+            // from one that was RoleRestricted before the conversion.
+            migrationBuilder.AddColumn<string>(
+                name: "required_roles",
+                table: "tracker_definitions",
+                type: "jsonb",
+                nullable: true);
+        }
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Monitoring/TrackersControllerVisibilityTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Monitoring/TrackersControllerVisibilityTests.cs
@@ -1,0 +1,186 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Nocturne.API.Controllers.V4.Monitoring;
+using Nocturne.API.Services.Monitoring;
+using Nocturne.API.Services.Realtime;
+using Nocturne.Core.Contracts.Alerts;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Infrastructure.Data.Abstractions;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Services;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4.Monitoring;
+
+/// <summary>
+/// Pins who <c>TrackersController.CanViewTracker</c> lets read a definition back.
+/// The owner clause is deliberately not conditional on a visibility value, so that no visibility
+/// can hide a tracker from the person who set it.
+/// </summary>
+[Trait("Category", "Unit")]
+public class TrackersControllerVisibilityTests
+{
+    private const string OwnerId = "11111111-1111-1111-1111-111111111111";
+    private const string StrangerId = "22222222-2222-2222-2222-222222222222";
+
+    private readonly Mock<ITrackerRepository> _repository = new();
+
+    private TrackersController CreateController(string? subjectId, bool isAdmin = false)
+    {
+        var controller = new TrackersController(
+            _repository.Object,
+            Mock.Of<ISignalRBroadcastService>(),
+            Mock.Of<ITrackerAlertRuleSyncService>(),
+            Mock.Of<ITenantDbContextFactory>(),
+            Mock.Of<IAlertAcknowledgementService>(),
+            Mock.Of<ILogger<TrackersController>>()
+        );
+
+        var httpContext = new DefaultHttpContext();
+        if (subjectId != null)
+        {
+            httpContext.Items["AuthContext"] = new AuthContext
+            {
+                IsAuthenticated = true,
+                SubjectId = Guid.Parse(subjectId),
+            };
+        }
+
+        if (isAdmin)
+        {
+            var trie = new PermissionTrie();
+            trie.Add("admin");
+            httpContext.Items["PermissionTrie"] = trie;
+        }
+
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        return controller;
+    }
+
+    private TrackerDefinitionEntity ArrangeDefinition(
+        TrackerVisibility visibility,
+        string userId = OwnerId)
+    {
+        var definition = new TrackerDefinitionEntity
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Name = "Sensor",
+            Visibility = visibility,
+        };
+
+        _repository
+            .Setup(x => x.GetDefinitionByIdAsync(definition.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(definition);
+        _repository
+            .Setup(x => x.GetDefinitionsForUserAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([definition]);
+
+        return definition;
+    }
+
+    [Theory]
+    [InlineData(TrackerVisibility.Public)]
+    [InlineData(TrackerVisibility.Private)]
+    [InlineData(TrackerVisibility.RoleRestricted)]
+    public async Task GetDefinition_OwnerReadsOwnTrackerBack_AtEveryVisibility(
+        TrackerVisibility visibility)
+    {
+        var definition = ArrangeDefinition(visibility);
+        var controller = CreateController(OwnerId);
+
+        var result = await controller.GetDefinition(definition.Id);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+    }
+
+    [Theory]
+    [InlineData(TrackerVisibility.Public)]
+    [InlineData(TrackerVisibility.Private)]
+    [InlineData(TrackerVisibility.RoleRestricted)]
+    public async Task GetDefinitions_OwnerSeesOwnTrackerListed_AtEveryVisibility(
+        TrackerVisibility visibility)
+    {
+        ArrangeDefinition(visibility);
+        var controller = CreateController(OwnerId);
+
+        var result = await controller.GetDefinitions();
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        ok.Value.Should().BeOfType<TrackerDefinitionDto[]>().Which.Should().HaveCount(1);
+    }
+
+    [Theory]
+    [InlineData(TrackerVisibility.Public)]
+    [InlineData(TrackerVisibility.Private)]
+    [InlineData(TrackerVisibility.RoleRestricted)]
+    public async Task GetDefinition_AdminReadsAnyTracker_AtEveryVisibility(
+        TrackerVisibility visibility)
+    {
+        var definition = ArrangeDefinition(visibility);
+        var controller = CreateController(StrangerId, isAdmin: true);
+
+        var result = await controller.GetDefinition(definition.Id);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetDefinition_NonOwnerReadsPublicTracker()
+    {
+        var definition = ArrangeDefinition(TrackerVisibility.Public);
+        var controller = CreateController(StrangerId);
+
+        var result = await controller.GetDefinition(definition.Id);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+    }
+
+    [Theory]
+    [InlineData(TrackerVisibility.Private)]
+    [InlineData(TrackerVisibility.RoleRestricted)]
+    public async Task GetDefinition_NonOwnerIsForbidden_WhenNotPublic(TrackerVisibility visibility)
+    {
+        var definition = ArrangeDefinition(visibility);
+        var controller = CreateController(StrangerId);
+
+        var result = await controller.GetDefinition(definition.Id);
+
+        result.Result.Should().BeOfType<ForbidResult>();
+    }
+
+    [Theory]
+    [InlineData(TrackerVisibility.Private)]
+    [InlineData(TrackerVisibility.RoleRestricted)]
+    public async Task GetDefinition_AnonymousIsForbidden_WhenNotPublic(TrackerVisibility visibility)
+    {
+        var definition = ArrangeDefinition(visibility);
+        var controller = CreateController(subjectId: null);
+
+        var result = await controller.GetDefinition(definition.Id);
+
+        result.Result.Should().BeOfType<ForbidResult>();
+    }
+
+    /// <summary>
+    /// An unattributed tracker (UserId left at its "" default) must not be claimed by a caller
+    /// that carries no subject of its own. Owning "" is not owning anything.
+    /// </summary>
+    [Theory]
+    [InlineData(TrackerVisibility.Private)]
+    [InlineData(TrackerVisibility.RoleRestricted)]
+    public async Task GetDefinition_SubjectlessCallerDoesNotOwnUnattributedTracker(
+        TrackerVisibility visibility)
+    {
+        var definition = ArrangeDefinition(visibility, userId: string.Empty);
+        var controller = CreateController(subjectId: null);
+
+        var result = await controller.GetDefinition(definition.Id);
+
+        result.Result.Should().BeOfType<ForbidResult>();
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Validators/Alerts/TrackerDefinitionRequestValidatorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Validators/Alerts/TrackerDefinitionRequestValidatorTests.cs
@@ -1,0 +1,89 @@
+using FluentValidation.TestHelper;
+using Nocturne.API.Controllers.V4.Monitoring;
+using Nocturne.API.Validators.Alerts;
+using Nocturne.Core.Models;
+using Xunit;
+
+namespace Nocturne.API.Tests.Validators.Alerts;
+
+/// <summary>
+/// Pins the request-boundary rejection of RoleRestricted tracker visibility, which has no view
+/// rule behind it and would hide the tracker from everyone but its owner and admins.
+/// </summary>
+[Trait("Category", "Unit")]
+public class TrackerDefinitionRequestValidatorTests
+{
+    private readonly CreateTrackerDefinitionRequestValidator _create = new();
+    private readonly UpdateTrackerDefinitionRequestValidator _update = new();
+
+    [Theory]
+    [InlineData(TrackerVisibility.Public)]
+    [InlineData(TrackerVisibility.Private)]
+    public void Create_AcceptsImplementedVisibilities(TrackerVisibility visibility)
+    {
+        var result = _create.TestValidate(
+            new CreateTrackerDefinitionRequest { Name = "Sensor", Visibility = visibility });
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Visibility);
+    }
+
+    [Fact]
+    public void Create_RejectsRoleRestricted()
+    {
+        var result = _create.TestValidate(new CreateTrackerDefinitionRequest
+        {
+            Name = "Sensor",
+            Visibility = TrackerVisibility.RoleRestricted,
+        });
+
+        result.ShouldHaveValidationErrorFor(x => x.Visibility)
+            .WithErrorMessage(CreateTrackerDefinitionRequestValidator.RoleRestrictedMessage);
+    }
+
+    [Fact]
+    public void Create_RejectsUndefinedVisibility()
+    {
+        var result = _create.TestValidate(new CreateTrackerDefinitionRequest
+        {
+            Name = "Sensor",
+            Visibility = (TrackerVisibility)99,
+        });
+
+        result.ShouldHaveValidationErrorFor(x => x.Visibility);
+    }
+
+    [Theory]
+    [InlineData(TrackerVisibility.Public)]
+    [InlineData(TrackerVisibility.Private)]
+    [InlineData(null)]
+    public void Update_AcceptsImplementedAndOmittedVisibilities(TrackerVisibility? visibility)
+    {
+        var result = _update.TestValidate(
+            new UpdateTrackerDefinitionRequest { Visibility = visibility });
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Visibility);
+    }
+
+    [Fact]
+    public void Update_RejectsRoleRestricted()
+    {
+        var result = _update.TestValidate(new UpdateTrackerDefinitionRequest
+        {
+            Visibility = TrackerVisibility.RoleRestricted,
+        });
+
+        result.ShouldHaveValidationErrorFor(x => x.Visibility)
+            .WithErrorMessage(CreateTrackerDefinitionRequestValidator.RoleRestrictedMessage);
+    }
+
+    [Fact]
+    public void Update_RejectsUndefinedVisibility()
+    {
+        var result = _update.TestValidate(new UpdateTrackerDefinitionRequest
+        {
+            Visibility = (TrackerVisibility)99,
+        });
+
+        result.ShouldHaveValidationErrorFor(x => x.Visibility);
+    }
+}


### PR DESCRIPTION
## What

Closes #653.

`TrackerVisibility.RoleRestricted` was settable through the API but `CanViewTracker` had no branch for it, and the owner clause was gated on `Private` — so flipping a tracker to `RoleRestricted` made it invisible to everyone except admins, including its creator, who then couldn't see it to change it back.

**Why reject rather than implement:** the only role artifact behind the enum value is `TrackerDefinitionEntity.RequiredRoles`, a jsonb column referenced nowhere else — no DTO field, no service, no frontend surface. Every stored `RoleRestricted` row necessarily has `required_roles = NULL`, so implementing the check would mean inventing the entire feature surface and still match nobody. Rejecting at the boundary is the honest fix until someone designs the real thing.

The change, in four parts:

1. **Owner clause unconditional on visibility** — a tracker's owner can always read it back at every visibility value, and the clause now requires a non-empty subject id so its safety doesn't depend on `GetSubjectIdString()`'s implementation detail.
2. **Boundary rejection** — FluentValidation validators (auto-discovered, following the `CreateAlertRuleRequestValidator` precedent) reject `RoleRestricted` on create and update, plus `IsInEnum()` because `JsonStringEnumConverter` still accepts raw numbers, so `"visibility": 99` previously bound and hit the same trap.
3. **Data migration** — `RetireTrackerRoleRestrictedVisibility` flips stored `RoleRestricted` rows to `Private` (per-tenant `set_config('app.current_tenant_id', ...)` loop, since `tracker_definitions` is under FORCE RLS) and drops the dead `required_roles` column. The API auto-migrates on startup, so the validator and the converted rows go live together — an owner editing a formerly-trapped tracker never sees a 400 about a value the UI can't display. `Down()` re-adds the column but deliberately doesn't reverse the conversion (a Private row can't be told from a formerly-RoleRestricted one).
4. **Enum member retained** so the wire values of `Public` and `Private` don't shift; docs swept.

Deliberately untouched: the `[AllowAnonymous]` read actions and the `Public` default (separate queued security work).

## Testing

4853 passed / 0 failed / 5 skipped (25 new tests; suite run twice clean). Four mutation proofs, each failing exactly its own pinning tests: reverting the owner clause fails only the two RoleRestricted owner cases; dropping `NotEqual(RoleRestricted)` fails only the rejection tests; dropping `IsInEnum` fails only the undefined-value tests; and for the subject-id guard, a straight revert isn't a valid mutation (no `""` path is reachable today), so the proof applies the feared future refactor (`GetSubjectIdString() ?? string.Empty`) and shows exactly the two new subject-less tests catch it.

https://claude.ai/code/session_01V2H2GSE3UWEgkMvsJE8Kfw
