### PR TITLE
fix(connectors): scope the activity catch-up watermark to the asking connector

### DIFF
--- a/src/API/Nocturne.API/Services/ConnectorPublishing/MetadataPublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/MetadataPublisher.cs
@@ -181,7 +181,15 @@ internal sealed class MetadataPublisher : IMetadataPublisher
     {
         try
         {
-            await _activityService.CreateActivitiesAsync(activities, cancellationToken);
+            // Attribution rule (shared with PublishStateSpansAsync): a record's source is the
+            // connector that wrote it into THIS instance, never a source carried in the payload.
+            // Stamped unconditionally so the decomposed destinations (state spans, heart rates,
+            // step counts) all resolve to this connector's watermark.
+            var activityList = activities.ToList();
+            foreach (var activity in activityList)
+                activity.DataSource = source;
+
+            await _activityService.CreateActivitiesAsync(activityList, cancellationToken);
             return true;
         }
         catch (OperationCanceledException) { throw; }
@@ -201,6 +209,24 @@ internal sealed class MetadataPublisher : IMetadataPublisher
         {
             foreach (var span in stateSpans)
             {
+                // Attribution rule (shared with PublishActivityAsync): a record's source is the
+                // connector that wrote it into THIS instance, never a source carried in the
+                // payload. Preserving an incoming Source would let a mirroring connector
+                // (NocturneRemote replays a remote instance's spans verbatim) file rows under
+                // another connector's name and advance a watermark that connector never earned,
+                // making it skip its own window. Every other producer already sets its own
+                // ConnectorSource here, so the overwrite is a no-op for them.
+                //
+                // When the overwrite actually displaces a value, the displaced one is stashed
+                // rather than dropped — mirroring how ToStateSpan stashes a displaced EnteredBy —
+                // so a mirrored span's origin on the remote instance stays recoverable.
+                if (span.Source is not null && span.Source != source)
+                {
+                    span.Metadata ??= [];
+                    span.Metadata["originSource"] = span.Source;
+                }
+
+                span.Source = source;
                 await _stateSpanService.UpsertStateSpanAsync(span, cancellationToken);
             }
             return true;
@@ -254,35 +280,17 @@ internal sealed class MetadataPublisher : IMetadataPublisher
     }
 
     /// <summary>
-    /// Returns the timestamp of the most recent activity record for the current tenant,
-    /// or <c>null</c> if none exist. Activities are stored across decomposed sources (StateSpans,
-    /// HeartRate, StepCount); <see cref="IActivityService.GetActivitiesAsync"/> merges them and
-    /// orders newest-first, so requesting a single record yields the global latest. Like
-    /// <see cref="ITreatmentPublisher.GetLatestTreatmentTimestampAsync"/>, this is not source-filtered.
+    /// Returns the resume watermark for the connector activity sync: the latest stored activity
+    /// timestamp across the decomposed destinations (StateSpans, HeartRate, StepCount) for THIS
+    /// source, or <c>null</c> when the source has written none. Source-scoping is required for
+    /// multi-connector catch-up — a tenant-global latest hands one connector another connector's
+    /// newest record, so it concludes it is caught up and silently skips the window it still
+    /// needs. Mirrors <see cref="ITreatmentPublisher.GetLatestTreatmentTimestampAsync"/>.
     /// </summary>
-    public async Task<DateTime?> GetLatestActivityTimestampAsync(
+    public Task<DateTime?> GetLatestActivityTimestampAsync(
         string source,
         CancellationToken cancellationToken = default)
-    {
-        // TODO: Filter by source to support multi-connector catch-up. Currently returns global latest.
-        var latest = (await _activityService.GetActivitiesAsync(
-                count: 1,
-                skip: 0,
-                cancellationToken: cancellationToken))
-            .FirstOrDefault();
-
-        if (latest == null)
-            return null;
-
-        if (!string.IsNullOrEmpty(latest.CreatedAt)
-            && DateTime.TryParse(latest.CreatedAt, out var createdAt))
-            return createdAt;
-
-        if (latest.Mills > 0)
-            return DateTimeOffset.FromUnixTimeMilliseconds(latest.Mills).UtcDateTime;
-
-        return null;
-    }
+        => _activityService.GetLatestTimestampAsync(source, cancellationToken);
 
     /// <inheritdoc />
     public async Task<DateTime?> GetBackfillLowWaterMarkAsync(

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/MetadataPublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/MetadataPublisher.cs
@@ -181,10 +181,8 @@ internal sealed class MetadataPublisher : IMetadataPublisher
     {
         try
         {
-            // Attribution rule (shared with PublishStateSpansAsync): a record's source is the
-            // connector that wrote it into THIS instance, never a source carried in the payload.
-            // Stamped unconditionally so the decomposed destinations (state spans, heart rates,
-            // step counts) all resolve to this connector's watermark.
+            // Stamp the publishing connector so every decomposed destination (state spans, heart
+            // rates, step counts) resolves to this connector's watermark.
             var activityList = activities.ToList();
             foreach (var activity in activityList)
                 activity.DataSource = source;
@@ -209,17 +207,10 @@ internal sealed class MetadataPublisher : IMetadataPublisher
         {
             foreach (var span in stateSpans)
             {
-                // Attribution rule (shared with PublishActivityAsync): a record's source is the
-                // connector that wrote it into THIS instance, never a source carried in the
-                // payload. Preserving an incoming Source would let a mirroring connector
-                // (NocturneRemote replays a remote instance's spans verbatim) file rows under
-                // another connector's name and advance a watermark that connector never earned,
-                // making it skip its own window. Every other producer already sets its own
-                // ConnectorSource here, so the overwrite is a no-op for them.
-                //
-                // When the overwrite actually displaces a value, the displaced one is stashed
-                // rather than dropped — mirroring how ToStateSpan stashes a displaced EnteredBy —
-                // so a mirrored span's origin on the remote instance stays recoverable.
+                // Source is the connector writing the row here, not one carried in the payload:
+                // NocturneRemote replays another instance's spans verbatim, and honouring their
+                // Source would advance a watermark the named connector never earned. A displaced
+                // value is stashed so the remote origin stays recoverable.
                 if (span.Source is not null && span.Source != source)
                 {
                     span.Metadata ??= [];
@@ -279,14 +270,7 @@ internal sealed class MetadataPublisher : IMetadataPublisher
         }
     }
 
-    /// <summary>
-    /// Returns the resume watermark for the connector activity sync: the latest stored activity
-    /// timestamp across the decomposed destinations (StateSpans, HeartRate, StepCount) for THIS
-    /// source, or <c>null</c> when the source has written none. Source-scoping is required for
-    /// multi-connector catch-up — a tenant-global latest hands one connector another connector's
-    /// newest record, so it concludes it is caught up and silently skips the window it still
-    /// needs. Mirrors <see cref="ITreatmentPublisher.GetLatestTreatmentTimestampAsync"/>.
-    /// </summary>
+    /// <inheritdoc />
     public Task<DateTime?> GetLatestActivityTimestampAsync(
         string source,
         CancellationToken cancellationToken = default)

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/MetadataPublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/MetadataPublisher.cs
@@ -211,7 +211,7 @@ internal sealed class MetadataPublisher : IMetadataPublisher
                 // NocturneRemote replays another instance's spans verbatim, and honouring their
                 // Source would advance a watermark the named connector never earned. A displaced
                 // value is stashed so the remote origin stays recoverable.
-                if (span.Source is not null && span.Source != source)
+                if (!string.IsNullOrEmpty(span.Source) && span.Source != source)
                 {
                     span.Metadata ??= [];
                     span.Metadata["originSource"] = span.Source;

--- a/src/API/Nocturne.API/Services/Glucose/StateSpanService.cs
+++ b/src/API/Nocturne.API/Services/Glucose/StateSpanService.cs
@@ -162,6 +162,12 @@ public class StateSpanService : IStateSpanService
     }
 
     /// <inheritdoc />
+    public Task<DateTime?> GetLatestActivityTimestampAsync(
+        string source,
+        CancellationToken cancellationToken = default)
+        => _repository.GetLatestActivityTimestampAsync(source, cancellationToken);
+
+    /// <inheritdoc />
     public async Task<Activity?> GetActivityByIdAsync(
         string id,
         CancellationToken cancellationToken = default)

--- a/src/API/Nocturne.API/Services/Health/ActivityService.cs
+++ b/src/API/Nocturne.API/Services/Health/ActivityService.cs
@@ -154,6 +154,23 @@ public class ActivityService : IActivityService
     }
 
     /// <inheritdoc />
+    public async Task<DateTime?> GetLatestTimestampAsync(
+        string source,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var candidates = new[]
+        {
+            await _stateSpanService.GetLatestActivityTimestampAsync(source, cancellationToken),
+            await _heartRateService.GetLatestTimestampAsync(source, cancellationToken),
+            await _stepCountService.GetLatestTimestampAsync(source, cancellationToken),
+        };
+
+        var present = candidates.Where(t => t.HasValue).Select(t => t!.Value).ToList();
+        return present.Count > 0 ? present.Max() : null;
+    }
+
+    /// <inheritdoc />
     public async Task<Activity?> GetActivityByIdAsync(
         string id,
         CancellationToken cancellationToken = default

--- a/src/API/Nocturne.API/Services/Health/ActivityService.cs
+++ b/src/API/Nocturne.API/Services/Health/ActivityService.cs
@@ -168,6 +168,8 @@ public class ActivityService : IActivityService
         CancellationToken cancellationToken = default
     )
     {
+        // Sequential: the three services share one DbContext. Max over DateTime? skips the
+        // destinations this source has never written to, and is null when that is all of them.
         var candidates = new[]
         {
             await _stateSpanService.GetLatestActivityTimestampAsync(source, cancellationToken),
@@ -175,8 +177,7 @@ public class ActivityService : IActivityService
             await _stepCountService.GetLatestTimestampAsync(source, cancellationToken),
         };
 
-        var present = candidates.Where(t => t.HasValue).Select(t => t!.Value).ToList();
-        return present.Count > 0 ? present.Max() : null;
+        return candidates.Max();
     }
 
     /// <inheritdoc />

--- a/src/API/Nocturne.API/Services/Health/HeartRateService.cs
+++ b/src/API/Nocturne.API/Services/Health/HeartRateService.cs
@@ -80,6 +80,15 @@ public class HeartRateService
         return entities.Select(ToDomainModel);
     }
 
+    public Task<DateTime?> GetLatestTimestampAsync(
+        string source,
+        CancellationToken cancellationToken = default
+    ) =>
+        EntitySet
+            .AsNoTracking()
+            .Where(h => h.DataSource == source)
+            .MaxAsync(h => (DateTime?)h.Timestamp, cancellationToken);
+
     public Task<HeartRate?> GetHeartRateByIdAsync(
         string id,
         CancellationToken cancellationToken = default

--- a/src/API/Nocturne.API/Services/Health/StepCountService.cs
+++ b/src/API/Nocturne.API/Services/Health/StepCountService.cs
@@ -80,6 +80,15 @@ public class StepCountService
         return entities.Select(ToDomainModel);
     }
 
+    public Task<DateTime?> GetLatestTimestampAsync(
+        string source,
+        CancellationToken cancellationToken = default
+    ) =>
+        EntitySet
+            .AsNoTracking()
+            .Where(s => s.DataSource == source)
+            .MaxAsync(s => (DateTime?)s.Timestamp, cancellationToken);
+
     public Task<StepCount?> GetStepCountByIdAsync(
         string id,
         CancellationToken cancellationToken = default

--- a/src/API/Nocturne.API/Services/V4/ActivityDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/ActivityDecomposer.cs
@@ -432,6 +432,7 @@ public class ActivityDecomposer : IActivityDecomposer, IDecomposer<Activity>
             EnteredBy = activity.EnteredBy,
             CreatedAt = activity.CreatedAt,
             UtcOffset = activity.UtcOffset,
+            DataSource = activity.DataSource,
         };
     }
 
@@ -444,11 +445,14 @@ public class ActivityDecomposer : IActivityDecomposer, IDecomposer<Activity>
             Id = activity.Id,
             Mills = activity.Mills,
             Metric = GetIntValue(props, "metric"),
+            // StepCount.Source is the absolute/delta bitmask, not a provenance string;
+            // the originating connector goes on DataSource.
             Source = GetIntValue(props, "source"),
             Device = GetStringValue(props, "device") ?? activity.EnteredBy,
             EnteredBy = activity.EnteredBy,
             CreatedAt = activity.CreatedAt,
             UtcOffset = activity.UtcOffset,
+            DataSource = activity.DataSource,
         };
     }
 

--- a/src/API/Nocturne.API/Services/V4/ActivityDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/ActivityDecomposer.cs
@@ -445,8 +445,7 @@ public class ActivityDecomposer : IActivityDecomposer, IDecomposer<Activity>
             Id = activity.Id,
             Mills = activity.Mills,
             Metric = GetIntValue(props, "metric"),
-            // StepCount.Source is the absolute/delta bitmask, not a provenance string;
-            // the originating connector goes on DataSource.
+            // StepCount.Source is the absolute/delta bitmask, not provenance — that is DataSource.
             Source = GetIntValue(props, "source"),
             Device = GetStringValue(props, "device") ?? activity.EnteredBy,
             EnteredBy = activity.EnteredBy,

--- a/src/Connectors/Nocturne.Connectors.Core/Interfaces/IMetadataPublisher.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Interfaces/IMetadataPublisher.cs
@@ -56,9 +56,12 @@ public interface IMetadataPublisher
         WriteOrigin origin, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Returns the timestamp of the most recent activity record for the current tenant,
-    /// used by connectors to resume catch-up from where they left off, or <c>null</c> if none exist.
+    /// Returns the timestamp of the most recent activity record written by
+    /// <paramref name="source"/>, used by connectors to resume catch-up from where they left off,
+    /// or <c>null</c> when this source has written none.
     /// </summary>
+    /// <param name="source">The connector data source (e.g. <c>nightscout-connector</c>).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     Task<DateTime?> GetLatestActivityTimestampAsync(
         string source,
         CancellationToken cancellationToken = default);

--- a/src/Core/Nocturne.Core.Contracts/Glucose/IStateSpanService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Glucose/IStateSpanService.cs
@@ -146,16 +146,9 @@ public interface IStateSpanService
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Returns the latest start timestamp across activity-category state spans, optionally scoped
-    /// to a data source. Returns <c>null</c> when the source has written no activity span.
+    /// Returns the latest start timestamp across activity-category state spans written by
+    /// <paramref name="source"/>, or <c>null</c> when it has written none.
     /// </summary>
-    /// <remarks>
-    /// This reads the attribution the connector publisher writes: <c>Source</c> is the connector
-    /// that wrote the row into this instance, never a source carried in the payload. That is what
-    /// makes the value safe as a resume watermark — a mirroring connector's replay of another
-    /// instance's spans is filed under the mirroring connector, so it cannot advance the mirrored
-    /// connector's own watermark past a window that connector has not actually synced.
-    /// </remarks>
     /// <param name="source">The data source to scope to.</param>
     /// <param name="cancellationToken">Cancellation token</param>
     Task<DateTime?> GetLatestActivityTimestampAsync(

--- a/src/Core/Nocturne.Core.Contracts/Glucose/IStateSpanService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Glucose/IStateSpanService.cs
@@ -146,6 +146,23 @@ public interface IStateSpanService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Returns the latest start timestamp across activity-category state spans, optionally scoped
+    /// to a data source. Returns <c>null</c> when the source has written no activity span.
+    /// </summary>
+    /// <remarks>
+    /// This reads the attribution the connector publisher writes: <c>Source</c> is the connector
+    /// that wrote the row into this instance, never a source carried in the payload. That is what
+    /// makes the value safe as a resume watermark — a mirroring connector's replay of another
+    /// instance's spans is filed under the mirroring connector, so it cannot advance the mirrored
+    /// connector's own watermark past a window that connector has not actually synced.
+    /// </remarks>
+    /// <param name="source">The data source to scope to.</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    Task<DateTime?> GetLatestActivityTimestampAsync(
+        string source,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Get a specific activity by ID
     /// </summary>
     /// <param name="id">Activity ID</param>

--- a/src/Core/Nocturne.Core.Contracts/Health/IActivityService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Health/IActivityService.cs
@@ -31,10 +31,9 @@ public interface IActivityService
     /// watermark — or <c>null</c> when that source has written no activity record.
     /// </summary>
     /// <remarks>
-    /// Sleep sessions are excluded: they carry a device-vendor <c>Source</c> (Apple, Oura, …),
-    /// not a connector data source, so they cannot be scoped. Omitting them can only under-report
-    /// the watermark, which makes a connector re-fetch a window it already holds — publishes are
-    /// idempotent, so that is safe, whereas over-reporting would silently skip a window.
+    /// Sleep sessions are excluded: their <c>Source</c> is a device vendor (Apple, Oura, …), not a
+    /// connector, so they cannot be scoped. That can only under-report the watermark, costing an
+    /// idempotent re-fetch; over-reporting would skip a window outright.
     /// </remarks>
     /// <param name="source">The data source to scope to.</param>
     /// <param name="cancellationToken">Cancellation token.</param>

--- a/src/Core/Nocturne.Core.Contracts/Health/IActivityService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Health/IActivityService.cs
@@ -26,6 +26,24 @@ public interface IActivityService
     );
 
     /// <summary>
+    /// Returns the latest activity timestamp written by <paramref name="source"/> across the
+    /// decomposed destinations (StateSpans, HeartRate, StepCount) — a connector's resume
+    /// watermark — or <c>null</c> when that source has written no activity record.
+    /// </summary>
+    /// <remarks>
+    /// Sleep sessions are excluded: they carry a device-vendor <c>Source</c> (Apple, Oura, …),
+    /// not a connector data source, so they cannot be scoped. Omitting them can only under-report
+    /// the watermark, which makes a connector re-fetch a window it already holds — publishes are
+    /// idempotent, so that is safe, whereas over-reporting would silently skip a window.
+    /// </remarks>
+    /// <param name="source">The data source to scope to.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<DateTime?> GetLatestTimestampAsync(
+        string source,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
     /// Get a specific <see cref="Activity"/> record by ID.
     /// </summary>
     /// <param name="id">Activity ID (legacy MongoDB ObjectId or UUID v7 string).</param>

--- a/src/Core/Nocturne.Core.Contracts/Health/IHeartRateService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Health/IHeartRateService.cs
@@ -34,6 +34,17 @@ public interface IHeartRateService
     );
 
     /// <summary>
+    /// Returns the latest heart rate timestamp written by <paramref name="source"/> (a connector's
+    /// resume watermark), or <c>null</c> when that source has written none.
+    /// </summary>
+    /// <param name="source">The data source to scope to.</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    Task<DateTime?> GetLatestTimestampAsync(
+        string source,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
     /// Get a specific heart rate record by ID
     /// </summary>
     /// <param name="id">Record ID</param>

--- a/src/Core/Nocturne.Core.Contracts/Health/IStepCountService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Health/IStepCountService.cs
@@ -34,6 +34,17 @@ public interface IStepCountService
     );
 
     /// <summary>
+    /// Returns the latest step count timestamp written by <paramref name="source"/> (a connector's
+    /// resume watermark), or <c>null</c> when that source has written none.
+    /// </summary>
+    /// <param name="source">The data source to scope to.</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    Task<DateTime?> GetLatestTimestampAsync(
+        string source,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
     /// Get a specific step count record by ID
     /// </summary>
     /// <param name="id">Record ID</param>

--- a/src/Core/Nocturne.Core.Contracts/Repositories/IStateSpanRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/Repositories/IStateSpanRepository.cs
@@ -189,6 +189,18 @@ public interface IStateSpanRepository
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Returns the latest <c>StartTimestamp</c> across activity-category state spans written by
+    /// <paramref name="source"/> (a connector's resume watermark), or <c>null</c> when that source
+    /// has written no activity span. Scoping is mandatory: an unscoped latest is what made
+    /// multi-connector catch-up skip windows.
+    /// </summary>
+    /// <param name="source">The data source to scope to.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<DateTime?> GetLatestActivityTimestampAsync(
+        string source,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Returns a single activity state span by its identifier.
     /// </summary>
     /// <param name="id">The state span identifier.</param>

--- a/src/Core/Nocturne.Core.Contracts/Repositories/IStateSpanRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/Repositories/IStateSpanRepository.cs
@@ -191,8 +191,7 @@ public interface IStateSpanRepository
     /// <summary>
     /// Returns the latest <c>StartTimestamp</c> across activity-category state spans written by
     /// <paramref name="source"/> (a connector's resume watermark), or <c>null</c> when that source
-    /// has written no activity span. Scoping is mandatory: an unscoped latest is what made
-    /// multi-connector catch-up skip windows.
+    /// has written no activity span.
     /// </summary>
     /// <param name="source">The data source to scope to.</param>
     /// <param name="cancellationToken">Cancellation token.</param>

--- a/src/Core/Nocturne.Core.Models/Activity.cs
+++ b/src/Core/Nocturne.Core.Models/Activity.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Nocturne.Core.Models.Attributes;
 
 namespace Nocturne.Core.Models;
 
@@ -118,6 +119,23 @@ public class Activity : ProcessableDocumentBase
     [JsonPropertyName("name")]
     [Sanitizable]
     public string? Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the data source identifier indicating where this activity originated from.
+    /// Use constants from <see cref="Core.Constants.DataSources"/> for consistent values.
+    /// </summary>
+    /// <remarks>
+    /// Carried through decomposition onto every destination that stores a connector source
+    /// (<see cref="StateSpan.Source"/>, <see cref="HeartRate.DataSource"/>,
+    /// <see cref="StepCount.DataSource"/>) so a connector's resume watermark can be scoped to
+    /// its own records.
+    /// </remarks>
+    /// <example>
+    /// Common values: "nightscout-connector", "glooko-connector", "manual"
+    /// </example>
+    [JsonPropertyName("data_source")]
+    [NocturneOnly]
+    public string? DataSource { get; set; }
 
     /// <summary>
     /// Gets or sets additional properties as a dynamic object

--- a/src/Core/Nocturne.Core.Models/Activity.cs
+++ b/src/Core/Nocturne.Core.Models/Activity.cs
@@ -125,10 +125,9 @@ public class Activity : ProcessableDocumentBase
     /// Use constants from <see cref="Core.Constants.DataSources"/> for consistent values.
     /// </summary>
     /// <remarks>
-    /// Carried through decomposition onto every destination that stores a connector source
-    /// (<see cref="StateSpan.Source"/>, <see cref="HeartRate.DataSource"/>,
-    /// <see cref="StepCount.DataSource"/>) so a connector's resume watermark can be scoped to
-    /// its own records.
+    /// Carried through decomposition onto <see cref="StateSpan.Source"/>,
+    /// <see cref="HeartRate.DataSource"/> and <see cref="StepCount.DataSource"/> so a connector's
+    /// resume watermark can be scoped to its own records.
     /// </remarks>
     /// <example>
     /// Common values: "nightscout-connector", "glooko-connector", "manual"

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/ActivityStateSpanMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/ActivityStateSpanMapper.cs
@@ -192,7 +192,10 @@ public static class ActivityStateSpanMapper
             State = activity.Type ?? category.ToString().ToLowerInvariant(),
             StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(activity.Mills).UtcDateTime,
             EndTimestamp = CalculateEndTimestamp(activity),
-            Source = activity.EnteredBy ?? "nightscout",
+            // DataSource first: it is the connector that wrote the record, which is what a
+            // resume watermark is scoped by. EnteredBy is the uploader name carried in the
+            // payload and stays the fallback for activities posted through the v1 API.
+            Source = activity.DataSource ?? activity.EnteredBy ?? "nightscout",
             OriginalId = activity.Id,
             Metadata = BuildMetadata(activity)
         };
@@ -225,6 +228,7 @@ public static class ActivityStateSpanMapper
             activity.Description = GetMetadataString(stateSpan.Metadata, "description");
             activity.Notes = GetMetadataString(stateSpan.Metadata, "notes");
             activity.Name = GetMetadataString(stateSpan.Metadata, "name");
+            activity.EnteredBy = GetMetadataString(stateSpan.Metadata, "enteredBy") ?? stateSpan.Source;
             activity.Intensity = GetMetadataString(stateSpan.Metadata, "intensity");
             activity.DateString = GetMetadataString(stateSpan.Metadata, "dateString");
             activity.CreatedAt = GetMetadataString(stateSpan.Metadata, "createdAt");
@@ -288,6 +292,11 @@ public static class ActivityStateSpanMapper
 
         if (!string.IsNullOrEmpty(activity.Name))
             metadata["name"] = activity.Name;
+
+        // Kept because Source now holds the connector for connector-published activities, so it
+        // is no longer the uploader name to read EnteredBy back from. Mirrors BuildSleepMetadata.
+        if (!string.IsNullOrEmpty(activity.EnteredBy))
+            metadata["enteredBy"] = activity.EnteredBy;
 
         if (!string.IsNullOrEmpty(activity.Intensity))
             metadata["intensity"] = activity.Intensity;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/ActivityStateSpanMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/ActivityStateSpanMapper.cs
@@ -192,9 +192,8 @@ public static class ActivityStateSpanMapper
             State = activity.Type ?? category.ToString().ToLowerInvariant(),
             StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(activity.Mills).UtcDateTime,
             EndTimestamp = CalculateEndTimestamp(activity),
-            // DataSource first: it is the connector that wrote the record, which is what a
-            // resume watermark is scoped by. EnteredBy is the uploader name carried in the
-            // payload and stays the fallback for activities posted through the v1 API.
+            // DataSource is the connector a resume watermark is scoped by; EnteredBy is the
+            // uploader name, and stays the fallback for activities posted through the v1 API.
             Source = activity.DataSource ?? activity.EnteredBy ?? "nightscout",
             OriginalId = activity.Id,
             Metadata = BuildMetadata(activity)
@@ -293,8 +292,8 @@ public static class ActivityStateSpanMapper
         if (!string.IsNullOrEmpty(activity.Name))
             metadata["name"] = activity.Name;
 
-        // Kept because Source now holds the connector for connector-published activities, so it
-        // is no longer the uploader name to read EnteredBy back from. Mirrors BuildSleepMetadata.
+        // Source holds the connector for connector-published activities, so EnteredBy round-trips
+        // through metadata instead. Mirrors BuildSleepMetadata.
         if (!string.IsNullOrEmpty(activity.EnteredBy))
             metadata["enteredBy"] = activity.EnteredBy;
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260807154822_AddActivityWatermarkSourceIndexes.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260807154822_AddActivityWatermarkSourceIndexes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260807154822_AddActivityWatermarkSourceIndexes")]
+    partial class AddActivityWatermarkSourceIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260807154822_AddActivityWatermarkSourceIndexes.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260807154822_AddActivityWatermarkSourceIndexes.Designer.cs
@@ -4919,10 +4919,6 @@ namespace Nocturne.Infrastructure.Data.Migrations
                         .HasColumnType("character varying(255)")
                         .HasColumnName("name");
 
-                    b.Property<string>("RequiredRoles")
-                        .HasColumnType("jsonb")
-                        .HasColumnName("required_roles");
-
                     b.Property<string>("StartEventType")
                         .HasMaxLength(100)
                         .HasColumnType("character varying(100)")

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260807154822_AddActivityWatermarkSourceIndexes.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260807154822_AddActivityWatermarkSourceIndexes.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddActivityWatermarkSourceIndexes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_state_spans_tenant_id",
+                table: "state_spans");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_step_counts_tenant_source_timestamp",
+                table: "step_counts",
+                columns: new[] { "tenant_id", "data_source", "timestamp" },
+                descending: new[] { false, false, true });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_state_spans_tenant_source_category_start",
+                table: "state_spans",
+                columns: new[] { "tenant_id", "source", "category", "start_timestamp" },
+                descending: new[] { false, false, false, true });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_heart_rates_tenant_source_timestamp",
+                table: "heart_rates",
+                columns: new[] { "tenant_id", "data_source", "timestamp" },
+                descending: new[] { false, false, true });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_step_counts_tenant_source_timestamp",
+                table: "step_counts");
+
+            migrationBuilder.DropIndex(
+                name: "ix_state_spans_tenant_source_category_start",
+                table: "state_spans");
+
+            migrationBuilder.DropIndex(
+                name: "ix_heart_rates_tenant_source_timestamp",
+                table: "heart_rates");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_state_spans_tenant_id",
+                table: "state_spans",
+                column: "tenant_id");
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -851,9 +851,8 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             .IsUnique()
             .HasFilter("sync_identifier IS NOT NULL AND deleted_at IS NULL");
 
-        // Connector resume watermark: MAX(timestamp) for one data source, run every sync cycle.
-        // The tenant+timestamp index above cannot serve it, and a source with no rows yet (every
-        // source, until its first publish) would otherwise scan the tenant's whole table.
+        // Connector resume watermark: MAX(timestamp) for one data source, every sync cycle. A
+        // source with no rows yet would otherwise scan the tenant's whole table.
         modelBuilder
             .Entity<StepCountEntity>()
             .HasIndex(s => new { s.TenantId, s.DataSource, s.Timestamp })
@@ -885,9 +884,8 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             .IsUnique()
             .HasFilter("sync_identifier IS NOT NULL AND deleted_at IS NULL");
 
-        // Connector resume watermark: MAX(timestamp) for one data source, run every sync cycle.
-        // Matters most here — heart rate arrives at up to 1 Hz, so an unindexed source filter
-        // scans the tenant's largest table on every cycle a source has no rows of its own.
+        // Connector resume watermark, as on step_counts. Heart rate arrives at up to 1 Hz, so this
+        // is the largest table an unindexed source filter would scan.
         modelBuilder
             .Entity<HeartRateEntity>()
             .HasIndex(h => new { h.TenantId, h.DataSource, h.Timestamp })
@@ -1204,10 +1202,8 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             .HasDatabaseName("ix_state_spans_source");
 
         // Connector resume watermark: MAX(start_timestamp) over the activity categories for one
-        // data source. ix_state_spans_source alone still walks every span that source ever wrote.
-        // Tenant leads: a source id is the same string installation-wide, so leading with it has
-        // near-zero selectivity and a tenant with no spans for that source would walk every
-        // tenant's.
+        // data source. Tenant leads because a source id is the same string installation-wide, so
+        // ix_state_spans_source would walk every tenant's spans for that source.
         modelBuilder
             .Entity<StateSpanEntity>()
             .HasIndex(s => new { s.TenantId, s.Source, s.Category, s.StartTimestamp })

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -851,6 +851,15 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             .IsUnique()
             .HasFilter("sync_identifier IS NOT NULL AND deleted_at IS NULL");
 
+        // Connector resume watermark: MAX(timestamp) for one data source, run every sync cycle.
+        // The tenant+timestamp index above cannot serve it, and a source with no rows yet (every
+        // source, until its first publish) would otherwise scan the tenant's whole table.
+        modelBuilder
+            .Entity<StepCountEntity>()
+            .HasIndex(s => new { s.TenantId, s.DataSource, s.Timestamp })
+            .HasDatabaseName("ix_step_counts_tenant_source_timestamp")
+            .IsDescending(false, false, true);
+
         // HeartRate indexes - optimized for time-range graph queries
         modelBuilder
             .Entity<HeartRateEntity>()
@@ -875,6 +884,15 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             .HasDatabaseName("ix_heart_rates_tenant_source_sync_id")
             .IsUnique()
             .HasFilter("sync_identifier IS NOT NULL AND deleted_at IS NULL");
+
+        // Connector resume watermark: MAX(timestamp) for one data source, run every sync cycle.
+        // Matters most here — heart rate arrives at up to 1 Hz, so an unindexed source filter
+        // scans the tenant's largest table on every cycle a source has no rows of its own.
+        modelBuilder
+            .Entity<HeartRateEntity>()
+            .HasIndex(h => new { h.TenantId, h.DataSource, h.Timestamp })
+            .HasDatabaseName("ix_heart_rates_tenant_source_timestamp")
+            .IsDescending(false, false, true);
 
         // BodyWeight indexes - optimized for time-range graph queries
         modelBuilder
@@ -1184,6 +1202,17 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             .Entity<StateSpanEntity>()
             .HasIndex(s => s.Source)
             .HasDatabaseName("ix_state_spans_source");
+
+        // Connector resume watermark: MAX(start_timestamp) over the activity categories for one
+        // data source. ix_state_spans_source alone still walks every span that source ever wrote.
+        // Tenant leads: a source id is the same string installation-wide, so leading with it has
+        // near-zero selectivity and a tenant with no spans for that source would walk every
+        // tenant's.
+        modelBuilder
+            .Entity<StateSpanEntity>()
+            .HasIndex(s => new { s.TenantId, s.Source, s.Category, s.StartTimestamp })
+            .HasDatabaseName("ix_state_spans_tenant_source_category_start")
+            .IsDescending(false, false, false, true);
 
         modelBuilder
             .Entity<StateSpanEntity>()

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/StateSpanRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/StateSpanRepository.cs
@@ -33,6 +33,13 @@ public class StateSpanRepository : IStateSpanRepository
     };
 
     /// <summary>
+    /// The stored <c>Category</c> values that represent v1 Activity records, as strings for
+    /// translation into SQL.
+    /// </summary>
+    private static readonly List<string> ActivityCategories =
+        ActivityStateSpanMapper.ActivityCategories.Select(c => c.ToString()).ToList();
+
+    /// <summary>
     /// Initializes a new instance of the StateSpanRepository class
     /// </summary>
     /// <param name="context">The database context</param>
@@ -505,11 +512,7 @@ public class StateSpanRepository : IStateSpanRepository
         CancellationToken cancellationToken = default
     )
     {
-        var activityCategories = ActivityStateSpanMapper
-            .ActivityCategories.Select(c => c.ToString())
-            .ToList();
-
-        var query = _context.StateSpans.AsNoTracking().Where(s => activityCategories.Contains(s.Category));
+        var query = _context.StateSpans.AsNoTracking().Where(s => ActivityCategories.Contains(s.Category));
 
         // Filter by type/state if provided
         if (!string.IsNullOrEmpty(type))
@@ -524,6 +527,16 @@ public class StateSpanRepository : IStateSpanRepository
         return entities.Select(StateSpanMapper.ToDomainModel);
     }
 
+    /// <inheritdoc />
+    public async Task<DateTime?> GetLatestActivityTimestampAsync(
+        string source,
+        CancellationToken cancellationToken = default
+    ) =>
+        await _context.StateSpans
+            .AsNoTracking()
+            .Where(s => ActivityCategories.Contains(s.Category) && s.Source == source)
+            .MaxAsync(s => (DateTime?)s.StartTimestamp, cancellationToken);
+
     /// <summary>
     /// Get a state span by ID that represents an Activity record
     /// </summary>
@@ -535,19 +548,15 @@ public class StateSpanRepository : IStateSpanRepository
         CancellationToken cancellationToken = default
     )
     {
-        var activityCategories = ActivityStateSpanMapper
-            .ActivityCategories.Select(c => c.ToString())
-            .ToList();
-
         var entity = await _context.StateSpans.AsNoTracking().FirstOrDefaultAsync(
-            s => s.OriginalId == id && activityCategories.Contains(s.Category),
+            s => s.OriginalId == id && ActivityCategories.Contains(s.Category),
             cancellationToken
         );
 
         if (entity == null && Guid.TryParse(id, out var guidId))
         {
             entity = await _context.StateSpans.AsNoTracking().FirstOrDefaultAsync(
-                s => s.Id == guidId && activityCategories.Contains(s.Category),
+                s => s.Id == guidId && ActivityCategories.Contains(s.Category),
                 cancellationToken
             );
         }
@@ -603,19 +612,15 @@ public class StateSpanRepository : IStateSpanRepository
         CancellationToken cancellationToken = default
     )
     {
-        var activityCategories = ActivityStateSpanMapper
-            .ActivityCategories.Select(c => c.ToString())
-            .ToList();
-
         var entity = await _context.StateSpans.FirstOrDefaultAsync(
-            s => s.OriginalId == id && activityCategories.Contains(s.Category),
+            s => s.OriginalId == id && ActivityCategories.Contains(s.Category),
             cancellationToken
         );
 
         if (entity == null && Guid.TryParse(id, out var guidId))
         {
             entity = await _context.StateSpans.FirstOrDefaultAsync(
-                s => s.Id == guidId && activityCategories.Contains(s.Category),
+                s => s.Id == guidId && ActivityCategories.Contains(s.Category),
                 cancellationToken
             );
         }
@@ -639,19 +644,15 @@ public class StateSpanRepository : IStateSpanRepository
         CancellationToken cancellationToken = default
     )
     {
-        var activityCategories = ActivityStateSpanMapper
-            .ActivityCategories.Select(c => c.ToString())
-            .ToList();
-
         var entity = await _context.StateSpans.FirstOrDefaultAsync(
-            s => s.OriginalId == id && activityCategories.Contains(s.Category),
+            s => s.OriginalId == id && ActivityCategories.Contains(s.Category),
             cancellationToken
         );
 
         if (entity == null && Guid.TryParse(id, out var guidId))
         {
             entity = await _context.StateSpans.FirstOrDefaultAsync(
-                s => s.Id == guidId && activityCategories.Contains(s.Category),
+                s => s.Id == guidId && ActivityCategories.Contains(s.Category),
                 cancellationToken
             );
         }

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/ActivityWatermarkSourceScopeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/ActivityWatermarkSourceScopeTests.cs
@@ -1,0 +1,300 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.ConnectorPublishing;
+using Nocturne.API.Services.Glucose;
+using Nocturne.API.Services.Health;
+using Nocturne.API.Services.Realtime;
+using Nocturne.API.Services.V4;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Connectors;
+using Nocturne.Core.Contracts.Events;
+using Nocturne.Core.Contracts.Identity;
+using Nocturne.Core.Contracts.Infrastructure;
+using Nocturne.Core.Contracts.Legacy;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Contracts.Profiles;
+using Nocturne.Core.Contracts.Repositories;
+using Nocturne.Core.Contracts.Sleep;
+using Nocturne.Core.Contracts.Treatments;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Repositories;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.ConnectorPublishing;
+
+/// <summary>
+/// End-to-end cover for the connector activity watermark: two connectors publish activity into the
+/// same tenant, and each must resolve its catch-up window from its OWN newest record. Runs the real
+/// publish and read paths (decomposer, state spans, heart rates, step counts) over an in-memory
+/// database rather than mocks, because the bug being pinned is that the source never reached
+/// storage in the first place.
+/// </summary>
+[Trait("Category", "Unit")]
+public class ActivityWatermarkSourceScopeTests : IDisposable
+{
+    private const string SourceA = "nightscout-connector";
+    private const string SourceB = "glooko-connector";
+    private const string SourceMirror = "nocturne-remote-connector";
+
+    private static readonly DateTime EarlyJune = new(2026, 6, 1, 8, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime MidJune = new(2026, 6, 15, 8, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime LateJune = new(2026, 6, 28, 8, 0, 0, DateTimeKind.Utc);
+
+    private readonly NocturneDbContext _context;
+    private readonly StateSpanService _stateSpanService;
+    private readonly MetadataPublisher _publisher;
+
+    public ActivityWatermarkSourceScopeTests()
+    {
+        _context = new NocturneDbContext(
+            new DbContextOptionsBuilder<NocturneDbContext>()
+                .UseInMemoryDatabase($"activity-watermark-{Guid.NewGuid():N}")
+                .Options)
+        {
+            TenantId = Guid.Parse("33333333-3333-3333-3333-333333333333"),
+        };
+
+        var processing = new Mock<IDocumentProcessingService>();
+        processing
+            .Setup(p => p.ProcessDocuments(It.IsAny<IEnumerable<Activity>>()))
+            .Returns((IEnumerable<Activity> docs) => docs);
+        processing
+            .Setup(p => p.ProcessDocuments(It.IsAny<IEnumerable<HeartRate>>()))
+            .Returns((IEnumerable<HeartRate> docs) => docs);
+        processing
+            .Setup(p => p.ProcessDocuments(It.IsAny<IEnumerable<StepCount>>()))
+            .Returns((IEnumerable<StepCount> docs) => docs);
+
+        var stateSpanRepository = new StateSpanRepository(
+            _context,
+            Mock.Of<IDeduplicationService>(),
+            Mock.Of<IAuditContext>(),
+            NullLogger<StateSpanRepository>.Instance);
+
+        _stateSpanService = new StateSpanService(
+            stateSpanRepository, NullLogger<StateSpanService>.Instance);
+
+        var heartRateService = new HeartRateService(
+            _context, processing.Object, Mock.Of<ISignalRBroadcastService>(),
+            NullLogger<HeartRateService>.Instance);
+
+        var stepCountService = new StepCountService(
+            _context, processing.Object, Mock.Of<ISignalRBroadcastService>(),
+            NullLogger<StepCountService>.Instance);
+
+        var activityService = new ActivityService(
+            _stateSpanService,
+            Mock.Of<ISleepService>(),
+            processing.Object,
+            Mock.Of<ISignalRBroadcastService>(),
+            Mock.Of<IDataEventSink<Activity>>(),
+            new ActivityDecomposer(
+                _context, stateSpanRepository, NullLogger<ActivityDecomposer>.Instance),
+            heartRateService,
+            stepCountService,
+            NullLogger<ActivityService>.Instance);
+
+        _publisher = new MetadataPublisher(
+            Mock.Of<IProfileWriteService>(),
+            Mock.Of<IFoodService>(),
+            Mock.Of<IConnectorFoodEntryService>(),
+            activityService,
+            _stateSpanService,
+            Mock.Of<ISystemEventRepository>(),
+            Mock.Of<INoteRepository>(),
+            Mock.Of<ITenantOwnerResolver>(),
+            Mock.Of<ITenantAccessor>(),
+            _context,
+            NullLogger<MetadataPublisher>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static Activity Exercise(DateTime at) => new()
+    {
+        Id = $"exercise-{at:yyyyMMddHHmm}",
+        Type = "exercise",
+        Mills = new DateTimeOffset(at).ToUnixTimeMilliseconds(),
+        EnteredBy = "some-uploader",
+    };
+
+    private static Activity HeartRate(DateTime at) => new()
+    {
+        Id = $"hr-{at:yyyyMMddHHmm}",
+        Mills = new DateTimeOffset(at).ToUnixTimeMilliseconds(),
+        AdditionalProperties = new Dictionary<string, object> { ["bpm"] = 64 },
+    };
+
+    private static Activity Steps(DateTime at) => new()
+    {
+        Id = $"steps-{at:yyyyMMddHHmm}",
+        Mills = new DateTimeOffset(at).ToUnixTimeMilliseconds(),
+        AdditionalProperties = new Dictionary<string, object> { ["metric"] = 900 },
+    };
+
+    [Fact]
+    public async Task Each_connector_resolves_its_own_latest_state_span()
+    {
+        await _publisher.PublishActivityAsync([Exercise(EarlyJune)], SourceA, WriteOrigin.Live);
+        await _publisher.PublishActivityAsync([Exercise(LateJune)], SourceB, WriteOrigin.Live);
+
+        // Before the fix both calls returned LateJune (the tenant-global newest), so SourceA
+        // concluded it was caught up and skipped everything between EarlyJune and LateJune.
+        (await _publisher.GetLatestActivityTimestampAsync(SourceA)).Should().Be(EarlyJune);
+        (await _publisher.GetLatestActivityTimestampAsync(SourceB)).Should().Be(LateJune);
+    }
+
+    [Fact]
+    public async Task Each_connector_resolves_its_own_latest_heart_rate()
+    {
+        await _publisher.PublishActivityAsync([HeartRate(EarlyJune)], SourceA, WriteOrigin.Live);
+        await _publisher.PublishActivityAsync([HeartRate(LateJune)], SourceB, WriteOrigin.Live);
+
+        (await _publisher.GetLatestActivityTimestampAsync(SourceA)).Should().Be(EarlyJune);
+        (await _publisher.GetLatestActivityTimestampAsync(SourceB)).Should().Be(LateJune);
+    }
+
+    [Fact]
+    public async Task Each_connector_resolves_its_own_latest_step_count()
+    {
+        await _publisher.PublishActivityAsync([Steps(EarlyJune)], SourceA, WriteOrigin.Live);
+        await _publisher.PublishActivityAsync([Steps(LateJune)], SourceB, WriteOrigin.Live);
+
+        (await _publisher.GetLatestActivityTimestampAsync(SourceA)).Should().Be(EarlyJune);
+        (await _publisher.GetLatestActivityTimestampAsync(SourceB)).Should().Be(LateJune);
+    }
+
+    [Fact]
+    public async Task Watermark_is_the_newest_across_a_sources_own_decomposed_destinations()
+    {
+        await _publisher.PublishActivityAsync(
+            [Exercise(EarlyJune), HeartRate(MidJune), Steps(EarlyJune)], SourceA, WriteOrigin.Live);
+        await _publisher.PublishActivityAsync([Steps(LateJune)], SourceB, WriteOrigin.Live);
+
+        (await _publisher.GetLatestActivityTimestampAsync(SourceA)).Should().Be(MidJune);
+    }
+
+    [Fact]
+    public async Task Source_that_has_never_written_activity_has_no_watermark()
+    {
+        await _publisher.PublishActivityAsync(
+            [Exercise(LateJune), HeartRate(LateJune), Steps(LateJune)], SourceA, WriteOrigin.Live);
+
+        // Null is the "no prior data" signal the connector turns into an initial backfill; a
+        // borrowed timestamp from SourceA would silently strand SourceB's history.
+        (await _publisher.GetLatestActivityTimestampAsync(SourceB)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Published_activity_is_attributed_to_the_publishing_connector()
+    {
+        var published = await _publisher.PublishActivityAsync(
+            [Exercise(MidJune), HeartRate(MidJune), Steps(MidJune)], SourceA, WriteOrigin.Live);
+        published.Should().BeTrue();
+
+        // A filter is only as good as the value it matches: the connector source has to reach
+        // every destination column, not the payload's own EnteredBy.
+        (await _context.StateSpans.AsNoTracking().Select(s => s.Source).ToListAsync())
+            .Should().Equal(SourceA);
+        (await _context.HeartRates.AsNoTracking().Select(h => h.DataSource).ToListAsync())
+            .Should().Equal(SourceA);
+        (await _context.StepCounts.AsNoTracking().Select(s => s.DataSource).ToListAsync())
+            .Should().Equal(SourceA);
+    }
+
+    [Fact]
+    public async Task Attributing_an_activity_to_its_connector_does_not_lose_the_uploader_name()
+    {
+        // The state span's Source column now carries the connector, so EnteredBy — which the v1
+        // activity read used to recover from Source — has to round-trip through metadata instead.
+        await _publisher.PublishActivityAsync([Exercise(MidJune)], SourceA, WriteOrigin.Live);
+
+        var stored = await _stateSpanService.GetActivitiesAsync(cancellationToken: default);
+
+        stored.Should().ContainSingle().Which.EnteredBy.Should().Be("some-uploader");
+    }
+
+    [Fact]
+    public async Task State_spans_are_attributed_to_the_publishing_connector_whatever_they_arrived_with()
+    {
+        var carriesForeignSource = new StateSpan
+        {
+            Category = StateSpanCategory.Exercise,
+            State = "exercise",
+            StartTimestamp = MidJune,
+            Source = SourceA,
+            OriginalId = "carries-foreign-source",
+        };
+        var carriesNone = new StateSpan
+        {
+            Category = StateSpanCategory.Exercise,
+            State = "exercise",
+            StartTimestamp = EarlyJune,
+            OriginalId = "carries-none",
+        };
+
+        await _publisher.PublishStateSpansAsync(
+            [carriesForeignSource, carriesNone], SourceMirror, WriteOrigin.Live);
+
+        carriesForeignSource.Source.Should().Be(SourceMirror);
+        carriesNone.Source.Should().Be(SourceMirror);
+
+        // A displaced source is stashed, not dropped, so the origin stays recoverable. A span
+        // that arrived with nothing has nothing to stash.
+        carriesForeignSource.Metadata.Should().Contain("originSource", SourceA);
+        carriesNone.Metadata.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task A_producer_that_already_names_itself_stashes_no_origin()
+    {
+        // Glooko, MyLife and Tandem set their own ConnectorSource, so the overwrite is a no-op
+        // and must not litter every span with a metadata key repeating the Source column.
+        var ownSource = new StateSpan
+        {
+            Category = StateSpanCategory.Exercise,
+            State = "exercise",
+            StartTimestamp = MidJune,
+            Source = SourceB,
+            OriginalId = "own-source",
+        };
+
+        await _publisher.PublishStateSpansAsync([ownSource], SourceB, WriteOrigin.Live);
+
+        ownSource.Source.Should().Be(SourceB);
+        ownSource.Metadata.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task A_mirrored_span_does_not_advance_the_watermark_of_the_connector_it_names()
+    {
+        // NocturneRemote replays a remote instance's StateSpan records verbatim, Source included.
+        // Honouring that Source would file the row under the Nightscout connector and hand it a
+        // watermark it never earned — #656 relocated, and the local connector would then skip the
+        // window it still has to sync.
+        await _publisher.PublishActivityAsync([Exercise(EarlyJune)], SourceA, WriteOrigin.Live);
+
+        var mirrored = new StateSpan
+        {
+            Category = StateSpanCategory.Exercise,
+            State = "exercise",
+            StartTimestamp = LateJune,
+            Source = SourceA,
+            OriginalId = "mirrored-from-remote",
+        };
+        await _publisher.PublishStateSpansAsync([mirrored], SourceMirror, WriteOrigin.Live);
+
+        (await _publisher.GetLatestActivityTimestampAsync(SourceA)).Should().Be(EarlyJune);
+        (await _publisher.GetLatestActivityTimestampAsync(SourceMirror)).Should().Be(LateJune);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/ActivityWatermarkSourceScopeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/ActivityWatermarkSourceScopeTests.cs
@@ -240,17 +240,27 @@ public class ActivityWatermarkSourceScopeTests : IDisposable
             StartTimestamp = EarlyJune,
             OriginalId = "carries-none",
         };
+        var carriesBlank = new StateSpan
+        {
+            Category = StateSpanCategory.Exercise,
+            State = "exercise",
+            StartTimestamp = EarlyJune,
+            Source = "",
+            OriginalId = "carries-blank",
+        };
 
         await _publisher.PublishStateSpansAsync(
-            [carriesForeignSource, carriesNone], SourceMirror, WriteOrigin.Live);
+            [carriesForeignSource, carriesNone, carriesBlank], SourceMirror, WriteOrigin.Live);
 
         carriesForeignSource.Source.Should().Be(SourceMirror);
         carriesNone.Source.Should().Be(SourceMirror);
+        carriesBlank.Source.Should().Be(SourceMirror);
 
-        // A displaced source is stashed, not dropped, so the origin stays recoverable. A span
-        // that arrived with nothing has nothing to stash.
+        // A displaced source is stashed, not dropped, so the origin stays recoverable. A span that
+        // arrived with no source — null or blank — has nothing worth stashing.
         carriesForeignSource.Metadata.Should().Contain("originSource", SourceA);
         carriesNone.Metadata.Should().BeNull();
+        carriesBlank.Metadata.Should().BeNull();
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/ActivityWatermarkSourceScopeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/ActivityWatermarkSourceScopeTests.cs
@@ -29,11 +29,10 @@ using Xunit;
 namespace Nocturne.API.Tests.Services.ConnectorPublishing;
 
 /// <summary>
-/// End-to-end cover for the connector activity watermark: two connectors publish activity into the
-/// same tenant, and each must resolve its catch-up window from its OWN newest record. Runs the real
-/// publish and read paths (decomposer, state spans, heart rates, step counts) over an in-memory
-/// database rather than mocks, because the bug being pinned is that the source never reached
-/// storage in the first place.
+/// Two connectors publish activity into the same tenant, and each must resolve its catch-up window
+/// from its own newest record. Runs the real publish and read paths (decomposer, state spans, heart
+/// rates, step counts) over an in-memory database rather than mocks, so a filter that never matches
+/// because nothing stamped the source fails here.
 /// </summary>
 [Trait("Category", "Unit")]
 public class ActivityWatermarkSourceScopeTests : IDisposable
@@ -148,8 +147,8 @@ public class ActivityWatermarkSourceScopeTests : IDisposable
         await _publisher.PublishActivityAsync([Exercise(EarlyJune)], SourceA, WriteOrigin.Live);
         await _publisher.PublishActivityAsync([Exercise(LateJune)], SourceB, WriteOrigin.Live);
 
-        // Before the fix both calls returned LateJune (the tenant-global newest), so SourceA
-        // concluded it was caught up and skipped everything between EarlyJune and LateJune.
+        // A tenant-global latest hands SourceA LateJune, so it concludes it is caught up and skips
+        // everything in between.
         (await _publisher.GetLatestActivityTimestampAsync(SourceA)).Should().Be(EarlyJune);
         (await _publisher.GetLatestActivityTimestampAsync(SourceB)).Should().Be(LateJune);
     }
@@ -202,8 +201,7 @@ public class ActivityWatermarkSourceScopeTests : IDisposable
             [Exercise(MidJune), HeartRate(MidJune), Steps(MidJune)], SourceA, WriteOrigin.Live);
         published.Should().BeTrue();
 
-        // A filter is only as good as the value it matches: the connector source has to reach
-        // every destination column, not the payload's own EnteredBy.
+        // The connector source has to reach every destination column, not the payload's EnteredBy.
         (await _context.StateSpans.AsNoTracking().Select(s => s.Source).ToListAsync())
             .Should().Equal(SourceA);
         (await _context.HeartRates.AsNoTracking().Select(h => h.DataSource).ToListAsync())
@@ -280,8 +278,7 @@ public class ActivityWatermarkSourceScopeTests : IDisposable
     {
         // NocturneRemote replays a remote instance's StateSpan records verbatim, Source included.
         // Honouring that Source would file the row under the Nightscout connector and hand it a
-        // watermark it never earned — #656 relocated, and the local connector would then skip the
-        // window it still has to sync.
+        // watermark it never earned, so it would skip the window it still has to sync.
         await _publisher.PublishActivityAsync([Exercise(EarlyJune)], SourceA, WriteOrigin.Live);
 
         var mirrored = new StateSpan

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/ActivityStateSpanMapperSourceTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/ActivityStateSpanMapperSourceTests.cs
@@ -1,0 +1,106 @@
+using FluentAssertions;
+using Nocturne.Core.Models;
+using Nocturne.Infrastructure.Data.Mappers;
+
+namespace Nocturne.Infrastructure.Data.Tests.Mappers;
+
+/// <summary>
+/// A state span's Source now carries the connector that wrote it, displacing the uploader name it
+/// used to hold. These pin both directions of that displacement, including the fallbacks that keep
+/// rows written before the change readable.
+/// </summary>
+[Trait("Category", "Unit")]
+public class ActivityStateSpanMapperSourceTests
+{
+    private static readonly DateTime MidJune = new(2026, 6, 15, 8, 0, 0, DateTimeKind.Utc);
+
+    private static Activity Exercise() => new()
+    {
+        Id = "activity-1",
+        Type = "exercise",
+        Mills = new DateTimeOffset(MidJune).ToUnixTimeMilliseconds(),
+    };
+
+    [Fact]
+    public void ToStateSpan_prefers_the_connector_over_the_uploader_name()
+    {
+        var activity = Exercise();
+        activity.DataSource = "nightscout-connector";
+        activity.EnteredBy = "xdrip";
+
+        ActivityStateSpanMapper.ToStateSpan(activity).Source.Should().Be("nightscout-connector");
+    }
+
+    [Fact]
+    public void ToStateSpan_falls_back_to_the_uploader_name_when_no_connector_wrote_it()
+    {
+        // The v1 activity API path: no connector is publishing, so EnteredBy stays the source.
+        var activity = Exercise();
+        activity.EnteredBy = "xdrip";
+
+        ActivityStateSpanMapper.ToStateSpan(activity).Source.Should().Be("xdrip");
+    }
+
+    [Fact]
+    public void ToStateSpan_falls_back_to_nightscout_when_neither_is_present()
+    {
+        ActivityStateSpanMapper.ToStateSpan(Exercise()).Source.Should().Be("nightscout");
+    }
+
+    [Fact]
+    public void ToActivity_recovers_the_uploader_name_from_a_row_written_before_the_change()
+    {
+        // Old-shape row: Source IS the uploader name, and metadata is populated (the old
+        // BuildMetadata always wrote description/notes/etc.) but has no enteredBy key, because
+        // nothing stashed one until Source was displaced. Every pre-existing
+        // exercise/illness/travel row looks like this, and the fallback is the only thing keeping
+        // their v1 enteredBy from reading as null. Metadata must be non-empty: a null bag skips
+        // the whole read block and would leave the assertion pinning nothing.
+        var oldShape = new StateSpan
+        {
+            Category = StateSpanCategory.Exercise,
+            State = "exercise",
+            StartTimestamp = MidJune,
+            Source = "xdrip",
+            OriginalId = "activity-1",
+            Metadata = new Dictionary<string, object> { ["notes"] = "morning walk" },
+        };
+
+        var activity = ActivityStateSpanMapper.ToActivity(oldShape)!;
+
+        activity.Notes.Should().Be("morning walk");
+        activity.EnteredBy.Should().Be("xdrip");
+    }
+
+    [Fact]
+    public void ToActivity_surfaces_the_source_when_the_span_carries_no_metadata_at_all()
+    {
+        // A span posted through the v4 StateSpans controller can have a null metadata bag, which
+        // skips the metadata read block entirely — EnteredBy has to come from the initializer.
+        var noMetadata = new StateSpan
+        {
+            Category = StateSpanCategory.Exercise,
+            State = "exercise",
+            StartTimestamp = MidJune,
+            Source = "xdrip",
+            OriginalId = "activity-1",
+        };
+
+        ActivityStateSpanMapper.ToActivity(noMetadata)!.EnteredBy.Should().Be("xdrip");
+    }
+
+    [Fact]
+    public void ToActivity_prefers_the_stashed_uploader_name_over_the_connector_source()
+    {
+        var span = ActivityStateSpanMapper.ToStateSpan(new Activity
+        {
+            Id = "activity-1",
+            Type = "exercise",
+            Mills = new DateTimeOffset(MidJune).ToUnixTimeMilliseconds(),
+            EnteredBy = "xdrip",
+            DataSource = "nightscout-connector",
+        });
+
+        ActivityStateSpanMapper.ToActivity(span)!.EnteredBy.Should().Be("xdrip");
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/ActivityStateSpanMapperSourceTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/ActivityStateSpanMapperSourceTests.cs
@@ -5,9 +5,9 @@ using Nocturne.Infrastructure.Data.Mappers;
 namespace Nocturne.Infrastructure.Data.Tests.Mappers;
 
 /// <summary>
-/// A state span's Source now carries the connector that wrote it, displacing the uploader name it
-/// used to hold. These pin both directions of that displacement, including the fallbacks that keep
-/// rows written before the change readable.
+/// A state span's Source carries the connector that wrote it, displacing the uploader name it used
+/// to hold. Pins both directions of that displacement, including the fallbacks that keep rows
+/// written before the change readable.
 /// </summary>
 [Trait("Category", "Unit")]
 public class ActivityStateSpanMapperSourceTests
@@ -50,12 +50,9 @@ public class ActivityStateSpanMapperSourceTests
     [Fact]
     public void ToActivity_recovers_the_uploader_name_from_a_row_written_before_the_change()
     {
-        // Old-shape row: Source IS the uploader name, and metadata is populated (the old
-        // BuildMetadata always wrote description/notes/etc.) but has no enteredBy key, because
-        // nothing stashed one until Source was displaced. Every pre-existing
-        // exercise/illness/travel row looks like this, and the fallback is the only thing keeping
-        // their v1 enteredBy from reading as null. Metadata must be non-empty: a null bag skips
-        // the whole read block and would leave the assertion pinning nothing.
+        // Old-shape row: Source IS the uploader name and metadata carries no enteredBy key. Every
+        // pre-existing exercise/illness/travel row looks like this. Metadata has to be non-empty
+        // or the read block is skipped wholesale and the assertion pins nothing.
         var oldShape = new StateSpan
         {
             Category = StateSpanCategory.Exercise,


### PR DESCRIPTION
## What

Closes #656.

`MetadataPublisher.GetLatestActivityTimestampAsync` dropped its `source` argument and returned the tenant-global latest, so a tenant running two connectors with overlapping data types resolved activity catch-up windows against the other connector's newest record — duplicate or missed windows. Glucose, treatments, and device status were already source-scoped; activity was the last unscoped watermark.

**The filter alone would have been worse than the bug**: nothing on the activity write path stamped connector provenance (`heart_rates`/`step_counts.data_source` were always NULL; `state_spans.source` held the uploader's `EnteredBy`), so an exact-match filter would simply never match. The fix is therefore end to end:

- `Activity` gains the same `[NocturneOnly]` `DataSource` field `Entry` and `Treatment` already carry (invisible to v1–v3); `PublishActivityAsync` stamps it and decomposition carries it to state spans, heart rates, and step counts. Sleep is deliberately excluded (publishes upsert by `(Source, OriginalId)`, so under-reporting only re-fetches idempotently).
- **One attribution rule at every chokepoint**: the source column answers "which connector wrote this row into this instance" and is stamped unconditionally. This matters for the NocturneRemote connector, which mirrors spans verbatim from a remote instance — under preserve-semantics a mirrored span labeled `nightscout-connector` would advance the *local* Nightscout connector's watermark past its real window (the bug, relocated). Displaced attribution isn't lost: the uploader name round-trips through `enteredBy` span metadata (with a fallback keeping it intact on all pre-existing rows), and a mirrored span's original source is stashed as `originSource` metadata.
- A schema-only migration adds `(tenant_id, source/data_source, …, timestamp DESC)` indexes on all three tables so the per-tenant filtered MAX doesn't full-scan 1 Hz heart-rate data every sync cycle (it also drops `IX_state_spans_tenant_id`, covered as a leading prefix — same trade `AddHealthMetricsSyncDedup` made for `heart_rates`).

**Deploy behavior — no mass re-pull**: pre-existing rows carry no source, so the first cycle resolves NULL and falls back to the glucose cursor (minutes old), exactly as device status already does; the watermark self-heals on the next cycle's attributed writes.

Declared behavior changes: connector-published activities with no uploader name now read `enteredBy` as the connector source (was the literal `"nightscout"`); mirrored spans' dedup provenance label is the mirroring connector (grouping keys unaffected).

## Testing

API 4838 / 0 / 5, Infrastructure.Data 500 / 0, plus a green per-project solution sweep. The watermark tests run the real publish and read paths over an in-memory DB because the bug was precisely that the source never reached storage. Eleven mutation proofs across the two rounds, each failing exactly its own pinning test — including "drop the stamping" (the filter-that-never-matches case), "restore preserve-semantics" (fails the NocturneRemote poisoning test), and two rebuilt tests whose first versions were caught passing vacuously and de-vacuumed before being claimed.

https://claude.ai/code/session_01V2H2GSE3UWEgkMvsJE8Kfw
