### PR TITLE
fix(security): require auth for the connector effective-config endpoint

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Connectors/ConfigurationController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Connectors/ConfigurationController.cs
@@ -83,16 +83,16 @@ public class ConfigurationController : ControllerBase
     }
 
     /// <summary>
-    /// Gets the effective configuration from a running connector.
-    /// This returns the actual runtime values including those resolved from environment variables.
-    /// This endpoint is public since it only exposes non-secret configuration values.
+    /// Gets the effective configuration for a connector: the non-secret runtime values resolved
+    /// from stored configuration and environment variables. Secret values (passwords, tokens) are
+    /// excluded, but the result includes non-secret account identifiers such as the connector
+    /// account username or email, so it requires authentication (the class-level <c>[Authorize]</c>).
     /// </summary>
     /// <param name="connectorName">The connector name</param>
     /// <param name="ct">Cancellation token</param>
     /// <returns>Dictionary of property names to effective values</returns>
     [HttpGet("{connectorName}/effective")]
     [RemoteQuery]
-    [AllowAnonymous]
     [ProducesResponseType(typeof(Dictionary<string, object?>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
     public async Task<ActionResult<Dictionary<string, object?>>> GetEffectiveConfiguration(

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Connectors/ConfigurationControllerAttributeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Connectors/ConfigurationControllerAttributeTests.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Authorization;
+using Nocturne.API.Controllers.V4.Connectors;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4.Connectors;
+
+/// <summary>
+/// Guards the authorization attributes on <see cref="ConfigurationController"/>. The effective
+/// configuration endpoint returns saved non-secret connector values, which include account
+/// identifiers such as the connector account username or email. It must require authentication:
+/// the class-level <c>[Authorize]</c> gates it, so a per-action <c>[AllowAnonymous]</c> would
+/// return those identifiers to any unauthenticated caller.
+/// </summary>
+public class ConfigurationControllerAttributeTests
+{
+    [Fact]
+    public void GetEffectiveConfiguration_IsNotAllowAnonymous()
+    {
+        var method = typeof(ConfigurationController)
+            .GetMethod(nameof(ConfigurationController.GetEffectiveConfiguration));
+
+        Assert.NotNull(method);
+        Assert.Null(method!.GetCustomAttribute<AllowAnonymousAttribute>());
+    }
+
+    [Fact]
+    public void Controller_RequiresAuthorization()
+    {
+        var authorize = typeof(ConfigurationController).GetCustomAttribute<AuthorizeAttribute>();
+        Assert.NotNull(authorize);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/ConnectorEffectiveConfigurationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/ConnectorEffectiveConfigurationTests.cs
@@ -1,0 +1,95 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Connectors;
+using Nocturne.API.Services.Realtime;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Glooko.Configurations;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Infrastructure.Data;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Connectors;
+
+/// <summary>
+/// Characterizes what the connector effective-configuration read returns. The account identifier
+/// (username/email) is not a <c>Secret</c> property, so it is included in the effective values;
+/// that is why the endpoint returning them must require authentication
+/// (<see cref="Controllers.V4.Connectors.ConfigurationControllerAttributeTests"/>). Passwords and
+/// other secrets are excluded here regardless of the transport gate.
+/// </summary>
+public class ConnectorEffectiveConfigurationTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly NocturneDbContext _dbContext;
+
+    public ConnectorEffectiveConfigurationTests()
+    {
+        // Force-load the Glooko connector assembly so the service's reflection-based type lookup
+        // (AppDomain scan for [ConnectorRegistration]) can resolve "Glooko".
+        _ = typeof(GlookoConnectorConfiguration);
+
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var dbOptions = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+
+        _dbContext = new NocturneDbContext(dbOptions) { TenantId = Guid.CreateVersion7() };
+        _dbContext.Database.EnsureCreated();
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        _connection.Dispose();
+    }
+
+    private ConnectorConfigurationService CreateService(IConfiguration configuration) =>
+        new(
+            _dbContext,
+            Mock.Of<ISecretEncryptionService>(),
+            Mock.Of<ISignalRBroadcastService>(),
+            Mock.Of<IAuditContext>(),
+            configuration,
+            Mock.Of<IHostEnvironment>(),
+            Enumerable.Empty<IConnectorCacheInvalidator>(),
+            NullLogger<ConnectorConfigurationService>.Instance);
+
+    [Fact]
+    public async Task GetEffectiveConfiguration_IncludesAccountIdentifier_ExcludesSecret()
+    {
+        // A connector configured with an account identifier and a secret. The account email is a
+        // non-secret field, so a filter that did nothing would return it — this seeds the value the
+        // filter and the authorization gate must handle.
+        const string accountEmail = "connector-user@example.test";
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Connectors:Glooko:Email"] = accountEmail,
+                ["Connectors:Glooko:Password"] = "connector-secret",
+            })
+            .Build();
+
+        var service = CreateService(configuration);
+
+        var effective = await service.GetEffectiveConfigurationAsync("Glooko");
+
+        effective.Should().NotBeNull();
+
+        // The account identifier is present — this is the data the anonymous leak exposed, and the
+        // legitimate authenticated caller still needs it to render the configuration form.
+        effective!.Should().ContainKey("email");
+        effective["email"].Should().Be(accountEmail);
+
+        // Secrets are never part of the effective values.
+        effective.Should().NotContainKey("password");
+    }
+}


### PR DESCRIPTION
## What

`GET /api/v4/connectors/config/{name}/effective` carried a per-action `[AllowAnonymous]` on an otherwise `[Authorize]` controller, with a comment claiming it "only exposes non-secret configuration values." It returned every non-`Secret` `[ConnectorProperty]` — which is more than the comment implied: not just usernames (Dexcom/CareLink/Eversense/LibreLinkUp/MyFitnessPal/MyLife/Tidepool/Twiist) but emails (Glooko/Tandem), patient ids, patient usernames, user ids, pump serial numbers, country codes, and server URLs. Only `Password`/`ApiSecret`/`RefreshToken` were `Secret`-flagged and excluded; `Hidden = true` suppresses UI rendering but not the effective response. Connector names are enumerable via the sibling anonymous `/schema`, so a caller could walk them.

Fix: drop the `[AllowAnonymous]` so the class-level `[Authorize]` gates it, and correct the comment.

**Why not flag `Username` as `Secret` instead:** that leaves every other identifier leaking, forces each future connector to remember the flag, and misuses `Secret` semantics — `Secret` fields are AES-encrypted at rest, write-only through a separate `/secrets` endpoint, and masked in logs; reclassifying user-editable form fields that way would also break the config form that reads their current values.

**Why this doesn't need anonymous access:** the only caller of the generated `getEffectiveConfiguration` is `ConnectorSetup.svelte`, which pre-fills the connector form. It renders only after authentication — in the onboarding wizard it's in the post-auth branch, reached only once account creation has set the session cookie — and its authenticated siblings `getConfiguration` (already `[Authorize]`) and `getAllConnectorStatus` are called in the same flow. A 401 on the effective call isn't wired into the wizard's error state either: the pre-fill just becomes null, so even a transient unauthenticated window degrades gracefully rather than erroring onboarding.

`/schema` stays anonymous deliberately — it reads class-level defaults from a fresh instance and never binds saved or environment values, so it exposes only property shapes and connector names, not account data.

Scope note: `effective` binds from `IConfiguration` (env/appsettings), not a per-tenant DB config source, so on the multi-tenant cloud it returns mostly server defaults; the concrete identifier leak is sharpest on env-configured self-hosted deployments. The fix is correct either way.

## Testing

4830 passing (+3; the one unrelated failure is the known `PasskeyControllerTests`/`ConnectorCursorResetJobServiceTests` UUID-v7/background-job flake, disjoint from this diff). An attribute test asserts the effective action is no longer `[AllowAnonymous]` and the controller keeps `[Authorize]`; a non-vacuous service test seeds a Glooko connector with an email and password and asserts the effective response contains the email but not the password, through the same method the controller calls. Reverting the fix (re-adding `[AllowAnonymous]`) fails the attribute test. Synthetic fixtures only — no real identifiers in code, tests, or history.

## Noted for follow-up (not in this PR)

The whole controller — including the write endpoints `SaveConfiguration`/`SaveSecrets`/`SetActive`/`DeleteConfiguration` — is only `[Authorize]` with no scope, so any authenticated member (Viewer, guest-link session) can read connector identifiers and modify connector config. This PR closes the anonymous hole and matches the sibling read bar; a connectors/admin scope for the controller is worth a separate pass.

https://claude.ai/code/session_01V2H2GSE3UWEgkMvsJE8Kfw
