### PR TITLE
fix(auth): authenticate token introspection and gate invite-info on validity

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/OAuthController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/OAuthController.cs
@@ -602,6 +602,11 @@ public class OAuthController : ControllerBase
     /// Token revocation endpoint (RFC 7009). Per the specification, always returns <c>200 OK</c>
     /// regardless of whether the token was found or already revoked.
     /// </summary>
+    /// <remarks>
+    /// Anonymous, unlike the introspection endpoint below: the response carries nothing about the
+    /// token, and a client whose token has already stopped working still needs to be able to
+    /// retire it.
+    /// </remarks>
     /// <param name="token">The access token or refresh token to revoke.</param>
     /// <param name="token_type_hint">Optional hint: <c>access_token</c> or <c>refresh_token</c>.</param>
     [HttpPost("revoke")]
@@ -877,20 +882,49 @@ public class OAuthController : ControllerBase
     /// <summary>
     /// Token introspection endpoint (RFC 7662).
     /// Returns metadata about a token including its active status, scopes, and subject.
-    /// Per RFC 7662, always returns 200 OK; invalid tokens get <c>active=false</c>.
+    /// Per RFC 7662, an authenticated caller always gets 200 OK; invalid tokens get <c>active=false</c>.
     /// </summary>
+    /// <remarks>
+    /// RFC 7662 section 2.1 requires the endpoint to authenticate its caller. Every client here is
+    /// public (no client secrets), so the caller authenticates as a subject the same way the other
+    /// credential-bearing endpoints on this controller do, and a request with no identity is
+    /// refused rather than answered.
+    /// <para>
+    /// The response is bounded by that identity: a token issued to another subject reads as
+    /// inactive, so the endpoint resolves only tokens the caller already holds an identity for.
+    /// </para>
+    /// </remarks>
     /// <param name="token">The token to introspect (access token or refresh token).</param>
     /// <param name="token_type_hint">Optional hint: <c>access_token</c> or <c>refresh_token</c>.</param>
     /// <returns>A <see cref="TokenIntrospectionResponse"/> with <c>active=false</c> for invalid, expired, or revoked tokens.</returns>
     [HttpPost("introspect")]
-    [AllowAnonymous]
     [EnableRateLimiting("oauth-token")]
     [Consumes("application/x-www-form-urlencoded")]
     [ProducesResponseType(typeof(TokenIntrospectionResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(OAuthError), StatusCodes.Status401Unauthorized)]
     public async Task<ActionResult<TokenIntrospectionResponse>> Introspect(
         [FromForm] string token,
         [FromForm] string? token_type_hint = null)
     {
+        if (!HttpContext.IsAuthenticated())
+        {
+            return Unauthorized(new OAuthError
+            {
+                Error = "access_denied",
+                ErrorDescription = "User is not authenticated.",
+            });
+        }
+
+        var callerSubjectId = HttpContext.GetSubjectId();
+        if (callerSubjectId == null)
+        {
+            return Unauthorized(new OAuthError
+            {
+                Error = "access_denied",
+                ErrorDescription = "Could not determine authenticated user.",
+            });
+        }
+
         if (string.IsNullOrEmpty(token))
         {
             return Ok(new TokenIntrospectionResponse { Active = false });
@@ -914,6 +948,18 @@ public class OAuthController : ControllerBase
                 // A revoked grant takes its outstanding access tokens with it
                 if (claims is { GrantId: not null, TenantId: not null } &&
                     await _grantService.IsGrantRevokedAsync(claims.GrantId.Value, claims.TenantId.Value))
+                {
+                    return Ok(new TokenIntrospectionResponse { Active = false });
+                }
+
+                // A token belonging to someone else is reported as inactive rather than resolved
+                // to its subject and scopes. Subjects are global across tenants, so a tenant-pinned
+                // token is bound to the caller's tenant too — the same subject in tenant A cannot
+                // resolve its tenant-B token here. A non-pinned token (legacy session JWT, no
+                // TenantId claim) carries no such restriction and is matched on subject alone.
+                var callerTenantId = HttpContext.GetAuthContext()?.TenantId;
+                if (claims.SubjectId != callerSubjectId.Value
+                    || (claims.TenantId.HasValue && claims.TenantId != callerTenantId))
                 {
                     return Ok(new TokenIntrospectionResponse { Active = false });
                 }

--- a/src/API/Nocturne.API/Controllers/V4/Identity/MemberInviteController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/MemberInviteController.cs
@@ -168,6 +168,12 @@ public class MemberInviteController : ControllerBase
     /// is reported in <see cref="MemberInviteInfo.Viewer"/> so the join page can offer acceptance
     /// instead of a second registration — including when they are signed in as a member of some
     /// other tenant on this instance, whose session cookie is domain-wide.
+    /// <para>
+    /// The token is the whole of the authorization, so an invite that can no longer be accepted
+    /// answers with the reason alone, as the sibling alert-invite lookup does. The record it would
+    /// otherwise return names the tenant, the inviter, the roles and permissions being granted and
+    /// every subject that has already joined through it.
+    /// </para>
     /// </remarks>
     [HttpGet("{token}/info")]
     [AllowAnonymous]
@@ -175,12 +181,27 @@ public class MemberInviteController : ControllerBase
     [RemoteQuery]
     [ProducesResponseType(typeof(MemberInviteInfo), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> GetInviteInfo(string token, CancellationToken ct)
     {
         var tenantId = _tenantAccessor.TenantId;
         var invite = await _memberInviteService.GetInviteByTokenAsync(token, tenantId);
         if (invite == null)
             return NotFound();
+
+        if (!invite.IsValid)
+        {
+            // 400 rather than 410, matching AcceptInvite below: the generated client passes a 400
+            // ProblemDetails through to the caller, and describeSubmitError surfaces the reason,
+            // whereas other 4xx statuses collapse to the generic message. The reason is carried in
+            // the title as well as the detail because openapi-remote-codegen 0.2.0 resolves a
+            // ProblemDetails to `title` first. Wording and order match the acceptance refusal.
+            var reason = invite.IsExpired ? "This invite has expired."
+                : invite.IsRevoked ? "This invite has been revoked."
+                : "This invite has reached its maximum uses.";
+
+            return Problem(detail: reason, statusCode: StatusCodes.Status400BadRequest, title: reason);
+        }
 
         var subjectId = HttpContext.GetSubjectId();
         if (subjectId == null)

--- a/src/API/Nocturne.API/Controllers/WellKnownController.cs
+++ b/src/API/Nocturne.API/Controllers/WellKnownController.cs
@@ -150,7 +150,11 @@ public class WellKnownController : ControllerBase
                 TokenEndpoint = $"{baseUrl}/api/oauth/token",
                 DeviceAuthorizationEndpoint = $"{baseUrl}/api/oauth/device",
                 RevocationEndpoint = $"{baseUrl}/api/oauth/revoke",
-                IntrospectionEndpoint = $"{baseUrl}/api/oauth/introspect",
+                // Introspection is first-party self-introspection: the caller authenticates with
+                // its own session or bearer credential, not a client secret, and there is no
+                // registered token_endpoint_auth_method that describes that. It is left out of the
+                // advertised metadata so an external resource server reading discovery does not
+                // treat it as a client-authenticated RFC 7662 endpoint and get an undocumented 401.
                 RegistrationEndpoint = $"{baseUrl}/api/oauth/register",
                 JwksUri = $"{baseUrl}/.well-known/jwks.json",
                 ResponseTypesSupported = new[] { "code" },

--- a/src/Web/packages/app/src/routes/(unauthenticated)/join/+page.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/join/+page.svelte
@@ -53,14 +53,16 @@
   const isAlreadyMember = $derived(viewer?.isMember ?? false);
 
   // ── Invite validity ───────────────────────────────────────────────
+  // An invite that can no longer be accepted comes back as an error carrying the reason, not as a
+  // record with its validity flags set — the details of a spent invite aren't served to whoever
+  // holds the link.
   const inviteError = $derived.by(() => {
     if (!token) return "No invite token provided. Please check the link you were given.";
-    if (inviteInfoQuery?.error) return "This invite link is invalid or has expired.";
-    if (inviteInfo && !inviteInfo.isValid) {
-      if (inviteInfo.isExpired) return "This invite has expired.";
-      if (inviteInfo.isRevoked) return "This invite has been revoked.";
-      return "This invite is no longer valid.";
-    }
+    if (inviteInfoQuery?.error)
+      return describeSubmitError(
+        inviteInfoQuery.error,
+        "This invite link is invalid or has expired."
+      );
     return null;
   });
 
@@ -169,7 +171,7 @@
         >
           <AlertTriangle class="h-6 w-6 text-destructive" />
         </div>
-        <Card.Title class="text-2xl font-bold">Invalid Invite</Card.Title>
+        <Card.Title class="text-2xl font-bold">Invite Unavailable</Card.Title>
         <Card.Description>{inviteError}</Card.Description>
       </Card.Header>
     {:else if !inviteInfo}

--- a/tests/Integration/Nocturne.API.Tests/Auth/TokenRevocationIntegrationTests.cs
+++ b/tests/Integration/Nocturne.API.Tests/Auth/TokenRevocationIntegrationTests.cs
@@ -53,8 +53,9 @@ public class TokenRevocationIntegrationTests : AspireIntegrationTestBase
         using var authedClient = AuthTestHelpers.CreateAuthenticatedSubjectClient(Fixture, _accessToken);
         var tokens = await AuthTestHelpers.ExecutePkceFlowAsync(authedClient, clientId);
 
-        // Verify the access token is active before revocation
-        var introspectBefore = await ApiClient.PostAsync("/api/oauth/introspect",
+        // Verify the access token is active before revocation. Introspection authenticates its
+        // caller, so it is asked as the subject the token belongs to.
+        var introspectBefore = await authedClient.PostAsync("/api/oauth/introspect",
             new FormUrlEncodedContent(new Dictionary<string, string>
             {
                 ["token"] = tokens.AccessToken,
@@ -76,7 +77,7 @@ public class TokenRevocationIntegrationTests : AspireIntegrationTestBase
         revokeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         // Introspect again — should now be inactive
-        var introspectAfter = await ApiClient.PostAsync("/api/oauth/introspect",
+        var introspectAfter = await authedClient.PostAsync("/api/oauth/introspect",
             new FormUrlEncodedContent(new Dictionary<string, string>
             {
                 ["token"] = tokens.AccessToken,
@@ -144,7 +145,7 @@ public class TokenRevocationIntegrationTests : AspireIntegrationTestBase
         var tokens = await AuthTestHelpers.ExecutePkceFlowAsync(authedClient, clientId);
 
         // Act
-        var introspectResponse = await ApiClient.PostAsync("/api/oauth/introspect",
+        var introspectResponse = await authedClient.PostAsync("/api/oauth/introspect",
             new FormUrlEncodedContent(new Dictionary<string, string>
             {
                 ["token"] = tokens.AccessToken
@@ -161,10 +162,35 @@ public class TokenRevocationIntegrationTests : AspireIntegrationTestBase
     }
 
     [Fact]
+    public async Task Introspect_Unauthenticated_IsRefused()
+    {
+        // Arrange — a real, live token, asked for by a caller with no identity of its own
+        using var adminClient = CreateAuthenticatedClient();
+        var clientId = await AuthTestHelpers.RegisterOAuthClientAsync(adminClient);
+        using var authedClient = AuthTestHelpers.CreateAuthenticatedSubjectClient(Fixture, _accessToken);
+        var tokens = await AuthTestHelpers.ExecutePkceFlowAsync(authedClient, clientId);
+
+        // Act
+        var introspectResponse = await ApiClient.PostAsync("/api/oauth/introspect",
+            new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["token"] = tokens.AccessToken
+            }));
+
+        // Assert — RFC 7662 section 2.1: the endpoint authenticates its caller
+        introspectResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        var body = await introspectResponse.Content.ReadAsStringAsync();
+        body.Should().NotContain(_subjectId.ToString(),
+            "an unauthenticated caller must not learn the token's subject");
+    }
+
+    [Fact]
     public async Task Introspect_ExpiredToken_ReturnsInactive()
     {
+        using var authedClient = AuthTestHelpers.CreateAuthenticatedSubjectClient(Fixture, _accessToken);
+
         // Act — introspect a clearly invalid JWT (expired / malformed)
-        var introspectResponse = await ApiClient.PostAsync("/api/oauth/introspect",
+        var introspectResponse = await authedClient.PostAsync("/api/oauth/introspect",
             new FormUrlEncodedContent(new Dictionary<string, string>
             {
                 ["token"] = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiZXhwIjoxfQ.invalid-signature",
@@ -180,8 +206,10 @@ public class TokenRevocationIntegrationTests : AspireIntegrationTestBase
     [Fact]
     public async Task Introspect_GarbageToken_ReturnsInactive()
     {
+        using var authedClient = AuthTestHelpers.CreateAuthenticatedSubjectClient(Fixture, _accessToken);
+
         // Act — introspect a string that is clearly not a token
-        var introspectResponse = await ApiClient.PostAsync("/api/oauth/introspect",
+        var introspectResponse = await authedClient.PostAsync("/api/oauth/introspect",
             new FormUrlEncodedContent(new Dictionary<string, string>
             {
                 ["token"] = "not-a-token"

--- a/tests/Unit/Nocturne.API.Tests/Authorization/OAuthControllerIntrospectTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/OAuthControllerIntrospectTests.cs
@@ -1,0 +1,240 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Controllers.Authentication;
+using Nocturne.API.Models.OAuth;
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Models.Authorization;
+using Xunit;
+
+namespace Nocturne.API.Tests.Authorization;
+
+/// <summary>
+/// The introspection endpoint (<c>POST /api/oauth/introspect</c>) resolves a token to its subject
+/// id, client and scopes. RFC 7662 section 2.1 requires the endpoint to authenticate its caller;
+/// every client on this server is public, so the caller authenticates as a subject the way the
+/// other credential-bearing endpoints on the controller do, and the answer is bounded by that
+/// identity.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Category", "OAuth")]
+public class OAuthControllerIntrospectTests
+{
+    private const string Token = "header.payload.signature";
+
+    private readonly Guid _callerSubjectId = Guid.CreateVersion7();
+    private readonly Guid _tenantId = Guid.CreateVersion7();
+    private readonly Mock<IJwtService> _jwtService = new();
+    private readonly Mock<IOAuthGrantService> _grantService = new();
+    private readonly Mock<IOAuthTokenRevocationCache> _revocationCache = new();
+
+    /// <summary>A token that validates, is not revoked, and belongs to <paramref name="subjectId"/>.</summary>
+    private void TokenBelongsTo(Guid subjectId)
+    {
+        _jwtService
+            .Setup(s => s.ValidateAccessToken(Token))
+            .Returns(JwtValidationResult.Success(new JwtClaims
+            {
+                SubjectId = subjectId,
+                TenantId = _tenantId,
+                ClientId = "test-client-id",
+                JwtId = "test-jwt-id",
+                Scopes = [OAuthScopes.GlucoseRead],
+                IssuedAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+                ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+            }));
+        _revocationCache
+            .Setup(c => c.IsRevokedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _grantService
+            .Setup(g => g.IsGrantRevokedAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+    }
+
+    private OAuthController CreateController(AuthContext? authContext)
+    {
+        var httpContext = new DefaultHttpContext();
+        if (authContext != null)
+        {
+            httpContext.Items["AuthContext"] = authContext;
+        }
+
+        return new OAuthController(
+            Mock.Of<IOAuthClientService>(),
+            _grantService.Object,
+            Mock.Of<IOAuthTokenService>(),
+            Mock.Of<IOAuthDeviceCodeService>(),
+            Mock.Of<ISubjectService>(),
+            _jwtService.Object,
+            _revocationCache.Object,
+            NullLogger<OAuthController>.Instance
+        )
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext },
+        };
+    }
+
+    private OAuthController AuthenticatedAs(Guid subjectId) => CreateController(new AuthContext
+    {
+        IsAuthenticated = true,
+        AuthType = AuthType.SessionCookie,
+        SubjectId = subjectId,
+        TenantId = _tenantId,
+    });
+
+    private static TokenIntrospectionResponse ResponseOf(
+        ActionResult<TokenIntrospectionResponse> result) =>
+        result.Result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeOfType<TokenIntrospectionResponse>().Subject;
+
+    [Fact]
+    public async Task An_unauthenticated_caller_is_refused()
+    {
+        TokenBelongsTo(_callerSubjectId);
+
+        var result = await CreateController(authContext: null).Introspect(Token);
+
+        var unauthorized = result.Result.Should().BeOfType<UnauthorizedObjectResult>().Subject;
+        unauthorized.Value.Should().BeOfType<OAuthError>()
+            .Which.Error.Should().Be("access_denied");
+    }
+
+    /// <summary>
+    /// The public share subject is carried as an unauthenticated context with a subject id
+    /// attached, so the gate has to read the flag rather than the presence of an id.
+    /// </summary>
+    [Fact]
+    public async Task An_unauthenticated_caller_carrying_a_subject_id_is_refused()
+    {
+        TokenBelongsTo(_callerSubjectId);
+
+        var result = await CreateController(new AuthContext
+        {
+            IsAuthenticated = false,
+            AuthType = AuthType.None,
+            SubjectId = Guid.CreateVersion7(),
+            TenantId = _tenantId,
+        }).Introspect(Token);
+
+        result.Result.Should().BeOfType<UnauthorizedObjectResult>();
+    }
+
+    [Fact]
+    public async Task An_unauthenticated_caller_learns_nothing_about_the_token()
+    {
+        TokenBelongsTo(_callerSubjectId);
+
+        var result = await CreateController(authContext: null).Introspect(Token);
+
+        result.Result.Should().NotBeOfType<OkObjectResult>();
+        result.Value.Should().BeNull();
+        _jwtService.Verify(s => s.ValidateAccessToken(It.IsAny<string>()), Times.Never);
+    }
+
+    /// <summary>
+    /// A guest session authenticates as a principal with no subject of its own — it acts as the
+    /// data owner via <see cref="AuthContext.ActingAsSubjectId"/>. Introspection resolves the
+    /// caller's own <see cref="AuthContext.SubjectId"/>, never the acting-as owner, so a guest is
+    /// refused rather than handed the owner's token metadata. Instance-key and dev-auth admins are
+    /// the other subjectless-but-authenticated principals this same guard covers.
+    /// </summary>
+    [Fact]
+    public async Task A_subjectless_guest_principal_is_refused_and_no_token_is_resolved()
+    {
+        var dataOwnerSubjectId = Guid.CreateVersion7();
+        TokenBelongsTo(dataOwnerSubjectId);
+
+        var result = await CreateController(new AuthContext
+        {
+            IsAuthenticated = true,
+            AuthType = AuthType.Guest,
+            SubjectId = null,
+            ActingAsSubjectId = dataOwnerSubjectId,
+            TenantId = _tenantId,
+        }).Introspect(Token);
+
+        result.Result.Should().BeOfType<UnauthorizedObjectResult>();
+        _jwtService.Verify(s => s.ValidateAccessToken(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task An_authenticated_caller_introspecting_its_own_token_gets_the_metadata()
+    {
+        TokenBelongsTo(_callerSubjectId);
+
+        var result = await AuthenticatedAs(_callerSubjectId).Introspect(Token);
+
+        var response = ResponseOf(result);
+        response.Active.Should().BeTrue();
+        response.Sub.Should().Be(_callerSubjectId.ToString());
+        response.Scope.Should().Be(OAuthScopes.GlucoseRead);
+        response.TokenType.Should().Be("access_token");
+    }
+
+    [Fact]
+    public async Task Another_subjects_token_reads_as_inactive()
+    {
+        TokenBelongsTo(Guid.CreateVersion7());
+
+        var result = await AuthenticatedAs(_callerSubjectId).Introspect(Token);
+
+        var response = ResponseOf(result);
+        response.Active.Should().BeFalse();
+        response.Sub.Should().BeNull();
+        response.Scope.Should().BeNull();
+        response.ClientId.Should().BeNull();
+    }
+
+    /// <summary>
+    /// Subjects are global across tenants, so a tenant-pinned token is bound to the caller's tenant
+    /// as well as its subject: the same subject, authenticated on tenant A, must not resolve its
+    /// tenant-B token here.
+    /// </summary>
+    [Fact]
+    public async Task The_callers_own_token_pinned_to_another_tenant_reads_as_inactive()
+    {
+        // Same subject as the caller, but the token is pinned to a different tenant.
+        var otherTenantId = Guid.CreateVersion7();
+        _jwtService
+            .Setup(s => s.ValidateAccessToken(Token))
+            .Returns(JwtValidationResult.Success(new JwtClaims
+            {
+                SubjectId = _callerSubjectId,
+                TenantId = otherTenantId,
+                ClientId = "test-client-id",
+                JwtId = "test-jwt-id",
+                Scopes = [OAuthScopes.GlucoseRead],
+                IssuedAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+                ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+            }));
+        _revocationCache
+            .Setup(c => c.IsRevokedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _grantService
+            .Setup(g => g.IsGrantRevokedAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await AuthenticatedAs(_callerSubjectId).Introspect(Token);
+
+        var response = ResponseOf(result);
+        response.Active.Should().BeFalse();
+        response.Sub.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task A_revoked_token_of_the_callers_own_reads_as_inactive()
+    {
+        TokenBelongsTo(_callerSubjectId);
+        _revocationCache
+            .Setup(c => c.IsRevokedAsync("test-jwt-id", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await AuthenticatedAs(_callerSubjectId).Introspect(Token);
+
+        ResponseOf(result).Active.Should().BeFalse();
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/MemberInviteControllerAuthorizationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/MemberInviteControllerAuthorizationTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text.Json;
 using FluentAssertions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -472,7 +473,11 @@ public sealed class MemberInviteControllerAuthorizationTests : IDisposable
     }
 
     /// <summary>An invite as the tenant-bounded lookup returns it.</summary>
-    private MemberInviteInfo Invite() => new(
+    private MemberInviteInfo Invite(
+        bool isValid = true,
+        bool isExpired = false,
+        bool isRevoked = false,
+        List<InviteUsageInfo>? usedBy = null) => new(
         Guid.CreateVersion7(),
         _tenantId,
         "Chris",
@@ -484,11 +489,11 @@ public sealed class MemberInviteControllerAuthorizationTests : IDisposable
         DateTime.UtcNow.AddDays(7),
         null,
         0,
-        true,
-        false,
-        false,
+        isValid,
+        isExpired,
+        isRevoked,
         DateTime.UtcNow,
-        []);
+        usedBy ?? []);
 
     /// <summary>
     /// The invitee's browser resolves the tenant by host, and the invite belongs to exactly one
@@ -550,6 +555,93 @@ public sealed class MemberInviteControllerAuthorizationTests : IDisposable
 
         result.Should().BeOfType<OkObjectResult>().Which.Value
             .Should().BeOfType<MemberInviteInfo>().Which.Viewer.Should().BeNull();
+        _tenantMemberService.VerifyNoOtherCalls();
+    }
+
+    /// <summary>
+    /// The accept page names the tenant and the inviter and lists what is being granted, so an
+    /// invite that can still be accepted keeps returning all of it — the redaction below must not
+    /// reach the case the page exists for.
+    /// </summary>
+    [Fact]
+    public async Task GetInviteInfo_forAnAcceptableInvite_returnsWhatTheAcceptPageNeeds()
+    {
+        _inviteService.Setup(s => s.GetInviteByTokenAsync("tok", _tenantId)).ReturnsAsync(Invite());
+
+        var controller = BuildController();
+
+        var result = await controller.GetInviteInfo("tok", CancellationToken.None);
+
+        var info = result.Should().BeOfType<OkObjectResult>().Which.Value
+            .Should().BeOfType<MemberInviteInfo>().Subject;
+        info.TenantName.Should().Be("Chris");
+        info.CreatedByName.Should().Be("Chris");
+        info.DirectPermissions.Should().Equal(TenantPermissions.GlucoseRead);
+        info.ExpiresAt.Should().BeAfter(DateTime.UtcNow);
+    }
+
+    /// <summary>
+    /// The token is the only thing gating this endpoint, and a link outlives the invite behind it.
+    /// An invite that can no longer be accepted answers with the reason alone: the record names the
+    /// tenant, the inviter, the roles and permissions being granted, and every subject that has
+    /// already joined through it.
+    /// <para>
+    /// 400, like the acceptance refusal: the generated client passes a 400 ProblemDetails through
+    /// to the join page, where the reason is shown; other 4xx statuses collapse to the generic
+    /// message. The reason is asserted on the title because openapi-remote-codegen 0.2.0 resolves a
+    /// ProblemDetails to <c>title</c> before <c>detail</c>.
+    /// </para>
+    /// </summary>
+    [Theory]
+    [InlineData(true, false, "This invite has expired.")]
+    [InlineData(false, true, "This invite has been revoked.")]
+    [InlineData(false, false, "This invite has reached its maximum uses.")]
+    public async Task GetInviteInfo_forAnUnacceptableInvite_returnsTheReasonAndNothingElse(
+        bool isExpired, bool isRevoked, string expectedReason)
+    {
+        var joinedSubjectId = Guid.CreateVersion7();
+        var invite = Invite(
+            isValid: false,
+            isExpired: isExpired,
+            isRevoked: isRevoked,
+            usedBy: [new InviteUsageInfo(joinedSubjectId, "Prior Joiner", DateTime.UtcNow)])
+            with
+        { TenantName = "Acme Clinic", CreatedByName = "Invite Author" };
+        _inviteService.Setup(s => s.GetInviteByTokenAsync("tok", _tenantId)).ReturnsAsync(invite);
+
+        var controller = BuildController();
+
+        var result = await controller.GetInviteInfo("tok", CancellationToken.None);
+
+        var problem = result.Should().BeOfType<ObjectResult>().Subject;
+        problem.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        var details = problem.Value.Should().BeOfType<ProblemDetails>().Subject;
+        details.Title.Should().Be(expectedReason);
+        details.Detail.Should().Be(expectedReason);
+
+        var body = JsonSerializer.Serialize(problem.Value);
+        body.Should().NotContain("Acme Clinic");
+        body.Should().NotContain("Invite Author");
+        body.Should().NotContain("Prior Joiner");
+        body.Should().NotContain(joinedSubjectId.ToString());
+        body.Should().NotContain(TenantPermissions.GlucoseRead);
+    }
+
+    /// <summary>
+    /// Membership is not consulted for an invite nobody can accept — the viewer block exists to
+    /// let the page offer acceptance.
+    /// </summary>
+    [Fact]
+    public async Task GetInviteInfo_forAnUnacceptableInvite_doesNotReportTheViewer()
+    {
+        _inviteService
+            .Setup(s => s.GetInviteByTokenAsync("tok", _tenantId))
+            .ReturnsAsync(Invite(isValid: false, isExpired: true));
+
+        var controller = BuildController();
+
+        await controller.GetInviteInfo("tok", CancellationToken.None);
+
         _tenantMemberService.VerifyNoOtherCalls();
     }
 


### PR DESCRIPTION
## What

Two anonymous-disclosure gaps from an endpoint audit, both in the OAuth/invite surface.

**Token introspection was unauthenticated.** `POST /api/oauth/introspect` carried `[AllowAnonymous]` and resolved any presented token to its subject id, client id, and scopes — a subject-id oracle for any leaked token, contrary to RFC 7662 §2.3. This OAuth server has no client-secret concept (all clients are public, PKCE-mandatory), so "client authentication" here means the caller-authentication pattern the other credential-bearing `/api/oauth/*` endpoints use: `[AllowAnonymous]` removed so the default-deny fallback policy applies, plus an explicit `IsAuthenticated()` check. That check is load-bearing rather than belt-and-braces — removing `[AllowAnonymous]` alone wouldn't close it, because the fallback policy succeeds for the anonymous public-share subject's non-empty permission trie. The response is also bounded to the caller's own identity (subject and, for tenant-pinned tokens, tenant): another subject's token reads as `active=false` rather than resolving, so an authenticated caller can't use it as an oracle either. No first-party component uses introspection as a resource-server (swept both repos); the only callers were tests.

**Member-invite info leaked on spent invites.** `GET /api/v4/member-invites/{token}/info` returned the full record — tenant name, inviter, granted role ids and permissions, and the subject ids and names of everyone who had already joined — for expired, revoked, or exhausted invites, with no validity check (the one caller of this service method that lacked the `IsValid` gate the others have). Now: unknown token → 404, live invite → the full record the accept page needs, and expired/revoked/exhausted → a `ProblemDetails` carrying only the reason (structurally a different type, so the fields are absent, not nulled). The invitee still sees the specific reason ("This invite has been revoked.") on the join page.

`revoke` deliberately stays anonymous with a documented rationale: RFC 7009 mandates a bare 200 regardless of outcome, so there's no oracle to protect, and requiring auth would strand the client whose token has already stopped working.

## Testing

4840 passing (15 new/changed across introspect and invite-auth; the one unrelated failure is a pre-existing background-job race, `ConnectorCursorResetJobServiceTests`, disjoint from this diff). Each gate is proven load-bearing by reverting it: deleting the `IsAuthenticated()` block fails exactly the share-subject test; deleting the null-subject guard fails exactly the subjectless-guest test (the guard that stops a guest session from introspecting the data owner's tokens); removing the tenant clause fails exactly the cross-tenant-token test; removing the invite `IsValid` gate fails the three reason cases plus the "doesn't report the viewer" case — and that invite test asserts the leaked strings are absent from the serialized body, not just the status code. The discovery document no longer advertises the introspection endpoint, since there's no registered auth-method identifier for first-party self-introspection.

All fixtures are synthetic — no tokens, secrets, or identifiers in code, tests, or history.

https://claude.ai/code/session_01V2H2GSE3UWEgkMvsJE8Kfw
