### PR TITLE
fix(glooko): move per-sync state off instance fields into a sync context

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -71,33 +71,6 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         SyncDataType.Profiles
     ];
 
-    // ── Per-sync state (populated in PerformSyncInternalAsync) ─────────
-    // TODO: These instance fields are not safe for concurrent multi-tenant syncs.
-    // They should be refactored to local variables threaded through helper methods.
-
-    private string? _sessionCookie;
-    private GlookoUserData? _userData;
-    private GlookoConnectorConfiguration? _syncConfig;
-    private GlookoTimeMapper? _timeMapper;
-    private GlookoSensorGlucoseMapper? _sensorGlucoseMapper;
-    private GlookoV4TreatmentMapper? _v4TreatmentMapper;
-    private GlookoStateSpanMapper? _stateSpanMapper;
-    private GlookoTempBasalMapper? _tempBasalMapper;
-    private GlookoSystemEventMapper? _systemEventMapper;
-    private GlookoProfileMapper? _profileMapper;
-
-    private void InitializeMappers(GlookoConnectorConfiguration config)
-    {
-        _syncConfig = config;
-        _timeMapper = new GlookoTimeMapper(config, _glookoLogger);
-        _sensorGlucoseMapper = new GlookoSensorGlucoseMapper(config, ConnectorSource, _timeMapper, _glookoLogger);
-        _v4TreatmentMapper = new GlookoV4TreatmentMapper(ConnectorSource, _timeMapper, _glookoLogger);
-        _stateSpanMapper = new GlookoStateSpanMapper(ConnectorSource, _timeMapper, _glookoLogger);
-        _tempBasalMapper = new GlookoTempBasalMapper(ConnectorSource, _timeMapper, _glookoLogger);
-        _systemEventMapper = new GlookoSystemEventMapper(ConnectorSource, _timeMapper, _glookoLogger);
-        _profileMapper = new GlookoProfileMapper(ConnectorSource, _glookoLogger);
-    }
-
     // ── Authentication ──────────────────────────────────────────────────
 
     public override async Task<bool> AuthenticateAsync()
@@ -107,9 +80,9 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         return true;
     }
 
-    private async Task<bool> AuthenticateWithConfigAsync(GlookoConnectorConfiguration config)
+    private async Task<bool> AuthenticateWithConfigAsync(GlookoSyncContext context)
     {
-        var token = await _tokenProvider.GetValidTokenAsync(config);
+        var token = await _tokenProvider.GetValidTokenAsync(context.Config);
         if (token == null)
         {
             TrackFailedRequest("Failed to get valid token");
@@ -117,13 +90,13 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         }
 
         // The token IS the session cookie for Glooko
-        _sessionCookie = token;
+        context.SessionCookie = token;
 
         // Retrieve user data from cache metadata via the token provider's public accessor
         var cached = await _tokenProvider.GetCachedSessionAsync();
         if (cached?.Metadata != null && cached.Metadata.TryGetValue("UserData", out var userDataJson))
         {
-            _userData = JsonSerializer.Deserialize<GlookoUserData>(userDataJson);
+            context.UserData = JsonSerializer.Deserialize<GlookoUserData>(userDataJson);
         }
 
         TrackSuccessfulRequest();
@@ -135,20 +108,18 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     ///     Throws <see cref="InvalidOperationException"/> if not authenticated.
     ///     Returns null and logs a warning if the user code is missing.
     /// </summary>
-    private string? EnsureAuthenticatedAndGetCode()
+    private string? EnsureAuthenticatedAndGetCode(GlookoSyncContext context)
     {
-        if (string.IsNullOrEmpty(_sessionCookie))
+        if (string.IsNullOrEmpty(context.SessionCookie))
             throw new InvalidOperationException(
                 "Not authenticated with Glooko. Call AuthenticateAsync first.");
 
-        var code = _userData?.GlookoCode;
+        var code = context.PatientCode;
         if (code == null)
             _logger.LogWarning("Missing Glooko user code, cannot fetch data");
 
         return code;
     }
-
-    private bool IsSessionExpired() => string.IsNullOrEmpty(_sessionCookie);
 
     // ── HTTP helpers ────────────────────────────────────────────────────
 
@@ -156,10 +127,10 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     ///     Sends a GET request to a Glooko API endpoint with standard headers.
     ///     Relative paths are resolved against the configured server region.
     /// </summary>
-    private async Task<JsonElement?> FetchFromGlookoEndpoint(string url)
+    private async Task<JsonElement?> FetchFromGlookoEndpoint(GlookoSyncContext context, string url)
     {
-        var baseUrl = GlookoConstants.ResolveBaseUrl(_syncConfig!.Server);
-        var webOrigin = GlookoConstants.ResolveWebOrigin(_syncConfig!.Server);
+        var baseUrl = GlookoConstants.ResolveBaseUrl(context.Config.Server);
+        var webOrigin = GlookoConstants.ResolveWebOrigin(context.Config.Server);
         var absoluteUrl = url.StartsWith("http", StringComparison.OrdinalIgnoreCase)
             ? url
             : $"{baseUrl}{url}";
@@ -167,7 +138,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         _logger.LogDebug("GLOOKO FETCHER LOADING {Url}", absoluteUrl);
 
         var request = new HttpRequestMessage(HttpMethod.Get, absoluteUrl);
-        GlookoHttpHelper.ApplyStandardHeaders(request, webOrigin, _sessionCookie);
+        GlookoHttpHelper.ApplyStandardHeaders(request, webOrigin, context.SessionCookie);
 
         var response = await _httpClient.SendAsync(request);
 
@@ -203,7 +174,8 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     /// <summary>
     ///     Fetches from a Glooko endpoint with retry logic and exponential backoff.
     /// </summary>
-    private async Task<JsonElement?> FetchFromGlookoEndpointWithRetry(string url, int maxRetries = 3)
+    private async Task<JsonElement?> FetchFromGlookoEndpointWithRetry(
+        GlookoSyncContext context, string url, int maxRetries = 3)
     {
         HttpRequestException? lastException = null;
 
@@ -211,7 +183,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         {
             try
             {
-                var result = await FetchFromGlookoEndpoint(url);
+                var result = await FetchFromGlookoEndpoint(context, url);
                 if (result.HasValue) return result;
 
                 _logger.LogWarning("Attempt {AttemptNumber} failed for {Url}", attempt + 1, url);
@@ -252,9 +224,10 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
 
     // ── URL construction ────────────────────────────────────────────────
 
-    private string ConstructV2Url(string endpoint, DateTime startDate, DateTime endDate)
+    private static string ConstructV2Url(
+        GlookoSyncContext context, string endpoint, DateTime startDate, DateTime endDate)
     {
-        var patientCode = _userData?.GlookoCode;
+        var patientCode = context.PatientCode;
         var maxCount = Math.Max(1, (int)Math.Ceiling((endDate - startDate).TotalMinutes / 5));
 
         return $"{endpoint}?patient={patientCode}"
@@ -265,14 +238,14 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
              + $"&limit={maxCount}";
     }
 
-    private string ConstructV3GraphUrl(DateTime startDate, DateTime endDate)
+    private static string ConstructV3GraphUrl(GlookoSyncContext context, DateTime startDate, DateTime endDate)
     {
-        var patientCode = _userData?.GlookoCode;
+        var patientCode = context.PatientCode;
 
         var series = GlookoConstants.V3GraphSeries
             .Concat(GlookoConstants.V3PumpModeSeries);
 
-        if (_syncConfig!.V3IncludeCgmBackfill)
+        if (context.Config.V3IncludeCgmBackfill)
             series = series.Concat(GlookoConstants.V3CgmBackfillSeries);
 
         var seriesParams = string.Join("&", series.Select(s => $"series[]={s}"));
@@ -302,17 +275,18 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
 
         try
         {
-            InitializeMappers(config);
+            // See GlookoSyncContext: this run's entire working state lives here, never on the service.
+            var context = new GlookoSyncContext(config, ConnectorSource, _glookoLogger);
+
             await ReportMessageAsync(progressReporter, SyncMessageType.Authenticating, null, cancellationToken);
 
-            if (IsSessionExpired())
-                if (!await AuthenticateWithConfigAsync(config))
-                {
-                    result.Success = false;
-                    result.Message = "Authentication failed";
-                    result.Errors.Add("Authentication failed");
-                    return result;
-                }
+            if (!await AuthenticateWithConfigAsync(context))
+            {
+                result.Success = false;
+                result.Message = "Authentication failed";
+                result.Errors.Add("Authentication failed");
+                return result;
+            }
 
             if (!request.DataTypes.Any())
                 request.DataTypes = SupportedDataTypes;
@@ -323,15 +297,15 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             // zone (from the V3 profile) seeds the timeline's origin on first sync; thereafter the
             // user's travel/relocation entries drive per-record conversion. Falls back to the legacy
             // static offset when the timeline is empty (e.g. V2-only accounts, or profile tz unknown).
-            await ConfigureTimezoneTimelineAsync(config, cancellationToken);
+            await ConfigureTimezoneTimelineAsync(context, cancellationToken);
 
             // The request window is real-UTC; Glooko queries expect fake-UTC (local wall-clock). Pad by
             // a day each side so a non-zero offset between the two never clips edge data (dedup absorbs
             // the overlap).
             var from = request.From.HasValue
-                ? _timeMapper.ToGlookoTime(request.From.Value).AddDays(-1)
-                : _timeMapper.ToGlookoTime(DateTime.UtcNow.AddMonths(-6)).AddDays(-1);
-            var to = _timeMapper.ToGlookoTime(DateTime.UtcNow).AddDays(1);
+                ? context.TimeMapper.ToGlookoTime(request.From.Value).AddDays(-1)
+                : context.TimeMapper.ToGlookoTime(DateTime.UtcNow.AddMonths(-6)).AddDays(-1);
+            var to = context.TimeMapper.ToGlookoTime(DateTime.UtcNow).AddDays(1);
 
             var chunks = DateChunker.Chunk(from, to, TimeSpan.FromDays(14)).ToList();
 
@@ -347,7 +321,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             {
                 try
                 {
-                    await RunSyncPassAsync(chunks, activeTypes, result, config, cancellationToken, progressReporter);
+                    await RunSyncPassAsync(context, chunks, activeTypes, result, cancellationToken, progressReporter);
                     break;
                 }
                 catch (GlookoDataForbiddenException ex) when (attempt == 0)
@@ -355,15 +329,12 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                     _logger.LogWarning(ex,
                         "[{ConnectorSource}] Glooko returned 403 (data_cant_view) for patient code {Code}; the account's "
                         + "glookoCode likely changed. Invalidating cached session and re-authenticating.",
-                        ConnectorSource, _userData?.GlookoCode);
+                        ConnectorSource, context.PatientCode);
 
                     _tokenProvider.InvalidateToken();
-                    _sessionCookie = null;
-                    _userData = null;
-                    _meterUnits = null;
-                    _timezone = null;
+                    context.ClearSessionAndProfile();
 
-                    if (!await AuthenticateWithConfigAsync(config))
+                    if (!await AuthenticateWithConfigAsync(context))
                     {
                         result.Success = false;
                         result.Message = "Re-authentication failed after Glooko denied data access";
@@ -371,7 +342,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                         break;
                     }
 
-                    await ConfigureTimezoneTimelineAsync(config, cancellationToken);
+                    await ConfigureTimezoneTimelineAsync(context, cancellationToken);
 
                     // Drop partial results from the aborted pass; the retry re-syncs from scratch
                     // with the refreshed patient code.
@@ -383,7 +354,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
 
                     _logger.LogInformation(
                         "[{ConnectorSource}] Re-authenticated after 403; retrying sync with patient code {Code}",
-                        ConnectorSource, _userData?.GlookoCode);
+                        ConnectorSource, context.PatientCode);
                 }
             }
 
@@ -412,10 +383,10 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     ///     the caller can re-authenticate and retry with a refreshed code.
     /// </summary>
     private async Task RunSyncPassAsync(
+        GlookoSyncContext context,
         List<(DateTime From, DateTime To)> chunks,
         HashSet<SyncDataType> activeTypes,
         SyncResult result,
-        GlookoConnectorConfiguration config,
         CancellationToken cancellationToken,
         ISyncProgressReporter? progressReporter)
     {
@@ -432,9 +403,9 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                 },
                 cancellationToken);
 
-            var chunkSuccess = _syncConfig!.UseV3Api
-                ? await FetchAndMapViaV3Async(chunkFrom, chunkTo, activeTypes, result, config, cancellationToken)
-                : await FetchAndMapViaV2Async(chunkFrom, chunkTo, activeTypes, result, config, cancellationToken);
+            var chunkSuccess = context.Config.UseV3Api
+                ? await FetchAndMapViaV3Async(context, chunkFrom, chunkTo, activeTypes, result, cancellationToken)
+                : await FetchAndMapViaV2Async(context, chunkFrom, chunkTo, activeTypes, result, cancellationToken);
 
             if (!chunkSuccess)
             {
@@ -460,21 +431,21 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         {
             try
             {
-                var deviceSettings = await FetchV3DeviceSettingsAsync();
+                var deviceSettings = await FetchV3DeviceSettingsAsync(context);
                 if (deviceSettings != null)
                 {
-                    var profiles = _profileMapper!.TransformDeviceSettingsToProfiles(deviceSettings);
-                    if (profiles.Any() && await PublishProfileDataAsync(profiles, config, cancellationToken))
+                    var profiles = context.ProfileMapper.TransformDeviceSettingsToProfiles(deviceSettings);
+                    if (profiles.Any() && await PublishProfileDataAsync(profiles, context.Config, cancellationToken))
                     {
                         result.ItemsSynced[SyncDataType.Profiles] = profiles.Count;
                         _logger.LogInformation("[{ConnectorSource}] Published {Count} profiles from device settings",
                             ConnectorSource, profiles.Count);
                     }
 
-                    var profileStateSpans = _profileMapper.TransformDeviceSettingsToStateSpans(deviceSettings);
+                    var profileStateSpans = context.ProfileMapper.TransformDeviceSettingsToStateSpans(deviceSettings);
                     if (profileStateSpans.Count > 0)
                     {
-                        await PublishStateSpanDataAsync(profileStateSpans, config, cancellationToken);
+                        await PublishStateSpanDataAsync(profileStateSpans, context.Config, cancellationToken);
                         _logger.LogInformation("[{ConnectorSource}] Published {Count} profile state spans from device settings",
                             ConnectorSource, profileStateSpans.Count);
                     }
@@ -494,28 +465,30 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     ///     Fetches from all V2 endpoints, maps each record type, and publishes inline.
     /// </summary>
     private async Task<bool> FetchAndMapViaV2Async(
+        GlookoSyncContext context,
         DateTime fromDate,
         DateTime toDate,
         HashSet<SyncDataType> activeTypes,
         SyncResult result,
-        GlookoConnectorConfiguration config,
         CancellationToken cancellationToken)
     {
-        var batchData = await FetchBatchDataAsync(fromDate, toDate);
+        var config = context.Config;
+
+        var batchData = await FetchBatchDataAsync(context, fromDate, toDate);
         if (batchData == null) return false;
 
         // 1. Glucose
-        var sensorGlucose = _sensorGlucoseMapper.TransformBatchDataToSensorGlucose(batchData).ToList();
+        var sensorGlucose = context.SensorGlucoseMapper.TransformBatchDataToSensorGlucose(batchData).ToList();
         await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
             sensorGlucose, PublishSensorGlucoseDataAsync, config, cancellationToken);
         UpdateLastEntryTime(result, SyncDataType.Glucose, sensorGlucose);
 
-        var bgChecks = _sensorGlucoseMapper.TransformBatchDataToBGChecks(batchData).ToList();
+        var bgChecks = context.SensorGlucoseMapper.TransformBatchDataToBGChecks(batchData).ToList();
         await PublishRecordTypeAsync(result, SyncDataType.ManualBG, activeTypes,
             bgChecks, PublishBGCheckDataAsync, config, cancellationToken);
 
         // 2. Treatments (boluses → carbs+foods)
-        var (boluses, carbs, _) = _v4TreatmentMapper.MapBatchData(batchData);
+        var (boluses, carbs, _) = context.V4TreatmentMapper.MapBatchData(batchData);
 
         await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
             boluses, PublishBolusDataAsync, config, cancellationToken);
@@ -525,7 +498,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
 
         // 3. Foods + attribution (coupled with carbs)
         var foodEntryImports = batchData.Foods is { Length: > 0 }
-            ? _v4TreatmentMapper.MapFoodsToConnectorEntries(batchData) : [];
+            ? context.V4TreatmentMapper.MapFoodsToConnectorEntries(batchData) : [];
         Func<string, string?> foodResolver = externalEntryId => $"glooko_food_{externalEntryId}";
         await PublishFoodEntriesAndAttributeAsync(
             foodEntryImports, carbs, foodResolver, config, cancellationToken);
@@ -533,7 +506,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         // 4. State spans
         if (activeTypes.Contains(SyncDataType.StateSpans))
         {
-            var stateSpans = _stateSpanMapper.TransformV2ToStateSpans(batchData);
+            var stateSpans = context.StateSpanMapper.TransformV2ToStateSpans(batchData);
             if (stateSpans.Count > 0)
                 await PublishStateSpanDataAsync(stateSpans, config, cancellationToken);
         }
@@ -541,7 +514,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         // 5. Temp basals
         if (activeTypes.Contains(SyncDataType.TempBasals))
         {
-            var tempBasals = _tempBasalMapper.TransformV2ToTempBasals(batchData);
+            var tempBasals = context.TempBasalMapper.TransformV2ToTempBasals(batchData);
             if (tempBasals.Count > 0 && await PublishTempBasalDataAsync(tempBasals, config, cancellationToken))
                 result.ItemsSynced[SyncDataType.TempBasals] = tempBasals.Count;
         }
@@ -555,50 +528,52 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     ///     Fetches from V3 graph/data and histories endpoints, maps each record type, and publishes inline.
     /// </summary>
     private async Task<bool> FetchAndMapViaV3Async(
+        GlookoSyncContext context,
         DateTime fromDate,
         DateTime toDate,
         HashSet<SyncDataType> activeTypes,
         SyncResult result,
-        GlookoConnectorConfiguration config,
         CancellationToken cancellationToken)
     {
+        var config = context.Config;
+
         _logger.LogInformation("[{ConnectorSource}] Fetching data from v3 API...", ConnectorSource);
 
-        var v3Data = await FetchV3GraphDataAsync(fromDate, toDate);
+        var v3Data = await FetchV3GraphDataAsync(context, fromDate, toDate);
         if (v3Data == null) return false;
 
         GlookoV3HistoriesResponse? v3Histories = null;
-        try { v3Histories = await FetchV3HistoriesAsync(fromDate, toDate); }
+        try { v3Histories = await FetchV3HistoriesAsync(context, fromDate, toDate); }
         catch (Exception histEx)
         {
             _logger.LogWarning(histEx, "[{ConnectorSource}] V3 histories fetch failed, meal data will be unavailable", ConnectorSource);
         }
 
         // 1. Glucose
-        if (_syncConfig!.V3IncludeCgmBackfill)
+        if (config.V3IncludeCgmBackfill)
         {
-            var sensorGlucose = _sensorGlucoseMapper.TransformV3ToSensorGlucose(v3Data, _meterUnits).ToList();
+            var sensorGlucose = context.SensorGlucoseMapper.TransformV3ToSensorGlucose(v3Data, context.MeterUnits).ToList();
             await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
                 sensorGlucose, PublishSensorGlucoseDataAsync, config, cancellationToken);
             UpdateLastEntryTime(result, SyncDataType.Glucose, sensorGlucose);
         }
 
-        var bgChecks = _sensorGlucoseMapper.TransformV3ToBGChecks(v3Data, _meterUnits).ToList();
+        var bgChecks = context.SensorGlucoseMapper.TransformV3ToBGChecks(v3Data, context.MeterUnits).ToList();
         await PublishRecordTypeAsync(result, SyncDataType.ManualBG, activeTypes,
             bgChecks, PublishBGCheckDataAsync, config, cancellationToken);
 
         // 2. Treatments (boluses → carbs+foods)
-        var (v3Boluses, v3BolusCarbIntakes, _) = _v4TreatmentMapper.MapV3Boluses(v3Data);
+        var (v3Boluses, v3BolusCarbIntakes, _) = context.V4TreatmentMapper.MapV3Boluses(v3Data);
 
         // Carbs: bolus wizard + history meals (preferred) or carbAll (fallback)
         var allCarbs = new List<CarbIntake>(v3BolusCarbIntakes);
         var historyMealCarbs = v3Histories?.Histories != null
-            ? _v4TreatmentMapper.MapV3HistoryMealsToCarbIntakes(v3Histories) : [];
+            ? context.V4TreatmentMapper.MapV3HistoryMealsToCarbIntakes(v3Histories) : [];
 
         if (historyMealCarbs.Count > 0)
             allCarbs.AddRange(historyMealCarbs);
         else
-            allCarbs.AddRange(_v4TreatmentMapper.MapV3CarbAll(v3Data));
+            allCarbs.AddRange(context.V4TreatmentMapper.MapV3CarbAll(v3Data));
 
         await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
             v3Boluses, PublishBolusDataAsync, config, cancellationToken);
@@ -607,7 +582,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             allCarbs, PublishCarbIntakeDataAsync, config, cancellationToken);
 
         // 2b. Manual insulin (pen injections: gkInsulinBasal → BasalInjection, gkInsulinBolus → Bolus)
-        var (manualBasalInjections, manualBoluses) = _v4TreatmentMapper.MapV3ManualInsulin(v3Data);
+        var (manualBasalInjections, manualBoluses) = context.V4TreatmentMapper.MapV3ManualInsulin(v3Data);
 
         await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
             manualBoluses, PublishBolusDataAsync, config, cancellationToken);
@@ -619,7 +594,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         GlookoFood[]? v2Foods = null;
         if (historyMealCarbs.Count > 0)
         {
-            try { v2Foods = await FetchV2FoodsAsync(fromDate, toDate); }
+            try { v2Foods = await FetchV2FoodsAsync(context, fromDate, toDate); }
             catch (Exception v2Ex)
             {
                 _logger.LogWarning(v2Ex, "[{ConnectorSource}] V2 foods fetch failed, food entries will lack externalId/brand metadata", ConnectorSource);
@@ -627,7 +602,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         }
 
         var foodEntryImports = historyMealCarbs.Count > 0 && v3Histories?.Histories != null
-            ? _v4TreatmentMapper.MapV3HistoryMealsToConnectorEntries(v3Histories, v2Foods) : [];
+            ? context.V4TreatmentMapper.MapV3HistoryMealsToConnectorEntries(v3Histories, v2Foods) : [];
 
         // Build food resolver
         Func<string, string?>? foodResolver = null;
@@ -655,8 +630,8 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         // 4. State spans
         if (activeTypes.Contains(SyncDataType.StateSpans))
         {
-            var stateSpans = _stateSpanMapper.TransformV3ToStateSpans(v3Data);
-            stateSpans.AddRange(_stateSpanMapper.TransformV3PumpModeToStateSpans(v3Data));
+            var stateSpans = context.StateSpanMapper.TransformV3ToStateSpans(v3Data);
+            stateSpans.AddRange(context.StateSpanMapper.TransformV3PumpModeToStateSpans(v3Data));
             if (stateSpans.Count > 0)
                 await PublishStateSpanDataAsync(stateSpans, config, cancellationToken);
         }
@@ -664,7 +639,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         // 4b. Temp basals
         if (activeTypes.Contains(SyncDataType.TempBasals))
         {
-            var tempBasals = _tempBasalMapper.TransformV3ToTempBasals(v3Data);
+            var tempBasals = context.TempBasalMapper.TransformV3ToTempBasals(v3Data);
             if (tempBasals.Count > 0 && await PublishTempBasalDataAsync(tempBasals, config, cancellationToken))
                 result.ItemsSynced[SyncDataType.TempBasals] = tempBasals.Count;
         }
@@ -674,11 +649,11 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         {
             var deviceEventCount = 0;
 
-            var deviceEvents = _v4TreatmentMapper.MapV3DeviceEvents(v3Data);
+            var deviceEvents = context.V4TreatmentMapper.MapV3DeviceEvents(v3Data);
             if (deviceEvents.Count > 0 && await PublishDeviceEventDataAsync(deviceEvents, config, cancellationToken))
                 deviceEventCount += deviceEvents.Count;
 
-            var systemEvents = _systemEventMapper.TransformV3ToSystemEvents(v3Data);
+            var systemEvents = context.SystemEventMapper.TransformV3ToSystemEvents(v3Data);
             if (systemEvents.Count > 0 && await PublishSystemEventDataAsync(systemEvents, config, cancellationToken))
                 deviceEventCount += systemEvents.Count;
 
@@ -769,11 +744,12 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     /// <summary>
     ///     Fetches comprehensive batch data from all v2 Glooko endpoints.
     /// </summary>
-    public async Task<GlookoBatchData?> FetchBatchDataAsync(DateTime fromDate, DateTime toDate)
+    private async Task<GlookoBatchData?> FetchBatchDataAsync(
+        GlookoSyncContext context, DateTime fromDate, DateTime toDate)
     {
         try
         {
-            var patientCode = EnsureAuthenticatedAndGetCode();
+            var patientCode = EnsureAuthenticatedAndGetCode(context);
             if (patientCode == null) return null;
 
             _logger.LogInformation("Fetching comprehensive Glooko data from {From:yyyy-MM-dd} to {To:yyyy-MM-dd}", fromDate, toDate);
@@ -822,13 +798,13 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             for (var i = 0; i < endpointDefinitions.Length; i++)
             {
                 var (endpoint, handler) = endpointDefinitions[i];
-                var url = ConstructV2Url(endpoint, fromDate, toDate);
+                var url = ConstructV2Url(context, endpoint, fromDate, toDate);
 
                 await _rateLimitingStrategy.ApplyDelayAsync(i);
 
                 try
                 {
-                    var fetchResult = await FetchFromGlookoEndpointWithRetry(url);
+                    var fetchResult = await FetchFromGlookoEndpointWithRetry(context, url);
                     if (fetchResult.HasValue)
                     {
                         try { handler(fetchResult.Value); }
@@ -873,15 +849,16 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     ///     Fetches only the V2 foods endpoint. Used by the V3 sync path to get
     ///     rich food metadata (externalId, brand) that V3 histories doesn't provide.
     /// </summary>
-    public async Task<GlookoFood[]?> FetchV2FoodsAsync(DateTime fromDate, DateTime toDate)
+    private async Task<GlookoFood[]?> FetchV2FoodsAsync(
+        GlookoSyncContext context, DateTime fromDate, DateTime toDate)
     {
         try
         {
-            var patientCode = EnsureAuthenticatedAndGetCode();
+            var patientCode = EnsureAuthenticatedAndGetCode(context);
             if (patientCode == null) return null;
 
-            var url = ConstructV2Url(GlookoConstants.FoodsPath, fromDate, toDate);
-            var result = await FetchFromGlookoEndpointWithRetry(url);
+            var url = ConstructV2Url(context, GlookoConstants.FoodsPath, fromDate, toDate);
+            var result = await FetchFromGlookoEndpointWithRetry(context, url);
             if (!result.HasValue) return null;
 
             if (result.Value.TryGetProperty("foods", out var el))
@@ -901,28 +878,25 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         }
     }
 
-    private string? _meterUnits;
-    private string? _timezone;
-
     /// <summary>
     ///     Fetches user profile from v3 API to get meter units and the account's home timezone.
     /// </summary>
-    public async Task<GlookoV3UsersResponse?> FetchV3UserProfileAsync()
+    private async Task<GlookoV3UsersResponse?> FetchV3UserProfileAsync(GlookoSyncContext context)
     {
         try
         {
-            EnsureAuthenticatedAndGetCode();
+            EnsureAuthenticatedAndGetCode(context);
 
-            var result = await FetchFromGlookoEndpoint(GlookoConstants.V3UsersPath);
+            var result = await FetchFromGlookoEndpoint(context, GlookoConstants.V3UsersPath);
             if (!result.HasValue) return null;
 
             var profile = JsonSerializer.Deserialize<GlookoV3UsersResponse>(result.Value.GetRawText());
             if (profile?.CurrentUser != null)
             {
-                _meterUnits = profile.CurrentUser.MeterUnits;
-                _timezone = profile.CurrentUser.Timezone;
+                context.MeterUnits = profile.CurrentUser.MeterUnits;
+                context.Timezone = profile.CurrentUser.Timezone;
                 _logger.LogInformation("[{ConnectorSource}] User profile loaded. MeterUnits: {Units}, Timezone: {Timezone}",
-                    ConnectorSource, _meterUnits, _timezone ?? "(none)");
+                    ConnectorSource, context.MeterUnits, context.Timezone ?? "(none)");
             }
 
             return profile;
@@ -940,25 +914,26 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     ///     and seeds the timeline origin from that zone on first sync. When no timezone service is wired
     ///     or the timeline is empty, conversion falls back to the legacy static offset.
     /// </summary>
-    private async Task ConfigureTimezoneTimelineAsync(GlookoConnectorConfiguration config, CancellationToken cancellationToken)
+    private async Task ConfigureTimezoneTimelineAsync(GlookoSyncContext context, CancellationToken cancellationToken)
     {
-        if (_timezoneTimelineService is null || _timeMapper is null)
+        if (_timezoneTimelineService is null)
             return;
 
         try
         {
-            if (config.UseV3Api && string.IsNullOrEmpty(_meterUnits))
-                await FetchV3UserProfileAsync();
+            if (context.Config.UseV3Api && string.IsNullOrEmpty(context.MeterUnits))
+                await FetchV3UserProfileAsync(context);
 
-            if (!string.IsNullOrWhiteSpace(_timezone))
-                await _timezoneTimelineService.EnsureOriginAsync(_timezone, cancellationToken);
+            if (!string.IsNullOrWhiteSpace(context.Timezone))
+                await _timezoneTimelineService.EnsureOriginAsync(context.Timezone, cancellationToken);
 
-            var resolver = await _timezoneTimelineService.GetResolverAsync(config.TimezoneOffset, cancellationToken);
-            _timeMapper.UseTimeline(resolver);
+            var resolver = await _timezoneTimelineService.GetResolverAsync(
+                context.Config.TimezoneOffset, cancellationToken);
+            context.TimeMapper.UseTimeline(resolver);
 
             _logger.LogInformation(
                 "[{ConnectorSource}] Timezone timeline configured (entries present: {HasEntries}, home zone: {Zone})",
-                ConnectorSource, resolver.HasEntries, _timezone ?? "(none)");
+                ConnectorSource, resolver.HasEntries, context.Timezone ?? "(none)");
         }
         catch (Exception ex)
         {
@@ -970,20 +945,21 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     /// <summary>
     ///     Fetches data from v3 graph/data API — single call for all data types.
     /// </summary>
-    public async Task<GlookoV3GraphResponse?> FetchV3GraphDataAsync(DateTime fromDate, DateTime toDate)
+    private async Task<GlookoV3GraphResponse?> FetchV3GraphDataAsync(
+        GlookoSyncContext context, DateTime fromDate, DateTime toDate)
     {
         try
         {
-            var patientCode = EnsureAuthenticatedAndGetCode();
+            var patientCode = EnsureAuthenticatedAndGetCode(context);
             if (patientCode == null) return null;
 
-            if (string.IsNullOrEmpty(_meterUnits)) await FetchV3UserProfileAsync();
+            if (string.IsNullOrEmpty(context.MeterUnits)) await FetchV3UserProfileAsync(context);
 
-            var url = ConstructV3GraphUrl(fromDate, toDate);
+            var url = ConstructV3GraphUrl(context, fromDate, toDate);
             _logger.LogInformation("[{ConnectorSource}] Fetching v3 graph data from {StartDate:yyyy-MM-dd} to {EndDate:yyyy-MM-dd}",
                 ConnectorSource, fromDate, toDate);
 
-            var result = await FetchFromGlookoEndpointWithRetry(url);
+            var result = await FetchFromGlookoEndpointWithRetry(context, url);
             if (!result.HasValue) return null;
 
             var graphData = JsonSerializer.Deserialize<GlookoV3GraphResponse>(result.Value.GetRawText());
@@ -1031,17 +1007,17 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     /// <summary>
     ///     Fetches pump device settings from the v3 devices_and_settings API.
     /// </summary>
-    public async Task<GlookoV3DeviceSettingsResponse?> FetchV3DeviceSettingsAsync()
+    private async Task<GlookoV3DeviceSettingsResponse?> FetchV3DeviceSettingsAsync(GlookoSyncContext context)
     {
         try
         {
-            var patientCode = EnsureAuthenticatedAndGetCode();
+            var patientCode = EnsureAuthenticatedAndGetCode(context);
             if (patientCode == null) return null;
 
             var url = $"{GlookoConstants.V3DeviceSettingsPath}?patient={patientCode}";
             _logger.LogInformation("[{ConnectorSource}] Fetching device settings from v3 API", ConnectorSource);
 
-            var result = await FetchFromGlookoEndpointWithRetry(url);
+            var result = await FetchFromGlookoEndpointWithRetry(context, url);
             if (!result.HasValue) return null;
 
             var settings = JsonSerializer.Deserialize<GlookoV3DeviceSettingsResponse>(result.Value.GetRawText());
@@ -1066,11 +1042,12 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     ///     Fetches rich history data from the v3 users/summary/histories API.
     ///     Contains meals with per-food nutritional data, medications, exercises, etc.
     /// </summary>
-    public async Task<GlookoV3HistoriesResponse?> FetchV3HistoriesAsync(DateTime fromDate, DateTime toDate)
+    private async Task<GlookoV3HistoriesResponse?> FetchV3HistoriesAsync(
+        GlookoSyncContext context, DateTime fromDate, DateTime toDate)
     {
         try
         {
-            var patientCode = EnsureAuthenticatedAndGetCode();
+            var patientCode = EnsureAuthenticatedAndGetCode(context);
             if (patientCode == null) return null;
 
             var url = $"{GlookoConstants.V3HistoriesPath}?patient={patientCode}"
@@ -1080,7 +1057,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             _logger.LogInformation("[{ConnectorSource}] Fetching v3 histories from {StartDate:yyyy-MM-dd} to {EndDate:yyyy-MM-dd}",
                 ConnectorSource, fromDate, toDate);
 
-            var result = await FetchFromGlookoEndpointWithRetry(url);
+            var result = await FetchFromGlookoEndpointWithRetry(context, url);
             if (!result.HasValue) return null;
 
             var historiesData = JsonSerializer.Deserialize<GlookoV3HistoriesResponse>(result.Value.GetRawText());

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoSyncContext.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoSyncContext.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.Logging;
+using Nocturne.Connectors.Glooko.Configurations;
+using Nocturne.Connectors.Glooko.Mappers;
+
+namespace Nocturne.Connectors.Glooko.Services;
+
+/// <summary>
+///     One sync run's working state: the tenant's configuration, the Glooko session that run
+///     authenticated with, and the mappers bound to that configuration's time mapping. Created in
+///     the sync entry point and threaded through every helper, so a connector instance reached by
+///     two overlapping runs cannot serve one tenant's session, patient code or timezone timeline
+///     to another tenant's requests.
+/// </summary>
+internal sealed class GlookoSyncContext
+{
+    internal GlookoSyncContext(GlookoConnectorConfiguration config, string connectorSource, ILogger logger)
+    {
+        Config = config;
+        TimeMapper = new GlookoTimeMapper(config, logger);
+        SensorGlucoseMapper = new GlookoSensorGlucoseMapper(config, connectorSource, TimeMapper, logger);
+        V4TreatmentMapper = new GlookoV4TreatmentMapper(connectorSource, TimeMapper, logger);
+        StateSpanMapper = new GlookoStateSpanMapper(connectorSource, TimeMapper, logger);
+        TempBasalMapper = new GlookoTempBasalMapper(connectorSource, TimeMapper, logger);
+        SystemEventMapper = new GlookoSystemEventMapper(connectorSource, TimeMapper, logger);
+        ProfileMapper = new GlookoProfileMapper(connectorSource, logger);
+    }
+
+    internal GlookoConnectorConfiguration Config { get; }
+
+    internal GlookoTimeMapper TimeMapper { get; }
+    internal GlookoSensorGlucoseMapper SensorGlucoseMapper { get; }
+    internal GlookoV4TreatmentMapper V4TreatmentMapper { get; }
+    internal GlookoStateSpanMapper StateSpanMapper { get; }
+    internal GlookoTempBasalMapper TempBasalMapper { get; }
+    internal GlookoSystemEventMapper SystemEventMapper { get; }
+    internal GlookoProfileMapper ProfileMapper { get; }
+
+    /// <summary>Glooko's session cookie, which doubles as this run's auth token. Null until authenticated.</summary>
+    internal string? SessionCookie { get; set; }
+
+    internal GlookoUserData? UserData { get; set; }
+
+    /// <summary>The patient code every patient-scoped Glooko URL is built from.</summary>
+    internal string? PatientCode => UserData?.GlookoCode;
+
+    /// <summary>Meter units from the V3 profile; fetched once per run.</summary>
+    internal string? MeterUnits { get; set; }
+
+    /// <summary>The account's home timezone from the V3 profile; seeds the timeline origin.</summary>
+    internal string? Timezone { get; set; }
+
+    /// <summary>
+    ///     Drops everything Glooko told this run about the account — the session and the profile
+    ///     values resolved through it — so a 403 recovery re-authenticates and re-resolves from
+    ///     scratch rather than reusing a patient code or home zone tied to the stale session.
+    /// </summary>
+    internal void ClearSessionAndProfile()
+    {
+        SessionCookie = null;
+        UserData = null;
+        MeterUnits = null;
+        Timezone = null;
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceStateIsolationTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceStateIsolationTests.cs
@@ -1,0 +1,335 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.Glooko.Configurations;
+using Nocturne.Connectors.Glooko.Services;
+using Nocturne.Core.Constants;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Contracts.Timezones;
+using Nocturne.Core.Models.Timezones;
+using Xunit;
+
+namespace Nocturne.Connectors.Glooko.Tests.Services;
+
+/// <summary>
+/// Pins that a single <see cref="GlookoConnectorService"/> instance cannot leak one tenant's
+/// session, patient code, server region or timezone timeline into another tenant's sync. The
+/// connector is registered as a typed HTTP client (transient) today, so overlapping runs on one
+/// instance are not reachable in production — these tests keep the property structural rather than
+/// a consequence of the registration lifetime.
+/// </summary>
+public class GlookoConnectorServiceStateIsolationTests
+{
+    private const string TenantACookie = "_logbook-web_session=sess-a";
+    private const string TenantBCookie = "_logbook-web_session=sess-b";
+    private const string TenantACode = "eu-west-1-indigo-killdeer-4650";
+    private const string TenantBCode = "us-east-1-blue-duke-4165";
+
+    private static readonly Guid TenantA = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid TenantB = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    // One CGM reading at fake-UTC midnight on 2026-01-10, i.e. local midnight in whichever zone the
+    // run's own timeline says the person was in. Sydney (AEDT, +11) and Toronto (EST, -5) resolve it
+    // to instants 18 hours apart, so a shared time mapper is visible in the result.
+    private static readonly DateTime FakeUtcReading = new(2026, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime SydneyUtc = new(2026, 1, 9, 13, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime TorontoUtc = new(2026, 1, 10, 5, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task SyncDataAsync_WhenTwoTenantsSyncConcurrentlyOnOneInstance_EachKeepsItsOwnSession()
+    {
+        // The handler parks whichever run authenticates first inside its user-profile request until a
+        // profile request bearing the *other* run's session arrives, so the second run's session is
+        // established while the first is mid-flight. The parked run then builds its graph request from
+        // whatever state it can still see; if that state is shared, it queries as the other tenant.
+        var handler = new InterleavingHandler();
+        var service = BuildService(handler);
+
+        await Task.WhenAll(
+            RunSyncAsync(service, TenantA, BuildConfig("a@example.com", GlookoConstants.RegionEU)),
+            RunSyncAsync(service, TenantB, BuildConfig("b@example.com", GlookoConstants.RegionUS)));
+
+        handler.RunsOverlapped.Should().BeTrue(
+            "the parked run must have been released by the other run's session, not by the timeout — "
+            + "otherwise the runs never overlapped and the assertion below proves nothing");
+
+        handler.GraphRequests.Should().BeEquivalentTo(
+            new[]
+            {
+                new GlookoRequestIdentity("eu.api.glooko.com", TenantACookie, TenantACode),
+                new GlookoRequestIdentity("api.glooko.com", TenantBCookie, TenantBCode),
+            },
+            "each run must query Glooko with its own host, session cookie and patient code");
+    }
+
+    [Fact]
+    public async Task SyncDataAsync_WhenTwoTenantsSyncConcurrentlyOnOneInstance_EachMapsOnItsOwnTimezoneTimeline()
+    {
+        // The sharpest failure mode: a shared time mapper doesn't 401, it silently stamps one tenant's
+        // glucose on the other tenant's timezone timeline. Both runs receive the same fake-UTC reading;
+        // each must resolve it through the timeline its own tenant's service handed back.
+        var handler = new InterleavingHandler();
+        var service = BuildService(handler, new AmbientTenantTimezoneTimelineService());
+
+        var configA = BuildConfig("a@example.com", GlookoConstants.RegionEU, includeCgmBackfill: true);
+        var configB = BuildConfig("b@example.com", GlookoConstants.RegionUS, includeCgmBackfill: true);
+
+        var results = await Task.WhenAll(
+            RunSyncAsync(service, TenantA, configA),
+            RunSyncAsync(service, TenantB, configB));
+
+        handler.RunsOverlapped.Should().BeTrue(
+            "the runs must actually overlap for the timeline isolation to be under test");
+
+        results[0].LastEntryTimes[SyncDataType.Glucose].Should().Be(SydneyUtc);
+        results[1].LastEntryTimes[SyncDataType.Glucose].Should().Be(TorontoUtc);
+    }
+
+    /// <summary>
+    /// Keeps per-sync state off the service type itself. Deliberately narrow — it enforces only that
+    /// <see cref="GlookoConnectorService"/> declares no mutable field of its own, instance or static.
+    /// It does not (and cannot cheaply) prove a readonly field holds nothing mutable, and
+    /// <c>DeclaredOnly</c> excludes <c>BaseConnectorService</c>, which does declare mutable per-run
+    /// fields (<c>_glucosePublishOrigin</c>, <c>_treatmentPublishOrigin</c>, <c>_devicePublishOrigin</c>,
+    /// <c>_failedRequestCount</c>) whose own comment says they are safe *because* the connector is
+    /// resolved fresh per run. That base-class reliance on the registration lifetime is out of this
+    /// issue's scope and is not covered here.
+    /// </summary>
+    [Fact]
+    public void GlookoConnectorService_DeclaresNoMutableFields()
+    {
+        const BindingFlags visibility = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
+
+        var instanceFields = typeof(GlookoConnectorService).GetFields(visibility | BindingFlags.Instance);
+        var staticFields = typeof(GlookoConnectorService).GetFields(visibility | BindingFlags.Static);
+
+        instanceFields.Where(f => f.IsInitOnly).Should().NotBeEmpty(
+            "the service declares its injected dependencies as readonly fields — an empty result would "
+            + "mean the reflection query found nothing and the assertions below are vacuous");
+
+        // A conversion to a primary constructor would emit non-readonly private fields for the
+        // captured parameters and fail this, even though nothing became shared.
+        instanceFields.Where(f => !f.IsInitOnly).Should().BeEmpty(
+            "per-sync state belongs on GlookoSyncContext; a mutable instance field is one DI lifetime "
+            + "change away from serving one tenant's session to another tenant's sync");
+
+        staticFields.Where(f => !f.IsInitOnly && !f.IsLiteral).Should().BeEmpty(
+            "a mutable static field is shared across every tenant regardless of the DI lifetime");
+    }
+
+    // ── Test infrastructure ─────────────────────────────────────────────
+
+    private sealed record GlookoRequestIdentity(string Host, string? Cookie, string PatientCode);
+
+    private static async Task<SyncResult> RunSyncAsync(
+        GlookoConnectorService service, Guid tenantId, GlookoConnectorConfiguration config)
+    {
+        await Task.Yield(); // start both runs on their own async flow before pinning the tenant
+        AmbientTenant.Use(tenantId);
+
+        var request = new SyncRequest
+        {
+            DataTypes = [SyncDataType.Glucose],
+            From = DateTime.UtcNow.AddDays(-3), // single chunk keeps one graph request per run
+        };
+
+        return await service.SyncDataAsync(request, config, CancellationToken.None);
+    }
+
+    private static GlookoConnectorConfiguration BuildConfig(
+        string email, string region, bool includeCgmBackfill = false) => new()
+    {
+        ConnectSource = ConnectSource.Glooko,
+        Email = email,
+        Password = "secret",
+        Server = region,
+        UseV3Api = true,
+        V3IncludeCgmBackfill = includeCgmBackfill,
+    };
+
+    private static GlookoConnectorService BuildService(
+        InterleavingHandler handler, ITimezoneTimelineService? timezoneTimelineService = null) =>
+        new(
+            new HttpClient(handler),
+            new ConnectorServerResolver<GlookoConnectorConfiguration>(null, null, null),
+            NullLogger<GlookoConnectorService>.Instance,
+            Mock.Of<IRetryDelayStrategy>(),
+            Mock.Of<IRateLimitingStrategy>(),
+            new PerTenantGlookoTokenProvider(),
+            timezoneTimelineService: timezoneTimelineService);
+
+    /// <summary>
+    /// The tenant each run is pinned to, per async flow — standing in for the per-tenant DI scope a
+    /// background sync runs in. Without it both runs would share one token-cache key and one timeline.
+    /// </summary>
+    private static class AmbientTenant
+    {
+        private static readonly AsyncLocal<Guid> Current = new();
+
+        public static void Use(Guid tenantId) => Current.Value = tenantId;
+        public static Guid Id => Current.Value;
+    }
+
+    private sealed class AmbientTenantAccessor : ITenantAccessor
+    {
+        public bool IsResolved => AmbientTenant.Id != Guid.Empty;
+        public Guid TenantId => AmbientTenant.Id;
+        public TenantContext? Context => null;
+        public void SetTenant(TenantContext context) { }
+    }
+
+    /// <summary>
+    /// Issues a distinct session cookie and glookoCode per tenant, so a request carrying tenant B's
+    /// cookie or code is unambiguously tenant B's session.
+    /// </summary>
+    private sealed class PerTenantGlookoTokenProvider : GlookoAuthTokenProvider
+    {
+        public PerTenantGlookoTokenProvider()
+            : base(
+                new HttpClient(),
+                new ConnectorTokenCache(),
+                new ConnectorServerResolver<GlookoConnectorConfiguration>(null, null, null),
+                new AmbientTenantAccessor(),
+                NullLogger<GlookoAuthTokenProvider>.Instance)
+        {
+        }
+
+        protected override Task<(string? Token, DateTime ExpiresAt, IReadOnlyDictionary<string, string>? Metadata)> AcquireTokenAsync(
+            GlookoConnectorConfiguration config, CancellationToken cancellationToken)
+        {
+            var isTenantA = AmbientTenant.Id == TenantA;
+            var cookie = isTenantA ? TenantACookie : TenantBCookie;
+            var code = isTenantA ? TenantACode : TenantBCode;
+
+            var userData = JsonSerializer.Serialize(
+                new GlookoUserData { User = new GlookoUserLogin { GlookoCode = code } });
+
+            return Task.FromResult<(string?, DateTime, IReadOnlyDictionary<string, string>?)>(
+                (cookie, DateTime.UtcNow.AddHours(1), new Dictionary<string, string>
+                {
+                    ["SessionCookie"] = cookie,
+                    ["UserData"] = userData,
+                }));
+        }
+    }
+
+    /// <summary>
+    /// Hands each tenant its own timeline, as the real tenant-scoped service does.
+    /// </summary>
+    private sealed class AmbientTenantTimezoneTimelineService : ITimezoneTimelineService
+    {
+        public Task<TimezoneTimeline> GetResolverAsync(
+            double? fallbackOffsetHours, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new TimezoneTimeline(
+            [
+                new TimezoneTimelineEntry
+                {
+                    Timezone = AmbientTenant.Id == TenantA ? "Australia/Sydney" : "America/Toronto",
+                    EffectiveFrom = DateTime.MinValue,
+                },
+            ], fallbackOffsetHours));
+
+        public Task<IReadOnlyList<TimezoneTimelineEntry>> GetTimelineAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<TimezoneTimelineEntry>>([]);
+
+        public Task<bool> EnsureOriginAsync(string ianaTimezone, CancellationToken cancellationToken = default) =>
+            Task.FromResult(false);
+
+        public Task<TimezoneTimelineEntry> UpsertAsync(TimezoneTimelineEntry entry, CancellationToken cancellationToken = default) =>
+            Task.FromResult(entry);
+
+        public Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default) =>
+            Task.FromResult(false);
+    }
+
+    /// <summary>
+    /// Holds the first user-profile request open until one from the *other run* arrives, forcing the
+    /// two runs to overlap, and records the identity every graph request was built from. Keyed on the
+    /// ambient tenant — the run's own async flow, which no amount of shared service state can forge —
+    /// rather than on a request count (which a run fetching its profile twice could satisfy itself) or
+    /// on the session cookie (which is one of the things under test).
+    /// </summary>
+    private sealed class InterleavingHandler : HttpMessageHandler
+    {
+        private readonly TaskCompletionSource _otherRunAuthenticated =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private readonly object _gate = new();
+        private Guid _parkedRun;
+
+        public ConcurrentBag<GlookoRequestIdentity> GraphRequests { get; } = [];
+
+        /// <summary>True when the parked run was released by the other run rather than by the timeout.</summary>
+        public bool RunsOverlapped { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri?.PathAndQuery ?? string.Empty;
+            var cookie = CookieOf(request);
+
+            if (path.Contains("/api/v3/session/users", StringComparison.OrdinalIgnoreCase))
+            {
+                bool park;
+                bool release;
+                lock (_gate)
+                {
+                    park = _parkedRun == Guid.Empty;
+                    if (park) _parkedRun = AmbientTenant.Id;
+                    release = !park && _parkedRun != AmbientTenant.Id;
+                }
+
+                if (park)
+                {
+                    // A timeout rather than an indefinite wait, so a run that never reaches this point
+                    // fails the test instead of hanging it.
+                    var released = await Task.WhenAny(_otherRunAuthenticated.Task, Task.Delay(30_000));
+                    RunsOverlapped = released == _otherRunAuthenticated.Task;
+                }
+                else if (release)
+                {
+                    _otherRunAuthenticated.TrySetResult();
+                }
+
+                return Json("{\"currentUser\":{\"meterUnits\":\"mgdl\",\"timezone\":\"Australia/Sydney\"}}");
+            }
+
+            if (path.Contains("/api/v3/graph/data", StringComparison.OrdinalIgnoreCase))
+            {
+                GraphRequests.Add(new GlookoRequestIdentity(request.RequestUri!.Host, cookie, ExtractPatient(path)));
+
+                var x = new DateTimeOffset(FakeUtcReading).ToUnixTimeSeconds();
+                return Json($"{{\"series\":{{\"cgmNormal\":[{{\"x\":{x},\"y\":120}}]}}}}");
+            }
+
+            if (path.Contains("/api/v3/users/summary/histories", StringComparison.OrdinalIgnoreCase))
+                return Json("{\"histories\":[]}");
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        }
+
+        private static string? CookieOf(HttpRequestMessage request) =>
+            request.Headers.TryGetValues("Cookie", out var cookies) ? string.Join(";", cookies) : null;
+
+        private static string ExtractPatient(string pathAndQuery)
+        {
+            const string key = "patient=";
+            var start = pathAndQuery.IndexOf(key, StringComparison.OrdinalIgnoreCase);
+            if (start < 0) return string.Empty;
+            start += key.Length;
+            var end = pathAndQuery.IndexOf('&', start);
+            return end < 0 ? pathAndQuery[start..] : pathAndQuery[start..end];
+        }
+
+        private static HttpResponseMessage Json(string body) =>
+            new(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+    }
+}


### PR DESCRIPTION
## What

Closes #657.

`GlookoConnectorService` held per-sync state in a dozen instance fields — `_sessionCookie`, `_userData`, `_syncConfig`, seven mappers, plus the undocumented-but-identical `_meterUnits`/`_timezone` — flagged in its own comments as unsafe for concurrent multi-tenant syncs. Only the transient typed-client registration prevented cross-tenant corruption; any lifetime change or internal fan-out would have silently served one tenant's session cookie, patient code, or timezone timeline to another tenant's sync.

All of it now lives on an `internal sealed GlookoSyncContext`, constructed once per sync at the single root and threaded as a parameter (the `MyLifeContext` precedent for the shape; Tandem's no-instance-state property as the goal). Mappers are per-sync objects owned by the context — `GlookoTimeMapper` holds a genuinely mutable per-tenant timezone timeline, which is exactly the state that must not be shared. The six formerly-public fetch methods had no external callers and are now private and context-taking, so no Glooko request can be built without a context.

Mid-sync 403 recovery is unchanged (verified against the old flow line by line): clear session+profile state, re-authenticate, reconfigure the timeline, retry once. Two dead guards were removed as provably inert: `IsSessionExpired()` had one caller and was constant-true under the per-sync lifetime, and the null-mapper bail is unreachable now that the context constructs its mapper unconditionally.

## Concurrency pins

Three tests keep the state from quietly coming back:

- **Session/request isolation**: one service instance, two tenants interleaved mid-auth via a parking handshake keyed on the run's *ambient tenant* (deliberately not the cookie — under the shared-state bug both runs present the same cookie and cookie-keying would silently degrade the test to non-overlapping). Both tests assert the runs genuinely overlapped, so a degraded interleave fails instead of passing.
- **Timezone isolation** (the highest-consequence axis — a shared time mapper mis-stamps every glucose reading silently, where a shared cookie just 401s): per-tenant timeline services (Sydney/Toronto, 18 hours apart across the January DST split), same fake-UTC reading to both runs, each run's mapped instant must be its own zone's.
- **Structural guard**: reflection asserts the service declares no mutable field, instance or static, with the two remaining holes (readonly-held mutables; base-class fields excluded by `DeclaredOnly`) explicitly disclaimed in the comment rather than overclaimed — `BaseConnectorService`'s own per-run fields rely on the transient lifetime and are out of this issue's scope.

Proven by mutation: re-introducing a shared-context field fails the session test on the identity assertion (wrong host/cookie/patient-code); extending the sharing into the mapping path fails the timezone test with tenant A's glucose stamped on Toronto's timeline; both mutations also fail the guard.

## Testing

Glooko 57/0 (54 pre-existing kept green + 3 new), Connectors.Core 62/0, API build clean (nothing consumed the privatized methods). The diff is mechanical field→context substitution with no method reordering, to minimize conflict with the open SSV2 work (#429).

Noted for a separate cleanup: two distinct `GlookoUserData` classes exist (Models/ vs GlookoAuthTokenProvider.cs) — the binding here is proven by compilation (only the Services one has `GlookoCode`), but the namespace-proximity trap is real.

https://claude.ai/code/session_01V2H2GSE3UWEgkMvsJE8Kfw
