### PR TITLE
fix(glooko): drop the per-sync fields the context refactor left behind

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -71,33 +71,6 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         SyncDataType.Profiles
     ];
 
-    // ── Per-sync state (populated in PerformSyncInternalAsync) ─────────
-    // These fields are not safe for concurrent syncs on one instance: a second
-    // InitializeMappers overwrites the first sync's session and mappers.
-
-    private string? _sessionCookie;
-    private GlookoUserData? _userData;
-    private GlookoConnectorConfiguration? _syncConfig;
-    private GlookoTimeMapper? _timeMapper;
-    private GlookoSensorGlucoseMapper? _sensorGlucoseMapper;
-    private GlookoV4TreatmentMapper? _v4TreatmentMapper;
-    private GlookoStateSpanMapper? _stateSpanMapper;
-    private GlookoTempBasalMapper? _tempBasalMapper;
-    private GlookoSystemEventMapper? _systemEventMapper;
-    private GlookoProfileMapper? _profileMapper;
-
-    private void InitializeMappers(GlookoConnectorConfiguration config)
-    {
-        _syncConfig = config;
-        _timeMapper = new GlookoTimeMapper(config, _glookoLogger);
-        _sensorGlucoseMapper = new GlookoSensorGlucoseMapper(config, ConnectorSource, _timeMapper, _glookoLogger);
-        _v4TreatmentMapper = new GlookoV4TreatmentMapper(ConnectorSource, _timeMapper, _glookoLogger);
-        _stateSpanMapper = new GlookoStateSpanMapper(ConnectorSource, _timeMapper, _glookoLogger);
-        _tempBasalMapper = new GlookoTempBasalMapper(ConnectorSource, _timeMapper, _glookoLogger);
-        _systemEventMapper = new GlookoSystemEventMapper(ConnectorSource, _timeMapper, _glookoLogger);
-        _profileMapper = new GlookoProfileMapper(ConnectorSource, _glookoLogger);
-    }
-
     // ── Authentication ──────────────────────────────────────────────────
 
     public override async Task<bool> AuthenticateAsync()


### PR DESCRIPTION
## What

Unblocks `main`, whose `unit` job has been failing since #666.

#666 moved `GlookoConnectorService`'s per-sync state onto `GlookoSyncContext` and added a reflection guard asserting the service declares no mutable instance fields. The refactor converted every *read and write* to `context.X`, but its diff starts below the declaration block — so all ten fields, and the `InitializeMappers` method that populated them, survived with no callers. The guard then failed on the first one it found:

```
Expected instanceFields.Where(f => !f.IsInitOnly) to be empty because per-sync
state belongs on GlookoSyncContext, ... but found at least one item
{System.String _sessionCookie}.
```

This deletes the block. It is behaviour-neutral — `InitializeMappers` had no call sites and nothing read any of the fields, so nothing was ever populated or consumed.

Worth being precise about the risk, since #666's description frames these fields as a cross-tenant session-bleed vector: as they stood on `main` they were *orphaned*, not shared. Nothing assigned them, so no tenant's session could reach another through them. The leak #666 describes was real before that refactor and is closed by the context threading; what remained was dead code that only the guard could see.

## Testing

`Nocturne.Connectors.Glooko.Tests` 57 / 0 (was 56 / 1). Full solution build clean.