### PR TITLE
fix(alerts): page the replay glucose fetch and cap the replay window

### DIFF
--- a/src/API/Nocturne.API/Configuration/AlertEvaluationOptions.cs
+++ b/src/API/Nocturne.API/Configuration/AlertEvaluationOptions.cs
@@ -19,4 +19,24 @@ public sealed class AlertEvaluationOptions
     /// suppress a real suspension, but a sustained outage cannot latch the projection.
     /// </summary>
     public TimeSpan PumpFreshnessThreshold { get; set; } = TimeSpan.FromMinutes(10);
+
+    /// <summary>
+    /// Longest window a single replay call will cover. Replay re-evaluates every enabled rule
+    /// on a 5-minute tick and re-enriches the tick context from the historical repositories, so
+    /// both the work and the returned transition log grow linearly with the span. A request
+    /// beyond this is rejected rather than truncated. The widest window a first-party caller
+    /// asks for is a DST-stretched calendar day (25 h); the default leaves roughly double that
+    /// headroom, and a deployment that wants longer debug replays raises it here.
+    /// </summary>
+    public TimeSpan MaxReplayWindow { get; set; } = TimeSpan.FromHours(48);
+
+    /// <summary>
+    /// Rows per page of the historical glucose fetch that feeds replay. The fetch is keyset-paged
+    /// and streamed through the tick loop, so the resident reading set is bounded by this plus
+    /// the rows of one held-back 5-minute bucket rather than by the window's total row count.
+    /// A single bucket holding more rows than one page (bulk backfill, duplicate import) is
+    /// flushed per page instead of held whole, trading exact bucket-winner resolution for the
+    /// memory bound on a shape the live engine never produces. Values below 1 are treated as 1.
+    /// </summary>
+    public int ReplayGlucosePageSize { get; set; } = 2000;
 }

--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertReplayController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertReplayController.cs
@@ -30,12 +30,20 @@ public class AlertReplayController : ControllerBase
     [HttpPost]
     [RemoteCommand]
     [ProducesResponseType(typeof(AlertReplayResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<AlertReplayResult>> Replay(
         [FromBody] AlertReplayRequest request, CancellationToken ct)
     {
-        var result = await _replayService.ReplayAsync(
-            request.Date, request.Timezone, request.From, request.To, ct);
-        return Ok(result);
+        try
+        {
+            var result = await _replayService.ReplayAsync(
+                request.Date, request.Timezone, request.From, request.To, ct);
+            return Ok(result);
+        }
+        catch (ReplayWindowTooLargeException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
     }
 
     /// <summary>
@@ -46,6 +54,7 @@ public class AlertReplayController : ControllerBase
     [HttpPost("dry-run")]
     [RemoteCommand]
     [ProducesResponseType(typeof(AlertReplayResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<AlertReplayResult>> ReplayDryRun(
         [FromBody] AlertReplayDryRunRequest request, CancellationToken ct)
     {
@@ -59,9 +68,16 @@ public class AlertReplayController : ControllerBase
             AutoResolveEnabled: request.Rule.AutoResolveEnabled,
             AutoResolveParams: request.Rule.AutoResolveParams);
 
-        var result = await _replayService.ReplayDryRunAsync(
-            request.Date, request.Timezone, request.From, request.To, ruleOverride, ct);
-        return Ok(result);
+        try
+        {
+            var result = await _replayService.ReplayDryRunAsync(
+                request.Date, request.Timezone, request.From, request.To, ruleOverride, ct);
+            return Ok(result);
+        }
+        catch (ReplayWindowTooLargeException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
     }
 }
 

--- a/src/API/Nocturne.API/Services/Alerts/AlertReplayService.cs
+++ b/src/API/Nocturne.API/Services/Alerts/AlertReplayService.cs
@@ -1,5 +1,8 @@
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Nocturne.API.Configuration;
 using Nocturne.API.Extensions;
 using Nocturne.API.Services.Alerts.Evaluators;
 using Nocturne.Core.Contracts.Alerts;
@@ -31,6 +34,7 @@ internal sealed class AlertReplayService(
     ICanonicalGlucoseService canonicalGlucose,
     ISensorContextEnricher enricher,
     ITenantAccessor tenantAccessor,
+    IOptions<AlertEvaluationOptions> evaluationOptions,
     ILogger<AlertReplayService> logger)
     : IAlertReplayService
 {
@@ -66,13 +70,20 @@ internal sealed class AlertReplayService(
         ReplayRuleOverride? ruleOverride,
         CancellationToken ct)
     {
+        // Window validation is pure input checking, so it runs before tenant resolution and any
+        // DB work — an over-wide window is the same client error whatever the tenant state is.
+        var (windowStart, windowEnd) = ResolveWindow(localDate, timezone, fromUtc, toUtc);
+        var maxWindow = evaluationOptions.Value.MaxReplayWindow;
+        if (windowEnd - windowStart > maxWindow)
+        {
+            throw new ReplayWindowTooLargeException(windowEnd - windowStart, maxWindow);
+        }
+
         var tenantId = tenantAccessor.TenantId;
         if (tenantId == Guid.Empty)
         {
             return new AlertReplayResult(DateTime.UtcNow, DateTime.UtcNow, []);
         }
-
-        var (windowStart, windowEnd) = ResolveWindow(localDate, timezone, fromUtc, toUtc);
 
         var stored = await alertRepository.GetEnabledRulesAsync(tenantId, ct);
         var rules = ApplyOverride(stored, ruleOverride, tenantId);
@@ -86,14 +97,11 @@ internal sealed class AlertReplayService(
         // by AlertReferenceService) would short-circuit to insertion order.
         var ordered = TopologicallySort(rules);
 
-        // Replay walks the canonical stream — the same series the live engine alarms on.
-        var readings = (await canonicalGlucose.SelectAsync(
-                (await glucoseRepository.GetAsync(
-                    from: windowStart, to: windowEnd, device: null, source: null,
-                    limit: int.MaxValue, offset: 0, descending: false, nativeOnly: false, ct: ct)).ToList(),
-                ct))
-            .OrderBy(r => r.Timestamp)
-            .ToList();
+        // Replay walks the canonical stream — the same series the live engine alarms on. The
+        // window is keyset-paged and consumed by the tick loop as a left-to-right fold, so the
+        // whole series is never resident.
+        await using var readings = await ReadingCursor.CreateAsync(
+            StreamCanonicalReadingsAsync(windowStart, windowEnd, ct), ct);
 
         // Scoped DND (ADR 0004 D5): the tenant's windows received by the replay's end, resolved
         // per tick with WasActiveAt (receipt-gated) so replay reproduces what the live engine
@@ -138,7 +146,6 @@ internal sealed class AlertReplayService(
         var activeAlerts = new Dictionary<Guid, ActiveAlertSnapshot>();
 
         var events = new List<AlertReplayEvent>();
-        var readingIndex = 0;
 
         for (var tick = windowStart; tick < windowEnd; tick += TickInterval)
         {
@@ -149,15 +156,11 @@ internal sealed class AlertReplayService(
             // pump_suspended, override_active) sees `tick` as "now".
             fakeTime.SetUtcNow(DateTime.SpecifyKind(tick, DateTimeKind.Utc));
 
-            // Walk the readings list once across the whole replay rather than re-scanning per
+            // Walk the reading stream once across the whole replay rather than re-scanning per
             // tick. Snap to the most recent reading at-or-before tick; trailing readings
             // (those after tick) stay queued for later ticks.
-            while (readingIndex < readings.Count - 1
-                   && readings[readingIndex + 1].Timestamp <= tick)
-            {
-                readingIndex++;
-            }
-            var current = readings.Count == 0 ? null : readings[readingIndex];
+            await readings.AdvanceToAsync(tick);
+            var current = readings.Current;
             var hasReadingForTick = current is not null && current.Timestamp <= tick;
 
             var baseContext = new SensorContext
@@ -381,6 +384,181 @@ internal sealed class AlertReplayService(
             LeafTransitionsByRule = leafTransitionsByRule,
             FactTimelines = factTimelines,
         };
+    }
+
+    /// <summary>
+    /// Keyset-pages the window's glucose rows in ascending time order and yields the canonical
+    /// stream page by page.
+    /// </summary>
+    /// <remarks>
+    /// Canonical selection resolves a winner per aligned 5-minute bucket, so a bucket split
+    /// across a page boundary is held back and re-selected together with the next page's head.
+    /// Without that overlap two concurrent CGMs could each win their half of the same bucket and
+    /// the tick loop would see a reading whole-window selection drops. Selection is otherwise
+    /// bucket-local — a stream's priority relative to any other stream does not depend on which
+    /// further streams happen to be in the same batch — so per-page selection over complete
+    /// buckets yields exactly the whole-window result, provided each bucket fits within a page.
+    /// A bucket wider than a page is flushed and selected per page instead of held back (see
+    /// <see cref="Configuration.AlertEvaluationOptions.ReplayGlucosePageSize"/>).
+    /// </remarks>
+    private async IAsyncEnumerable<SensorGlucose> StreamCanonicalReadingsAsync(
+        DateTime windowStart,
+        DateTime windowEnd,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        var pageSize = Math.Max(1, evaluationOptions.Value.ReplayGlucosePageSize);
+        DateTime? afterTimestamp = null;
+        Guid? afterId = null;
+        var heldBack = new List<SensorGlucose>();
+
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var fetched = (await glucoseRepository.GetAsync(
+                from: windowStart, to: windowEnd, device: null, source: null,
+                limit: pageSize, offset: 0, descending: false, nativeOnly: false,
+                afterTimestamp: afterTimestamp, afterId: afterId, ct: ct)).ToList();
+
+            // A short page is the last one.
+            var isFinalPage = fetched.Count < pageSize;
+            if (fetched.Count > 0)
+            {
+                var last = fetched[^1];
+                // Every non-empty page must end strictly past the cursor it was fetched with. A
+                // fetch that ignores the cursor returns the same full page forever, and the loop
+                // would never terminate; fail loudly instead of spinning.
+                if (afterTimestamp is { } cursorTimestamp && afterId is { } cursorId
+                    && (last.Timestamp < cursorTimestamp
+                        || (last.Timestamp == cursorTimestamp && last.Id.CompareTo(cursorId) <= 0)))
+                {
+                    throw new InvalidOperationException(
+                        "The glucose fetch returned a page that did not advance past the keyset " +
+                        "cursor; replay paging cannot make progress.");
+                }
+
+                afterTimestamp = last.Timestamp;
+                afterId = last.Id;
+            }
+
+            var batch = fetched;
+            if (heldBack.Count > 0)
+            {
+                // Held-back rows precede the fetched page: they came from the previous page's
+                // tail, and the keyset cursor only ever seeks forward.
+                heldBack.AddRange(fetched);
+                batch = heldBack;
+                heldBack = [];
+            }
+
+            if (isFinalPage)
+            {
+                foreach (var reading in await SelectCanonicalAsync(batch, ct))
+                {
+                    yield return reading;
+                }
+                yield break;
+            }
+
+            var trailingBucket = BucketOf(batch[^1]);
+            var completeCount = batch.Count;
+            while (completeCount > 0 && BucketOf(batch[completeCount - 1]) == trailingBucket)
+            {
+                completeCount--;
+            }
+
+            if (completeCount == 0)
+            {
+                // A single bucket holding more rows than one page. Holding it back until it ends
+                // would grow the resident set by a page per iteration, so it is flushed and
+                // selected per page instead — the memory bound wins over exact bucket-winner
+                // resolution on a shape only a bulk backfill or duplicate import produces.
+                foreach (var reading in await SelectCanonicalAsync(batch, ct))
+                {
+                    yield return reading;
+                }
+                continue;
+            }
+
+            heldBack.AddRange(batch.Skip(completeCount));
+            foreach (var reading in await SelectCanonicalAsync(batch.Take(completeCount).ToList(), ct))
+            {
+                yield return reading;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Canonical selection over one batch, re-sorted by timestamp. Selection preserves input
+    /// order and the repository returns ascending rows, so the sort is a no-op on well-ordered
+    /// input; it holds the ascending invariant the tick-loop fold depends on.
+    /// </summary>
+    private async Task<IEnumerable<SensorGlucose>> SelectCanonicalAsync(
+        IReadOnlyList<SensorGlucose> batch, CancellationToken ct)
+    {
+        if (batch.Count == 0) return [];
+        return (await canonicalGlucose.SelectAsync(batch, ct)).OrderBy(r => r.Timestamp);
+    }
+
+    private static long BucketOf(SensorGlucose reading) =>
+        reading.Timestamp.Ticks / CanonicalGlucoseStream.BucketSize.Ticks;
+
+    /// <summary>
+    /// One-reading-lookahead cursor over the paged canonical stream. The tick loop needs the most
+    /// recent reading at-or-before each tick, which a left-to-right fold over ascending readings
+    /// gets from the current reading plus a peek at the next one — so no reading older than the
+    /// playhead has to stay resident. <see cref="Current"/> is seeded with the first reading (as
+    /// the pre-paging list walk did, starting at index 0) and never advances past the last, so a
+    /// window whose readings all post-date a tick reports no reading for it, and ticks after the
+    /// final reading keep seeing that reading.
+    /// </summary>
+    private sealed class ReadingCursor : IAsyncDisposable
+    {
+        private readonly IAsyncEnumerator<SensorGlucose> _source;
+        private SensorGlucose? _next;
+        private bool _exhausted;
+
+        private ReadingCursor(IAsyncEnumerator<SensorGlucose> source) => _source = source;
+
+        public SensorGlucose? Current { get; private set; }
+
+        public static async Task<ReadingCursor> CreateAsync(
+            IAsyncEnumerable<SensorGlucose> source, CancellationToken ct)
+        {
+            var cursor = new ReadingCursor(source.GetAsyncEnumerator(ct));
+            try
+            {
+                cursor.Current = await cursor.PullAsync();
+                cursor._next = await cursor.PullAsync();
+            }
+            catch
+            {
+                // Seeding owns the enumerator before the caller's `await using` does.
+                await cursor.DisposeAsync();
+                throw;
+            }
+            return cursor;
+        }
+
+        /// <summary>Advances <see cref="Current"/> to the last reading at-or-before <paramref name="tick"/>.</summary>
+        public async Task AdvanceToAsync(DateTime tick)
+        {
+            while (_next is { } next && next.Timestamp <= tick)
+            {
+                Current = next;
+                _next = await PullAsync();
+            }
+        }
+
+        private async Task<SensorGlucose?> PullAsync()
+        {
+            if (_exhausted) return null;
+            if (await _source.MoveNextAsync()) return _source.Current;
+            _exhausted = true;
+            return null;
+        }
+
+        public ValueTask DisposeAsync() => _source.DisposeAsync();
     }
 
     /// <summary>

--- a/src/Core/Nocturne.Core.Contracts/Alerts/IAlertReplayService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Alerts/IAlertReplayService.cs
@@ -51,6 +51,32 @@ public interface IAlertReplayService
 }
 
 /// <summary>
+/// Thrown when a replay request's resolved window is longer than the configured maximum
+/// (<c>AlertEvaluation:MaxReplayWindow</c>). Replay evaluates every enabled rule on a 5-minute
+/// tick and re-enriches each tick from the historical repositories, so an unbounded window is
+/// an unbounded amount of work and an unbounded transition log. The request is rejected so the
+/// caller narrows it, rather than being answered with a silently truncated window.
+/// </summary>
+public sealed class ReplayWindowTooLargeException : Exception
+{
+    /// <param name="requested">The resolved window span the caller asked for.</param>
+    /// <param name="maximum">The configured maximum span.</param>
+    public ReplayWindowTooLargeException(TimeSpan requested, TimeSpan maximum)
+        : base(FormattableString.Invariant(
+            $"Replay window of {requested.TotalHours:F1} hours exceeds the maximum of {maximum.TotalHours:F1} hours."))
+    {
+        Requested = requested;
+        Maximum = maximum;
+    }
+
+    /// <summary>The resolved window span the caller asked for.</summary>
+    public TimeSpan Requested { get; }
+
+    /// <summary>The configured maximum span.</summary>
+    public TimeSpan Maximum { get; }
+}
+
+/// <summary>
 /// In-memory rule definition layered into a dry-run replay. Mirrors the editor's pre-save
 /// shape. <see cref="Id"/> is optional: when present and matching an existing rule it
 /// replaces it for the replay; otherwise the override is appended to the rule list.

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/AlertReplayServiceLeafLogTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/AlertReplayServiceLeafLogTests.cs
@@ -86,6 +86,7 @@ public class AlertReplayServiceLeafLogTests
             TestDoubles.CanonicalGlucosePassThrough.Create(),
             enricher,
             _tenantAccessor.Object,
+            Options.Create(new AlertEvaluationOptions()),
             NullLogger<AlertReplayService>.Instance);
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/AlertReplayServicePagingTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/AlertReplayServicePagingTests.cs
@@ -1,0 +1,506 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Nocturne.API.Configuration;
+using Nocturne.API.Controllers.V4.Monitoring;
+using Nocturne.API.Services.Alerts;
+using Nocturne.API.Services.Glucose;
+using Nocturne.API.Services.Treatments;
+using Nocturne.Core.Contracts.Alerts;
+using Nocturne.Core.Contracts.Glucose;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Contracts.Treatments;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Alerts;
+using Nocturne.Core.Models.V4;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Alerts;
+
+/// <summary>
+/// Pins the two properties the paged glucose fetch has to hold: the replay output is identical
+/// however the window's readings are split into pages, and a window wider than the configured
+/// maximum is a client error rather than a truncated answer.
+/// </summary>
+[Trait("Category", "Unit")]
+public class AlertReplayServicePagingTests
+{
+    private readonly Mock<IAlertRepository> _alertRepository = new();
+    private readonly Mock<ISensorGlucoseRepository> _glucoseRepository = new();
+    private readonly Mock<ITenantAccessor> _tenantAccessor = new();
+    private readonly Mock<IIobCalculator> _iobCalculator = new();
+    private readonly Mock<ICobCalculator> _cobCalculator = new();
+    private readonly Mock<ITreatmentService> _treatmentService = new();
+    private readonly Mock<IBolusRepository> _bolusRepository = new();
+    private readonly Mock<ICarbIntakeRepository> _carbIntakeRepository = new();
+    private readonly Mock<IDeviceEventRepository> _deviceEventRepository = new();
+    private readonly Mock<IPumpSnapshotRepository> _pumpSnapshotRepository = new();
+    private readonly Mock<IApsSnapshotRepository> _apsSnapshotRepository = new();
+    private readonly Mock<ITempBasalRepository> _tempBasalRepository = new();
+    private readonly Mock<IUploaderSnapshotRepository> _uploaderSnapshotRepository = new();
+    private readonly Mock<IStateSpanService> _stateSpanService = new();
+    private readonly Mock<Nocturne.API.Services.Devices.IReservoirEstimationService> _reservoirEstimation = new();
+
+    private readonly Guid _tenantId = Guid.NewGuid();
+    private readonly DateTime _dayStart = new(2026, 4, 28, 0, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>Registered devices backing the canonical selector; tests append to this.</summary>
+    private readonly List<PatientDevice> _devices = [];
+
+    /// <summary>
+    /// Row count of every batch handed to the canonical selector. The selector is the only place
+    /// the service materialises readings, so the largest entry here is the resident reading set.
+    /// </summary>
+    private readonly List<int> _selectedBatchSizes = [];
+
+    public AlertReplayServicePagingTests()
+    {
+        _tenantAccessor.Setup(t => t.TenantId).Returns(_tenantId);
+        _alertRepository
+            .Setup(r => r.GetDndWindowsAsOfAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<DndWindowSnapshot>());
+        _alertRepository
+            .Setup(r => r.GetUnexpiredDndWindowsAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<DndWindowSnapshot>());
+    }
+
+    private AlertReplayService CreateSut(int pageSize, TimeSpan? maxWindow = null)
+    {
+        var enricherDeps = new SensorContextEnricherDependencies(
+            _iobCalculator.Object,
+            _cobCalculator.Object,
+            _treatmentService.Object,
+            _bolusRepository.Object,
+            _carbIntakeRepository.Object,
+            _deviceEventRepository.Object,
+            _pumpSnapshotRepository.Object,
+            _apsSnapshotRepository.Object,
+            _tempBasalRepository.Object,
+            _uploaderSnapshotRepository.Object,
+            _stateSpanService.Object,
+            _alertRepository.Object,
+            new Mock<ITargetRangeScheduleRepository>().Object,
+            new Mock<Nocturne.Core.Contracts.Profiles.Resolvers.IActiveProfileResolver>().Object,
+            new Mock<Nocturne.Core.Contracts.Profiles.Resolvers.ITherapySettingsResolver>().Object,
+            new Mock<Nocturne.Core.Contracts.Sleep.ISleepService>().Object,
+            new Mock<Nocturne.Infrastructure.Data.Abstractions.ITrackerRepository>().Object,
+            _reservoirEstimation.Object,
+            Options.Create(new AlertEvaluationOptions()));
+        var enricher = new SensorContextEnricher(
+            enricherDeps,
+            new ServiceCollection().BuildServiceProvider(),
+            TimeProvider.System,
+            NullLogger<SensorContextEnricher>.Instance);
+
+        var options = new AlertEvaluationOptions { ReplayGlucosePageSize = pageSize };
+        if (maxWindow is { } max) options.MaxReplayWindow = max;
+
+        return new AlertReplayService(
+            _alertRepository.Object,
+            _glucoseRepository.Object,
+            CanonicalSelector(),
+            enricher,
+            _tenantAccessor.Object,
+            Options.Create(options),
+            NullLogger<AlertReplayService>.Instance);
+    }
+
+    /// <summary>
+    /// The real bucket-winner selection over <see cref="_devices"/> — a pass-through double would
+    /// hide the bucket-split hazard the page-boundary carry exists to prevent.
+    /// </summary>
+    private ICanonicalGlucoseService CanonicalSelector()
+    {
+        var mock = new Mock<ICanonicalGlucoseService>();
+        mock.Setup(s => s.SelectAsync(It.IsAny<IReadOnlyList<SensorGlucose>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<SensorGlucose> readings, CancellationToken _) =>
+            {
+                _selectedBatchSizes.Add(readings.Count);
+                return CanonicalGlucoseStream.Select(readings, _devices);
+            });
+        return mock.Object;
+    }
+
+    /// <summary>
+    /// Backs the glucose repository with an in-memory series that honours the keyset cursor and
+    /// the row limit exactly as <c>SensorGlucoseRepository</c> does — ordering by
+    /// <c>(Timestamp, Id)</c> ascending and seeking strictly past the cursor.
+    /// </summary>
+    private void SetupSeries(IReadOnlyList<SensorGlucose> all)
+    {
+        _glucoseRepository
+            .Setup(r => r.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), null, null,
+                It.IsAny<int>(), It.IsAny<int>(), false, false,
+                It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+            .Returns((DateTime? from, DateTime? to, string? _, string? _,
+                int limit, int _, bool _, bool _,
+                DateTime? afterTimestamp, Guid? afterId, CancellationToken _, Guid? _) =>
+            {
+                IEnumerable<SensorGlucose> rows = all
+                    .Where(r => (from is null || r.Timestamp >= from.Value)
+                             && (to is null || r.Timestamp <= to.Value))
+                    .OrderBy(r => r.Timestamp)
+                    .ThenBy(r => r.Id);
+
+                if (afterTimestamp is { } ts && afterId is { } id)
+                {
+                    rows = rows.Where(r => r.Timestamp > ts
+                        || (r.Timestamp == ts && r.Id.CompareTo(id) > 0));
+                }
+
+                return Task.FromResult<IEnumerable<SensorGlucose>>(rows.Take(limit).ToList());
+            });
+    }
+
+    private static long _idCounter;
+
+    private static SensorGlucose Reading(DateTime at, double mgdl, Guid? patientDeviceId = null,
+        string dataSource = "test", string device = "cgm")
+        => new()
+        {
+            // A counter-derived id, not CreateVersion7: v7 ids minted within the same millisecond
+            // order by their random bits, so the keyset tiebreaker would be non-deterministic for
+            // same-timestamp readings.
+            Id = new Guid((uint)Interlocked.Increment(ref _idCounter), 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0),
+            Timestamp = at,
+            Mgdl = mgdl,
+            PatientDeviceId = patientDeviceId,
+            DataSource = dataSource,
+            Device = device,
+        };
+
+    private static AlertRuleSnapshot ThresholdBelow(Guid id, decimal value) =>
+        new(id, Guid.NewGuid(), $"below-{value}", AlertConditionType.Threshold,
+            $$"""{"direction":"below","value":{{value}}}""", AlertRuleSeverity.Warning, "{}", 0,
+            AutoResolveEnabled: false, AutoResolveParams: null);
+
+    private static (
+        IReadOnlyList<(DateTime At, Guid RuleId, AlertReplayEventKind Kind)> Events,
+        IReadOnlyList<(Guid RuleId, int LeafId, long AtMs, bool Value)> Leaves,
+        IReadOnlyList<(string Key, long AtMs, decimal Value)> Facts) Shape(AlertReplayResult result)
+        => (
+            result.Events.Select(e => (e.At, e.RuleId, e.Kind)).ToList(),
+            result.LeafTransitionsByRule
+                .OrderBy(kvp => kvp.Key)
+                .SelectMany(kvp => kvp.Value.SelectMany(l =>
+                    l.Points.Select(p => (kvp.Key, l.LeafId, p.AtMs, p.Value))))
+                .ToList(),
+            result.FactTimelines
+                .OrderBy(kvp => kvp.Key, StringComparer.Ordinal)
+                .SelectMany(kvp => kvp.Value.Select(p => (kvp.Key, p.AtMs, p.Value)))
+                .ToList());
+
+    /// <summary>
+    /// A sparse series: the tick loop must keep the last reading it saw as "current" for the many
+    /// ticks that follow it, including across a page boundary. A cursor rebuilt per page would see
+    /// no reading at-or-before those ticks and clear the excursion, producing extra fired events.
+    /// </summary>
+    [Fact]
+    public async Task PageSize_DoesNotChangeReplayOutput_SparseSeries()
+    {
+        var ruleId = Guid.NewGuid();
+        _alertRepository.Setup(r => r.GetEnabledRulesAsync(_tenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { ThresholdBelow(ruleId, 70m) });
+
+        // Readings two hours apart so most ticks carry a reading fetched on an earlier page.
+        SetupSeries(
+        [
+            Reading(_dayStart.AddHours(2), 60),
+            Reading(_dayStart.AddHours(4), 60),
+            Reading(_dayStart.AddHours(6), 120),
+            Reading(_dayStart.AddHours(8), 55),
+        ]);
+
+        var reference = Shape(await CreateSut(pageSize: 1000)
+            .ReplayAsync(new DateOnly(2026, 4, 28), "UTC", null, null, CancellationToken.None));
+
+        // A single fired event that survives across the whole low run is the property at risk.
+        reference.Events.Should().HaveCount(2);
+
+        foreach (var pageSize in new[] { 1, 2, 3, 5 })
+        {
+            var paged = Shape(await CreateSut(pageSize)
+                .ReplayAsync(new DateOnly(2026, 4, 28), "UTC", null, null, CancellationToken.None));
+
+            paged.Events.Should().Equal(reference.Events, "page size {0} must not change events", pageSize);
+            paged.Leaves.Should().Equal(reference.Leaves, "page size {0} must not change the leaf log", pageSize);
+            paged.Facts.Should().Equal(reference.Facts, "page size {0} must not change fact timelines", pageSize);
+        }
+    }
+
+    /// <summary>
+    /// Two concurrent CGMs writing into the same aligned 5-minute bucket. Canonical selection gives
+    /// the whole bucket to the ranked device, so the 60 mg/dL reading from the unregistered stream
+    /// never reaches the evaluator. Selecting page-locally without holding back the split bucket
+    /// lets both halves win their own page and the low surfaces — hence the boundary carry.
+    /// </summary>
+    /// <remarks>
+    /// Page sizes start at the contested bucket's row count: a bucket wider than a page is flushed
+    /// per page by design (see <see cref="AlertEvaluationOptions.ReplayGlucosePageSize"/>), so
+    /// whole-bucket resolution is only guaranteed once a bucket fits in a page.
+    /// </remarks>
+    [Fact]
+    public async Task PageSize_DoesNotChangeReplayOutput_WhenABucketStraddlesAPageBoundary()
+    {
+        var rankedDevice = new PatientDevice
+        {
+            Id = Guid.CreateVersion7(),
+            DeviceCategory = DeviceCategory.CGM,
+            Rank = 0,
+            CreatedAt = _dayStart,
+        };
+        _devices.Add(rankedDevice);
+
+        var ruleId = Guid.NewGuid();
+        _alertRepository.Setup(r => r.GetEnabledRulesAsync(_tenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { ThresholdBelow(ruleId, 70m) });
+
+        // Bucket [04:00, 04:05): ranked device at 04:00 (200), a second unregistered stream at
+        // 04:01 (60). Two readings ahead of it offset the paging so a page boundary lands inside
+        // the contested bucket at page size 3; two behind it keep the window from ending there.
+        SetupSeries(
+        [
+            Reading(_dayStart.AddHours(3).AddMinutes(50), 200, patientDeviceId: rankedDevice.Id),
+            Reading(_dayStart.AddHours(3).AddMinutes(55), 200, patientDeviceId: rankedDevice.Id),
+            Reading(_dayStart.AddHours(4), 200, patientDeviceId: rankedDevice.Id),
+            Reading(_dayStart.AddHours(4).AddMinutes(1), 60, dataSource: "other", device: "cgm-b"),
+            Reading(_dayStart.AddHours(4).AddMinutes(10), 200, patientDeviceId: rankedDevice.Id),
+            Reading(_dayStart.AddHours(4).AddMinutes(20), 200, patientDeviceId: rankedDevice.Id),
+        ]);
+
+        var reference = Shape(await CreateSut(pageSize: 1000)
+            .ReplayAsync(new DateOnly(2026, 4, 28), "UTC", null, null, CancellationToken.None));
+
+        // The loser stream's low is invisible to the whole-window selection, so nothing fires —
+        // anchored by a non-empty fact timeline so an empty event list can't come from a
+        // reference run that never ticked.
+        reference.Events.Should().BeEmpty();
+        reference.Facts.Should().NotBeEmpty();
+
+        // The contested bucket holds two readings, so page sizes from two upward. Page size 3
+        // splits it across a boundary, which is the case the hold-back exists for.
+        foreach (var pageSize in new[] { 2, 3, 4, 5 })
+        {
+            var paged = Shape(await CreateSut(pageSize)
+                .ReplayAsync(new DateOnly(2026, 4, 28), "UTC", null, null, CancellationToken.None));
+
+            paged.Events.Should().Equal(reference.Events, "page size {0} must not change events", pageSize);
+            paged.Leaves.Should().Equal(reference.Leaves, "page size {0} must not change the leaf log", pageSize);
+            paged.Facts.Should().Equal(reference.Facts, "page size {0} must not change fact timelines", pageSize);
+        }
+    }
+
+    /// <summary>
+    /// The fetch must page rather than ask for the whole window in one go — an unpaged read is
+    /// what let a multi-month replay allocate the entire series.
+    /// </summary>
+    [Fact]
+    public async Task GlucoseFetch_RequestsBoundedPages()
+    {
+        _alertRepository.Setup(r => r.GetEnabledRulesAsync(_tenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { ThresholdBelow(Guid.NewGuid(), 70m) });
+        SetupSeries([Reading(_dayStart.AddHours(4), 60)]);
+
+        await CreateSut(pageSize: 250)
+            .ReplayAsync(new DateOnly(2026, 4, 28), "UTC", null, null, CancellationToken.None);
+
+        _glucoseRepository.Verify(r => r.GetAsync(
+            It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), null, null,
+            250, It.IsAny<int>(), false, false,
+            It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+        _glucoseRepository.Verify(r => r.GetAsync(
+            It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), null, null,
+            int.MaxValue, It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<bool>(),
+            It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
+    /// A bucket holding more rows than one page must not accumulate in the hold-back buffer —
+    /// the resident set stays within a page. Every reading here is one stream, so per-page
+    /// selection is identity and the flushed result still matches the single-page reference.
+    /// </summary>
+    [Fact]
+    public async Task ABucketWiderThanAPage_IsFlushedRatherThanHeldBack()
+    {
+        var ruleId = Guid.NewGuid();
+        _alertRepository.Setup(r => r.GetEnabledRulesAsync(_tenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { ThresholdBelow(ruleId, 70m) });
+
+        // Six readings inside the single bucket [04:00, 04:05), then one well clear of it.
+        SetupSeries(
+        [
+            .. Enumerable.Range(0, 6).Select(i => Reading(_dayStart.AddHours(4).AddSeconds(i * 30), 60)),
+            Reading(_dayStart.AddHours(5), 120),
+        ]);
+
+        var reference = Shape(await CreateSut(pageSize: 1000)
+            .ReplayAsync(new DateOnly(2026, 4, 28), "UTC", null, null, CancellationToken.None));
+        reference.Events.Should().ContainSingle();
+
+        _selectedBatchSizes.Clear();
+        const int pageSize = 2;
+        var paged = Shape(await CreateSut(pageSize)
+            .ReplayAsync(new DateOnly(2026, 4, 28), "UTC", null, null, CancellationToken.None));
+
+        paged.Events.Should().Equal(reference.Events);
+        paged.Leaves.Should().Equal(reference.Leaves);
+        paged.Facts.Should().Equal(reference.Facts);
+        _selectedBatchSizes.Should().NotBeEmpty();
+        _selectedBatchSizes.Max().Should().BeLessThanOrEqualTo(pageSize,
+            "an over-wide bucket must be flushed per page, not accumulated");
+    }
+
+    /// <summary>
+    /// A fetch that ignores the keyset cursor hands back the same full page forever, and the
+    /// paging loop must fail rather than spin.
+    /// </summary>
+    /// <remarks>
+    /// The replay runs under an expiring token so a regression that removes the guard surfaces as
+    /// the wrong exception type within seconds. <c>[Fact(Timeout)]</c> is not enough on its own:
+    /// xUnit reports the timeout but does not abandon the runaway loop, which wedges the run.
+    /// </remarks>
+    [Fact(Timeout = 30000)]
+    public async Task AFetchThatIgnoresTheKeysetCursor_Fails_RatherThanSpinning()
+    {
+        using var spinGuard = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        _alertRepository.Setup(r => r.GetEnabledRulesAsync(_tenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { ThresholdBelow(Guid.NewGuid(), 70m) });
+
+        // Deliberately cursor-blind: always the same two rows, which is a full page at pageSize 2.
+        var stuck = new[]
+        {
+            Reading(_dayStart.AddHours(4), 60),
+            Reading(_dayStart.AddHours(4).AddMinutes(10), 60),
+        };
+        _glucoseRepository
+            .Setup(r => r.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), null, null,
+                It.IsAny<int>(), It.IsAny<int>(), false, false,
+                It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stuck);
+
+        await CreateSut(pageSize: 2)
+            .Invoking(s => s.ReplayAsync(new DateOnly(2026, 4, 28), "UTC", null, null, spinGuard.Token))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*did not advance past the keyset cursor*");
+    }
+
+    /// <summary>
+    /// The shipped default has to clear the widest window a first-party caller asks for — a
+    /// DST-stretched calendar day — while still rejecting something far beyond it.
+    /// </summary>
+    [Fact]
+    public async Task TheDefaultWindowCap_ClearsACalendarDayAndRejectsFarBeyondIt()
+    {
+        var shipped = new AlertEvaluationOptions().MaxReplayWindow;
+        shipped.Should().BeGreaterThanOrEqualTo(TimeSpan.FromHours(25));
+        // The ceiling matters as much as the floor: each replayed tick costs a round of as-of
+        // enrichment queries, so a default far past the documented ~2x need re-opens the
+        // unbounded-work hole the cap exists to close.
+        shipped.Should().BeLessThanOrEqualTo(TimeSpan.FromHours(72));
+
+        _alertRepository.Setup(r => r.GetEnabledRulesAsync(_tenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<AlertRuleSnapshot>());
+        SetupSeries([]);
+        var sut = CreateSut(pageSize: 1000, maxWindow: shipped);
+
+        // A DST-stretched calendar day must still run under the shipped default.
+        var accepted = await sut.ReplayAsync(
+            null, null, _dayStart, _dayStart.AddHours(25), CancellationToken.None);
+        accepted.WindowEnd.Should().Be(_dayStart.AddHours(25));
+
+        await sut.Invoking(s => s.ReplayAsync(
+                null, null, _dayStart, _dayStart + shipped + TimeSpan.FromMinutes(5), CancellationToken.None))
+            .Should().ThrowAsync<ReplayWindowTooLargeException>();
+    }
+
+    [Fact]
+    public async Task WindowExactlyAtTheMaximum_IsReplayed()
+    {
+        _alertRepository.Setup(r => r.GetEnabledRulesAsync(_tenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { ThresholdBelow(Guid.NewGuid(), 70m) });
+        SetupSeries([Reading(_dayStart.AddMinutes(30), 60)]);
+
+        var max = TimeSpan.FromHours(2);
+        var sut = CreateSut(pageSize: 1000, maxWindow: max);
+
+        var result = await sut.ReplayAsync(null, null, _dayStart, _dayStart + max, CancellationToken.None);
+
+        result.WindowStart.Should().Be(_dayStart);
+        result.WindowEnd.Should().Be(_dayStart + max);
+        result.Events.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task WindowOneTickOverTheMaximum_IsRejected()
+    {
+        var max = TimeSpan.FromHours(2);
+        var sut = CreateSut(pageSize: 1000, maxWindow: max);
+
+        var act = () => sut.ReplayAsync(
+            null, null, _dayStart, _dayStart + max + TimeSpan.FromMinutes(5), CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<ReplayWindowTooLargeException>();
+        thrown.Which.Maximum.Should().Be(max);
+        thrown.Which.Requested.Should().Be(max + TimeSpan.FromMinutes(5));
+    }
+
+    /// <summary>
+    /// The cap is input validation, so it must reject before any tenant data is touched — an
+    /// over-wide window is the same error whatever the rule set or reading count is.
+    /// </summary>
+    [Fact]
+    public async Task OverWideWindow_IsRejectedWithoutFetchingRulesOrReadings()
+    {
+        var sut = CreateSut(pageSize: 1000, maxWindow: TimeSpan.FromHours(2));
+
+        await sut.Invoking(s => s.ReplayAsync(
+                null, null, _dayStart, _dayStart.AddDays(90), CancellationToken.None))
+            .Should().ThrowAsync<ReplayWindowTooLargeException>();
+
+        _alertRepository.Verify(
+            r => r.GetEnabledRulesAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+        _glucoseRepository.Verify(
+            r => r.GetAsync(It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<bool>(),
+                It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DryRunReplay_IsSubjectToTheSameWindowCap()
+    {
+        var sut = CreateSut(pageSize: 1000, maxWindow: TimeSpan.FromHours(2));
+        var ruleOverride = new ReplayRuleOverride(
+            Id: null, Name: "draft", ConditionType: AlertConditionType.Threshold,
+            ConditionParams: """{"direction":"below","value":70}""",
+            Severity: AlertRuleSeverity.Warning, AllowThroughDnd: false,
+            AutoResolveEnabled: false, AutoResolveParams: null);
+
+        await sut.Invoking(s => s.ReplayDryRunAsync(
+                null, null, _dayStart, _dayStart.AddDays(30), ruleOverride, CancellationToken.None))
+            .Should().ThrowAsync<ReplayWindowTooLargeException>();
+    }
+
+    [Fact]
+    public async Task Controller_MapsAnOverWideWindowToBadRequest()
+    {
+        var replayService = new Mock<IAlertReplayService>();
+        replayService
+            .Setup(s => s.ReplayAsync(It.IsAny<DateOnly?>(), It.IsAny<string?>(),
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ReplayWindowTooLargeException(TimeSpan.FromDays(90), TimeSpan.FromDays(7)));
+        var controller = new AlertReplayController(replayService.Object);
+
+        var response = await controller.Replay(
+            new AlertReplayRequest(null, null, _dayStart, _dayStart.AddDays(90)), CancellationToken.None);
+
+        response.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/AlertReplayServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/AlertReplayServiceTests.cs
@@ -89,6 +89,7 @@ public class AlertReplayServiceTests
             TestDoubles.CanonicalGlucosePassThrough.Create(),
             enricher,
             _tenantAccessor.Object,
+            Options.Create(new AlertEvaluationOptions()),
             NullLogger<AlertReplayService>.Instance);
     }
 


### PR DESCRIPTION
## What

`AlertReplayService` fetched the entire glucose window with `limit: int.MaxValue` and held the full series resident for the whole replay. A replay over a multi-month window on an active tenant could allocate unbounded memory and block a worker — and the fetch was only half the cost, since per-tick as-of enrichment (~15 gated round trips per 5-minute tick) and the transition-log payload grow with the window regardless of how the series is fed. So this does both:

- **Keyset paging** (page size 2000, `AlertEvaluation:ReplayGlucosePageSize`) over the repository's existing `afterTimestamp`/`afterId` cursor, streamed as `IAsyncEnumerable<SensorGlucose>` — the same shape #654's engine-seam refactor will want. A `ReadingCursor` (current + one-reading lookahead) reproduces the old index-walk semantics exactly; a guard throws if a fetch fails to advance past the cursor rather than spinning forever.
- **Window cap** (default 48h, `AlertEvaluation:MaxReplayWindow` — 2× the widest first-party need, a DST-stretched 25h calendar day) mapped to 400 on both replay and dry-run before any DB work.

Canonical selection resolves winners per aligned 5-minute bucket, so a bucket straddling a page boundary is held back and re-selected with the next page's head. Per-page selection equals whole-window selection because stream priority is batch-invariant (registered devices from the device list; unknown pseudo-devices ordered ordinally on the key string) — provided a bucket fits in a page; a degenerate wider-than-page bucket (bulk backfill shape) is flushed rather than accumulated.

Evaluator behavior is untouched — nothing under `Services/Alerts/Evaluators/`, no Rust crate, no `engine-semantics.md` change; the frozen contract explicitly leaves window resolution and reading fetch host-side. Related: #654 (routing replay through `IAlertEvaluationEngine`) is deliberately not addressed; the `TODO(alerts-engine-seam)` marker stays.

## Testing

4839 passed / 0 failed / 5 skipped (11 tests in the new paging file). Five mutation proofs, each failing exactly its own pinning test: cap operator flip → the at-boundary test; final page emitting unheld rows → both page-size identity tests (exact comparison of events + leaf transitions + fact timelines across page sizes vs a single-page reference, non-triviality anchored); hold-back removed → the straddle test (fixture built so a page boundary lands inside the contested bucket); oversized-bucket flush disabled → the peak-residency test (asserts on the largest batch handed to the selector, since the flush changes residency, not results); cursor guard weakened → the cursor-blind-fetch test fails cleanly in 5s via a CancellationTokenSource (xUnit's `[Fact(Timeout)]` doesn't abandon a runaway loop). The shipped default is pinned on both sides: ≥ 25h (must clear a DST day) and ≤ 72h (the ceiling is the point of the cap).

## Noted for follow-up (not in this PR)

`AlertReplayController` is `[Authorize]`-only — the sole alerts controller without a `[RequireScope]` gate, and replay fact timelines are a broad PHI read. The cap bounds throughput, not authorization; a scope gate is queued as separate work.

https://claude.ai/code/session_01V2H2GSE3UWEgkMvsJE8Kfw
